### PR TITLE
feat(cli): detect uv.lock changes and refresh python dependencies on hermes update

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3665,6 +3665,180 @@ def _record_npm_lockfile_hash(hermes_root: Path) -> None:
     except OSError:
         logger.debug("Could not write npm lockfile hash cache")
 
+def _python_manifests_digest() -> str | None:
+    """Return a checkout-specific digest for the reviewed Python resolution."""
+    lock_file = _m().PROJECT_ROOT / "uv.lock"
+    pyproject = _m().PROJECT_ROOT / "pyproject.toml"
+    if not lock_file.exists() and not pyproject.exists():
+        return None
+    digest = hashlib.sha256()
+    for path in (pyproject, lock_file):
+        if not path.exists():
+            continue
+        digest.update(path.name.encode())
+        try:
+            digest.update(path.read_bytes())
+        except OSError:
+            digest.update(b"<unreadable>")
+    return digest.hexdigest()
+
+
+def _python_lock_hash_file(hermes_root: Path | None = None) -> Path:
+    root = hermes_root or get_hermes_home()
+    cache_key = hashlib.sha256(str(_m().PROJECT_ROOT).encode()).hexdigest()[:12]
+    return root / f".python_lock_hash_{cache_key}"
+
+
+def _python_lockfile_changed(hermes_root: Path | None = None) -> bool:
+    """Fail closed when no successful reconciliation has been recorded."""
+    current = _python_manifests_digest()
+    if current is None:
+        return False
+    try:
+        cache_file = _python_lock_hash_file(hermes_root)
+        return (
+            not cache_file.exists()
+            or cache_file.read_text(encoding="utf-8").strip() != current
+        )
+    except OSError:
+        return True
+
+
+def _record_python_lockfile_hash(hermes_root: Path | None = None) -> None:
+    digest = _python_manifests_digest()
+    if digest is None:
+        return
+    try:
+        _python_lock_hash_file(hermes_root).write_text(digest, encoding="utf-8")
+    except OSError:
+        logger.debug("Could not write python lockfile hash cache")
+
+
+def _python_environment_inventory(python_exe: Path) -> tuple[dict[str, str], dict]:
+    """Read installed distributions and marker values from the target venv."""
+    probe = (
+        "import importlib.metadata as m, json, os, platform, re, sys\n"
+        "canonical = lambda name: re.sub(r'[-_.]+', '-', name).lower()\n"
+        "installed = {canonical(d.metadata['Name']): d.version "
+        "for d in m.distributions() if d.metadata.get('Name')}\n"
+        "version = platform.python_version()\n"
+        "markers = {'implementation_name': sys.implementation.name, "
+        "'implementation_version': version, 'os_name': os.name, "
+        "'platform_machine': platform.machine(), "
+        "'platform_python_implementation': platform.python_implementation(), "
+        "'platform_release': platform.release(), 'platform_system': platform.system(), "
+        "'platform_version': platform.version(), 'python_full_version': version, "
+        "'python_version': '.'.join(version.split('.')[:2]), "
+        "'sys_platform': sys.platform}\n"
+        "print(json.dumps({'installed': installed, 'markers': markers}))\n"
+    )
+    result = subprocess.run(
+        [str(python_exe), "-c", probe],
+        cwd=_m().PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    return payload["installed"], payload["markers"]
+
+
+def _reconcile_installed_python_packages_with_lock(
+    install_cmd_prefix: list[str], *, env: dict[str, str] | None = None
+) -> bool:
+    """Converge installed registry packages without pruning independent extras."""
+    lock_file = _m().PROJECT_ROOT / "uv.lock"
+    if not lock_file.is_file():
+        return True
+
+    try:
+        import tomllib
+
+        from packaging.markers import Marker
+        from packaging.utils import canonicalize_name
+
+        target_venv = Path((env or {}).get("VIRTUAL_ENV", _m().PROJECT_ROOT / "venv"))
+        target_python = venv_python_path(target_venv, windows=_m()._is_windows())
+        if not target_python.exists():
+            if install_cmd_prefix and not _m()._is_uv_command(install_cmd_prefix):
+                target_python = Path(install_cmd_prefix[0])
+            if not target_python.exists():
+                raise OSError(f"target interpreter not found: {target_python}")
+
+        installed, marker_env = _python_environment_inventory(target_python)
+        with lock_file.open("rb") as handle:
+            lock_data = tomllib.load(handle)
+
+        locked_versions: dict[str, set[str]] = {}
+        for package in lock_data.get("package", []):
+            source = package.get("source") or {}
+            if not isinstance(source, dict) or not source.get("registry"):
+                continue
+            markers = package.get("resolution-markers") or []
+            if markers and not any(Marker(marker).evaluate(marker_env) for marker in markers):
+                continue
+            name = canonicalize_name(package["name"])
+            locked_versions.setdefault(name, set()).add(str(package["version"]))
+
+        requirements: list[str] = []
+        for name, installed_version in sorted(installed.items()):
+            versions = locked_versions.get(name)
+            if not versions:
+                continue
+            if len(versions) != 1:
+                print(
+                    f"  ⚠ Cannot reconcile {name}: uv.lock has multiple applicable "
+                    f"versions ({', '.join(sorted(versions))})."
+                )
+                return False
+            locked_version = next(iter(versions))
+            if installed_version != locked_version:
+                requirements.append(f"{name}=={locked_version}")
+
+        if requirements:
+            command = list(install_cmd_prefix) + ["install", "--no-deps"]
+            if _m()._is_uv_command(install_cmd_prefix):
+                command += ["--python", str(target_python)]
+            command += requirements
+            scripts_dir = _m()._venv_scripts_dir() if _m()._is_windows() else None
+            _m()._run_quarantined_install(
+                command,
+                env=env,
+                scripts_dir=scripts_dir,
+                strict_quarantine=True,
+            )
+
+            installed_after, _ = _python_environment_inventory(target_python)
+            for requirement in requirements:
+                name, locked_version = requirement.rsplit("==", 1)
+                if installed_after.get(name) != locked_version:
+                    print(
+                        "  ⚠ Python lock reconciliation did not reach the locked versions."
+                    )
+                    return False
+        return True
+    except (OSError, ValueError, KeyError, json.JSONDecodeError, subprocess.SubprocessError) as exc:
+        print(f"  ⚠ Python lock reconciliation failed: {exc}")
+        logger.debug("Python lock reconciliation failed", exc_info=True)
+        return False
+
+
+def _reconcile_and_record_python_lockfile(
+    install_cmd_prefix: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    hermes_root: Path | None = None,
+) -> bool:
+    """Record the manifest only after the target venv reaches locked versions."""
+    if not _reconcile_installed_python_packages_with_lock(
+        install_cmd_prefix, env=env
+    ):
+        return False
+    _record_python_lockfile_hash(hermes_root)
+    return True
+
 def _repair_node_deps_on_current_checkout(
     print_completion,
     *,
@@ -7868,6 +8042,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # otherwise "Already up to date!" gaslights the user while their
             # install stays bricked.
             healthy, detail = _venv_core_imports_healthy()
+            python_lock_changed = _python_lockfile_changed()
             # The Windows shim hand-off spawns this child precisely to run a
             # sync its parent could not. The parent already pulled, so the
             # checkout is current BY DESIGN and venv health is not the
@@ -7881,7 +8056,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 print("⚠ Checkout is current, but the venv is unhealthy:")
                 print(f"  {detail}")
                 print("→ Repairing Python dependencies...")
-            if handed_off_sync or not healthy:
+            elif python_lock_changed:
+                print("→ Python lock state is unverified; reconciling dependencies...")
+            if handed_off_sync or not healthy or python_lock_changed:
+                full_repair = handed_off_sync or not healthy
                 # Self-lock deferral (#86735): the repair rewrites the venv
                 # too — same mapped-extension hazard as the update sync.
                 _m()._abort_dependency_sync_if_self_locked(_windows_gateway_resume)
@@ -7897,7 +8075,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         _m().PROJECT_ROOT / "venv", windows=_m()._is_windows()
                     )
                 ).exists()
-                if venv_python_missing and repair_uv:
+                if full_repair and venv_python_missing and repair_uv:
                     print("→ Recreating virtual environment...")
                     subprocess.run(
                         [repair_uv, "venv", "venv"],
@@ -7911,35 +8089,52 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
                     repair_env = managed_python_env()
                     repair_env["VIRTUAL_ENV"] = str(_m().PROJECT_ROOT / "venv")
-                    _m()._install_python_dependencies_with_optional_fallback(
-                        [repair_uv, "pip"], env=repair_env, group="all"
-                    )
-                    _m()._refresh_active_lazy_features(
-                        [repair_uv, "pip"],
-                        env=repair_env,
-                        features=active_lazy_features,
-                    )
-                    _m()._restore_active_tool_dependencies(
-                        active_tool_dependencies,
-                        [repair_uv, "pip"],
-                        env=repair_env,
-                    )
+                    if full_repair:
+                        _m()._install_python_dependencies_with_optional_fallback(
+                            [repair_uv, "pip"], env=repair_env, group="all"
+                        )
+                        _m()._refresh_active_lazy_features(
+                            [repair_uv, "pip"],
+                            env=repair_env,
+                            features=active_lazy_features,
+                        )
+                        _m()._restore_active_tool_dependencies(
+                            active_tool_dependencies,
+                            [repair_uv, "pip"],
+                            env=repair_env,
+                        )
                 else:
-                    _m()._install_python_dependencies_with_optional_fallback(
-                        [sys.executable, "-m", "pip"], group="all"
-                    )
-                    _m()._refresh_active_lazy_features(
-                        [sys.executable, "-m", "pip"],
-                        features=active_lazy_features,
-                    )
-                    _m()._restore_active_tool_dependencies(
-                        active_tool_dependencies,
-                        [sys.executable, "-m", "pip"],
-                    )
-                _m()._clear_update_incomplete_marker()
+                    if full_repair:
+                        _m()._install_python_dependencies_with_optional_fallback(
+                            [sys.executable, "-m", "pip"], group="all"
+                        )
+                        _m()._refresh_active_lazy_features(
+                            [sys.executable, "-m", "pip"],
+                            features=active_lazy_features,
+                        )
+                        _m()._restore_active_tool_dependencies(
+                            active_tool_dependencies,
+                            [sys.executable, "-m", "pip"],
+                        )
+                install_prefix = [repair_uv, "pip"] if repair_uv else [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                ]
+                reconcile_env = repair_env if repair_uv else None
+                lock_reconciled = _reconcile_and_record_python_lockfile(
+                    install_prefix, env=reconcile_env
+                )
+                if lock_reconciled:
+                    _m()._clear_update_incomplete_marker()
+                else:
+                    print("  Re-run `hermes update` to retry lock reconciliation.")
                 healthy_after, detail_after = _venv_core_imports_healthy()
-                if healthy_after:
-                    print("✓ Dependencies repaired!")
+                if healthy_after and lock_reconciled:
+                    if full_repair:
+                        print("✓ Dependencies repaired!")
+                    else:
+                        print("✓ Python lock state reconciled!")
                     _check_and_apply_config_migration(
                         assume_yes=assume_yes,
                         gateway_mode=gateway_mode,
@@ -7947,8 +8142,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     )
                     _print_update_completion("✓ Update complete!")
                 else:
-                    print(f"⚠ Venv still unhealthy after repair: {detail_after}")
-                    print("  Close all Hermes windows/gateways and re-run: hermes update")
+                    if not healthy_after:
+                        print(f"⚠ Venv still unhealthy after repair: {detail_after}")
+                        print("  Close all Hermes windows/gateways and re-run: hermes update")
             else:
                 _repair_node_deps_on_current_checkout(
                     _print_update_completion,
@@ -8330,11 +8526,18 @@ def _cmd_update_impl(args, gateway_mode: bool):
             )
             _m()._verify_console_scripts_installed(install_prefix, env=lazy_env)
 
-        # Core ``.[all]`` install finished. Clear the generic core breadcrumb
+        lock_reconciled = _reconcile_and_record_python_lockfile(
+            install_prefix, env=lazy_env
+        )
+        if not lock_reconciled:
+            print("  Re-run `hermes update` to retry lock reconciliation.")
+
+        # Core ``.[all]`` install and lock reconciliation finished. Clear the generic core breadcrumb
         # before the lazy-refresh phase — that phase uses its own marker so a
         # later lazy failure cannot be "healed" by clearing the core marker
         # based on a narrow 7-package import probe (#58004 review).
-        _m()._clear_update_incomplete_marker()
+        if lock_reconciled:
+            _m()._clear_update_incomplete_marker()
 
         # The update process is still the old Python interpreter process. Run
         # one final cache/module refresh immediately before lazy backend

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1497,7 +1497,7 @@ class TestPythonLockfileTracking:
             )
         return wheel
 
-    def test_no_cache_reconciles_real_venv_without_pruning_unlocked_package(
+    def test_no_cache_reconciles_real_transitive_without_pruning_unlocked_package(
         self, tmp_path, monkeypatch
     ):
         import json
@@ -1522,11 +1522,10 @@ class TestPythonLockfileTracking:
         self._write_wheel(wheelhouse, "locked-demo", "1.0.0")
         self._write_wheel(
             wheelhouse,
-            "locked-demo",
-            "2.0.0",
-            requires_dist="transitive-demo==1.0.0",
+            "app-demo",
+            "1.0.0",
+            requires_dist="locked-demo>=1,<3",
         )
-        self._write_wheel(wheelhouse, "transitive-demo", "1.0.0")
         self._write_wheel(wheelhouse, "unrelated-demo", "1.0.0")
 
         (project / "pyproject.toml").write_text(
@@ -1559,12 +1558,43 @@ class TestPythonLockfileTracking:
                 "install",
                 "--python",
                 str(python_exe),
-                "locked-demo==1.0.0",
+                "app-demo==1.0.0",
                 "unrelated-demo==1.0.0",
             ],
             env=install_env,
             check=True,
         )
+
+        def probe_environment():
+            result = subprocess.run(
+                [
+                    str(python_exe),
+                    "-c",
+                    "import importlib.metadata as m, json; "
+                    "print(json.dumps({'versions': {n: m.version(n) for n in "
+                    "('app-demo', 'locked-demo', 'unrelated-demo')}, "
+                    "'app_requires': m.requires('app-demo')}))",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return json.loads(result.stdout)
+
+        # The stale lock-managed distribution is present only because the
+        # installed application depends on it, matching the real report.
+        assert probe_environment() == {
+            "versions": {
+                "app-demo": "1.0.0",
+                "locked-demo": "1.0.0",
+                "unrelated-demo": "1.0.0",
+            },
+            "app_requires": ["locked-demo>=1,<3"],
+        }
+
+        # Make the reviewed lock target available only after seeding the stale
+        # environment, so app-demo genuinely installed locked-demo transitively.
+        self._write_wheel(wheelhouse, "locked-demo", "2.0.0")
 
         # Existing installs start with no digest cache; this must drive the
         # same non-pruning reconciliation used by hermes update.
@@ -1573,32 +1603,14 @@ class TestPythonLockfileTracking:
             [uv, "pip"], env=install_env, hermes_root=hermes_root
         )
 
-        probe = subprocess.run(
-            [
-                str(python_exe),
-                "-c",
-                "import importlib.metadata as m, json; "
-                "print(json.dumps({n: m.version(n) for n in "
-                "('locked-demo', 'unrelated-demo')}))",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        assert json.loads(probe.stdout) == {
-            "locked-demo": "2.0.0",
-            "unrelated-demo": "1.0.0",
+        assert probe_environment() == {
+            "versions": {
+                "app-demo": "1.0.0",
+                "locked-demo": "2.0.0",
+                "unrelated-demo": "1.0.0",
+            },
+            "app_requires": ["locked-demo>=1,<3"],
         }
-        missing_transitive = subprocess.run(
-            [
-                str(python_exe),
-                "-c",
-                "import importlib.metadata as m; m.version('transitive-demo')",
-            ],
-            capture_output=True,
-            text=True,
-        )
-        assert missing_transitive.returncode != 0
         assert uc._python_lockfile_changed(hermes_root) is False
 
     def test_failed_reconciliation_does_not_record_hash(

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -89,6 +89,21 @@ def _patch_gateway_discovery():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _patch_python_lockfile_default(request):
+    """By default, assume python lockfile unchanged during update tests unless overridden."""
+    if "TestPythonLockfileTracking" in request.node.nodeid:
+        yield
+        return
+    with patch(
+        "hermes_cli.update_cmd._python_lockfile_changed", return_value=False
+    ), patch(
+        "hermes_cli.update_cmd._reconcile_and_record_python_lockfile",
+        return_value=True,
+    ):
+        yield
+
+
 class TestCmdUpdateNpmLockfileCache:
     @staticmethod
     def _cache_file(hermes_root, project_root):
@@ -1372,3 +1387,238 @@ class TestUpdateNodeDependencies:
         assert cwd_calls, "expected at least one npm call"
         for cwd in cwd_calls:
             assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"
+
+
+class TestPythonLockfileTracking:
+    """Test Python lockfile digest computation and change detection."""
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_current_healthy_checkout_reconciles_without_broad_reinstall(
+        self, mock_run, _mock_which, mock_args
+    ):
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd as uc
+
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="0"
+        )
+
+        with patch.object(
+            hm,
+            "_get_origin_url",
+            return_value="https://github.com/example/hermes-agent.git",
+        ), patch.object(hm, "_sync_with_upstream_if_needed"), patch.object(
+            uc, "_python_lockfile_changed", return_value=True
+        ), patch.object(
+            uc, "_venv_core_imports_healthy", return_value=(True, "ok")
+        ), patch.object(
+            uc, "_reconcile_and_record_python_lockfile", return_value=True
+        ) as reconcile, patch.object(
+            hm, "_install_python_dependencies_with_optional_fallback"
+        ) as broad_install, patch.object(
+            hm, "_refresh_active_lazy_features"
+        ) as lazy_refresh, patch.object(
+            hm, "_restore_active_tool_dependencies"
+        ) as tool_restore, patch.object(
+            hm, "_abort_dependency_sync_if_self_locked"
+        ), patch.object(
+            uc, "_write_update_incomplete_marker"
+        ), patch.object(
+            hm, "_clear_update_incomplete_marker"
+        ):
+            cmd_update(mock_args)
+
+        reconcile.assert_called_once()
+        broad_install.assert_not_called()
+        lazy_refresh.assert_not_called()
+        tool_restore.assert_not_called()
+
+    def test_python_lockfile_changed_when_no_cache(self, tmp_path, monkeypatch):
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd as uc
+
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='hermes'\n", encoding="utf-8")
+        (tmp_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir()
+
+        # Without recorded hash cache, un-synced installs must trip the change detector
+        assert uc._python_lockfile_changed(hermes_root) is True
+
+    def test_python_lockfile_detects_mutation_after_recorded(self, tmp_path, monkeypatch):
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd as uc
+
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='hermes'\n", encoding="utf-8")
+        (tmp_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir()
+
+        uc._record_python_lockfile_hash(hermes_root)
+        assert uc._python_lockfile_changed(hermes_root) is False
+
+        # Modifying uv.lock trips the change detector
+        (tmp_path / "uv.lock").write_text("version = 2\n", encoding="utf-8")
+        assert uc._python_lockfile_changed(hermes_root) is True
+
+    @staticmethod
+    def _write_wheel(wheelhouse, name, version, *, requires_dist=None):
+        import zipfile
+
+        distribution = name.replace("-", "_")
+        dist_info = f"{distribution}-{version}.dist-info"
+        wheel = wheelhouse / f"{distribution}-{version}-py3-none-any.whl"
+        records = [
+            f"{distribution}/__init__.py",
+            f"{dist_info}/METADATA",
+            f"{dist_info}/WHEEL",
+            f"{dist_info}/RECORD",
+        ]
+        with zipfile.ZipFile(wheel, "w") as archive:
+            archive.writestr(f"{distribution}/__init__.py", "")
+            archive.writestr(
+                f"{dist_info}/METADATA",
+                f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n"
+                + (f"Requires-Dist: {requires_dist}\n" if requires_dist else ""),
+            )
+            archive.writestr(
+                f"{dist_info}/WHEEL",
+                "Wheel-Version: 1.0\nGenerator: hermes-test\n"
+                "Root-Is-Purelib: true\nTag: py3-none-any\n",
+            )
+            archive.writestr(
+                f"{dist_info}/RECORD",
+                "".join(f"{record},,\n" for record in records),
+            )
+        return wheel
+
+    def test_no_cache_reconciles_real_venv_without_pruning_unlocked_package(
+        self, tmp_path, monkeypatch
+    ):
+        import json
+        import os
+        import shutil
+        import sys
+
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd as uc
+        from hermes_constants import venv_python_path
+
+        uv = shutil.which("uv")
+        if not uv:
+            pytest.skip("uv is required for the real-venv reconciliation regression")
+
+        project = tmp_path / "checkout"
+        wheelhouse = tmp_path / "wheels"
+        hermes_root = tmp_path / ".hermes"
+        project.mkdir()
+        wheelhouse.mkdir()
+        hermes_root.mkdir()
+        self._write_wheel(wheelhouse, "locked-demo", "1.0.0")
+        self._write_wheel(
+            wheelhouse,
+            "locked-demo",
+            "2.0.0",
+            requires_dist="transitive-demo==1.0.0",
+        )
+        self._write_wheel(wheelhouse, "transitive-demo", "1.0.0")
+        self._write_wheel(wheelhouse, "unrelated-demo", "1.0.0")
+
+        (project / "pyproject.toml").write_text(
+            "[project]\nname = 'hermes-test'\nversion = '0.0.0'\n",
+            encoding="utf-8",
+        )
+        (project / "uv.lock").write_text(
+            "version = 1\n"
+            "[[package]]\n"
+            "name = 'locked-demo'\n"
+            "version = '2.0.0'\n"
+            "source = { registry = 'https://pypi.org/simple' }\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(hm, "PROJECT_ROOT", project)
+
+        venv = tmp_path / "venv"
+        subprocess.run([uv, "venv", str(venv), "--python", sys.executable], check=True)
+        python_exe = venv_python_path(venv, windows=hm._is_windows())
+        install_env = {
+            **os.environ,
+            "VIRTUAL_ENV": str(venv),
+            "UV_NO_INDEX": "1",
+            "UV_FIND_LINKS": str(wheelhouse),
+        }
+        subprocess.run(
+            [
+                uv,
+                "pip",
+                "install",
+                "--python",
+                str(python_exe),
+                "locked-demo==1.0.0",
+                "unrelated-demo==1.0.0",
+            ],
+            env=install_env,
+            check=True,
+        )
+
+        # Existing installs start with no digest cache; this must drive the
+        # same non-pruning reconciliation used by hermes update.
+        assert uc._python_lockfile_changed(hermes_root) is True
+        assert uc._reconcile_and_record_python_lockfile(
+            [uv, "pip"], env=install_env, hermes_root=hermes_root
+        )
+
+        probe = subprocess.run(
+            [
+                str(python_exe),
+                "-c",
+                "import importlib.metadata as m, json; "
+                "print(json.dumps({n: m.version(n) for n in "
+                "('locked-demo', 'unrelated-demo')}))",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert json.loads(probe.stdout) == {
+            "locked-demo": "2.0.0",
+            "unrelated-demo": "1.0.0",
+        }
+        missing_transitive = subprocess.run(
+            [
+                str(python_exe),
+                "-c",
+                "import importlib.metadata as m; m.version('transitive-demo')",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert missing_transitive.returncode != 0
+        assert uc._python_lockfile_changed(hermes_root) is False
+
+    def test_failed_reconciliation_does_not_record_hash(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import main as hm
+        from hermes_cli import update_cmd as uc
+
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname='hermes'\n", encoding="utf-8"
+        )
+        (tmp_path / "uv.lock").write_text("version = 1\n", encoding="utf-8")
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir()
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(
+            uc, "_reconcile_installed_python_packages_with_lock", lambda *_a, **_k: False
+        )
+
+        assert not uc._reconcile_and_record_python_lockfile(
+            ["uv", "pip"], hermes_root=hermes_root
+        )
+        assert uc._python_lockfile_changed(hermes_root) is True


### PR DESCRIPTION
## What does this PR do?

Fixes #91424.

`hermes update` now tracks the reviewed Python resolution (`pyproject.toml` + `uv.lock`) and reconciles a healthy-but-stale shared venv even when the checkout has no new commits. Existing installs without a digest cache take the same reconciliation path.

The repair intentionally keeps the existing non-pruning editable-install helper unchanged for genuinely unhealthy/handoff repairs. A healthy checkout with a missing or stale digest skips that broad path: it compares distributions already present in the target venv with applicable registry entries in `uv.lock` and installs only differing exact versions in one targeted command. Packages absent from the venv stay absent; packages outside the lock stay untouched. Ambiguous entries, inspection failures, install failures, and failed post-install verification leave the digest stale so a later update retries.

## Related Issue

Fixes #91424

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd.py`
  - tracks the Python lock/manifest digest, with missing cache treated as unreconciled;
  - evaluates platform-specific `uv.lock` resolution markers against the target interpreter;
  - converges only already-installed registry packages to one applicable locked version using dependency-free exact installs, so absent packages remain absent;
  - records the digest only after reconciliation and post-install version verification succeed;
  - keeps failed reconciliation retryable through the existing update-incomplete path.
- `tests/hermes_cli/test_cmd_update.py`
  - covers missing-cache and changed-lock detection;
  - proves a healthy current checkout takes only the targeted reconciliation path, without the broad editable install or lazy/tool refreshes;
  - uses a real temporary venv and local wheels to install `locked-demo==1.0.0` solely as an actual transitive dependency of `app-demo`, then proves reconciliation upgrades it to the reviewed `2.0.0` lock while preserving both the parent package and an unrelated installed capability;
  - proves failed reconciliation does not record the digest.

## How to Test

```bash
python -m pytest tests/hermes_cli/test_cmd_update.py -k 'TestPythonLockfileTracking' -q
python -m pytest tests/hermes_cli/test_cmd_update.py -q
python -m ruff check hermes_cli/update_cmd.py tests/hermes_cli/test_cmd_update.py
python -m py_compile hermes_cli/update_cmd.py tests/hermes_cli/test_cmd_update.py
git diff --check upstream/main...HEAD
```

Results:

- focused lockfile/reconciliation tests: **5 passed**;
- full `test_cmd_update.py`: **43 passed, 6 failed**;
- the same six tests fail on clean `upstream/main` (`1a66134404b891170e953f51662e6429f0b7b5a9`; **48 passed, 6 failed**) on this machine because live local gateway/profile state leaks into those update-flow tests; no PR-only failure was found;
- Ruff, Python compilation, and diff checks: **passed**;
- a targeted mutation that omitted the transitive lock entry made the strengthened real-venv regression fail, proving it detects the disputed behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs, including the overlapping cache work in #81760
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — focused tests pass; the affected full file has six host-state failures reproduced unchanged on clean `upstream/main`, as documented above
- [x] I've added tests for my changes
- [x] I've tested on Linux x86_64

### Documentation & Housekeeping

- [x] Relevant documentation — N/A; no user-facing command/config contract changed
- [x] `cli-config.yaml.example` — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no contributor workflow changed
- [x] Cross-platform impact considered — target interpreter and venv script paths use existing platform-aware helpers; lock markers are evaluated using the target interpreter environment
- [x] Tool descriptions/schemas — N/A; no agent tool changed

## Screenshots / Logs

No UI change. The real-venv regression creates `app-demo==1.0.0` with `Requires-Dist: locked-demo>=1,<3`, seeds a wheelhouse containing only `locked-demo==1.0.0`, and installs `app-demo` plus unrelated `unrelated-demo==1.0.0`. It verifies that `locked-demo` is genuinely present as a stale transitive dependency, then makes the reviewed `2.0.0` wheel available and reconciles from an initial no-cache state. The final assertions prove `locked-demo` reached `2.0.0`, while `app-demo` and `unrelated-demo` both remain installed unchanged.
