### PR TITLE
feat(slack): add per-message !ignore escape hatch

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -407,6 +407,54 @@ def _slack_mention_detection_text(event: dict) -> str:
     return (flat.strip() + "\n" + " ".join(extra)).strip()
 
 
+def _leading_bang_command_name(text: str) -> str:
+    """Return the first leading ``!cmd`` token, or ``""`` if none.
+
+    Mirrors the Slack thread ``!cmd`` convention: only the first token is
+    considered, after optional composer whitespace and a leading bot mention.
+    Mid-message ``!ignore`` / ``!stop`` is not a command.
+    """
+    if not text:
+        return ""
+    probe = text.lstrip()
+    if not probe.startswith("!"):
+        return ""
+    rest = probe[1:]
+    if not rest:
+        return ""
+    first_token = rest.split(maxsplit=1)[0]
+    cmd_name = first_token.split("@", 1)[0].lower()
+    if not cmd_name or "/" in cmd_name:
+        return ""
+    return cmd_name
+
+
+def _strip_leading_slack_bot_mention(text: str, bot_user_ids: list[str] | None) -> str:
+    """Strip a leading ``<@BOT>`` mention so ``@Hermes !cmd`` can be probed."""
+    if not text or not bot_user_ids:
+        return text
+    probe = text.lstrip()
+    for uid in bot_user_ids:
+        if not uid:
+            continue
+        mention = f"<@{uid}>"
+        if probe.startswith(mention):
+            return probe[len(mention) :].lstrip()
+    return text
+
+
+def _is_slack_ignore_command(text: str, bot_user_ids: list[str] | None = None) -> bool:
+    """True when this Slack event is a per-message ``!ignore`` escape hatch.
+
+    Slack-only admission control — not a registered gateway command. Registering
+    ``ignore`` would publish a native ``/ignore`` slash (which cannot carry the
+    original channel message) and would dispatch too late to skip reactions,
+    session create/resume, and queue/steer.
+    """
+    probe = _strip_leading_slack_bot_mention(text, bot_user_ids)
+    return _leading_bang_command_name(probe) == "ignore"
+
+
 def _rewrite_known_bang_command(text: str) -> str:
     """Rewrite a known leading ``!cmd`` to the gateway ``/cmd`` form."""
     if not text.startswith("!"):
@@ -415,9 +463,8 @@ def _rewrite_known_bang_command(text: str) -> str:
     try:
         from hermes_cli.commands import is_gateway_known_command
 
-        first_token = text[1:].split(maxsplit=1)[0]
-        cmd_name = first_token.split("@", 1)[0].lower()
-        if cmd_name and "/" not in cmd_name and is_gateway_known_command(cmd_name):
+        cmd_name = _leading_bang_command_name(text)
+        if cmd_name and is_gateway_known_command(cmd_name):
             return "/" + text[1:]
     except Exception:  # pragma: no cover - defensive
         pass
@@ -5868,6 +5915,20 @@ class SlackAdapter(BasePlatformAdapter):
             return
 
         original_text = event.get("text", "")
+
+        # Per-message Slack escape hatch: drop this event only. Checked
+        # before bang rewrite, mention/thread routing, session lookup,
+        # reactions, and handle_message so nothing stateful happens.
+        # Not registered in COMMAND_REGISTRY — see _is_slack_ignore_command.
+        ignore_bot_ids = [self._bot_user_id, *self._team_bot_user_ids.values()]
+        if _is_slack_ignore_command(original_text, ignore_bot_ids):
+            logger.debug(
+                "[Slack] Dropping event due to !ignore escape hatch: "
+                "channel=%s ts=%s",
+                channel_id,
+                event.get("ts", ""),
+            )
+            return
 
         # Slack blocks native slash commands inside threads ("/queue is not
         # supported in threads. Sorry!").  As a workaround, recognise a

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1483,6 +1483,191 @@ class TestBangPrefixCommands:
 
 
 # ---------------------------------------------------------------------------
+# TestSlackIgnoreEscapeHatch
+# ---------------------------------------------------------------------------
+
+
+class TestSlackIgnoreEscapeHatch:
+    """``!ignore`` is a Slack-only per-event drop, not a gateway command."""
+
+    def _make_event(self, text, thread_ts=None, channel_type="im", channel="D123"):
+        evt = {
+            "text": text,
+            "user": "U_USER",
+            "channel": channel,
+            "channel_type": channel_type,
+            "ts": "1234567890.000001",
+        }
+        if thread_ts:
+            evt["thread_ts"] = thread_ts
+        return evt
+
+    def _spy_downstream(self, adapter):
+        adapter._register_mentioned_thread = MagicMock(
+            wraps=adapter._register_mentioned_thread
+        )
+        adapter._has_active_session_for_thread = MagicMock(return_value=True)
+        adapter._fetch_thread_context = AsyncMock(
+            return_value="[Slack thread context] should never be fetched"
+        )
+        adapter._add_reaction = AsyncMock()
+        return adapter
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "!ignore",
+            "!ignore this is for Alex",
+            "!IGNORE hello",
+            "!Ignore hello",
+            "  !ignore leading space",
+            "<@U_BOT> !ignore mentioned form",
+        ],
+    )
+    def test_ignore_token_matches(self, text):
+        assert _slack_mod._is_slack_ignore_command(text, ["U_BOT"]) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "!ignored hello",
+            "!ignorethis",
+            "hello !ignore",
+            "/ignore hello",
+            "!stop",
+            "!queue later",
+            "",
+        ],
+    )
+    def test_ignore_token_does_not_match(self, text):
+        assert _slack_mod._is_slack_ignore_command(text, ["U_BOT"]) is False
+
+    @pytest.mark.asyncio
+    async def test_ignore_in_engaged_thread_does_not_dispatch(self, adapter):
+        """Primary case: human-only reply in an already-followed thread."""
+        self._spy_downstream(adapter)
+        adapter._mentioned_threads.add("1111111111.000001")
+
+        await adapter._handle_slack_message(
+            self._make_event(
+                "!ignore this is for Alex",
+                thread_ts="1111111111.000001",
+                channel_type="channel",
+                channel="C123",
+            )
+        )
+
+        adapter.handle_message.assert_not_called()
+        adapter._has_active_session_for_thread.assert_not_called()
+        adapter._fetch_thread_context.assert_not_awaited()
+        adapter._register_mentioned_thread.assert_not_called()
+        adapter._add_reaction.assert_not_awaited()
+        assert adapter._reacting_message_ids == set()
+        assert "1111111111.000001" in adapter._mentioned_threads
+
+    @pytest.mark.asyncio
+    async def test_ignore_while_session_active_does_not_dispatch(self, adapter):
+        """Must not become queued / steer / interrupt input for a running turn."""
+        self._spy_downstream(adapter)
+        adapter._mentioned_threads.add("1111111111.000001")
+
+        await adapter._handle_slack_message(
+            self._make_event(
+                "!IGNORE hello",
+                thread_ts="1111111111.000001",
+                channel_type="channel",
+                channel="C123",
+            )
+        )
+
+        adapter.handle_message.assert_not_called()
+        adapter._has_active_session_for_thread.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ignore_does_not_create_or_register_a_session(self, adapter):
+        """Cold start: !ignore must not wake a new session or remember the thread."""
+        self._spy_downstream(adapter)
+        adapter._has_active_session_for_thread = MagicMock(return_value=False)
+
+        await adapter._handle_slack_message(
+            self._make_event(
+                "<@U_BOT> !ignore do not start work",
+                thread_ts="1111111111.000001",
+                channel_type="channel",
+                channel="C123",
+            )
+        )
+
+        adapter.handle_message.assert_not_called()
+        adapter._register_mentioned_thread.assert_not_called()
+        adapter._fetch_thread_context.assert_not_awaited()
+        adapter._has_active_session_for_thread.assert_not_called()
+        assert adapter._mentioned_threads == set()
+
+    @pytest.mark.asyncio
+    async def test_ignored_does_not_trigger_ignore(self, adapter):
+        adapter._mentioned_threads.add("1111111111.000001")
+
+        await adapter._handle_slack_message(
+            self._make_event(
+                "!ignored hello",
+                thread_ts="1111111111.000001",
+                channel_type="channel",
+                channel="C123",
+            )
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.await_args.args[0]
+        assert msg_event.text == "!ignored hello"
+        assert msg_event.message_type == MessageType.TEXT
+
+    def test_ignore_is_not_a_native_slack_slash(self):
+        from hermes_cli.commands import slack_native_slashes
+
+        names = {name for name, _, _ in slack_native_slashes()}
+        assert "ignore" not in names
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "text,command",
+        [
+            ("!stop", "stop"),
+            ("!queue later", "queue"),
+            ("!steer go left", "steer"),
+        ],
+    )
+    async def test_existing_bang_commands_still_dispatch(self, adapter, text, command):
+        await adapter._handle_slack_message(
+            self._make_event(text, thread_ts="1111111111.000001")
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.await_args.args[0]
+        assert msg_event.message_type == MessageType.COMMAND
+        assert msg_event.get_command() == command
+        assert msg_event.text.startswith(f"/{command}")
+
+    @pytest.mark.asyncio
+    async def test_normal_thread_followup_still_dispatches(self, adapter):
+        adapter._mentioned_threads.add("1111111111.000001")
+
+        await adapter._handle_slack_message(
+            self._make_event(
+                "can you check the env var too?",
+                thread_ts="1111111111.000001",
+                channel_type="channel",
+                channel="C123",
+            )
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.await_args.args[0]
+        assert msg_event.text == "can you check the env var too?"
+        assert msg_event.message_type == MessageType.TEXT
+
+
+# ---------------------------------------------------------------------------
 # TestIncomingDocumentHandling
 # ---------------------------------------------------------------------------
 

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -219,7 +219,7 @@ Commands support prefix matching: typing `/h` resolves to `/help`, `/mod` resolv
 ## Messaging slash commands
 
 > **Slack thread commands (`!` prefix):**
-> Slack itself blocks native slash commands inside message threads ("/queue is not supported in threads. Sorry!") and never delivers them to Hermes. Inside a Slack thread, use the `!` prefix instead — `!stop`, `!new`, `!status` — and the gateway dispatches it exactly like the slash form. `@Hermes !stop` and `@Hermes /stop` work in threads too. Only the first token is checked against the known command list, so messages like `!nice work` pass through to the agent unchanged. See [Using commands inside threads](/user-guide/messaging/slack#using-commands-inside-threads-the-cmd-prefix) for details.
+> Slack itself blocks native slash commands inside message threads ("/queue is not supported in threads. Sorry!") and never delivers them to Hermes. Inside a Slack thread, use the `!` prefix instead — `!stop`, `!new`, `!status` — and the gateway dispatches it exactly like the slash form. `@Hermes !stop` and `@Hermes /stop` work in threads too. Only the first token is checked against the known command list, so messages like `!nice work` pass through to the agent unchanged. Slack also accepts `!ignore` as a per-message admission hatch (the event is dropped; it is not a registered `/ignore` slash). See [Using commands inside threads](/user-guide/messaging/slack#using-commands-inside-threads-the-cmd-prefix) for details.
 
 The messaging gateway supports the following built-in commands inside Telegram, Discord, Slack, WhatsApp, Signal, Email, Home Assistant, and Teams chats:
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -323,6 +323,30 @@ casual messages like `!nice work` pass through to the agent unchanged.
 The bang form also works behind a mention (`@Hermes !stop`) and with
 leading whitespace — both dispatch as commands in threads.
 
+### Ignoring a single message (`!ignore`)
+
+Prefix a thread message with `!ignore` when the message is intended
+only for the human participants. Hermes silently drops that individual
+event without changing the thread's ongoing engagement state.
+
+```text
+!ignore Alex, I think the issue is actually in the auth middleware.
+```
+
+The Slack message stays visible to everyone. Hermes does not process
+it, react to it, queue it, steer an active run, or reply. The next
+ordinary message in the same thread still follows normal engagement.
+
+This is different from workspace/thread routing config:
+
+- `thread_require_mention` — requires an @mention on **every** thread reply
+- `strict_mention` — requires a fresh @mention on **every** channel message
+- `!ignore` — a one-message escape hatch; later messages are unchanged
+
+`!ignore` is Slack-only and is **not** a registered `/ignore` slash
+command. Slack never delivers native slash-command text as the original
+channel message, so a slash form could not serve this purpose.
+
 Approval prompts (dangerous command / `execute_code` approval) normally
 render as interactive buttons. When buttons can't be delivered and
 Hermes falls back to a text prompt, the prompt instructs you to reply


### PR DESCRIPTION
## Summary

Engaged Slack threads intentionally auto-follow after Hermes is mentioned. That is the right default, but it leaves no way to send a single human-only message in the same thread without changing workspace/thread routing config.

This adds a Slack-only per-message escape hatch: prefix a message with `!ignore` and Hermes drops that one event. Later messages in the thread still follow the existing engagement rules.

## Behavior

```text
!ignore Alex, can you check the deployment logs?
```

The Slack message stays visible to humans. Hermes silently drops the event: no LLM turn, no session create/resume, no queue/steer/interrupt, no 👀 / completion reaction, and no "Ignored" confirmation.

`!ignore`, `!IGNORE hello`, and `@Hermes !ignore …` match. Token boundaries are preserved (`!ignored` / `!ignorethis` / mid-message `hello !ignore` do not). Existing thread aliases (`!stop`, `!queue`, `!steer`) are unchanged.

## Why not strict_mention / thread_require_mention?

Those options change routing policy for an entire workspace or every thread reply. `!ignore` is explicitly a single-event hatch: the next ordinary message still wakes Hermes if thread-follow would have woken it before.

## Implementation

Option A (Slack transport escape hatch), not `COMMAND_REGISTRY`.

The drop happens in `SlackAdapter._handle_slack_message` immediately after identity/channel/bot filters and **before** bang rewrite, mention/thread routing, session lookup, reaction bookkeeping, and `handle_message`.

`ignore` is not registered as a gateway command because:

- `slack_native_slashes()` would publish a native `/ignore` slash, and Slack slash-command text is not the original channel message.
- Gateway command dispatch is too late to guarantee no reactions, session mutations, or busy-path queue/steer.

## Tests

`TestSlackIgnoreEscapeHatch` in `tests/gateway/test_slack.py` covers:

- ignored message in an already-engaged thread
- ignored message while a thread session is active (no dispatch / no session probe)
- no session/thread registration on a cold-start `!ignore`
- no processing-reaction bookkeeping
- case-insensitive `!IGNORE`
- token boundary (`!ignored` still reaches the agent)
- existing `!stop` / `!queue` / `!steer`
- normal unprefixed thread follow-up unchanged
- `ignore` is not published as a native Slack slash

```bash
scripts/run_tests.sh tests/gateway/test_slack.py -k "TestSlackIgnoreEscapeHatch or TestBangPrefixCommands"
scripts/run_tests.sh tests/gateway/test_slack.py
```