### PR TITLE
fix(cron): yield continuable jobs to live gateway

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1601,6 +1601,56 @@ def _resolve_origin(job: dict) -> Optional[dict]:
     return None
 
 
+def _has_live_gateway_delivery_context(adapters: Any, loop: Any) -> bool:
+    """Return True when this process can deliver through live gateway adapters."""
+    if not adapters or loop is None:
+        return False
+    try:
+        return bool(getattr(loop, "is_running", lambda: False)())
+    except Exception:
+        return False
+
+
+def _live_gateway_running_for_profile() -> bool:
+    """Return True when a live gateway owns the active profile's runtime lock."""
+    try:
+        from gateway.status import resolve_gateway_liveness
+
+        return resolve_gateway_liveness(
+            profile_dir=_get_hermes_home().resolve(),
+            use_cache=True,
+        ).running
+    except Exception:
+        # Fail open: an unreadable PID/lock probe must not suppress cron forever.
+        return False
+
+
+def _job_needs_live_gateway_for_continuation(job: dict) -> bool:
+    """Whether direct execution would lose continuable platform delivery state."""
+    try:
+        if not _cron_mirror_delivery_enabled(job):
+            return False
+        targets = _resolve_delivery_targets(job)
+    except Exception:
+        return False
+    for target in targets:
+        platform = str(target.get("platform") or "").strip().lower()
+        if platform in _KNOWN_DELIVERY_PLATFORMS:
+            return True
+    return False
+
+
+def _should_yield_cron_to_live_gateway(
+    job: dict, adapters: Any = None, loop: Any = None
+) -> bool:
+    """True when an adapter-less owner should leave this job for the gateway tick."""
+    if _has_live_gateway_delivery_context(adapters, loop):
+        return False
+    if not _job_needs_live_gateway_for_continuation(job):
+        return False
+    return _live_gateway_running_for_profile()
+
+
 def _cron_mirror_delivery_enabled(job: dict, cfg: Optional[dict] = None) -> bool:
     """Whether a cron delivery should also be mirrored into the target chat's
     gateway session transcript.
@@ -7123,6 +7173,20 @@ def tick(
 
         if verbose:
             logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
+
+        gateway_handoff_ids = {
+            job.get("id")
+            for job in due_jobs
+            if _should_yield_cron_to_live_gateway(job, adapters, loop)
+        }
+        if gateway_handoff_ids:
+            logger.info(
+                "Cron tick yielded %d continuable platform job(s) to live gateway",
+                len(gateway_handoff_ids),
+            )
+            due_jobs = [job for job in due_jobs if job.get("id") not in gateway_handoff_ids]
+            if not due_jobs:
+                return 0
 
         # Advance next_run_at for all recurring jobs FIRST, under the file lock,
         # before any execution begins.  This preserves at-most-once semantics.

--- a/tests/cron/test_cron_gateway_ownership.py
+++ b/tests/cron/test_cron_gateway_ownership.py
@@ -1,0 +1,72 @@
+"""Regression tests for live-gateway ownership of continuable cron delivery."""
+
+from __future__ import annotations
+
+import time
+
+
+class _RunningLoop:
+    def is_running(self) -> bool:
+        return True
+
+
+def _continuable_discord_job(job_id: str = "cron-gateway-owner") -> dict:
+    return {
+        "id": job_id,
+        "name": "continuable discord",
+        "prompt": "brief me",
+        "deliver": "discord:123456789",
+        "attach_to_session": True,
+        "schedule": {"kind": "interval", "seconds": 3600},
+        "next_run_at": "2000-01-01T00:00:00+00:00",
+    }
+
+
+def test_should_yield_cron_to_live_gateway_for_adapterless_continuable_job(monkeypatch):
+    from cron import scheduler as sched
+
+    monkeypatch.setattr(sched, "_live_gateway_running_for_profile", lambda: True)
+
+    assert sched._should_yield_cron_to_live_gateway(_continuable_discord_job()) is True
+
+
+def test_should_not_yield_when_current_process_has_live_adapter_context(monkeypatch):
+    from cron import scheduler as sched
+
+    monkeypatch.setattr(sched, "_live_gateway_running_for_profile", lambda: True)
+
+    assert (
+        sched._should_yield_cron_to_live_gateway(
+            _continuable_discord_job(),
+            adapters={"discord": object()},
+            loop=_RunningLoop(),
+        )
+        is False
+    )
+
+
+def test_tick_leaves_due_jobs_for_live_gateway_before_advancing_claims(
+    tmp_path, monkeypatch
+):
+    from cron import scheduler as sched
+
+    due_job = _continuable_discord_job()
+    monkeypatch.setattr(
+        sched, "_get_lock_paths", lambda: (tmp_path, tmp_path / ".tick.lock")
+    )
+    monkeypatch.setattr(sched, "_last_dead_owner_reap_at", time.monotonic())
+    monkeypatch.setattr(sched, "get_due_jobs", lambda: [due_job])
+    monkeypatch.setattr(sched, "_live_gateway_running_for_profile", lambda: True)
+
+    advanced: list[list[str]] = []
+    claimed: list[str] = []
+    monkeypatch.setattr(
+        sched, "advance_next_runs", lambda ids: advanced.append(list(ids)) or 1
+    )
+    monkeypatch.setattr(
+        sched, "claim_job_for_fire", lambda job_id, **_: claimed.append(job_id) or True
+    )
+
+    assert sched.tick(verbose=False, adapters=None, loop=None, sync=True) == 0
+    assert advanced == []
+    assert claimed == []

--- a/tests/tools/test_cronjob_run_gateway_handoff.py
+++ b/tests/tools/test_cronjob_run_gateway_handoff.py
@@ -1,0 +1,48 @@
+"""Regression tests for manual cron runs yielding continuable delivery to gateway."""
+
+from __future__ import annotations
+
+
+def _job(job_id: str = "manual-gateway-handoff") -> dict:
+    return {
+        "id": job_id,
+        "name": "manual handoff",
+        "prompt": "brief me",
+        "deliver": "discord:123456789",
+        "attach_to_session": True,
+        "schedule": {"kind": "interval", "seconds": 3600},
+    }
+
+
+def test_execute_job_now_queues_for_gateway_before_taking_fire_claim(monkeypatch):
+    from cron import scheduler as sched
+    from tools import cronjob_tools
+
+    monkeypatch.setattr(sched, "_should_yield_cron_to_live_gateway", lambda job: True)
+
+    updates: list[tuple[str, dict]] = []
+    claims: list[str] = []
+    monkeypatch.setattr(
+        cronjob_tools,
+        "update_job",
+        lambda job_id, update: (
+            updates.append((job_id, update)) or {**_job(job_id), **update}
+        ),
+    )
+    monkeypatch.setattr(
+        cronjob_tools,
+        "claim_job_for_fire",
+        lambda job_id, **_: (
+            claims.append(job_id) or {**_job(job_id), "fire_claim": {"by": "owner"}}
+        ),
+    )
+
+    result = cronjob_tools._execute_job_now(_job())
+
+    assert result["claimed"] is False
+    assert result["success"] is True
+    assert result["queued_for_gateway"] is True
+    assert "live gateway" in result["error"]
+    assert updates and updates[0][0] == "manual-gateway-handoff"
+    assert "next_run_at" in updates[0][1]
+    assert claims == []

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -690,6 +690,12 @@ def _execute_job_now(
 ) -> Dict[str, Any]:
     """Execute a cron job immediately, outside the scheduler tick.
 
+    Adapter-less callers must not run continuable platform deliveries while a
+    live gateway owns the profile: the gateway process has the Discord/Slack/etc.
+    adapter state needed to create or reuse continuation threads. Queue the job
+    for the next gateway tick before taking the fire claim so the direct caller
+    cannot advance ``next_run_at`` or fall back to standalone delivery.
+
     Atomically claims the job first via ``claim_job_for_fire`` — the same
     at-most-once CAS the scheduler/external-provider fire path uses — so a
     concurrently-running gateway ticker cannot also fire it (the claim both
@@ -704,6 +710,26 @@ def _execute_job_now(
     Returns {"claimed": bool, "success": bool, "error": str|None}.
     """
     job_id = job["id"]
+    try:
+        from cron.scheduler import _should_yield_cron_to_live_gateway
+
+        if _should_yield_cron_to_live_gateway(job):
+            from hermes_time import now as _hermes_now
+
+            update_job(job_id, {"next_run_at": _hermes_now().isoformat()})
+            return {
+                "claimed": False,
+                "success": True,
+                "queued_for_gateway": True,
+                "error": (
+                    "A live gateway is running for this profile; queued this "
+                    "continuable platform cron for the gateway scheduler so "
+                    "delivery can use the live adapter/thread context."
+                ),
+            }
+    except Exception as e:
+        logger.debug("Gateway handoff check failed for cron job %s: %s", job_id, e)
+
     claimed_job = None
     try:
         # At-most-once claim: bail without running if a tick/other fire owns it.
@@ -1465,13 +1491,18 @@ def cronjob(
             # external one-shot for the same occurrence. If Chronos loses that
             # claim, its consumed fire cannot re-arm itself; reconcile from the
             # winning direct path after the run has persisted its final state.
-            if exec_result.get("claimed", False):
+            if exec_result.get("claimed", False) or exec_result.get(
+                "queued_for_gateway", False
+            ):
                 _notify_provider_jobs_changed_safe()
             # Re-read so the response reflects the post-run last_run_at/last_status.
             result = _format_job(get_job(job_id) or {"id": job_id})
             result["executed"] = exec_result.get("claimed", False)
             result["execution_success"] = exec_result.get("success", False)
-            if not exec_result.get("claimed", False):
+            if exec_result.get("queued_for_gateway", False):
+                result["execution_queued"] = True
+                result["execution_skipped"] = exec_result.get("error")
+            elif not exec_result.get("claimed", False):
                 result["execution_skipped"] = exec_result.get("error") or (
                     "Already being fired by the scheduler; not run again."
                 )


### PR DESCRIPTION
Summary
Desktop/CLI cron tickers could run continuable Discord cron jobs while a live gateway for the same profile was available, bypassing the live adapter context required for continuation thread/session delivery. This adds a gateway handoff guard for continuable platform deliveries and queues manual immediate runs for the live gateway before taking the fire claim.

Changes
cron/scheduler.py: Added live-gateway delivery-context predicates and made adapter-less ticks leave continuable platform jobs due for the gateway instead of advancing or claiming them.
tools/cronjob_tools.py: Queues manual `cronjob(action="run")` continuable platform jobs for the live gateway before claiming, and reports `execution_queued` in the tool response.
tests/cron/test_cron_gateway_ownership.py: Added three regression tests covering adapter-less yield, live adapter context, and tick behavior before advance/claim.
tests/tools/test_cronjob_run_gateway_handoff.py: Added one regression test proving manual run queues before taking the fire claim.

How to Test
python -m pytest tests/cron/test_cron_gateway_ownership.py tests/tools/test_cronjob_run_gateway_handoff.py tests/tools/test_cronjob_run_background.py tests/tools/test_cronjob_run_immediate.py -v
# ✅ 30/30 passed

ruff check cron/scheduler.py tools/cronjob_tools.py tests/cron/test_cron_gateway_ownership.py tests/tools/test_cronjob_run_gateway_handoff.py
# ✅ passed

python scripts/check-windows-footguns.py --diff upstream/main
# ✅ passed

Note: `scripts/run_tests.sh` was attempted on Termux but the per-file parallel runner crashed every discovered test file with `PermissionError(13, 'Permission denied')` before executing tests; targeted pytest above passed.

Checklist
- [x] Tests pass — 30/30 targeted
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

Risk & Impact
Low. The guard only affects continuable platform cron jobs when another live gateway process owns the profile; standalone cron delivery remains fail-open if the liveness check is unavailable.
Type: Bug fix
Closes: #91356
