### PR TITLE
fix(kanban): make show usable outside worker env

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -6,6 +6,7 @@ Verifies:
   - Each handler's happy path.
   - Error paths (missing required args, bad metadata type, etc).
 """
+
 from __future__ import annotations
 
 import json
@@ -18,6 +19,7 @@ import pytest
 # ---------------------------------------------------------------------------
 # Gating
 # ---------------------------------------------------------------------------
+
 
 def test_kanban_tools_hidden_without_env_var(monkeypatch, tmp_path):
     """Normal `hermes chat` sessions (no HERMES_KANBAN_TASK) must have
@@ -35,14 +37,13 @@ def test_kanban_tools_hidden_without_env_var(monkeypatch, tmp_path):
     schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
     names = {s["function"].get("name") for s in schema if "function" in s}
     kanban = {n for n in names if n and n.startswith("kanban_")}
-    assert kanban == set(), (
-        f"kanban tools leaked into normal chat schema: {kanban}"
-    )
+    assert kanban == set(), f"kanban tools leaked into normal chat schema: {kanban}"
 
 
 # ---------------------------------------------------------------------------
 # Handler happy paths
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def worker_env(monkeypatch, tmp_path):
@@ -54,9 +55,11 @@ def worker_env(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_PROFILE", "test-worker")
     monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
     from pathlib import Path as _Path
+
     monkeypatch.setattr(_Path, "home", lambda: tmp_path)
 
     from hermes_cli import kanban_db as kb
+
     kb._INITIALIZED_PATHS.clear()
     kb.init_db()
     conn = kb.connect()
@@ -71,6 +74,7 @@ def worker_env(monkeypatch, tmp_path):
 
 def test_show_defaults_to_env_task_id(worker_env):
     from tools import kanban_tools as kt
+
     out = kt._handle_show({})
     d = json.loads(out)
     assert "task" in d
@@ -80,10 +84,60 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "runs" in d
 
 
+def test_show_without_current_task_returns_board_listing(monkeypatch, worker_env):
+    """Orchestrator/chat sessions can call kanban_show with no args to orient.
+
+    Regression for #91431: the tool schema marks task_id optional, but outside
+    dispatcher workers there is no HERMES_KANBAN_TASK fallback. Returning the
+    compact board listing lets the agent choose an explicit task_id instead of
+    surfacing an env-var instruction it cannot satisfy.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    from tools import kanban_tools as kt
+
+    out = kt._handle_show({})
+    d = json.loads(out)
+    assert d.get("error") is None
+    assert d["fallback"] == "kanban_list"
+    assert worker_env in {task["id"] for task in d["tasks"]}
+    assert "call kanban_show" in d["hint"]
+
+
+def test_comment_defaults_to_env_task_id(worker_env):
+    """Worker comments match other lifecycle tools: task_id can default to env."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    out = kt._handle_comment({"body": "left a worker note"})
+    d = json.loads(out)
+    assert d.get("ok") is True
+    assert d["task_id"] == worker_env
+
+    conn = kb.connect()
+    try:
+        comments = kb.list_comments(conn, worker_env)
+        assert comments[-1].body == "left a worker note"
+    finally:
+        conn.close()
+
+
+def test_comment_without_current_task_points_to_list(monkeypatch, worker_env):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    from tools import kanban_tools as kt
+
+    out = kt._handle_comment({"body": "needs an explicit task"})
+    d = json.loads(out)
+    assert "error" in d
+    assert "Use kanban_list" in d["error"]
+
+
 def test_list_filters_tasks(monkeypatch, worker_env):
     """kanban_list gives orchestrators filtered board discovery."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         a = kb.create_task(conn, title="alpha", assignee="factory", priority=5)
@@ -93,6 +147,7 @@ def test_list_filters_tasks(monkeypatch, worker_env):
         conn.close()
 
     from tools import kanban_tools as kt
+
     out = kt._handle_list({"assignee": "factory", "status": "ready", "limit": 10})
     d = json.loads(out)
     ids = [t["id"] for t in d["tasks"]]
@@ -113,6 +168,7 @@ def test_list_filters_tasks(monkeypatch, worker_env):
 
 def test_complete_happy_path(worker_env):
     from tools import kanban_tools as kt
+
     out = kt._handle_complete({
         "summary": "got the thing done",
         "metadata": {"files": 2},
@@ -122,6 +178,7 @@ def test_complete_happy_path(worker_env):
     assert d["task_id"] == worker_env
     # Verify via kernel
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         run = kb.latest_run(conn, worker_env)
@@ -140,17 +197,21 @@ def test_complete_retry_with_empty_created_cards_succeeds(worker_env):
     from tools import kanban_tools as kt
 
     # Hit the gate first.
-    rejected = json.loads(kt._handle_complete({
-        "summary": "oops",
-        "created_cards": ["t_phantomdeadbeef"],
-    }))
+    rejected = json.loads(
+        kt._handle_complete({
+            "summary": "oops",
+            "created_cards": ["t_phantomdeadbeef"],
+        })
+    )
     assert rejected.get("error")
 
     # Retry with the escape hatch.
-    ok = json.loads(kt._handle_complete({
-        "summary": "retry without claims",
-        "created_cards": [],
-    }))
+    ok = json.loads(
+        kt._handle_complete({
+            "summary": "retry without claims",
+            "created_cards": [],
+        })
+    )
     assert ok.get("ok") is True
 
     conn = kb.connect()
@@ -180,8 +241,11 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
     conn = kb.connect()
     try:
         goal_task_id = kb.create_task(
-            conn, title="goal-mode-test", assignee="test-worker",
-            body="Must achieve X with verified evidence.", goal_mode=True
+            conn,
+            title="goal-mode-test",
+            assignee="test-worker",
+            body="Must achieve X with verified evidence.",
+            goal_mode=True,
         )
         kb.claim_task(conn, goal_task_id)
     finally:
@@ -217,10 +281,12 @@ def test_complete_goal_mode_rejected_by_judge(monkeypatch, tmp_path):
 
 def test_block_happy_path(worker_env):
     from tools import kanban_tools as kt
+
     out = kt._handle_block({"reason": "need clarification"})
     d = json.loads(out)
     assert d["ok"] is True
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         assert kb.get_task(conn, worker_env).status == "blocked"
@@ -246,8 +312,11 @@ def _make_goal_mode_worker_env(monkeypatch, tmp_path):
     conn = kb.connect()
     try:
         goal_task_id = kb.create_task(
-            conn, title="goal-mode-block-test", assignee="test-worker",
-            body="Must achieve X.", goal_mode=True,
+            conn,
+            title="goal-mode-block-test",
+            assignee="test-worker",
+            body="Must achieve X.",
+            goal_mode=True,
         )
         kb.claim_task(conn, goal_task_id)
     finally:
@@ -352,6 +421,7 @@ def test_heartbeat_extends_claim_expires(worker_env):
 
 def test_comment_happy_path(worker_env):
     from tools import kanban_tools as kt
+
     out = kt._handle_comment({
         "task_id": worker_env,
         "body": "hello thread",
@@ -360,6 +430,7 @@ def test_comment_happy_path(worker_env):
     assert d["ok"] is True
     assert d["comment_id"]
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         comments = kb.list_comments(conn, worker_env)
@@ -380,11 +451,15 @@ def test_comment_ignores_caller_supplied_author(worker_env):
     is removed.
     """
     from tools import kanban_tools as kt
+
     out = kt._handle_comment({
-        "task_id": worker_env, "body": "hi", "author": "hermes-system",
+        "task_id": worker_env,
+        "body": "hi",
+        "author": "hermes-system",
     })
     assert json.loads(out)["ok"]
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         comments = kb.list_comments(conn, worker_env)
@@ -397,6 +472,7 @@ def test_comment_ignores_caller_supplied_author(worker_env):
 
 def test_create_happy_path(worker_env):
     from tools import kanban_tools as kt
+
     out = kt._handle_create({
         "title": "child task",
         "assignee": "peer",
@@ -407,6 +483,7 @@ def test_create_happy_path(worker_env):
     assert d["task_id"]
     assert d["status"] == "todo"  # parent isn't done yet
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         child = kb.get_task(conn, d["task_id"])
@@ -418,6 +495,7 @@ def test_create_happy_path(worker_env):
 
 def test_link_happy_path(worker_env):
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         a = kb.create_task(conn, title="A", assignee="x")
@@ -425,6 +503,7 @@ def test_link_happy_path(worker_env):
     finally:
         conn.close()
     from tools import kanban_tools as kt
+
     out = kt._handle_link({"parent_id": a, "child_id": b})
     d = json.loads(out)
     assert d["ok"] is True
@@ -433,6 +512,7 @@ def test_link_happy_path(worker_env):
 def test_unblock_happy_path(monkeypatch, worker_env):
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         tid = kb.create_task(conn, title="blocked", assignee="worker")
@@ -441,6 +521,7 @@ def test_unblock_happy_path(monkeypatch, worker_env):
         conn.close()
 
     from tools import kanban_tools as kt
+
     out = kt._handle_unblock({"task_id": tid})
     d = json.loads(out)
     assert d["ok"] is True
@@ -460,9 +541,11 @@ def test_unblock_with_pending_parents_returns_todo(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
     from pathlib import Path as _Path
+
     monkeypatch.setattr(_Path, "home", lambda: tmp_path)
 
     from hermes_cli import kanban_db as kb
+
     kb._INITIALIZED_PATHS.clear()
     kb.init_db()
     conn = kb.connect()
@@ -475,6 +558,7 @@ def test_unblock_with_pending_parents_returns_todo(monkeypatch, tmp_path):
         conn.close()
 
     from tools import kanban_tools as kt
+
     out = kt._handle_unblock({"task_id": child})
     d = json.loads(out)
     assert d["ok"] is True
@@ -501,28 +585,35 @@ def test_worker_lifecycle_through_tools(worker_env):
     assert json.loads(kt._handle_heartbeat({"note": "warming up"}))["ok"]
 
     # 3. comment for a future peer
-    assert json.loads(kt._handle_comment({
-        "task_id": worker_env,
-        "body": "note: using stdlib sqlite3 bindings",
-    }))["ok"]
+    assert json.loads(
+        kt._handle_comment({
+            "task_id": worker_env,
+            "body": "note: using stdlib sqlite3 bindings",
+        })
+    )["ok"]
 
     # 4. spawn a child task for follow-up
-    child_out = json.loads(kt._handle_create({
-        "title": "write integration test",
-        "assignee": "qa",
-        "parents": [worker_env],
-    }))
+    child_out = json.loads(
+        kt._handle_create({
+            "title": "write integration test",
+            "assignee": "qa",
+            "parents": [worker_env],
+        })
+    )
     assert child_out["ok"]
 
     # 5. complete with structured handoff
-    comp = json.loads(kt._handle_complete({
-        "summary": "implemented + spawned QA follow-up",
-        "metadata": {"child_task": child_out["task_id"]},
-    }))
+    comp = json.loads(
+        kt._handle_complete({
+            "summary": "implemented + spawned QA follow-up",
+            "metadata": {"child_task": child_out["task_id"]},
+        })
+    )
     assert comp["ok"]
 
     # Verify final state
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         parent = kb.get_task(conn, worker_env)
@@ -599,6 +690,7 @@ def test_kanban_guidance_orchestrator_decision_ownership():
 def test_worker_complete_rejects_foreign_task_id(worker_env):
     """A worker cannot complete a task that isn't its own (#19534)."""
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         other = kb.create_task(conn, title="sibling")
@@ -608,6 +700,7 @@ def test_worker_complete_rejects_foreign_task_id(worker_env):
         conn.close()
 
     from tools import kanban_tools as kt
+
     out = kt._handle_complete({"task_id": other, "summary": "HIJACK"})
     d = json.loads(out)
     assert d.get("ok") is not True
@@ -631,6 +724,7 @@ def test_worker_can_comment_on_foreign_task(worker_env):
     to ``_handle_comment`` would fail CI immediately.
     """
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         other = kb.create_task(conn, title="sibling")
@@ -638,6 +732,7 @@ def test_worker_can_comment_on_foreign_task(worker_env):
         conn.close()
 
     from tools import kanban_tools as kt
+
     out = kt._handle_comment({
         "task_id": other,
         "body": "handoff: see prior findings before starting",
@@ -666,6 +761,7 @@ def test_worker_unblock_rejects_foreign_task_id(worker_env):
     pinning is "worker cannot mutate foreign task via kanban_unblock".
     """
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         other = kb.create_task(conn, title="blocked sibling", assignee="peer")
@@ -674,6 +770,7 @@ def test_worker_unblock_rejects_foreign_task_id(worker_env):
         conn.close()
 
     from tools import kanban_tools as kt
+
     out = kt._handle_unblock({"task_id": other})
     d = json.loads(out)
     err = d.get("error", "")
@@ -696,9 +793,11 @@ def test_orchestrator_complete_any_task_allowed(monkeypatch, tmp_path):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     from pathlib import Path as _P
+
     monkeypatch.setattr(_P, "home", lambda: tmp_path)
 
     from hermes_cli import kanban_db as kb
+
     kb._INITIALIZED_PATHS.clear()
     kb.init_db()
     conn = kb.connect()
@@ -710,6 +809,7 @@ def test_orchestrator_complete_any_task_allowed(monkeypatch, tmp_path):
         conn.close()
 
     from tools import kanban_tools as kt
+
     out = kt._handle_complete({"task_id": tid, "summary": "orchestrator close"})
     d = json.loads(out)
     assert d.get("ok") is True and d.get("task_id") == tid
@@ -746,24 +846,22 @@ def multi_board_env(monkeypatch, tmp_path):
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     monkeypatch.setenv("HERMES_PROFILE", "test-orchestrator")
     from pathlib import Path as _Path
+
     monkeypatch.setattr(_Path, "home", lambda: tmp_path)
 
     from hermes_cli import kanban_db as kb
+
     kb._INITIALIZED_PATHS.clear()
     # Default board — implicit
     conn = kb.connect()
     try:
-        seed_default = kb.create_task(
-            conn, title="seed-default", assignee="worker-d"
-        )
+        seed_default = kb.create_task(conn, title="seed-default", assignee="worker-d")
     finally:
         conn.close()
     # Alt board — explicit slug routes the connection to a separate DB
     conn = kb.connect(board="alt")
     try:
-        seed_alt = kb.create_task(
-            conn, title="seed-alt", assignee="worker-a"
-        )
+        seed_alt = kb.create_task(conn, title="seed-alt", assignee="worker-a")
     finally:
         conn.close()
     return {
@@ -809,8 +907,10 @@ def test_board_param_none_falls_back_to_env(worker_env):
 #   even when the session has a delivery channel.
 # ---------------------------------------------------------------------------
 
+
 def _list_subs_for_task(task_id):
     from hermes_cli import kanban_db as kb
+
     conn = kb.connect()
     try:
         return list(kb.list_notify_subs(conn, task_id))
@@ -843,6 +943,7 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     to its own kanban_create result, and the response surfaces the
     ``subscribed`` flag so the orchestrator can react."""
     from tools import kanban_tools as kt
+
     monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
     monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
     monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "thread-7")
@@ -877,6 +978,7 @@ def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):
     We should still auto-subscribe, with platform='tui' and
     chat_id=<key>."""
     from tools import kanban_tools as kt
+
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
@@ -905,6 +1007,7 @@ def test_create_does_not_subscribe_in_cli_session(monkeypatch, worker_env):
     """CLI / cron / test sessions have no persistent delivery channel.
     _maybe_auto_subscribe returns False and no row is written."""
     from tools import kanban_tools as kt
+
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
@@ -921,7 +1024,9 @@ def test_create_does_not_subscribe_in_cli_session(monkeypatch, worker_env):
     assert _list_subs_for_task(d["task_id"]) == []
 
 
-def test_create_respects_auto_subscribe_on_create_false(monkeypatch, worker_env, tmp_path):
+def test_create_respects_auto_subscribe_on_create_false(
+    monkeypatch, worker_env, tmp_path
+):
     """The config gate kanban.auto_subscribe_on_create=false must
     suppress auto-subscription even when the session has a delivery
     channel. This is the knob that addresses the upstream design
@@ -931,14 +1036,13 @@ def test_create_respects_auto_subscribe_on_create_false(monkeypatch, worker_env,
     # home to avoid mkdir() colliding with the worker's directory.
     home = tmp_path / "gate-home" / ".hermes"
     home.mkdir(parents=True)
-    (home / "config.yaml").write_text(
-        "kanban:\n  auto_subscribe_on_create: false\n"
-    )
+    (home / "config.yaml").write_text("kanban:\n  auto_subscribe_on_create: false\n")
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
     monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "channel-1")
 
     from tools import kanban_tools as kt
+
     out = kt._handle_create({
         "title": "no sub gated",
         "assignee": "peer",
@@ -956,6 +1060,7 @@ def test_maybe_auto_subscribe_swallows_add_notify_sub_failure(monkeypatch, worke
     kanban_create. The function returns False and the parent create
     still succeeds with subscribed=False."""
     from tools import kanban_tools as kt
+
     monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
     monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
 
@@ -1068,6 +1173,7 @@ def _fake_public_dns(monkeypatch, mapping):
         return [(real_af, real_sock, 6, "", (ip, 0))]
 
     from tools import url_safety
+
     monkeypatch.setattr(url_safety.socket, "getaddrinfo", fake_getaddrinfo)
 
 
@@ -1089,7 +1195,7 @@ class _FakeStreamResponse:
 
     def iter_bytes(self, chunk_size):
         for i in range(0, len(self._body), chunk_size):
-            yield self._body[i:i + chunk_size]
+            yield self._body[i : i + chunk_size]
 
     def __enter__(self):
         return self

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1036,7 +1036,10 @@ def test_create_respects_auto_subscribe_on_create_false(
     # home to avoid mkdir() colliding with the worker's directory.
     home = tmp_path / "gate-home" / ".hermes"
     home.mkdir(parents=True)
-    (home / "config.yaml").write_text("kanban:\n  auto_subscribe_on_create: false\n")
+    (home / "config.yaml").write_text(
+        "kanban:\n  auto_subscribe_on_create: false\n",
+        encoding="utf-8",
+    )
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
     monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "channel-1")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -26,6 +26,7 @@ three bypass the agent entirely. The tools are for dispatcher-spawned
 worker handoffs and for configured orchestrator profiles that route work
 through the board.
 """
+
 from __future__ import annotations
 
 import json
@@ -55,6 +56,7 @@ def _profile_has_kanban_toolset() -> bool:
     # (~30s) by the tool registry.
     try:
         from hermes_cli.config import load_config
+
         cfg = load_config()
         toolsets = cfg.get("toolsets", [])
         return "kanban" in toolsets
@@ -138,6 +140,7 @@ def _check_kanban_orchestrator_mode() -> bool:
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
 
 def _default_task_id(arg: Optional[str]) -> Optional[str]:
     """Resolve ``task_id`` arg or fall back to the env var the dispatcher set."""
@@ -224,6 +227,7 @@ def _connect(board: Optional[str] = None):
     the env-pinned active board without restarting Hermes.
     """
     from hermes_cli import kanban_db as kb
+
     return kb, kb.connect(board=board)
 
 
@@ -245,6 +249,7 @@ def _goal_judge_available() -> bool:
     """
     try:
         from agent.auxiliary_client import get_text_auxiliary_client
+
         client, model = get_text_auxiliary_client("goal_judge")
     except Exception:
         return False
@@ -324,6 +329,7 @@ def heartbeat_current_worker_from_env() -> bool:
     if not tid:
         return False
     import time as _time
+
     now = _time.monotonic()
     if (now - _auto_heartbeat_last_attempt) < _AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS:
         return False
@@ -386,6 +392,7 @@ def inject_new_comments_from_env(agent: Any) -> bool:
         return False
     global _comment_poll_last_attempt
     import time as _time
+
     now = _time.monotonic()
     if (now - _comment_poll_last_attempt) < _COMMENT_POLL_MIN_INTERVAL_SECONDS:
         return False
@@ -417,7 +424,9 @@ def inject_new_comments_from_env(agent: Any) -> bool:
     _comment_watermark[tid] = max(c.id for c in rows)
 
     own = (os.environ.get("HERMES_PROFILE") or "").strip()
-    fresh = [c for c in rows if (c.author or "").strip() != own and (c.body or "").strip()]
+    fresh = [
+        c for c in rows if (c.author or "").strip() != own and (c.body or "").strip()
+    ]
     if not fresh:
         return False
 
@@ -514,14 +523,32 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
 # Handlers
 # ---------------------------------------------------------------------------
 
+
 def _handle_show(args: dict, **kw) -> str:
     """Read a task's full state: task row, parents, children, comments,
     runs (attempt history), and the last N events."""
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        # In orchestrator/chat contexts there is no current dispatcher task.
+        # The schema advertises task_id as optional because worker sessions can
+        # inherit HERMES_KANBAN_TASK; outside a worker, a no-arg orientation
+        # call should be useful instead of returning an env-var hint the agent
+        # cannot act on. Reuse the board listing surface so the model can pick
+        # an explicit task id for a follow-up kanban_show call.
+        out = _handle_list({"board": args.get("board")})
+        try:
+            data = json.loads(out)
+        except Exception:
+            return out
+        if isinstance(data, dict) and not data.get("error"):
+            data.setdefault("fallback", "kanban_list")
+            data.setdefault(
+                "hint",
+                "No current Kanban task is set for this chat. Pick a task_id "
+                "from tasks and call kanban_show with it for full details.",
+            )
+            return json.dumps(data)
+        return out
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -537,12 +564,17 @@ def _handle_show(args: dict, **kw) -> str:
 
             def _task_dict(t):
                 return {
-                    "id": t.id, "title": t.title, "body": t.body,
-                    "assignee": t.assignee, "status": t.status,
-                    "tenant": t.tenant, "priority": t.priority,
+                    "id": t.id,
+                    "title": t.title,
+                    "body": t.body,
+                    "assignee": t.assignee,
+                    "status": t.status,
+                    "tenant": t.tenant,
+                    "priority": t.priority,
                     "workspace_kind": t.workspace_kind,
                     "workspace_path": t.workspace_path,
-                    "created_by": t.created_by, "created_at": t.created_at,
+                    "created_by": t.created_by,
+                    "created_at": t.created_at,
                     "started_at": t.started_at,
                     "completed_at": t.completed_at,
                     "result": t.result,
@@ -553,11 +585,15 @@ def _handle_show(args: dict, **kw) -> str:
 
             def _run_dict(r):
                 return {
-                    "id": r.id, "profile": r.profile,
-                    "status": r.status, "outcome": r.outcome,
-                    "summary": r.summary, "error": r.error,
+                    "id": r.id,
+                    "profile": r.profile,
+                    "status": r.status,
+                    "outcome": r.outcome,
+                    "summary": r.summary,
+                    "error": r.error,
                     "metadata": r.metadata,
-                    "started_at": r.started_at, "ended_at": r.ended_at,
+                    "started_at": r.started_at,
+                    "ended_at": r.ended_at,
                 }
 
             return json.dumps({
@@ -565,14 +601,17 @@ def _handle_show(args: dict, **kw) -> str:
                 "parents": parents,
                 "children": children,
                 "comments": [
-                    {"author": c.author, "body": c.body,
-                     "created_at": c.created_at}
+                    {"author": c.author, "body": c.body, "created_at": c.created_at}
                     for c in comments
                 ],
                 "events": [
-                    {"kind": e.kind, "payload": e.payload,
-                     "created_at": e.created_at, "run_id": e.run_id}
-                    for e in events[-50:]   # cap; full log via CLI
+                    {
+                        "kind": e.kind,
+                        "payload": e.payload,
+                        "created_at": e.created_at,
+                        "run_id": e.run_id,
+                    }
+                    for e in events[-50:]  # cap; full log via CLI
                 ],
                 "runs": [_run_dict(r) for r in runs],
                 # Also surface the worker's own context block so the
@@ -639,7 +678,8 @@ def _handle_list(args: dict, **kw) -> str:
                 "truncated": truncated,
                 "next_limit": (
                     min(limit * 2, KANBAN_LIST_MAX_LIMIT)
-                    if truncated and limit < KANBAN_LIST_MAX_LIMIT else None
+                    if truncated and limit < KANBAN_LIST_MAX_LIMIT
+                    else None
                 ),
                 "promoted": promoted,
             })
@@ -659,9 +699,7 @@ def _handle_complete(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -691,9 +729,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 f"{type(created_cards).__name__}"
             )
         # Normalise: strings only, stripped, non-empty.
-        created_cards = [
-            str(c).strip() for c in created_cards if str(c).strip()
-        ]
+        created_cards = [str(c).strip() for c in created_cards if str(c).strip()]
     if artifacts is not None:
         if isinstance(artifacts, str):
             # Accept a single path as a string for convenience.
@@ -703,9 +739,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 f"artifacts must be a list of file paths, got "
                 f"{type(artifacts).__name__}"
             )
-        artifacts = [
-            str(p).strip() for p in artifacts if str(p).strip()
-        ]
+        artifacts = [str(p).strip() for p in artifacts if str(p).strip()]
         # Carry the artifact list inside metadata so it rides the
         # existing completed-event payload without a schema change at
         # the DB layer.  The gateway notifier reads payload['artifacts']
@@ -716,8 +750,7 @@ def _handle_complete(args: dict, **kw) -> str:
                 metadata = {}
             elif not isinstance(metadata, dict):
                 return tool_error(
-                    f"metadata must be an object/dict, got "
-                    f"{type(metadata).__name__}"
+                    f"metadata must be an object/dict, got {type(metadata).__name__}"
                 )
             # Don't overwrite an existing metadata.artifacts the worker
             # passed manually — merge instead.
@@ -734,9 +767,7 @@ def _handle_complete(args: dict, **kw) -> str:
             else:
                 metadata["artifacts"] = artifacts
     if not (summary or result):
-        return tool_error(
-            "provide at least one of: summary (preferred), result"
-        )
+        return tool_error("provide at least one of: summary (preferred), result")
     if metadata is not None and not isinstance(metadata, dict):
         return tool_error(
             f"metadata must be an object/dict, got {type(metadata).__name__}"
@@ -767,8 +798,11 @@ def _handle_complete(args: dict, **kw) -> str:
 
             try:
                 ok = kb.complete_task(
-                    conn, tid,
-                    result=result, summary=summary, metadata=metadata,
+                    conn,
+                    tid,
+                    result=result,
+                    summary=summary,
+                    metadata=metadata,
                     created_cards=created_cards,
                     expected_run_id=_worker_run_id(tid),
                 )
@@ -821,9 +855,7 @@ def _handle_block(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -851,11 +883,7 @@ def _handle_block(args: dict, **kw) -> str:
         # and `transient` (or an unset kind) route back through
         # kanban_complete, which the judge now gates.
         task = kb.get_task(conn, tid)
-        if (
-            task
-            and task.goal_mode
-            and kind not in _GOAL_MODE_BLOCK_ALLOWED_KINDS
-        ):
+        if task and task.goal_mode and kind not in _GOAL_MODE_BLOCK_ALLOWED_KINDS:
             conn.close()
             return tool_error(
                 f"goal_mode tasks can only block with kind in "
@@ -866,15 +894,15 @@ def _handle_block(args: dict, **kw) -> str:
             )
         try:
             ok = kb.block_task(
-                conn, tid,
+                conn,
+                tid,
                 reason=reason,
                 kind=kind,
                 expected_run_id=_worker_run_id(tid),
             )
             if not ok:
                 return tool_error(
-                    f"could not block {tid} (unknown id or not in "
-                    f"running/ready)"
+                    f"could not block {tid} (unknown id or not in running/ready)"
                 )
             run = kb.latest_run(conn, tid)
             # Tell the worker where the task actually landed so it doesn't
@@ -902,9 +930,7 @@ def _handle_request_review(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -945,7 +971,8 @@ def _handle_request_review(args: dict, **kw) -> str:
                     "requesting review."
                 )
             ok, fail_reason = kb.request_review(
-                conn, tid,
+                conn,
+                tid,
                 summary=summary,
                 metadata=metadata,
                 reviewer=reviewer,
@@ -954,9 +981,7 @@ def _handle_request_review(args: dict, **kw) -> str:
             )
             if not ok:
                 detail = fail_reason or "unknown id or not in running/ready"
-                return tool_error(
-                    f"could not request review for {tid}: {detail}"
-                )
+                return tool_error(f"could not request review for {tid}: {detail}")
             run = kb.latest_run(conn, tid)
             landed = kb.get_task(conn, tid)
             return _ok(
@@ -980,9 +1005,7 @@ def _handle_request_changes(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -1036,9 +1059,7 @@ def _handle_heartbeat(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -1080,11 +1101,11 @@ def _handle_comment(args: dict, **kw) -> str:
     delegated_err = _reject_delegated_child_mutation("kanban_comment")
     if delegated_err:
         return delegated_err
-    tid = args.get("task_id")
+    tid = _default_task_id(args.get("task_id"))
     if not tid:
         return tool_error(
-            "task_id is required (use the current task id if that's what "
-            "you mean — pulls from env but kept explicit here)"
+            "task_id is required outside a dispatcher-spawned Kanban worker. "
+            "Use kanban_list to find a task, then pass its id explicitly."
         )
     body = args.get("body")
     if not body or not str(body).strip():
@@ -1130,9 +1151,7 @@ def _handle_attach(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -1144,6 +1163,7 @@ def _handle_attach(args: dict, **kw) -> str:
         return tool_error("content_base64 is required")
     import base64
     import binascii
+
     try:
         data = base64.b64decode(str(content_b64), validate=True)
     except (binascii.Error, ValueError) as e:
@@ -1222,11 +1242,15 @@ def _download_url_with_cap(url: str, max_bytes: int) -> tuple[bytes, Optional[st
             if resp.is_redirect:
                 location = resp.headers.get("location")
                 if not location:
-                    raise ValueError(f"redirect without Location header from {current_url}")
+                    raise ValueError(
+                        f"redirect without Location header from {current_url}"
+                    )
                 current_url = urljoin(current_url, location)
                 continue
             resp.raise_for_status()
-            content_type = (resp.headers.get("content-type") or "").split(";")[0].strip() or None
+            content_type = (resp.headers.get("content-type") or "").split(";")[
+                0
+            ].strip() or None
             for chunk in resp.iter_bytes(1024 * 1024):
                 total += len(chunk)
                 if total > max_bytes:
@@ -1252,9 +1276,7 @@ def _handle_attach_url(args: dict, **kw) -> str:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
@@ -1266,6 +1288,7 @@ def _handle_attach_url(args: dict, **kw) -> str:
     if not filename or not str(filename).strip():
         # Derive a name from the URL path's leaf component.
         from urllib.parse import unquote, urlparse
+
         leaf = unquote(urlparse(url).path.rsplit("/", 1)[-1]).strip()
         filename = leaf or "download"
     content_type = args.get("content_type")
@@ -1305,9 +1328,7 @@ def _handle_attachments(args: dict, **kw) -> str:
     """List a task's attachments (read-only; no ownership restriction)."""
     tid = _default_task_id(args.get("task_id"))
     if not tid:
-        return tool_error(
-            "task_id is required (or set HERMES_KANBAN_TASK in the env)"
-        )
+        return tool_error("task_id is required (or set HERMES_KANBAN_TASK in the env)")
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -1449,7 +1470,8 @@ def _handle_create(args: dict, **kw) -> str:
                 idempotency_key=idempotency_key,
                 max_runtime_seconds=(
                     int(max_runtime_seconds)
-                    if max_runtime_seconds is not None else None
+                    if max_runtime_seconds is not None
+                    else None
                 ),
                 skills=skills,
                 model_override=model_override,
@@ -1532,6 +1554,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     chat_id = ""
     try:
         from gateway.session_context import get_session_env
+
         platform = get_session_env("HERMES_SESSION_PLATFORM", "")
         chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
         if not platform or not chat_id:
@@ -1548,9 +1571,8 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             # every CLI invocation, which is exactly the over-eager
             # behaviour that got #19718 reverted upstream. The TUI
             # poller keys on HERMES_SESSION_KEY.
-            session_key = (
-                get_session_env("HERMES_SESSION_KEY", "")
-                or os.environ.get("HERMES_SESSION_KEY", "")
+            session_key = get_session_env("HERMES_SESSION_KEY", "") or os.environ.get(
+                "HERMES_SESSION_KEY", ""
             )
             if not session_key:
                 return False  # CLI / cron / test — no persistent channel
@@ -1563,13 +1585,13 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
         user_id_alt = get_session_env("HERMES_SESSION_USER_ID_ALT", "") or None
         message_id = get_session_env("HERMES_SESSION_MESSAGE_ID", "") or ""
-        notifier_profile = (
-            get_session_env("HERMES_SESSION_PROFILE", "")
-            or os.environ.get("HERMES_PROFILE")
-        )
+        notifier_profile = get_session_env(
+            "HERMES_SESSION_PROFILE", ""
+        ) or os.environ.get("HERMES_PROFILE")
         if not notifier_profile:
             try:
                 from hermes_cli.profiles import get_active_profile_name
+
                 notifier_profile = get_active_profile_name() or "default"
             except Exception:
                 notifier_profile = "default"
@@ -1591,10 +1613,15 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
 
         # Lazy-import to keep the module-level dependency light
         from hermes_cli import kanban_db as _kb
+
         _kb.add_notify_sub(
-            conn, task_id=task_id,
-            platform=platform, chat_id=chat_id,
-            thread_id=thread_id, user_id=user_id, user_id_alt=user_id_alt,
+            conn,
+            task_id=task_id,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            user_id=user_id,
+            user_id_alt=user_id_alt,
             chat_type=chat_type,
             notifier_profile=notifier_profile,
             delivery_mode=delivery_mode,
@@ -1604,7 +1631,9 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     except Exception as _exc:
         logger.warning(
             "_maybe_auto_subscribe failed: %r (platform=%r key_set=%r)",
-            _exc, platform, bool(chat_id),
+            _exc,
+            platform,
+            bool(chat_id),
         )
         return False
 
@@ -1671,8 +1700,15 @@ def _handle_link(args: dict, **kw) -> str:
 # ---------------------------------------------------------------------------
 
 _DESC_TASK_ID_DEFAULT = (
-    "Task id. If omitted, defaults to HERMES_KANBAN_TASK from the env "
-    "(the task the dispatcher spawned you to work on)."
+    "Task id. In dispatcher-spawned workers this can be omitted and defaults "
+    "to HERMES_KANBAN_TASK (the task the dispatcher spawned you to work on). "
+    "In ordinary chat/orchestrator sessions, pass a task_id explicitly."
+)
+
+_DESC_TASK_ID_SHOW = (
+    _DESC_TASK_ID_DEFAULT
+    + " If omitted outside a worker, kanban_show returns the compact "
+    "kanban_list view so you can choose a task_id."
 )
 
 _DESC_BOARD = (
@@ -1693,6 +1729,7 @@ def _board_schema_prop() -> dict[str, str]:
     """
     return {"type": "string", "description": _DESC_BOARD}
 
+
 KANBAN_SHOW_SCHEMA = {
     "name": "kanban_show",
     "description": (
@@ -1701,14 +1738,15 @@ KANBAN_SHOW_SCHEMA = {
         "and recent events. Use this to (re)orient yourself before "
         "starting work, especially on retries. The response includes a "
         "pre-formatted ``worker_context`` string suitable for inclusion "
-        "verbatim in your reasoning."
+        "verbatim in your reasoning. When no current dispatcher task exists "
+        "and no task_id is provided, returns the compact kanban_list view."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "task_id": {
                 "type": "string",
-                "description": _DESC_TASK_ID_DEFAULT,
+                "description": _DESC_TASK_ID_SHOW,
             },
             "board": _board_schema_prop(),
         },
@@ -1738,8 +1776,13 @@ KANBAN_LIST_SCHEMA = {
             "status": {
                 "type": "string",
                 "enum": [
-                    "triage", "todo", "ready", "running",
-                    "blocked", "done", "archived",
+                    "triage",
+                    "todo",
+                    "ready",
+                    "running",
+                    "blocked",
+                    "done",
+                    "archived",
                 ],
                 "description": "Optional task status filter.",
             },
@@ -1799,8 +1842,8 @@ KANBAN_COMPLETE_SCHEMA = {
                 "type": "object",
                 "description": (
                     "Free-form dict of structured facts about this "
-                    "attempt — {\"changed_files\": [...], \"tests_run\": 12, "
-                    "\"findings\": [...]}. Surfaced to downstream "
+                    'attempt — {"changed_files": [...], "tests_run": 12, '
+                    '"findings": [...]}. Surfaced to downstream '
                     "workers alongside ``summary``."
                 ),
             },
@@ -1836,8 +1879,8 @@ KANBAN_COMPLETE_SCHEMA = {
                     "Optional list of absolute paths to deliverable "
                     "files you produced during this run — generated "
                     "charts, PDFs, spreadsheets, images, archives. "
-                    "Examples: [\"/tmp/q3-revenue.png\", "
-                    "\"/tmp/report.pdf\"]. The gateway notifier "
+                    'Examples: ["/tmp/q3-revenue.png", '
+                    '"/tmp/report.pdf"]. The gateway notifier '
                     "uploads each path as a native attachment to the "
                     "subscribed chat (images embed inline, everything "
                     "else uploads as a file) so the deliverable "
@@ -2019,8 +2062,9 @@ KANBAN_COMMENT_SCHEMA = {
             "task_id": {
                 "type": "string",
                 "description": (
-                    "Task id. Required (may be your own task or "
-                    "another's — comment threads are per-task)."
+                    _DESC_TASK_ID_DEFAULT
+                    + " Comments may target your own task or another task — "
+                    "comment threads are per-task."
                 ),
             },
             "body": {
@@ -2029,7 +2073,7 @@ KANBAN_COMMENT_SCHEMA = {
             },
             "board": _board_schema_prop(),
         },
-        "required": ["task_id", "body"],
+        "required": ["body"],
     },
 }
 
@@ -2341,7 +2385,7 @@ KANBAN_LINK_SCHEMA = {
         "type": "object",
         "properties": {
             "parent_id": {"type": "string", "description": "Parent task id."},
-            "child_id":  {"type": "string", "description": "Child task id."},
+            "child_id": {"type": "string", "description": "Child task id."},
             "board": _board_schema_prop(),
         },
         "required": ["parent_id", "child_id"],


### PR DESCRIPTION
Summary
kanban_show exposed task_id as optional because worker sessions can default to HERMES_KANBAN_TASK, but ordinary chat/orchestrator sessions have no current task and received an unactionable env-var error. This makes a no-arg kanban_show return the compact kanban_list view with a hint so the agent can choose an explicit task_id, and aligns kanban_comment with the same worker env fallback while keeping chat errors actionable.

Changes
tools/kanban_tools.py: fall back from no-arg kanban_show to the compact board listing outside worker env, let kanban_comment default to HERMES_KANBAN_TASK in worker sessions, and update schema descriptions/required fields to match runtime behavior.
tests/tools/test_kanban_tools.py: add regressions for no-current-task kanban_show, env-default kanban_comment, and actionable chat-mode kanban_comment errors.

How to Test
python -m pytest tests/tools/test_kanban_tools.py tests/tools/test_kanban_comment_injection.py tests/tools/test_delegate_kanban_isolation.py -q
# ✅ 44/44 passed

Checklist
- [x] Tests pass — 44/44 targeted
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

Risk & Impact
Low. The change only affects Kanban tool calls with omitted task_id and preserves explicit task_id behavior.
Type: Bug fix
Closes: #91431

Notes
- ruff check . passed with pre-existing noqa warnings.
- scripts/run_tests.sh is blocked in this Termux environment by per-file runner PermissionError across 3155 files; targeted regressions pass.
- python scripts/check-windows-footguns.py --diff upstream/main passed.
