### PR TITLE
fix(bot-mode): durableGroupChatRooms drops tombstones and roomId on the remote-merge persist path

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -800,12 +800,25 @@ function durableGroupChatRooms(all = $groupChats.get()) {
     if (!room || !Array.isArray(room.log)) {
       continue
     }
+    // Disband tombstones are runtime-only coordination state (they hold the
+    // epoch bump for an in-flight drive). Persisting one would resurrect the
+    // room as an empty record on the next load AND keep its name "taken" for
+    // same-name recreates. Mirrors updateGroupChat's inline durable map.
+    if (room.tombstone) {
+      continue
+    }
     durable[name] = {
       log: room.log,
       watermarks: room.watermarks || {},
       sessions: room.sessions || {},
       stranded: room.stranded || {},
       members: Array.isArray(room.members) ? room.members : [],
+      // Immutable room identity: without this, a room merged in via the
+      // remote-sync path (the only caller of this function) loses its
+      // roomId on the next cold hydrate and falls back to legacy
+      // name-keyed identity — same field updateGroupChat's inline map
+      // already carries.
+      roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
       image: room.image || null,
       syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -196,7 +196,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -1829,4 +1829,74 @@ test('source contract: approval card renders the command and routes approval.res
   assert.match(pluginSource, /'approval\.respond'/)
   assert.match(pluginSource, /kind: 'approval'/)
   assert.match(pluginSource, /wants to run a command/)
+})
+
+test('durableGroupChatRooms excludes tombstoned rooms — the remote-merge persist path\'s own durable-map builder, independent of updateGroupChat\'s inline one', () => {
+  const gc = load(() => '(pass)')
+
+  const durable = gc.durableGroupChatRooms({
+    Live: { tombstone: true, log: [], watermarks: {}, epoch: 4, running: false },
+    Keep: { log: [{ from: { kind: 'user' }, text: 'hi', at: 1 }], watermarks: {}, members: [] }
+  })
+
+  assert.ok(!('Live' in durable), 'tombstone excluded from the remote-merge persist path too')
+  assert.ok('Keep' in durable, 'real room still persisted')
+})
+
+test('durableGroupChatRooms carries roomId — omitting it drops the durable id on the next cold hydrate', () => {
+  const gc = load(() => '(pass)')
+
+  const durable = gc.durableGroupChatRooms({
+    Team: {
+      log: [{ from: { kind: 'user' }, text: 'hi', at: 1 }],
+      watermarks: {},
+      members: [],
+      roomId: 'room-abc123'
+    },
+    Legacy: {
+      log: [{ from: { kind: 'user' }, text: 'hi', at: 1 }],
+      watermarks: {},
+      members: []
+    }
+  })
+
+  assert.equal(durable.Team.roomId, 'room-abc123', 'immutable room identity must survive the remote-merge persist path')
+  assert.equal(durable.Legacy.roomId, null, 'a room with no roomId persists an explicit null, not undefined')
+})
+
+test('remote-merge reachability: a disband tombstone that survives a merge (gateway has not received the delete yet) is never written to storage', async () => {
+  const gc = load(() => '(pass)')
+
+  // Simulate a drive still mid-turn at disband time, exactly like the
+  // sibling disband test above — this room is a live tombstone in $groupChats.
+  gc.$groupChats.set({
+    Live: { tombstone: true, log: [], watermarks: {}, epoch: 4, running: false }
+  })
+
+  // The remote gateway has NOT yet received the delete (plausible now that
+  // sync fans out to every reachable default-profile gateway independently)
+  // — its snapshot still carries a live copy of the room under the same
+  // display name.
+  const merged = gc.mergeRemoteGroupChatSnapshotIntoRooms(
+    {
+      rooms: {
+        Live: {
+          log: [{ from: { kind: 'member', name: 'research' }, text: 'still going', at: 1 }],
+          members: [{ name: 'research' }]
+        }
+      }
+    },
+    gc.$groupChats.get()
+  )
+
+  // The merge spreads `...existing` before its explicit field overrides,
+  // none of which touch `tombstone` — so the flag survives into the merged
+  // room. This is the reachability step: without it, durableGroupChatRooms
+  // would never even see a tombstoned room from this path.
+  assert.equal(merged.Live.tombstone, true, 'tombstone forwarded by the merge (reachability precondition)')
+
+  await gc.persistGroupChatRooms(merged)
+
+  const durable = gc.storageWrites.get('group-chats')
+  assert.ok(durable && !('Live' in durable), 'merged tombstone must not resurrect as a persisted room')
 })


### PR DESCRIPTION
## What

`updateGroupChat`'s inline durable-map builder (the local-mutation persist path) skips tombstoned rooms and carries `roomId`. But `durableGroupChatRooms` — the **separate** builder `persistGroupChatRooms` uses for the remote-merge path (`pullGroupChatServerState`, and the two "already-synced" quick-paths in `flushGroupChatServerSync` — every gateway/connection swap) — has neither. Two independent gaps in the same function:

### 1. Tombstone resurrection

`disbandGroupChat` sets a runtime-only tombstone (`{tombstone: true, log: [], ...}`) while a drive may still be mid-turn. `mergeRemoteGroupChatSnapshotIntoRooms` spreads `...existing` before its explicit field overrides (none of which touch `tombstone`), so if a remote gateway hasn't yet received the delete (plausible now that sync fans out to every reachable default-profile gateway with independent per-connection backoff) and still has a live copy of the room, the tombstone flag survives into the merged room object. That merged map goes straight to `persistGroupChatRooms`, which wrote it to storage because `durableGroupChatRooms` had no tombstone check. On the next cold hydrate, the persisted tombstone reads back as an empty, non-tombstoned room — resurrecting the original bug (recreating a room under the same name silently becomes `"<name> 2"`) through a path the earlier tombstone fix (`d1ea11d589`) didn't cover.

### 2. roomId loss

`mergeRemoteGroupChatSnapshotIntoRooms` correctly carries `roomId` into the merged in-memory room (`...(projectedRoomId || existing.roomId ? { roomId: ... } : {})`), but `durableGroupChatRooms` never included it in the persisted snapshot. Every room merged in via the remote-sync path therefore loses its immutable room identity on the next cold hydrate (comes back with `roomId: null`) and falls back to legacy name-keyed identity — breaking id-based rename/merge resolution (`id:<roomId>` keying) and member-session titling (`Group: <roomId>`). This one doesn't need any race — it happens on every persisted remote-merge snapshot.

## Fix

`durableGroupChatRooms` now mirrors `updateGroupChat`'s inline map exactly: skip tombstones, carry `roomId`.

## Tests

- Two `durableGroupChatRooms` unit tests (one per gap), exercised directly against the now test-exposed function.
- An end-to-end reachability test: seed a tombstone → `mergeRemoteGroupChatSnapshotIntoRooms` (proves the merge really does forward the tombstone) → `persistGroupChatRooms` (proves the fix really does keep it out of storage).
- Mutation-verified against pre-fix code: all 3 new tests fail (2 assertion failures + the reachability test).
- Full `hermes-bots` plugin test suite (60+ files, node's built-in test runner) green, including the pre-existing 80 tests in `group-chat.test.mjs`.

## Competing PRs

Searched multiple keyword combinations — no direct hit. The one thematically-adjacent open PR, #91134 ("unify Bot Mode across registered gateways"), touches the same file but its diff doesn't include `durableGroupChatRooms` or `persistGroupChatRooms`.