### PR TITLE
fix(gateway): protect blockquotes before bold conversion in telegram adapter

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -481,6 +481,11 @@ def _strip_mdv2(text: str) -> str:
     """
     # Remove escape backslashes before special characters
     cleaned = re.sub(r'\\([_*\[\]()~`>#\+\-=|{}.!\\])', r'\1', text)
+    # Remove blockquote / expandable blockquote markers (> or **> at line start)
+    # before bold conversion so that **> is not eaten by **bold** regex.
+    cleaned = re.sub(r'(?m)^(?:\*\*)?>{1,3}\s?', '', cleaned)
+    # Remove standalone trailing || from expandable blockquote closer
+    cleaned = re.sub(r'(?m)\|\|$', '', cleaned)
     # Remove standard markdown bold (**text** → text) BEFORE MarkdownV2 bold
     cleaned = re.sub(r'\*\*([^*]+)\*\*', r'\1', cleaned)
     # Remove MarkdownV2 bold markers that format_message converted from **bold**
@@ -8392,37 +8397,7 @@ class TelegramAdapter(BasePlatformAdapter):
             r'^#{1,6}\s+(.+)$', _convert_header, text, flags=re.MULTILINE
         )
 
-        # 5) Convert bold: **text** → *text* (MarkdownV2 bold)
-        text = re.sub(
-            r'\*\*(.+?)\*\*',
-            lambda m: _ph(f'*{_escape_mdv2(m.group(1))}*'),
-            text,
-        )
-
-        # 6) Convert italic: *text* (single asterisk) → _text_ (MarkdownV2 italic)
-        #    [^*\n]+ prevents matching across newlines (which would corrupt
-        #    bullet lists using * markers and multi-line content).
-        text = re.sub(
-            r'\*([^*\n]+)\*',
-            lambda m: _ph(f'_{_escape_mdv2(m.group(1))}_'),
-            text,
-        )
-
-        # 7) Convert strikethrough: ~~text~~ → ~text~ (MarkdownV2)
-        text = re.sub(
-            r'~~(.+?)~~',
-            lambda m: _ph(f'~{_escape_mdv2(m.group(1))}~'),
-            text,
-        )
-
-        # 8) Convert spoiler: ||text|| → ||text|| (protect from | escaping)
-        text = re.sub(
-            r'\|\|(.+?)\|\|',
-            lambda m: _ph(f'||{_escape_mdv2(m.group(1))}||'),
-            text,
-        )
-
-        # 9) Convert blockquotes: > at line start → protect > from escaping
+        # 5) Convert blockquotes: > at line start → protect > and **> from escaping & bold conversion
         #    Handle both regular blockquotes (> text) and expandable blockquotes
         #    (Telegram MarkdownV2: **> for expandable start, || to end the quote)
         def _convert_blockquote(m):
@@ -8431,14 +8406,44 @@ class TelegramAdapter(BasePlatformAdapter):
             # Check if content ends with || (expandable blockquote end marker)
             # In this case, preserve the trailing || unescaped for Telegram
             if prefix.startswith('**') and content.endswith('||'):
-                return _ph(f'{prefix} {_escape_mdv2(content[:-2])}||')
-            return _ph(f'{prefix} {_escape_mdv2(content)}')
+                return f"{_ph(prefix)} {content[:-2]}{_ph('||')}"
+            return f"{_ph(prefix)} {content}"
 
         text = re.sub(
             r'^((?:\*\*)?>{1,3}) (.+)$',
             _convert_blockquote,
             text,
             flags=re.MULTILINE,
+        )
+
+        # 6) Convert bold: **text** → *text* (MarkdownV2 bold)
+        text = re.sub(
+            r'\*\*(.+?)\*\*',
+            lambda m: _ph(f'*{_escape_mdv2(m.group(1))}*'),
+            text,
+        )
+
+        # 7) Convert italic: *text* (single asterisk) → _text_ (MarkdownV2 italic)
+        #    [^*\n]+ prevents matching across newlines (which would corrupt
+        #    bullet lists using * markers and multi-line content).
+        text = re.sub(
+            r'\*([^*\n]+)\*',
+            lambda m: _ph(f'_{_escape_mdv2(m.group(1))}_'),
+            text,
+        )
+
+        # 8) Convert strikethrough: ~~text~~ → ~text~ (MarkdownV2)
+        text = re.sub(
+            r'~~(.+?)~~',
+            lambda m: _ph(f'~{_escape_mdv2(m.group(1))}~'),
+            text,
+        )
+
+        # 9) Convert spoiler: ||text|| → ||text|| (protect from | escaping)
+        text = re.sub(
+            r'\|\|(.+?)\|\|',
+            lambda m: _ph(f'||{_escape_mdv2(m.group(1))}||'),
+            text,
         )
 
         # 10) Escape remaining special characters in plain text

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -288,6 +288,15 @@ class TestFormatMessageBlockquote:
         assert "\\|" in result
         assert "\\>" not in result
 
+    def test_expandable_blockquote_with_nested_bold_at_start(self, adapter):
+        """Regression for #90773: **> expandable blockquote with nested **bold**."""
+        text = "**> **Action Plan for Health** 1. **Health Shag Area Skill** - do the thing||"
+        result = adapter.format_message(text)
+        assert result.startswith("**>")
+        assert result.endswith("||")
+        assert "*Action Plan for Health*" in result
+        assert "*Health Shag Area Skill*" in result
+
 
 # =========================================================================
 # format_message - mixed/complex
@@ -334,6 +343,12 @@ class TestStripMdv2:
 
     def test_plain_text_unchanged(self):
         assert _strip_mdv2("plain text") == "plain text"
+
+    def test_strips_blockquote_and_expandable_markers(self):
+        """Regression for #90773: _strip_mdv2 removes > and **> prefixes and trailing ||."""
+        assert _strip_mdv2("> standard blockquote") == "standard blockquote"
+        assert _strip_mdv2("**> expandable blockquote||") == "expandable blockquote"
+        assert _strip_mdv2("**> **Bold Title** content||") == "Bold Title content"
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Ensures blockquotes and expandable blockquotes (`**>`) are protected before bold/italic conversions run in Telegram's `format_message()`, and updates `_strip_mdv2()` to clean blockquote syntax before bold stripping.

Previously, generic bold regex `\*\*(.+?)\*\*` ran before step 9's blockquote detection. When an expandable blockquote began with bold text (e.g. `**> **Heading** details||`), the bold regex matched across the opening `**` of `**>` to the first `**` of the inner bold text, destroying the `**>` opener.

## Related Issue

Fixes #90773

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`:
  - Reordered blockquote conversion in `format_message()` to run before bold/italic/strikethrough/spoiler conversions, protecting the `**>` prefix and trailing `||` behind placeholders.
  - Updated `_strip_mdv2()` to remove leading blockquote prefixes (`^(?:\*\*)?>{1,3}\s?`) and trailing `||` before bold stripping.
- `tests/gateway/test_telegram_format.py`:
  - Added test for expandable blockquote with nested bold at start in `TestFormatMessageBlockquote`.
  - Added test for blockquote and expandable marker stripping in `TestStripMdv2`.

## How to Test

1. Run `pytest tests/gateway/test_telegram_format.py -v`
2. Verify that `test_expandable_blockquote_with_nested_bold_at_start` and `test_strips_blockquote_and_expandable_markers` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A