### PR TITLE
fix(tools): protect Hermes state from Docker cwd mounts

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -101,6 +101,37 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     assert f"{project_dir}:/workspace" in run_args_str
 
 
+@pytest.mark.parametrize("host_cwd_kind", ["parent", "exact"])
+def test_auto_mount_refuses_cwd_containing_hermes_home(
+    monkeypatch, tmp_path, host_cwd_kind
+):
+    """A writable workspace mount must never expose the live Hermes database."""
+    host_home = tmp_path / "home"
+    hermes_home = host_home / ".hermes"
+    hermes_home.mkdir(parents=True)
+    host_cwd = host_home if host_cwd_kind == "parent" else hermes_home
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    with pytest.raises(
+        docker_env.EnvironmentConnectionError,
+        match="contains HERMES_HOME",
+    ) as excinfo:
+        _make_dummy_env(
+            cwd="/workspace",
+            host_cwd=str(host_cwd),
+            auto_mount_cwd=True,
+        )
+
+    assert "terminal.cwd" in excinfo.value.retry_hint
+    assert not any(
+        isinstance(call[0], list) and call[0][1:2] == ["run"]
+        for call in calls
+    )
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persist_across_processes=false, cleanup() must docker stop AND
     docker rm so containers don't leak across hermes processes.

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -18,6 +18,7 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
+from hermes_constants import get_hermes_home
 from tools.environments.base import (
     BaseEnvironment,
     EnvironmentConnectionError,
@@ -913,6 +914,23 @@ class DockerEnvironment(BaseEnvironment):
             logger.warning("docker_volumes config is not a list: %r", volumes)
             volumes = []
 
+        host_cwd_abs = (
+            os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
+        )
+        if auto_mount_cwd and host_cwd_abs and os.path.isdir(host_cwd_abs):
+            mounted_cwd = Path(host_cwd_abs).resolve()
+            hermes_home = get_hermes_home().expanduser().resolve()
+            if hermes_home.is_relative_to(mounted_cwd):
+                raise EnvironmentConnectionError(
+                    "Refusing to mount the configured host cwd into Docker because "
+                    f"it contains HERMES_HOME ({hermes_home}). A container with a "
+                    "different SQLite runtime could corrupt the live Hermes state database.",
+                    retry_hint=(
+                        "Set terminal.cwd to a project directory outside HERMES_HOME, "
+                        "or disable terminal.docker_mount_cwd_to_workspace."
+                    ),
+                )
+
         # Fail fast if Docker is not available.
         _ensure_docker_available()
 
@@ -966,7 +984,6 @@ class DockerEnvironment(BaseEnvironment):
             else:
                 logger.warning("Docker volume '%s' missing colon, skipping", vol)
 
-        host_cwd_abs = os.path.abspath(os.path.expanduser(host_cwd)) if host_cwd else ""
         bind_host_cwd = (
             auto_mount_cwd
             and bool(host_cwd_abs)


### PR DESCRIPTION
## What does this PR do?

Refuses `terminal.docker_mount_cwd_to_workspace` when the configured host cwd contains the active `HERMES_HOME`.

Mounting a user home directory into `/workspace` also exposes `~/.hermes/state.db` as a writable container path. A container-side Hermes process can then open the live WAL database with a different SQLite runtime, risking corruption. The error points users to a project-only `terminal.cwd` or disabling the automatic mount.

Related to #70480 and #75467. This is complementary to #75483: stale-container cleanup does not prevent a newly created container from opening a host state database that was mounted into its workspace.

## Type of Change

- [x] Bug fix
- [x] Security hardening / data-loss prevention

## Changes Made

- Resolve the active profile's `HERMES_HOME` and configured host cwd before container startup.
- Refuse exact and ancestor mounts that would expose Hermes state.
- Preserve normal project-directory workspace mounts.
- Add behavior tests for both unsafe path shapes.

## How to Test

```bash
python -m pytest tests/tools/test_docker_environment.py -q
```

Result: `53 passed` on macOS.

## Checklist

- [x] Read the contributing guide
- [x] Searched open PRs and issues for duplicates
- [x] Conventional commit message
- [x] Focused change with regression tests
- [x] Considered cross-platform path handling (`pathlib.Path.resolve` and `is_relative_to`)
- [x] Documentation/config examples not required; no config key changed
