### PR TITLE
fix(desktop): stop a stale composer model pinning every new chat

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -37,6 +37,7 @@ import {
   setCurrentCwd,
   setCurrentFastMode,
   setCurrentModel,
+  setCurrentModelSource,
   setCurrentProvider,
   setCurrentReasoningEffort,
   setMessages,
@@ -475,6 +476,7 @@ describe('createBackendSessionForSend profile routing', () => {
     $currentFastMode.set(false)
     $currentModel.set('')
     $currentProvider.set('')
+    setCurrentModelSource('')
     $currentReasoningEffort.set('')
     setNewChatWorkspaceTarget(undefined)
     vi.restoreAllMocks()
@@ -517,6 +519,67 @@ describe('createBackendSessionForSend profile routing', () => {
     expect(params).toMatchObject({ source: 'desktop' })
   })
 
+  // Regression (Settings → Model doesn't stick): a stale composer selection
+  // must not be shipped as a per-session override on a NEW chat.
+  //
+  // Saving Settings → Model while a session is live deliberately leaves
+  // $currentModel painted with the LIVE agent's model (applySavedMainModel
+  // keeps the live session authoritative) and only flips the source to
+  // 'default'. If session.create still sent that value, every new chat was
+  // pinned to the old model and the backend never resolved model.default —
+  // the user-visible "my default won't change" bug.
+  it('omits a default-sourced selection so the backend resolves model.default', async () => {
+    const params = await createWith(() => {
+      // What the composer holds after Settings saved a new default while a
+      // chat was open: the previous session's model, marked default-sourced.
+      setCurrentModel('openai/gpt-5.6-sol')
+      setCurrentProvider('openai-codex')
+      setCurrentModelSource('default')
+    })
+
+    expect(params).not.toHaveProperty('model')
+    expect(params).not.toHaveProperty('provider')
+  })
+
+  it('still sends an explicit manual pick as a per-session override', async () => {
+    const params = await createWith(() => {
+      setCurrentModel('anthropic/claude-opus-5')
+      setCurrentProvider('anthropic')
+      setCurrentModelSource('manual')
+    })
+
+    expect(params).toMatchObject({
+      model: 'anthropic/claude-opus-5',
+      provider: 'anthropic'
+    })
+  })
+
+  // An unset source is the first-run/cleared state — nothing the user picked,
+  // so it must not pin the session either.
+  it('omits the model when no selection source is recorded', async () => {
+    const params = await createWith(() => {
+      setCurrentModel('openai/gpt-5.6-sol')
+      setCurrentProvider('openai-codex')
+      setCurrentModelSource('')
+    })
+
+    expect(params).not.toHaveProperty('model')
+    expect(params).not.toHaveProperty('provider')
+  })
+
+  // Effort and fast mode are independent of the model-override decision.
+  it('keeps sending reasoning effort even when the model is omitted', async () => {
+    const params = await createWith(() => {
+      setCurrentModel('openai/gpt-5.6-sol')
+      setCurrentProvider('openai-codex')
+      setCurrentModelSource('default')
+      setCurrentReasoningEffort('high')
+    })
+
+    expect(params).not.toHaveProperty('model')
+    expect(params).toMatchObject({ reasoning_effort: 'high' })
+  })
+
   it('passes the current workspace cwd into session.create', async () => {
     const params = await createWith(() => {
       $currentCwd.set('/remote/worktree')
@@ -531,6 +594,10 @@ describe('createBackendSessionForSend profile routing', () => {
 
     setCurrentModel('anthropic/claude-sonnet-4.6')
     setCurrentProvider('anthropic')
+    // A real composer pick marks the selection manual; this test drives the
+    // atoms directly, so set the source explicitly. Only a manual selection
+    // rides along as a per-session override.
+    setCurrentModelSource('manual')
     setCurrentReasoningEffort('high')
     setCurrentFastMode(false)
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -45,6 +45,7 @@ import {
   $newChatWorkspaceTarget,
   $sessions,
   $yoloActive,
+  getCurrentModelSource,
   type NewChatWorkspaceTarget,
   resolveComposerSessionKey,
   sessionPinId,
@@ -196,11 +197,21 @@ async function desktopSessionCreateParams(cwd: string): Promise<Record<string, u
   // profile handshake below can yield long enough for background config/model
   // refreshes to finish; reading atoms afterward would silently create the
   // session with a different selection than the one the user submitted.
+  // A 'default'-sourced selection is a MIRROR of the profile default, not a
+  // user override — shipping it as an explicit per-session model pins the new
+  // chat to whatever the composer happened to hold and makes Settings → Model
+  // look like it never took effect. Settings saves while a session is live
+  // deliberately leave $currentModel painted with the live agent's model
+  // (applySavedMainModel), so that stale value must not ride along here.
+  // Omitting model/provider lets the backend resolve model.default itself.
+  // Only a 'manual' pick is a real override.
+  const isManualSelection = getCurrentModelSource() === 'manual'
+
   const selection = {
     effort: $currentReasoningEffort.get().trim(),
     fast: $currentFastMode.get(),
-    model: $currentModel.get().trim(),
-    provider: $currentProvider.get().trim()
+    model: isManualSelection ? $currentModel.get().trim() : '',
+    provider: isManualSelection ? $currentProvider.get().trim() : ''
   }
 
   const profile = $newChatProfile.get() ?? normalizeProfileKey($activeGatewayProfile.get())


### PR DESCRIPTION
## What

Changing **Settings → Model** had no effect on new chats: they kept starting on the previously used model, even though `config.yaml` already held the newly saved `model.default`.

`desktopSessionCreateParams` sent `$currentModel` / `$currentProvider` as an explicit per-session override on **every** `session.create`. A per-session model short-circuits backend resolution, so `model.default` was never consulted.

The problem is that this atom is not always a user choice. Saving Settings → Model *while a session is live* deliberately leaves the composer painted with the **live agent's** model — `applySavedMainModel` keeps the live session authoritative and only flips the selection source to `'default'`:

```ts
// use-model-controls.ts
const liveSessionId = $activeSessionId.get()
setCurrentModelSource('default')
if (!liveSessionId) {           // ← composer NOT updated when a session is live
  setCurrentProvider(provider)
  setCurrentModel(model)
}
```

That stale value then rode along to the next chat and pinned it. Because the composer pill also persists to `localStorage` (`hermes.desktop.composer.model`), the wrong model could stick indefinitely across restarts.

## Why this fix

The selection source already distinguishes the two cases — this change just honours it:

- `'manual'` → a real user pick → send it as a per-session override (unchanged behavior)
- `'default'` / unset → a *mirror* of profile config → omit it and let the backend resolve `model.default`

```ts
const isManualSelection = getCurrentModelSource() === 'manual'

const selection = {
  effort: $currentReasoningEffort.get().trim(),
  fast: $currentFastMode.get(),
  model: isManualSelection ? $currentModel.get().trim() : '',
  provider: isManualSelection ? $currentProvider.get().trim() : ''
}
```

This deliberately does **not** touch the live-session guard in `applySavedMainModel`. That guard is intentional and covered by an existing test (*"keeps a live session authoritative when Settings saves a new profile default"*) — Settings must not repaint an agent that didn't actually switch. The leak was one layer down, at session creation.

Reasoning effort and fast mode are unaffected and still sent.

## How to test

Reproduction (fails before, passes after):

1. Start a chat with model **A**.
2. With that chat still open, go to **Settings → Model** and save model **B** as the default.
3. Start a **new** chat.

**Before:** the new chat runs on **A**; `hermes config get model.default` reports **B**.
**After:** the new chat runs on **B**.

A manual pick from the composer pill still overrides for that session, as before.

Automated coverage — 4 new cases in the `createBackendSessionForSend` suite:

| Case | Asserts |
|---|---|
| default-sourced selection | `model` / `provider` omitted |
| manual pick | still sent as an override |
| unset source (first run / cleared) | omitted |
| effort independence | `reasoning_effort` still sent when model is omitted |

The default-sourced and unset-source cases fail against the previous code with `expected { … } to not have property "model"` / `Received: "openai/gpt-5.6-sol"`.

One existing test (`freezes the visible selector state before profile readiness`) now sets the selection source explicitly — it drives the atoms directly rather than going through a composer pick, so it needs to opt into `'manual'` to keep asserting override behavior.

## Verification

Run against this branch, rebased on `76e0ca8`:

- `npx vitest run src/app/session src/store src/app/settings` — **1998 passed / 167 files**
- `npx tsc -p tsconfig.json --noEmit` — clean
- `npx eslint` on both changed files — clean

## Platforms

Tested on **macOS 26.6.2 (arm64)**, packaged Electron build. The change is platform-independent renderer logic (no file I/O, process, or terminal handling), so no cross-platform impact is expected.
