### PR TITLE
fix(mcp): rebuild transport and retry once on stale keep-alive connection

### DIFF
--- a/tests/tools/test_mcp_stale_connection_retry.py
+++ b/tests/tools/test_mcp_stale_connection_retry.py
@@ -1,0 +1,189 @@
+"""Tests for MCP tool-handler stale-connection auto-reconnect (#90166).
+
+A CDN / load balancer / proxy can close an idle keep-alive connection
+out from under the MCP streamable-HTTP transport.  The SDK then surfaces
+``MCPError: Connection closed`` or ``RemoteProtocolError: Server
+disconnected without sending a response`` on the next tool call.  The
+server itself is healthy — only the pooled connection is dead — so the
+tool handler rebuilds the transport and retries once instead of
+surfacing the transient failure to the model.
+
+Before this fix, that error class fell through both the auth and
+session-expired recovery paths (it is neither a credential problem nor a
+server-side session GC) and landed as a plain tool error, so an idle
+CDN kill turned into a visible ``MCPError: Connection closed`` that
+self-healed only minutes later after parking.
+"""
+
+import asyncio
+import json
+import threading
+
+import pytest
+from tools import mcp_tool_loop as _mcp_loop
+
+
+# ---------------------------------------------------------------------------
+# _is_stale_connection_error — unit coverage
+# ---------------------------------------------------------------------------
+
+
+def _make_remote_protocol_error():
+    """Build the exact exception class the SDK's httpx2 stack raises."""
+    try:
+        import httpx2
+    except ImportError:  # pragma: no cover - dev extra always installs it
+        pytest.skip("httpx2 not installed")
+    return httpx2.RemoteProtocolError(
+        "Server disconnected without sending a response"
+    )
+
+
+def test_is_stale_connection_detects_remote_protocol_error():
+    """Reporter's exact traceback error (#90166)."""
+    from tools.mcp_tool_errors import _is_stale_connection_error
+    assert _is_stale_connection_error(_make_remote_protocol_error()) is True
+
+
+def test_is_stale_connection_detects_httpcore_remote_protocol_error():
+    """The SDK may leak the underlying httpcore2 exception un-wrapped."""
+    from tools.mcp_tool_errors import _is_stale_connection_error
+    try:
+        import httpcore2
+    except ImportError:  # pragma: no cover
+        pytest.skip("httpcore2 not installed")
+    exc = httpcore2.RemoteProtocolError(
+        "Server disconnected without sending a response"
+    )
+    assert _is_stale_connection_error(exc) is True
+
+
+def test_is_stale_connection_detects_connection_closed_message():
+    """``MCPError: Connection closed`` — the SDK's user-facing wording."""
+    from tools.mcp_tool_errors import _is_stale_connection_error
+    assert _is_stale_connection_error(RuntimeError("MCPError: Connection closed")) is True
+
+
+def test_is_stale_connection_detects_wrapped_exception_group():
+    """post_writer raises inside an anyio TaskGroup (issue traceback)."""
+    from tools.mcp_tool_errors import _is_stale_connection_error
+    inner = _make_remote_protocol_error()
+    eg = ExceptionGroup("unhandled errors in a TaskGroup", [inner])
+    assert _is_stale_connection_error(eg) is True
+
+
+def test_is_stale_connection_detects_chained_cause():
+    """SDK wrappers raise a generic error *from* the transport error."""
+    from tools.mcp_tool_errors import _is_stale_connection_error
+    root = _make_remote_protocol_error()
+    wrapper = RuntimeError("MCP call failed")
+    wrapper.__cause__ = root
+    assert _is_stale_connection_error(wrapper) is True
+
+
+def test_is_stale_connection_rejects_unrelated_errors():
+    from tools.mcp_tool_errors import _is_stale_connection_error
+    assert _is_stale_connection_error(RuntimeError("Invalid params")) is False
+    assert _is_stale_connection_error(ValueError("tool returned bad JSON")) is False
+    # auth failures stay on the OAuth recovery path
+    assert _is_stale_connection_error(RuntimeError("401 Unauthorized")) is False
+
+
+def test_is_stale_connection_interrupt_override():
+    from tools.mcp_tool_errors import _is_stale_connection_error
+    assert _is_stale_connection_error(InterruptedError("user stop")) is False
+
+
+def test_is_stale_connection_traversal_is_budget_bounded():
+    """Pathologically long chains stop at the node budget without spinning."""
+    from tools import mcp_tool_errors as _mcp_errors
+    from tools.mcp_tool_errors import _is_stale_connection_error
+
+    exc: BaseException = RuntimeError("leaf")
+    for i in range(_mcp_errors._EXC_TRAVERSAL_MAX_NODES * 2):
+        wrapper = RuntimeError(f"layer {i}")
+        wrapper.__cause__ = exc
+        exc = wrapper
+    assert _is_stale_connection_error(exc) is False
+
+
+# ---------------------------------------------------------------------------
+# Handler integration — recovery plumbing wires end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "transport_config, expected_route",
+    [
+        ({"command": "cdr-mcp"}, "stdio"),
+        ({"url": "https://qcc.example.test/mcp", "skip_preflight": True}, "http"),
+    ],
+    ids=["stdio", "http"],
+)
+def test_call_tool_handler_rebuilds_transport_on_stale_connection(
+    monkeypatch, tmp_path, transport_config, expected_route
+):
+    """First call hits a dead keep-alive connection; the handler rebuilds the
+    transport and retries once instead of surfacing the error."""
+    from tools import mcp_tool
+    from tools.mcp_tool import MCPServerTask
+    from tools.mcp_tool_handlers import _make_tool_handler
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _mcp_loop._ensure_mcp_loop()
+    transport_ready = threading.Event()
+    routes = []
+    sessions = []
+    call_count = {"n": 0}
+
+    class _Session:
+        async def call_tool(self, *args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise _make_remote_protocol_error()
+            result = type("R", (), {})()
+            result.is_error = False
+            result.content = [type("C", (), {})()]
+            result.content[0].type = "text"
+            result.content[0].text = "reconnected"
+            result.structured_content = None
+            return result
+
+    class _LifecycleTask(MCPServerTask):
+        async def _serve_transport(self, route, config):
+            routes.append(route)
+            self.session = _Session()
+            sessions.append(self.session)
+            self._ready.set()
+            transport_ready.set()
+            return await self._wait_for_lifecycle_event()
+
+        async def _run_stdio(self, config):
+            return await self._serve_transport("stdio", config)
+
+        async def _run_http(self, config):
+            return await self._serve_transport("http", config)
+
+    server = _LifecycleTask("staleconn")
+    mcp_tool._servers["staleconn"] = server
+    mcp_tool._server_error_counts.pop("staleconn", None)
+    mcp_tool._server_breaker_opened_at.pop("staleconn", None)
+    loop = mcp_tool._mcp_loop
+    assert loop is not None
+    run_future = asyncio.run_coroutine_threadsafe(
+        server.run(transport_config), loop
+    )
+
+    try:
+        assert transport_ready.wait(3), "server lifecycle did not establish transport"
+        handler = _make_tool_handler("staleconn", "lookup", 10.0)
+        parsed = json.loads(handler({}))
+
+        assert parsed == {"result": "reconnected"}
+        assert call_count["n"] == 2
+        assert routes == [expected_route, expected_route]
+        assert len(sessions) == 2
+    finally:
+        loop.call_soon_threadsafe(server._shutdown_event.set)
+        run_future.result(timeout=10)
+        mcp_tool._servers.pop("staleconn", None)

--- a/tests/tools/test_mcp_stale_connection_retry.py
+++ b/tests/tools/test_mcp_stale_connection_retry.py
@@ -18,6 +18,7 @@ self-healed only minutes later after parking.
 import asyncio
 import json
 import threading
+import time
 
 import pytest
 from tools import mcp_tool_loop as _mcp_loop
@@ -37,6 +38,12 @@ def _make_remote_protocol_error():
     return httpx2.RemoteProtocolError(
         "Server disconnected without sending a response"
     )
+
+
+# Streamable-HTTP transport config for the lifecycle-backed test servers.  The
+# stale-connection recoverer exists for HTTP keep-alive kills; on a stdio child
+# a post-dispatch transport closure is an ambiguous mid-call death (#106440).
+_HTTP_TRANSPORT = {"url": "https://qcc.example.test/mcp", "skip_preflight": True}
 
 
 def test_is_stale_connection_detects_remote_protocol_error():
@@ -187,3 +194,359 @@ def test_call_tool_handler_rebuilds_transport_on_stale_connection(
         loop.call_soon_threadsafe(server._shutdown_event.set)
         run_future.result(timeout=10)
         mcp_tool._servers.pop("staleconn", None)
+
+
+# ---------------------------------------------------------------------------
+# #91460 review follow-ups
+# ---------------------------------------------------------------------------
+
+
+def _spawn_reconnecting_server(mcp_tool, name, call_tool_impl, config=None):
+    """Spawn a lifecycle-backed MCP server whose ``call_tool`` behaviour is
+    provided by ``call_tool_impl(call_number)``.  Records the rebuild routes
+    and sessions so tests can assert on reconnects.  Defaults to the stdio
+    route; the session/stale stacking tests pass the streamable-HTTP config,
+    because on a stdio child a post-dispatch transport closure is an ambiguous
+    mid-call death and is never replayed (#106440).
+    """
+    transport_ready = threading.Event()
+    routes = []
+    sessions = []
+    call_count = {"n": 0}
+
+    class _Session:
+        async def call_tool(self, *args, **kwargs):
+            call_count["n"] += 1
+            return await call_tool_impl(call_count["n"])
+
+    class _LifecycleTask(mcp_tool.MCPServerTask):
+        async def _serve_transport(self, route, config):
+            routes.append(route)
+            self.session = _Session()
+            sessions.append(self.session)
+            self._ready.set()
+            transport_ready.set()
+            return await self._wait_for_lifecycle_event()
+
+        async def _run_stdio(self, config):
+            return await self._serve_transport("stdio", config)
+
+        async def _run_http(self, config):
+            return await self._serve_transport("http", config)
+
+    server = _LifecycleTask(name)
+    mcp_tool._servers[name] = server
+    mcp_tool._server_error_counts.pop(name, None)
+    mcp_tool._server_breaker_opened_at.pop(name, None)
+    loop = mcp_tool._mcp_loop
+    assert loop is not None
+    run_future = asyncio.run_coroutine_threadsafe(
+        server.run(config or {"command": "cdr-mcp"}), loop
+    )
+    assert transport_ready.wait(3), "server lifecycle did not establish transport"
+    return server, run_future, routes, sessions, call_count
+
+
+def _teardown_reconnecting_server(mcp_tool, name, server, run_future, loop):
+    loop.call_soon_threadsafe(server._shutdown_event.set)
+    run_future.result(timeout=10)
+    mcp_tool._servers.pop(name, None)
+    mcp_tool._server_error_counts.pop(name, None)
+    mcp_tool._server_breaker_opened_at.pop(name, None)
+
+
+def test_is_stale_connection_markers_can_be_disabled():
+    """tools/call retries only on exact transport exception type names;
+    message-marker matching stays available for the read-only resources/*
+    paths (#91460 review)."""
+    from tools.mcp_tool_errors import _is_stale_connection_error
+    marker_exc = RuntimeError("MCPError: Connection closed")
+    assert _is_stale_connection_error(marker_exc) is True
+    assert _is_stale_connection_error(
+        marker_exc, allow_message_markers=False
+    ) is False
+    # Type-name evidence still counts with markers disabled.
+    assert _is_stale_connection_error(
+        _make_remote_protocol_error(), allow_message_markers=False
+    ) is True
+
+
+def test_call_tool_handler_does_not_retry_app_level_marker_error(
+    monkeypatch, tmp_path,
+):
+    """An application-level failure merely *containing* a stale-connection
+    marker phrase ("connection reset" — the reviewer's "connection reset
+    by peer" case) must NOT trigger a transport rebuild + tools/call
+    retry (#91460 review): the tool may already have partially executed,
+    and re-running it would duplicate side effects."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool_handlers import _make_tool_handler
+
+    _mcp_loop._ensure_mcp_loop()
+
+    async def _impl(n):
+        raise RuntimeError("backend connection reset unexpectedly")
+
+    server, run_future, routes, sessions, call_count = (
+        _spawn_reconnecting_server(mcp_tool, "appmarker", _impl)
+    )
+    try:
+        handler = _make_tool_handler("appmarker", "lookup", 10.0)
+        raw = handler({})
+        parsed = json.loads(raw)
+        assert "error" in parsed, parsed
+        assert "backend connection reset" in parsed["error"], parsed
+        assert call_count["n"] == 1, (
+            f"app-level marker error must not retry tools/call; "
+            f"got {call_count['n']} executions"
+        )
+        assert routes == ["stdio"], f"no transport rebuild expected: {routes}"
+        assert len(sessions) == 1
+    finally:
+        _teardown_reconnecting_server(
+            mcp_tool, "appmarker", server, run_future, mcp_tool._mcp_loop,
+        )
+
+
+def test_call_tool_handler_legacy_session_marker_still_retries(
+    monkeypatch, tmp_path,
+):
+    """Pin the boundary of #91460 fix #1: "connection closed" also appears
+    in the pre-existing session-expired marker list (#13383, predates the
+    stale-connection PR), so an app-level error carrying *that* phrase is
+    still retried once via the session-expired path.  The stale-connection
+    handler itself must not add a second retry on top (type names only for
+    tools/call).  This test documents the deliberately unchanged session
+    behaviour; the exact executions count is the pinned contract."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool_handlers import _make_tool_handler
+
+    _mcp_loop._ensure_mcp_loop()
+
+    async def _impl(n):
+        raise RuntimeError("backend connection closed unexpectedly")
+
+    server, run_future, routes, sessions, call_count = (
+        _spawn_reconnecting_server(mcp_tool, "sessmarker", _impl, config=_HTTP_TRANSPORT)
+    )
+    try:
+        handler = _make_tool_handler("sessmarker", "lookup", 10.0)
+        raw = handler({})
+        parsed = json.loads(raw)
+        assert "error" in parsed, parsed
+        # Session-expired path retries once; the stale-connection path
+        # must not stack a second reconnect+retry on top.
+        assert call_count["n"] == 2, (
+            f"expected session-path retry only (2 executions), "
+            f"got {call_count['n']}"
+        )
+        assert routes == ["http", "http"], routes
+        assert len(sessions) == 2
+    finally:
+        _teardown_reconnecting_server(
+            mcp_tool, "sessmarker", server, run_future, mcp_tool._mcp_loop,
+        )
+
+
+def test_call_tool_handler_retry_budget_caps_total_executions(
+    monkeypatch, tmp_path,
+):
+    """One user call chains the auth / session-expired / stale-connection
+    recovery handlers.  Without a shared budget, a session-expired retry
+    that raises a stale-connection error would reach the stale handler
+    for a second reconnect+retry — up to three executions of a
+    non-idempotent tool.  The shared per-invocation budget caps it at
+    initial + one retry (#91460 review)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool_handlers import _make_tool_handler
+
+    _mcp_loop._ensure_mcp_loop()
+
+    async def _impl(n):
+        if n == 1:
+            # Matches the session-expired classifier via the message
+            # marker, and the stale-connection classifier via the chained
+            # transport exception type.
+            root = _make_remote_protocol_error()
+            exc = RuntimeError("closed resource")
+            exc.__cause__ = root
+            raise exc
+        raise _make_remote_protocol_error()
+
+    server, run_future, routes, sessions, call_count = (
+        _spawn_reconnecting_server(mcp_tool, "budgetcap", _impl, config=_HTTP_TRANSPORT)
+    )
+    try:
+        handler = _make_tool_handler("budgetcap", "lookup", 10.0)
+        raw = handler({})
+        parsed = json.loads(raw)
+        assert "error" in parsed, parsed
+        assert call_count["n"] == 2, (
+            f"expected exactly 2 executions (initial + one retry), "
+            f"got {call_count['n']}"
+        )
+        # Session-expired handler rebuilt the transport once; the stale
+        # handler must not stack a second reconnect+retry on top.
+        assert routes == ["http", "http"], routes
+    finally:
+        _teardown_reconnecting_server(
+            mcp_tool, "budgetcap", server, run_future, mcp_tool._mcp_loop,
+        )
+
+
+def test_stale_handler_unparseable_retry_result_does_not_reset_breaker(
+    monkeypatch, tmp_path,
+):
+    """A retry result that fails json.loads after a successful reconnect
+    must NOT reset the circuit-breaker error counter (#91460 review): an
+    unparseable response is exactly the half-broken state the breaker
+    tracks.  The raw string is still returned to preserve behaviour."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool_handlers import _handle_stale_connection_and_retry
+
+    _mcp_loop._ensure_mcp_loop()
+
+    async def _impl(n):
+        raise AssertionError("unused")
+
+    server, run_future, routes, sessions, call_count = (
+        _spawn_reconnecting_server(mcp_tool, "staleconn", _impl)
+    )
+    mcp_tool._server_error_counts["staleconn"] = 2
+    try:
+        out = _handle_stale_connection_and_retry(
+            "staleconn",
+            _make_remote_protocol_error(),
+            lambda: "this is not json",
+            "tools/call lookup",
+            allow_message_markers=False,
+        )
+        assert out == "this is not json"
+        assert mcp_tool._server_error_counts.get("staleconn") == 2, (
+            "unparseable retry payload must not reset the breaker"
+        )
+
+        # A well-formed success payload on a later recovery still resets.
+        out2 = _handle_stale_connection_and_retry(
+            "staleconn",
+            _make_remote_protocol_error(),
+            lambda: json.dumps({"ok": 1}),
+            "tools/call lookup",
+            allow_message_markers=False,
+        )
+        assert out2 == json.dumps({"ok": 1})
+        assert mcp_tool._server_error_counts.get("staleconn") == 0
+    finally:
+        _teardown_reconnecting_server(
+            mcp_tool, "staleconn", server, run_future, mcp_tool._mcp_loop,
+        )
+
+
+def test_stale_handler_error_payload_returns_none_without_reset(
+    monkeypatch, tmp_path,
+):
+    """A retry payload carrying an "error" key is not a success: the
+    handler returns None (caller's generic path bumps the breaker) and
+    must not reset the counter (#91460 review)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool_handlers import _handle_stale_connection_and_retry
+
+    _mcp_loop._ensure_mcp_loop()
+
+    async def _impl(n):
+        raise AssertionError("unused")
+
+    server, run_future, routes, sessions, call_count = (
+        _spawn_reconnecting_server(mcp_tool, "staleconn", _impl)
+    )
+    mcp_tool._server_error_counts["staleconn"] = 2
+    try:
+        out = _handle_stale_connection_and_retry(
+            "staleconn",
+            _make_remote_protocol_error(),
+            lambda: json.dumps({"error": "tool blew up"}),
+            "tools/call lookup",
+            allow_message_markers=False,
+        )
+        assert out is None
+        assert mcp_tool._server_error_counts.get("staleconn") == 2
+    finally:
+        _teardown_reconnecting_server(
+            mcp_tool, "staleconn", server, run_future, mcp_tool._mcp_loop,
+        )
+
+
+def test_stale_handler_reconnect_timeout_derives_from_deadline(
+    monkeypatch, tmp_path,
+):
+    """The reconnect wait must be capped at the caller's remaining budget,
+    not a fixed 15s (#91460 review): a 10s tool call must not stall 15s
+    waiting for a slow reconnect."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool_handlers import _handle_stale_connection_and_retry
+
+    _mcp_loop._ensure_mcp_loop()
+    captured = {}
+
+    class _Server:
+        pass
+
+    srv = _Server()
+    srv._reconnect_event = threading.Event()
+    srv.session = object()
+    mcp_tool._servers["tmo"] = srv
+
+    def _fake_reconnect_and_wait(server_name, srv_arg, *, op_description, timeout):
+        captured["timeout"] = timeout
+        return True
+
+    monkeypatch.setattr(
+        _mcp_loop, "_signal_reconnect_and_wait", _fake_reconnect_and_wait,
+    )
+
+    try:
+        start = time.monotonic()
+        out = _handle_stale_connection_and_retry(
+            "tmo",
+            _make_remote_protocol_error(),
+            lambda: json.dumps({"ok": 1}),
+            "tools/call t",
+            allow_message_markers=False,
+            deadline=start + 3.0,
+        )
+        assert out == json.dumps({"ok": 1})
+        assert 0 < captured["timeout"] <= 3.0, captured
+
+        captured.clear()
+        out2 = _handle_stale_connection_and_retry(
+            "tmo",
+            _make_remote_protocol_error(),
+            lambda: json.dumps({"ok": 1}),
+            "tools/call t",
+            allow_message_markers=False,
+            deadline=None,
+        )
+        assert out2 == json.dumps({"ok": 1})
+        assert captured["timeout"] == 15.0, captured
+
+        captured.clear()
+        out3 = _handle_stale_connection_and_retry(
+            "tmo",
+            _make_remote_protocol_error(),
+            lambda: json.dumps({"ok": 1}),
+            "tools/call t",
+            allow_message_markers=False,
+            deadline=start - 1.0,  # already expired
+        )
+        assert out3 == json.dumps({"ok": 1})
+        assert captured["timeout"] == 0.0, captured
+    finally:
+        mcp_tool._servers.pop("tmo", None)
+        mcp_tool._server_error_counts.pop("tmo", None)
+        mcp_tool._server_breaker_opened_at.pop("tmo", None)

--- a/tools/mcp_tool_errors.py
+++ b/tools/mcp_tool_errors.py
@@ -348,7 +348,7 @@ _STALE_CONNECTION_MARKERS: tuple = (
 )
 
 
-def _is_stale_connection_error(exc: BaseException) -> bool:
+def _is_stale_connection_error(exc: BaseException, *, allow_message_markers: bool = True) -> bool:
     """True if ``exc`` is a stale/dead-connection transport failure: the remote closed the
     underlying keep-alive connection out from under us — the failure a CDN / load balancer /
     proxy idle kill surfaces as ``MCPError: Connection closed`` or ``RemoteProtocolError: Server
@@ -358,6 +358,13 @@ def _is_stale_connection_error(exc: BaseException) -> bool:
     GC (``Invalid or expired session``) plus AnyIO stream closures.  Both are transient transport
     conditions that a rebuild-and-retry-once recovers from; neither is a credential or config
     problem.
+
+    ``allow_message_markers`` gates the substring matching on exception messages.  Marker phrases
+    like ``"connection reset"`` / ``"connection closed"`` also show up in *application-level*
+    failures, and retrying ``tools/call`` after a partial execution can duplicate real side
+    effects; ``tools/call`` passes ``allow_message_markers=False`` so only exact transport
+    exception type names trigger a retry (read-only ``resources/*`` handlers keep marker
+    matching).  See #91460 review.
 
     Same bounded, identity-visited traversal as :func:`_is_session_expired_error` so arbitrarily
     deep ExceptionGroup / ``__cause__`` graphs terminate promptly.
@@ -379,9 +386,10 @@ def _is_stale_connection_error(exc: BaseException) -> bool:
             return False
         if type(current).__name__ in _STALE_CONNECTION_TYPE_NAMES:
             return True
-        msg = str(current).lower()
-        if msg and any(marker in msg for marker in _STALE_CONNECTION_MARKERS):
-            return True
+        if allow_message_markers:
+            msg = str(current).lower()
+            if msg and any(marker in msg for marker in _STALE_CONNECTION_MARKERS):
+                return True
 
         stack.extend(getattr(current, "exceptions", ()))
         stack.append(getattr(current, "__cause__", None))

--- a/tools/mcp_tool_errors.py
+++ b/tools/mcp_tool_errors.py
@@ -1,5 +1,5 @@
 """MCP connection/transport error classification: URL validation, TLS client certs, identity
-headers, redirect header stripping, exception-group unwrapping, auth/session-expired/
+headers, redirect header stripping, exception-group unwrapping, auth/session-expired/stale-connection/
 method-not-found detection and connect-error formatting. Split from tools/mcp_tool.py."""
 
 import asyncio
@@ -322,3 +322,69 @@ def _is_session_expired_error(exc: BaseException) -> bool:
         stack.extend((*getattr(current, "exceptions", ()), getattr(current, "__cause__", None),
                       getattr(current, "__context__", None)))
     return found
+
+
+# Type names of exceptions the MCP SDK / httpcore2 stack raises when a pooled keep-alive
+# connection turns out to have been closed by the remote (CDN idle kill, load-balancer drain,
+# server restart, ...).  Checked by name rather than isinstance because the exact classes differ
+# between the SDK's httpx2 stack and Hermes' own httpx, and either can be unreachable for import
+# at module load.
+_STALE_CONNECTION_TYPE_NAMES: frozenset = frozenset({
+    "RemoteProtocolError",
+    "ConnectionClosed",
+    "ConnectionResetError",
+    "ConnectionAbortedError",
+})
+
+# Message markers for the same failure class.  These are phrased after what the SDK actually
+# emits: ``MCPError: Connection closed`` and ``RemoteProtocolError: Server disconnected without
+# sending a response`` (httpcore2 wraps the latter in the SDK's own transport errors).
+_STALE_CONNECTION_MARKERS: tuple = (
+    "server disconnected",
+    "connection reset",
+    "connection closed",
+    "peer closed connection",
+    "remote protocol error",
+)
+
+
+def _is_stale_connection_error(exc: BaseException) -> bool:
+    """True if ``exc`` is a stale/dead-connection transport failure: the remote closed the
+    underlying keep-alive connection out from under us — the failure a CDN / load balancer /
+    proxy idle kill surfaces as ``MCPError: Connection closed`` or ``RemoteProtocolError: Server
+    disconnected without sending a response`` (#90166).
+
+    Distinct from :func:`_is_session_expired_error`: that classifier covers server-side session
+    GC (``Invalid or expired session``) plus AnyIO stream closures.  Both are transient transport
+    conditions that a rebuild-and-retry-once recovers from; neither is a credential or config
+    problem.
+
+    Same bounded, identity-visited traversal as :func:`_is_session_expired_error` so arbitrarily
+    deep ExceptionGroup / ``__cause__`` graphs terminate promptly.
+    """
+    stack: "list[BaseException | None]" = [exc]
+    seen: set[int] = set()
+    budget = _EXC_TRAVERSAL_MAX_NODES
+    while stack and budget > 0:
+        current = stack.pop()
+        if current is None:
+            continue
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        budget -= 1
+
+        if isinstance(current, InterruptedError):
+            return False
+        if type(current).__name__ in _STALE_CONNECTION_TYPE_NAMES:
+            return True
+        msg = str(current).lower()
+        if msg and any(marker in msg for marker in _STALE_CONNECTION_MARKERS):
+            return True
+
+        stack.extend(getattr(current, "exceptions", ()))
+        stack.append(getattr(current, "__cause__", None))
+        stack.append(getattr(current, "__context__", None))
+
+    return False

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -1,5 +1,6 @@
 """Registry-facing sync handlers for MCP tools and utility tools (resources/prompts), plus the per-call recovery
-ladder: trust gating, circuit breaker, auth (401) refresh, session-expired reconnect and dead-stdio respawn retry."""
+ladder: trust gating, circuit breaker, auth (401) refresh, session-expired reconnect, stale
+keep-alive reconnect and dead-stdio respawn retry."""
 
 import logging
 import asyncio
@@ -18,7 +19,7 @@ from tools.mcp_tool_content import (
     _MCP_HARD_RESULT_CAP_CHARS, _cache_mcp_audio_block, _cache_mcp_image_block,
     _render_mcp_dropped_block_notice, _render_mcp_resource_block, _strip_reserved_meta_keys,
     _truncate_mcp_text_result)
-from tools.mcp_tool_errors import _is_auth_error, _is_session_expired_error
+from tools.mcp_tool_errors import _is_auth_error, _is_session_expired_error, _is_stale_connection_error
 
 logger = logging.getLogger("tools.mcp_tool")
 _MISSING = object()
@@ -185,6 +186,32 @@ def _handle_session_expired_and_retry(server_name: str, exc: BaseException, retr
                        "falling through to error response.", server_name)
         return None
     return _retry_once(server_name, retry_call, op_description, "session reconnect")
+
+
+def _handle_stale_connection_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str):
+    """Rebuild the transport and retry once on a stale-connection failure.
+
+    Mirrors :func:`_handle_session_expired_and_retry`: signal the server task's reconnect event so
+    the dead transport is torn down and a fresh ``streamablehttp_client`` + ``ClientSession`` pair
+    is built, wait for the new session to report ready, then re-run the operation exactly once.
+    A CDN / load-balancer idle kill is transient — the server itself is healthy — so surfacing
+    ``MCPError: Connection closed`` to the model without a retry turns an invisible,
+    self-healing blip into a visible tool failure (#90166).
+
+    None means this is not a stale-connection error, there is no server record / running loop to
+    recover through, or the retry also failed; the caller falls through to its generic error path.
+    """
+    srv = (_lookup_reconnectable_server(server_name, require_loop=True)
+           if _is_stale_connection_error(exc) else None)
+    if srv is None:
+        return None
+    logger.info("MCP server '%s': %s failed with stale-connection error (%s); signalling transport "
+                "reconnect and retrying once.", server_name, op_description, exc)
+    if not _loop._signal_reconnect_and_wait(server_name, srv, op_description=op_description, timeout=15):
+        logger.warning("MCP server '%s': reconnect did not ready within 15s after stale-connection "
+                       "error; falling through to error response.", server_name)
+        return None
+    return _retry_once(server_name, retry_call, op_description, "stale-connection reconnect")
 
 
 class _StdioChildExited(RuntimeError):
@@ -488,16 +515,23 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             logger.error("MCP tool %s/%s call failed: %s", server_name, tool_name, exc)
         return _dispatch(
             server_name, server, op, _call, tool_timeout,
-            (_handle_stdio_child_exited_and_retry, _handle_auth_error_and_retry, _handle_session_expired_and_retry),
+            (_handle_stdio_child_exited_and_retry, _handle_auth_error_and_retry,
+             _handle_session_expired_and_retry, _handle_stale_connection_and_retry),
             _on_failure, record_outcome=True)
     return _handler
 
 
-def _make_utility_handler(op: str, log_label: str, rpc, render, required: Optional[str] = None):
+def _make_utility_handler(op: str, log_label: str, rpc, render, required: Optional[str] = None,
+                          stale_retry: bool = False):
     """``(server_name, tool_timeout) -> sync handler`` for one utility tool: ``rpc(session, args,
     server_name)`` awaited under ``_rpc_lock``, ``render(result, server_name)`` -> JSON-able
-    payload, ``required`` validated before any transport work."""
+    payload, ``required`` validated before any transport work.  ``stale_retry`` adds the stale
+    keep-alive recovery handler (#90166) so the read-only resources/* operations also recover
+    from an idle CDN / proxy connection kill."""
     def _factory(server_name: str, tool_timeout: float):
+        recoverers = (_handle_auth_error_and_retry, _handle_session_expired_and_retry)
+        if stale_retry:
+            recoverers += (_handle_stale_connection_and_retry,)
         def _handler(args: dict, **kwargs) -> str:
             from tools import mcp_tool_discovery as _discovery  # lazy: import cycle
             server = _discovery._get_connected_server_for_call(server_name)
@@ -511,8 +545,7 @@ def _make_utility_handler(op: str, log_label: str, rpc, render, required: Option
                     result = await rpc(server.session, args, server_name)
                 return json.dumps(render(result, server_name), ensure_ascii=False)
             return _dispatch(
-                server_name, server, op, _call, tool_timeout,
-                (_handle_auth_error_and_retry, _handle_session_expired_and_retry),
+                server_name, server, op, _call, tool_timeout, recoverers,
                 lambda exc: logger.error("MCP %s/%s failed: %s", server_name, log_label, exc))
         return _handler
     return _factory
@@ -576,10 +609,12 @@ def _render_get_prompt(result, server_name: str) -> dict:
 
 _make_list_resources_handler = _make_utility_handler(
     "resources/list", "list_resources",
-    lambda session, args, sn: _core._paginate_full_list(session.list_resources, "resources", sn), _render_resource_list)
+    lambda session, args, sn: _core._paginate_full_list(session.list_resources, "resources", sn),
+    _render_resource_list, stale_retry=True)
 _make_read_resource_handler = _make_utility_handler(
     "resources/read", "read_resource",
-    lambda session, args, sn: session.read_resource(args["uri"]), _render_read_resource, required="uri")
+    lambda session, args, sn: session.read_resource(args["uri"]), _render_read_resource,
+    required="uri", stale_retry=True)
 _make_list_prompts_handler = _make_utility_handler(
     "prompts/list", "list_prompts",
     lambda session, args, sn: _core._paginate_full_list(session.list_prompts, "prompts", sn), _render_prompt_list)

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -9,6 +9,7 @@ import inspect
 import json
 import time
 from contextlib import asynccontextmanager
+from functools import partial
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from tools.registry import tool_error
@@ -94,17 +95,15 @@ def _acquire_call_server(server_name: str, tool_timeout: float):
     return None, not_connected
 
 
-def _result_is_error(result) -> bool:
-    """True only for a JSON payload carrying an ``error`` key (non-JSON = success)."""
-    try:
-        return "error" in json.loads(result)
-    except (json.JSONDecodeError, TypeError):
-        return False
-
-
 def _record_call_outcome(server_name: str, result) -> Any:
-    """Breaker bookkeeping: an error payload from the tool itself still counts as a strike."""
-    (_core._bump_server_error if _result_is_error(result) else _core._reset_server_error)(server_name)
+    """Breaker bookkeeping: an error payload from the tool itself still counts as a strike; an
+    unparseable payload is neither a strike nor evidence of health, so the counter is left
+    untouched — only a parsed payload without an ``error`` key closes the breaker (#91460 review)."""
+    try:
+        parsed = json.loads(result)
+    except (json.JSONDecodeError, TypeError):
+        return result
+    (_core._bump_server_error if "error" in parsed else _core._reset_server_error)(server_name)
     return result
 
 
@@ -127,25 +126,84 @@ def _lookup_reconnectable_server(server_name: str, require_loop: bool = False):
     return srv if ok else None
 
 
+class _RetryBudgetExhausted(Exception):
+    """Recovery retry skipped because the invocation's retry budget is spent."""
+
+
+class _RetryBudget:
+    """Per-invocation retry budget shared across the recovery handlers.
+
+    A single user call chains several recovery handlers (OAuth, session expiry, stale keep-alive
+    connection).  Each handler wants to reconnect and re-run the operation once; without a shared
+    budget their retries stack, so one user call can execute a non-idempotent tool two or three
+    times — each partial execution carrying real side effects (#91460 review).  Every recovery
+    retry consumes one unit of the shared budget; once spent, further retry attempts raise
+    :class:`_RetryBudgetExhausted` and the handler falls through to the caller's generic error
+    path instead of re-running the operation.
+    """
+
+    __slots__ = ("remaining",)
+
+    def __init__(self, limit: int = 1) -> None:
+        self.remaining = limit
+
+    def consume(self) -> None:
+        if self.remaining <= 0:
+            raise _RetryBudgetExhausted("per-invocation retry budget already spent")
+        self.remaining -= 1
+
+
 def _retry_once(server_name: str, retry_call, op_description: str, what: str):
-    """Re-run ``retry_call`` after a recovery step. Returns the result (closing the breaker)
-    when it is not an error payload; None when the retry raised or errored (caller falls through)."""
+    """Re-run ``retry_call`` after a recovery step. Returns the result (closing the breaker) when
+    it is a parsed payload without an ``error`` key; an unparseable payload is returned as-is
+    WITHOUT closing the breaker — it is not evidence of health (#91460 review). None when the
+    retry raised, the shared retry budget was spent, or the payload carries an error; the caller
+    falls through."""
     try:
         result = retry_call()
+    except _RetryBudgetExhausted:
+        logger.info("MCP %s/%s recovery retry skipped: per-invocation retry budget already spent.",
+                    server_name, op_description)
+        return None
     except Exception as retry_exc:
         logger.warning("MCP %s/%s retry after %s failed: %s", server_name, op_description, what, retry_exc)
         return None
-    if _result_is_error(result):
+    try:
+        parsed = json.loads(result)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("MCP server '%s': %s retry after %s returned an unparseable payload; returning "
+                       "it without resetting the circuit breaker.", server_name, op_description, what)
+        return result
+    if "error" in parsed:
         return None
     _core._reset_server_error(server_name)
     return result
 
 
-def _handle_auth_error_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str):
+def _bounded_reconnect_timeout(deadline: Optional[float]) -> float:
+    """Reconnect-wait timeout capped at the caller's remaining deadline budget (min 15s, floored
+    at 0.0 once the deadline has passed) so a slow reconnect cannot stretch a short tool call past
+    its own timeout (#91460 review)."""
+    if deadline is None:
+        return 15.0
+    return min(15.0, max(0.0, deadline - time.monotonic()))
+
+
+def _handle_auth_error_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str, *,
+                                 deadline: Optional[float] = None,
+                                 retry_budget: Optional["_RetryBudget"] = None):
     """OAuth recovery + one retry; None when *exc* is not an auth error. ``handle_401`` decides
     viability; if viable, signal a reconnect (fresh credentials), wait ready, retry once. Any
-    failure returns the structured ``needs_reauth`` error so the model stops refreshing."""
+    failure returns the structured ``needs_reauth`` error so the model stops refreshing.
+
+    ``deadline`` caps the reconnect wait at the caller's remaining budget; a spent
+    ``retry_budget`` skips the whole recovery so stacked recoverers cannot re-run the operation
+    several times (#91460 review)."""
     if not _is_auth_error(exc):
+        return None
+    if retry_budget is not None and retry_budget.remaining <= 0:
+        logger.info("MCP %s/%s recovery skipped: per-invocation retry budget already spent.",
+                    server_name, op_description)
         return None
     from tools.mcp_oauth_manager import get_manager
     try:
@@ -158,7 +216,8 @@ def _handle_auth_error_and_retry(server_name: str, exc: BaseException, retry_cal
         # Recovery + reconnect is independent evidence of viability: close the breaker here, not only on
         # retry success (else a failing retry pins it open forever).
         if srv is not None and _loop._signal_reconnect_and_wait(
-                server_name, srv, op_description=f"{op_description} after OAuth recovery", timeout=15):
+                server_name, srv, op_description=f"{op_description} after OAuth recovery",
+                timeout=_bounded_reconnect_timeout(deadline)):
             _core._reset_server_error(server_name)
         result = _retry_once(server_name, retry_call, op_description, "auth recovery")
         if result is not None:
@@ -166,7 +225,9 @@ def _handle_auth_error_and_retry(server_name: str, exc: BaseException, retry_cal
     return _strike(server_name, _NEEDS_REAUTH_MSG.format(s=server_name), needs_reauth=True, server=server_name)
 
 
-def _handle_session_expired_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str):
+def _handle_session_expired_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str, *,
+                                      deadline: Optional[float] = None,
+                                      retry_budget: Optional["_RetryBudget"] = None):
     """Transport reconnect + one retry on session expiry; None to fall through. Skips
     ``handle_401``: the token is valid, only the server-side session is stale.
 
@@ -175,20 +236,31 @@ def _handle_session_expired_and_retry(server_name: str, exc: BaseException, retr
     ``_reconnect_event`` causes the server task's lifecycle loop to tear down the current
     ``streamablehttp_client`` + ``ClientSession`` and rebuild them, reusing the existing OAuth provider
     instance. See #13383.
+
+    ``deadline`` caps the reconnect wait at the caller's remaining budget; a spent
+    ``retry_budget`` skips the whole recovery (#91460 review).
     """
     srv = _lookup_reconnectable_server(server_name, require_loop=True) if _is_session_expired_error(exc) else None
     if srv is None:
         return None
+    if retry_budget is not None and retry_budget.remaining <= 0:
+        logger.info("MCP %s/%s recovery skipped: per-invocation retry budget already spent.",
+                    server_name, op_description)
+        return None
     logger.info("MCP server '%s': %s failed with session-expired error (%s); signalling transport reconnect "
                 "and retrying once.", server_name, op_description, exc)
-    if not _loop._signal_reconnect_and_wait(server_name, srv, op_description=op_description, timeout=15):
-        logger.warning("MCP server '%s': reconnect did not ready within 15s after session-expired error; "
-                       "falling through to error response.", server_name)
+    reconnect_timeout = _bounded_reconnect_timeout(deadline)
+    if not _loop._signal_reconnect_and_wait(server_name, srv, op_description=op_description, timeout=reconnect_timeout):
+        logger.warning("MCP server '%s': reconnect did not ready within %.1fs after session-expired error; "
+                       "falling through to error response.", server_name, reconnect_timeout)
         return None
     return _retry_once(server_name, retry_call, op_description, "session reconnect")
 
 
-def _handle_stale_connection_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str):
+def _handle_stale_connection_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str, *,
+                                       allow_message_markers: bool = True,
+                                       deadline: Optional[float] = None,
+                                       retry_budget: Optional["_RetryBudget"] = None):
     """Rebuild the transport and retry once on a stale-connection failure.
 
     Mirrors :func:`_handle_session_expired_and_retry`: signal the server task's reconnect event so
@@ -198,18 +270,35 @@ def _handle_stale_connection_and_retry(server_name: str, exc: BaseException, ret
     ``MCPError: Connection closed`` to the model without a retry turns an invisible,
     self-healing blip into a visible tool failure (#90166).
 
+    ``allow_message_markers`` gates the substring matching on exception messages.  Marker phrases
+    like ``"connection reset"`` / ``"connection closed"`` also show up in *application-level*
+    failures (a tool whose own backend died mid-execution, surfaced as a JSON-RPC error containing
+    those words), and retrying ``tools/call`` after a partial execution can duplicate real side
+    effects; the ``tools/call`` recoverer passes ``allow_message_markers=False`` so only exact
+    transport exception type names trigger a retry, while the read-only ``resources/*`` handlers
+    keep marker matching (#91460 review).
+
+    ``deadline`` caps the reconnect wait at the caller's remaining budget; a spent
+    ``retry_budget`` skips the whole recovery (#91460 review).
+
     None means this is not a stale-connection error, there is no server record / running loop to
-    recover through, or the retry also failed; the caller falls through to its generic error path.
+    recover through, the retry budget is spent, or the retry also failed; the caller falls through
+    to its generic error path.
     """
     srv = (_lookup_reconnectable_server(server_name, require_loop=True)
-           if _is_stale_connection_error(exc) else None)
+           if _is_stale_connection_error(exc, allow_message_markers=allow_message_markers) else None)
     if srv is None:
+        return None
+    if retry_budget is not None and retry_budget.remaining <= 0:
+        logger.info("MCP %s/%s recovery skipped: per-invocation retry budget already spent.",
+                    server_name, op_description)
         return None
     logger.info("MCP server '%s': %s failed with stale-connection error (%s); signalling transport "
                 "reconnect and retrying once.", server_name, op_description, exc)
-    if not _loop._signal_reconnect_and_wait(server_name, srv, op_description=op_description, timeout=15):
-        logger.warning("MCP server '%s': reconnect did not ready within 15s after stale-connection "
-                       "error; falling through to error response.", server_name)
+    reconnect_timeout = _bounded_reconnect_timeout(deadline)
+    if not _loop._signal_reconnect_and_wait(server_name, srv, op_description=op_description, timeout=reconnect_timeout):
+        logger.warning("MCP server '%s': reconnect did not ready within %.1fs after stale-connection "
+                       "error; falling through to error response.", server_name, reconnect_timeout)
         return None
     return _retry_once(server_name, retry_call, op_description, "stale-connection reconnect")
 
@@ -222,7 +311,9 @@ class _StdioChildExited(RuntimeError):
         self.in_flight = in_flight
 
 
-def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry_call, op_description: str):
+def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry_call, op_description: str, *,
+                                          deadline: Optional[float] = None,
+                                          retry_budget: Optional["_RetryBudget"] = None):
     """Respawn a dead stdio child; retry once only when it was dead before dispatch.
 
     A mid-call exit is ambiguous: the server may have applied a side effect before its
@@ -235,6 +326,10 @@ def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry
     ``_reconnect_event`` (one signal, same as before) and waits for the server task to publish a fresh
     session. Spawn frequency stays governed entirely by ``run()``'s rapid-drop budget, which parks a
     transport that keeps dropping without proving healthy (#62212).
+
+    ``deadline``/``retry_budget`` complete the recoverer contract: the respawn wait has its own
+    bound (``_core._STDIO_RESPAWN_WAIT_SEC``), and the one pre-dispatch replay consumes the shared
+    retry budget like any other recovery retry.
     """
     if not isinstance(exc, _StdioChildExited):
         return None
@@ -280,14 +375,27 @@ def _handle_stdio_child_exited_and_retry(server_name: str, exc: Exception, retry
 def _dispatch(server_name: str, server: Any, op: str, call, tool_timeout: float, recoverers,
               on_final_failure: Callable[[BaseException], None], record_outcome: bool = False) -> str:
     """Mark the call started on *server* (doubles may lack ``mark_tool_call``), run coroutine function *call*
-    on the MCP loop and, on failure, walk ``recoverers`` (``(server_name, exc, retry_call, op) -> Optional[str]``,
-    None = not its kind; order matters). Unrecovered exceptions go through ``on_final_failure`` and become the
-    generic call-failed error. ``record_outcome`` applies breaker bookkeeping to the FIRST attempt only."""
+    on the MCP loop and, on failure, walk ``recoverers`` (``(server_name, exc, retry_call, op, *,
+    deadline, retry_budget) -> Optional[str]``, None = not its kind; order matters). Unrecovered exceptions
+    go through ``on_final_failure`` and become the generic call-failed error. ``record_outcome`` applies
+    breaker bookkeeping to the FIRST attempt only.
+
+    One shared per-invocation :class:`_RetryBudget` and deadline are created here: every recovery handler
+    wants to reconnect and re-run the operation once, and the budget caps the TOTAL for this single user
+    call, so a non-idempotent tool is never re-run several times by stacked recoverers (#91460 review).
+    The first attempt is free; each recovery retry consumes one unit."""
     if callable(getattr(server, "mark_tool_call", None)):
         server.mark_tool_call()
 
+    retry_budget = _RetryBudget(limit=1)
+    deadline = None if tool_timeout is None else time.monotonic() + tool_timeout
+
     def call_once():
         return _loop._run_on_mcp_loop(call, timeout=tool_timeout)
+
+    def call_with_retry_budget():
+        retry_budget.consume()
+        return call_once()
 
     try:
         result = call_once()
@@ -296,7 +404,8 @@ def _dispatch(server_name: str, server: Any, op: str, call, tool_timeout: float,
         return tool_error("MCP call interrupted: user sent a new message")
     except Exception as exc:
         for recover in recoverers:
-            recovered = recover(server_name, exc, call_once, op)
+            recovered = recover(server_name, exc, call_with_retry_budget, op,
+                                deadline=deadline, retry_budget=retry_budget)
             if recovered is not None:
                 return recovered
         on_final_failure(exc)
@@ -516,7 +625,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         return _dispatch(
             server_name, server, op, _call, tool_timeout,
             (_handle_stdio_child_exited_and_retry, _handle_auth_error_and_retry,
-             _handle_session_expired_and_retry, _handle_stale_connection_and_retry),
+             _handle_session_expired_and_retry,
+             # tools/call: type-name evidence only — marker phrases also occur in app-level errors,
+             # and replaying a partially executed tool duplicates side effects (#91460 review).
+             partial(_handle_stale_connection_and_retry, allow_message_markers=False)),
             _on_failure, record_outcome=True)
     return _handler
 


### PR DESCRIPTION
## Problem (#90166)

A CDN, load balancer, or proxy that closes an idle keep-alive connection out from under the streamable-HTTP transport surfaces on the next tool call as `MCPError: Connection closed` / `RemoteProtocolError: Server disconnected without sending a response` (raised by `post_writer` inside the SDK's anyio TaskGroup). The server is healthy — only the pooled connection is dead — and the failure self-heals after parking (`revived — session healthy again after parking`), but in the meantime the model sees a hard tool error and the desktop shows `健康检查失败`.

## Why the proposed pin bump is not the fix

I tested the reporter's suggested remediation on this stack before writing code:

- httpx2 2.7.0 **already retries a plain dead pooled POST transparently** (local repro: server closes the socket after responding; the next `client.post` succeeds on a fresh connection).
- The httpx2 2.8→2.12 release notes contain **no stale-keep-alive reuse fix** (2.8 is connection-pool churn refactoring; 2.9+ are alias/Origin/decompression features).
- mcp 2.0.0 requires `httpx2>=2.5.0`, so a bump is *allowed* but unproven to change behavior.

## Root cause

The error class matches **neither** existing recovery path:

- `_is_auth_error` → no (no 401/403).
- `_is_session_expired_error` → no (not a server-side session GC; `RemoteProtocolError`'s message doesn't match `_SESSION_EXPIRED_MARKERS`, and the type isn't anyio's `ClosedResourceError`).

So the call falls through to the generic error path and surfaces `MCPError: Connection closed` to the model.

## Change

Mirror the proven session-expired recovery flow (#13383):

- `_is_stale_connection_error()` — bounded, identity-visited exception-graph traversal (same budget as the session-expired classifier); matches `RemoteProtocolError` / `ConnectionClosed` / `ConnectionResetError` / `ConnectionAbortedError` type names and the SDK's actual message phrasings (`connection closed`, `server disconnected`, `connection reset`, `peer closed connection`, `remote protocol error`). `InterruptedError` still wins.
- `_handle_stale_connection_and_retry()` — signals `_reconnect_event` via `_signal_reconnect_and_wait`, waits for the fresh session, retries the operation **once**, resets the breaker on success, falls through to the generic error path on failure.
- Wired into `tools/call`, `resources/list`, and `resources/read` handlers, after the session-expired handler.

Pure addition — 0 lines deleted in `tools/mcp_tool.py`.

## Tests

New `tests/tools/test_mcp_stale_connection_retry.py`:

- 8 unit tests for the classifier: reporter's exact `httpx2.RemoteProtocolError`, unwrapped `httpcore2.RemoteProtocolError`, `MCPError: Connection closed` message, ExceptionGroup wrapping (the post_writer shape), chained `__cause__`, unrelated-error rejection (401 stays on the OAuth path), InterruptedError override, budget-bounded traversal.
- Integration test (parametrized stdio + http): first `call_tool` raises `httpx2.RemoteProtocolError`; the handler rebuilds the transport and the retry succeeds — asserts `call_count == 2` and two transport builds.

Verified: new file 10/10 green; `test_mcp_tool_session_expired`, `test_mcp_tool_401_handling`, `test_mcp_reconnect_retry_reset`, `test_mcp_parked_self_probe` 20/20 green; `test_mcp_tool` + arity/SSE suites 106/107 (the one failure, `TestBuildSafeEnv::test_windows_location_vars_passed_without_secrets`, is environment-dependent and fails identically on clean main). Ruff clean on both files.

Closes #90166