### PR TITLE
fix(tui_gateway): validate profile parameter in _profile_home against traversal

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -19830,3 +19830,12 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
     assert captured["row_update"] == (target, str(new_cwd))
     assert live["cwd"] == str(new_cwd)
     assert live.get("explicit_cwd") is True
+
+
+def test_profile_home_rejects_path_traversal_and_invalid_names():
+    """Regression for #90699: _profile_home must validate profile names to prevent traversal."""
+    assert server._profile_home("../../outside") is None
+    assert server._profile_home("/etc") is None
+    assert server._profile_home("..") is None
+    assert server._profile_home("foo/bar") is None
+    assert server._profile_home("invalid*name") is None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1528,7 +1528,9 @@ def _profile_home(profile: str | None) -> Path | None:
     try:
         from hermes_cli import profiles as profiles_mod
 
-        home = Path(profiles_mod.get_profile_dir(name))
+        canon = profiles_mod.normalize_profile_name(name)
+        profiles_mod.validate_profile_name(canon)
+        home = Path(profiles_mod.get_profile_dir(canon))
     except Exception:
         return None
     # Already the launch profile? No override needed.


### PR DESCRIPTION
## What does this PR do?

Normalizes and validates the `profile` parameter in `tui_gateway.server._profile_home` using `profiles_mod.normalize_profile_name()` and `profiles_mod.validate_profile_name()`.

Previously, `_profile_home` directly passed the raw profile name string to `profiles_mod.get_profile_dir()` without validation. Malformed inputs containing path traversals (e.g. `../../outside`) or absolute paths could escape the profiles root directory.

## Related Issue

Fixes #90699

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: Added `normalize_profile_name(name)` and `validate_profile_name(canon)` checks inside `_profile_home(profile)`.
- `tests/test_tui_gateway_server.py`: Added regression test `test_profile_home_rejects_path_traversal_and_invalid_names`.

## How to Test

1. Run `pytest tests/test_tui_gateway_server.py -k "test_profile_home_rejects_path_traversal_and_invalid_names" -v`
2. Verify that traversal paths (such as `../../outside`, `/etc`, `foo/bar`) return `None` from `_profile_home`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A