### PR TITLE
fix(install): refresh Playwright upgrade for current main

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -160,7 +160,7 @@
   "devDependencies": {
     "@babel/core": "8.0.1",
     "@electron/rebuild": "4.2.0",
-    "@playwright/test": "1.58.2",
+    "@playwright/test": "1.62.1",
     "@rolldown/plugin-babel": "0.2.3",
     "@testing-library/dom": "10.4.1",
     "@testing-library/react": "16.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,7 @@
       "devDependencies": {
         "@babel/core": "8.0.1",
         "@electron/rebuild": "4.2.0",
-        "@playwright/test": "1.58.2",
+        "@playwright/test": "1.62.1",
         "@rolldown/plugin-babel": "0.2.3",
         "@testing-library/dom": "10.4.1",
         "@testing-library/react": "16.3.2",
@@ -3632,19 +3632,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -15547,35 +15547,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/plist": {


### PR DESCRIPTION
@teknium1 When you have a moment, would you please review this PR or let us know whether anything further is needed before it can be merged?

This PR reapplies the fix from #77773 to current `main` because the original branch now has merge conflicts. It fixes #76312, where Playwright 1.58.2 can hang while extracting Chromium under Node 26.

Special and heartfelt thanks to @zhyu for the original contribution in #77773. He identified the Playwright incompatibility, tested the upgrade, updated the lockfile, and prepared the substantive fix. The technical credit belongs to him. This PR exists only to preserve his work and make it apply cleanly to today’s fast-moving `main`.

Changes:

- Pin `@playwright/test` to exact version 1.62.1.
- Update the corresponding `@playwright/test`, `playwright`, and `playwright-core` lockfile records.
- Make no unrelated changes.

Validation:

- One commit directly on current `main`.
- Exactly two changed files.
- npm 11.17.0 lock synchronization dry run completed successfully.
- Package versions, dependency links, engine requirements, tarball URLs, and integrity hashes match npm registry metadata.
- Playwright 1.62.1 is currently npm’s `latest` release.

Fixes #76312
Supersedes #77773