### PR TITLE
fix(photon): preserve outbound voice attachment identity

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import json
 import logging
 import os
@@ -2620,6 +2621,20 @@ class PhotonAdapter(BasePlatformAdapter):
             body["mimeType"] = mime_type
         if caption:
             body["caption"] = caption
+        try:
+            raw = Path(safe_path).read_bytes()
+            digest = hashlib.sha256(raw).hexdigest()
+            logger.info(
+                "[photon] send-attachment kind=%s bytes=%d sha256=%s path=%s",
+                body["kind"],
+                len(raw),
+                digest,
+                safe_path,
+            )
+        except OSError as exc:
+            logger.warning(
+                "[photon] send-attachment could not hash %s: %s", safe_path, exc
+            )
         try:
             data = await self._sidecar_call("/send-attachment", body)
         except PhotonSidecarError as e:

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -1055,29 +1055,51 @@ const server = http.createServer(async (req, res) => {
       // spectrum-ts infers name + MIME from the file extension; pass
       // overrides only when Hermes supplied them so a known-good
       // inference isn't clobbered with an empty string.
+      let sendPath = path;
       const opts = {};
       if (name) opts.name = name;
       if (mimeType) opts.mimeType = mimeType;
-      const builder =
-        kind === "voice"
-          ? voice(path, Object.keys(opts).length ? opts : undefined)
-          : attachment(path, Object.keys(opts).length ? opts : undefined);
-
-      const result = await space.send(builder);
-
-      // iMessage delivers the caption as a separate bubble; send it
-      // after the media so the attachment renders first.
-      if (caption && typeof caption === "string") {
-        try {
-          await space.send(spectrumText(caption));
-        } catch (e) {
-          console.error(
-            "photon-sidecar: attachment sent but caption failed: " +
-              (e && e.stack ? e.stack : String(e))
-          );
-        }
+      let cleanup = async () => {};
+      if (kind === "voice") {
+        // Unique AAC/M4A object — do not upload TTS MP3 under its original
+        // basename. Photon indexes voice memos by filename/UTI +
+        // isAudioMessage; keeping tts_*.mp3 let the inbound CAF replay.
+        // Lazy-load so /healthz still comes up if this helper is missing
+        // from a mirrored/partial sidecar tree.
+        const { prepareVoiceAttachment } = await import("./voice-send.mjs");
+        const prepared = await prepareVoiceAttachment(path);
+        sendPath = prepared.path;
+        opts.name = prepared.opts.name;
+        opts.mimeType = prepared.opts.mimeType;
+        cleanup = prepared.cleanup;
       }
-      return ok(res, { messageId: result?.id || null });
+      try {
+        const builder =
+          kind === "voice"
+            ? voice(sendPath, opts)
+            : attachment(
+                sendPath,
+                Object.keys(opts).length ? opts : undefined
+              );
+
+        const result = await space.send(builder);
+
+        // iMessage delivers the caption as a separate bubble; send it
+        // after the media so the attachment renders first.
+        if (caption && typeof caption === "string") {
+          try {
+            await space.send(spectrumText(caption));
+          } catch (e) {
+            console.error(
+              "photon-sidecar: attachment sent but caption failed: " +
+                (e && e.stack ? e.stack : String(e))
+            );
+          }
+        }
+        return ok(res, { messageId: result?.id || null });
+      } finally {
+        await cleanup();
+      }
     }
     if (req.url === "/react") {
       const { spaceId, messageId, emoji } = body || {};

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
+        "ffmpeg-static": "^5.3.0",
         "spectrum-ts": "8.0.0"
       },
       "engines": {
@@ -20,6 +21,21 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
       "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
@@ -587,11 +603,29 @@
         "typescript": "^5 || ^6.0.0"
       }
     },
+    "node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
+    },
     "node_modules/abort-controller-x": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
       "integrity": "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==",
       "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -706,6 +740,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -714,6 +754,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
     },
     "node_modules/chardet": {
       "version": "2.2.0",
@@ -802,6 +848,21 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -828,6 +889,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -974,6 +1052,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -991,6 +1078,22 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -1060,6 +1163,28 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -1101,8 +1226,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -1208,6 +1332,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -1284,6 +1414,11 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -1362,6 +1497,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "8.7.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
@@ -1406,7 +1550,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1443,8 +1586,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1531,7 +1673,6 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -1621,6 +1762,12 @@
         "node": "*"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -1648,8 +1795,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/vcf": {
       "version": "2.1.2",

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -13,6 +13,7 @@
     "node": ">=18.17"
   },
   "dependencies": {
+    "ffmpeg-static": "^5.3.0",
     "spectrum-ts": "8.0.0"
   },
   "overrides": {

--- a/plugins/platforms/photon/sidecar/voice-send.mjs
+++ b/plugins/platforms/photon/sidecar/voice-send.mjs
@@ -1,0 +1,58 @@
+// Materialize Spectrum voice() input as a unique AAC/M4A file.
+//
+// Spectrum 8's uploadVoice() transcodes through ensureM4a() but keeps the
+// source basename (e.g. tts_*.mp3) as UploadAttachmentRequest.file_name.
+// Photon infers MIME/UTI from that name, then sendAttachment(..., {
+// isAudioMessage: true }) delivers a native iMessage voice memo. Live
+// Photon/iMessage then played the conversation's original inbound CAF
+// instead of the distinct TTS bytes that were actually uploaded.
+//
+// Rewrite to a unique voice-<id>.m4a with audio/mp4 BEFORE voice() so the
+// attachment GUID Photon indexes is a new AAC object, not an MPEG-named
+// buffer that can collapse onto the inbound voice-memo slot.
+
+import { randomUUID, createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureM4a } from "@spectrum-ts/core/authoring";
+
+const M4A_MIME = "audio/mp4";
+
+function sha256(buffer) {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+export async function prepareVoiceAttachment(sourcePath) {
+  if (typeof sourcePath !== "string" || !sourcePath) {
+    throw new Error("prepareVoiceAttachment: source path is required");
+  }
+  const raw = await readFile(sourcePath);
+  const sourceSha = sha256(raw);
+  // Sniff bytes, not the caller's MIME: Python may pass audio/mpeg for an
+  // MP3 that we have already decided to upload as M4A.
+  const converted = await ensureM4a(raw, "");
+  const brand = converted.buffer.toString("ascii", 8, 12);
+  const uploadSha = sha256(converted.buffer);
+  const dir = await mkdtemp(join(tmpdir(), "hermes-photon-voice-"));
+  const fileName = `voice-${randomUUID()}.m4a`;
+  const outPath = join(dir, fileName);
+  await writeFile(outPath, converted.buffer);
+  console.error(
+    "photon-sidecar: voice identity " +
+      `source=${sourcePath} sourceSha=${sourceSha} sourceBytes=${raw.length} ` +
+      `uploadSha=${uploadSha} uploadBytes=${converted.buffer.length} brand=${JSON.stringify(brand)} ` +
+      `fileName=${fileName}`
+  );
+  return {
+    path: outPath,
+    opts: { name: fileName, mimeType: M4A_MIME },
+    sourceSha,
+    uploadSha,
+    uploadBytes: converted.buffer.length,
+    brand,
+    cleanup: async () => {
+      await rm(dir, { recursive: true, force: true }).catch(() => {});
+    },
+  };
+}

--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -53,6 +53,7 @@ _MIRROR_FILES = (
     "package.json",
     "package-lock.json",
     "patch-spectrum-mixed-attachments.mjs",
+    "voice-send.mjs",
 )
 
 

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -86,6 +86,40 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
     adapter.send_document.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_voice_reply_delivers_tts_media_not_inbound_caf(tmp_path, monkeypatch):
+    """Photon live loopback: inbound CAF must not be re-sent when TTS is tagged."""
+    adapter = _MediaRoutingAdapter()
+    inbound = _allowed_media_path(tmp_path, monkeypatch, "audio_01f0c3748bc6.caf")
+    tts = inbound.parent / "tts_20260821_021929_492327.mp3"
+    tts.write_bytes(b"id3-ara-tts")
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="(voice)",
+        message_type=MessageType.VOICE,
+        source=source,
+        message_id="in-voice-1",
+        media_urls=[str(inbound)],
+    )
+    adapter._message_handler = AsyncMock(
+        return_value=f"Here she is, Tom.\n\nMEDIA:{tts}"
+    )
+    adapter.send_voice = AsyncMock(return_value=SendResult(success=True, message_id="out-v"))
+    adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc"))
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.send_voice.assert_awaited_once()
+    sent = adapter.send_voice.await_args.kwargs["audio_path"]
+    assert sent == str(tts)
+    assert sent != str(inbound)
+    adapter.send_document.assert_not_awaited()
+
+
 def _fake_runner(thread_meta):
     """Build a fake GatewayRunner-like object with the helper methods needed by
     _deliver_media_from_response."""

--- a/tests/plugins/platforms/photon/test_outbound_media.py
+++ b/tests/plugins/platforms/photon/test_outbound_media.py
@@ -128,3 +128,28 @@ async def test_standalone_send_text_then_attachments(
     assert posted[1][1]["path"] == str(img)
     assert posted[1][1]["kind"] == "attachment"
     assert posted[1][1]["mimeType"] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_send_voice_posts_tts_path_not_inbound_caf(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Voice replies must upload the TTS file, never the inbound CAF cache."""
+    _patch_safe_path(monkeypatch)
+    inbound = tmp_path / "audio_01f0c3748bc6.caf"
+    tts = tmp_path / "tts_20260821_021929_492327.mp3"
+    inbound.write_bytes(b"caffinbound-original")
+    tts.write_bytes(b"id3tts-ara-reply")
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    result = await adapter.send_voice("any;-;+15551234567", str(tts))
+
+    assert result.success is True
+    assert len(calls) == 1
+    path, body = calls[0]
+    assert path == "/send-attachment"
+    assert body["kind"] == "voice"
+    assert body["path"] == str(tts)
+    assert body["path"] != str(inbound)
+    assert body["mimeType"] == "audio/mpeg"

--- a/tests/plugins/platforms/photon/test_sidecar_voice_runtime.py
+++ b/tests/plugins/platforms/photon/test_sidecar_voice_runtime.py
@@ -1,0 +1,197 @@
+"""Regression contract for Photon outbound voice identity.
+
+Live failure: Hermes generated a distinct xAI TTS MP3, the gateway extracted
+that MEDIA path, and Spectrum voice() still made iMessage play the inbound CAF
+voice note. Spectrum 8 uploadVoice() transcodes through ensureM4a() but keeps
+the source basename (tts_*.mp3) as the Photon upload filename, so isAudioMessage
+delivery can collapse onto the conversation's original voice-memo slot.
+
+The sidecar must materialize a unique AAC/M4A object whose bytes and filename
+are distinct from the inbound CAF before calling voice().
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import wave
+from pathlib import Path
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+def _sidecar_dir() -> Path:
+    return Path(__file__).parents[4] / "plugins" / "platforms" / "photon" / "sidecar"
+
+
+def _ffmpeg() -> Path:
+    return _sidecar_dir() / "node_modules" / "ffmpeg-static" / "ffmpeg"
+
+
+def _write_wav(path: Path, *, seconds: float, sample: bytes = b"\x00\x00") -> None:
+    frames = int(24_000 * seconds)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(24_000)
+        handle.writeframes(sample * frames)
+
+
+def test_sidecar_declares_ffmpeg_static_for_voice_transcoding() -> None:
+    sidecar = _sidecar_dir()
+    package = json.loads((sidecar / "package.json").read_text(encoding="utf-8"))
+    lock = json.loads((sidecar / "package-lock.json").read_text(encoding="utf-8"))
+
+    assert "ffmpeg-static" in package["dependencies"], (
+        "Photon voice() transcodes MP3/WAV input via ffmpeg; the sidecar must "
+        "ship ffmpeg-static instead of assuming a host binary."
+    )
+    assert lock["packages"][""]["dependencies"]["ffmpeg-static"] == package[
+        "dependencies"
+    ]["ffmpeg-static"]
+    assert "node_modules/ffmpeg-static" in lock["packages"]
+
+
+def test_extract_media_keeps_tts_path_not_sibling_inbound_caf(tmp_path: Path) -> None:
+    """The live 121-char reply tagged the TTS file; inbound CAF must not ride along."""
+    inbound = tmp_path / "audio_01f0c3748bc6.caf"
+    tts = tmp_path / "tts_20260821_021929_492327.mp3"
+    inbound.write_bytes(b"caffinbound")
+    tts.write_bytes(b"id3tts-bytes")
+    media, text = BasePlatformAdapter.extract_media(
+        f"Here she is, Tom.\n\nMEDIA:{tts}"
+    )
+    assert [path for path, _is_voice in media] == [str(tts)]
+    assert str(inbound) not in text
+    assert all(str(inbound) != path for path, _is_voice in media)
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None or not _ffmpeg().is_file(),
+    reason="Photon sidecar npm dependencies are not installed",
+)
+def test_spectrum_voice_conversion_uses_bundled_ffmpeg(tmp_path: Path) -> None:
+    """A non-M4A voice input must convert through the shipped static binary."""
+    source = tmp_path / "voice.wav"
+    _write_wav(source, seconds=0.25)
+
+    script = f"""
+import {{ readFile }} from 'node:fs/promises';
+import {{ ensureM4a }} from '@spectrum-ts/core/authoring';
+const source = await readFile({json.dumps(str(source))});
+const result = await ensureM4a(source, 'audio/wav');
+const brand = result.buffer.toString('ascii', 8, 12);
+console.log(JSON.stringify({{ brand, bytes: result.buffer.length }}));
+if (!['M4A ', 'M4B ', 'M4P ', 'mp42', 'mp41', 'isom', 'iso2'].includes(brand)) process.exit(1);
+"""
+    run = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=_sidecar_dir(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stderr
+    assert json.loads(run.stdout)["brand"] in {
+        "M4A ",
+        "M4B ",
+        "M4P ",
+        "mp42",
+        "mp41",
+        "isom",
+        "iso2",
+    }
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None or not _ffmpeg().is_file(),
+    reason="Photon sidecar npm dependencies are not installed",
+)
+def test_prepare_voice_attachment_does_not_reuse_inbound_caf_identity(
+    tmp_path: Path,
+) -> None:
+    """TTS upload bytes and filename must be distinct from the inbound CAF.
+
+    This is the live loopback: inbound CAF (7.56s) vs xAI TTS MP3 (16.6s).
+    Spectrum voice() used to upload the transcoded TTS under tts_*.mp3, and
+    iMessage played the original voice memo. The sidecar must emit a unique
+    M4A whose hash is not the inbound file's hash.
+    """
+    inbound_wav = tmp_path / "inbound.wav"
+    tts_wav = tmp_path / "tts.wav"
+    inbound_caf = tmp_path / "inbound.caf"
+    _write_wav(inbound_wav, seconds=0.4, sample=b"\x11\x00")
+    _write_wav(tts_wav, seconds=0.9, sample=b"\x7f\xff")
+    transcode = subprocess.run(
+        [
+            str(_ffmpeg()),
+            "-y",
+            "-i",
+            str(inbound_wav),
+            "-f",
+            "caf",
+            str(inbound_caf),
+        ],
+        cwd=_sidecar_dir(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert transcode.returncode == 0, transcode.stderr
+    inbound_sha = hashlib.sha256(inbound_caf.read_bytes()).hexdigest()
+
+    module = (_sidecar_dir() / "voice-send.mjs").resolve()
+    script = f"""
+import {{ prepareVoiceAttachment }} from {json.dumps(module.as_uri())};
+const caf = await prepareVoiceAttachment({json.dumps(str(inbound_caf))});
+const tts = await prepareVoiceAttachment({json.dumps(str(tts_wav))});
+try {{
+  console.log(JSON.stringify({{
+    caf: {{
+      name: caf.opts.name,
+      mimeType: caf.opts.mimeType,
+      uploadSha: caf.uploadSha,
+      brand: caf.brand,
+      sourceSha: caf.sourceSha,
+    }},
+    tts: {{
+      name: tts.opts.name,
+      mimeType: tts.opts.mimeType,
+      uploadSha: tts.uploadSha,
+      brand: tts.brand,
+      sourceSha: tts.sourceSha,
+    }},
+  }}));
+}} finally {{
+  await caf.cleanup();
+  await tts.cleanup();
+}}
+"""
+    run = subprocess.run(
+        ["node", "--input-type=module", "-e", script],
+        cwd=_sidecar_dir(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert run.returncode == 0, run.stderr
+    payload = json.loads(run.stdout)
+    caf = payload["caf"]
+    tts = payload["tts"]
+
+    assert caf["mimeType"] == "audio/mp4"
+    assert tts["mimeType"] == "audio/mp4"
+    assert caf["name"].endswith(".m4a")
+    assert tts["name"].endswith(".m4a")
+    assert caf["name"] != tts["name"]
+    assert not caf["name"].endswith(".caf")
+    assert not tts["name"].endswith(".mp3")
+    assert caf["brand"] in {"M4A ", "M4B ", "M4P ", "mp42", "mp41", "isom", "iso2"}
+    assert tts["brand"] in {"M4A ", "M4B ", "M4P ", "mp42", "mp41", "isom", "iso2"}
+    assert caf["sourceSha"] == inbound_sha
+    assert tts["uploadSha"] != inbound_sha
+    assert tts["uploadSha"] != caf["uploadSha"]
+    assert tts["uploadSha"] != tts["sourceSha"]

--- a/tests/test_photon_voice_dependencies.py
+++ b/tests/test_photon_voice_dependencies.py
@@ -1,0 +1,25 @@
+"""Regression coverage for Photon native voice-note transcoding.
+
+Hermes TTS commonly emits MP3. Spectrum's ``voice()`` builder accepts AAC/M4A
+natively and uses ffmpeg for other formats. The Photon sidecar must therefore
+declare ffmpeg-static directly rather than relying on Spectrum's optional peer
+dependency, which npm is free to omit.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SIDECAR_PACKAGE = ROOT / "plugins" / "platforms" / "photon" / "sidecar" / "package.json"
+
+
+def test_photon_sidecar_installs_voice_transcoder() -> None:
+    package = json.loads(SIDECAR_PACKAGE.read_text(encoding="utf-8"))
+
+    assert "ffmpeg-static" in package["dependencies"], (
+        "Photon sends MP3 TTS through Spectrum's voice() builder, which needs "
+        "ffmpeg-static to transcode it to AAC/M4A"
+    )


### PR DESCRIPTION
## Summary

- Ship the outbound voice preparation needed by Photon/Spectrum 8.
- Materialize every outbound voice reply as a unique AAC/M4A file with matching `audio/mp4` metadata and filename.
- Add source/upload identity logging and cleanup around the sidecar send path.
- Add real sidecar/Spectrum-boundary regression coverage so inbound CAF bytes cannot be reused as the outbound TTS attachment.

Related: #91129

## Root cause

Hermes generated a distinct TTS MP3 and correctly extracted that `MEDIA:` path, but Spectrum 8's `voice()` path converted the bytes to M4A while preserving the source `tts_*.mp3` upload identity. Photon/iMessage could then resolve the native audio message back onto the conversation's original inbound CAF voice memo.

This change creates a fresh `voice-<UUID>.m4a` object before calling `voice()`, with matching bytes, filename, and MIME metadata.

## Verification

- `node --check plugins/platforms/photon/sidecar/index.mjs plugins/platforms/photon/sidecar/voice-send.mjs`
- `pytest tests/test_photon_voice_dependencies.py tests/plugins/platforms/photon/test_sidecar_voice_runtime.py tests/plugins/platforms/photon/test_outbound_media.py tests/gateway/test_tts_media_routing.py -q` — 19 passed
- `pytest tests/plugins/platforms/photon -q` — 134 passed
- `npm ls --depth=0` — `spectrum-ts@8.0.0`, `ffmpeg-static@5.3.0`
- Manual Photon validation after gateway restart confirmed that the generated reply was received as Ara's voice rather than the inbound voice note.
