### PR TITLE
i18n(desktop): localize sidebar filter menu and memory provider settings

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { useI18n } from '@/i18n'
+import type { Translations } from '@/i18n/types'
 import { desktopGit } from '@/lib/desktop-git'
 import { cn } from '@/lib/utils'
 import {
@@ -68,48 +69,51 @@ interface Option<T extends string = string> {
   dot?: string
   icon?: string
   id: T
+  /** Static option label — deprecated in favor of `labelKey` for translatable options. */
   label: string
+  /** i18n key into `t.sidebar.filters`; takes precedence over `label`. */
+  labelKey?: keyof Translations['sidebar']['filters']
 }
 
 const GROUPINGS: Option<SidebarGrouping>[] = [
-  { icon: 'clock', id: 'date', label: 'Updated' },
-  { icon: 'root-folder', id: 'project', label: 'Project' },
-  { icon: 'pulse', id: 'status', label: 'Status' },
-  { icon: 'account', id: 'profile', label: 'Profile' }
+  { icon: 'clock', id: 'date', label: 'Updated', labelKey: 'updated' },
+  { icon: 'root-folder', id: 'project', label: 'Project', labelKey: 'project' },
+  { icon: 'pulse', id: 'status', label: 'Status', labelKey: 'status' },
+  { icon: 'account', id: 'profile', label: 'Profile', labelKey: 'profile' }
 ]
 
 const ORDERINGS: Option<SidebarOrdering>[] = [
-  { icon: 'clock', id: 'updated', label: 'Updated' },
-  { icon: 'add', id: 'created', label: 'Created' },
-  { icon: 'pulse', id: 'status', label: 'Status' },
-  { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens' },
-  { icon: 'credit-card', id: 'cost', label: 'Cost' },
-  { icon: 'list-ordered', id: 'manual', label: 'Manual' }
+  { icon: 'clock', id: 'updated', label: 'Updated', labelKey: 'updated' },
+  { icon: 'add', id: 'created', label: 'Created', labelKey: 'created' },
+  { icon: 'pulse', id: 'status', label: 'Status', labelKey: 'status' },
+  { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens', labelKey: 'tokens' },
+  { icon: 'credit-card', id: 'cost', label: 'Cost', labelKey: 'cost' },
+  { icon: 'list-ordered', id: 'manual', label: 'Manual', labelKey: 'manual' }
 ]
 
 const ROW_META: Option<SidebarRowMeta>[] = [
-  { icon: 'clock', id: 'updated', label: 'Updated' },
-  { icon: 'comment', id: 'preview', label: 'Preview' },
-  { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens' },
-  { icon: 'credit-card', id: 'cost', label: 'Cost' },
-  { icon: 'git-pull-request', id: 'pr', label: 'PR' },
-  { icon: 'account', id: 'profile', label: 'Profile' }
+  { icon: 'clock', id: 'updated', label: 'Updated', labelKey: 'updated' },
+  { icon: 'comment', id: 'preview', label: 'Preview', labelKey: 'preview' },
+  { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens', labelKey: 'tokens' },
+  { icon: 'credit-card', id: 'cost', label: 'Cost', labelKey: 'cost' },
+  { icon: 'git-pull-request', id: 'pr', label: 'PR', labelKey: 'pr' },
+  { icon: 'account', id: 'profile', label: 'Profile', labelKey: 'profile' }
 ]
 
 const PR_FILTERS: Option<PullRequestBucket>[] = [
-  { icon: 'git-pull-request', id: 'open', label: 'Open' },
-  { icon: 'git-pull-request-draft', id: 'draft', label: 'Draft' },
-  { icon: 'git-merge', id: 'merged', label: 'Merged' },
-  { icon: 'git-pull-request-closed', id: 'closed', label: 'Closed' },
-  { icon: 'circle-slash', id: 'none', label: 'No PR' }
+  { icon: 'git-pull-request', id: 'open', label: 'Open', labelKey: 'open' },
+  { icon: 'git-pull-request-draft', id: 'draft', label: 'Draft', labelKey: 'draft' },
+  { icon: 'git-merge', id: 'merged', label: 'Merged', labelKey: 'merged' },
+  { icon: 'git-pull-request-closed', id: 'closed', label: 'Closed', labelKey: 'closed' },
+  { icon: 'circle-slash', id: 'none', label: 'No PR', labelKey: 'noPr' }
 ]
 
 const STATUS_FILTERS: Option<SessionStatusBucket>[] = [
-  { dot: sessionDotClassName('needs-input'), id: 'needs-input', label: 'Needs input' },
-  { dot: sessionDotClassName('working'), id: 'working', label: 'Working' },
-  { dot: sessionDotClassName('unread'), id: 'unread', label: 'Unread' },
-  { dot: sessionDotClassName('draft'), id: 'draft', label: 'Draft' },
-  { dot: cn(sessionDotClassName('idle'), 'bg-(--ui-text-quaternary)'), id: 'idle', label: 'Idle' }
+  { dot: sessionDotClassName('needs-input'), id: 'needs-input', label: 'Needs input', labelKey: 'needsInput' },
+  { dot: sessionDotClassName('working'), id: 'working', label: 'Working', labelKey: 'working' },
+  { dot: sessionDotClassName('unread'), id: 'unread', label: 'Unread', labelKey: 'unread' },
+  { dot: sessionDotClassName('draft'), id: 'draft', label: 'Draft', labelKey: 'draft' },
+  { dot: cn(sessionDotClassName('idle'), 'bg-(--ui-text-quaternary)'), id: 'idle', label: 'Idle', labelKey: 'idle' }
 ]
 
 function OptionGlyph({ option }: { option: Option }) {
@@ -120,11 +124,28 @@ function OptionGlyph({ option }: { option: Option }) {
   return option.icon ? <Codicon className="text-(--ui-text-tertiary)" name={option.icon} size="0.8125rem" /> : null
 }
 
+function optionText(
+  option: Option,
+  filters: Translations['sidebar']['filters']
+): string {
+  return option.labelKey ? filters[option.labelKey] : option.label
+}
+
 /** Every option row — single or multi select — leaves the menu open, so a whole
  *  view can be set up in one pass. Only the actions at the bottom dismiss it. */
 const keepOpen = (event: Event) => event.preventDefault()
 
-function OptionCheckbox({ checked, onCheck, option }: { checked: boolean; onCheck: () => void; option: Option }) {
+function OptionCheckbox({
+  checked,
+  filters,
+  onCheck,
+  option
+}: {
+  checked: boolean
+  filters: Translations['sidebar']['filters']
+  onCheck: () => void
+  option: Option
+}) {
   return (
     <DropdownMenuCheckboxItem
       checked={checked}
@@ -134,22 +155,29 @@ function OptionCheckbox({ checked, onCheck, option }: { checked: boolean; onChec
       }}
     >
       <OptionGlyph option={option} />
-      {option.label}
+      {optionText(option, filters)}
     </DropdownMenuCheckboxItem>
   )
 }
 
-function OptionRadio({ option }: { option: Option }) {
+function OptionRadio({
+  filters,
+  option
+}: {
+  filters: Translations['sidebar']['filters']
+  option: Option
+}) {
   return (
     <DropdownMenuRadioItem onSelect={keepOpen} value={option.id}>
       <OptionGlyph option={option} />
-      {option.label}
+      {optionText(option, filters)}
     </DropdownMenuRadioItem>
   )
 }
 
 export function SidebarFilterMenu({ className }: { className?: string }) {
   const { t } = useI18n()
+  const filters = t.sidebar.filters
   const grouping = useStore($sidebarGrouping)
   const ordering = useStore($sidebarOrdering)
   const rowMeta = useStore($sidebarRowMeta)
@@ -176,7 +204,10 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
   // been explicitly shut.
   const projectsCollapsed = projects.length > 0 && projects.every(project => nodeOpen[project.id] === false)
 
-  const groupingLabel = GROUPINGS.find(option => option.id === grouping)?.label
+  const groupingLabel = optionText(
+    GROUPINGS.find(option => option.id === grouping) ?? GROUPINGS[0],
+    filters
+  )
 
   // Two options are conditional: dragging a row is what picks manual, so it
   // only appears as a way back out once there's a hand-picked order to leave;
@@ -206,7 +237,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          aria-label="Filters"
+          aria-label={filters.filters}
           className={cn(
             className,
             'data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground data-[state=open]:opacity-100',
@@ -227,7 +258,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
         <DropdownMenuGroup>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger hideChevron>
-              Grouping
+              {filters.grouping}
               <span className="ml-auto flex items-center gap-1 pl-4 text-(--ui-text-tertiary)">
                 {groupingLabel}
                 <Codicon name="chevron-right" size="1rem" />
@@ -239,32 +270,33 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
                 value={grouping}
               >
                 {GROUPINGS.map(option => (
-                  <OptionRadio key={option.id} option={option} />
+                  <OptionRadio filters={filters} key={option.id} option={option} />
                 ))}
               </DropdownMenuRadioGroup>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Ordering</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{filters.ordering}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               <DropdownMenuRadioGroup
                 onValueChange={value => setSidebarOrdering(value as SidebarOrdering)}
                 value={ordering}
               >
                 {orderings.map(option => (
-                  <OptionRadio key={option.id} option={option} />
+                  <OptionRadio filters={filters} key={option.id} option={option} />
                 ))}
               </DropdownMenuRadioGroup>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Show</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{filters.show}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {rowMetaOptions.map(option => (
                 <OptionCheckbox
                   checked={rowMeta.includes(option.id)}
+                  filters={filters}
                   key={option.id}
                   onCheck={() => toggleSidebarRowMeta(option.id)}
                   option={option}
@@ -277,22 +309,24 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
               title / model · size) compose with whichever grouping is active. */}
           <OptionCheckbox
             checked={cardRows}
+            filters={filters}
             onCheck={() => setSidebarCardRows(!cardRows)}
-            option={{ icon: 'inbox', id: 'card-rows', label: 'Inbox style' }}
+            option={{ icon: 'inbox', id: 'card-rows', label: 'Inbox style', labelKey: 'inboxStyle' }}
           />
         </DropdownMenuGroup>
 
         <DropdownMenuSeparator />
 
         <DropdownMenuGroup>
-          <DropdownMenuLabel>Filters</DropdownMenuLabel>
+          <DropdownMenuLabel>{filters.filters}</DropdownMenuLabel>
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Status</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{filters.status}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {STATUS_FILTERS.map(option => (
                 <OptionCheckbox
                   checked={statusFilter.includes(option.id)}
+                  filters={filters}
                   key={option.id}
                   onCheck={() => toggleSidebarStatusFilter(option.id)}
                   option={option}
@@ -305,11 +339,12 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
               this submenu never appears rather than filtering everything out. */}
           {prAvailable && (
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger>Pull request</DropdownMenuSubTrigger>
+              <DropdownMenuSubTrigger>{filters.pullRequest}</DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
                 {PR_FILTERS.map(option => (
                   <OptionCheckbox
                     checked={prFilter.includes(option.id)}
+                    filters={filters}
                     key={option.id}
                     onCheck={() => toggleSidebarPrFilter(option.id)}
                     option={option}
@@ -320,7 +355,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           )}
 
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Profile</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{filters.profile}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent className="max-h-80 overflow-y-auto">
               {/* Scoped to one profile the rail is already the filter, so the
                   per-profile boxes only appear where they can narrow something.
@@ -330,6 +365,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
                   {profileNames.map(name => (
                     <OptionCheckbox
                       checked={profileFilter.includes(name)}
+                      filters={filters}
                       key={name}
                       onCheck={() => toggleSidebarProfileFilter(name)}
                       option={{ icon: 'account', id: name, label: name }}
@@ -347,11 +383,12 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
 
           {projects.length > 1 && (
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger>Project</DropdownMenuSubTrigger>
+              <DropdownMenuSubTrigger>{filters.project}</DropdownMenuSubTrigger>
               <DropdownMenuSubContent className="max-h-80 overflow-y-auto">
                 {projects.map(project => (
                   <OptionCheckbox
                     checked={projectFilter.includes(project.id)}
+                    filters={filters}
                     key={project.id}
                     onCheck={() => toggleSidebarProjectFilter(project.id)}
                     option={{
@@ -374,6 +411,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           {(profileNames.length > 1 || showAllProfiles) && (
             <OptionCheckbox
               checked={showAllProfiles}
+              filters={filters}
               onCheck={toggleShowAllProfiles}
               option={{ id: 'all-profiles', label: t.profiles.allProfiles }}
             />
@@ -381,13 +419,16 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
 
           <OptionCheckbox
             checked={showArchived}
+            filters={filters}
             onCheck={() => setSidebarShowArchived(!showArchived)}
-            option={{ id: 'archived', label: 'Archived' }}
+            option={{ id: 'archived', label: 'Archived', labelKey: 'archived' }}
           />
 
           {/* One way back rather than two near-identical ones: this drops the
               grouping and sort too, which "clear filters" left behind. */}
-          {viewCustomized && <DropdownMenuItem onSelect={resetSidebarView}>Reset to defaults</DropdownMenuItem>}
+          {viewCustomized && (
+            <DropdownMenuItem onSelect={resetSidebarView}>{filters.resetToDefaults}</DropdownMenuItem>
+          )}
         </DropdownMenuGroup>
 
         <DropdownMenuSeparator />
@@ -405,11 +446,11 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
               )
             }
           >
-            {projectsCollapsed ? 'Expand all' : 'Collapse all'}
+            {projectsCollapsed ? filters.expandAll : filters.collapseAll}
           </DropdownMenuItem>
         )}
         <DropdownMenuItem disabled={unreadIds.length === 0} onSelect={markAllSessionsRead}>
-          Mark all as read
+          {t.sidebar.markAllRead}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/desktop/src/app/settings/memory/field-control.tsx
+++ b/apps/desktop/src/app/settings/memory/field-control.tsx
@@ -3,6 +3,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
 import { Check, Info } from '@/lib/icons'
 import type { MemoryProviderField } from '@/types/hermes'
 
@@ -13,6 +14,9 @@ const FIELD_INPUT = `font-mono ${CONTROL_TEXT} placeholder:text-muted-foreground
 
 // Field label with an optional info tooltip, shared by the panel and modal rows.
 export function FieldTitle({ field }: { field: MemoryProviderField }) {
+  const { t } = useI18n()
+  const mk = t.settings.memoryProvider
+
   if (!field.info) {
     return <>{field.label}</>
   }
@@ -21,7 +25,7 @@ export function FieldTitle({ field }: { field: MemoryProviderField }) {
     <span className="inline-flex items-center gap-1.5">
       {field.label}
       <Tip className="max-w-60 font-normal leading-snug whitespace-normal" label={field.info}>
-        <Info aria-label={`About ${field.label}`} className="size-3.5 text-muted-foreground/70" />
+        <Info aria-label={mk.aboutField(field.label)} className="size-3.5 text-muted-foreground/70" />
       </Tip>
     </span>
   )
@@ -41,6 +45,9 @@ export function FieldControl({
   // controls commit on blur. Absent (the modal), edits stay drafts until Save.
   onCommit?: (value: string) => void
 }) {
+  const { t } = useI18n()
+  const mk = t.settings.memoryProvider
+
   const set = (next: string) => {
     onChange(next)
     onCommit?.(next)
@@ -103,14 +110,14 @@ export function FieldControl({
           className={`w-full ${FIELD_INPUT}`}
           onBlur={commitDraft}
           onChange={event => onChange(event.target.value)}
-          placeholder={field.is_set ? 'Leave blank to keep current value' : field.placeholder}
+          placeholder={field.is_set ? mk.leaveBlank : field.placeholder}
           type="password"
           value={value}
         />
         {field.is_set && (
           <span className="inline-flex items-center gap-1 self-start font-mono text-[0.65rem] text-(--ui-text-tertiary)">
             <Check className="size-3 text-(--ui-accent-secondary)" />
-            set
+            {mk.setBadge}
           </span>
         )}
       </div>

--- a/apps/desktop/src/app/settings/memory/localize-provider.test.ts
+++ b/apps/desktop/src/app/settings/memory/localize-provider.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { zh } from '@/i18n/zh'
+import type { MemoryProviderField } from '@/types/hermes'
+
+import { localizeField, localizeFields } from './localize-provider'
+
+// A Hindsight-ish field carrying the backend's English schema text.
+function hindsightField(overrides: Partial<MemoryProviderField> = {}): MemoryProviderField {
+  return {
+    key: 'api_key',
+    label: 'API key',
+    kind: 'secret',
+    value: '',
+    description: 'Used to authenticate with the Hindsight API.',
+    placeholder: 'Enter Hindsight API key',
+    is_set: false,
+    inline: true,
+    group: 'Connection',
+    options: [],
+    ...overrides
+  }
+}
+
+describe('localizeField', () => {
+  it('overlays the active locale copy for a known provider field', () => {
+    const field = localizeField('hindsight', hindsightField(), zh.settings.memoryProvider)
+
+    expect(field.label).toBe('API 密钥')
+    expect(field.description).toBe('用于通过 Hindsight API 进行身份验证。')
+    expect(field.placeholder).toBe('输入 Hindsight API 密钥')
+  })
+
+  it('passes through unknown providers untouched', () => {
+    const field = localizeField('honcho', hindsightField(), zh.settings.memoryProvider)
+
+    expect(field.label).toBe('API key')
+    expect(field.description).toBe('Used to authenticate with the Hindsight API.')
+    expect(field.placeholder).toBe('Enter Hindsight API key')
+  })
+
+  it('leaves fields without a locale override alone', () => {
+    const field = localizeField('hindsight', hindsightField({ key: 'api_url', label: 'API URL' }), zh.settings.memoryProvider)
+
+    // No override registered beyond the ones in zh.ts — label falls back to schema text.
+    expect(field.label).toBe('API URL')
+  })
+
+  it('translates select option labels for known option values', () => {
+    const field = localizeField(
+      'hindsight',
+      hindsightField({
+        key: 'mode',
+        kind: 'select',
+        label: 'Mode',
+        options: [
+          { value: 'cloud', label: 'Cloud', description: 'Hindsight Cloud API (lightweight, just needs an API key)' },
+          { value: 'local_external', label: 'Local External', description: 'Connect to an existing Hindsight instance' }
+        ]
+      }),
+      zh.settings.memoryProvider
+    )
+
+    expect(field.label).toBe('模式')
+    expect(field.options[0].label).toBe('云端')
+    expect(field.options[0].description).toContain('轻量')
+    expect(field.options[1].label).toBe('本地外部')
+  })
+
+  it('does not mutate the schema field object', () => {
+    const original = hindsightField()
+    localizeField('hindsight', original, zh.settings.memoryProvider)
+
+    expect(original.label).toBe('API key')
+    expect(original.description).toBe('Used to authenticate with the Hindsight API.')
+  })
+})
+
+describe('localizeFields', () => {
+  it('maps every field of a config payload', () => {
+    const fields = localizeFields(
+      'hindsight',
+      [hindsightField(), hindsightField({ key: 'bank_id', label: 'Bank ID' })],
+      zh.settings.memoryProvider
+    )
+
+    expect(fields[0].label).toBe('API 密钥')
+    expect(fields[1].label).toBe('Bank ID') // no zh override for bank_id
+  })
+})

--- a/apps/desktop/src/app/settings/memory/localize-provider.ts
+++ b/apps/desktop/src/app/settings/memory/localize-provider.ts
@@ -1,0 +1,50 @@
+/**
+ * Render-layer localization for backend-provided memory provider config
+ * surfaces (Hindsight & friends). The backend schema text is shared by every
+ * language, so it stays English; these helpers overlay per-provider overrides
+ * from the active locale bundle at render time — without touching the schema.
+ */
+
+import type { Translations } from '@/i18n/types'
+import type { MemoryProviderField, MemoryProviderFieldOption } from '@/types/hermes'
+
+type ProviderCopy = Translations['settings']['memoryProvider']
+
+/** Overlay locale overrides onto a backend-provided field (label/description/
+ *  placeholder/option labels). Returns a new object; the schema field is untouched. */
+export function localizeField(
+  provider: string,
+  field: MemoryProviderField,
+  copy: ProviderCopy
+): MemoryProviderField {
+  const key = `${provider}.${field.key}`
+  const label = copy.fieldOverrides[key] ?? field.label
+  const description = copy.descOverrides[key] ?? field.description
+  const placeholder = copy.placeholderOverrides[key] ?? field.placeholder
+
+  let options = field.options
+  if (options && options.length > 0) {
+    options = options.map((option: MemoryProviderFieldOption) => {
+      const optionLabel = copy.optionOverrides[`${key}.${option.value}`] ?? option.label
+      const optionDesc = copy.optionOverrides[`${key}.${option.value}.desc`] ?? option.description
+      return optionLabel === option.label && optionDesc === option.description
+        ? option
+        : { ...option, label: optionLabel, description: optionDesc }
+    })
+  }
+
+  if (label === field.label && description === field.description && placeholder === field.placeholder && options === field.options) {
+    return field
+  }
+
+  return { ...field, label, description, placeholder, options }
+}
+
+/** Apply `localizeField` to every field of a config payload. */
+export function localizeFields(
+  provider: string,
+  fields: MemoryProviderField[],
+  copy: ProviderCopy
+): MemoryProviderField[] {
+  return fields.map(field => localizeField(provider, field, copy))
+}

--- a/apps/desktop/src/app/settings/memory/provider-config-modal.tsx
+++ b/apps/desktop/src/app/settings/memory/provider-config-modal.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog'
+import { useI18n } from '@/i18n'
 import { saveMemoryProviderConfig } from '@/hermes'
 import { ExternalLink, Loader2, Save, SlidersHorizontal } from '@/lib/icons'
 import { notify, notifyError } from '@/store/notifications'
@@ -20,6 +21,7 @@ import type { MemoryProviderConfig, MemoryProviderField } from '@/types/hermes'
 import { ListRow } from '../primitives'
 
 import { FieldControl, FieldTitle } from './field-control'
+import { localizeFields } from './localize-provider'
 
 // Secrets seed blank: values are write-only and blank keeps the stored one.
 function seedAll(config: MemoryProviderConfig): Record<string, string> {
@@ -59,6 +61,8 @@ export function ProviderConfigModal({
   onOpenChange: (open: boolean) => void
   onSaved: () => Promise<void> | void
 }) {
+  const { t } = useI18n()
+  const mk = t.settings.memoryProvider
   const activeProfile = useStore($activeGatewayProfile)
   const [values, setValues] = useState<Record<string, string>>({})
   const [seeded, setSeeded] = useState<Record<string, string>>({})
@@ -81,11 +85,11 @@ export function ProviderConfigModal({
 
     try {
       await saveMemoryProviderConfig(provider, edited, profile)
-      notify({ kind: 'success', title: `${config.label} saved`, message: 'Memory provider configuration updated.' })
+      notify({ kind: 'success', title: mk.savedTitle(config.label), message: mk.savedMessage })
       await onSaved()
       onOpenChange(false)
     } catch (err) {
-      notifyError(err, `Failed to save ${config.label} settings`)
+      notifyError(err, mk.saveFailed(config.label))
     } finally {
       setSaving(false)
     }
@@ -95,10 +99,11 @@ export function ProviderConfigModal({
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent bodyClassName="dt-portal-scrollbar" className="max-w-2xl">
         <DialogHeader>
-          <DialogTitle icon={SlidersHorizontal}>{config.label} — full configuration</DialogTitle>
+          <DialogTitle icon={SlidersHorizontal}>{mk.fullTitle(config.label)}</DialogTitle>
           <DialogDescription>
-            Every {config.label} option for the <span className="font-medium">{profile ?? activeProfile}</span> profile.
-            Blank fields fall back to the resolved host or built-in default.
+            {mk.fullEmptyDesc(config.label, profile ?? activeProfile)}
+            <br />
+            {mk.fullFallbackDesc}
           </DialogDescription>
           {config.docs_url && (
             <a
@@ -111,14 +116,14 @@ export function ProviderConfigModal({
               rel="noreferrer"
               target="_blank"
             >
-              {config.label} configuration reference
+              {mk.docsRef(config.label)}
               <ExternalLink className="size-3" />
             </a>
           )}
         </DialogHeader>
 
         <div className="min-w-0">
-          {groupFields(config.fields).map(([group, fields]) => (
+          {groupFields(localizeFields(provider, config.fields, mk)).map(([group, fields]) => (
             <section className="mt-6 first:mt-2" key={group}>
               <h3 className="border-b border-(--ui-accent-secondary)/30 pb-1.5 font-mono text-[0.68rem] uppercase tracking-wide text-(--ui-accent-secondary)">
                 {group}
@@ -147,12 +152,12 @@ export function ProviderConfigModal({
         <DialogFooter>
           <DialogClose asChild>
             <Button size="sm" type="button" variant="ghost">
-              Cancel
+              {mk.cancel}
             </Button>
           </DialogClose>
           <Button disabled={saving} onClick={() => void save()} size="sm">
             {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Save />}
-            Save changes
+            {mk.saveChanges}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/desktop/src/app/settings/memory/provider-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/memory/provider-config-panel.test.tsx
@@ -207,3 +207,75 @@ describe('ProviderConfigPanel', () => {
     expect(container.querySelector('section')).toBeNull()
   })
 })
+
+describe('ProviderConfigPanel locale localization', () => {
+  function hindsightSchema(): MemoryProviderConfig {
+    return {
+      name: 'hindsight',
+      label: 'Hindsight',
+      docs_url: '',
+      fields: [
+        {
+          key: 'api_key',
+          label: 'API key',
+          kind: 'secret',
+          value: '',
+          description: 'Used to authenticate with the Hindsight API.',
+          placeholder: 'Enter Hindsight API key',
+          is_set: false,
+          inline: true,
+          group: 'Connection',
+          options: []
+        },
+        {
+          key: 'recall_budget',
+          label: 'Recall budget',
+          kind: 'select',
+          value: 'mid',
+          description: '',
+          placeholder: '',
+          is_set: true,
+          inline: true,
+          group: 'Connection',
+          options: [
+            { value: 'low', label: 'low', description: '' },
+            { value: 'mid', label: 'mid', description: '' },
+            { value: 'high', label: 'high', description: '' }
+          ]
+        }
+      ]
+    }
+  }
+
+  async function renderPanelZh(provider = 'hindsight') {
+    const { I18nProvider } = await import('@/i18n/context')
+    const { ProviderConfigPanel } = await import('./provider-config-panel')
+
+    return render(
+      <I18nProvider configClient={null} initialLocale="zh">
+        <ProviderConfigPanel provider={provider} />
+      </I18nProvider>
+    )
+  }
+
+  it('renders provider settings in Chinese when the locale is zh', async () => {
+    getMemoryProviderConfig.mockResolvedValue(hindsightSchema())
+
+    await renderPanelZh()
+
+    // Panel title, secret pill, localized field label + description + placeholder.
+    expect(await screen.findByRole('button', { name: /Hindsight 设置/ })).toBeTruthy()
+    expect(screen.getByText('API 密钥 尚未设置')).toBeTruthy()
+    expect(screen.getByText('API 密钥')).toBeTruthy()
+    expect(screen.getByText('用于通过 Hindsight API 进行身份验证。')).toBeTruthy()
+    expect(screen.getByPlaceholderText('输入 Hindsight API 密钥')).toBeTruthy()
+  })
+
+  it('overlays zh option labels on select fields', async () => {
+    getMemoryProviderConfig.mockResolvedValue(hindsightSchema())
+
+    await renderPanelZh()
+
+    expect(await screen.findByText('召回预算')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/settings/memory/provider-config-panel.tsx
+++ b/apps/desktop/src/app/settings/memory/provider-config-panel.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
+import { useI18n } from '@/i18n'
 import { getMemoryProviderConfig, saveMemoryProviderConfig } from '@/hermes'
 import { SlidersHorizontal } from '@/lib/icons'
 import { notifyError } from '@/store/notifications'
@@ -11,6 +12,7 @@ import type { MemoryProviderConfig, MemoryProviderField } from '@/types/hermes'
 import { ListRow, Pill } from '../primitives'
 
 import { FieldControl, FieldTitle } from './field-control'
+import { localizeFields } from './localize-provider'
 import { ProviderConfigModal } from './provider-config-modal'
 
 // Inline fields only: the compact panel must never re-write modal-owned keys.
@@ -21,6 +23,8 @@ function seedValues(config: MemoryProviderConfig): Record<string, string> {
 }
 
 export function ProviderConfigPanel({ profile = null, provider }: { profile?: null | string; provider: string }) {
+  const { t } = useI18n()
+  const mk = t.settings.memoryProvider
   const [config, setConfig] = useState<MemoryProviderConfig | null>(null)
   const [loadError, setLoadError] = useState<null | string>(null)
   const [values, setValues] = useState<Record<string, string>>({})
@@ -87,20 +91,24 @@ export function ProviderConfigPanel({ profile = null, provider }: { profile?: nu
       return (
         <div className="flex items-center justify-between gap-3 py-2">
           <span className="text-[length:var(--conversation-caption-font-size)] text-muted-foreground">
-            Memory provider settings failed to load: {loadError}
+            {mk.loadFailed}: {loadError}
           </span>
           <Button onClick={() => void refresh()} size="sm" type="button" variant="secondary">
-            Retry
+            {mk.retry}
           </Button>
         </div>
       )
     }
 
-    return <PageLoader className="min-h-24" label="Loading memory provider settings..." />
+    return <PageLoader className="min-h-24" label={mk.loading} />
   }
 
-  const inlineFields = config.fields.filter(field => field.inline)
-  const secretFields = config.fields.filter(field => field.kind === 'secret')
+  const inlineFields = localizeFields(provider, config.fields.filter(field => field.inline), mk)
+  const secretFields = localizeFields(
+    provider,
+    config.fields.filter(field => field.kind === 'secret'),
+    mk
+  )
   const hasFullConfig = config.fields.some(field => !field.inline)
 
   return (
@@ -114,16 +122,16 @@ export function ProviderConfigPanel({ profile = null, provider }: { profile?: nu
         >
           <DisclosureCaret open={expanded} />
           <span className="text-[length:var(--conversation-text-font-size)] font-medium text-foreground">
-            {config.label} settings
+            {mk.settingsTitle(config.label)}
           </span>
           {secretFields.map(field => (
-            <Pill key={field.key}>{field.is_set ? `${field.label} set` : `${field.label} not set`}</Pill>
+            <Pill key={field.key}>{field.is_set ? mk.fieldSet(field.label) : mk.fieldNotSet(field.label)}</Pill>
           ))}
         </button>
         {hasFullConfig && (
           <Button onClick={() => setShowModal(true)} size="sm" type="button" variant="secondary">
             <SlidersHorizontal className="size-3.5" />
-            Full config…
+            {mk.fullConfig}
           </Button>
         )}
       </div>

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -313,6 +313,12 @@ function AgentPluginsSection() {
 function PluginRow({ record }: { record: PluginRecord }) {
   const { t } = useI18n()
   const p = t.settings.plugins
+  // Bundled plugins carry their author-facing English name/description; overlay
+  // the locale copy when one is registered for the id (third-party plugins fall
+  // back to their own metadata).
+  const builtin = record.kind === 'bundled' ? p.builtin[record.id] : undefined
+  const name = builtin?.name ?? record.name
+  const description = builtin?.description ?? record.description
 
   return (
     <PluginLine
@@ -326,7 +332,7 @@ function PluginRow({ record }: { record: PluginRecord }) {
             </Tip>
           )}
           <Switch
-            aria-label={`${record.status === 'disabled' ? p.enable : p.disable} ${record.name}`}
+            aria-label={`${record.status === 'disabled' ? p.enable : p.disable} ${name}`}
             checked={record.status !== 'disabled'}
             onCheckedChange={on => {
               triggerHaptic('selection')
@@ -339,13 +345,13 @@ function PluginRow({ record }: { record: PluginRecord }) {
         record.status === 'error' ? (
           <span className="text-(--ui-danger,#f87171)">{record.error}</span>
         ) : (
-          (record.description ?? record.file ?? record.id)
+          (description ?? record.file ?? record.id)
         )
       }
       id={pluginElementId(record.id)}
       title={
         <>
-          <span>{record.name}</span>
+          <span>{name}</span>
           <Pill>{p.kinds[record.kind]}</Pill>
           {record.status === 'error' && <Pill tone="primary">{p.failed}</Pill>}
         </>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -429,6 +429,63 @@ export const en: Translations = {
         agentFailed: 'Agent plugin install failed',
         desktopFailed: 'Desktop plugin install failed',
         missingEnv: vars => `Missing env vars: ${vars}. Add them in Settings → Keys.`
+      },
+      builtin: {
+        accent: {
+          name: 'Accent Picker',
+          description:
+            'Pick the theme accent from an OKLCH color picker in the status bar; the palette re-derives live. Authoring tool — the color is not persisted.'
+        },
+        'hermes-bots': {
+          name: 'Bots',
+          description:
+            'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.'
+        },
+        kanban: {
+          name: 'Kanban',
+          description: 'Multi-agent task board — board page, sidebar entry, and a live in-flight count in the status bar.'
+        }
+      }
+    },
+    memoryProvider: {
+      settingsTitle: label => `${label} settings`,
+      fullConfig: 'Full config…',
+      loading: 'Loading memory provider settings...',
+      loadFailed: 'Memory provider settings failed to load',
+      retry: 'Retry',
+      fieldSet: label => `${label} set`,
+      fieldNotSet: label => `${label} not set`,
+      fullTitle: label => `${label} — full configuration`,
+      fullEmptyDesc: (label, profile) => `Every ${label} option for the ${profile} profile.`,
+      fullFallbackDesc: 'Blank fields fall back to the resolved host or built-in default.',
+      docsRef: label => `${label} configuration reference`,
+      cancel: 'Cancel',
+      saveChanges: 'Save changes',
+      savedTitle: label => `${label} saved`,
+      savedMessage: 'Memory provider configuration updated.',
+      saveFailed: label => `Failed to save ${label} settings`,
+      leaveBlank: 'Leave blank to keep current value',
+      setBadge: 'set',
+      aboutField: label => `About ${label}`,
+      fieldOverrides: {
+        'hindsight.mode': 'Mode',
+        'hindsight.api_key': 'API key',
+        'hindsight.api_url': 'API URL',
+        'hindsight.bank_id': 'Bank ID',
+        'hindsight.recall_budget': 'Recall budget'
+      },
+      descOverrides: {
+        'hindsight.mode': 'How Hermes connects to Hindsight.',
+        'hindsight.api_key': 'Used to authenticate with the Hindsight API.'
+      },
+      placeholderOverrides: {
+        'hindsight.api_key': 'Enter Hindsight API key'
+      },
+      optionOverrides: {
+        'hindsight.mode.cloud': 'Cloud',
+        'hindsight.mode.cloud.desc': 'Hindsight Cloud API (lightweight, just needs an API key)',
+        'hindsight.mode.local_external': 'Local External',
+        'hindsight.mode.local_external.desc': 'Connect to an existing Hindsight instance'
       }
     },
     notifications: {
@@ -2208,6 +2265,37 @@ export const en: Translations = {
     statusDivider: {
       working: 'Working',
       done: 'Done'
+    },
+    filters: {
+      grouping: 'Grouping',
+      ordering: 'Ordering',
+      show: 'Show',
+      filters: 'Filters',
+      status: 'Status',
+      pullRequest: 'Pull request',
+      profile: 'Profile',
+      project: 'Project',
+      updated: 'Updated',
+      created: 'Created',
+      tokens: 'Tokens',
+      cost: 'Cost',
+      manual: 'Manual',
+      preview: 'Preview',
+      pr: 'PR',
+      open: 'Open',
+      draft: 'Draft',
+      merged: 'Merged',
+      closed: 'Closed',
+      noPr: 'No PR',
+      needsInput: 'Needs input',
+      working: 'Working',
+      unread: 'Unread',
+      idle: 'Idle',
+      inboxStyle: 'Inbox style',
+      archived: 'Archived',
+      resetToDefaults: 'Reset to defaults',
+      expandAll: 'Expand all',
+      collapseAll: 'Collapse all'
     },
     markAllRead: 'Mark all as read'
   },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1089,6 +1089,64 @@ export const ja = defineLocale({
         failedSelect: backend => `${backend} の選択に失敗しました`,
         needsSetupHint: 'このバックエンドは今すぐ選択できますが、セットアップが完了するまでコマンドは失敗します。'
       }
+    },
+    plugins: {
+      builtin: {
+        accent: {
+          name: 'アクセントピッカー',
+          description: 'ステータスバーの OKLCH カラーピッカーでテーマのアクセントカラーを選択。パレットはライブで再生成されます。作者向けツール——色は保持されません。'
+        },
+        'hermes-bots': {
+          name: 'ボット',
+          description:
+            'ボットモード——アバター、ルーティン、グループチャット、ボット間メッセージを備えた、エージェントごとに 1 チャットのロースター。アプリに同梱。不要ならここで無効化できます。'
+        },
+        kanban: {
+          name: 'カンバン',
+          description: 'マルチエージェントタスクボード——ボードページ、サイドバーエントリ、ステータスバーの実行中カウント。'
+        }
+      }
+    },
+    memoryProvider: {
+      settingsTitle: label => `${label} 設定`,
+      fullConfig: '全設定…',
+      loading: 'メモリプロバイダー設定を読み込み中…',
+      loadFailed: 'メモリプロバイダー設定の読み込みに失敗しました',
+      retry: '再試行',
+      fieldSet: label => `${label} は設定済み`,
+      fieldNotSet: label => `${label} は未設定`,
+      fullTitle: label => `${label} — 全設定`,
+      fullEmptyDesc: (label, profile) => `${profile} プロファイルのすべての${label}オプションを設定します。`,
+      fullFallbackDesc: '空欄にすると、解決済みのホストまたは内蔵デフォルトにフォールバックします。',
+      docsRef: label => `${label} 設定リファレンス`,
+      cancel: 'キャンセル',
+      saveChanges: '変更を保存',
+      savedTitle: label => `${label} を保存しました`,
+      savedMessage: 'メモリプロバイダー設定が更新されました。',
+      saveFailed: label => `${label} 設定の保存に失敗しました`,
+      leaveBlank: '空欄のままにすると現在の値が保持されます',
+      setBadge: '設定済み',
+      aboutField: label => `${label} について`,
+      fieldOverrides: {
+        'hindsight.mode': 'モード',
+        'hindsight.api_key': 'API キー',
+        'hindsight.api_url': 'API URL',
+        'hindsight.bank_id': 'Bank ID',
+        'hindsight.recall_budget': 'リコール予算'
+      },
+      descOverrides: {
+        'hindsight.mode': 'Hermes が Hindsight に接続する方法。',
+        'hindsight.api_key': 'Hindsight API との認証に使用します。'
+      },
+      placeholderOverrides: {
+        'hindsight.api_key': 'Hindsight API キーを入力'
+      },
+      optionOverrides: {
+        'hindsight.mode.cloud': 'クラウド',
+        'hindsight.mode.cloud.desc': 'Hindsight クラウド API（軽量、API キーのみで可）',
+        'hindsight.mode.local_external': 'ローカル外部',
+        'hindsight.mode.local_external.desc': '既存の Hindsight インスタンスに接続'
+      }
     }
   },
 
@@ -1910,6 +1968,37 @@ export const ja = defineLocale({
     statusDivider: {
       working: '実行中',
       done: '完了'
+    },
+    filters: {
+      grouping: 'グループ化',
+      ordering: '並び替え',
+      show: '表示',
+      filters: 'フィルター',
+      status: '状態',
+      pullRequest: 'プルリクエスト',
+      profile: 'プロファイル',
+      project: 'プロジェクト',
+      updated: '更新日時',
+      created: '作成日時',
+      tokens: 'トークン数',
+      cost: 'コスト',
+      manual: '手動',
+      preview: 'プレビュー',
+      pr: 'PR',
+      open: 'オープン',
+      draft: '下書き',
+      merged: 'マージ済み',
+      closed: 'クローズ済み',
+      noPr: 'PR なし',
+      needsInput: '入力待ち',
+      working: '実行中',
+      unread: '未読',
+      idle: 'アイドル',
+      inboxStyle: '受信トレイ風',
+      archived: 'アーカイブ済み',
+      resetToDefaults: 'デフォルトに戻す',
+      expandAll: 'すべて展開',
+      collapseAll: 'すべて折りたたむ'
     }
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -376,6 +376,37 @@ export interface Translations {
         desktopFailed: string
         missingEnv: (vars: string) => string
       }
+      /** Bundled desktop plugin display names, keyed by plugin id. */
+      builtin: Record<string, { name: string; description: string }>
+    }
+    memoryProvider: {
+      settingsTitle: (label: string) => string
+      fullConfig: string
+      loading: string
+      loadFailed: string
+      retry: string
+      fieldSet: (label: string) => string
+      fieldNotSet: (label: string) => string
+      fullTitle: (label: string) => string
+      fullEmptyDesc: (label: string, profile: string) => string
+      fullFallbackDesc: string
+      docsRef: (label: string) => string
+      cancel: string
+      saveChanges: string
+      savedTitle: (label: string) => string
+      savedMessage: string
+      saveFailed: (label: string) => string
+      leaveBlank: string
+      setBadge: string
+      aboutField: (label: string) => string
+      /** Overrides for known provider field labels, keyed by `provider.fieldKey`. */
+      fieldOverrides: Record<string, string>
+      /** Overrides for known provider field descriptions, keyed by `provider.fieldKey`. */
+      descOverrides: Record<string, string>
+      /** Overrides for known provider field placeholders, keyed by `provider.fieldKey`. */
+      placeholderOverrides: Record<string, string>
+      /** Overrides for known provider select option labels, keyed by `provider.fieldKey.optionValue`. */
+      optionOverrides: Record<string, string>
     }
     notifications: {
       title: string
@@ -1883,6 +1914,37 @@ export interface Translations {
     statusDivider: {
       working: string
       done: string
+    }
+    filters: {
+      grouping: string
+      ordering: string
+      show: string
+      filters: string
+      status: string
+      pullRequest: string
+      profile: string
+      project: string
+      updated: string
+      created: string
+      tokens: string
+      cost: string
+      manual: string
+      preview: string
+      pr: string
+      open: string
+      draft: string
+      merged: string
+      closed: string
+      noPr: string
+      needsInput: string
+      working: string
+      unread: string
+      idle: string
+      inboxStyle: string
+      archived: string
+      resetToDefaults: string
+      expandAll: string
+      collapseAll: string
     }
     markAllRead: string
   }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1052,6 +1052,64 @@ export const zhHant = defineLocale({
         failedSelect: backend => `選擇 ${backend} 失敗`,
         needsSetupHint: '現在即可選擇此後端——但在完成設定前命令將會失敗。'
       }
+    },
+    plugins: {
+      builtin: {
+        accent: {
+          name: '強調色選擇器',
+          description: '在狀態列以 OKLCH 色彩選擇器挑選主題強調色，調色盤即時重新產生。作者工具——顏色不會持久保存。'
+        },
+        'hermes-bots': {
+          name: '機器人',
+          description:
+            '機器人模式——每個代理一個聊天的話務員名冊，支援頭像、例行任務、群聊與機器人間互傳訊息。隨應用程式內建；不需要時可在此停用。'
+        },
+        kanban: {
+          name: '看板',
+          description: '多代理任務看板——看板頁面、側邊欄入口，以及狀態列中的即時進行中計數。'
+        }
+      }
+    },
+    memoryProvider: {
+      settingsTitle: label => `${label} 設定`,
+      fullConfig: '完整設定…',
+      loading: '正在載入記憶提供者設定…',
+      loadFailed: '記憶提供者設定載入失敗',
+      retry: '重試',
+      fieldSet: label => `${label} 已設定`,
+      fieldNotSet: label => `${label} 尚未設定`,
+      fullTitle: label => `${label} — 完整設定`,
+      fullEmptyDesc: (label, profile) => `為 ${profile} 設定檔設定每個${label}選項。`,
+      fullFallbackDesc: '留空則回退到已解析的主機或內建預設值。',
+      docsRef: label => `${label} 設定參考`,
+      cancel: '取消',
+      saveChanges: '儲存變更',
+      savedTitle: label => `${label} 已儲存`,
+      savedMessage: '記憶提供者設定已更新。',
+      saveFailed: label => `儲存 ${label} 設定失敗`,
+      leaveBlank: '留空以保留目前值',
+      setBadge: '已設定',
+      aboutField: label => `關於 ${label}`,
+      fieldOverrides: {
+        'hindsight.mode': '模式',
+        'hindsight.api_key': 'API 金鑰',
+        'hindsight.api_url': 'API URL',
+        'hindsight.bank_id': 'Bank ID',
+        'hindsight.recall_budget': '召回預算'
+      },
+      descOverrides: {
+        'hindsight.mode': 'Hermes 如何連線到 Hindsight。',
+        'hindsight.api_key': '用於透過 Hindsight API 進行身分驗證。'
+      },
+      placeholderOverrides: {
+        'hindsight.api_key': '輸入 Hindsight API 金鑰'
+      },
+      optionOverrides: {
+        'hindsight.mode.cloud': '雲端',
+        'hindsight.mode.cloud.desc': 'Hindsight 雲 API（輕量級，僅需 API 金鑰）',
+        'hindsight.mode.local_external': '本機外部',
+        'hindsight.mode.local_external.desc': '連線到現有的 Hindsight 實例'
+      }
     }
   },
 
@@ -1848,6 +1906,37 @@ export const zhHant = defineLocale({
     statusDivider: {
       working: '進行中',
       done: '已完成'
+    },
+    filters: {
+      grouping: '分組方式',
+      ordering: '排序方式',
+      show: '顯示',
+      filters: '篩選',
+      status: '狀態',
+      pullRequest: '拉取請求',
+      profile: '設定檔',
+      project: '專案',
+      updated: '最近更新',
+      created: '建立時間',
+      tokens: 'Token 數',
+      cost: '費用',
+      manual: '手動',
+      preview: '預覽',
+      pr: 'PR',
+      open: '開啟',
+      draft: '草稿',
+      merged: '已合併',
+      closed: '已關閉',
+      noPr: '無 PR',
+      needsInput: '需要輸入',
+      working: '進行中',
+      unread: '未讀',
+      idle: '閒置',
+      inboxStyle: '收件匣樣式',
+      archived: '已封存',
+      resetToDefaults: '恢復預設',
+      expandAll: '全部展開',
+      collapseAll: '全部摺疊'
     }
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -418,6 +418,62 @@ export const zh: Translations = {
         agentFailed: '智能体插件安装失败',
         desktopFailed: '桌面插件安装失败',
         missingEnv: vars => `缺少环境变量：${vars}。请在设置 → 密钥中添加。`
+      },
+      builtin: {
+        accent: {
+          name: '强调色选择器',
+          description: '在状态栏的 OKLCH 颜色选择器中挑选主题强调色，调色板即时重新生成。作者工具——颜色不会持久保存。'
+        },
+        'hermes-bots': {
+          name: '机器人',
+          description:
+            '机器人模式——每个代理一个聊天的话务员花名册，支持头像、例行任务、群聊与机器人间互发消息。随应用内置；不需要时可在此禁用。'
+        },
+        kanban: {
+          name: '看板',
+          description: '多代理任务看板——看板页面、侧边栏入口，以及状态栏中的实时进行中计数。'
+        }
+      }
+    },
+    memoryProvider: {
+      settingsTitle: label => `${label} 设置`,
+      fullConfig: '完整配置…',
+      loading: '正在加载记忆提供程序设置…',
+      loadFailed: '记忆提供程序设置加载失败',
+      retry: '重试',
+      fieldSet: label => `${label} 已设置`,
+      fieldNotSet: label => `${label} 尚未设置`,
+      fullTitle: label => `${label} — 完整配置`,
+      fullEmptyDesc: (label, profile) => `为 ${profile} 配置档案设置每个${label}选项。`,
+      fullFallbackDesc: '留空则回退到已解析的主机或内置默认值。',
+      docsRef: label => `${label} 配置参考`,
+      cancel: '取消',
+      saveChanges: '保存更改',
+      savedTitle: label => `${label} 已保存`,
+      savedMessage: '记忆提供程序配置已更新。',
+      saveFailed: label => `保存 ${label} 设置失败`,
+      leaveBlank: '留空以保留当前值',
+      setBadge: '已设置',
+      aboutField: label => `关于 ${label}`,
+      fieldOverrides: {
+        'hindsight.mode': '模式',
+        'hindsight.api_key': 'API 密钥',
+        'hindsight.api_url': 'API URL',
+        'hindsight.bank_id': 'Bank ID',
+        'hindsight.recall_budget': '召回预算'
+      },
+      descOverrides: {
+        'hindsight.mode': 'Hermes 如何连接 Hindsight。',
+        'hindsight.api_key': '用于通过 Hindsight API 进行身份验证。'
+      },
+      placeholderOverrides: {
+        'hindsight.api_key': '输入 Hindsight API 密钥'
+      },
+      optionOverrides: {
+        'hindsight.mode.cloud': '云端',
+        'hindsight.mode.cloud.desc': 'Hindsight 云 API（轻量级，仅需 API 密钥）',
+        'hindsight.mode.local_external': '本地外部',
+        'hindsight.mode.local_external.desc': '连接到现有 Hindsight 实例'
       }
     },
     notifications: {
@@ -2393,6 +2449,37 @@ export const zh: Translations = {
     statusDivider: {
       working: '进行中',
       done: '已完成'
+    },
+    filters: {
+      grouping: '分组方式',
+      ordering: '排序方式',
+      show: '显示',
+      filters: '筛选',
+      status: '状态',
+      pullRequest: '拉取请求',
+      profile: '配置档案',
+      project: '项目',
+      updated: '最近更新',
+      created: '创建时间',
+      tokens: 'Token 数',
+      cost: '费用',
+      manual: '手动',
+      preview: '预览',
+      pr: 'PR',
+      open: '开启',
+      draft: '草稿',
+      merged: '已合并',
+      closed: '已关闭',
+      noPr: '无 PR',
+      needsInput: '需要输入',
+      working: '进行中',
+      unread: '未读',
+      idle: '空闲',
+      inboxStyle: '收件箱样式',
+      archived: '已归档',
+      resetToDefaults: '恢复默认',
+      expandAll: '全部展开',
+      collapseAll: '全部折叠'
     },
     markAllRead: '全部标记为已读'
   },


### PR DESCRIPTION
## Summary

The desktop app's Chinese (and other) locale was incomplete in two areas, leaving hardcoded English UI text on screen even when the app language is set to Chinese:

### 1. Sidebar filter menu (`filter-menu.tsx`)
The session-list filter dropdown (Grouping / Ordering / Show / Inbox style / Filters / Status / Pull request / Profile / Project / Archived / Reset to defaults / Collapse all / Mark all as read) was entirely hardcoded English and never wired into i18n.

- Added a `labelKey` field to `Option`, resolved through `t.sidebar.filters`
- Added full `sidebar.filters` message set to `types.ts` + `en`/`zh`/`zh-hant`/`ja` locale bundles
- Menu titles, pill badges, and actions now render through the translator

### 2. Memory provider settings (Hindsight) + built-in plugin list
The provider config panel/modal (title, field labels, descriptions, placeholders, select options, pill status like "API key not set", save/cancel buttons) and the Settings → Plugins rows (Accent Picker / Bots / Kanban name + description) were hardcoded English.

- New render-layer localization helper `memory/localize-provider.ts` overlays per-provider overrides from the active locale bundle onto backend-declared schema fields — the backend schema (shared across all languages) stays untouched
- Added `settings.memoryProvider` and `settings.plugins.builtin` message sets to `types.ts` + locale bundles
- Full Chinese (Simplified/Traditional) and Japanese translations included; English baseline unchanged; other locales fall back to English via the existing merge mechanism

## Verification

- `tsc --noEmit` clean
- Vitest: i18n (31) + memory/plugin settings (18) + sidebar (13) tests pass