### PR TITLE
fix(delegate): cap sub-agent output at delegation.max_output_tokens

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1925,6 +1925,14 @@ DEFAULT_CONFIG = {
         # budget still applies.
         "max_summary_chars": 24000,
 
+        # Hard per-turn token ceiling for subagent completion calls. When a
+        # delegation runtime does not set max_output_tokens, child agents fall
+        # back to this value. 0 (default) = uncapped, preserving current stock
+        # behavior. Set a positive integer to bound sub-agent output cost.
+        # For backward compatibility, the legacy key ``max_tokens`` is also
+        # honored by the delegation params builder.
+        "max_output_tokens": 0,
+
         "child_timeout_seconds": 0,  # optional wall-clock cap per child agent. 0 (default)
                                      # = no timeout: children fail only from real errors
                                      # (API, tools, iteration budget), never a delegation

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4550,7 +4550,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "api_key": api_key,
         "api_mode": runtime.get("api_mode"),
         "request_overrides": dict(runtime.get("request_overrides") or {}),
-        "max_output_tokens": runtime.get("max_output_tokens"),
+        "max_output_tokens": runtime.get("max_output_tokens") or cfg.get("max_output_tokens") or cfg.get("max_tokens"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }


### PR DESCRIPTION
When a delegation runtime sets no `max_output_tokens`, child completion calls receive `max_output_tokens=None` → uncapped output. A sub-agent can spend unbounded tokens on a single turn with no config knob to bound it.

This adds `delegation.max_output_tokens` to the schema (default `0` = uncapped, preserving stock behavior) and makes the delegation params builder fall back to it when the runtime doesn't set a cap. For backward compatibility, the legacy `delegation.max_tokens` key is also honored on the same line.

The change is additive: only users who set `delegation.max_output_tokens` (or already have `delegation.max_tokens`) get a cap. Stock installs see zero behavior change. Config is merged permissively over defaults, so there is no schema-validation risk.
