### PR TITLE
chore: release v0.20.5 (2026.8.19)

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.20.4"
-__release_date__ = "2026.8.18"
+__version__ = "0.20.5"
+__release_date__ = "2026.8.19"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "hermes-agent"
-version = "0.20.4"
+version = "0.20.5"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-04T07:06:16.774262776Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P14D"
 
 [options.exclude-newer-package]
@@ -1569,7 +1569,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.20.4"
+version = "0.20.5"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
Release v0.20.5 (v2026.8.19) — infrastructure rollup patch tag. Rolls up ~323 PRs / ~746 commits merged since v2026.8.18 into a stable tagged release for downstream consumers (Docker images, hosted deployments, fresh installs). Full curated notes for the v0.20.x window ship with v0.21.0.

## Changes
- `hermes_cli/__init__.py`: `__version__` 0.20.4 → 0.20.5, `__release_date__` → 2026.8.19
- `pyproject.toml`: version 0.20.5
- `uv.lock`: regenerated (`uv lock --check` clean)

## Verification
| Gate | Result |
|---|---|
| Version read off origin/main files (not tag name) | 0.20.4 on main → bump to 0.20.5 |
| Anchored stale-version grep (`"0.20.4"` forms) | zero hits |
| `uv lock --check` after regen | clean (253 packages) |
| Bootstrap squash-rewrite check (install.sh / install.ps1) | no commits touched either file in window |
| Revert scan | 3 reverts, all CI parse-cache busters (no shipped-feature reverts) |

## Infographic

![v0.20.5 rollup patch](https://files.catbox.moe/zfp55y.png)
