### PR TITLE
fix(desktop): preserve bot identity across gateways

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -24,6 +24,7 @@ import {
   migrateV1ToRegistry,
   normalizeConnectionInput,
   normalizeRegistry,
+  normalizeRosterProfiles,
   parseRemoteProfileListing,
   REGISTRY_VERSION,
   rememberSshEnumeration,
@@ -251,6 +252,57 @@ test('roster: unique profiles keep bare handles; duplicates get @name-device', (
   assert.equal(byKey.get('local/default'), 'default')
   assert.equal(byKey.get('homelab/coder'), 'coder')
   assert.equal(roster.length, 4)
+})
+
+test('roster: rich metadata remains scoped to each same-name source', () => {
+  const local = { id: 'local', kind: 'local' as const, label: 'This device' }
+  const homelab = { id: 'homelab', kind: 'remote' as const, label: 'Homelab', url: 'http://h:1' }
+  const localMeta = { 'hermes-bots': { title: 'Local Hermes', color: '#123456' } }
+  const remoteMeta = { 'hermes-bots': { title: 'Remote Hermes', color: '#abcdef' } }
+
+  const roster = buildAgentRoster([
+    {
+      connection: local,
+      profiles: [{ name: 'default', display_name: 'Local', ui_meta: localMeta, has_avatar: true }]
+    },
+    {
+      connection: homelab,
+      profiles: [{ name: 'default', display_name: 'Remote', ui_meta: remoteMeta, has_avatar: true }]
+    }
+  ])
+  const localRow = roster.find(agent => agent.connectionId === 'local')
+  const remoteRow = roster.find(agent => agent.connectionId === 'homelab')
+
+  assert.equal(localRow?.display_name, 'Local')
+  assert.deepEqual(localRow?.ui_meta, localMeta)
+  assert.equal(localRow?.has_avatar, true)
+  assert.equal(remoteRow?.display_name, 'Remote')
+  assert.deepEqual(remoteRow?.ui_meta, remoteMeta)
+  assert.equal(remoteRow?.has_avatar, true)
+})
+
+test('normalizeRosterProfiles accepts legacy names and whitelists rich fields', () => {
+  const rows = normalizeRosterProfiles([
+    'legacy',
+    {
+      name: ' remote ',
+      display_name: ' Remote Bot ',
+      ui_meta: { 'hermes-bots': { title: 'Remote Bot' } },
+      has_avatar: true,
+      path: '/private/backend/path'
+    },
+    { display_name: 'missing name' }
+  ])
+
+  assert.deepEqual(rows, [
+    { name: 'legacy' },
+    {
+      name: 'remote',
+      display_name: 'Remote Bot',
+      ui_meta: { 'hermes-bots': { title: 'Remote Bot' } },
+      has_avatar: true
+    }
+  ])
 })
 
 test('rememberSshEnumeration: live list wins, cache then seed default', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -315,9 +315,9 @@ export function shouldDeferLocalEnumeration(
 
 export interface ConnectionAgents {
   connection: RegistryConnection
-  /** Profile names enumerated from the connection, or null when unreachable /
-   * connect-on-demand (ssh not yet dialed). */
-  profiles: null | string[]
+  /** Profile roster rows (legacy string names accepted), or null when
+   * unreachable / connect-on-demand (ssh not yet dialed). */
+  profiles: null | RosterProfileInput[]
   /** Present when profiles is null: why enumeration was skipped. */
   error?: string
   /** Stable backend identity from the connection's /api/status (`install_id`).
@@ -328,7 +328,16 @@ export interface ConnectionAgents {
   installId?: string
 }
 
-export interface RosterAgent {
+export interface RosterProfile {
+  name: string
+  display_name?: string
+  ui_meta?: Record<string, unknown>
+  has_avatar?: boolean
+}
+
+export type RosterProfileInput = RosterProfile | string
+
+export interface RosterAgent extends Omit<RosterProfile, 'name'> {
   connectionId: string
   connectionKind: ConnectionKind
   connectionLabel: string
@@ -336,6 +345,59 @@ export interface RosterAgent {
   /** Bare profile name, or `<profile>-<label-slug>` when the profile name
    * exists on more than one registered source (the @name-device rule). */
   handle: string
+}
+
+const MAX_ROSTER_UI_META_CHARS = 65_536
+
+/** Keep only bounded presentation fields from an authenticated backend row. */
+export function normalizeRosterProfiles(value: unknown): RosterProfile[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const byName = new Map<string, RosterProfile>()
+
+  for (const item of value) {
+    const source = item && typeof item === 'object' ? (item as Record<string, unknown>) : null
+    const rawName = source ? source.name : item
+    const name = typeof rawName === 'string' ? rawName.trim() : ''
+
+    if (!name) {
+      continue
+    }
+
+    const row: RosterProfile = { name }
+    const displayName = typeof source?.display_name === 'string' ? source.display_name.trim().slice(0, 128) : ''
+
+    if (displayName) {
+      row.display_name = displayName
+    }
+
+    if (source?.has_avatar === true) {
+      row.has_avatar = true
+    }
+
+    if (source?.ui_meta && typeof source.ui_meta === 'object' && !Array.isArray(source.ui_meta)) {
+      try {
+        const encoded = JSON.stringify(source.ui_meta)
+
+        if (encoded.length <= MAX_ROSTER_UI_META_CHARS) {
+          row.ui_meta = JSON.parse(encoded) as Record<string, unknown>
+        }
+      } catch {
+        // A malformed remote row must not fail the whole connection roster.
+      }
+    }
+
+    const previous = byName.get(name)
+    byName.set(name, {
+      ...previous,
+      ...row,
+      ...(previous?.has_avatar || row.has_avatar ? { has_avatar: true } : {})
+    })
+  }
+
+  return [...byName.values()]
 }
 
 /**
@@ -351,7 +413,7 @@ export interface RosterAgent {
  */
 export function rememberSshEnumeration(
   enumeration: Pick<ConnectionAgents, 'error' | 'profiles'>,
-  cached: null | string[] | undefined,
+  cached: ConnectionAgents['profiles'] | undefined,
   kind: ConnectionKind
 ): Pick<ConnectionAgents, 'error' | 'profiles'> {
   if (enumeration.profiles && enumeration.profiles.length > 0) {
@@ -432,18 +494,25 @@ export function buildAgentRoster(
   // counting names for @name-device disambiguation.
   const identities = new Map<
     string,
-    { connection: RegistryConnection; installId?: string; order: number; profile: string }
+    { connection: RegistryConnection; installId?: string; order: number; profile: RosterProfile }
   >()
 
   let order = 0
 
   for (const { connection, installId, profiles } of enumerations) {
-    for (const profile of profiles || []) {
-      const name = String(profile || '').trim() || 'default'
+    for (const profile of normalizeRosterProfiles(profiles)) {
+      const name = profile.name || 'default'
       const key = `${connection.id}\0${name}`
 
       if (!identities.has(key)) {
-        identities.set(key, { connection, installId, order, profile: name })
+        identities.set(key, { connection, installId, order, profile })
+      } else {
+        const existing = identities.get(key)!
+        existing.profile = {
+          ...existing.profile,
+          ...profile,
+          ...(existing.profile.has_avatar || profile.has_avatar ? { has_avatar: true } : {})
+        }
       }
     }
 
@@ -454,10 +523,10 @@ export function buildAgentRoster(
   // are the SAME physical install registered under two addresses, so their
   // (install, profile) rows are one bot, not two. Connections without an id
   // (older backends, undialed ssh) keep a per-connection key — no collapse.
-  const backends = new Map<string, { connection: RegistryConnection; order: number; profile: string }[]>()
+  const backends = new Map<string, { connection: RegistryConnection; order: number; profile: RosterProfile }[]>()
 
   for (const { connection, installId, order: rank, profile } of identities.values()) {
-    const key = installId ? `id:${installId}\0${profile}` : `conn:${connection.id}\0${profile}`
+    const key = installId ? `id:${installId}\0${profile.name}` : `conn:${connection.id}\0${profile.name}`
     const group = backends.get(key)
 
     if (group) {
@@ -475,18 +544,20 @@ export function buildAgentRoster(
   const counts = new Map<string, number>()
 
   for (const { profile } of rows) {
-    counts.set(profile, (counts.get(profile) || 0) + 1)
+    counts.set(profile.name, (counts.get(profile.name) || 0) + 1)
   }
 
   const roster: RosterAgent[] = []
 
   for (const { connection, profile } of rows) {
+    const { name, ...metadata } = profile
     roster.push({
       connectionId: connection.id,
       connectionKind: connection.kind,
       connectionLabel: connection.label,
-      profile,
-      handle: agentHandle(profile, connection.label, (counts.get(profile) || 0) > 1)
+      profile: name,
+      handle: agentHandle(name, connection.label, (counts.get(name) || 0) > 1),
+      ...metadata
     })
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -105,10 +105,12 @@ import {
   migrateV1ToRegistry,
   normalizeConnectionInput,
   normalizeRegistry,
+  normalizeRosterProfiles,
   rememberSshEnumeration,
   removeConnection,
   resolvedConnectionId,
   resolveRegistryLocalRoute,
+  type RosterProfileInput,
   setConnectionLaunchMode,
   setLastUsedConnection,
   setPrimaryConnection,
@@ -12804,7 +12806,7 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
 // would spawn tunnels the user never asked for); once dialed, their pooled
 // descriptor serves the enumeration like any remote. Last-known SSH profile
 // lists are reused so switching the window back to local does not empty Bot Mode.
-const sshRosterCache = new Map<string, string[]>()
+const sshRosterCache = new Map<string, RosterProfileInput[]>()
 const sshInventoryAttemptedAt = new Map<string, number>()
 const SSH_INVENTORY_RETRY_MS = 60_000
 
@@ -12929,7 +12931,12 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
 
   return Promise.all(
     registry.connections.map(async connection => {
-      let raw: { connection: typeof connection; error?: string; installId?: string; profiles: null | string[] }
+      let raw: {
+        connection: typeof connection
+        error?: string
+        installId?: string
+        profiles: null | RosterProfileInput[]
+      }
 
       try {
         // SSH roster listing must never spawn a dashboard. A stale
@@ -12970,14 +12977,12 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
           // requests for the backend-identity probe.
           const installId = await probeConnectionInstallId(connection.id, descriptor)
 
-          const profiles = Array.isArray(body?.profiles)
-            ? body.profiles.map(p => String(p?.name || '').trim()).filter(Boolean)
-            : []
+          const profiles = normalizeRosterProfiles(body?.profiles)
 
           // The root HERMES_HOME is an agent too; enumerations that omit it
           // (older backends list only named profiles) still get a default row.
-          if (!profiles.includes('default')) {
-            profiles.unshift('default')
+          if (!profiles.some(profile => profile.name === 'default')) {
+            profiles.unshift({ name: 'default' })
           }
 
           raw = { connection, profiles, ...(installId ? { installId } : {}) }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -880,6 +880,9 @@ export interface DesktopRosterAgent {
   connectionLabel: string
   profile: string
   handle: string
+  display_name?: string
+  ui_meta?: Record<string, unknown>
+  has_avatar?: boolean
 }
 
 export interface DesktopAgentRoster {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4888,6 +4888,36 @@ function formatGroupChatLine(entry, viewerName) {
   return `${groupSpeakerLabel(entry.from.name)}${suffix}${source}: ${entry.text}${attached}`
 }
 
+function groupEntryMember(entry, members) {
+  if (entry?.from?.kind === 'user') {
+    return null
+  }
+
+  const name = String(entry?.from?.name || '')
+  const source = String(entry?.from?.source || '')
+  const current = (Array.isArray(members) ? members : []).find(
+    member =>
+      member.name === name &&
+      (source ? (member.connectionLabel || member.connectionId) === source : !member.remoteSource)
+  )
+
+  if (current) {
+    return current
+  }
+
+  return {
+    name,
+    ...(source
+      ? {
+          connectionId: source,
+          connectionLabel: source,
+          remoteSource: true,
+          sourceScoped: true
+        }
+      : {})
+  }
+}
+
 /** The full per-turn payload for one member: participation rules + the room
  *  delta. Rules travel in the turn payload (not SOUL) so every existing bot
  *  can join a group chat without a profile migration. */
@@ -10486,14 +10516,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
                   // names and disambiguating handles come from the roster (the
                   // primary "default" profile renders as Hermes, remote dupes
                   // carry their @name-device handle) instead of raw profile ids.
-                  const member = isUser
-                    ? null
-                    : members.find(b =>
-                        b.name === entry.from.name &&
-                        (entry.from.source
-                          ? (b.connectionLabel || b.connectionId) === entry.from.source
-                          : !b.remoteSource)
-                      ) || null
+                  const member = groupEntryMember(entry, members)
                   const meta = isUser ? null : botRosterMeta(member || { name: entry.from.name }, allMeta)
                   const display = isUser ? 'You' : displayName(member || { name: entry.from.name }, meta)
                   const entryKey = `${entry.at}:${index}`

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -1139,6 +1139,10 @@ function handleSessionsGatewayTransition() {
  *  { [botName]: { shape, color, title } } */
 const $botMeta = atom({})
 
+/** Read-only metadata fetched from bots on other registered connections.
+ *  Keys are source-qualified so two `default` profiles never share art. */
+const $remoteBotMeta = atom({})
+
 /** Freshness fence for the server-meta overlay: the last moment each bot's
  *  local meta was written (stamped again once the server write settles).
  *  mergeServerMeta refuses to overlay a roster snapshot FETCHED BEFORE this
@@ -1414,6 +1418,10 @@ const avatarPushInflight = new Set()
  *  cross-machine roster art, so local-only images are a bug, not a state. */
 function pushLocalAvatars(roster) {
   for (const bot of roster) {
+    if (bot.remoteSource) {
+      continue
+    }
+
     if (bot.has_avatar || avatarPushInflight.has(bot.name)) {
       continue
     }
@@ -1506,19 +1514,27 @@ function pullServerAvatars(roster) {
   pushLocalAvatars(roster)
 
   for (const bot of roster) {
-    if (!bot.has_avatar || avatarFetchInflight.has(bot.name)) {
+    const cacheKey = bot.remoteSource ? botRosterKey(bot) : bot.name
+
+    if (!bot.has_avatar || avatarFetchInflight.has(cacheKey)) {
       continue
     }
 
-    if ($botMeta.get()[bot.name]?.image) {
+    if (botRosterMeta(bot, $botMeta.get())?.image) {
       continue
     }
 
-    avatarFetchInflight.add(bot.name)
-    host
-      .request('profiles.get_asset', { name: bot.name, asset: 'avatar' })
+    avatarFetchInflight.add(cacheKey)
+    Promise.resolve(requestForBot(bot, 'profiles.get_asset', { name: bot.name, asset: 'avatar' }))
       .then(res => {
         if (res?.found && res.data) {
+          if (bot.remoteSource) {
+            const current = $remoteBotMeta.get()
+            const mine = current[cacheKey] || {}
+            $remoteBotMeta.set({ ...current, [cacheKey]: { ...mine, image: res.data } })
+            return
+          }
+
           const current = $botMeta.get()
           const mine = current[bot.name] || {}
           // A 160px raster of the vector face is only for inter-agent
@@ -1536,7 +1552,7 @@ function pullServerAvatars(roster) {
         }
       })
       .catch(() => undefined)
-      .finally(() => avatarFetchInflight.delete(bot.name))
+      .finally(() => avatarFetchInflight.delete(cacheKey))
   }
 }
 
@@ -3816,7 +3832,14 @@ function mergeMultiSourceRoster(local, union, activeConnectionId, previous = [])
       connectionKind: agent.connectionKind,
       connectionLabel: agent.connectionLabel,
       remoteSource: true,
-      sourceScoped: true
+      sourceScoped: true,
+      ...(typeof agent.display_name === 'string' && agent.display_name.trim()
+        ? { display_name: agent.display_name.trim() }
+        : {}),
+      ...(agent.ui_meta && typeof agent.ui_meta === 'object' && !Array.isArray(agent.ui_meta)
+        ? { ui_meta: agent.ui_meta }
+        : {}),
+      ...(agent.has_avatar === true ? { has_avatar: true } : {})
     })
   }
 
@@ -4036,13 +4059,13 @@ function botRosterKey(bot) {
 function botConnectionRoute(bot) {
   const id = String(bot?.connectionId || '').trim()
 
-  if (!bot?.remoteSource || !id || id === 'local' || typeof host.requestProfile !== 'function') {
+  if (!bot?.remoteSource || !id || typeof host.requestProfile !== 'function') {
     return null
   }
 
   const profile = String(bot?.name || '').trim() || 'default'
 
-  return { connectionId: id, mode: 'remote', profile, targetProfile: profile }
+  return { connectionId: id, mode: id === 'local' ? 'local' : 'remote', profile, targetProfile: profile }
 }
 
 /** Gateway RPC on the bot's OWN source: requestProfile for remote rows,
@@ -4065,12 +4088,25 @@ function groupMemberKey(member) {
   return member?.remoteSource ? botRosterKey(member) : member?.name
 }
 
-// Bot metadata is scoped to the active gateway until the server exposes a
-// union of rich profile rows. Never paint that metadata onto a thin row from
-// another source: two `default` agents must not borrow each other's title,
-// pin, avatar, group, unread state, or canonical-chat pointer.
+// Metadata for another source comes only from that source's rich roster row
+// plus its source-qualified avatar cache. Never consult name-keyed local meta:
+// two `default` agents must not borrow each other's identity or chat pointer.
 function botRosterMeta(bot, metaByName) {
-  return bot?.remoteSource ? null : metaByName?.[bot?.name]
+  if (!bot?.remoteSource) {
+    return metaByName?.[bot?.name]
+  }
+
+  const server = bot?.ui_meta?.['hermes-bots']
+  const cached = $remoteBotMeta.get()[botRosterKey(bot)]
+
+  if ((!server || typeof server !== 'object') && !cached) {
+    return null
+  }
+
+  return {
+    ...(server && typeof server === 'object' ? server : {}),
+    ...(cached || {})
+  }
 }
 
 function showsHandle(name, meta, bot) {
@@ -4465,15 +4501,6 @@ async function prepareBotSource(bot, pinnedChat) {
 }
 
 function displayName(bot, meta) {
-  // Only THIN rows from another source trade the friendly name for their
-  // connection label — the active gateway's own default must keep reading
-  // "Hermes". Annotated active rows carry sourceScoped too, and keying this
-  // off sourceScoped renamed the user's main agent to an IP-derived label
-  // (community report, Aug 17 2026).
-  if (bot?.remoteSource && (bot.name || '').trim().toLowerCase() === 'default' && bot.connectionLabel) {
-    return bot.connectionLabel
-  }
-
   if (meta?.title?.trim()) {
     return meta.title.trim()
   }
@@ -4483,6 +4510,13 @@ function displayName(bot, meta) {
   // Mode title. Rides the profiles.list row; presentation-only.
   if (typeof bot?.display_name === 'string' && bot.display_name.trim()) {
     return bot.display_name.trim()
+  }
+
+  // A genuinely thin remote default still needs a source-specific fallback.
+  // Rich rows above keep their own title/display_name; the active gateway's
+  // annotated default remains Hermes rather than an IP-derived label.
+  if (bot?.remoteSource && (bot.name || '').trim().toLowerCase() === 'default' && bot.connectionLabel) {
+    return bot.connectionLabel
   }
 
   // The primary profile is literally named "default" — as a bot identity
@@ -9185,7 +9219,7 @@ function ActiveNowStrip({ roster, activeProfile, gatewayState, metaByName, onOpe
         children: 'Active now'
       }),
       ...active.map(bot => {
-        const meta = metaByName?.[bot.name]
+        const meta = botRosterMeta(bot, metaByName)
         const { shape, color, image } = botAppearance(bot.name, meta)
         const photo = Boolean(image && !isBackfilledFacePng(image))
         const label = displayName(bot, meta)
@@ -10290,7 +10324,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   const memberDescriptors = () =>
     members.map(b => ({
       ...b,
-      title: (b.remoteSource ? '' : allMeta[b.name]?.title) || b.title || ''
+      title: botRosterMeta(b, allMeta)?.title || b.title || ''
     }))
 
   // Activity disclosure: quiet, collapsed by default. The collapsed row shows
@@ -10448,7 +10482,6 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
   // One log entry, rendered exactly as before conversation folding existed.
   const renderEntry = (entry, index) => {
                   const isUser = entry.from.kind === 'user'
-                  const meta = isUser || entry.from.source ? null : allMeta[entry.from.name]
                   // Match this speaker back to its member descriptor so display
                   // names and disambiguating handles come from the roster (the
                   // primary "default" profile renders as Hermes, remote dupes
@@ -10461,6 +10494,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
                           ? (b.connectionLabel || b.connectionId) === entry.from.source
                           : !b.remoteSource)
                       ) || null
+                  const meta = isUser ? null : botRosterMeta(member || { name: entry.from.name }, allMeta)
                   const display = isUser ? 'You' : displayName(member || { name: entry.from.name }, meta)
                   const entryKey = `${entry.at}:${index}`
                   const revealed = !isUser && revealedSpeaker === entryKey
@@ -11002,7 +11036,7 @@ function GroupRow({ active, group, members, needsYou, onOpen, onDisband }) {
           ? jsx('div', {
               className: 'flex items-center -space-x-2.5',
               children: faces.map(member => {
-                const meta = member.remoteSource ? null : allMeta[member.name]
+                const meta = botRosterMeta(member, allMeta)
                 const { shape, color, image } = botAppearance(member.name, meta)
 
                 return jsx(
@@ -11187,7 +11221,7 @@ function BotsPane() {
   if (live) {
     $lastRoster.set(roster)
     mergeServerMeta(activeSourceRoster, data?.fetchedAt || 0)
-    pullServerAvatars(activeSourceRoster)
+    pullServerAvatars(roster)
     trackInboundActivity(activeSourceRoster)
     backfillMessagingProtocol(activeSourceRoster)
   }

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-asset-sync.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-meta-asset-sync.test.mjs
@@ -20,6 +20,7 @@ function load() {
     return slot
   }
   const requests = []
+  const profileRequests = []
   const context = {
     atom,
     PALETTE_AREA: 'palette',
@@ -30,7 +31,19 @@ function load() {
         requests.push([method, params])
         return Promise.resolve({})
       },
-      state: { profile: { get: () => 'default', listen: () => undefined }, gateway: { listen: () => undefined } }
+      requestProfile: (route, method, params) => {
+        profileRequests.push([route, method, params])
+        return Promise.resolve(
+          method === 'profiles.get_asset'
+            ? { found: true, data: 'data:image/png;base64,REMOTE' }
+            : {}
+        )
+      },
+      state: {
+        profile: { get: () => 'default', listen: () => undefined },
+        connectionId: { get: () => 'local', listen: () => undefined },
+        gateway: { listen: () => undefined }
+      }
     }
   }
   const source = pluginSource
@@ -40,13 +53,15 @@ function load() {
     .replace(/^import .* from 'react'\r?\n/m, '')
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
-    .concat('\nglobalThis.__meta = { saveBotMeta, $botMeta };\n')
+    .concat(
+      '\nglobalThis.__meta = { saveBotMeta, $botMeta, $remoteBotMeta, pullServerAvatars, botRosterMeta };\n'
+    )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   context.plugin.register({
     storage: { get: () => null, set: () => undefined },
     register: () => undefined
   })
-  return { ...context.__meta, requests }
+  return { ...context.__meta, requests, profileRequests }
 }
 
 test('regression: set_asset fires only when the avatar image changes', async () => {
@@ -88,4 +103,35 @@ test('regression: duplicating a bot still pushes the copied avatar once', async 
     { name: 'source', asset: 'avatar', data: png },
     { name: 'source-2', asset: 'avatar', data: png } // fresh profile: image differs from its (empty) meta
   ])
+})
+
+test('remote avatars are fetched through their source and cached by source-qualified key', async () => {
+  const { pullServerAvatars, botRosterMeta, $botMeta, $remoteBotMeta, requests, profileRequests } = load()
+  const remote = {
+    name: 'default',
+    connectionId: 'homelab',
+    remoteSource: true,
+    has_avatar: true,
+    ui_meta: { 'hermes-bots': { title: 'Homelab Hermes' } }
+  }
+
+  pullServerAvatars([remote])
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(requests.filter(([method]) => method === 'profiles.get_asset').length, 0)
+  assert.equal(profileRequests.length, 1)
+  assert.deepEqual(JSON.parse(JSON.stringify(profileRequests[0])), [
+    {
+      connectionId: 'homelab',
+      mode: 'remote',
+      profile: 'default',
+      targetProfile: 'default'
+    },
+    'profiles.get_asset',
+    { name: 'default', asset: 'avatar' }
+  ])
+  assert.equal($botMeta.get().default, undefined)
+  assert.equal($remoteBotMeta.get()['homelab::default'].image, 'data:image/png;base64,REMOTE')
+  assert.equal(botRosterMeta(remote, $botMeta.get()).title, 'Homelab Hermes')
+  assert.equal(botRosterMeta(remote, $botMeta.get()).image, 'data:image/png;base64,REMOTE')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
@@ -73,6 +73,18 @@ test('botConnectionRoute: remote rows get a route descriptor, local rows do not'
     profile: 'dixie',
     targetProfile: 'dixie'
   })
+
+  assert.deepEqual(
+    JSON.parse(
+      JSON.stringify(botConnectionRoute({ name: 'writer', connectionId: 'local', remoteSource: true }))
+    ),
+    {
+      connectionId: 'local',
+      mode: 'local',
+      profile: 'writer',
+      targetProfile: 'writer'
+    }
+  )
 })
 
 test('requestForBot: remote members go through requestProfile, local through host.request', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/cross-connection-bots.test.mjs
@@ -51,7 +51,7 @@ function runtime() {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__x = { botConnectionRoute, requestForBot, groupMemberKey, parseGroupChatMentions, resolveGroupResponders, formatGroupChatLine, buildGroupChatTurnPrompt };\n'
+      '\nglobalThis.__x = { botConnectionRoute, requestForBot, groupMemberKey, groupEntryMember, botRosterMeta, parseGroupChatMentions, resolveGroupResponders, formatGroupChatLine, buildGroupChatTurnPrompt };\n'
     )
   vm.runInNewContext(code, context, { filename: 'plugin.js' })
   return context
@@ -156,6 +156,24 @@ test('room lines and turn prompts badge cross-connection speakers with their dev
     deltaLines: ['You (user): hi']
   })
   assert.match(prompt, /@dixie \[on Mac Mini\]/)
+})
+
+test('stale remote group speakers never borrow same-name local metadata', () => {
+  const ctx = runtime()
+  const { groupEntryMember, botRosterMeta } = ctx.__x
+  const speaker = groupEntryMember(
+    { from: { kind: 'member', name: 'default', source: 'Mac Mini' } },
+    []
+  )
+
+  assert.deepEqual(JSON.parse(JSON.stringify(speaker)), {
+    name: 'default',
+    connectionId: 'Mac Mini',
+    connectionLabel: 'Mac Mini',
+    remoteSource: true,
+    sourceScoped: true
+  })
+  assert.equal(botRosterMeta(speaker, { default: { title: 'Local Hermes' } }), null)
 })
 
 test('source contract: New Agent has a Create on picker that routes creation to the target backend', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/multi-source-roster.test.mjs
@@ -251,6 +251,42 @@ test('default rows use source identity without borrowing another source title', 
   assert.equal(name(active, undefined), 'Hermes')
 })
 
+test('rich remote rows use their own title and never borrow same-name local metadata', () => {
+  const { __mergeMultiSourceRoster: merge, __botRosterMeta: metaFor, __displayName: name } = runtime()
+  const local = { profiles: [{ name: 'default', display_name: 'Local Hermes' }] }
+  const union = {
+    agents: [
+      {
+        connectionId: 'local',
+        connectionKind: 'local',
+        connectionLabel: 'This device',
+        profile: 'default',
+        handle: 'default-this-device'
+      },
+      {
+        connectionId: 'personal',
+        connectionKind: 'remote',
+        connectionLabel: 'Personal',
+        profile: 'default',
+        handle: 'default-personal',
+        display_name: 'Remote Hermes',
+        ui_meta: { 'hermes-bots': { title: 'Asus', color: '#abcdef' } },
+        has_avatar: true
+      }
+    ]
+  }
+
+  const remote = merge(local, union, 'local').profiles.find(row => row.remoteSource)
+  const metadata = { default: { title: 'Local title', color: '#123456' } }
+  const remoteMeta = metaFor(remote, metadata)
+
+  assert.equal(remote.display_name, 'Remote Hermes')
+  assert.equal(remote.has_avatar, true)
+  assert.equal(remoteMeta.title, 'Asus')
+  assert.equal(remoteMeta.color, '#abcdef')
+  assert.equal(name(remote, remoteMeta), 'Asus')
+})
+
 test('botHandle: precomputed multi-source handle wins; default stays hermes', () => {
   const { __botHandle: botHandle } = runtime()
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14577,8 +14577,40 @@ def _profile_attr(info, name: str, default: Any = None) -> Any:
         return default
 
 
+_PROFILE_ROSTER_UI_META_MAX_CHARS = 64 * 1024
+
+
+def _profile_roster_fields(profile_dir: Path) -> Dict[str, Any]:
+    """Return bounded presentation metadata safe for cross-source rosters."""
+    fields: Dict[str, Any] = {"has_avatar": False}
+
+    try:
+        meta_path = profile_dir / "profile.yaml"
+        if meta_path.is_file():
+            with open(meta_path, "r", encoding="utf-8") as f:
+                raw = yaml.safe_load(f) or {}
+            ui_meta = raw.get("ui_meta") if isinstance(raw, dict) else None
+            if isinstance(ui_meta, dict):
+                encoded = json.dumps(ui_meta, allow_nan=False)
+                if len(encoded) <= _PROFILE_ROSTER_UI_META_MAX_CHARS:
+                    fields["ui_meta"] = json.loads(encoded)
+    except Exception:
+        pass
+
+    try:
+        assets = profile_dir / "assets"
+        fields["has_avatar"] = any(
+            (assets / f"avatar.{ext}").is_file()
+            for ext in ("png", "jpg", "webp")
+        )
+    except Exception:
+        pass
+
+    return fields
+
+
 def _profile_to_dict(info) -> Dict[str, Any]:
-    return {
+    row = {
         "name": _profile_attr(info, "name", ""),
         "path": str(_profile_attr(info, "path", "")),
         "is_default": bool(_profile_attr(info, "is_default", False)),
@@ -14595,6 +14627,8 @@ def _profile_to_dict(info) -> Dict[str, Any]:
         "distribution_source": _profile_attr(info, "distribution_source"),
         "has_alias": _profile_attr(info, "alias_path") is not None,
     }
+    row.update(_profile_roster_fields(Path(row["path"])))
+    return row
 
 
 def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
@@ -14619,6 +14653,7 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
             "gateway_running": _safe(lambda: profiles_mod._check_gateway_running(default_home), False),
             "description": _safe(lambda: profiles_mod.read_profile_meta(default_home).get("description", ""), ""),
             "description_auto": _safe(lambda: profiles_mod.read_profile_meta(default_home).get("description_auto", False), False),
+            "display_name": _safe(lambda: profiles_mod.read_profile_meta(default_home).get("display_name", ""), ""),
             "distribution_name": None,
             "distribution_version": None,
             "distribution_source": None,
@@ -14649,11 +14684,15 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
                 "gateway_running": _safe(lambda entry=entry_path: profiles_mod._check_gateway_running(entry), False),
                 "description": _safe(lambda entry=entry_path: profiles_mod.read_profile_meta(entry).get("description", ""), ""),
                 "description_auto": _safe(lambda entry=entry_path: profiles_mod.read_profile_meta(entry).get("description_auto", False), False),
+                "display_name": _safe(lambda entry=entry_path: profiles_mod.read_profile_meta(entry).get("display_name", ""), ""),
                 "distribution_name": None,
                 "distribution_version": None,
                 "distribution_source": None,
                 "has_alias": False,
             })
+
+    for row in profiles:
+        row.update(_profile_roster_fields(Path(row["path"])))
 
     return profiles
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14578,15 +14578,41 @@ def _profile_attr(info, name: str, default: Any = None) -> Any:
 
 
 _PROFILE_ROSTER_UI_META_MAX_CHARS = 64 * 1024
+_PROFILE_ROSTER_FIELDS_CACHE_MAX = 256
+_PROFILE_ROSTER_FIELDS_CACHE: Dict[str, tuple] = {}
+_PROFILE_ROSTER_FIELDS_CACHE_LOCK = threading.Lock()
+
+
+def _profile_roster_fingerprint(path: Path) -> Optional[Tuple[int, int, int, int]]:
+    try:
+        info = path.stat()
+        if not stat.S_ISREG(info.st_mode):
+            return None
+        return (info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns)
+    except OSError:
+        return None
 
 
 def _profile_roster_fields(profile_dir: Path) -> Dict[str, Any]:
     """Return bounded presentation metadata safe for cross-source rosters."""
+    meta_path = profile_dir / "profile.yaml"
+    assets = profile_dir / "assets"
+    avatar_paths = tuple(assets / f"avatar.{ext}" for ext in ("png", "jpg", "webp"))
+    signature = tuple(
+        _profile_roster_fingerprint(path)
+        for path in (meta_path, *avatar_paths)
+    )
+    cache_key = str(profile_dir)
+
+    with _PROFILE_ROSTER_FIELDS_CACHE_LOCK:
+        cached = _PROFILE_ROSTER_FIELDS_CACHE.get(cache_key)
+        if cached is not None and cached[0] == signature:
+            return dict(cached[1])
+
     fields: Dict[str, Any] = {"has_avatar": False}
 
     try:
-        meta_path = profile_dir / "profile.yaml"
-        if meta_path.is_file():
+        if signature[0] is not None:
             with open(meta_path, "r", encoding="utf-8") as f:
                 raw = yaml.safe_load(f) or {}
             ui_meta = raw.get("ui_meta") if isinstance(raw, dict) else None
@@ -14594,17 +14620,29 @@ def _profile_roster_fields(profile_dir: Path) -> Dict[str, Any]:
                 encoded = json.dumps(ui_meta, allow_nan=False)
                 if len(encoded) <= _PROFILE_ROSTER_UI_META_MAX_CHARS:
                     fields["ui_meta"] = json.loads(encoded)
-    except Exception:
-        pass
+                else:
+                    _log.warning(
+                        "Ignoring oversized ui_meta in %s (%d chars; max %d)",
+                        meta_path,
+                        len(encoded),
+                        _PROFILE_ROSTER_UI_META_MAX_CHARS,
+                    )
+    except (TypeError, ValueError) as exc:
+        _log.warning("Ignoring non-JSON ui_meta in %s: %s", meta_path, exc)
+    except Exception as exc:
+        _log.warning("Unable to read roster metadata from %s: %s", meta_path, exc)
 
-    try:
-        assets = profile_dir / "assets"
-        fields["has_avatar"] = any(
-            (assets / f"avatar.{ext}").is_file()
-            for ext in ("png", "jpg", "webp")
-        )
-    except Exception:
-        pass
+    fields["has_avatar"] = any(item is not None for item in signature[1:])
+
+    with _PROFILE_ROSTER_FIELDS_CACHE_LOCK:
+        if (
+            cache_key not in _PROFILE_ROSTER_FIELDS_CACHE
+            and len(_PROFILE_ROSTER_FIELDS_CACHE) >= _PROFILE_ROSTER_FIELDS_CACHE_MAX
+        ):
+            oldest = next(iter(_PROFILE_ROSTER_FIELDS_CACHE), None)
+            if oldest is not None:
+                _PROFILE_ROSTER_FIELDS_CACHE.pop(oldest, None)
+        _PROFILE_ROSTER_FIELDS_CACHE[cache_key] = (signature, dict(fields))
 
     return fields
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import json
+import logging
 import re
 import shutil
 import sys
@@ -2433,6 +2434,61 @@ class TestNewEndpoints:
             }
         }
         assert default["has_avatar"] is True
+
+    def test_profile_roster_fields_cache_invalidates_on_metadata_change(
+        self, monkeypatch, tmp_path
+    ):
+        from hermes_cli import web_server
+
+        meta_path = tmp_path / "profile.yaml"
+        meta_path.write_text(
+            yaml.safe_dump({"ui_meta": {"hermes-bots": {"title": "One"}}}),
+            encoding="utf-8",
+        )
+        calls = 0
+        original_safe_load = web_server.yaml.safe_load
+
+        def counted_safe_load(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original_safe_load(*args, **kwargs)
+
+        monkeypatch.setattr(web_server.yaml, "safe_load", counted_safe_load)
+
+        first = web_server._profile_roster_fields(tmp_path)
+        cached = web_server._profile_roster_fields(tmp_path)
+        assert first == cached
+        assert calls == 1
+
+        meta_path.write_text(
+            yaml.safe_dump({"ui_meta": {"hermes-bots": {"title": "Updated"}}}),
+            encoding="utf-8",
+        )
+        current_mtime = meta_path.stat().st_mtime_ns
+        os.utime(meta_path, ns=(current_mtime + 1_000_000, current_mtime + 1_000_000))
+
+        refreshed = web_server._profile_roster_fields(tmp_path)
+        assert refreshed["ui_meta"]["hermes-bots"]["title"] == "Updated"
+        assert calls == 2
+
+    def test_profile_roster_fields_warns_once_when_ui_meta_is_dropped(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        from hermes_cli import web_server
+
+        monkeypatch.setattr(web_server, "_PROFILE_ROSTER_UI_META_MAX_CHARS", 8)
+        (tmp_path / "profile.yaml").write_text(
+            yaml.safe_dump({"ui_meta": {"hermes-bots": {"title": "Too long"}}}),
+            encoding="utf-8",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.web_server"):
+            first = web_server._profile_roster_fields(tmp_path)
+            second = web_server._profile_roster_fields(tmp_path)
+
+        assert "ui_meta" not in first
+        assert first == second
+        assert caplog.text.count("Ignoring oversized ui_meta") == 1
 
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2400,6 +2400,41 @@ class TestNewEndpoints:
     # --- Profiles ---
 
 
+    def test_profiles_list_includes_cross_source_identity_metadata(self):
+        from hermes_constants import get_hermes_home
+
+        root = get_hermes_home()
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "profile.yaml").write_text(
+            yaml.safe_dump({
+                "display_name": "Asus",
+                "ui_meta": {
+                    "hermes-bots": {
+                        "title": "Asus Bot",
+                        "color": "#abcdef",
+                    }
+                },
+            }),
+            encoding="utf-8",
+        )
+        assets = root / "assets"
+        assets.mkdir(exist_ok=True)
+        (assets / "avatar.png").write_bytes(b"avatar")
+
+        response = self.client.get("/api/profiles")
+
+        assert response.status_code == 200
+        default = next(row for row in response.json()["profiles"] if row["name"] == "default")
+        assert default["display_name"] == "Asus"
+        assert default["ui_meta"] == {
+            "hermes-bots": {
+                "title": "Asus Bot",
+                "color": "#abcdef",
+            }
+        }
+        assert default["has_avatar"] is True
+
+
 
     def test_profiles_create_builder_mcp_auth_is_profile_scoped(
         self, monkeypatch


### PR DESCRIPTION
## Summary
- expose bounded profile display metadata and avatar presence through the authenticated REST roster
- preserve rich metadata per `(connection, profile)` in Electron's union roster while keeping legacy string rows compatible
- fetch remote avatars through each bot's owning gateway and cache them with source-qualified keys
- use source-scoped titles and avatars across roster, activity, and group-chat surfaces
- cache profile metadata by YAML/avatar fingerprints and diagnose discarded malformed or oversized metadata
- retain source identity for stale remote group speakers after they leave the live roster

## Validation
- `uv run --extra dev pytest tests/hermes_cli/test_web_server.py -q` (167 passed, 1 skipped)
- `uv run --extra dev ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `npm run test:desktop:platforms` (112 files passed, 1 skipped; 1592 tests passed, 3 skipped)
- `npm run check:test:plugins` (393 passed)
- Prettier check on changed TypeScript files

Fixes #91365