### PR TITLE
fix(weixin): allow legacy TLS 1.2 ciphers from WeChat CDN

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -157,6 +157,10 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     if not AIOHTTP_AVAILABLE:
         return None
     ssl_ctx = ssl.create_default_context(cafile=certifi.where())
+    # WeChat CDN (novac2c.cdn.weixin.qq.com) only offers legacy TLS 1.2
+    # ciphers (AES256-GCM-SHA384) that OpenSSL 3.x rejects at SECLEVEL=2.
+    # Drop to SECLEVEL=1 to allow them — cert verification stays on.
+    ssl_ctx.set_ciphers('DEFAULT:@SECLEVEL=1')
     return aiohttp.TCPConnector(
         ssl=ssl_ctx,
         # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451, #69089).


### PR DESCRIPTION
## Summary

WeChat's CDN (`novac2c.cdn.weixin.qq.com`) only offers legacy TLS 1.2 cipher suites (e.g. `AES256-GCM-SHA384`) that OpenSSL 3.x rejects at the default `SECLEVEL=2`. This causes media upload/download handshake failures on Ubuntu 22.04+, Debian 12+, and other systems shipping OpenSSL 3.x.

## Fix

Drop `ssl.create_default_context()` to `SECLEVEL=1` via `set_ciphers('DEFAULT:@SECLEVEL=1')` in `_make_ssl_connector()`. This allows the legacy cipher suites while keeping **certificate verification fully intact** — only the cipher security level is relaxed, not the trust chain.

## Testing

- Verified on Ubuntu 22.04 with OpenSSL 3.0.2 — WeChat CDN media uploads now succeed after this change.
- No impact on certificate verification (certifi CA bundle still enforced).
- Other platforms (Telegram, Discord, etc.) are unaffected — this only touches the WeChat SSL connector.

## Context

This is a production fix that's been running on a live WeChat (Weixin) gateway for several weeks without issues. The WeChat CDN does not appear to support modern cipher suites, so this workaround is necessary until Tencent updates their CDN TLS configuration.
