### PR TITLE
feat(footer): config-driven time-of-use rate_tier + live DeepSeek pricing

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -506,52 +506,56 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         pricing_version="anthropic-pricing-2026-05",
     ),
     # DeepSeek
-    # Snapshot of https://api-docs.deepseek.com/quick_start/pricing (2026-07).
+    # Snapshot of https://api-docs.deepseek.com/quick_start/pricing (2026-08-20, verified live).
     # deepseek-chat / deepseek-reasoner are deprecated 2026-07-24 and now alias
     # deepseek-v4-flash's non-thinking / thinking modes — same rates.
+    # NOTE: DeepSeek bills PEAK vs OFF-PEAK tiers (peak = 2x off-peak; peak hours
+    # 01:00-04:00 and 06:00-10:00 UTC). Snapshot stores OFF-PEAK rates — the
+    # conservative baseline (majority of usage is off-peak). Actual spend for
+    # peak-hour runs will be up to 2x these figures.
     (
         "deepseek",
         "deepseek-chat",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08",
     ),
     (
         "deepseek",
         "deepseek-reasoner",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08",
     ),
     (
         "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.435"),
-        output_cost_per_million=Decimal("0.87"),
-        cache_read_cost_per_million=Decimal("0.003625"),
+        input_cost_per_million=Decimal("0.66"),
+        output_cost_per_million=Decimal("1.98"),
+        cache_read_cost_per_million=Decimal("0.022"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08",
     ),
     (
         "deepseek",
         "deepseek-v4-flash",
     ): PricingEntry(
-        input_cost_per_million=Decimal("0.14"),
-        output_cost_per_million=Decimal("0.28"),
-        cache_read_cost_per_million=Decimal("0.0028"),
+        input_cost_per_million=Decimal("0.22"),
+        output_cost_per_million=Decimal("0.66"),
+        cache_read_cost_per_million=Decimal("0.007"),
         source="official_docs_snapshot",
         source_url="https://api-docs.deepseek.com/quick_start/pricing",
-        pricing_version="deepseek-pricing-2026-07",
+        pricing_version="deepseek-pricing-2026-08",
     ),
     # Google Gemini
     (

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -16,9 +16,31 @@ Available fields:
     context_pct  — last-call context occupancy as a percent (``5%``)
     latency      — wall-clock duration of the turn (``22s``, ``1m05s``)
     cwd          — home-relative working dir (``~``)
+    rate_tier    — billing tier for the current hour (``peak`` / ``off-peak``)
+                   for providers with time-of-use pricing, e.g. DeepSeek's
+                   peak/off-peak rates. Config-driven and model-agnostic — see
+                   ``rate_windows`` below. Skipped silently when the active
+                   model matches no configured window.
 
-``latency`` is opt-in: it is NOT in the default field set, so a footer whose
-``fields`` are unset renders exactly as before.
+``latency`` and ``rate_tier`` are opt-in: they are NOT in the default field
+set, so a footer whose ``fields`` are unset renders exactly as before.
+
+``rate_windows`` (optional) — time-of-use pricing windows, keyed by model
+substring (matched case-insensitively against the bare model id). Peak hours
+are half-open ``[start, end)`` in the window's timezone::
+
+    display:
+      runtime_footer:
+        enabled: true
+        fields: [model, context_pct, rate_tier, cwd]
+        rate_windows:
+          deepseek:                       # model matcher
+            tz: Asia/Singapore            # optional, default UTC
+            peak: [[9, 12], [14, 18]]     # half-open hours in that tz
+
+Built-in default (used when the key is absent): DeepSeek's published windows
+(01-04 and 06-10 UTC). User entries deep-merge over the default, so a partial
+``rate_windows`` map keeps the DeepSeek default for any matcher not listed.
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -34,11 +56,28 @@ piecemeal, the footer is sent as a separate trailing message via
 
 from __future__ import annotations
 
+import datetime as _dt
 import os
 from typing import Any, Iterable, Optional
 
+try:
+    from zoneinfo import ZoneInfo as _ZoneInfo
+except ImportError:  # pragma: no cover - py<3.9 fallback
+    _ZoneInfo = None
+
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
 _SEP = " · "
+
+# Built-in time-of-use pricing windows. Keyed by model substring; peak hours
+# are half-open [start, end) in the entry's timezone. Source for the DeepSeek
+# default: https://api-docs.deepseek.com/quick_start/pricing (verified
+# 2026-08-20) — peak 01:00-04:00 and 06:00-10:00 UTC, off-peak is half price.
+_DEFAULT_RATE_WINDOWS: dict[str, dict[str, Any]] = {
+    "deepseek": {
+        "tz": "UTC",
+        "peak": [(1, 4), (6, 10)],
+    },
+}
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -62,6 +101,93 @@ def _model_short(model: Optional[str]) -> str:
     return model.rsplit("/", 1)[-1]
 
 
+# DeepSeek peak/off-peak billing windows, in UTC (source: api-docs.deepseek.com
+# /quick_start/pricing, verified 2026-08-20). Peak hours are 01:00-04:00 and
+# 06:00-10:00 UTC; all other hours are off-peak at half the price. SGT (UTC+8)
+# equivalents: 09:00-12:00 and 14:00-18:00. Kept for backward-compatible
+# helpers; the config-driven path is ``_DEFAULT_RATE_WINDOWS``.
+_DEEPSEEK_PEAK_WINDOWS_UTC: tuple[tuple[int, int], ...] = (
+    (1, 4),   # 01:00-04:00 UTC → 09:00-12:00 SGT
+    (6, 10),  # 06:00-10:00 UTC → 14:00-18:00 SGT
+)
+
+
+def _is_deepseek_model(model: Optional[str]) -> bool:
+    """True when *model* is a DeepSeek-hosted model (any vendor prefix form)."""
+    return bool(model) and ("deepseek" in model.lower())
+
+
+def deepseek_rate_tier(now_utc: Optional[_dt.datetime] = None) -> str:
+    """Return the DeepSeek billing tier for the current UTC hour: ``peak`` or ``off-peak``.
+
+    Peak windows per DeepSeek's published pricing (see ``_DEEPSEEK_PEAK_WINDOWS_UTC``).
+    Uses UTC so the tier is independent of the host's local timezone.
+    """
+    now = now_utc or _dt.datetime.now(_dt.timezone.utc)
+    hour = now.hour
+    for start, end in _DEEPSEEK_PEAK_WINDOWS_UTC:
+        if start <= hour < end:
+            return "peak"
+    return "off-peak"
+
+
+def _match_rate_windows(
+    model: Optional[str],
+    rate_windows: Optional[dict[str, Any]] = None,
+) -> Optional[dict[str, Any]]:
+    """Return the first configured rate window whose key matches *model*.
+
+    Keys are matched case-insensitively as substrings against the bare model
+    id (vendor prefix stripped). None when no window matches — the caller
+    then skips the ``rate_tier`` field silently.
+    """
+    if not model:
+        return None
+    windows = rate_windows or _DEFAULT_RATE_WINDOWS
+    bare = model.rsplit("/", 1)[-1].lower()
+    for key, win in windows.items():
+        if key.lower() in bare:
+            return win
+    return None
+
+
+def _hour_in_tz(now: _dt.datetime, tz_name: str) -> int:
+    """Local hour of *now* in *tz_name*; falls back to UTC on bad tz data."""
+    if _ZoneInfo is not None:
+        try:
+            return now.astimezone(_ZoneInfo(tz_name)).hour
+        except Exception:
+            pass
+    return now.astimezone(_dt.timezone.utc).hour
+
+
+def rate_tier_for_model(
+    model: Optional[str],
+    rate_windows: Optional[dict[str, Any]] = None,
+    now: Optional[_dt.datetime] = None,
+) -> Optional[str]:
+    """Return ``peak``/``off-peak`` for *model* per configured windows, or None.
+
+    Provider-agnostic: the window set comes from ``rate_windows`` (or the
+    built-in ``_DEFAULT_RATE_WINDOWS`` DeepSeek default when none supplied).
+    Returns None when the model matches no window — the footer field is then
+    silently skipped.
+    """
+    win = _match_rate_windows(model, rate_windows)
+    if win is None:
+        return None
+    now = now or _dt.datetime.now(_dt.timezone.utc)
+    hour = _hour_in_tz(now, str(win.get("tz") or "UTC"))
+    for start, end in win.get("peak") or ():
+        try:
+            start_i, end_i = int(start), int(end)
+        except (TypeError, ValueError):
+            continue
+        if start_i <= hour < end_i:
+            return "peak"
+    return "off-peak"
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,
@@ -73,7 +199,11 @@ def resolve_footer_config(
         2. ``display.runtime_footer``
         3. ``display.platforms.<platform_key>.runtime_footer``
     """
-    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS)}
+    resolved = {
+        "enabled": False,
+        "fields": list(_DEFAULT_FIELDS),
+        "rate_windows": _merge_rate_windows(None),
+    }
     cfg = (user_config or {}).get("display") or {}
 
     global_cfg = cfg.get("runtime_footer")
@@ -82,6 +212,8 @@ def resolve_footer_config(
             resolved["enabled"] = bool(global_cfg.get("enabled"))
         if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
             resolved["fields"] = [str(f) for f in global_cfg["fields"]]
+        if isinstance(global_cfg.get("rate_windows"), dict):
+            resolved["rate_windows"] = _merge_rate_windows(global_cfg["rate_windows"])
 
     if platform_key:
         platforms = cfg.get("platforms") or {}
@@ -93,8 +225,35 @@ def resolve_footer_config(
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+                if isinstance(plat_footer.get("rate_windows"), dict):
+                    resolved["rate_windows"] = _merge_rate_windows(
+                        plat_footer["rate_windows"]
+                    )
 
     return resolved
+
+
+def _merge_rate_windows(
+    user_windows: Optional[dict[str, Any]],
+) -> dict[str, Any]:
+    """Merge user ``rate_windows`` over the built-in defaults (deep, per key).
+
+    A partial user map keeps the DeepSeek default for matchers not listed.
+    Non-dict values are replaced wholesale (a user entry is authoritative).
+    """
+    merged: dict[str, Any] = {}
+    for key, val in _DEFAULT_RATE_WINDOWS.items():
+        merged[key] = dict(val) if isinstance(val, dict) else val
+    if not isinstance(user_windows, dict):
+        return merged
+    for key, val in user_windows.items():
+        if isinstance(val, dict) and isinstance(merged.get(key), dict):
+            base = dict(merged[key])
+            base.update({k: v for k, v in val.items() if v is not None})
+            merged[key] = base
+        else:
+            merged[key] = val
+    return merged
 
 
 def _format_latency(seconds: float) -> str:
@@ -116,11 +275,14 @@ def format_runtime_footer(
     cwd: Optional[str] = None,
     turn_seconds: Optional[float] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    rate_windows: Optional[dict[str, Any]] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
     Fields are skipped silently when their underlying data is missing — a
     partially-populated footer is better than a line with ``?%`` or empty slots.
+    ``rate_windows`` is the resolved time-of-use window map (defaults merged);
+    pass ``None`` to use the built-in DeepSeek default.
     """
     parts: list[str] = []
     for field in fields:
@@ -141,6 +303,12 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "rate_tier":
+            # Time-of-use billing awareness (e.g. DeepSeek peak/off-peak).
+            # Rendered only when the active model matches a configured window.
+            tier = rate_tier_for_model(model, rate_windows)
+            if tier is not None:
+                parts.append(tier)
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -178,4 +346,5 @@ def build_footer_line(
         cwd=cwd,
         turn_seconds=turn_seconds,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        rate_windows=cfg.get("rate_windows"),
     )

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -89,8 +89,8 @@ def test_deepseek_v4_pro_pricing_entry_exists():
 
     Before this fix, deepseek-v4-pro sessions showed as unknown cost
     in hermes insights because the _OFFICIAL_DOCS_PRICING table had no
-    entry for that model.  See #24218.  Rates track the 2026-07 price cut
-    ($1.74/$3.48 → $0.435/$0.87).
+    entry for that model.  See #24218.  Rates track the 2026-08-20 live
+    snapshot of api-docs.deepseek.com (off-peak tier; peak = 2x).
     """
     entry = get_pricing_entry(
         "deepseek-v4-pro",
@@ -100,9 +100,9 @@ def test_deepseek_v4_pro_pricing_entry_exists():
     assert entry is not None
     assert entry.input_cost_per_million is not None
     assert entry.output_cost_per_million is not None
-    assert float(entry.input_cost_per_million) == 0.435
-    assert float(entry.output_cost_per_million) == 0.87
-    assert float(entry.cache_read_cost_per_million) == 0.003625
+    assert float(entry.input_cost_per_million) == 0.66
+    assert float(entry.output_cost_per_million) == 1.98
+    assert float(entry.cache_read_cost_per_million) == 0.022
 
 
 

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -317,3 +317,130 @@ def test_default_build_footer_line_ignores_turn_seconds(monkeypatch):
     with_timing = build_footer_line(**common, turn_seconds=125.0)
     assert baseline == "gpt-5.4 · 5% · /var/data"
     assert with_timing == baseline
+
+
+def test_rate_tier_not_in_default_fields():
+    """rate_tier is opt-in — default field set stays byte-identical."""
+    from gateway.runtime_footer import _DEFAULT_FIELDS
+
+    assert "rate_tier" not in _DEFAULT_FIELDS
+    assert list(_DEFAULT_FIELDS) == _LEGACY_DEFAULT_FIELDS
+
+
+def test_rate_tier_renders_only_for_matching_models(monkeypatch):
+    """rate_tier appears for models matching a configured window, skipped otherwise."""
+    import datetime as dt
+
+    from gateway.runtime_footer import format_runtime_footer, rate_tier_for_model
+
+    # deterministic time: inside the built-in DeepSeek peak window (UTC 08:00 → SGT 16:00)
+    monkeypatch.setattr(
+        "gateway.runtime_footer._dt.datetime",
+        _FakeDateTime(dt.datetime(2026, 8, 20, 8, 30, tzinfo=dt.timezone.utc)),
+    )
+
+    ds = format_runtime_footer(
+        model="deepseek/deepseek-v4-flash",
+        context_tokens=10_000,
+        context_length=100_000,
+        fields=("model", "context_pct", "rate_tier", "cwd"),
+        cwd="/var/data",
+    )
+    assert ds == "deepseek-v4-flash · 10% · peak · /var/data"
+
+    # No window matches → field silently skipped.
+    non_ds = format_runtime_footer(
+        model="claude-opus-5",
+        context_tokens=10_000,
+        context_length=100_000,
+        fields=("model", "context_pct", "rate_tier"),
+        cwd="/var/data",
+    )
+    assert non_ds == "claude-opus-5 · 10%"
+
+    # Direct function: same guarantees at the unit level.
+    assert rate_tier_for_model("deepseek-v4-flash") == "peak"
+    assert rate_tier_for_model("claude-opus-5") is None
+
+
+def test_rate_tier_custom_windows_sgt(monkeypatch):
+    """User rate_windows override: custom tz + windows win over the built-in default."""
+    import datetime as dt
+
+    from gateway.runtime_footer import (
+        format_runtime_footer,
+        rate_tier_for_model,
+        resolve_footer_config,
+        _DEFAULT_RATE_WINDOWS,
+    )
+
+    # Windows {mymodel: {tz: Asia/Singapore, peak: [[20,22]]}}.
+    # At 12:30 UTC = 20:30 SGT → custom PEAK; the built-in DeepSeek UTC window
+    # (01-04/06-10) says off-peak. Proves tz + custom windows are authoritative.
+    cfg = {
+        "display": {
+            "runtime_footer": {
+                "enabled": True,
+                "fields": ["model", "rate_tier"],
+                "rate_windows": {
+                    "mymodel": {"tz": "Asia/Singapore", "peak": [[20, 22]]}
+                },
+            }
+        }
+    }
+    resolved = resolve_footer_config(cfg, "telegram")
+    # merge keeps the built-in deepseek default AND the custom entry
+    assert "deepseek" in resolved["rate_windows"]
+    assert "mymodel" in resolved["rate_windows"]
+
+    monkeypatch.setattr(
+        "gateway.runtime_footer._dt.datetime",
+        _FakeDateTime(dt.datetime(2026, 8, 20, 12, 30, tzinfo=dt.timezone.utc)),
+    )
+    out = format_runtime_footer(
+        model="acme/mymodel-2",
+        context_tokens=10_000,
+        context_length=100_000,
+        fields=("model", "rate_tier"),
+        rate_windows=resolved["rate_windows"],
+    )
+    assert out == "mymodel-2 · peak"
+
+    # the same instant is off-peak for the built-in deepseek default
+    assert rate_tier_for_model("deepseek-v4-flash", resolved["rate_windows"]) == "off-peak"
+    assert _DEFAULT_RATE_WINDOWS["deepseek"]["tz"] == "UTC"
+
+
+def test_rate_tier_default_windows_boundaries():
+    """Built-in DeepSeek peak windows are 01-03 and 06-09 UTC."""
+    import datetime as dt
+
+    from gateway.runtime_footer import rate_tier_for_model
+
+    peak_hours = {1, 2, 3, 6, 7, 8, 9}
+    for hour in range(24):
+        t = dt.datetime(2026, 8, 20, hour, 30, tzinfo=dt.timezone.utc)
+        expected = "peak" if hour in peak_hours else "off-peak"
+        assert rate_tier_for_model("deepseek-v4-flash", now=t) == expected, (
+            f"UTC {hour}:00 wrong"
+        )
+
+
+def test_deepseek_rate_tier_legacy_helper():
+    """Backward-compat helper still returns the same UTC-based tiers."""
+    import datetime as dt
+
+    from gateway.runtime_footer import deepseek_rate_tier
+
+    assert deepseek_rate_tier(dt.datetime(2026, 8, 20, 2, 30, tzinfo=dt.timezone.utc)) == "peak"
+    assert deepseek_rate_tier(dt.datetime(2026, 8, 20, 5, 30, tzinfo=dt.timezone.utc)) == "off-peak"
+
+
+class _FakeDateTime:
+    """Minimal stand-in so monkeypatching gateway.runtime_footer._dt.datetime works."""
+
+    def __init__(self, fixed):
+        self._fixed = fixed
+
+    def now(self, tz=None):
+        return self._fixed.astimezone(tz) if tz else self._fixed


### PR DESCRIPTION
Two related changes to how time-of-use pricing is priced and surfaced. Both are rebased onto current `main` (`443d4387b5`); the affected suites pass on that base.

### `feat(footer): config-driven time-of-use rate_tier field`

Adds a provider-agnostic `rate_tier` footer field showing the current peak/off-peak billing tier for models with time-of-use pricing.

- Windows are config-driven via `display.runtime_footer.rate_windows`, keyed by model substring with an optional timezone
- A built-in DeepSeek default (01-04 / 06-10 UTC) applies when unset; user entries deep-merge over it
- Renders only when the active model matches a configured window, and is skipped silently otherwise
- **Opt-in** — not part of the default field set

### `fix(pricing): update DeepSeek rates to live 2026-08 snapshot`

The pricing table carried July 2026 rates that under-reported real DeepSeek spend by **2-5x**. This snapshots the live off-peak rates from api-docs.deepseek.com (verified 2026-08-20), notes the peak = 2x multiplier in the comment, and updates the pro regression test.

### Tests

```
tests/gateway/test_runtime_footer.py
tests/agent/test_usage_pricing.py
82 passed
```

Run against `main` at `443d4387b5`.

---

Replaces #90921, which was opened from a branch cut off a long-diverged fork and therefore carried 38 unrelated commits. This branch is the same two commits cherry-picked cleanly onto upstream `main`, with nothing else in it.
