### PR TITLE
fix(skills): stop a skill's own files registering as rival skill candidates

### DIFF
--- a/tests/tools/test_skill_name_collision_candidates.py
+++ b/tests/tools/test_skill_name_collision_candidates.py
@@ -1,0 +1,121 @@
+"""A skill's own supporting files must not register as rival skills.
+
+`skill_view` collects candidates three ways; the third is
+``search_dir.rglob(f"{name}.md")``, which matches ANY file with that basename. A
+workflow skill keeping ``references/<topic>.md`` beside its SKILL.md follows the
+layout skills_tool itself reads (references/, templates/, assets/, scripts/) — but
+each of those files registered as a second candidate for <topic>, and skill_view
+then refused the real skill as ambiguous.
+
+Observed on one install: `notion` and `airtable` each matched three candidates — the
+real productivity/<name>/SKILL.md, creative/web-design-prototype/references/<name>.md,
+and an archived templates/<name>.md — so neither skill could be loaded at all.
+Refusing a genuine collision is right; these candidates were not skills.
+
+The github-pr-workflow style of name is NOT an instance of this: those live under
+.archive/ and are meant to be unresolvable, having been consolidated into
+github-workflow / structured-development / ml-ops. A first pass at measuring the
+blast radius counted them as live skills by rglob-ing SKILL.md without excluding
+.archive — the same over-broad matching this patch fixes.
+
+.archive/ was the other source. EXCLUDED_SKILL_DIRS lists it and
+is_excluded_skill_path says to apply it to every rglob result; Strategy 2 gets that
+via iter_skill_index_files, and this loop was the one scanning site that did not.
+
+Drives the real skill_view with SKILLS_DIR pointed at a temp tree, rather than
+reproducing the loop — a copy of the logic cannot fail when the module changes.
+"""
+
+import json
+
+import pytest
+
+import agent.skill_utils as skill_utils
+import tools.skills_tool as skills_tool
+
+
+@pytest.fixture
+def skills_root(tmp_path, monkeypatch):
+    """Point skill_view at an isolated tree with no external dirs.
+
+    get_external_skills_dirs is imported INSIDE skill_view, so patching the attribute on
+    skills_tool would create a name nothing reads and let the real external dirs leak in —
+    the tests would then depend on whatever is installed on the machine running them.
+    Patch it where it is defined.
+    """
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", tmp_path)
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda *a, **k: [])
+    return tmp_path
+
+
+def _skill(root, rel, name):
+    d = root / rel / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(f"---\nname: {name}\n---\n# {name}\nbody\n")
+    return d
+
+
+def _view(name):
+    return json.loads(skills_tool.skill_view(name))
+
+
+class TestASupportingFileIsNotASkill:
+    def test_a_reference_named_after_another_skill(self, skills_root):
+        """The 41-skill case: github-workflow documents github-pr-workflow."""
+        _skill(skills_root, "github", "github-pr-workflow")
+        owner = _skill(skills_root, "github", "github-workflow")
+        (owner / "references").mkdir()
+        (owner / "references" / "github-pr-workflow.md").write_text("# how PRs work\n")
+
+        res = _view("github-pr-workflow")
+        assert res.get("success") is True, res.get("error")
+
+    @pytest.mark.parametrize("sub", ["references", "templates", "assets", "scripts"])
+    def test_every_content_dir(self, skills_root, sub):
+        _skill(skills_root, "productivity", "notion")
+        owner = _skill(skills_root, "creative", "web-design-prototype")
+        (owner / sub).mkdir()
+        (owner / sub / "notion.md").write_text("# Design System: Notion\n")
+
+        res = _view("notion")
+        assert res.get("success") is True, res.get("error")
+
+    def test_archived_content(self, skills_root):
+        """.archive is in EXCLUDED_SKILL_DIRS and was scanned anyway."""
+        _skill(skills_root, "productivity", "notion")
+        arch = skills_root / ".archive" / "popular-web-designs" / "templates"
+        arch.mkdir(parents=True)
+        (arch / "notion.md").write_text("# archived\n")
+
+        res = _view("notion")
+        assert res.get("success") is True, res.get("error")
+
+
+class TestItStillRefusesRealAmbiguity:
+    """Non-vacuity. A filter that dropped every candidate would make the tests above
+    pass while destroying the collision check they depend on."""
+
+    def test_two_real_flat_skills_still_collide(self, skills_root):
+        for sub in ("a", "b"):
+            (skills_root / sub).mkdir()
+            (skills_root / sub / "deploy.md").write_text("---\nname: deploy\n---\n# deploy\n")
+
+        res = _view("deploy")
+        assert res.get("success") is False
+        assert "Ambiguous" in str(res.get("error")), res
+
+    def test_a_flat_skill_is_still_findable(self, skills_root):
+        """Strategy 3 exists for legacy flat <name>.md skills; it must still find one."""
+        (skills_root / "legacy").mkdir()
+        (skills_root / "legacy" / "deploy.md").write_text("---\nname: deploy\n---\n# deploy\nbody\n")
+
+        res = _view("deploy")
+        assert res.get("success") is True, res.get("error")
+
+    def test_a_real_duplicate_skill_dir_still_collides(self, skills_root):
+        _skill(skills_root, "a", "deploy")
+        _skill(skills_root, "b", "deploy")
+
+        res = _view("deploy")
+        assert res.get("success") is False
+        assert "Ambiguous" in str(res.get("error")), res

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -935,13 +935,18 @@ def skill_view(
         skill_dir = None
         skill_md = None
 
+        # Subdirectories that hold a skill's own supporting files rather than other
+        # skills. Read as skill CONTENT further down (references/, templates/,
+        # assets/, scripts/); a .md inside one is never itself a skill.
+        _SKILL_CONTENT_DIRS = frozenset(("references", "templates", "assets", "scripts"))
+
         # Collision detection: collect ALL candidates across every dir using
         # every lookup strategy (direct path, recursive by parent dir name,
         # legacy flat <name>.md). If more than one matches, refuse and tell
         # the caller — silent shadowing of a local skill by a same-named
         # external skill is a real bug class (`/skills` shows one, agent
         # loaded the other) so we surface it loudly instead of guessing.
-        from agent.skill_utils import iter_skill_index_files
+        from agent.skill_utils import iter_skill_index_files, is_excluded_skill_path
 
         candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
         seen_md: set = set()
@@ -982,9 +987,32 @@ def skill_view(
                     _record(found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
+            #
+            # rglob matches ANY file with that basename, including a skill's own
+            # supporting documents. A workflow skill that keeps
+            # references/<topic>.md beside its SKILL.md is following the layout this
+            # module reads below (references/, templates/, assets/, scripts/), but
+            # every such file used to register as a rival candidate for <topic>.
+            # Observed on one install: `notion` and `airtable` each resolved to three
+            # candidates — the real productivity/<name>/SKILL.md plus
+            # creative/web-design-prototype/references/<name>.md and an archived
+            # templates/<name>.md, both 322-line "Design System" documents — so
+            # skill_view refused to load either skill. The refusal is right on a real
+            # collision; these candidates were not skills.
+            #
+            # is_excluded_skill_path is applied here for the same reason its own
+            # docstring gives: "use this on every SKILL.md path produced by rglob."
+            # Strategy 2 goes through iter_skill_index_files and gets it already;
+            # this loop was the one scanning site that did not, so .archive/ content
+            # counted as candidates too.
             for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md":
-                    _record(None, found_md)
+                if found_md.name == "SKILL.md":
+                    continue
+                if is_excluded_skill_path(found_md):
+                    continue
+                if _SKILL_CONTENT_DIRS.intersection(found_md.parent.parts):
+                    continue
+                _record(None, found_md)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]


### PR DESCRIPTION
## What

Strategy 3 of `_resolve_skill` treats a skill's own `references/`, `templates/`, `assets/` and `scripts/` files — and anything under `.archive/` — as rival skill candidates, so `skill_view` refuses the real skill as ambiguous.

## Why it matters

_resolve_skill collects candidates three ways. Strategy 3 is
`search_dir.rglob(f"{name}.md")`, which matches ANY file with that basename —
including the supporting documents skills_tool itself reads a few hundred lines
later as skill CONTENT (references/, templates/, assets/, scripts/).

A skill that keeps references/<topic>.md beside its SKILL.md therefore registered
as a rival candidate for <topic>, and skill_view refused to load the real skill as
ambiguous. Observed on one install: `notion` and `airtable` each matched three
candidates — the real productivity/<name>/SKILL.md, plus
creative/web-design-prototype/references/<name>.md and an archived
templates/<name>.md, both 322-line "Design System" documents. Neither skill could
be loaded at all. Refusing a genuine collision is correct; these were not
collisions.

.archive/ was the second source. EXCLUDED_SKILL_DIRS already lists it, and
is_excluded_skill_path's docstring says to apply it to "every SKILL.md path
produced by rglob" so that "every skill-scanning site stays in sync with the
shared exclusion set". Strategy 2 gets that via iter_skill_index_files; this loop
was the one scanning site that did not call it.

Both halves of the fix were already in the repo; Strategy 3 just wasn't using
them. Genuine ambiguity still refuses: two real flat <name>.md skills, or two real
skill directories with one name, both still return the Ambiguous error.

The test drives the real skill_view with SKILLS_DIR pointed at a temp tree rather
than reproducing the loop — an earlier draft copied the logic and passed with the
fix reverted, because it was testing the copy. get_external_skills_dirs is patched
at its definition in agent.skill_utils, since skill_view imports it inside the
function body and patching the attribute on skills_tool would leave the real
external dirs leaking into the tests.

tests/tools before and after are identical: 81 failures in both, none in skill
modules, +9 passes for the new file.

## Testing

`tests/tools/test_skill_name_collision_candidates.py` — 9 tests driving the real `skill_view` with `SKILLS_DIR` pointed at a temp tree. 6 of the 9 fail without the change; the other 3 assert genuine ambiguity is *still* refused and must pass either way.

`tests/tools` before and after: 81 failures in both, identical sets, none in skill modules (the 81 are pre-existing, mostly missing optional deps). +9 passes for the new file.
