### PR TITLE
fix(cli): skip invalid rows during partial session recovery

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -601,6 +601,7 @@ def _copy_table_salvage(
         "columns": columns,
         "range_queries": 0,
         "exact_lookup_recovered": 0,
+        "destination_rejected_rows": 0,
         "skipped_rowid_ranges": [],
     }
     if not source_columns:
@@ -686,6 +687,16 @@ def _copy_table_salvage(
         try:
             destination.execute(insert_sql, value)
             destination.execute("COMMIT")
+        except sqlite3.IntegrityError as exc:
+            destination.execute("ROLLBACK")
+            result["destination_rejected_rows"] += 1
+            _append_skipped_range(
+                result["skipped_rowid_ranges"],
+                rowid,
+                rowid,
+                f"destination constraint rejected row: {exc}",
+            )
+            return True
         except BaseException:
             destination.execute("ROLLBACK")
             raise

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -487,6 +487,68 @@ def test_partial_recovery_keeps_messages_when_sessions_are_unsalvageable(
 
 
 
+def test_partial_recovery_skips_rows_rejected_by_current_schema(
+    tmp_path: Path,
+) -> None:
+    """Legacy optional rows must not abort recovery of the canonical data."""
+    source = tmp_path / "legacy-delegation.db"
+    output = tmp_path / "legacy-delegation-recovered.db"
+    _make_source(source)
+
+    with sqlite3.connect(str(source), isolation_level=None) as conn:
+        create_sql = conn.execute(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'async_delegations'"
+        ).fetchone()[0]
+        conn.execute(
+            "ALTER TABLE async_delegations RENAME TO async_delegations_strict"
+        )
+        conn.execute(create_sql.replace("state TEXT NOT NULL", "state TEXT"))
+        columns = [
+            str(row[1])
+            for row in conn.execute("PRAGMA table_info(async_delegations)")
+        ]
+        quoted = ", ".join(f'"{column}"' for column in columns)
+        conn.execute(
+            f"INSERT INTO async_delegations ({quoted}) "
+            f"SELECT {quoted} FROM async_delegations_strict"
+        )
+        conn.execute("DROP TABLE async_delegations_strict")
+        conn.execute(
+            """
+            INSERT INTO async_delegations (
+                delegation_id, origin_session, state, dispatched_at, updated_at
+            ) VALUES (?, ?, NULL, ?, ?)
+            """,
+            ("legacy-invalid", "recovery-session-0", 3.0, 4.0),
+        )
+
+    report = recover_session_database(
+        source,
+        output,
+        work_dir=tmp_path,
+        chunk_size=16,
+        allow_partial=True,
+    )
+
+    copied = report["copy"]["async_delegations"]
+    assert copied["status"] == "partial"
+    assert copied["copied_rows"] == 1
+    assert copied["destination_rejected_rows"] == 1
+    assert any(
+        "destination constraint rejected row" in item["error"]
+        for item in copied["skipped_rowid_ranges"]
+    )
+    assert report["verified"] is True
+    assert report["partial"] is True
+
+    with sqlite3.connect(str(output)) as conn:
+        rows = conn.execute(
+            "SELECT delegation_id, state FROM async_delegations"
+        ).fetchall()
+    assert rows == [("delegation-1", "completed")]
+
+
 def test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf(
     tmp_path: Path,
 ) -> None:
@@ -646,6 +708,5 @@ def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
         )
     finally:
         conn.close()
-
 
 


### PR DESCRIPTION
## What does this PR do?

Makes `hermes sessions recover --allow-partial` continue when a readable source row violates a constraint in the current destination schema.

The rowid salvage path already bisects a failed batch down to one row. At that point, however, a destination `sqlite3.IntegrityError` was re-raised and aborted the entire recovery. A field database reproduced this with `NOT NULL constraint failed: async_delegations.state` after canonical sessions and messages had already been salvaged.

The singleton path now skips only constraint-invalid rows, records the rejected rowid and error in the recovery report, and marks the table partial. Other destination failures such as operational errors still propagate. Strict recovery behavior is unchanged.

Related to #70480.

## Type of Change

- [x] Bug fix
- [x] Data-loss prevention / recovery robustness

## Changes Made

- Catch destination `sqlite3.IntegrityError` at the singleton salvage boundary.
- Report `destination_rejected_rows` and the rejected rowid range/reason.
- Add an end-to-end legacy-schema regression test with `async_delegations.state = NULL`.
- Verify canonical data is retained and the output database remains valid while reporting a partial recovery.

## How to Test

```bash
python -m pytest \
  tests/hermes_cli/test_session_recovery.py \
  tests/hermes_cli/test_session_recovery_lost_and_found.py -q
```

Result: `12 passed` on macOS.

## Checklist

- [x] Read the contributing guide
- [x] Searched open PRs and issues for duplicates
- [x] Conventional commit message
- [x] Focused change with end-to-end regression coverage
- [x] Strict recovery behavior remains unchanged
- [x] Documentation/config changes not required
