### PR TITLE
fix(desktop-update): use the system default browser for the update shim

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -95,9 +95,9 @@ function Write-HandoffLog([string]$Message) {
     Write-Host $line
 }
 
-# ── The shim: repo-owned HTML in a chromeless Edge app window ──────────────
+# ── The shim: repo-owned HTML in a chromeless default-browser app window ───
 # The window is a veneer, not a participant: the update runs identically with
-# or without it (Edge missing/failed degrades to the WinForms card below,
+# or without it (default browser missing/failed degrades to the WinForms card below,
 # then log-only). It never consumes child output; it polls /progress for the
 # current hand-off stage or a terminal event and reacts. The loopback listener
 # is not a web server in any meaningful sense; it exists because file:// pages
@@ -109,7 +109,7 @@ $script:UiState = [hashtable]::Synchronized(@{
     message    = $script:UiStage
     clock      = $script:UiStopwatch
 })
-$script:UiServer = $null     # @{ Listener; Runspace; PowerShell; Port; EdgeProc }
+$script:UiServer = $null     # @{ Listener; Runspace; PowerShell; Port; BrowserProc; Profile }
 
 function Get-UiHtmlPath {
     # Lives next to this script in the checkout. Missing file = fall back to
@@ -119,10 +119,37 @@ function Get-UiHtmlPath {
     return $null
 }
 
-function Find-EdgeExe {
+function Get-DefaultBrowserExe {
+    # The OS default browser, read from the UserChoice ProgId that the
+    # Windows Settings app writes (https first, http as fallback). Only
+    # Chromium-family browsers (ChromeHTML / MSEdgeHTM) support the
+    # --app + --user-data-dir combo the shim relies on; any other
+    # default browser returns $null and degrades to the WinForms card.
+    $progId = $null
+    foreach ($proto in @("https", "http")) {
+        try {
+            $progId = (Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\$proto\UserChoice" -Name ProgId -ErrorAction Stop).ProgId
+        } catch { continue }
+        if ($progId) { break }
+    }
+    if (-not $progId) { return $null }
+    $family = switch ($progId) {
+        "ChromeHTML" { "Google\Chrome\Application\chrome.exe" }
+        "MSEdgeHTM"  { "Microsoft\Edge\Application\msedge.exe" }
+        default      { $null }
+    }
+    if (-not $family) { return $null }
+    # Exact path from the ProgId's open command first, then standard roots.
+    try {
+        $cmd = (Get-ItemProperty -Path "Registry::HKEY_CLASSES_ROOT\$progId\shell\open\command" -ErrorAction Stop).'(default)'
+        if ($cmd -and $cmd -match '"([^"]+\.exe)"') {
+            $exe = $Matches[1]
+            if (Test-Path -LiteralPath $exe) { return $exe }
+        }
+    } catch {}
     foreach ($root in @($env:ProgramFiles, ${env:ProgramFiles(x86)}, $env:LOCALAPPDATA)) {
         if (-not $root) { continue }
-        $p = Join-Path $root "Microsoft\Edge\Application\msedge.exe"
+        $p = Join-Path $root $family
         if (Test-Path -LiteralPath $p) { return $p }
     }
     return $null
@@ -185,7 +212,7 @@ function Start-UiServer([string]$HtmlPath) {
         })
         [void]$ps.BeginInvoke()
 
-        return @{ Listener = $listener; Runspace = $rs; PowerShell = $ps; Port = $port; EdgeProc = $null }
+        return @{ Listener = $listener; Runspace = $rs; PowerShell = $ps; Port = $port; BrowserProc = $null; Profile = $null }
     } catch {
         try { if ($listener) { $listener.Stop() } } catch {}
         return $null
@@ -202,11 +229,26 @@ function Stop-UiServer([switch]$LeaveWindow) {
     # user closes it when they've read it.
     if (-not $LeaveWindow) {
         try {
-            if ($script:UiServer.EdgeProc -and -not $script:UiServer.EdgeProc.HasExited) {
-                $script:UiServer.EdgeProc.CloseMainWindow() | Out-Null
+            if ($script:UiServer.BrowserProc -and -not $script:UiServer.BrowserProc.HasExited) {
+                $script:UiServer.BrowserProc.CloseMainWindow() | Out-Null
             }
         } catch {}
     }
+    # Best-effort removal of the dedicated browser profile dirs: this run's
+    # profile plus any stale hermes-update-ui-* leftovers from interrupted
+    # past runs. A browser that is still shutting down may hold the lock, in
+    # which case the delete silently no-ops. Safe to sweep by prefix: the
+    # update marker (.hermes-update-in-progress) serialises hand-offs, so no
+    # other run's profile can be in active use here.
+    try {
+        $profileDirs = @()
+        if ($script:UiServer.Profile) { $profileDirs += $script:UiServer.Profile }
+        Get-ChildItem -LiteralPath $TempDir -Directory -Filter "hermes-update-ui-*" -ErrorAction SilentlyContinue |
+            ForEach-Object { $profileDirs += $_.FullName }
+        foreach ($dir in ($profileDirs | Select-Object -Unique)) {
+            Remove-Item -LiteralPath $dir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    } catch {}
     $script:UiServer = $null
 }
 
@@ -258,30 +300,31 @@ function Get-AppsUseLightTheme {
 function Show-ProgressWindow {
     if ($NoUi) { return }
 
-    # ── Primary: the HTML shim in a chromeless Edge app window ─────────────
+    # ── Primary: the HTML shim in a chromeless default-browser app window ──
     # Same footprint as the card (280x320), spawned as a normal window: it
     # claims attention once by appearing, then competes with nothing.
     $htmlPath = Get-UiHtmlPath
-    $edge = Find-EdgeExe
-    if ($htmlPath -and $edge) {
+    $browser = Get-DefaultBrowserExe
+    if ($htmlPath -and $browser) {
         $server = Start-UiServer $htmlPath
         if ($server) {
             try {
                 # Dedicated tiny profile dir: guarantees a NEW WINDOW + process
                 # we own (a default-profile launch delegates to an existing
-                # Edge and returns instantly, leaving nothing to close), and
+                # browser and returns instantly, leaving nothing to close), and
                 # avoids touching the user's real browser profile.
-                $edgeProfile = Join-Path $TempDir ("hermes-update-ui-{0}" -f $PID)
-                $edgeArgs = @(
+                $browserProfile = Join-Path $TempDir ("hermes-update-ui-{0}" -f $PID)
+                $browserArgs = @(
                     "--app=http://127.0.0.1:$($server.Port)/",
-                    "--user-data-dir=$edgeProfile",
+                    "--user-data-dir=$browserProfile",
                     "--no-first-run", "--no-default-browser-check",
                     "--disable-features=msImplicitSignin",
                     "--window-size=280,320"
                 )
-                $server.EdgeProc = Start-Process -FilePath $edge -ArgumentList $edgeArgs -PassThru
+                $server.BrowserProc = Start-Process -FilePath $browser -ArgumentList $browserArgs -PassThru
+                $server.Profile = $browserProfile
                 $script:UiServer = $server
-                Write-HandoffLog "shim: Edge app window on 127.0.0.1:$($server.Port)"
+                Write-HandoffLog "shim: default-browser app window on 127.0.0.1:$($server.Port)"
                 return
             } catch {
                 try { $server.Listener.Stop() } catch {}


### PR DESCRIPTION
## What does this PR do?

On Windows the desktop-update hand-off shim (`scripts/desktop-update/windows.ps1`) hardcoded Microsoft Edge as the renderer for the update progress window (`Find-EdgeExe`). Machines whose default browser is Chrome still got an Edge `--app` window, ignoring the user's browser choice, and every run left a throwaway browser profile (`hermes-update-ui-<pid>` under `%TEMP%`, ~19 MB / 240+ files) that was never cleaned up.

This PR:

- **Follows the OS default browser**: `Get-DefaultBrowserExe` resolves the default browser from the `UserChoice` ProgId (`https` first, `http` fallback) — `ChromeHTML` → Chrome, `MSEdgeHTM` → Edge. Any other default (Firefox, etc.) returns `$null` and the shim degrades to the existing WinForms card, unchanged.
- **Cleans up the temp profile**: the dedicated `--user-data-dir` profile is removed when the shim closes, and stale `hermes-update-ui-*` leftovers from interrupted past runs are swept from `%TEMP%` in the same pass.

The whitelist is intentionally limited to `chrome`/`msedge` — `--app` + `--user-data-dir` is a Chromium-only combination, and Edge keeps `--disable-features=msImplicitSignin` to suppress the implicit MSA sign-in that leaks into shim windows (see #88410 for the macOS-side leak).

## Related Issue

No direct issue for the Windows side; complements #88418 (macOS/Linux: drop Edge from `find_browser()`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/desktop-update/windows.ps1`: `Find-EdgeExe` → `Get-DefaultBrowserExe` (UserChoice ProgId resolution, exact exe path from `HKCR\<ProgId>\shell\open\command`, standard-root fallback); `Stop-UiServer` now removes this run's profile plus sweeps stale `hermes-update-ui-*` dirs.

## How to Test

1. PowerShell syntax: parse `scripts/desktop-update/windows.ps1` — no errors.
2. Default-browser detection: with default Chrome, `Get-DefaultBrowserExe` returns the `chrome.exe` path; with default Edge it returns the `msedge.exe` path; with any other default it returns `$null` (WinForms fallback).
3. Cleanup: after a hand-off, no `hermes-update-ui-*` directory remains under `%TEMP%`.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I have run syntax checks and verified `Get-DefaultBrowserExe` against the live default browser (ChromeHTML → Chrome)
- [x] I have added tests for my changes — N/A: standalone PowerShell hand-off script with no test harness; verification steps above
- [x] I have tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no config keys or docs changed
