### PR TITLE
fix(terminal): resolve the container key in cleanup_vm so envs stop leaking

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -974,7 +974,9 @@ def test_cleanup_vm_default_honors_persist_mode(monkeypatch):
 
     env = _make_dummy_env(task_id="session-close-test")
     container_id = env._container_id
-    terminal_tool._active_environments["session-close-test"] = env
+    # Mirror the real write path: terminal_tool stores envs under the
+    # RESOLVED container key (a raw session id collapses to "default").
+    terminal_tool._active_environments["default"] = env
 
     cleanup_calls = []
     real_run = docker_env.subprocess.run
@@ -988,7 +990,7 @@ def test_cleanup_vm_default_honors_persist_mode(monkeypatch):
     try:
         terminal_tool.cleanup_vm("session-close-test")
     finally:
-        terminal_tool._active_environments.pop("session-close-test", None)
+        terminal_tool._active_environments.pop("default", None)
 
     stops = [c for c in cleanup_calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "stop"]
     rms = [c for c in cleanup_calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "rm"]
@@ -1000,6 +1002,33 @@ def test_cleanup_vm_default_honors_persist_mode(monkeypatch):
         f"cleanup_vm() default must not docker rm a persist-mode container; "
         f"got: {rms}"
     )
+
+
+def test_cleanup_vm_resolves_container_key(monkeypatch):
+    """Regression #91440: environments are stored under the RESOLVED
+    container key (``_resolve_container_task_id`` collapses raw API session
+    ids to ``"default"``), but ``cleanup_vm`` popped the RAW id — so the
+    pop missed, the env leaked out of tracking, and ``AIAgent.close()``
+    never reached the persist-mode no-op/cleanup logic at all."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+    _install_fake_thread(monkeypatch)
+
+    from tools import terminal_tool
+
+    env = _make_dummy_env(task_id="default")
+    terminal_tool._active_environments["default"] = env
+    try:
+        # AIAgent.close() passes the RAW session id; the entry lives under
+        # the resolved key. The lookup must resolve the same way.
+        terminal_tool.cleanup_vm("raw-api-session-id")
+        assert "default" not in terminal_tool._active_environments, (
+            "cleanup_vm(raw_session_id) must remove the env stored under the "
+            "resolved container key, not leak it"
+        )
+    finally:
+        terminal_tool._active_environments.pop("default", None)
 
 
 def test_cleanup_with_persist_disabled_stops_and_rms(monkeypatch):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2209,6 +2209,12 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     via this function), so persist-mode idle envs are similarly no-op'd —
     only the orphan reaper at next startup reclaims them.
     """
+    # The environment was stored under the RESOLVED container key
+    # (``_resolve_container_task_id`` — e.g. a raw API session ID collapses
+    # to "default"), so the lookup here must resolve the same way. Popping
+    # the raw task_id missed the entry and leaked the env on
+    # AIAgent.close() / per-turn cleanup (#91440).
+    task_id = _resolve_container_task_id(task_id)
     # Remove from tracking dicts while holding the lock, but defer the
     # actual (potentially slow) env.cleanup() call to outside the lock
     # so other tool calls aren't blocked.


### PR DESCRIPTION
## What does this PR do?

Fixes an asymmetric dict key in the terminal sandbox lifecycle: environments are **stored** under the resolved container key (`_resolve_container_task_id(task_id)` — raw API session ids collapse to `"default"`), but `cleanup_vm()` **popped** the raw `task_id`. The pop missed, so on `AIAgent.close()` (TUI session close, gateway session teardown) and the per-turn cleanup branch, the environment entry leaked out of `_active_environments` / `_last_activity` and the cleanup logic never even reached the persist-mode no-op decision for it (#91440).

The fix resolves the task id once at `cleanup_vm` entry, so the store and the pop share one key space — mirroring how every write path (`effective_task_id` at terminal_tool.py:2080/2129/2780) already keys these dicts.

## Related Issue

Fixes #91440

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py`: In `cleanup_vm()`, resolve `task_id` through `_resolve_container_task_id` before the `_active_environments` / `_last_activity` / `_creation_locks` lookups, with a comment explaining the raw-vs-resolved key mismatch.
- `tests/tools/test_docker_environment.py`: Add `test_cleanup_vm_resolves_container_key` (store under `"default"`, clean up with a raw session id, assert the entry is removed). Also align `test_cleanup_vm_default_honors_persist_mode` with the real write path (it now stores under the resolved `"default"` key while still calling `cleanup_vm` with the raw session id), keeping its persist-mode assertions unchanged.

## How to Test

1. Run `terminal` from a regular API session — the env is stored under the resolved key (`"default"`)
2. Close the session — `AIAgent.close()` calls `cleanup_vm(raw_session_id)`; before the fix the tracking entry survived (leaked) and the persist-mode logic was bypassed for it; after the fix the entry is removed and the persist-mode no-op path runs (Observed result: `test_cleanup_vm_resolves_container_key` fails on unpatched main with the entry still present and passes with this patch)
3. `scripts/run_tests.sh tests/tools/test_docker_environment.py -q` → should pass (Observed result: 52 passed locally, including the aligned persist-mode test)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
