### PR TITLE
fix: catalog drift sync — 6 dead free slugs delisted, 5 live models added, keyless heal gated on membership not suffix

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -508,6 +508,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     # ensures "glm-5.2" resolves to 1M while older variants still hit the
     # generic 202K fallback.
     "glm-5.2": 1_048_576,
+    # OpenRouter's free GLM-5.2 variant is capped at 256K (live metadata,
+    # 2026-08-21) — longer key wins over the 1M paid entry above.
+    "glm-5.2:free": 256_000,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to
@@ -563,7 +566,15 @@ DEFAULT_CONTEXT_LENGTHS = {
     # (stealth/ox-alpha). 1M context per OpenRouter live metadata (2026-08-20).
     "ox-alpha": 1_048_576,
     # Nemotron — NVIDIA's open-weights series (128K context across all sizes)
+    # EXCEPT 3.5 Lightning, which ships a 1M window (OpenRouter live metadata
+    # + OpenCode Zen free tier, verified 2026-08-21).
+    "nemotron-3.5-lightning": 1_000_000,
     "nemotron": 131072,
+    # Poolside Laguna 2.1 (s/xs) — 256K window per OpenRouter live metadata
+    # (2026-08-21). Covers laguna-s-2.1:free, laguna-xs-2.1:free, and the
+    # OpenCode Zen laguna-s-2.1-free slug via substring matching.
+    "laguna-s-2.1": 262144,
+    "laguna-xs-2.1": 262144,
     # Arcee
     "trinity": 262144,
     # OpenRouter

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -135,11 +135,12 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Free tier
     ("stealth/ox-alpha",                       "free"),  # "Ox Alpha" stealth reasoning model — 1M ctx
     ("openrouter/elephant-alpha",              "free"),
-    ("poolside/laguna-m.1:free",               "free"),
-    ("tencent/hy3:free",                       "free"),
+    ("z-ai/glm-5.2:free",                      "free"),
+    ("poolside/laguna-s-2.1:free",             "free"),
+    ("poolside/laguna-xs-2.1:free",            "free"),
     ("nvidia/nemotron-3-super-120b-a12b:free", "free"),
     ("nvidia/nemotron-3-ultra-550b-a55b:free", "free"),
-    ("inclusionai/ring-2.6-1t:free",           "free"),
+    ("nvidia/nemotron-3.5-lightning:free",     "free"),
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
@@ -519,7 +520,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "claude-opus-4-7",
         "claude-opus-4-6",
         "claude-opus-4-5",
-        "claude-opus-4-1",
         "claude-sonnet-4-6",
         "claude-sonnet-4-5",
         "claude-sonnet-4",
@@ -544,8 +544,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek-v4-pro",
         "deepseek-v4-flash",
         "deepseek-v4-flash-free",
-        "qwen3.7-max",
-        "qwen3.7-plus",
         "qwen3.6-plus",
         "qwen3.5-plus",
         "big-pickle",
@@ -601,6 +599,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "hy3",
         "hy3-preview",
         "muse-spark-1.2-contributor",
+        # Go-subscription twin of the Zen keyless Ox Alpha (live go/v1
+        # catalog 2026-08-21; NOT keyless — Go relay requires a Go key).
+        "ox-alpha-free",
     ],
     "kilocode": [
         "anthropic/claude-opus-4.6",
@@ -5401,14 +5402,22 @@ def opencode_zen_free_runtime(provider_id: Optional[str], model_id: Optional[str
     - ``provider_id`` is ``opencode-free`` (the dedicated keyless provider —
       EVERY model on it routes anonymously; that is the provider's contract), or
     - ``provider_id`` is any other OpenCode-family provider and ``model_id``
-      is a free-tier slug (heals a free-model selection made under
-      opencode-zen/opencode-go, whose keys the free tier rejects).
+      is in the VERIFIED keyless catalog (``_PROVIDER_MODELS["opencode-free"]``)
+      — heals a free-model selection made under opencode-zen/opencode-go,
+      whose keys the free tier rejects.
+
+    Membership, not the ``-free`` suffix, is the heal criterion: the suffix
+    stopped being a reliable keyless signal when ``ox-alpha-free`` appeared
+    on the Go relay as a KEYED subscription model (2026-08-21) — suffix-based
+    healing would have routed it to a Zen relay that doesn't serve it.
     """
     family = opencode_provider_family(provider_id)
     if family is None:
         return None
-    if family != "opencode-free" and not is_opencode_zen_free_model(model_id):
-        return None
+    if family != "opencode-free":
+        bare = normalize_opencode_model_id(provider_id, model_id).strip().lower()
+        if bare not in {m.lower() for m in _PROVIDER_MODELS.get("opencode-free", [])}:
+            return None
     normalized = normalize_opencode_model_id(provider_id, model_id)
     api_mode = opencode_model_api_mode("opencode-zen", normalized)
     base_url = normalize_opencode_base_url(

--- a/tests/hermes_cli/test_opencode_zen_free_keyless.py
+++ b/tests/hermes_cli/test_opencode_zen_free_keyless.py
@@ -78,6 +78,13 @@ class TestFreeRuntime:
         assert rt is not None
         assert rt["base_url"] == "https://opencode.ai/zen/v1"
 
+    def test_go_ox_alpha_free_does_not_heal_to_zen(self):
+        """ox-alpha-free is a KEYED Go-subscription model despite its -free
+        suffix (Zen doesn't serve it; Go 401s anonymous). Membership in the
+        verified keyless catalog — not the suffix — gates the heal."""
+        assert opencode_zen_free_runtime("opencode-go", "ox-alpha-free") is None
+        assert opencode_zen_free_runtime("opencode-zen", "ox-alpha-free") is None
+
     def test_paid_model_returns_none(self):
         assert opencode_zen_free_runtime("opencode-zen", "claude-sonnet-5") is None
 

--- a/tests/hermes_cli/test_tencent_tokenhub_provider.py
+++ b/tests/hermes_cli/test_tencent_tokenhub_provider.py
@@ -294,7 +294,12 @@ class TestTencentTokenhubAgentInit:
 
 
 class TestTencentTokenhubModelCatalogJSON:
-    """Verify tencent/hy3:free and tencent/hy3 are present in the website model-catalog.json."""
+    """Verify tencent/hy3 is present in the website model-catalog.json.
+
+    tencent/hy3:free was delisted 2026-08-21 — the slug vanished from
+    OpenRouter's live catalog (free promo rotated out), so the paid hy3
+    entry is the surviving assertion target.
+    """
 
     def test_in_model_catalog_json(self):
         catalog_path = os.path.join(
@@ -318,7 +323,6 @@ class TestTencentTokenhubModelCatalogJSON:
             for provider_entry in providers:
                 for model in provider_entry.get("models", []):
                     all_ids.add(model.get("id", ""))
-        assert "tencent/hy3:free" in all_ids
         assert "tencent/hy3" in all_ids
 
 

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-21T03:50:21Z",
+  "updated_at": "2026-08-21T11:29:05Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -162,11 +162,15 @@
           "description": "free"
         },
         {
-          "id": "poolside/laguna-m.1:free",
+          "id": "z-ai/glm-5.2:free",
           "description": "free"
         },
         {
-          "id": "tencent/hy3:free",
+          "id": "poolside/laguna-s-2.1:free",
+          "description": "free"
+        },
+        {
+          "id": "poolside/laguna-xs-2.1:free",
           "description": "free"
         },
         {
@@ -178,7 +182,7 @@
           "description": "free"
         },
         {
-          "id": "inclusionai/ring-2.6-1t:free",
+          "id": "nvidia/nemotron-3.5-lightning:free",
           "description": "free"
         }
       ]


### PR DESCRIPTION
## Summary
First actioned drift report from the overhauled `model-catalog-scout` cron: 6 dead free-tier slugs delisted, 5 live models added, and the keyless heal predicate hardened against a new counterexample the scout surfaced (`ox-alpha-free` — a `-free`-suffixed model that is NOT keyless). Every item independently re-verified against live catalogs before editing.

## Changes
**Delisted (gone from live catalogs):**
- opencode-zen curated: `claude-opus-4-1`, `qwen3.7-max`, `qwen3.7-plus` (absent from live zen `/v1/models`; qwen3.7 family survives on Go)
- `OPENROUTER_MODELS` free section: `poolside/laguna-m.1:free` (rotated to s-2.1/xs-2.1), `tencent/hy3:free`, `inclusionai/ring-2.6-1t:free`

**Added (live-verified):**
- OpenRouter free: `z-ai/glm-5.2:free` (256K), `poolside/laguna-s-2.1:free` + `laguna-xs-2.1:free` (262K), `nvidia/nemotron-3.5-lightning:free` (1M)
- opencode-go curated: `ox-alpha-free` (Go-subscription twin of the Zen keyless Ox Alpha; keyed — Go 401s anonymous)

**Metadata (`DEFAULT_CONTEXT_LENGTHS`):** laguna-s/xs-2.1 → 262,144; `nemotron-3.5-lightning` → 1,000,000 (overrides the generic 131K nemotron entry); `glm-5.2:free` → 256,000 (free variant capped below the 1M paid entry — longest-key-first substring matching would otherwise inherit 1M).

**Keyless-heal hardening (the load-bearing fix):** `opencode_zen_free_runtime` now gates the zen/go→keyless heal on MEMBERSHIP in the verified `opencode-free` catalog instead of the `-free` suffix. `ox-alpha-free` broke the suffix heuristic: it's a keyed Go model (zen 401s "not supported", go 401s "Missing API key" anonymously) that suffix-based healing would have routed to a relay that doesn't serve it. Regression test pins the counterexample.

**Fixture sweep:** `tencent/hy3:free` catalog assertion updated (delisted slug); nous-route fixtures using it as an incidental mock name left alone (self-consistent). `model-catalog.json` regenerated.

## Validation
| Check | Result |
|---|---|
| Every delist/add re-probed live before edit | zen/go/OR catalogs + anon endpoint probes |
| Context resolution | all 4 new free slugs + zen twins resolve to verified values; `glm-5.2:free` no longer inherits paid 1M |
| Heal routing | verified members still heal; `ox-alpha-free` correctly does NOT |
| Targeted suites | 272 + 268 passed across two batches (catalog gate + keyless + fixtures); 1 pre-existing batch-only `TestMoAContextLength` red (fails identically on clean main, passes in isolation) |

## Infographic

![Catalog drift sync](https://v3b.fal.media/files/b/0aa738b7/1X67b0xHAPrABs6BQiq5i_k02ebtjR.png)
