### PR TITLE
fix(desktop): add placeholder for SSH identity file setting

### DIFF
--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -1413,6 +1413,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
               <Input
                 className={cn('h-8 font-mono', CONTROL_TEXT)}
                 onChange={event => setState(current => ({ ...current, sshKeyPath: event.target.value }))}
+                placeholder={g.sshKeyPlaceholder}
                 value={state.sshKeyPath}
               />
             }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -887,6 +887,7 @@ export const en: Translations = {
       sshPortDesc: 'Blank = 22 or the ~/.ssh/config port.',
       sshKeyTitle: 'Identity file',
       sshKeyDesc: 'Private key path. Blank = ssh-agent or ~/.ssh/config.',
+      sshKeyPlaceholder: 'from ssh-agent or ~/.ssh/config',
       sshHermesPathTitle: 'Hermes path (optional)',
       sshHermesPathDesc: 'Full path to the remote hermes binary. Blank = auto-detect.',
       sshHermesPathPlaceholder: 'auto-detect',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -836,6 +836,7 @@ export const ja = defineLocale({
       sshPortDesc: '空欄 = 22 または ~/.ssh/config のポート。',
       sshKeyTitle: '鍵ファイル',
       sshKeyDesc: '秘密鍵のパス。空欄 = ssh-agent または ~/.ssh/config。',
+      sshKeyPlaceholder: 'ssh-agent または ~/.ssh/config から',
       sshHermesPathTitle: 'Hermes パス（任意）',
       sshHermesPathDesc: 'リモートの hermes バイナリへのフルパス。空欄 = 自動検出。',
       sshHermesPathPlaceholder: '自動検出',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -761,6 +761,7 @@ export interface Translations {
       sshPortDesc: string
       sshKeyTitle: string
       sshKeyDesc: string
+      sshKeyPlaceholder: string
       sshHermesPathTitle: string
       sshHermesPathDesc: string
       sshHermesPathPlaceholder: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -813,6 +813,7 @@ export const zhHant = defineLocale({
       sshPortDesc: '留空 = 22 或 ~/.ssh/config 中的連接埠。',
       sshKeyTitle: '金鑰檔案',
       sshKeyDesc: '私密金鑰路徑。留空 = ssh-agent 或 ~/.ssh/config。',
+      sshKeyPlaceholder: '來自 ssh-agent 或 ~/.ssh/config',
       sshHermesPathTitle: 'Hermes 路徑（選用）',
       sshHermesPathDesc: '遠端 hermes 執行檔的完整路徑。留空 = 自動偵測。',
       sshHermesPathPlaceholder: '自動偵測',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1088,6 +1088,7 @@ export const zh: Translations = {
       sshPortDesc: '留空 = 22 或 ~/.ssh/config 中的端口。',
       sshKeyTitle: '密钥文件',
       sshKeyDesc: '私钥路径。留空 = ssh-agent 或 ~/.ssh/config。',
+      sshKeyPlaceholder: '来自 ssh-agent 或 ~/.ssh/config',
       sshHermesPathTitle: 'Hermes 路径（可选）',
       sshHermesPathDesc: '远程 hermes 可执行文件的完整路径。留空 = 自动检测。',
       sshHermesPathPlaceholder: '自动检测',


### PR DESCRIPTION
## What does this PR do?

Adds `placeholder={g.sshKeyPlaceholder}` to the SSH Identity file input in Gateway Settings, with corresponding localized placeholder strings across `en`, `ja`, `zh`, and `zh-hant`.

Previously, the Identity file input lacked a placeholder (unlike host, user, port, and hermes path inputs), causing empty or stale values to be easily misinterpreted as configured defaults.

This is intentionally limited to the missing blank-state cue. It does not address the separate stale persisted `keyPath` behavior also tracked in #90811.

## Related Issue

Partially addresses #90811

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/settings/gateway-settings.tsx`: Passed `placeholder={g.sshKeyPlaceholder}` to the `sshKeyPath` `Input` component.
- `apps/desktop/src/i18n/types.ts`: Added `sshKeyPlaceholder` field to `GatewaySettings` i18n interface.
- `apps/desktop/src/i18n/en.ts`, `ja.ts`, `zh.ts`, `zh-hant.ts`: Added translated `sshKeyPlaceholder` strings.

## How to Test

1. Open Desktop Gateway Settings in SSH mode.
2. Observe that when the Identity file input is empty, the placeholder (`from ssh-agent or ~/.ssh/config`) is clearly shown.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A