### PR TITLE
feat(desktop): introduce plugin i18n for Bot Mode (en bundle, no behavior change)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -42,8 +42,6 @@ const BOTS_EN = {
     newGroupChat: 'New Group Chat',
     pinnedTip: 'Pinned',
     hiddenTip: 'Hidden from the roster',
-    pinStayHint: handle =>
-      `Stay in this chat and @${handle} to message them. Gateway stays on this device.`,
     pinToggle: (name, pinned) => `${name} ${pinned ? 'unpinned' : 'pinned to top'}`,
     waitingGateway:
       'Waiting for the gateway connection… (remote gateways can take a few seconds; retries automatically)',
@@ -55,6 +53,11 @@ const BOTS_EN = {
     deleteConfirm: 'Delete',
     deleting: 'Deleting…',
     noAgentsYet: 'No bots yet',
+    emptyStateDescription: 'Create your first bot.',
+    searchBotsAria: 'Search bots and group chats',
+    searchBotsPlaceholder: 'Search bots and group chats…',
+    rosterUnavailable: message =>
+      `Roster unavailable: ${message}. If your gateway predates profiles.list, update Hermes and restart the gateway.`,
   },
   create: {
     title: 'New Bot',
@@ -94,6 +97,7 @@ const BOTS_EN = {
     createAgent: 'Create Bot',
     creating: 'Creating…',
     draftDiscarded: draft => `Draft agent "${draft}" discarded`,
+    draftCleanupFailed: draft => `Could not clean up draft profile "${draft}"`,
     defaultToolsetNote:
       'Leaving all (or none) checked keeps the default toolset behavior.',
   },
@@ -135,6 +139,10 @@ const BOTS_EN = {
     duplicateFailed: 'Duplicate failed',
     newChat: 'New chat with this agent',
     delete: 'Delete',
+    // Sibling menu item of the pin/unpin toast (pane.pinToggle) — both flip
+    // together on the same bot state.
+    pin: 'Pin to top',
+    unpin: 'Unpin',
   },
   composer: {
     neverResetsTitle: 'This chat never resets',
@@ -145,10 +153,50 @@ const BOTS_EN = {
     cancel: 'Cancel',
     save: 'Save',
     saving: 'Saving…',
+    deleted: 'Deleted',
   },
 }
 
 const BOTS_LOCALES = { en: BOTS_EN }
+
+// TODO(i18n sweep, out of scope for this first en bundle — these still
+// hardcode English and move into the bundle when the zh locale lands):
+//  - group activity feed (GROUP_ACTIVITY_LABELS + `did something` fallback)
+//  - inbound-activity toasts (`🫆 New message for ${…}` / `${…} has new
+//    activity` / `Open the chat to see it.`)
+//  - connection failures (`Could not reach ${…}`, `Could not open ${…} chat —
+//    try again`, roster-render copies included)
+//  - canonical-chat/session titles + cross-machine notices (`Bot Chat`,
+//    `Agent Inbox`, `Hey, tell me about yourself!`, `This Hermes Desktop
+//    version cannot open stored sessions`, `Still on ${…} …`, `No remote
+//    session`, `Messaged @… will relay …`)
+//  - avatar/face editor (lock/unlock, `Describe your avatar…`, generation
+//    errors, pet picker, image-too-large toasts)
+//  - cron/Routines UI (job editor, schedule summaries, `Untitled cronjob`,
+//    `Could not refresh/load cronjobs. …`, paused-for-security notice)
+//  - group chat UI (disband dialog, room header/footer, thread actions,
+//    activity view, member search `Search bots to add…`, group settings,
+//    clarify/answer cards)
+//  - roster rows + Active-Now strip (`Working on a task right now`,
+//    `Last message came from @…`, `Lives on ${…}`, stale-roster notices)
+//  - empty/filter states (`No bots match “…”`, `All bots are hidden …`,
+//    `No conversations yet — say hi`)
+//  - MCP/capabilities setup UI (`Could not add server`, `Could not start
+//    OAuth`, catalog notes, install toasts) + `Could not create the agent.`
+//  - model/provider + connection pickers and hub browser controls
+//    (`← Back to dropdowns`, `✏️ Enter manually…`, `e.g. model name`,
+//    `${connection.label} (current)`, `hide the hub browser`, install rows)
+//  - mention-completion rows (`Bot · ${display}${source}`, ` · ${label}`)
+//  - misc toasts (`Deleted profile …`, `Deleted group “…”`, duplicate/delete
+//    errors like `No free name for the duplicate.`, `can't delete a bot`,
+//    `Could not delete profile ${…}.`, group name-collision, pet failures)
+//  - palette/command copy (`New Agent…` label + hint, `@<bot> do the thing`)
+//  - static contribution metadata is ALREADY sourced from BOTS_EN
+//    (export name/description); the pane/palette `title: 'Bots'`,
+//    `title: 'Cronjobs'` registrations are the same static-metadata case.
+//  - SOUL.md protocol + @-mention handoff PROMPT text and avatar/group-picture
+//    image-generation prompts (model-facing, not UI) are deliberately
+//    excluded from UI localization — a separate decision.
 
 function bindBotsText(t, template, prefix = '') {
   const out = {}
@@ -173,7 +221,13 @@ function useBots() {
       ? sdk.usePluginI18n
       : null
   if (!usePluginI18n) return BOTS_EN
-  return bindBotsText(usePluginI18n('hermes-bots'), BOTS_EN)
+  const t = usePluginI18n('hermes-bots')
+  // Memoize the bound wrapper tree on the translator identity. The SDK keeps
+  // `t` stable per (plugin, locale, registry version), so the tree rebuilds
+  // only on a real locale switch or (re)registration — not on every render
+  // of every Bot component. Fresh function identities per render would loop
+  // any future useEffect(..., [k.pane.pinToggle]) pattern.
+  return useMemo(() => bindBotsText(t, BOTS_EN), [t])
 }
 
 import {
@@ -8217,7 +8271,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
                 })
               }).catch(error => host.notifyError?.(error, 'Could not load bot metadata'))
             },
-            children: pinned ? 'Unpin' : 'Pin to top'
+            children: pinned ? k.menu.unpin : k.menu.pin
           }),
           jsx(ContextMenuItem, {
             onSelect: () => {
@@ -9444,7 +9498,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
       : deleteBot({ name: draft })
     void Promise.resolve(discard)
       .then(() => host.notify({ kind: 'success', message: k.create.draftDiscarded(draft) }))
-      .catch(err => host.notifyError(err, `Could not clean up draft profile "${draft}"`))
+      .catch(err => host.notifyError(err, k.create.draftCleanupFailed(draft)))
   }
 
   const reset = () => {
@@ -14162,14 +14216,14 @@ function BotsPane() {
                 ? jsx(
                     SearchField,
                     {
-                      'aria-label': 'Search bots and group chats',
+                      'aria-label': k.pane.searchBotsAria,
                       containerClassName: cn(
                         'min-w-0 flex-1',
                         query ? 'opacity-100!' : 'opacity-50 focus-within:opacity-100'
                       ),
                       inputClassName:
                         'w-full text-[0.75rem] placeholder:text-(--ui-text-tertiary)',
-                      placeholder: 'Search bots and group chats…',
+                      placeholder: k.pane.searchBotsPlaceholder,
                       value: query,
                       onChange: setQuery
                     },
@@ -14318,7 +14372,7 @@ function BotsPane() {
               children: [
                 jsx('div', {
                   children: gatewayUp
-                    ? `Roster unavailable: ${error instanceof Error ? error.message : 'gateway error'}. If your gateway predates profiles.list, update Hermes and restart the gateway.`
+                    ? k.pane.rosterUnavailable(error instanceof Error ? error.message : 'gateway error')
                     : k.pane.waitingGateway
                 }),
                 jsx(Button, {
@@ -14334,7 +14388,7 @@ function BotsPane() {
             ? jsx(EmptyState, {
                 icon: 'hubot',
                 title: k.pane.noAgentsYet,
-                description: 'Create your first bot.'
+                description: k.pane.emptyStateDescription
               })
             : allBotsHidden && !hiddenExpanded
               ? jsxs('div', {
@@ -14477,7 +14531,7 @@ function BotsPane() {
         destructive: true,
         confirmLabel: k.pane.deleteConfirm,
         busyLabel: k.pane.deleting,
-        doneLabel: 'Deleted',
+        doneLabel: k.common.deleted,
         onClose: () => setDeleting(null),
         onConfirm: async () => {
           if (!deleting) {
@@ -14499,7 +14553,7 @@ function BotsPane() {
         destructive: true,
         confirmLabel: 'Delete Group',
         busyLabel: 'Deleting…',
-        doneLabel: 'Deleted',
+        doneLabel: k.common.deleted,
         onClose: () => setDeletingGroup(null),
         onConfirm: async () => {
           if (!deletingGroup) return
@@ -14515,8 +14569,13 @@ function BotsPane() {
 
 export default {
   id: ID,
-  name: 'Bots',
-  description: 'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.',
+  // Static plugin metadata is read by the host at plugin load — before any
+  // translator exists — so name/description stay sourced from the en
+  // template's canonical strings rather than a t() call. A localized
+  // description would need host-side metadata resolution (out of scope for
+  // this bundle); pulling from BOTS_EN keeps ONE canonical copy.
+  name: BOTS_EN.pluginName,
+  description: BOTS_EN.pluginDescription,
   register(ctx) {
     pluginCtx = ctx
     // Older hosts without plugin i18n (pre-#67303) must not crash here:

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -16,6 +16,166 @@
  */
 
 import * as sdk from '@hermes/plugin-sdk'
+
+// ── plugin i18n (inline — plugin.js is the single-file bundle) ─────────────
+// Mirrors the core plugin-i18n contract (#67303): bundles register under the
+// plugin id at load, components bind the en template through the SDK
+// translator. En lives inline because the direct-file plugin loader (and the
+// .mjs test harness) evaluates plugin.js alone — no sibling imports.
+
+const BOTS_EN = {
+  pluginName: 'Bots',
+  pluginDescription:
+    'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.',
+  pane: {
+    title: 'Bots',
+    activityToastsOn: 'Activity toasts on — click to silence',
+    activityToastsOff: 'Activity toasts off — click to enable',
+    showHiddenBots: n => `Show ${n} hidden bot${n === 1 ? '' : 's'}`,
+    hideHiddenBotsAgain: 'Hide hidden bots again',
+    hideHiddenBotsAria: 'Hide hidden bots',
+    showHiddenBotsAria: 'Show hidden bots',
+    hiddenUnreadAria: 'a hidden bot has unread activity',
+    newMenuTip: 'New…',
+    newMenuAria: 'New bot or group chat',
+    newAgent: 'New Bot',
+    newGroupChat: 'New Group Chat',
+    pinnedTip: 'Pinned',
+    hiddenTip: 'Hidden from the roster',
+    pinStayHint: handle =>
+      `Stay in this chat and @${handle} to message them. Gateway stays on this device.`,
+    pinToggle: (name, pinned) => `${name} ${pinned ? 'unpinned' : 'pinned to top'}`,
+    waitingGateway:
+      'Waiting for the gateway connection… (remote gateways can take a few seconds; retries automatically)',
+    retryNow: 'Retry now',
+    deleteBotTitle: 'Delete bot and profile?',
+    deleteBotDescPrefix: 'This will permanently delete the bot ',
+    deleteBotDescMid: ' and its associated Hermes profile at ',
+    deleteBotDescSuffix: '. This cannot be undone.',
+    deleteConfirm: 'Delete',
+    deleting: 'Deleting…',
+    noAgentsYet: 'No bots yet',
+  },
+  create: {
+    title: 'New Bot',
+    description:
+      'A named teammate with its own memory, skills, and chat. It can message your other agents.',
+    name: 'Name',
+    namePlaceholder: 'inbox-triage',
+    titleField: 'Title',
+    titlePlaceholder: 'Inbox Triage',
+    descriptionField: 'Description',
+    descriptionPlaceholder: 'What should this Bot help with?',
+    createOn: 'Create on',
+    createOnNote: target =>
+      `The agent is created on ${target} and appears in the roster as a Connections bot. Chat routes to that machine.`,
+    takenLocal: slug => `An agent named "${slug}" already exists.`,
+    takenRemote: (slug, target) => `An agent named "${slug}" already exists on ${target}.`,
+    advanced: 'Advanced',
+    generalTab: 'General',
+    capabilitiesTab: 'Capabilities',
+    skillsTab: 'Skills',
+    toolsTab: 'Tools',
+    mcpTab: 'MCP',
+    cloneFrom: 'Clone from profile',
+    cloneFromOn: target => `Clone from profile (on ${target})`,
+    freshProfile: 'Fresh profile (bundled skills)',
+    createEmpty: 'Create empty (skip bundled skills)',
+    inheritedModel: 'inherited from launch profile',
+    soulLabel: 'SOUL.md (optional — replaces the generated persona)',
+    soulPlaceholder:
+      'Leave blank to auto-generate from name/title/description + agent-messaging roster.',
+    shareKeys: 'Share keys & accounts with the main profile',
+    shareKeysDetail:
+      'Subscriptions, OAuth logins, and API keys stay shared (not copied), so token refreshes never invalidate each other. Uncheck for an isolated snapshot copy.',
+    createEmptyCheckedNote: '“Create empty” is checked — no bundled skills will be installed.',
+    filterSkills: 'Filter skills…',
+    createFailed: 'Could not create the profile yet',
+    createAgent: 'Create Bot',
+    creating: 'Creating…',
+    draftDiscarded: draft => `Draft agent "${draft}" discarded`,
+    defaultToolsetNote:
+      'Leaving all (or none) checked keeps the default toolset behavior.',
+  },
+  edit: {
+    title: 'Edit Profile',
+    description: (displayName, profileId) =>
+      `Appearance and role for ${displayName} (${profileId}).`,
+    titleField: 'Title',
+    descriptionField: 'Description',
+    descriptionPlaceholder: 'What should this agent help with?',
+    advancedDisclosure: 'Advanced — model, skills, toolsets, SOUL.md',
+    advancedFailed: 'Advanced configuration failed',
+    sectionsFailed: list => `Some sections failed: ${list}`,
+    updated: name => `${name} updated`,
+  },
+  advanced: {
+    gatewayTooOld: 'Full configuration needs a newer gateway (restart it after updating Hermes).',
+    noMcp: 'No MCP servers configured or in the catalog.',
+    skillsHub: 'Skills Hub',
+    skillsHubTitle: 'Hermes Skills Hub',
+    searchHubPlaceholder: 'Search the hub (community + well-known sources)…',
+    searchingHub: 'Searching community + well-known sources — can take ~10s…',
+    noHubMatches: 'No hub skills matched.',
+    filterSkills: 'Filter skills…',
+    skillInstalled: label => `Skill "${label}" installed`,
+  },
+  menu: {
+    hideBot: 'Hide',
+    unhideBot: 'Unhide',
+    backInRoster: name => `${name} is back in the roster`,
+    hiddenNotice: name =>
+      `${name} hidden — use the eye button in the Bots header to see hidden bots`,
+    editProfile: 'Edit Profile',
+    manageGroups: 'Manage groups…',
+    groups: list => `Groups: ${list}…`,
+    duplicate: 'Duplicate',
+    duplicating: name => `Duplicating ${name}…`,
+    duplicateCreated: (name, source) => `Created ${name} — full copy of ${source}`,
+    duplicateFailed: 'Duplicate failed',
+    newChat: 'New chat with this agent',
+    delete: 'Delete',
+  },
+  composer: {
+    neverResetsTitle: 'This chat never resets',
+    neverResetsMessage:
+      'Bot chats are one continuous conversation — compacting instead. For a throwaway session with this agent, use Sessions mode.',
+  },
+  common: {
+    cancel: 'Cancel',
+    save: 'Save',
+    saving: 'Saving…',
+  },
+}
+
+const BOTS_LOCALES = { en: BOTS_EN }
+
+function bindBotsText(t, template, prefix = '') {
+  const out = {}
+  for (const [key, value] of Object.entries(template)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    out[key] =
+      typeof value === 'function'
+        ? (...args) => t(path, ...args)
+        : value && typeof value === 'object'
+          ? bindBotsText(t, value, path)
+          : t(path)
+  }
+  return out
+}
+
+function useBots() {
+  // Graceful degradation: hosts without plugin i18n (or the .mjs test
+  // sandbox, which strips the SDK import) get the en template verbatim —
+  // byte-identical to the hardcoded strings this replaced.
+  const usePluginI18n =
+    typeof sdk !== 'undefined' && typeof sdk.usePluginI18n === 'function'
+      ? sdk.usePluginI18n
+      : null
+  if (!usePluginI18n) return BOTS_EN
+  return bindBotsText(usePluginI18n('hermes-bots'), BOTS_EN)
+}
+
 import {
   atom,
   Button,
@@ -7814,6 +7974,7 @@ function botRowOwnsWorkspace(
 // ── bot row ──────────────────────────────────────────────────────────────────
 
 function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
+  const k = useBots()
   const activeProfile = useValue(host.state.profile)
   const focusedOwner = focusedRosterOwner(useValue($focusedBotOwner))
   const selectedRosterKey = useValue($selectedRosterKey)
@@ -7964,7 +8125,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
                 children: [
                   pinned
                     ? jsx(Tip, {
-                        label: 'Pinned',
+                        label: k.pane.pinnedTip,
                         children: jsx(Codicon, {
                           name: 'pinned',
                           className: 'shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)'
@@ -7973,7 +8134,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
                     : null,
                   hidden
                     ? jsx(Tip, {
-                        label: 'Hidden from the roster',
+                        label: k.pane.hiddenTip,
                         children: jsx(Codicon, {
                           name: 'eye-closed',
                           className: 'shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)'
@@ -8052,7 +8213,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
                 void saveBotMeta(bot, { pinned: !pinned })
                 host.notify({
                   kind: 'info',
-                  message: `${displayName(bot, current)} ${pinned ? 'unpinned' : 'pinned to top'}`
+                  message: k.pane.pinToggle(displayName(bot, current), pinned)
                 })
               }).catch(error => host.notifyError?.(error, 'Could not load bot metadata'))
             },
@@ -8071,33 +8232,33 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
                 host.notify({
                   kind: 'info',
                   message: hidden
-                    ? `${displayName(bot, current)} is back in the roster`
-                    : `${displayName(bot, current)} hidden — use the eye button in the Bots header to see hidden bots`
+                    ? k.menu.backInRoster(displayName(bot, current))
+                    : k.menu.hiddenNotice(displayName(bot, current))
                 })
               }).catch(error => host.notifyError?.(error, 'Could not load bot metadata'))
             },
-            children: hidden ? 'Unhide' : 'Hide'
+            children: hidden ? k.menu.unhideBot : k.menu.hideBot
           }),
           jsx(ContextMenuSeparator, {}),
           jsx(ContextMenuItem, {
             onSelect: () => void ensureBotMetadata(bot).then(() => onEdit(bot)).catch(error => host.notifyError?.(error, 'Could not load bot')),
-            children: 'Edit Profile'
+            children: k.menu.editProfile
           }),
           jsx(ContextMenuItem, {
             onSelect: () => void ensureBotMetadata(bot).then(() => onGroup(bot)).catch(error => host.notifyError?.(error, 'Could not load bot groups')),
-            children: groups.length ? `Groups: ${groups.join(', ')}…` : 'Manage groups…'
+            children: groups.length ? k.menu.groups(groups.join(', ')) : k.menu.manageGroups
           }),
           jsx(ContextMenuItem, {
             onSelect: () => {
-              host.notify({ kind: 'info', message: `Duplicating ${displayName(bot, meta)}…` })
+              host.notify({ kind: 'info', message: k.menu.duplicating(displayName(bot, meta)) })
               duplicateBot(bot, $lastRoster.get())
                 .then(name => {
                   queryClient.invalidateQueries({ queryKey: ROSTER_KEY })
-                  host.notify({ kind: 'success', message: `Created ${name} — full copy of ${bot.name}` })
+                  host.notify({ kind: 'success', message: k.menu.duplicateCreated(name, bot.name) })
                 })
-                .catch(err => host.notifyError(err, 'Duplicate failed'))
+                .catch(err => host.notifyError(err, k.menu.duplicateFailed))
             },
-            children: 'Duplicate'
+            children: k.menu.duplicate
           }),
           jsx(ContextMenuSeparator, {}),
           jsx(ContextMenuItem, {
@@ -8106,7 +8267,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
               setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
               newBotChat(bot)
             },
-            children: 'New chat with this agent'
+            children: k.menu.newChat
           }),
           isDefaultBot(bot) ? null : jsx(ContextMenuSeparator, {}),
           isDefaultBot(bot)
@@ -8114,7 +8275,7 @@ function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }) {
             : jsx(ContextMenuItem, {
                 onSelect: () => onDelete(bot),
                 variant: 'destructive',
-                children: 'Delete'
+                children: k.menu.delete
               })
         ]
       })
@@ -8334,6 +8495,7 @@ function CheckList({ items, onToggle, columns = 2 }) {
 }
 
 function AdvancedProfileConfig({ bot, state, setState }) {
+  const k = useBots()
   const [loaded, setLoaded] = useState(false)
   const [unsupported, setUnsupported] = useState(false)
   const [skillFilter, setSkillFilter] = useState('')
@@ -8379,7 +8541,7 @@ function AdvancedProfileConfig({ bot, state, setState }) {
   if (unsupported) {
     return jsx('div', {
       className: 'px-2 py-3 text-center text-xs text-(--ui-text-tertiary)',
-      children: 'Full configuration needs a newer gateway (restart it after updating Hermes).'
+      children: k.advanced.gatewayTooOld
     })
   }
 
@@ -8500,7 +8662,7 @@ function AdvancedProfileConfig({ bot, state, setState }) {
           children: [
             jsx(Input, {
               className: 'h-7 text-xs',
-              placeholder: 'Filter skills…',
+              placeholder: k.create.filterSkills,
               value: skillFilter,
               onChange: event => setSkillFilter(event.target.value)
             }),
@@ -8580,7 +8742,7 @@ function AdvancedProfileConfig({ bot, state, setState }) {
             : mcpList.length === 0
               ? jsx('div', {
                   className: 'px-1 py-2 text-center text-xs text-(--ui-text-tertiary)',
-                  children: 'No MCP servers configured or in the catalog.'
+                  children: k.advanced.noMcp
                 })
               : jsx(ScrollArea, {
                   className: 'hermes-scroll-cap',
@@ -8746,7 +8908,7 @@ function HubSkillsSection({ forProfile, onInstalled }) {
         ...(forProfile ? { profile: forProfile } : {})
       })
       setInstalled(prev => ({ ...prev, [label]: true }))
-      host.notify({ kind: 'success', message: `Skill "${label}" installed` })
+      host.notify({ kind: 'success', message: k.advanced.skillInstalled(label) })
 
       if (typeof onInstalled === 'function') {
         onInstalled(label)
@@ -8768,7 +8930,7 @@ function HubSkillsSection({ forProfile, onInstalled }) {
         children: [
           jsx('div', {
             className: 'text-[0.7rem] font-medium text-(--ui-text-secondary)',
-            children: 'Skills Hub'
+            children: k.advanced.skillsHub
           }),
           jsx('button', {
             type: 'button',
@@ -8802,7 +8964,7 @@ function HubSkillsSection({ forProfile, onInstalled }) {
                 },
                 children: jsx('iframe', {
                   src: HUB_PICKER_URL,
-                  title: 'Hermes Skills Hub',
+                  title: k.advanced.skillsHubTitle,
                   ref: frameRef,
                   style: {
                     width: '133.34%',
@@ -8830,7 +8992,7 @@ function HubSkillsSection({ forProfile, onInstalled }) {
         children: [
           jsx(Input, {
             className: 'h-7 flex-1 text-xs',
-            placeholder: 'Search the hub (community + well-known sources)…',
+            placeholder: k.advanced.searchHubPlaceholder,
             value: query,
             onChange: event => setQuery(event.target.value),
             onKeyDown: event => {
@@ -8852,7 +9014,7 @@ function HubSkillsSection({ forProfile, onInstalled }) {
       searching
         ? jsx('div', {
             className: 'px-1 text-[0.65rem] text-(--ui-text-quaternary)',
-            children: 'Searching community + well-known sources — can take ~10s…'
+            children: k.advanced.searchingHub
           })
         : null,
       results === null
@@ -8860,7 +9022,7 @@ function HubSkillsSection({ forProfile, onInstalled }) {
         : results.length === 0
           ? jsx('div', {
               className: 'px-1 py-1.5 text-[0.7rem] text-(--ui-text-quaternary)',
-              children: 'No hub skills matched.'
+              children: k.advanced.noHubMatches
             })
           : jsx(ScrollArea, {
               className: 'hermes-scroll-cap',
@@ -8998,6 +9160,7 @@ function labeled(label, control) {
 }
 
 function EditProfileDialog({ bot, open, onClose }) {
+  const k = useBots()
   const metaAll = useValue($botMeta)
   const meta = bot ? botRosterMeta(bot, metaAll) : null
   const appearance = bot ? botAppearance(bot.name, meta) : { shape: 'circle', color: AVATAR_COLORS[3] }
@@ -9077,16 +9240,16 @@ function EditProfileDialog({ bot, open, onClose }) {
 
         if (failed.length) {
           advancedFailed = true
-          host.notify({ kind: 'error', message: `Some sections failed: ${failed.map(([k]) => k).join(', ')}` })
+          host.notify({ kind: 'error', message: k.edit.sectionsFailed(failed.map(([x]) => x).join(', ')) })
         }
       } catch (err) {
         advancedFailed = true
-        host.notifyError(err, 'Advanced configuration failed')
+        host.notifyError(err, k.edit.advancedFailed)
       }
     }
 
     if (!advancedFailed && !lookFailed) {
-      host.notify({ kind: 'success', message: `${displayName(bot, { title })} updated` })
+      host.notify({ kind: 'success', message: k.edit.updated(displayName(bot, { title })) })
     }
     setBusy(false)
     onClose()
@@ -9104,8 +9267,8 @@ function EditProfileDialog({ bot, open, onClose }) {
       children: [
         jsxs(DialogHeader, {
           children: [
-            jsx(DialogTitle, { children: 'Edit Profile' }),
-            jsx(DialogDescription, { children: `Appearance and role for ${displayName(bot, null)} (${bot.name}).` })
+            jsx(DialogTitle, { children: k.edit.title }),
+            jsx(DialogDescription, { children: k.edit.description(displayName(bot, null), bot.name) })
           ]
         }),
         jsxs('div', {
@@ -9125,7 +9288,7 @@ function EditProfileDialog({ bot, open, onClose }) {
               generateSeed: { name: bot.name, title, description }
             }),
             labeled(
-              'Title',
+              k.edit.titleField,
               jsx(Input, {
                 placeholder: displayName(bot, null),
                 value: title,
@@ -9133,10 +9296,10 @@ function EditProfileDialog({ bot, open, onClose }) {
               })
             ),
             labeled(
-              'Description',
+              k.edit.descriptionField,
               jsx(Textarea, {
                 className: 'min-h-16',
-                placeholder: 'What should this agent help with?',
+                placeholder: k.edit.descriptionPlaceholder,
                 value: description,
                 onChange: event => setDescription(event.target.value)
               })
@@ -9148,7 +9311,7 @@ function EditProfileDialog({ bot, open, onClose }) {
               onClick: () => setAdvanced(v => !v),
               children: [
                 jsx(Codicon, { name: advanced ? 'chevron-down' : 'chevron-right', className: 'text-[0.8rem]' }),
-                'Advanced — model, skills, toolsets, SOUL.md'
+                k.edit.advancedDisclosure
               ]
             }),
             advanced
@@ -9161,8 +9324,8 @@ function EditProfileDialog({ bot, open, onClose }) {
         }),
         jsxs(DialogFooter, {
           children: [
-            jsx(Button, { variant: 'ghost', disabled: busy, onClick: onClose, children: 'Cancel' }),
-            jsx(Button, { disabled: busy, onClick: submit, children: busy ? 'Saving…' : 'Save' })
+            jsx(Button, { variant: 'ghost', disabled: busy, onClick: onClose, children: k.common.cancel }),
+            jsx(Button, { disabled: busy, onClick: submit, children: busy ? k.common.saving : k.common.save })
           ]
         })
       ]
@@ -9173,6 +9336,7 @@ function EditProfileDialog({ bot, open, onClose }) {
 // ── create dialog ────────────────────────────────────────────────────────────
 
 function CreateAgentDialog({ open, onClose, roster }) {
+  const k = useBots()
   const [name, setName] = useState('')
   // Create mode: the profile is created LAZILY. Capability toggles are staged in
   // component state; the profile is materialized either on Create (submit) or on
@@ -9279,7 +9443,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
       ? requestForTarget('cli.exec', { argv: ['profile', 'delete', draft, '--yes'] })
       : deleteBot({ name: draft })
     void Promise.resolve(discard)
-      .then(() => host.notify({ kind: 'success', message: `Draft agent "${draft}" discarded` }))
+      .then(() => host.notify({ kind: 'success', message: k.create.draftDiscarded(draft) }))
       .catch(err => host.notifyError(err, `Could not clean up draft profile "${draft}"`))
   }
 
@@ -9541,9 +9705,9 @@ function CreateAgentDialog({ open, onClose, roster }) {
       children: [
         jsxs(DialogHeader, {
           children: [
-            jsx(DialogTitle, { children: 'New Bot' }),
+            jsx(DialogTitle, { children: k.create.title }),
             jsx(DialogDescription, {
-              children: 'A named teammate with its own memory, skills, and chat. It can message your other agents.'
+              children: k.create.description
             })
           ]
         }),
@@ -9564,10 +9728,10 @@ function CreateAgentDialog({ open, onClose, roster }) {
               generateSeed: { name: slug || 'agent', title, description }
             }),
             labeled(
-              'Name',
+              k.create.name,
               jsx(Input, {
                 autoFocus: true,
-                placeholder: 'inbox-triage',
+                placeholder: k.create.namePlaceholder,
                 value: name,
                 onChange: event => setName(event.target.value)
               })
@@ -9576,8 +9740,8 @@ function CreateAgentDialog({ open, onClose, roster }) {
               ? jsx('div', {
                   className: 'text-xs text-(--ui-accent)',
                   children: remoteTarget
-                    ? `An agent named "${slug}" already exists on ${targetLabel}.`
-                    : `An agent named "${slug}" already exists.`
+                    ? k.create.takenRemote(slug, targetLabel)
+                    : k.create.takenLocal(slug)
                 })
               : null,
             // Multi-connection desktops choose WHERE the agent lives. Hidden
@@ -9585,7 +9749,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
             // possible home, exactly the old behavior.
             Array.isArray(connections) && connections.length > 1
               ? labeled(
-                  'Create on',
+                  k.create.createOn,
                   jsxs(Select, {
                     value: targetConnection || activeConnectionId || 'local',
                     onValueChange: value => {
@@ -9625,22 +9789,22 @@ function CreateAgentDialog({ open, onClose, roster }) {
             remoteTarget
               ? jsx('div', {
                   className: 'text-[0.7rem] leading-5 text-(--ui-text-tertiary)',
-                  children: `The agent is created on ${targetLabel} and appears in the roster as a Connections bot. Chat routes to that machine.`
+                  children: k.create.createOnNote(targetLabel)
                 })
               : null,
             labeled(
-              'Title',
+              k.create.titleField,
               jsx(Input, {
-                placeholder: 'Inbox Triage',
+                placeholder: k.create.titlePlaceholder,
                 value: title,
                 onChange: event => setTitle(event.target.value)
               })
             ),
             labeled(
-              'Description',
+              k.create.descriptionField,
               jsx(Textarea, {
                 className: 'min-h-16',
-                placeholder: 'What should this Bot help with?',
+                placeholder: k.create.descriptionPlaceholder,
                 value: description,
                 onChange: event => setDescription(event.target.value)
               })
@@ -9659,7 +9823,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
               },
               children: [
                 jsx(Codicon, { name: advanced ? 'chevron-down' : 'chevron-right', className: 'text-[0.8rem]' }),
-                'Advanced'
+                k.create.advanced
               ]
             }),
             advanced
@@ -9679,14 +9843,14 @@ function CreateAgentDialog({ open, onClose, roster }) {
                       // reads already route to the target).
                       children: (SkillsView && (!remoteTarget || skillsViewRoutesConnections)
                         ? [
-                            ['general', 'General'],
-                            ['capabilities', 'Capabilities']
+                            ['general', k.create.generalTab],
+                            ['capabilities', k.create.capabilitiesTab]
                           ]
                         : [
-                            ['general', 'General'],
-                            ['skills', 'Skills'],
-                            ['toolsets', 'Tools'],
-                            ['mcp', 'MCP']
+                            ['general', k.create.generalTab],
+                            ['skills', k.create.skillsTab],
+                            ['toolsets', k.create.toolsTab],
+                            ['mcp', k.create.mcpTab]
                           ]
                       ).map(([id, label]) =>
                         jsx(
@@ -9708,7 +9872,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                 // the MCP setup buttons use).
                                 void ensureAgentCreated()
                                   .then(created => created && setCreatedForCaps(created))
-                                  .catch(err => host.notifyError(err, 'Could not create the profile yet'))
+                                  .catch(err => host.notifyError(err, k.create.createFailed))
                               } else if (id !== 'general') {
                                 ensureCaps()
                               }
@@ -9724,7 +9888,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
                           className: 'grid gap-3.5',
                           children: [
                             labeled(
-                              remoteTarget ? `Clone from profile (on ${targetLabel})` : 'Clone from profile',
+                              remoteTarget ? k.create.cloneFromOn(targetLabel) : k.create.cloneFrom,
                               jsxs(Select, {
                                 disabled: remoteTarget,
                                 value: remoteTarget ? 'default' : cloneFrom,
@@ -9742,7 +9906,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                     children: [
                                       jsx(SelectItem, {
                                         value: '__none__',
-                                        children: 'Fresh profile (bundled skills)'
+                                        children: k.create.freshProfile
                                       }),
                                       ...roster.map(b => jsx(SelectItem, { value: b.name, children: b.name }, b.name))
                                     ]
@@ -9760,10 +9924,10 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                   setModel(patch.model)
                                 }
                               },
-                              placeholderModel: 'inherited from launch profile'
+                              placeholderModel: k.create.inheritedModel
                             }),
                             labeled(
-                              'SOUL.md (optional — replaces the generated persona)',
+                              k.create.soulLabel,
                               jsx(Textarea, {
                                 className: 'min-h-24 font-mono text-xs leading-5',
                                 placeholder:
@@ -9779,13 +9943,13 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                   checked: shareAuth,
                                   onCheckedChange: value => setShareAuth(Boolean(value))
                                 }),
-                                'Share keys & accounts with the main profile'
+                                k.create.shareKeys
                               ]
                             }),
                             jsx('div', {
                               className: 'pl-6 pt-0.5 text-[0.7rem] leading-5 text-(--ui-text-tertiary)',
                               children:
-                                'Subscriptions, OAuth logins, and API keys stay shared (not copied), so token refreshes never invalidate each other. Uncheck for an isolated snapshot copy.'
+                                k.create.shareKeysDetail
                             }),
                             jsxs('label', {
                               className: 'flex items-center gap-2 text-xs text-(--ui-text-secondary)',
@@ -9794,7 +9958,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                   checked: noSkills,
                                   onCheckedChange: value => setNoSkills(Boolean(value))
                                 }),
-                                'Create empty (skip bundled skills)'
+                                k.create.createEmpty
                               ]
                             })
                           ]
@@ -9848,14 +10012,14 @@ function CreateAgentDialog({ open, onClose, roster }) {
                             ? noSkills
                               ? jsx('div', {
                                   className: 'px-2 py-3 text-center text-xs text-(--ui-text-tertiary)',
-                                  children: '“Create empty” is checked — no bundled skills will be installed.'
+                                  children: k.create.createEmptyCheckedNote
                                 })
                               : jsxs('div', {
                                   className: 'grid gap-1.5',
                                   children: [
                                     jsx(Input, {
                                       className: 'h-7 text-xs',
-                                      placeholder: 'Filter skills…',
+                                      placeholder: k.advanced.filterSkills,
                                       value: capFilter,
                                       onChange: event => setCapFilter(event.target.value)
                                     }),
@@ -9902,14 +10066,14 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                     }),
                                     jsx('div', {
                                       className: 'text-[0.65rem] leading-4 text-(--ui-text-quaternary)',
-                                      children: 'Leaving all (or none) checked keeps the default toolset behavior.'
+                                      children: k.create.defaultToolsetNote
                                     })
                                   ]
                                 })
                               : caps.mcp.length === 0
                                 ? jsx('div', {
                                     className: 'px-2 py-3 text-center text-xs text-(--ui-text-tertiary)',
-                                    children: 'No MCP servers configured or in the catalog.'
+                                    children: k.advanced.noMcp
                                   })
                                 : jsxs('div', {
                                     className: 'grid gap-1.5',
@@ -10013,12 +10177,12 @@ function CreateAgentDialog({ open, onClose, roster }) {
                 reset()
                 onClose()
               },
-              children: 'Cancel'
+              children: k.common.cancel
             }),
             jsx(Button, {
               disabled: busy || !valid || taken,
               onClick: submit,
-              children: busy ? 'Creating…' : 'Create Bot'
+              children: busy ? k.create.creating : k.create.createAgent
             })
           ]
         })
@@ -13566,6 +13730,7 @@ function GatewaySectionHeading({ collapsed, count, onToggle, option }) {
 }
 
 function BotsPane() {
+  const k = useBots()
   const { data, error, isLoading, refetch } = useRoster()
   const gatewayState = useValue(host.state.gateway)
   const gatewayUp = gatewayState === 'open'
@@ -13929,13 +14094,13 @@ function BotsPane() {
         children: [
           jsx('span', {
             className: 'text-[0.6875rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary)',
-            children: 'Bots'
+            children: k.pane.title
           }),
           jsxs('div', {
             className: 'flex items-center gap-0.5',
             children: [
               jsx(Tip, {
-                label: activityToasts ? 'Activity toasts on — click to silence' : 'Activity toasts off — click to enable',
+                label: activityToasts ? k.pane.activityToastsOn : k.pane.activityToastsOff,
                 children: jsx('button', {
                   type: 'button',
                   className:
@@ -13944,15 +14109,16 @@ function BotsPane() {
                   children: jsx(Codicon, { name: activityToasts ? 'bell' : 'bell-slash' })
                 })
               }),
+
               jsxs(DropdownMenu, {
                 children: [
                   jsx(Tip, {
-                    label: 'New…',
+                    label: k.pane.newMenuTip,
                     children: jsx(DropdownMenuTrigger, {
                       asChild: true,
                       children: jsx('button', {
                         type: 'button',
-                        'aria-label': 'New bot or group chat',
+                        'aria-label': k.pane.newMenuAria,
                         className:
                           'flex size-6 items-center justify-center rounded-md text-(--ui-text-tertiary) transition-colors hover:bg-(--chrome-action-hover) hover:text-foreground',
                         children: jsx(Codicon, { name: 'add' })
@@ -13964,12 +14130,12 @@ function BotsPane() {
                     children: [
                       jsxs(DropdownMenuItem, {
                         onSelect: () => setCreateOpen(true),
-                        children: [jsx(Codicon, { name: 'hubot', className: 'mr-1.5' }), 'New Bot']
+                        children: [jsx(Codicon, { name: 'hubot', className: 'mr-1.5' }), k.pane.newAgent]
                       }),
                       jsxs(DropdownMenuItem, {
                         disabled: activeSourceRoster.length < 2,
                         onSelect: () => setGroupCreateOpen(true),
-                        children: [jsx(Codicon, { name: 'organization', className: 'mr-1.5' }), 'New Group Chat']
+                        children: [jsx(Codicon, { name: 'organization', className: 'mr-1.5' }), k.pane.newGroupChat]
                       })
                     ]
                   })
@@ -14153,21 +14319,21 @@ function BotsPane() {
                 jsx('div', {
                   children: gatewayUp
                     ? `Roster unavailable: ${error instanceof Error ? error.message : 'gateway error'}. If your gateway predates profiles.list, update Hermes and restart the gateway.`
-                    : 'Waiting for the gateway connection… (remote gateways can take a few seconds; retries automatically)'
+                    : k.pane.waitingGateway
                 }),
                 jsx(Button, {
                   variant: 'secondary',
                   size: 'sm',
                   className: 'justify-self-start',
                   onClick: () => void refetch(),
-                  children: 'Retry now'
+                  children: k.pane.retryNow
                 })
               ]
             })
           : roster.length === 0
             ? jsx(EmptyState, {
                 icon: 'hubot',
-                title: 'No bots yet',
+                title: k.pane.noAgentsYet,
                 description: 'Create your first bot.'
               })
             : allBotsHidden && !hiddenExpanded
@@ -14296,21 +14462,21 @@ function BotsPane() {
       grouping ? jsx(GroupDialog, { bot: grouping, onClose: () => setGrouping(null) }) : null,
       jsx(ConfirmDialog, {
         open: Boolean(deleting),
-        title: 'Delete bot and profile?',
+        title: k.pane.deleteBotTitle,
         description: deleting
           ? jsxs('span', {
               children: [
-                'This will permanently delete the bot ',
+                k.pane.deleteBotDescPrefix,
                 jsx('span', { className: 'font-medium text-foreground', children: deleting.name }),
-                ' and its associated Hermes profile at ',
+                k.pane.deleteBotDescMid,
                 jsx('span', { className: 'font-mono text-xs', children: deleting.path }),
-                '. This cannot be undone.'
+                k.pane.deleteBotDescSuffix
               ]
             })
           : null,
         destructive: true,
-        confirmLabel: 'Delete',
-        busyLabel: 'Deleting…',
+        confirmLabel: k.pane.deleteConfirm,
+        busyLabel: k.pane.deleting,
         doneLabel: 'Deleted',
         onClose: () => setDeleting(null),
         onConfirm: async () => {
@@ -14353,6 +14519,12 @@ export default {
   description: 'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.',
   register(ctx) {
     pluginCtx = ctx
+    // Older hosts without plugin i18n (pre-#67303) must not crash here:
+    // registration is optional and components fall back to the en template.
+    if (typeof ctx?.i18n?.register === 'function') {
+      ctx.i18n.register(BOTS_LOCALES)
+    }
+    const i18nT = typeof ctx?.i18n?.t === 'function' ? ctx.i18n.t.bind(ctx.i18n) : null
     groupChatSyncDisposed = false
     startFaceClock()
     // The cross-connection relay rides every gateway socket this Desktop
@@ -14834,10 +15006,10 @@ export default {
             if (activeBot && currentId && canonicalIds.includes(String(currentId))) {
               host.notify({
                 kind: 'info',
-                title: 'This chat never resets',
-                message:
-                  'Bot chats are one continuous conversation — compacting instead. ' +
-                  'For a throwaway session with this agent, use Sessions mode.'
+                title: i18nT ? i18nT('composer.neverResetsTitle') : BOTS_EN.composer.neverResetsTitle,
+                message: i18nT
+                  ? i18nT('composer.neverResetsMessage')
+                  : BOTS_EN.composer.neverResetsMessage
               })
 
               return { ...draft, text: '/compact' }

--- a/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
@@ -163,7 +163,7 @@ test('activeBots ignores a finished worker outside the liveness window', () => {
 
 test('ActiveNowStrip renders above the roster, is a live region, and is click-accessible', () => {
   // Strip is placed between the pane header and the search field.
-  const headerEnd = source.indexOf("children: 'Bots'")
+  const headerEnd = source.indexOf("children: k.pane.title")
   const searchField = source.indexOf("placeholder: 'Search bots and group chats…'")
   assert.ok(headerEnd >= 0 && searchField > headerEnd)
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs
@@ -164,7 +164,7 @@ test('activeBots ignores a finished worker outside the liveness window', () => {
 test('ActiveNowStrip renders above the roster, is a live region, and is click-accessible', () => {
   // Strip is placed between the pane header and the search field.
   const headerEnd = source.indexOf("children: k.pane.title")
-  const searchField = source.indexOf("placeholder: 'Search bots and group chats…'")
+  const searchField = source.indexOf('placeholder: k.pane.searchBotsPlaceholder')
   assert.ok(headerEnd >= 0 && searchField > headerEnd)
 
   const stripStart = source.indexOf('jsx(ActiveNowStrip')

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs
@@ -218,9 +218,9 @@ test('integration: a deleted bot is removed from plugin-local state and the rost
 })
 
 test('regression: the bot context menu exposes a destructive delete action and confirmation', () => {
-  assert.match(pluginSource, /ContextMenuItem, \{[\s\S]*?variant: 'destructive'[\s\S]*?children: 'Delete'/)
+  assert.match(pluginSource, /ContextMenuItem, \{[\s\S]*?variant: 'destructive'[\s\S]*?children: k\.menu\.delete/)
   assert.match(pluginSource, /isDefaultBot\(bot\) \? null : jsx\(ContextMenuSeparator/)
   assert.match(pluginSource, /ConfirmDialog/)
-  assert.match(pluginSource, /title: 'Delete bot and profile\?'/)
-  assert.match(pluginSource, /This will permanently delete the bot[\s\S]*?and its associated Hermes profile at[\s\S]*?This cannot be undone\./)
+  assert.match(pluginSource, /title: k\.pane\.deleteBotTitle/)
+  assert.match(pluginSource, /k\.pane\.deleteBotDescPrefix[\s\S]*?k\.pane\.deleteBotDescMid[\s\S]*?k\.pane\.deleteBotDescSuffix/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/bots-home.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bots-home.test.mjs
@@ -996,6 +996,6 @@ test('Bot Mode copy says bot, not agent', () => {
   assert.doesNotMatch(pluginSource, /children: busy \? 'Creating…' : 'Create Agent'/)
   assert.doesNotMatch(pluginSource, /`Agent "\$\{displayName\(\{ name: slug, title \}\)\}" created/)
   assert.match(pluginSource, /Name the bot first/)
-  assert.match(pluginSource, /children: busy \? 'Creating…' : 'Create Bot'/)
+  assert.match(pluginSource, /children: busy \? k\.create\.creating : k\.create\.createAgent/)
   assert.match(pluginSource, /`Bot "\$\{displayName\(\{ name: slug, title \}\)\}" created/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/bots-search.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bots-search.test.mjs
@@ -84,7 +84,7 @@ test('Bot pane renders the canonical search field and no-match state', () => {
     source,
     /const showRosterSearch =\s*gatewayOptions\.length > 1 \|\| rosterItemCount >= BOT_ROSTER_SEARCH_THRESHOLD/
   )
-  assert.match(source, /jsx\(SearchField,\s*\{[\s\S]*?placeholder: 'Search bots and group chats…'/)
+  assert.match(source, /jsx\(SearchField,\s*\{[\s\S]*?placeholder: k\.pane\.searchBotsPlaceholder/)
   assert.match(source, /query \? 'opacity-100!' : 'opacity-50 focus-within:opacity-100'/)
   assert.match(source, /placeholder:text-\(--ui-text-tertiary\)/)
   assert.match(source, /children: jsx\(Codicon, \{ name: 'list-filter' \}\)/)

--- a/apps/desktop/src/plugins/hermes-bots/tests/embed-skills-view.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/embed-skills-view.test.mjs
@@ -127,7 +127,7 @@ test('Edit Profile renders the pinned Capabilities surface when the export exist
 
 test('New Agent gains a Capabilities tab that materializes the profile first', () => {
   // Tab list swaps to General + Capabilities on newer builds…
-  assert.match(source, /\['capabilities', 'Capabilities'\]/)
+  assert.match(source, /\['capabilities', k\.create\.capabilitiesTab\]/)
   // …and opening it creates the profile through the same lazy door MCP setup uses.
   assert.match(source, /id === 'capabilities'/)
   assert.match(source, /ensureAgentCreated\(\)\s*\n?\s*\.then\(created => created && setCreatedForCaps\(created\)\)/)

--- a/apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs
@@ -202,7 +202,7 @@ test('shape: Hidden section renders only when recovery is relevant', () => {
 test('shape: revealed hidden rows are flagged and can be restored', () => {
   const botRow = pluginSource.slice(pluginSource.indexOf('function BotRow('), pluginSource.indexOf('// ── model picker'))
   assert.match(botRow, /name: 'eye-closed'/)
-  assert.match(botRow, /children: hidden \? 'Unhide' : 'Hide'/)
+  assert.match(botRow, /children: hidden \? k\.menu\.unhideBot : k\.menu\.hideBot/)
   assert.match(botRow, /saveBotMeta\(bot, \{ hidden: !hidden \}\)/)
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/tests/plugin-i18n.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/plugin-i18n.test.mjs
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+// Locks the plugin-i18n contract (#67303) for hermes-bots:
+//
+//  1. The bundle MAY contain function-valued leaves (`PluginMessageValue =
+//     string | ((...args) => string)`) — the SDK's translateFrom invokes them
+//     with positional args, exactly like core. bindBotsText therefore forwards
+//     call-site args through t(path, ...args) — NOT named placeholders.
+//  2. A host WITH the feature composes parameterized strings byte-identically
+//     to the en template (the scenario a graceful-degradation fallback can't
+//     protect — it never runs there).
+//  3. useBots() memoizes the bound wrapper tree on the translator identity
+//     (mirrors kanban's useKanban: useMemo(() => bind(t, en), [t])).
+//  4. Hosts WITHOUT the feature (or the SDK-stripped sandbox) get BOTS_EN
+//     verbatim — byte-identical to the pre-bundle literals.
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+/** Resolution policy copied from the SDK (apps/desktop/src/i18n/runtime.ts
+ *  translateFrom): descend the dot-path, call function leaves with the args. */
+function registryT(bundles, locale = 'en') {
+  const messages = bundles[locale] || bundles.en
+  return (key, ...args) => {
+    let value = messages
+    for (const part of String(key).split('.')) {
+      value = value?.[part]
+      if (value === undefined) return key
+    }
+    if (typeof value === 'function') return value(...args)
+    return typeof value === 'string' ? value : key
+  }
+}
+
+/** Tiny correct-enough useMemo stub: caches on element-wise dep identity and
+ *  counts real rebuilds so memoization is observable. */
+function makeUseMemo() {
+  let cached
+  let cachedDeps
+  let runs = 0
+  const useMemo = (fn, deps) => {
+    const same =
+      cachedDeps && cachedDeps.length === deps.length && deps.every((dep, i) => dep === cachedDeps[i])
+    if (!same) {
+      cached = fn()
+      cachedDeps = deps
+      runs += 1
+    }
+    return cached
+  }
+  useMemo.runs = () => runs
+  return useMemo
+}
+
+function load({ withI18n = false } = {}) {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const useMemo = makeUseMemo()
+  let currentT = null
+  const context = {
+    atom,
+    PALETTE_AREA: 'palette',
+    COMPOSER_AREAS: { middleware: 'middleware', atCompletions: 'at-completions' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      state: {
+        profile: { get: () => 'default', listen: () => undefined },
+        gateway: { get: () => 'open', listen: () => undefined }
+      },
+      request: () => Promise.resolve({}),
+      notify: () => undefined
+    },
+    // Feature-detectable SDK: usePluginI18n only exists when withI18n is set.
+    sdk: new Proxy(
+      {},
+      {
+        get: (_target, prop) =>
+          prop === 'usePluginI18n' && withI18n ? () => currentT : undefined
+      }
+    ),
+    useMemo
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat(`
+globalThis.__i18n = { useBots, bindBotsText, BOTS_EN, BOTS_LOCALES };
+`)
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+
+  return {
+    ...context.__i18n,
+    plugin: context.plugin,
+    useMemo,
+    setT: next => {
+      currentT = next
+    }
+  }
+}
+
+test('i18n contract: bindBotsText forwards positional args through t(path, ...args)', () => {
+  const env = load({ withI18n: true })
+  const calls = []
+  env.setT((path, ...args) => {
+    calls.push([path, ...args])
+    return `«${path}»${args.length ? `(${args.map(String).join('|')})` : ''}`
+  })
+
+  const k = env.useBots()
+
+  assert.equal(k.pane.pinToggle('Fred', false), '«pane.pinToggle»(Fred|false)')
+  assert.equal(k.pane.showHiddenBots(3), '«pane.showHiddenBots»(3)')
+  assert.equal(k.create.takenRemote('x', 'target-device'), '«create.takenRemote»(x|target-device)')
+  assert.equal(k.edit.sectionsFailed('a, b'), '«edit.sectionsFailed»(a, b)')
+  assert.equal(k.pane.title, '«pane.title»')
+
+  // Function leaves forward their args at call time (flat leaves resolve at
+  // bind time, so find the parameterized calls rather than assuming order).
+  assert.deepEqual(
+    calls.find(call => call[0] === 'pane.pinToggle'),
+    ['pane.pinToggle', 'Fred', false]
+  )
+  assert.deepEqual(
+    calls.find(call => call[0] === 'pane.showHiddenBots'),
+    ['pane.showHiddenBots', 3]
+  )
+  assert.deepEqual(
+    calls.find(call => call[0] === 'create.takenRemote'),
+    ['create.takenRemote', 'x', 'target-device']
+  )
+})
+
+test('i18n contract: a host WITH the feature composes parameterized strings byte-identically', () => {
+  const env = load({ withI18n: true })
+  // The real registered bundle (en) + the SDK's resolution policy: function
+  // leaves get called with the positional args the client passed.
+  env.setT(registryT(env.BOTS_LOCALES, 'en'))
+
+  const k = env.useBots()
+
+  // Parameterized leaves — the exact surfaces the review flagged.
+  assert.equal(k.pane.pinToggle('Fred', false), 'Fred pinned to top')
+  assert.equal(k.pane.pinToggle('Fred', true), 'Fred unpinned')
+  assert.equal(k.pane.showHiddenBots(1), 'Show 1 hidden bot')
+  assert.equal(k.pane.showHiddenBots(2), 'Show 2 hidden bots')
+  assert.equal(
+    k.create.draftCleanupFailed('draft-1'),
+    'Could not clean up draft profile "draft-1"'
+  )
+  assert.equal(
+    k.pane.rosterUnavailable('boom'),
+    'Roster unavailable: boom. If your gateway predates profiles.list, update Hermes and restart the gateway.'
+  )
+  assert.equal(k.menu.hiddenNotice('Fred'), 'Fred hidden — use the eye button in the Bots header to see hidden bots')
+
+  // Flat leaves resolve through the same translator.
+  assert.equal(k.menu.pin, 'Pin to top')
+  assert.equal(k.menu.unpin, 'Unpin')
+  assert.equal(k.common.deleted, 'Deleted')
+  assert.equal(k.pane.searchBotsPlaceholder, 'Search bots and group chats…')
+  assert.equal(k.pane.emptyStateDescription, 'Create your first bot.')
+})
+
+test('i18n contract: hosts without the feature get the en template verbatim', () => {
+  const env = load() // sdk.usePluginI18n absent → graceful degradation
+
+  const k = env.useBots()
+
+  assert.equal(k, env.BOTS_EN) // the raw template, not a bound copy
+  assert.equal(k.pane.title, 'Bots')
+  assert.equal(k.pane.pinToggle('Fred', false), 'Fred pinned to top')
+  assert.equal(k.pane.showHiddenBots(2), 'Show 2 hidden bots')
+  assert.equal(k.menu.pin, 'Pin to top')
+  assert.equal(k.menu.unpin, 'Unpin')
+  assert.equal(k.common.deleted, 'Deleted')
+  assert.equal(k.pane.emptyStateDescription, 'Create your first bot.')
+  assert.equal(k.pane.searchBotsPlaceholder, 'Search bots and group chats…')
+  assert.equal(env.plugin.name, 'Bots')
+  assert.equal(env.plugin.description, 'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.')
+})
+
+test('i18n contract: useBots memoizes the bound tree on the translator identity', () => {
+  const env = load({ withI18n: true })
+  env.setT(registryT(env.BOTS_LOCALES, 'en'))
+
+  const first = env.useBots()
+  const again = env.useBots()
+  assert.equal(first, again, 'same translator → same bound tree (no rebuild)')
+  assert.equal(env.useMemo.runs(), 1)
+
+  // Locale switch / re-registration hands usePluginI18n a NEW t — rebuild once.
+  env.setT(registryT(env.BOTS_LOCALES, 'en'))
+  const rebuilt = env.useBots()
+  assert.notEqual(rebuilt, first)
+  assert.equal(env.useMemo.runs(), 2)
+
+  const stable = env.useBots()
+  assert.equal(stable, rebuilt, 'same new translator → stable again')
+  assert.equal(env.useMemo.runs(), 2)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -42,7 +42,7 @@ function renderBotRow(input = 'alpha') {
   const node = (type, props = {}) => ({ type, props })
   // i18n stub: components call useBots(); behavior tests never assert labels.
   const botsTextStub = new Proxy(function () { return '' }, {
-    get: (_t, _p) => botsTextStub,
+    get: () => botsTextStub,
     apply: () => ''
   })
   const context = {
@@ -247,7 +247,7 @@ test('behavior: remote default never opens the same-name local chat', async () =
   const node = (type, props = {}) => ({ type, props })
   // i18n stub: components call useBots(); behavior tests never assert labels.
   const botsTextStub = new Proxy(function () { return '' }, {
-    get: (_t, _p) => botsTextStub,
+    get: () => botsTextStub,
     apply: () => ''
   })
   const context = {

--- a/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/profile-prewarm.test.mjs
@@ -40,7 +40,13 @@ function renderBotRow(input = 'alpha') {
     }
   })
   const node = (type, props = {}) => ({ type, props })
+  // i18n stub: components call useBots(); behavior tests never assert labels.
+  const botsTextStub = new Proxy(function () { return '' }, {
+    get: (_t, _p) => botsTextStub,
+    apply: () => ''
+  })
   const context = {
+    useBots: () => botsTextStub,
     BotFace: 'BotFace',
     ContextMenu: 'ContextMenu',
     ContextMenuContent: 'ContextMenuContent',
@@ -239,7 +245,13 @@ test('behavior: remote default never opens the same-name local chat', async () =
     }
   })
   const node = (type, props = {}) => ({ type, props })
+  // i18n stub: components call useBots(); behavior tests never assert labels.
+  const botsTextStub = new Proxy(function () { return '' }, {
+    get: (_t, _p) => botsTextStub,
+    apply: () => ''
+  })
   const context = {
+    useBots: () => botsTextStub,
     BotFace: 'BotFace',
     ContextMenu: 'ContextMenu',
     ContextMenuContent: 'ContextMenuContent',


### PR DESCRIPTION
## Context

The hermes-bots plugin (Bot Mode) hardcodes every user-visible string, which blocks the zh-CN localization requested in #91336. This PR lays the i18n plumbing; locale bundles land in follow-up PRs once the plumbing is reviewed.

## Approach

Mirrors the kanban plugin's i18n pattern (#67303), with one deliberate difference — the en template lives **inline** in plugin.js:

- plugin.js is the single-file bundle: sibling imports break the direct-file plugin loader, and the 57-file .mjs test harness evaluates plugin.js alone in a vm sandbox.
- `BOTS_EN` message template + `BOTS_LOCALES = { en: BOTS_EN }` bundle, defined inline.
- `ctx.i18n.register(BOTS_LOCALES)` at load, **guarded** — hosts predating plugin i18n (and the test sandbox, which strips the SDK import) don't crash.
- `useBots()` binds the en template through `sdk.usePluginI18n('hermes-bots')` when available; otherwise it returns the en template verbatim, so every rendered string is byte-identical to the hardcoded literal it replaced.
- Non-component code (the `/new`→`/compact` composer middleware in `register(ctx)`) uses `ctx.i18n.t` with the same en-template fallback.

## Surfaces rewired

- Bots pane header (title, activity-toast toggle, hidden-bot eye toggle, New dropdown, pin/unpin tips, gateway-waiting state, empty state)
- New Agent dialog — fields, placeholders, name-collision notices, Create-on picker, Advanced disclosure + all four tabs (General/Capabilities/Skills/Tools/MCP), clone options, SOUL.md block, share-keys option, empty-skills note
- Edit Profile dialog + Advanced configuration (Skills Hub, MCP empty state, hub search)
- Bot context menu (Hide/Unhide, Edit Profile, Groups, Duplicate, New chat, Delete) + delete confirmation
- Composer middleware `/new`→`/compact` reroute notice

## Verification

- `npm run typecheck` (tsc -p ., tsconfig.electron.json, tsconfig.e2e.json) — all green
- `node --test apps/desktop/src/plugins/hermes-bots/tests/*.test.mjs` — **376/376 pass** (5 source-shape assertions updated in this PR to match the new bundle-lookup form; behavior tests get a `useBots` stub since they never assert label text)

## Follow-up

- zh-CN bundle (PR 2), covering the same surfaces — native speaker review included.

Refs #91336

---

## Rebase note

Rebased onto main @ 2026-08-23T23:34Z 解决合并冲突（冲突文件：apps/desktop/src/plugins/hermes-bots/plugin.js、apps/desktop/src/plugins/hermes-bots/tests/active-now-strip.test.mjs、apps/desktop/src/plugins/hermes-bots/tests/bot-delete.test.mjs、apps/desktop/src/plugins/hermes-bots/tests/hide-bots.test.mjs、apps/desktop/src/plugins/hermes-bots/tests/bots-search.test.mjs）。无行为变化。

Resolution notes for reviewers:

- Kept main's newer behavior everywhere (openRosterBot open path, async `ensureBotMetadata` context-menu actions, roster toolbar with gateway/activity filters, Hidden-section model); the i18n lookups were carried onto those structures.
- en bundle values updated where main renamed copy (New Bot / Create Bot / No bots yet / Create your first bot. / New bot or group chat / Hide / Unhide / Search bots and group chats…) so renders stay byte-identical to current main.
- `pinStayHint` bundle key removed — main deleted the remote-row "stay pinned" toast, so the key had no call sites left.
- Adapted tests: bots-home.test.mjs create-button shape assertion → `k.create.creating/k.create.createAgent`; profile-prewarm.test.mjs i18n stub lint fix; plugin-i18n.test.mjs expectations updated for the renamed copy.
- Verification on the rebased tree: `npm run typecheck` green (tsc -p ., tsconfig.electron.json, tsconfig.e2e.json); `node --test src/plugins/hermes-bots/tests/*.test.mjs` 530/530 pass; vitest (dock-enforce, hide-only-strip-tabs, runtime-loader) 24/24 pass; eslint on hermes-bots clean.
