### PR TITLE
fix: opencode-free picker only lists models that actually answer keyless — 2 UA-gated slugs delisted

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -559,12 +559,14 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # OpenCode free tier — keyless (no OpenCode account needed). Synced
     # against live GET /zen/v1/models + anonymous probes (2026-08-21);
     # deepseek-v4-flash-free delisted (promo ended, now 401s).
+    # big-pickle + mimo-v2.5-free delisted (UA-gated: the relay 429s
+    # FreeUsageLimitError for every client except User-Agent
+    # "opencode/latest"; we send honest Hermes attribution and don't
+    # impersonate other clients — verified 2026-08-21).
     "opencode-free": [
         "x-preview-f-free",  # "Ox Alpha" stealth model — free, 1M ctx, ZDR
-        "big-pickle",
         "hy3-free",
         "laguna-s-2.1-free",
-        "mimo-v2.5-free",
         "nemotron-3-ultra-free",
         "nemotron-3.5-lightning-free",
         "muse-spark-1.2-contributor-free",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -109,7 +109,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-sonnet-5", "anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["x-preview-f-free", "gpt-5.6-sol", "gpt-5.4", "gpt-5.3-codex", "claude-opus-5", "claude-sonnet-5", "gemini-3.7-flash", "glm-5.2", "kimi-k3", "minimax-m3"],
-    "opencode-free": ["x-preview-f-free", "big-pickle", "hy3-free", "laguna-s-2.1-free", "mimo-v2.5-free", "nemotron-3-ultra-free", "nemotron-3.5-lightning-free", "muse-spark-1.2-contributor-free"],
+    "opencode-free": ["x-preview-f-free", "hy3-free", "laguna-s-2.1-free", "nemotron-3-ultra-free", "nemotron-3.5-lightning-free", "muse-spark-1.2-contributor-free"],
     "opencode-go": ["kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "gpt-5.6-luna", "grok-4.5", "glm-5.3", "glm-5.2", "mimo-v2.5-pro", "mimo-v2.5", "minimax-m3", "minimax-m2.7", "qwen3.8-max", "qwen3.7-max", "deepseek-v4-pro", "hy3"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",

--- a/plugins/model-providers/opencode-free/__init__.py
+++ b/plugins/model-providers/opencode-free/__init__.py
@@ -59,7 +59,9 @@ opencode_free = OpenCodeFreeProfile(
     display_name="OpenCode Free",
     description="OpenCode free models — keyless, no account needed",
     default_headers=dict(_KEYLESS_HEADERS),
-    default_aux_model="big-pickle",
+    # laguna is the fastest non-UA-gated free model; big-pickle 429s every
+    # client except the opencode CLI's own User-Agent (verified 2026-08-21).
+    default_aux_model="laguna-s-2.1-free",
 )
 
 register_provider(opencode_free)


### PR DESCRIPTION
## Summary
Every model in the opencode-free picker now actually answers keyless. Full-catalog live verification (plain + streaming + tools per model) found `big-pickle` and `mimo-v2.5-free` are UA-gated by the relay: 429 `FreeUsageLimitError` for ANY client except User-Agent `opencode/latest` (same IP, no cooldown effect), while the other six serve our honest HermesAgent attribution freely. Hermes doesn't impersonate other clients, so the two gated models are delisted rather than shipped as dead picker entries.

## Changes
- `hermes_cli/models.py` + `hermes_cli/setup.py`: opencode-free catalog 8 → 6 (delist reason in the catalog comment)
- `plugins/model-providers/opencode-free/__init__.py`: `default_aux_model` big-pickle → `laguna-s-2.1-free` (fastest non-gated free model)
- Keyless predicate intentionally keeps big-pickle: it IS free tier, so manual entry still routes keyless and surfaces the relay's own 429 instead of a misleading 401

## Validation
| Model | plain / stream / tools (keyless, Hermes UA) |
|---|---|
| x-preview-f-free, hy3-free, laguna-s-2.1-free, nemotron-3-ultra-free, nemotron-3.5-lightning-free | 200 / 200 / 200 |
| muse-spark-1.2-contributor-free | 200 (`/v1/responses`) |
| big-pickle, mimo-v2.5-free | 429 all shapes; 200 only as `opencode/latest` → delisted |

E2E: picker lists 6, laguna aux default completes a keyless agent turn. 195 targeted tests green.

## Infographic

![Free tier verified access](https://v3b.fal.media/files/b/0aa737b1/bhT59VYvX3UjdE2qcwBMn_hZsZ6Y5W.png)
