### PR TITLE
fix(compression): preserve conversation language in context summaries

### DIFF
--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -615,6 +615,8 @@ class TrajectoryCompressor:
         """
         prompt = f"""Summarize the following agent conversation turns concisely. This summary will replace these turns in the conversation history.
 
+CRITICAL: Write the summary in the SAME LANGUAGE as the conversation turns below. If the turns are in Arabic, write the summary in Arabic. If in English, write in English. If mixed, match the dominant language. Never translate — preserve the original language so nuance and dialect are not lost.
+
 Write the summary from a neutral perspective describing what the assistant did and learned. Include:
 1. What actions the assistant took (tool calls, searches, file operations)
 2. Key information or results obtained
@@ -683,6 +685,8 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
             Summary string
         """
         prompt = f"""Summarize the following agent conversation turns concisely. This summary will replace these turns in the conversation history.
+
+CRITICAL: Write the summary in the SAME LANGUAGE as the conversation turns below. If the turns are in Arabic, write the summary in Arabic. If in English, write in English. If mixed, match the dominant language. Never translate — preserve the original language so nuance and dialect are not lost.
 
 Write the summary from a neutral perspective describing what the assistant did and learned. Include:
 1. What actions the assistant took (tool calls, searches, file operations)


### PR DESCRIPTION
## Summary

The trajectory compressor's summary prompts did not instruct the LLM to match the language of the conversation being summarized. This caused Arabic (and other non-English) conversations to be **silently translated to English** during context compression, losing dialect nuance and breaking continuity.

## Problem

When context compression triggers on long conversations, the `TrajectoryCompressor` sends the conversation turns to the LLM with a summary prompt. The prompt had no language instruction, so the LLM defaults to English — even when the entire conversation is in Arabic, Chinese, Korean, or another language.

After compression, the user sees a jarring language switch: Arabic conversation → English summary → back to Arabic. This also loses cultural context, dialect specifics (e.g. Iraqi Arabic vs MSA), and technical terms that don't translate cleanly.

## Fix

Add explicit instruction to both summary prompt templates in `trajectory_compressor.py`:

```
CRITICAL: Write the summary in the SAME LANGUAGE as the conversation turns below.
If the turns are in Arabic, write the summary in Arabic. If in English, write in English.
If mixed, match the dominant language. Never translate — preserve the original
language so nuance and dialect are not lost.
```

Applied to both the `_build_summary_prompt` and the second prompt template (lines ~616 and ~685).

## Testing

- Verified on bilingual (English/Arabic) conversations — summaries now preserve the dominant language.
- No regression on English-only conversations (instruction is a no-op when English is the language).
- Mixed-language conversations correctly match the dominant language.
