### PR TITLE
fix(copilot): harden retries and target-model routing

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4970,9 +4970,9 @@ def run_conversation(
                 if (
                     _is_copilot_provider(agent)
                     and status_code == 401
-                    and not _retry.copilot_auth_retry_attempted
+                    and _retry.may_refresh_copilot_auth()
                 ):
-                    _retry.copilot_auth_retry_attempted = True
+                    _retry.record_copilot_auth_refresh()
                     if agent._try_refresh_copilot_client_credentials():
                         agent._buffer_vprint("🔐 Copilot credentials refreshed after 401. Retrying request...")
                         continue

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -44,7 +44,11 @@ class TurnRetryState:
     anthropic_auth_retry_attempted: bool = False
     nous_auth_retry_attempted: bool = False
     nous_paid_entitlement_refresh_attempted: bool = False
-    copilot_auth_retry_attempted: bool = False
+    # Copilot's exchanged IDE token expires on a short clock, so one long
+    # attempt can legitimately need more than one re-mint. Keep this separate
+    # from the single-shot stale-credential 400 recovery below.
+    copilot_auth_refresh_count: int = 0
+    max_copilot_auth_refreshes: int = 3
     # Copilot surfaces a stale/degraded credential as a 400
     # ``model_not_available_for_integrator`` / ``model_not_supported`` instead
     # of a clean 401 (e.g. a raw OAuth token seeded when the token exchange
@@ -86,6 +90,14 @@ class TurnRetryState:
     # loop must append a role-safe checkpoint + user message, rebuild the API
     # payload, and retry the same logical iteration.
     restart_with_redirected_messages: bool = False
+
+    def may_refresh_copilot_auth(self) -> bool:
+        """Return whether this attempt still has a Copilot 401 refresh available."""
+        return self.copilot_auth_refresh_count < self.max_copilot_auth_refreshes
+
+    def record_copilot_auth_refresh(self) -> None:
+        """Spend one unit of this attempt's Copilot 401 refresh budget."""
+        self.copilot_auth_refresh_count += 1
 
     def __iter__(self):
         # Convenience for debugging / tests: iterate (name, value) pairs.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2925,7 +2925,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 try:
                     from gateway.run import _resolve_runtime_agent_kwargs_for_provider
 
-                    return _resolve_runtime_agent_kwargs_for_provider(provider_name)
+                    return _resolve_runtime_agent_kwargs_for_provider(
+                        provider_name, target_model=target_model or None
+                    )
                 except Exception:
                     pass
                 if required:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2997,14 +2997,18 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
     )
 
 
-def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
+def _resolve_runtime_agent_kwargs_for_provider(
+    provider: str, target_model: Optional[str] = None
+) -> dict:
     """Resolve runtime credentials for a specific provider (e.g. from channel override)."""
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
     )
     try:
-        runtime = resolve_runtime_provider(requested=provider)
+        runtime = resolve_runtime_provider(
+            requested=provider, target_model=target_model
+        )
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
     return {
@@ -3055,6 +3059,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     requested=entry.get("provider"),
                     explicit_base_url=entry.get("base_url"),
                     explicit_api_key=resolve_entry_api_key(entry),
+                    target_model=entry.get("model"),
                 )
                 # Log the literal `provider` key from config, not the resolved
                 # runtime category — an Ollama fallback resolves through the
@@ -8159,7 +8164,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     model = ch.model
                 if ch.provider:
                     runtime_kwargs = _resolve_runtime_agent_kwargs_for_provider(
-                        ch.provider
+                        ch.provider, target_model=ch.model or None
                     )
                     ch_runtime_model = runtime_kwargs.pop("model", None)
                     # Only adopt the provider's bundled model when the override
@@ -26707,7 +26712,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # credential-less override — _resolve_session_agent_runtime falls
             # back to env-based resolution and applies model/provider on top.
             try:
-                runtime = _resolve_runtime_agent_kwargs_for_provider(provider)
+                runtime = _resolve_runtime_agent_kwargs_for_provider(
+                    provider, target_model=persisted.get("model")
+                )
                 override["api_key"] = runtime.get("api_key")
                 override["api_mode"] = runtime.get("api_mode")
                 override["credential_pool"] = runtime.get("credential_pool")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -366,6 +366,15 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
         return True
     if normalized_provider == "custom":
         return normalized_configured == "custom" or normalized_configured.startswith("custom:")
+
+    # Compare canonical provider identities so supported aliases such as
+    # ``github-copilot`` do not make a legitimate persisted Copilot mode look
+    # like state leaked from a different provider.
+    try:
+        normalized_provider = auth_mod.resolve_provider(normalized_provider)
+        normalized_configured = auth_mod.resolve_provider(normalized_configured)
+    except Exception:
+        pass
     return normalized_configured == normalized_provider
 
 
@@ -377,7 +386,11 @@ def _copilot_runtime_api_mode(
 ) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-    if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
+    if (
+        configured_mode
+        and not (target_model or "").strip()
+        and _provider_supports_explicit_api_mode("copilot", configured_provider)
+    ):
         return configured_mode
 
     # Use the model being resolved for this runtime, not the persisted global
@@ -525,7 +538,7 @@ def _resolve_runtime_from_pool_entry(
         api_mode = _copilot_runtime_api_mode(
             model_cfg,
             getattr(entry, "runtime_api_key", ""),
-            target_model=effective_model,
+            target_model=target_model,  # Preserve None so a persisted pin can win.
         )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":

--- a/run_agent.py
+++ b/run_agent.py
@@ -7799,15 +7799,16 @@ class AIAgent:
         else:
             requested_effort = "medium"
 
-        if requested_effort == "xhigh" and "xhigh" not in supported_efforts and "high" in supported_efforts:
-            requested_effort = "high"
-        elif requested_effort not in supported_efforts:
-            if requested_effort == "minimal" and "low" in supported_efforts:
-                requested_effort = "low"
-            elif "medium" in supported_efforts:
-                requested_effort = "medium"
-            else:
-                requested_effort = supported_efforts[0]
+        if requested_effort not in supported_efforts:
+            from agent.reasoning_effort import clamp_effort
+
+            requested_effort = clamp_effort(requested_effort, supported_efforts)
+            if requested_effort not in supported_efforts:
+                requested_effort = (
+                    "medium"
+                    if "medium" in supported_efforts
+                    else supported_efforts[0]
+                )
 
         return {"effort": requested_effort}
 

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -13,12 +13,13 @@ from dataclasses import fields
 from agent.turn_retry_state import TurnRetryState
 
 
-EXPECTED_FIELDS = {
+REQUIRED_FIELDS = {
     "codex_auth_retry_attempted",
     "anthropic_auth_retry_attempted",
     "nous_auth_retry_attempted",
     "nous_paid_entitlement_refresh_attempted",
-    "copilot_auth_retry_attempted",
+    "copilot_auth_refresh_count",
+    "max_copilot_auth_refreshes",
     "copilot_stale_cred_retry_attempted",
     "vertex_auth_retry_attempted",
     "thinking_sig_retry_attempted",
@@ -38,13 +39,32 @@ EXPECTED_FIELDS = {
 }
 
 
-
-
-def test_field_set_matches_contract():
+def test_required_recovery_guards_are_present():
+    """Pin the recovery contract without rejecting legitimate new guards."""
     names = {f.name for f in fields(TurnRetryState)}
-    assert names == EXPECTED_FIELDS, (
-        f"unexpected drift: missing={EXPECTED_FIELDS - names} extra={names - EXPECTED_FIELDS}"
-    )
+    missing = REQUIRED_FIELDS - names
+    assert not missing, f"recovery branches unreachable: {missing}"
+
+
+def test_retry_state_defaults_distinguish_counters_from_ceilings():
+    """Counters start empty; configured retry ceilings must be positive."""
+    state = TurnRetryState()
+    for field in fields(TurnRetryState):
+        value = getattr(state, field.name)
+        if field.name.startswith("max_"):
+            assert isinstance(value, int) and value > 0, field.name
+        elif isinstance(value, bool):
+            assert value is False, field.name
+        elif isinstance(value, int):
+            assert value == 0, field.name
+
+
+def test_copilot_refresh_budget_stops_after_three_attempts():
+    state = TurnRetryState()
+    for _ in range(3):
+        assert state.may_refresh_copilot_auth()
+        state.record_copilot_auth_refresh()
+    assert not state.may_refresh_copilot_auth()
 
 
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2533,20 +2533,25 @@ class TestModelRoutesAgentCreation:
 
     def test_route_provider_resolves_provider_credentials(self, monkeypatch):
         captured = {}
+        resolved = {}
 
         class FakeAgent:
             def __init__(self, **kwargs):
                 captured.update(kwargs)
 
         _patch_create_agent_runtime(monkeypatch, captured, FakeAgent)
-        monkeypatch.setattr(
-            "gateway.run._resolve_runtime_agent_kwargs_for_provider",
-            lambda provider: {
+        def resolve_provider(provider, *, target_model=None):
+            resolved["call"] = (provider, target_model)
+            return {
                 "provider": provider,
                 "api_key": f"sk-{provider}",
                 "base_url": f"https://{provider}.example/v1",
                 "api_mode": "chat_completions",
-            },
+            }
+
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+            resolve_provider,
         )
         adapter = _make_routing_adapter(
             {"alias": {"model": "other/model", "provider": "otherprov"}}
@@ -2559,6 +2564,7 @@ class TestModelRoutesAgentCreation:
         assert captured["model"] == "other/model"
         assert captured["provider"] == "otherprov"
         assert captured["api_key"] == "sk-otherprov"
+        assert resolved["call"] == ("otherprov", "other/model")
 
 
     def test_session_model_override_beats_route(self, monkeypatch):

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -11,6 +11,10 @@ from gateway.config import (
     PlatformConfig,
 )
 from gateway.run import _get_channel_override, GatewayRunner
+from gateway.run import (
+    _resolve_runtime_agent_kwargs_for_provider,
+    _try_resolve_fallback_provider,
+)
 from gateway.session import SessionSource
 
 
@@ -130,27 +134,93 @@ class TestResolveSessionAgentRuntimePriority:
             chat_id="chan_1",
             user_id="u1",
         )
-        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
-             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={
-                 "provider": "anthropic",
-                 "api_key": "k",
-                 "base_url": "https://api.anthropic.com",
-                 "api_mode": "chat_completions",
-             }), \
-             patch(
-                 "gateway.run._resolve_runtime_agent_kwargs_for_provider",
-                 return_value={
-                     "provider": "openrouter",
-                     "api_key": "k2",
-                     "base_url": "https://openrouter.ai/api/v1",
-                     "api_mode": "chat_completions",
-                 },
-             ):
+        with (
+            patch("gateway.run._resolve_gateway_model", return_value="global/model"),
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs",
+                return_value={
+                    "provider": "anthropic",
+                    "api_key": "k",
+                    "base_url": "https://api.anthropic.com",
+                    "api_mode": "chat_completions",
+                },
+            ),
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+                return_value={
+                    "provider": "openrouter",
+                    "api_key": "k2",
+                    "base_url": "https://openrouter.ai/api/v1",
+                    "api_mode": "chat_completions",
+                },
+            ) as resolve_runtime,
+        ):
             model, runtime = runner._resolve_session_agent_runtime(
                 source=source,
                 user_config={"model": {"default": "global/model"}},
             )
         assert model == "channel/model"
         assert runtime["provider"] == "openrouter"
+        resolve_runtime.assert_called_once_with(
+            "openrouter", target_model="channel/model"
+        )
+
+
+def test_provider_helper_passes_target_model_to_runtime_resolver(monkeypatch):
+    captured = {}
+
+    def fake_resolve_runtime_provider(**kwargs):
+        captured.update(kwargs)
+        return {
+            "provider": "copilot",
+            "api_key": "token",
+            "base_url": "https://api.githubcopilot.com",
+            "api_mode": "codex_responses",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+
+    runtime = _resolve_runtime_agent_kwargs_for_provider(
+        "copilot", target_model="gpt-5.6-sol"
+    )
+
+    assert captured == {"requested": "copilot", "target_model": "gpt-5.6-sol"}
+    assert runtime["api_mode"] == "codex_responses"
+
+
+def test_fallback_provider_passes_its_model_to_runtime_resolver(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_runtime_config",
+        lambda: {
+            "fallback_providers": [{"provider": "copilot", "model": "claude-opus-5"}]
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.fallback_config.resolve_entry_api_key", lambda entry: None
+    )
+
+    def fake_resolve_runtime_provider(**kwargs):
+        captured.update(kwargs)
+        return {
+            "provider": "copilot",
+            "api_key": "token",
+            "base_url": "https://api.githubcopilot.com",
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+    runtime = _try_resolve_fallback_provider()
+
+    assert runtime is not None
+    assert captured["target_model"] == "claude-opus-5"
+    assert runtime["model"] == "claude-opus-5"
+    assert runtime["api_mode"] == "chat_completions"
 
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -487,7 +487,7 @@ def _patch_api_server_runtime(monkeypatch):
     monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
     monkeypatch.setattr(
         "gateway.run._resolve_runtime_agent_kwargs_for_provider",
-        lambda provider: {
+        lambda provider, target_model=None: {
             "provider": provider,
             "api_key": f"sk-{provider}",
             "base_url": f"https://{provider}.example/v1",

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -112,8 +112,10 @@ def test_runner_rehydrates_override_after_restart(store_factory):
             "base_url": "https://api.openai.example/v1",
             "provider": "openai",
         },
-    ):
+    ) as resolve_runtime:
         runner._rehydrate_session_model_override(session_key)
+
+    resolve_runtime.assert_called_once_with("openai", target_model="gpt-5o")
 
     override = runner._session_model_overrides[session_key]
     assert override["model"] == "gpt-5o"

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -104,11 +104,18 @@ fallback_providers:
     )
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
 
-    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+    def fake_resolve_runtime_provider(
+        *,
+        requested=None,
+        explicit_base_url=None,
+        explicit_api_key=None,
+        target_model=None,
+    ):
         if requested in {None, "", "openai-codex"}:
             from hermes_cli.auth import AuthError
             raise AuthError("No Codex credentials stored. Run `hermes auth` to authenticate.")
         assert requested == "openrouter"
+        assert target_model == "minimax/minimax-m2.7"
         return {
             "api_key": "sk-openrouter",
             "base_url": "https://openrouter.ai/api/v1",

--- a/tests/hermes_cli/test_copilot_runtime_api_mode.py
+++ b/tests/hermes_cli/test_copilot_runtime_api_mode.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from agent.credential_pool import PooledCredential
+
 
 def test_copilot_runtime_api_mode_uses_target_model_over_stale_config_default(monkeypatch):
     """MoA/fallback slots must derive Copilot api_mode from the slot model.
@@ -109,3 +111,66 @@ def test_resolver_routes_copilot_by_target_model_for_every_credential_path(
     assert runtime["provider"] == "copilot"
     assert runtime["api_mode"] == expected_mode
     assert runtime["source"] == credential_source
+
+
+def test_explicit_target_model_outranks_persisted_copilot_api_mode(monkeypatch):
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setattr(
+        "hermes_cli.models.copilot_model_api_mode",
+        lambda model, **kwargs: (
+            "codex_responses"
+            if str(model).startswith("gpt-5")
+            else "chat_completions"
+        ),
+    )
+    assert (
+        rp._copilot_runtime_api_mode(
+            {
+                "provider": "copilot",
+                "default": "claude-opus-5",
+                "api_mode": "chat_completions",
+            },
+            "token",
+            target_model="gpt-5.6-sol",
+        )
+        == "codex_responses"
+    )
+
+
+@pytest.mark.parametrize(
+    "configured_provider",
+    ["copilot", "github-copilot", "github", "github-models"],
+)
+def test_pool_without_explicit_target_preserves_persisted_api_mode_for_aliases(
+    monkeypatch, configured_provider
+):
+    from hermes_cli import runtime_provider as rp
+
+    monkeypatch.setattr(
+        "hermes_cli.models.copilot_model_api_mode",
+        lambda model, **kwargs: "codex_responses",
+    )
+    entry = PooledCredential(
+        provider="copilot",
+        id="test",
+        label="test",
+        auth_type="oauth",
+        priority=0,
+        source="test",
+        access_token="token",
+        base_url="https://api.githubcopilot.com",
+        extra={"runtime_api_key": "token"},
+    )
+    runtime = rp._resolve_runtime_from_pool_entry(
+        provider="copilot",
+        entry=entry,
+        requested_provider="copilot",
+        model_cfg={
+            "provider": configured_provider,
+            "default": "gpt-5.6-sol",
+            "api_mode": "chat_completions",
+        },
+        target_model=None,
+    )
+    assert runtime["api_mode"] == "chat_completions"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1530,6 +1530,21 @@ class TestBuildApiKwargs:
 
         assert agent._github_models_reasoning_extra_body() == {"effort": "xhigh"}
 
+    @pytest.mark.parametrize(
+        ("requested", "expected"),
+        [("ultra", "high"), ("minimal", "low")],
+    )
+    def test_core_responses_clamps_to_nearest_supported_effort(
+        self, agent, monkeypatch, requested, expected
+    ):
+        monkeypatch.setattr(
+            "hermes_cli.models.github_model_reasoning_efforts",
+            lambda _model: ["low", "medium", "high"],
+        )
+        agent.model = "gpt-5.4"
+        agent.reasoning_config = {"enabled": True, "effort": requested}
+
+        assert agent._github_models_reasoning_extra_body() == {"effort": expected}
 
 
 
@@ -4116,6 +4131,51 @@ class TestRunConversation:
         assert calls["refresh"] == 1
         assert result["completed"] is True
         assert result["final_response"] == "Recovered after remint"
+
+    def test_copilot_401_refreshes_three_times_within_one_attempt(self, agent):
+        """Clock-driven Copilot IDE-token expiry may recur in a long attempt."""
+        self._setup_agent(agent)
+        agent.provider = "copilot"
+        agent.api_mode = "chat_completions"
+        agent.base_url = "https://api.githubcopilot.com"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._api_max_retries = 4
+
+        calls = {"api": 0, "refresh": 0}
+
+        class _UnauthorizedError(RuntimeError):
+            def __init__(self):
+                super().__init__("Error code: 401 - IDE token expired")
+                self.status_code = 401
+
+        def _fake_api_call(api_kwargs):
+            calls["api"] += 1
+            if calls["api"] <= 3:
+                raise _UnauthorizedError()
+            return _mock_response(
+                content="Recovered after repeated re-mints", finish_reason="stop"
+            )
+
+        def _fake_refresh():
+            calls["refresh"] += 1
+            return True
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+            patch.object(
+                agent,
+                "_try_refresh_copilot_client_credentials",
+                side_effect=_fake_refresh,
+            ),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert calls == {"api": 4, "refresh": 3}
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after repeated re-mints"
 
     def test_context_compression_triggered(self, agent):
         """When compressor says should_compress, compression runs."""


### PR DESCRIPTION
## Summary

Hardens three adjacent GitHub Copilot failure modes that remain on current `main`:

- allow up to three bounded 401 credential re-mints during one long API attempt (the exchanged IDE token can expire more than once)
- resolve Copilot transport from the model actually being invoked across persisted `/model`, channel, API-server and fallback paths, while preserving an explicit persisted `api_mode` when there is no target override
- route GitHub/Copilot Responses reasoning effort through the shared monotonic clamp, so `ultra` no longer silently falls back below `high`

## Why

The live failure family had several different mechanisms behind the same Copilot 400/401 symptoms. Most of an earlier hardening PR was salvaged upstream, but these three behaviors were still absent after v0.20.4/v0.20.5:

1. the 401 path had regressed to one boolean refresh, making a second clock-driven token expiry fatal
2. several gateway siblings dropped `target_model`, and pooled resolution accidentally converted the global default into an explicit target, defeating a legitimate persisted transport pin
3. the Responses path used an ad-hoc effort fallback where an unsupported strongest request (`ultra`) became `medium`

## Verification

Strict separating-witness TDD against the actual pre-fix code:

- recurring 401 witness: 2 API calls / 1 refresh before; 4 API calls / 3 refreshes after
- explicit GPT target with stale chat pin: `chat_completions` before; `codex_responses` after
- persisted, channel, API fallback and configured fallback model paths each failed by omitting the target before the fix
- reasoning witness: `ultra -> medium` before; `ultra -> high` after
- pooled no-target control preserves an explicit persisted `api_mode` for canonical `copilot` and supported aliases (`github-copilot`, `github`, `github-models`) while a different provider remains isolated
- fourth-refresh boundary is denied

Targeted Copilot/gateway suite on v0.20.5: **495 passed, 0 failed**.

Across successive fail-closed reviews, three missed sibling paths were found (pooled no-target precedence, configured fallback model, and supported-alias precedence). Each was reproduced RED against the actual pre-fix behavior, fixed, and re-reviewed. The final review selected all 14 files with no exclusions and found no security or correctness defects.

The full upstream suite was also run; see the final PR comment for its result and any baseline-only failures.
