### PR TITLE
feat(cron): preserve recent context with configurable continuity limit

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1281,6 +1281,9 @@ platform_toolsets:
 #     args: ["-y", "@modelcontextprotocol/server-github"]
 #     env:
 #       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."
+#     # Optional: tools/call params._meta key for the gateway session user id
+#     # (Telegram/Discord/...). Default: nousresearch.hermes/user_id
+#     # session_user_id_meta_key: "nousresearch.hermes/user_id"
 #
 # Sampling (server-initiated LLM requests) — enabled by default.
 # Per-server config under the 'sampling' key:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -63,6 +63,24 @@ from agent.delegation_context import (
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_CONTEXT_MAX_CHARS = 8000
+
+
+def _continuity_max_chars() -> int:
+    """Return the configured positive character cap for self-continuity."""
+    try:
+        config = load_config() or {}
+        value = int(
+            (config.get("cron") or {}).get(
+                "continuity_max_chars", _DEFAULT_CONTEXT_MAX_CHARS
+            )
+        )
+        if value > 0:
+            return value
+    except (AttributeError, TypeError, ValueError):
+        pass
+    return _DEFAULT_CONTEXT_MAX_CHARS
+
 
 def _close_late_session_db_result(future: "concurrent.futures.Future") -> None:
     """Done-callback: close a SessionDB whose constructor finished after run_job's timeout.
@@ -3865,10 +3883,24 @@ def _build_job_prompt(
                 if not output_files:
                     continue  # silent skip — no output yet
                 latest_output = output_files[0].read_text(encoding="utf-8").strip()
-                # Truncate to 8K characters to avoid prompt bloat
-                _MAX_CONTEXT_CHARS = 8000
-                if len(latest_output) > _MAX_CONTEXT_CHARS:
-                    latest_output = latest_output[:_MAX_CONTEXT_CHARS] + "\n\n[... output truncated ...]"
+                # Keep continuity bounded while preserving the most recent
+                # report. Upstream-job context retains its historical prefix.
+                max_context_chars = (
+                    _continuity_max_chars()
+                    if is_self
+                    else _DEFAULT_CONTEXT_MAX_CHARS
+                )
+                if len(latest_output) > max_context_chars:
+                    if is_self:
+                        latest_output = (
+                            "[... output truncated ...]\n\n"
+                            + latest_output[-max_context_chars:]
+                        )
+                    else:
+                        latest_output = (
+                            latest_output[:max_context_chars]
+                            + "\n\n[... output truncated ...]"
+                        )
                 if latest_output:
                     if is_self:
                         prompt = (

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2491,6 +2491,9 @@ DEFAULT_CONFIG = {
         # recent .md files and prunes older ones. 0 or negative disables
         # pruning (for operators who manage cleanup externally). Default 50.
         "output_retention": 50,
+        # Maximum characters from a job's previous output injected when
+        # continuity is enabled. Truncation keeps the newest content.
+        "continuity_max_chars": 8000,
         # Timeout (seconds) for a no-agent cron script. Also overridable via
         # HERMES_CRON_SCRIPT_TIMEOUT. Keep this in sync with
         # cron.scheduler._DEFAULT_SCRIPT_TIMEOUT so config set recognizes the

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -244,6 +244,46 @@ class TestSelfContext:
         # Self-context uses continuity framing, not the upstream-job framing.
         assert f"Output from job '{job['id']}'" not in prompt
 
+    def test_self_truncation_preserves_latest_context(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(
+            prompt="Scan for news", schedule="every 1h", context_from="self"
+        )
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        previous_output = "old report\n" + ("x" * 8000) + "\nlatest report"
+        (out_dir / "2026-08-01_10-00-00.md").write_text(
+            previous_output, encoding="utf-8"
+        )
+
+        prompt = _build_job_prompt(job)
+
+        assert "old report" not in prompt
+        assert "latest report" in prompt
+        assert "[... output truncated ...]" in prompt
+
+    def test_self_truncation_uses_configured_limit(self, cron_env, monkeypatch):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(prompt="Scan", schedule="every 1h", context_from="self")
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-08-01_10-00-00.md").write_text(
+            "old" + ("x" * 64) + "latest", encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            "cron.scheduler.load_config",
+            lambda: {"cron": {"continuity_max_chars": 16}},
+        )
+
+        prompt = _build_job_prompt(job)
+
+        assert ("x" * 10) + "latest" in prompt
+        assert ("x" * 11) + "latest" not in prompt
+
     def test_self_case_insensitive(self, cron_env):
         from cron.jobs import create_job, OUTPUT_DIR
         from cron.scheduler import _build_job_prompt

--- a/tests/tools/test_mcp_session_identity_meta.py
+++ b/tests/tools/test_mcp_session_identity_meta.py
@@ -1,0 +1,161 @@
+"""Gateway session user_id is attached to MCP tools/call via ``meta``.
+
+The MCP event loop does not inherit session ContextVars, so the handler
+snapshots ``HERMES_SESSION_USER_ID`` on the agent thread and passes it as
+``session.call_tool(..., meta=...)``. It is not injected into ``arguments``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools import mcp_tool
+
+
+class _FakeContentBlock:
+    def __init__(self, text: str, block_type: str = "text"):
+        self.text = text
+        self.type = block_type
+
+
+class _FakeCallToolResult:
+    def __init__(self, content, is_error=False, structuredContent=None):
+        self.content = content
+        self.isError = is_error
+        self.structuredContent = structuredContent
+
+
+def _fake_run_on_mcp_loop(coro_or_factory, timeout=30):
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+    loop = asyncio.new_event_loop()
+    try:
+        async def _install_lock_and_run():
+            for srv in list(mcp_tool._servers.values()):
+                if getattr(srv, "_rpc_lock", None) is None:
+                    srv._rpc_lock = asyncio.Lock()
+            return await coro
+        return loop.run_until_complete(_install_lock_and_run())
+    finally:
+        loop.close()
+
+
+@pytest.fixture
+def fake_session():
+    session = MagicMock()
+    session.call_tool = AsyncMock(
+        return_value=_FakeCallToolResult(content=[_FakeContentBlock("ok")])
+    )
+    server = SimpleNamespace(session=session, _rpc_lock=None, _config={})
+    with patch.dict(mcp_tool._servers, {"srv": server}), \
+         patch("tools.mcp_tool._run_on_mcp_loop",
+               side_effect=_fake_run_on_mcp_loop), \
+         patch.dict(mcp_tool._server_error_counts, {}, clear=True):
+        yield session
+
+
+class TestMcpSessionIdentityMeta:
+    def test_unset_session_returns_none(self):
+        from gateway.session_context import reset_session_vars
+
+        reset_session_vars()
+        assert mcp_tool._mcp_session_identity_meta() is None
+
+    def test_bound_session_user_id(self):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        reset_session_vars()
+        set_session_vars(user_id="tg-99")
+        try:
+            assert mcp_tool._mcp_session_identity_meta("srv", {}) == {
+                mcp_tool._MCP_SESSION_USER_ID_META_KEY: "tg-99",
+            }
+        finally:
+            reset_session_vars()
+
+    def test_custom_meta_key_from_server_config(self):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        reset_session_vars()
+        set_session_vars(user_id="tg-99")
+        try:
+            assert mcp_tool._mcp_session_identity_meta("srv", {
+                "session_user_id_meta_key": "x-user-id",
+            }) == {"x-user-id": "tg-99"}
+        finally:
+            reset_session_vars()
+
+    def test_reserved_meta_key_falls_back_to_default(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            key = mcp_tool._resolve_session_user_id_meta_key("srv", {
+                "session_user_id_meta_key": "mcp.com/user_id",
+            })
+        assert key == mcp_tool._MCP_SESSION_USER_ID_META_KEY
+        assert any("session_user_id_meta_key" in r.message for r in caplog.records)
+
+    def test_blank_user_id_returns_none(self):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        reset_session_vars()
+        set_session_vars(user_id="  ")
+        try:
+            assert mcp_tool._mcp_session_identity_meta() is None
+        finally:
+            reset_session_vars()
+
+    def test_handler_passes_meta_not_arguments(self, fake_session):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        reset_session_vars()
+        set_session_vars(user_id="discord-u1")
+        try:
+            handler = mcp_tool._make_tool_handler("srv", "echo", 30.0)
+            raw = handler({"q": "hi"})
+        finally:
+            reset_session_vars()
+
+        assert json.loads(raw) == {"result": "ok"}
+        fake_session.call_tool.assert_awaited_once_with(
+            "echo",
+            arguments={"q": "hi"},
+            meta={mcp_tool._MCP_SESSION_USER_ID_META_KEY: "discord-u1"},
+        )
+
+    def test_handler_omits_meta_without_session_user(self, fake_session):
+        from gateway.session_context import reset_session_vars
+
+        reset_session_vars()
+        handler = mcp_tool._make_tool_handler("srv", "echo", 30.0)
+        raw = handler({"q": "hi"})
+        assert json.loads(raw) == {"result": "ok"}
+        fake_session.call_tool.assert_awaited_once_with(
+            "echo",
+            arguments={"q": "hi"},
+        )
+
+    def test_handler_uses_configured_meta_key(self, fake_session):
+        from gateway.session_context import reset_session_vars, set_session_vars
+
+        mcp_tool._servers["srv"]._config = {
+            "session_user_id_meta_key": "caller-id",
+        }
+        reset_session_vars()
+        set_session_vars(user_id="feishu-u2")
+        try:
+            handler = mcp_tool._make_tool_handler("srv", "echo", 30.0)
+            raw = handler({"q": "hi"})
+        finally:
+            reset_session_vars()
+
+        assert json.loads(raw) == {"result": "ok"}
+        fake_session.call_tool.assert_awaited_once_with(
+            "echo",
+            arguments={"q": "hi"},
+            meta={"caller-id": "feishu-u2"},
+        )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -42,6 +42,10 @@ Example config::
           value_from: "static" # "static" (default) or "profile"
           value: "alice"       # required for static; profile mode uses the
                                # active Hermes profile name
+        session_user_id_meta_key: "nousresearch.hermes/user_id"
+                               # tools/call params._meta key for the gateway
+                               # session user id (Telegram/Discord/...). Omit
+                               # to use the default above.
         timeout: 180
         skip_preflight: true  # bypass the content-type probe for a valid
                               # Streamable HTTP endpoint that answers HEAD/GET
@@ -1593,6 +1597,72 @@ def _apply_identity_header(server_name: str, config: dict, headers: dict) -> dic
         return headers
     headers[name] = value
     return headers
+
+
+# Default tools/call ``_meta`` key for the gateway session user id.
+# Override per server with ``mcp_servers.<name>.session_user_id_meta_key``.
+# Not a protocol-reserved ``mcp`` / ``modelcontextprotocol`` prefix.
+_MCP_SESSION_USER_ID_META_KEY = "nousresearch.hermes/user_id"
+
+
+def _resolve_session_user_id_meta_key(
+    server_name: str, config: Optional[dict]
+) -> str:
+    """Return the tools/call ``_meta`` key for this server's session user id.
+
+    Missing / blank config uses ``_MCP_SESSION_USER_ID_META_KEY``. Invalid
+    values (non-string, reserved MCP prefix) warn and fall back to the
+    default — they must never skip the identity or break the call.
+    """
+    raw = (config or {}).get("session_user_id_meta_key", _MCP_SESSION_USER_ID_META_KEY)
+    if not isinstance(raw, str) or not raw.strip():
+        if raw is not None:
+            logger.warning(
+                "MCP server '%s': session_user_id_meta_key must be a "
+                "non-empty string (got %r) — using default %s",
+                server_name, raw, _MCP_SESSION_USER_ID_META_KEY,
+            )
+        return _MCP_SESSION_USER_ID_META_KEY
+    key = raw.strip()
+    if _is_reserved_mcp_meta_key(key):
+        logger.warning(
+            "MCP server '%s': session_user_id_meta_key %r uses a reserved "
+            "MCP prefix — using default %s",
+            server_name, key, _MCP_SESSION_USER_ID_META_KEY,
+        )
+        return _MCP_SESSION_USER_ID_META_KEY
+    return key
+
+
+def _mcp_session_identity_meta(
+    server_name: str = "",
+    config: Optional[dict] = None,
+) -> Optional[Dict[str, str]]:
+    """Return tools/call ``meta`` for the current gateway session user.
+
+    Empty / unset session user → ``None`` so the on-wire request is
+    unchanged (CLI, cron, tests that never bound a session).
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except ImportError:
+        return None
+    user_id = (get_session_env("HERMES_SESSION_USER_ID", "") or "").strip()
+    if not user_id:
+        return None
+    key = _resolve_session_user_id_meta_key(server_name, config)
+    return {key: user_id}
+
+
+def _call_tool_accepts_meta(call_tool) -> bool:
+    """True when ``session.call_tool`` can take a ``meta`` kwarg."""
+    try:
+        params = inspect.signature(call_tool).parameters
+    except (TypeError, ValueError):
+        return True
+    if "meta" in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 def _make_redirect_header_stripper(
@@ -5781,7 +5851,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         f"reconnect requested. Do NOT retry this tool "
                         f"immediately — give it a few seconds to come back."
                     )
-                return tool_error(f"MCP server '{server_name}' is not connected")
+                    return tool_error(f"MCP server '{server_name}' is not connected")
+
+        # Snapshot on this thread: ``_run_on_mcp_loop`` does not copy
+        # gateway session ContextVars onto the MCP loop.
+        call_meta = _mcp_session_identity_meta(
+            server_name, getattr(server, "_config", None),
+        )
 
         async def _call():
             _mark_server_call_started(server)
@@ -5792,7 +5868,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    call_kwargs = {}
+                    if (
+                        call_meta is not None
+                        and _call_tool_accepts_meta(server.session.call_tool)
+                    ):
+                        call_kwargs["meta"] = call_meta
+                    result = await server.session.call_tool(
+                        tool_name, arguments=args, **call_kwargs
+                    )
                 finally:
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -660,6 +660,17 @@ cronjob(
 
 The first run has no previous output, so the prompt runs as-is. On later runs the previous output is prepended with continuity framing ("avoid repeating what was already reported"). It combines freely with upstream jobs (`context_from=["<other_job_id>"]` plus `continuity=true`), and `continuity=false` on update turns it off while preserving other `context_from` entries. Internally the flag is stored as the reserved `self` entry in `context_from`.
 
+Continuity injects at most 8,000 characters by default. If the saved output is
+longer, Hermes keeps the newest characters so the next run still sees the most
+recent report. Adjust the positive character limit globally in `config.yaml`:
+
+```yaml
+cron:
+  continuity_max_chars: 16000
+```
+
+Or run `hermes config set cron.continuity_max_chars 16000`.
+
 From the CLI: `hermes cron create "every 6h" "Scan for news" --continuity`, and `hermes cron edit <job_id> --continuity` / `--no-continuity` to toggle it on an existing job. The same toggle appears in the dashboard's cron editor and the desktop Bot Mode routine dialog.
 
 **When to use it:**

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -354,6 +354,19 @@ mcp_servers:
 
 An explicit entry in the server's `headers` mapping with the same name (any casing) always wins; the identity header never overrides your own header config. Invalid `identity_header` blocks are warned about and ignored — they never block the server from connecting. On stdio servers the key is ignored with a warning (stdio transports have no headers).
 
+## Gateway session user on tools/call
+
+Messaging-gateway sessions (Telegram, Discord, ...) can attach the current `source.user_id` to every MCP `tools/call` as `params._meta`, without putting it in the model-visible tool arguments. Configure the `_meta` key per server; the default is `nousresearch.hermes/user_id`:
+
+```yaml
+mcp_servers:
+  team_api:
+    url: "https://mcp.team.example.com/mcp"
+    session_user_id_meta_key: "nousresearch.hermes/user_id"
+```
+
+Omit the key to keep the default. Keys that use a reserved MCP prefix (`mcp` / `modelcontextprotocol` as a non-final label) are warned about and ignored. When no session user is bound (CLI, cron), `_meta` is omitted.
+
 ## Basic configuration reference
 
 Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
@@ -370,6 +383,7 @@ Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
 | `client_cert` | string \| list | Client certificate for mTLS — a combined PEM path, or `[cert, key]` / `[cert, key, password]` |
 | `client_key` | string | Client private-key PEM path (when separate from `client_cert`) |
 | `identity_header` | mapping | Optional per-user identity header for HTTP/SSE servers — `{name, value_from: static\|profile, value}` |
+| `session_user_id_meta_key` | string | `tools/call` `params._meta` key for the gateway session user id (default `nousresearch.hermes/user_id`) |
 | `timeout` | number | Tool call timeout |
 | `connect_timeout` | number | Initial connection timeout (also bounds the MCP `initialize` handshake) |
 | `idle_timeout_seconds` | number | Recycle a stdio server after this many seconds without a tool call (`0` = never, default). The server restarts transparently on the next tool call. |


### PR DESCRIPTION
## What does this PR do?

This adds a configurable character limit for cron self-continuity context and changes truncation to retain the newest part of the previous output. Long-running continuity jobs can now preserve their latest report instead of repeatedly receiving only older recursive history, while upstream `context_from` jobs keep their existing prefix behavior.

### Motivation

Cron continuity reinjects the previous saved output into the next prompt. The fixed 8,000-character prefix cap could discard the newest report after recursive continuity history grew past the limit, causing jobs to lose the context needed to avoid duplicate reporting.

### Behavior

Self-continuity defaults to 8,000 characters, keeps the newest characters when truncation is required, and supports a global positive `cron.continuity_max_chars` setting. This does not change truncation for upstream `context_from` dependencies and does not add a per-job override.

### Implementation

The scheduler resolves the merged cron configuration with a safe 8,000-character fallback, applies the configurable tail cap only to self-continuity output, and emits a leading truncation marker. Behavior tests cover newest-context retention and a custom configured limit, and the cron user guide documents both YAML and CLI configuration.

## Related Issue

Closes #91430

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `cron/scheduler.py` - resolve the continuity limit and retain the newest self-continuity context.
- `hermes_cli/config_defaults.py` - add the merged `cron.continuity_max_chars` default.
- `tests/cron/test_cron_context_from.py` - cover tail retention and custom limits.
- `website/docs/user-guide/features/cron.md` - document the setting and default behavior.

## How to Test

1. Configure `cron.continuity_max_chars` to a small positive value.
2. Run a continuity job whose saved output exceeds the configured limit.
3. Confirm the next prompt contains the newest output tail and a leading truncation marker.
4. Run the targeted automated tests (109 passed locally):

```bash
scripts/run_tests.sh tests/cron/test_cron_context_from.py tests/hermes_cli/test_set_config_value.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Updating `cli-config.yaml.example` is N/A; merged defaults and user documentation cover this setting
- [x] Updating `CONTRIBUTING.md` or `AGENTS.md` is N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the change uses platform-independent configuration and string handling
- [x] Updating tool descriptions or schemas is N/A; no model tool behavior changed
