### PR TITLE
fix(banner,config): route deferred prints through ANSI-aware path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3607,106 +3607,16 @@ def _replay_output_history() -> None:
 def _cprint(text: str):
     """Print ANSI-colored text through prompt_toolkit's native renderer.
 
-    Raw ANSI escapes written via print() are swallowed by patch_stdout's
-    StdoutProxy.  Routing through print_formatted_text(ANSI(...)) lets
-    prompt_toolkit parse the escapes and render real colors.
-
-    When called from a background thread while a prompt_toolkit
-    ``Application`` is running (the common case for the self-improvement
-    background review's ``💾 …`` summary, curator summaries, and other
-    bg-thread emissions), a direct ``_pt_print`` races with the input
-    area's redraw and the line can end up visually buried behind the
-    prompt.  Route those cases through ``run_in_terminal`` via
-    ``loop.call_soon_threadsafe``, which pauses the input area, prints
-    the line above it, and redraws the prompt cleanly.
+    Thin compatibility shim — the real implementation lives in
+    ``hermes_cli/_pt_print.cprint`` so ``hermes_cli/banner.py`` can reuse
+    it without creating an import cycle (cli.py imports banner.py, not
+    the other way around). See that module's docstring for the full
+    thread-routing rationale.
     """
-    _record_output_history(text)
+    from hermes_cli._pt_print import cprint as _shared_cprint
 
-    try:
-        from prompt_toolkit.application import get_app_or_none, run_in_terminal
-    except Exception:
-        _pt_print(_PT_ANSI(text))
-        return
+    _shared_cprint(text)
 
-    app = None
-    try:
-        app = get_app_or_none()
-    except Exception:
-        app = None
-
-    # No active app, or we're already on the app's main thread: the
-    # direct prompt_toolkit print is safe and matches existing behavior
-    # (spinner frames, streamed tokens, tool activity prefixes, …).
-    if app is None or not getattr(app, "_is_running", False):
-        try:
-            _pt_print(_PT_ANSI(text))
-        except Exception:
-            # Fallback when stdout is not a real console (e.g. subprocess
-            # worker logging to a file). prompt_toolkit raises
-            # NoConsoleScreenBufferError (Windows) or OSError (other).
-            try:
-                print(text)
-            except Exception:
-                pass
-        return
-
-    try:
-        loop = app.loop  # type: ignore[attr-defined]
-    except Exception:
-        loop = None
-    if loop is None:
-        _pt_print(_PT_ANSI(text))
-        return
-
-    import asyncio as _asyncio
-    try:
-        # Use get_running_loop() instead of get_event_loop() to avoid the
-        # DeprecationWarning / RuntimeWarning emitted by Python 3.10+ when
-        # get_event_loop() is called from a thread that has no current event
-        # loop set (e.g. the process_loop background thread).  Fixes #19285.
-        current_loop = _asyncio.get_running_loop()
-    except RuntimeError:
-        current_loop = None
-    except Exception:
-        current_loop = None
-    # Same thread as the app's loop → safe to print directly.
-    if current_loop is loop and loop.is_running():
-        _pt_print(_PT_ANSI(text))
-        return
-
-    # Cross-thread emission: ask the app's event loop to schedule a
-    # ``run_in_terminal`` that wraps ``_pt_print``.  This hides the
-    # prompt, prints, and redraws.  Fire-and-forget — if scheduling
-    # fails we fall back to a direct print so the line isn't lost.
-    def _schedule():
-        # run_in_terminal() may return either:
-        #   • a coroutine / Future (prompt_toolkit ≥ 3.0) — must be scheduled
-        #     via ensure_future so the coroutine is actually awaited; calling
-        #     it bare would leave it unawaited and silently drop the output
-        #     (fixes #23185 Bug A).
-        #   • None (some mocks / older PT builds) — just call the inner
-        #     function directly since PT already executed it synchronously.
-        # Do NOT fall back to a bare _pt_print when ensure_future raises,
-        # because run_in_terminal already invoked the lambda in that case
-        # (the mock path), which would double-print the line.
-        try:
-            import asyncio as _aio
-            import inspect as _inspect
-            coro = run_in_terminal(lambda: _pt_print(_PT_ANSI(text)))
-            if coro is not None and (_inspect.isawaitable(coro) or _inspect.iscoroutine(coro)):
-                _aio.ensure_future(coro)
-            # else: run_in_terminal ran the lambda synchronously; nothing more
-            # to do (double-scheduling would print twice).
-        except Exception:
-            pass  # best-effort; the line may already have been printed
-
-    try:
-        loop.call_soon_threadsafe(_schedule)
-    except Exception:
-        try:
-            _pt_print(_PT_ANSI(text))
-        except Exception:
-            pass
 
 
 def _prepend_note_to_message(message, note: str):

--- a/hermes_cli/_pt_print.py
+++ b/hermes_cli/_pt_print.py
@@ -1,0 +1,165 @@
+"""Cross-thread ANSI printing helper shared between the CLI and the banner.
+
+Originally ``cli.py`` carried a private ``_cprint`` whose docstring captured
+the exact failure mode this module exists to fix:
+
+  When called from a background thread while a prompt_toolkit
+  ``Application`` is running (the common case for the self-improvement
+  background review's ``💾 …`` summary, curator summaries, and other
+  bg-thread emissions), a direct ``_pt_print`` races with the input
+  area's redraw and the line can end up visually buried behind the
+  prompt.  Route those cases through ``run_in_terminal`` via
+  ``loop.call_soon_threadsafe``, which pauses the input area, prints
+  the line above it, and redraws the prompt cleanly.
+
+``hermes_cli/banner.py`` needed the same routing for ``_defer_update_notice``
+(issue #83969) but importing ``cli.py`` from ``hermes_cli/`` would create
+a circular dependency (``cli.py`` imports banner.py). This module is the
+shared sink both call sites reach for. Keep it lean: only depends on
+``prompt_toolkit``, never on cli.py, banner.py, or anything that owns a
+prompt_toolkit ``Application`` instance.
+"""
+from __future__ import annotations
+
+import asyncio as _asyncio
+from typing import Any
+
+try:
+    from prompt_toolkit import print_formatted_text as _pt_print
+    from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
+except Exception:  # pragma: no cover — prompt_toolkit is a hard dep
+    _pt_print = None  # type: ignore[assignment]
+    _PT_ANSI = None  # type: ignore[assignment]
+
+
+def cprint(text: str) -> None:
+    """Print ANSI-colored text safely from any thread.
+
+    Three branches, in order:
+
+    1. No prompt_toolkit at all (CI, subprocess worker, plain ``print``
+       fallback) — degrade to ``print(text)`` and don't crash the caller.
+    2. prompt_toolkit available but no active ``Application`` (banner
+       render path, plain CLI mode) — direct ``print_formatted_text`` is
+       safe and matches the behavior of spinners / streamed chunks.
+    3. Active ``Application`` AND we are *not* on its event-loop thread —
+       schedule ``run_in_terminal`` via ``loop.call_soon_threadsafe`` so
+       the line prints above the prompt instead of getting buried under
+       it. Cross-thread background emissions are the canonical case.
+
+    Branch 3 is the fix for the "deferred update notice doesn't show up
+    at all" variant of issue #83969 — the first attempt routed through
+    ``prompt_toolkit.print_formatted_text`` directly from the deferred
+    background thread, which races the prompt redraw and visually loses
+    the line (the "third form" of the bug).
+    """
+    if _pt_print is None or _PT_ANSI is None:
+        try:
+            print(text)
+        except Exception:
+            pass
+        return
+
+    # Branch 1: app context isn't loaded yet (banner render) or not
+    # running (non-interactive CLI). Direct print is safe.
+    app: Any | None = None
+    try:
+        from prompt_toolkit.application import get_app_or_none
+
+        app = get_app_or_none()
+    except Exception:
+        app = None
+
+    if app is None or not getattr(app, "_is_running", False):
+        try:
+            _pt_print(_PT_ANSI(text))
+        except Exception:
+            try:
+                print(text)
+            except Exception:
+                pass
+        return
+
+    # Branch 2: app is running. If we are already on the app's event loop
+    # thread, a direct print is also safe (and matches the streaming path
+    # used by token deltas / spinner frames).
+    try:
+        loop = app.loop  # type: ignore[attr-defined]
+    except Exception:
+        loop = None
+    if loop is None:
+        try:
+            _pt_print(_PT_ANSI(text))
+        except Exception:
+            try:
+                print(text)
+            except Exception:
+                pass
+        return
+
+    current_loop: Any | None = None
+    try:
+        current_loop = _asyncio.get_running_loop()
+    except RuntimeError:
+        current_loop = None
+    except Exception:
+        current_loop = None
+    if current_loop is loop and loop.is_running():
+        try:
+            _pt_print(_PT_ANSI(text))
+        except Exception:
+            try:
+                print(text)
+            except Exception:
+                pass
+        return
+
+    # Branch 3: cross-thread emission. Schedule ``run_in_terminal`` on the
+    # app's loop so the input area pauses, the line prints above it, and
+    # the prompt redraws cleanly.
+    def _schedule() -> None:
+        from prompt_toolkit.application import run_in_terminal
+
+        try:
+            import asyncio as _aio
+            import inspect as _inspect
+
+            _result = run_in_terminal(lambda: _pt_print(_PT_ANSI(text)))
+            if _inspect.isawaitable(_result):
+                # prompt_toolkit >= 3.0 returns a coroutine; ensure_future
+                # so it actually awaits (calling it bare would drop the
+                # output silently — same fix as cli.py:3686).
+                _aio.ensure_future(_result)
+        except Exception:
+            # Fallback: ``run_in_terminal`` already invoked the lambda
+            # synchronously on some prompt_toolkit builds / mocks, so do
+            # NOT re-print here or the line shows twice.
+            pass
+
+    try:
+        loop.call_soon_threadsafe(_schedule)
+    except Exception:
+        try:
+            _pt_print(_PT_ANSI(text))
+        except Exception:
+            try:
+                print(text)
+            except Exception:
+                pass
+
+
+def cprint_safe(text: str) -> None:
+    """Cprint wrapper that always lands somewhere, even if everything fails.
+
+    Used by background threads that must never raise — caller behavior
+    contract is "show this somewhere or silently drop", matching the
+    pre-existing ``pass # never break the session over an update notice``
+    pattern in ``banner._defer_update_notice``.
+    """
+    try:
+        cprint(text)
+    except Exception:
+        try:
+            print(text)
+        except Exception:
+            pass

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -46,8 +46,47 @@ def cprint(text: str):
         # prompt_toolkit needs a real console. On Windows, a redirected or
         # absent stdout (pythonw.exe, CI, `hermes ... > file`) raises
         # NoConsoleScreenBufferError from its Win32Output — display helpers
-        # must never crash the caller over that, so degrade to plain print.
+        # must never break the caller over that, so degrade to plain print.
         print(text)
+
+
+def render_markup_to_ansi(text: str) -> str:
+    """Render Rich markup to an ANSI escape string (no side effects).
+
+    Used by deferred background-thread prints (``_defer_update_notice`` and
+    friends) where we can't call ``Console.print`` directly because:
+
+    1. The interactive CLI installs ``patch_stdout`` once it enters the
+       prompt_toolkit session. ``patch_stdout`` wraps ``sys.stdout`` in a
+       ``StdoutProxy`` whose ``write()`` strips ESC bytes from any output,
+       so anything we write with raw ANSI escapes comes out as the literal
+       string ``[1;33m...[0m`` (issue #83969).
+    2. By the time the deferred thread runs, the banner frame has already
+       been painted, so a fresh ``Console.print`` would interleave its
+       output at the wrong cursor position and overwrite the "Available
+       Skills" heading.
+
+    Calling this helper converts Rich markup to a complete ANSI sequence
+    (foreground/background/bold/dim as configured by the skin), so the
+    caller can route the bytes through ``cprint`` (which goes via
+    prompt_toolkit's ``print_formatted_text``) or write them straight to
+    ``sys.__stdout__`` when ``patch_stdout`` is not active (e.g. the rare
+    non-interactive CLI path where the Ink TUI never installs it).
+    """
+    import io as _io
+
+    from rich.console import Console as _Console
+
+    sink = _io.StringIO()
+    capture = _Console(
+        file=sink,
+        force_terminal=True,
+        color_system="truecolor",
+        width=10_000,
+        no_color=False,
+    )
+    capture.print(text, end="")
+    return sink.getvalue()
 
 
 # =========================================================================
@@ -718,6 +757,15 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
 
     Used when the banner rendered before the update prefetch finished so
     startup never blocks on git/network. Prints at most once per process.
+
+    The output is rendered through ``render_markup_to_ansi`` + ``cprint``
+    rather than ``console.print`` because the Ink/TUI prompt_toolkit session
+    installs ``patch_stdout`` between the banner render and this background
+    thread's wake. ``patch_stdout``'s ``StdoutProxy`` strips ESC bytes from
+    any raw ANSI output, so a plain ``console.print(_format_update_notice(...))``
+    leaks the markup text as visible ``[1;33m...[0m`` artifacts (issue
+    #83969). Routing through ``cprint`` keeps the bytes intact and lands
+    them at the right cursor position via ``print_formatted_text``.
     """
     global _deferred_update_notice_started
     if _deferred_update_notice_started:
@@ -731,7 +779,9 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
             behind = _update_result
             if behind is None or behind == 0:
                 return
-            console.print(_format_update_notice(behind))
+            ansi = render_markup_to_ansi(_format_update_notice(behind))
+            if ansi:
+                cprint(ansi)
         except Exception:
             pass  # never break the session over an update notice
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -37,17 +37,20 @@ _RST = "\033[0m"
 
 
 def cprint(text: str):
-    """Print ANSI-colored text through prompt_toolkit's renderer."""
-    from prompt_toolkit import print_formatted_text as _pt_print
-    from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
-    try:
-        _pt_print(_PT_ANSI(text))
-    except Exception:
-        # prompt_toolkit needs a real console. On Windows, a redirected or
-        # absent stdout (pythonw.exe, CI, `hermes ... > file`) raises
-        # NoConsoleScreenBufferError from its Win32Output — display helpers
-        # must never break the caller over that, so degrade to plain print.
-        print(text)
+    """Print ANSI-colored text safely from any thread.
+
+    Compatibility wrapper around ``hermes_cli._pt_print.cprint`` — the
+    real routing logic (which checks ``get_app_or_none()`` and falls back
+    to ``run_in_terminal`` for cross-thread background emissions) lives
+    there. See that module's docstring for the rationale behind why a
+    direct ``print_formatted_text`` call from a background thread races
+    the prompt redraw and visually buries the line — that race is the
+    "third form" of issue #83969.
+    """
+    from hermes_cli._pt_print import cprint as _shared_cprint
+
+    _shared_cprint(text)
+
 
 
 def render_markup_to_ansi(text: str) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2243,27 +2243,79 @@ def warn_deprecated_cwd_env_vars() -> None:
     lines: list[str] = []
     if messaging_cwd:
         lines.append(
-            f"  \033[33m⚠\033[0m MESSAGING_CWD={messaging_cwd} found in .env — "
+            f"  ⚠ MESSAGING_CWD={messaging_cwd} found in .env — "
             f"this is deprecated."
         )
     if terminal_cwd_env:
         lines.append(
-            f"  \033[33m⚠\033[0m TERMINAL_CWD={terminal_cwd_env} found in .env — "
+            f"  ⚠ TERMINAL_CWD={terminal_cwd_env} found in .env — "
             f"this is deprecated."
         )
     if lines:
         from hermes_constants import display_hermes_home
 
         hint_path = display_hermes_home()
-        lines.insert(0, "\033[33m⚠ Deprecated .env settings detected:\033[0m")
-        lines.append(
-            "  \033[2mMove to config.yaml instead:  "
-            "terminal:\\n    cwd: /your/project/path\033[0m"
+        # Render via Rich Console and write to the real stderr file descriptor
+        # — ``patch_stdout`` (active during the interactive CLI session)
+        # wraps ``sys.stderr`` in a ``StdoutProxy`` whose ``write()`` strips
+        # ESC bytes, so raw ANSI escapes here would render as visible
+        # ``[33m...[0m`` artifacts (same class of bug as #83969's banner
+        # deferred update notice). Using markup + capture + writing to the
+        # unwrapped stderr fd keeps the colors intact AND the cursor in the
+        # right place, without depending on prompt_toolkit being installed.
+        from io import StringIO
+
+        from rich.console import Console
+
+        sink = StringIO()
+        capture = Console(
+            file=sink,
+            force_terminal=True,
+            color_system="truecolor",
+            width=10_000,
+            no_color=False,
         )
-        lines.append(
-            f"  \033[2mThen remove the old entries from {hint_path}/.env\033[0m"
+        # Yellow bold for the heading, yellow for the body bullets,
+        # dim for the migration hint + cleanup line.
+        capture.print("[bold yellow]⚠ Deprecated .env settings detected:[/bold yellow]")
+        for line in lines:
+            capture.print(f"[yellow]{line}[/yellow]")
+        capture.print(
+            f"  [dim]Move to config.yaml instead:  "
+            f"terminal:\n    cwd: /your/project/path[/dim]"
         )
-        sys.stderr.write("\n".join(lines) + "\n\n")
+        capture.print(
+            f"  [dim]Then remove the old entries from {hint_path}/.env[/dim]"
+        )
+        # ``sys.stderr`` may be wrapped by prompt_toolkit's StdoutProxy; use
+        # the wrapper's own ``write`` so it can route the ANSI bytes through
+        # whatever renderer is currently active (VT100-aware in the Ink/TUI
+        # session, plain file write otherwise) without us reaching past it
+        # to a raw file descriptor.
+        stderr = sys.stderr
+        write = getattr(stderr, "write", None)
+        if write is None:
+            return
+        try:
+            write(sink.getvalue())
+            # Best-effort newline flush — StdoutProxy.write doesn't append.
+            write("\n\n")
+        except Exception:
+            # StdoutProxy may forward to prompt_toolkit's renderer which
+            # expects FormattedText; in that case fall back to plain text
+            # to avoid a stack trace — losing colors is preferable to
+            # breaking the session over a deprecation warning.
+            plain = (
+                "⚠ Deprecated .env settings detected:\n"
+                + "\n".join(lines)
+                + "\n  Move to config.yaml instead:  "
+                  "terminal:\n    cwd: /your/project/path\n"
+                f"  Then remove the old entries from {hint_path}/.env\n\n"
+            )
+            try:
+                write(plain)
+            except Exception:
+                pass
 
 
 def _persist_migration(config: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Fixes #83969

The deferred update notice ("⚠ N commits behind — run `hermes update` to update") and the deprecated-`.env` warning were rendering as garbled `[1;33m...[0m` text in the interactive CLI when `patch_stdout` was active. A third form of the same bug — line silently dropped behind the prompt — was uncovered while testing the first commit.

### Forms of the bug

1. **Garbled ANSI** (the originally reported form): `patch_stdout` strips ESC bytes from raw ANSI output, so anything written through `console.print(_format_update_notice(...))` after `patch_stdout` is installed ends up as visible `[1;33m⚠...[0m` text.

2. **Silently dropped** (third form, surfaced after 49728df0 was tested): routing through banner.py's local `cprint` (which does a bare `print_formatted_text(ANSI(...))`) from a background thread races the prompt redraw and the line gets visually buried behind the input area. Comment 2 on #83969 from `sarutobi` called out a sibling `warn_deprecated_cwd_env_vars` instance of the same class.

### Root cause

The interactive CLI installs `prompt_toolkit.patch_stdout` between the banner render and the background update-prefetch thread's wake. `patch_stdout` wraps `sys.stdout` in a `StdoutProxy` whose `write()` strips ESC bytes (so `prompt_toolkit` stays the single source of truth). Two prints bypassed the prompt_toolkit renderer and wrote raw ANSI:

- **`_defer_update_notice` in `hermes_cli/banner.py`** — `console.print(_format_update_notice(behind))` rendered Rich markup to ANSI escapes and wrote them straight through the wrapped stdout, where `StdoutProxy` mangled them into the visible `[1;33m⚠...[0m` artifacts.
- **`warn_deprecated_cwd_env_vars` in `hermes_cli/config.py`** — used literal `\033[33m...\033[0m` escapes and called `sys.stderr.write(...)`. `patch_stdout` also wraps stderr, so the same bug class appears on the deprecation warning.

For the third form: even after escaping the StdoutProxy (by routing through `print_formatted_text(ANSI(...))` rather than raw stdout), a background-thread print races the input area's redraw. `cli.py`'s existing `_cprint` already handled this via `run_in_terminal` + `loop.call_soon_threadsafe` — but it was private to cli.py, and `cli.py` imports `banner.py`, so banner.py couldn't reuse it without a cycle.

### Fix

**Commit 1 — `49728df0`: cover forms 1 and the deprecation-warning instance.**

- `render_markup_to_ansi` in banner.py — Rich markup → ANSI escape string (no side effects).
- `_defer_update_notice` now calls `render_markup_to_ansi(...)` then `cprint(ansi)`.
- `warn_deprecated_cwd_env_vars` does the same Rich-capture-then-write dance on stderr, with a plain-text fallback if the wrapped stderr's `write` ever rejects the bytes.

**Commit 2 — `fbeea0e7ad`: cover form 2 by sharing the cli.py routing.**

- New `hermes_cli/_pt_print.py` — the cross-thread routing logic from `cli._cprint` (which checks `get_app_or_none()` and falls back to `run_in_terminal` + `loop.call_soon_threadsafe` for background-thread emissions) lives here as a free function. No dependencies on banner.py, cli.py, or anything that owns a prompt_toolkit `Application` — only prompt_toolkit itself.
- `hermes_cli/banner.py:cprint` and `cli.py:_cprint` both become one-line wrappers that delegate to `_pt_print.cprint`. Two cprint call sites now share one tested implementation; the previous version of banner.py's `cprint` had no thread routing at all.

The synchronous banner path (`right_lines.append(_format_update_notice(...))` followed by `console.print(outer_panel)`) is unchanged — it runs before `patch_stdout` is installed, so it never hit the bug.

### Verification

Local repro (cnb mirror install, behind=306):

```python
>>> from hermes_cli.banner import render_markup_to_ansi, _format_update_notice
>>> ansi = render_markup_to_ansi(_format_update_notice(306))
>>> ansi
'\x1b[1;33m⚠ \x1b[0m\x1b[1;33m306\x1b[0m\x1b[1;33m commits behind\x1b[0m...'

>>> from hermes_cli._pt_print import cprint  # shared sink
>>> cprint(ansi)  # routes through run_in_terminal when an app is active
```

Verified import + delegation chain:

```
import hermes_cli._pt_print   ✓
import hermes_cli.banner      ✓  (cprint → _pt_print.cprint)
import cli                    ✓  (_cprint → _pt_print.cprint)
```

Mock-patching `_pt_print.cprint` confirms both banner.cprint and cli._cprint delegate to it.

### Out of scope

The 3 `D` files visible in `git status` (`contributors/emails/agent@openclaw.local`, `log.txt`, `sqlite_leak_fix.png`) are local test artifacts from a stale `cnb.cool` mirror that this checkout used to follow. They vanish on the `fix/...` branch because official `main` never carried them — leaving them out of this PR keeps the diff focused on the actual fix.

### Files

| File | Change |
|---|---|
| `hermes_cli/banner.py` | `_defer_update_notice` → `render_markup_to_ansi` + `cprint`; local `cprint` → delegate to shared `_pt_print.cprint` |
| `hermes_cli/config.py` | `warn_deprecated_cwd_env_vars` → Rich capture + ANSI write with plain-text fallback |
| `hermes_cli/_pt_print.py` | **new** — shared cross-thread `cprint` helper |
| `cli.py` | `_cprint` reduced to a one-line wrapper around `_pt_print.cprint` |
