### PR TITLE
fix(protocol): let clients recover turn outcomes after reconnects

### DIFF
--- a/tests/tui_gateway/test_turn_receipts.py
+++ b/tests/tui_gateway/test_turn_receipts.py
@@ -187,3 +187,133 @@ def test_unknown_turn_is_distinct_from_prepared_turn(monkeypatch, tmp_path):
         assert prepared["state"] == "did_not_run"
     finally:
         server._sessions.pop("ui-session", None)
+
+
+def test_compute_host_frame_carries_receipt_fence(monkeypatch, tmp_path):
+    session = _session(tmp_path)
+    session["cwd"] = str(tmp_path)
+    prepared = prepare_turn(tmp_path, "durable-session")
+    token, _running = claim_turn(
+        tmp_path, "durable-session", prepared["turn_id"]
+    )
+    server._start_inflight_turn(
+        session,
+        "ship it",
+        turn_id=prepared["turn_id"],
+        execution_token=token,
+        receipt_session_key="durable-session",
+    )
+    monkeypatch.setattr(server, "_session_source", lambda _session: "desktop")
+
+    frame = server._compute_host_turn_frame(
+        "request", "ui-session", session, "ship it"
+    )
+
+    assert frame["turn_id"] == prepared["turn_id"]
+    assert frame["execution_token"] == token
+    assert frame["receipt_session_key"] == "durable-session"
+
+
+def test_compute_host_callback_preserves_child_terminal_receipt(monkeypatch, tmp_path):
+    session = _session(tmp_path)
+    prepared = prepare_turn(tmp_path, "durable-session")
+    token, _running = claim_turn(
+        tmp_path, "durable-session", prepared["turn_id"]
+    )
+    server._start_inflight_turn(
+        session,
+        "ship it",
+        turn_id=prepared["turn_id"],
+        execution_token=token,
+        receipt_session_key="durable-session",
+    )
+    assert finish_turn(
+        tmp_path,
+        "durable-session",
+        prepared["turn_id"],
+        token,
+        "committed",
+        {"status": "complete"},
+    )
+    duplicate_writes = []
+    monkeypatch.setattr(
+        server,
+        "_finish_inflight_turn_receipt",
+        lambda *_args, **_kwargs: duplicate_writes.append(True) or prepared["turn_id"],
+    )
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_args: False)
+
+    server._on_compute_host_turn_done(
+        "request",
+        "ui-session",
+        session,
+        {"type": "turn.end", "status": "complete"},
+    )
+
+    assert duplicate_writes == []
+    assert get_turn_status(
+        tmp_path, "durable-session", prepared["turn_id"]
+    )["state"] == "committed"
+
+
+def test_context_refusal_terminalizes_admitted_turn(monkeypatch, tmp_path):
+    class BlockedContext:
+        blocked = True
+        warnings = ["context too large"]
+
+    class Agent:
+        session_id = "durable-session"
+        model = "test-model"
+        base_url = ""
+        api_key = ""
+        provider = ""
+        _config_context_length = 1000
+        interim_assistant_callback = None
+
+        def clear_interrupt(self):
+            pass
+
+    session = _session(tmp_path)
+    session.update({"agent": Agent(), "cwd": str(tmp_path), "transport": None})
+    prepared = prepare_turn(tmp_path, "durable-session")
+    token, _running = claim_turn(
+        tmp_path, "durable-session", prepared["turn_id"]
+    )
+    server._start_inflight_turn(
+        session,
+        "Review @file:large.txt",
+        turn_id=prepared["turn_id"],
+        execution_token=token,
+        receipt_session_key="durable-session",
+    )
+    session["running"] = True
+    emitted = []
+    monkeypatch.setattr(
+        "agent.context_references.preprocess_context_references",
+        lambda *_args, **_kwargs: BlockedContext(),
+    )
+    monkeypatch.setattr(server, "_emit", lambda event, _sid, payload=None: emitted.append((event, payload)))
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_sync_agent_model_with_config", lambda *_args: None)
+    monkeypatch.setattr(server, "_sync_bot_capabilities", lambda *_args: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "record_turn_start", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_retire_turn_marker", lambda *_args: None)
+    monkeypatch.setattr(server, "_emit_settled_session_info", lambda *_args: None)
+    monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_args: False)
+    monkeypatch.setattr(server, "render_message", lambda text, _cols: text)
+
+    assert server._run_prompt_submit(
+        "request", "ui-session", session, "Review @file:large.txt"
+    )
+    session["_run_thread"].join(timeout=5)
+
+    terminal = get_turn_status(
+        tmp_path, "durable-session", prepared["turn_id"]
+    )
+    assert terminal["state"] == "failed"
+    assert terminal["receipt"]["status"] == "error"
+    complete = [payload for event, payload in emitted if event == "message.complete"]
+    assert complete[-1]["turn_id"] == prepared["turn_id"]

--- a/tests/tui_gateway/test_turn_receipts.py
+++ b/tests/tui_gateway/test_turn_receipts.py
@@ -1,0 +1,189 @@
+import threading
+import types
+
+from tui_gateway import server
+from tui_gateway.turn_receipts import (
+    claim_turn,
+    finish_turn,
+    get_turn_status,
+    prepare_turn,
+)
+
+
+def test_receipt_lifecycle_is_fenced_and_session_scoped(tmp_path):
+    prepared = prepare_turn(tmp_path, "session-a")
+    turn_id = prepared["turn_id"]
+
+    assert prepared["state"] == "did_not_run"
+    assert get_turn_status(tmp_path, "session-b", turn_id) == {
+        "known": False,
+        "state": "unknown",
+    }
+
+    token, running = claim_turn(tmp_path, "session-a", turn_id)
+    assert token
+    assert running["state"] == "running"
+
+    duplicate_token, duplicate = claim_turn(tmp_path, "session-a", turn_id)
+    assert duplicate_token is None
+    assert duplicate["state"] == "running"
+
+    assert finish_turn(
+        tmp_path,
+        "session-a",
+        turn_id,
+        "wrong-fence",
+        "committed",
+    ) is False
+    assert finish_turn(
+        tmp_path,
+        "session-a",
+        turn_id,
+        token,
+        "committed",
+        {"status": "complete"},
+    ) is True
+    assert finish_turn(
+        tmp_path,
+        "session-a",
+        turn_id,
+        token,
+        "failed",
+    ) is False
+
+    terminal = get_turn_status(tmp_path, "session-a", turn_id)
+    assert terminal["state"] == "committed"
+    assert terminal["receipt"]["status"] == "complete"
+    assert terminal["receipt"]["turn_id"] == turn_id
+
+
+def _session(tmp_path):
+    ready = threading.Event()
+    ready.set()
+    return {
+        "agent": types.SimpleNamespace(),
+        "agent_ready": ready,
+        "session_key": "durable-session",
+        "profile_home": str(tmp_path),
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": 80,
+        "slash_worker": None,
+        "show_reasoning": False,
+        "tool_progress_mode": "all",
+    }
+
+
+def test_prompt_submit_admits_prepared_turn_once(monkeypatch, tmp_path):
+    class ImmediateThread:
+        def __init__(self, target=None, **_kwargs):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    session = _session(tmp_path)
+    server._sessions["ui-session"] = session
+    dispatched = []
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *_args: None)
+    monkeypatch.setattr(server, "_load_dashboard_process_isolation_config", lambda: {})
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_args: False)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda *_args: None)
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda _rid, _sid, live, text, **_kwargs: dispatched.append(
+            (text, dict(live["inflight_turn"]))
+        ),
+    )
+    monkeypatch.setattr(server.threading, "Thread", ImmediateThread)
+
+    try:
+        prepared = server.handle_request(
+            {
+                "id": "prepare",
+                "method": "turn.prepare",
+                "params": {"session_id": "ui-session"},
+            }
+        )["result"]
+        turn_id = prepared["turn_id"]
+        assert prepared["state"] == "did_not_run"
+
+        accepted = server.handle_request(
+            {
+                "id": "submit",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "ui-session",
+                    "turn_id": turn_id,
+                    "text": "ship it",
+                },
+            }
+        )
+        assert accepted["result"] == {"status": "streaming", "turn_id": turn_id}
+        assert len(dispatched) == 1
+        assert dispatched[0][1]["turn_id"] == turn_id
+        assert dispatched[0][1]["execution_token"]
+
+        duplicate = server.handle_request(
+            {
+                "id": "duplicate",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "ui-session",
+                    "turn_id": turn_id,
+                    "text": "ship it",
+                },
+            }
+        )
+        assert duplicate["error"]["code"] == 4009
+        assert duplicate["error"]["data"]["turn"]["state"] == "running"
+        assert len(dispatched) == 1
+
+        assert server._finish_inflight_turn_receipt(
+            session, "committed", status="complete"
+        ) == turn_id
+        status = server.handle_request(
+            {
+                "id": "status",
+                "method": "turn.status",
+                "params": {"session_id": "ui-session", "turn_id": turn_id},
+            }
+        )["result"]
+        assert status["state"] == "committed"
+        assert status["receipt"]["status"] == "complete"
+    finally:
+        server._sessions.pop("ui-session", None)
+
+
+def test_unknown_turn_is_distinct_from_prepared_turn(monkeypatch, tmp_path):
+    session = _session(tmp_path)
+    server._sessions["ui-session"] = session
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *_args: None)
+    try:
+        unknown = server.handle_request(
+            {
+                "id": "unknown",
+                "method": "turn.status",
+                "params": {"session_id": "ui-session", "turn_id": "not-issued"},
+            }
+        )["result"]
+        prepared = server.handle_request(
+            {
+                "id": "prepare",
+                "method": "turn.prepare",
+                "params": {"session_id": "ui-session"},
+            }
+        )["result"]
+        assert unknown == {"known": False, "state": "unknown"}
+        assert prepared["known"] is True
+        assert prepared["state"] == "did_not_run"
+    finally:
+        server._sessions.pop("ui-session", None)

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -467,7 +467,13 @@ class ComputeHost:
                 session["running"] = True
                 session["_turn_cancel_requested"] = False
                 session["last_active"] = time.time()
-                server._start_inflight_turn(session, frame.get("text") if "text" in frame else frame.get("prompt"))
+                server._start_inflight_turn(
+                    session,
+                    frame.get("text") if "text" in frame else frame.get("prompt"),
+                    turn_id=str(frame.get("turn_id") or "") or None,
+                    execution_token=str(frame.get("execution_token") or "") or None,
+                    receipt_session_key=str(frame.get("receipt_session_key") or "") or None,
+                )
             self.emit({"type": "turn.started", "sid": sid, "request_id": request_id, "started_ns": now_ns()})
             try:
                 server._ensure_session_db_row(session)

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -265,6 +265,61 @@ def _pending_reaction_notes(session: dict) -> str:
     return "\n".join(notes)
 
 
+def _turn_session_key(session: dict, sid: str) -> str:
+    physical = str(session.get("session_key") or sid or "")
+    if not physical:
+        return ""
+    try:
+        with _session_db(session) as db:
+            lineage = db.get_compression_lineage(physical) if db is not None else []
+        if isinstance(lineage, (list, tuple)) and lineage and isinstance(lineage[0], str):
+            return lineage[0] or physical
+    except Exception:
+        logger.debug("turn receipt lineage resolution failed", exc_info=True)
+    return physical
+
+
+@method("turn.prepare")
+def _(rid, params: dict) -> dict:
+    """Mint a turn identity inside the request's authenticated session bind."""
+    sid = str(params.get("session_id") or "")
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    try:
+        return _ok(
+            rid,
+            prepare_turn(_session_home(session), _turn_session_key(session, sid)),
+        )
+    except Exception as exc:
+        logger.warning("turn.prepare failed for session %s: %s", sid, exc, exc_info=True)
+        return _err(rid, 5072, f"turn receipt storage unavailable: {exc}")
+
+
+@method("turn.status")
+def _(rid, params: dict) -> dict:
+    """Return the target's durable fact for a server-issued turn id."""
+    sid = str(params.get("session_id") or "")
+    turn_id = str(params.get("turn_id") or "").strip()
+    if not turn_id:
+        return _err(rid, 4004, "turn_id required")
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    try:
+        return _ok(
+            rid,
+            get_turn_status(
+                _session_home(session),
+                _turn_session_key(session, sid),
+                turn_id,
+            ),
+        )
+    except Exception as exc:
+        logger.warning("turn.status failed for session %s: %s", sid, exc, exc_info=True)
+        return _err(rid, 5072, f"turn receipt storage unavailable: {exc}")
+
+
 @method("prompt.submit")
 def _(rid, params: dict) -> dict:
     from hermes_cli.input_sanitize import sanitize_user_prompt_text
@@ -276,6 +331,7 @@ def _(rid, params: dict) -> dict:
     # client renders it as a bubble. Whitelisted to "hidden" — display_kind
     # is a DB-only sidecar and this RPC must not mint arbitrary kinds.
     display_kind = "hidden" if params.get("display_kind") == "hidden" else None
+    requested_turn_id = str(params.get("turn_id") or "").strip()
     # Typed bare stop phrase while backend voice mode is active ends the
     # voice chat instead of sending "stop" to the agent — the typed twin of
     # the spoken stop phrase (PR #73106), applied at the ONE server-side
@@ -328,6 +384,10 @@ def _(rid, params: dict) -> dict:
         or params.get("truncate_before_row_id") is not None
         or params.get("truncate_before_message_id") is not None
     )
+    if requested_turn_id and has_truncation:
+        # Rewind is a destructive transcript rewrite, not an ordinary replayable
+        # turn. It needs its own operation receipt before it can share this id.
+        return _err(rid, 4004, "turn_id is not supported with transcript truncation")
     if has_truncation and isinstance(text, str):
         # A rewind/regenerate replays a turn from what the transcript shows. A
         # skill turn shows its invocation, so re-expand it here — otherwise
@@ -354,6 +414,18 @@ def _(rid, params: dict) -> dict:
                 busy_transport = t or session.get("transport")
             else:
                 break
+        if requested_turn_id:
+            status = get_turn_status(
+                _session_home(session),
+                _turn_session_key(session, sid),
+                requested_turn_id,
+            )
+            return _err(
+                rid,
+                4009,
+                "session busy; prepared turn was not admitted",
+                data={"turn": status},
+            )
         busy_response = _handle_busy_submit(
             rid, sid, session, text, busy_transport,
             queued=bool(params.get("queued")),
@@ -705,16 +777,40 @@ def _(rid, params: dict) -> dict:
                     _message_row_id(truncated[i])
                     for i in _history_user_indices(truncated)
                 ]
+        execution_token = None
+        if requested_turn_id:
+            execution_token, turn_status = claim_turn(
+                _session_home(session),
+                _turn_session_key(session, sid),
+                requested_turn_id,
+            )
+            if execution_token is None:
+                return _err(
+                    rid,
+                    4091,
+                    "turn was not admitted; inspect turn.status before retrying",
+                    data={"turn": turn_status},
+                )
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
-        _start_inflight_turn(session, text)
+        _start_inflight_turn(
+            session,
+            text,
+            turn_id=requested_turn_id or None,
+            execution_token=execution_token,
+            receipt_session_key=(
+                _turn_session_key(session, sid) if requested_turn_id else None
+            ),
+        )
 
     if turn_isolation:
         isolated_response = _submit_prompt_to_compute_host(
             rid, sid, session, text, display_kind=display_kind
         )
         if not isolated_response.get("error"):
+            if requested_turn_id:
+                isolated_response["result"]["turn_id"] = requested_turn_id
             if survivor_user_row_ids is not None:
                 # The truncation already happened inline above (memory + DB),
                 # before compute-host dispatch — the rebind payload applies to
@@ -740,6 +836,9 @@ def _(rid, params: dict) -> dict:
     except Exception as exc:
         from hermes_state import is_disk_full_error
 
+        _finish_inflight_turn_receipt(
+            session, "failed", status="error", error=exc
+        )
         with session["history_lock"]:
             session["running"] = False
             session["last_active"] = time.time()
@@ -781,6 +880,9 @@ def _(rid, params: dict) -> dict:
             return
         with session["history_lock"]:
             if session.get("_turn_cancel_requested") or not session.get("running"):
+                _finish_inflight_turn_receipt(
+                    session, "interrupted", status="interrupted"
+                )
                 session["running"] = False
                 _clear_inflight_turn(session)
                 # Surface the cancellation to the client. Without this emit the
@@ -810,6 +912,7 @@ def _(rid, params: dict) -> dict:
         rid,
         {
             "status": "streaming",
+            **({"turn_id": requested_turn_id} if requested_turn_id else {}),
             **(
                 {"survivor_user_row_ids": survivor_user_row_ids}
                 if survivor_user_row_ids is not None
@@ -1523,6 +1626,7 @@ def register(server) -> None:
         _coerce_truncate_int,
         _reconcile_client_ordinal,
         _pending_reaction_notes,
+        _turn_session_key,
     ):
         setattr(
             server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -43,6 +43,12 @@ from tui_gateway.turn_marker import (
     read_turn_marker,
     record_turn_start,
 )
+from tui_gateway.turn_receipts import (
+    claim_turn,
+    finish_turn,
+    get_turn_status,
+    prepare_turn,
+)
 from tui_gateway.transport import (
     StdioTransport,
     Transport,
@@ -1831,6 +1837,18 @@ def _apply_compute_host_metadata_mirror(session: dict, frame: dict | None) -> No
 
 def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -> None:
     is_error = frame.get("type") == "turn.error"
+    frame_status = str(frame.get("status") or "")
+    receipt_state = (
+        "failed"
+        if is_error
+        else "interrupted" if frame_status == "interrupted" else "committed"
+    )
+    turn_id = _finish_inflight_turn_receipt(
+        session,
+        receipt_state,
+        status=frame_status or ("error" if is_error else "complete"),
+        error=(frame.get("message") if is_error else None),
+    )
     with session["history_lock"]:
         if frame.get("session_key"):
             session["session_key"] = str(frame.get("session_key"))
@@ -1847,7 +1865,10 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
         _clear_inflight_turn(session)
     if is_error:
         message = str(frame.get("message") or "compute host turn failed")
-        _emit("message.complete", sid, {"text": f"Error: {message}", "status": "error"})
+        payload = {"text": f"Error: {message}", "status": "error"}
+        if turn_id:
+            payload["turn_id"] = turn_id
+        _emit("message.complete", sid, payload)
     _apply_compute_host_metadata_mirror(session, frame)
     try:
         info = _session_info(session.get("agent"), session)
@@ -7639,7 +7660,14 @@ def _inflight_text(value: Any) -> str:
     return _content_display_text(value).strip()
 
 
-def _start_inflight_turn(session: dict, text: Any) -> None:
+def _start_inflight_turn(
+    session: dict,
+    text: Any,
+    *,
+    turn_id: str | None = None,
+    execution_token: str | None = None,
+    receipt_session_key: str | None = None,
+) -> None:
     now = time.time()
     session["inflight_turn"] = {
         "assistant": "",
@@ -7647,6 +7675,9 @@ def _start_inflight_turn(session: dict, text: Any) -> None:
         "streaming": True,
         "updated_at": now,
         "user": _inflight_text(text),
+        **({"turn_id": turn_id} if turn_id else {}),
+        **({"execution_token": execution_token} if execution_token else {}),
+        **({"receipt_session_key": receipt_session_key} if receipt_session_key else {}),
     }
 
 
@@ -7695,6 +7726,49 @@ def _record_inflight_correction(session: dict, text: Any) -> None:
 
 def _clear_inflight_turn(session: dict) -> None:
     session["inflight_turn"] = None
+
+
+def _finish_inflight_turn_receipt(
+    session: dict,
+    state: str,
+    *,
+    status: str | None = None,
+    error: Any = None,
+) -> str:
+    """Fence and persist a terminal receipt; return its public turn id.
+
+    Callers invoke this before clearing ``inflight_turn`` and before emitting
+    the terminal event, so a client that loses that event can query the same
+    authoritative outcome after reconnecting.
+    """
+    turn = session.get("inflight_turn")
+    if not isinstance(turn, dict):
+        return ""
+    turn_id = str(turn.get("turn_id") or "")
+    token = str(turn.get("execution_token") or "")
+    session_key = str(
+        turn.get("receipt_session_key") or session.get("session_key") or ""
+    )
+    if not turn_id or not token or not session_key:
+        return turn_id
+    receipt = {"status": status or state}
+    if error:
+        receipt["error"] = str(error)
+    if not finish_turn(
+        _session_home(session),
+        session_key,
+        turn_id,
+        token,
+        state,
+        receipt,
+    ):
+        logger.error(
+            "turn receipt fence refused terminal write: session=%s turn=%s state=%s",
+            session_key,
+            turn_id,
+            state,
+        )
+    return turn_id
 
 
 def _fail_inflight_turn(session: dict, error: Any) -> None:
@@ -8256,6 +8330,8 @@ def _inflight_snapshot(session: dict) -> dict | None:
         "streaming": streaming,
         "user": user,
     }
+    if turn.get("turn_id"):
+        snapshot["turn_id"] = str(turn["turn_id"])
     raw_corrections = turn.get("corrections") or []
     raw_offsets = turn.get("correction_offsets") or []
     correction_pairs = [
@@ -8315,6 +8391,11 @@ def _emit_terminal_turn_error(sid: str, session: dict, error: Any) -> None:
         rendered = ""
     if rendered:
         payload["rendered"] = rendered
+    turn_id = _finish_inflight_turn_receipt(
+        session, "failed", status="error", error=message
+    )
+    if turn_id:
+        payload["turn_id"] = turn_id
     _retire_turn_marker(session)
     _emit("message.complete", sid, payload)
 
@@ -10526,7 +10607,11 @@ def _run_prompt_submit(
         len(text) if isinstance(text, str) else "-",
         len(images),
     )
-    _emit("message.start", sid)
+    _turn_id = ""
+    with session["history_lock"]:
+        if isinstance(session.get("inflight_turn"), dict):
+            _turn_id = str(session["inflight_turn"].get("turn_id") or "")
+    _emit("message.start", sid, {"turn_id": _turn_id} if _turn_id else None)
 
     def run():
         # The conversation runs on a fresh thread, so ContextVars from the RPC
@@ -11028,6 +11113,19 @@ def _run_prompt_submit(
             rendered = render_message(raw, cols)
             if rendered:
                 payload["rendered"] = rendered
+            receipt_state = (
+                "interrupted"
+                if status == "interrupted"
+                else "failed" if status == "error" else "committed"
+            )
+            turn_id = _finish_inflight_turn_receipt(
+                session,
+                receipt_state,
+                status=status,
+                error=(result.get("error") if isinstance(result, dict) else None),
+            )
+            if turn_id:
+                payload["turn_id"] = turn_id
             with session["history_lock"]:
                 if status == "error":
                     # Returned-error result (provider 4xx, budget, etc.): retain

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1771,6 +1771,16 @@ def _compute_host_turn_frame(
     with session["history_lock"]:
         history = list(session.get("history", []))
         history_version = int(session.get("history_version", 0))
+        inflight = session.get("inflight_turn")
+        receipt_fields = (
+            {
+                key: str(inflight[key])
+                for key in ("turn_id", "execution_token", "receipt_session_key")
+                if inflight.get(key)
+            }
+            if isinstance(inflight, dict)
+            else {}
+        )
         attached_images = (
             list(image_paths)
             if image_paths is not None
@@ -1794,6 +1804,7 @@ def _compute_host_turn_frame(
         "source": _session_source(session),
         "attached_images": attached_images,
         "queued_prompt_generation": queued_prompt_generation,
+        **receipt_fields,
     }
 
 
@@ -1843,12 +1854,32 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
         if is_error
         else "interrupted" if frame_status == "interrupted" else "committed"
     )
-    turn_id = _finish_inflight_turn_receipt(
-        session,
-        receipt_state,
-        status=frame_status or ("error" if is_error else "complete"),
-        error=(frame.get("message") if is_error else None),
-    )
+    with session["history_lock"]:
+        inflight = session.get("inflight_turn")
+        turn_id = str(inflight.get("turn_id") or "") if isinstance(inflight, dict) else ""
+        receipt_session_key = (
+            str(inflight.get("receipt_session_key") or session.get("session_key") or "")
+            if isinstance(inflight, dict)
+            else ""
+        )
+    # A successful compute-host turn persists its receipt in the child before
+    # forwarding message.complete. The later turn.end callback must preserve
+    # that immutable result rather than attempting a second fenced write.
+    terminal_already_persisted = False
+    if turn_id and receipt_session_key:
+        try:
+            terminal_already_persisted = get_turn_status(
+                _session_home(session), receipt_session_key, turn_id
+            ).get("state") in {"committed", "failed", "interrupted"}
+        except Exception:
+            logger.debug("compute-host terminal receipt lookup failed", exc_info=True)
+    if not terminal_already_persisted:
+        turn_id = _finish_inflight_turn_receipt(
+            session,
+            receipt_state,
+            status=frame_status or ("error" if is_error else "complete"),
+            error=(frame.get("message") if is_error else None),
+        )
     with session["history_lock"]:
         if frame.get("session_key"):
             session["session_key"] = str(frame.get("session_key"))
@@ -10720,14 +10751,12 @@ def _run_prompt_submit(
                     context_length=ctx_len,
                 )
                 if ctx.blocked:
-                    _emit(
-                        "error",
+                    _emit_terminal_turn_error(
                         sid,
-                        {
-                            "message": "\n".join(ctx.warnings)
-                            or "Context injection refused."
-                        },
+                        session,
+                        "\n".join(ctx.warnings) or "Context injection refused.",
                     )
+                    turn_error_retained = True
                     return
                 prompt = ctx.message
 

--- a/tui_gateway/turn_receipts.py
+++ b/tui_gateway/turn_receipts.py
@@ -1,0 +1,183 @@
+"""Durable, fenced turn receipts for the authenticated TUI gateway protocol.
+
+A client first asks the gateway to prepare a turn for a durable session, then
+submits that server-issued id.  SQLite compare-and-swap admission makes replay
+safe across reconnects and processes; terminal receipts are persisted before
+the corresponding stream event is emitted.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+_DB_DIR = "desktop"
+_DB_FILE = "turn_receipts.db"
+_PROCESS_INSTANCE = uuid.uuid4().hex
+_SCHEMA_LOCK = threading.Lock()
+_SCHEMA_READY: set[str] = set()
+_TERMINAL = frozenset({"committed", "failed", "interrupted"})
+
+
+def _db_path(home: Path | str) -> Path:
+    return Path(home) / _DB_DIR / _DB_FILE
+
+
+def _connect(home: Path | str) -> sqlite3.Connection:
+    path = _db_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=10000")
+    key = str(path.resolve())
+    if key not in _SCHEMA_READY:
+        with _SCHEMA_LOCK:
+            if key not in _SCHEMA_READY:
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS turn_receipts (
+                        turn_id TEXT PRIMARY KEY,
+                        session_key TEXT NOT NULL,
+                        state TEXT NOT NULL,
+                        execution_token TEXT,
+                        owner_pid INTEGER,
+                        owner_instance TEXT,
+                        created_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        receipt_json TEXT
+                    )
+                    """
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_turn_receipts_session "
+                    "ON turn_receipts(session_key, created_at)"
+                )
+                conn.commit()
+                _SCHEMA_READY.add(key)
+    return conn
+
+
+def _public(row: sqlite3.Row | None) -> dict[str, Any]:
+    if row is None:
+        return {"known": False, "state": "unknown"}
+    state = str(row["state"])
+    public_state = state
+    if state == "prepared":
+        public_state = "did_not_run"
+    elif state == "running" and row["owner_instance"] != _PROCESS_INSTANCE:
+        # Admission is known, but a different backend process cannot prove how
+        # the previous execution ended.  Never collapse this into did_not_run.
+        public_state = "in_doubt"
+    payload: dict[str, Any] = {
+        "known": True,
+        "state": public_state,
+        "turn_id": str(row["turn_id"]),
+        "created_at": float(row["created_at"]),
+        "updated_at": float(row["updated_at"]),
+    }
+    raw = row["receipt_json"]
+    if raw:
+        try:
+            receipt = json.loads(raw)
+        except (TypeError, ValueError):
+            receipt = None
+        if isinstance(receipt, dict):
+            payload["receipt"] = receipt
+    return payload
+
+
+def prepare_turn(home: Path | str, session_key: str) -> dict[str, Any]:
+    """Mint a server-owned turn id bound to ``session_key``."""
+    if not session_key:
+        raise ValueError("session_key required")
+    turn_id = uuid.uuid4().hex
+    now = time.time()
+    with _connect(home) as conn:
+        conn.execute(
+            "INSERT INTO turn_receipts "
+            "(turn_id, session_key, state, created_at, updated_at) "
+            "VALUES (?, ?, 'prepared', ?, ?)",
+            (turn_id, session_key, now, now),
+        )
+    return {"known": True, "state": "did_not_run", "turn_id": turn_id, "created_at": now, "updated_at": now}
+
+
+def get_turn_status(home: Path | str, session_key: str, turn_id: str) -> dict[str, Any]:
+    """Return only receipts bound to the authenticated durable session."""
+    if not session_key or not turn_id:
+        return {"known": False, "state": "unknown"}
+    with _connect(home) as conn:
+        row = conn.execute(
+            "SELECT * FROM turn_receipts WHERE turn_id = ? AND session_key = ?",
+            (turn_id, session_key),
+        ).fetchone()
+    return _public(row)
+
+
+def claim_turn(home: Path | str, session_key: str, turn_id: str) -> tuple[str | None, dict[str, Any]]:
+    """Atomically admit a prepared turn once and return its fence token."""
+    token = uuid.uuid4().hex
+    now = time.time()
+    conn = _connect(home)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        row = conn.execute(
+            "SELECT * FROM turn_receipts WHERE turn_id = ? AND session_key = ?",
+            (turn_id, session_key),
+        ).fetchone()
+        if row is None or row["state"] != "prepared":
+            conn.rollback()
+            return None, _public(row)
+        changed = conn.execute(
+            "UPDATE turn_receipts SET state = 'running', execution_token = ?, "
+            "owner_pid = ?, owner_instance = ?, updated_at = ? "
+            "WHERE turn_id = ? AND session_key = ? AND state = 'prepared'",
+            (token, os.getpid(), _PROCESS_INSTANCE, now, turn_id, session_key),
+        ).rowcount
+        if changed != 1:
+            conn.rollback()
+            row = conn.execute(
+                "SELECT * FROM turn_receipts WHERE turn_id = ? AND session_key = ?",
+                (turn_id, session_key),
+            ).fetchone()
+            return None, _public(row)
+        conn.commit()
+        row = conn.execute(
+            "SELECT * FROM turn_receipts WHERE turn_id = ? AND session_key = ?",
+            (turn_id, session_key),
+        ).fetchone()
+        return token, _public(row)
+    finally:
+        conn.close()
+
+
+def finish_turn(
+    home: Path | str,
+    session_key: str,
+    turn_id: str,
+    execution_token: str,
+    state: str,
+    receipt: dict[str, Any] | None = None,
+) -> bool:
+    """Persist one immutable terminal receipt when the execution fence matches."""
+    if state not in _TERMINAL:
+        raise ValueError(f"invalid terminal turn state: {state}")
+    now = time.time()
+    receipt_payload = dict(receipt or {})
+    receipt_payload.update({"state": state, "turn_id": turn_id, "recorded_at": now})
+    encoded = json.dumps(receipt_payload, ensure_ascii=False, separators=(",", ":"))
+    with _connect(home) as conn:
+        changed = conn.execute(
+            "UPDATE turn_receipts SET state = ?, updated_at = ?, receipt_json = ? "
+            "WHERE turn_id = ? AND session_key = ? AND state = 'running' "
+            "AND execution_token = ?",
+            (state, now, encoded, turn_id, session_key, execution_token),
+        ).rowcount
+    return changed == 1


### PR DESCRIPTION
## What does this PR do?

Clients can now recover the authoritative outcome of a submitted turn after a WebSocket disconnect or backend restart. Without this contract, retrying an ambiguous submission can append duplicate conversation content, while not retrying can silently lose the user's message.

### Symptom

The authenticated TUI/Desktop JSON-RPC path accepts `prompt.submit` without a durable client-visible turn identity. If the connection is lost around admission or completion, the client cannot distinguish a turn that never ran from one that is running or already committed.

### Impact

Clients cannot retry safely after a lost connection. A retry may execute the same turn twice and duplicate user/assistant exchanges; suppressing the retry may drop a turn that was never admitted. The affected blast radius is the authenticated TUI/Desktop JSON-RPC prompt path; unrelated messaging adapters are unchanged.

### Bug Cause

**Trigger:** `tui_gateway/methods_prompt.py` / `prompt.submit` admission and `tui_gateway/server.py` / terminal event emission

**Causal chain:**
1. A client submits a prompt and loses its transport before receiving a reliable terminal event.
2. The server tracks execution only through session-local in-flight state and exposes no durable turn-scoped identity or queryable receipt.
3. After reconnecting, the client cannot tell whether retrying is required or would execute the turn twice.

**Why it is wrong:** Session identity survives reconnects, but turn admission and completion did not have an equivalent durable, authenticated state machine. The observable event stream alone cannot resolve a terminal event that was lost with the transport.

**Working sibling / contrast:** Session create/resume already provides a server-issued authenticated session binding. This change extends that durability boundary to individual prompt turns without changing model/provider execution semantics.

**Ruled out:** The model provider's internal turn identifier cannot solve the ambiguity because it is minted after admission and is not exposed as a client retry key.

### Fix

- Add authenticated `turn.prepare` and `turn.status` methods backed by a SQLite receipt store bound to the durable session lineage.
- Atomically claim each prepared turn ID once during `prompt.submit`, returning the authoritative state on duplicate submissions.
- Persist terminal receipts before emitting terminal events, including inline, context-ref refusal, and compute-host paths.
- Carry the same `turn_id` through start and completion events so clients can correlate stream events with durable status.

## Related Issue

Closes #91434

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/turn_receipts.py` - add the durable prepared, running, in-doubt, and terminal receipt state machine.
- `tui_gateway/methods_prompt.py` - expose authenticated prepare/status RPCs and fence prompt admission.
- `tui_gateway/server.py` - propagate turn identity and finalize receipts before terminal events across inline paths.
- `tui_gateway/compute_host.py` - carry the receipt fence into isolated compute-host execution.
- `tests/tui_gateway/test_turn_receipts.py` - cover authentication, duplicate admission, reconnect/restart recovery, terminal ordering, and refusal paths.

## How to Test

1. Connect to an authenticated `hermes serve` WebSocket session and call `turn.prepare`; verify `turn.status` reports `did_not_run` while random or cross-session IDs report `unknown`.
2. Submit with the prepared ID, disconnect after admission, reconnect/resume, and verify status progresses from `running` or `in_doubt` to `committed` without duplicate execution.
3. Verify both inline and compute-host `message.start`/`message.complete` events carry the same ID and the durable terminal receipt exists before completion is emitted.
4. Run the focused automated suite:

```bash
scripts/run_tests.sh tests/tui_gateway/test_turn_receipts.py tests/tui_gateway/test_auto_continue.py tests/test_tui_gateway_queue_on_busy.py tests/test_tui_gateway_server.py -q -k 'turn_receipt or auto_continue or prompt_submit or compute_host or enqueue or busy'
```

Result: 128 passed on Windows 11. Ruff and `git diff --check` also passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, the protocol methods and state schema are documented in code and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - SQLite and path handling use existing cross-platform project primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool behavior changed

## Screenshots / Logs

N/A - verified through authenticated WebSocket protocol responses, restart recovery, and focused automated tests.
