### PR TITLE
feat(webhook): support ${VAR} env expansion for route HMAC secrets

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -20,6 +20,12 @@ Each route defines:
 
 Security:
   - HMAC secret is required per route (validated at startup)
+  - Secrets may be written as whole-value ``${VAR}`` templates, resolved
+    once from the environment at adapter load time, so the key can live in
+    an env file / secret store instead of config.yaml. An unset or empty
+    variable refuses to start (never os.path.expandvars, which would leave
+    ``${MISSING}`` in place and fail open). Agent-created dynamic routes
+    are deliberately never expanded.
   - Rate limiting per route (fixed-window, configurable)
   - Idempotency cache prevents duplicate agent runs on webhook retries
   - Body size limits checked before reading payload
@@ -37,6 +43,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
@@ -169,6 +176,45 @@ def _hmac_str_equal(provided: str, expected: str) -> bool:
     return hmac.compare_digest(provided.encode(), expected.encode())
 
 
+_SECRET_ENV_TEMPLATE_RE = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$")
+
+
+def _resolve_secret_template(value: str, where: str) -> str:
+    """Resolve a whole-value ``${VAR}`` secret from the environment.
+
+    Only an entire value of the form ``${VAR}`` is treated as a template,
+    so a literal secret that merely contains a ``$`` is never rewritten.
+
+    Deliberately NOT ``os.path.expandvars``: that leaves ``${MISSING}`` in
+    place when the variable is unset, and the resulting non-empty string
+    sails past the "secret is required" startup check as if it were a real
+    secret — a fail-OPEN hole. An unset or empty variable raises here
+    instead, so the adapter refuses to serve a route whose HMAC secret
+    would be the literal text ``${MISSING}``.
+
+    Load-time resolution only (``WebhookAdapter.__init__``). Dynamic,
+    agent-created routes (``webhook_subscriptions.json``) are deliberately
+    NOT expanded: if the agent could set ``secret: ${SOME_VAR}`` on its own
+    routes it would gain an oracle for comparing arbitrary gateway env vars
+    against chosen signatures. Static routes come from config.yaml, written
+    by the operator.
+    """
+    if not value or not isinstance(value, str):
+        return value
+    match = _SECRET_ENV_TEMPLATE_RE.match(value.strip())
+    if not match:
+        return value
+    name = match.group(1)
+    resolved = os.environ.get(name, "")
+    if not resolved:
+        raise ValueError(
+            f"[webhook] {where} references ${{{name}}} but that environment "
+            f"variable is unset or empty. Refusing to serve with an "
+            f"unresolved secret."
+        )
+    return resolved
+
+
 def check_webhook_requirements() -> bool:
     """Check if webhook adapter dependencies are available."""
     return AIOHTTP_AVAILABLE
@@ -191,8 +237,28 @@ class WebhookAdapter(BasePlatformAdapter):
         _cfg_host = config.extra.get("host", DEFAULT_HOST)
         self._host: Optional[str] = _cfg_host or None
         self._port: int = int(config.extra.get("port", DEFAULT_PORT))
-        self._global_secret: str = config.extra.get("secret", "")
-        self._static_routes: Dict[str, dict] = config.extra.get("routes", {})
+        # P15 (F-M75-48): ${VAR} secret templates resolve once, at load
+        # time. Resolution failures are RECORDED, not raised: __init__
+        # runs outside the try-block that guards connect() in
+        # gateway/run.py, so raising here would kill the whole gateway
+        # (crash-loop under Restart=always) instead of degrading to
+        # "webhook platform down". connect() re-raises; that path IS
+        # guarded. Failed templates become secret: "" (the key is kept
+        # so the route cannot silently inherit the global secret).
+        self._unresolved_secret_errors: List[str] = []
+        self._global_secret: str = self._resolve_config_secret(
+            config.extra.get("secret", ""), "global secret"
+        )
+        self._static_routes: Dict[str, dict] = {
+            _name: (
+                {**_route, "secret": self._resolve_config_secret(
+                    _route["secret"], f"route {_name!r}"
+                )}
+                if isinstance(_route, dict) and _route.get("secret")
+                else _route
+            )
+            for _name, _route in (config.extra.get("routes", {}) or {}).items()
+        }
         self._dynamic_routes: Dict[str, dict] = {}
         self._dynamic_routes_mtime: float = 0.0
         self._routes: Dict[str, dict] = dict(self._static_routes)
@@ -241,11 +307,33 @@ class WebhookAdapter(BasePlatformAdapter):
             script_timeout_seconds=self._script_timeout_seconds
         )
 
+    def _resolve_config_secret(self, value: Any, where: str) -> str:
+        """Resolve a ``${VAR}`` template from config, capturing failures.
+
+        Returns ``""`` when the template cannot be resolved and records
+        the reason; :meth:`connect` re-raises the recorded errors inside
+        the guarded startup path. See the note on ``__init__`` for why
+        raising here directly would crash-loop the whole gateway.
+        """
+        try:
+            return _resolve_secret_template(value, where)
+        except ValueError as exc:
+            self._unresolved_secret_errors.append(str(exc))
+            return ""
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
+        # P15 (F-M75-48): fail-closed for ${VAR} secrets that did not
+        # resolve at load time. Recorded in __init__ (NOT guarded by the
+        # startup try-block) and re-raised here (guarded), so an
+        # unresolved secret takes down the webhook platform only,
+        # never the whole gateway.
+        if self._unresolved_secret_errors:
+            raise ValueError("; ".join(self._unresolved_secret_errors))
+
         # Load agent-created subscriptions before validating
         self._reload_dynamic_routes()
 

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -205,7 +205,27 @@ def _resolve_secret_template(value: str, where: str) -> str:
     if not match:
         return value
     name = match.group(1)
-    resolved = os.environ.get(name, "")
+    # Route through gateway.config._getenv, not os.environ: under multiplexed
+    # profile startup a per-profile secret scope is installed, and the scoped
+    # value is the correct one. Imported lazily to keep this module importable
+    # without the gateway config package.
+    try:
+        from gateway.config import _getenv
+
+        resolved = _getenv(name, "") or ""
+    except Exception:
+        resolved = os.environ.get(name, "")
+    if resolved:
+        # Whatever name the operator chose now holds a live HMAC secret in the
+        # gateway process environment. Register it so the terminal/subprocess
+        # filters strip it; the static HERMES_WEBHOOK_SECRET_* rule only covers
+        # the conventional spelling.
+        try:
+            from tools.environments.local import register_resolved_secret_env_name
+
+            register_resolved_secret_env_name(name)
+        except Exception:
+            pass
     if not resolved:
         raise ValueError(
             f"[webhook] {where} references ${{{name}}} but that environment "
@@ -237,7 +257,7 @@ class WebhookAdapter(BasePlatformAdapter):
         _cfg_host = config.extra.get("host", DEFAULT_HOST)
         self._host: Optional[str] = _cfg_host or None
         self._port: int = int(config.extra.get("port", DEFAULT_PORT))
-        # P15 (F-M75-48): ${VAR} secret templates resolve once, at load
+        # ${VAR} secret templates resolve once, at load
         # time. Resolution failures are RECORDED, not raised: __init__
         # runs outside the try-block that guards connect() in
         # gateway/run.py, so raising here would kill the whole gateway
@@ -326,7 +346,7 @@ class WebhookAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        # P15 (F-M75-48): fail-closed for ${VAR} secrets that did not
+        # Fail-closed for ${VAR} secrets that did not
         # resolve at load time. Recorded in __init__ (NOT guarded by the
         # startup try-block) and re-raised here (guarded), so an
         # unresolved secret takes down the webhook platform only,

--- a/tests/gateway/test_webhook_secret_templates.py
+++ b/tests/gateway/test_webhook_secret_templates.py
@@ -1,0 +1,169 @@
+"""Tests for ``${VAR}`` secret-template expansion in the webhook adapter.
+
+Static routes in ``config.yaml`` may reference a whole-value ``${VAR}``
+template that is resolved from the process environment once, at adapter
+load time. Dynamic (agent-created) routes are deliberately never expanded.
+"""
+
+import json
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import (
+    WebhookAdapter,
+    _resolve_secret_template,
+)
+
+
+def _make_adapter(routes=None, secret="", tmp_path=None, monkeypatch=None):
+    if monkeypatch is not None and tmp_path is not None:
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    extra = {"host": "127.0.0.1", "port": 0, "routes": routes or {}}
+    if secret:
+        extra["secret"] = secret
+    return WebhookAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+# ---------------------------------------------------------------------------
+# _resolve_secret_template unit behavior
+# ---------------------------------------------------------------------------
+
+def test_literal_secret_is_unchanged():
+    assert _resolve_secret_template("plain-secret", "t") == "plain-secret"
+    # A literal that merely CONTAINS a $ must never be rewritten.
+    assert _resolve_secret_template("a$b", "t") == "a$b"
+    assert _resolve_secret_template("INSECURE_NO_AUTH", "t") == "INSECURE_NO_AUTH"
+    assert _resolve_secret_template("", "t") == ""
+    assert _resolve_secret_template(None, "t") is None
+
+
+def test_partial_template_is_not_expanded(monkeypatch):
+    """Only an ENTIRE value of the form ${VAR} is a template."""
+    monkeypatch.setenv("P15_TEST_VAR", "resolved")
+    assert _resolve_secret_template("prefix-${P15_TEST_VAR}", "t") == "prefix-${P15_TEST_VAR}"
+    assert _resolve_secret_template("${P15_TEST_VAR}-suffix", "t") == "${P15_TEST_VAR}-suffix"
+
+
+def test_template_resolves_from_environment(monkeypatch):
+    monkeypatch.setenv("P15_TEST_VAR", "resolved-value")
+    assert _resolve_secret_template("${P15_TEST_VAR}", "t") == "resolved-value"
+    assert _resolve_secret_template("  ${P15_TEST_VAR}  ", "t") == "resolved-value"
+
+
+def test_template_unset_variable_raises():
+    """Fail-closed: NOT os.path.expandvars, which would leave ${MISSING} in
+    place and sail past the startup secret-required check (fail-OPEN)."""
+    with pytest.raises(ValueError, match="unset or empty"):
+        _resolve_secret_template("${P15_SURELY_UNSET_VAR}", "t")
+
+
+def test_template_empty_variable_raises(monkeypatch):
+    monkeypatch.setenv("P15_TEST_EMPTY", "")
+    with pytest.raises(ValueError, match="unset or empty"):
+        _resolve_secret_template("${P15_TEST_EMPTY}", "t")
+
+
+# ---------------------------------------------------------------------------
+# Adapter load-time behavior
+# ---------------------------------------------------------------------------
+
+def test_init_resolves_route_template(monkeypatch, tmp_path):
+    monkeypatch.setenv("P15_ROUTE_SECRET", "s3cret")
+    adapter = _make_adapter(
+        routes={"r1": {"secret": "${P15_ROUTE_SECRET}", "prompt": "x"}},
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+    assert adapter._static_routes["r1"]["secret"] == "s3cret"
+    assert adapter._unresolved_secret_errors == []
+
+
+def test_init_resolves_global_secret_template(monkeypatch, tmp_path):
+    monkeypatch.setenv("P15_GLOBAL_SECRET", "gl0bal")
+    adapter = _make_adapter(
+        routes={"r1": {"prompt": "x"}},
+        secret="${P15_GLOBAL_SECRET}",
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+    assert adapter._global_secret == "gl0bal"
+
+
+def test_init_does_not_raise_on_unresolved_template(tmp_path, monkeypatch):
+    """__init__ runs OUTSIDE the guarded startup path in gateway/run.py;
+    raising there would crash-loop the whole gateway. Resolution failures
+    are recorded and re-raised in connect() instead (which IS guarded)."""
+    adapter = _make_adapter(
+        routes={"r1": {"secret": "${P15_SURELY_UNSET_VAR}", "prompt": "x"}},
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+    # The key is kept with an empty value: dropping it would make the route
+    # silently inherit the global secret.
+    assert "secret" in adapter._static_routes["r1"]
+    assert adapter._static_routes["r1"]["secret"] == ""
+    assert adapter._unresolved_secret_errors, "failure was not recorded"
+
+
+@pytest.mark.asyncio
+async def test_connect_raises_on_unresolved_template(tmp_path, monkeypatch):
+    adapter = _make_adapter(
+        routes={"r1": {"secret": "${P15_SURELY_UNSET_VAR}", "prompt": "x"}},
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+    with pytest.raises(ValueError, match="P15_SURELY_UNSET_VAR"):
+        await adapter.connect()
+
+
+@pytest.mark.asyncio
+async def test_connect_succeeds_with_resolved_template(tmp_path, monkeypatch):
+    monkeypatch.setenv("P15_ROUTE_SECRET", "s3cret")
+    adapter = _make_adapter(
+        routes={"r1": {"secret": "${P15_ROUTE_SECRET}", "prompt": "x"}},
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+    try:
+        assert await adapter.connect()
+    finally:
+        await adapter.disconnect()
+
+
+def test_config_extra_not_mutated_by_resolution(monkeypatch, tmp_path):
+    """save_config round-trip: resolution must not leak the resolved value
+    back into the config structure (it would be written to config.yaml)."""
+    monkeypatch.setenv("P15_ROUTE_SECRET", "s3cret")
+    routes = {"r1": {"secret": "${P15_ROUTE_SECRET}", "prompt": "x"}}
+    adapter = _make_adapter(routes=routes, tmp_path=tmp_path, monkeypatch=monkeypatch)
+    assert adapter._static_routes["r1"]["secret"] == "s3cret"
+    # The original dict passed via config.extra keeps the template.
+    assert routes["r1"]["secret"] == "${P15_ROUTE_SECRET}"
+    assert adapter.config.extra["routes"]["r1"]["secret"] == "${P15_ROUTE_SECRET}"
+
+
+# ---------------------------------------------------------------------------
+# Dynamic (agent-created) routes are never expanded
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dynamic_route_template_is_not_expanded(tmp_path, monkeypatch):
+    """If the agent could set secret: ${SOME_VAR} on its own routes it would
+    gain an oracle for comparing arbitrary gateway env vars against chosen
+    signatures. Dynamic routes keep the literal value."""
+    monkeypatch.setenv("P15_AGENT_VAR", "agent-secret")
+    (tmp_path / "webhook_subscriptions.json").write_text(
+        json.dumps({"agent-route": {"secret": "${P15_AGENT_VAR}", "prompt": "x"}}),
+        encoding="utf-8",
+    )
+    adapter = _make_adapter(
+        routes={"static": {"secret": "static-secret", "prompt": "x"}},
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+    )
+    try:
+        assert await adapter.connect()
+        assert adapter._routes["agent-route"]["secret"] == "${P15_AGENT_VAR}"
+    finally:
+        await adapter.disconnect()

--- a/tests/tools/test_build_subprocess_env.py
+++ b/tests/tools/test_build_subprocess_env.py
@@ -132,3 +132,58 @@ def test_hermes_subprocess_env_strips_webhook_secret_even_with_credentials(monke
     assert "HERMES_WEBHOOK_SECRET_SELFTEST" not in hermes_subprocess_env(
         inherit_credentials=False
     )
+
+
+# ---------------------------------------------------------------------------
+# Secrets referenced under a name no static rule knows.
+#
+# Route secrets are operator-chosen: ``secret: ${WEBHOOK_HMAC}`` is as valid as
+# the conventional ``${HERMES_WEBHOOK_SECRET_X}``. Such a name matches neither
+# the prefix rule above nor the substring KEY/SECRET/TOKEN filter used by
+# code_execution_tool.py, so without registration it would reach subprocesses.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def clean_secret_registry():
+    """Keep the append-only registry from leaking between tests."""
+    from tools.environments import local as _local
+
+    before = set(_local._RESOLVED_SECRET_ENV_NAMES)
+    yield
+    _local._RESOLVED_SECRET_ENV_NAMES.clear()
+    _local._RESOLVED_SECRET_ENV_NAMES.update(before)
+
+
+def test_unregistered_unconventional_name_is_not_stripped(clean_secret_registry):
+    from tools.environments.local import _is_hermes_internal_secret
+
+    # Baseline: without registration the name is ordinary, and the test below
+    # would pass vacuously if this were not true.
+    assert not _is_hermes_internal_secret("WEBHOOK_HMAC")
+
+
+def test_registered_unconventional_name_is_stripped(monkeypatch, clean_secret_registry):
+    from tools.environments.local import (
+        _is_hermes_internal_secret,
+        hermes_subprocess_env,
+        register_resolved_secret_env_name,
+    )
+
+    monkeypatch.setenv("WEBHOOK_HMAC", "sentinel-value")
+    register_resolved_secret_env_name("WEBHOOK_HMAC")
+
+    assert _is_hermes_internal_secret("WEBHOOK_HMAC")
+    assert "WEBHOOK_HMAC" not in build_subprocess_env()
+    assert "WEBHOOK_HMAC" not in hermes_subprocess_env(inherit_credentials=True)
+    assert "WEBHOOK_HMAC" not in hermes_subprocess_env(inherit_credentials=False)
+
+
+def test_resolving_a_template_registers_the_name(monkeypatch, clean_secret_registry):
+    """Resolution and stripping must not drift apart: resolving IS registering."""
+    from gateway.platforms.webhook import _resolve_secret_template
+    from tools.environments.local import _is_hermes_internal_secret
+
+    monkeypatch.setenv("WEBHOOK_HMAC", "sentinel-value")
+    assert _resolve_secret_template("${WEBHOOK_HMAC}", "route 'x'") == "sentinel-value"
+    assert _is_hermes_internal_secret("WEBHOOK_HMAC")
+    assert "WEBHOOK_HMAC" not in build_subprocess_env()

--- a/tests/tools/test_build_subprocess_env.py
+++ b/tests/tools/test_build_subprocess_env.py
@@ -97,3 +97,38 @@ def test_e2e_no_scrub_child_keeps_planted_secret(tmp_path, monkeypatch):
         env=env, capture_output=True, text=True, timeout=60, check=True,
     )
     assert out.stdout.strip() == "sk-FAKE-planted"
+
+
+# ---------------------------------------------------------------------------
+# Webhook-platform HMAC secrets (${VAR} expansion support): stripped on every
+# spawn path, including the inherit_credentials=True path that skips the
+# Tier-2 provider blocklist.
+# ---------------------------------------------------------------------------
+
+def test_scrub_on_strips_hermes_webhook_secret_vars(monkeypatch):
+    monkeypatch.setenv("HERMES_WEBHOOK_SECRET_DA_PART1", "hex-secret")
+    env = build_subprocess_env()
+    assert "HERMES_WEBHOOK_SECRET_DA_PART1" not in env
+
+
+def test_webhook_secret_predicate_is_case_insensitive():
+    from tools.environments.local import _is_hermes_internal_secret
+
+    assert _is_hermes_internal_secret("HERMES_WEBHOOK_SECRET_DA_PART1")
+    assert _is_hermes_internal_secret("hermes_webhook_secret_x")
+    # No name part after the prefix -> not a webhook secret var.
+    assert not _is_hermes_internal_secret("HERMES_WEBHOOK_SECRET")
+    # Outside the convention -> untouched (users may name other vars freely).
+    assert not _is_hermes_internal_secret("MY_WEBHOOK_SECRET")
+
+
+def test_hermes_subprocess_env_strips_webhook_secret_even_with_credentials(monkeypatch):
+    from tools.environments.local import hermes_subprocess_env
+
+    monkeypatch.setenv("HERMES_WEBHOOK_SECRET_SELFTEST", "sentinel")
+    assert "HERMES_WEBHOOK_SECRET_SELFTEST" not in hermes_subprocess_env(
+        inherit_credentials=True
+    )
+    assert "HERMES_WEBHOOK_SECRET_SELFTEST" not in hermes_subprocess_env(
+        inherit_credentials=False
+    )

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -384,6 +384,13 @@ def _is_hermes_internal_secret(key: str) -> bool:
       (``GATEWAY_RELAY_URL``, ``GATEWAY_RELAY_PLATFORMS``, …) are NOT matched
       and remain visible.
 
+    - ``HERMES_WEBHOOK_SECRET_*`` — HMAC secrets for the webhook platform
+      adapter, referenced from ``platforms.webhook.extra`` config as
+      ``secret: ${HERMES_WEBHOOK_SECRET_<NAME>}`` and resolved from the
+      environment at adapter load time. Only consumer is the in-process
+      webhook adapter; leaking one lets the holder forge signed webhook
+      POSTs into the gateway.
+
     ``code_execution_tool.py`` already catches these via substring matching on
     ``KEY`` / ``SECRET`` / ``TOKEN``; the terminal backend's narrower name-based
     blocklist did not, which is the leak this predicate closes.
@@ -404,6 +411,11 @@ def _is_hermes_internal_secret(key: str) -> bool:
     if upper.startswith("GATEWAY_RELAY_") and (
         upper.endswith("_SECRET") or upper.endswith("_KEY") or upper.endswith("_TOKEN")
     ):
+        return True
+    if upper.startswith("HERMES_WEBHOOK_SECRET_"):
+        # P15 (F-M75-48): webhook-platform HMAC secrets referenced from
+        # config.yaml as secret: ${HERMES_WEBHOOK_SECRET_<NAME>}; stripped
+        # unconditionally on every spawn surface (see docstring).
         return True
     return False
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -363,6 +363,33 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 _ACTIVE_VENV_MARKER_VARS = ("VIRTUAL_ENV", "CONDA_PREFIX", "PYTHONHOME")
 
 
+# Env var names that were resolved into a *secret* at runtime, registered by
+# the resolving code itself rather than matched by a static name rule.
+#
+# The webhook adapter accepts ``secret: ${ANY_NAME}`` in operator config, so
+# the set of env vars holding gateway secrets is open-ended and cannot be
+# enumerated ahead of time. Registration closes the gap between "any name may
+# be referenced" and "only conventional names are stripped": whatever gets
+# resolved is stripped, whatever its spelling.
+#
+# Append-only and process-local. Adding a name can only ever remove a variable
+# from a subprocess environment, never expose one, so a lost registration
+# degrades to the previous name-based behaviour instead of failing open.
+_RESOLVED_SECRET_ENV_NAMES: set = set()
+
+
+def register_resolved_secret_env_name(name: str) -> None:
+    """Mark ``name`` as an env var whose value is used as a gateway secret.
+
+    Called by resolvers (e.g. the webhook adapter's ``${VAR}`` expansion) so
+    :func:`_is_hermes_internal_secret` strips the variable from every spawned
+    subprocess regardless of how the operator spelled it.
+    """
+    if name and isinstance(name, str):
+        _RESOLVED_SECRET_ENV_NAMES.add(name)
+        _RESOLVED_SECRET_ENV_NAMES.add(name.upper())
+
+
 def _is_hermes_internal_secret(key: str) -> bool:
     """Return True for Hermes-internal secrets injected under *dynamic* names.
 
@@ -413,9 +440,16 @@ def _is_hermes_internal_secret(key: str) -> bool:
     ):
         return True
     if upper.startswith("HERMES_WEBHOOK_SECRET_"):
-        # P15 (F-M75-48): webhook-platform HMAC secrets referenced from
-        # config.yaml as secret: ${HERMES_WEBHOOK_SECRET_<NAME>}; stripped
-        # unconditionally on every spawn surface (see docstring).
+        # Webhook-platform HMAC secrets referenced from config.yaml as
+        # secret: ${HERMES_WEBHOOK_SECRET_<NAME>}; stripped unconditionally
+        # on every spawn surface (see docstring).
+        return True
+    if key in _RESOLVED_SECRET_ENV_NAMES or upper in _RESOLVED_SECRET_ENV_NAMES:
+        # Registered at resolution time by whoever pulled the value out of the
+        # environment and used it AS a secret. Name-based rules above cannot
+        # cover an operator who writes ``secret: ${WEBHOOK_HMAC}`` — a name no
+        # static registry knows and that the substring KEY/SECRET/TOKEN filter
+        # in code_execution_tool.py does not match either.
         return True
     return False
 


### PR DESCRIPTION
### Problem

Webhook route secrets (`platforms.webhook.extra.secret` and per-route
`secret`) can only be stored as literals in `config.yaml`. That file is the
one users share in bug reports, back up to cloud storage, and check into
version control — so the HMAC key that authenticates inbound webhook callers
routinely ends up outside the machine. Anyone holding it can forge signed
POSTs and trigger agent runs or direct deliveries on the affected routes.

There is currently no way to keep this key out of `config.yaml`: the config
loader performs no environment expansion for platform blocks.

### Change

Whole-value `${VAR}` templates in webhook secrets, resolved once from the
process environment at adapter load time:

```yaml
platforms:
  webhook:
    extra:
      routes:
        my-route:
          secret: ${HERMES_WEBHOOK_SECRET_MY_ROUTE}
          prompt: ...
```

The key itself then lives wherever the operator already manages secrets
(`~/.hermes/.env`, a systemd `EnvironmentFile`, a secret manager's injected
env), following the same pattern as other env-resolved credentials.

### Security semantics (the details that matter)

- **Whole-value only.** A literal secret that merely contains `$` is never
  rewritten. Only an entire value matching `${VAR}` is a template.
- **Fail-closed, deliberately not `os.path.expandvars`.** `expandvars` leaves
  `${MISSING}` in place when the variable is unset — a non-empty string that
  sails past the existing "secret is required" startup check as if it were a
  real secret (fail-open). An unset or empty variable raises instead, so the
  adapter refuses to serve a route whose secret would be the literal text
  `${MISSING}`.
- **`__init__` captures, `connect()` raises.** Adapter construction runs
  outside the try-block that guards `connect()` in `gateway/run.py`. Raising
  in `__init__` would crash-loop the entire gateway (systemd
  `Restart=always`) instead of degrading gracefully. Failures are recorded
  in `__init__` and re-raised in `connect()` — which IS guarded — so an
  unresolved secret takes down the webhook platform only; other platforms
  stay up. A failed template becomes `secret: ""` (the key is kept) so the
  route cannot silently inherit the global secret.
- **Dynamic routes are never expanded.** Agent-created subscriptions
  (`webhook_subscriptions.json`) keep `${X}` literal: letting the agent write
  `secret: ${X}` on its own routes would give it an oracle for comparing
  arbitrary gateway environment variables against chosen signatures. Only
  operator-written static routes expand.
- **`save_config` round-trip is clean.** Resolution builds new dicts and
  never mutates `config.extra`, so a config save writes the template back —
  not the resolved secret.
- **Subprocess strip.** Moving the secret to the environment would WIDEN the
  surface if the variable then leaked into agent-spawned processes, so
  `HERMES_WEBHOOK_SECRET_*` is stripped via `_is_hermes_internal_secret` on
  every spawn path (`_sanitize_subprocess_env` and
  `hermes_subprocess_env(inherit_credentials=True)` included), matching the
  `GATEWAY_RELAY_*` precedent. The prefix is a documented convention for
  these vars.

### Compatibility

Fully backward compatible: literal secrets (including ones containing `$`)
behave exactly as before; `INSECURE_NO_AUTH` handling, rate limiting,
idempotency and the health endpoint are untouched. No config changes
required.

### Tests

- New `tests/gateway/test_webhook_secret_templates.py` (resolution, partial
  templates, unset/empty fail-closed, init-capture/connect-raise, global
  secret, config round-trip, dynamic routes not expanded).
- Strip coverage added to `tests/tools/test_build_subprocess_env.py`.
- Existing webhook suites pass unchanged.
