### PR TITLE
fix(telegram): keep DM-topic tables on sendRichMessage when drafts degrade

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -746,9 +746,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # Rich draft previews use a separate opt-in. Telegram macOS / Desktop
         # can leave Bot API 10.1 rich draft frames visually overlaid until the
         # chat is redrawn, while final rich messages remain useful.
-        # When rich_messages is on but rich_drafts is off, supports_draft_streaming
-        # declines drafts so transport=auto uses edit-in-place + rich finalize
-        # instead of MDV2 drafts that jump to sendRichMessage at the end.
+        # When rich_messages is on but rich_drafts is off, keep native DM draft
+        # *transport* and only skip rich draft *rendering*. The persistent
+        # reply still lands through sendRichMessage so tables are not flattened
+        # by the MarkdownV2 formatter.
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
@@ -1610,6 +1611,31 @@ class TelegramAdapter(BasePlatformAdapter):
             }
         return {"message_thread_id": cls._message_thread_id_for_send(thread_id)}
 
+    def _thread_kwargs_for_draft(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Routing kwargs for ``sendMessageDraft`` / ``sendRichMessageDraft``.
+
+        Reuse :meth:`_thread_kwargs_for_send` so private DM topics get an
+        integer ``message_thread_id`` (or ``direct_messages_topic_id``) instead
+        of the raw string ``thread_id`` the draft path used to forward.
+        Telegram rejects that string on topics, which disabled draft streaming
+        for the rest of the turn and fell through to the table-to-bullets
+        formatter.
+        """
+        thread_id = self._metadata_thread_id(metadata)
+        reply_to_id = self._reply_to_message_id_for_send(None, metadata)
+        kwargs = self._thread_kwargs_for_send(
+            chat_id,
+            thread_id,
+            metadata,
+            reply_to_message_id=reply_to_id,
+            reply_to_mode=getattr(self, "_reply_to_mode", None),
+        )
+        return {k: v for k, v in kwargs.items() if v is not None}
+
     @classmethod
     def _message_thread_id_for_send(cls, thread_id: Optional[str]) -> Optional[int]:
         if not thread_id or str(thread_id) == cls._GENERAL_TOPIC_THREAD_ID:
@@ -2068,15 +2094,23 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> bool:
         """Whether to replace a streamed preview with a fresh rich final.
 
-        Disabled for Telegram. The fresh-final path briefly shows two copies of
-        the final answer, then deletes the streaming preview after the rich send
-        succeeds — it looks like duplicate delivery at the end of every streamed
-        turn (the reason #46206 reverted it).  Rich finalize is instead handled
-        by editing the existing preview in place via Bot API 10.1's
-        ``editMessageText`` ``rich_message`` parameter (see
-        :meth:`_try_edit_rich`), so no fresh re-send / delete is needed.
+        Root DMs keep this off (#46206 / #47048): successful draft streaming
+        has no preview ``message_id``, so the hook is not consulted, and
+        in-place ``editMessageText.rich_message`` would duplicate a live draft
+        turn.  Private DM *topics* often reject ``sendMessageDraft``; the
+        consumer then degrades to edit-in-place. Telegram rejects a rich edit
+        of that plain MarkdownV2 preview, and the fallback formatter
+        permanently turns pipe tables into bullet lists.  Fresh
+        ``sendRichMessage`` plus deleting the preview is the remaining way to
+        keep native tables on that degraded path.
         """
-        return False
+        metadata = metadata or {}
+        if not (
+            metadata.get("telegram_dm_topic_reply_fallback")
+            or metadata.get("direct_messages_topic_id")
+        ):
+            return False
+        return self._rich_eligible(content)
 
     def streaming_overflow_limit(self) -> Optional[int]:
         """Allow the stream consumer to accumulate up to the rich-message cap
@@ -2423,9 +2457,7 @@ class TelegramAdapter(BasePlatformAdapter):
             "draft_id": int(draft_id),
             "rich_message": self._rich_message_payload(content),
         }
-        thread_id = self._metadata_thread_id(metadata)
-        if thread_id is not None:
-            payload["message_thread_id"] = int(thread_id)
+        payload.update(self._thread_kwargs_for_draft(chat_id, metadata))
         try:
             ok = await self._bot.do_api_request("sendRichMessageDraft", api_kwargs=payload)
             return bool(ok)
@@ -6006,8 +6038,6 @@ class TelegramAdapter(BasePlatformAdapter):
         text = content if len(content) <= self.MAX_MESSAGE_LENGTH else \
             self.truncate_message(content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len)[0]
 
-        thread_id = self._metadata_thread_id(metadata)
-
         # Apply the same MarkdownV2 conversion the regular ``send`` path uses
         # so the animated draft preview renders with identical formatting to
         # the final message.  Without this, the draft streams as raw text and
@@ -6029,6 +6059,7 @@ class TelegramAdapter(BasePlatformAdapter):
             and self._needs_rich_rendering(text)
         )
         draft_modes = (False,) if plain_rich_preview else (True, False)
+        draft_thread_kwargs = self._thread_kwargs_for_draft(chat_id, metadata)
         for use_markdown in draft_modes:
             kwargs: Dict[str, Any] = {
                 "chat_id": normalize_telegram_chat_id(chat_id),
@@ -6037,8 +6068,7 @@ class TelegramAdapter(BasePlatformAdapter):
             }
             if use_markdown:
                 kwargs["parse_mode"] = ParseMode.MARKDOWN_V2
-            if thread_id is not None:
-                kwargs["message_thread_id"] = thread_id
+            kwargs.update(draft_thread_kwargs)
 
             try:
                 ok = await self._bot.send_message_draft(**kwargs)

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -377,13 +377,29 @@ async def test_cjk_rich_content_skips_rich_draft_to_avoid_tdesktop_garble():
 
 
 # ----------------------------------------------------------------------
-# prefers_fresh_final_streaming: Telegram keeps streamed finals on the edit
-# path, even when rich messages are enabled, so users do not briefly see two
-# copies of the answer while the preview cleanup delete races the fresh send.
+# prefers_fresh_final_streaming: root DMs stay on the no-duplicate edit/draft
+# path (#47048). DM topics that degrade off drafts still need a fresh
+# sendRichMessage so tables are not flattened by format_message.
 # ----------------------------------------------------------------------
 def test_prefers_fresh_final_streaming_stays_disabled_when_rich_enabled():
     adapter = _make_adapter()
     assert adapter.prefers_fresh_final_streaming(RICH_CONTENT) is False
+    assert adapter.prefers_fresh_final_streaming(RICH_CONTENT, None) is False
+
+
+def test_prefers_fresh_final_streaming_for_dm_topic_tables():
+    adapter = _make_adapter()
+    topic_meta = {
+        "thread_id": "20189",
+        "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "20189",
+        "telegram_reply_to_message_id": "42",
+    }
+    assert adapter.prefers_fresh_final_streaming(RICH_CONTENT, topic_meta) is True
+    assert adapter.prefers_fresh_final_streaming("Just a sentence.", topic_meta) is False
+    assert adapter.prefers_fresh_final_streaming(
+        RICH_CONTENT, {"direct_messages_topic_id": "20189"}
+    ) is True
 
 
 @pytest.mark.asyncio
@@ -468,6 +484,128 @@ async def test_dm_table_stream_persists_through_send_rich_message():
     assert rich_endpoints == ["sendRichMessage"]
     adapter._bot.edit_message_text.assert_not_called()
     adapter._bot.send_message.assert_not_called()
+
+
+TOPIC_METADATA = {
+    "thread_id": "20189",
+    "telegram_dm_topic_reply_fallback": True,
+    "direct_messages_topic_id": "20189",
+    "telegram_reply_to_message_id": "42",
+}
+
+# Shape from the Telegram iOS DM-topic report: blank line, then a GFM table.
+TOPIC_TABLE = (
+    "Here's a table:\n"
+    "\n"
+    "| Sport | Followed? | Notes |\n"
+    "|---|---|---|\n"
+    "| F1 | ✅ | |\n"
+    "| MLB | ✅ | |\n"
+    "| LoL | ✅ | |\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_send_draft_routes_dm_topic_thread_id_as_int():
+    """Drafts must use the same integer thread routing as send(), not the
+    raw string thread_id. Telegram rejects the string on private topics."""
+    adapter = _make_adapter()
+
+    result = await adapter.send_draft(
+        "12345", draft_id=7, content=TOPIC_TABLE, metadata=TOPIC_METADATA,
+    )
+
+    assert result.success is True
+    kwargs = adapter._bot.send_message_draft.call_args.kwargs
+    assert kwargs["message_thread_id"] == 20189
+    assert kwargs["text"] == TOPIC_TABLE
+    assert "parse_mode" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_dm_topic_table_stream_uses_send_rich_message():
+    """Happy-path topic stream: drafts land, persistent final is rich."""
+    adapter = _make_adapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "12345",
+        StreamConsumerConfig(
+            transport="auto",
+            chat_type="dm",
+            edit_interval=0.01,
+            buffer_threshold=1,
+            cursor="",
+        ),
+        metadata=dict(TOPIC_METADATA),
+        initial_reply_to_id="42",
+    )
+
+    task = asyncio.create_task(consumer.run())
+    consumer.on_delta(TOPIC_TABLE)
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter._bot.send_message_draft.assert_awaited()
+    draft_kwargs = adapter._bot.send_message_draft.call_args.kwargs
+    assert draft_kwargs["text"] == TOPIC_TABLE
+    assert draft_kwargs["message_thread_id"] == 20189
+    rich_endpoints = [call.args[0] for call in adapter._bot.do_api_request.await_args_list]
+    assert rich_endpoints == ["sendRichMessage"]
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dm_topic_table_survives_when_drafts_degrade_to_edit():
+    """Reporter path: sendMessageDraft fails in a private topic, Telegram
+    then rejects a rich edit of the plain MarkdownV2 preview. The final
+    must still persist through sendRichMessage — not convert_table_to_bullets.
+    """
+    adapter = _make_adapter()
+    adapter._bot.send_message_draft = AsyncMock(
+        side_effect=BadRequest("Bad Request: message thread not found")
+    )
+
+    async def _api(endpoint, api_kwargs=None, **kwargs):
+        if endpoint == "editMessageText" and api_kwargs and "rich_message" in api_kwargs:
+            raise BadRequest("can't parse rich message")
+        if endpoint == "sendRichMessage":
+            return SimpleNamespace(message_id=123)
+        return SimpleNamespace(message_id=1)
+
+    adapter._bot.do_api_request = AsyncMock(side_effect=_api)
+
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "12345",
+        StreamConsumerConfig(
+            transport="auto",
+            chat_type="dm",
+            edit_interval=0.01,
+            buffer_threshold=1,
+            cursor="",
+        ),
+        metadata=dict(TOPIC_METADATA),
+        initial_reply_to_id="42",
+    )
+
+    task = asyncio.create_task(consumer.run())
+    consumer.on_delta(TOPIC_TABLE)
+    await asyncio.sleep(0.08)
+    consumer.finish()
+    await task
+
+    rich_endpoints = [call.args[0] for call in adapter._bot.do_api_request.await_args_list]
+    assert "sendRichMessage" in rich_endpoints
+    rich_kwargs = None
+    for call in adapter._bot.do_api_request.await_args_list:
+        if call.args[0] == "sendRichMessage":
+            rich_kwargs = call.kwargs["api_kwargs"]
+            break
+    assert rich_kwargs is not None
+    assert "| F1 |" in rich_kwargs["rich_message"]["markdown"]
+    # Degraded preview is deleted so the user is not left with the bullet rewrite.
+    adapter._bot.delete_message.assert_awaited()
 
 
 def test_supports_draft_streaming_enabled_when_rich_drafts_opt_in():


### PR DESCRIPTION
## Summary
- #91241 stopped root-DM pipe tables collapsing to bullet lists when `rich_messages` is on and `rich_drafts` is off, by keeping native draft transport so the persistent reply goes through `sendRichMessage`.
- Private Telegram **topics** still reject `sendMessageDraft` (string `thread_id`, forum-style thread fields). The stream consumer then degrades to edit-in-place; Telegram rejects a rich `editMessageText` of that plain MarkdownV2 preview; `format_message` permanently rewrites the table into `• Col: value` groups. That is the remaining report after updating to `main`.
- Route drafts through the same integer topic kwargs as `send()`, and on that degraded topic path prefer a fresh `sendRichMessage` (then delete the preview) instead of the table-to-bullets formatter. Root DMs keep the no-duplicate path from #47048.

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_send_draft_format.py tests/gateway/test_stream_consumer.py tests/gateway/test_telegram_reply_mode.py tests/gateway/test_telegram_thread_fallback.py`
- [ ] Telegram DM topic, `rich_messages: true`, `rich_drafts: false`, streaming on: ask for a markdown table with a blank line above it. Final message should be a native table, not `*F1*` / `• Followed?:`.
- [ ] Same prompt in a root DM (no topic): still a native table, no duplicate preview.