### PR TITLE
fix(update): run config migration on the 'Already up to date' repair path (#91360)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -287,7 +287,7 @@ def _migrate_sibling_profile_configs() -> list[tuple[str, int, int]]:
         logger.debug("Sibling profile enumeration failed: %s", exc)
     return migrated
 
-def _maybe_migrate_config_on_current(print_completion) -> None:
+def _maybe_migrate_config_on_current() -> None:
     """Run config migration on the ``commit_count == 0`` repair path.
 
     A previous update attempt can pull new code onto disk and then fail
@@ -6492,13 +6492,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 healthy_after, detail_after = _venv_core_imports_healthy()
                 if healthy_after:
                     print("✓ Dependencies repaired!")
-                    _maybe_migrate_config_on_current(_print_update_completion)
+                    _maybe_migrate_config_on_current()
                     _print_update_completion("✓ Update complete!")
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
-                _maybe_migrate_config_on_current(_print_update_completion)
+                _maybe_migrate_config_on_current()
                 _repair_node_deps_on_current_checkout(_print_update_completion)
             if runtime_repaired is not None and not _m()._is_windows():
                 print()

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -287,6 +287,49 @@ def _migrate_sibling_profile_configs() -> list[tuple[str, int, int]]:
         logger.debug("Sibling profile enumeration failed: %s", exc)
     return migrated
 
+def _maybe_migrate_config_on_current(print_completion) -> None:
+    """Run config migration on the ``commit_count == 0`` repair path.
+
+    A previous update attempt can pull new code onto disk and then fail
+    before reaching the config-migration block (e.g. PyPI timeout during
+    the dependency sync, #91360). The retry then enters the \"Already up
+    to date\" branch and returns early — skipping ``_run_config_check_fresh``
+    / ``migrate_config`` entirely. The fresh code (which may require a
+    newer ``_config_version``) keeps running against the old config, and
+    the next Hermes launch refuses to start.
+
+    This mirrors the version-bump handling from the normal update path
+    (``version_bump_only``): silently apply format-only migrations, and
+    warn about anything that needs attention. It is a no-op when the
+    config version is already current.
+    """
+    try:
+        current_ver, latest_ver = _run_config_check_fresh()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Config check on current-checkout path failed: %s", exc)
+        return
+    if current_ver >= latest_ver:
+        return
+    print()
+    print(
+        f"  ℹ Updating config format (v{current_ver} → v{latest_ver})…"
+    )
+    try:
+        _mig_results = _run_migrate_config_fresh(
+            interactive=False, quiet=True
+        )
+        print("  ✓ Config format updated (no new settings to configure)")
+        # quiet=True also mutes migration steps that RESET or REMOVE an
+        # existing setting; re-surface those notes so an unattended update
+        # never silently changes user configuration (#86656).
+        for _note in _mig_results.get("config_added") or []:
+            print(f"  ℹ {_note}")
+        for _warn in _mig_results.get("warnings") or []:
+            print(f"  ⚠️  {_warn}")
+    except Exception as _mig_err:
+        print(f"  ⚠️  Config format update failed: {_mig_err}")
+        print("     Run 'hermes config migrate' to retry.")
+
 
 # Critical files that Hermes must be able to import immediately after an
 # update/install. Most are imported on every CLI startup; ``web_server.py``
@@ -6449,11 +6492,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 healthy_after, detail_after = _venv_core_imports_healthy()
                 if healthy_after:
                     print("✓ Dependencies repaired!")
+                    _maybe_migrate_config_on_current(_print_update_completion)
                     _print_update_completion("✓ Update complete!")
                 else:
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
                     print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
+                _maybe_migrate_config_on_current(_print_update_completion)
                 _repair_node_deps_on_current_checkout(_print_update_completion)
             if runtime_repaired is not None and not _m()._is_windows():
                 print()

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -536,6 +536,19 @@ log "hermes update exit code: $CODE"
 if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 2 ]; then
   # Retry once: update-boundary class (fresh code on disk, stale in memory).
   # Exit 2 ("close all Hermes windows") is not retryable.
+  #
+  # A parked-branch SKIP (checkout on a feature branch with unmerged
+  # commits) is also deterministic — the retry would hit the exact same
+  # branch state and skip again, so it only wastes time. Detect the skip
+  # by its banner, skip the retry, and surface an honest message with a
+  # dedicated exit code (8) so callers can distinguish "skipped" from a
+  # real failure.
+  if printf '%s' "$OUT" | grep -q "CODE UPDATE SKIPPED"; then
+    log "hermes update skipped (checkout parked on a non-target branch); not retrying"
+    FINAL_CODE=8
+    FINAL_MSG="Update skipped: the git checkout is on a branch that isn't fully merged into $BRANCH. Switch to the target branch and update again (see the terminal output for the exact commands)."
+    exit 8
+  fi
   log "retrying once (freshly pulled fix loads on the second run)"
   publish_stage "Retrying update"
   OUT="$("$HERMES_BIN" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?

--- a/tests/hermes_cli/test_update_config_migration_on_current.py
+++ b/tests/hermes_cli/test_update_config_migration_on_current.py
@@ -1,0 +1,107 @@
+"""Tests for config migration on the \"Already up to date\" repair path.
+
+Covers ``_maybe_migrate_config_on_current``, added for #91360: a previous
+update attempt can pull new code onto disk and then fail before reaching
+the config-migration block (e.g. PyPI timeout during dependency sync); the
+retry then enters the ``commit_count == 0`` branch and returns early,
+skipping config migration entirely. The fresh code (which may require a
+newer ``_config_version``) keeps running against the old config and the
+next Hermes launch refuses to start.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import hermes_cli.update_cmd as update_cmd
+
+
+def _run(current: int, latest: int):
+    """Run _maybe_migrate_config_on_current with mocked config checks.
+
+    Returns (stdout, migrate_calls).
+    """
+    migrate_calls = []
+
+    def _fake_migrate(interactive=False, quiet=False):
+        migrate_calls.append((interactive, quiet))
+        return {"env_added": [], "config_added": [], "warnings": []}
+
+    with patch.object(
+        update_cmd, "_run_config_check_fresh", return_value=(current, latest)
+    ), patch.object(
+        update_cmd, "_run_migrate_config_fresh", side_effect=_fake_migrate
+    ) as mig:
+        import io
+        import contextlib
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            update_cmd._maybe_migrate_config_on_current(lambda msg: None)
+        return buf.getvalue(), migrate_calls
+
+
+def test_migrates_when_config_behind():
+    """Version bump on the repair path must be applied silently."""
+    out, calls = _run(current=37, latest=38)
+    assert "v37 → v38" in out
+    assert "Config format updated" in out
+    assert calls == [(False, True)]  # non-interactive, quiet
+
+
+def test_noop_when_config_current():
+    """No migration when the config version is already current."""
+    out, calls = _run(current=38, latest=38)
+    assert out == ""
+    assert calls == []
+
+
+def test_noop_when_config_ahead():
+    """No migration when local config is newer than the code's default."""
+    out, calls = _run(current=39, latest=38)
+    assert out == ""
+    assert calls == []
+
+
+def test_surfaces_migration_warnings():
+    """Warnings from a quiet migration must be re-surfaced (#86656)."""
+
+    def _fake_migrate(interactive=False, quiet=False):
+        return {
+            "env_added": [],
+            "config_added": [],
+            "warnings": ["personality reset: kawaii → default"],
+        }
+
+    with patch.object(
+        update_cmd, "_run_config_check_fresh", return_value=(37, 38)
+    ), patch.object(
+        update_cmd, "_run_migrate_config_fresh", side_effect=_fake_migrate
+    ):
+        import io
+        import contextlib
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            update_cmd._maybe_migrate_config_on_current(lambda msg: None)
+        out = buf.getvalue()
+
+    assert "personality reset" in out
+
+
+def test_check_failure_is_silent():
+    """A config-check failure must not break the repair path."""
+    with patch.object(
+        update_cmd, "_run_config_check_fresh", side_effect=RuntimeError("boom")
+    ), patch.object(
+        update_cmd, "_run_migrate_config_fresh", return_value={}
+    ) as mig:
+        import io
+        import contextlib
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            # Should not raise and should not attempt migration.
+            update_cmd._maybe_migrate_config_on_current(lambda msg: None)
+        assert buf.getvalue() == ""
+        mig.assert_not_called()

--- a/tests/hermes_cli/test_update_config_migration_on_current.py
+++ b/tests/hermes_cli/test_update_config_migration_on_current.py
@@ -37,7 +37,7 @@ def _run(current: int, latest: int):
 
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
-            update_cmd._maybe_migrate_config_on_current(lambda msg: None)
+            update_cmd._maybe_migrate_config_on_current()
         return buf.getvalue(), migrate_calls
 
 
@@ -83,7 +83,7 @@ def test_surfaces_migration_warnings():
 
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
-            update_cmd._maybe_migrate_config_on_current(lambda msg: None)
+            update_cmd._maybe_migrate_config_on_current()
         out = buf.getvalue()
 
     assert "personality reset" in out
@@ -102,6 +102,6 @@ def test_check_failure_is_silent():
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
             # Should not raise and should not attempt migration.
-            update_cmd._maybe_migrate_config_on_current(lambda msg: None)
+            update_cmd._maybe_migrate_config_on_current()
         assert buf.getvalue() == ""
         mig.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #91360: `hermes update` can leave the install **non-bootable** after a mid-update failure, because the automatic retry's "Already up to date" path skips the config-version migration entirely.

### Root cause

In `hermes_cli/update_cmd.py`, the early-return repair path (`commit_count == 0` branch, `_repair_node_deps_on_current_checkout` / interrupted-install recovery) returns **before** the config-migration block runs. Sequence that bricks the install:

1. First attempt pulls fresh code onto disk (`Found N new commit(s)` → pull OK).
2. Python dependency sync fails (e.g. PyPI timeout) → exits 1 **before** the config check.
3. Desktop hand-off retries; retry sees the checkout already current (`commit_count == 0`), repairs deps, prints `✓ Already up to date!` and returns — **skipping `_run_config_check_fresh` / `migrate_config`**.
4. Fresh code (requiring a newer `_config_version`) runs against the old config; next Hermes launch refuses to start until `hermes doctor --fix` runs the migration manually.

### Fix

- **`_maybe_migrate_config_on_current()`** — a new helper that mirrors the existing `version_bump_only` handling (silent, non-interactive migration; re-surfaces mutation/warning notes per #86656), and is a no-op when the config version is already current.
- Called on **both** repair-path completion points (deps-repaired success and plain "Already up to date") before claiming success.

- **`scripts/desktop-update/posix.sh`** — the desktop hand-off no longer wastes a deterministic retry when the update was deliberately **SKIPPED** (checkout parked on a non-target branch). Detects the `CODE UPDATE SKIPPED` banner, skips the retry, and exits with a dedicated **code 8** (not colliding with existing 0/2/3/4/6/64 semantics) carrying an honest message instead of "Update failed (exit 1)".

### Tests

`tests/hermes_cli/test_update_config_migration_on_current.py` (new, 5 cases):
- migrates when config version is behind (non-interactive + quiet)
- no-op when current / ahead
- re-surfaces warnings from a quiet migration (#86656)
- silent when config check itself fails (repair path must not break)

Verified: `34 passed` for the touched update tests including existing `test_update_venv_health.py`, `test_update_parked_branch_guard.py`, `test_update_hangup_protection.py`.

## Related

- #91360 (this bug report)
- PR #89507 — different (but related) parked-branch problem: in-place update of unmerged branches. Independent fix.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (touched update tests: 34 passed)
- [x] I've added tests for my changes