### PR TITLE
fix(desktop): allow deleting individual cron runs

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -20,6 +20,7 @@ import { notify, notifyError } from '@/store/notifications'
 import { $selectedStoredSessionId } from '@/store/session'
 import type { CronJob } from '@/types/hermes'
 
+import { CronRunRow } from '../../cron/cron-run-row'
 import { jobState, jobTitle, STATE_DOT } from '../../cron/job-state'
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
 
@@ -70,6 +71,8 @@ interface SidebarCronJobsSectionProps {
   jobs: CronJob[]
   label: string
   max?: number
+  // Delete one run's stored session through the shared session action path.
+  onDeleteRun: (sessionId: string, profile?: string) => Promise<boolean>
   // Open a run session's chat (1 click to output).
   onOpenRun: (sessionId: string) => void
   // Open the full Cron page focused on this job (manage / full history).
@@ -84,6 +87,7 @@ export function SidebarCronJobsSection({
   jobs,
   label,
   max = 50,
+  onDeleteRun,
   onManageJob,
   onOpenRun,
   onTriggerJob,
@@ -200,6 +204,7 @@ export function SidebarCronJobsSection({
               job={job}
               key={job.id}
               nowMs={nowMs}
+              onDeleteRun={onDeleteRun}
               onManage={() => onManageJob(job.id)}
               onOpenRun={onOpenRun}
               onTogglePeek={() => setPeekJobId(prev => (prev === job.id ? null : job.id))}
@@ -223,6 +228,7 @@ function CronJobSidebarRow({
   expanded,
   job,
   nowMs,
+  onDeleteRun,
   onManage,
   onOpenRun,
   onTogglePeek,
@@ -232,6 +238,7 @@ function CronJobSidebarRow({
   expanded: boolean
   job: CronJob
   nowMs: number
+  onDeleteRun: (sessionId: string, profile?: string) => Promise<boolean>
   onManage: () => void
   onOpenRun: (sessionId: string) => void
   onTogglePeek: () => void
@@ -377,12 +384,20 @@ function CronJobSidebarRow({
           </Tip>
         </SidebarRowShell>
       </ActionsContextMenu>
-      {expanded && <CronJobSidebarRuns jobId={job.id} onOpenRun={onOpenRun} />}
+      {expanded && <CronJobSidebarRuns jobId={job.id} onDeleteRun={onDeleteRun} onOpenRun={onOpenRun} />}
     </div>
   )
 }
 
-function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (sessionId: string) => void }) {
+function CronJobSidebarRuns({
+  jobId,
+  onDeleteRun,
+  onOpenRun
+}: {
+  jobId: string
+  onDeleteRun: (sessionId: string, profile?: string) => Promise<boolean>
+  onOpenRun: (sessionId: string) => void
+}) {
   const { t } = useI18n()
   const c = t.cron
   const selectedSessionId = useStore($selectedStoredSessionId)
@@ -445,19 +460,16 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
       ) : (
         <>
           {runs.map(run => (
-            <button
-              className={cn(
-                'truncate rounded-md px-1.5 py-0.5 text-left text-[0.6875rem] tabular-nums focus-visible:bg-(--chrome-action-hover) focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
-                run.id === selectedSessionId
-                  ? 'bg-(--ui-row-active-background) text-foreground'
-                  : 'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-foreground'
-              )}
+            <CronRunRow
+              active={run.id === selectedSessionId}
               key={run.id}
-              onClick={() => onOpenRun(run.id)}
-              type="button"
-            >
-              {formatRunTime(run.last_active || run.started_at)}
-            </button>
+              onDelete={onDeleteRun}
+              onDeleted={sessionId => setRuns(current => current?.filter(item => item.id !== sessionId) ?? [])}
+              onOpen={onOpenRun}
+              run={run}
+              time={formatRunTime(run.last_active || run.started_at)}
+              variant="sidebar"
+            />
           ))}
         </>
       )}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -297,7 +297,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onLoadMoreSessions: () => Promise<void> | void
   onLoadMoreMessaging?: (platform: string) => Promise<void> | void
   onResumeSession: (sessionId: string, session?: SessionInfo) => void
-  onDeleteSession: (sessionId: string) => void
+  onDeleteSession: (sessionId: string, profile?: string) => boolean | Promise<boolean | void> | void
   onArchiveSession: (sessionId: string) => void
   onBranchSession: (sessionId: string) => void
   onNewSessionInWorkspace: (path: null | string) => void
@@ -1874,6 +1874,7 @@ export function ChatSidebar({
               <SidebarCronJobsSection
                 jobs={cronJobs}
                 label={s.cronJobs}
+                onDeleteRun={async (sessionId, profile) => (await onDeleteSession(sessionId, profile)) !== false}
                 onManageJob={onManageCronJob}
                 onOpenRun={onResumeSession}
                 onToggle={() => setSidebarCronOpen(!cronOpen)}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -970,7 +970,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         void removeSession(id)
       }
     },
-    onDeleteSession: sessionId => void removeSession(sessionId),
+    onDeleteSession: (sessionId, profile) => removeSession(sessionId, profile),
     onDismissError: dismissError,
     onEdit: editMessage,
     onLoadMoreMessaging: loadMoreMessagingForPlatform,
@@ -1199,7 +1199,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           <CommandCenterView
             initialSection={commandCenterInitialSection}
             onClose={closeOverlayToPreviousRoute}
-            onDeleteSession={removeSession}
+            onDeleteSession={async sessionId => {
+              await removeSession(sessionId)
+            }}
             onNavigateRoute={path => navigateToWorkspacePage(navigate, path)}
             onOpenSession={sessionId => openSession(sessionId, navigate)}
           />
@@ -1216,6 +1218,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         <Suspense fallback={null}>
           <CronView
             onClose={closeOverlayToPreviousRoute}
+            onDeleteSession={removeSession}
             onOpenSession={sessionId => openSession(sessionId, navigate)}
           />
         </Suspense>

--- a/apps/desktop/src/app/cron/cron-run-row.test.tsx
+++ b/apps/desktop/src/app/cron/cron-run-row.test.tsx
@@ -40,6 +40,12 @@ function renderRow(variant: 'detail' | 'sidebar') {
 }
 
 describe('CronRunRow', () => {
+  it('names the sidebar run button with both its title and time', () => {
+    renderRow('sidebar')
+
+    expect(screen.getByRole('button', { name: 'Nightly report — Aug 21, 10:00' })).toBeTruthy()
+  })
+
   it.each(['detail', 'sidebar'] as const)(
     'deletes one %s run after confirmation and preserves its profile',
     async variant => {

--- a/apps/desktop/src/app/cron/cron-run-row.test.tsx
+++ b/apps/desktop/src/app/cron/cron-run-row.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { makeSessionInfo } from '@/test/session-info'
+
+import { CronRunRow } from './cron-run-row'
+
+afterEach(cleanup)
+
+function openActions() {
+  const trigger = screen.getByRole('button', { name: 'Session actions' })
+
+  fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+  fireEvent.click(trigger)
+}
+
+function renderRow(variant: 'detail' | 'sidebar') {
+  const onDelete = vi.fn().mockResolvedValue(true)
+  const onDeleted = vi.fn()
+  const onOpen = vi.fn()
+  const run = makeSessionInfo({ id: 'cron-run-1', profile: 'work', title: 'Nightly report' })
+
+  render(
+    <I18nProvider configClient={null}>
+      <CronRunRow
+        active={variant === 'sidebar'}
+        onDelete={onDelete}
+        onDeleted={onDeleted}
+        onOpen={onOpen}
+        run={run}
+        time="Aug 21, 10:00"
+        variant={variant}
+      />
+    </I18nProvider>
+  )
+
+  return { onDelete, onDeleted, onOpen }
+}
+
+describe('CronRunRow', () => {
+  it.each(['detail', 'sidebar'] as const)(
+    'deletes one %s run after confirmation and preserves its profile',
+    async variant => {
+      const { onDelete, onDeleted } = renderRow(variant)
+
+      openActions()
+      fireEvent.click(await screen.findByRole('menuitem', { name: 'Delete' }))
+
+      const dialog = await screen.findByRole('dialog')
+      expect(within(dialog).getByText(/Nightly report/)).toBeTruthy()
+      expect(onDelete).not.toHaveBeenCalled()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+      expect(await screen.findByText('Session deleted')).toBeTruthy()
+      expect(onDelete).toHaveBeenCalledWith('cron-run-1', 'work')
+      expect(onDeleted).toHaveBeenCalledWith('cron-run-1')
+    }
+  )
+
+  it('keeps the row when session deletion reports failure', async () => {
+    const { onDelete, onDeleted } = renderRow('detail')
+    onDelete.mockResolvedValue(false)
+
+    openActions()
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Delete' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete' }))
+
+    expect(await screen.findByText('Delete failed')).toBeTruthy()
+    expect(onDeleted).not.toHaveBeenCalled()
+    expect(screen.getByText('Nightly report')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/cron/cron-run-row.tsx
+++ b/apps/desktop/src/app/cron/cron-run-row.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+
+import { PanelListRow, type PanelMenuItem, PanelRowMenu } from '@/app/overlays/panel'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+import type { SessionInfo } from '@/types/hermes'
+
+interface CronRunRowProps {
+  active?: boolean
+  onDelete: (sessionId: string, profile?: string) => Promise<boolean>
+  onDeleted: (sessionId: string) => void
+  onOpen: (sessionId: string) => void
+  run: SessionInfo
+  time: string
+  variant: 'detail' | 'sidebar'
+}
+
+function runTitle(run: SessionInfo): string {
+  return run.title?.trim() || run.preview?.trim() || run.id
+}
+
+/**
+ * One cron-run row for both run-history surfaces. Cron runs are stored sessions,
+ * so deletion deliberately goes through the app's session action instead of
+ * issuing a second REST path here. The caller removes the row only after that
+ * action reports success.
+ */
+export function CronRunRow({ active = false, onDelete, onDeleted, onOpen, run, time, variant }: CronRunRowProps) {
+  const { t } = useI18n()
+  const copy = t.sidebar.row
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const title = runTitle(run)
+
+  const menuItems: PanelMenuItem[] = [
+    {
+      icon: 'trash',
+      label: t.common.delete,
+      onSelect: () => setDeleteOpen(true),
+      tone: 'danger'
+    }
+  ]
+
+  const confirmDelete = async () => {
+    const deleted = await onDelete(run.id, run.profile ?? undefined)
+
+    if (!deleted) {
+      throw new Error(t.desktop.deleteFailed)
+    }
+
+    onDeleted(run.id)
+  }
+
+  return (
+    <>
+      {variant === 'detail' ? (
+        <PanelListRow
+          active={false}
+          menuItems={menuItems}
+          menuLabel={t.sidebar.row.sessionActions}
+          meta={time}
+          onSelect={() => onOpen(run.id)}
+          rowKey={run.id}
+          title={title}
+        />
+      ) : (
+        <div
+          className={cn(
+            'group/row flex min-w-0 items-center rounded-md focus-within:ring-2 focus-within:ring-ring/40',
+            active ? 'bg-(--ui-row-active-background) text-foreground' : 'text-(--ui-text-secondary)'
+          )}
+        >
+          <button
+            className="min-w-0 flex-1 truncate rounded-md px-1.5 py-0.5 text-left text-[0.6875rem] tabular-nums hover:bg-(--chrome-action-hover) hover:text-foreground focus-visible:bg-(--chrome-action-hover) focus-visible:text-foreground focus-visible:outline-none"
+            onClick={() => onOpen(run.id)}
+            type="button"
+          >
+            {time}
+          </button>
+          <div className="shrink-0 pr-0.5">
+            <PanelRowMenu items={menuItems} label={t.sidebar.row.sessionActions} />
+          </div>
+        </div>
+      )}
+
+      <ConfirmDialog
+        busyLabel={copy.deleting}
+        confirmLabel={t.common.delete}
+        description={copy.deleteDesc(title)}
+        destructive
+        doneLabel={copy.deleted}
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={confirmDelete}
+        open={deleteOpen}
+        title={copy.deleteTitle}
+      />
+    </>
+  )
+}

--- a/apps/desktop/src/app/cron/cron-run-row.tsx
+++ b/apps/desktop/src/app/cron/cron-run-row.tsx
@@ -71,6 +71,7 @@ export function CronRunRow({ active = false, onDelete, onDeleted, onOpen, run, t
           )}
         >
           <button
+            aria-label={`${title} — ${time}`}
             className="min-w-0 flex-1 truncate rounded-md px-1.5 py-0.5 text-left text-[0.6875rem] tabular-nums hover:bg-(--chrome-action-hover) hover:text-foreground focus-visible:bg-(--chrome-action-hover) focus-visible:text-foreground focus-visible:outline-none"
             onClick={() => onOpen(run.id)}
             type="button"

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -82,6 +82,7 @@ import {
   toggleCronDeliveryTarget,
   validateCronEditor
 } from './cron-job-model'
+import { CronRunRow } from './cron-run-row'
 import { jobState, jobTitle, STATE_DOT } from './job-state'
 
 const DEFAULT_DELIVER = 'local'
@@ -291,11 +292,17 @@ function matchesQuery(job: CronJob, q: string): boolean {
 
 interface CronViewProps extends React.ComponentProps<'section'> {
   onClose: () => void
+  onDeleteSession: (sessionId: string, profile?: string) => Promise<boolean>
   onOpenSession?: (sessionId: string) => void
   setStatusbarItemGroup?: SetStatusbarItemGroup
 }
 
-export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setStatusbarItemGroup }: CronViewProps) {
+export function CronView({
+  onClose,
+  onDeleteSession,
+  onOpenSession,
+  setStatusbarItemGroup: _setStatusbarItemGroup
+}: CronViewProps) {
   const { t } = useI18n()
   const c = t.cron
   // Source of truth is the shared atom (also fed by the controller poll), so the
@@ -701,6 +708,7 @@ export function CronView({ onClose, onOpenSession, setStatusbarItemGroup: _setSt
               busy={busyJobTokens.has(selectedJob.id) || triggeringJobKeys.has(`${profile}:${selectedJob.id}`)}
               c={c}
               job={selectedJob}
+              onDeleteSession={onDeleteSession}
               onOpenSession={onOpenSession}
               onPauseResume={() => void handlePauseResume(selectedJob)}
               onTrigger={() => void handleTrigger(selectedJob)}
@@ -781,6 +789,7 @@ function CronJobDetail({
   busy,
   c,
   job,
+  onDeleteSession,
   onOpenSession,
   onPauseResume,
   onTrigger
@@ -788,6 +797,7 @@ function CronJobDetail({
   busy: boolean
   c: Translations['cron']
   job: CronJob
+  onDeleteSession: (sessionId: string, profile?: string) => Promise<boolean>
   onOpenSession?: (sessionId: string) => void
   onPauseResume: () => void
   onTrigger: () => void
@@ -841,7 +851,7 @@ function CronJobDetail({
         </section>
       ) : null}
 
-      <CronJobRuns c={c} jobId={job.id} onOpenSession={onOpenSession} />
+      <CronJobRuns c={c} jobId={job.id} onDeleteSession={onDeleteSession} onOpenSession={onOpenSession} />
     </PanelDetail>
   )
 }
@@ -866,10 +876,12 @@ const RUNS_BACKSTOP_INTERVAL_MS = 60_000
 function CronJobRuns({
   c,
   jobId,
+  onDeleteSession,
   onOpenSession
 }: {
   c: Translations['cron']
   jobId: string
+  onDeleteSession: (sessionId: string, profile?: string) => Promise<boolean>
   onOpenSession?: (sessionId: string) => void
 }) {
   const [runs, setRuns] = useState<null | SessionInfo[]>(null)
@@ -934,17 +946,15 @@ function CronJobRuns({
       ) : (
         <div className="flex flex-col gap-px">
           {runs.map(run => (
-            <button
-              className="row-hover flex items-center justify-between gap-3 rounded-md px-2 py-1 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            <CronRunRow
               key={run.id}
-              onClick={() => onOpenSession?.(run.id)}
-              type="button"
-            >
-              <span className="truncate text-foreground/85">{run.title?.trim() || run.preview?.trim() || run.id}</span>
-              <span className="shrink-0 text-[0.62rem] text-muted-foreground/55 tabular-nums">
-                {formatRunTime(run.last_active || run.started_at)}
-              </span>
-            </button>
+              onDelete={onDeleteSession}
+              onDeleted={sessionId => setRuns(current => current?.filter(item => item.id !== sessionId) ?? [])}
+              onOpen={sessionId => onOpenSession?.(sessionId)}
+              run={run}
+              time={formatRunTime(run.last_active || run.started_at)}
+              variant="detail"
+            />
           ))}
         </div>
       )}

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2109,7 +2109,7 @@ export function useSessionActions({
   )
 
   const removeSession = useCallback(
-    async (storedSessionId: string) => {
+    async (storedSessionId: string, explicitProfile?: string): Promise<boolean> => {
       clearNotifications()
 
       // The row may live in the main list, the messaging/cron sidebar slices,
@@ -2125,8 +2125,9 @@ export function useSessionActions({
       // Messaging/cron rows frequently arrive without an inline profile; fall
       // back to the stored-session ownership lookup so their DELETE routes to
       // the owning profile instead of the ambient one.
+      const requestedProfile = explicitProfile?.trim()
       const stampedProfile = removed?.profile?.trim()
-      const profile = stampedProfile || (await resolveSessionProfile(storedSessionId))
+      const profile = requestedProfile || stampedProfile || (await resolveSessionProfile(storedSessionId))
 
       // Listed profile-less row + multiple profiles + unresolved owner:
       // never fall through to the primary backend (fake already_absent).
@@ -2138,7 +2139,7 @@ export function useSessionActions({
       ) {
         notifyError(new Error('Session ownership could not be resolved'), copy.deleteFailed)
 
-        return
+        return false
       }
 
       const wasSelected = selectedStoredSessionId === storedSessionId
@@ -2205,6 +2206,8 @@ export function useSessionActions({
           sessionStateByRuntimeIdRef.current.delete(tiledRuntimeId)
           dropSessionState(tiledRuntimeId)
         }
+
+        return true
       } catch (err) {
         if (listed?.session) {
           restoreListedSession(listed.session, listed.slice)
@@ -2236,6 +2239,8 @@ export function useSessionActions({
         }
 
         notifyError(err, copy.deleteFailed)
+
+        return false
       } finally {
         // Release the tombstone to the normal projects.tree prune now the RPC has
         // settled (kept on success — the backend has deleted it; cleared on the

--- a/apps/desktop/src/app/session/hooks/use-session-actions/remove-archived-session.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/remove-archived-session.test.tsx
@@ -10,7 +10,7 @@ import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { deleteSession, type SessionInfo } from '@/hermes'
-import { setSessions } from '@/store/session'
+import { $cronSessions, setSessions } from '@/store/session'
 import { $archivedSessions } from '@/store/sidebar-archive'
 
 import type { ClientSessionState } from '../../../types'
@@ -95,6 +95,7 @@ async function mountHarness(): Promise<Handle> {
 describe('removeSession × archived view store', () => {
   beforeEach(() => {
     setSessions([])
+    $cronSessions.set([])
     $archivedSessions.set([])
     vi.mocked(deleteSession).mockReset()
   })
@@ -102,6 +103,7 @@ describe('removeSession × archived view store', () => {
   afterEach(() => {
     cleanup()
     setSessions([])
+    $cronSessions.set([])
     $archivedSessions.set([])
   })
 
@@ -137,5 +139,28 @@ describe('removeSession × archived view store', () => {
     await act(() => handle.removeSession('arch-1'))
 
     expect(vi.mocked(deleteSession)).toHaveBeenCalledWith('arch-1', 'sage')
+  })
+
+  it('evicts a cron run from its dedicated store and passes its explicit profile', async () => {
+    $cronSessions.set([archivedSession({ archived: false, id: 'cron-run-1', source: 'cron' })])
+    vi.mocked(deleteSession).mockResolvedValue({ ok: true })
+
+    const handle = await mountHarness()
+    const deleted = await act(() => handle.removeSession('cron-run-1', 'work'))
+
+    expect(deleted).toBe(true)
+    expect(vi.mocked(deleteSession)).toHaveBeenCalledWith('cron-run-1', 'work')
+    expect($cronSessions.get()).toEqual([])
+  })
+
+  it('restores a cron run when the delete RPC fails', async () => {
+    $cronSessions.set([archivedSession({ archived: false, id: 'cron-run-1', source: 'cron' })])
+    vi.mocked(deleteSession).mockRejectedValue(new Error('backend down'))
+
+    const handle = await mountHarness()
+    const deleted = await act(() => handle.removeSession('cron-run-1', 'work'))
+
+    expect(deleted).toBe(false)
+    expect($cronSessions.get().map(session => session.id)).toEqual(['cron-run-1'])
   })
 })


### PR DESCRIPTION
## What does this PR do?

Adds a destructive action for deleting an individual cron run session from both Desktop surfaces that list runs: the chat sidebar and **Cron Jobs → Run history**.

The implementation reuses the existing session-deletion path rather than introducing cron-specific backend semantics. It forwards the run's profile explicitly, waits for deletion to succeed before removing the local history row, and restores optimistic session-store state when deletion fails. The cron job and every other run are left untouched.

## Related Issue

Fixes #91386

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `apps/desktop/src/app/cron/cron-run-row.tsx`, a shared run row with the standard destructive menu action and confirmation dialog.
- Reused that row in `apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx` and `apps/desktop/src/app/cron/index.tsx` so both surfaces expose the same delete behavior.
- Made `removeSession` awaitable and profile-aware for run-history rows fetched outside the main session store.
- Evicted deleted runs from the cron session store, with rollback on API failure, while preserving the cron job and sibling runs.
- Gave sidebar run buttons an accessible name combining the run title and rendered time.
- Added regression coverage for accessible naming, confirmation, profile forwarding, successful removal, and failed-delete restoration.

## How to Test

1. Open a cron job with multiple completed runs in the chat sidebar and in **Cron Jobs → Run history**.
2. Open one run's actions menu, choose **Delete**, and cancel the confirmation; verify nothing changes.
3. Confirm deletion; verify only the selected run disappears, the cron job and sibling runs remain, and deleting a run from another profile routes through that profile.
4. Simulate a rejected delete request and verify the row remains/restores instead of disappearing falsely.

Automated verification performed:

- Desktop renderer, Electron, and E2E TypeScript project checks: passed.
- `npx vitest run --project ui src/app/cron/cron-run-row.test.tsx src/app/session/hooks/use-session-actions/remove-archived-session.test.tsx src/app/cron/cron-actions.test.ts src/app/contrib/latest-actions.test.ts src/app/contrib/surfaces.test.tsx`: 24/24 passed.
- `npm run test:ui`: 5,348/5,348 passed across 558 files.
- `npm run build`: passed, including Electron main/preload bundles and native dependency staging.
- `npm run lint`: 0 errors (the repository currently reports 120 pre-existing warnings).
- `python3 scripts/check-windows-footguns.py --diff origin/main`: passed; no relevant OS-sensitive files in this diff.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run because this is a Desktop TypeScript-only change; the complete Desktop UI suite passed instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 Linux (TypeScript checks, full Desktop UI suite, lint, and production build)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no documented behavior or public API changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific APIs or file/process behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool behavior changed

## Screenshots / Logs

No screenshot attached; the interaction uses existing Desktop row-menu and confirmation-dialog primitives. The automated results above cover both row variants and deletion state handling.
