### PR TITLE
fix(agent): exclude .git and .curator_backups in curator snapshot_skills

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -11,6 +11,7 @@ is undoable, then extracts the chosen snapshot into place.
 The snapshot does NOT include:
   - ``.curator_backups/`` (would recurse)
   - ``.hub/`` (hub-installed skills — managed by the hub, not us)
+  - ``.git/`` (repository metadata — managed by git, not the curator)
 
 It DOES include:
   - all SKILL.md files + their directories (``scripts/``, ``references/``,
@@ -60,7 +61,8 @@ DEFAULT_KEEP = 5
 # Entries under skills/ that should NEVER be rolled up into a snapshot.
 # .hub/ is managed by the skills hub; rolling it back would break lockfile
 # invariants. .curator_backups is the backup dir itself — recursion bomb.
-_EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub"}
+# .git is repository metadata — rolling it back would break git tracking.
+_EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub", ".git"}
 
 # Snapshot id regex: UTC ISO with colons replaced by dashes so the filename
 # is portable (Windows-safe). An optional ``-NN`` suffix handles two
@@ -260,6 +262,12 @@ def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] =
         return None
 
     archive = dest / "skills.tar.gz"
+    def _tar_filter(tarinfo: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
+        parts = Path(tarinfo.name).parts
+        if any(p in _EXCLUDE_TOP_LEVEL for p in parts):
+            return None
+        return tarinfo
+
     try:
         # Stream into the tarball — no tempdir copy needed.
         with tarfile.open(archive, "w:gz", compresslevel=6) as tf:
@@ -268,7 +276,7 @@ def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] =
                     continue
                 # arcname: store paths relative to skills/ so extraction
                 # drops cleanly back into the skills dir.
-                tf.add(str(entry), arcname=entry.name, recursive=True)
+                tf.add(str(entry), arcname=entry.name, recursive=True, filter=_tar_filter)
         # Capture cron/jobs.json alongside the tarball. Never fails the
         # snapshot — the skills side is the core guarantee; cron is
         # additive. We still record in the manifest whether it was

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -484,3 +484,67 @@ def test_rollback_recovers_cleanly_from_a_partial_extract(backup_env, monkeypatc
     assert present == ["alpha", "beta"], f"tree not restored: {present}"
     assert "current copy" in (skills / "alpha" / "SKILL.md").read_text(encoding="utf-8")
     assert "current only" in (skills / "beta" / "SKILL.md").read_text(encoding="utf-8")
+
+
+def test_snapshot_excludes_git_and_curator_backups_and_hub(backup_env):
+    """Tar snapshots must exclude .git, .curator_backups, and .hub (top-level and nested)."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+
+    # Top-level excluded structures
+    (skills / ".git").mkdir()
+    (skills / ".git" / "config").write_text("[core]\nrepositoryformatversion = 0\n", encoding="utf-8")
+    (skills / ".hub").mkdir()
+    (skills / ".hub" / "lock.json").write_text("{}", encoding="utf-8")
+
+    # Regular skill with nested .git
+    _write_skill(skills, "alpha", body="alpha body")
+    nested_git = skills / "alpha" / ".git"
+    nested_git.mkdir()
+    (nested_git / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    snap_dir = cb.snapshot_skills(reason="test-exclude-git")
+    assert snap_dir is not None
+
+    archive = snap_dir / "skills.tar.gz"
+    assert archive.exists()
+
+    with tarfile.open(archive, "r:gz") as tf:
+        members = tf.getnames()
+
+    # Ensure no member contains .git, .curator_backups, or .hub
+    for name in members:
+        parts = Path(name).parts
+        assert ".git" not in parts, f".git found in archive: {name}"
+        assert ".curator_backups" not in parts, f".curator_backups found in archive: {name}"
+        assert ".hub" not in parts, f".hub found in archive: {name}"
+
+    assert "alpha/SKILL.md" in members
+
+
+def test_rollback_preserves_top_level_git(backup_env):
+    """Rollback must preserve repository .git metadata untouched in the skills root."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+
+    git_dir = skills / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    _write_skill(skills, "alpha", body="v1")
+
+    snap_dir = cb.snapshot_skills(reason="snap-v1")
+    assert snap_dir is not None
+
+    # Mutate skills tree and git metadata
+    _write_skill(skills, "alpha", body="v2")
+    _write_skill(skills, "beta", body="new")
+    (git_dir / "HEAD").write_text("ref: refs/heads/feature\n", encoding="utf-8")
+
+    ok, msg, _ = cb.rollback(backup_id=snap_dir.name)
+    assert ok, f"rollback failed: {msg}"
+
+    assert (skills / "alpha" / "SKILL.md").read_text(encoding="utf-8").find("v1") != -1
+    assert not (skills / "beta").exists()
+    assert (git_dir / "HEAD").exists()
+    assert (git_dir / "HEAD").read_text(encoding="utf-8") == "ref: refs/heads/feature\n"
+


### PR DESCRIPTION
## What does this PR do?

Excludes `.git`, `.curator_backups`, and `.hub` directories from curator skill backup tarballs created by `snapshot_skills()`.

When `skills/` is located within a git repository or contains `.curator_backups`, previous versions recursively packaged the repository's `.git` folder and all historical backups, resulting in runaway disk consumption (up to 24GB) and CPU hangs on startup.

## Related Issue

Fixes #91449

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/curator_backup.py`: Added `".git"` to `_EXCLUDE_TOP_LEVEL`, and added a tar member filter in `snapshot_skills()` that skips any member matching `.git`, `.curator_backups`, or `.hub`.
- `tests/agent/test_curator_backup.py`: Added unit tests verifying exclusion during snapshot creation and preservation during rollback.

## How to Test

1. Run `pytest tests/agent/test_curator_backup.py -k "test_snapshot_excludes_git_and_curator_backups_and_hub or test_rollback_preserves_top_level_git" -v`
2. Verify that top-level `.git` is never archived into `skills.tar.gz` and remains intact during rollback operations.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A