### PR TITLE
fix(gateway): add bot-to-bot loop guard for Telegram

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -458,6 +458,59 @@ class GatewayAuthorizationMixin:
         # documented behavior matches reality
         # (website/docs/reference/environment-variables.md,
         # website/docs/user-guide/messaging/telegram.md).
+        # Pair loop protection for bot-authored traffic (#79077).  MUST run
+        # before the group-allowlist shortcut below: TELEGRAM_GROUP_ALLOWED_CHATS
+        # returns True for any sender in an allowlisted chat, bots included, so a
+        # guard placed after it never executes for the exact configuration that
+        # needs it (an allowlisted group with two bots in it).
+        #
+        # Telegram Bot API 10.0 ships no loop guard of its own --
+        # core.telegram.org/api/bots/bot-to-bot requires the BOT to "make
+        # bot-message handling terminate predictably" via dedupe, rate limits and
+        # maximum interaction depth per sender/receiver pair.  ALLOW_BOTS is
+        # admission policy only: a bot replying to another bot satisfies the
+        # "mentions" test, so each turn re-arms the peer and the exchange never
+        # terminates (observed 2026-08-21: 132 messages in one group before a
+        # human intervened).
+        #
+        # The budget is per CONVERSATION, not per (sender, receiver): this
+        # process only ever sees inbound messages, so the receiver side is a
+        # constant (our own profile) and keying on the pair would hand every
+        # distinct sender its own budget -- N bots in one group would then need
+        # N x budget messages to trip a guard meant to cap the whole exchange.
+        if getattr(source, "is_bot", False):
+            _allow_var = {
+                Platform.DISCORD: "DISCORD_ALLOW_BOTS",
+                Platform.FEISHU: "FEISHU_ALLOW_BOTS",
+                Platform.TELEGRAM: "TELEGRAM_ALLOW_BOTS",
+                Platform.SLACK: "SLACK_ALLOW_BOTS",
+            }.get(source.platform)
+            if _allow_var and _platform_gate_env(_allow_var, "none").lower().strip() in {"mentions", "all"}:
+                try:
+                    from gateway.bot_loop_guard import allow_bot_event
+
+                    _ok, _why = allow_bot_event(
+                        scope=str(getattr(self, "profile_name", "") or "-"),
+                        conversation=str(getattr(source, "chat_id", "") or "-"),
+                        sender_bot="bots",
+                        receiver_bot="bots",
+                    )
+                    if not _ok:
+                        try:
+                            import logging
+
+                            logging.getLogger(__name__).warning(
+                                "Bot-to-bot loop guard suppressed message from %s in %s (%s)",
+                                getattr(source, "user_id", "?"),
+                                getattr(source, "chat_id", "?"),
+                                _why,
+                            )
+                        except Exception:
+                            pass
+                        return False
+                except ImportError:
+                    pass
+
         if source.chat_type in {"group", "forum", "channel"} and source.chat_id:
             chat_allowlist_env = {
                 Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
@@ -507,6 +560,9 @@ class GatewayAuthorizationMixin:
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
             if allow_bots_var and _platform_gate_env(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
+                # Loop guard already ran above, before the group-allowlist
+                # shortcut -- see the pair loop protection block near the top of
+                # this method.  Reaching here means the pair was within budget.
                 return True
 
         if not user_id:

--- a/gateway/bot_loop_guard.py
+++ b/gateway/bot_loop_guard.py
@@ -1,0 +1,155 @@
+"""Pair loop protection for bot-to-bot messaging.
+
+Telegram Bot API 10.0 (2026-05-08) allows bots to receive messages from other
+bots.  The platform ships NO loop guard: core.telegram.org/api/bots/bot-to-bot
+states plainly that "Bot-to-bot communication can create infinite reply loops.
+Bots using this feature must make bot-message handling terminate predictably"
+and lists the required safeguards:
+
+  * Deduplicate repeated messages.
+  * Apply per-chat and per-bot rate limits.
+  * Enforce maximum interaction depth and timeouts, both globally and per
+    sender/receiver pair.
+
+This module implements a sliding-window budget per (conversation, bot pair).
+The pair is tracked order-independently -- A->B and B->A count as the SAME
+pair -- so a two-bot ping-pong burns one shared budget instead of two.
+
+Observed failure this guards against (2026-08-21, profiles medicina + ytmed):
+132 messages exchanged in a single Telegram group before a human intervened.
+TELEGRAM_ALLOW_BOTS=mentions did NOT stop it: when bot A replies to bot B, the
+reply itself satisfies the "mention" test, so each turn re-armed the other bot.
+
+Tunables (env, all optional):
+  HERMES_BOT_LOOP_PROTECTION   on|off           (default on)
+  HERMES_BOT_LOOP_MAX_EVENTS   int              (default 20)
+  HERMES_BOT_LOOP_WINDOW_SEC   int              (default 60)
+  HERMES_BOT_LOOP_COOLDOWN_SEC int              (default 60)
+
+Defaults match the OpenClaw reference implementation (20 events / 60 s window /
+60 s cooldown), which solves the same problem on Discord, Slack, Matrix,
+Feishu and Google Chat.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections import deque
+from typing import Deque, Dict, Optional, Tuple
+
+__all__ = ["allow_bot_event", "loop_guard_state", "reset_loop_guard"]
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        val = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+    return val if val > 0 else default
+
+
+def _enabled() -> bool:
+    raw = (os.getenv("HERMES_BOT_LOOP_PROTECTION") or "on").strip().lower()
+    return raw not in {"off", "false", "0", "no", "disabled"}
+
+
+_LOCK = threading.Lock()
+# key -> (deque of event timestamps, cooldown_until)
+_EVENTS: Dict[Tuple[str, str, str], Deque[float]] = {}
+_COOLDOWN: Dict[Tuple[str, str, str], float] = {}
+_LAST_SWEEP = 0.0
+
+
+def _key(scope: str, conversation: str, a: str, b: str) -> Tuple[str, str, str]:
+    """Order-independent pair key: A->B and B->A collapse to one bucket."""
+    lo, hi = sorted([str(a or "?"), str(b or "?")])
+    return (str(scope or "-"), str(conversation or "-"), f"{lo}|{hi}")
+
+
+def _sweep(now: float, window: float) -> None:
+    """Drop buckets untouched for 10 windows so memory stays bounded."""
+    global _LAST_SWEEP
+    if now - _LAST_SWEEP < window:
+        return
+    _LAST_SWEEP = now
+    horizon = now - (window * 10)
+    for k in [k for k, dq in _EVENTS.items() if not dq or dq[-1] < horizon]:
+        _EVENTS.pop(k, None)
+        if _COOLDOWN.get(k, 0.0) < now:
+            _COOLDOWN.pop(k, None)
+
+
+def allow_bot_event(
+    scope: str,
+    conversation: str,
+    sender_bot: str,
+    receiver_bot: str,
+    *,
+    now: Optional[float] = None,
+) -> Tuple[bool, str]:
+    """Return (allowed, reason) for one inbound bot-authored message.
+
+    Call ONLY for messages authored by another bot, at the moment the message
+    is admitted. Human traffic must never reach this function.
+    """
+    if not _enabled():
+        return True, "guard-disabled"
+
+    max_events = _env_int("HERMES_BOT_LOOP_MAX_EVENTS", 20)
+    window = float(_env_int("HERMES_BOT_LOOP_WINDOW_SEC", 60))
+    cooldown = float(_env_int("HERMES_BOT_LOOP_COOLDOWN_SEC", 60))
+
+    t = time.monotonic() if now is None else now
+    k = _key(scope, conversation, sender_bot, receiver_bot)
+
+    with _LOCK:
+        _sweep(t, window)
+
+        until = _COOLDOWN.get(k, 0.0)
+        if until > t:
+            return False, f"cooldown:{until - t:.0f}s-left"
+
+        dq = _EVENTS.setdefault(k, deque())
+        cutoff = t - window
+        while dq and dq[0] < cutoff:
+            dq.popleft()
+
+        if len(dq) >= max_events:
+            _COOLDOWN[k] = t + cooldown
+            dq.clear()
+            return False, f"budget-exceeded:{max_events}/{window:.0f}s"
+
+        dq.append(t)
+        return True, f"ok:{len(dq)}/{max_events}"
+
+
+def loop_guard_state() -> dict:
+    """Snapshot for diagnostics."""
+    t = time.monotonic()
+    with _LOCK:
+        return {
+            "enabled": _enabled(),
+            "max_events": _env_int("HERMES_BOT_LOOP_MAX_EVENTS", 20),
+            "window_seconds": _env_int("HERMES_BOT_LOOP_WINDOW_SEC", 60),
+            "cooldown_seconds": _env_int("HERMES_BOT_LOOP_COOLDOWN_SEC", 60),
+            "tracked_pairs": len(_EVENTS),
+            "pairs": {
+                "|".join(k): len(dq) for k, dq in list(_EVENTS.items())[:20]
+            },
+            "cooling_down": {
+                "|".join(k): round(v - t, 1)
+                for k, v in _COOLDOWN.items()
+                if v > t
+            },
+        }
+
+
+def reset_loop_guard() -> None:
+    with _LOCK:
+        _EVENTS.clear()
+        _COOLDOWN.clear()

--- a/tests/gateway/test_bot_loop_guard.py
+++ b/tests/gateway/test_bot_loop_guard.py
@@ -1,0 +1,238 @@
+"""Bot-to-bot pair loop protection (Telegram Bot API 10.0).
+
+Telegram ships no loop guard of its own: core.telegram.org/api/bots/bot-to-bot
+requires the BOT to "make bot-message handling terminate predictably" via
+dedupe, rate limits and maximum interaction depth per sender/receiver pair.
+
+Every test here was verified FAILING against the tree without the guard
+(mutation-checked), which matters more than the count: exercising the real
+configuration is what makes them meaningful.  In particular they run with
+TELEGRAM_GROUP_ALLOWED_CHATS set, because that env var short-circuits
+_is_user_authorized with `return True` ~32 lines before the is_bot block --
+a guard placed in the is_bot block would never run for the one configuration
+that needs it, and a test without the allowlist would go green through a
+different code path.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.session import Platform, SessionSource
+
+GROUP_CHAT = "-1001234567890"
+OTHER_GROUP = "-1009876543210"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    for var in (
+        "TELEGRAM_ALLOW_BOTS",
+        "TELEGRAM_ALLOWED_USERS",
+        "TELEGRAM_ALLOW_ALL_USERS",
+        "TELEGRAM_GROUP_ALLOWED_USERS",
+        "TELEGRAM_GROUP_ALLOWED_CHATS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "HERMES_BOT_LOOP_PROTECTION",
+        "HERMES_BOT_LOOP_MAX_EVENTS",
+        "HERMES_BOT_LOOP_WINDOW_SEC",
+        "HERMES_BOT_LOOP_COOLDOWN_SEC",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    from gateway.bot_loop_guard import reset_loop_guard
+
+    reset_loop_guard()
+    yield
+    reset_loop_guard()
+
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    """Drive the guard's sliding window deterministically."""
+    from gateway import bot_loop_guard
+
+    state = {"t": 1_000_000.0}
+    monkeypatch.setattr(bot_loop_guard.time, "monotonic", lambda: state["t"])
+    return SimpleNamespace(
+        advance=lambda secs: state.__setitem__("t", state["t"] + secs),
+        now=lambda: state["t"],
+    )
+
+
+def _runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    return runner
+
+
+def _bot(user_id: str, chat_id: str = GROUP_CHAT) -> SessionSource:
+    """A fresh inbound bot message.
+
+    A new SessionSource per turn, mirroring production (each update builds its
+    own).  A hand-rolled stub does not work here: _is_user_authorized touches
+    delivered_via_upstream_relay and other real fields and blows up with
+    AttributeError.
+    """
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="group",
+        user_id=user_id,
+        user_name=f"Bot{user_id}",
+    )
+    source.is_bot = True
+    return source
+
+
+def _human(user_id: str = "100200300", chat_id: str = GROUP_CHAT, chat_type: str = "group") -> SessionSource:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name="Alice",
+    )
+    source.is_bot = False
+    return source
+
+
+def _real_config(monkeypatch, *, max_events="20"):
+    """The configuration that actually reproduces the incident."""
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "100200300")
+    # The short-circuit that makes guard placement matter.
+    monkeypatch.setenv("TELEGRAM_GROUP_ALLOWED_CHATS", f"{GROUP_CHAT},{OTHER_GROUP}")
+    monkeypatch.setenv("HERMES_BOT_LOOP_MAX_EVENTS", max_events)
+    monkeypatch.setenv("HERMES_BOT_LOOP_WINDOW_SEC", "60")
+    monkeypatch.setenv("HERMES_BOT_LOOP_COOLDOWN_SEC", "60")
+
+
+# --------------------------------------------------------------------------- 1
+
+
+def test_ping_pong_of_40_turns_is_cut_at_turn_21(monkeypatch, fake_clock):
+    """The incident, reduced: two bots replying to each other must terminate.
+
+    Observed 2026-08-21 in production: 132 messages between two Hermes profiles
+    in one group before a human intervened.  With a budget of 20 the 21st
+    inbound bot message must be suppressed.
+    """
+    _real_config(monkeypatch, max_events="20")
+    runner = _runner()
+
+    verdicts = []
+    for turn in range(40):
+        sender = "111111111" if turn % 2 == 0 else "222222222"
+        verdicts.append(runner._is_user_authorized(_bot(sender)))
+
+    assert verdicts[:20] == [True] * 20, "first 20 turns must pass"
+    assert verdicts[20] is False, "turn 21 must be suppressed"
+    assert not any(verdicts[20:]), "the exchange must not resume inside cooldown"
+
+
+# --------------------------------------------------------------------------- 2
+
+
+def test_human_in_same_group_still_authorized_during_cooldown(monkeypatch, fake_clock):
+    """The guard must never take the group down for people."""
+    _real_config(monkeypatch, max_events="20")
+    runner = _runner()
+
+    for turn in range(25):
+        runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222"))
+
+    assert runner._is_user_authorized(_bot("111111111")) is False, "precondition: bots are cooling down"
+    assert runner._is_user_authorized(_human()) is True
+    fake_clock.advance(5)
+    assert runner._is_user_authorized(_human()) is True
+
+
+# --------------------------------------------------------------------------- 3
+
+
+def test_human_dm_unaffected(monkeypatch, fake_clock):
+    """Human DMs never enter the guard at all."""
+    monkeypatch.setenv("TELEGRAM_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "100200300")
+    monkeypatch.setenv("HERMES_BOT_LOOP_MAX_EVENTS", "20")
+    runner = _runner()
+
+    for _ in range(50):
+        assert runner._is_user_authorized(_human(chat_id="123", chat_type="dm")) is True
+
+    from gateway.bot_loop_guard import loop_guard_state
+
+    assert loop_guard_state()["tracked_pairs"] == 0, "human traffic must not be metered"
+
+
+# --------------------------------------------------------------------------- 4
+
+
+def test_three_bots_in_one_group_share_a_single_budget(monkeypatch, fake_clock):
+    """Budget is keyed per CONVERSATION, not per (sender, receiver).
+
+    This process only sees inbound messages, so the receiver is a constant.
+    Keying on the pair would hand each sender its own budget, and N bots would
+    need N x budget messages to trip a guard meant to cap the whole exchange.
+    """
+    _real_config(monkeypatch, max_events="20")
+    runner = _runner()
+    senders = ["111111111", "222222222", "333333333"]
+
+    verdicts = [runner._is_user_authorized(_bot(senders[i % 3])) for i in range(30)]
+
+    assert verdicts[:20] == [True] * 20
+    assert not any(verdicts[20:]), "three bots must not get 3 x budget"
+
+
+# --------------------------------------------------------------------------- 5
+
+
+def test_other_group_has_its_own_budget(monkeypatch, fake_clock):
+    """One noisy group must not silence bots elsewhere."""
+    _real_config(monkeypatch, max_events="20")
+    runner = _runner()
+
+    for turn in range(25):
+        runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222"))
+    assert runner._is_user_authorized(_bot("111111111")) is False
+
+    assert runner._is_user_authorized(_bot("111111111", chat_id=OTHER_GROUP)) is True
+    assert runner._is_user_authorized(_bot("222222222", chat_id=OTHER_GROUP)) is True
+
+
+# --------------------------------------------------------------------------- 6
+
+
+def test_slow_traffic_never_blocks(monkeypatch, fake_clock):
+    """1 message / 10 s for 10 minutes: legitimate pace, zero false positives."""
+    _real_config(monkeypatch, max_events="20")
+    runner = _runner()
+
+    verdicts = []
+    for turn in range(60):
+        verdicts.append(runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222")))
+        fake_clock.advance(10)
+
+    assert all(verdicts), f"slow traffic blocked at index {verdicts.index(False) if not all(verdicts) else -1}"
+
+
+# --------------------------------------------------------------------------- 7
+
+
+def test_kill_switch_disables_the_guard(monkeypatch, fake_clock):
+    """HERMES_BOT_LOOP_PROTECTION=off restores the previous behaviour exactly."""
+    _real_config(monkeypatch, max_events="20")
+    monkeypatch.setenv("HERMES_BOT_LOOP_PROTECTION", "off")
+    runner = _runner()
+
+    verdicts = [
+        runner._is_user_authorized(_bot("111111111" if turn % 2 == 0 else "222222222"))
+        for turn in range(40)
+    ]
+
+    assert all(verdicts), "kill switch must suppress the guard entirely"


### PR DESCRIPTION
Fixes #91481

## What this changes

Adds a sliding-window loop guard for bot-authored traffic, so bot-to-bot exchanges terminate on their own instead of running until a human notices.

- **New** `gateway/bot_loop_guard.py` — thread-safe sliding window + cooldown, with sweeping of stale buckets so memory stays bounded. API: `allow_bot_event(scope, conversation, sender_bot, receiver_bot) -> (bool, reason)`, plus `loop_guard_state()` and `reset_loop_guard()` for diagnostics and tests.
- **Modified** `gateway/authz_mixin.py` — one block in `_is_user_authorized` that consults the guard on the bot branch.
- **New** `tests/gateway/test_bot_loop_guard.py` — 7 cases.

Defaults match the OpenClaw reference implementation (`docs.openclaw.ai/channels/bot-loop-protection`), which solves the same problem on Discord, Slack, Matrix, Feishu and Google Chat:

| Env var | Default | Meaning |
|---|---|---|
| `HERMES_BOT_LOOP_PROTECTION` | `on` | kill switch (`off`/`false`/`0`/`no`/`disabled`) |
| `HERMES_BOT_LOOP_MAX_EVENTS` | `20` | bot messages allowed per window, per conversation |
| `HERMES_BOT_LOOP_WINDOW_SEC` | `60` | sliding window size |
| `HERMES_BOT_LOOP_COOLDOWN_SEC` | `60` | suppression period after the budget is exceeded |

## Why

Telegram Bot API 10.0 ships no loop guard, and `core.telegram.org/api/bots/bot-to-bot` explicitly makes it the bot's job — dedupe, per-chat rate limits, maximum interaction depth — warning that *"failure to handle loops properly may lead to degraded performance or platform restrictions."* Hermes had a bare `return True` on that path. Full incident write-up in #91481 (132 messages between two profiles in one group).

Worth stating because it looks like the existing answer: **`TELEGRAM_ALLOW_BOTS=mentions` does not prevent the loop.** When bot A replies to bot B, the reply satisfies the mention test, so each turn re-arms the peer. `mentions` is admission policy; it filters third-party noise, not mutual feedback.

## Two details a reviewer would reasonably get wrong

Calling these out because both were found the hard way, and the obvious implementation gets both backwards.

**1. Ordering — the guard must run *before* the group-allowlist shortcut.**

`TELEGRAM_GROUP_ALLOWED_CHATS` does `return True` for *any* sender in an allowlisted chat, bots included, roughly 32 lines before the `is_bot` block. Putting the guard in the `is_bot` block — the obvious place — means it never runs in the exact configuration that needs it: an allowlisted group with two bots in it. The first version of this patch did precisely that and looked fine until traced. Hence the placement near the top of the method, with a comment at the old site pointing back.

**2. Key by conversation, not by `(sender, receiver)` pair.**

This process only ever sees *inbound* messages, so the receiver side is a constant (our own profile). Keying on the pair gives every distinct sender its own budget, and N bots in one group then need N × budget messages to trip a guard that is supposed to cap the whole exchange. An early version keyed by pair and a 40-turn ping-pong sailed straight through, because alternating the sender created two buckets. The guard keys on `(scope, conversation)` and uses a fixed sentinel on both sides; the pair key is order-independent so A→B and B→A collapse into one bucket.

## Compatibility

**Installations that do not set `ALLOW_BOTS` are byte-identical in behaviour.** The guard only executes on the `source.is_bot` branch with `ALLOW_BOTS` set to `mentions` or `all`; anything else never reaches it. Human traffic never enters the guard — verified by a test asserting `tracked_pairs == 0` after 50 human DMs. `HERMES_BOT_LOOP_PROTECTION=off` is a complete kill switch. The import is local and wrapped in `try/except ImportError`, so a partial deployment degrades to the old behaviour rather than breaking admission.

One incidental note: `authz_mixin.py` has no module-scope `logger`, so the block uses `logging.getLogger(__name__)` inside a `try/except`. A bare `logger.warning` there raises `NameError` *only on the blocking path*, i.e. exactly when the guard fires.

## Tests

7 cases in `tests/gateway/test_bot_loop_guard.py`, run against the **real** configuration with `TELEGRAM_GROUP_ALLOWED_CHATS` enabled — without it the tests pass through a different branch and give a false green. Each turn builds a fresh `SessionSource` as production does; a hand-rolled stub is not usable here since `_is_user_authorized` touches `delivered_via_upstream_relay` and other real fields.

1. 40-turn ping-pong is cut at turn 21 (budget 20)
2. a human in the same group stays authorized during the bot cooldown
3. human DMs are untouched and never metered
4. 3 bots in one group share a single budget
5. a different group has its own budget
6. slow traffic (1 msg / 10 s × 60) is never blocked — no false positives
7. `HERMES_BOT_LOOP_PROTECTION=off` disables the guard entirely

**Every test was verified failing without the fix**, which I consider more informative than the count. Four (1, 2, 4, 5) fail directly against unpatched `authz_mixin.py`. The other three assert the *absence* of blocking, so they cannot fail against a tree with no guard at all; each was instead verified against a targeted mutation:

- #3 — removing the `is_bot` condition so the guard meters humans → fails with `budget-exceeded:20/60s` for a human user
- #6 — disabling window expiry so old events never leave the window → fails with `cooldown:30s-left`
- #7 — making `_enabled()` return `True` unconditionally → fails with `cooldown:60s-left`

Doing this pass caught a decorative assertion in my own draft, which is the argument for it.

```
$ venv/Scripts/python.exe -m pytest tests/gateway/test_bot_loop_guard.py -v
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
collected 7 items

tests/gateway/test_bot_loop_guard.py::test_ping_pong_of_40_turns_is_cut_at_turn_21 PASSED [ 14%]
tests/gateway/test_bot_loop_guard.py::test_human_in_same_group_still_authorized_during_cooldown PASSED [ 28%]
tests/gateway/test_bot_loop_guard.py::test_human_dm_unaffected PASSED    [ 42%]
tests/gateway/test_bot_loop_guard.py::test_three_bots_in_one_group_share_a_single_budget PASSED [ 57%]
tests/gateway/test_bot_loop_guard.py::test_other_group_has_its_own_budget PASSED [ 71%]
tests/gateway/test_bot_loop_guard.py::test_slow_traffic_never_blocks PASSED [ 85%]
tests/gateway/test_bot_loop_guard.py::test_kill_switch_disables_the_guard PASSED [100%]

============================== 7 passed in 4.44s ==============================
```

No regressions in the neighbouring authorization suites:

```
$ venv/Scripts/python.exe -m pytest tests/gateway/test_telegram_bot_auth_bypass.py \
    tests/gateway/test_discord_bot_auth_bypass.py tests/gateway/test_slack_bot_auth_bypass.py \
    tests/gateway/test_feishu_bot_auth_bypass.py tests/gateway/test_feishu_bot_admission.py \
    tests/gateway/test_discord_bot_filter.py tests/gateway/test_multiplex_profile_authz.py \
    tests/gateway/test_relay_upstream_authz.py tests/gateway/test_slack_wake_external_bot_messages.py \
    tests/gateway/test_bot_loop_guard.py -q
49 passed in 3.81s
```

All runs are from a clean `--shared` clone of the branch, not from the working checkout, which confirms the patch is self-contained.

## Production behaviour

Running on two profiles since 2026-08-21 with a tighter config (8 / 60 s / 120 s — only two bots in that group). On the retest, 45 messages were suppressed, with the log showing the budget trip followed by a decreasing cooldown:

```
WARNING gateway.authz_mixin: Bot-to-bot loop guard suppressed message from <id> in <chat> (budget-exceeded:8/60s)
WARNING gateway.authz_mixin: ... (cooldown:116s-left)
WARNING gateway.authz_mixin: ... (cooldown:70s-left)
WARNING gateway.authz_mixin: ... (cooldown:44s-left)
WARNING gateway.authz_mixin: ... (cooldown:20s-left)
```

Happy to adjust naming, defaults, or the placement comment if you'd prefer a different shape. If you'd rather have this generalized across Discord/Slack/Feishu in the same PR, say so — the guard module is platform-agnostic already and the call site is the only Telegram-specific part.
