### PR TITLE
fix(launchd): stop gateway restart loop on fatal-config exit

### DIFF
--- a/hermes_cli/stderr_timestamp.py
+++ b/hermes_cli/stderr_timestamp.py
@@ -44,6 +44,19 @@ def _copy_stderr_with_timestamps(stderr: BinaryIO, log_path: Path) -> None:
 def _command_exit_code(returncode: int) -> int:
     if returncode < 0:
         return 128 + abs(returncode)
+    # A fatal-config exit (78, EX_CONFIG — e.g. WhatsApp enabled but never
+    # paired) must not trigger launchd's unconditional KeepAlive restart.
+    # launchd has no RestartPreventExitStatus equivalent, so translate the
+    # "don't restart" signal into the one thing KeepAlive=true honors: exit 0
+    # (clean stop). This mirrors the s6 finish script's 78 -> 125 mapping
+    # (service_manager._render_finish_script) for the other supervisors.
+    try:
+        from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
+
+        if returncode == GATEWAY_FATAL_CONFIG_EXIT_CODE:
+            return 0
+    except Exception:
+        pass
     return returncode
 
 

--- a/tests/hermes_cli/test_stderr_timestamp.py
+++ b/tests/hermes_cli/test_stderr_timestamp.py
@@ -3,7 +3,7 @@
 import re
 import sys
 
-from gateway.restart import EXTERNAL_GATEWAY_SUPERVISOR_ENV
+from gateway.restart import EXTERNAL_GATEWAY_SUPERVISOR_ENV, GATEWAY_FATAL_CONFIG_EXIT_CODE
 from hermes_cli import stderr_timestamp
 
 _STALE_GATEWAY_ARGV = [
@@ -45,6 +45,29 @@ def test_main_timestamps_each_stderr_line(tmp_path):
     assert re.fullmatch(f"{timestamp} first failure", lines[0])
     assert re.fullmatch(f"{timestamp} second failure without newline", lines[1])
     assert lines[2] == "2026-07-15 12:34:56,789 already timestamped"
+
+
+def test_main_maps_fatal_config_exit_to_zero(tmp_path):
+    """Exit 78 (fatal config) must surface as a clean exit so launchd's
+    unconditional KeepAlive stops restarting the gateway."""
+    log_path = tmp_path / "gateway.error.log"
+    code = (
+        "import sys\n"
+        f"sys.exit({GATEWAY_FATAL_CONFIG_EXIT_CODE})\n"
+    )
+
+    rc = stderr_timestamp.main(
+        [
+            "--error-log",
+            str(log_path),
+            "--",
+            sys.executable,
+            "-c",
+            code,
+        ]
+    )
+
+    assert rc == 0
 
 
 def test_prepare_upgrades_stale_gateway_argv_under_launchd():


### PR DESCRIPTION
## Problem

On macOS, the gateway crash-loops forever when startup hits a **fatal config error** (e.g. `WHATSAPP_ENABLED=true` but the bridge was never paired — "WhatsApp enabled but not paired").

Every ~30s:
```
ERROR gateway.run: Gateway hit a non-retryable startup conflict: whatsapp: ...
ERROR gateway.run: Gateway exiting cleanly: whatsapp: ...
SystemExit: 78   (gateway/run.py:30733)
```
then launchd respawns it. 767 restart cycles in one day on the reporter's machine.

## Root cause

The gateway signals "fatal config — do not restart" by exiting **78** (`EX_CONFIG`, `gateway/restart.py`). Every supervisor honors this contract **except launchd**:

| Supervisor | Mechanism |
|---|---|
| systemd | `RestartPreventExitStatus=78` (`hermes_cli/gateway.py:3384`) |
| s6 | finish script: `78 -> 125` = permanent failure (`service_manager._render_finish_script`) |
| **launchd** | **nothing** — plist has unconditional `<key>KeepAlive</key><true/>` (`generate_launchd_plist`) with no exit-status handling |

launchd has no `RestartPreventExitStatus` equivalent. With `KeepAlive=true`, the only way to stop the respawn is a **clean exit 0**.

## Fix

The launchd `ProgramArguments` wrap the gateway in `hermes_cli.stderr_timestamp` (timestamps stderr), which already returns the child's exit code. Translate the gateway's fatal-config exit (78) to **0** there — the same "don't restart" signal the s6 finish script produces via 78→125, expressed in the one form `KeepAlive=true` honors.

## Verification

- New test: `test_main_maps_fatal_config_exit_to_zero` — child exits 78 → wrapper returns 0.
- Existing suite: `tests/hermes_cli/test_stderr_timestamp.py` + `test_timestamps_command.py` → **11 passed**.
- Direct check: `_command_exit_code(78) == 0`, `_command_exit_code(1) == 1`, `_command_exit_code(-9) == 137`.

## Notes

The wrapper only applies the mapping when `gateway.restart.GATEWAY_FATAL_CONFIG_EXIT_CODE` imports cleanly (guarded), so arbitrary launchd children are unaffected.
