### PR TITLE
fix(model_switch): OpenCode api_mode override missed opencode-free and custom family providers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1489,6 +1489,7 @@ def switch_model(
         detect_provider_for_model,
         validate_requested_model,
         opencode_model_api_mode,
+        opencode_provider_family,
         _get_ollama_request_headers,
         _get_provider_config_dict,
         _same_ollama_native_root,
@@ -2134,7 +2135,14 @@ def switch_model(
         api_mode = copilot_model_api_mode(new_model, api_key=api_key)
 
     # --- OpenCode api_mode override ---
-    if target_provider in {"opencode-zen", "opencode-go", "opencode"}:
+    # opencode_provider_family is the single owner of family membership (its
+    # own docstring says so): it also matches opencode-free (Zen-hosted, same
+    # per-model routing) and custom providers whose name extends a family
+    # slug (opencode-go-bridge, opencode-zen-custom, issue #85589) — both of
+    # which this exact-set check used to miss, silently falling through to
+    # the generic determine_api_mode() and landing on the wrong wire for any
+    # model whose family routing isn't chat_completions.
+    if opencode_provider_family(target_provider) is not None:
         api_mode = opencode_model_api_mode(target_provider, new_model)
 
     # --- Nous Portal dual-wire override ---

--- a/tests/hermes_cli/test_model_switch_opencode_anthropic.py
+++ b/tests/hermes_cli/test_model_switch_opencode_anthropic.py
@@ -172,6 +172,51 @@ class TestAgentSwitchModelDefenseInDepth:
         )
 
 
+class TestOpenCodeApiModeOverrideCoversTheWholeFamily:
+    """The api_mode override at the top of switch_model used to gate on a
+    literal ``{"opencode-zen", "opencode-go", "opencode"}`` set instead of
+    ``opencode_provider_family()`` — the SAME predicate ``models.py`` already
+    uses 30 lines below for the /v1 base_url normalization, and whose own
+    docstring says it is "the single owner of that family-membership
+    question; do not re-implement it inline." The exact-set check missed
+    two real members of the family: the built-in ``opencode-free`` provider
+    (Zen-hosted, same per-model routing) and any custom provider whose name
+    extends a family slug (``opencode-go-bridge``, issue #85589). Both used
+    to silently fall through to the generic ``determine_api_mode()``, which
+    has no per-model OpenCode routing table and defaults to
+    ``chat_completions`` — reproducing the exact "double /v1 404 / wrong
+    wire" bug class this whole override exists to prevent, but only for
+    models whose family routing isn't chat_completions.
+    """
+
+    def test_opencode_free_claude_model_gets_anthropic_messages(self):
+        """opencode-free is Zen-hosted; a Claude-family model on it must get
+        the same anthropic_messages routing opencode-zen gets."""
+        result = _run_opencode_switch(
+            raw_input="claude-opus-5",
+            current_provider="opencode-free",
+            current_model="grok-4.5",
+            current_base_url="https://opencode.ai/zen/v1",
+        )
+
+        assert result.success, f"switch_model failed: {result.error_message}"
+        assert result.api_mode == "anthropic_messages"
+
+    def test_custom_opencode_go_family_provider_gets_codex_responses(self):
+        """A custom provider whose name extends the opencode-go family slug
+        (issue #85589) must get the same per-model routing the built-in
+        opencode-go provider gets — here codex_responses for a Grok model."""
+        result = _run_opencode_switch(
+            raw_input="grok-4.5",
+            current_provider="opencode-go-bridge",
+            current_model="kimi-k2.6",
+            current_base_url="https://my-opencode-mirror.example/v1",
+        )
+
+        assert result.success, f"switch_model failed: {result.error_message}"
+        assert result.api_mode == "codex_responses"
+
+
 class TestStaleConfigDefaultDoesNotWedgeResolver:
     """Regression for the real bug Quentin hit.
 


### PR DESCRIPTION
## What

The `api_mode` override at the top of `switch_model()` gates on a literal `{"opencode-zen", "opencode-go", "opencode"}` set instead of `opencode_provider_family()` — the same predicate `hermes_cli/models.py` already uses 30 lines below, in the same function, for the `/v1` base_url normalization. That predicate's own docstring says it is *"the single owner of that family-membership question; do not re-implement it inline."*

The exact-set check misses two real family members:

### 1. `opencode-free`

The built-in, keyless OpenCode provider shipped this week is Zen-hosted and shares Zen's per-model routing (`opencode_model_api_mode` has an explicit `if family == "opencode-free": family = "opencode-zen"` branch for this). Confirmed empirically — with the pre-fix code, switching to a Claude-family model on `opencode-free` falls through to the generic `determine_api_mode()`, which has no per-model OpenCode routing table and returns the provider's static registered transport (`chat_completions`) regardless of which model was picked:

```
>>> determine_api_mode('opencode-free', '', 'claude-opus')
'chat_completions'   # wrong — should be 'anthropic_messages'
>>> opencode_model_api_mode('opencode-free', 'claude-opus')  # what it should get
'anthropic_messages'
```

This is a first-class, just-shipped provider — not a niche edge case.

### 2. Custom family providers

Providers whose name extends a family slug (`opencode-go-bridge`, `opencode-zen-custom` — issue #85589, the reason `opencode_provider_family` exists at all). Every other call site in the codebase was migrated to the family predicate; this one — in the same file as one of the sites a same-day migration commit's own message claimed to have fixed ("4 sibling sites: cli.py, agent_runtime_helpers.py, model_normalize.py, model_switch.py base_url normalization") — was left on the old exact-set check. The commit fixed the base_url-normalization block 30 lines below in the *same function*, but not this one.

## Impact

This is the exact "double `/v1` 404 / wrong wire" bug class the whole `opencode_provider_family` migration exists to eliminate. `switch_model()`'s `api_mode` result isn't just informational — callers apply it immediately to the live agent and persist it (`cli.py`, `gateway/slash_commands.py`, `tui_gateway/server.py`). A user on `opencode-free` or a custom `opencode-*`-family provider who runs `/model <claude-or-grok-model>` mid-session gets routed onto the wrong wire.

## Fix

Gate on `opencode_provider_family(target_provider) is not None`, matching the pattern already used 30 lines later in the same function (`_oc_family_fn` alias for the base_url strip). Verified the bare `"opencode"` provider id (which the old exact-set check also covered) still resolves through the family predicate (`opencode_provider_family("opencode") == "opencode-zen"`), so no regression there.

## Tests

Two new regression tests in `tests/hermes_cli/test_model_switch_opencode_anthropic.py`, mirroring the file's existing `_run_opencode_switch` harness:
- `opencode-free` + Claude-family model → must get `anthropic_messages`.
- Custom `opencode-go-bridge` + Grok model → must get `codex_responses`.

Mutation-verified against pre-fix code: both fail with `api_mode == 'chat_completions'`.

## Verification

- Targeted file: 6/6 tests pass, including all 3 pre-existing.
- Broader neighbor sweep (opencode/copilot/model-switch/runtime-provider surfaces, 6 files, 100+ tests): green except one unrelated, pre-existing `test_qwen_oauth_auto_fallthrough_on_auth_failure` failure — confirmed independent of this change (reproduces identically, in isolation, with the fix stashed).
- `ruff check`: clean.

## Competing PRs

Searched multiple keyword combinations — no open PR targets this call site.