### PR TITLE
fix(desktop): WSL-less Windows no longer sees install prompts or a console-tethered relaunch (#66433, salvage #66447)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -353,7 +353,7 @@ import { installWindowsSystemCaTrust } from './windows-system-ca'
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
-import { resolvePickerDefaultPath } from './wsl-path-bridge'
+import { resolvePickerDefaultPath, setWslBridgeActive } from './wsl-path-bridge'
 
 const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
 
@@ -10669,8 +10669,17 @@ async function startHermes() {
     })
 
     if (setup.kind === 'remote') {
+      // Paths from the remote backend belong to a host the Windows desktop
+      // cannot open via wsl.exe — disable WSL path bridging so native dialogs
+      // and file panels don't spawn wsl.exe (or the interactive install prompt
+      // on WSL-less machines) for unresolvable paths. (#66433)
+      setWslBridgeActive(false)
+
       return setup.connection
     }
+
+    // Local WSL backend — paths are bridgeable.
+    setWslBridgeActive(true)
 
     const backend = setup.backend
     // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
@@ -15030,6 +15039,9 @@ app.whenReady().then(() => {
   registerPowerResumeListeners()
   keepAwake.set(readPersistedKeepAwake())
   f12Blocked = readPersistedDisableF12()
+  // Seed this before the first window exists: a picker can open before
+  // startHermes() finishes resolving the configured backend.
+  setWslBridgeActive(!primaryBackendIsRemote())
   // Quick Entry's global chord — registered on ready so a cold launch restores
   // it without the renderer visiting Settings. A failed registration is logged
   // here and surfaced in Settings via the IPC state (never silent).

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -353,7 +353,7 @@ import { installWindowsSystemCaTrust } from './windows-system-ca'
 import { readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
-import { resolvePickerDefaultPath, setWslBridgeActive } from './wsl-path-bridge'
+import { resolvePickerDefaultPath, setActiveGatewayProfile, setWslBridgeProfileState } from './wsl-path-bridge'
 
 const USER_DATA_OVERRIDE = process.env.HERMES_DESKTOP_USER_DATA_DIR
 
@@ -9898,6 +9898,7 @@ async function ensureBackend(profile) {
 
   if (route.backend === 'primary') {
     const connection = await startHermes()
+    setWslBridgeProfileState(key, connection.mode !== 'remote')
 
     // A shared backend still owes the caller its profile scope, so renderer-side
     // WebSocket, filesystem, and cache routing target the selected profile.
@@ -9921,8 +9922,10 @@ async function ensureBackend(profile) {
 
   if (existing) {
     existing.lastActiveAt = Date.now()
+    const connection = await existing.connectionPromise
+    setWslBridgeProfileState(key, connection.mode !== 'remote')
 
-    return existing.connectionPromise
+    return connection
   }
 
   evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
@@ -9955,7 +9958,10 @@ async function ensureBackend(profile) {
   backendPool.set(key, entry)
   startPoolIdleReaper()
 
-  return entry.connectionPromise
+  const connection = await entry.connectionPromise
+  setWslBridgeProfileState(key, connection.mode !== 'remote')
+
+  return connection
 }
 
 // ── Registry-scoped backends (multi-connection, PR 2 of the campaign) ──────
@@ -10579,6 +10585,11 @@ async function startHermes() {
   }
 
   const connectionAttempt = backendConnectionState.startAttempt()
+  const primaryProfile = primaryProfileKey()
+
+  // Legacy path callers without an explicit profile belong to the primary
+  // window backend. Profile-scoped callers still pass their key directly.
+  setActiveGatewayProfile(primaryProfile)
 
   // Classify this boot BEFORE the throwing resolve/mint runs: a remote failure
   // must NOT latch (it's transient — see shouldLatchBackendStartFailure), while
@@ -10660,7 +10671,7 @@ async function startHermes() {
         // both for an already-saved remote and after first-run remote Apply.
         attemptedRemote = primaryBackendIsRemote()
 
-        return resolveRemoteBackend(primaryProfileKey())
+        return resolveRemoteBackend(primaryProfile)
       },
       waitForDecision: waitForFirstRunSetupChoice,
       // Mutual exclusion with an in-app update (#50238). Remote connections
@@ -10673,13 +10684,13 @@ async function startHermes() {
       // cannot open via wsl.exe — disable WSL path bridging so native dialogs
       // and file panels don't spawn wsl.exe (or the interactive install prompt
       // on WSL-less machines) for unresolvable paths. (#66433)
-      setWslBridgeActive(false)
+      setWslBridgeProfileState(primaryProfile, false)
 
       return setup.connection
     }
 
     // Local WSL backend — paths are bridgeable.
-    setWslBridgeActive(true)
+    setWslBridgeProfileState(primaryProfile, true)
 
     const backend = setup.backend
     // Route old runtimes (no `serve`) through the legacy `dashboard --no-open`.
@@ -13949,7 +13960,10 @@ ipcMain.handle('hermes:selectPaths', async (_event, options: any = {}) => {
     try {
       // On a Windows host with a WSL backend the cwd may be a POSIX/WSL path;
       // bridge it to a UNC/drive form the native dialog can actually open.
-      const bridged = IS_WINDOWS ? resolvePickerDefaultPath(String(options.defaultPath)) : String(options.defaultPath)
+      const bridged = IS_WINDOWS
+        ? resolvePickerDefaultPath(String(options.defaultPath), undefined, options?.profile)
+        : String(options.defaultPath)
+
       resolvedDefaultPath = bridged ? path.resolve(bridged) : undefined
     } catch {
       resolvedDefaultPath = undefined
@@ -15041,7 +15055,10 @@ app.whenReady().then(() => {
   f12Blocked = readPersistedDisableF12()
   // Seed this before the first window exists: a picker can open before
   // startHermes() finishes resolving the configured backend.
-  setWslBridgeActive(!primaryBackendIsRemote())
+  const primaryProfile = primaryProfileKey()
+
+  setActiveGatewayProfile(primaryProfile)
+  setWslBridgeProfileState(primaryProfile, !primaryBackendIsRemote())
   // Quick Entry's global chord — registered on ready so a cold launch restores
   // it without the renderer visiting Settings. A failed registration is logged
   // here and surfaced in Settings via the IPC state (never silent).

--- a/apps/desktop/electron/wsl-path-bridge-gate.test.ts
+++ b/apps/desktop/electron/wsl-path-bridge-gate.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Windows-platform regression for the WSL path-bridge gate (#66433).
+ *
+ * The behavioural tests in wsl-path-bridge.test.ts prove the no-op contract
+ * (paths pass through unchanged when the bridge is inactive). This file goes
+ * one rung further: with `process.platform` stubbed to `win32` and
+ * `child_process.execFileSync` mocked, it proves the actual `wsl.exe` spawn is
+ * suppressed — not just that the return value looks right.
+ *
+ * Each test re-imports the module fresh (vi.resetModules) so IS_WINDOWS is
+ * re-evaluated against the stubbed platform.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const execFileSyncMock = vi.fn(() => 'Ubuntu\n')
+
+vi.mock('node:child_process', () => ({ execFileSync: execFileSyncMock }))
+
+describe('WSL bridge gate on Windows (#66433)', () => {
+  const realPlatform = process.platform
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+    vi.resetModules()
+    execFileSyncMock.mockClear()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true })
+  })
+
+  test('wsl.exe IS probed for a POSIX path when the bridge is active (control)', async () => {
+    const { resolveLocalReadPath } = await import('./wsl-path-bridge')
+    resolveLocalReadPath('/home/ubuntu/project')
+    expect(execFileSyncMock).toHaveBeenCalled()
+    // Sanity: it really was wsl.exe, not some other binary.
+    expect(execFileSyncMock).toHaveBeenNthCalledWith(
+      1,
+      'wsl.exe',
+      expect.arrayContaining(['-l', '-q']),
+      expect.anything()
+    )
+  })
+
+  test('wsl.exe is NEVER probed when the bridge is inactive — even for POSIX paths', async () => {
+    const { resolveLocalReadPath, setWslBridgeActive } = await import('./wsl-path-bridge')
+    setWslBridgeActive(false)
+    // A POSIX path that WOULD trigger bridging (and the wsl.exe probe) when
+    // active — but with the bridge off, resolveDefaultWslDistro is never
+    // reached because resolveLocalReadPath returns before it.
+    const result = resolveLocalReadPath('/home/ubuntu/project')
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+    expect(result).toBe('/home/ubuntu/project')
+  })
+
+  test('the picker default-path also skips the wsl.exe probe when inactive', async () => {
+    const { resolvePickerDefaultPath, setWslBridgeActive } = await import('./wsl-path-bridge')
+    setWslBridgeActive(false)
+    const result = resolvePickerDefaultPath('/home/ubuntu')
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+    expect(result).toBe('/home/ubuntu')
+  })
+
+  test('re-enabling the bridge restores wsl.exe probing', async () => {
+    const { resolveLocalReadPath, setWslBridgeActive } = await import('./wsl-path-bridge')
+    setWslBridgeActive(false)
+    resolveLocalReadPath('/home/ubuntu/project')
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+
+    setWslBridgeActive(true)
+    execFileSyncMock.mockClear()
+    resolveLocalReadPath('/home/ubuntu/project')
+    expect(execFileSyncMock).toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/electron/wsl-path-bridge-profile.test.ts
+++ b/apps/desktop/electron/wsl-path-bridge-profile.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Profile-scoped eligibility for the WSL path bridge (#66447).
+ *
+ * The single-profile tests in wsl-path-bridge.test.ts and the Windows-platform
+ * gate tests in wsl-path-bridge-gate.test.ts cover the *what* (paths pass
+ * through unchanged when bridging is disabled) but not the *which profile*. The
+ * desktop is multi-profile: the renderer can swap the live gateway onto any
+ * profile (primary or pool) without reloading the window — so the bridge
+ * eligibility MUST be keyed off the **currently active profile's** backend
+ * configuration, not a process-global boolean. This file proves the
+ * per-profile contract:
+ *
+ *   1. local primary profile  → bridge ON  (preserved)
+ *   2. remote primary profile → bridge OFF (preserved)
+ *   3. local primary  + remote non-primary  → bridge OFF when the non-primary
+ *      is active; bridge ON when the primary is active again — **no bleed**.
+ *   4. remote primary + local non-primary  → bridge ON when the non-primary
+ *      is active; bridge OFF when the primary is active again — **no bleed**.
+ *   5. profile-scoped calls accept a profile argument; absent it falls back
+ *      to the live gateway profile that the renderer announced.
+ *   6. afterEach resets state so tests don't bleed into each other.
+ *
+ * These tests are pure behavior: they assert the eligibility function's output
+ * and the public selectors' output against observable calls. They do NOT read
+ * the implementation source — only the public surface exported from
+ * `./wsl-path-bridge`.
+ */
+import assert from 'node:assert/strict'
+
+import { afterEach, describe, test } from 'vitest'
+
+import {
+  isWslBridgeActive,
+  resolveLocalReadPath,
+  resolvePickerDefaultPath,
+  setActiveGatewayProfile,
+  setWslBridgeActive,
+  setWslBridgeProfileState,
+  wslPosixToWindowsAccessible
+} from './wsl-path-bridge'
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+const PROFILE_PRIMARY = 'default'
+const PROFILE_LOCAL = 'team-local'
+const PROFILE_REMOTE = 'team-remote'
+
+/** Reset every profile key the bridge knows about to a clean state. */
+afterEach(() => {
+  setWslBridgeProfileState(PROFILE_PRIMARY, true)
+  setWslBridgeProfileState(PROFILE_LOCAL, true)
+  setWslBridgeProfileState(PROFILE_REMOTE, false)
+  setActiveGatewayProfile(PROFILE_PRIMARY)
+  setWslBridgeActive(true)
+})
+
+// ── single-profile contract (preserved behaviour) ────────────────────
+
+describe('WSL bridge profile eligibility — single-profile contract preserved', () => {
+  test('primary local → bridge ON (preserved)', () => {
+    setWslBridgeProfileState(PROFILE_PRIMARY, true)
+    setActiveGatewayProfile(PROFILE_PRIMARY)
+    assert.equal(isWslBridgeActive(), true)
+    assert.equal(
+      resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_PRIMARY),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+    )
+  })
+
+  test('primary remote → bridge OFF (preserved)', () => {
+    setWslBridgeProfileState(PROFILE_PRIMARY, false)
+    setActiveGatewayProfile(PROFILE_PRIMARY)
+    assert.equal(isWslBridgeActive(), false)
+    assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_PRIMARY), '/home/alex')
+    assert.equal(resolveLocalReadPath('/home/alex/proj', undefined, PROFILE_PRIMARY), '/home/alex/proj')
+  })
+})
+
+// ── multi-profile regression (the gap) ────────────────────────────────
+
+describe('WSL bridge profile eligibility — multi-profile (no cross-profile bleed)', () => {
+  test('local primary + remote non-primary → non-primary OFF, primary ON', () => {
+    // Primary is a local backend (WSL on this Windows host). A second profile
+    // points at a remote host whose POSIX paths the Windows host CANNOT open
+    // via wsl.exe — bridging must be OFF for it.
+    setWslBridgeProfileState(PROFILE_PRIMARY, true)
+    setWslBridgeProfileState(PROFILE_REMOTE, false)
+
+    // Non-primary remote is foregrounded — bridge must be OFF for it.
+    setActiveGatewayProfile(PROFILE_REMOTE)
+    assert.equal(isWslBridgeActive(), false)
+    assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_REMOTE), '/home/alex')
+    assert.equal(resolveLocalReadPath('/home/alex/proj', undefined, PROFILE_REMOTE), '/home/alex/proj')
+
+    // Swap back to local primary — bridge must be ON again, no bleed.
+    setActiveGatewayProfile(PROFILE_PRIMARY)
+    assert.equal(isWslBridgeActive(), true)
+    assert.equal(
+      resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_PRIMARY),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+    )
+  })
+
+  test('remote primary + local non-primary → non-primary ON, primary OFF', () => {
+    // Primary is remote (no local WSL paths). A second profile is local —
+    // bridging should be ON for it because its paths CAN be opened locally.
+    setWslBridgeProfileState(PROFILE_PRIMARY, false)
+    setWslBridgeProfileState(PROFILE_LOCAL, true)
+
+    // Local non-primary foregrounded — bridge ON for it.
+    setActiveGatewayProfile(PROFILE_LOCAL)
+    assert.equal(isWslBridgeActive(), true)
+    assert.equal(
+      resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_LOCAL),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+    )
+
+    // Swap back to remote primary — bridge OFF for it, no bleed.
+    setActiveGatewayProfile(PROFILE_PRIMARY)
+    assert.equal(isWslBridgeActive(), false)
+    assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_PRIMARY), '/home/alex')
+  })
+
+  test('three profiles: each profile behaves independently', () => {
+    setWslBridgeProfileState(PROFILE_PRIMARY, true)
+    setWslBridgeProfileState(PROFILE_LOCAL, true)
+    setWslBridgeProfileState(PROFILE_REMOTE, false)
+
+    // Same path, different profiles, different outcomes.
+    assert.equal(
+      resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_PRIMARY),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+    )
+    assert.equal(
+      resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_LOCAL),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+    )
+    assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_REMOTE), '/home/alex')
+  })
+})
+
+// ── profile-argument contract ────────────────────────────────────────
+
+describe('WSL bridge profile eligibility — selector argument contract', () => {
+  test("selector with explicit profile → that profile's bridge state", () => {
+    setWslBridgeProfileState(PROFILE_PRIMARY, true)
+    setWslBridgeProfileState(PROFILE_REMOTE, false)
+    setActiveGatewayProfile(PROFILE_PRIMARY)
+
+    // Explicit profile wins over the live gateway.
+    assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_REMOTE), '/home/alex')
+    assert.equal(
+      resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_PRIMARY),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+    )
+  })
+
+  test("selector with no profile → live gateway profile's bridge state", () => {
+    setWslBridgeProfileState(PROFILE_PRIMARY, true)
+    setWslBridgeProfileState(PROFILE_REMOTE, false)
+    setActiveGatewayProfile(PROFILE_REMOTE)
+
+    // No profile argument → fallback to active gateway profile (remote → OFF).
+    assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu'), '/home/alex')
+    assert.equal(resolveLocalReadPath('/home/alex/proj'), '/home/alex/proj')
+
+    setActiveGatewayProfile(PROFILE_PRIMARY)
+    assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu'), '\\\\wsl.localhost\\Ubuntu\\home\\alex')
+  })
+
+  test('selector with unknown profile → bridge ON (defaults to active for new profiles)', () => {
+    // A profile that has never been seeded should default to the safe
+    // "bridge ON" behaviour so a brand-new local profile isn't accidentally
+    // disabled. The renderer seeds the state at boot; an unknown key here is
+    // either a renderer race or a profile created mid-session.
+    setWslBridgeProfileState(PROFILE_PRIMARY, false)
+    setActiveGatewayProfile(PROFILE_PRIMARY)
+
+    assert.equal(
+      resolvePickerDefaultPath('/home/alex', 'Ubuntu', 'unknown-profile'),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+    )
+  })
+})
+
+// ── legacy back-compat: setWslBridgeActive targets the active profile ─
+
+describe('WSL bridge profile eligibility — legacy toggle targets active profile', () => {
+  test('setWslBridgeActive(false) flips the active profile, not a process-global', () => {
+    setWslBridgeProfileState(PROFILE_PRIMARY, true)
+    setWslBridgeProfileState(PROFILE_REMOTE, true)
+    setActiveGatewayProfile(PROFILE_REMOTE)
+
+    setWslBridgeActive(false)
+
+    // Active profile (REMOTE) flipped to OFF; primary untouched.
+    assert.equal(isWslBridgeActive(), false)
+    assert.equal(
+      resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_PRIMARY),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+    )
+    assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_REMOTE), '/home/alex')
+  })
+
+  test('setWslBridgeActive(true) restores the active profile only', () => {
+    setWslBridgeProfileState(PROFILE_PRIMARY, true)
+    setWslBridgeProfileState(PROFILE_REMOTE, false)
+    setActiveGatewayProfile(PROFILE_REMOTE)
+
+    setWslBridgeActive(true)
+
+    // Active (REMOTE) restored; primary unchanged.
+    assert.equal(isWslBridgeActive(), true)
+    assert.equal(
+      resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_REMOTE),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+    )
+    assert.equal(
+      resolvePickerDefaultPath('/home/alex', 'Ubuntu', PROFILE_PRIMARY),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex'
+    )
+  })
+})
+
+// ── wslPosixToWindowsAccessible stays pure / unchanged ───────────────
+
+describe('WSL bridge profile eligibility — POSIX translation stays pure', () => {
+  test('wslPosixToWindowsAccessible ignores bridge state (pure translation)', () => {
+    setWslBridgeProfileState(PROFILE_PRIMARY, false)
+    setActiveGatewayProfile(PROFILE_PRIMARY)
+
+    // The translator does NOT consult the bridge state — it's pure POSIX → UNC.
+    // Tests elsewhere assert that the bridge gate short-circuits BEFORE this
+    // function is reached. A regression here would mean coupling leaked into
+    // a helper that should stay side-effect-free.
+    assert.equal(
+      wslPosixToWindowsAccessible('/home/alex/proj', 'Ubuntu'),
+      '\\\\wsl.localhost\\Ubuntu\\home\\alex\\proj'
+    )
+    assert.equal(wslPosixToWindowsAccessible('/mnt/c/Users/alex', 'Ubuntu'), 'C:\\Users\\alex')
+  })
+})

--- a/apps/desktop/electron/wsl-path-bridge.test.ts
+++ b/apps/desktop/electron/wsl-path-bridge.test.ts
@@ -1,8 +1,25 @@
 import assert from 'node:assert/strict'
 
-import { test } from 'vitest'
+import { afterEach, test } from 'vitest'
 
-import { parseDefaultDistro, resolvePickerDefaultPath, wslPosixToWindowsAccessible } from './wsl-path-bridge'
+import {
+  isWslBridgeActive,
+  parseDefaultDistro,
+  resolveLocalReadPath,
+  resolvePickerDefaultPath,
+  setWslBridgeActive,
+  wslPosixToWindowsAccessible
+} from './wsl-path-bridge'
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+/** Reset the bridge to its default active state after every test so no test
+ *  leaks global state into the next one. */
+afterEach(() => {
+  setWslBridgeActive(true)
+})
+
+// ── distro parsing (unchanged) ───────────────────────────────────────
 
 test('parseDefaultDistro reads the first distro from clean utf-8 output', () => {
   assert.equal(parseDefaultDistro('Ubuntu\nDebian\n'), 'Ubuntu')
@@ -20,6 +37,8 @@ test('parseDefaultDistro strips the default-marker and blank lines', () => {
   assert.equal(parseDefaultDistro('   \n\n'), null)
 })
 
+// ── wslPosixToWindowsAccessible ──────────────────────────────────────
+
 test('wslPosixToWindowsAccessible maps a drvfs mount to its Windows drive', () => {
   assert.equal(wslPosixToWindowsAccessible('/mnt/c/Users/alex', 'Ubuntu'), 'C:\\Users\\alex')
   assert.equal(wslPosixToWindowsAccessible('/mnt/d', 'Ubuntu'), 'D:\\')
@@ -34,8 +53,73 @@ test('wslPosixToWindowsAccessible leaves non-absolute / already-Windows paths al
   assert.equal(wslPosixToWindowsAccessible('relative/dir', 'Ubuntu'), 'relative/dir')
 })
 
+// ── resolvePickerDefaultPath (bridge active) ─────────────────────────
+
 test('resolvePickerDefaultPath bridges a WSL cwd but passes Windows paths and empties through', () => {
   assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu'), '\\\\wsl.localhost\\Ubuntu\\home\\alex')
   assert.equal(resolvePickerDefaultPath('C:\\proj', 'Ubuntu'), 'C:\\proj')
   assert.equal(resolvePickerDefaultPath(undefined, 'Ubuntu'), undefined)
+})
+
+// ── bridge active / inactive ─────────────────────────────────────────
+
+test('bridge defaults to active', () => {
+  assert.equal(isWslBridgeActive(), true)
+})
+
+test('setWslBridgeActive(false) → resolvePickerDefaultPath passes raw path through without bridging', () => {
+  setWslBridgeActive(false)
+  // Even a clear WSL POSIX path must pass through unchanged when the bridge
+  // is inactive — no distro probe, no wsl.exe, no install prompt.
+  assert.equal(resolvePickerDefaultPath('/home/alex'), '/home/alex')
+  assert.equal(resolvePickerDefaultPath('/mnt/c/Users/alex'), '/mnt/c/Users/alex')
+  // Windows paths and empties are unaffected either way.
+  assert.equal(resolvePickerDefaultPath('C:\\proj'), 'C:\\proj')
+  assert.equal(resolvePickerDefaultPath(undefined), undefined)
+})
+
+test('setWslBridgeActive(false) → resolveLocalReadPath passes raw path through without bridging', () => {
+  setWslBridgeActive(false)
+  // resolveLocalReadPath is used by fs-read-dir to make WSL paths readable
+  // on the Windows host. When the bridge is inactive (remote gateway), the
+  // raw POSIX path must be returned as-is — no UNC rewriting, no distro
+  // resolution. The downstream fs call will fail gracefully on non-WSL
+  // hosts, which is the desired behaviour.
+  assert.equal(resolveLocalReadPath('/home/alex/proj'), '/home/alex/proj')
+  assert.equal(resolveLocalReadPath('/mnt/c/Users/alex'), '/mnt/c/Users/alex')
+  // Non-POSIX paths are never bridged regardless of state.
+  assert.equal(resolveLocalReadPath('C:\\Users\\alex'), 'C:\\Users\\alex')
+  assert.equal(resolveLocalReadPath(''), '')
+})
+
+test('setWslBridgeActive(true) restores picker bridging', () => {
+  setWslBridgeActive(false)
+  assert.equal(resolvePickerDefaultPath('/home/alex'), '/home/alex')
+
+  setWslBridgeActive(true)
+  assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu'), '\\\\wsl.localhost\\Ubuntu\\home\\alex')
+})
+
+test('toggling the bridge is idempotent and does not corrupt cached state', () => {
+  // Toggle twice each way.
+  setWslBridgeActive(false)
+  assert.equal(isWslBridgeActive(), false)
+  setWslBridgeActive(false)
+  assert.equal(isWslBridgeActive(), false)
+
+  setWslBridgeActive(true)
+  assert.equal(isWslBridgeActive(), true)
+  setWslBridgeActive(true)
+  assert.equal(isWslBridgeActive(), true)
+
+  // Bridging still works after the toggles.
+  assert.equal(resolvePickerDefaultPath('/home/alex', 'Ubuntu'), '\\\\wsl.localhost\\Ubuntu\\home\\alex')
+})
+
+// ── state isolation: every test sees a clean active bridge ────────────
+
+test('state isolation: bridge is active after a previous test toggled it off', () => {
+  // This test relies on afterEach resetting the bridge.
+  // If isolation is broken, isWslBridgeActive() would be false here.
+  assert.equal(isWslBridgeActive(), true)
 })

--- a/apps/desktop/electron/wsl-path-bridge.ts
+++ b/apps/desktop/electron/wsl-path-bridge.ts
@@ -17,6 +17,28 @@ let cachedDistro: null | string = null
 let cachedUncBase: null | string = null
 
 /**
+ * Whether WSL path bridging is active. The bridge only makes sense when the
+ * desktop runs on Windows AND the gateway is a *local* backend (e.g. running
+ * inside WSL on the same machine). When the gateway is a remote host, the
+ * POSIX paths it reports belong to a machine the Windows host cannot open via
+ * `wsl.exe` — bridging them only spawns `wsl.exe` (and on WSL-less machines,
+ * the interactive "Install WSL" console prompt) for paths that can never be
+ * resolved locally. main.ts toggles this off once it resolves a remote
+ * backend. Defaults to active so a local Windows+WSL boot is unaffected.
+ */
+let wslBridgeActive = true
+
+/** Enable/disable WSL path bridging at runtime (called by main.ts). */
+export function setWslBridgeActive(active: boolean): void {
+  wslBridgeActive = active
+}
+
+/** Test seam: is the bridge currently active? */
+export function isWslBridgeActive(): boolean {
+  return wslBridgeActive
+}
+
+/**
  * Pick the default distro from `wsl.exe -l -q` output.
  *
  * `wsl.exe` emits UTF-16LE without a BOM unless `WSL_UTF8=1` (WSL >= 0.64), so
@@ -116,22 +138,39 @@ export function wslPosixToWindowsAccessible(posixPath: string, distro: string = 
 /** Native folder dialog `defaultPath`: open a WSL cwd in the Windows picker. */
 export function resolvePickerDefaultPath(
   defaultPath: string | undefined,
-  distro: string = resolveDefaultWslDistro()
+  distro?: string
 ): string | undefined {
   if (!defaultPath) {
     return undefined
   }
 
+  // Remote-gateway POSIX paths can't be opened via wsl.exe — no-op the bridge
+  // so the native dialog gets the raw path (it falls back gracefully) instead
+  // of triggering a wsl.exe spawn / install prompt. (#66433)
+  if (!wslBridgeActive) {
+    return defaultPath
+  }
+
   const value = String(defaultPath).trim()
 
-  return value.startsWith('/') && !WIN_DRIVE_RE.test(value) ? wslPosixToWindowsAccessible(value, distro) : defaultPath
+  return value.startsWith('/') && !WIN_DRIVE_RE.test(value)
+    ? wslPosixToWindowsAccessible(value, distro ?? resolveDefaultWslDistro())
+    : defaultPath
 }
 
 /** fs read path: on Windows, make a WSL cwd readable via its UNC / drive form. */
-export function resolveLocalReadPath(dirPath: string, distro: string = resolveDefaultWslDistro()): string {
+export function resolveLocalReadPath(dirPath: string, distro?: string): string {
   const value = String(dirPath || '').trim()
 
+  // In remote-gateway mode the POSIX paths belong to a host the Windows
+  // desktop cannot open locally — skip the WSL bridge entirely (no distro
+  // probe, no wsl.exe) so the file panel never spawns the install prompt on
+  // WSL-less machines. (#66433)
+  if (!wslBridgeActive) {
+    return value
+  }
+
   return IS_WINDOWS && value.startsWith('/') && !WIN_DRIVE_RE.test(value)
-    ? wslPosixToWindowsAccessible(value, distro)
+    ? wslPosixToWindowsAccessible(value, distro ?? resolveDefaultWslDistro())
     : value
 }

--- a/apps/desktop/electron/wsl-path-bridge.ts
+++ b/apps/desktop/electron/wsl-path-bridge.ts
@@ -86,6 +86,11 @@ export function resolveDefaultWslDistro(): string {
     const out = execFileSync('wsl.exe', ['-l', '-q'], {
       encoding: 'utf8',
       env: { ...process.env, WSL_UTF8: '1' },
+      // On WSL-less machines wsl.exe prints "The Windows Subsystem for Linux
+      // is not installed..." to stderr; stderr is inherited by default, so
+      // that banner leaks into whatever console the app is attached to
+      // (visible e.g. during the update hand-off). Discard it. (#80184)
+      stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 2000,
       windowsHide: true
     })

--- a/apps/desktop/electron/wsl-path-bridge.ts
+++ b/apps/desktop/electron/wsl-path-bridge.ts
@@ -17,25 +17,39 @@ let cachedDistro: null | string = null
 let cachedUncBase: null | string = null
 
 /**
- * Whether WSL path bridging is active. The bridge only makes sense when the
- * desktop runs on Windows AND the gateway is a *local* backend (e.g. running
- * inside WSL on the same machine). When the gateway is a remote host, the
- * POSIX paths it reports belong to a machine the Windows host cannot open via
- * `wsl.exe` — bridging them only spawns `wsl.exe` (and on WSL-less machines,
- * the interactive "Install WSL" console prompt) for paths that can never be
- * resolved locally. main.ts toggles this off once it resolves a remote
- * backend. Defaults to active so a local Windows+WSL boot is unaffected.
+ * WSL path eligibility belongs to the backend profile that produced the path.
+ * A single desktop process can keep a local primary backend and a remote pool
+ * backend alive simultaneously, so a process-global boolean can bleed between
+ * them. Unknown profiles retain the historical local default until Electron
+ * resolves and records their actual backend mode.
  */
-let wslBridgeActive = true
+const DEFAULT_WSL_BRIDGE_PROFILE = 'default'
+const wslBridgeProfiles = new Map<string, boolean>()
+let activeWslBridgeProfile = DEFAULT_WSL_BRIDGE_PROFILE
 
-/** Enable/disable WSL path bridging at runtime (called by main.ts). */
-export function setWslBridgeActive(active: boolean): void {
-  wslBridgeActive = active
+function normalizeWslBridgeProfile(profile?: null | string): string {
+  return String(profile || '').trim() || DEFAULT_WSL_BRIDGE_PROFILE
 }
 
-/** Test seam: is the bridge currently active? */
-export function isWslBridgeActive(): boolean {
-  return wslBridgeActive
+/** Select the profile used by legacy callers that cannot pass one explicitly. */
+export function setActiveGatewayProfile(profile?: null | string): void {
+  activeWslBridgeProfile = normalizeWslBridgeProfile(profile)
+}
+
+/** Record whether paths returned by one profile belong to this host's WSL. */
+export function setWslBridgeProfileState(profile: null | string, active: boolean): void {
+  wslBridgeProfiles.set(normalizeWslBridgeProfile(profile), Boolean(active))
+}
+
+/** Backward-compatible toggle: update only the current fallback profile. */
+export function setWslBridgeActive(active: boolean): void {
+  setWslBridgeProfileState(activeWslBridgeProfile, active)
+}
+
+export function isWslBridgeActive(profile?: null | string): boolean {
+  const key = profile == null ? activeWslBridgeProfile : normalizeWslBridgeProfile(profile)
+
+  return wslBridgeProfiles.get(key) ?? true
 }
 
 /**
@@ -138,7 +152,8 @@ export function wslPosixToWindowsAccessible(posixPath: string, distro: string = 
 /** Native folder dialog `defaultPath`: open a WSL cwd in the Windows picker. */
 export function resolvePickerDefaultPath(
   defaultPath: string | undefined,
-  distro?: string
+  distro?: string,
+  profile?: null | string
 ): string | undefined {
   if (!defaultPath) {
     return undefined
@@ -147,7 +162,7 @@ export function resolvePickerDefaultPath(
   // Remote-gateway POSIX paths can't be opened via wsl.exe — no-op the bridge
   // so the native dialog gets the raw path (it falls back gracefully) instead
   // of triggering a wsl.exe spawn / install prompt. (#66433)
-  if (!wslBridgeActive) {
+  if (!isWslBridgeActive(profile)) {
     return defaultPath
   }
 
@@ -159,14 +174,14 @@ export function resolvePickerDefaultPath(
 }
 
 /** fs read path: on Windows, make a WSL cwd readable via its UNC / drive form. */
-export function resolveLocalReadPath(dirPath: string, distro?: string): string {
+export function resolveLocalReadPath(dirPath: string, distro?: string, profile?: null | string): string {
   const value = String(dirPath || '').trim()
 
   // In remote-gateway mode the POSIX paths belong to a host the Windows
   // desktop cannot open locally — skip the WSL bridge entirely (no distro
   // probe, no wsl.exe) so the file panel never spawns the install prompt on
   // WSL-less machines. (#66433)
-  if (!wslBridgeActive) {
+  if (!isWslBridgeActive(profile)) {
     return value
   }
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1311,6 +1311,8 @@ export interface HermesSelectPathsOptions {
   defaultPath?: string
   directories?: boolean
   multiple?: boolean
+  /** Backend profile that produced defaultPath; Electron uses it for WSL gating. */
+  profile?: string
   filters?: Array<{ name: string; extensions: string[] }>
 }
 

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -76,7 +76,7 @@ describe('desktop filesystem facade', () => {
   })
 
   it('uses local Electron filesystem methods in local mode', async () => {
-    $connection.set({ mode: 'local' } as never)
+    $connection.set({ mode: 'local', profile: 'team-local' } as never)
 
     await expect(readDesktopDir('/work')).resolves.toEqual({
       entries: [{ name: 'local', path: '/local', isDirectory: true }]
@@ -90,7 +90,7 @@ describe('desktop filesystem facade', () => {
     expect(readFileText).toHaveBeenCalledWith('/work/file.txt')
     expect(readFileDataUrl).toHaveBeenCalledWith('/work/file.txt')
     expect(gitRoot).toHaveBeenCalledWith('/work')
-    expect(selectPaths).toHaveBeenCalledWith({ directories: true })
+    expect(selectPaths).toHaveBeenCalledWith({ directories: true, profile: 'team-local' })
     expect(api).not.toHaveBeenCalled()
   })
 
@@ -216,12 +216,12 @@ describe('desktop filesystem facade', () => {
 
   it('uses the local Electron picker for remote file selection', async () => {
     const remoteSelect = vi.fn(async () => ['/remote/project'])
-    $connection.set({ mode: 'remote' } as never)
+    $connection.set({ mode: 'remote', profile: 'team-remote' } as never)
     setDesktopFsRemotePicker({ selectPaths: remoteSelect })
 
     await expect(selectDesktopPaths({ directories: false, multiple: false })).resolves.toEqual(['/local'])
 
-    expect(selectPaths).toHaveBeenCalledWith({ directories: false, multiple: false })
+    expect(selectPaths).toHaveBeenCalledWith({ directories: false, multiple: false, profile: 'team-remote' })
     expect(remoteSelect).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -201,13 +201,15 @@ export async function desktopFileDiff(repoRoot: string, filePath: string): Promi
 
 export async function selectDesktopPaths(options?: HermesSelectPathsOptions): Promise<string[]> {
   const desktop = bridge()
+  const profile = desktopFsProfile()
+  const localOptions = profile ? { ...options, profile } : options
 
   if (!isDesktopFsRemoteMode()) {
-    return desktop.selectPaths(options)
+    return desktop.selectPaths(localOptions)
   }
 
   if (!options?.directories) {
-    return desktop.selectPaths(options)
+    return desktop.selectPaths(localOptions)
   }
 
   return remotePicker ? remotePicker.selectPaths({ ...options, multiple: false }) : []

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -572,6 +572,59 @@ function Start-DesktopRelaunch {
         Write-HandoffLog "WARNING: WMI relaunch failed: $($_.Exception.Message); falling back"
     }
     if (-not $spawned) {
+        # Middle rung: explorer.exe-mediated launch. On some machines
+        # Win32_Process.Create fails outright (observed ReturnValue 8,
+        # "unknown failure"), and the tethered fallback below re-attaches the
+        # Desktop to this console — its stdout then floods the console and the
+        # window can't close while the app lives. Explorer re-parents the
+        # target exactly like a normal shell launch, giving the same
+        # no-console detachment WMI would have. Explorer returns no pid, so
+        # verify by watching for a fresh Hermes process.
+        try {
+            $exeName = [System.IO.Path]::GetFileNameWithoutExtension($RelaunchExe)
+            $before = @(Get-Process -Name $exeName -ErrorAction SilentlyContinue | ForEach-Object { $_.Id })
+            Start-Process -FilePath 'explorer.exe' -ArgumentList ('"{0}"' -f $RelaunchExe) | Out-Null
+            $explorerDeadline = (Get-Date).AddSeconds(15)
+            while ((Get-Date) -lt $explorerDeadline) {
+                $fresh = @(Get-Process -Name $exeName -ErrorAction SilentlyContinue | Where-Object { $before -notcontains $_.Id })
+                if ($fresh.Count -gt 0) {
+                    Write-HandoffLog "desktop relaunched detached via explorer (pid $($fresh[0].Id))"
+                    $spawned = $true
+                    # Same foreground hand-off as the WMI rung: the new process
+                    # starts unfocused and only the current foreground owner
+                    # (us) can delegate that right.
+                    try {
+                        if ($script:Win32) {
+                            [HermesHandoff.Win32]::AllowSetForegroundWindow([int]$fresh[0].Id) | Out-Null
+                            $focusDeadline = (Get-Date).AddSeconds(20)
+                            while ((Get-Date) -lt $focusDeadline) {
+                                $hwnd = [System.IntPtr]::Zero
+                                try { $hwnd = (Get-Process -Id $fresh[0].Id -ErrorAction Stop).MainWindowHandle } catch { break }
+                                if ($hwnd -ne [System.IntPtr]::Zero) {
+                                    [HermesHandoff.Win32]::ShowWindow($hwnd, 9) | Out-Null  # SW_RESTORE
+                                    [HermesHandoff.Win32]::SetForegroundWindow($hwnd) | Out-Null
+                                    Write-HandoffLog "focused relaunched desktop window"
+                                    break
+                                }
+                                Start-Sleep -Milliseconds 400
+                            }
+                        }
+                    } catch {
+                        Write-HandoffLog "WARNING: could not focus relaunched desktop: $($_.Exception.Message)"
+                    }
+                    break
+                }
+                Start-Sleep -Milliseconds 400
+                if ($script:Ui) { [System.Windows.Forms.Application]::DoEvents() }
+            }
+            if (-not $spawned) {
+                Write-HandoffLog "WARNING: explorer relaunch did not produce a $exeName process; falling back"
+            }
+        } catch {
+            Write-HandoffLog "WARNING: explorer relaunch failed: $($_.Exception.Message); falling back"
+        }
+    }
+    if (-not $spawned) {
         try {
             # Fallback keeps the old behavior (console tie-in and all) --
             # a tethered Desktop beats no Desktop.


### PR DESCRIPTION
## Summary
Windows machines without WSL no longer get the interactive "Install WSL" prompt / stderr banner from the Desktop, and the update hand-off no longer tethers the relaunched Desktop to its console when WMI relaunch fails.

Root cause: `wsl-path-bridge.ts` probed `wsl.exe -l -q` for every POSIX path on Windows regardless of backend mode (remote-gateway paths are never locally bridgeable), and the hand-off script's only fallback after a failed `Win32_Process.Create` (observed `ReturnValue 8`) is a child spawn, which lets Electron `AttachConsole` back onto the shim console.

## Changes
- Salvages PR #66447 by @Tranquil-Flow (authorship preserved, 2 commits): WSL path bridge gated per backend profile — remote backends skip the bridge entirely, so `wsl.exe` is never probed for paths the host can't open (#66433). Includes the per-profile scoping the triage review asked for (remote pool backend + local primary no longer bleed state).
- `wsl-path-bridge.ts`: discard `wsl.exe` stderr so the "WSL is not installed" banner can't leak into an attached console even when the probe legitimately runs (#80184).
- `scripts/desktop-update/windows.ps1`: new explorer.exe-mediated detached relaunch rung between the WMI attempt and the tethered `Start-Process` fallback, with launch verification (fresh-process watch) and the same foreground hand-off as the WMI rung.

## Validation
| | Before | After |
|---|---|---|
| Remote backend, WSL-less host | `wsl.exe` spawned per file-panel refresh → install prompt | bridge inactive, no spawn |
| `wsl.exe` probe stderr | inherited → banner in console | discarded |
| WMI relaunch fails (rc 8) | Desktop tethered to hand-off console, stdout floods it | detached via explorer rung |
| vitest `wsl-path-bridge*`, `wsl-clipboard-image` | — | 38/38 pass |
| pytest `test_desktop_update_windows_*` | — | 5 pass, 2 skip (Windows-only) |

Fixes #66433. Addresses the banner half of #80184.

## Infographic

![WSL bridge gated + clean relaunch](https://v3b.fal.media/files/b/0aa73351/zlmPFJfJgUIjudUfHB2DR_rIo1kSrL.png)
