### PR TITLE
feat(usage): debug-log chat_completions payloads missing any cache-hit field

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1416,7 +1416,8 @@ def normalize_usage(
     # normalize_usage call. Standard level-gated logger.debug.
     _ptd = _usage_get(response_usage, "prompt_tokens_details", None)
     if (
-        mode not in {"anthropic_messages", "codex_responses"}
+        logger.isEnabledFor(logging.DEBUG)
+        and mode not in {"anthropic_messages", "codex_responses"}
         and provider_name != "anthropic"
         and _usage_get(_ptd, "cached_tokens", None) is None
         and _usage_get(response_usage, "cache_read_input_tokens", None) is None

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1396,6 +1396,53 @@ def normalize_usage(
                 _usage_get(completion_details, "reasoning_tokens", 0)
             )
 
+    # Cache observability for OpenAI-compatible wires: a chat_completions
+    # payload carrying NONE of the known cache-hit fields (nested
+    # prompt_tokens_details, Anthropic-style top-level, DeepSeek/Kimi
+    # variants) means the provider stripped or never sent the field — most
+    # often on streaming usage chunks (#89770). Hermes-side accounting
+    # preserves these fields end-to-end, so when this fires the recovery is
+    # provider-side; the keys list shows what the payload did carry.
+    # Presence-based (is not None), so a genuine cache miss that includes
+    # the field with 0 stays quiet — checked at the NESTED level too, so a
+    # proxy that strips only the inner cached_tokens key (container left
+    # behind) still fires. codex_responses is excluded: its cache
+    # signal lives in input_tokens_details, handled by the Responses branch
+    # above. Standard level-gated logger.debug.
+    _ptd = _usage_get(response_usage, "prompt_tokens_details", None)
+    if (
+        mode != "anthropic_messages"
+        and mode != "codex_responses"
+        and provider_name != "anthropic"
+        and _usage_get(_ptd, "cached_tokens", None) is None
+        and _usage_get(response_usage, "cache_read_input_tokens", None) is None
+        and _usage_get(response_usage, "prompt_cache_hit_tokens", None) is None
+        and _usage_get(response_usage, "cached_tokens", None) is None
+        and logger.isEnabledFor(logging.DEBUG)
+    ):
+        try:
+            if isinstance(response_usage, dict):
+                _observed_keys = sorted(str(k) for k in response_usage.keys())
+            elif hasattr(response_usage, "model_dump"):
+                _observed_keys = sorted(str(k) for k in response_usage.model_dump())
+            else:
+                _observed_keys = sorted(
+                    attr
+                    for attr in dir(response_usage)
+                    if not attr.startswith("_")
+                    and not callable(getattr(response_usage, attr, None))
+                )
+        except Exception:  # pragma: no cover - defensive: never break accounting
+            _observed_keys = ["<unintrospectable>"]
+        logger.debug(
+            "cache_observability provider=%s mode=%s cache_read_tokens=0 — "
+            "usage payload carries no cache-hit field; keys=%s (if this "
+            "fires on every call, the provider is not sending "
+            "prompt_tokens_details.cached_tokens — check its streaming "
+            "usage chunk)",
+            provider_name, mode, _observed_keys,
+        )
+
     # Cache observability for MiniMax's Anthropic wire: on MiniMax-M3,
     # usage.cache_read_input_tokens carries a constant +128 floor and
     # cache_creation_input_tokens is always 0, so cache_read is NOT a

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1406,13 +1406,17 @@ def normalize_usage(
     # Presence-based (is not None), so a genuine cache miss that includes
     # the field with 0 stays quiet — checked at the NESTED level too, so a
     # proxy that strips only the inner cached_tokens key (container left
-    # behind) still fires. codex_responses is excluded: its cache
-    # signal lives in input_tokens_details, handled by the Responses branch
-    # above. Standard level-gated logger.debug.
+    # behind) still fires. Mode audit (every api_mode in the codebase):
+    # anthropic_messages / provider=anthropic and codex_responses are
+    # excluded below; bedrock_converse responses are pre-converted by
+    # bedrock_adapter.py to an OpenAI-style namespace that always carries
+    # cache_read_input_tokens (even when 0) so they stay quiet;
+    # copilot_acp synthesizes prompt_tokens_details.cached_tokens so it
+    # stays quiet; codex_app_server bypasses this loop entirely before any
+    # normalize_usage call. Standard level-gated logger.debug.
     _ptd = _usage_get(response_usage, "prompt_tokens_details", None)
     if (
-        mode != "anthropic_messages"
-        and mode != "codex_responses"
+        mode not in {"anthropic_messages", "codex_responses"}
         and provider_name != "anthropic"
         and _usage_get(_ptd, "cached_tokens", None) is None
         and _usage_get(response_usage, "cache_read_input_tokens", None) is None
@@ -1435,7 +1439,7 @@ def normalize_usage(
         except Exception:  # pragma: no cover - defensive: never break accounting
             _observed_keys = ["<unintrospectable>"]
         logger.debug(
-            "cache_observability provider=%s mode=%s cache_read_tokens=0 — "
+            "cache_observability provider=%s mode=%s — "
             "usage payload carries no cache-hit field; keys=%s (if this "
             "fires on every call, the provider is not sending "
             "prompt_tokens_details.cached_tokens — check its streaming "

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -766,3 +766,175 @@ def test_normalize_usage_nested_details_win_over_qwen_flat_top_level():
 
     assert normalized.cache_read_tokens == 900
     assert normalized.input_tokens == 1100
+
+
+# ── Cache observability: usage payloads with no cache-hit signal ─────────
+
+
+def _mimo_streaming_final_chunk_usage():
+    """Real SDK objects mirroring MiMo's documented usage shape (#89770)."""
+    from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
+
+    return CompletionUsage(
+        prompt_tokens=249,
+        completion_tokens=5,
+        total_tokens=254,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=192),
+    )
+
+
+def test_normalize_usage_mimo_openai_shape_captures_cache_read():
+    """MiMo's standard OpenAI shape normalizes to cache_read_tokens > 0.
+
+    Pins the parser half of #89770: the generic branch must keep reading
+    prompt_tokens_details.cached_tokens first for OpenAI-compatible
+    providers, including real SDK typed objects from streaming chunks."""
+    normalized = normalize_usage(
+        _mimo_streaming_final_chunk_usage(),
+        provider="xiaomi",
+        api_mode="chat_completions",
+    )
+
+    assert normalized.cache_read_tokens == 192
+    # prompt_tokens includes cached; input = 249 - 192 = the miss bucket
+    assert normalized.input_tokens == 57
+    assert normalized.output_tokens == 5
+
+
+def test_normalize_usage_debug_logs_when_cache_signal_missing(caplog):
+    """A chat_completions payload with NO prompt_tokens_details and no known
+    fallback field emits one debug line naming the provider, mode, and the
+    keys it did carry — the triage signal for provider-side omission
+    (#89770): if this fires on MiMo streams, the field never arrived on the
+    wire and no Hermes-side accounting change can recover it."""
+    import logging
+
+    usage = SimpleNamespace(prompt_tokens=249, completion_tokens=5)
+    with caplog.at_level(logging.DEBUG, logger="agent.usage_pricing"):
+        normalized = normalize_usage(
+            usage, provider="xiaomi", api_mode="chat_completions"
+        )
+
+    assert normalized.cache_read_tokens == 0
+    hits = [r for r in caplog.records if "cache_observability" in r.getMessage()]
+    assert hits, "expected a cache_observability debug record"
+    message = hits[0].getMessage()
+    assert "xiaomi" in message
+    assert "chat_completions" in message
+    assert "prompt_tokens" in message  # lists the keys that WERE present
+
+
+def test_normalize_usage_quiet_when_cache_signal_present(caplog):
+    """Payloads carrying prompt_tokens_details.cached_tokens stay quiet —
+    the log is a missing-data signal, not per-call noise."""
+    import logging
+
+    with caplog.at_level(logging.DEBUG, logger="agent.usage_pricing"):
+        normalize_usage(
+            _mimo_streaming_final_chunk_usage(),
+            provider="xiaomi",
+            api_mode="chat_completions",
+        )
+
+    assert not [
+        r
+        for r in caplog.records
+        if r.name == "agent.usage_pricing" and "cache_observability" in r.getMessage()
+    ]
+
+
+def test_normalize_usage_missing_signal_not_logged_for_anthropic_mode(caplog):
+    """Anthropic-mode payloads legitimately lack prompt_tokens_details —
+    the observability log must stay scoped to the OpenAI-compatible branch."""
+    import logging
+
+    usage = SimpleNamespace(input_tokens=100, output_tokens=10)
+    with caplog.at_level(logging.DEBUG, logger="agent.usage_pricing"):
+        normalize_usage(usage, provider="anthropic", api_mode="anthropic_messages")
+
+    assert not [
+        r
+        for r in caplog.records
+        if r.name == "agent.usage_pricing" and "cache_observability" in r.getMessage()
+    ]
+
+
+def test_normalize_usage_missing_signal_not_logged_for_codex_mode(caplog):
+    """codex_responses payloads carry their cache signal in
+    input_tokens_details.cached_tokens — parsed by the Responses branch.
+    The OpenAI-compatible missing-signal log must not fire there (#89770
+    review: it would claim cache_read_tokens=0 while parsing extracted 500)."""
+    import logging
+
+    usage = SimpleNamespace(
+        input_tokens=2000,
+        output_tokens=100,
+        input_tokens_details=SimpleNamespace(cached_tokens=500),
+    )
+    with caplog.at_level(logging.DEBUG, logger="agent.usage_pricing"):
+        normalized = normalize_usage(
+            usage, provider="openai", api_mode="codex_responses"
+        )
+
+    assert normalized.cache_read_tokens == 500
+    assert not [
+        r
+        for r in caplog.records
+        if r.name == "agent.usage_pricing" and "cache_observability" in r.getMessage()
+    ]
+
+
+def test_normalize_usage_missing_signal_lists_dict_keys(caplog):
+    """Dict payloads (JSON-deserialized usage) take the .keys() branch and
+    list their keys in the log."""
+    import logging
+
+    with caplog.at_level(logging.DEBUG, logger="agent.usage_pricing"):
+        normalize_usage(
+            {"prompt_tokens": 10, "completion_tokens": 2},
+            provider="xiaomi",
+            api_mode="chat_completions",
+        )
+
+    hits = [r for r in caplog.records if "cache_observability" in r.getMessage()]
+    assert hits
+    message = hits[0].getMessage()
+    assert "prompt_tokens" in message and "completion_tokens" in message
+
+
+def test_normalize_usage_missing_signal_fires_when_nested_key_stripped(caplog):
+    """A proxy that strips only the inner cached_tokens key (leaving an
+    empty prompt_tokens_details container behind) must still fire — the
+    container-presence check alone would miss exactly this stripping
+    pattern (#89770 proxy hypothesis)."""
+    import logging
+
+    usage = SimpleNamespace(
+        prompt_tokens=249,
+        completion_tokens=5,
+        prompt_tokens_details=SimpleNamespace(),
+    )
+    with caplog.at_level(logging.DEBUG, logger="agent.usage_pricing"):
+        normalized = normalize_usage(
+            usage, provider="xiaomi", api_mode="chat_completions"
+        )
+
+    assert normalized.cache_read_tokens == 0
+    assert [r for r in caplog.records if "cache_observability" in r.getMessage()]
+
+
+def test_normalize_usage_missing_signal_quiet_for_anthropic_provider_chat_mode(caplog):
+    """provider='anthropic' on chat_completions mode enters the Anthropic
+    branch (top-level field names), so the OpenAI-shape missing-signal log
+    must stay quiet there too."""
+    import logging
+
+    usage = SimpleNamespace(input_tokens=100, output_tokens=10)
+    with caplog.at_level(logging.DEBUG, logger="agent.usage_pricing"):
+        normalize_usage(usage, provider="anthropic", api_mode="chat_completions")
+
+    assert not [
+        r
+        for r in caplog.records
+        if r.name == "agent.usage_pricing" and "cache_observability" in r.getMessage()
+    ]

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -938,3 +938,64 @@ def test_normalize_usage_missing_signal_quiet_for_anthropic_provider_chat_mode(c
         for r in caplog.records
         if r.name == "agent.usage_pricing" and "cache_observability" in r.getMessage()
     ]
+
+
+# ── Mode-audit witnesses: every other api_mode must stay quiet ────────────
+# The missing-signal log is scoped to the generic OpenAI-compatible branch.
+# These pin the quietness of the two remaining modes that DO reach
+# normalize_usage, so an adapter change that drops the always-present cache
+# field fails loudly here instead of producing a permanent misleading debug
+# line in production.
+
+
+def test_normalize_usage_missing_signal_quiet_for_bedrock_converse_shape(caplog):
+    """bedrock_converse reaches the generic branch via bedrock_adapter.py,
+    which always emits cache_read_input_tokens (even when 0) on its converted
+    OpenAI-style namespace — so the missing-signal log must never fire for
+    the Converse shape, including a genuine zero-cache response."""
+    import logging
+
+    # Mirrors agent/bedrock_adapter.py:795-804 exactly (zero-cache case).
+    from types import SimpleNamespace as NS
+
+    usage = NS(
+        prompt_tokens=100 + 0 + 0,
+        completion_tokens=10,
+        total_tokens=110,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+    )
+    with caplog.at_level(logging.DEBUG, logger="agent.usage_pricing"):
+        normalized = normalize_usage(usage, provider="bedrock", api_mode="bedrock_converse")
+
+    assert normalized.cache_read_tokens == 0
+    assert not [
+        r
+        for r in caplog.records
+        if r.name == "agent.usage_pricing" and "cache_observability" in r.getMessage()
+    ]
+
+
+def test_normalize_usage_missing_signal_quiet_for_copilot_acp_shape(caplog):
+    """copilot_acp synthesizes a usage namespace carrying
+    prompt_tokens_details.cached_tokens (copilot_acp_client.py) — present,
+    even at 0, so the missing-signal log must stay quiet."""
+    import logging
+
+    from types import SimpleNamespace as NS
+
+    usage = NS(
+        prompt_tokens=0,
+        completion_tokens=0,
+        total_tokens=0,
+        prompt_tokens_details=NS(cached_tokens=0),
+    )
+    with caplog.at_level(logging.DEBUG, logger="agent.usage_pricing"):
+        normalized = normalize_usage(usage, provider="copilot", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 0
+    assert not [
+        r
+        for r in caplog.records
+        if r.name == "agent.usage_pricing" and "cache_observability" in r.getMessage()
+    ]


### PR DESCRIPTION
## Summary

Investigation of #89770 (MiMo/Xiaomi `cache_read_tokens` always 0) found the Hermes-side capture chain **lossless end-to-end** on v0.20.4/current `main`:

- Streaming requests `stream_options={"include_usage": True}` (`agent/chat_completion_helpers.py:3920`) and captures the full final-chunk usage object verbatim (`:4099`, `:4268`) — including a usage chunk arriving *after* `finish_reason`, which matters because MiMo sends its usage chunk last.
- `normalize_usage()` reads `prompt_tokens_details.cached_tokens` first for every OpenAI-compatible provider (`agent/usage_pricing.py`), and the xiaomi profile adds no usage customization.
- Session accumulators (`agent/conversation_loop.py:4193`), per-call persistence (`queue_token_counts` with `cache_read_tokens=`), and `turn_finalizer` reporting are all intact.

This was verified both statically and **dynamically**: a probe executed the real `interruptible_streaming_api_call` with real OpenAI SDK `ChatCompletionChunk` objects mirroring MiMo's documented shape (final chunk `prompt_tokens_details.cached_tokens=192`) and observed `session_cache_read_tokens == 192`.

So when session data still shows 0, the most likely explanation is that the field never arrived on the wire — provider-side omission on streaming chunks, or a stripping intermediary. No accounting change can recover data that was never received. This PR ships the triage signal for exactly that case.

## Changes

- `normalize_usage()` emits one level-gated `logger.debug` when a non-Anthropic, non-Codex payload carries **none** of the known cache-hit fields (`prompt_tokens_details`, `cache_read_input_tokens`, `prompt_cache_hit_tokens`, top-level `cached_tokens`), naming the provider, mode, and the keys the payload did carry. Presence-based conditions keep genuine zero-cache misses quiet. Mirrors the existing MiniMax `cache_observability` debug block in the same function.
- Tests: MiMo's real SDK shape (`CompletionUsage`/`PromptTokensDetails` → `cache_read_tokens=192`, `input_tokens=57`) pins parser behavior; log-fires / log-quiet / dict-payload / nested-key-stripped / Anthropic-scope / Codex-scope cases pin the signal semantics.

Refs #89770

## Notes

**Open question:** Is `token-plan-sgp.xiaomimimo.com/v1` (the base URL in the issue) an official regional endpoint? The bundled xiaomi profile ships `api.xiaomimimo.com/v1`. If the reporter's host is a proxy/gateway, stripped nested usage details would explain the symptom independently of provider behavior.

If the reporter's experiments confirm the streaming usage chunk lacks the field, the resolution is provider-side (or endpoint-side), and this PR's debug line is what makes that confirmation a one-step reproduction.

## Verification

```bash
pytest tests/agent/test_usage_pricing.py
# 48 passed
```
The full suite runs in CI on this PR.
