### PR TITLE
fix(cli): stop doctor flagging CommandCode's vendor-prefixed model ids

### DIFF
--- a/contributors/emails/phong.dinh2108@gmail.com
+++ b/contributors/emails/phong.dinh2108@gmail.com
@@ -1,0 +1,2 @@
+dennytosp
+# PR: fix(cli): doctor CommandCode vendor-prefix false positive

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1417,6 +1417,12 @@ def run_doctor(args):
                 # is exclusively ``vendor/model`` slugs (Qwen/Qwen3.5-…,
                 # meta-llama/Llama-3-…, anthropic/claude-opus-4-7, …).
                 "deepinfra",
+                # CommandCode fronts 20+ vendors and serves vendor-prefixed
+                # ids (deepseek/deepseek-v4-flash, Qwen/Qwen3.7-Max, …). The
+                # prefix is not optional: the bare name is rejected with HTTP
+                # 400 "Model is not supported on this endpoint", so warning
+                # users to drop it broke working configs (#91144).
+                "commandcode",
             }
             provider_accepts_vendor_slug = (
                 provider_policy_id in providers_accepting_vendor_slugs

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -657,6 +657,94 @@ def test_run_doctor_accepts_vendor_slugs_for_named_custom_provider(monkeypatch, 
 
 
 
+def test_run_doctor_accepts_vendor_slugs_for_commandcode(monkeypatch, tmp_path):
+    """CommandCode's catalogue is natively vendor-prefixed, so no warning.
+
+    Its /v1/models serves ``deepseek/deepseek-v4-flash``, ``Qwen/Qwen3.7-Max``
+    and friends, and the endpoint rejects the bare form with HTTP 400. Doctor
+    used to tell users to drop that prefix — advice that breaks the install
+    (#91144).
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("COMMANDCODE_API_KEY=***\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: commandcode\n"
+        "  default: deepseek/deepseek-v4-flash\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    out = buf.getvalue()
+    assert (
+        "model.default 'deepseek/deepseek-v4-flash' uses a vendor/model slug "
+        "but provider is 'commandcode'"
+        not in out
+    )
+    assert "Either set model.provider to 'openrouter', or drop the vendor prefix." not in out
+
+
+def test_run_doctor_still_flags_vendor_slugs_for_direct_providers(monkeypatch, tmp_path):
+    """The allowlist widening must not silence the warning for direct APIs."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".env").write_text("DEEPSEEK_API_KEY=***\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: deepseek\n"
+        "  default: deepseek/deepseek-v4-flash\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    assert "uses a vendor/model slug but provider is 'deepseek'" in buf.getvalue()
+
+
 def test_run_doctor_accepts_kimi_coding_cn_provider(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` warns when `model.default` carries a `vendor/model` slug but the
configured provider is not in `providers_accepting_vendor_slugs`, and tells the
user to *"drop the vendor prefix"*.

CommandCode is an aggregator whose catalogue is **natively** vendor-prefixed. Its
`/v1/models` serves `deepseek/deepseek-v4-flash`, `Qwen/Qwen3.7-Max`,
`xiaomi/mimo-v2.5-pro`, … (see the `fallback_models` tuple in
`plugins/model-providers/commandcode/__init__.py`), and the endpoint rejects the
bare form with HTTP 400 *"Model is not supported on this endpoint"*.

So the warning fired on every correct CommandCode config, and following its
advice broke the install. Adding `commandcode` to the allowlist puts it next to
the other aggregator-style gateways already there (`opencode-zen`, `deepinfra`,
`fireworks`, …).

### One deliberate deviation from the issue's proposed fix

The issue also proposes adding `commandcode` to `_AGGREGATOR_PROVIDERS`. I left
that out, for two reasons:

1. **Wrong module.** `normalize_model_for_provider()` lives in
   `hermes_cli/model_normalize.py` and reads *that* module's own
   `_AGGREGATOR_PROVIDERS`, not the one in `hermes_cli/models.py` that the issue
   names. Editing `models.py` would not change normalization at all.
2. **Wrong shape.** Membership in that set routes bare names through
   `_prepend_vendor()`, which guesses a vendor from the name. CommandCode's
   catalogue contains a legitimately bare `gpt-5.5`, which would be rewritten to
   `openai/gpt-5.5` and rejected. It would also lower-case `Qwen3.7-Max` into
   `qwen/…` where the real id is `Qwen/…`.

   The correct mechanism for this provider is
   `_CATALOGUE_PREFIX_REPAIR_PROVIDERS` — a catalogue lookup rather than a guess,
   which repairs `deepseek-v4-flash` while leaving `gpt-5.5` alone. That needs a
   curated `_PROVIDER_MODELS["commandcode"]` entry, which is a separate change
   from the false-positive reported here, so I kept this PR to one logical change
   per the contributing guide. Happy to follow up with that half if maintainers
   want it in-tree.

## Related Issue

Fixes #91144

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py` — add `commandcode` to `providers_accepting_vendor_slugs`.
- `tests/hermes_cli/test_doctor.py` — `test_run_doctor_accepts_vendor_slugs_for_commandcode`
  (regression) and `test_run_doctor_still_flags_vendor_slugs_for_direct_providers`
  (guards that widening the allowlist doesn't silence the warning for direct APIs).

## How to Test

```bash
# ~/.hermes/config.yaml
model:
  provider: commandcode
  default: deepseek/deepseek-v4-flash
```

```bash
hermes doctor
```

Before: `model.default 'deepseek/deepseek-v4-flash' is vendor-prefixed but
model.provider is 'commandcode'. Either set model.provider to 'openrouter', or
drop the vendor prefix.` After: no warning.

Automated:

```bash
scripts/run_tests.sh tests/hermes_cli/test_doctor.py
```

The commandcode test fails on `main` and passes with the fix; the `deepseek`
control test passes on both, confirming the warning still fires for direct
providers. 58 passed on the changed file; the adjacent doctor test files
(`test_doctor_dedicated_provider_skip.py`, `test_doctor_command_install.py`,
`test_doctor_journal_modes.py`) also pass (40 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0, Apple Silicon), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure config-validation logic, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Notes

`contributors/emails/phong.dinh2108@gmail.com` is added in a separate commit so
the Contributor Attribution Check resolves this email.
