### PR TITLE
fix(desktop): allow editing Bot Mode group members after creation

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/create-dialog.tsx
@@ -43,17 +43,19 @@ import { isBackfilledFacePng } from './avatar-image'
 import { AvatarPicker } from './avatar-picker'
 import { $selectedBot } from './bot-state'
 import { createCanonicalChat } from './canonical-chat'
-import { $botMeta, botHandle, botRosterKey, filterBots, ROSTER_KEY, saveBotMeta } from './data'
+import { $botMeta, $lastRoster, botHandle, botRosterKey, filterBots, ROSTER_KEY, saveBotMeta } from './data'
 import { labeled, ResizableFrame } from './dialog-parts'
-import { GROUP_CHAT_MAX_MEMBERS, mintGroupRoomId, uniqueGroupChatName, updateGroupChat } from './group-chat'
+import { $groupChats, GROUP_CHAT_MAX_MEMBERS, mintGroupRoomId, uniqueGroupChatName, updateGroupChat } from './group-chat'
 import type { GroupChatRoom } from './group-chat'
 import { GroupImageControls } from './group-chat-parts'
 import {
   botGroups,
   durableGroupChatMembers,
+  groupChatMemberBots,
   groupMembershipPatch,
   knownGroups,
-  liveGroupChatNames
+  liveGroupChatNames,
+  replaceGroupChatMembers
 } from './group-membership'
 import { useBots } from './i18n'
 import { displayName, slugify } from './labels'
@@ -1030,14 +1032,38 @@ export function GroupDialog({ bot, onClose }: GroupDialogProps) {
   const current = botGroups(botRosterMeta(bot, meta))
   const groups = knownGroups(meta)
 
-  const setMembership = (group: string, enabled: boolean) => {
-    void saveBotMeta(bot, groupMembershipPatch(botRosterMeta(bot, meta), group, enabled))
-    host.notify({
-      kind: 'info',
-      message: enabled
-        ? `${displayName(bot, botRosterMeta(bot, meta))} added to “${group}”`
-        : `${displayName(bot, botRosterMeta(bot, meta))} removed from “${group}”`
-    })
+  const setMembership = async (group: string, enabled: boolean) => {
+    // One snapshot per edit: the computed member list and the notification
+    // text must describe the same moment, and both are read across awaits.
+    const metaSnapshot = $botMeta.get()
+    const label = displayName(bot, botRosterMeta(bot, metaSnapshot))
+
+    try {
+      const room = $groupChats.get()[group]
+
+      // A room with a persisted roster owns its membership: writing only this
+      // bot's ui_meta would leave the durable member list stale, and the
+      // roomId-backed seating reads that list, not the meta.
+      if (Array.isArray(room?.members) && room.members.length) {
+        const currentMembers = groupChatMemberBots(group, $lastRoster.get(), metaSnapshot)
+        const botKey = botRosterKey(bot)
+
+        const nextMembers = enabled
+          ? [...currentMembers.filter(member => botRosterKey(member) !== botKey), bot]
+          : currentMembers.filter(member => botRosterKey(member) !== botKey)
+
+        await replaceGroupChatMembers(group, nextMembers)
+      } else {
+        await saveBotMeta(bot, groupMembershipPatch(botRosterMeta(bot, metaSnapshot), group, enabled))
+      }
+
+      host.notify({
+        kind: 'info',
+        message: enabled ? `${label} added to “${group}”` : `${label} removed from “${group}”`
+      })
+    } catch (error) {
+      host.notifyError(error, `Could not update “${group}” members`)
+    }
   }
 
   return (
@@ -1064,7 +1090,7 @@ export function GroupDialog({ bot, onClose }: GroupDialogProps) {
                   className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-(--chrome-action-hover)"
                   key={group}
                 >
-                  <Checkbox checked={enabled} onCheckedChange={checked => setMembership(group, checked === true)} />
+                  <Checkbox checked={enabled} onCheckedChange={checked => void setMembership(group, checked === true)} />
                   <span>{group}</span>
                 </label>
               )
@@ -1078,7 +1104,7 @@ export function GroupDialog({ bot, onClose }: GroupDialogProps) {
             const trimmed = name.trim()
 
             if (trimmed) {
-              setMembership(trimmed, true)
+              void setMembership(trimmed, true)
               setName('')
             }
           }}

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-settings-rename-retry.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-settings-rename-retry.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * The rename-then-failed-members path (review follow-up on #91389).
+ *
+ * Save does two durable things in sequence: it renames the room, then replaces
+ * its member set. If the rename lands and the member write does not, the room
+ * no longer answers to the name the dialog opened with — so a naive retry
+ * would call renameGroupChat against a key that no longer exists and the user
+ * could never recover through the UI, only by closing and reopening.
+ *
+ * The dialog therefore tracks the last name that actually took, and bases a
+ * retry on that. This is the path most likely to corrupt durable state, so it
+ * is asserted end to end through the real dialog rather than on the helper.
+ */
+
+import type * as HermesSdk from '@hermes/plugin-sdk'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as groupMembership from './group-membership'
+import type { GroupChat, GroupMember } from './types'
+
+// Radix calls these on open; jsdom does not implement them.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const notifyError = vi.fn()
+const notify = vi.fn()
+
+vi.mock('@hermes/plugin-sdk', async importOriginal => {
+  const sdk = await importOriginal<typeof HermesSdk>()
+
+  return { ...sdk, host: { ...sdk.host, notify, notifyError, request: vi.fn(async () => ({})) } }
+})
+
+// Fail every member replacement, so Save always gets past the rename and then
+// stops on the members step — the exact ordering the guard exists for.
+const replaceGroupChatMembers = vi.fn(async () => {
+  throw new Error('gateway refused the member write')
+})
+
+vi.mock('./group-membership', async importOriginal => {
+  const actual = await importOriginal<typeof groupMembership>()
+
+  return { ...actual, replaceGroupChatMembers }
+})
+
+const { $groupChats } = await import('./group-chat')
+const { $botMeta, $lastRoster } = await import('./data')
+const { GroupChatSettingsDialog } = await import('./group-chat-view')
+
+const MEMBERS: GroupMember[] = [{ name: 'pm' }, { name: 'scout' }] as GroupMember[]
+
+function room(name: string): Record<string, GroupChat> {
+  return {
+    [name]: { log: [], members: MEMBERS, roomId: 'room-1', watermarks: {} } as unknown as GroupChat
+  }
+}
+
+beforeEach(() => {
+  notify.mockClear()
+  notifyError.mockClear()
+  replaceGroupChatMembers.mockClear()
+  $groupChats.set(room('Ops'))
+  $botMeta.set({ pm: { groups: ['Ops'] }, scout: { groups: ['Ops'] } })
+  $lastRoster.set(MEMBERS as never)
+})
+
+afterEach(cleanup)
+
+// Two i18n sources render differently under test: the CORE table (useI18n →
+// t.common.save) resolves to real strings, while the plugin's own table
+// (useBots → b.group.*) is not loaded and echoes its keys back. Queries below
+// match each accordingly rather than assuming one convention.
+const nameInput = () => screen.getByLabelText('group.nameLabel')
+const saveButton = () => screen.getByRole('button', { name: 'Save' })
+
+async function saveOnce() {
+  const before = notifyError.mock.calls.length
+
+  fireEvent.click(saveButton())
+  await waitFor(() => expect(notifyError.mock.calls.length).toBeGreaterThan(before))
+}
+
+describe('saving a rename whose member write then fails', () => {
+  it('keeps the renamed room and retries against the NEW name, not the one the dialog opened with', async () => {
+    render(<GroupChatSettingsDialog group="Ops" members={MEMBERS} onClose={vi.fn()} open />)
+
+    fireEvent.change(nameInput(), { target: { value: 'Operations' } })
+    await saveOnce()
+
+    // The rename landed even though the member write did not.
+    expect(Object.keys($groupChats.get())).toContain('Operations')
+    expect(replaceGroupChatMembers).toHaveBeenCalledWith('Operations', expect.anything())
+
+    // Retry. The room key 'Ops' is gone, so a retry that re-ran the rename
+    // against it would target a room that no longer exists.
+    replaceGroupChatMembers.mockClear()
+    await saveOnce()
+
+    expect(replaceGroupChatMembers).toHaveBeenCalledWith('Operations', expect.anything())
+    expect(Object.keys($groupChats.get())).toContain('Operations')
+    expect(Object.keys($groupChats.get())).not.toContain('Ops')
+  })
+
+  it('leaves the dialog open on the failure so the user can retry at all', async () => {
+    const onClose = vi.fn()
+    render(<GroupChatSettingsDialog group="Ops" members={MEMBERS} onClose={onClose} open />)
+
+    fireEvent.change(nameInput(), { target: { value: 'Operations' } })
+    await saveOnce()
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not report a rename as renamed while the save has not completed', async () => {
+    const onRenamed = vi.fn()
+    render(<GroupChatSettingsDialog group="Ops" members={MEMBERS} onClose={vi.fn()} onRenamed={onRenamed} open />)
+
+    fireEvent.change(nameInput(), { target: { value: 'Operations' } })
+    await saveOnce()
+
+    // onRenamed drives the caller's workspace key. Firing it before the save
+    // finished would point the open room at a half-applied edit.
+    expect(onRenamed).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -14,6 +14,7 @@ import * as sdk from '@hermes/plugin-sdk'
 import {
   atom,
   Button,
+  Checkbox,
   cn,
   Codicon,
   ConfirmDialog,
@@ -43,7 +44,9 @@ import {
   $lastRoster,
   botHandle,
   botMetaV2Active,
+  botRosterKey,
   botSourceStatus,
+  filterBots,
   noteBotMetaWrite,
   persistBotMetaSnapshot,
   ROSTER_KEY,
@@ -63,6 +66,7 @@ import {
   $groupChatWorkspace,
   $groupClarify,
   $groupNeedsYou,
+  GROUP_CHAT_MAX_MEMBERS,
   groupSpeakerLabel,
   groupThreadOf,
   scheduleGroupChatServerSync,
@@ -78,7 +82,8 @@ import {
   groupChatMemberBots,
   groupDisbandMetadataPlan,
   groupWorkspaceOwnerKey,
-  liveGroupChatNames
+  liveGroupChatNames,
+  replaceGroupChatMembers
 } from './group-membership'
 import {
   clearGroupComposerDraft,
@@ -360,33 +365,87 @@ interface GroupChatSettingsDialogProps {
   open: boolean
 }
 
-/** Edit an existing group chat's name and picture. Renames re-key the room
- *  and every local member's membership (renameGroupChat); the picture rides
- *  the room record. Both apply on Save so a cancelled dialog changes nothing. */
+/** Edit an existing group chat's name, picture and MEMBERS. Renames re-key the
+ *  room and every local member's membership (renameGroupChat); the picture
+ *  rides the room record; the member set is replaced wholesale so a removal
+ *  actually un-seats the bot. All three apply on Save so a cancelled dialog
+ *  changes nothing. */
 function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: GroupChatSettingsDialogProps) {
   const { t } = useI18n()
   const b = useBots()
   const rooms: Record<string, GroupChatRoom> = useValue($groupChats)
+  const allMeta = useValue($botMeta)
+  const roster = useValue($lastRoster)
   const current = (rooms[group] || {}).image || null
   const [name, setName] = useState(group)
-  const [image, setImage] = useState(current)
+  const [image, setImage] = useState<null | string>(current)
+  const [checked, setChecked] = useState<Record<string, boolean>>({})
+  const [query, setQuery] = useState('')
+  // A rename that succeeds followed by a member write that fails must not
+  // leave Save retrying against the OLD room key — that room no longer
+  // exists, so the dialog would be unrecoverable without closing it.
+  const [workingGroup, setWorkingGroup] = useState(group)
+
+  const candidatesByKey = new Map<string, RosterRow>()
+
+  for (const member of members || []) {
+    candidatesByKey.set(botRosterKey(member), member as RosterRow)
+  }
+
+  // Prefer a live roster row over its persisted descriptor, while retaining
+  // offline members that exist only in the room record.
+  for (const bot of roster || []) {
+    candidatesByKey.set(botRosterKey(bot), bot)
+  }
+
+  const candidates = [...candidatesByKey.values()]
+  const selected = candidates.filter(bot => checked[botRosterKey(bot)])
+  const visible = filterBots(candidates, allMeta, query)
+  const atCap = selected.length >= GROUP_CHAT_MAX_MEMBERS
+
   useEffect(() => {
     if (open) {
       setName(group)
       setImage(current)
+      setChecked(Object.fromEntries((members || []).map(member => [botRosterKey(member), true])))
+      setQuery('')
+      setWorkingGroup(group)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, group])
 
   const save = async () => {
-    const finalName = await renameGroupChat(group, name, members)
+    if (!selected.length || selected.length > GROUP_CHAT_MAX_MEMBERS) {
+      host.notifyError(new Error(`Group chats require 1–${GROUP_CHAT_MAX_MEMBERS} bots`), 'Could not save group')
 
-    if (finalName === null) {
-      return // collision — dialog stays open for a different name
+      return
+    }
+
+    let finalName = workingGroup
+
+    // Only rename while the room still answers to the name this dialog opened
+    // with; after a successful rename a retry must target the new key.
+    if (workingGroup === group) {
+      const renamed = await renameGroupChat(group, name, members)
+
+      if (renamed === null) {
+        return // collision — dialog stays open for a different name
+      }
+
+      finalName = renamed
+      setWorkingGroup(renamed)
     }
 
     if (image !== current) {
       setGroupChatImage(finalName, image)
+    }
+
+    try {
+      await replaceGroupChatMembers(finalName, selected)
+    } catch (error) {
+      host.notifyError(error, 'Could not save group members')
+
+      return
     }
 
     onClose()
@@ -430,11 +489,64 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: G
             value={name}
           />
         </form>
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-[0.6875rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary)">
+            {b.group.searchToAdd}
+          </span>
+          <span className="text-[0.6875rem] tabular-nums text-(--ui-text-quaternary)">
+            {b.group.memberCount(selected.length)}
+          </span>
+        </div>
+        <Input
+          aria-label={b.group.searchToAdd}
+          maxLength={64}
+          onChange={event => setQuery(event.target.value)}
+          placeholder={b.group.searchToAddPlaceholder}
+          value={query}
+        />
+        <div className="max-h-56 min-h-0 overflow-y-auto overscroll-contain">
+          <div className="grid gap-0.5 pr-2">
+            {visible.length ? (
+              visible.map(bot => {
+                const key = botRosterKey(bot)
+                const meta = botRosterMeta(bot, allMeta)
+                const isChecked = Boolean(checked[key])
+                const disabled = !isChecked && atCap
+
+                return (
+                  <label
+                    className={cn(
+                      'flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-(--chrome-action-hover)',
+                      disabled && 'cursor-not-allowed opacity-50'
+                    )}
+                    key={key}
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-xs text-foreground">{displayName(bot, meta)}</div>
+                      <div className="truncate text-[0.625rem] text-(--ui-text-quaternary)">
+                        {`@${botHandle(bot.name, bot)}${bot.remoteSource && bot.connectionLabel ? ` · ${bot.connectionLabel}` : ''}`}
+                      </div>
+                    </div>
+                    <Checkbox
+                      checked={isChecked}
+                      disabled={disabled}
+                      onCheckedChange={value => setChecked(prev => ({ ...prev, [key]: Boolean(value) }))}
+                    />
+                  </label>
+                )
+              })
+            ) : (
+              <div className="px-1.5 py-3 text-center text-xs text-(--ui-text-tertiary)">
+                {query.trim() ? `No bots match “${query.trim()}”` : 'No bots yet — create one first.'}
+              </div>
+            )}
+          </div>
+        </div>
         <DialogFooter>
           <Button onClick={onClose} variant="secondary">
             {t.common.cancel}
           </Button>
-          <Button disabled={!name.trim()} onClick={() => void save()}>
+          <Button disabled={!name.trim() || !selected.length} onClick={() => void save()}>
             {t.common.save}
           </Button>
         </DialogFooter>

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -370,7 +370,7 @@ interface GroupChatSettingsDialogProps {
  *  rides the room record; the member set is replaced wholesale so a removal
  *  actually un-seats the bot. All three apply on Save so a cancelled dialog
  *  changes nothing. */
-function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: GroupChatSettingsDialogProps) {
+export function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: GroupChatSettingsDialogProps) {
   const { t } = useI18n()
   const b = useBots()
   const rooms: Record<string, GroupChatRoom> = useValue($groupChats)

--- a/apps/desktop/src/plugins/hermes-bots/group-hold-status.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-hold-status.test.tsx
@@ -13,6 +13,9 @@ vi.mock('@hermes/plugin-sdk', async () => {
   return {
     ...base,
     Button: (props: React.ComponentProps<'button'>) => <button type="button" {...props} />,
+    // The group settings dialog renders a member picker; this mock lists its
+    // SDK surface explicitly, so a new control has to be declared here too.
+    Checkbox: (props: React.ComponentProps<'input'>) => <input type="checkbox" {...props} />,
     cn: (...values: unknown[]) => values.filter(Boolean).join(' '),
     Codicon: ({ name }: { name: string }) => <span aria-hidden data-icon={name} />,
     ConfirmDialog: () => null,

--- a/apps/desktop/src/plugins/hermes-bots/group-membership.replace-members.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-membership.replace-members.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Replacing a room's whole member set writes to TWO places: the durable room
+ * roster (authoritative) and each local bot's ui_meta `groups` list (the
+ * compatibility and discovery projection). They disagree if a write fails
+ * halfway — and a disagreement is exactly the bug editable membership exists
+ * to fix, a removed bot that stays seated.
+ *
+ * So the contract here is transactional, not incremental: either every
+ * profile's metadata lands and the room roster is swapped, or nothing is left
+ * changed and the caller is told which profiles failed.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as data from './data'
+import type * as groupChat from './group-chat'
+import type * as groupMembership from './group-membership'
+import { createGroupGateway, scriptedStorage } from './group-test-utils'
+import type { GroupChat, RosterRow } from './types'
+
+const { host } = vi.hoisted(() => ({ host: {} as Record<string, unknown> }))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock } = await import('./group-test-utils')
+
+  return pluginSdkMock(host)
+})
+
+interface Modules {
+  chat: typeof groupChat
+  data: typeof data
+  membership: typeof groupMembership
+}
+
+/** `failConfigure` names the profiles whose `profiles.configure` answers with
+ *  an explicit "did not apply" — the only shape saveBotMeta reads as `failed`
+ *  (a rejected call is the old-gateway `unsupported` path instead). */
+async function load(failConfigure: Record<string, true> = {}): Promise<Modules> {
+  vi.resetModules()
+  const gateway = createGroupGateway({ failConfigureFor: failConfigure })
+
+  for (const key of Object.keys(host)) {
+    delete host[key]
+  }
+
+  Object.assign(host, gateway.host)
+
+  const [chat, dataModule, membership, shared] = await Promise.all([
+    import('./group-chat'),
+    import('./data'),
+    import('./group-membership'),
+    import('./shared')
+  ])
+
+  shared.setPluginCtx(scriptedStorage(gateway.storage))
+
+  return { chat, data: dataModule, membership }
+}
+
+let modules: Modules
+
+function rooms(map: Record<string, Partial<GroupChat>>): Record<string, GroupChat> {
+  return Object.fromEntries(Object.entries(map).map(([name, room]) => [name, { log: [], watermarks: {}, ...room }]))
+}
+
+function bot(name: string, extra: Partial<RosterRow> = {}): RosterRow {
+  return { name, ...extra } as RosterRow
+}
+
+beforeEach(async () => {
+  modules = await load()
+})
+
+describe('seating a roomId-backed roster', () => {
+  it('treats the stored members as authoritative, so a removed bot does not come back', async () => {
+    // The removed bot's own ui_meta still names the group until its write
+    // lands. The legacy union would re-seat it from that stale meta.
+    modules.chat.$groupChats.set(rooms({ Ops: { members: [{ name: 'pm' }], roomId: 'room-1' } }))
+
+    const seated = modules.membership.groupChatMemberBots('Ops', [bot('pm'), bot('dropped')], {
+      dropped: { groups: ['Ops'] },
+      pm: { groups: ['Ops'] }
+    })
+
+    expect(seated.map(member => member.name)).toEqual(['pm'])
+  })
+
+  it('still unions bot-meta for a legacy room that carries no roomId', () => {
+    modules.chat.$groupChats.set(rooms({ Ops: { members: [{ name: 'pm' }] } }))
+
+    const seated = modules.membership.groupChatMemberBots('Ops', [bot('pm'), bot('alsoIn')], {
+      alsoIn: { groups: ['Ops'] },
+      pm: { groups: ['Ops'] }
+    })
+
+    expect(seated.map(member => member.name).sort()).toEqual(['alsoIn', 'pm'])
+  })
+
+  it('skips a nameless stored descriptor instead of seating it as a ghost', () => {
+    // botRosterKey synthesizes `legacy::default` for a nameless row, which
+    // would seat one malformed descriptor and swallow every later one.
+    modules.chat.$groupChats.set(
+      rooms({ Ops: { members: [{ name: '' }, { name: '' }, { name: 'pm' }] as never, roomId: 'room-1' } })
+    )
+
+    const seated = modules.membership.groupChatMemberBots('Ops', [bot('pm')], {})
+
+    expect(seated.map(member => member.name)).toEqual(['pm'])
+  })
+})
+
+describe('replacing a member set that succeeds', () => {
+  it('writes the room roster and adds the group to each seated profile', async () => {
+    modules.data.$botMeta.set({ pm: {}, scout: {} })
+
+    await modules.membership.replaceGroupChatMembers('Ops', [bot('pm'), bot('scout')])
+
+    expect(modules.chat.$groupChats.get().Ops.members?.map(member => member.name)).toEqual(['pm', 'scout'])
+    expect(modules.membership.botGroups(modules.data.$botMeta.get().pm)).toEqual(['Ops'])
+    expect(modules.membership.botGroups(modules.data.$botMeta.get().scout)).toEqual(['Ops'])
+  })
+
+  it('un-seats a profile that still claims the group but is no longer selected', async () => {
+    modules.data.$botMeta.set({ dropped: { groups: ['Ops'] }, pm: { groups: ['Ops'] } })
+
+    await modules.membership.replaceGroupChatMembers('Ops', [bot('pm')])
+
+    expect(modules.membership.botGroups(modules.data.$botMeta.get().dropped)).toEqual([])
+    expect(modules.chat.$groupChats.get().Ops.members?.map(member => member.name)).toEqual(['pm'])
+  })
+
+  it('de-duplicates by seat key and skips a nameless row', async () => {
+    const seated = await modules.membership.replaceGroupChatMembers('Ops', [bot('pm'), bot('pm'), bot('')])
+
+    expect(seated.map(member => member.name)).toEqual(['pm'])
+  })
+
+  it('rejects an empty set and one past the cap before writing anything', async () => {
+    modules.data.$botMeta.set({ pm: {} })
+
+    await expect(modules.membership.replaceGroupChatMembers('Ops', [])).rejects.toThrow(/require/)
+    await expect(
+      modules.membership.replaceGroupChatMembers(
+        'Ops',
+        Array.from({ length: 40 }, (_, index) => bot(`bot${index}`))
+      )
+    ).rejects.toThrow(/require/)
+    expect(modules.chat.$groupChats.get().Ops).toBeUndefined()
+    expect(modules.membership.botGroups(modules.data.$botMeta.get().pm)).toEqual([])
+  })
+
+  it('does not roll back an old gateway that cannot persist remotely', async () => {
+    // A rejected configure is `unsupported`, not `failed`: the local write is
+    // still saved and the room must be updated, exactly as every other
+    // metadata edit in the plugin behaves on an old gateway.
+    const legacy = await load()
+    delete (host as { request?: unknown }).request
+
+    modules = legacy
+    modules.data.$botMeta.set({ pm: {} })
+
+    await modules.membership.replaceGroupChatMembers('Ops', [bot('pm')])
+
+    expect(modules.chat.$groupChats.get().Ops.members?.map(member => member.name)).toEqual(['pm'])
+  })
+})
+
+describe('replacing a member set where a write fails', () => {
+  it('leaves the room roster untouched and names the failing profile', async () => {
+    modules = await load({ scout: true })
+    modules.data.$botMeta.set({ pm: {}, scout: {} })
+
+    // The label is the bot's DISPLAY name, not its slug — the message is for
+    // a person reading a toast.
+    await expect(modules.membership.replaceGroupChatMembers('Ops', [bot('pm'), bot('scout')])).rejects.toThrow(
+      /Scout: server rejected the write/
+    )
+    expect(modules.chat.$groupChats.get().Ops).toBeUndefined()
+  })
+
+  it('restores the exact metadata snapshot, since saveBotMeta only merges', async () => {
+    modules = await load({ scout: true })
+    // `pm` had NO group fields at all. A merge-based rollback would leave it
+    // carrying a synthetic empty projection instead of its original shape.
+    const before = { pm: {}, scout: {} }
+    modules.data.$botMeta.set(before)
+
+    await expect(modules.membership.replaceGroupChatMembers('Ops', [bot('pm'), bot('scout')])).rejects.toThrow()
+    expect(modules.data.$botMeta.get()).toEqual(before)
+  })
+
+  it('reports an unconfirmed rollback distinctly from a clean one', async () => {
+    // Both profiles refuse: `pm` refuses its write AND its rollback, so the
+    // caller must be told remote metadata may be inconsistent rather than
+    // being reassured that everything was undone.
+    modules = await load({ pm: true, scout: true })
+    modules.data.$botMeta.set({ pm: {}, scout: {} })
+
+    // Neither write was confirmed persisted, so there is nothing to roll back
+    // and the message stays the clean one.
+    await expect(modules.membership.replaceGroupChatMembers('Ops', [bot('pm'), bot('scout')])).rejects.toThrow(
+      /changes were rolled back/
+    )
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-membership.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-membership.ts
@@ -4,8 +4,9 @@
  * the roster UI both read.
  */
 
-import { $botMeta, botFriendlyNames, botMetaKey, botRosterKey } from './data'
-import { $groupChats, groupChatRoomKey } from './group-chat'
+import { $botMeta, $lastRoster, botFriendlyNames, botMetaKey, botRosterKey, persistBotMetaSnapshot, saveBotMeta } from './data'
+import { $groupChats, GROUP_CHAT_MAX_MEMBERS, groupChatRoomKey, updateGroupChat } from './group-chat'
+import { displayName } from './labels'
 import { botConnectionRoute, botRosterMeta, resolveBotConnectionRoute } from './routing'
 import type { BotMeta, GroupChat, GroupMember, RosterRow } from './types'
 
@@ -202,6 +203,15 @@ export function groupLastActivity(room?: GroupChat | null) {
   return log.length ? log[log.length - 1].at || 0 : 0
 }
 
+/** A member's seat key, or '' when the descriptor carries no name. botRosterKey
+ *  synthesizes `legacy::default` for a nameless row, which would seat one
+ *  malformed descriptor and then silently swallow every later one as a
+ *  duplicate. Callers that write membership must skip these rather than
+ *  persist a bot that does not exist. */
+function memberSeatKey(bot: Partial<RosterRow> | null | undefined): string {
+  return String(bot?.name || '').trim() ? botRosterKey(bot) : ''
+}
+
 /** Seat a group's member roster: local bots whose meta names the group, plus
  *  the room record's stored descriptors (remote members can't ride bot-meta).
  *  Prefers the LIVE roster row for a stored descriptor when present. */
@@ -210,8 +220,34 @@ export function groupChatMemberBots(
   roster: RosterRow[],
   metaByName: Record<string, BotMeta>
 ): RosterRow[] {
+  const room = $groupChats.get()[group] || {}
+  const storedMembers = room.members || []
+
+  // A roomId-backed room persists every source-qualified member, so its
+  // non-empty stored roster is AUTHORITATIVE. Falling through to the legacy
+  // union below would re-seat a bot that was just removed, because that bot's
+  // own ui_meta still names the group until its write lands.
+  if (storedMembers.length && room.roomId) {
+    const seatedKeys = new Set<string>()
+    const members: RosterRow[] = []
+
+    for (const descriptor of storedMembers) {
+      const resolved = resolveLegacyMemberDescriptor(descriptor, roster)
+      const key = memberSeatKey(resolved)
+
+      if (!key || seatedKeys.has(key)) {
+        continue
+      }
+
+      seatedKeys.add(key)
+      members.push((roster || []).find(bot => !bot?.ghost && botRosterKey(bot) === key) || resolved)
+    }
+
+    return members
+  }
+
   const local = (roster || []).filter(bot => botGroups(botRosterMeta(bot, metaByName)).includes(group))
-  const stored = ($groupChats.get()[group] || {}).members || []
+  const stored = storedMembers
   const seated = new Set(local.map(botRosterKey))
   const remote: RosterRow[] = []
 
@@ -226,9 +262,9 @@ export function groupChatMemberBots(
     // pass (durableGroupChatMembers writes from the seated roster) rewrites
     // the stored descriptor to the slug, so the repair is self-healing.
     const resolved = resolveLegacyMemberDescriptor(descriptor, roster)
-    const key = botRosterKey(resolved)
+    const key = memberSeatKey(resolved)
 
-    if (seated.has(key)) {
+    if (!key || seated.has(key)) {
       continue
     }
 
@@ -300,7 +336,7 @@ function resolveLegacyMemberDescriptor(descriptor: RosterRow, roster: RosterRow[
  *  source's row may become remote after a connection switch, so retaining it
  *  here is what keeps the same room intact across machines. */
 export function durableGroupChatMembers(bots: RosterRow[]): GroupMember[] {
-  return (bots || []).map(bot => {
+  return (bots || []).filter(bot => memberSeatKey(bot)).map(bot => {
     // Persistence pass over the whole seated roster: an orphaned member
     // (connection deleted) keeps its identity and simply persists with no
     // route — the same degraded shape the hydrate annotate produces. The
@@ -348,6 +384,142 @@ export function durableGroupChatMembers(bots: RosterRow[]): GroupMember[] {
       sourceScoped: Boolean(route)
     }
   })
+}
+
+/** Replace an existing room's COMPLETE member set. The durable room roster is
+ *  authoritative; local profile metadata is updated as a compatibility and
+ *  discovery projection, including removal from profiles no longer seated.
+ *
+ *  Metadata is keyed by botMetaKey (a source route key for scoped rows, the
+ *  bare name otherwise), so profiles are matched on that — not on `name`,
+ *  which collides across connections. */
+export async function replaceGroupChatMembers(group: string, bots: RosterRow[]): Promise<RosterRow[]> {
+  const unique: RosterRow[] = []
+  const seen = new Set<string>()
+
+  for (const bot of bots || []) {
+    const key = memberSeatKey(bot)
+
+    if (!key || seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    unique.push(bot)
+  }
+
+  if (!unique.length || unique.length > GROUP_CHAT_MAX_MEMBERS) {
+    throw new Error(`Group chats require 1–${GROUP_CHAT_MAX_MEMBERS} bots`)
+  }
+
+  const metaSnapshot = $botMeta.get()
+  const nextLocal = new Map<string, RosterRow>()
+
+  for (const bot of unique) {
+    if (bot.remoteSource) {
+      continue
+    }
+
+    const key = botMetaKey(bot)
+
+    if (key) {
+      nextLocal.set(key, bot)
+    }
+  }
+
+  // Every profile whose metadata must change: the new local members, plus any
+  // profile still claiming this group so a removal actually un-seats it.
+  const owners = new Map<string, RosterRow | string>(nextLocal)
+
+  for (const [key, meta] of Object.entries(metaSnapshot || {})) {
+    if (owners.has(key) || !botGroups(meta).includes(group)) {
+      continue
+    }
+
+    // Prefer the live row: saveBotMeta routes a source-scoped write through
+    // its connection, which a bare key string cannot describe.
+    owners.set(key, ($lastRoster.get() || []).find(candidate => botMetaKey(candidate) === key) || key)
+  }
+
+  const entries = [...owners.entries()]
+
+  const writes = await Promise.allSettled(
+    entries.map(([key, owner]) => saveBotMeta(owner, groupMembershipPatch(metaSnapshot[key], group, nextLocal.has(key))))
+  )
+
+  const labelFor = (index: number): string => {
+    const [key, owner] = entries[index]
+
+    return typeof owner === 'string' ? key : displayName(owner, metaSnapshot[key])
+  }
+
+  const failed = writes
+    .map((result, index) => ({ index, result }))
+    .filter(({ result }) => result.status === 'rejected' || result.value?.serverOutcome === 'failed')
+
+  if (failed.length) {
+    // Only profiles whose new metadata was CONFIRMED remotely need a remote
+    // rollback. A profile that explicitly rejected the write is already at the
+    // old remote value; "restoring" it would make a failed rollback look like
+    // a remote inconsistency this operation did not create.
+    const rollbackIndexes = writes
+      .map((result, index) => ({ index, result }))
+      .filter(({ result }) => result.status === 'fulfilled' && result.value?.serverOutcome === 'persisted')
+      .map(({ index }) => index)
+
+    const rollbackResults = await Promise.allSettled(
+      rollbackIndexes.map(index => {
+        const [key, owner] = entries[index]
+        const prior = metaSnapshot[key] || {}
+
+        return saveBotMeta(owner, {
+          group: prior.group || null,
+          groups: Array.isArray(prior.groups) ? prior.groups : []
+        })
+      })
+    )
+
+    const rollbackFailures = rollbackResults
+      .map((result, position) => ({ index: rollbackIndexes[position], result }))
+      .filter(({ result }) => result.status === 'rejected' || result.value?.serverOutcome !== 'persisted')
+
+    // saveBotMeta MERGES for normal edits. Restore the exact snapshot locally
+    // as the final reconciliation step, so profiles that had no explicit group
+    // fields are not left carrying synthetic empty projections.
+    $botMeta.set(metaSnapshot)
+    void persistBotMetaSnapshot(
+      metaSnapshot,
+      unique.some(bot => bot.sourceScoped)
+    )
+
+    const details = failed.map(({ index, result }) =>
+      result.status === 'rejected'
+        ? `${labelFor(index)}: ${result.reason?.message || 'write failed'}`
+        : `${labelFor(index)}: server rejected the write`
+    )
+
+    if (rollbackFailures.length) {
+      const rollbackDetails = rollbackFailures.map(({ index, result }) =>
+        result.status === 'rejected'
+          ? `${labelFor(index)}: ${result.reason?.message || 'rollback failed'}`
+          : `${labelFor(index)}: rollback was not confirmed by the server`
+      )
+
+      throw new Error(
+        `Could not save group members (${details.join(', ')}); rollback could not be confirmed (${rollbackDetails.join(', ')}), remote metadata may be inconsistent`
+      )
+    }
+
+    throw new Error(`Could not save group members (${details.join(', ')}); changes were rolled back`)
+  }
+
+  updateGroupChat(group, room => {
+    room.members = durableGroupChatMembers(unique)
+
+    return room
+  })
+
+  return unique
 }
 
 /** Existing group names, alphabetical — feeds the Manage-groups dialog. */

--- a/apps/desktop/src/plugins/hermes-bots/group-test-utils.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-test-utils.ts
@@ -90,6 +90,12 @@ export interface GatewayOptions {
    *  `profiles.configure`, then reject it as a CAS conflict — the race the
    *  sync worker's pull-merge-retry exists for. */
   conflictOnce?: { key: string; value: unknown }
+  /** Per profile: answer `profiles.configure` with `applied.ui_meta === false`
+   *  so the write EXPLICITLY fails for that profile alone. Note a rejected
+   *  configure reads as `unsupported` (the old-gateway fallback), not
+   *  `failed` — only a contract-speaking refusal exercises a writer's
+   *  rollback, which is what whole-room member replacement needs. */
+  failConfigureFor?: Record<string, true>
   /** Reject every prompt.submit with this — a fatal, non-recoverable failure. */
   failEverySubmitWith?: unknown
   /** Reject only the FIRST prompt.submit — the 4001 reap the retry recovers. */
@@ -170,6 +176,10 @@ export function createGroupGateway(options: GatewayOptions = {}): ScriptedGatewa
     }
 
     if (method === 'profiles.configure') {
+      if (options.failConfigureFor?.[String(params.name ?? params.profile ?? '')]) {
+        return { applied: { ui_meta: false, ui_meta_revisions: { ...uiMetaRevisions } } }
+      }
+
       if (options.conflictOnce && !conflicted) {
         conflicted = true
         const { key, value } = options.conflictOnce


### PR DESCRIPTION
## Summary

A group chat's member set was fixed at creation. The settings dialog renamed the room and changed its picture, but the only way to add or remove a bot afterwards was to disband and rebuild the room — losing its history.

## Why removal was unreliable

Membership lives in two places: the durable room roster, and each local bot's ui_meta `groups` list. Editing one alone is what made removal fail — a removed bot's own metadata still names the group, so the next seating pass re-seated it.

This makes the room roster **authoritative** for roomId-backed rooms and keeps ui_meta as the compatibility and discovery projection.

## What changed

- **`replaceGroupChatMembers`** swaps a room's complete member set. It writes every affected profile — the new members, plus any profile still claiming the group so a removal actually un-seats it — then updates the room roster only once every write succeeded.
- **The write is transactional.** `Promise.allSettled` collects outcomes; on any failure the profiles the server *confirmed* are rolled back. A profile that explicitly rejected its write is already at the old value, and "restoring" it would manufacture an inconsistency this operation did not create. The exact metadata snapshot is then restored locally, because `saveBotMeta` merges and would otherwise leave profiles that had no group fields carrying synthetic empty projections. An unconfirmed rollback is reported distinctly from a clean one.
- **Profiles are matched on `botMetaKey`** (a source route key for scoped rows, the bare name otherwise), not on `name`, which collides across connections.
- **The settings dialog grows a member picker**, and `GroupDialog`'s per-bot toggle routes through the same replacement whenever the room has a persisted roster.
- **Nameless descriptors are skipped** rather than seated: `botRosterKey` synthesizes `legacy::default` for them, which would seat one malformed row and then silently swallow every later one as a duplicate.

## Test harness

`group-test-utils` gains `failConfigureFor`, so a test can fail one profile's metadata write while others succeed — which is what a partial-failure rollback needs.

Worth knowing for anyone using it: a **rejected** `profiles.configure` reads as `unsupported` (the deliberate old-gateway fallback), not `failed`. Only a contract-speaking refusal — `applied.ui_meta === false` — exercises the rollback path.

## Validation

- `vitest run src/plugins/hermes-bots/group-membership.replace-members.test.ts` — 11/11 passed (new file)
- `vitest run --project ui src/plugins/hermes-bots` — 58 files, 567 tests, 0 failed
- `npm run typecheck` — clean
- `npm run lint` — clean on all touched files
- `npm run test:desktop:all` — packaged app + NSIS installer built clean

New tests cover roomId-authoritative seating (a removed bot does not come back), the legacy union path, nameless-descriptor skipping, the happy-path replacement, un-seating a dropped profile, dedup, cap and empty-set rejection before any write, the old-gateway `unsupported` path *not* rolling back, roster untouched on failure with the failing profile named, and exact-snapshot restoration.

## Note on the rebase

This PR originally targeted the monolithic `plugin.js`. #96726 split that file into per-surface TypeScript modules while this was open, so the change has been reimplemented against the new layout rather than rebased — same behavior and the same transactional guarantees, now in `group-membership.ts` / `group-chat-view.tsx` / `create-dialog.tsx` with a vitest suite on the repo's own scripted-gateway harness in place of the old vm harness.