### PR TITLE
fix(plugins): mirror all photon sidecar .mjs sources, not a fixed list

### DIFF
--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -48,12 +48,31 @@ SOURCE_SIDECAR_DIR = Path(__file__).parent / "sidecar"
 # The files that define the sidecar. Mirrored into the writable runtime dir
 # when the install tree is read-only. node_modules is deliberately absent —
 # it is either baked (managed image) or installed by npm in the mirror.
+#
+# The .mjs sources are matched by glob rather than listed by name: index.mjs
+# imports sibling modules (send-format.mjs, stream-staleness.mjs, ...) that
+# are extracted from it over time, and a hand-maintained manifest silently
+# drops each new one — the mirror then holds an index.mjs whose imports do
+# not resolve and the sidecar exits at boot with ERR_MODULE_NOT_FOUND.
+_MIRROR_GLOBS = ("*.mjs",)
 _MIRROR_FILES = (
-    "index.mjs",
     "package.json",
     "package-lock.json",
-    "patch-spectrum-mixed-attachments.mjs",
 )
+
+
+def _mirror_sources(source: Path) -> list[Path]:
+    """Every sidecar source file that must exist in the runtime mirror."""
+    found: dict[str, Path] = {}
+    for name in _MIRROR_FILES:
+        candidate = source / name
+        if candidate.is_file():
+            found[name] = candidate
+    for pattern in _MIRROR_GLOBS:
+        for candidate in sorted(source.glob(pattern)):
+            if candidate.is_file():
+                found[candidate.name] = candidate
+    return list(found.values())
 
 
 def dir_writable(path: Path) -> bool:
@@ -122,11 +141,8 @@ def resolve_sidecar_dir(source_dir: Optional[Path] = None) -> Path:
     mirror = get_hermes_home() / "photon" / "sidecar"
     try:
         mirror.mkdir(parents=True, exist_ok=True)
-        for name in _MIRROR_FILES:
-            src = source / name
-            if not src.exists():
-                continue
-            dst = mirror / name
+        for src in _mirror_sources(source):
+            dst = mirror / src.name
             if not dst.exists() or not filecmp.cmp(str(src), str(dst), shallow=False):
                 shutil.copy2(str(src), str(dst))
         return mirror

--- a/tests/plugins/platforms/photon/test_sidecar_paths.py
+++ b/tests/plugins/platforms/photon/test_sidecar_paths.py
@@ -16,9 +16,21 @@ import pytest
 import plugins.platforms.photon.sidecar_paths as sidecar_paths
 
 
+# Mirrors the real sidecar layout: manifest files plus index.mjs and the
+# sibling modules it imports.
+_SOURCE_FILES = (
+    "package.json",
+    "package-lock.json",
+    "index.mjs",
+    "patch-spectrum-mixed-attachments.mjs",
+    "send-format.mjs",
+    "stream-staleness.mjs",
+)
+
+
 def _seed_source(source: Path, *, with_node_modules: bool = False) -> None:
     source.mkdir(parents=True, exist_ok=True)
-    for name in sidecar_paths._MIRROR_FILES:
+    for name in _SOURCE_FILES:
         (source / name).write_text(f"// {name}\n", encoding="utf-8")
     if with_node_modules:
         (source / "node_modules").mkdir()
@@ -86,6 +98,61 @@ def test_mirror_refresh_updates_changed_files_and_keeps_node_modules(
     assert resolved == mirror
     assert (mirror / "index.mjs").read_text(encoding="utf-8") == "// index.mjs v2\n"
     assert (mirror / "node_modules" / "installed.txt").exists()
+
+
+def test_mirror_includes_sibling_mjs_modules(tmp_path, monkeypatch) -> None:
+    """Regression for #85046.
+
+    index.mjs imports send-format.mjs and stream-staleness.mjs. A mirror
+    missing either leaves the sidecar dead at boot with
+    ERR_MODULE_NOT_FOUND, while `photon status` still reports the npm deps
+    as installed.
+    """
+    monkeypatch.delenv("PHOTON_SIDECAR_DIR", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    source = tmp_path / "src"
+    _seed_source(source)
+    _freeze_writability(monkeypatch, writable=False)
+
+    mirror = sidecar_paths.resolve_sidecar_dir(source)
+
+    for name in _SOURCE_FILES:
+        assert (mirror / name).is_file(), f"{name} missing from mirror"
+
+
+def test_mirror_picks_up_newly_added_mjs_module(tmp_path, monkeypatch) -> None:
+    """A module extracted from index.mjs upstream needs no manifest edit."""
+    monkeypatch.delenv("PHOTON_SIDECAR_DIR", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    source = tmp_path / "src"
+    _seed_source(source)
+    _freeze_writability(monkeypatch, writable=False)
+
+    mirror = sidecar_paths.resolve_sidecar_dir(source)
+    assert not (mirror / "future-module.mjs").exists()
+
+    (source / "future-module.mjs").write_text("// new\n", encoding="utf-8")
+    resolved = sidecar_paths.resolve_sidecar_dir(source)
+
+    assert resolved == mirror
+    assert (mirror / "future-module.mjs").read_text(encoding="utf-8") == "// new\n"
+
+
+def test_mirror_excludes_node_modules(tmp_path, monkeypatch) -> None:
+    """node_modules is npm's to manage; the mirror never copies it."""
+    monkeypatch.delenv("PHOTON_SIDECAR_DIR", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    source = tmp_path / "src"
+    _seed_source(source, with_node_modules=True)
+    # Stale marker forces the mirror path rather than run-in-place.
+    os.utime(source / "package-lock.json", (2000.0, 2000.0))
+    os.utime(source / "node_modules" / ".package-lock.json", (1000.0, 1000.0))
+    _freeze_writability(monkeypatch, writable=False)
+
+    mirror = sidecar_paths.resolve_sidecar_dir(source)
+
+    assert mirror != source
+    assert not (mirror / "node_modules").exists()
 
 
 def test_dir_writable_probe(tmp_path) -> None:


### PR DESCRIPTION
## What does this PR do?

`_MIRROR_FILES` in `plugins/platforms/photon/sidecar_paths.py` enumerates the sidecar's source files by name. `index.mjs` imports sibling modules that have been extracted out of it over time — `send-format.mjs` and `stream-staleness.mjs` — and neither was ever added to that tuple.

On a managed image the install tree is read-only, so `resolve_sidecar_dir()` mirrors the sidecar to `$HERMES_HOME/photon/sidecar`. The mirror gets `index.mjs` but not the modules it imports, so the sidecar exits at boot:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'/opt/data/photon/sidecar/send-format.mjs'
imported from /opt/data/photon/sidecar/index.mjs
```

The gateway surfaces only `✗ photon failed to connect` and retries on a growing backoff. Two things make this hard to diagnose:

- `hermes photon status` reports `sidecar deps: ✓ installed` — a misleading green light. The npm deps genuinely are installed; it's the `.mjs` siblings that are missing.
- Re-running `hermes photon install-sidecar` does not fix it. `node_modules/` is reinstalled but the copy manifest is untouched, so the same files stay absent.

## Fix

Match `.mjs` sources by glob instead of listing them by name, so a module extracted upstream reaches the mirror without a manifest edit. `package.json` and `package-lock.json` remain listed explicitly, and `node_modules` stays excluded — it is either baked at build time or installed by npm inside the mirror.

## Related Issue

Fixes #85046

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/photon/sidecar_paths.py`: added `_MIRROR_GLOBS = ("*.mjs",)` and a `_mirror_sources()` helper; `_MIRROR_FILES` now holds only the two manifest files. The copy loop in `resolve_sidecar_dir()` iterates resolved paths, which also drops the now-redundant `if not src.exists(): continue` guard.
- `tests/plugins/platforms/photon/test_sidecar_paths.py`: `_seed_source` now seeds a `_SOURCE_FILES` tuple reflecting the real sidecar layout instead of deriving the seed set from `_MIRROR_FILES` (which would have made the fix untestable — the helper would only ever create files the manifest already listed). Three new tests.

## How to Test

```
scripts/run_tests.sh tests/plugins/platforms/photon/test_sidecar_paths.py
```

9 passed, 1 skipped (the skip is the pre-existing root-permissions skip in `test_dir_writable_probe`).

The two new mirror tests fail on `main` without the source change and pass with it:

```
FAILED test_sidecar_paths.py::test_mirror_includes_sibling_mjs_modules
FAILED test_sidecar_paths.py::test_mirror_picks_up_newly_added_mjs_module
2 failed, 6 passed, 1 skipped
```

Full `tests/plugins/platforms/photon/` run, before vs. after, in an identical environment: same failure count both ways, 69 → 72 passing (the three added tests). No regressions.

New tests:

- `test_mirror_includes_sibling_mjs_modules` — regression for #85046; asserts every source file reaches the mirror
- `test_mirror_picks_up_newly_added_mjs_module` — a module added upstream reaches an existing mirror on the next resolve
- `test_mirror_excludes_node_modules` — guards the glob against over-copying

## Verified in production

Applied by hand on a live deployment (official `nousresearch/hermes-agent` image, v0.20.4 `[76952ba5]`, Node v26.5.1, `HERMES_HOME=/opt/data` bind-mounted, Docker Compose):

```
[photon-sidecar] photon-sidecar: listening on 127.0.0.1:8789
[photon] connected — sidecar on 127.0.0.1:8789, streaming inbound over gRPC
✓ photon connected
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nothing touches `_MIRROR_FILES` or the mirror manifest
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the photon test suite and compared against baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux x86_64 (Docker, official image)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the module docstring already describes mirroring; the mechanism is unchanged, only the file selection)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `Path.glob` and `Path.is_file` are platform-neutral; no new OS-specific calls
- [x] I've updated tool descriptions/schemas — N/A

## Notes for reviewers

Two adjacent things I noticed but deliberately left out of this diff:

1. On the affected deployment the resolver took the mirror path at all, which per the module docstring should be the exception — a managed image is meant to hit case 3 (`node_modules` baked at build time and current). Either the image's `npm ci` bake isn't landing or the lockfile postdates the install marker. That's a separate packaging question and doesn't belong here.
2. `_MIRROR_GLOBS` is a tuple rather than a bare constant so a future non-`.mjs` pattern (e.g. `*.json` if the sidecar grows config files) is a one-line change. Happy to inline it if that reads as premature.
