### PR TITLE
fix(models): add claude-opus-5 to Anthropic provider model list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -444,6 +444,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "anthropic": [
         "claude-fable-5",
+        "claude-opus-5",
         "claude-sonnet-5",
         "claude-opus-4-8",
         "claude-opus-4-7",


### PR DESCRIPTION
## Summary
- `hermes model` → provider "Anthropic" model picker builds its list from the static `_PROVIDER_MODELS["anthropic"]" catalog in `hermes_cli/models.py`, not the live `/v1/models` endpoint.
- `claude-opus-5` is reachable via both an API key and Claude Code OAuth credentials (verified live against `api.anthropic.com/v1/models`), but was missing from the static list, so it never showed up as a selectable option in the picker even though the account could use it.
- Adds `claude-opus-5` to the static list, right after `claude-fable-5`, matching the existing opus-first-then-sonnet ordering convention used elsewhere in the file (e.g. the OpenRouter/Nous catalogs already include it).

## Test Plan
- [x] Confirmed `claude-opus-5` is present in the live Anthropic `/v1/models` response using the account's Claude Code OAuth token.
- [x] Ran `hermes model` interactively, selected provider "Anthropic" → existing credentials, and confirmed `claude-opus-5` now appears in "Select default model" (previously absent).
- [x] `hermes config set model.default claude-opus-5` / `hermes config get model` round-trip works (this was already possible before the fix via manual config, this PR just fixes the picker menu).