### PR TITLE
perf(desktop): idle renderers stop burning CPU on infinite CSS animations (#53902, #73082)

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -982,11 +982,19 @@
 }
 
 @keyframes arc-border {
+  /* Compositor-only travel. The ::before layer is 300% × 300% of the host
+     (mirroring the old `background-size: 300%`), so translating it from
+     -10% → -50% of its own size reproduces the old
+     `background-position: 15% → 75%` exactly (offset = -2·W·p), while
+     `transform` animates on the compositor with zero per-frame style
+     recalc/paint. The old background-position version cost ~3,600
+     main-thread style recalcs per minute per arc, pinning idle renderers
+     (#53902, #73082). */
   0% {
-    background-position: 15% 15%;
+    transform: translate(-10%, -10%);
   }
   100% {
-    background-position: 75% 75%;
+    transform: translate(-50%, -50%);
   }
 }
 
@@ -1067,8 +1075,14 @@
 .arc-border::before {
   content: '';
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
+  top: 0;
+  left: 0;
+  /* The gradient layer IS 300% of the ring (the old version kept a host-sized
+     ::before and slid a 300%-sized background through it). Sizing the layer
+     itself lets the travel be a `transform` — composited, no main-thread
+     style/paint work — while the host's mask + overflow clip it to the ring. */
+  width: 300%;
+  height: 300%;
   background: linear-gradient(
     var(--arc-angle),
     transparent 0%,
@@ -1085,7 +1099,7 @@
     var(--arc-c0) 95%,
     var(--arc-c1) 100%
   );
-  background-size: 300% 300%;
+  will-change: transform;
   animation: arc-border var(--arc-duration) linear infinite;
 }
 
@@ -2489,15 +2503,21 @@ button[data-slot='aui_msg-reactions'] svg {
    flow). Color/positioning come from the primitive; this owns the animation. */
 .progress-slide {
   width: 40%;
+  /* left is pinned; travel is compositor-only (see arc-border note). */
+  left: 0;
+  will-change: transform;
   animation: progress-slide 1.15s ease-in-out infinite;
 }
 
 @keyframes progress-slide {
+  /* Old version animated `left: -42% → 100%`, forcing main-thread layout
+     every frame for the whole hatch flow. The block is 40% of its track, so
+     the same travel in units of its own width is -105% → 250%. */
   0% {
-    left: -42%;
+    transform: translateX(-105%);
   }
   100% {
-    left: 100%;
+    transform: translateX(250%);
   }
 }
 


### PR DESCRIPTION
## Summary

Idle desktop renderers stop burning a core: the two infinite CSS animations that repainted/relayouted every frame now run entirely on the compositor. Same visuals, ~96% less idle renderer main-thread work.

Root cause of #53902 / #73082's idle burn: the `arc-border` running indicator animated `background-position` (uncomposited — full style-recalc + repaint at 60fps, forever) and `progress-slide` animated `left` (forced layout every frame). One visible arc alone cost ~3,600 main-thread style recalcs/min at true idle. The React Compiler (#91103) was measured against this loop first and does not touch it — JS was already ~10ms/min at idle; the burn is pure CSS.

## Changes

- `apps/desktop/src/styles.css` — `@keyframes arc-border`: `background-position: 15% → 75%` becomes `transform: translate(-10%, -10%) → translate(-50%, -50%)`; the `::before` gradient layer is now itself 300% × 300% (was a host-sized layer sliding a 300% background), so the travel is mathematically identical (offset = −2·W·p) but composited. Host `mask` + `overflow: hidden` clip exactly as before; `prefers-reduced-motion` and `data-renderer-animations-paused` gates untouched.
- `apps/desktop/src/styles.css` — `@keyframes progress-slide`: `left: -42% → 100%` becomes `translateX(-105% → 250%)` (same travel in units of the 40%-wide block), killing per-frame layout in the pet-hatch progress bar.

## Validation

60s true idle, fresh sandbox HERMES_HOME, Electron headless, CDP `Performance.getMetrics` (harness identical to the pre-fix A/B on #91103's builds):

| 60s idle | main (before) | this PR | delta |
|---|---|---|---|
| style recalcs / min | 3,607–3,617 | 79 | −97.8% |
| renderer task ms / min | 4,104–4,108 | 153 | −96.3% |
| layouts / min | 0 | 0 | — |
| script ms / min | ~10 (already idle) | ~7 | — |

- Visual parity: CDP screenshots of the animated `arc-nous` onboarding hero, two frames 1.1s apart — arc renders and travels; the one corner artifact vision flagged on the fixed build reproduces identically on unmodified main (pre-existing, not introduced).
- `session-dot-state` tests pass; `check:lint` 0 errors (120 pre-existing warnings).
- Identity guard: measured builds asserted via install stamp (`892ec7af57` main vs fixed worktree build).

Addresses the idle-loop half of #53902 and #73082. The stale `isWorking`/running-flag half (arc armed for sessions that finished hours ago) is a separate state-lifecycle bug — the arc store (`session-dot-state.ts`) derives from backend-fed atoms and needs its own fix; with this PR the cost of a stale arc drops from a pinned core to near zero, but the indicator can still lie. Left open on both issues.

## Infographic

![Idle means idle — desktop renderer stops burning CPU between turns: 3,617 to 79 style recalcs per minute (-96%), the ring now rides the compositor](https://v3b.fal.media/files/b/0aa7335e/M5GdGkdKukXNHWaA2FzE6_vAoOs8hj.png)
