### PR TITLE
fix(cron): expose monitor snapshot output hash

### DIFF
--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -133,7 +133,15 @@ def _run_monitor_source(job: dict) -> tuple[bool, str]:
         from cron.scheduler import _run_job_script
 
         workdir = (job.get("workdir") or "").strip() or None
-        return _run_job_script(monitor_script, workdir=workdir)
+        raw_state = job.get("monitor_state")
+        state = raw_state if isinstance(raw_state, dict) else {}
+        last_hash = state.get("last_output_hash")
+        snapshot_hash = last_hash if isinstance(last_hash, str) else ""
+        return _run_job_script(
+            monitor_script,
+            workdir=workdir,
+            monitor_last_output_hash=snapshot_hash,
+        )
     monitor_url = (job.get("monitor_url") or "").strip()
     if monitor_url:
         return _fetch_monitor_url(monitor_url)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3732,6 +3732,8 @@ def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    *,
+    monitor_last_output_hash: Optional[str] = None,
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -3764,6 +3766,12 @@ def _run_job_script(
             mutated, avoiding the global-side-effect bug where a cron
             job's ``os.chdir()`` leaks into concurrent gateway sessions
             (#69396).
+        cancel_event: Optional fire-ownership cancellation signal. When set,
+            the subprocess group is terminated if ownership is lost.
+        monitor_last_output_hash: For a monitor-script invocation, the exact
+            prior output hash from this run's immutable job snapshot. An empty
+            string means that no prior output exists. This invocation-scoped
+            value overrides any ambient variable of the same name.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -3862,6 +3870,8 @@ def _run_job_script(
             }
         env = build_subprocess_env()
         env.update(env_overlay)
+        if monitor_last_output_hash is not None:
+            env["HERMES_MONITOR_LAST_OUTPUT_HASH"] = monitor_last_output_hash
         # Use the job's workdir as the subprocess cwd when configured,
         # otherwise default to the scripts-dir parent (back-compat).
         # NEVER mutate the Python process cwd — that would leak into

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -250,6 +250,56 @@ def test_hash_is_exact_bytes(hermes_env):
     assert hash_monitor_output("a\nb") != hash_monitor_output("a\nb ")
 
 
+def test_monitor_script_receives_job_snapshot_last_output_hash(hermes_env, monkeypatch):
+    """A monitor script must see the hash from this run's job snapshot.
+
+    Another scheduler process can persist a newer monitor hash while this run's
+    source subprocess is still starting. Passing the snapshot hash lets a
+    single-flight adapter replay bytes that are unchanged for this exact run,
+    rather than guessing from mutable jobs.json state.
+    """
+    from cron.monitor import _run_monitor_source
+
+    expected = "a" * 64
+    _write_script(
+        hermes_env,
+        "snapshot_hash.py",
+        "import os\n"
+        "print(os.environ.get('HERMES_MONITOR_LAST_OUTPUT_HASH', '<missing>'))\n",
+    )
+    # Ambient state must never override the invocation-scoped job snapshot.
+    monkeypatch.setenv("HERMES_MONITOR_LAST_OUTPUT_HASH", "ambient-stale-value")
+    job = {
+        "id": "monitor-snapshot-test",
+        "monitor_script": "snapshot_hash.py",
+        "monitor_state": {"last_output_hash": expected},
+    }
+
+    ok, output = _run_monitor_source(job)
+
+    assert ok is True
+    assert output == expected
+
+
+def test_monitor_script_clears_ambient_snapshot_hash_on_first_run(
+    hermes_env, monkeypatch
+):
+    from cron.monitor import _run_monitor_source
+
+    _write_script(
+        hermes_env,
+        "first_run_hash.py",
+        "import os\nprint(repr(os.environ.get('HERMES_MONITOR_LAST_OUTPUT_HASH')))\n",
+    )
+    monkeypatch.setenv("HERMES_MONITOR_LAST_OUTPUT_HASH", "ambient-stale-value")
+    job = {"id": "monitor-first-run-test", "monitor_script": "first_run_hash.py"}
+
+    ok, output = _run_monitor_source(job)
+
+    assert ok is True
+    assert output == "''"
+
+
 def test_unified_diff_is_capped(hermes_env):
     from cron.monitor import MAX_DIFF_CHARS, build_monitor_diff
 

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -215,6 +215,12 @@ The script timeout defaults to 3600 seconds (1 hour). `_get_script_timeout()` re
 
 This timeout bounds the **pre-run script only**, not the agent. Skill-based / LLM-driven jobs run on a separate *inactivity*-based budget (`HERMES_CRON_TIMEOUT`, default 600s of idle time, `0` = unlimited) — they can run for hours as long as they keep calling tools or streaming tokens, and are only killed after the configured idle period with no activity. Scripts are dispatched to a persistent thread pool (not held under the tick lock), so a long-running script does not block other due jobs from firing.
 
+### Monitor-Script Snapshot Contract
+
+A `monitor_script` runs before change detection. Hermes strips outer whitespace, hashes the resulting stdout, and compares it with `monitor_state.last_output_hash` from that invocation's job snapshot. The script receives that same snapshot value in `HERMES_MONITOR_LAST_OUTPUT_HASH`; the variable is an empty string on the first run. Hermes sets it after sanitizing the child environment, so an ambient value cannot override the invocation snapshot.
+
+This matters for cross-process single-flight adapters. While the script is running, another scheduler process may persist a newer monitor hash. An adapter that suppresses an overlapping run must select cached stdout using `HERMES_MONITOR_LAST_OUTPUT_HASH`, not by rereading mutable `jobs.json` or replaying an uncommitted latest-cache value. If no byte-identical cached output exists for that hash, the adapter should fail closed rather than guess.
+
 ### Provider Recovery
 
 `run_job()` passes the user's configured fallback providers and credential pool into the `AIAgent` instance:


### PR DESCRIPTION
## Summary
- pass each monitor script the `last_output_hash` captured in that job invocation's monitor-state snapshot
- override ambient `HERMES_MONITOR_LAST_OUTPUT_HASH` only after Hermes builds its sanitized subprocess environment
- pass an empty value on first run and preserve existing cancellation, timeout, redaction, and script-resolution behavior
- document the invocation-snapshot contract for monitor script authors

## Exact lineage
- upstream base: `fc9cbc872d8050c22f1192b16bc5ff4aed471e10`
- head: `a8ccbecf80384ad80edf275ca79dd434c57d2954`
- four-path SHA-256 manifest: `4df592b770ac23a4bc64de490b8370a3843c50c54019a16cacf9b2ee35856356`

## Why
A single-flight monitor can safely coalesce overlapping scheduler invocations only if a denied invocation can replay the exact bytes that *its own* captured job snapshot expects. Reading mutable `jobs.json` or replaying a newly published cache entry cannot provide that guarantee: another invocation may have advanced state after the current job dictionary was captured. Exposing the captured hash directly closes that race without exposing credentials or broadening script authority.

## Verification
- `scripts/run_tests.sh tests/cron/test_monitor_kind.py tests/cron/test_cron_script.py -q`: 47 passed, 1 Windows-only skip
- `ruff==0.15.10 check` on the changed Python files: clean
- deterministic real-subprocess consumer holdout: grant changed once; stale and current denied snapshots both remained unchanged; only one state transition persisted
- independent exact-byte review returned matching opening/closing manifest `4df592b7…` with no P0-P2 defect
- the complete local suite was attempted, but the existing development venv lacks optional voice/image/provider dependencies and produced unrelated collection/runtime failures; affected cron paths above are green

## Compatibility and safety
- internal, non-secret SHA-256 state only; no provider secret is restored after sanitization
- scripts that ignore the variable behave exactly as before
- malformed monitor state is exported as an empty value so consumers can fail closed
- no new user-facing configuration knob or external dependency
