### PR TITLE
fix(desktop): constrain intro wordmark width

### DIFF
--- a/apps/desktop/src/components/chat/intro.tsx
+++ b/apps/desktop/src/components/chat/intro.tsx
@@ -168,7 +168,7 @@ export function Intro({ personality, seed }: IntroProps) {
       <div className="w-full min-w-0">
         <p
           aria-label={WORDMARK}
-          className="fit-text mx-auto mb-1 w-[calc(100%-1rem)] font-['Collapse'] font-bold uppercase leading-[0.9] tracking-[0.08em] text-midground mix-blend-plus-lighter dark:text-foreground/90"
+          className="fit-text mx-auto mb-1 w-[calc(100%-1rem)] max-w-3xl font-['Collapse'] font-bold uppercase leading-[0.9] tracking-[0.08em] text-midground mix-blend-plus-lighter dark:text-foreground/90"
           style={{ '--fit-min': '2.75rem' } as CSSProperties}
         >
           <span>


### PR DESCRIPTION
## Before

<img width="4594" height="2534" alt="CleanShot 2026-08-21 at 12 54 48@2x" src="https://github.com/user-attachments/assets/2d8ad4c2-48b5-4c1a-b99a-032aa4928cee" />


## After

<img width="4546" height="2538" alt="CleanShot 2026-08-21 at 13 06 10@2x" src="https://github.com/user-attachments/assets/2fd75c42-6520-4764-8e0b-74c105980037" />

The Hermes Desktop empty-chat wordmark expands across nearly the entire chat surface on wide windows.

Validation:
- `npm run typecheck`
- `npm run lint` (existing warnings only)
- `npm run build`
- `npx -y react-doctor@latest . --verbose --scope changed --base origin/main` (100/100)