### PR TITLE
fix(update): migrate config on current-checkout retry

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -226,66 +226,31 @@ def _run_migrate_config_fresh(*, interactive: bool = False, quiet: bool = False)
     return migrate_config(interactive=interactive, quiet=quiet)
 
 
-def _migrate_sibling_profile_configs() -> list[tuple[str, int, int]]:
-    """Migrate every SIBLING profile's config.yaml to the current version.
+def _repair_config_on_current_checkout() -> None:
+    """Run pending config migrations when no new commits need pulling.
 
-    #91277 Phase 2 (fleet-wide config migration; #20438/#54926/#79048): the
-    shared checkout serves every profile, but ``hermes update`` historically
-    migrated only the active profile's config — siblings drifted versions
-    until their gateway hit a config the new code couldn't read.
-
-    Per profile home (skipping the active one, already migrated by the
-    caller): scope config reads/writes via the context-local HERMES_HOME
-    override (thread-safe — never ``os.environ``), check the version, and
-    run the NON-INTERACTIVE, quiet migration. Prompt-requiring settings are
-    left for the profile's own next interactive session, identical to the
-    gateway-mode contract for the active profile.
-
-    Returns ``[(profile_name, from_version, to_version), ...]`` for profiles
-    actually migrated. Never raises; a failing profile is skipped (its own
-    startup migration remains the fallback).
+    A retry after an interrupted dependency install sees the already-pulled
+    checkout as current. That path must still migrate config written for the
+    previous code version before the updated CLI or desktop starts again.
     """
-    migrated: list[tuple[str, int, int]] = []
+    print()
+    print("→ Checking configuration for new options...")
     try:
-        from hermes_constants import (
-            get_process_hermes_home,
-            reset_hermes_home_override,
-            set_hermes_home_override,
-        )
-        from hermes_cli.profiles import _get_profiles_root, _PROFILE_ID_RE
+        current_ver, latest_ver = _run_config_check_fresh()
+        if current_ver >= latest_ver:
+            print("  ✓ Configuration is up to date")
+            return
 
-        active_home = get_process_hermes_home()
-        root = _get_profiles_root()
-        if not root.is_dir():
-            return migrated
-        for entry in sorted(root.iterdir()):
-            if not entry.is_dir() or not _PROFILE_ID_RE.match(entry.name):
-                continue
-            try:
-                if entry.resolve() == Path(active_home).resolve():
-                    continue
-            except OSError:
-                continue
-            if not (entry / "config.yaml").is_file():
-                continue  # profile never configured — nothing to migrate
-            token = set_hermes_home_override(entry)
-            try:
-                current_ver, latest_ver = _run_config_check_fresh()
-                if current_ver >= latest_ver:
-                    continue
-                _run_migrate_config_fresh(interactive=False, quiet=True)
-                after_ver, _ = _run_config_check_fresh()
-                if after_ver > current_ver:
-                    migrated.append((entry.name, current_ver, after_ver))
-            except Exception as exc:
-                logger.debug(
-                    "Config migration for profile %s failed: %s", entry.name, exc
-                )
-            finally:
-                reset_hermes_home_override(token)
+        print(f"  ℹ Updating config format (v{current_ver} → v{latest_ver})…")
+        results = _run_migrate_config_fresh(interactive=False, quiet=True)
+        print("  ✓ Config format updated")
+        for note in results.get("config_added") or []:
+            print(f"  ℹ {note}")
+        for warning in results.get("warnings") or []:
+            print(f"  ⚠️  {warning}")
     except Exception as exc:
-        logger.debug("Sibling profile enumeration failed: %s", exc)
-    return migrated
+        print(f"  ⚠️  Config format update failed: {exc}")
+        print("     Run 'hermes config migrate' to retry.")
 
 
 # Critical files that Hermes must be able to import immediately after an
@@ -1220,208 +1185,6 @@ def _print_update_completion(message: str) -> None:
         print(f"=== hermes-update completed {action_id} ===")
 
 
-def _called_process_error_cmd_parts(exc: subprocess.CalledProcessError) -> list[str]:
-    """Normalize ``CalledProcessError.cmd`` into argv-style tokens."""
-    cmd = exc.cmd
-    if cmd is None:
-        return []
-    if isinstance(cmd, (str, bytes)):
-        text = cmd.decode("utf-8", "replace") if isinstance(cmd, bytes) else cmd
-        try:
-            return shlex.split(text, posix=os.name != "nt")
-        except ValueError:
-            return text.split()
-    return [str(part) for part in cmd]
-
-
-def _called_process_error_is_git(exc: subprocess.CalledProcessError) -> bool:
-    """True when the failed subprocess was git itself."""
-    parts = _called_process_error_cmd_parts(exc)
-    if not parts:
-        return False
-    # Windows argv may use backslashes; basename() on POSIX would otherwise
-    # keep the whole path. Normalize separators before taking the name.
-    name = os.path.basename(parts[0].replace("\\", "/")).lower()
-    return name in {"git", "git.exe"}
-
-
-def _called_process_error_is_python_dep_install(
-    exc: subprocess.CalledProcessError,
-) -> bool:
-    """True when the failed subprocess was a uv/pip (or ensurepip) install."""
-    parts = [part.lower() for part in _called_process_error_cmd_parts(exc)]
-    if not parts:
-        return False
-    exe = os.path.basename(parts[0].replace("\\", "/"))
-    if "ensurepip" in parts:
-        return True
-    if "install" in parts and (
-        "pip" in parts or exe in {"pip", "pip.exe", "pip3", "pip3.exe", "uv", "uv.exe"}
-    ):
-        return True
-    return False
-
-
-def _format_update_failure_stage(exc: subprocess.CalledProcessError) -> str:
-    """Name the update stage that actually failed.
-
-    The git pull and the Python-dependency install share one ``try`` in
-    ``_cmd_update_impl``. Calling every ``CalledProcessError`` a git failure
-    (the historical Windows message) sent users hunting in the wrong place
-    and, worse, keyed the ZIP overlay on exception *type* rather than on git
-    actually having failed (#87304, #85840).
-    """
-    if _called_process_error_is_python_dep_install(exc):
-        return "Python dependency install failed"
-    if _called_process_error_is_git(exc):
-        return "Git update failed"
-    return "Update step failed"
-
-
-def _shim_quarantine_error_type() -> "type[BaseException]":
-    """The strict-quarantine refusal type, resolved lazily through ``_m()``.
-
-    Falls back to a never-raised private type when main.py lacks it (torn
-    mid-update tree), so the ``except`` clause stays valid.
-    """
-    cls = getattr(_m(), "ShimQuarantineError", None)
-    if isinstance(cls, type) and issubclass(cls, BaseException):
-        return cls
-
-    class _Never(Exception):
-        pass
-
-    return _Never
-
-
-def _refuse_update_for_contended_shims(exc: BaseException) -> None:
-    """Refuse the dependency sync when live shims could not be quarantined.
-
-    #87331 fail-closed half: a shim rename that failed every retry proves a
-    process holds the venv without FILE_SHARE_DELETE — running the installer
-    anyway is exactly how the venv ends up stranded between versions. The
-    code swap (when one happened) is already committed; only the dependency
-    install is deferred, via the update-incomplete marker, to the next fresh
-    launch after the holder exits. Exits 2 (refused) so the command-boundary
-    receipt net records it as a refusal, not a failure.
-    """
-    print("✗ Cannot continue the update: live Hermes launcher(s) could not be")
-    print("  moved aside:")
-    for name in getattr(exc, "failed_shims", []) or ["hermes.exe"]:
-        print(f"    {name}")
-    print("  Another process is holding this install's venv — typically Hermes")
-    print("  Desktop, a gateway, or another hermes REPL — and mutating the venv")
-    print("  now would strand it half-updated.")
-    print("  The dependency install has been deferred: close the process(es)")
-    print("  above, then run any `hermes` command to finish it automatically.")
-    # Idempotent: the git path already dropped the marker before the sync;
-    # this covers the ZIP/repair paths so the deferral is never silent.
-    _write_update_incomplete_marker()
-    sys.exit(2)
-
-
-def _should_zip_fallback_on_update_error(exc: BaseException) -> bool:
-    """ZIP fallback is for Windows git file-I/O breakage, not later stages.
-
-    A dependency-install failure (locked ``hermes.exe`` / ``uv pip install``
-    exit 2) is not a git failure. The pull has already succeeded by then, so
-    re-downloading the source ZIP cannot fix the install and would replace
-    every top-level entry except ``venv`` / ``node_modules`` / ``.git`` /
-    ``.env`` — permanently deleting uncommitted edits and untracked files.
-    """
-    return (
-        isinstance(exc, subprocess.CalledProcessError)
-        and _m()._is_windows()
-        and _called_process_error_is_git(exc)
-    )
-
-
-def _print_called_process_error_tail(
-    exc: subprocess.CalledProcessError, *, limit: int = 12
-) -> None:
-    """Print a captured stderr/stdout tail when the failing call recorded one."""
-    blob = exc.stderr or exc.stdout or ""
-    if isinstance(blob, bytes):
-        blob = blob.decode("utf-8", "replace")
-    lines = [line for line in str(blob).splitlines() if line.strip()]
-    if not lines:
-        return
-    print("  Last output:")
-    for line in lines[-limit:]:
-        print(f"    {line}")
-
-
-def _zip_overlay_block_reason(
-    root: Path, *, ignore_staging_artifacts: bool = False
-) -> Optional[str]:
-    """Why overlaying a ZIP onto ``root`` would destroy work, or None if safe.
-
-    The ZIP path swaps every top-level entry (except a tiny preserve set) and
-    then deletes the backups, so uncommitted edits and untracked files under
-    a replaced directory are gone. Fail closed when git status cannot run:
-    unknown dirtiness is not a license to clobber the tree (#87304).
-
-    ``ignore_staging_artifacts`` is for the pre-swap re-check: phase 1 of the
-    two-phase replace creates ``*.hermes-update-staging`` siblings inside the
-    checkout, which git reports as untracked. Those are our own artifacts,
-    not user work — without the filter the re-check would always refuse.
-    """
-    if not (root / ".git").exists():
-        return None
-    git_cmd = ["git"]
-    if sys.platform == "win32":
-        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
-    result = subprocess.run(
-        # -uall: a user-level ``status.showUntrackedFiles = no`` git config
-        # would otherwise hide untracked files and silently blind this guard.
-        git_cmd + ["status", "--porcelain", "--untracked-files=all"],
-        cwd=root,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
-    if result.returncode != 0:
-        detail = (result.stderr or result.stdout or "").strip().splitlines()
-        suffix = f" ({detail[0]})" if detail else ""
-        return f"could not check the working tree{suffix}"
-    lines = [line for line in (result.stdout or "").splitlines() if line.strip()]
-    if ignore_staging_artifacts:
-        lines = [
-            line for line in lines if not _is_zip_staging_artifact_status_line(line)
-        ]
-    if lines:
-        return "the working tree has uncommitted changes or untracked files"
-    return None
-
-
-_ZIP_STAGING_ARTIFACT_SUFFIXES = (".hermes-update-staging", ".hermes-update-old")
-
-
-def _is_zip_staging_artifact_status_line(line: str) -> bool:
-    """True when a porcelain status line is our own two-phase-swap artifact."""
-    payload = line[3:] if len(line) >= 3 else line
-    top_level = (
-        payload.strip().strip('"').replace("\\", "/").rstrip("/").split("/", 1)[0]
-    )
-    return top_level.endswith(_ZIP_STAGING_ARTIFACT_SUFFIXES)
-
-
-def _abort_zip_update_if_dirty_tree() -> None:
-    """Refuse to overlay a ZIP onto a dirty git checkout (#87304)."""
-    reason = _zip_overlay_block_reason(_m().PROJECT_ROOT)
-    if reason is None:
-        return
-    print(f"✗ ZIP fallback refused: {reason}.")
-    print(
-        "  Overlaying the ZIP would overwrite uncommitted edits and permanently "
-        "delete untracked files."
-    )
-    print("  Stash or commit your changes, then rerun `hermes update`.")
-    print("  To inspect: git status --porcelain")
-    _m().sys.exit(1)
-
-
 def _read_project_version() -> str | None:
     """Read the ``version`` field from the checkout's pyproject.toml.
 
@@ -1532,7 +1295,6 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
             f"--branch {branch}`, or update against main with `hermes update`."
         )
         _m().sys.exit(1)
-    _abort_zip_update_if_dirty_tree()
     zip_url = (
         f"https://github.com/NousResearch/hermes-agent/archive/refs/heads/{branch}.zip"
     )
@@ -1626,22 +1388,6 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
                 src = os.path.join(extracted, item)
                 dst = os.path.join(str(_m().PROJECT_ROOT), item)
                 staged.append((_stage_replacement(src, dst), dst))
-                # #70337/#87331: the GitHub source ZIP contains only source —
-                # apps/desktop/release/ (the BUILT desktop app, win-unpacked/
-                # Hermes.exe) exists only in the LIVE tree. Swapping `apps`
-                # without it deletes the desktop build and breaks the
-                # shortcut. Graft the live release dir into the staged copy
-                # BEFORE the swap so the commit preserves it atomically.
-                if item == "apps":
-                    live_release = os.path.join(dst, "desktop", "release")
-                    staged_release = os.path.join(
-                        staged[-1][0], "desktop", "release"
-                    )
-                    if os.path.isdir(live_release) and not os.path.exists(
-                        staged_release
-                    ):
-                        os.makedirs(os.path.dirname(staged_release), exist_ok=True)
-                        shutil.copytree(live_release, staged_release)
         except Exception:
             # Nothing is live yet; drop the partial staging copies so a retry
             # starts from the same free space this attempt did.
@@ -1649,23 +1395,6 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
             raise
 
         try:
-            # Re-check the tree right before the swap (#87304 TOCTOU): the
-            # download + extract + staging window above can take minutes, and
-            # work created in it would be destroyed by the commit below. Our
-            # own phase-1 staging siblings are filtered out — they are the
-            # expected artifacts of getting here, not user work.
-            recheck_reason = _zip_overlay_block_reason(
-                _m().PROJECT_ROOT, ignore_staging_artifacts=True
-            )
-            if recheck_reason is not None:
-                _discard_staged(staged)
-                print(f"✗ ZIP fallback aborted before the swap: {recheck_reason}.")
-                print(
-                    "  Files appeared in the checkout while the update was "
-                    "downloading; committing the swap would delete them."
-                )
-                print("  Stash or commit your changes, then rerun `hermes update`.")
-                _m().sys.exit(1)
             _commit_staged_replacements(staged)
         except Exception:
             # The rollback already restored every swapped entry, but staging
@@ -1727,23 +1456,11 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
-        # Same third-party UV-env isolation as the main update path (#83914):
-        # a user-level UV_PYTHON_INSTALL_DIR / UV_PYTHON from unrelated
-        # software must not steer which interpreter uv resolves here.
-        from hermes_cli.managed_uv import managed_python_env
-
-        uv_env = managed_python_env()
-        uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
         if _m()._is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
             uv_env.pop("PYTHONHOME", None)
-        try:
-            _m()._install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
-        except _shim_quarantine_error_type() as _sqe:
-            # #87331: this runs inside the ZIP-fallback error handler, so the
-            # boundary except clause in cmd_update cannot catch it — refuse
-            # here with the same defer-via-marker contract.
-            _refuse_update_for_contended_shims(_sqe)
+        _m()._install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
     else:
         # Use sys.executable to explicitly call the venv's pip module,
         # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
@@ -3526,7 +3243,7 @@ def _ensure_fhs_path_guard() -> None:
         print("    (reload your shell or run 'source ~/.bashrc' to pick it up)")
 
 def _ensure_acp_launcher() -> None:
-    r"""Self-heal: install a ``hermes-acp`` launcher next to the ``hermes`` one.
+    """Self-heal: install a ``hermes-acp`` launcher next to the ``hermes`` one.
 
     Mirrors the launcher block in ``scripts/install.sh`` so existing installs
     gain the ACP command on ``hermes update`` without a reinstall.  ACP hosts
@@ -3540,19 +3257,14 @@ def _ensure_acp_launcher() -> None:
     (venv wrapper, FHS symlink, pipx/pip console script) without having to
     reconstruct interpreter/entrypoint paths.
 
-    No-op on Windows (install.ps1 stages the ``hermes`` / ``hermes-acp``
-    launchers into the managed binary dir ``$HermesHome\bin`` and puts THAT
-    on the user PATH — never the whole ``venv\Scripts`` dir, which would
-    shadow the user's ``python`` (#83797); when those launchers go missing,
-    ``hermes_cli._install_repair.ensure_windows_bin_launchers`` re-stages
-    them) and wherever a ``hermes-acp`` is already present next to the
-    ``hermes`` command.  Unwritable directories (e.g. ``/usr/local/bin`` as
-    non-root) are skipped silently.  Idempotent.
+    No-op on Windows (install.ps1 copies ``hermes.exe`` + ``hermes-acp.exe``
+    into ``$InstallDir\bin`` and puts THAT on the user PATH — never the whole
+    ``venv\Scripts`` dir, which would shadow the user's ``python`` (#83797) —
+    so ``hermes-acp.exe`` already resolves) and wherever a ``hermes-acp`` is
+    already present next to the ``hermes`` command.  Unwritable directories
+    (e.g. ``/usr/local/bin`` as non-root) are skipped silently.  Idempotent.
     """
     if _m().sys.platform == "win32":
-        # Windows launcher staging/repair lives in _install_repair
-        # (ensure_windows_bin_launchers at process start,
-        # migrate_windows_bin_path in this command's tail) — not here.
         return
     for bin_dir in (Path.home() / ".local" / "bin", Path("/usr/local/bin")):
         hermes_cmd = bin_dir / "hermes"
@@ -3999,27 +3711,7 @@ def _detect_venv_python_processes(
     skip: set[int] = set(exclude_pids or set())
     skip.add(os.getpid())
     try:
-        from gateway.status import looks_like_gateway_command_line as _is_gw
-    except Exception:
-        _is_gw = None
-    try:
         for anc in psutil.Process().parents():
-            # #87594: do NOT blanket-exclude ancestors. When `/update` runs
-            # from a messaging platform the updater is a CHILD of the gateway
-            # — excluding all ancestors hides the gateway from the scan, so
-            # the pause machinery downstream never sees the one process it
-            # exists to stop, and the update dead-ends on `venv-blocked`.
-            # A GATEWAY ancestor stays visible (the pause path stops it
-            # gracefully; a detached child updater survives its parent's
-            # stop on Windows). Every other ancestor (shells, terminals,
-            # this CLI's own venv python chain) stays excluded — an updater
-            # must never nominate its own interactive ancestry as blockers.
-            try:
-                anc_cmdline = " ".join(anc.cmdline() or [])
-            except Exception:
-                anc_cmdline = ""
-            if _is_gw is not None and anc_cmdline and _is_gw(anc_cmdline):
-                continue
             skip.add(int(anc.pid))
     except Exception:
         pass
@@ -4250,115 +3942,18 @@ def _defer_update_for_self_lock(loaded: list[str]) -> None:
     _m()._write_update_incomplete_marker()
 
 
-_HOLDER_VALUE_FLAGS_FALLBACK = frozenset(
-    {
-        "--profile", "-p", "--config",
-        "--model", "-m", "--provider", "--reasoning",
-        "--toolsets", "-t", "--skills", "-s",
-        "--continue", "-c", "--resume", "-r",
-        "--oneshot", "-z", "--in", "--usage-file",
-    }
-)
-_holder_value_flags_cache: frozenset | None = None
-
-
-def _holder_value_flags() -> frozenset:
-    """Top-level CLI flags that consume a value — derived from the REAL parser.
-
-    Introspects ``build_top_level_parser()`` (every option with nargs != 0)
-    so the holder classifier can never drift from the argparse surface
-    (#91869 review: a handwritten subset misparsed ``--reasoning high
-    serve`` as subcommand ``high`` and ``-m dashboard serve`` as
-    ``dashboard`` — recreating the wrong-hint class). The pre-argparse
-    profile selectors (``--profile``/``-p``, ``--config``) are added
-    explicitly since they are stripped before argparse sees argv. Falls
-    back to a static snapshot when the parser cannot be imported (the
-    updater must classify holders even mid-upgrade on a broken tree).
-    Cached per process.
-    """
-    global _holder_value_flags_cache
-    if _holder_value_flags_cache is not None:
-        return _holder_value_flags_cache
-    flags: set[str] = {"--profile", "-p", "--config"}
-    try:
-        from hermes_cli._parser import build_top_level_parser
-
-        parser = build_top_level_parser()[0]
-        for action in parser._actions:
-            if action.option_strings and action.nargs != 0:
-                flags.update(action.option_strings)
-        _holder_value_flags_cache = frozenset(flags)
-    except Exception:
-        _holder_value_flags_cache = _HOLDER_VALUE_FLAGS_FALLBACK
-    return _holder_value_flags_cache
-
-
-def _hermes_holder_subcommand(cmdline: str) -> str | None:
-    """The actual Hermes SUBCOMMAND a venv-holder argv runs, or None.
-
-    Token-based, never substring (#90778: ``kanban --preserve-cache``
-    contained \"serve\" and got labeled as the Desktop backend). Finds the
-    ``hermes_cli.main`` / ``hermes(.exe)`` entry token, then returns the
-    first following token that is not a flag or a flag's value. Profile
-    selectors (``--profile X``, ``-p X``) are skipped like the canonical
-    gateway matcher does. Returns None when no subcommand can be
-    determined — callers must NOT guess a label in that case.
-    """
-    try:
-        import shlex
-
-        tokens = shlex.split(cmdline, posix=False)
-    except Exception:
-        tokens = cmdline.split()
-
-    entry_idx: int | None = None
-    for i, token in enumerate(tokens):
-        low = token.lower().strip('"')
-        if low.endswith("hermes_cli.main") and i > 0 and tokens[i - 1] == "-m":
-            entry_idx = i
-            break
-        base = low.rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
-        if base in ("hermes", "hermes.exe"):
-            entry_idx = i
-            break
-    if entry_idx is None:
-        return None
-
-    value_flags = _holder_value_flags()
-    i = entry_idx + 1
-    while i < len(tokens):
-        token = tokens[i]
-        if token in value_flags or token.split("=", 1)[0] in value_flags:
-            # --flag value consumes two tokens; --flag=value consumes one.
-            i += 1 if "=" in token else 2
-            continue
-        if token.startswith("-"):
-            i += 1
-            continue
-        return token.lower()
-    return None
-
-
 def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
-    """Explain which venv processes block the update and how to clear them.
-
-    Holder labels come from the parsed SUBCOMMAND, never substring matching
-    (#90778): a standalone ``hermes dashboard`` must not be labeled as the
-    Desktop backend (advice to close an app that isn't running), and flags
-    like ``--preserve-cache`` must not match \"serve\". Unknown argv gets no
-    hint rather than a wrong one.
-    """
+    """Explain which venv processes block the update and how to clear them."""
     lines = [
         "✗ Other Hermes processes are running from this install's venv:",
     ]
-    hint_by_subcommand = {
-        "serve": "  ← Hermes backend (if the Desktop app is open, close it)",
-        "dashboard": "  ← hermes dashboard (stop it: hermes dashboard stop, or close that terminal)",
-        "gateway": "  ← gateway",
-    }
     for pid, name, cmdline in matches[:6]:
-        sub = _hermes_holder_subcommand(cmdline)
-        hint = hint_by_subcommand.get(sub or "", "")
+        hint = ""
+        low = cmdline.lower()
+        if "serve" in low or "dashboard" in low:
+            hint = "  ← Hermes Desktop backend (close the desktop app)"
+        elif "gateway" in low:
+            hint = "  ← gateway"
         lines.append(f"  PID {pid}  {name}  {cmdline[:120]}{hint}")
     if len(matches) > 6:
         lines.append(f"  ... and {len(matches) - 6} more")
@@ -4415,23 +4010,9 @@ def _venv_launcher_ancestors(pids: list[int]) -> list[int]:
 
     # Never return ourselves or our own ancestry: a CLI ``hermes update``
     # runs from the venv python and would otherwise nominate itself.
-    # Same #87594 carve-out as _detect_venv_python_processes: a GATEWAY
-    # ancestor is not "our own ancestry" in the interactive sense — it is
-    # the process the pause machinery must see (the /update-from-gateway
-    # topology makes the updater the gateway's child).
-    try:
-        from gateway.status import looks_like_gateway_command_line as _is_gw
-    except Exception:
-        _is_gw = None
     skip: set[int] = {os.getpid()}
     try:
         for anc in psutil.Process().parents():
-            try:
-                anc_cmdline = " ".join(anc.cmdline() or [])
-            except Exception:
-                anc_cmdline = ""
-            if _is_gw is not None and anc_cmdline and _is_gw(anc_cmdline):
-                continue
             skip.add(int(anc.pid))
     except Exception:
         pass
@@ -4742,78 +4323,6 @@ def _stop_process_trees(pids: list[int]) -> None:
             logger.debug("Could not stop process tree %s: %s", pid, exc)
 
 
-def _looks_like_desktop_control_plane(cmdline: str) -> bool:
-    """True for this-install ``hermes serve`` / ``hermes dashboard`` argv.
-
-    That is the Desktop control plane, not the messaging gateway. Serve and
-    dashboard do not host platform adapters (#92091); do not feed this into
-    ``looks_like_gateway_command_line``.
-
-    Token-based via the parser-derived subcommand classifier — never
-    substring (#90778/#91869: ``kanban --preserve-cache`` contains "serve",
-    ``-m dashboard chat`` contains " dashboard"; both are NOT control
-    planes). A cmdline whose subcommand cannot be determined is NOT a
-    control plane — callers must not guess ownership.
-    """
-    if "hermes_cli.main" not in (cmdline or "").lower():
-        return False
-    return _hermes_holder_subcommand(cmdline) in ("serve", "dashboard")
-
-
-def _desktop_owns_gateway_lifecycle() -> bool:
-    """True when Desktop currently supervises this install's control plane.
-
-    The updater must not steal gateway start in that case: Desktop owns
-    start/stop via ``/api/gateway/*``. This is *not* proof messaging is
-    already served — a live serve process is the control plane, and the
-    gateway is a detached sibling (#76129 / #92091).
-
-    Prefer the spawn ledger (owned identity). Fall back to the install-scoped
-    venv-holder scan already used by the lock guard; an orphaned control-plane
-    process (supervisor gone) does not count.
-    """
-    try:
-        from hermes_cli.process_identity import ledger_entries, spawner_is_dead
-
-        for entry in ledger_entries():
-            if entry.get("purpose") not in ("serve", "dashboard"):
-                continue
-            if spawner_is_dead(entry) is False:
-                return True
-    except Exception as exc:
-        logger.debug("Desktop-lifecycle ledger probe failed: %s", exc)
-
-    try:
-        import psutil
-    except Exception:
-        psutil = None
-
-    try:
-        holders = _m()._detect_venv_python_processes()
-    except Exception as exc:
-        logger.debug("Desktop-lifecycle holder scan failed: %s", exc)
-        return False
-
-    for pid, _name, cmdline in holders:
-        if not _looks_like_desktop_control_plane(cmdline):
-            continue
-        if psutil is None:
-            # Cannot prove orphanhood; a live this-install control plane is
-            # enough to refuse stealing gateway start.
-            return True
-        try:
-            proc = psutil.Process(int(pid))
-            parent = proc.parent()
-            if parent is None or not parent.is_running():
-                continue
-            if parent.create_time() > proc.create_time():
-                continue
-            return True
-        except Exception:
-            continue
-    return False
-
-
 def _pause_windows_gateways_for_update() -> dict | None:
     """Stop running Windows gateways before mutating the checkout or venv.
 
@@ -4852,24 +4361,6 @@ def _pause_windows_gateways_for_update() -> dict | None:
         # gateways that were running when the update began. Cold-start one after
         # the update so an installed gateway is actually up post-update. Users
         # who run gateway-less (no autostart entry) get nothing forced on them.
-        #
-        # Exception: Desktop currently owns this install's gateway lifecycle
-        # (live supervised serve/dashboard). A vestigial Startup/Scheduled
-        # Task is not the owner — spawning ``gateway run`` beside Desktop
-        # races ports/state (#76129). Serve is the control plane, not proof
-        # messaging is served; the skip is ownership, not liveness (#92091).
-        try:
-            if _desktop_owns_gateway_lifecycle():
-                logger.debug(
-                    "Skipping Windows gateway cold-start plan: "
-                    "Desktop owns gateway lifecycle"
-                )
-                return None
-        except Exception as exc:
-            logger.debug(
-                "Could not check Desktop gateway-lifecycle ownership before update: %s",
-                exc,
-            )
         try:
             from hermes_cli import gateway_windows
 
@@ -5023,18 +4514,6 @@ def _cold_start_windows_gateway_after_update() -> None:
         return
 
     try:
-        if _desktop_owns_gateway_lifecycle():
-            logger.debug(
-                "Skipping Windows gateway cold-start: Desktop owns gateway lifecycle"
-            )
-            return
-    except Exception as exc:
-        logger.debug(
-            "Could not re-check Desktop gateway-lifecycle ownership before cold-start: %s",
-            exc,
-        )
-
-    try:
         pid = gateway_windows._spawn_detached()
     except Exception as exc:
         logger.debug("Could not cold-start Windows gateway after update: %s", exc)
@@ -5102,8 +4581,6 @@ def _service_unit_supports_graceful_sigusr1_restart(svc_name: str) -> bool:
 
 def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
     """Print an explicit incomplete-update warning for unrestarted units."""
-    from hermes_cli.gateway import is_macos
-
     if not failed_units:
         return
     # Preserve discovery order while de-duplicating.
@@ -5118,18 +4595,6 @@ def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
     print("⚠ Update incomplete — some units were not restarted:")
     for name in ordered:
         print(f"    - {name}")
-    if is_macos():
-        # A launchd label reaches this list when launchd was not supervising a
-        # live process after the restart (#88848), so the unit is not merely
-        # stale — it is very likely deregistered, and `launchctl kickstart`
-        # cannot revive a job launchd no longer knows about.
-        print("  Listed services may be deregistered from launchd, or still")
-        print("  running pre-update code (mixed sys.modules). Recover with:")
-        print("    hermes gateway status")
-        print("    launchctl list | grep <label>")
-        print("    launchctl bootstrap gui/$(id -u) "
-              "~/Library/LaunchAgents/<label>.plist")
-        return
     print("  Skipped units may still be running pre-update code (mixed")
     print("  sys.modules). Restart them manually, then verify:")
     print("    hermes gateway status")
@@ -5171,7 +4636,6 @@ def _restart_macos_launchd_gateways(
         _launchd_service_registered,
         _locate_launchd_gateway_service,
         _wait_for_launchd_service_pid,
-        wait_for_launchd_gateway_supervision,
     )
 
     # --- Current profile: unchanged single-service path ---------------------
@@ -5189,38 +4653,11 @@ def _restart_macos_launchd_gateways(
         ):
             try:
                 launchd_restart()
+                restarted_services.append(current_label)
             except subprocess.CalledProcessError as e:
                 stderr = (getattr(e, "stderr", "") or "").strip()
                 print(f"  ⚠ Gateway restart failed: {stderr}")
                 failed_or_stale_units.append(current_label)
-            else:
-                # Siblings below are only counted as restarted once launchd
-                # reports a fresh supervised pid; the invoking profile was
-                # counted on "launchd_restart() did not raise" alone. That is
-                # not the same claim: launchd_restart() returns as soon as the
-                # restart has been REQUESTED -- the self-restart branch hands
-                # the work to the running gateway and returns immediately, and
-                # a plist reload is handed to a detached helper. Both are
-                # asynchronous, so a helper that dies before its first
-                # bootstrap (#88848), or a `launchctl bootstrap` that exits 0
-                # without registering (measured on macOS 26.6.1), both reached
-                # "Update complete!" with nothing supervising the gateway.
-                #
-                # Verified domain-agnostically, NOT via
-                # _wait_for_launchd_service_pid: that needs an explicit domain,
-                # and the gate above deliberately avoids a domain locate
-                # because it fails on macOS-26 hosts whose per-user domains
-                # reject service management even though launchd_restart() owns
-                # that fallback.
-                if wait_for_launchd_gateway_supervision(label=current_label):
-                    restarted_services.append(current_label)
-                else:
-                    failed_or_stale_units.append(current_label)
-                    print(
-                        f"  ✗ {current_label} restarted but launchd is not "
-                        "supervising it.\n"
-                        "    Check logs, then: hermes gateway restart"
-                    )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 
@@ -5806,10 +5243,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # running Hermes runtime, its supervisor, and its running code version —
     # into the receipt, so a post-mortem can compare what the update SAW
     # against what it did. Read-only; a probe failure records nothing.
-    # ``_pre_update_plan`` is read again AFTER the restart phase to reconcile
-    # every planned runtime against the phase's bookkeeping (restart via
-    # declared mechanism — the plan is the worklist, not just a printout).
-    _pre_update_plan = None
     try:
         from hermes_cli.update_inventory import (
             collect_runtime_inventory,
@@ -6295,31 +5728,12 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # not behind, fall through to the up-to-date path.
             commit_count = counted if counted is not None else -1
 
-        # A fork can match origin while still trailing upstream. The sync can
-        # therefore advance HEAD even though the origin comparison found no
-        # commits. Detect that BEFORE taking the no-update return so dependency
-        # refreshes, gateway restarts, AND the fleet version matrix still run
-        # for the pulled code (#73108 — previously the sync lived inside the
-        # commit_count == 0 branch, which returns immediately after: an update
-        # that pulled hundreds of upstream commits printed "Already up to
-        # date!" and verified nothing).
-        if commit_count == 0 and is_fork and branch == "main":
-            pre_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
-            _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
-            post_sync_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
-            if pre_sync_sha and post_sync_sha and pre_sync_sha != post_sync_sha:
-                synced_count = _count_commits_between(
-                    git_cmd,
-                    _m().PROJECT_ROOT,
-                    pre_sync_sha,
-                    post_sync_sha,
-                )
-                # HEAD moving is itself proof of an update. Keep the update
-                # path active even if the informational count cannot be read.
-                commit_count = max(1, synced_count)
-
         if commit_count == 0:
             _invalidate_update_cache()
+
+            # Even if origin is up to date, the fork may be behind upstream
+            if is_fork and branch == "main":
+                _m()._sync_with_upstream_if_needed(git_cmd, _m().PROJECT_ROOT)
 
             # Restore stash and switch back to original branch if we moved.
             # EXCEPTION: a parked feature branch we verified clean + fully
@@ -6414,12 +5828,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         check=False,
                     )
                 if repair_uv:
-                    # Isolated from third-party UV env vars (#83914), same as
-                    # the main-path and git-path dependency syncs.
-                    from hermes_cli.managed_uv import managed_python_env
-
-                    repair_env = managed_python_env()
-                    repair_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
+                    repair_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
                     _m()._install_python_dependencies_with_optional_fallback(
                         [repair_uv, "pip"], env=repair_env, group="all"
                     )
@@ -6455,6 +5864,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
                 _repair_node_deps_on_current_checkout(_print_update_completion)
+            _repair_config_on_current_checkout()
             if runtime_repaired is not None and not _m()._is_windows():
                 print()
                 print(
@@ -6757,13 +6167,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         install_group = "all"
 
         if uv_bin:
-            # Use official managed_python_env() isolation so third-party
-            # UV_PYTHON_INSTALL_DIR (e.g. WorkBuddy) cannot hijack uv; then
-            # point VIRTUAL_ENV at this install's venv.
-            from hermes_cli.managed_uv import managed_python_env
-
-            uv_env = managed_python_env()
-            uv_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(_m().PROJECT_ROOT / "venv")}
             if _m()._is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)
@@ -7246,25 +6650,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
         else:
             print("  ✓ Configuration is up to date")
 
-        # Fleet-wide config migration (#91277 Phase 2; #20438 earliest report,
-        # #54926, #79048): the shared checkout serves EVERY profile, but the
-        # migration above only touched the active profile's config.yaml.
-        # Sibling profiles kept their old _config_version and silently
-        # drifted (field repro: sibling gateway restarted onto new code but
-        # stayed at config v33 vs v37). Run the same NON-INTERACTIVE safe
-        # migration for every sibling profile home, scoped via the
-        # context-local HERMES_HOME override (never os.environ — other
-        # threads must not see it).
-        try:
-            _migrated_siblings = _migrate_sibling_profile_configs()
-            for _name, _from_ver, _to_ver in _migrated_siblings:
-                print(
-                    f"  ✓ Profile '{_name}': config format updated "
-                    f"(v{_from_ver} → v{_to_ver})"
-                )
-        except Exception as exc:
-            logger.debug("Sibling config migration failed: %s", exc)
-
         # Safety net: config-version migrations have been observed to leave
         # cron/jobs.json valid-but-empty, silently dropping every scheduled
         # job (issue #34600). The desktop scheduler can also overwrite with
@@ -7350,30 +6735,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         # Self-heal the hermes-acp launcher for installs that predate it, so
         # ACP hosts (Zed, JetBrains, Buzz) can resolve Hermes on PATH without
-        # a reinstall.  No-op on Windows (the launcher migration below owns
-        # that) and when already present.
+        # a reinstall.  No-op on Windows and when already present.
         try:
             _ensure_acp_launcher()
         except Exception as e:
             logger.debug("hermes-acp launcher self-heal failed: %s", e)
-
-        # Migrate the Windows hermes launchers to the managed binary dir
-        # (the default Hermes root's bin, next to the managed uv) and repair
-        # them if they are missing. Earlier layouts put them inside the git
-        # checkout (hermes-agent\bin) or put venv\Scripts itself on PATH; the
-        # in-checkout copies were swept by this command's own pre-update
-        # autostash (git stash push --include-untracked) and, with
-        # --keep-stash (the desktop updater), never restored — `hermes`
-        # stopped resolving in every new terminal. Updates never run
-        # install.ps1, so this tail call is how existing installs reach the
-        # new layout. No-op on POSIX and on source checkouts (root is not
-        # the managed clone under the default Hermes root).
-        try:
-            from hermes_cli._install_repair import migrate_windows_bin_path
-
-            migrate_windows_bin_path(_m().PROJECT_ROOT)
-        except Exception as e:
-            logger.debug("Windows bin launcher migration failed: %s", e)
 
         # Refresh the cua-driver binary used by the Computer Use toolset.
         # The upstream installer is gated on supported platforms and on the
@@ -8017,28 +7383,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 for proc in find_profile_gateway_processes(exclude_pids=service_pids)
                 if proc.pid in manual_pids
             }
-            # Profile gateways we could not arm a relaunch for.  These must
-            # NOT be left running: their modules are the pre-update ones and
-            # every lazy import from here on mixes versions against the new
-            # code on disk (#88654).  Handing them to the unmapped sweep
-            # below stops them and surfaces them in the "Stopped N manual
-            # gateway process(es) / Restart manually" summary, which is the
-            # contract already used for gateways with no profile mapping.
-            unrestartable_pids = set()
             for pid, proc in profile_processes.items():
                 restart_mode = _prepare_profile_gateway_update_restart(
                     proc.profile, pid
                 )
                 if restart_mode is None:
-                    # Previously a bare ``continue``: the gateway was neither
-                    # relaunched nor stopped nor mentioned, so it kept serving
-                    # from stale modules with no operator signal at all.
-                    print(
-                        f"  ⚠ {proc.profile}: could not arm an automatic "
-                        f"gateway restart for PID {pid} — stopping it instead "
-                        "so it cannot keep running pre-update code"
-                    )
-                    unrestartable_pids.add(pid)
                     continue
                 # Prefer a graceful SIGUSR1 drain so in-flight agent runs
                 # finish before the watcher respawns the gateway.  If the
@@ -8105,7 +7454,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     relaunched_profiles.append(proc.profile)
 
             for pid in manual_pids:
-                if pid in profile_processes and pid not in unrestartable_pids:
+                if pid in profile_processes:
                     continue
                 try:
                     os.kill(pid, _signal.SIGTERM)
@@ -8303,83 +7652,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print_fleet_version_matrix,
             )
 
-            # Cross-platform "we expected fleet rows" signal (#93406). The
-            # old (restarted_services or killed_pids) condition never fires
-            # on Windows: the pause/resume phase populates neither list, so
-            # a healthy resumed gateway yielded zero rows and exit 0.
-            _fleet_rows_expected = _m()._fleet_probe_expected_runtimes(
-                _pre_update_plan,
-                _pre_restart_gateway_pids,
-                _windows_gateway_resume,
-                restarted_services,
-                killed_pids,
-            )
-            # A brief settle window: freshly restarted/resumed gateways need
-            # a moment to rewrite gateway_state.json with their new identity.
+            # A brief settle window: freshly restarted gateways need a
+            # moment to rewrite gateway_state.json with their new identity.
             # Skipped when the restart phase touched nothing (no gateways
             # were running) — nothing to settle.
-            if _fleet_rows_expected:
+            if restarted_services or killed_pids:
                 _time.sleep(2.0)
-            # Pass the pre-restart PID snapshot so a gateway the restart
-            # phase stopped WITHOUT a verified replacement shows as a DOWN
-            # row (exit 1) instead of silently producing no row at all.
-            _fleet_snapshot = collect_fleet_versions(
-                pre_restart_pids=_pre_restart_gateway_pids
-            )
+            _fleet_snapshot = collect_fleet_versions()
             if print_fleet_version_matrix(_fleet_snapshot):
-                gateway_fleet_restart_incomplete = True
-            elif not _fleet_snapshot and _fleet_rows_expected:
-                # Fleet probe returned zero rows even though at least one
-                # gateway runtime was (or may have been) live pre-update —
-                # POSIX restart bookkeeping, the pre-restart PID snapshot,
-                # the pre-update plan inventory, or the Windows pause/resume
-                # token all count as that signal.  Every failure path inside
-                # collect_fleet_versions() is swallowed via logger.debug(),
-                # so an empty list is indistinguishable from a healthy fleet
-                # in the current output.  Treat it as verification failure
-                # so the receipt records "partial" and the exit code is 1
-                # (#93406).
-                print(
-                    "\n⚠ Fleet version check returned no rows even though"
-                    " gateway runtimes were expected — verification incomplete."
-                )
                 gateway_fleet_restart_incomplete = True
         except Exception as _fleet_exc:
             logger.debug("Fleet version verification failed: %s", _fleet_exc)
-
-        # Plan-vs-execution reconciliation (#91277 Phase 2, restart via
-        # declared mechanism): every runtime the PLAN saw must be accounted
-        # for by the restart phase's bookkeeping. An unaccounted runtime is
-        # the silent-miss class (a platform branch re-discovered its own
-        # targets and skipped one the inventory knew about) — escalate it
-        # exactly like a STALE/DOWN fleet row.
-        _runtime_outcomes: list = []
-        try:
-            if _pre_update_plan is not None and _pre_update_plan.runtimes:
-                from hermes_cli.update_inventory import (
-                    match_runtime_outcomes,
-                    report_unaccounted_runtimes,
-                )
-
-                _runtime_outcomes = match_runtime_outcomes(
-                    _pre_update_plan,
-                    restarted_services=restarted_services,
-                    relaunched_profiles=relaunched_profiles,
-                    externally_supervised_profiles=externally_supervised_profiles,
-                    killed_pids=killed_pids,
-                    failed_units=failed_or_stale_units,
-                )
-                if report_unaccounted_runtimes(_runtime_outcomes):
-                    gateway_fleet_restart_incomplete = True
-                try:
-                    import hermes_cli.update_receipt as _ur
-
-                    if _ur._current is not None:
-                        _ur._current.data["runtime_outcomes"] = _runtime_outcomes
-                except Exception:
-                    pass
-        except Exception as _outcome_exc:
-            logger.debug("Runtime-outcome reconciliation failed: %s", _outcome_exc)
 
         try:
             from hermes_cli.update_receipt import finalize_update_receipt
@@ -8399,14 +7682,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # automation / operators do not treat the fleet as healthy.
             sys.exit(1)
 
-    except _shim_quarantine_error_type() as e:
-        # Fail-closed shim contention (#87331): strict quarantine refused
-        # BEFORE any installer ran — defer via marker, exit 2, no ZIP.
-        _refuse_update_for_contended_shims(e)
     except subprocess.CalledProcessError as e:
-        stage = _format_update_failure_stage(e)
-        if _should_zip_fallback_on_update_error(e):
-            print(f"⚠ {stage}: {e}")
+        if _m()._is_windows():
+            print(f"⚠ Git update failed: {e}")
             print("→ Falling back to ZIP download...")
             print()
             desktop_build_ok = _update_via_zip(
@@ -8416,20 +7694,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if gateway_mode:
                 _write_gateway_update_exit_code(desktop_build_ok)
         else:
-            print(f"✗ {stage}: {e}")
-            _print_called_process_error_tail(e)
-            if _called_process_error_is_python_dep_install(e):
-                print(
-                    "  The git update already finished. Re-downloading the source "
-                    "ZIP cannot fix a dependency install error and would overwrite "
-                    "local files."
-                )
-                if _m()._is_windows():
-                    print("  Retry through the venv interpreter:")
-                    print(
-                        '    venv\\Scripts\\python.exe -c '
-                        '"from hermes_cli.main import main; main()" update --yes'
-                    )
+            print(f"✗ Update failed: {e}")
             try:
                 from hermes_cli.update_receipt import finalize_update_receipt
 
@@ -8459,61 +7724,6 @@ def _restart_phase_failure_is_incomplete(surviving, pre_restart_pids) -> bool:
         return True
     # surviving == []: safe only if we know nothing was running beforehand.
     return pre_restart_pids is None or bool(pre_restart_pids)
-
-
-def _fleet_probe_expected_runtimes(
-    pre_update_plan,
-    pre_restart_pids,
-    windows_resume_token,
-    restarted_services,
-    killed_pids,
-) -> bool:
-    """Whether the post-update fleet probe should have produced rows.
-
-    The zero-rows fail-open (#93406): ``collect_fleet_versions()`` swallows
-    every probe failure via ``logger.debug()`` and ``print_fleet_version_matrix([])``
-    early-returns ``False``, so an empty snapshot reads as \"healthy fleet\" and
-    the update exits 0.  An empty snapshot is only proof-of-safety when NOTHING
-    says a gateway existed before the update.  Any of these signals means at
-    least one runtime was (or may have been) live pre-update, so zero rows is
-    verification failure, not health:
-
-    * ``restarted_services`` / ``killed_pids`` — the POSIX restart phase
-      touched live gateways.
-    * ``pre_restart_pids`` non-empty, or ``None`` (pre-state unreadable —
-      cannot prove nothing was running; same contract as
-      ``_restart_phase_failure_is_incomplete``, #78574).
-    * the pre-update plan inventoried ≥1 runtime.
-    * the Windows pause/resume token carries paused ``profiles`` or
-      ``unmapped`` entries — ``_pause_windows_gateways_for_update`` /
-      ``_resume_windows_gateways_after_update`` populate NEITHER
-      ``restarted_services`` NOR ``killed_pids``, which is exactly why the
-      original ``(restarted_services or killed_pids)`` guard never fires on
-      Windows.
-
-    The same condition gates the 2.0s settle sleep: a freshly resumed Windows
-    gateway needs the settle window to rewrite ``gateway_state.json`` just
-    like a systemd-restarted one.
-
-    Note this keys ONLY on zero-rows-despite-expected-runtimes.  A non-empty
-    snapshot — including rows in ``unknown`` state — is still judged solely by
-    ``print_fleet_version_matrix``.
-    """
-    if restarted_services or killed_pids:
-        return True
-    if pre_restart_pids is None or pre_restart_pids:
-        return True
-    try:
-        if pre_update_plan is not None and pre_update_plan.runtimes:
-            return True
-    except Exception:
-        pass
-    if isinstance(windows_resume_token, dict) and (
-        windows_resume_token.get("profiles")
-        or windows_resume_token.get("unmapped")
-    ):
-        return True
-    return False
 
 
 def _print_items(items, label, key, fallback_key=None):

--- a/tests/hermes_cli/test_update_current_node_repair.py
+++ b/tests/hermes_cli/test_update_current_node_repair.py
@@ -10,9 +10,51 @@ only after a successful install, so healthy installs stay a cheap no-op).
 
 from __future__ import annotations
 
+import subprocess
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from hermes_cli import update_cmd
+
+
+def _current_checkout_git(cmd, **_kwargs):
+    joined = " ".join(str(part) for part in cmd)
+    if "rev-parse --abbrev-ref" in joined:
+        stdout = "main\n"
+    elif "rev-list" in joined:
+        stdout = "0\n"
+    elif "rev-parse --is-shallow-repository" in joined:
+        stdout = "false\n"
+    else:
+        stdout = ""
+    return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+
+def test_current_checkout_branch_wires_config_repair():
+    args = SimpleNamespace(
+        yes=True,
+        branch=None,
+        force=False,
+        force_venv=False,
+        no_backup=True,
+        backup=False,
+    )
+    with (
+        patch.object(update_cmd.subprocess, "run", side_effect=_current_checkout_git),
+        patch.object(update_cmd, "_run_pre_update_backup"),
+        patch.object(update_cmd, "_pause_windows_gateways_for_update", return_value=None),
+        patch.object(update_cmd, "_resume_windows_gateways_after_update"),
+        patch.object(update_cmd, "_detect_venv_python_processes", return_value=[]),
+        patch.object(update_cmd, "_venv_core_imports_healthy", return_value=(True, "")),
+        patch.object(update_cmd, "_repair_node_deps_on_current_checkout") as repair_node,
+        patch.object(update_cmd, "_repair_config_on_current_checkout") as repair_config,
+        patch("hermes_cli.managed_uv.update_managed_uv"),
+        patch("hermes_cli.managed_uv.ensure_uv"),
+    ):
+        update_cmd._cmd_update_impl(args, gateway_mode=False)
+
+    repair_node.assert_called_once()
+    repair_config.assert_called_once_with()
 
 
 def test_current_checkout_repairs_failed_node_deps(capsys):
@@ -42,3 +84,41 @@ def test_current_checkout_healthy_node_deps_reports_up_to_date():
     # The refresh pairs with the web build like every other call site.
     m.return_value._build_web_ui.assert_called_once()
     completion.assert_called_once_with("✓ Already up to date!")
+
+
+def test_current_checkout_migrates_config_from_already_pulled_code(capsys):
+    """An interrupted-install retry must not leave old config unbootable."""
+    with (
+        patch.object(update_cmd, "_run_config_check_fresh", return_value=(37, 38)),
+        patch.object(
+            update_cmd,
+            "_run_migrate_config_fresh",
+            return_value={"config_added": [], "warnings": []},
+        ) as migrate,
+    ):
+        update_cmd._repair_config_on_current_checkout()
+
+    migrate.assert_called_once_with(interactive=False, quiet=True)
+    assert "Updating config format (v37 → v38)" in capsys.readouterr().out
+
+
+def test_current_checkout_skips_config_migration_when_current(capsys):
+    with (
+        patch.object(update_cmd, "_run_config_check_fresh", return_value=(38, 38)),
+        patch.object(update_cmd, "_run_migrate_config_fresh") as migrate,
+    ):
+        update_cmd._repair_config_on_current_checkout()
+
+    migrate.assert_not_called()
+    assert "Configuration is up to date" in capsys.readouterr().out
+
+
+def test_current_checkout_config_migration_failure_is_actionable(capsys):
+    with patch.object(
+        update_cmd, "_run_config_check_fresh", side_effect=RuntimeError("broken")
+    ):
+        update_cmd._repair_config_on_current_checkout()
+
+    out = capsys.readouterr().out
+    assert "Config format update failed: broken" in out
+    assert "hermes config migrate" in out


### PR DESCRIPTION
## Summary

- run pending config-version migration on the `commit_count == 0` update path
- cover interrupted-install retries where code was already pulled before dependency installation failed
- keep current-version retries a no-op and surface an actionable manual recovery command if migration fails

Fixes #91360.

## Evidence

Base: `8e77d031888fe26922e2658be79ee48efab791e9`

Head: `892892a41c6a715a138161e9cb5cd26be447e583`

Before: after a pull succeeded but dependency installation failed, the retry reached `commit_count == 0`, repaired dependencies, and returned before the only config-migration block. Code requiring config v38 could therefore restart against v37.

After: every current-checkout completion path calls `_repair_config_on_current_checkout()` after dependency repair. A stale config runs the fresh-module, non-interactive migration; an already-current config does no write; failures point to `hermes config migrate`.

## Validation

```text
uv run --with pytest python -m pytest \
  tests/hermes_cli/test_update_current_node_repair.py \
  tests/hermes_cli/test_update_venv_health.py \
  tests/hermes_cli/test_update_yes_flag.py \
  tests/hermes_cli/test_update_interrupted_recovery.py -q
18 passed

uv run --with ruff ruff check \
  hermes_cli/update_cmd.py \
  tests/hermes_cli/test_update_current_node_repair.py
All checks passed!

git diff origin/main...HEAD --check
passed
```

TruffleHog filesystem scan of both changed files found 0 verified and 0 unknown secrets. Git-mode scanning could not clone the shared local object store because an unrelated historical object is missing; no secret result was suppressed.

## Scope

This does not change pull, dependency repair, interactive migration policy, config schema, or migration contents. It only restores the existing migration operation on the early-return retry path.

