### PR TITLE
feat(tools): pass gateway session user id on MCP tools/call

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1281,6 +1281,9 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-github"]
 #     env:
 #       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+#     # Optional: tools/call params._meta key for the gateway session user id
+#     # (Telegram/Discord/...). Default: nousresearch.hermes/user_id
+#     # session_user_id_meta_key: "nousresearch.hermes/user_id"
 #
 # Sampling (server-initiated LLM requests) — enabled by default.
 # Per-server config under the 'sampling' key:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1281,8 +1281,8 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-github"]
 #     env:
 #       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
-#     # Optional: tools/call params._meta key for the gateway session user id
-#     # (Telegram/Discord/...). Default: nousresearch.hermes/user_id
+#     # Optional: tools/call params._meta key for the qualified gateway principal
+#     # (platform, scope_id, user_id). Default: nousresearch.hermes/user_id
 #     # session_user_id_meta_key: "nousresearch.hermes/user_id"
 #
 # Sampling (server-initiated LLM requests) — enabled by default.

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2986,6 +2986,13 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("Failed to resolve Feishu update prompt: %s", exc)
 
+    def _event_identity_scope(self, data: Any) -> str:
+        """Return the app-and-tenant namespace for an inbound Feishu event."""
+        header = getattr(data, "header", None)
+        tenant_key = str(getattr(header, "tenant_key", "") or "").strip()
+        app_id = str(getattr(self, "_app_id", "") or "").strip()
+        return ":".join(part for part in (app_id, tenant_key) if part)
+
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""
         if not self._client:
@@ -3034,6 +3041,7 @@ class FeishuAdapter(BasePlatformAdapter):
             user_name=sender_profile["user_name"],
             thread_id=None,
             user_id_alt=sender_profile["user_id_alt"],
+            scope_id=self._event_identity_scope(data),
         )
         synthetic_event = MessageEvent(
             text=synthetic_text,
@@ -3097,6 +3105,7 @@ class FeishuAdapter(BasePlatformAdapter):
             user_name=sender_profile["user_name"],
             thread_id=None,
             user_id_alt=sender_profile["user_id_alt"],
+            scope_id=self._event_identity_scope(data),
         )
         synthetic_event = MessageEvent(
             text=synthetic_text,
@@ -3376,10 +3385,6 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id, is_bot=is_bot)
-        header = getattr(data, "header", None)
-        tenant_key = str(getattr(header, "tenant_key", "") or "").strip()
-        app_id = str(getattr(self, "_app_id", "") or "").strip()
-        identity_scope = ":".join(part for part in (app_id, tenant_key) if part)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
@@ -3389,7 +3394,7 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
-            scope_id=identity_scope,
+            scope_id=self._event_identity_scope(data),
         )
         normalized = MessageEvent(
             text=text,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2988,8 +2988,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _event_identity_scope(self, data: Any) -> str:
         """Return the app-and-tenant namespace for an inbound Feishu event."""
-        header = getattr(data, "header", None)
-        tenant_key = str(getattr(header, "tenant_key", "") or "").strip()
+        header = data.get("header") if isinstance(data, dict) else getattr(data, "header", None)
+        tenant_key = (
+            header.get("tenant_key")
+            if isinstance(header, dict)
+            else getattr(header, "tenant_key", "")
+        )
+        tenant_key = str(tenant_key or "").strip()
         app_id = str(getattr(self, "_app_id", "") or "").strip()
         return ":".join(part for part in (app_id, tenant_key) if part)
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3376,6 +3376,10 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id = getattr(message, "chat_id", "") or ""
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id, is_bot=is_bot)
+        header = getattr(data, "header", None)
+        tenant_key = str(getattr(header, "tenant_key", "") or "").strip()
+        app_id = str(getattr(self, "_app_id", "") or "").strip()
+        identity_scope = ":".join(part for part in (app_id, tenant_key) if part)
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_info.get("name") or chat_id or "Feishu Chat",
@@ -3385,6 +3389,7 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
+            scope_id=identity_scope,
         )
         normalized = MessageEvent(
             text=text,

--- a/plugins/platforms/feishu/feishu_meeting_invite.py
+++ b/plugins/platforms/feishu/feishu_meeting_invite.py
@@ -202,6 +202,7 @@ async def handle_meeting_invited_event(adapter: Any, data: Any) -> None:
         user_id=sender_profile.get("user_id") or inviter.user_id or inviter.open_id,
         user_name=user_name,
         user_id_alt=sender_profile.get("user_id_alt") or inviter.union_id or None,
+        scope_id=adapter._event_identity_scope(data),
     )
     event = MessageEvent(
         text=build_meeting_invite_prompt(payload),

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -423,6 +423,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             chat_type="dm",
             user_id=user_id,
             user_name=user_id,
+            scope_id=corp_id,
         )
         return MessageEvent(
             text=content,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -546,6 +546,28 @@ class TestAdapterBehavior(unittest.TestCase):
         )
         adapter._handle_message_with_guards.assert_not_awaited()
 
+    def test_reaction_source_is_scoped_by_app_and_tenant(self):
+        adapter = self._build_reaction_adapter(msg_sender_id="cli_self_app")
+        event = SimpleNamespace(
+            message_id="om_self_msg",
+            user_id=SimpleNamespace(
+                open_id="ou_human", user_id="u_human", union_id=None
+            ),
+            reaction_type=SimpleNamespace(emoji_type="THUMBSUP"),
+        )
+        data = SimpleNamespace(
+            event=event,
+            header=SimpleNamespace(tenant_key="tenant_a"),
+        )
+
+        asyncio.run(
+            adapter._handle_reaction_event("im.message.reaction.created_v1", data)
+        )
+
+        adapter._handle_message_with_guards.assert_awaited_once()
+        routed = adapter._handle_message_with_guards.call_args.args[0]
+        assert routed.source.scope_id == "cli_self_app:tenant_a"
+
 
     def test_per_group_allowlist_policy_gates_by_sender(self):
         from gateway.config import PlatformConfig

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -62,6 +62,7 @@ def _make_card_action_data(
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
     return SimpleNamespace(
+        header=SimpleNamespace(tenant_key="tenant_a"),
         event=SimpleNamespace(
             token=token,
             context=SimpleNamespace(open_chat_id=chat_id),
@@ -266,6 +267,7 @@ class TestNonApprovalCardAction:
         mock_handle.assert_called_once()
         event = mock_handle.call_args[0][0]
         assert "/card button" in event.text
+        assert event.source.scope_id == "tenant_a"
 
 
 # ===========================================================================

--- a/tests/gateway/test_feishu_channel_prompts.py
+++ b/tests/gateway/test_feishu_channel_prompts.py
@@ -78,3 +78,10 @@ def test_inbound_source_is_scoped_by_app_and_tenant():
     assert adapter.build_source.call_args.kwargs["scope_id"] == "cli_app:tenant_a"
 
 
+def test_identity_scope_accepts_mapping_event_payload():
+    adapter = _build_adapter()
+    assert adapter._event_identity_scope(
+        {"header": {"tenant_key": "tenant_b"}}
+    ) == "cli_app:tenant_b"
+
+

--- a/tests/gateway/test_feishu_channel_prompts.py
+++ b/tests/gateway/test_feishu_channel_prompts.py
@@ -19,6 +19,7 @@ def _build_adapter(extra=None):
 
     adapter = FeishuAdapter.__new__(FeishuAdapter)
     adapter.config = PlatformConfig(extra=extra or {})
+    adapter._app_id = "cli_app"
     adapter._bot_open_id = "ou_bot"
     adapter._bot_user_id = ""
     adapter._bot_name = "Hermes"
@@ -47,7 +48,11 @@ def _run_inbound(adapter, chat_id="oc_chat"):
     )
     asyncio.run(
         adapter._process_inbound_message(
-            data=message, message=message, sender_id=None, chat_type="group", message_id="m",
+            data=SimpleNamespace(header=SimpleNamespace(tenant_key="tenant_a")),
+            message=message,
+            sender_id=None,
+            chat_type="group",
+            message_id="m",
         )
     )
     return adapter._dispatch_inbound_event.call_args.args[0]
@@ -65,5 +70,11 @@ def test_inbound_event_carries_channel_prompt():
     adapter = _build_adapter({"channel_prompts": {"oc_chat": "Feishu role prompt."}})
     event = _run_inbound(adapter, chat_id="oc_chat")
     assert event.channel_prompt == "Feishu role prompt."
+
+
+def test_inbound_source_is_scoped_by_app_and_tenant():
+    adapter = _build_adapter()
+    _run_inbound(adapter)
+    assert adapter.build_source.call_args.kwargs["scope_id"] == "cli_app:tenant_a"
 
 

--- a/tests/gateway/test_feishu_meeting_invite.py
+++ b/tests/gateway/test_feishu_meeting_invite.py
@@ -27,6 +27,7 @@ def _make_payload(event_id="evt_1"):
         "header": {
             "event_id": event_id,
             "event_type": "vc.bot.meeting_invited_v1",
+            "tenant_key": "tenant_a",
         },
         "event": {
             "meeting": {
@@ -72,6 +73,7 @@ def _make_payload_with_numeric_inviter_id():
 class _Adapter:
     def __init__(self, duplicate=False):
         self.duplicate = duplicate
+        self._app_id = "cli_app"
         self.events = []
         self.dedup_keys = []
         self.profile_requests = []
@@ -82,6 +84,11 @@ class _Adapter:
 
     def build_source(self, **kwargs):
         return SimpleNamespace(**kwargs)
+
+    def _event_identity_scope(self, data):
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        return FeishuAdapter._event_identity_scope(self, data)
 
     async def _resolve_sender_profile(self, sender_id):
         self.profile_requests.append(sender_id)
@@ -158,6 +165,7 @@ class TestMeetingInviteHandler(unittest.TestCase):
         self.assertEqual(event.source.user_name, "Resolved Inviter")
         self.assertEqual(event.source.chat_name, "Resolved Inviter")
         self.assertEqual(event.source.user_id_alt, "on_e19a19e6ffafbd54fbb3c4d251d6fa19")
+        self.assertEqual(event.source.scope_id, "cli_app:tenant_a")
         self.assertEqual(len(adapter.profile_requests), 1)
         self.assertEqual(adapter.profile_requests[0].open_id, "ou_390b35dca44816efc9afa812aaff3a69")
         self.assertEqual(adapter.profile_requests[0].user_id, "e65g874e")

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -63,8 +63,33 @@ class TestWecomCallbackEventConstruction:
         assert event.source is not None
         assert event.source.user_id == "zhangsan"
         assert event.source.chat_id == "ww1234567890:zhangsan"
+        assert event.source.scope_id == "ww1234567890"
         assert event.message_id == "123456789"
         assert event.text == "\u4f60\u597d"
+
+    def test_same_user_in_different_corporations_has_distinct_scope(self):
+        adapter = WecomCallbackAdapter(_config())
+
+        def event_for(corp_id):
+            return adapter._build_event(
+                _app(corp_id=corp_id),
+                f"""
+                <xml>
+                  <ToUserName>{corp_id}</ToUserName>
+                  <FromUserName>alice</FromUserName>
+                  <CreateTime>1710000000</CreateTime>
+                  <MsgType>text</MsgType>
+                  <Content>hello</Content>
+                  <MsgId>{corp_id}-1</MsgId>
+                </xml>
+                """,
+            )
+
+        corp_a = event_for("corpA")
+        corp_b = event_for("corpB")
+        assert corp_a.source.user_id == corp_b.source.user_id == "alice"
+        assert corp_a.source.scope_id == "corpA"
+        assert corp_b.source.scope_id == "corpB"
 
 
 class TestWecomCallbackRouting:

--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -267,6 +267,28 @@ def test_half_open_probe_on_dead_session_requests_reconnect(monkeypatch, tmp_pat
         _cleanup(mcp_tool, "srv")
 
 
+def test_dead_session_without_reconnect_signal_returns_clean_error(monkeypatch, tmp_path):
+    """A server without reconnect machinery must not fall through to call_tool."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    server = _install_stub_server(mcp_tool, "srv", None)
+    server.session = None
+    server._reconnect_event = None
+    monkeypatch.setattr(
+        mcp_tool, "_wait_for_server_session_ready", lambda *_a, **_kw: False
+    )
+
+    try:
+        result = json.loads(_make_tool_handler("srv", "tool1", 10.0)({}))
+        assert "not connected" in result.get("error", "").lower(), result
+        assert "nonetype" not in result.get("error", "").lower(), result
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_half_open_dead_session_recovers_after_reconnect(monkeypatch, tmp_path):
     """Once the transport comes back (session repopulated + breaker reset by
     the run loop), the next call must go straight through — proving the wedge

--- a/tests/tools/test_mcp_session_identity_meta.py
+++ b/tests/tools/test_mcp_session_identity_meta.py
@@ -1,0 +1,161 @@
+"""Gateway session user_id is attached to MCP tools/call via ``meta``.
+
+The MCP event loop does not inherit session ContextVars, so the handler
+snapshots ``HERMES_SESSION_USER_ID`` on the agent thread and passes it as
+``session.call_tool(..., meta=...)``. It is not injected into ``arguments``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools import mcp_tool
+
+
+class _FakeContentBlock:
+    def __init__(self, text: str, block_type: str = "text"):
+        self.text = text
+        self.type = block_type
+
+
+class _FakeCallToolResult:
+    def __init__(self, content, is_error=False, structuredContent=None):
+        self.content = content
+        self.isError = is_error
+        self.structuredContent = structuredContent
+
+
+def _fake_run_on_mcp_loop(coro_or_factory, timeout=30):
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+    loop = asyncio.new_event_loop()
+    try:
+        async def _install_lock_and_run():
+            for srv in list(mcp_tool._servers.values()):
+                if getattr(srv, "_rpc_lock", None) is None:
+                    srv._rpc_lock = asyncio.Lock()
+            return await coro
+        return loop.run_until_complete(_install_lock_and_run())
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def fake_session():
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=_FakeCallToolResult(content=[_FakeContentBlock("ok")])
+    )
+    server = SimpleNamespace(session=session, _rpc_lock=None, _config={})
+    with patch.dict(mcp_tool._servers, {"srv": server}), \
+         patch("tools.mcp_tool._run_on_mcp_loop",
+               side_effect=_fake_run_on_mcp_loop), \
+         patch.dict(mcp_tool._server_error_counts, {}, clear=True):
+        yield session
+
+
+class TestMcpSessionIdentityMeta:
+    def test_unset_session_returns_none(self):
+        from gateway.session_context import reset_session_vars
+
+        reset_session_vars()
+        assert mcp_tool._mcp_session_identity_meta() is None
+
+    def test_bound_session_user_id(self):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        reset_session_vars()
+        set_session_vars(user_id="tg-99")
+        try:
+            assert mcp_tool._mcp_session_identity_meta("srv", {}) == {
+                mcp_tool._MCP_SESSION_USER_ID_META_KEY: "tg-99",
+            }
+        finally:
+            reset_session_vars()
+
+    def test_custom_meta_key_from_server_config(self):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        reset_session_vars()
+        set_session_vars(user_id="tg-99")
+        try:
+            assert mcp_tool._mcp_session_identity_meta("srv", {
+                "session_user_id_meta_key": "x-user-id",
+            }) == {"x-user-id": "tg-99"}
+        finally:
+            reset_session_vars()
+
+    def test_reserved_meta_key_falls_back_to_default(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            key = mcp_tool._resolve_session_user_id_meta_key("srv", {
+                "session_user_id_meta_key": "mcp.com/user_id",
+            })
+        assert key == mcp_tool._MCP_SESSION_USER_ID_META_KEY
+        assert any("session_user_id_meta_key" in r.message for r in caplog.records)
+
+    def test_blank_user_id_returns_none(self):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        reset_session_vars()
+        set_session_vars(user_id="  ")
+        try:
+            assert mcp_tool._mcp_session_identity_meta() is None
+        finally:
+            reset_session_vars()
+
+    def test_handler_passes_meta_not_arguments(self, fake_session):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        reset_session_vars()
+        set_session_vars(user_id="discord-u1")
+        try:
+            handler = mcp_tool._make_tool_handler("srv", "echo", 30.0)
+            raw = handler({"q": "hi"})
+        finally:
+            reset_session_vars()
+
+        assert json.loads(raw) == {"result": "ok"}
+        fake_session.call_tool.assert_awaited_once_with(
+            "echo",
+            arguments={"q": "hi"},
+            meta={mcp_tool._MCP_SESSION_USER_ID_META_KEY: "discord-u1"},
+        )
+
+    def test_handler_omits_meta_without_session_user(self, fake_session):
+        from gateway.session_context import reset_session_vars
+
+        reset_session_vars()
+        handler = mcp_tool._make_tool_handler("srv", "echo", 30.0)
+        raw = handler({"q": "hi"})
+        assert json.loads(raw) == {"result": "ok"}
+        fake_session.call_tool.assert_awaited_once_with(
+            "echo",
+            arguments={"q": "hi"},
+        )
+
+    def test_handler_uses_configured_meta_key(self, fake_session):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        mcp_tool._servers["srv"]._config = {
+            "session_user_id_meta_key": "caller-id",
+        }
+        reset_session_vars()
+        set_session_vars(user_id="feishu-u2")
+        try:
+            handler = mcp_tool._make_tool_handler("srv", "echo", 30.0)
+            raw = handler({"q": "hi"})
+        finally:
+            reset_session_vars()
+
+        assert json.loads(raw) == {"result": "ok"}
+        fake_session.call_tool.assert_awaited_once_with(
+            "echo",
+            arguments={"q": "hi"},
+            meta={"caller-id": "feishu-u2"},
+        )

--- a/tests/tools/test_mcp_session_identity_meta.py
+++ b/tests/tools/test_mcp_session_identity_meta.py
@@ -1,14 +1,16 @@
-"""Gateway session user_id is attached to MCP tools/call via ``meta``.
+"""A qualified gateway principal is attached to MCP tools/call via ``meta``.
 
 The MCP event loop does not inherit session ContextVars, so the handler
-snapshots ``HERMES_SESSION_USER_ID`` on the agent thread and passes it as
-``session.call_tool(..., meta=...)``. It is not injected into ``arguments``.
+snapshots platform, scope, and user on the agent thread and passes them as
+``session.call_tool(..., meta=...)``. They are not injected into ``arguments``.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -65,14 +67,18 @@ class TestMcpSessionIdentityMeta:
         reset_session_vars()
         assert mcp_tool._mcp_session_identity_meta() is None
 
-    def test_bound_session_user_id(self):
+    def test_bound_session_principal(self):
         from gateway.session_context import reset_session_vars, set_session_vars
 
         reset_session_vars()
-        set_session_vars(user_id="tg-99")
+        set_session_vars(platform="telegram", user_id="tg-99")
         try:
             assert mcp_tool._mcp_session_identity_meta("srv", {}) == {
-                mcp_tool._MCP_SESSION_USER_ID_META_KEY: "tg-99",
+                mcp_tool._MCP_SESSION_USER_ID_META_KEY: {
+                    "platform": "telegram",
+                    "scope_id": "",
+                    "user_id": "tg-99",
+                },
             }
         finally:
             reset_session_vars()
@@ -81,11 +87,19 @@ class TestMcpSessionIdentityMeta:
         from gateway.session_context import reset_session_vars, set_session_vars
 
         reset_session_vars()
-        set_session_vars(user_id="tg-99")
+        set_session_vars(
+            platform="slack", scope_id="workspace-1", user_id="U99"
+        )
         try:
             assert mcp_tool._mcp_session_identity_meta("srv", {
                 "session_user_id_meta_key": "x-user-id",
-            }) == {"x-user-id": "tg-99"}
+            }) == {
+                "x-user-id": {
+                    "platform": "slack",
+                    "scope_id": "workspace-1",
+                    "user_id": "U99",
+                }
+            }
         finally:
             reset_session_vars()
 
@@ -103,7 +117,7 @@ class TestMcpSessionIdentityMeta:
         from gateway.session_context import reset_session_vars, set_session_vars
 
         reset_session_vars()
-        set_session_vars(user_id="  ")
+        set_session_vars(platform="telegram", user_id="  ")
         try:
             assert mcp_tool._mcp_session_identity_meta() is None
         finally:
@@ -113,7 +127,9 @@ class TestMcpSessionIdentityMeta:
         from gateway.session_context import reset_session_vars, set_session_vars
 
         reset_session_vars()
-        set_session_vars(user_id="discord-u1")
+        set_session_vars(
+            platform="discord", scope_id="guild-1", user_id="discord-u1"
+        )
         try:
             handler = mcp_tool._make_tool_handler("srv", "echo", 30.0)
             raw = handler({"q": "hi"})
@@ -124,7 +140,13 @@ class TestMcpSessionIdentityMeta:
         fake_session.call_tool.assert_awaited_once_with(
             "echo",
             arguments={"q": "hi"},
-            meta={mcp_tool._MCP_SESSION_USER_ID_META_KEY: "discord-u1"},
+            meta={
+                mcp_tool._MCP_SESSION_USER_ID_META_KEY: {
+                    "platform": "discord",
+                    "scope_id": "guild-1",
+                    "user_id": "discord-u1",
+                }
+            },
         )
 
     def test_handler_omits_meta_without_session_user(self, fake_session):
@@ -146,7 +168,7 @@ class TestMcpSessionIdentityMeta:
             "session_user_id_meta_key": "caller-id",
         }
         reset_session_vars()
-        set_session_vars(user_id="feishu-u2")
+        set_session_vars(platform="feishu", user_id="feishu-u2")
         try:
             handler = mcp_tool._make_tool_handler("srv", "echo", 30.0)
             raw = handler({"q": "hi"})
@@ -157,5 +179,103 @@ class TestMcpSessionIdentityMeta:
         fake_session.call_tool.assert_awaited_once_with(
             "echo",
             arguments={"q": "hi"},
-            meta={"caller-id": "feishu-u2"},
+            meta={
+                "caller-id": {
+                    "platform": "feishu",
+                    "scope_id": "",
+                    "user_id": "feishu-u2",
+                }
+            },
         )
+
+    def test_same_user_in_different_namespaces_has_distinct_stable_principals(self):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        def principal(platform, scope_id):
+            reset_session_vars()
+            set_session_vars(
+                platform=platform, scope_id=scope_id, user_id="shared-user"
+            )
+            try:
+                return mcp_tool._mcp_session_identity_meta("srv", {})
+            finally:
+                reset_session_vars()
+
+        slack_a = principal("slack", "workspace-a")
+        slack_b = principal("slack", "workspace-b")
+        discord = principal("discord", "workspace-a")
+
+        assert slack_a != slack_b
+        assert slack_a != discord
+        assert slack_a == principal("slack", "workspace-a")
+
+    def test_concurrent_handlers_do_not_cross_wire_principals(self):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        loop = asyncio.new_event_loop()
+        loop_ready = threading.Event()
+
+        def run_loop():
+            asyncio.set_event_loop(loop)
+            loop_ready.set()
+            loop.run_forever()
+
+        loop_thread = threading.Thread(target=run_loop, daemon=True)
+        loop_thread.start()
+        assert loop_ready.wait(timeout=5)
+
+        session = MagicMock()
+        seen_meta = []
+
+        async def call_tool(_name, *, arguments, meta):
+            seen_meta.append((arguments["caller"], meta))
+            await asyncio.sleep(0)
+            return _FakeCallToolResult(content=[_FakeContentBlock("ok")])
+
+        session.call_tool = call_tool
+        server = SimpleNamespace(session=session, _rpc_lock=None, _config={})
+
+        async def install_lock():
+            server._rpc_lock = asyncio.Lock()
+
+        asyncio.run_coroutine_threadsafe(install_lock(), loop).result(timeout=5)
+
+        def run_on_loop(coro_or_factory, timeout=30):
+            coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+            return asyncio.run_coroutine_threadsafe(coro, loop).result(timeout=timeout)
+
+        barrier = threading.Barrier(2)
+
+        def call(scope_id):
+            reset_session_vars()
+            set_session_vars(platform="slack", scope_id=scope_id, user_id="U1")
+            try:
+                barrier.wait(timeout=5)
+                return mcp_tool._make_tool_handler("srv", "echo", 30.0)(
+                    {"caller": scope_id}
+                )
+            finally:
+                reset_session_vars()
+
+        try:
+            with patch.dict(mcp_tool._servers, {"srv": server}), patch(
+                "tools.mcp_tool._run_on_mcp_loop", side_effect=run_on_loop
+            ), patch.dict(mcp_tool._server_error_counts, {}, clear=True):
+                with ThreadPoolExecutor(max_workers=2) as pool:
+                    results = list(pool.map(call, ("workspace-a", "workspace-b")))
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            loop_thread.join(timeout=5)
+            loop.close()
+
+        assert [json.loads(result) for result in results] == [
+            {"result": "ok"},
+            {"result": "ok"},
+        ]
+        by_caller = dict(seen_meta)
+        assert by_caller["workspace-a"] != by_caller["workspace-b"]
+        assert by_caller["workspace-a"][mcp_tool._MCP_SESSION_USER_ID_META_KEY] == {
+            "platform": "slack",
+            "scope_id": "workspace-a",
+            "user_id": "U1",
+        }

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5862,7 +5862,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         f"reconnect requested. Do NOT retry this tool "
                         f"immediately — give it a few seconds to come back."
                     )
-                    return tool_error(f"MCP server '{server_name}' is not connected")
+                return tool_error(f"MCP server '{server_name}' is not connected")
 
         # Snapshot on this thread: ``_run_on_mcp_loop`` does not copy
         # gateway session ContextVars onto the MCP loop.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -43,8 +43,8 @@ Example config::
           value: "alice"       # required for static; profile mode uses the
                                # active Hermes profile name
         session_user_id_meta_key: "nousresearch.hermes/user_id"
-                               # tools/call params._meta key for the gateway
-                               # session user id (Telegram/Discord/...). Omit
+                               # tools/call params._meta key for the qualified
+                               # gateway principal (platform/scope/user). Omit
                                # to use the default above.
         timeout: 180
         skip_preflight: true  # bypass the content-type probe for a valid
@@ -1637,21 +1637,32 @@ def _resolve_session_user_id_meta_key(
 def _mcp_session_identity_meta(
     server_name: str = "",
     config: Optional[dict] = None,
-) -> Optional[Dict[str, str]]:
-    """Return tools/call ``meta`` for the current gateway session user.
+) -> Optional[Dict[str, Any]]:
+    """Return tools/call ``meta`` for the current gateway principal.
 
-    Empty / unset session user → ``None`` so the on-wire request is
+    A bare platform-local user id is not an authorization principal: Slack
+    ids are workspace-scoped, for example. Preserve the complete identity
+    namespace so MCP servers cannot collapse callers from different tenants.
+    Empty / unset platform or user → ``None`` so non-gateway calls remain
     unchanged (CLI, cron, tests that never bound a session).
     """
     try:
         from gateway.session_context import get_session_env
     except ImportError:
         return None
+    platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip()
+    scope_id = (get_session_env("HERMES_SESSION_SCOPE_ID", "") or "").strip()
     user_id = (get_session_env("HERMES_SESSION_USER_ID", "") or "").strip()
-    if not user_id:
+    if not platform or not user_id:
         return None
     key = _resolve_session_user_id_meta_key(server_name, config)
-    return {key: user_id}
+    return {
+        key: {
+            "platform": platform,
+            "scope_id": scope_id,
+            "user_id": user_id,
+        }
+    }
 
 
 def _call_tool_accepts_meta(call_tool) -> bool:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -42,6 +42,10 @@ Example config::
           value_from: "static" # "static" (default) or "profile"
           value: "alice"       # required for static; profile mode uses the
                                # active Hermes profile name
+        session_user_id_meta_key: "nousresearch.hermes/user_id"
+                               # tools/call params._meta key for the gateway
+                               # session user id (Telegram/Discord/...). Omit
+                               # to use the default above.
         timeout: 180
         skip_preflight: true  # bypass the content-type probe for a valid
                               # Streamable HTTP endpoint that answers HEAD/GET
@@ -1593,6 +1597,72 @@ def _apply_identity_header(server_name: str, config: dict, headers: dict) -> dic
         return headers
     headers[name] = value
     return headers
+
+
+# Default tools/call ``_meta`` key for the gateway session user id.
+# Override per server with ``mcp_servers.<name>.session_user_id_meta_key``.
+# Not a protocol-reserved ``mcp`` / ``modelcontextprotocol`` prefix.
+_MCP_SESSION_USER_ID_META_KEY = "nousresearch.hermes/user_id"
+
+
+def _resolve_session_user_id_meta_key(
+    server_name: str, config: Optional[dict]
+) -> str:
+    """Return the tools/call ``_meta`` key for this server's session user id.
+
+    Missing / blank config uses ``_MCP_SESSION_USER_ID_META_KEY``. Invalid
+    values (non-string, reserved MCP prefix) warn and fall back to the
+    default — they must never skip the identity or break the call.
+    """
+    raw = (config or {}).get("session_user_id_meta_key", _MCP_SESSION_USER_ID_META_KEY)
+    if not isinstance(raw, str) or not raw.strip():
+        if raw is not None:
+            logger.warning(
+                "MCP server '%s': session_user_id_meta_key must be a "
+                "non-empty string (got %r) — using default %s",
+                server_name, raw, _MCP_SESSION_USER_ID_META_KEY,
+            )
+        return _MCP_SESSION_USER_ID_META_KEY
+    key = raw.strip()
+    if _is_reserved_mcp_meta_key(key):
+        logger.warning(
+            "MCP server '%s': session_user_id_meta_key %r uses a reserved "
+            "MCP prefix — using default %s",
+            server_name, key, _MCP_SESSION_USER_ID_META_KEY,
+        )
+        return _MCP_SESSION_USER_ID_META_KEY
+    return key
+
+
+def _mcp_session_identity_meta(
+    server_name: str = "",
+    config: Optional[dict] = None,
+) -> Optional[Dict[str, str]]:
+    """Return tools/call ``meta`` for the current gateway session user.
+
+    Empty / unset session user → ``None`` so the on-wire request is
+    unchanged (CLI, cron, tests that never bound a session).
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except ImportError:
+        return None
+    user_id = (get_session_env("HERMES_SESSION_USER_ID", "") or "").strip()
+    if not user_id:
+        return None
+    key = _resolve_session_user_id_meta_key(server_name, config)
+    return {key: user_id}
+
+
+def _call_tool_accepts_meta(call_tool) -> bool:
+    """True when ``session.call_tool`` can take a ``meta`` kwarg."""
+    try:
+        params = inspect.signature(call_tool).parameters
+    except (TypeError, ValueError):
+        return True
+    if "meta" in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 def _make_redirect_header_stripper(
@@ -5781,7 +5851,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         f"reconnect requested. Do NOT retry this tool "
                         f"immediately — give it a few seconds to come back."
                     )
-                return tool_error(f"MCP server '{server_name}' is not connected")
+                    return tool_error(f"MCP server '{server_name}' is not connected")
+
+        # Snapshot on this thread: ``_run_on_mcp_loop`` does not copy
+        # gateway session ContextVars onto the MCP loop.
+        call_meta = _mcp_session_identity_meta(
+            server_name, getattr(server, "_config", None),
+        )
 
         async def _call():
             _mark_server_call_started(server)
@@ -5792,7 +5868,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    call_kwargs = {}
+                    if (
+                        call_meta is not None
+                        and _call_tool_accepts_meta(server.session.call_tool)
+                    ):
+                        call_kwargs["meta"] = call_meta
+                    result = await server.session.call_tool(
+                        tool_name, arguments=args, **call_kwargs
+                    )
                 finally:
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -354,9 +354,9 @@ mcp_servers:
 
 An explicit entry in the server's `headers` mapping with the same name (any casing) always wins; the identity header never overrides your own header config. Invalid `identity_header` blocks are warned about and ignored — they never block the server from connecting. On stdio servers the key is ignored with a warning (stdio transports have no headers).
 
-## Gateway session user on tools/call
+## Gateway session identity on tools/call
 
-Messaging-gateway sessions (Telegram, Discord, ...) can attach the current `source.user_id` to every MCP `tools/call` as `params._meta`, without putting it in the model-visible tool arguments. Configure the `_meta` key per server; the default is `nousresearch.hermes/user_id`:
+Messaging-gateway sessions (Telegram, Discord, ...) can attach the current qualified caller identity to every MCP `tools/call` as `params._meta`, without putting it in the model-visible tool arguments. The value is an object containing `platform`, `scope_id`, and `user_id`, so workspace- or server-local user IDs cannot collide across tenants. `scope_id` is an empty string on platforms whose user namespace is global. Configure the `_meta` key per server; the default is `nousresearch.hermes/user_id`:
 
 ```yaml
 mcp_servers:
@@ -365,7 +365,7 @@ mcp_servers:
     session_user_id_meta_key: "nousresearch.hermes/user_id"
 ```
 
-Omit the key to keep the default. Keys that use a reserved MCP prefix (`mcp` / `modelcontextprotocol` as a non-final label) are warned about and ignored. When no session user is bound (CLI, cron), `_meta` is omitted.
+Omit the key to keep the default. Keys that use a reserved MCP prefix (`mcp` / `modelcontextprotocol` as a non-final label) are warned about and ignored. When no complete gateway identity is bound (CLI, cron), `_meta` is omitted.
 
 ## Basic configuration reference
 
@@ -383,7 +383,7 @@ Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
 | `client_cert` | string \| list | Client certificate for mTLS — a combined PEM path, or `[cert, key]` / `[cert, key, password]` |
 | `client_key` | string | Client private-key PEM path (when separate from `client_cert`) |
 | `identity_header` | mapping | Optional per-user identity header for HTTP/SSE servers — `{name, value_from: static\|profile, value}` |
-| `session_user_id_meta_key` | string | `tools/call` `params._meta` key for the gateway session user id (default `nousresearch.hermes/user_id`) |
+| `session_user_id_meta_key` | string | `tools/call` `params._meta` key for the qualified gateway caller identity (default `nousresearch.hermes/user_id`) |
 | `timeout` | number | Tool call timeout |
 | `connect_timeout` | number | Initial connection timeout (also bounds the MCP `initialize` handshake) |
 | `idle_timeout_seconds` | number | Recycle a stdio server after this many seconds without a tool call (`0` = never, default). The server restarts transparently on the next tool call. |

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -354,6 +354,19 @@ mcp_servers:
 
 An explicit entry in the server's `headers` mapping with the same name (any casing) always wins; the identity header never overrides your own header config. Invalid `identity_header` blocks are warned about and ignored — they never block the server from connecting. On stdio servers the key is ignored with a warning (stdio transports have no headers).
 
+## Gateway session user on tools/call
+
+Messaging-gateway sessions (Telegram, Discord, ...) can attach the current `source.user_id` to every MCP `tools/call` as `params._meta`, without putting it in the model-visible tool arguments. Configure the `_meta` key per server; the default is `nousresearch.hermes/user_id`:
+
+```yaml
+mcp_servers:
+  team_api:
+    url: "https://mcp.team.example.com/mcp"
+    session_user_id_meta_key: "nousresearch.hermes/user_id"
+```
+
+Omit the key to keep the default. Keys that use a reserved MCP prefix (`mcp` / `modelcontextprotocol` as a non-final label) are warned about and ignored. When no session user is bound (CLI, cron), `_meta` is omitted.
+
 ## Basic configuration reference
 
 Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
@@ -370,6 +383,7 @@ Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
 | `client_cert` | string \| list | Client certificate for mTLS — a combined PEM path, or `[cert, key]` / `[cert, key, password]` |
 | `client_key` | string | Client private-key PEM path (when separate from `client_cert`) |
 | `identity_header` | mapping | Optional per-user identity header for HTTP/SSE servers — `{name, value_from: static\|profile, value}` |
+| `session_user_id_meta_key` | string | `tools/call` `params._meta` key for the gateway session user id (default `nousresearch.hermes/user_id`) |
 | `timeout` | number | Tool call timeout |
 | `connect_timeout` | number | Initial connection timeout (also bounds the MCP `initialize` handshake) |
 | `idle_timeout_seconds` | number | Recycle a stdio server after this many seconds without a tool call (`0` = never, default). The server restarts transparently on the next tool call. |


### PR DESCRIPTION
## What does this PR do?

Enterprise MCP applications need the current gateway user on every tool call so they can enforce per-user authorization. This PR snapshots `HERMES_SESSION_USER_ID` on the agent thread and attaches it to MCP `tools/call` as `params._meta`, with a per-server configurable key. It does not inject the id into model-visible tool arguments, and it does not put it on the shared HTTP client's default headers (those are connection-scoped and would mix users).

## Related Issue

Fixes #91426

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Tests (adding or improving test coverage)
- [x] Documentation update

## Changes Made

- `tools/mcp_tool.py`: snapshot gateway session user id before `_run_on_mcp_loop` and pass `session.call_tool(..., meta=...)` when a user is bound
- `mcp_servers.<name>.session_user_id_meta_key` configures the `_meta` key (default `nousresearch.hermes/user_id`); reserved MCP prefixes warn and fall back
- `tests/tools/test_mcp_session_identity_meta.py`: helper, default key, custom key, reserved-key fallback, handler include/omit
- `website/docs/user-guide/features/mcp.md` and `cli-config.yaml.example`: document the key

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_mcp_session_identity_meta.py` (or `python scripts/run_tests_parallel.py tests/tools/test_mcp_session_identity_meta.py` on native Windows)
2. In a gateway session, call any tool on an HTTP/stdio MCP server and confirm `params._meta` contains the Telegram/Discord user id under the configured key
3. From CLI with no session user bound, confirm `tools/call` is unchanged (no `meta`)
4. Set `session_user_id_meta_key: "caller-id"` on one server and confirm that key is used

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/tools/test_mcp_session_identity_meta.py` (Windows: `python scripts/run_tests_parallel.py tests/tools/test_mcp_session_identity_meta.py`) and the file passed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
