### PR TITLE
fix(gateway): accept binary launchd plists in the staleness check

### DIFF
--- a/contributors/emails/phong.dinh2108@gmail.com
+++ b/contributors/emails/phong.dinh2108@gmail.com
@@ -1,0 +1,2 @@
+dennytosp
+# PR: fix(gateway): binary launchd plist staleness check

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4741,14 +4741,57 @@ def generate_launchd_plist() -> str:
 """
 
 
+def _plist_bytes_as_xml_text(raw: bytes) -> str | None:
+    """Re-render plist bytes as XML text, or None when they don't parse."""
+    import plistlib
+
+    try:
+        return plistlib.dumps(plistlib.loads(raw), fmt=plistlib.FMT_XML).decode("utf-8")
+    except Exception:
+        return None
+
+
+def _launchd_plist_comparison_pair(raw: bytes, expected: str) -> tuple[str, str] | None:
+    """Return (installed, expected) as comparable text, or None if unreadable.
+
+    launchctl is free to rewrite an installed plist into Apple's binary format
+    (``bplist00…``) during bootstrap/bootout cycles or after a reboot, and that
+    magic is not valid UTF-8 — decoding it strictly crashed every path gated on
+    the staleness check (#90606).
+
+    A binary plist is therefore parsed and re-rendered as XML, and the expected
+    plist is pushed through the *same* round-trip so the two sides are compared
+    in one canonical serialization. Comparing re-rendered XML against the
+    generated text directly would differ on formatting alone, report the plist
+    stale on every call, and rewrite it — which launchctl may re-binarize, an
+    endless refresh loop.
+    """
+    if raw.startswith(b"bplist00"):
+        installed_xml = _plist_bytes_as_xml_text(raw)
+        expected_xml = _plist_bytes_as_xml_text(expected.encode("utf-8"))
+        if installed_xml is None or expected_xml is None:
+            return None
+        return installed_xml, expected_xml
+
+    try:
+        return raw.decode("utf-8"), expected
+    except UnicodeDecodeError:
+        return None
+
+
 def launchd_plist_is_current() -> bool:
     """Check if the installed launchd plist matches the currently generated one."""
     plist_path = get_launchd_plist_path()
     if not plist_path.exists():
         return False
 
-    installed = plist_path.read_text(encoding="utf-8")
     expected = generate_launchd_plist()
+    # An unreadable plist counts as stale so the caller reinstalls it, rather
+    # than raising out of `hermes gateway status` / `install`.
+    pair = _launchd_plist_comparison_pair(plist_path.read_bytes(), expected)
+    if pair is None:
+        return False
+    installed, expected = pair
     return _normalize_launchd_plist_for_comparison(
         installed
     ) == _normalize_launchd_plist_for_comparison(expected)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4741,6 +4741,10 @@ def generate_launchd_plist() -> str:
 """
 
 
+# Latched so a generator regression is reported once, not on every status call.
+_WARNED_GENERATED_PLIST_UNPARSEABLE = False
+
+
 def _plist_bytes_as_xml_text(raw: bytes) -> str | None:
     """Re-render plist bytes as XML text, or None when they don't parse."""
     import plistlib
@@ -4769,6 +4773,19 @@ def _launchd_plist_comparison_pair(raw: bytes, expected: str) -> tuple[str, str]
     if raw.startswith(b"bplist00"):
         installed_xml = _plist_bytes_as_xml_text(raw)
         expected_xml = _plist_bytes_as_xml_text(expected.encode("utf-8"))
+        if expected_xml is None:
+            # The GENERATED plist doesn't parse — a template regression, not a
+            # bad file on disk. Both cases fall through to "stale", so without
+            # this line a generator bug would surface only as plists being
+            # rewritten more often than expected, with nothing naming the cause.
+            global _WARNED_GENERATED_PLIST_UNPARSEABLE
+            if not _WARNED_GENERATED_PLIST_UNPARSEABLE:
+                _WARNED_GENERATED_PLIST_UNPARSEABLE = True
+                logger.warning(
+                    "Generated launchd plist is not parseable; the installed "
+                    "binary plist cannot be compared against it and will be "
+                    "treated as stale."
+                )
         if installed_xml is None or expected_xml is None:
             return None
         return installed_xml, expected_xml

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2245,3 +2245,29 @@ class TestLaunchdBinaryPlistStaleCheck:
         self._install(tmp_path, monkeypatch, b"\xff\xfe\x00garbage", self.XML_PLIST)
 
         assert gateway_cli.launchd_plist_is_current() is False
+
+    def test_unparseable_generated_plist_is_reported_once(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A generator regression must name itself, not just look like churn.
+
+        An unparseable *generated* plist and an unreadable *installed* file
+        both fall through to "stale", so without a distinct signal a template
+        bug would surface only as plists being rewritten unusually often.
+        """
+        monkeypatch.setattr(gateway_cli, "_WARNED_GENERATED_PLIST_UNPARSEABLE", False)
+        self._install(
+            tmp_path,
+            monkeypatch,
+            self._as_binary(self.XML_PLIST),
+            "<plist>not valid xml &",
+        )
+
+        with caplog.at_level("WARNING", logger=gateway_cli.logger.name):
+            assert gateway_cli.launchd_plist_is_current() is False
+            assert gateway_cli.launchd_plist_is_current() is False
+
+        warnings = [
+            r for r in caplog.records if "Generated launchd plist" in r.getMessage()
+        ]
+        assert len(warnings) == 1, "the warning must latch, not repeat per call"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2147,3 +2147,101 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is False
         assert list_calls["n"] >= 1
+
+
+class TestLaunchdBinaryPlistStaleCheck:
+    """launchctl may rewrite an installed plist to Apple's binary format.
+
+    `launchd_plist_is_current()` used to read the file with
+    `read_text(encoding="utf-8")`, which raises `UnicodeDecodeError` on the
+    `bplist00\\xd8` magic and crashed `hermes gateway status` / `install` and
+    every auto-refresh path that gates on the staleness check (#90606).
+    """
+
+    XML_PLIST = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+        '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+        '<plist version="1.0">\n'
+        "<dict>\n"
+        "\t<key>Label</key>\n"
+        "\t<string>ai.hermes.gateway</string>\n"
+        "\t<key>EnvironmentVariables</key>\n"
+        "\t<dict>\n"
+        "\t\t<key>PATH</key>\n"
+        "\t\t<string>/opt/homebrew/bin:/usr/bin:/bin</string>\n"
+        "\t</dict>\n"
+        "</dict>\n"
+        "</plist>\n"
+    )
+
+    def _install(self, tmp_path, monkeypatch, raw: bytes, expected: str):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_bytes(raw)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "generate_launchd_plist", lambda: expected)
+        return plist_path
+
+    @staticmethod
+    def _as_binary(xml_text: str) -> bytes:
+        return plistlib.dumps(
+            plistlib.loads(xml_text.encode("utf-8")), fmt=plistlib.FMT_BINARY
+        )
+
+    def test_binary_plist_matching_generated_is_current(self, tmp_path, monkeypatch):
+        """A binary plist with the generated contents must not crash, nor be stale.
+
+        Reporting it stale would make every status call rewrite the plist,
+        which launchctl is then free to re-binarize — an endless refresh loop.
+        """
+        binary = self._as_binary(self.XML_PLIST)
+        assert binary.startswith(b"bplist00")
+        self._install(tmp_path, monkeypatch, binary, self.XML_PLIST)
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_binary_plist_with_different_contents_is_stale(self, tmp_path, monkeypatch):
+        outdated = self.XML_PLIST.replace("ai.hermes.gateway", "ai.hermes.gateway.old")
+        self._install(
+            tmp_path, monkeypatch, self._as_binary(outdated), self.XML_PLIST
+        )
+
+        assert gateway_cli.launchd_plist_is_current() is False
+
+    def test_binary_plist_path_still_ignores_path_payload(self, tmp_path, monkeypatch):
+        """The PATH normalization must survive the binary round-trip.
+
+        The generated plist captures the invoking shell's PATH, so a plist
+        differing only in PATH is not stale — the same rule the XML path
+        already applies.
+        """
+        installed = self.XML_PLIST.replace(
+            "/opt/homebrew/bin:/usr/bin:/bin", "/usr/local/bin:/usr/bin:/bin"
+        )
+        self._install(
+            tmp_path, monkeypatch, self._as_binary(installed), self.XML_PLIST
+        )
+
+        assert gateway_cli.launchd_plist_is_current() is True
+
+    def test_xml_plist_comparison_is_unchanged(self, tmp_path, monkeypatch):
+        self._install(
+            tmp_path, monkeypatch, self.XML_PLIST.encode("utf-8"), self.XML_PLIST
+        )
+        assert gateway_cli.launchd_plist_is_current() is True
+
+        self._install(
+            tmp_path,
+            monkeypatch,
+            b"<plist>old content</plist>",
+            self.XML_PLIST,
+        )
+        assert gateway_cli.launchd_plist_is_current() is False
+
+    def test_undecodable_non_plist_file_is_stale_not_a_crash(
+        self, tmp_path, monkeypatch
+    ):
+        """A corrupt plist must reinstall, not raise out of `gateway status`."""
+        self._install(tmp_path, monkeypatch, b"\xff\xfe\x00garbage", self.XML_PLIST)
+
+        assert gateway_cli.launchd_plist_is_current() is False


### PR DESCRIPTION
## What does this PR do?

`launchd_plist_is_current()` read the installed launchd plist with
`plist_path.read_text(encoding="utf-8")`. macOS `launchctl` is free to rewrite an
installed plist into Apple's binary format (`bplist00…`) during bootstrap/bootout
cycles, after a reboot, or as a normalization step — and the `\xd8` byte right
after the magic is not valid UTF-8. Python's strict decoder raises before the
file is ever parsed, so `hermes gateway status`, `gateway install`, and every
auto-refresh path that gates on the staleness check die with
`UnicodeDecodeError` on a plist that is otherwise perfectly valid.

The fix reads the file as bytes. A binary plist is parsed and re-rendered as XML
via `plistlib`, **and the generated plist is pushed through the same round-trip**
so both sides are compared in one canonical serialization.

That second half is the part worth reviewing. Comparing re-rendered XML directly
against `generate_launchd_plist()`'s text would differ on formatting alone — the
plist would be reported stale on *every* call and rewritten as XML, which
`launchctl` is then free to re-binarize, producing an endless refresh loop
(each one a bootout/bootstrap cycle on the live gateway). Canonicalizing both
sides keeps a binary plist with the generated contents correctly reported as
current.

XML plists keep the existing raw-text comparison path unchanged, so nothing
about the common case moves.

A plist that neither parses as binary nor decodes as UTF-8 is reported stale, so
the caller reinstalls it rather than raising out of the CLI.

## Related Issue

Fixes #90606

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` — new `_plist_bytes_as_xml_text()` and
  `_launchd_plist_comparison_pair()` helpers; `launchd_plist_is_current()` now
  reads bytes and routes through them.
- `tests/hermes_cli/test_gateway_service.py` — new
  `TestLaunchdBinaryPlistStaleCheck` (5 tests).

## How to Test

Reproduce on macOS (the issue's own repro step):

```bash
hermes gateway install
plutil -convert binary1 ~/Library/LaunchAgents/ai.hermes.gateway.plist
hermes gateway status     # before: UnicodeDecodeError traceback
```

Automated:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py
```

All 5 new tests fail on `main` with the exact reported
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd8 in position 8` (and
`0xff` for the corrupt-file case), and pass with the fix. 88 passed, 1 skipped
on the changed file; `tests/hermes_cli/test_gateway.py`,
`tests/hermes_cli/test_ensure_gateway_service.py` and `tests/gateway/test_status.py`
also pass (107 passed, 5 skipped).

I additionally verified end-to-end against a plist converted by the real macOS
`plutil -convert binary1` (magic `b'bplist00\xd2'`): `launchd_plist_is_current()`
returns `True` instead of raising.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0, Apple Silicon), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(docstrings on both new helpers)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — macOS-only code path; Linux/Windows have no launchd and are untouched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes

`contributors/emails/phong.dinh2108@gmail.com` is added in a separate commit so
the Contributor Attribution Check resolves this email.
