### PR TITLE
feat(desktop): add composer.dictate push-to-talk keybind

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -49,6 +49,7 @@ const ATTACH_IMAGES_EVENT = 'hermes:composer-attach-images'
 const INSERT_REFS_EVENT = 'hermes:composer-insert-refs'
 const SUBMIT_EVENT = 'hermes:composer-submit'
 const VOICE_TOGGLE_EVENT = 'hermes:composer-voice-toggle'
+const DICTATE_EVENT = 'hermes:composer-dictate'
 const MODEL_MENU_EVENT = 'hermes:composer-model-menu'
 
 /** Inline edit composer root — mounted only while a user bubble is being edited. */
@@ -341,6 +342,14 @@ export const requestVoiceToggle = (target: ComposerTarget | 'active' = 'active')
 
 export const onComposerVoiceToggleRequest = (handler: (target: ComposerTarget) => void) =>
   subscribe<{ target: ComposerTarget }>(VOICE_TOGGLE_EVENT, ({ target }) => handler(target))
+
+/** One-shot push-to-talk dictation on the active composer — the `composer.dictate`
+ *  keybind action; calls the mic icon's `dictate()`. */
+export const requestDictate = (target: ComposerTarget | 'active' = 'active') =>
+  dispatch<{ target: ComposerTarget }>(DICTATE_EVENT, { target: resolve(target) })
+
+export const onComposerDictateRequest = (handler: (target: ComposerTarget) => void) =>
+  subscribe<{ target: ComposerTarget }>(DICTATE_EVENT, ({ target }) => handler(target))
 
 /** The chat surface inside the zone the pointer is over, if any. Mirrors the
  *  tab verbs' hover-first targeting (`tabTargetGroupId`, #74447): the model

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -14,7 +14,7 @@ import { $autoSpeakReplies, $voiceStopPhrase, setAutoSpeakReplies } from '@/stor
 import { resumeWakeAfterVoice } from '@/store/wake-word'
 
 import type { ComposerTarget } from '../focus'
-import { onComposerVoiceToggleRequest } from '../focus'
+import { onComposerDictateRequest, onComposerVoiceToggleRequest } from '../focus'
 import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
 
@@ -196,6 +196,13 @@ export function useComposerVoice({
   useEffect(
     () => onComposerVoiceToggleRequest(toggled => toggled === target && toggleVoiceConversation()),
     [target, toggleVoiceConversation]
+  )
+
+  // `composer.dictate` → the mic icon's one-shot push-to-talk: record →
+  // transcribe → insert into the draft. No conversation loop, no auto-submit.
+  useEffect(
+    () => onComposerDictateRequest(toggled => toggled === target && dictate()),
+    [target, dictate]
   )
 
   useEffect(() => {

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -63,7 +63,7 @@ import { toggleStatusbarVisible } from '@/store/statusbar-prefs'
 import { openNewWindow } from '@/store/windows'
 import { useTheme } from '@/themes/context'
 
-import { requestComposerFocus, requestModelMenuToggle, requestVoiceToggle } from '../chat/composer/focus'
+import { requestComposerFocus, requestDictate, requestModelMenuToggle, requestVoiceToggle } from '../chat/composer/focus'
 import { handleWindowPaste } from '../chat/composer/paste-to-focus'
 import { openSession } from '../open-session'
 import {
@@ -190,6 +190,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
       }
     },
     'composer.voice': requestVoiceToggle,
+    'composer.dictate': requestDictate,
 
     // On the Settings overlay, ⌘K scopes to settings search; the second press
     // (or Esc) still closes as usual via toggle.

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -240,6 +240,7 @@ export const ar = defineLocale({
       'composer.focus': 'التركيز على المحرّر',
       'composer.modelPicker': 'فتح منتقي النموذج',
       'composer.voice': 'بدء / إيقاف المحادثة الصوتية',
+      'composer.dictate': 'إملاء (اضغط وتحدث)',
       'view.toggleSidebar': 'تبديل الشريط الجانبي للجلسات',
       'view.toggleRightSidebar': 'تبديل متصفح الملفات',
       'view.toggleReview': 'تبديل لوحة المراجعة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -272,6 +272,7 @@ export const en: Translations = {
       'composer.focus': 'Focus composer',
       'composer.modelPicker': 'Open model picker',
       'composer.voice': 'Start / stop voice conversation',
+      'composer.dictate': 'Dictate (push-to-talk)',
       'view.toggleSidebar': 'Toggle sessions sidebar',
       'view.toggleRightSidebar': 'Toggle file browser',
       'view.toggleReview': 'Toggle review pane',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -267,6 +267,7 @@ export const zh: Translations = {
       'composer.focus': '聚焦输入框',
       'composer.modelPicker': '打开模型选择器',
       'composer.voice': '开始 / 停止语音对话',
+      'composer.dictate': '听写（按住说话）',
       'view.toggleSidebar': '切换会话侧边栏',
       'view.toggleRightSidebar': '切换文件浏览器',
       'view.toggleReview': '切换审查面板',

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -66,6 +66,10 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // chord, so ship it unbound there (rebindable in the panel) rather than
   // stealing the long-standing sidebar binding.
   { id: 'composer.voice', category: 'composer', defaults: IS_MAC ? ['ctrl+b'] : [] },
+  // Push-to-talk dictation — the mic icon's one-shot record→transcribe→insert,
+  // NOT the conversation loop. Ships unbound: users assign a chord in the
+  // Shortcuts panel, so the default never collides with platform shortcuts.
+  { id: 'composer.dictate', category: 'composer', defaults: [] },
 
   // ── Profiles ─────────────────────────────────────────────────────────────
   { id: 'profile.default', category: 'profiles', defaults: ['mod+d'] },


### PR DESCRIPTION
## What does this PR do?

Binds the user-defined shortcut to a new `composer.dictate` action that triggers the mic icon's one-shot dictation: record → transcribe → insert into the composer draft. No conversation loop, no auto-submit, no spoken reply.

Until now the only keybindable voice action was `composer.voice`, which starts a full voice *conversation* (auto-submits the draft, speaks replies, requires "stop" to end). Users who want plain push-to-talk dictation had no way to bind it to a key.

The action ships **unbound** — users assign a chord in the Shortcuts panel. This follows the convention of the two previous attempts (#46240, #86404): a default binding risks colliding with platform/system shortcuts (e.g. Ctrl+Space on macOS is Spotlight / input source). Once assigned, the action is rebindable like any other.

This is the third attempt at this capability (#46240, #86404 — both closed, capability still absent on main). It follows the structure prescribed in #46240's review: the dictate subscription lives in `use-composer-voice.ts` beside `onComposerVoiceToggleRequest`, targeting the composer instance that owns the recorder.

## Related Issue

No issue — small self-contained feature. Related (closed) attempts:
- #46240 — `composer.dictate` rebindable action, closed Jul 14 (review prescribed the structure used here)
- #86404 — push-to-dictate hotkey, closed Aug 14

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/keybinds/actions.ts` — register `composer.dictate` in the `composer` category, shipped unbound (`defaults: []`)
- `apps/desktop/src/app/chat/composer/focus.ts` — add `DICTATE_EVENT`, `requestDictate()`, `onComposerDictateRequest()` (mirrors the existing voice-toggle plumbing)
- `apps/desktop/src/app/hooks/use-keybinds.ts` — map `'composer.dictate': requestDictate`
- `apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts` — subscribe `onComposerDictateRequest` → `dictate()` for the targeted composer
- `apps/desktop/src/i18n/en.ts` — label `'composer.dictate': 'Dictate (push-to-talk)'`
- `apps/desktop/src/i18n/ar.ts` — label `'composer.dictate': 'إملاء (اضغط وتحدث)'`
- `apps/desktop/src/i18n/zh.ts` — label `'composer.dictate': '听写（按住说话）'`

The en label covers all locales via the active → en → key fallback chain (`i18n/runtime.ts`); ar/zh additionally translate it in the same locales that already translate `composer.voice`. The Shortcuts panel never falls back to a raw action id.

## How to Test

1. `cd apps/desktop && npx tsc --build tsconfig.json` — typecheck passes
2. `npm run build`, restart the desktop app
3. Open the Shortcuts panel (Ctrl+/) and assign a chord to **Dictate (push-to-talk)** (e.g. Ctrl+Space)
4. Focus a chat composer, press the chord → mic recording starts
5. Speak, release → transcription is inserted into the draft
6. Confirm: no conversation UI, nothing auto-submits, no spoken reply
7. Rebind to another chord — the binding is user-rebindable

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — found #46240/#86404 (closed), referenced above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: desktop TypeScript change, no Python touched; verified with `npx tsc --build` + manual steps above
- [ ] I've added tests for my changes — not yet; can port `focus.test.ts` coverage from #46240 if maintainers want it
- [x] I've tested on my platform: Fedora Linux (x86_64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: no docs site changes; i18n labels added in-tree
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS): the action is registered on all platforms; shipping unbound avoids default collisions (macOS Ctrl+Space = Spotlight / input source); users assign any chord in the Shortcuts panel
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: no tool changes

## For New Skills

N/A — not a skill.

## Screenshots / Logs

N/A — behavior verified per the steps above.