### PR TITLE
fix(curator): exclude .git from skill snapshots to stop runaway growth

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -60,7 +60,11 @@ DEFAULT_KEEP = 5
 # Entries under skills/ that should NEVER be rolled up into a snapshot.
 # .hub/ is managed by the skills hub; rolling it back would break lockfile
 # invariants. .curator_backups is the backup dir itself — recursion bomb.
-_EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub"}
+# .git is repo infrastructure, not skill content: snapshots that include it
+# grow with the full history, and once backups are committed back the
+# history contains prior backups — each snapshot bigger than the last
+# (observed: 38MB of skills inflating to 24GB in weeks, #91449).
+_EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub", ".git"}
 
 # Snapshot id regex: UTC ISO with colons replaced by dashes so the filename
 # is portable (Windows-safe). An optional ``-NN`` suffix handles two

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -66,6 +66,29 @@ def test_snapshot_uniquifies_when_same_second(backup_env, monkeypatch):
     assert s2.name == f"{frozen}-01"
 
 
+def test_snapshot_excludes_git_dir(backup_env):
+    """.git must never be rolled into a snapshot: it is repo infrastructure,
+    not skill content. Snapshots that include it grow with the full history,
+    and once backups are committed back the history itself contains prior
+    backups — each snapshot bigger than the last (observed ~38MB of skills
+    inflating to 24GB within weeks, #91449)."""
+    import tarfile
+
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    git_dir = skills / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    snap = cb.snapshot_skills(reason="test")
+    assert snap is not None
+    with tarfile.open(snap / "skills.tar.gz") as tf:
+        names = tf.getnames()
+    assert any(n.startswith("alpha") for n in names)
+    assert not any(n.startswith(".git") for n in names)
+
+
 def test_snapshot_prunes_to_keep_count(backup_env, monkeypatch):
     cb = backup_env["cb"]
     _write_skill(backup_env["skills"], "alpha")


### PR DESCRIPTION
## What does this PR do?

Stops curator skill snapshots from growing without bound. `snapshot_skills()` rolled the skills directory's `.git` into every backup tar; `.git` is repo infrastructure, not skill content, so each snapshot grew with the full history — and once backups were committed back, the history itself contained prior backups, compounding the growth (observed: ~38MB of actual skills inflating to 24GB across a few weeks, with `hermes` hanging at 100% CPU while tarring the tree on startup, #91449).

The fix adds `.git` to `_EXCLUDE_TOP_LEVEL`. The set is shared by snapshot, restore staging, and restore rollback, so `.git` is consistently treated as infrastructure on all three paths — restore never moves or deletes it either.

Note on scope: the issue also floats excluding `.archive/` and adding a size guard. `.archive` currently participates in snapshots (archived skills are recoverable curator state, and rolling a snapshot back plausibly should restore them), so changing that is a semantic call left to maintainers; the size guard is likewise a separate hardening change. This PR is the one-line root-cause fix.

## Related Issue

Fixes #91449

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/curator_backup.py`: Add `.git` to `_EXCLUDE_TOP_LEVEL` with a comment explaining the compounding-growth failure mode.
- `tests/agent/test_curator_backup.py`: Add `test_snapshot_excludes_git_dir` — a skills tree with a real skill plus a `.git/HEAD` snapshots the skill but not `.git`.

## How to Test

1. In a skills directory backed by git, run a curator pass that triggers `snapshot_skills()`
2. Before the fix each `skills.tar.gz` includes the full `.git` history and grows every run (backups committed back compound it); after the fix the tarball contains only skill entries (Observed result: `test_snapshot_excludes_git_dir` fails on unpatched main with `.git/HEAD` present in the tarball and passes with this patch)
3. `scripts/run_tests.sh tests/agent/test_curator_backup.py -q` → should pass (Observed result: 13 passed locally)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
