### PR TITLE
feat(delegation): user-wired fixed model per named sub-agent (delegat…

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1492,6 +1492,19 @@ delegation:
   #                                           # delegation.model to an inexpensive one — children carry the
   #                                           # vast majority of tokens, so this is where spend is cut while
   #                                           # planning quality stays with the frontier parent.
+  # agent_models:                             # Named sub-agents, each hard-wired to a fixed model BY YOU.
+  #                                           # delegate_task(agent: "research") runs that child on the wired
+  #                                           # model — the LLM picks WHICH named agent, never a model, and
+  #                                           # unknown names fail loudly. Beats delegation.model/provider
+  #                                           # for that child; unwired children keep the global behavior.
+  #   research: "anthropic/claude-opus-4-5"   # String form: pin model only (uses delegation.provider
+  #                                           # credentials if set, else inherits the parent's).
+  #   coder:                                  # Mapping form: full provider:model override for this agent.
+  #     provider: "deepseek"
+  #     model: "deepseek-chat"
+  #   local-scout:                            # Direct-endpoint form also works (base_url/api_key/api_mode).
+  #     base_url: "http://localhost:11434/v1"
+  #     model: "qwen3:14b"
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1901,6 +1901,17 @@ DEFAULT_CONFIG = {
                            # "codex_responses", or "anthropic_messages". Empty = auto-detect
                            # from URL (e.g. /anthropic suffix → anthropic_messages). Set this
                            # explicitly for non-standard endpoints the heuristic can't detect.
+        # Named sub-agents, each hard-wired by the USER to a fixed model.
+        # delegate_task(agent="research") runs that child on the wired model —
+        # the LLM selects WHICH named agent, never a model, and unknown names
+        # fail loudly. Entry forms: "model-id" string (pins model only), or a
+        # mapping with any of provider/model/base_url/api_key/api_mode
+        # (same semantics as the global keys above; wins over them for that
+        # child). Unwired children keep the global/inherited behavior.
+        #   agent_models:
+        #     research: "anthropic/claude-opus-4-5"
+        #     coder: {provider: "deepseek", model: "deepseek-chat"}
+        "agent_models": {},
         # When delegate_task narrows child toolsets explicitly, preserve any
         # MCP toolsets the parent already has enabled. On by default so
         # narrowing (e.g. toolsets=["web","browser"]) expresses "I want these

--- a/run_agent.py
+++ b/run_agent.py
@@ -8371,6 +8371,7 @@ class AIAgent:
             action=function_args.get("action"),
             subagent_id=function_args.get("subagent_id"),
             message=function_args.get("message"),
+            agent=function_args.get("agent"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1949,5 +1949,275 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIn("missing-acp-binary", str(ctx.exception))
 
 
+class TestAgentModelWiring(unittest.TestCase):
+    """Tests for delegation.agent_models — user-wired, per-named-sub-agent
+    fixed models selected via delegate_task's `agent` parameter."""
+
+    # -- _get_agent_model_overlay unit tests --------------------------------
+
+    def test_no_name_is_passthrough(self):
+        from tools.delegate_tool import _get_agent_model_overlay
+
+        overlay, err = _get_agent_model_overlay({"agent_models": {"a": "m"}}, None)
+        self.assertIsNone(overlay)
+        self.assertIsNone(err)
+        overlay, err = _get_agent_model_overlay({"agent_models": {"a": "m"}}, "  ")
+        self.assertIsNone(overlay)
+        self.assertIsNone(err)
+
+    def test_string_entry_pins_model_only(self):
+        from tools.delegate_tool import _get_agent_model_overlay
+
+        overlay, err = _get_agent_model_overlay(
+            {"agent_models": {"research": "anthropic/claude-opus-4-5"}}, "research"
+        )
+        self.assertIsNone(err)
+        self.assertEqual(overlay, {"model": "anthropic/claude-opus-4-5"})
+
+    def test_mapping_entry_full_override(self):
+        from tools.delegate_tool import _get_agent_model_overlay
+
+        overlay, err = _get_agent_model_overlay(
+            {
+                "agent_models": {
+                    "coder": {
+                        "provider": "deepseek",
+                        "model": "deepseek-chat",
+                        "unknown_key": "ignored",
+                    }
+                }
+            },
+            "coder",
+        )
+        self.assertIsNone(err)
+        self.assertEqual(overlay, {"provider": "deepseek", "model": "deepseek-chat"})
+
+    def test_case_insensitive_name_match(self):
+        from tools.delegate_tool import _get_agent_model_overlay
+
+        overlay, err = _get_agent_model_overlay(
+            {"agent_models": {"Research": "x/y"}}, "research"
+        )
+        self.assertIsNone(err)
+        self.assertEqual(overlay, {"model": "x/y"})
+
+    def test_unknown_name_fails_loudly_with_wired_names(self):
+        from tools.delegate_tool import _get_agent_model_overlay
+
+        overlay, err = _get_agent_model_overlay(
+            {"agent_models": {"research": "x/y", "coder": {"model": "z"}}}, "reserch"
+        )
+        self.assertIsNone(overlay)
+        self.assertIn("Unknown sub-agent name", err)
+        self.assertIn("'reserch'", err)
+        self.assertIn("coder", err)
+        self.assertIn("research", err)
+
+    def test_name_without_any_wiring_errors(self):
+        from tools.delegate_tool import _get_agent_model_overlay
+
+        for cfg in ({}, {"agent_models": {}}, {"agent_models": None}):
+            overlay, err = _get_agent_model_overlay(cfg, "research")
+            self.assertIsNone(overlay)
+            self.assertIn("agent_models", err)
+
+    def test_invalid_entry_types_error(self):
+        from tools.delegate_tool import _get_agent_model_overlay
+
+        overlay, err = _get_agent_model_overlay({"agent_models": {"a": ""}}, "a")
+        self.assertIsNone(overlay)
+        self.assertIn("empty string", err)
+
+        overlay, err = _get_agent_model_overlay({"agent_models": {"a": 42}}, "a")
+        self.assertIsNone(overlay)
+        self.assertIn("int", err)
+
+        overlay, err = _get_agent_model_overlay(
+            {"agent_models": {"a": {"unrelated": True}}}, "a"
+        )
+        self.assertIsNone(overlay)
+        self.assertIn("sets none of", err)
+
+    # -- schema surface ------------------------------------------------------
+
+    def test_agent_param_exposed_but_model_is_not(self):
+        """The model may pick WHICH wired agent — never a model. `agent` is in
+        the schema; no `model`/`provider` parameter may ever appear."""
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("agent", props)
+        self.assertIn("agent", props["tasks"]["items"]["properties"])
+        for forbidden in ("model", "provider", "base_url", "api_key"):
+            self.assertNotIn(forbidden, props)
+            self.assertNotIn(forbidden, props["tasks"]["items"]["properties"])
+
+    def test_agent_description_lists_names_not_models(self):
+        from tools.delegate_tool import (
+            _build_agent_param_description,
+            _build_dynamic_schema_overrides,
+        )
+
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={
+                "agent_models": {
+                    "research": "anthropic/claude-opus-4-5",
+                    "coder": {"provider": "deepseek", "model": "deepseek-chat"},
+                }
+            },
+        ):
+            desc = _build_agent_param_description()
+            self.assertIn("research", desc)
+            self.assertIn("coder", desc)
+            # Wired models must not leak into the model-facing schema.
+            self.assertNotIn("claude-opus", desc)
+            self.assertNotIn("deepseek-chat", desc)
+            overrides = _build_dynamic_schema_overrides()
+            self.assertEqual(
+                overrides["parameters"]["properties"]["agent"]["description"], desc
+            )
+
+    def test_agent_description_without_wiring_says_omit(self):
+        from tools.delegate_tool import _build_agent_param_description
+
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            desc = _build_agent_param_description()
+            self.assertIn("omit this parameter", desc)
+
+    # -- end-to-end: wiring reaches the built child ---------------------------
+
+    @patch("tools.delegate_tool._load_config")
+    def test_named_agent_model_reaches_child(self, mock_cfg):
+        """A wired name forces its provider:model on the child, overriding
+        parent inheritance (direct-endpoint form — no network resolution)."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "agent_models": {
+                "local-scout": {
+                    "base_url": "http://localhost:9999/v1",
+                    "model": "qwen3:14b",
+                    "api_key": "scout-key",
+                }
+            },
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Scout the local model", agent="local-scout", parent_agent=parent)
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "qwen3:14b")
+            self.assertEqual(kwargs["base_url"], "http://localhost:9999/v1")
+            self.assertEqual(kwargs["api_key"], "scout-key")
+            self.assertEqual(kwargs["provider"], "custom")
+            self.assertNotEqual(kwargs["base_url"], parent.base_url)
+            # Attribution: the wired name is stamped on the child.
+            self.assertEqual(mock_child._delegate_agent_name, "local-scout")
+
+    @patch("tools.delegate_tool._load_config")
+    def test_batch_mixed_named_and_unnamed_tasks(self, mock_cfg):
+        """Each task in a batch resolves independently: named tasks run on
+        their wired model, unnamed tasks keep the global/inherited behavior."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "agent_models": {
+                "local-scout": {
+                    "base_url": "http://localhost:9999/v1",
+                    "model": "qwen3:14b",
+                    "api_key": "scout-key",
+                }
+            },
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                tasks=[
+                    {
+                        "goal": "Scout the local model for capability boundaries",
+                        "agent": "local-scout",
+                    },
+                    {
+                        "goal": "Summarize the findings into a short briefing note",
+                    },
+                ],
+                parent_agent=parent,
+            )
+
+            self.assertEqual(MockAgent.call_count, 2)
+            named_kwargs = MockAgent.call_args_list[0][1]
+            plain_kwargs = MockAgent.call_args_list[1][1]
+            self.assertEqual(named_kwargs["model"], "qwen3:14b")
+            self.assertEqual(named_kwargs["base_url"], "http://localhost:9999/v1")
+            # Unnamed task: no global pin configured → inherits the parent.
+            self.assertEqual(plain_kwargs["model"], parent.model)
+            self.assertEqual(plain_kwargs["base_url"], parent.base_url)
+
+    @patch("tools.delegate_tool._load_config")
+    def test_unknown_agent_name_refuses_spawn(self, mock_cfg):
+        """A typo'd agent name must fail loudly BEFORE any child is built —
+        never silently run on the parent/global model."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "agent_models": {"research": "x/y"},
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            result = delegate_task(
+                goal="Research something", agent="reserch", parent_agent=parent
+            )
+            MockAgent.assert_not_called()
+        self.assertIn("Unknown sub-agent name", result)
+        self.assertIn("research", result)
+
+    @patch("tools.delegate_tool._load_config")
+    def test_top_level_agent_applies_to_batch_default(self, mock_cfg):
+        """Top-level agent= is the default for batch tasks that don't set
+        their own (mirrors top-level role semantics)."""
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "agent_models": {
+                "local-scout": {
+                    "base_url": "http://localhost:9999/v1",
+                    "model": "qwen3:14b",
+                    "api_key": "scout-key",
+                }
+            },
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                agent="local-scout",
+                tasks=[
+                    {"goal": "First scouting task with enough detail to pass"},
+                    {"goal": "Second scouting task with enough detail to pass"},
+                ],
+                parent_agent=parent,
+            )
+
+            self.assertEqual(MockAgent.call_count, 2)
+            for call in MockAgent.call_args_list:
+                self.assertEqual(call[1]["model"], "qwen3:14b")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2605,6 +2605,13 @@ def _run_single_child(
                     if isinstance(getattr(child, "model", None), str)
                     else None
                 ),
+                # Named sub-agent wiring (delegation.agent_models) — which
+                # user-wired name this child was spawned as, if any.
+                "agent_name": (
+                    getattr(child, "_delegate_agent_name", None)
+                    if isinstance(getattr(child, "_delegate_agent_name", None), str)
+                    else None
+                ),
                 "started_at": time.time(),
                 "status": "running",
                 "tool_count": 0,
@@ -3605,6 +3612,7 @@ def delegate_task(
     action: Optional[str] = None,
     subagent_id: Optional[str] = None,
     message: Optional[str] = None,
+    agent: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -3733,6 +3741,8 @@ def delegate_task(
         single_task: Dict[str, Any] = {"goal": goal, "context": context, "role": top_role}
         if output_schema is not None:
             single_task["output_schema"] = output_schema
+        if agent and str(agent).strip():
+            single_task["agent"] = str(agent).strip()
         task_list = [single_task]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -3829,6 +3839,24 @@ def delegate_task(
         # Per-task role beats top-level; normalise again so unknown
         # per-task values warn and degrade to leaf uniformly.
         effective_role = _normalize_role(t.get("role") or top_role)
+        # Named sub-agent wiring: a per-task (or top-level) 'agent' name is
+        # resolved against delegation.agent_models and its provider/model
+        # overlay is FORCED for this child — the caller picks the name, the
+        # user's config picks the model. Unknown names are a hard error so a
+        # typo never silently runs on the wrong model.
+        agent_name = str(t.get("agent") or agent or "").strip()
+        task_creds = creds
+        if agent_name:
+            overlay, overlay_err = _get_agent_model_overlay(cfg, agent_name)
+            if overlay_err:
+                return tool_error(overlay_err)
+            task_cfg = dict(cfg)
+            if overlay:
+                task_cfg.update(overlay)
+            try:
+                task_creds = _resolve_delegation_credentials(task_cfg, parent_agent)
+            except ValueError as exc:
+                return tool_error(str(exc))
         # T1-24: schema'd tasks get the contract appended to their context
         # so the child knows the expected output shape before it starts.
         _task_schema = task_schemas[i] if i < len(task_schemas) else None
@@ -3845,18 +3873,18 @@ def delegate_task(
                 # Subagents always inherit the parent's toolsets; the model
                 # cannot choose or narrow them (no model-facing toolsets arg).
                 toolsets=None,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_request_overrides=creds.get("request_overrides"),
-                override_max_tokens=creds.get("max_output_tokens"),
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
+                override_request_overrides=task_creds.get("request_overrides"),
+                override_max_tokens=task_creds.get("max_output_tokens"),
+                override_acp_command=task_creds.get("command"),
+                override_acp_args=task_creds.get("args"),
                 role=effective_role,
             )
         except ValueError as exc:
@@ -3870,6 +3898,13 @@ def delegate_task(
                 child._delegate_output_schema = _task_schema
             except Exception:
                 logger.debug("Could not attach output schema to child %d", i)
+        # Stamp the wired sub-agent name for attribution (registry record,
+        # action='list' output).
+        if agent_name:
+            try:
+                setattr(child, "_delegate_agent_name", agent_name)
+            except Exception:
+                logger.debug("Could not stamp agent name on child %d", i)
         # Tee the child's progress events into its live transcript log.
         # wrap_progress_callback preserves the inner callback contract
         # (including the _flush attribute) and never lets writer failures
@@ -4414,6 +4449,77 @@ def _resolve_child_credential_pool(
     return None
 
 
+# ---------------------------------------------------------------------------
+# Named sub-agent model wiring (delegation.agent_models)
+# ---------------------------------------------------------------------------
+
+_AGENT_MODEL_ENTRY_KEYS = ("provider", "model", "base_url", "api_key", "api_mode")
+
+
+def _get_agent_model_overlay(cfg: dict, agent_name: Optional[str]):
+    """Resolve a named sub-agent's pinned model wiring to a config overlay.
+
+    ``delegation.agent_models`` maps a user-chosen agent name to a fixed
+    model spec::
+
+        delegation:
+          agent_models:
+            research: anthropic/claude-opus-4.5   # string: pin model only
+            coder:                                  # mapping: full override
+              provider: deepseek
+              model: deepseek-chat
+
+    Returns ``(overlay, error)``. ``overlay`` holds only the recognized
+    ``delegation.*`` keys the entry sets; callers merge it over the global
+    delegation config before ``_resolve_delegation_credentials``. ``error``
+    is a user-facing message when the name is not wired — a wiring miss is
+    loud on purpose: a typo must not silently run on the parent model, and
+    the model cannot invent names that bypass the user's fixed wiring.
+    """
+    name = (agent_name or "").strip()
+    if not name:
+        return None, None
+    wiring = cfg.get("agent_models")
+    if not isinstance(wiring, dict) or not wiring:
+        return None, (
+            f"delegate_task got agent={name!r}, but no named sub-agents are "
+            f"wired: delegation.agent_models is empty or missing in "
+            f"config.yaml. Wire '{name}' there (name -> model) or omit the "
+            f"agent parameter."
+        )
+    entry = wiring.get(name)
+    if entry is None:
+        lowered = name.casefold()
+        for wired_name, wired_entry in wiring.items():
+            if isinstance(wired_name, str) and wired_name.casefold() == lowered:
+                entry = wired_entry
+                break
+    if entry is None:
+        available = ", ".join(sorted(str(k) for k in wiring))
+        return None, (
+            f"Unknown sub-agent name {name!r}. Named sub-agents are wired "
+            f"by the user in config.yaml under delegation.agent_models — "
+            f"they cannot be invented on the fly. Wired names: {available}."
+        )
+    if isinstance(entry, str):
+        model = entry.strip()
+        if not model:
+            return None, f"delegation.agent_models.{name} is an empty string."
+        return {"model": model}, None
+    if isinstance(entry, dict):
+        overlay = {k: entry[k] for k in _AGENT_MODEL_ENTRY_KEYS if entry.get(k)}
+        if not overlay:
+            return None, (
+                f"delegation.agent_models.{name} sets none of "
+                f"{list(_AGENT_MODEL_ENTRY_KEYS)}."
+            )
+        return overlay, None
+    return None, (
+        f"delegation.agent_models.{name} must be a model string or a mapping "
+        f"of {list(_AGENT_MODEL_ENTRY_KEYS)}; got {type(entry).__name__}."
+    )
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -4617,8 +4723,8 @@ def _build_top_level_description() -> str:
         "you. Provide 'goal' for a single task or 'tasks' for a parallel batch "
         "(limits and nesting rules are in the parameter descriptions).\n\n"
         "Runs in the background: dispatch returns immediately with live "
-        "transcript paths, and the completed result (one consolidated message "
-        "for a batch) re-enters the conversation on its own. Do NOT wait or "
+        "transcript paths, and the result (one consolidated message per "
+        "batch) re-enters the conversation on its own. Do NOT wait or "
         "poll; continue other work.\n\n"
         "LIVE ORCHESTRATION: while children run, this tool also controls "
         "them — action='list' (live children + ids), action='steer' "
@@ -4626,7 +4732,7 @@ def _build_top_level_description() -> str:
         "(subagent_id, end early; partial result still returns). Steer when "
         "a live transcript shows a child drifting.\n\n"
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
-        "with intermediate data, or independent parallel workstreams.\n"
+        "with intermediate data, or parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"
         "- Mechanical multi-step work with no reasoning needed -> execute_code\n"
         "- A single tool call -> call the tool directly\n"
@@ -4648,7 +4754,8 @@ def _build_top_level_description() -> str:
         "memory, send_message, or cronjob; orchestrators regain only "
         "delegate_task.\n"
         "- Children inherit the parent model and fallback chain unless pinned "
-        "globally via delegation.provider / delegation.model in config.yaml. "
+        "via delegation.provider / delegation.model or delegation.agent_models "
+        "('agent' param). "
         "Results are returned as an array, one entry per task."
     )
 
@@ -4704,6 +4811,31 @@ def _build_role_param_description() -> str:
     )
 
 
+def _build_agent_param_description() -> str:
+    """Compose the 'agent' parameter description with the user's wired names.
+
+    Rebuilt per get_definitions() call so the model sees the actual names
+    wired under delegation.agent_models — and only the names. The mapped
+    models are deliberately NOT shown: the caller picks WHICH named agent,
+    never a model.
+    """
+    try:
+        wiring = _load_config().get("agent_models")
+    except Exception:
+        wiring = None
+    base = (
+        "Named sub-agent to run this task as. Names are hard-wired by the "
+        "user in config.yaml (delegation.agent_models), each pinned to a "
+        "fixed model the user chose. You select WHICH named agent handles "
+        "the task — you never choose a model. Unknown names fail loudly; "
+        "omit this parameter for a generic subagent."
+    )
+    names = [str(k) for k in wiring] if isinstance(wiring, dict) else []
+    if names:
+        return base + " Wired names: " + ", ".join(sorted(names)) + "."
+    return base + " No names are currently wired — omit this parameter."
+
+
 def _build_dynamic_schema_overrides() -> dict:
     """Return per-call schema overrides reflecting current config.
 
@@ -4720,6 +4852,7 @@ def _build_dynamic_schema_overrides() -> dict:
     }
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
     overrides_params["properties"]["role"]["description"] = _build_role_param_description()
+    overrides_params["properties"]["agent"]["description"] = _build_agent_param_description()
 
     return {
         "description": _build_top_level_description(),
@@ -4776,6 +4909,13 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "agent": {
+                            "type": "string",
+                            "description": (
+                                "Per-task named sub-agent override. See "
+                                "top-level 'agent' for semantics."
+                            ),
+                        },
                         "output_schema": {
                             "type": "object",
                             "description": (
@@ -4800,6 +4940,10 @@ DELEGATE_TASK_SCHEMA = {
             "role": {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
+                "description": "(rebuilt at get_definitions() time)",
+            },
+            "agent": {
+                "type": "string",
                 "description": "(rebuilt at get_definitions() time)",
             },
             "output_schema": {
@@ -4918,6 +5062,7 @@ registry.register(
         action=args.get("action"),
         subagent_id=args.get("subagent_id"),
         message=args.get("message"),
+        agent=args.get("agent"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -168,7 +168,39 @@ delegation:
 
 Resolution order: `delegation.base_url` (direct endpoint) takes precedence, then `delegation.provider` (full credential bundle resolved via the runtime provider system), and when neither is set children inherit the parent's provider and credentials; `delegation.model` applies in all cases, and when it is empty children inherit the parent's model.
 
-Note that the pin is global: `delegate_task` has no per-task model parameter, so every child in a batch runs on the configured delegation model. For quality-sensitive subtasks that need a stronger model, either leave `delegation.model` unset for that session or hand the task to the [kanban board](kanban.md#per-task-model-override), which does support a per-task model override.
+Note that the pin is global: `delegate_task` has no per-task model parameter, so every child in a batch runs on the configured delegation model — unless the task names a wired sub-agent (next section). For quality-sensitive subtasks that need a stronger model, either leave `delegation.model` unset for that session or hand the task to the [kanban board](kanban.md#per-task-model-override), which does support a per-task model override.
+
+### Named sub-agents: a fixed model per agent, wired by you
+
+`delegation.agent_models` maps a name of your choosing to a fixed model. The parent agent then selects *which named agent* handles a task via `delegate_task`'s `agent` parameter — it never selects, or even sees, a model. The wiring is yours alone:
+
+```yaml
+# ~/.hermes/config.yaml
+delegation:
+  agent_models:
+    research: "anthropic/claude-opus-4-5"   # string form: pin the model only
+    coder:                                  # mapping form: full provider:model pair
+      provider: "deepseek"
+      model: "deepseek-chat"
+    local-scout:                            # direct-endpoint form also works
+      base_url: "http://localhost:11434/v1"
+      model: "qwen3:14b"
+```
+
+```
+delegate_task(agent="research", goal="...", context="...")        # single
+delegate_task(tasks=[                                            # batch — per-task names
+  {"agent": "research", "goal": "..."},
+  {"agent": "coder", "goal": "..."},
+])
+```
+
+Semantics:
+
+- **Resolution order for a named child:** its `agent_models` entry (base_url → provider → model, same rules as the global keys) beats the global `delegation.*` pin, which beats parent inheritance. A string entry pins only the model and otherwise follows the global credentials (or the parent's).
+- **Fail-loud:** an `agent` name with no matching `agent_models` entry is a hard error listing the wired names — a typo never silently runs on the wrong model, and names cannot be invented on the fly to bypass your wiring.
+- **Visibility:** the tool schema lists only the wired *names*. The mapped models never appear in the model-facing schema.
+- Tasks without an `agent` name behave exactly as before (global pin or parent inheritance). The wired name is recorded on the subagent registry record (`agent_name`), so `delegate_task(action="list")` and `/agents` show which named agent each child is.
 
 ## Inherited Tool Access
 


### PR DESCRIPTION
## What does this PR do?

`delegation.provider` / `delegation.model` is a single **global** override — every `delegate_task` child runs on the same pinned pair. Users who run named specialists (researcher, coder, documenter, …) have no way to pin a different model per specialist.

The obvious fix — a `model` parameter on `delegate_task` — puts model selection in the LLM-facing tool schema, which is the cost/security surface rejected in #17756. This PR achieves per-specialist pinning **without** giving the model any say over models: the user wires names to fixed models in config, the LLM only selects *which named agent* handles a task.

```yaml
delegation:
  agent_models:
    research: "anthropic/claude-opus-4-5"   # string form: pin model only
    coder:                                     # mapping form: full override
      provider: "deepseek"
      model: "deepseek-chat"
    local-scout:                               # direct endpoint also works
      base_url: "http://localhost:11434/v1"
      model: "qwen3:14b"
```

`delegate_task` gains an `agent` parameter (top-level + per-task) carrying only the **name**:

```
delegate_task(agent="research", goal="...", context="...")
delegate_task(tasks=[{"agent": "research", "goal": "..."},
                     {"agent": "coder", "goal": "..."}])
```

The model is resolved runtime-side from the user's config; the schema's dynamic description lists only the wired **names** — the mapped models never reach the model context. No `model`/`provider`/`base_url` parameter is added to the schema (regression test asserts this).

Semantics:

- **Precedence per named child:** its `agent_models` entry > global `delegation.*` pin > parent inheritance. String entries pin only the model (credentials follow the global keys or the parent); mapping entries accept `provider`/`model`/`base_url`/`api_key`/`api_mode` with the same resolution rules as the global keys.
- **Per-task resolution** in the spawn loop: one batch can mix differently-wired specialists and plain children.
- **Fail-loud:** an unknown (e.g. typo'd) `agent` name is a hard error listing the wired names, raised *before* any child spawns — no silent fallback to the wrong model, and names cannot be invented on the fly to bypass the wiring. Matching is case-insensitive.
- **Attribution:** the wired name is recorded as `agent_name` on the subagent registry record, visible via `delegate_task(action="list")` and `/agents`.
- Top-level `agent=` acts as the default for batch tasks without their own name (mirrors top-level `role` semantics). Children spawned without a name behave exactly as before.

## Related Issue

No issue filed — this is the alternative to the rejected approach in #17756 (a `model` parameter in the tool schema).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py` — `_get_agent_model_overlay()` resolver; `agent` param in schema (top-level + per-task) with dynamic description rebuilt per `get_definitions()`; per-task credential resolution in the spawn loop; `agent_name` on the registry record
- `run_agent.py` — `agent` passthrough in `_dispatch_delegate_task`
- `hermes_cli/config_defaults.py` — `agent_models: {}` default + doc comments
- `cli-config.yaml.example` — documented config block
- `website/docs/user-guide/features/delegation.md` — "Named sub-agents" section under Model Override
- `tests/tools/test_delegate.py` — `TestAgentModelWiring`, 14 tests

## How to Test

1. Add a wiring to `~/.hermes/config.yaml` under `delegation:`:
   ```yaml
   delegation:
     agent_models:
       research: "anthropic/claude-opus-4-5"
       local-scout: {base_url: "http://localhost:11434/v1", model: "qwen3:14b"}
   ```
2. In a session, call `delegate_task(agent="research", goal="...")` (or a batch with per-task `agent` names) — the child spawns on the wired model, visible in its log as `provider=... model=<wired model>`.
3. Call `delegate_task(agent="reserch", ...)` (typo) — expect a hard error listing the wired names and **no** child spawn, no fallback to the parent model.
4. Run the test suite: `pytest tests/tools/test_delegate.py -q` (83/83 pass, incl. the 14 new) and `ruff check tools/delegate_tool.py run_agent.py hermes_cli/config_defaults.py tests/tools/test_delegate.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — 83/83 `test_delegate.py`, 261 delegation-suite, 1 skip
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — `TestAgentModelWiring` (14 tests)
- [x] I've tested on my platform: Fedora Linux 43 (Loki)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — `website/docs/user-guide/features/delegation.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — N/A, no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — pure Python, config-only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — dynamic `agent` schema description

## Screenshots / Logs

Live smoke tests (throwaway `HERMES_HOME` sandbox, real config untouched):

| Test | Outcome |
|---|---|
| `agent="test-bogus"` (wired to 127.0.0.1:9999) | Child log: `provider=custom base_url=http://127.0.0.1:9999/v1 model=bogus-model` + connection error — wiring forced, **no silent parent fallback** |
| `agent="nope"` (not wired) | Hard error before any spawn: `Unknown sub-agent name 'nope' … Wired names: test-bogus, test-scout.` |
| `agent="test-scout"` (wired openrouter/deepseek-v4-flash, parent on kimi-k3) | Child completed: `provider=openrouter model=deepseek/deepseek-v4-flash … status=completed` — cross-provider wiring |
