### PR TITLE
fix(tools): exclude delegated child and cron session markers from terminal snapshots

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -405,3 +405,19 @@ class TestCwdMarker:
         env1 = _TestableEnv()
         env2 = _TestableEnv()
         assert env1._cwd_marker != env2._cwd_marker
+
+
+class TestSnapshotExcludeDelegatedAndCronSession:
+    """Regression for #90782: terminal snapshot must exclude per-session lifecycle markers."""
+
+    def test_export_dump_unsets_delegated_and_cron_session_markers(self):
+        from tools.environments.base import (
+            _export_dump_excluding_session_vars,
+            _SNAPSHOT_EXCLUDED_ENV_REGEX,
+        )
+
+        dump = _export_dump_excluding_session_vars("/tmp/snap.tmp")
+        assert "HERMES_DELEGATED_CHILD_CONTEXT" in dump
+        assert "HERMES_CRON_SESSION" in dump
+        assert "HERMES_DELEGATED_CHILD_CONTEXT" in _SNAPSHOT_EXCLUDED_ENV_REGEX
+        assert "HERMES_CRON_SESSION" in _SNAPSHOT_EXCLUDED_ENV_REGEX

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -530,7 +530,7 @@ def _cwd_marker(session_id: str) -> str:
 # name/prefix instead of grepping declare lines (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
     "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|"
-    "HERMES_CRON_SESSION|HERMES_BROWSER_CONTROL_)"
+    "HERMES_CRON_SESSION|HERMES_BROWSER_CONTROL_|HERMES_DELEGATED_CHILD_CONTEXT)"
 )
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -582,6 +582,7 @@ def _export_dump_excluding_session_vars(
         # harness value arriving via the process env, exactly like the
         # session-var leak this dump already guards against.
         "AI_AGENT HERMES_AGENT "
+        "HERMES_DELEGATED_CHILD_CONTEXT HERMES_CRON_SESSION "
         f"HERMES_UI_SESSION_ID{extra_unset} 2>/dev/null; "
         "export -p; "
         ") || true; } "


### PR DESCRIPTION
## What does this PR do?

Unsets `HERMES_DELEGATED_CHILD_CONTEXT` and `HERMES_CRON_SESSION` before dumping `export -p` in `_export_dump_excluding_session_vars`.

When a session runs `delegate_task`, `HERMES_DELEGATED_CHILD_CONTEXT=1` is injected into the subprocess environment. Previously, the terminal environment snapshot persisted this variable. Subsequent commands in the parent session sourced this snapshot and inherited the marker, causing `hermes kanban` operations to fail with `delegate_task child contexts cannot mutate Kanban tasks or boards`.

## Related Issue

Fixes #90782

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/base.py`: Added `HERMES_DELEGATED_CHILD_CONTEXT` and `HERMES_CRON_SESSION` to the unset list in `_export_dump_excluding_session_vars()` and updated `_SNAPSHOT_EXCLUDED_ENV_REGEX`.
- `tests/tools/test_base_environment.py`: Added regression test `TestSnapshotExcludeDelegatedAndCronSession`.

## How to Test

1. Run `pytest tests/tools/test_base_environment.py -k "TestSnapshotExcludeDelegatedAndCronSession" -v`
2. Verify that environment dump scripts unset `HERMES_DELEGATED_CHILD_CONTEXT` and `HERMES_CRON_SESSION`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A