### PR TITLE
fix(cli): parse tokens in venv python holders message and separate dashboard hint

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3848,10 +3848,16 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
     ]
     for pid, name, cmdline in matches[:6]:
         hint = ""
-        low = cmdline.lower()
-        if "serve" in low or "dashboard" in low:
+        try:
+            argv = shlex.split(cmdline, posix=False)
+        except ValueError:
+            argv = cmdline.split()
+        tokens = {a.strip('"').lower() for a in argv}
+        if "serve" in tokens:
             hint = "  ← Hermes Desktop backend (close the desktop app)"
-        elif "gateway" in low:
+        elif "dashboard" in tokens:
+            hint = "  ← Hermes dashboard (run `hermes dashboard --stop`)"
+        elif any(t == "gateway" or t.startswith("gateway.") for t in tokens):
             hint = "  ← gateway"
         lines.append(f"  PID {pid}  {name}  {cmdline[:120]}{hint}")
     if len(matches) > 6:
@@ -3864,7 +3870,7 @@ def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> 
         "  dependency update would fail partway and leave a broken install."
     )
     lines.append(
-        "  Close the Hermes desktop app / other Hermes terminals, then re-run:"
+        "  Close the Hermes desktop app, stop the dashboard (`hermes dashboard --stop`), or close other Hermes terminals, then re-run:"
     )
     lines.append("    hermes update")
     lines.append("  (or use `hermes update --force-venv` to proceed anyway at your own risk)")

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1236,3 +1236,21 @@ class TestUpdateNodeDependencies:
         assert cwd_calls, "expected at least one npm call"
         for cwd in cwd_calls:
             assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"
+
+
+class TestVenvPythonHoldersMessage:
+    """Regression for #90778: venv holder message derived from token, distinguishing serve and dashboard."""
+
+    def test_holder_message_distinguishes_serve_and_dashboard(self):
+        from hermes_cli.update_cmd import _format_venv_python_holders_message
+
+        matches = [
+            (1234, "python.exe", r"C:\serve_path\venv\Scripts\python.exe -m hermes_cli.main dashboard"),
+            (5678, "python.exe", r"C:\tools\hermes\venv\Scripts\python.exe serve --port 9120"),
+            (9999, "python.exe", r"C:\tools\hermes\venv\Scripts\python.exe -m gateway.run"),
+        ]
+        msg = _format_venv_python_holders_message(matches)
+        assert "← Hermes dashboard (run `hermes dashboard --stop`)" in msg
+        assert "← Hermes Desktop backend (close the desktop app)" in msg
+        assert "← gateway" in msg
+        assert "hermes dashboard --stop" in msg


### PR DESCRIPTION
## What does this PR do?

Improves the venv python holder detection message in `hermes_cli.update_cmd._format_venv_python_holders_message` by:
1. Parsing command line tokens using `shlex.split` rather than raw substring matching on the whole command line.
2. Separating `dashboard` processes from `serve` (desktop backend) processes, providing the explicit hint `← Hermes dashboard (run `hermes dashboard --stop`)` and mentioning `hermes dashboard --stop` in the remedy instructions.
3. Correctly identifying `gateway` and `gateway.run` tokens.

## Related Issue

Fixes #90778

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd.py`: Parsed argv tokens via `shlex.split` in `_format_venv_python_holders_message()`, assigned distinct hints for `serve` and `dashboard`, and added `hermes dashboard --stop` to the guidance text.
- `tests/hermes_cli/test_cmd_update.py`: Added `TestVenvPythonHoldersMessage` test suite.

## How to Test

1. Run `pytest tests/hermes_cli/test_cmd_update.py -k "TestVenvPythonHoldersMessage" -v`
2. Verify that command lines containing `serve` in the path (e.g. `C:\serve_path\...`) with subcommand `dashboard` receive the dashboard hint rather than desktop backend.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A