### PR TITLE
fix(compression): preflight display-seed must not overwrite real provider usage

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -929,8 +929,22 @@ def build_turn_context(
 
         if not _preflight_deferred:
             _last = _compressor.last_prompt_tokens
-            # Do NOT overwrite the -1 sentinel (#36718).
-            if _last >= 0 and _preflight_tokens > _last:
+            # The seed exists so the status bar shows current occupancy when a
+            # provider reports no usage (#34282's motivation). But
+            # ``last_prompt_tokens`` is also the post-response compression
+            # gate's "real tokens" input (conversation_loop) and the CLI
+            # context meter's source (cli.py). Overwriting a REAL provider
+            # reading with the rough preflight estimate makes the bar jump to
+            # an inflated number and can push the real-usage gate over the
+            # threshold on estimator noise — compression then fires at far
+            # below the user-configured threshold (observed: 492K real vs
+            # ~685K rough on a 1M window; reasoning-heavy sessions inflate
+            # the rough estimate 1.4-2.5x, see #81481).
+            #
+            # Policy: a real provider reading (>0) always wins. Seed only
+            # from the 0 state ("no reading yet"); -1 stays protected as the
+            # post-compression sentinel (#36718).
+            if _last == 0 and _preflight_tokens > _last:
                 _compressor.last_prompt_tokens = _preflight_tokens
 
         _compression_cooldown = getattr(

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2247,9 +2247,9 @@ class TestPreflightSentinelGuard:
     """
 
     def _seed(self, last_prompt_tokens, preflight_tokens):
-        # Mirror the exact guard in agent/conversation_loop.py run_conversation.
+        # Mirror the exact guard in agent/turn_context.py build_turn_context.
         _last = last_prompt_tokens
-        if _last >= 0 and preflight_tokens > _last:
+        if _last == 0 and preflight_tokens > _last:
             return preflight_tokens  # would overwrite
         return last_prompt_tokens   # preserved
 
@@ -2259,10 +2259,20 @@ class TestPreflightSentinelGuard:
         result = self._seed(compressor.last_prompt_tokens, 250_000)
         assert result == -1
 
-    def test_real_value_still_revises_upward(self, compressor):
-        compressor.last_prompt_tokens = 10_000
+    def test_zero_state_still_seeded(self, compressor):
+        # 0 means "no reading yet" — the seed keeps the status bar live when
+        # providers report no usage.
+        compressor.last_prompt_tokens = 0
         result = self._seed(compressor.last_prompt_tokens, 50_000)
         assert result == 50_000
+
+    def test_real_provider_reading_wins_over_rough_estimate(self, compressor):
+        # Regression for the 492K-vs-685K display jump: a real provider
+        # reading must never be replaced by the schema/reasoning-inflated
+        # rough preflight estimate (#81481 class inflation).
+        compressor.last_prompt_tokens = 492_000
+        result = self._seed(compressor.last_prompt_tokens, 685_344)
+        assert result == 492_000
 
 
 


### PR DESCRIPTION
## What does this PR do?

The preflight compression path seeds `context_compressor.last_prompt_tokens` with its rough token estimate whenever the estimate exceeds the current value (`_last >= 0`). That seed exists so the status bar can show current occupancy, but `last_prompt_tokens` is not display-only state — it also feeds:

- the post-response compression gate's "real tokens" input (`agent/conversation_loop.py`: `should_compress(_real_tokens)`), and
- the CLI status bar's context meter (`cli.py`).

Rough estimates can exceed real usage by ~1.4-2.5x on reasoning-heavy sessions (#81481 class inflation). One seed therefore made the context meter jump to an inflated number AND could push the real-usage gate over the threshold on estimator noise alone.

Observed in a production CLI session on a 1M-token window with a reasoning-heavy history: the status bar showed ~492K real provider prompt tokens; the next turn's preflight estimated ~685K and seeded it into `last_prompt_tokens`; compression then fired at ~69% of the window while real usage was ~49%.

## Change

A real provider reading (>0) always wins. The seed only fills the `0` state ("no reading yet"), keeping the status bar live for providers that report no usage (#34282's motivation). `-1` remains protected as the post-compression sentinel (#36718).

| `last_prompt_tokens` state | Before | After |
|---|---|---|
| `-1` (post-compression sentinel) | preserved | preserved |
| `0` (no reading yet) | seeded | seeded |
| `>0` (real provider reading) | overwritten when estimate larger | **preserved** |

## Related Issue

No open issue covers this exact site. #23902 covered the post-compression overwrite (fixed via the -1 sentinel, #40582); this PR covers the remaining preflight-seed overwrite. #81481 documents the estimator inflation that makes this seed dangerous; #81504 fixes that estimator side independently — both fixes compose.

## How to Test

1. Set `compressor.last_prompt_tokens = 492_000` (real provider reading).
2. Run a turn whose preflight rough estimate is 685_344.
3. Before: `last_prompt_tokens` becomes 685_344 (bar jumps, gate may cross threshold).
4. After: `last_prompt_tokens` stays 492_000.

Automated: updated `TestPreflightSentinelGuard` encodes the full policy table above, including a regression test with the measured 492K/685K numbers. All existing compression/preflight suites pass unchanged.
