### PR TITLE
fix(gateway): defer interrupt_session_activity's typing-clear off the relay read loop

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5297,15 +5297,40 @@ class BasePlatformAdapter(ABC):
         self._typing_paused.discard(chat_id)
 
     async def interrupt_session_activity(self, session_key: str, chat_id: str, metadata=None) -> None:
-        """Signal the active session loop to stop and clear typing immediately."""
+        """Signal the active session loop to stop and clear typing immediately.
+
+        The Event.set() below is synchronous and happens inline — that is the
+        part that actually cancels the turn, and callers (e.g. RelayAdapter's
+        interrupt-frame test) rely on it being visible the instant this
+        coroutine returns.
+
+        The typing-clear rides a background task instead of a direct await.
+        For the relay adapter, stop_typing() answers by sending an outbound
+        frame through the SAME WS transport this method can be invoked from:
+        RelayAdapter.on_interrupt runs ON the connector's read loop (an
+        interrupt_inbound frame is dispatched to it directly from
+        _handle_frame). Awaiting the send there self-deadlocks the transport
+        for the full outbound timeout — the frame's own outbound_result can
+        only be resolved by a LATER call to the very read loop this coroutine
+        would be blocking. Same shape as the lifecycle-ack deadlock fixed for
+        prompt-response sends (see RelayAdapter._send_lifecycle_ack); typing
+        clear is cosmetic by contract (stop_typing's own docstring) so
+        deferring it is safe for every adapter, not just relay.
+        """
         if session_key:
             interrupt_event = self._active_sessions.get(session_key)
             if interrupt_event is not None:
                 interrupt_event.set()
-        try:
-            await self._stop_typing_with_metadata(chat_id, metadata)
-        except Exception:
-            pass
+
+        async def _clear_typing() -> None:
+            try:
+                await self._stop_typing_with_metadata(chat_id, metadata)
+            except Exception:
+                pass
+
+        task = asyncio.create_task(_clear_typing())
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     def register_post_delivery_callback(
         self,

--- a/tests/gateway/relay/test_relay_interrupt.py
+++ b/tests/gateway/relay/test_relay_interrupt.py
@@ -32,6 +32,20 @@ def _desc() -> CapabilityDescriptor:
     )
 
 
+def _slack_desc() -> CapabilityDescriptor:
+    return CapabilityDescriptor(
+        contract_version=CONTRACT_VERSION,
+        platform="slack",
+        label="Slack",
+        max_message_length=4000,
+        supports_draft_streaming=True,
+        supports_edit=True,
+        supports_threads=True,
+        markdown_dialect="slack",
+        len_unit="chars",
+    )
+
+
 @pytest.fixture
 def adapter():
     return RelayAdapter(PlatformConfig(), _desc(), transport=StubConnector(_desc()))
@@ -50,5 +64,70 @@ async def test_interrupt_sets_only_target_session_event(adapter):
 
     assert ev_a.is_set() is True, "target session's interrupt Event must be set"
     assert ev_b.is_set() is False, "sibling session must be untouched"
+
+
+class TestInterruptDoesNotBlockOnStopTypingSend:
+    """RelayAdapter.on_interrupt runs ON the connector's read loop (an
+    interrupt_inbound frame is dispatched to it directly from
+    _handle_frame). stop_typing() is Slack-gated — for every other platform
+    it no-ops — and for Slack it sends an outbound "typing" frame through
+    the SAME transport this handler is invoked from. Awaiting that send
+    self-deadlocks the read loop for the full outbound timeout, because the
+    frame's own outbound_result can only be resolved by a later call to the
+    very read loop this coroutine would be blocking. Same shape as the
+    lifecycle-ack deadlock fixed for prompt-response sends.
+    """
+
+    def _slack_adapter(self) -> RelayAdapter:
+        desc = _slack_desc()
+        a = RelayAdapter(PlatformConfig(), desc, transport=StubConnector(desc))
+        a._platform_by_chat["chanA"] = "slack"
+        return a
+
+    @pytest.mark.asyncio
+    async def test_on_interrupt_returns_promptly_even_if_stop_typing_send_hangs(self):
+        a = self._slack_adapter()
+        key_a = "agent:main:slack:group:chanA:userX"
+        ev_a = asyncio.Event()
+        a._active_sessions[key_a] = ev_a
+
+        gate = asyncio.Event()
+        orig = a._transport.send_outbound
+
+        async def gated_send(frame, platform=None):
+            if frame.get("op") == "typing":
+                await gate.wait()  # simulate outbound_result not readable yet
+            return await orig(frame, platform=platform)
+
+        a._transport.send_outbound = gated_send
+
+        # Pre-fix this hangs until the gate opens (deadlock shape) and the
+        # wait_for trips with TimeoutError. Post-fix it returns promptly,
+        # and — critically — the interrupt Event is ALREADY set by the time
+        # it does, because that half is synchronous and inline.
+        await asyncio.wait_for(a.on_interrupt(key_a, chat_id="chanA"), timeout=1.0)
+        assert ev_a.is_set() is True, (
+            "the turn must be cancelled even though the typing-clear send is stuck"
+        )
+
+        # Release the gate; the background typing-clear must still go out.
+        gate.set()
+        await asyncio.sleep(0.05)
+        typing_frames = [f for f in a._transport.sent if f.get("op") == "typing"]
+        assert typing_frames, "background typing-clear was never sent"
+
+    @pytest.mark.asyncio
+    async def test_on_interrupt_still_clears_typing_when_the_send_resolves_promptly(self):
+        """Regression contract: deferring the send must not silently drop it
+        on the fast path (no hang at all)."""
+        a = self._slack_adapter()
+        key_a = "agent:main:slack:group:chanA:userX"
+        a._active_sessions[key_a] = asyncio.Event()
+
+        await a.on_interrupt(key_a, chat_id="chanA")
+        await asyncio.sleep(0.05)  # yield once for the background task
+
+        typing_frames = [f for f in a._transport.sent if f.get("op") == "typing"]
+        assert typing_frames, "typing-clear frame should still be sent on the fast path"
 
 


### PR DESCRIPTION
## What

`RelayAdapter.on_interrupt` runs **on the connector's read loop** — an `interrupt_inbound` frame is dispatched to it directly from `_handle_frame`. It calls the shared `BasePlatformAdapter.interrupt_session_activity`, which awaited `stop_typing()` inline.

For a Slack chat, `stop_typing()` sends an outbound `"typing"` frame through the *same* WS transport this coroutine is executing on. That send blocks on an `outbound_result` future that only the read loop can resolve — by processing a *later* frame. The read loop is blocked inside this very call, so the await guarantees a self-deadlock for the full outbound timeout (30s) on every relay-fronted Slack `/stop`, wedging the whole multiplexed connection (every platform sharing it, not just the interrupted session) for the duration.

This is the same shape as the prompt-lifecycle-ack deadlock fixed in `RelayAdapter._send_lifecycle_ack` (approval/clarify sends dispatched from `_consume_prompt_response`) — that fix covered six lifecycle sends but not this one, which is dispatched from a different read-loop entry point (`on_interrupt` → `interrupt_session_activity`).

## Fix

The `Event.set()` that actually cancels the turn stays synchronous and inline — callers (including the existing `test_interrupt_sets_only_target_session_event` test) rely on it being visible the instant `on_interrupt` returns.

The typing-clear now rides a background task via the adapter's existing `_background_tasks` retention set (the same fire-and-forget-with-strong-ref pattern already used elsewhere in `gateway/platforms/base.py`), so the handler returns immediately and the read loop keeps consuming — the clear frame's own `outbound_result` then resolves normally on a subsequent read-loop iteration.

Applied at the base-class level (`interrupt_session_activity`) rather than only in the relay adapter, since typing-clear is already documented as cosmetic and "must never break turn completion" for every platform — deferring it is safe everywhere, and it's the one call site every adapter shares. Verified the two other production callers (`gateway/run.py`'s `/stop` dispatch, and the LINE adapter's override) don't depend on the typing-clear completing before they proceed.

## Tests

- New deadlock-shape test: gates the transport's `send_outbound` on the `"typing"` op, then asserts `on_interrupt` returns within 1s *and* the turn's interrupt `Event` is already set — this fails with `TimeoutError` on pre-fix code (mutation-verified) and passes post-fix.
- Fast-path regression test proving the deferred send still actually goes out when nothing is stuck (no silent drop).
- Existing `test_interrupt_sets_only_target_session_event` still passes unmodified.

## Verification

- `tests/gateway/relay/` + `tests/relay/` (277 tests): green.
- Cross-platform typing/interrupt neighbor sweep (`test_slack*`, `test_matrix`, `test_google_chat`, `test_signal`, `test_keep_typing_timeout`, `test_run_progress_interrupt`, LINE plugin tests, Photon overflow-recovery, etc. — 556 tests): green except one pre-existing, unrelated `ModuleNotFoundError: aiohttp` environment gap in `test_matrix.py`, confirmed identical with the fix stashed.
- `ruff check`: clean.
- Mutation-verify: stashed the production fix, confirmed the new deadlock-shape test fails with `TimeoutError` on pre-fix code, then restored it.

## Competing PRs

Searched multiple keyword combinations (`interrupt_session_activity stop_typing deadlock`, `relay read loop deadlock typing`, `on_interrupt relay slack`) — no open PR targets this call chain.