### PR TITLE
fix(mcp): emit typed array schemas instead of bare list in hermes-tools MCP server

### DIFF
--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -64,6 +64,22 @@ _JSON_TO_PY = {
 }
 
 
+def _resolve_json_type(pspec: dict) -> type:
+    """Resolve a JSON Schema type spec to a Python type.
+
+    Handles nested arrays recursively so that
+    {"type": "array", "items": {"type": "string"}} becomes
+    list[str] instead of bare list.
+    """
+    pspec = pspec or {}
+    ptype = pspec.get("type")
+    if ptype == "array" and pspec.get("items"):
+        return list[_resolve_json_type(pspec["items"])]
+    if ptype == "object":
+        return dict
+    return _JSON_TO_PY.get(ptype, Any)
+
+
 def _signature_from_schema(schema: dict | None) -> tuple[inspect.Signature, dict[str, type]]:
     """Build a Python function signature and annotations from a JSON schema.
 
@@ -81,7 +97,7 @@ def _signature_from_schema(schema: dict | None) -> tuple[inspect.Signature, dict
     for pname, pspec in props.items():
         if pname.startswith("_"):
             continue
-        py = _JSON_TO_PY.get((pspec or {}).get("type"), Any)
+        py = _resolve_json_type(pspec)
         ann, default = (
             (py, inspect.Parameter.empty)
             if pname in required


### PR DESCRIPTION
### Problem

`_signature_from_schema()` maps JSON Schema `array` to bare `list`, causing MCP SDK to emit `{"type":"array"}` without `items`. Strict MCP clients skip tools with incomplete schemas.

### Fix

Extract `_resolve_json_type()` helper: array+items → `list[T]` (recursive), object → dict, fallback to _JSON_TO_PY.

### Diff: +17/-1

### Testing

- urls (array+items:string) → list[str] ✓
- matrix (array[array[int]]) → list[list[int]] ✓  
- tags (array, no items) → bare list (safe fallback) ✓
- Codely no longer skips web_extract/vision_analyze