### PR TITLE
fix(api-server): pass agent.disabled_toolsets through to the API agent

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2937,7 +2937,18 @@ class APIServerAdapter(BasePlatformAdapter):
         from agent.skill_utils import parse_config_string_list
 
         agent_cfg = user_config.get("agent") or {}
-        disabled_toolsets = parse_config_string_list(agent_cfg.get("disabled_toolsets")) or None
+        _raw_disabled_toolsets = agent_cfg.get("disabled_toolsets")
+        disabled_toolsets = parse_config_string_list(_raw_disabled_toolsets) or None
+        if _raw_disabled_toolsets and not disabled_toolsets:
+            # A denial policy whose configured value fails to parse degrades
+            # to "deny nothing" (fail-open) — surface the misconfiguration in
+            # the gateway log rather than letting it be discovered from an
+            # unexpectedly available toolset.
+            logger.warning(
+                "agent.disabled_toolsets value %r parsed to no toolsets; "
+                "disabling nothing for this api_server agent",
+                _raw_disabled_toolsets,
+            )
 
         max_iterations = _current_max_iterations()
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2927,6 +2927,17 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        # Mirror the messaging-platform agent build (GatewayRunner
+        # _run_background_task_inner): agent.disabled_toolsets is a
+        # per-profile denial policy, and skipping it here silently
+        # re-enables toolsets the routed profile explicitly disabled —
+        # e.g. delegation removed as an operational/safety measure
+        # (#91415). Applies to every api_server deployment, not just
+        # multiplexed ones.
+        from agent.skill_utils import parse_config_string_list
+
+        agent_cfg = user_config.get("agent") or {}
+        disabled_toolsets = parse_config_string_list(agent_cfg.get("disabled_toolsets")) or None
 
         max_iterations = _current_max_iterations()
 
@@ -2961,6 +2972,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "verbose_logging": False,
             "ephemeral_system_prompt": ephemeral_system_prompt or None,
             "enabled_toolsets": enabled_toolsets,
+            "disabled_toolsets": disabled_toolsets,
             "session_id": session_id,
             "platform": "api_server",
             "stream_delta_callback": stream_delta_callback,

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -80,3 +80,63 @@ class TestApiServerAdapterToolset:
             assert len(toolsets) > 0
             assert call_kwargs.kwargs.get("platform") == "api_server"
 
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_applies_disabled_toolsets(self):
+        """Regression #91415: agent.disabled_toolsets is a denial policy that
+        the messaging-platform agent build honors; the api_server build used
+        to ignore it, silently re-enabling toolsets (e.g. delegation) the
+        deployment explicitly disabled."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+        # Placeholder-shaped fake key (not a usable credential).
+        fake_key = "k" + "-" * 10
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {"api_key": fake_key, "base_url": None,
+                                        "provider": None, "api_mode": None,
+                                        "command": None, "args": []}
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {
+                "agent": {"disabled_toolsets": ["delegation"]},
+            }
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent()
+
+            mock_agent_cls.assert_called_once()
+            call_kwargs = mock_agent_cls.call_args
+            # FAIL-CLOSED policy check: the explicit denial must reach the agent.
+            assert call_kwargs.kwargs.get("disabled_toolsets") == ["delegation"]
+
+    @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", True)
+    def test_create_agent_without_disabled_toolsets_passes_none(self):
+        """No agent.disabled_toolsets config → None, preserving prior behavior."""
+        from gateway.platforms.api_server import APIServerAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = APIServerAdapter(PlatformConfig())
+        fake_key = "k" + "-" * 10
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs") as mock_kwargs, \
+             patch("gateway.run._resolve_gateway_model") as mock_model, \
+             patch("gateway.run._load_gateway_config") as mock_config, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+
+            mock_kwargs.return_value = {"api_key": fake_key, "base_url": None,
+                                        "provider": None, "api_mode": None,
+                                        "command": None, "args": []}
+            mock_model.return_value = "test/model"
+            mock_config.return_value = {}
+            mock_agent_cls.return_value = MagicMock()
+
+            adapter._create_agent()
+
+            call_kwargs = mock_agent_cls.call_args
+            assert call_kwargs.kwargs.get("disabled_toolsets") is None
+


### PR DESCRIPTION
## What does this PR do?

Makes the `api_server` platform honor `agent.disabled_toolsets` from the gateway config. The messaging-platform agent builds (`GatewayRunner._run_background_task_inner` and the main turn path) read this key and forward it to `AIAgent`, but the api_server's `_create_agent()` never did — so a deployment that disables a toolset (e.g. `delegation` removed as an operational/safety policy after production incidents) had it **silently re-enabled** on the OpenAI-compatible API paths (`/v1/chat/completions`, `/p/<profile>/v1/chat/completions`, `/v1/responses`, `/v1/runs`). This affects every api_server deployment, not only multiplexed ones — the multiplex report in #91415 is where it surfaced (`GET /v1/toolsets` showed an explicitly-disabled toolset as `enabled=True`).

The fix mirrors the messaging path exactly: parse `agent.disabled_toolsets` with `parse_config_string_list` and forward it in `agent_kwargs`. With no configuration the value is `None`, preserving prior behavior.

Note on scope: this PR fixes the denial half of #91415 (`agent.disabled_toolsets` ignored). The separate grant half (top-level `toolsets:` names that are not platform toolsets, e.g. `kanban`, not being grantable to api_server agents) goes through `_get_platform_tools`'s `platform_toolsets` resolution semantics and is a distinct config-resolution change; this PR deliberately does not touch that layer.

## Related Issue

Fixes #91415

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`: In `_create_agent()`, after resolving `enabled_toolsets`, read `agent.disabled_toolsets` via `parse_config_string_list` (mirroring `GatewayRunner._run_background_task_inner`) and pass `disabled_toolsets` in `agent_kwargs`, with a comment explaining the silent policy-reversal failure mode.
- `tests/gateway/test_api_server_toolset.py`: Add two tests in `TestApiServerAdapterToolset` — the explicit denial reaches the agent kwargs (fail-closed policy check), and absent config passes `None` (regression guard).

## How to Test

1. Configure a gateway with `api_server` enabled and `agent: {disabled_toolsets: [delegation]}` in `config.yaml`
2. `GET /v1/toolsets` — before the fix `delegation` shows `enabled=True` despite the explicit denial; after the fix the denial reaches the agent (Observed result: `test_create_agent_applies_disabled_toolsets` fails on unpatched main with `disabled_toolsets is None` and passes with this patch)
3. Without any `agent.disabled_toolsets` config, behavior is unchanged (Observed result: `test_create_agent_without_disabled_toolsets_passes_none` passes)
4. `scripts/run_tests.sh tests/gateway/test_api_server_toolset.py -q` → should pass (Observed result: 7 passed locally, including the 5 pre-existing tests)
5. `scripts/run_tests.sh tests/gateway/test_api_server_multiplex_secret_scope.py -q` → should pass (Observed result: 3 passed locally)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
