### PR TITLE
feat: opencode-free visible in /model and desktop pickers for everyone — keyless counts as authenticated

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7096,6 +7096,25 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "api_key":
         return {"configured": False}
 
+    # Keyless providers (opencode-free) are served anonymously: no credential
+    # exists, so every install counts as configured/logged in. Derived from
+    # the HermesOverlay keyless flag — the same source the provider catalog
+    # and GUI contract tests use.
+    try:
+        from hermes_cli.providers import HERMES_OVERLAYS
+        _overlay = HERMES_OVERLAYS.get(provider_id)
+    except Exception:
+        _overlay = None
+    if _overlay is not None and getattr(_overlay, "keyless", False):
+        return {
+            "configured": True,
+            "provider": provider_id,
+            "name": pconfig.name,
+            "key_source": "keyless",
+            "base_url": pconfig.inference_base_url,
+            "logged_in": True,
+        }
+
     api_key = ""
     key_source = ""
     api_key, key_source = _resolve_api_key_provider_secret(provider_id, pconfig)

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -691,9 +691,25 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
             if _raw_config_has_enabled_moa_preset():
                 kept.append(row)
             continue
+        if _provider_is_keyless(slug):
+            # Keyless providers (opencode-free) require no configuration at
+            # all — there is nothing to "explicitly configure", and hiding
+            # them would defeat their purpose (zero-setup discoverability).
+            kept.append(row)
+            continue
         if is_provider_explicitly_configured(slug):
             kept.append(row)
     return kept
+
+
+def _provider_is_keyless(slug: str) -> bool:
+    """True when the provider's Hermes overlay declares it keyless."""
+    try:
+        from hermes_cli.providers import HERMES_OVERLAYS
+        overlay = HERMES_OVERLAYS.get(slug)
+        return bool(overlay is not None and getattr(overlay, "keyless", False))
+    except Exception:
+        return False
 
 
 def _raw_config_has_enabled_moa_preset() -> bool:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2948,7 +2948,11 @@ def list_authenticated_providers(
 
         # Check if credentials exist
         has_creds = False
-        if overlay.auth_type == "aws_sdk":
+        if getattr(overlay, "keyless", False):
+            # Keyless providers (opencode-free) are served anonymously —
+            # there is no credential to check, so everyone is authenticated.
+            has_creds = True
+        elif overlay.auth_type == "aws_sdk":
             has_creds = _has_aws_sdk_creds_for_listing(hermes_slug)
         elif overlay.auth_type == "vertex":
             # Vertex authenticates via OAuth2 (service-account JSON / ADC),

--- a/tests/hermes_cli/test_opencode_zen_free_keyless.py
+++ b/tests/hermes_cli/test_opencode_zen_free_keyless.py
@@ -122,3 +122,47 @@ class TestRuntimeProviderKeylessRouting:
 
         with pytest.raises(AuthError):
             self._resolve("opencode-zen", "claude-sonnet-5")
+
+
+class TestKeylessProviderAlwaysAuthenticated:
+    """opencode-free counts as authenticated everywhere, with zero keys.
+
+    The provider is keyless: there is no credential to configure, so every
+    surface that gates on auth (get_auth_status, provider:model listing,
+    the /model picker source, the desktop explicit-only filter) must treat
+    every install as logged in.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_creds(self, monkeypatch):
+        for var in ("OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_auth_status_logged_in(self):
+        from hermes_cli.auth import get_auth_status
+
+        st = get_auth_status("opencode-free")
+        assert st["logged_in"] is True
+        assert st["configured"] is True
+        assert st["key_source"] == "keyless"
+
+    def test_list_available_providers_authenticated(self):
+        from hermes_cli.models import list_available_providers
+
+        rows = {r["id"]: r["authenticated"] for r in list_available_providers()}
+        assert rows.get("opencode-free") is True
+
+    def test_picker_source_includes_provider_with_models(self):
+        import model_tools  # noqa: F401 — plugin discovery
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        provs = list_authenticated_providers(for_picker=True)
+        free = [p for p in provs if p["slug"] == "opencode-free"]
+        assert free, "opencode-free must appear in the picker with zero keys"
+        assert free[0]["models"], "picker row must carry the curated models"
+
+    def test_explicit_only_filter_keeps_keyless(self):
+        from hermes_cli.inventory import _provider_is_keyless
+
+        assert _provider_is_keyless("opencode-free") is True
+        assert _provider_is_keyless("opencode-zen") is False


### PR DESCRIPTION
## Summary
`opencode-free` now shows up in `/model`, the TUI picker, and the Hermes Desktop model pickers for EVERY user with zero setup — a keyless provider has no credential to lack, so everyone counts as authenticated to it.

Previously all auth-gated surfaces treated "no key" as "not authenticated" and hid the provider unless unrelated OpenCode env vars happened to be set, defeating the point of a zero-setup free tier.

## Changes
One policy, three gates, all derived from the `HermesOverlay.keyless` flag (#91358):
- `hermes_cli/auth.py` — `get_api_key_provider_status`: keyless providers report `configured`/`logged_in: True` with `key_source: "keyless"`; flows through `get_auth_status` to `hermes status`, dashboards, and `list_available_providers` (provider:model syntax)
- `hermes_cli/model_switch.py` — `list_authenticated_providers`: keyless overlay rows get `has_creds=True` ahead of env/pool/auth-store checks; this is the single source for `/model`, the TUI picker, and the desktop `/api/model/options` payload
- `hermes_cli/inventory.py` — desktop explicit-only chat-picker filter keeps keyless providers (nothing exists to "explicitly configure")
- 4 new tests in `test_opencode_zen_free_keyless.py` covering each gate

## Validation
| Surface (temp HERMES_HOME, ALL keys stripped) | Result |
|---|---|
| `get_auth_status("opencode-free")` | `logged_in: True`, `key_source: keyless` |
| `list_available_providers` | `authenticated: True` (opencode-zen without key stays False) |
| `list_authenticated_providers(for_picker=True)` | row present with all 6 curated models |
| Desktop payload — default AND `explicit_only` | provider + models present in both |
| Full switch pipeline (`free:x-preview-f-free` → `switch_model`) | resolves keyless runtime, `provider_changed: True` |
| Targeted suites | 103 passed (keyless + catalog + parity + model-switch + provider + runtime) |

## Infographic

![Keyless = always signed in](https://v3b.fal.media/files/b/0aa73857/5E0r-b8ZDNXaXKM5be4d3_PiEdVo0p.png)
