### PR TITLE
fix(browser): handle IPv4-only debug port allocation

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -222,22 +222,32 @@ def local_port_in_use(port: int, timeout: float = 0.5) -> bool:
 
 
 def find_free_debug_port(preferred: int = DEFAULT_BROWSER_CDP_PORT, attempts: int = 10) -> int:
-    """Return the first port after ``preferred`` bindable on both loopbacks.
+    """Return the first port after ``preferred`` bindable on available loopbacks.
 
     Used when ``preferred`` is occupied by a non-CDP application: rather
     than launching a browser into a bind conflict, pick a nearby free
-    port. Falls back to ``preferred + 1`` if nothing binds (the launch
-    will then fail with a clear browser-side error instead of silently
-    doing nothing).
+    port. Some kernels and containers expose ``AF_INET6`` while rejecting
+    binds to ``::1``; unavailable IPv6 must not reject every IPv4 candidate.
+    Falls back to ``preferred + 1`` if nothing binds (the launch will then fail
+    with a clear browser-side error instead of silently doing nothing).
     """
     import socket
 
+    loopbacks = [(socket.AF_INET, "127.0.0.1")]
+    if socket.has_ipv6:
+        try:
+            with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as probe:
+                probe.bind(("::1", 0))
+        except OSError:
+            pass
+        else:
+            loopbacks.append((socket.AF_INET6, "::1"))
+
     for port in range(preferred + 1, preferred + 1 + attempts):
         bindable = True
-        for family, host in ((socket.AF_INET, "127.0.0.1"), (socket.AF_INET6, "::1")):
+        for family, host in loopbacks:
             try:
                 with socket.socket(family, socket.SOCK_STREAM) as sock:
-                    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                     sock.bind((host, port))
             except OSError:
                 bindable = False

--- a/tests/hermes_cli/test_browser_connect_dual_stack.py
+++ b/tests/hermes_cli/test_browser_connect_dual_stack.py
@@ -107,3 +107,31 @@ class TestFindFreeDebugPort:
             pytest.skip("successor port unavailable to bind in this environment")
         finally:
             blocker.close()
+
+    def test_ipv4_only_host_skips_occupied_successor(self, monkeypatch):
+        """Unavailable IPv6 must not force the occupied fallback port."""
+        import hermes_cli.browser_connect as bc
+
+        class _Socket:
+            def __init__(self, family, _socktype):
+                self.family = family
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def setsockopt(self, *_args):
+                return None
+
+            def bind(self, address):
+                _host, port = address
+                if self.family == socket.AF_INET6:
+                    raise OSError("IPv6 loopback is unavailable")
+                if port == 20001:
+                    raise OSError("IPv4 successor is occupied")
+
+        monkeypatch.setattr(socket, "socket", _Socket)
+
+        assert bc.find_free_debug_port(preferred=20000, attempts=3) == 20002


### PR DESCRIPTION
## Summary

Fix `find_free_debug_port()` on IPv4-only kernels and containers where Python exposes `AF_INET6`, but the running host cannot bind the IPv6 loopback.

This is a narrow follow-up to #66847. That PR correctly made `/browser connect` dual-stack, but the nearby-port allocator still required every candidate to bind on both `127.0.0.1` and `::1` unconditionally.

## Problem

On an IPv4-only host:

1. `preferred + 1` is occupied on IPv4;
2. `preferred + 2` is free on IPv4;
3. every `::1` bind fails because IPv6 loopback is unavailable.

The current allocator rejects every candidate because of the IPv6 failure, then falls back to `preferred + 1` — the occupied port it was supposed to avoid.

Deterministic reproduction on current `main`:

```text
expected free port: 20002
selected port:      20001
```

## Fix

- Probe actual `::1` bind capability once before scanning candidate ports.
- Require a port to be free on IPv6 only when that loopback is usable.
- Keep the existing dual-stack behavior on hosts that support both families.
- Do not set `SO_REUSEADDR` while checking availability; a debug-browser launch needs an exclusively bindable port, not a reusable listener address.

## Verification

- New regression test fails before the fix (`20001 != 20002`) and passes after it.
- Browser-connect suites and adjacent gateway connect tests: **19 passed**.
- `py_compile`: PASS.
- Ruff: PASS.
- Windows footgun checker: PASS (`996` files).
- `git diff --check`: PASS.
- Independent socket-semantics review: PASS, no findings.

The tested base advanced by two unrelated commits before submit; neither touches the two changed files.
