### PR TITLE
fix(skills): verify the live dir is gone before reporting a curator delete

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -947,3 +947,33 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+class TestCuratorArchiveFalseSuccessGuard:
+    """#91442: archive_skill() re-resolves the skill directory on its own, and
+    a name-collision can make it report ok while a DIFFERENT same-named entry
+    was moved — leaving this skill at its live path. _delete_skill must never
+    report success (and write a ledger entry with before == after) unless the
+    live directory it resolved at entry is actually gone."""
+
+    def test_misresolved_archive_reported_as_failure(self, tmp_path, monkeypatch):
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch) as skills_root:
+            _create_curator_skill("umbrella", _skill_content("umbrella"))
+            _create_curator_skill("collide", _skill_content("collide"))
+            with patch(
+                "tools.skill_usage.archive_skill",
+                return_value=(True, "archived to .archive/collide-20260821"),
+            ):
+                result = _delete_skill("collide", absorbed_into="umbrella")
+        assert result["success"] is False, result
+        assert "still present" in result["error"], result
+        assert (skills_root / "collide").exists()
+
+    def test_real_archive_still_succeeds(self, tmp_path, monkeypatch):
+        with _curator_pass(tmp_path, monkeypatch=monkeypatch) as skills_root:
+            _create_curator_skill("umbrella", _skill_content("umbrella"))
+            _create_curator_skill("collide", _skill_content("collide"))
+            result = _delete_skill("collide", absorbed_into="umbrella")
+        assert result["success"] is True, result
+        assert result.get("_archived") is True
+        assert not (skills_root / "collide").exists()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1272,6 +1272,24 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
             return {"success": False, "error": f"failed to archive '{name}': {e}"}
         if not ok:
             return {"success": False, "error": archive_msg}
+        # FAIL-CLOSED verification: archive_skill() re-resolves the skill
+        # directory on its own, and in name-collision scenarios it can
+        # report ok while having moved a different entry (e.g. the
+        # just-archived original) — leaving this skill at its live path.
+        # Reporting success then writes a false ledger entry (before ==
+        # after) and downstream fail-closed consumers (duplicate-name
+        # reconcilers) trip over the leftover for hours (#91442). Never
+        # claim success unless the live directory we resolved at entry is
+        # actually gone.
+        if skill_dir.exists():
+            return {
+                "success": False,
+                "error": (
+                    f"archive reported success for '{name}' but its directory "
+                    f"is still present at {skill_dir} — refusing to report a "
+                    "false delete (possible name-collision mis-resolution)"
+                ),
+            }
         message = f"Skill '{name}' archived ({archive_msg})."
         if is_consolidation:
             message += f" Content absorbed into '{absorbed_target}'."


### PR DESCRIPTION
## What does this PR do?

Stops `skill_manage(delete)` from reporting a **false success** during a curator background pass. The curator path routes through `archive_skill()`, which re-resolves the skill directory on its own; in a name-collision scenario (a probe skill sharing its frontmatter name with a just-archived skill) it can return `ok` while having moved a different same-named entry — leaving the target skill at its live path. `_delete_skill` then returned `{"success": True, "_archived": True}` and the audit ledger wrote an entry whose `before` and `after` manifests were byte-identical. The leftover directory collided by name and tripped a downstream fail-closed consumer (`reconcile-brain-skills.py` refuses duplicate skill names) every 10 minutes for ~2 hours until manual removal (#91442).

The fix fails closed: after `archive_skill()` reports ok, verify the live directory that `_delete_skill` resolved at entry is actually gone; if it is still present, return an explicit error instead of a false success (and no false ledger claim).

## Related Issue

Fixes #91442

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_manager_tool.py`: In `_delete_skill`'s curator archive branch, after a reported-ok `archive_skill()` call, check `skill_dir.exists()` and return `success: False` with an explanatory error when the live directory is still present.
- `tests/tools/test_skill_manager_tool.py`: New `TestCuratorArchiveFalseSuccessGuard` — a mis-resolving archive (mocked `archive_skill` returns ok without moving the directory) must be reported as failure with the skill still on disk, and the real archive path (unmocked) still succeeds end-to-end.

## How to Test

1. In a curator background pass, create a probe skill whose frontmatter name collides with a just-archived skill, then call `skill_manage(action=delete, absorbed_into=<umbrella>)`
2. Before the fix: `{"success": True, "_archived": True}` while the directory remained at its live path and the ledger recorded `before == after`; after the fix the mismatch is reported as an explicit error (Observed result: `test_misresolved_archive_reported_as_failure` fails on unpatched main — success is True despite the leftover — and passes with this patch)
3. A genuine archive still succeeds (Observed result: `test_real_archive_still_succeeds` passes — success True, `_archived` True, live dir removed)
4. `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -q` → should pass (Observed result: 49 passed locally)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
