### PR TITLE
fix(gateway): include interim commentary in cleanup_progress

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5470,6 +5470,11 @@ class TurnRunner:
                             else None
                         ),
                         on_before_finalize=_pause_typing_before_finalize,
+                        on_temporary_message=(
+                            (lambda mid: ctx._cleanup_msg_ids.append(str(mid)))
+                            if ctx._cleanup_progress
+                            else None
+                        ),
                         initial_reply_to_id=ctx.event_message_id,
                         run_still_current=ctx._run_still_current,
                     )
@@ -28299,8 +28304,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Auto-cleanup of temporary progress bubbles (Telegram + any adapter
         # that implements ``delete_message``). When enabled via
         # ``display.platforms.<platform>.cleanup_progress: true``, message IDs
-        # from the tool-progress / "⏳ Working — N min" / status-callback bubbles
-        # are collected here and deleted after the final response lands.
+        # from the tool-progress / "⏳ Working — N min" / status-callback
+        # bubbles and mid-turn assistant commentary are collected here and
+        # deleted after the final response lands.
         # Failed runs skip cleanup so the bubbles remain as breadcrumbs.
         _cleanup_progress = bool(
             resolve_display_setting(user_config, platform_key, "cleanup_progress")

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -218,6 +218,7 @@ class GatewayStreamConsumer:
         metadata: Optional[dict] = None,
         on_new_message: Optional[callable] = None,
         on_before_finalize: Optional[Callable[[], Any]] = None,
+        on_temporary_message: Optional[Callable[[str], Any]] = None,
         initial_reply_to_id: Optional[str] = None,
         run_still_current: Optional[Callable[[], bool]] = None,
     ):
@@ -237,6 +238,10 @@ class GatewayStreamConsumer:
         # Gateway callers use this to pause typing refreshes before a slow
         # final rich-text edit (Telegram MarkdownV2 finalize, etc.).
         self._on_before_finalize = on_before_finalize
+        # Fired with a platform message_id after a successful interim
+        # commentary send. Gateway cleanup_progress uses this to delete
+        # those bubbles after a successful final response.
+        self._on_temporary_message = on_temporary_message
         self._initial_reply_to_id = initial_reply_to_id
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
@@ -591,6 +596,16 @@ class GatewayStreamConsumer:
             cb()
         except Exception:
             logger.debug("on_new_message callback error", exc_info=True)
+
+    def _notify_temporary_message(self, message_id: str) -> None:
+        """Fire on_temporary_message with a delivered interim message id."""
+        cb = self._on_temporary_message
+        if cb is None or not message_id:
+            return
+        try:
+            cb(str(message_id))
+        except Exception:
+            logger.debug("on_temporary_message callback error", exc_info=True)
 
     @staticmethod
     def _signal_flush(flush_event) -> None:
@@ -2092,6 +2107,9 @@ class GatewayStreamConsumer:
                 # stale tool bubble above it so the next tool starts a
                 # new bubble below.
                 self._notify_new_message()
+                mid = getattr(result, "message_id", None)
+                if mid:
+                    self._notify_temporary_message(str(mid))
                 # Record the exact delivered text so run.py can confirm whether
                 # an interim "preview" actually carried the final response, vs.
                 # unrelated commentary delivered during a session split (#14238).

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -295,3 +295,121 @@ async def test_cleanup_chains_with_existing_callback(monkeypatch, tmp_path):
     # deletes at least one progress bubble.
     assert pre_existing_fired == [True]
     assert len(adapter.deleted) >= 1
+
+
+class CommentaryAgent:
+    """Emits one mid-turn assistant commentary message, then a final answer."""
+
+    def __init__(self, **kwargs):
+        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.interim_assistant_callback
+        if cb is not None:
+            cb("I'll inspect the repo first.")
+            time.sleep(0.2)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class FailingCommentaryAgent(CommentaryAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.interim_assistant_callback
+        if cb is not None:
+            cb("I'll inspect the repo first.")
+            time.sleep(0.2)
+        return {
+            "final_response": "",
+            "messages": [],
+            "api_calls": 1,
+            "failed": True,
+            "error": "simulated provider failure",
+        }
+
+
+async def _fire_cleanup(adapter, session_key):
+    cb = adapter.pop_post_delivery_callback(session_key)
+    if not callable(cb):
+        return
+    await _fire_post_delivery_cb(cb)
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if adapter.deleted:
+            break
+
+
+def _commentary_ids(adapter):
+    return [
+        str(item["message_id"])
+        for item in adapter.sent
+        if item.get("content") == "I'll inspect the repo first."
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_interim_commentary_after_success(monkeypatch, tmp_path):
+    """cleanup_progress also removes mid-turn assistant commentary."""
+    adapter = CleanupCaptureAdapter(platform=Platform.SLACK)
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        CommentaryAgent,
+        cleanup_on=True,
+        cleanup_platform=Platform.SLACK,
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.SLACK, chat_id="D123", chat_type="dm")
+    session_key = "agent:main:slack:dm:D123"
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-commentary",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    commentary_ids = _commentary_ids(adapter)
+    assert commentary_ids, f"expected commentary send, got {adapter.sent!r}"
+    final_ids = [
+        str(item["message_id"])
+        for item in adapter.sent
+        if item.get("content") == "done"
+    ]
+
+    await _fire_cleanup(adapter, session_key)
+    deleted = {item["message_id"] for item in adapter.deleted}
+    assert set(commentary_ids) <= deleted
+    assert not (set(final_ids) & deleted)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_keeps_interim_commentary_on_failed_run(monkeypatch, tmp_path):
+    """Failed runs leave commentary in place as breadcrumbs."""
+    adapter = CleanupCaptureAdapter(platform=Platform.SLACK)
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(
+        monkeypatch,
+        FailingCommentaryAgent,
+        cleanup_on=True,
+        cleanup_platform=Platform.SLACK,
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.SLACK, chat_id="D123", chat_type="dm")
+    session_key = "agent:main:slack:dm:D123"
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-commentary-fail",
+        session_key=session_key,
+    )
+
+    assert result.get("failed") is True
+    assert _commentary_ids(adapter)
+    await _fire_cleanup(adapter, session_key)
+    assert adapter.deleted == []

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -831,6 +831,25 @@ class TestInterimCommentaryMessages:
         assert sent_texts == ["I'll inspect the repository first.", "Done."]
         assert consumer.final_response_sent is True
 
+    @pytest.mark.asyncio
+    async def test_commentary_notifies_temporary_message_callback(self):
+        """Successful commentary sends expose their message id for cleanup."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_interim")
+        )
+        seen: list[str] = []
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            on_temporary_message=lambda mid: seen.append(str(mid)),
+        )
+
+        ok = await consumer._send_commentary("I'll inspect the repository first.")
+
+        assert ok is True
+        assert seen == ["msg_interim"]
+
 
 class TestCancelledConsumerSetsFlags:
     """Cancellation must set final_response_sent when already_sent is True.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1980,7 +1980,7 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 
 Signal is listed as a valid platform key because the setting can be saved per platform, but the current Signal adapter cannot edit sent messages and does not render tool-progress bubbles. Keep Signal `tool_progress` set to `off`; use the CLI or an editing-capable messaging platform if you need to watch each tool call live.
 
-`interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+`interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming. On platforms whose adapter implements `delete_message`, set `display.platforms.<platform>.cleanup_progress: true` to delete those commentary messages after a successful final response. Failed runs leave them in place.
 
 `show_commentary` (default `true`) controls Codex Responses models' commentary channel — the polished progress narration these models produce alongside their private reasoning. When enabled, each completed commentary message is delivered as a visible mid-turn update (on the gateway this also requires `interim_assistant_messages`). Set it to `false` if the extra narration annoys you: commentary then falls back to the reasoning channel and is only shown when `show_reasoning` is enabled.
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -758,7 +758,7 @@ display:
 
 ### Progress bubble cleanup (opt-in)
 
-Tool-progress messages, the "still working…" heartbeat, and status-callback bubbles can also be auto-deleted after the final response lands. Enable per-platform via `display.platforms.<platform>.cleanup_progress`:
+Tool-progress messages, the "still working…" heartbeat, status-callback bubbles, and mid-turn assistant commentary (`interim_assistant_messages`) can also be auto-deleted after the final response lands. Enable per-platform via `display.platforms.<platform>.cleanup_progress`:
 
 ```yaml
 display:
@@ -767,9 +767,12 @@ display:
       cleanup_progress: true
     discord:
       cleanup_progress: true
+    slack:
+      interim_assistant_messages: true
+      cleanup_progress: true
 ```
 
-Defaults to `false`. Only platforms whose adapter implements `delete_message` honor the setting (currently Telegram and Discord). Failed runs **skip** cleanup so the bubbles remain as breadcrumbs.
+Defaults to `false`. Only platforms whose adapter implements `delete_message` honor the setting (Telegram, Discord, Slack, and others with a real `delete_message`). Failed runs **skip** cleanup so the bubbles remain as breadcrumbs.
 
 ## Next Steps
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -82,7 +82,7 @@ Navigate to **Features → OAuth & Permissions** in the sidebar. Scroll to **Sco
 
 | Scope | Purpose |
 |-------|---------|
-| `chat:write` | Send messages as the bot |
+| `chat:write` | Send messages as the bot. Also enough for the bot to `chat.delete` its own progress/commentary bubbles when `cleanup_progress` is on |
 | `app_mentions:read` | Detect when @mentioned in channels |
 | `channels:history` | Read messages in public channels the bot is in |
 | `channels:read` | List and get info about public channels |


### PR DESCRIPTION
## Summary

- `display.platforms.<plat>.cleanup_progress` now also deletes mid-turn assistant commentary (`interim_assistant_messages`) after a successful final response.
- Failed runs still leave commentary in place as breadcrumbs.
- Docs list Slack: the adapter already implements `delete_message` (`chat.delete`).

## Motivation

Desktop/browser `interim_assistant_messages: false` folds commentary in the renderer (one bubble replaced by the final). On Slack/Telegram the same commentary is a separate `adapter.send()`. `cleanup_progress` already deleted tool-progress / heartbeat / status bubbles; commentary IDs were never collected, so those messages stayed in the thread.

No new config key. Same opt-in.

## Changes

- `GatewayStreamConsumer` fires `on_temporary_message(message_id)` after a successful commentary send.
- Gateway `run.py` appends those IDs to the existing `_cleanup_msg_ids` list when `cleanup_progress` is on.
- Tests: unit (callback) + Slack `_run_agent` success/failure.
- Docs: messaging index, configuration, Slack `chat:write` scope note.

## Test Plan

- [x] `scripts/run_tests.sh tests/gateway/test_stream_consumer.py tests/gateway/test_run_cleanup_progress.py tests/gateway/test_run_progress_topics.py tests/gateway/test_display_config.py`
- [ ] After merge: `display.platforms.slack.cleanup_progress: true` with `interim_assistant_messages: true`, `/restart`, confirm commentary appears mid-turn and is deleted after a successful final.

## Notes for Reviewers

Sibling of the existing cleanup path — not a new display setting. Telegram already has `cleanup_progress: true` in some installs; those users will also see commentary disappear after success, which matches the documented cleanup intent.