### PR TITLE
fix(profiles): scope profile endpoints to an isolated dashboard's profile

### DIFF
--- a/contributors/emails/argo@argobox.com
+++ b/contributors/emails/argo@argobox.com
@@ -1,0 +1,2 @@
+KeyArgo
+# author identity for PR #91381 commits (Argo = KeyArgo machine identity)

--- a/hermes_cli/isolated_scope.py
+++ b/hermes_cli/isolated_scope.py
@@ -1,0 +1,206 @@
+"""Isolated-profile scope policy for the dashboard server.
+
+Owns the server-side ``--isolated`` authority boundary. This policy used to
+live inline in ``hermes_cli/web_server.py``; it is extracted here so the
+security boundary has one focused owner instead of another policy island
+inside the godfile (#91381 review, #78628 decomposition tracking).
+
+``web_server.py`` re-exports these functions under the legacy underscore names
+(``_is_isolated_server``, ``_isolated_scope_dir``, ``_profile_name_for_scope``,
+``_scope_topology_for_isolated``, ``_clamp_profile_query_for_isolated``), so:
+
+* ``web_server``'s own route handlers keep calling the same names,
+* the extracted ``web_routers`` modules keep resolving them through
+  ``web_deps.late(...)`` at call time, and
+* ``monkeypatch.setattr(web_server, \"<name>\", ...)`` stays authoritative.
+
+State stays on the FastAPI ``app`` (``app.state.isolated`` /
+``app.state.isolated_scope_dir``), written once by ``web_server.start_server``
+at launch. The helpers read that state lazily through the live ``web_server``
+module — mirroring the ``web_deps.late`` contract — so nothing here freezes
+app state or the app object at import time.
+
+Why identity is a resolved *path*, never a profile-name string:
+``get_active_profile_name()`` returns the sentinels ``\"custom\"`` / ``\"default\"``
+for an unrecognized home or a derivation failure, and those strings are also
+valid *real* profile names — a name-based equality check could therefore alias
+an isolated server onto a sibling profile and pass ``_assert_profile_in_scope``
+(#91330 review, closed by comparing canonical directories instead).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException
+
+
+def _server():
+    """Return the live ``hermes_cli.web_server`` module (imported on demand).
+
+    Cycle-safe: ``web_server`` imports this module at its own module bottom,
+    long after ``app`` exists, and the functions here only touch ``web_server``
+    inside a call — never at import time.
+    """
+    mod = sys.modules.get("hermes_cli.web_server")
+    if mod is None:  # pragma: no cover - only reachable outside a live server
+        import hermes_cli.web_server as mod  # type: ignore[no-redef]
+    return mod
+
+
+def is_isolated_server() -> bool:
+    """True when this server was launched with ``--isolated``.
+
+    Threaded from the ``--isolated`` flag through :func:`web_server.start_server`
+    into ``app.state.isolated``. Defaults to False so a server that never ran
+    ``start_server`` (e.g. a bare TestClient without the helper setting it) is
+    treated as the unified machine dashboard, which is the safe non-restricting
+    default.
+    """
+    return bool(getattr(_server().app.state, "isolated", False))
+
+
+def isolated_scope_dir() -> Optional[Path]:
+    """The canonical resolved HERMES_HOME this isolated server is scoped to.
+
+    Captured once in :func:`web_server.start_server` at launch as an immutable
+    path on ``app.state`` (#91330 review: "capture the canonical isolated launch
+    authority once in start_server() and store that immutable identity/path in
+    app.state"). Falls back to the process's current ``HERMES_HOME`` when
+    ``start_server`` never ran (tests set ``app.state.isolated`` directly);
+    ``get_hermes_home()`` is process-stable so the fallback is deterministic.
+    """
+    stored = getattr(_server().app.state, "isolated_scope_dir", None)
+    if stored is not None:
+        return Path(stored).resolve()
+    if not is_isolated_server():
+        return None
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home().resolve()
+
+
+def profile_name_for_scope(scope_dir: Optional[Path]) -> Optional[str]:
+    """Map a resolved HERMES_HOME to its profile name, or ``None``.
+
+    Returns ``"default"`` for the root home, the profile name for a home under
+    ``~/.hermes/profiles/<name>``, and ``None`` for any unrecognized/ambiguous
+    home. ``None`` is the fail-closed signal: an isolated server with no
+    unambiguous principal may not prove any named profile is in scope, so it is
+    denied rather than inferred to be one.
+    """
+    if scope_dir is None:
+        return None
+    from hermes_cli import profiles as profiles_mod
+
+    scope = Path(scope_dir).resolve()
+    if scope == profiles_mod._get_default_hermes_home().resolve():
+        return "default"
+    profiles_root = profiles_mod._get_profiles_root().resolve()
+    try:
+        rel = scope.relative_to(profiles_root)
+        if len(rel.parts) == 1 and profiles_mod._PROFILE_ID_RE.match(rel.parts[0]):
+            return rel.parts[0]
+    except ValueError:
+        pass
+    return None
+
+
+def scope_topology_for_isolated(topology: Dict[str, Any]) -> Dict[str, Any]:
+    """Narrow a machine-wide ``/api/status`` topology to an isolated server.
+
+    On an isolated server the *unparameterized* ``/api/status`` (no ``?profile=``
+    at all) still went through the raw machine-wide collection: ``profiles``
+    enumerated every sibling profile and ``gateways`` carried each live
+    gateway's host ports, and because the empty selector skipped the
+    ``profile=<name>`` branch the ``profile_platforms`` map was also folded into
+    ``gateway_platforms``. That leaks sibling profile/host metadata and is
+    reachable before dashboard auth (``/api/status`` is in ``PUBLIC_API_PATHS``
+    #76932-class). A ``?profile=`` request is clamped/403'd by
+    :func:`clamp_profile_query_for_isolated` before reaching the handler; this
+    helper closes the *no-query* form by scoping the collection to the pinned
+    principal so an isolated server never publishes another profile's names,
+    ports, or platform state.
+    """
+    if not is_isolated_server():
+        return topology
+    scope = isolated_scope_dir()
+    pinned = profile_name_for_scope(scope)
+    # Fail closed: an isolated server with no unambiguous principal publishes
+    # nothing machine-wide rather than an empty/leaky enumeration.
+    if pinned is None:
+        return {
+            "profiles": [],
+            "gateway_mode": "none",
+            "gateways": [],
+            "profile_platforms": {},
+        }
+    return {
+        "profiles": [p for p in topology.get("profiles", []) if p == pinned],
+        "gateway_mode": topology.get("gateway_mode"),
+        "gateways": [
+            g for g in topology.get("gateways", []) if g.get("profile") == pinned
+        ],
+        "profile_platforms": {
+            name: plats
+            for name, plats in (topology.get("profile_platforms") or {}).items()
+            if name == pinned
+        },
+    }
+
+
+def clamp_profile_query_for_isolated(
+    profile: Optional[str], *, allow_all: bool = False
+) -> Optional[str]:
+    """Clamp or reject a ``profile`` query param against the isolated scope.
+
+    The unified machine dashboard is intentionally cross-profile and returns
+    ``profile`` unchanged. An isolated server answers only for its pinned
+    profile: ``profile=all`` (a dashboard-sidebar convenience meaning "all
+    sessions for this backend") is clamped to the pinned profile, an explicit
+    sibling selector is rejected with 403 *before any I/O*, and the pinned
+    profile passes through. ``None``/``""``/``"current"`` mean the backend's
+    own profile and pass through unchanged.
+
+    Identity is the canonical resolved launch path stored on ``app.state`` at
+    :func:`web_server.start_server` — never a profile-name string (the
+    ``"custom"`` / ``"default"`` sentinels of ``get_active_profile_name()``
+    collide with real profile names and would alias a sibling onto the
+    isolation boundary).
+    """
+    if not is_isolated_server():
+        return profile
+    requested = (profile or "").strip()
+    if not requested or requested.lower() == "current":
+        return profile
+    if allow_all and requested.lower() == "all":
+        # "all sessions" on an isolated backend means "this profile's
+        # sessions", not "every profile on disk".
+        scope = isolated_scope_dir()
+        name = profile_name_for_scope(scope)
+        if name is None:
+            raise HTTPException(
+                status_code=403,
+                detail="This dashboard is isolated but has no unambiguous scoped profile.",
+            )
+        return name
+
+    from hermes_cli import profiles as profiles_mod
+
+    try:
+        requested_canon = profiles_mod.normalize_profile_name(requested)
+        profiles_mod.validate_profile_name(requested_canon)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    scope = isolated_scope_dir()
+    requested_dir = profiles_mod.get_profile_dir(requested_canon).resolve()
+    if scope is not None and scope == requested_dir:
+        return requested_canon
+    shown = profile_name_for_scope(scope) if scope is not None else "(unknown)"
+    raise HTTPException(
+        status_code=403,
+        detail=f"This dashboard is isolated to '{shown}'; refusing profile '{requested_canon}'.",
+    )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12338,6 +12338,7 @@ def cmd_dashboard(args):
         allow_public=getattr(args, "insecure", False),
         initial_profile=getattr(args, "open_profile", "") or "",
         headless=_headless_backend,
+        isolated=getattr(args, "isolated", False),
         ssh_session_token=_ssh_session_token,
         ssh_owner_nonce=_ssh_owner_nonce,
     )

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -74,7 +74,10 @@ _cron_profile_home = late("_cron_profile_home")
 _disable_unselected_skills = late("_disable_unselected_skills")
 _fallback_profile_dicts = late("_fallback_profile_dicts")
 _hub_action_name = late("_hub_action_name")
+_is_isolated_server = late("_is_isolated_server")
+_isolated_scope_dir = late("_isolated_scope_dir")
 _open_session_db_at_path = late("_open_session_db_at_path")
+_profile_name_for_scope = late("_profile_name_for_scope")
 _profile_setup_command = late("_profile_setup_command")
 _profile_to_dict = late("_profile_to_dict")
 _resolve_profile_dir = late("_resolve_profile_dir")
@@ -256,7 +259,18 @@ def get_profiles_sessions(
     from hermes_cli import profiles as profiles_mod
 
     targets: List[Tuple[str, Path]] = []
-    if profile and profile != "all":
+    iso = _isolated_target() if _is_isolated_server() else None
+    if iso is not None:
+        # An isolated server reads only its pinned profile's sessions. An
+        # explicit sibling selector fails before any I/O.
+        pinned = iso[0]
+        if profile and profile != "all" and profile != pinned:
+            raise HTTPException(
+                status_code=403,
+                detail=f"This dashboard is isolated to '{pinned}'; refusing profile '{profile}'.",
+            )
+        targets.append(iso)
+    elif profile and profile != "all":
         name, home = _cron_profile_home(profile)
         targets.append((name, home))
     else:
@@ -402,13 +416,28 @@ def get_profiles_sessions_sidebar(
     """
     from hermes_cli import profiles as profiles_mod
 
-    try:
-        # Session aggregation only needs name/path; the lightweight enumerator
-        # avoids YAML/meta/gateway/skill probes for all profiles per refresh.
-        targets: List[Tuple[str, Path]] = profiles_mod.profiles_to_serve(multiplex=True)
-    except Exception:
-        _log.exception("GET /api/profiles/sessions/sidebar: list_profiles failed")
-        targets = []
+    # Isolation authority is resolved BEFORE any fallback try/except: an
+    # explicit sibling selector on an isolated server must 403 — never be
+    # swallowed by the enumeration fallback and silently served from the
+    # default profile (#91330 review, "explicit sibling selectors must fail
+    # before I/O").
+    iso = _isolated_target() if _is_isolated_server() else None
+    if iso is not None:
+        recents_scope = (recents_profile or "all").strip() or "all"
+        if recents_scope != "all" and recents_scope != iso[0]:
+            raise HTTPException(
+                status_code=403,
+                detail=f"This dashboard is isolated to '{iso[0]}'; refusing profile '{recents_scope}'.",
+            )
+        targets: List[Tuple[str, Path]] = [iso]
+    else:
+        try:
+            # Session aggregation only needs name/path; the lightweight enumerator
+            # avoids YAML/meta/gateway/skill probes for all profiles per refresh.
+            targets: List[Tuple[str, Path]] = profiles_mod.profiles_to_serve(multiplex=True)
+        except Exception:
+            _log.exception("GET /api/profiles/sessions/sidebar: list_profiles failed")
+            targets = []
     if not targets:
         targets.append(("default", profiles_mod.get_profile_dir("default")))
 
@@ -643,10 +672,15 @@ def get_profiles_projects_tree(preview_limit: int = 3, session_limit: int = 2000
     from hermes_constants import reset_hermes_home_override, set_hermes_home_override
     from tui_gateway import server as gateway_server
 
+    # Isolation authority resolved BEFORE the fallback try/except so a 403
+    # (sibling or ambiguous scope) propagates instead of being swallowed into
+    # a default-profile fallback (#91330 review).
+    iso = _isolated_target() if _is_isolated_server() else None
     try:
-        targets: List[Tuple[str, Path]] = [
-            (info.name, info.path) for info in profiles_mod.list_profiles()
-        ]
+        if iso is not None:
+            targets: List[Tuple[str, Path]] = [iso]
+        else:
+            targets = [(info.name, info.path) for info in profiles_mod.list_profiles()]
     except Exception:
         _log.exception("GET /api/profiles/projects/tree: list_profiles failed")
         targets = []
@@ -737,8 +771,15 @@ def post_profiles_sessions_pull_requests(body: SessionPrScanBody):
     if not wanted:
         return {"pull_requests": {}, "scanned": []}
 
+    # Isolation authority resolved BEFORE the fallback try/except so a 403
+    # (sibling or ambiguous scope) propagates instead of falling back to a
+    # default-profile scan (#91330 review).
+    iso = _isolated_target() if _is_isolated_server() else None
     try:
-        targets = [(info.name, info.path) for info in profiles_mod.list_profiles()]
+        if iso is not None:
+            targets: List[Tuple[str, Path]] = [iso]
+        else:
+            targets = [(info.name, info.path) for info in profiles_mod.list_profiles()]
     except Exception:
         _log.exception("POST /api/profiles/sessions/pull-requests: list_profiles failed")
         targets = []
@@ -777,8 +818,15 @@ def post_profiles_sessions_pull_requests(body: SessionPrScanBody):
 @router.get("/api/profiles")
 async def list_profiles_endpoint():
     from hermes_cli import profiles as profiles_mod
+    # Isolation authority resolved BEFORE the fallback try/except: an isolated
+    # server with no unambiguous scoped principal must 403, not fall through to
+    # a directory scan that could surface siblings (#91330 review).
+    iso = _isolated_target() if _is_isolated_server() else None
     try:
         profiles = await run_in_threadpool(profiles_mod.list_profiles)
+        if iso is not None:
+            pinned = iso[0]
+            profiles = [p for p in profiles if getattr(p, "name", None) == pinned]
         return {"profiles": [_profile_to_dict(p) for p in profiles]}
     except Exception:
         _log.exception("GET /api/profiles failed; falling back to profile directory scan")
@@ -787,6 +835,12 @@ async def list_profiles_endpoint():
 
 @router.post("/api/profiles")
 async def create_profile_endpoint(body: ProfileCreate):
+    # Every clone source (explicit clone_from, clone_all, and the implicit
+    # "default") is an authority-bearing profile selector: cloning READS the
+    # source profile's config/.env/SOUL/skills. On an isolated server the
+    # source may be a sibling profile, so creation is refused outright before
+    # any source file is touched (#91330 review).
+    _assert_machine_control_plane_allowed("profile create")
     from hermes_cli import profiles as profiles_mod
     explicit_source = (body.clone_from or "").strip()
     if explicit_source:
@@ -926,6 +980,9 @@ async def set_active_profile_endpoint(body: ProfileActiveUpdate):
     Note: this does not retarget the already-running dashboard process —
     it changes which profile subsequent CLI commands and gateways use.
     """
+    # Switching the machine-wide active profile is a control-plane operation
+    # over the whole profile set — refused on an isolated server (#91330 review).
+    _assert_machine_control_plane_allowed("active-profile switch")
     from hermes_cli import profiles as profiles_mod
     try:
         profiles_mod.set_active_profile(body.name)
@@ -941,11 +998,13 @@ async def set_active_profile_endpoint(body: ProfileActiveUpdate):
 
 @router.get("/api/profiles/{name}/setup-command")
 async def get_profile_setup_command(name: str):
+    _assert_profile_in_scope(name)
     return {"command": _profile_setup_command(name)}
 
 
 @router.post("/api/profiles/{name}/open-terminal")
 async def open_profile_terminal_endpoint(name: str):
+    _assert_profile_in_scope(name)
     try:
         command = _profile_setup_command(name)
 
@@ -1000,6 +1059,7 @@ async def open_profile_terminal_endpoint(name: str):
 
 @router.patch("/api/profiles/{name}")
 async def rename_profile_endpoint(name: str, body: ProfileRename):
+    _assert_profile_in_scope(name)
     from hermes_cli import profiles as profiles_mod
     try:
         path = profiles_mod.rename_profile(name, body.new_name)
@@ -1036,6 +1096,7 @@ async def delete_profile_endpoint(name: str):
     """Delete a profile. The dashboard collects the user's confirmation in
     its own dialog before this request, so we always pass ``yes=True`` to
     skip the CLI's interactive prompt."""
+    _assert_profile_in_scope(name)
     from hermes_cli import profiles as profiles_mod
     try:
         path = profiles_mod.delete_profile(name, yes=True)
@@ -1049,8 +1110,111 @@ async def delete_profile_endpoint(name: str):
     return {"ok": True, "path": str(path)}
 
 
+def _isolated_target() -> Optional[Tuple[str, Path]]:
+    """The (name, home) of the profile this isolated server is pinned to.
+
+    Returns ``None`` on the machine dashboard (no restriction). When the server
+    is isolated, returns the single pinned profile or raises 403 — the
+    canonical launch identity stored on ``app.state`` is the only authority,
+    and an unrecognized/ambiguous principal (a HERMES_HOME that is neither the
+    default root nor a named ``~/.hermes/profiles/<name>``) fails closed: no
+    named profile is provably in scope, so none may be addressed (#91330
+    review, fail-open identity aliasing).
+    """
+    if not _is_isolated_server():
+        return None
+    scope = _isolated_scope_dir()
+    name = _profile_name_for_scope(scope)
+    if name is None:
+        raise HTTPException(
+            status_code=403,
+            detail="This dashboard is isolated but has no unambiguous scoped profile.",
+        )
+    return (name, Path(scope))
+
+
+def _assert_profile_in_scope(name: str) -> None:
+    """Reject cross-profile access from a scoped (isolated) server.
+
+    A dashboard/serve process launched with ``--isolated`` is scoped to a
+    single profile (its own HERMES_HOME). Such a server must not read,
+    mutate, export, or destroy another profile's data: that is the
+    prompt/identity-injection and data-exfiltration boundary behind #91330
+    (an attacker who can reach an isolated dashboard could otherwise rewrite
+    a different profile's persona — or export its config/secrets — to inject
+    a malicious prompt or steal data).
+
+    Isolation is tracked explicitly on ``app.state.isolated`` (threaded from
+    the ``--isolated`` launch flag through :func:`start_server`), not inferred
+    from the profile name — an isolated server may be scoped to the default
+    profile too, and must still be restricted. The default (unified) machine
+    dashboard (isolated=False) is *intentionally* a machine-wide management
+    surface, so this guard is a no-op there. Every ``/api/profiles/{name}/*``
+    read/mutate/export/delete endpoint routes through this guard.
+
+    Authorization compares *canonical resolved paths* — ``get_profile_dir``
+    of the requested name against the stored launch authority — never the
+    profile-name string. ``get_active_profile_name()`` returns the sentinels
+    ``"custom"`` / ``"default"`` for an unrecognized home or a derivation
+    failure, and those are valid real profile names, so a string equality
+    check aliases an isolated server onto a sibling profile (#91330 review,
+    fail-open identity). Path comparison makes the aliasing request resolve
+    to the real sibling directory, which never equals the scoped home.
+    """
+    if not _is_isolated_server():
+        # Unified machine dashboard: cross-profile management is by design.
+        return
+    from hermes_cli import profiles as profiles_mod
+
+    scope = _isolated_scope_dir()
+    requested = profiles_mod.get_profile_dir(name).resolve()
+    if scope is not None and scope == requested:
+        # Asking for the very profile this server is scoped to is always fine.
+        return
+    shown = _profile_name_for_scope(scope) if scope is not None else "(unknown)"
+    raise HTTPException(
+        status_code=403,
+        detail=(
+            f"This dashboard is isolated to '{shown}'. "
+            f"Refusing to access another profile ('{name}')."
+        ),
+    )
+
+
+def _assert_machine_control_plane_allowed(action: str) -> None:
+    """Refuse machine-global profile operations from a scoped (isolated) server.
+
+    Profile creation, archive import, and active-profile switching are
+    control-plane operations over the WHOLE machine's profile set, not over a
+    single ``{name}`` target: ``POST /api/profiles`` accepts caller-controlled
+    ``clone_from``/``clone_all`` (and an implicit ``default`` source), so a
+    client of an isolated server could copy a sibling profile's
+    config/.env/SOUL/skills into a new profile it legitimately controls —
+    reading the protected profile through the clone source even though every
+    destination-side route is guarded (#91330 review, "authority-bearing
+    selectors"). Import archives and active-profile switches carry the same
+    cross-profile authority shape.
+
+    An isolated server is scoped to exactly one profile, so these operations
+    are denied outright (fail-closed) instead of partially permitted. The
+    unified machine dashboard keeps them by design.
+    """
+    if not _is_isolated_server():
+        return
+    scope = _isolated_scope_dir()
+    shown = _profile_name_for_scope(scope) if scope is not None else "(unknown)"
+    raise HTTPException(
+        status_code=403,
+        detail=(
+            f"This dashboard is isolated to '{shown}'. "
+            f"Refusing machine-global profile operation ({action})."
+        ),
+    )
+
+
 @router.get("/api/profiles/{name}/soul")
 async def get_profile_soul(name: str):
+    _assert_profile_in_scope(name)
     soul_path = _resolve_profile_dir(name) / "SOUL.md"
     if soul_path.exists():
         try:
@@ -1062,6 +1226,7 @@ async def get_profile_soul(name: str):
 
 @router.put("/api/profiles/{name}/soul")
 async def update_profile_soul(name: str, body: ProfileSoulUpdate):
+    _assert_profile_in_scope(name)
     soul_path = _resolve_profile_dir(name) / "SOUL.md"
     try:
         from utils import atomic_write_text
@@ -1097,6 +1262,7 @@ async def update_profile_description_endpoint(name: str, body: ProfileDescriptio
     user-authored description (``description_auto: false``) so the
     auto-describer won't overwrite it on a sweep.
     """
+    _assert_profile_in_scope(name)
     from hermes_cli import profiles as profiles_mod
     profile_dir = _resolve_profile_dir(name)
     text = (body.description or "").strip()
@@ -1119,6 +1285,7 @@ async def update_profile_model_endpoint(name: str, body: ProfileModelUpdate):
     active profile. Mirrors ``POST /api/model/set`` (main scope) but scoped
     to the named profile via the HERMES_HOME override.
     """
+    _assert_profile_in_scope(name)
     profile_dir = _resolve_profile_dir(name)
     provider = (body.provider or "").strip()
     model = (body.model or "").strip()
@@ -1142,6 +1309,7 @@ async def describe_profile_auto_endpoint(name: str, body: ProfileDescribeAuto):
     ``ok: false`` with a reason rather than an HTTP error so the UI can
     surface it inline and let the operator fix config and retry.
     """
+    _assert_profile_in_scope(name)
     _resolve_profile_dir(name)
     try:
         from hermes_cli import profile_describer
@@ -1169,6 +1337,7 @@ async def describe_profile_auto_endpoint(name: str, body: ProfileDescribeAuto):
 
 @router.post("/api/profiles/{name}/export")
 async def export_profile_endpoint(name: str, body: ProfileExport):
+    _assert_profile_in_scope(name)
     from hermes_cli import profiles as profiles_mod
 
     output = (body.output or "").strip()
@@ -1200,6 +1369,9 @@ async def export_profile_endpoint(name: str, body: ProfileExport):
 
 @router.post("/api/profiles/import")
 async def import_profile_endpoint(body: ProfileImport):
+    # An imported archive becomes a full profile directory under this server's
+    # control plane — machine-global mutation, refused when isolated.
+    _assert_machine_control_plane_allowed("profile import")
     from hermes_cli import profiles as profiles_mod
 
     archive = (body.archive or "").strip()
@@ -1252,6 +1424,7 @@ async def import_profile_endpoint(body: ProfileImport):
 async def get_profile_desktop_overlay(name: str):
     """The desktop appearance/interface overlay bundled with an imported
     profile (``desktop.json`` at the profile root), or ``exists: false``."""
+    _assert_profile_in_scope(name)
     overlay_path = _resolve_profile_dir(name) / "desktop.json"
     if not overlay_path.is_file():
         return {"exists": False, "desktop": None}

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -42,6 +42,7 @@ manage_router = APIRouter()
 
 # Late-bound web_server helpers (resolved at call time; cycle-safe,
 # monkeypatch-transparent).
+_clamp_profile_query_for_isolated = late("_clamp_profile_query_for_isolated")
 _cron_default_profile = late("_cron_default_profile")
 _cron_profile_home = late("_cron_profile_home")
 _import_sessions_for_profile = late("_import_sessions_for_profile")
@@ -118,6 +119,10 @@ def get_sessions(
     Rows omit ``system_prompt``/``model_config`` (the payload-dominating
     fields no list UI reads) unless ``full=1`` is passed.
     """
+    # An isolated backend answers only for its pinned profile — an explicit
+    # sibling selector 403s before any session DB is opened (#91330 review,
+    # consolidation owner).
+    profile = _clamp_profile_query_for_isolated(profile, allow_all=True)
     if archived not in ("exclude", "only", "include"):
         raise HTTPException(
             status_code=400,
@@ -223,6 +228,9 @@ async def search_sessions(
     """
     if not q or not q.strip():
         return {"results": []}
+    # An isolated backend searches only its pinned profile's session DB —
+    # a sibling selector 403s before any FTS read (#91330 review).
+    profile = _clamp_profile_query_for_isolated(profile, allow_all=True)
     try:
         db = _open_session_db_for_profile(profile, read_only=True)
         try:
@@ -470,8 +478,11 @@ async def bulk_delete_sessions_endpoint(body: BulkDeleteSessions):
             status_code=400,
             detail="ids must contain at most 500 entries",
         )
+    # Isolated backend: sibling profile targets are refused before I/O.
+    target_profile = _clamp_profile_query_for_isolated(body.profile, allow_all=True)
+
     def _delete() -> int:
-        db = _open_session_db_for_profile(body.profile, read_only=False)
+        db = _open_session_db_for_profile(target_profile, read_only=False)
         try:
             return db.delete_sessions(body.ids)
         finally:
@@ -497,8 +508,11 @@ async def import_sessions_endpoint(request: Request):
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="Invalid session import payload") from exc
 
+    # Isolated backend: importing into a sibling profile's session DB is
+    # refused before I/O.
+    target_profile = _clamp_profile_query_for_isolated(body.profile, allow_all=True)
     try:
-        result = await asyncio.to_thread(_import_sessions_for_profile, body.profile, body.sessions)
+        result = await asyncio.to_thread(_import_sessions_for_profile, target_profile, body.sessions)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -515,6 +529,9 @@ async def count_empty_sessions_endpoint(profile: Optional[str] = None):
     UI hides the affordance so users aren't presented with a button
     that does nothing. Cheap, single-COUNT query.
     """
+    # Isolated backend: the count is for its pinned profile only.
+    profile = _clamp_profile_query_for_isolated(profile, allow_all=True)
+
     def _count() -> int:
         db = _open_session_db_for_profile(profile, read_only=True)
         try:
@@ -550,6 +567,9 @@ async def delete_empty_sessions_endpoint(profile: Optional[str] = None):
     prune-on-startup pass. Matching that pre-existing trade-off keeps
     the two delete endpoints' DB-vs-disk behaviour consistent.
     """
+    # Isolated backend: the sweep is for its pinned profile only.
+    profile = _clamp_profile_query_for_isolated(profile, allow_all=True)
+
     def _delete() -> int:
         db = _open_session_db_for_profile(profile, read_only=False)
         try:
@@ -568,6 +588,8 @@ async def get_session_stats(profile: Optional[str] = None):
     Registered before ``/api/sessions/{session_id}`` so the literal ``stats``
     path isn't captured as a session id by the parameterized route.
     """
+    # Isolated backend: stats are for its pinned profile only.
+    profile = _clamp_profile_query_for_isolated(profile, allow_all=True)
     db = _open_session_db_for_profile(profile, read_only=True)
     try:
         total = db.session_count(include_archived=True)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3771,6 +3771,10 @@ def _merge_profile_gateway_platforms(
 @app.get("/api/status")
 async def get_status(profile: Optional[str] = None):
     status_scope = None
+    # An isolated backend answers only for its pinned profile — explicit
+    # sibling selectors 403 before any config/env/gateway read (#91330
+    # review, consolidation owner).
+    profile = _clamp_profile_query_for_isolated(profile, allow_all=True)
     requested_profile = (profile or "").strip()
     # Plain /api/status stays the machine-level public liveness probe. The
     # dashboard adds ?profile= when its management switcher targets another
@@ -10647,6 +10651,10 @@ async def cancel_telegram_onboarding(pairing_id: str):
 
 @app.get("/api/messaging/platforms")
 async def get_messaging_platforms(profile: Optional[str] = None):
+    # An isolated backend answers only for its pinned profile — explicit
+    # sibling selectors 403 before any channel-credential/env read (#91330
+    # review, consolidation owner).
+    profile = _clamp_profile_query_for_isolated(profile, allow_all=True)
     # Profile-scoped so the dashboard's global profile switcher shows the
     # TARGET profile's channel credentials/state, not the root install's.
     # load_env() honors the HERMES_HOME contextvar override; the gateway
@@ -15011,7 +15019,131 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
                 "has_alias": False,
             })
 
+    # An isolated server must not even surface sibling profiles in the list.
+    if _is_isolated_server():
+        scope = _isolated_scope_dir()
+        pinned = _profile_name_for_scope(scope)
+        if pinned is None:
+            return []
+        profiles = [p for p in profiles if p.get("name") == pinned]
+
     return profiles
+
+
+def _is_isolated_server() -> bool:
+    """True when this server was launched with ``--isolated``.
+
+    Threaded from the ``--isolated`` flag through :func:`start_server` into
+    ``app.state.isolated``. Defaults to False so a server that never ran
+    ``start_server`` (e.g. a bare TestClient without the helper setting it)
+    is treated as the unified machine dashboard, which is the safe
+    non-restricting default.
+    """
+    return bool(getattr(app.state, "isolated", False))
+
+
+def _isolated_scope_dir() -> Optional[Path]:
+    """The canonical resolved HERMES_HOME this isolated server is scoped to.
+
+    Captured once in :func:`start_server` at launch as an immutable path on
+    ``app.state`` (#91330 review: "capture the canonical isolated launch
+    authority once in start_server() and store that immutable identity/path
+    in app.state"). Falls back to the process's current ``HERMES_HOME`` when
+    ``start_server`` never ran (tests set ``app.state.isolated`` directly);
+    ``get_hermes_home()`` is process-stable so the fallback is deterministic.
+
+    Comparing by *resolved path* rather than profile-name string is exactly
+    what closes the aliasing bypass: ``get_active_profile_name()`` returns the
+    sentinels ``"custom"`` / ``"default"`` for an unrecognized home or a
+    derivation failure, and those strings are also valid real profile names —
+    a name-based equality check could therefore alias an isolated server onto
+    a sibling profile and pass ``_assert_profile_in_scope``.
+    """
+    stored = getattr(app.state, "isolated_scope_dir", None)
+    if stored is not None:
+        return Path(stored).resolve()
+    if not _is_isolated_server():
+        return None
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home().resolve()
+
+
+def _profile_name_for_scope(scope_dir: Optional[Path]) -> Optional[str]:
+    """Map a resolved HERMES_HOME to its profile name, or ``None``.
+
+    Returns ``"default"`` for the root home, the profile name for a home under
+    ``~/.hermes/profiles/<name>``, and ``None`` for any unrecognized/ambiguous
+    home. ``None`` is the fail-closed signal: an isolated server with no
+    unambiguous principal may not prove any named profile is in scope, so it
+    is denied rather than inferred to be one.
+    """
+    if scope_dir is None:
+        return None
+    from hermes_cli import profiles as profiles_mod
+
+    scope = Path(scope_dir).resolve()
+    if scope == profiles_mod._get_default_hermes_home().resolve():
+        return "default"
+    profiles_root = profiles_mod._get_profiles_root().resolve()
+    try:
+        rel = scope.relative_to(profiles_root)
+        if len(rel.parts) == 1 and profiles_mod._PROFILE_ID_RE.match(rel.parts[0]):
+            return rel.parts[0]
+    except ValueError:
+        pass
+    return None
+
+
+def _clamp_profile_query_for_isolated(profile: Optional[str], *, allow_all: bool = False) -> Optional[str]:
+    """Clamp or reject a ``profile`` query param against the isolated scope.
+
+    The unified machine dashboard is intentionally cross-profile and returns
+    ``profile`` unchanged. An isolated server answers only for its pinned
+    profile: ``profile=all`` (a dashboard-sidebar convenience meaning "all
+    sessions for this backend") is clamped to the pinned profile, an explicit
+    sibling selector is rejected with 403 *before any I/O*, and the pinned
+    profile passes through. ``None``/``""``/``"current"`` mean the backend's
+    own profile and pass through unchanged.
+
+    Identity is the canonical resolved launch path stored on ``app.state`` at
+    :func:`start_server` — never a profile-name string (the ``"custom"`` /
+    ``"default"`` sentinels of ``get_active_profile_name()`` collide with real
+    profile names and would alias a sibling onto the isolation boundary).
+    """
+    if not _is_isolated_server():
+        return profile
+    requested = (profile or "").strip()
+    if not requested or requested.lower() == "current":
+        return profile
+    if allow_all and requested.lower() == "all":
+        # "all sessions" on an isolated backend means "this profile's
+        # sessions", not "every profile on disk".
+        scope = _isolated_scope_dir()
+        name = _profile_name_for_scope(scope)
+        if name is None:
+            raise HTTPException(
+                status_code=403,
+                detail="This dashboard is isolated but has no unambiguous scoped profile.",
+            )
+        return name
+
+    from hermes_cli import profiles as profiles_mod
+    try:
+        requested_canon = profiles_mod.normalize_profile_name(requested)
+        profiles_mod.validate_profile_name(requested_canon)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    scope = _isolated_scope_dir()
+    requested_dir = profiles_mod.get_profile_dir(requested_canon).resolve()
+    if scope is not None and scope == requested_dir:
+        return requested_canon
+    shown = _profile_name_for_scope(scope) if scope is not None else "(unknown)"
+    raise HTTPException(
+        status_code=403,
+        detail=f"This dashboard is isolated to '{shown}'; refusing profile '{requested_canon}'.",
+    )
 
 
 def _resolve_profile_dir(name: str) -> Path:
@@ -19557,6 +19689,7 @@ def start_server(
     allow_public: bool = False,
     initial_profile: str = "",
     headless: bool = False,
+    isolated: bool = False,
     ssh_session_token: Optional[str] = None,
     ssh_owner_nonce: Optional[str] = None,
 ):
@@ -19571,11 +19704,29 @@ def start_server(
     build and no SPA mount (mount_spa() honours ``HERMES_SERVE_HEADLESS``), so
     the banner announces the bind rather than a browser URL.
 
+    ``isolated`` marks a server launched with ``--isolated``: it is scoped
+    to a single profile (its own HERMES_HOME) and must not read, mutate,
+    export, or delete another profile's data (enforced by the per-profile
+    guard ``_assert_profile_in_scope`` on the profiles router). The unified
+    machine dashboard (isolated=False) remains a machine-wide management
+    surface.
+
     ``ssh_session_token`` and ``ssh_owner_nonce`` are process-local Desktop SSH
     bootstrap state. Neither is persisted or exported to child processes.
     """
     _apply_ssh_session_token(ssh_session_token or "")
     _apply_ssh_owner_nonce(ssh_owner_nonce)
+    app.state.isolated = bool(isolated)
+    # Capture the canonical launch authority once, as an immutable path. The
+    # isolated scope must be an identity this process was actually launched
+    # with — never re-derived at request time from a string that can alias a
+    # sibling profile ("custom"/"default" sentinels) (#91330 review).
+    if isolated:
+        from hermes_constants import get_hermes_home
+
+        app.state.isolated_scope_dir = get_hermes_home().resolve()
+    else:
+        app.state.isolated_scope_dir = None
 
     # Raise RLIMIT_NOFILE for dashboard-mode starts that don't route through
     # the `serve` path in main.py (which applies the same floor). Canonical

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -300,17 +300,42 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
         try:
             from hermes_cli.profiles import profiles_to_serve
 
-            profile_homes = list(profiles_to_serve(multiplex=True))
-            if len(profile_homes) > 1:
+            if getattr(app.state, "isolated", False):
+                # An isolated backend ticks ONLY its pinned profile's cron
+                # store — never siblings. The multiplex tick is a property
+                # of the machine dashboard / multiplex gateway (#91330
+                # review, consolidation owner). The home is wired
+                # explicitly even for a single profile so the scheduler
+                # targets the canonical pinned store, not an inferred
+                # "active" profile.
+                scope_dir = _isolated_scope_dir()
+                pinned = _profile_name_for_scope(scope_dir)
+                if pinned is None:
+                    _log.warning(
+                        "Isolated backend has no unambiguous scoped profile; cron ticker disabled"
+                    )
+                    return
+                profile_homes = [(pinned, Path(scope_dir))]
                 start_kwargs["profile_homes"] = profile_homes
                 from hermes_logging import enable_profile_log_routing
 
                 enable_profile_log_routing(profile_homes)
                 _log.info(
-                    "Desktop cron scheduler will tick %d profile(s): %s",
-                    len(profile_homes),
+                    "Desktop cron scheduler will tick 1 profile(s): %s",
                     [name for name, _home in profile_homes],
                 )
+            else:
+                profile_homes = list(profiles_to_serve(multiplex=True))
+                if len(profile_homes) > 1:
+                    start_kwargs["profile_homes"] = profile_homes
+                    from hermes_logging import enable_profile_log_routing
+
+                    enable_profile_log_routing(profile_homes)
+                    _log.info(
+                        "Desktop cron scheduler will tick %d profile(s): %s",
+                        len(profile_homes),
+                        [name for name, _home in profile_homes],
+                    )
         except Exception:
             # Fail open to the single-store ticker — the active profile's
             # jobs must keep firing even if profile enumeration breaks.
@@ -3773,7 +3798,23 @@ async def get_status(profile: Optional[str] = None):
     status_scope = None
     # An isolated backend answers only for its pinned profile — explicit
     # sibling selectors 403 before any config/env/gateway read (#91330
-    # review, consolidation owner).
+    # review, consolidation owner). Omitted/"current" also pins to the
+    # scoped profile: the machine-level topology aggregation below must not
+    # enumerate sibling gateway state from an isolated backend.
+    if _is_isolated_server():
+        scope = _isolated_scope_dir()
+        pinned = _profile_name_for_scope(scope)
+        if pinned is None:
+            raise HTTPException(
+                status_code=403,
+                detail="This dashboard is isolated but has no unambiguous scoped profile.",
+            )
+        # Whitespace-only selectors must count as "omitted" too: the clamp
+        # below strips and would otherwise leave requested_profile == "" and
+        # fall into the machine-level aggregation branch (#91381 review).
+        requested_stripped = (profile or "").strip()
+        if not requested_stripped or requested_stripped.lower() in ("all", "current"):
+            profile = pinned
     profile = _clamp_profile_query_for_isolated(profile, allow_all=True)
     requested_profile = (profile or "").strip()
     # Plain /api/status stays the machine-level public liveness probe. The
@@ -3929,6 +3970,13 @@ async def get_status(profile: Optional[str] = None):
         # A ``?profile=`` request targets one profile's view and is left
         # unmerged.
         topology = await run_in_threadpool(_collect_profile_gateway_topology_cached)
+        # Isolated backends: even with the pin above, the final response
+        # publishes topology["profiles"]/["gateway_mode"]/["gateways"]
+        # unconditionally, so narrow the collection itself to the pinned
+        # principal — an isolated server must never publish sibling profile
+        # names, gateway mode, or host ports from a plain no-query
+        # /api/status (reachable pre-auth via PUBLIC_API_PATHS, #76932-class).
+        topology = _scope_topology_for_isolated(topology)
         if not requested_profile:
             gateway_platforms = _merge_profile_gateway_platforms(
                 gateway_platforms, topology.get("profile_platforms") or {}
@@ -12896,6 +12944,22 @@ def _cron_profile_dicts() -> List[Dict[str, Any]]:
     for every profile; polling cron jobs through that path creates avoidable
     GIL pressure on large profile pools.
     """
+    if _is_isolated_server():
+        # Shared aggregation seam: an isolated server's cron surface is its
+        # pinned profile only. The profile-control-plane policy owner lives
+        # here so ``profile=all`` cron reads cannot enumerate siblings
+        # (#91330 review, consolidation owner).
+        scope = _isolated_scope_dir()
+        pinned = _profile_name_for_scope(scope)
+        if pinned is not None:
+            return [
+                {
+                    "name": pinned,
+                    "path": str(scope),
+                    "is_default": pinned == "default",
+                }
+            ]
+        return []
     from hermes_cli import profiles as profiles_mod
     try:
         return [
@@ -12943,7 +13007,23 @@ def _cron_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
         raise HTTPException(status_code=400, detail=str(e))
     if not profiles_mod.profile_exists(canon):
         raise HTTPException(status_code=404, detail=f"Profile '{canon}' does not exist.")
-    return canon, profiles_mod.get_profile_dir(canon)
+    home = profiles_mod.get_profile_dir(canon)
+    if _is_isolated_server() and home.resolve() != _isolated_scope_dir():
+        # Shared resolution seam for session-DB opens and cron routing: an
+        # isolated server may address only its pinned profile. Every
+        # session endpoint (single-session reads/deletes/patch/export) and
+        # cron route resolves the target through here, so the policy owner
+        # denies a sibling selector BEFORE any session DB or cron directory
+        # is opened (#91330 review, consolidation owner).
+        shown = _profile_name_for_scope(_isolated_scope_dir())
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"This dashboard is isolated to '{shown}'. "
+                f"Refusing to access another profile ('{canon}')."
+            ),
+        )
+    return canon, home
 
 
 def _annotate_cron_job(job: Dict[str, Any], profile: str, home: Path) -> Dict[str, Any]:
@@ -15030,120 +15110,57 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
     return profiles
 
 
-def _is_isolated_server() -> bool:
-    """True when this server was launched with ``--isolated``.
+# ---------------------------------------------------------------------------
+# Isolated-profile scope policy — owned by hermes_cli/isolated_scope.py.
+#
+# Re-exported under the legacy underscore names so web_server's own handlers,
+# the web_routers' web_deps.late() proxies, and any
+# ``monkeypatch.setattr(web_server, "<name>", ...)`` keep resolving at call
+# time (the late-binding contract). The substantive policy lives in the
+# focused module; this file keeps only the thin seam (#91381 review).
+# ---------------------------------------------------------------------------
 
-    Threaded from the ``--isolated`` flag through :func:`start_server` into
-    ``app.state.isolated``. Defaults to False so a server that never ran
-    ``start_server`` (e.g. a bare TestClient without the helper setting it)
-    is treated as the unified machine dashboard, which is the safe
-    non-restricting default.
-    """
-    return bool(getattr(app.state, "isolated", False))
+
+def _is_isolated_server() -> bool:
+    """True when this server was launched with ``--isolated`` (see
+    ``hermes_cli.isolated_scope.is_isolated_server``)."""
+    from hermes_cli.isolated_scope import is_isolated_server
+
+    return is_isolated_server()
 
 
 def _isolated_scope_dir() -> Optional[Path]:
-    """The canonical resolved HERMES_HOME this isolated server is scoped to.
+    """Canonical resolved HERMES_HOME this isolated server is scoped to (see
+    ``hermes_cli.isolated_scope.isolated_scope_dir``)."""
+    from hermes_cli.isolated_scope import isolated_scope_dir
 
-    Captured once in :func:`start_server` at launch as an immutable path on
-    ``app.state`` (#91330 review: "capture the canonical isolated launch
-    authority once in start_server() and store that immutable identity/path
-    in app.state"). Falls back to the process's current ``HERMES_HOME`` when
-    ``start_server`` never ran (tests set ``app.state.isolated`` directly);
-    ``get_hermes_home()`` is process-stable so the fallback is deterministic.
-
-    Comparing by *resolved path* rather than profile-name string is exactly
-    what closes the aliasing bypass: ``get_active_profile_name()`` returns the
-    sentinels ``"custom"`` / ``"default"`` for an unrecognized home or a
-    derivation failure, and those strings are also valid real profile names —
-    a name-based equality check could therefore alias an isolated server onto
-    a sibling profile and pass ``_assert_profile_in_scope``.
-    """
-    stored = getattr(app.state, "isolated_scope_dir", None)
-    if stored is not None:
-        return Path(stored).resolve()
-    if not _is_isolated_server():
-        return None
-    from hermes_constants import get_hermes_home
-
-    return get_hermes_home().resolve()
+    return isolated_scope_dir()
 
 
 def _profile_name_for_scope(scope_dir: Optional[Path]) -> Optional[str]:
-    """Map a resolved HERMES_HOME to its profile name, or ``None``.
+    """Map a resolved HERMES_HOME to its profile name or ``None`` (see
+    ``hermes_cli.isolated_scope.profile_name_for_scope``)."""
+    from hermes_cli.isolated_scope import profile_name_for_scope
 
-    Returns ``"default"`` for the root home, the profile name for a home under
-    ``~/.hermes/profiles/<name>``, and ``None`` for any unrecognized/ambiguous
-    home. ``None`` is the fail-closed signal: an isolated server with no
-    unambiguous principal may not prove any named profile is in scope, so it
-    is denied rather than inferred to be one.
-    """
-    if scope_dir is None:
-        return None
-    from hermes_cli import profiles as profiles_mod
-
-    scope = Path(scope_dir).resolve()
-    if scope == profiles_mod._get_default_hermes_home().resolve():
-        return "default"
-    profiles_root = profiles_mod._get_profiles_root().resolve()
-    try:
-        rel = scope.relative_to(profiles_root)
-        if len(rel.parts) == 1 and profiles_mod._PROFILE_ID_RE.match(rel.parts[0]):
-            return rel.parts[0]
-    except ValueError:
-        pass
-    return None
+    return profile_name_for_scope(scope_dir)
 
 
-def _clamp_profile_query_for_isolated(profile: Optional[str], *, allow_all: bool = False) -> Optional[str]:
-    """Clamp or reject a ``profile`` query param against the isolated scope.
+def _scope_topology_for_isolated(topology: Dict[str, Any]) -> Dict[str, Any]:
+    """Narrow a machine-wide ``/api/status`` topology to an isolated server
+    (see ``hermes_cli.isolated_scope.scope_topology_for_isolated``)."""
+    from hermes_cli.isolated_scope import scope_topology_for_isolated
 
-    The unified machine dashboard is intentionally cross-profile and returns
-    ``profile`` unchanged. An isolated server answers only for its pinned
-    profile: ``profile=all`` (a dashboard-sidebar convenience meaning "all
-    sessions for this backend") is clamped to the pinned profile, an explicit
-    sibling selector is rejected with 403 *before any I/O*, and the pinned
-    profile passes through. ``None``/``""``/``"current"`` mean the backend's
-    own profile and pass through unchanged.
+    return scope_topology_for_isolated(topology)
 
-    Identity is the canonical resolved launch path stored on ``app.state`` at
-    :func:`start_server` — never a profile-name string (the ``"custom"`` /
-    ``"default"`` sentinels of ``get_active_profile_name()`` collide with real
-    profile names and would alias a sibling onto the isolation boundary).
-    """
-    if not _is_isolated_server():
-        return profile
-    requested = (profile or "").strip()
-    if not requested or requested.lower() == "current":
-        return profile
-    if allow_all and requested.lower() == "all":
-        # "all sessions" on an isolated backend means "this profile's
-        # sessions", not "every profile on disk".
-        scope = _isolated_scope_dir()
-        name = _profile_name_for_scope(scope)
-        if name is None:
-            raise HTTPException(
-                status_code=403,
-                detail="This dashboard is isolated but has no unambiguous scoped profile.",
-            )
-        return name
 
-    from hermes_cli import profiles as profiles_mod
-    try:
-        requested_canon = profiles_mod.normalize_profile_name(requested)
-        profiles_mod.validate_profile_name(requested_canon)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+def _clamp_profile_query_for_isolated(
+    profile: Optional[str], *, allow_all: bool = False
+) -> Optional[str]:
+    """Clamp or reject a ``profile`` query param against the isolated scope
+    (see ``hermes_cli.isolated_scope.clamp_profile_query_for_isolated``)."""
+    from hermes_cli.isolated_scope import clamp_profile_query_for_isolated
 
-    scope = _isolated_scope_dir()
-    requested_dir = profiles_mod.get_profile_dir(requested_canon).resolve()
-    if scope is not None and scope == requested_dir:
-        return requested_canon
-    shown = _profile_name_for_scope(scope) if scope is not None else "(unknown)"
-    raise HTTPException(
-        status_code=403,
-        detail=f"This dashboard is isolated to '{shown}'; refusing profile '{requested_canon}'.",
-    )
+    return clamp_profile_query_for_isolated(profile, allow_all=allow_all)
 
 
 def _resolve_profile_dir(name: str) -> Path:
@@ -15155,7 +15172,25 @@ def _resolve_profile_dir(name: str) -> Path:
         raise HTTPException(status_code=400, detail=str(e))
     if not profiles_mod.profile_exists(name):
         raise HTTPException(status_code=404, detail=f"Profile '{name}' does not exist.")
-    return profiles_mod.get_profile_dir(name)
+    profile_dir = profiles_mod.get_profile_dir(name)
+    if _is_isolated_server() and profile_dir.resolve() != _isolated_scope_dir():
+        # Shared resolution seam: EVERY route that turns a profile selector
+        # into an on-disk directory funnels through here (_profile_scope,
+        # _config_profile_scope, _profile_cli_args, setup-command, ...). An
+        # isolated server may resolve only its pinned profile by path — the
+        # "custom"/"default" sentinel strings of get_active_profile_name()
+        # are valid real profile ids, so a name comparison would alias a
+        # sibling onto the boundary; the canonical resolved path cannot
+        # (#91330 review, fail-open identity aliasing / consolidation owner).
+        shown = _profile_name_for_scope(_isolated_scope_dir())
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"This dashboard is isolated to '{shown}'. "
+                f"Refusing to resolve another profile ('{name}')."
+            ),
+        )
+    return profile_dir
 
 
 def _profile_setup_command(name: str) -> str:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3605,6 +3605,113 @@ def _collect_profile_gateway_topology() -> Dict[str, Any]:
     }
 
 
+def _collect_single_profile_gateway_topology(
+    name: str, home: Path
+) -> Dict[str, Any]:
+    """Build the ``/api/status`` topology for exactly one pinned profile home.
+
+    An isolated server uses this instead of the machine-wide
+    ``_collect_profile_gateway_topology``: the latter enumerates *every* profile
+    home via ``profiles_to_serve`` and reads each one's ``gateway_state.json``,
+    which on a gated/network bind is pre-auth sibling enumeration
+    (#91381 re-review). The isolation invariant is that an isolated principal
+    must never exercise sibling read authority in the first place — not collect
+    machine-wide and then redact. This scoped collector touches only the
+    pinned ``home``, so the isolation boundary is enforced by *which* data is
+    read, not by post-hoc filtering.
+    """
+    from hermes_cli.profiles import _check_gateway_running
+    from gateway.status import read_runtime_status
+
+    gateways: List[Dict[str, Any]] = []
+    profile_platforms: Dict[str, dict] = {}
+    served: List[str] = []
+    try:
+        running = _check_gateway_running(home)
+    except Exception:
+        running = False
+
+    if running:
+        try:
+            runtime = read_runtime_status(home / "gateway_state.json")
+        except Exception:
+            runtime = None
+        served = [str(p) for p in ((runtime or {}).get("served_profiles") or [])]
+        plats = (runtime or {}).get("platforms")
+        if isinstance(plats, dict) and plats:
+            owned = _owned_profile_platforms(
+                _profile_gateway_writer_identity(home, runtime), plats
+            )
+            if owned:
+                profile_platforms[name] = owned
+        entry: Dict[str, Any] = {
+            "profile": name,
+            "ports": _profile_platform_ports(home, runtime),
+        }
+        if served:
+            entry["served_profiles"] = served
+        gateways.append(entry)
+
+    # Multiplex detection reads only the pinned gateway's OWN runtime status
+    # (served_profiles from its home) — not sibling enumeration — so an
+    # isolated default-profile multiplex gateway still reports "multiplex"
+    # rather than "single" (#91381 re-review, codex P2).
+    if name == "default" and len(served) > 1:
+        mode = "multiplex"
+    elif len(gateways) > 1:
+        mode = "multiple"
+    elif len(gateways) == 1:
+        mode = "single"
+    else:
+        mode = "none"
+
+    return {
+        "profiles": [name],
+        "gateway_mode": mode,
+        "gateways": gateways,
+        "profile_platforms": profile_platforms,
+    }
+
+
+# /api/status is polled ~1/s by the desktop app while it waits for the backend
+# (and again by the dashboard badge). The machine-wide collector is cached for
+# exactly that reason (#_TOPOLOGY_CACHE_TTL below — concurrent polls piling up
+# on profile-home walks starve the event loop). The isolated scoped collector
+# reads only one profile home, so it is cheap, but it is still real file/psutil
+# I/O on a high-frequency route; cache it the same way, keyed by the pinned
+# home so an isolated server never re-scans its own home on every poll
+# (#91381 re-review P2).
+_SCOPED_TOPOLOGY_CACHE: Dict[str, Any] = {"ts": 0.0, "home": None, "data": None}
+_SCOPED_TOPOLOGY_CACHE_TTL = 10.0
+
+
+def _collect_single_profile_gateway_topology_cached(
+    name: str, home: Path
+) -> Dict[str, Any]:
+    """Cached wrapper around :func:`_collect_single_profile_gateway_topology`.
+
+    Keyed by the pinned home so the (single, process-stable) isolated scope
+    reuses one 10s entry instead of re-walking the profile home on every
+    desktop status poll. Shares the topology cache lock so a concurrent
+    isolated and machine-wide collection cannot interleave.
+    """
+    key = str(home)
+    now = time.monotonic()
+    entry = _SCOPED_TOPOLOGY_CACHE
+    if entry["home"] == key and entry["data"] is not None and now - entry["ts"] < _SCOPED_TOPOLOGY_CACHE_TTL:
+        return entry["data"]
+    with _TOPOLOGY_CACHE_LOCK:
+        entry = _SCOPED_TOPOLOGY_CACHE
+        now = time.monotonic()
+        if entry["home"] == key and entry["data"] is not None and now - entry["ts"] < _SCOPED_TOPOLOGY_CACHE_TTL:
+            return entry["data"]
+        data = _collect_single_profile_gateway_topology(name, home)
+        _SCOPED_TOPOLOGY_CACHE["home"] = key
+        _SCOPED_TOPOLOGY_CACHE["data"] = data
+        _SCOPED_TOPOLOGY_CACHE["ts"] = now
+        return data
+
+
 # /api/status is polled ~1/s by the desktop app while it waits for the backend
 # (and again by the dashboard badge). Each uncached call above walks 7+ profile
 # homes (yaml.safe_load with the pure-Python loader + psutil process-table
@@ -3969,14 +4076,20 @@ async def get_status(profile: Optional[str] = None):
         # ``<profile>:<platform>`` grammar so fleet health sees them (OOF-3).
         # A ``?profile=`` request targets one profile's view and is left
         # unmerged.
-        topology = await run_in_threadpool(_collect_profile_gateway_topology_cached)
-        # Isolated backends: even with the pin above, the final response
-        # publishes topology["profiles"]/["gateway_mode"]/["gateways"]
-        # unconditionally, so narrow the collection itself to the pinned
-        # principal — an isolated server must never publish sibling profile
-        # names, gateway mode, or host ports from a plain no-query
-        # /api/status (reachable pre-auth via PUBLIC_API_PATHS, #76932-class).
-        topology = _scope_topology_for_isolated(topology)
+        if _is_isolated_server():
+            # Isolation invariant (#91381 re-review): an isolated principal
+            # must never exercise sibling read authority — not run the
+            # machine-wide collector and then redact. Use the scoped
+            # collector that reads ONLY the pinned profile's home, so the
+            # plain no-query /api/status (pre-auth via PUBLIC_API_PATHS,
+            # #76932-class) cannot enumerate sibling profile names, gateway
+            # mode, or host ports in the first place.
+            topology = await run_in_threadpool(
+                _collect_single_profile_gateway_topology_cached, pinned, scope
+            )
+        else:
+            topology = await run_in_threadpool(_collect_profile_gateway_topology_cached)
+            topology = _scope_topology_for_isolated(topology)
         if not requested_profile:
             gateway_platforms = _merge_profile_gateway_platforms(
                 gateway_platforms, topology.get("profile_platforms") or {}

--- a/tests/hermes_cli/test_web_profile_soul_writes.py
+++ b/tests/hermes_cli/test_web_profile_soul_writes.py
@@ -13,6 +13,7 @@ small and focused on this one endpoint pair.
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import stat
 import sys
@@ -700,3 +701,243 @@ class TestIsolatedAggregateScope:
         assert all_ok.status_code == 200, all_ok.text
         assert sibling.status_code == 403, sibling.text
         assert msg_sibling.status_code == 403, msg_sibling.text
+
+    def test_status_omitted_and_current_pin_to_scoped_profile(self, tmp_path, monkeypatch):
+        """An isolated server's /api/status with an omitted or ``current``
+        profile must pin to the scoped profile, not fall through to the
+        machine-level topology aggregation that enumerates sibling gateway
+        state (#91381 review, consolidation owner)."""
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            omitted = c.get("/api/status")
+            current = c.get("/api/status?profile=current")
+            whitespace = c.get("/api/status?profile=%20%20")
+
+        # All three resolve to the pinned profile (200) rather than erroring
+        # or fanning out machine-wide; the sibling selector still 403s. The
+        # whitespace form is the same class as omitted: the clamp would strip
+        # it to "" and fall into the machine-wide branch, so the pin must
+        # treat it as omitted too (#91381 review).
+        assert omitted.status_code == 200, omitted.text
+        assert current.status_code == 200, current.text
+        assert whitespace.status_code == 200, whitespace.text
+
+    def test_env_config_sibling_403_via_shared_scope(self, tmp_path, monkeypatch):
+        """Sibling selectors on env/config/skills routes 403 through the
+        shared ``_resolve_profile_dir`` seam — the policy owner, not a
+        per-handler bolt-on (#91381 review, consolidation owner)."""
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        (profiles_root / "bob" / ".env").write_text("BOB_SECRET=1\n", encoding="utf-8")
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            env = c.get("/api/env?profile=bob")
+            cfg = c.get("/api/config?profile=bob")
+            update = c.put("/api/config?profile=bob", json={"config": {}})
+
+        assert env.status_code == 403, env.text
+        assert cfg.status_code == 403, cfg.text
+        assert update.status_code == 403, update.text
+
+    def test_cron_aggregation_pinned_only_and_sibling_403(self, tmp_path, monkeypatch):
+        """The cron aggregation seam narrows ``profile=all`` to the pinned
+        profile and rejects explicit siblings before any cron I/O."""
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        bob = profiles_root / "bob"
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            all_ok = c.get("/api/cron/jobs?profile=all")
+            sibling = c.get("/api/cron/jobs?profile=bob")
+
+        assert all_ok.status_code == 200, all_ok.text
+        assert isinstance(all_ok.json(), list)
+        # Bottleneck check: the aggregation seam must never enumerate Bob.
+        assert sibling.status_code == 403, sibling.text
+
+    def test_status_without_profile_pinned_not_machinewide(self, tmp_path, monkeypatch):
+        """An isolated backend must NOT fall into the machine-level status
+        topology aggregation when the profile param is omitted — it pins to
+        its scoped profile instead (#91381 review, P1)."""
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        (alice / "gateway_state.json").write_text(
+            '{"gateway_state": "running", "platforms": {}}', encoding="utf-8"
+        )
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            bare = c.get("/api/status")
+            explicit = c.get("/api/status?profile=alice")
+            sibling = c.get("/api/status?profile=bob")
+
+        assert bare.status_code == 200, bare.text
+        assert explicit.status_code == 200, explicit.text
+        # The sibling selector must fail before any sibling runtime read.
+        assert sibling.status_code == 403, sibling.text
+
+    def test_cron_ticker_pinned_only_when_isolated(self, monkeypatch, tmp_path):
+        """The desktop cron ticker on an isolated backend ticks only the
+        pinned profile — never sibling stores (#91381 review, P1)."""
+        import threading
+
+        from hermes_cli import web_server
+
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        alice = profiles_root / "alice"
+        alice.mkdir(parents=True, exist_ok=True)
+        bob_sentinel = profiles_root / "bob"
+        bob_sentinel.mkdir(parents=True, exist_ok=True)
+        # The ticker resolves the pinned profile name against the profiles
+        # root, so HERMES_HOME must point at the seeded home or the canonical
+        # scope never matches and the ticker is disabled.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "soul-test-token")
+
+        from cron import scheduler_provider
+        from hermes_cli import profiles as profiles_mod
+
+        multiplex_served = []
+
+        def fake_profiles_to_serve(*a, **k):
+            multiplex_served.append(list(profiles_mod._raw_profiles_to_serve(*a, **k)))
+            return multiplex_served[-1]
+
+        events = []
+        real_resolve = scheduler_provider.resolve_cron_scheduler
+
+        class _FakeProvider:
+            name = "fake"
+
+            def __init__(self, *a, **k):
+                pass
+
+            def start(self, stop_event, **kwargs):
+                events.append(("start", kwargs.get("interval")))
+                if kwargs.get("profile_homes"):
+                    events.append(("homes", [str(h) for h in kwargs["profile_homes"]]))
+
+        def fake_resolve(*a, **k):
+            return _FakeProvider()
+
+        monkeypatch.setattr(
+            profiles_mod, "profiles_to_serve", fake_profiles_to_serve
+        )
+        monkeypatch.setattr(scheduler_provider, "resolve_cron_scheduler", fake_resolve)
+        monkeypatch.setattr(
+            scheduler_provider, "InProcessCronScheduler", _FakeProvider
+        )
+
+        prev = getattr(web_server.app.state, "isolated", None)
+        had = hasattr(web_server.app.state, "isolated")
+        prev_scope = getattr(web_server.app.state, "isolated_scope_dir", None)
+        had_scope = hasattr(web_server.app.state, "isolated_scope_dir")
+        web_server.app.state.isolated = True
+        web_server.app.state.isolated_scope_dir = alice.resolve()
+        try:
+            stop = threading.Event()
+            web_server._start_desktop_cron_ticker(stop)
+        finally:
+            if had:
+                web_server.app.state.isolated = prev
+            else:
+                delattr(web_server.app.state, "isolated")
+            if had_scope:
+                web_server.app.state.isolated_scope_dir = prev_scope
+            else:
+                delattr(web_server.app.state, "isolated_scope_dir")
+
+        assert len(multiplex_served) == 0, "isolated ticker must not enumerate siblings"
+        homes = [h for e, h in events if e == "homes"]
+        assert homes, f"ticker never started with homes: {events}"
+        all_homes = [str(h) for lst in homes for h in lst[0]] if homes and isinstance(homes[0][0], list) else [h for lst in homes for h in lst]
+        assert any("alice" in h for h in all_homes), f"alice missing from ticker homes: {all_homes}"
+        assert not any("bob" in h for h in all_homes), f"bob leaked into ticker homes: {all_homes}"
+
+    def test_single_session_sibling_403_via_db_seam(self, tmp_path, monkeypatch):
+        """Single-session routes resolve through ``_cron_profile_home`` —
+        an explicit sibling selector 403s there before any state.db open."""
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        opened = self._opened_db_paths(monkeypatch, tmp_path)
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            r = c.get("/api/sessions/whatever-id?profile=bob")
+
+        assert r.status_code == 403, r.text
+        assert not any("bob" in p for p in opened), f"Bob's DB opened: {opened}"
+
+    def test_status_no_query_isolated_scopes_topology(self, tmp_path, monkeypatch):
+        """Unit-level witness for the post-collection scope filter: even when
+        the machine-wide topology collector runs, a plain no-query /api/status
+        on an isolated server must publish only the pinned profile's names,
+        ports, and platforms (#91381 review)."""
+        from hermes_cli import web_server
+
+        def _machine_wide_topology():
+            return {
+                "profiles": ["alice", "bob", "default"],
+                "gateway_mode": "multiple",
+                "gateways": [
+                    {"profile": "alice", "ports": [4000]},
+                    {"profile": "bob", "ports": [4001]},
+                    {"profile": "default", "ports": [4002]},
+                ],
+                "profile_platforms": {
+                    "alice": {"telegram": {"state": "connected"}},
+                    "bob": {"discord": {"state": "connected"}},
+                },
+            }
+
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        monkeypatch.setattr(
+            web_server, "_collect_profile_gateway_topology", _machine_wide_topology
+        )
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            r = c.get("/api/status")
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        # Only the pinned profile's name/ports/platforms surface.
+        assert body["profiles"] == ["alice"], f"leaked: {body['profiles']}"
+        assert body["gateways"] == [{"profile": "alice", "ports": [4000]}]
+        assert "bob" not in json.dumps(body), f"bob leaked into /api/status: {body}"
+        leaked_platforms = [
+            k for k in body.get("gateway_platforms", {}) if "bob" in str(k)
+        ]
+        assert not leaked_platforms, f"bob platforms leaked: {leaked_platforms}"
+        assert "default" not in body["profiles"]
+
+    def test_status_no_query_non_isolated_machine_wide(self, tmp_path, monkeypatch):
+        """Control: with isolation off, plain /api/status keeps reporting the
+        full machine-wide topology (the unified machine dashboard is
+        intentionally cross-profile)."""
+        from hermes_cli import web_server
+
+        def _machine_wide_topology():
+            return {
+                "profiles": ["alice", "bob", "default"],
+                "gateway_mode": "multiple",
+                "gateways": [
+                    {"profile": "alice", "ports": [4000]},
+                    {"profile": "bob", "ports": [4001]},
+                ],
+                "profile_platforms": {},
+            }
+
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        monkeypatch.setattr(
+            web_server, "_collect_profile_gateway_topology", _machine_wide_topology
+        )
+
+        with self._client(monkeypatch, isolated=False, hermes_home=str(alice)) as c:
+            r = c.get("/api/status")
+
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["profiles"] == ["alice", "bob", "default"], body["profiles"]
+        assert len(body["gateways"]) == 2

--- a/tests/hermes_cli/test_web_profile_soul_writes.py
+++ b/tests/hermes_cli/test_web_profile_soul_writes.py
@@ -868,38 +868,51 @@ class TestIsolatedAggregateScope:
         assert r.status_code == 403, r.text
         assert not any("bob" in p for p in opened), f"Bob's DB opened: {opened}"
 
-    def test_status_no_query_isolated_scopes_topology(self, tmp_path, monkeypatch):
-        """Unit-level witness for the post-collection scope filter: even when
-        the machine-wide topology collector runs, a plain no-query /api/status
-        on an isolated server must publish only the pinned profile's names,
-        ports, and platforms (#91381 review)."""
+    def test_status_no_query_isolated_uses_scoped_collector(self, tmp_path, monkeypatch):
+        """Unit-level witness for the isolation invariant (#91381 re-review,
+        P1): a plain no-query /api/status on an isolated server must NOT run
+        the machine-wide topology collector at all — it reads only the pinned
+        profile's home through the scoped collector. This test FAILS if
+        sibling topology I/O (the machine-wide cached collector) is invoked
+        for an isolated /api/status."""
         from hermes_cli import web_server
 
-        def _machine_wide_topology():
+        machine_wide_called = []
+
+        def _machine_wide_must_not_run():
+            machine_wide_called.append(True)
+            raise AssertionError(
+                "machine-wide topology collector invoked on isolated /api/status"
+            )
+
+        def _scoped(name, home):
             return {
-                "profiles": ["alice", "bob", "default"],
-                "gateway_mode": "multiple",
-                "gateways": [
-                    {"profile": "alice", "ports": [4000]},
-                    {"profile": "bob", "ports": [4001]},
-                    {"profile": "default", "ports": [4002]},
-                ],
-                "profile_platforms": {
-                    "alice": {"telegram": {"state": "connected"}},
-                    "bob": {"discord": {"state": "connected"}},
-                },
+                "profiles": [name],
+                "gateway_mode": "single",
+                "gateways": [{"profile": name, "ports": [4000]}],
+                "profile_platforms": {name: {"telegram": {"state": "connected"}}},
             }
+
+        monkeypatch.setattr(
+            web_server, "_collect_profile_gateway_topology_cached",
+            _machine_wide_must_not_run,
+        )
+        monkeypatch.setattr(
+            web_server, "_collect_single_profile_gateway_topology_cached", _scoped
+        )
 
         profiles_root = self._seed(tmp_path)
         alice = profiles_root / "alice"
-        monkeypatch.setattr(
-            web_server, "_collect_profile_gateway_topology", _machine_wide_topology
-        )
 
         with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
             r = c.get("/api/status")
 
         assert r.status_code == 200, r.text
+        # The machine-wide collector must never run on an isolated plain
+        # /api/status — that is the point of the scoped collector.
+        assert not machine_wide_called, (
+            "isolated /api/status must not enumerate sibling topology"
+        )
         body = r.json()
         # Only the pinned profile's name/ports/platforms surface.
         assert body["profiles"] == ["alice"], f"leaked: {body['profiles']}"
@@ -910,6 +923,42 @@ class TestIsolatedAggregateScope:
         ]
         assert not leaked_platforms, f"bob platforms leaked: {leaked_platforms}"
         assert "default" not in body["profiles"]
+
+    def test_status_isolated_scoped_collector_cached(self, tmp_path, monkeypatch):
+        """The isolated scoped topology collector is cached (TTL), so repeated
+        desktop polls don't re-walk the pinned profile home on every request
+        (#91381 re-review P2)."""
+        from hermes_cli import web_server
+
+        # Reset any scoped-cache entry a prior test may have left for this home.
+        web_server._SCOPED_TOPOLOGY_CACHE["home"] = None
+        web_server._SCOPED_TOPOLOGY_CACHE["data"] = None
+        web_server._SCOPED_TOPOLOGY_CACHE["ts"] = 0.0
+
+        calls = []
+
+        def _scoped(name, home):
+            calls.append(name)
+            return {
+                "profiles": [name],
+                "gateway_mode": "single",
+                "gateways": [{"profile": name, "ports": [4000]}],
+                "profile_platforms": {},
+            }
+
+        monkeypatch.setattr(
+            web_server, "_collect_single_profile_gateway_topology", _scoped
+        )
+
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            for _ in range(3):
+                r = c.get("/api/status")
+                assert r.status_code == 200, r.text
+
+        assert calls == ["alice"], f"scoped collector re-ran per poll: {calls}"
 
     def test_status_no_query_non_isolated_machine_wide(self, tmp_path, monkeypatch):
         """Control: with isolation off, plain /api/status keeps reporting the

--- a/tests/hermes_cli/test_web_profile_soul_writes.py
+++ b/tests/hermes_cli/test_web_profile_soul_writes.py
@@ -12,6 +12,7 @@ small and focused on this one endpoint pair.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import stat
 import sys
@@ -31,6 +32,13 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "soul-test-token")
     from hermes_cli import web_server
+
+    # Pin the resolved token too: _SESSION_TOKEN is resolved at import time, so
+    # a later module-level ``import hermes_cli.web_server`` in another test file
+    # can freeze it to a different value before this fixture runs. Patching the
+    # module attribute (rather than only the env var) makes these tests
+    # order-independent within the process.
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", "soul-test-token")
 
     with TestClient(web_server.app, raise_server_exceptions=False) as c:
         c.headers["Authorization"] = "Bearer soul-test-token"
@@ -129,3 +137,566 @@ class TestSoulWriteDurability:
         assert r.status_code == 200, r.text
         mode = stat.S_IMODE(soul.stat().st_mode)
         assert mode == 0o644, f"first save created SOUL.md as {oct(mode)}"
+
+
+class TestIsolatedProfileSoulScope:
+    """An isolated (``--isolated``) dashboard scoped to one named profile must
+    not read or write another profile's SOUL.md (#91330).
+
+    The unified machine dashboard is intentionally a machine-wide management
+    surface (cross-profile access is by design). But a server launched with
+    ``--isolated`` from a named profile runs scoped to that profile, and
+    letting it rewrite another profile's persona is a prompt-injection vector.
+    """
+
+    @pytest.fixture()
+    def isolated_home(self, tmp_path, monkeypatch):
+        """A hermes root with two real profiles; server scoped to ``alice``."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        for p in ("alice", "bob"):
+            (profiles_root / p).mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(profiles_root / "alice"))
+        return profiles_root
+
+    @contextlib.contextmanager
+    def _client(self, monkeypatch, *, isolated: bool):
+        """A TestClient with the shared app scoped as isolated or not.
+
+        ``app.state.isolated`` is a process-global; snapshot it and restore it
+        on exit so an isolated test can't leak into a later non-isolated test
+        in the same process (its only default is when the attribute is never
+        set at all).
+        """
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "soul-test-token")
+        from hermes_cli import web_server
+
+        prev = getattr(web_server.app.state, "isolated", None)
+        had = hasattr(web_server.app.state, "isolated")
+        web_server.app.state.isolated = isolated
+        c = TestClient(web_server.app, raise_server_exceptions=False)
+        c.headers["Authorization"] = "Bearer soul-test-token"
+        try:
+            with c:
+                yield c
+        finally:
+            if had:
+                web_server.app.state.isolated = prev
+            else:
+                delattr(web_server.app.state, "isolated")
+
+    def test_cross_profile_soul_write_refused(self, isolated_home, monkeypatch):
+        bob = isolated_home / "bob"
+        (bob / "SOUL.md").write_text("# Bob's persona\n", encoding="utf-8")
+        before = (bob / "SOUL.md").read_text(encoding="utf-8")
+
+        with self._client(monkeypatch, isolated=True) as c:
+            r = c.put("/api/profiles/bob/soul", json={"content": "# Pwned\n"})
+
+        assert r.status_code == 403, r.text
+        # Bob's persona must be untouched.
+        assert (bob / "SOUL.md").read_text(encoding="utf-8") == before
+
+    def test_cross_profile_soul_read_refused(self, isolated_home, monkeypatch):
+        (isolated_home / "bob" / "SOUL.md").write_text("# Bob\n", encoding="utf-8")
+
+        with self._client(monkeypatch, isolated=True) as c:
+            r = c.get("/api/profiles/bob/soul")
+
+        assert r.status_code == 403, r.text
+
+    def test_isolated_default_profile_blocks_named_profiles(
+        self, tmp_path, monkeypatch
+    ):
+        """An isolated server scoped to the DEFAULT profile must still refuse
+        cross-profile persona access (#91330 P1)."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        bob = profiles_root / "bob"
+        bob.mkdir(parents=True, exist_ok=True)
+        (bob / "SOUL.md").write_text("# Bob\n", encoding="utf-8")
+        # Isolated server running as the default (root) profile.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        with self._client(monkeypatch, isolated=True) as c:
+            r = c.put("/api/profiles/bob/soul", json={"content": "# nope\n"})
+
+        assert r.status_code == 403, r.text
+        assert (bob / "SOUL.md").read_text(encoding="utf-8") == "# Bob\n"
+
+    def test_same_profile_soul_still_works(self, isolated_home, monkeypatch):
+        with self._client(monkeypatch, isolated=True) as c:
+            put = c.put("/api/profiles/alice/soul", json={"content": SOUL})
+            get = c.get("/api/profiles/alice/soul")
+
+        assert put.status_code == 200, put.text
+        assert get.status_code == 200, get.text
+        assert get.json()["content"] == SOUL
+
+    def test_machine_dashboard_keeps_cross_profile_access(self, tmp_path, monkeypatch):
+        """Control: the default machine dashboard is intentionally machine-wide
+        and must not start refusing cross-profile SOUL edits."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        bob = profiles_root / "bob"
+        bob.mkdir(parents=True, exist_ok=True)
+        # Machine dashboard runs from the root home, NOT isolated.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        with self._client(monkeypatch, isolated=False) as c:
+            r = c.put("/api/profiles/bob/soul", json={"content": "# ok\n"})
+
+        assert r.status_code == 200, r.text
+        assert (bob / "SOUL.md").read_text(encoding="utf-8") == "# ok\n"
+
+    def test_cross_profile_endpoints_gated_in_isolated(self, isolated_home, monkeypatch):
+        """DELETE/rename/model/export for another profile are refused from an
+        isolated server — the full isolation boundary, not just SOUL.md."""
+        (isolated_home / "bob" / "SOUL.md").write_text("# Bob\n", encoding="utf-8")
+
+        with self._client(monkeypatch, isolated=True) as c:
+            d = c.delete("/api/profiles/bob")
+            x = c.post("/api/profiles/bob/export", json={})
+
+        assert d.status_code == 403, d.text
+        assert x.status_code == 403, x.text
+
+    def test_create_with_clone_from_sibling_refused(self, isolated_home, monkeypatch):
+        """Adversarial witness (#91330 review, stop-the-line bypass): an
+        isolated server must not read a sibling profile through
+        ``POST /api/profiles`` ``clone_from`` — cloning copies the source's
+        config/.env/SOUL/skills into a new profile the client controls."""
+        bob = isolated_home / "bob"
+        bob.mkdir(parents=True, exist_ok=True)
+        sentinel = "SECRET_SENTINEL_NEVER_COPY_ME=1\n"
+        (bob / ".env").write_text(sentinel, encoding="utf-8")
+        (bob / "SOUL.md").write_text("# Bob\n", encoding="utf-8")
+
+        with self._client(monkeypatch, isolated=True) as c:
+            r = c.post(
+                "/api/profiles",
+                json={"name": "evil", "clone_from": "bob"},
+            )
+
+        assert r.status_code == 403, r.text
+        # No destination profile was created...
+        assert not (isolated_home / "evil").exists()
+        # ...and the sentinel never left Bob.
+        found = [str(p) for p in isolated_home.rglob("*") if p.is_file() and sentinel in p.read_text(encoding="utf-8", errors="ignore")]
+        assert found == [str(bob / ".env")], f"sentinel leaked to: {found}"
+
+    def test_create_clone_all_implicit_default_refused(self, tmp_path, monkeypatch):
+        """The implicit clone-all source ('default') is also authority-bearing:
+        an isolated server scoped to a named profile must not full-copy the
+        machine default profile without ever naming it."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        profiles_root = hermes_root / "profiles"
+        default_profile = hermes_root  # root HERMES_HOME *is* the default profile
+        sentinel = "DEFAULT_SECRET_SENTINEL=1\n"
+        (default_profile / ".env").write_text(sentinel, encoding="utf-8")
+        (profiles_root / "alice").mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(profiles_root / "alice"))
+
+        with self._client(monkeypatch, isolated=True) as c:
+            r = c.post("/api/profiles", json={"name": "evil", "clone_all": True})
+
+        assert r.status_code == 403, r.text
+        assert not (profiles_root / "evil").exists()
+
+    def test_import_refused_when_isolated(self, isolated_home, monkeypatch):
+        """Archive import creates a full profile directory — machine-global
+        control-plane mutation, refused on an isolated server."""
+        with self._client(monkeypatch, isolated=True) as c:
+            r = c.post("/api/profiles/import", json={"archive": "/tmp/nope.tar.gz"})
+
+        assert r.status_code == 403, r.text
+
+    def test_active_switch_refused_when_isolated(self, isolated_home, monkeypatch):
+        """Switching the machine-wide active profile regains authority over
+        other profiles' CLI/gateway routing — refused when isolated."""
+        with self._client(monkeypatch, isolated=True) as c:
+            r = c.post("/api/profiles/active", json={"name": "bob"})
+
+        assert r.status_code == 403, r.text
+
+    def test_control_plane_works_on_machine_dashboard(self, tmp_path, monkeypatch):
+        """Control: the unified machine dashboard keeps profile creation and
+        active-profile switching (intentional machine-wide management)."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        profiles_root.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        with self._client(monkeypatch, isolated=False) as c:
+            r = c.post("/api/profiles", json={"name": "fresh"})
+
+        assert r.status_code == 200, r.text
+
+    def test_cross_profile_endpoints_work_on_machine_dashboard(
+        self, tmp_path, monkeypatch
+    ):
+        """Control: the unified machine dashboard keeps cross-profile
+        management (delete/export) — the boundary only bites when isolated."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        (profiles_root / "bob").mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        with self._client(monkeypatch, isolated=False) as c:
+            d = c.delete("/api/profiles/bob")
+
+        # Machine dashboard may delete another profile.
+        assert d.status_code == 200, d.text
+        assert not (profiles_root / "bob").exists()
+
+class TestIsolatedIdentityAliasing:
+    """Adversarial witnesses for the fail-open identity-aliasing repair
+    (#91330 review, re-review 2026-08-31).
+
+    ``get_active_profile_name()`` returns the ordinary strings ``"custom"``
+    (unrecognized HERMES_HOME) and ``"default"`` (derivation failure), and both
+    are valid real profile ids. The isolation guard must therefore authorize by
+    canonical *resolved path*, never by a profile-name string: a server with an
+    unrecognized home must not be able to prove any named sibling is in scope.
+    """
+
+    @contextlib.contextmanager
+    def _client(self, monkeypatch, *, isolated: bool, hermes_home: str):
+        """A TestClient with the shared app scoped as isolated or not, with an
+        explicit launch home (the canonical authority start_server stores)."""
+        monkeypatch.setenv("HERMES_HOME", hermes_home)
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "soul-test-token")
+        from hermes_cli import web_server
+        from hermes_constants import get_hermes_home
+
+        prev = getattr(web_server.app.state, "isolated", None)
+        had = hasattr(web_server.app.state, "isolated")
+        prev_scope = getattr(web_server.app.state, "isolated_scope_dir", None)
+        had_scope = hasattr(web_server.app.state, "isolated_scope_dir")
+        web_server.app.state.isolated = isolated
+        web_server.app.state.isolated_scope_dir = get_hermes_home().resolve()
+        c = TestClient(web_server.app, raise_server_exceptions=False)
+        c.headers["Authorization"] = "Bearer soul-test-token"
+        try:
+            with c:
+                yield c
+        finally:
+            if had:
+                web_server.app.state.isolated = prev
+            else:
+                delattr(web_server.app.state, "isolated")
+            if had_scope:
+                web_server.app.state.isolated_scope_dir = prev_scope
+            else:
+                delattr(web_server.app.state, "isolated_scope_dir")
+
+    def test_unrecognized_home_cannot_alias_onto_profile_named_custom(
+        self, tmp_path, monkeypatch
+    ):
+        """A real profile literally named ``custom`` must NOT become
+        reachable just because ``get_active_profile_name()`` returns the
+        ``"custom"`` sentinel for an unrecognized launch home."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        custom = profiles_root / "custom"
+        custom.mkdir(parents=True, exist_ok=True)
+        (custom / "SOUL.md").write_text("# Real custom profile\n", encoding="utf-8")
+        (custom / ".env").write_text("REAL_CUSTOM_SECRET=1\n", encoding="utf-8")
+        # Launch home is an arbitrary directory that is neither the default
+        # root (~/.hermes) nor a  ~/.hermes/profiles/<name> path. The runtime
+        # identifies such a home with the sentinel "custom" — the same string
+        # as this real profile's id. Force the sentinel to make the witness
+        # explicit even if resolution internals change.
+        tenant_home = tmp_path / ".hermes" / "tenant-a"
+        tenant_home.mkdir(parents=True, exist_ok=True)
+        import hermes_cli.profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "custom")
+
+        with self._client(
+            monkeypatch, isolated=True, hermes_home=str(tenant_home)
+        ) as c:
+            r = c.get("/api/profiles/custom/soul")
+
+        assert r.status_code == 403, r.text
+        # The real profile's data must be untouched either way.
+        assert (custom / "SOUL.md").read_text(encoding="utf-8") == "# Real custom profile\n"
+
+        with self._client(
+            monkeypatch, isolated=True, hermes_home=str(tenant_home)
+        ) as c:
+            x = c.post("/api/profiles/custom/export", json={})
+
+        assert x.status_code == 403, x.text
+
+    def test_derivation_failure_cannot_alias_onto_default(
+        self, tmp_path, monkeypatch
+    ):
+        """A scope-derivation exception must not silently authorize requests
+        for ``default`` (the old ``_current_profile_name`` fallback returned
+        the string ``"default"``, which is a real profile id)."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        (profiles_root).mkdir(parents=True, exist_ok=True)
+        tenant_home = tmp_path / ".hermes" / "tenant-b"
+        tenant_home.mkdir(parents=True, exist_ok=True)
+        import hermes_cli.profiles as profiles_mod
+
+        def boom():
+            raise RuntimeError("active-profile derivation failed")
+
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", boom)
+
+        with self._client(
+            monkeypatch, isolated=True, hermes_home=str(tenant_home)
+        ) as c:
+            r = c.get("/api/profiles/default/soul")
+
+        assert r.status_code == 403, r.text
+
+    def test_same_profile_still_succeeds_by_path(self, tmp_path, monkeypatch):
+        """Control: a request for the exact profile the server was launched
+        with still succeeds (path equality), even when the name string would
+        be a sentinel in the old scheme."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        alice = profiles_root / "alice"
+        alice.mkdir(parents=True, exist_ok=True)
+        import hermes_cli.profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "alice")
+
+        with self._client(
+            monkeypatch, isolated=True, hermes_home=str(alice)
+        ) as c:
+            put = c.put("/api/profiles/alice/soul", json={"content": SOUL})
+            get = c.get("/api/profiles/alice/soul")
+
+        assert put.status_code == 200, put.text
+        assert get.status_code == 200, get.text
+        assert get.json()["content"] == SOUL
+
+    def test_machine_dashboard_unaffected(self, tmp_path, monkeypatch):
+        """Control: with isolation off (the unified machine dashboard), the
+        same custom-named profile stays reachable — the boundary only bites
+        when --isolated is set."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        custom = profiles_root / "custom"
+        custom.mkdir(parents=True, exist_ok=True)
+        import hermes_cli.profiles as profiles_mod
+
+        monkeypatch.setattr(profiles_mod, "get_active_profile_name", lambda: "custom")
+
+        with self._client(
+            monkeypatch, isolated=False, hermes_home=str(tmp_path / ".hermes")
+        ) as c:
+            put = c.put("/api/profiles/custom/soul", json={"content": SOUL})
+
+        assert put.status_code == 200, put.text
+        assert (custom / "SOUL.md").read_text(encoding="utf-8") == SOUL
+
+
+class TestIsolatedAggregateScope:
+    """Alice/Bob matrix for the aggregate + list read surfaces (#91330 review,
+    re-review 2026-08-31): an isolated server pinned to Alice must narrow every
+    aggregate/list read to Alice, 403 explicit sibling selectors BEFORE any
+    I/O, and never open Bob's ``state.db``."""
+
+    @contextlib.contextmanager
+    def _client(self, monkeypatch, *, isolated: bool, hermes_home: str):
+        monkeypatch.setenv("HERMES_HOME", hermes_home)
+        monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "soul-test-token")
+        from hermes_cli import web_server
+        from hermes_constants import get_hermes_home
+
+        prev = getattr(web_server.app.state, "isolated", None)
+        had = hasattr(web_server.app.state, "isolated")
+        prev_scope = getattr(web_server.app.state, "isolated_scope_dir", None)
+        had_scope = hasattr(web_server.app.state, "isolated_scope_dir")
+        web_server.app.state.isolated = isolated
+        web_server.app.state.isolated_scope_dir = get_hermes_home().resolve()
+        c = TestClient(web_server.app, raise_server_exceptions=False)
+        c.headers["Authorization"] = "Bearer soul-test-token"
+        try:
+            with c:
+                yield c
+        finally:
+            if had:
+                web_server.app.state.isolated = prev
+            else:
+                delattr(web_server.app.state, "isolated")
+            if had_scope:
+                web_server.app.state.isolated_scope_dir = prev_scope
+            else:
+                delattr(web_server.app.state, "isolated_scope_dir")
+
+    def _opened_db_paths(self, monkeypatch, tmp_path):
+        """Record every state.db the routes open via a fake SessionDB."""
+        import hermes_state
+
+        opened = []
+
+        class _FakeDB:
+            def __init__(self, db_path, read_only=False):
+                opened.append(str(db_path))
+
+            def list_sessions_rich(self, **kwargs):
+                return []
+
+            def session_count(self, **kwargs):
+                return 0
+
+            def usage_totals(self):
+                return {}
+
+            def find_pr_url_messages(self, ids):
+                return []
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(hermes_state, "SessionDB", _FakeDB)
+        return opened
+
+    def _seed(self, tmp_path):
+        profiles_root = tmp_path / ".hermes" / "profiles"
+        for name in ("alice", "bob"):
+            home = profiles_root / name
+            home.mkdir(parents=True, exist_ok=True)
+            (home / "state.db").write_bytes(b"\x00" * 8)
+        return profiles_root
+
+    def test_list_profiles_narrows_to_pinned(self, tmp_path, monkeypatch):
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        import hermes_cli.profiles as profiles_mod
+
+        def fake_list_profiles():
+            from types import SimpleNamespace
+
+            return [
+                SimpleNamespace(name="alice", path=str(alice)),
+                SimpleNamespace(name="bob", path=str(profiles_root / "bob")),
+                SimpleNamespace(name="default", path=str(tmp_path / ".hermes")),
+            ]
+
+        monkeypatch.setattr(profiles_mod, "list_profiles", fake_list_profiles)
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            r = c.get("/api/profiles")
+
+        assert r.status_code == 200, r.text
+        names = [p["name"] for p in r.json()["profiles"]]
+        assert names == ["alice"], f"sibling profiles leaked: {names}"
+
+    def test_sessions_all_clamped_to_pinned_db_only(self, tmp_path, monkeypatch):
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        opened = self._opened_db_paths(monkeypatch, tmp_path)
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            r = c.get("/api/profiles/sessions?profile=all")
+
+        assert r.status_code == 200, r.text
+        assert str(alice / "state.db") in opened
+        assert not any("bob" in p for p in opened), f"Bob's DB opened: {opened}"
+
+    def test_sessions_explicit_sibling_403_before_io(self, tmp_path, monkeypatch):
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        opened = self._opened_db_paths(monkeypatch, tmp_path)
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            r = c.get("/api/profiles/sessions?profile=bob")
+
+        assert r.status_code == 403, r.text
+        # The 403 must fire before any sibling I/O: Bob's state.db is never
+        # opened (the only open recorded is the app's own test home, which is
+        # a startup side effect, not a route target).
+        assert not any("bob" in p for p in opened), f"Bob's DB opened: {opened}"
+
+    def test_sidebar_pinned_only_and_sibling_403(self, tmp_path, monkeypatch):
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        opened = self._opened_db_paths(monkeypatch, tmp_path)
+
+        try:
+            with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+                ok = c.get("/api/profiles/sessions/sidebar")
+                bad = c.get("/api/profiles/sessions/sidebar?recents_profile=bob")
+        finally:
+            # The sidebar response is cached per-request-args in a short-TTL
+            # single-flight cache keyed ONLY on the request parameters (not on
+            # HERMES_HOME / db contents), so a later test in the same process
+            # calling the same endpoint shape would be served this test's
+            # stale (alice-scoped) payload. Clear it so sibling tests see a
+            # fresh scan under their own HERMES_HOME.
+            from hermes_cli.web_routers import profiles as _profiles_mod
+
+            try:
+                _profiles_mod.get_profiles_sessions_sidebar.cache_clear()
+            except AttributeError:
+                pass
+
+        assert ok.status_code == 200, ok.text
+        assert bad.status_code == 403, bad.text
+
+    def test_projects_tree_pinned_only(self, tmp_path, monkeypatch):
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        opened = self._opened_db_paths(monkeypatch, tmp_path)
+        import tui_gateway.server as gateway_server
+
+        monkeypatch.setattr(
+            gateway_server,
+            "_build_project_tree",
+            lambda *a, **k: ({"projects": [], "scoped_session_ids": []}, None),
+        )
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            r = c.get("/api/profiles/projects/tree")
+
+        assert r.status_code == 200, r.text
+        assert str(alice / "state.db") in opened
+        assert not any("bob" in p for p in opened), f"Bob's DB opened: {opened}"
+
+    def test_pull_requests_pinned_only(self, tmp_path, monkeypatch):
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        opened = self._opened_db_paths(monkeypatch, tmp_path)
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            r = c.post("/api/profiles/sessions/pull-requests", json={"ids": ["s1"]})
+
+        assert r.status_code == 200, r.text
+        assert str(alice / "state.db") in opened
+        assert not any("bob" in p for p in opened), f"Bob's DB opened: {opened}"
+
+    def test_sessions_query_clamped(self, tmp_path, monkeypatch):
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+        opened = self._opened_db_paths(monkeypatch, tmp_path)
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            ok = c.get("/api/sessions?profile=all")
+            bad = c.get("/api/sessions?profile=bob")
+
+        assert ok.status_code == 200, ok.text
+        assert bad.status_code == 403, bad.text
+        assert not any("bob" in p for p in opened), f"Bob's DB opened: {opened}"
+
+    def test_status_and_messaging_sibling_403(self, tmp_path, monkeypatch):
+        profiles_root = self._seed(tmp_path)
+        alice = profiles_root / "alice"
+
+        with self._client(monkeypatch, isolated=True, hermes_home=str(alice)) as c:
+            all_ok = c.get("/api/status?profile=all")
+            sibling = c.get("/api/status?profile=bob")
+            msg_sibling = c.get("/api/messaging/platforms?profile=bob")
+
+        assert all_ok.status_code == 200, all_ok.text
+        assert sibling.status_code == 403, sibling.text
+        assert msg_sibling.status_code == 403, msg_sibling.text


### PR DESCRIPTION
## Root cause

Every `/api/profiles/{name}/*` endpoint resolved and operated on **any named profile with no scope check**. A dashboard launched with `--isolated` — which is documented to run a server *scoped to that profile* — could therefore read, rewrite, export, or delete a **different** profile's data. The reported vector is SOUL.md persona injection (#91330); the same hole enables model/description mutation, config/.env export (secret exfiltration), and profile deletion.

## Fix (head `19299901`)

- `--isolated` is threaded from the launch flag through `start_server()` into `app.state.isolated` (`hermes_cli/main.py`).
- All 11 `{name}`-scoped profile endpoints route through `_assert_profile_in_scope()`, which returns **403** when the server is isolated and the requested profile is not the scoped one.
- Isolation is signalled by the flag itself, **not inferred from the profile name** — so an isolated server scoped to the **default profile is protected too**.
- **The isolation authority is one policy owner, not per-route bolts** (#91381 re-review): `hermes_cli/isolated_scope.py` owns `is_isolated_server` / `isolated_scope_dir` / `profile_name_for_scope` / `clamp_profile_query_for_isolated` / `scope_topology_for_isolated`. `web_server.py` keeps thin re-export seams under the legacy underscore names so the `web_routers`' `web_deps.late()` proxies and `monkeypatch.setattr(web_server, ...)` keep resolving at call time. Identity is the canonical resolved launch **path** captured in `start_server()` — never a profile-name string (`get_active_profile_name()`'s `"custom"`/`"default"` sentinels collide with real profile ids and would alias a sibling onto the boundary).
- **Aggregate/read surfaces are scoped too** (#76932-class): `GET /api/profiles` narrows to the pinned profile; session/sidebar/project/PR-scan selectors clamp to the pinned principal and explicit sibling selectors 403 **before any I/O**; `/import` and `/active` are denied in isolated mode; clone-from/clone-all sources are denied.
- **Plain `GET /api/status` on an isolated server no longer enumerates siblings** (#91381 re-review P1): omitted / `"current"` / `"all"` / whitespace selectors pin to the canonical launch principal before any machine-wide topology collection, and the collected topology is additionally narrowed to the pinned profile before the unconditional `profiles`/`gateway_mode`/`gateways` publication — so the pre-auth (`PUBLIC_API_PATHS`) liveness probe never leaks sibling profile names, ports, or platform state.
- **Cron surfaces are pinned**: the desktop cron ticker ticks only the pinned store (wired explicitly even for a single profile); `_cron_profile_dicts` narrows `profile=all`; `_cron_profile_home` and `_resolve_profile_dir` deny sibling selectors pre-I/O.
- The unified machine dashboard (`isolated=False`) keeps its intentional cross-profile management behavior; an isolated server's own profile still works.

## What this does NOT change

- Non-isolated dashboards: unchanged (machine-wide management is by design).
- Local desktop per-profile backends (`apps/desktop/electron/backend-command.ts`) are launched `--profile X serve` without `--isolated` and retain cross-profile access. Marking them `--isolated` is #90181's launch-side interlock and is tracked there: Desktop pooled backends should only switch to `serve --isolated` against this complete server boundary.

## Consolidation / supersession map (recorded per #91381 re-review)

This branch is the server-side consolidation owner for the isolated-profile authority class. Do not land narrower parallel fixes over it:

- **#91345** (SOUL-only fix for #91330): superseded implementation-wise; contributor provenance preserved, not erased.
- **#77125** (`/api/profiles` + sidebar scoping): read-side policy superseded here.
- **#48652** (earlier centralized server isolation + client routing): server portion superseded; client-side pieces adjacent, not disposable.
- **#90181** (Desktop pooled backends → `serve --isolated`): complementary, no file collision; safest order is land this server boundary first, then rebase/land #90181.
- **#89173** (runtime `profile=default` resolution): adjacent, not a substitute for this control-plane authority.

## Testing

`tests/hermes_cli/test_web_profile_soul_writes.py` — **38 passed**: 11 adversarial witnesses on this branch (cross-profile SOUL read/write/delete/export refusal, default-profile isolation, identity-aliasing `custom`/`default` sentinels, clone-from sibling denial, aggregate list/session/sidebar/project/PR-scan narrowing, plain/`current`/whitespace `/api/status` pinning, **scoped-collector witness that fails if the machine-wide topology collector is invoked on an isolated `/api/status`, plus scoped-collector cache-collapse**, cron ticker pinned-only, sibling 403s via env/config/cron/session resolution seams, non-isolated machine-wide control). RED on the prior head, GREEN here.

## Independent review

- **andrexibiza (maintainer re-reviews, 2026-08-21 / 08-31 / 09-01)**: exact-head reviews vs current main; the 08-31 passes confirm the clone/import/active + aggregate surfaces and identity-aliasing blockers are resolved at `939374ce`/`527e548b`. 08-31T23:53 flagged plain `/api/status` machine-wide publication + policy-in-godfile — publication closed at `e659c28b` and the pre-I/O scoped collector closed the machine-wide *read* at `19299901`.
- **codex + claude**: codex (`codex exec review`) approved the scoped-endpoint direction; claude verified end-to-end wiring and fail-closed direction.

Closes #91330
