### PR TITLE
fix(gateway): do not --replace-kill a sibling profile's token lock

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3527,10 +3527,10 @@ class BasePlatformAdapter(ABC):
     def _acquire_platform_lock(self, scope: str, identity: str, resource_desc: str) -> bool:
         """Acquire a scoped lock for this adapter. Returns True on success.
 
-        A live cross-HERMES_HOME holder may be replaced only when the runner
-        explicitly arms this adapter for its initial ``--replace`` connect.
-        The status module validates PID/start-time/home ownership, places the
-        marker in the target's home, and performs the bounded termination.
+        When the runner arms this adapter for its initial ``--replace``
+        connect, a leftover *same-HERMES_HOME* holder may be terminated.
+        A live holder in another HERMES_HOME is a config conflict: the
+        lock stays retryable and that sibling is not SIGTERM'd (#88521).
         """
         from gateway.status import (
             acquire_scoped_lock,

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -631,9 +631,11 @@ def _build_pid_record() -> dict:
         "argv": list(sys.argv),
         "start_time": _get_process_start_time(os.getpid()),
         # Scoped credential locks are machine-global rather than
-        # HERMES_HOME-local.  Persist the owning gateway's process home so an
-        # explicit cross-profile --replace can place its planned-takeover
-        # marker where the target process will actually read it.
+        # HERMES_HOME-local.  Persist the owning gateway's process home so
+        # conflict errors can name the holder and same-home ``--replace``
+        # can place its planned-takeover marker where that process will
+        # actually read it.  A live sibling profile (different home) is
+        # never SIGTERM'd for the token — that is a config conflict (#88521).
         "hermes_home": str(_canonical_hermes_home(_get_process_hermes_home())),
     }
 
@@ -2074,23 +2076,34 @@ def take_over_scoped_lock_holder(
     graceful_attempts: int = 20,
     force_attempts: int = 20,
 ) -> Optional[int]:
-    """Terminate one verified scoped-lock holder for explicit ``--replace``.
+    """Terminate one verified same-home scoped-lock holder for ``--replace``.
 
     Returns the original owner PID only after that exact PID/start-time identity
-    has exited (or ``terminate_pid`` reports it already gone).  Validation or
-    marker-write failure returns ``None`` without signalling anything.  This is
-    deliberately stricter than the same-home PID-file replacement path: a
-    cross-home handoff must place a consumable marker in the target's home or a
-    service supervisor could revive the target and start a flap loop.
+    has exited (or ``terminate_pid`` reports it already gone).  Validation
+    failure, a live holder in a *different* HERMES_HOME, or marker-write
+    failure returns ``None`` without signalling anything.
 
-    On POSIX, after the owner is confirmed dead, its previously snapshotted
-    child processes are reaped best-effort (see :func:`reap_gateway_children`)
-    so orphaned adapter subprocesses cannot keep holding token locks.
+    Token locks are machine-global, so two profiles can claim the same bot
+    token.  ``--replace`` may reap a leftover process of *this* profile
+    (same HERMES_HOME) that still holds the lock; it must not SIGTERM a live
+    sibling profile.  Docker s6 starts every profile with ``--replace``, and
+    killing the sibling starts a supervisor flap that also reaps cron
+    children (#88521).  The caller then takes the retryable lock-conflict
+    path.
+
+    On POSIX, after a same-home owner is confirmed dead, its previously
+    snapshotted child processes are reaped best-effort
+    (see :func:`reap_gateway_children`) so orphaned adapter subprocesses
+    cannot keep holding token locks.
     """
     owner = _validated_scoped_lock_gateway_owner(record)
     if owner is None:
         return None
     owner_pid, owner_start_time, target_home = owner
+
+    # Live sibling profile: config conflict, not a stale same-slot holder.
+    if not _same_hermes_home(target_home, _get_process_hermes_home()):
+        return None
 
     # Snapshot descendants while the owner is still alive — after it exits
     # they are reparented and undiscoverable (POSIX; [] on Windows where

--- a/tests/gateway/test_replace_child_reap.py
+++ b/tests/gateway/test_replace_child_reap.py
@@ -115,11 +115,10 @@ class TestScopedLockTakeoverReapsChildren:
         return record
 
     def _verified_owner_env(self, tmp_path, monkeypatch, *, alive_polls):
-        replacer_home = tmp_path / "replacer"
-        target_home = tmp_path / "target"
-        replacer_home.mkdir()
-        monkeypatch.setenv("HERMES_HOME", str(replacer_home))
-        record = self._owner_record(target_home)
+        home = tmp_path / "profile"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        record = self._owner_record(home)
         alive = iter(alive_polls)
         monkeypatch.setattr(status, "_pid_exists", lambda _pid: next(alive))
         monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 123)

--- a/tests/gateway/test_stale_platform_lock_retryable.py
+++ b/tests/gateway/test_stale_platform_lock_retryable.py
@@ -12,11 +12,12 @@ process grab the lock first).
 so the reconnect watcher can retry after a delay — not permanently kill
 the platform.
 
-#65176 — a live gateway token conflict may attempt one-shot takeover only
-during the initial connect of an explicit ``gateway run --replace`` startup.
-``gateway run --replace`` only kills same-HERMES_HOME PID-file holders.
-A normal start or reconnect must retain the retryable conflict behavior and
-must never evict the active holder.
+#65176 / #88521 — a live gateway token conflict may attempt one-shot
+takeover only during the initial connect of an explicit ``gateway run
+--replace`` startup, and only when the holder is the *same* HERMES_HOME.
+A live sibling profile is a config conflict: retryable, never SIGTERM'd.
+A normal start or reconnect must retain the retryable conflict behavior
+and must never evict the active holder.
 """
 
 from typing import Any, Dict
@@ -182,3 +183,37 @@ def test_lock_conflict_keeps_pid_only_wording_for_legacy_record(adapter):
         "Telegram bot token already in use (PID 99999). "
         "Stop the other gateway first."
     )
+
+
+def test_replace_does_not_takeover_live_sibling_home(adapter):
+    """#88521: --replace must not treat a different HERMES_HOME as replaceable."""
+    existing = {
+        "pid": 4242,
+        "kind": "hermes-gateway",
+        "argv": ["hermes", "gateway", "run"],
+        "start_time": 123,
+        "profile": "personal",
+        "hermes_home": "/opt/data/profiles/personal",
+    }
+    adapter._platform_lock_takeover_allowed = True
+
+    with patch(
+        "gateway.status.acquire_scoped_lock",
+        return_value=(False, existing),
+    ), patch(
+        "gateway.status.take_over_scoped_lock_holder",
+        return_value=None,
+    ) as takeover, patch.object(
+        adapter, "_write_runtime_status_safe"
+    ):
+        result = adapter._acquire_platform_lock(
+            "telegram-bot-token", "test-token", "Telegram bot token"
+        )
+
+    assert result is False
+    assert adapter._fatal_error_retryable is True
+    assert adapter._fatal_error_code == "telegram-bot-token_lock"
+    assert "PID 4242" in adapter.fatal_error_message
+    assert "'personal' profile gateway" in adapter.fatal_error_message
+    takeover.assert_called_once_with(existing)
+

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -884,7 +884,7 @@ class TestTakeoverMarker:
 
 
 class TestScopedLockTakeover:
-    """Cross-home takeover requires explicit, corroborated process identity."""
+    """Token-lock ``--replace`` takeover is same-HERMES_HOME only (#88521)."""
 
     @staticmethod
     def _owner_record(target_home: Path, *, pid: int = 4242, start_time: int = 123):
@@ -899,31 +899,57 @@ class TestScopedLockTakeover:
         (target_home / "gateway.pid").write_text(json.dumps(record))
         return record
 
-    def test_verified_distinct_home_handoff_marks_target_before_sigterm(
-        self, tmp_path, monkeypatch
-    ):
-        replacer_home = tmp_path / "replacer"
-        target_home = tmp_path / "target"
-        replacer_home.mkdir()
-        monkeypatch.setenv("HERMES_HOME", str(replacer_home))
-        record = self._owner_record(target_home)
-
+    def _arm_live_owner(self, monkeypatch, *, start_time: int = 123):
         alive = iter([True, True, False])
         monkeypatch.setattr(status, "_pid_exists", lambda _pid: next(alive))
-        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 123)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: start_time)
         monkeypatch.setattr(
             status,
             "_read_process_cmdline",
             lambda _pid: "python -m hermes_cli.main gateway run",
         )
+
+    def test_live_distinct_home_holder_is_not_terminated(
+        self, tmp_path, monkeypatch
+    ):
+        """#88521: a live sibling profile holding the token is not SIGTERM'd."""
+        replacer_home = tmp_path / "replacer"
+        target_home = tmp_path / "target"
+        replacer_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(replacer_home))
+        record = self._owner_record(target_home)
+        self._arm_live_owner(monkeypatch)
+        calls = []
+        monkeypatch.setattr(
+            status, "terminate_pid", lambda *args, **kwargs: calls.append(args)
+        )
+
+        owner_pid = status.take_over_scoped_lock_holder(
+            record, graceful_attempts=1
+        )
+
+        assert owner_pid is None
+        assert calls == []
+        assert not (target_home / ".gateway-takeover.json").exists()
+        assert not (replacer_home / ".gateway-takeover.json").exists()
+
+    def test_same_home_handoff_marks_target_before_sigterm(
+        self, tmp_path, monkeypatch
+    ):
+        """Same-HERMES_HOME leftover holder is still taken over under --replace."""
+        home = tmp_path / "profile"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        record = self._owner_record(home)
+        self._arm_live_owner(monkeypatch)
         calls = []
 
         def terminate(pid, *, force=False):
-            marker_path = target_home / ".gateway-takeover.json"
+            marker_path = home / ".gateway-takeover.json"
             assert marker_path.exists()
             payload = json.loads(marker_path.read_text())
-            assert payload["target_hermes_home"] == str(target_home)
-            assert payload["replacer_hermes_home"] == str(replacer_home)
+            assert payload["target_hermes_home"] == str(home)
+            assert payload["replacer_hermes_home"] == str(home)
             calls.append((pid, force))
 
         monkeypatch.setattr(status, "terminate_pid", terminate)
@@ -934,8 +960,7 @@ class TestScopedLockTakeover:
 
         assert owner_pid == 4242
         assert calls == [(4242, False)]
-        assert not (target_home / ".gateway-takeover.json").exists()
-        assert not (replacer_home / ".gateway-takeover.json").exists()
+        assert not (home / ".gateway-takeover.json").exists()
 
     def test_handoff_rejects_uncorroborated_target_home(self, tmp_path, monkeypatch):
         target_home = tmp_path / "target"


### PR DESCRIPTION
## What does this PR do?

`--replace` on a profile gateway SIGTERMs a **live sibling profile** that holds the same bot token, then reaps its children (including cron). In Docker, every s6 slot starts with `--replace`, so two profiles that share a Telegram token (or inherit one from the container env) ping-pong every ~30s. Cron dies with `exit -15` / "Scheduler restarted after this execution's owner exited before a durable terminal state" ([#88521](https://github.com/NousResearch/hermes-agent/issues/88521)).

Token locks are machine-global on purpose: two profiles must not poll the same bot. The product contract is that the second gateway **refuses** (`already in use … Stop the other gateway first.`). PID-file `--replace` is already same-`HERMES_HOME`. Token `--replace` (#65176) was not — it killed the live holder in another home.

This PR gates `take_over_scoped_lock_holder`: same-home leftovers still get SIGTERM + child reap (Docker s6 NS-505). A live different `HERMES_HOME` returns `None` and takes the retryable lock-conflict path. The conflict message already names the owning profile (OOF-3); that wording is unchanged.

Sharing one token / webhook `:8644` across profiles is still a misconfiguration (unique bots, unique ports, or `gateway.multiplex_profiles`). This only stops that misconfig from becoming a SIGTERM deathmatch.

## Related Issue

Fixes #88521

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/status.py` — `take_over_scoped_lock_holder` returns `None` without signalling when the verified lock owner’s `hermes_home` is not this process’s `HERMES_HOME`. Same-home takeover + POSIX child reap unchanged.
- `gateway/platforms/base.py` — `_acquire_platform_lock` docstring matches the gate. Conflict copy stays the existing OOF-3 profile-named message.
- `tests/gateway/test_status.py` — distinct-home holder is not terminated; same-home leftover still SIGTERMs.
- `tests/gateway/test_stale_platform_lock_retryable.py` — `--replace` + sibling home stays retryable `telegram-bot-token_lock` and still names the owning profile.
- `tests/gateway/test_replace_child_reap.py` — successful reap fixture is same-home (the path that still kills).

## How to Test

1. **Same token, two profiles, both `--replace`:** second gateway logs `already in use by the '<profile>' profile gateway (PID …)` and stays retryable. First gateway and its cron keep running. No `[Telegram] … --replace handoff completed` against the sibling.
2. **Same-profile `--replace`:** stray `hermes gateway run` under the same `HERMES_HOME` is still reaped (s6 NS-505).
3. **Distinct tokens:** both profile gateways connect; no lock conflict.

```bash
scripts/run_tests.sh \
  tests/gateway/test_status.py \
  tests/gateway/test_stale_platform_lock_retryable.py \
  tests/gateway/test_replace_child_reap.py \
  tests/gateway/test_runner_startup_failures.py \
  tests/hermes_cli/test_service_manager.py -q
```

95 passed, 2 skipped (use `scripts/run_tests.sh`, not bare `pytest`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the files above and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 7.0.0-28-generic

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior matches existing FAQ / profile docs: two profiles cannot share a bot token; the bug was violating that contract)
- [x] `cli-config.yaml.example` — N/A (no new config key)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact — lock path is already POSIX/Windows-aware; gate is home-string compare only
- [x] Tool descriptions/schemas — N/A (no tool behavior change)

## Out of scope / follow-ups

- Unique webhook/API ports per profile (documented; reporter still needs distinct ports or multiplexing).
- Auto-stopping extra s6 `gateway-<profile>` slots when they share a token (operator config).
- `gateway.multiplex_profiles` as the one-process Docker layout (already shipped; opt-in).
