### PR TITLE
fix: classify provider empty worker exits

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1334,6 +1334,78 @@ def release_stale_claims(conn: sqlite3.Connection) -> int:
     return reclaimed
 
 
+def _profile_quiet_mode(profile: str) -> tuple[str, str] | None:
+    """Return an assignee quiet-mode marker and reason, if the profile is paused."""
+    from hermes_constants import get_hermes_home
+
+    marker = get_hermes_home() / "profiles" / profile / ".quiet_mode"
+    try:
+        if not marker.is_file():
+            return None
+        reason = marker.read_text(encoding="utf-8").strip() or "quiet mode marker present"
+        return str(marker), reason[:1000]
+    except OSError:
+        return None
+
+
+def release_task_for_retry(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+    summary: str | None = None,
+    metadata: dict | None = None,
+) -> bool:
+    """Close a running worker attempt and make the task dispatchable again."""
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status = 'ready', claim_lock = NULL, claim_expires = NULL,
+                   worker_pid = NULL
+             WHERE id = ? AND status = 'running'
+            """,
+            (task_id,),
+        )
+        if cur.rowcount != 1:
+            return False
+        run_id = _end_run(
+            conn, task_id, outcome="released", status="released", summary=summary,
+            error=reason, metadata=metadata,
+        )
+        _append_event(conn, task_id, "released", {"reason": reason, **(metadata or {})}, run_id=run_id)
+        return True
+
+
+def record_worker_child_crash(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    error: str,
+    metadata: dict | None = None,
+) -> bool:
+    """Record a child exit as a terminal attempt and release it for retry."""
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status = 'ready', claim_lock = NULL, claim_expires = NULL,
+                   worker_pid = NULL
+             WHERE id = ? AND status = 'running'
+            """,
+            (task_id,),
+        )
+        if cur.rowcount != 1:
+            return False
+        run_id = _end_run(
+            conn, task_id, outcome="crashed", status="crashed", error=error,
+            summary="Worker child exited before completing the task; released for retry.",
+            metadata=metadata,
+        )
+        _append_event(conn, task_id, "crashed", {"error": error, **(metadata or {})}, run_id=run_id)
+        return True
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,

--- a/hermes_cli/kanban_worker_supervisor.py
+++ b/hermes_cli/kanban_worker_supervisor.py
@@ -1,0 +1,460 @@
+"""Supervisor for dispatcher-spawned Kanban workers.
+
+The dispatcher needs one long-lived PID to monitor. The actual Hermes worker
+may exit cleanly because it hit its own max-turn budget before completing the
+Kanban task; that should become a retryable continuation, not a crash-loop
+failure. This wrapper owns periodic heartbeats and classifies that exit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Sequence
+
+
+MAX_ITERATION_MARKERS = (
+    "Iteration budget exhausted",
+    "Iteration budget reached",
+    "Reached maximum iterations",
+    "You've reached the maximum number of tool-calling iterations allowed",
+)
+
+
+def _same_path(left: str, right: str) -> bool:
+    return os.path.normcase(os.path.abspath(left)) == os.path.normcase(os.path.abspath(right))
+
+
+def _remove_workspace_from_sys_path(workspace: str) -> None:
+    """Avoid importing task workspace files as Python modules inside supervisor."""
+    if not workspace:
+        return
+    workspace_abs = os.path.abspath(workspace)
+    try:
+        cwd_abs = os.path.abspath(os.getcwd())
+    except OSError:
+        cwd_abs = ""
+
+    cleaned: list[str] = []
+    for entry in sys.path:
+        if entry == "":
+            if cwd_abs and _same_path(cwd_abs, workspace_abs):
+                continue
+            cleaned.append(entry)
+            continue
+        if _same_path(entry, workspace_abs):
+            continue
+        cleaned.append(entry)
+    sys.path[:] = cleaned
+
+
+def _worker_env(workspace: str) -> dict[str, str]:
+    env = dict(os.environ)
+    env["PYTHONSAFEPATH"] = "1"
+    if not workspace:
+        return env
+
+    workspace_abs = os.path.abspath(workspace)
+    pythonpath = env.get("PYTHONPATH")
+    if pythonpath:
+        safe_parts = [
+            part
+            for part in pythonpath.split(os.pathsep)
+            if part and not _same_path(part, workspace_abs)
+        ]
+        if safe_parts:
+            env["PYTHONPATH"] = os.pathsep.join(safe_parts)
+        else:
+            env.pop("PYTHONPATH", None)
+    return env
+
+
+def _tail_text(path: Path, max_bytes: int = 65536) -> str:
+    try:
+        with path.open("rb") as f:
+            try:
+                f.seek(0, os.SEEK_END)
+                size = f.tell()
+                f.seek(max(0, size - max_bytes), os.SEEK_SET)
+            except OSError:
+                pass
+            return f.read(max_bytes).decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _returncode_label(returncode: int | None) -> str:
+    if returncode is None:
+        return "returncode=unknown"
+    if returncode < 0:
+        sig_num = abs(int(returncode))
+        try:
+            sig_name = signal.Signals(sig_num).name
+        except ValueError:
+            sig_name = f"SIG{sig_num}"
+        return f"signal={sig_name} returncode={returncode}"
+    if returncode >= 128:
+        sig_num = int(returncode) - 128
+        try:
+            sig_name = signal.Signals(sig_num).name
+        except ValueError:
+            sig_name = f"SIG{sig_num}"
+        return f"returncode={returncode} ({sig_name})"
+    return f"returncode={returncode}"
+
+
+def _tail_failure_hint(tail: str) -> str:
+    markers = (
+        "KeyboardInterrupt",
+        "Traceback (most recent call last)",
+        "SIGTERM",
+        "SIGINT",
+        "TimeoutError",
+        "RuntimeError",
+        "ModuleNotFoundError",
+        "ImportError",
+        "Unknown skill",
+        "Killed",
+        "OOM",
+    )
+    for marker in markers:
+        if marker in tail:
+            return f"log_marker={marker}"
+    for line in reversed(tail.splitlines()):
+        clean = line.strip()
+        if clean:
+            return f"log_tail_last_line={clean[:300]}"
+    return "log_tail_empty"
+
+
+def _record_child_exit(
+    *,
+    task_id: str,
+    returncode: int | None,
+    log_path: Path,
+    command: Sequence[str],
+    started_at: float,
+    reason: str = "worker_child_exit",
+) -> bool:
+    try:
+        from hermes_cli import kanban_db as kb
+
+        tail = _tail_text(log_path, max_bytes=32768)
+        label = _returncode_label(returncode)
+        hint = _tail_failure_hint(tail)
+        error = f"{reason}: {label}; {hint}"
+        metadata = {
+            "reason": reason,
+            "child_returncode": returncode,
+            "returncode_label": label,
+            "elapsed_seconds": max(0, int(time.time() - started_at)),
+            "log_path": str(log_path),
+            "log_tail": tail[-6000:] if tail else "",
+            "command": list(command),
+        }
+        with contextlib.closing(kb.connect()) as conn:
+            return bool(
+                kb.record_worker_child_crash(
+                    conn,
+                    task_id,
+                    error=error,
+                    metadata=metadata,
+                )
+            )
+    except Exception as exc:
+        print(
+            f"kanban worker supervisor: failed to record child exit for {task_id}: {exc}",
+            file=sys.stderr,
+        )
+        return False
+
+
+def _task_is_running(task_id: str) -> bool:
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with contextlib.closing(kb.connect()) as conn:
+            task = kb.get_task(conn, task_id)
+            return bool(task and task.status == "running")
+    except Exception:
+        return False
+
+
+def _task_assignee(task_id: str) -> str:
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with contextlib.closing(kb.connect()) as conn:
+            task = kb.get_task(conn, task_id)
+            return str(task.assignee or "") if task else ""
+    except Exception:
+        return ""
+
+
+def _block_task(task_id: str, reason: str) -> bool:
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with contextlib.closing(kb.connect()) as conn:
+            return bool(kb.block_task(conn, task_id, reason=reason))
+    except Exception as exc:
+        print(f"kanban worker supervisor: failed to block {task_id}: {exc}", file=sys.stderr)
+        return False
+
+
+def _materials_token_guard_reason(task_id: str, log_path: Path, started_at: float) -> str | None:
+    if _task_assignee(task_id) != "nf-materials-producer":
+        return None
+
+    elapsed = max(0, int(time.time() - started_at))
+    max_seconds = int(os.getenv("HERMES_NF_MATERIALS_MAX_SECONDS", "1800"))
+    if elapsed >= max_seconds:
+        return (
+            f"materials_token_guard: nf-materials-producer worker exceeded "
+            f"{max_seconds}s runtime; stop routine material refill and hand off "
+            f"owner+next_action instead of continuing."
+        )
+
+    tail = _tail_text(log_path, max_bytes=131072)
+    compressed_counts = [int(x) for x in re.findall(r"Session compressed\s+(\d+)\s+times", tail)]
+    max_compressed = max(compressed_counts) if compressed_counts else 0
+    compact_markers = tail.count("compacting context")
+    if max_compressed >= 2 or compact_markers >= 4:
+        return (
+            "materials_token_guard: nf-materials-producer worker exceeded "
+            f"context budget (session_compressed={max_compressed}, "
+            f"compact_markers={compact_markers}); stop routine material refill "
+            "and hand off tooling/debug work instead of continuing."
+        )
+    return None
+
+
+def _heartbeat(task_id: str, ttl_seconds: int, note: str) -> None:
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with contextlib.closing(kb.connect()) as conn:
+            kb.heartbeat_worker(conn, task_id, note=note)
+    except Exception:
+        pass
+
+
+def _release_if_profile_quiet(task_id: str) -> bool:
+    try:
+        from hermes_cli import kanban_db as kb
+
+        with contextlib.closing(kb.connect()) as conn:
+            task = kb.get_task(conn, task_id)
+            if not task or not task.assignee:
+                return False
+            quiet_mode = kb._profile_quiet_mode(task.assignee)
+            if not quiet_mode:
+                return False
+            marker_path, quiet_reason = quiet_mode
+            summary = (
+                f"Worker launch paused because assignee profile {task.assignee!r} "
+                f"is in quiet mode: {quiet_reason}"
+            )
+            kb.release_task_for_retry(
+                conn,
+                task_id,
+                reason="profile_quiet_mode_paused",
+                summary=summary,
+                metadata={
+                    "assignee": task.assignee,
+                    "marker_path": marker_path,
+                    "quiet_reason": quiet_reason,
+                },
+            )
+            print(f"kanban worker supervisor: {summary}", file=sys.stderr)
+            return True
+    except Exception as exc:
+        print(f"kanban worker supervisor: quiet-mode check failed: {exc}", file=sys.stderr)
+        return False
+
+
+def _release_if_budget_exhausted(task_id: str, log_path: Path) -> bool:
+    tail = _tail_text(log_path)
+    if not any(marker in tail for marker in MAX_ITERATION_MARKERS):
+        return False
+    try:
+        from hermes_cli import kanban_db as kb
+
+        summary = (
+            "Worker hit its max-iteration budget before completing the task; "
+            "released for an automatic continuation."
+        )
+        with contextlib.closing(kb.connect()) as conn:
+            return kb.release_task_for_retry(
+                conn,
+                task_id,
+                reason="max_iterations_exhausted",
+                summary=summary,
+                metadata={"log_path": str(log_path)},
+            )
+    except Exception:
+        return False
+
+
+def _terminate_child(proc: subprocess.Popen) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except Exception:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+    try:
+        proc.wait(timeout=10)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except Exception:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+
+
+def run_supervisor(
+    *,
+    task_id: str,
+    ttl_seconds: int,
+    heartbeat_interval_seconds: int,
+    log_path: Path,
+    workspace: str,
+    command: Sequence[str],
+) -> int:
+    if not command:
+        print("kanban worker supervisor: missing child command", file=sys.stderr)
+        return 2
+    heartbeat_interval_seconds = max(30, int(heartbeat_interval_seconds))
+    ttl_seconds = max(heartbeat_interval_seconds * 2, int(ttl_seconds))
+    _remove_workspace_from_sys_path(workspace)
+
+    if _release_if_profile_quiet(task_id):
+        return 0
+
+    proc = subprocess.Popen(  # noqa: S603 -- command is dispatcher-constructed
+        list(command),
+        cwd=workspace if workspace and os.path.isdir(workspace) else None,
+        stdin=subprocess.DEVNULL,
+        env=_worker_env(workspace),
+        start_new_session=True,
+    )
+    started_at = time.time()
+
+    stopping = False
+
+    def _handle_stop(_signum, _frame):
+        nonlocal stopping
+        stopping = True
+        _terminate_child(proc)
+
+    for sig_name in ("SIGTERM", "SIGINT"):
+        sig = getattr(signal, sig_name, None)
+        if sig is not None:
+            try:
+                signal.signal(sig, _handle_stop)
+            except Exception:
+                pass
+
+    last_hb = 0.0
+    while proc.poll() is None and not stopping:
+        now = time.time()
+        if now - last_hb >= heartbeat_interval_seconds:
+            last_hb = now
+            _heartbeat(task_id, ttl_seconds, "worker supervisor heartbeat")
+        guard_reason = _materials_token_guard_reason(task_id, log_path, started_at)
+        if guard_reason:
+            _block_task(task_id, guard_reason)
+            _terminate_child(proc)
+            return 0
+        time.sleep(2)
+
+    rc = proc.poll()
+    if rc is None:
+        _terminate_child(proc)
+        rc = proc.poll()
+    if stopping:
+        if _task_is_running(task_id):
+            if _record_child_exit(
+                task_id=task_id,
+                returncode=rc,
+                log_path=log_path,
+                command=command,
+                started_at=started_at,
+                reason="worker_supervisor_stopped",
+            ):
+                return 0
+        return int(rc or 143)
+
+    if _task_is_running(task_id) and _release_if_budget_exhausted(task_id, log_path):
+        return 0
+    if _task_is_running(task_id):
+        tail = _tail_text(log_path)
+        provider_failure_markers = (
+            "provider_empty_response",
+            "provider_rate_limited",
+            "provider_protocol_error",
+        )
+        provider_failure = next(
+            (marker for marker in provider_failure_markers if marker in tail), None
+        )
+        if provider_failure:
+            if _record_child_exit(
+                task_id=task_id,
+                returncode=rc,
+                log_path=log_path,
+                command=command,
+                started_at=started_at,
+                reason=provider_failure,
+            ):
+                return 0
+        if _record_child_exit(
+            task_id=task_id,
+            returncode=rc,
+            log_path=log_path,
+            command=command,
+            started_at=started_at,
+        ):
+            return 0
+    return int(rc or 0)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--task-id", required=True)
+    parser.add_argument("--ttl", type=int, required=True)
+    parser.add_argument("--heartbeat-interval", type=int, required=True)
+    parser.add_argument("--log-path", required=True)
+    parser.add_argument("--workspace", default="")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    return run_supervisor(
+        task_id=args.task_id,
+        ttl_seconds=args.ttl,
+        heartbeat_interval_seconds=args.heartbeat_interval,
+        log_path=Path(args.log_path),
+        workspace=args.workspace,
+        command=command,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/run_agent.py
+++ b/run_agent.py
@@ -5838,10 +5838,11 @@ class AIAgent:
                             )
                     final_response = stream.get_final_response()
                     # PATCH: ChatGPT Codex backend streams valid output items
-                    # but get_final_response() can return an empty output list.
-                    # Backfill from collected items or synthesize from deltas.
+                    # but get_final_response() can return an empty output list
+                    # — or, on aicodemirror, a None output. Backfill from
+                    # collected items or synthesize from deltas in either case.
                     _out = getattr(final_response, "output", None)
-                    if isinstance(_out, list) and not _out:
+                    if _out is None or (isinstance(_out, list) and not _out):
                         if collected_output_items:
                             final_response.output = list(collected_output_items)
                             logger.debug(
@@ -5879,6 +5880,22 @@ class AIAgent:
                 return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
             except RuntimeError as exc:
                 err_text = str(exc)
+                codex_rate_limits_before_created = (
+                    "codex.rate_limits" in err_text
+                    and "response.created" in err_text
+                )
+                delta_before_created = (
+                    "response.output_text.delta" in err_text
+                    and "response.created" in err_text
+                )
+                if codex_rate_limits_before_created or delta_before_created:
+                    logger.warning(
+                        "Codex Responses stream lifecycle event arrived out of order; "
+                        "falling back to create(stream=True). %s error=%s",
+                        self._client_log_context(),
+                        exc,
+                    )
+                    return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
                 missing_completed = "response.completed" in err_text
                 if missing_completed and attempt < max_stream_retries:
                     logger.debug(
@@ -5895,6 +5912,43 @@ class AIAgent:
                     )
                     return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
                 raise
+            except TypeError as exc:
+                # Patched 2026-05-27: aicodemirror (and other Codex-compatible
+                # backends) occasionally emit a `response.completed` event
+                # whose `response.output` field is `null` instead of a list.
+                # The OpenAI SDK's accumulate_event → parse_response path
+                # iterates `response.output` without a None guard
+                # (openai/lib/_parsing/_responses.py line ~61), raising
+                # "TypeError: 'NoneType' object is not iterable" mid-stream.
+                # We have streamed deltas / collected items in hand — recover
+                # by synthesizing a final_response from them, or fall back to
+                # the non-streaming create() path which has its own backfill.
+                if "iterable" not in str(exc) and "output" not in str(exc):
+                    raise
+                streamed_chars = sum(len(p) for p in self._codex_streamed_text_parts)
+                logger.warning(
+                    "Codex Responses stream: SDK parse failed with NoneType.output "
+                    "(backend sent malformed response.completed). "
+                    "Recovered chars=%d items=%d. Falling back to create(stream=True). %s",
+                    streamed_chars, len(collected_output_items),
+                    self._client_log_context(),
+                )
+                if collected_output_items or streamed_chars > 0:
+                    synthesized = SimpleNamespace(
+                        output=list(collected_output_items) if collected_output_items else [
+                            SimpleNamespace(
+                                type="message", role="assistant", status="completed",
+                                content=[SimpleNamespace(
+                                    type="output_text",
+                                    text="".join(self._codex_streamed_text_parts),
+                                )],
+                            )
+                        ],
+                        status="completed",
+                        output_text="".join(self._codex_streamed_text_parts) or None,
+                    )
+                    return synthesized
+                return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
 
     def _run_codex_create_stream_fallback(self, api_kwargs: dict, client: Any = None):
         """Fallback path for stream completion edge cases on Codex-style Responses backends."""
@@ -5941,9 +5995,11 @@ class AIAgent:
                 if terminal_response is None and isinstance(event, dict):
                     terminal_response = event.get("response")
                 if terminal_response is not None:
-                    # Backfill empty output from collected stream events
+                    # Backfill empty output from collected stream events.
+                    # Patched 2026-05-27: also treat output=None as empty
+                    # (aicodemirror sometimes returns null instead of []).
                     _out = getattr(terminal_response, "output", None)
-                    if isinstance(_out, list) and not _out:
+                    if _out is None or (isinstance(_out, list) and not _out):
                         if collected_output_items:
                             terminal_response.output = list(collected_output_items)
                             logger.debug(
@@ -7707,10 +7763,12 @@ class AIAgent:
 
     # Which error types indicate a transient transport failure worth
     # one more attempt with a rebuilt client / connection pool.
+    # APITimeoutError removed — timeouts should fallback immediately rather than
+    # rebuilding the client and retrying the same slow/overloaded provider.
     _TRANSIENT_TRANSPORT_ERRORS = frozenset({
         "ReadTimeout", "ConnectTimeout", "PoolTimeout",
         "ConnectError", "RemoteProtocolError",
-        "APIConnectionError", "APITimeoutError",
+        "APIConnectionError",
     })
 
     def _try_recover_primary_transport(
@@ -8280,12 +8338,18 @@ class AIAgent:
             )
             is_xai_responses = self.provider == "xai" or self._base_url_hostname == "api.x.ai"
             _msgs_for_codex = self._prepare_messages_for_non_vision_model(api_messages)
+            codex_session_id = getattr(self, "session_id", None)
+            if (
+                self.provider == "aicodemirror"
+                or self._base_url_hostname == "api.aicodemirror.com"
+            ):
+                codex_session_id = None
             return _ct.build_kwargs(
                 model=self.model,
                 messages=_msgs_for_codex,
                 tools=self.tools,
                 reasoning_config=self.reasoning_config,
-                session_id=getattr(self, "session_id", None),
+                session_id=codex_session_id,
                 max_tokens=self.max_tokens,
                 request_overrides=self.request_overrides,
                 is_github_responses=is_github_responses,
@@ -10651,6 +10715,11 @@ class AIAgent:
         truncated_response_prefix = ""
         compression_attempts = 0
         _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
+        # Provider recovery may culminate in the visible `(empty)` sentinel.
+        # It must remain distinguishable from a successfully completed user turn.
+        _turn_failed = False
+        _needs_session_reset = False
+        _failure_code = None
         
         # Record the execution thread so interrupt()/clear_interrupt() can
         # scope the tool-level interrupt signal to THIS agent's thread only.
@@ -12547,6 +12616,21 @@ class AIAgent:
                         # ssl.SSLError explicitly so the error classifier's
                         # retryable=True mapping takes effect instead.
                         and not isinstance(api_error, ssl.SSLError)
+                        # Patched 2026-05-27: a TypeError raised mid-stream after
+                        # fallback activation is overwhelmingly an SDK/transport
+                        # mismatch with leftover state (e.g. reasoning items from
+                        # the primary model, an empty Codex output list, a None
+                        # tool_calls field on a SimpleNamespace).  These are
+                        # recoverable by retrying with another fallback or fresh
+                        # request — they are NOT local programming bugs in the
+                        # agent's own code.  Treating them as non-retryable
+                        # caused 6+ hours of cron-spam on 2026-05-27.  When
+                        # fallback is active, demote TypeError to a retryable
+                        # transport-class error.
+                        and not (
+                            isinstance(api_error, TypeError)
+                            and getattr(self, "_fallback_activated", False)
+                        )
                     )
                     is_client_error = (
                         is_local_validation_error
@@ -12600,7 +12684,7 @@ class AIAgent:
                                     self._vprint(f"{self.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
                         else:
                             self._vprint(f"{self.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
-                        logging.error(f"{self.log_prefix}Non-retryable client error: {api_error}")
+                        logging.error(f"{self.log_prefix}Non-retryable client error: {api_error}", exc_info=True)
                         # Skip session persistence when the error is likely
                         # context-overflow related (status 400 + large session).
                         # Persisting the failed user message would make the
@@ -12681,6 +12765,7 @@ class AIAgent:
                             "%sAPI call failed after %s retries. %s | provider=%s model=%s msgs=%s tokens=~%s",
                             self.log_prefix, max_retries, _final_summary,
                             _provider, _model, len(api_messages), f"{approx_tokens:,}",
+                            exc_info=True,
                         )
                         if api_kwargs is not None:
                             self._dump_api_request_debug(
@@ -13486,7 +13571,10 @@ class AIAgent:
                         # Exhausted retries and fallback chain (or no
                         # fallback configured).  Fall through to the
                         # "(empty)" terminal.
-                        _turn_exit_reason = "empty_response_exhausted"
+                        _turn_exit_reason = "provider_empty_response"
+                        _turn_failed = True
+                        _needs_session_reset = True
+                        _failure_code = "provider_empty_response"
                         reasoning_text = self._extract_reasoning(assistant_message)
                         assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
                         assistant_msg["content"] = "(empty)"
@@ -13650,7 +13738,11 @@ class AIAgent:
             final_response = self._handle_max_iterations(messages, api_call_count)
         
         # Determine if conversation completed successfully
-        completed = final_response is not None and api_call_count < self.max_iterations
+        completed = (
+            final_response is not None
+            and api_call_count < self.max_iterations
+            and not _turn_failed
+        )
 
         # Save trajectory if enabled.  ``user_message`` may be a multimodal
         # list of parts; the trajectory format wants a plain string.
@@ -13710,7 +13802,7 @@ class AIAgent:
         # Fired once per turn after the tool-calling loop completes.
         # Plugins can use this to persist conversation data (e.g. sync
         # to an external memory system).
-        if final_response and not interrupted:
+        if final_response and not interrupted and not _turn_failed:
             try:
                 from hermes_cli.plugins import invoke_hook as _invoke_hook
                 _invoke_hook(
@@ -13740,6 +13832,9 @@ class AIAgent:
             "api_calls": api_call_count,
             "completed": completed,
             "turn_exit_reason": _turn_exit_reason,
+            "failed": _turn_failed,
+            "failure_code": _failure_code,
+            "needs_session_reset": _needs_session_reset,
             "partial": False,  # True only when stopped due to invalid tool calls
             "interrupted": interrupted,
             "response_previewed": getattr(self, "_response_was_previewed", False),
@@ -13788,15 +13883,16 @@ class AIAgent:
             self._iters_since_skill = 0
 
         # External memory provider: sync the completed turn + queue next prefetch.
-        self._sync_external_memory_for_turn(
-            original_user_message=original_user_message,
-            final_response=final_response,
-            interrupted=interrupted,
-        )
+        if not _turn_failed:
+            self._sync_external_memory_for_turn(
+                original_user_message=original_user_message,
+                final_response=final_response,
+                interrupted=interrupted,
+            )
 
         # Background memory/skill review — runs AFTER the response is delivered
         # so it never competes with the user's task for model attention.
-        if final_response and not interrupted and (_should_review_memory or _should_review_skills):
+        if final_response and not interrupted and not _turn_failed and (_should_review_memory or _should_review_skills):
             try:
                 self._spawn_background_review(
                     messages_snapshot=list(messages),

--- a/tests/cron/test_natural_flow_closure_guard.py
+++ b/tests/cron/test_natural_flow_closure_guard.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path("/Users/yaphie/.hermes/scripts/natural_flow_closure_guard.py")
+
+
+@pytest.fixture(scope="module")
+def closure_guard():
+    spec = importlib.util.spec_from_file_location("natural_flow_closure_guard", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_publish_evidence_blob_ignores_body_field_names(closure_guard):
+    task = {
+        "title": "Takeflow 发布闭环",
+        "body": "需要确认 backend_task_id / backend_detail_id 是否存在，但这里只是要求，不是结果。",
+        "result": "",
+    }
+
+    blob = closure_guard.publish_evidence_blob(task, [], [])
+
+    assert "backend_task_id" not in blob
+    assert "backend_detail_id" not in blob
+    assert closure_guard.has_publish_done_evidence(blob) is False
+
+
+def test_publish_done_evidence_requires_real_values(closure_guard):
+    blob = "\n".join(
+        [
+            "已发布成功",
+            "publish_ledger.json 已记录",
+            'backend_task_id: "12345"',
+            'backend_detail_id: "67890"',
+        ]
+    )
+
+    assert closure_guard.has_publish_done_evidence(blob) is True
+
+
+def test_takeflow_publish_json_gate_rejects_todo_state(tmp_path, monkeypatch, closure_guard):
+    monkeypatch.setattr(closure_guard, "TAKEFLOW_TASKS_DIR", tmp_path)
+    task_name = "chinese_seal_incense_tiktok_task.json"
+    task_path = tmp_path / task_name
+    task_path.write_text(
+        json.dumps(
+            {
+                "strategy": {"workflow": "tiktok-native-publish", "platform": "tiktok"},
+                "state": "todo",
+                "artifacts": {
+                    "final_verification": {
+                        "surface": "backend_anchor_api",
+                        "endpoint": "/task/main-task/createShortDramaTask",
+                        "anchor_link_used": "https://www.tiktok.com/t/example",
+                        "material_path": "/tmp/video.mp4",
+                        "release_scheduled_time_match": True,
+                        "backend_task_id": "abc123",
+                        "backend_detail_id": "def456",
+                    }
+                },
+                "takeflow": {"seat_label": "22号坐席"},
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    gate = closure_guard.takeflow_publish_json_gate(f"tiktok {task_name}")
+
+    assert gate["applies"] is True
+    assert gate["ok"] is False
+    assert any("state=todo" in failure for failure in gate["failures"])
+
+
+def test_repair_owner_keeps_aivideo_publish_task_with_publish_ops(closure_guard):
+    task = {
+        "assignee": "nf-publish-ops",
+        "title": "Takeflow发布｜AIvideo TikTok 坐席24 普通发布 每日2条",
+    }
+
+    assert closure_guard.repair_owner(task) == (
+        "nf-publish-ops",
+        ["natural-flow-growth-operations"],
+    )
+
+
+def test_repair_owner_uses_current_business_delivery_skill_for_appdev(closure_guard):
+    task = {
+        "assignee": "appdev-worker-1",
+        "title": "App implementation repair",
+    }
+
+    assert closure_guard.repair_owner(task) == (
+        "bizline2",
+        ["business-delivery-operations"],
+    )
+
+
+def test_extract_direction_recognizes_aivideo_display_name(closure_guard):
+    assert closure_guard.extract_direction("Takeflow发布｜AIvideo TikTok 坐席24 普通发布") == "ai_video"

--- a/tests/hermes_cli/test_kanban_worker_supervisor.py
+++ b/tests/hermes_cli/test_kanban_worker_supervisor.py
@@ -1,0 +1,254 @@
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_worker_supervisor import (
+    _remove_workspace_from_sys_path,
+    run_supervisor,
+)
+
+
+@pytest.fixture
+def kanban_home():
+    kb.init_db()
+    return Path(os.environ["HERMES_HOME"])
+
+
+def test_supervisor_releases_max_iteration_worker(kanban_home, tmp_path):
+    log_path = tmp_path / "worker.log"
+    script = tmp_path / "worker.py"
+    script.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(log_path)!r}).write_text('Iteration budget exhausted (60/60)\\n')\n"
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, tid, ttl_seconds=60)
+
+    rc = run_supervisor(
+        task_id=tid,
+        ttl_seconds=60,
+        heartbeat_interval_seconds=30,
+        log_path=log_path,
+        workspace=str(tmp_path),
+        command=[sys.executable, str(script)],
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        task = kb.get_task(conn, tid)
+        runs = kb.list_runs(conn, tid)
+        events = kb.list_events(conn, tid)
+
+    assert rc == 0
+    assert task.status == "ready"
+    assert task.current_run_id is None
+    assert runs[-1].outcome == "released"
+    assert any(e.kind == "released" for e in events)
+
+
+def test_supervisor_child_ignores_workspace_stdlib_shadow(kanban_home, tmp_path):
+    log_path = tmp_path / "worker.log"
+    marker = tmp_path / "inspect_path.txt"
+    (tmp_path / "inspect.py").write_text(
+        "raise RuntimeError('workspace inspect imported')\n",
+        encoding="utf-8",
+    )
+    script = tmp_path / "worker.py"
+    script.write_text(
+        "import inspect\n"
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text("
+        "inspect.__file__ + '\\n' + str(hasattr(inspect, 'signature'))"
+        ")\n"
+        f"Path({str(log_path)!r}).write_text('Iteration budget exhausted (60/60)\\n')\n",
+        encoding="utf-8",
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, tid, ttl_seconds=60)
+
+    rc = run_supervisor(
+        task_id=tid,
+        ttl_seconds=60,
+        heartbeat_interval_seconds=30,
+        log_path=log_path,
+        workspace=str(tmp_path),
+        command=[sys.executable, str(script)],
+    )
+
+    inspect_path, has_signature = marker.read_text(encoding="utf-8").splitlines()
+
+    assert rc == 0
+    assert inspect_path != str(tmp_path / "inspect.py")
+    assert has_signature == "True"
+
+
+def test_supervisor_removes_workspace_from_own_sys_path(monkeypatch, tmp_path):
+    safe_path = str(tmp_path / "safe")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "path", ["", str(tmp_path), safe_path])
+
+    _remove_workspace_from_sys_path(str(tmp_path))
+
+    assert "" not in sys.path
+    assert str(tmp_path) not in sys.path
+    assert safe_path in sys.path
+
+
+def test_supervisor_records_child_crash_before_pid_watchdog(kanban_home, tmp_path):
+    log_path = tmp_path / "worker.log"
+    script = tmp_path / "worker.py"
+    script.write_text(
+        "from pathlib import Path\n"
+        "import sys\n"
+        f"Path({str(log_path)!r}).write_text('Traceback (most recent call last):\\nKeyboardInterrupt\\n')\n"
+        "sys.exit(130)\n"
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, tid, ttl_seconds=60)
+
+    rc = run_supervisor(
+        task_id=tid,
+        ttl_seconds=60,
+        heartbeat_interval_seconds=30,
+        log_path=log_path,
+        workspace=str(tmp_path),
+        command=[sys.executable, str(script)],
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        task = kb.get_task(conn, tid)
+        runs = kb.list_runs(conn, tid)
+        events = kb.list_events(conn, tid)
+
+    assert rc == 0
+    assert task.status == "ready"
+    assert task.current_run_id is None
+    assert runs[-1].outcome == "crashed"
+    assert runs[-1].error
+    assert "worker_child_exit" in runs[-1].error
+    assert "KeyboardInterrupt" in runs[-1].error
+    assert runs[-1].metadata
+    assert runs[-1].metadata["child_returncode"] == 130
+    assert "KeyboardInterrupt" in runs[-1].metadata["log_tail"]
+    assert any(
+        e.kind == "crashed"
+        and e.payload
+        and e.payload.get("child_returncode") == 130
+        for e in events
+    )
+
+
+def test_supervisor_releases_quiet_profile_without_spawning(kanban_home, tmp_path):
+    profile = kanban_home / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    (profile / ".quiet_mode").write_text("token guard", encoding="utf-8")
+    marker = tmp_path / "spawned.txt"
+    script = tmp_path / "worker.py"
+    script.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('spawned')\n"
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, tid, ttl_seconds=60)
+
+    rc = run_supervisor(
+        task_id=tid,
+        ttl_seconds=60,
+        heartbeat_interval_seconds=30,
+        log_path=tmp_path / "worker.log",
+        workspace=str(tmp_path),
+        command=[sys.executable, str(script)],
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        task = kb.get_task(conn, tid)
+        runs = kb.list_runs(conn, tid)
+        events = kb.list_events(conn, tid)
+
+    assert rc == 0
+    assert not marker.exists()
+    assert task.status == "ready"
+    assert runs[-1].outcome == "released"
+    assert runs[-1].summary and "quiet mode" in runs[-1].summary
+    assert any(
+        e.kind == "released" and e.payload.get("reason") == "profile_quiet_mode_paused"
+        for e in events
+    )
+
+
+def test_supervisor_records_provider_empty_response_exit_as_crash(kanban_home, tmp_path):
+    log_path = tmp_path / "worker.log"
+    script = tmp_path / "worker.py"
+    script.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(log_path)!r}).write_text("
+        "'turn_exit_reason=provider_empty_response failure_code=provider_empty_response\\n'"
+        ")\n"
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, tid, ttl_seconds=60)
+
+    rc = run_supervisor(
+        task_id=tid,
+        ttl_seconds=60,
+        heartbeat_interval_seconds=30,
+        log_path=log_path,
+        workspace=str(tmp_path),
+        command=[sys.executable, str(script)],
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        task = kb.get_task(conn, tid)
+        runs = kb.list_runs(conn, tid)
+
+    assert rc == 0
+    assert task.status == "ready"
+    assert task.current_run_id is None
+    assert runs[-1].outcome == "crashed"
+    assert "provider_empty_response" in runs[-1].error
+    assert runs[-1].metadata["child_returncode"] == 0
+
+
+def test_supervisor_ignores_tool_name_when_db_still_running(kanban_home, tmp_path):
+    log_path = tmp_path / "worker.log"
+    script = tmp_path / "worker.py"
+    script.write_text(
+        "from pathlib import Path\n"
+        f"Path({str(log_path)!r}).write_text("
+        "'tool available: kanban_complete\\nIteration budget exhausted (60/60)\\n'"
+        ")\n"
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        kb.claim_task(conn, tid, ttl_seconds=60)
+
+    rc = run_supervisor(
+        task_id=tid,
+        ttl_seconds=60,
+        heartbeat_interval_seconds=30,
+        log_path=log_path,
+        workspace=str(tmp_path),
+        command=[sys.executable, str(script)],
+    )
+
+    with contextlib.closing(kb.connect()) as conn:
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+
+    assert rc == 0
+    assert task.status == "ready"
+    assert any(e.kind == "released" for e in events)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2416,8 +2416,11 @@ class TestRunConversation:
             result = agent.run_conversation("hello", conversation_history=prefill)
 
         mock_compress.assert_not_called()  # no compression triggered
-        assert result["completed"] is True
+        assert result["completed"] is False
         assert result["final_response"] == "(empty)"
+        assert result["turn_exit_reason"] == "provider_empty_response"
+        assert result["failure_code"] == "provider_empty_response"
+        assert result["needs_session_reset"] is True
         assert result["api_calls"] == 6  # 1 original + 2 prefill + 3 retries
 
     def test_reasoning_only_response_prefill_then_empty(self, agent):
@@ -2436,8 +2439,11 @@ class TestRunConversation:
             patch.object(agent, "_cleanup_task_resources"),
         ):
             result = agent.run_conversation("answer me")
-        assert result["completed"] is True
+        assert result["completed"] is False
         assert result["final_response"] == "(empty)"
+        assert result["turn_exit_reason"] == "provider_empty_response"
+        assert result["failure_code"] == "provider_empty_response"
+        assert result["needs_session_reset"] is True
         assert result["api_calls"] == 6  # 1 original + 2 prefill + 3 retries
 
     def test_reasoning_only_prefill_succeeds_on_continuation(self, agent):
@@ -2483,8 +2489,12 @@ class TestRunConversation:
             patch.object(agent, "_cleanup_task_resources"),
         ):
             result = agent.run_conversation("answer me")
-        assert result["completed"] is True
+        assert result["completed"] is False
         assert result["final_response"] == "(empty)"
+        assert result["turn_exit_reason"] == "provider_empty_response"
+        assert result["failed"] is True
+        assert result["failure_code"] == "provider_empty_response"
+        assert result["needs_session_reset"] is True
         assert result["api_calls"] == 4  # 1 original + 3 retries
 
     def test_truly_empty_response_succeeds_on_nudge(self, agent):
@@ -2579,8 +2589,11 @@ class TestRunConversation:
             patch.object(agent, "_try_activate_fallback", side_effect=_mock_fallback),
         ):
             result = agent.run_conversation("answer me")
-        assert result["completed"] is True
+        assert result["completed"] is False
         assert result["final_response"] == "(empty)"
+        assert result["turn_exit_reason"] == "provider_empty_response"
+        assert result["failure_code"] == "provider_empty_response"
+        assert result["needs_session_reset"] is True
 
     def test_empty_response_emits_status_for_gateway(self, agent):
         """_emit_status is called during empty retries so gateway users see feedback."""

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -449,6 +449,60 @@ def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(mon
     assert response.output[0].content[0].text == "create fallback ok"
 
 
+def test_run_codex_stream_falls_back_when_delta_event_precedes_created(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            final_error=RuntimeError(
+                "Expected to have received `response.created` before `response.output_text.delta`"
+            )
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("delta metadata recovered")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create)
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert calls == {"stream": 1, "create": 1}
+    assert response.output[0].content[0].text == "delta metadata recovered"
+
+
+def test_run_codex_stream_falls_back_when_rate_limits_event_precedes_created(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            final_error=RuntimeError(
+                "Expected to have received `response.created` before `codex.rate_limits`"
+            )
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("rate-limit metadata recovered")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert calls["stream"] == 1
+    assert calls["create"] == 1
+    assert response.output[0].content[0].text == "rate-limit metadata recovered"
+
+
 def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     agent = _build_agent(monkeypatch)
     calls = {"stream": 0, "create": 0}


### PR DESCRIPTION
## Summary
- tolerate Responses SSE output delta before lifecycle creation and classify malformed protocol signals
- make exhausted empty/reasoning-only responses explicit non-completions with reset metadata
- supervise kanban workers and write structured child-exit events so silent zero-exit processes cannot be treated as publish closure

## Tests
- `scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/run_agent/test_run_agent_codex_responses.py tests/hermes_cli/test_kanban_worker_supervisor.py tests/cron/test_natural_flow_closure_guard.py` (384 passed)
- `python -m py_compile run_agent.py hermes_cli/kanban_db.py hermes_cli/kanban_worker_supervisor.py`