### PR TITLE
feat(config): add model proxy URL

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2507,7 +2507,9 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             }
             if "http_client" not in safe_kwargs:
                 keepalive_http = agent._build_keepalive_http_client(
-                    base_url, verify=httpx_verify,
+                    base_url,
+                    verify=httpx_verify,
+                    proxy_url=agent._configured_model_proxy_url(),
                 )
                 if keepalive_http is not None:
                     safe_kwargs["http_client"] = keepalive_http
@@ -2538,7 +2540,9 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
     if "http_client" not in client_kwargs:
         keepalive_http = agent._build_keepalive_http_client(
-            client_kwargs.get("base_url", ""), verify=httpx_verify,
+            client_kwargs.get("base_url", ""),
+            verify=httpx_verify,
+            proxy_url=agent._configured_model_proxy_url(),
         )
         if keepalive_http is not None:
             client_kwargs["http_client"] = keepalive_http

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -223,13 +223,17 @@ def _openai_http_client_kwargs(
     *,
     async_mode: bool = False,
 ) -> Dict[str, Any]:
-    """Inject keepalive httpx client with env-only proxy (not macOS system proxy)."""
+    """Inject keepalive httpx client with config or env proxy policy."""
     try:
-        from agent.process_bootstrap import build_keepalive_http_client
+        from agent.process_bootstrap import (
+            build_keepalive_http_client,
+            configured_model_proxy_url,
+        )
         client = build_keepalive_http_client(
             str(base_url or ""),
             async_mode=async_mode,
             verify=_resolve_aux_verify(base_url),
+            proxy_url=configured_model_proxy_url(),
         )
     except (ImportError, AttributeError):
         # Version-skewed installs (#64333): a process whose sys.path resolves
@@ -6979,8 +6983,7 @@ def resolve_provider_client(
         default_model = "google/gemini-3-flash-preview"
         final_model = _normalize_resolved_model(model or default_model, provider)
         try:
-            from openai import OpenAI
-            client = OpenAI(api_key=token, base_url=base_url)
+            client = _create_openai_client(api_key=token, base_url=base_url)
         except Exception as exc:
             logger.warning("resolve_provider_client: cannot create Vertex "
                            "client: %s", exc)

--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import os
 import sys
+import urllib.parse
 import urllib.request
 from typing import Any, Optional
 
@@ -142,19 +143,52 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
     return proxy
 
 
+def validate_proxy_url(proxy_url: str) -> str:
+    """Normalize and validate an explicit model proxy URL, failing closed."""
+    normalized = normalize_proxy_url(proxy_url)
+    if not normalized:
+        raise ValueError("model.proxy_url must not be empty")
+    parsed = urllib.parse.urlsplit(normalized)
+    if parsed.scheme.lower() not in {"http", "https", "socks4", "socks5", "socks5h"}:
+        raise ValueError(
+            "model.proxy_url must use http, https, socks4, socks5, or socks5h"
+        )
+    if not parsed.hostname:
+        raise ValueError("model.proxy_url must include a hostname")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("model.proxy_url contains an invalid port") from exc
+    return normalized
+
+
+def configured_model_proxy_url() -> Optional[str]:
+    """Return the active profile's validated ``model.proxy_url``."""
+    from hermes_cli.config import load_config_readonly
+
+    config = load_config_readonly() or {}
+    model_config = config.get("model") if isinstance(config, dict) else None
+    if not isinstance(model_config, dict):
+        return None
+    proxy_url = str(model_config.get("proxy_url") or "").strip()
+    return validate_proxy_url(proxy_url) if proxy_url else None
+
+
 def build_keepalive_http_client(
     base_url: str = "",
     *,
     async_mode: bool = False,
     verify: Any = True,
+    proxy_url: Optional[str] = None,
 ) -> Optional[Any]:
-    """Build an httpx client for OpenAI SDK calls with env-only proxy policy.
+    """Build an httpx client for OpenAI SDK calls with explicit or env proxy policy.
 
-    Uses explicit ``HTTPS_PROXY`` / ``NO_PROXY`` env vars via
-    ``_get_proxy_for_base_url``. Plain no-proxy mounts disable httpx's default
-    ``trust_env`` proxy path, so macOS system proxy settings from
-    ``urllib.request.getproxies()`` (which omit the ExceptionsList) are not
-    applied. Mirrors ``AIAgent._build_keepalive_http_client``.
+    ``proxy_url`` takes precedence when supplied by model configuration;
+    otherwise HTTPS_PROXY / HTTP_PROXY / ALL_PROXY and NO_PROXY apply.
+    Plain no-proxy mounts disable httpx's default ``trust_env`` proxy path,
+    so macOS system proxy settings from ``urllib.request.getproxies()`` (which
+    omit the ExceptionsList) are not applied. Mirrors
+    ``AIAgent._build_keepalive_http_client``.
 
     Connection lifecycle is managed at the HTTP pool layer
     (``keepalive_expiry=20.0`` reaps idle connections before reverse proxies'
@@ -169,10 +203,11 @@ def build_keepalive_http_client(
     client uses. It is passed on the client AND on the plain no-proxy mounts
     (a mounted transport owns the SSL context for its scheme).
     """
+    explicit_proxy = validate_proxy_url(proxy_url) if proxy_url else None
     try:
         import httpx
 
-        proxy = _get_proxy_for_base_url(base_url)
+        proxy = explicit_proxy or _get_proxy_for_base_url(base_url)
 
         limits = httpx.Limits(
             max_keepalive_connections=20,
@@ -223,5 +258,7 @@ __all__ = [
     "_install_safe_stdio",
     "_get_proxy_from_env",
     "_get_proxy_for_base_url",
+    "configured_model_proxy_url",
+    "validate_proxy_url",
     "build_keepalive_http_client",
 ]

--- a/run_agent.py
+++ b/run_agent.py
@@ -113,6 +113,8 @@ from agent.process_bootstrap import (
     OpenAI,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.OpenAI")
     _SafeWriter,  # noqa: F401  # re-exported for tests that `from run_agent import _SafeWriter`
     _get_proxy_for_base_url,
+    configured_model_proxy_url,
+    validate_proxy_url,
 )
 from agent.iteration_budget import IterationBudget
 from agent.interrupt_compat import request_hard_interrupt
@@ -5088,7 +5090,14 @@ class AIAgent:
         return False
 
     @staticmethod
-    def _build_keepalive_http_client(base_url: str = "", *, verify: Any = True) -> Any:
+    def _configured_model_proxy_url() -> Optional[str]:
+        """Return profile-local ``model.proxy_url`` without mutating process env."""
+        return configured_model_proxy_url()
+
+    @staticmethod
+    def _build_keepalive_http_client(
+        base_url: str = "", *, verify: Any = True, proxy_url: Optional[str] = None,
+    ) -> Any:
         """Build an httpx.Client with proactive idle-connection reaping.
 
         Previously this method injected a custom ``httpx.HTTPTransport``
@@ -5113,12 +5122,13 @@ class AIAgent:
         the plain no-proxy mounts (a mounted transport owns the SSL context
         for its scheme).
         """
+        explicit_proxy = validate_proxy_url(proxy_url) if proxy_url else None
         try:
             import httpx as _httpx
 
-            # Explicitly read proxy settings so requests route through
-            # HTTP_PROXY / HTTPS_PROXY / NO_PROXY correctly.
-            _proxy = _get_proxy_for_base_url(base_url)
+            # Model config takes precedence without mutating process-wide env;
+            # otherwise preserve the existing env + NO_PROXY behaviour.
+            _proxy = explicit_proxy or _get_proxy_for_base_url(base_url)
 
             # Proactive pool reaping: close idle connections at 20 s,
             # before reverse proxies (30–60 s typical) send FIN and

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2601,6 +2601,28 @@ class TestAuxiliaryAuthRefreshRetry:
 
 
 
+    def test_resolve_provider_client_vertex_uses_shared_proxy_aware_factory(self):
+        sentinel = MagicMock()
+        with (
+            patch("agent.vertex_adapter.has_vertex_credentials", return_value=True),
+            patch(
+                "agent.vertex_adapter.get_vertex_config",
+                return_value=("ya29.token", "https://aiplatform.googleapis.com/v1beta1/openapi"),
+            ),
+            patch("agent.auxiliary_client._create_openai_client", return_value=sentinel) as factory,
+        ):
+            client, model = resolve_provider_client(
+                "vertex", "google/gemini-3-flash-preview"
+            )
+
+        assert client is sentinel
+        assert model == "google/gemini-3-flash-preview"
+        factory.assert_called_once_with(
+            api_key="ya29.token",
+            base_url="https://aiplatform.googleapis.com/v1beta1/openapi",
+        )
+
+
 class TestAuxiliaryPoolRotationRetry:
     def test_call_llm_rotates_explicit_codex_pool_on_429(self):
         rate_err = Exception("usage limit reached")

--- a/tests/agent/test_auxiliary_client_proxy_env.py
+++ b/tests/agent/test_auxiliary_client_proxy_env.py
@@ -44,6 +44,27 @@ def test_create_openai_client_routes_via_env_proxy(mock_openai, monkeypatch):
 
 
 
+@patch("agent.auxiliary_client.OpenAI")
+def test_create_openai_client_routes_via_model_proxy_config(mock_openai, monkeypatch):
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):
+        monkeypatch.delenv(key, raising=False)
+
+    with patch(
+        "agent.process_bootstrap.configured_model_proxy_url",
+        return_value="http://127.0.0.1:7897",
+    ):
+        _create_openai_client(
+            api_key="test-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+
+    http_client = mock_openai.call_args.kwargs.get("http_client")
+    assert isinstance(http_client, httpx.Client)
+    assert "HTTPProxy" in _pool_types(http_client)
+    http_client.close()
+
+
 def test_get_proxy_for_base_url_respects_no_proxy(monkeypatch):
     for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                 "https_proxy", "http_proxy", "all_proxy", "NO_PROXY", "no_proxy"):

--- a/tests/run_agent/test_create_openai_client_proxy_env.py
+++ b/tests/run_agent/test_create_openai_client_proxy_env.py
@@ -13,7 +13,9 @@ custom socket-options transport is used (default httpx transport).
 from unittest.mock import patch
 
 import httpx
+import pytest
 
+from agent.process_bootstrap import build_keepalive_http_client
 from run_agent import AIAgent, _get_proxy_from_env, _get_proxy_for_base_url
 
 
@@ -52,12 +54,83 @@ def test_get_proxy_from_env_prefers_https_then_http_then_all(monkeypatch):
 
 
 
+def test_build_keepalive_http_client_uses_explicit_proxy_without_env(monkeypatch):
+    """A config-resolved proxy must work without mutating process env vars."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+
+    client = build_keepalive_http_client(
+        "https://chatgpt.com/backend-api/codex",
+        proxy_url="http://127.0.0.1:7897",
+    )
+    assert isinstance(client, httpx.Client)
+    proxied_pools = [
+        type(pool).__name__
+        for mount in client._mounts.values()
+        if mount is not None
+        for pool in [getattr(mount, "_pool", None)]
+        if pool is not None
+    ]
+    assert "HTTPProxy" in proxied_pools
+    client.close()
+
+
+def test_explicit_proxy_rejects_malformed_url_instead_of_falling_back_direct():
+    with pytest.raises(ValueError, match="model.proxy_url"):
+        build_keepalive_http_client(
+            "https://chatgpt.com/backend-api/codex",
+            proxy_url="not-a-proxy-url",
+        )
+
+    with pytest.raises(ValueError, match="model.proxy_url"):
+        AIAgent._build_keepalive_http_client(
+            "https://chatgpt.com/backend-api/codex",
+            proxy_url="http://127.0.0.1:not-a-port",
+        )
+
+
 def test_get_proxy_from_env_normalizes_socks_alias(monkeypatch):
     for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                 "https_proxy", "http_proxy", "all_proxy"):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:1080/")
     assert _get_proxy_from_env() == "socks5://127.0.0.1:1080/"
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_routes_via_model_proxy_config(mock_openai, monkeypatch):
+    """model.proxy_url must route the main provider without proxy env vars."""
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+
+    agent = _make_agent()
+    monkeypatch.setattr(
+        agent,
+        "_configured_model_proxy_url",
+        lambda: "http://127.0.0.1:7897",
+    )
+    agent._create_openai_client(
+        {
+            "api_key": "test-key",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        },
+        reason="test",
+        shared=False,
+    )
+
+    http_client = _extract_http_client(mock_openai.call_args.kwargs)
+    assert isinstance(http_client, httpx.Client)
+    proxied_pools = [
+        type(pool).__name__
+        for mount in http_client._mounts.values()
+        if mount is not None
+        for pool in [getattr(mount, "_pool", None)]
+        if pool is not None
+    ]
+    assert "HTTPProxy" in proxied_pools
+    http_client.close()
 
 
 @patch("run_agent.OpenAI")
@@ -89,9 +162,11 @@ def test_create_openai_client_routes_via_proxy_when_env_set(mock_openai, monkeyp
     # Verify a proxy mount exists. httpx Client(proxy=...) rewrites _mounts so
     # the proxied pool (HTTPProxy) sits alongside the base transport.
     proxied_pools = [
-        type(mount._pool).__name__
+        type(pool).__name__
         for mount in http_client._mounts.values()
-        if mount is not None and hasattr(mount, "_pool")
+        if mount is not None
+        for pool in [getattr(mount, "_pool", None)]
+        if pool is not None
     ]
     assert "HTTPProxy" in proxied_pools, (
         "Expected httpx.Client to route through HTTPProxy when HTTPS_PROXY is "

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -77,6 +77,15 @@ model:
 
 Hermes persists the endpoint, provider, and base URL in `config.yaml` so it survives restarts. If your local server has exactly one model loaded, `/model custom` auto-detects it. You can also set `provider: custom` in config.yaml — it's a first-class provider, not an alias for anything else.
 
+If the model endpoint must use an HTTP proxy, set it on the model block instead of process-wide proxy environment variables:
+
+```yaml
+model:
+  proxy_url: http://127.0.0.1:7897
+```
+
+This proxy applies to main and auxiliary model HTTP clients. It does not proxy messaging platforms, MCP servers, or unrelated tools. Remove the key or set it to an empty string to restore the existing `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` and `NO_PROXY` behavior.
+
 This works with Ollama, vLLM, llama.cpp server, SGLang, LocalAI, and others. See the [Configuration guide](../user-guide/configuration.md) for details.
 
 :::tip Ollama users


### PR DESCRIPTION
## Summary
- add profile-local `model.proxy_url` for main and auxiliary model HTTP clients
- preserve existing `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` and `NO_PROXY` behavior when unset
- validate explicit proxy URLs and fail closed instead of silently falling back to direct routing
- route the synchronous Vertex auxiliary path through the shared proxy-aware client factory

## Motivation
Some model endpoints must use an explicit local HTTP proxy even when the rest of Hermes (messaging platforms, MCP servers, and tools) should remain direct. Process-wide proxy environment variables are too broad and service-manager-specific.

## Verification
- `206 passed` across main/auxiliary proxy, SSL, reuse, bootstrap-skew, and auxiliary-client tests
- Ruff passed on all changed Python files
- `git diff --check` passed
- sabotage run confirmed the new main-client regression test fails when proxy wiring is removed
- live OpenAI Codex request with proxy env vars explicitly unset used `model.proxy_url`, completed on the primary provider, and did not activate fallback

## Compatibility
When `model.proxy_url` is absent or empty, behavior is unchanged: Hermes resolves proxy settings from the existing environment variables and honors `NO_PROXY`.