### PR TITLE
fix(background-review): preserve profile-scoped credentials

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -201,6 +201,43 @@ def cancel_background_review_for_live_turn(agent: Any) -> None:
 _REVIEW_MAX_ITERATIONS = 16
 
 
+def _review_provider_matches_parent(
+    agent: Any,
+    parent_runtime: Dict[str, Any],
+    task_provider: str,
+) -> bool:
+    """Return whether an aux provider name identifies the live parent route.
+
+    Named custom providers resolve to the generic runtime provider ``custom``
+    while the agent retains the user-facing alias in ``requested_provider``.
+    Compare both identities, but do not treat bare ``custom`` as equivalent to
+    every named custom endpoint: that would collapse a legitimate separate
+    route onto the parent credential.
+    """
+    task_identity = str(task_provider or "").strip().lower().replace(" ", "-")
+    resolved_identity = str(
+        parent_runtime.get("provider") or getattr(agent, "provider", "") or ""
+    ).strip().lower().replace(" ", "-")
+    requested_identity = str(
+        parent_runtime.get("requested_provider")
+        or getattr(agent, "requested_provider", "")
+        or ""
+    ).strip().lower().replace(" ", "-")
+
+    if requested_identity and task_identity == requested_identity:
+        return True
+    if resolved_identity and resolved_identity != "custom":
+        return task_identity == resolved_identity
+    if resolved_identity != "custom":
+        return False
+
+    if requested_identity and requested_identity not in {"auto", "custom"}:
+        from hermes_cli.providers import custom_provider_aliases
+
+        return task_identity in custom_provider_aliases(requested_identity)
+    return task_identity == "custom"
+
+
 def _background_review_task_config(
     task_cfg: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
@@ -295,6 +332,11 @@ def _resolve_review_runtime(
         parent_api_mode = "codex_responses"
     parent = {
         "provider": agent.provider,
+        "requested_provider": (
+            parent_runtime.get("requested_provider")
+            or getattr(agent, "requested_provider", "")
+            or agent.provider
+        ),
         "model": agent.model,
         "api_key": parent_runtime.get("api_key") or None,
         "base_url": parent_runtime.get("base_url") or None,
@@ -310,11 +352,26 @@ def _resolve_review_runtime(
     task_provider = (str(task.get("provider", "")).strip() or None)
     task_model = (str(task.get("model", "")).strip() or None)
     task_base_url = (str(task.get("base_url", "")).strip() or None)
-    task_api_key = (str(task.get("api_key", "")).strip() or None)
     if not (task_provider and task_provider != "auto" and task_model):
         return parent
-    if task_provider == (agent.provider or "") and task_model == (agent.model or ""):
+    if (
+        task_model == (agent.model or "")
+        and _review_provider_matches_parent(agent, parent_runtime, task_provider)
+    ):
         return parent  # same model/provider as parent -> not routed
+    task_key_env = str(
+        task.get("key_env") or task.get("api_key_env") or ""
+    ).strip()
+    if task_key_env:
+        from agent.secret_scope import get_secret
+
+        # ``key_env`` is the durable credential reference and is authoritative
+        # over any already-expanded ``api_key`` copy. In a multiplex process,
+        # that copy may have been interpolated from the default profile's
+        # process environment before this profile's scope was installed.
+        task_api_key = (get_secret(task_key_env, "") or "").strip() or None
+    else:
+        task_api_key = (str(task.get("api_key", "")).strip() or None)
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
         rp = resolve_runtime_provider(
@@ -325,6 +382,7 @@ def _resolve_review_runtime(
         )
         return {
             "provider": rp.get("provider") or task_provider,
+            "requested_provider": rp.get("requested_provider") or task_provider,
             "model": rp.get("model") or task_model,
             "api_key": rp.get("api_key"),
             "base_url": rp.get("base_url"),
@@ -1190,6 +1248,10 @@ def _run_review_in_thread(
                 quiet_mode=True,
                 platform=agent.platform,
                 provider=_rt.get("provider") or agent.provider,
+                requested_provider=(
+                    _rt.get("requested_provider")
+                    or getattr(agent, "requested_provider", None)
+                ),
                 api_mode=_rt.get("api_mode"),
                 base_url=_rt.get("base_url") or None,
                 api_key=_rt.get("api_key") or None,

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -20,6 +20,7 @@ def _make_agent_stub(agent_cls):
     agent.model = "test-model"
     agent.platform = "test"
     agent.provider = "openai"
+    agent.requested_provider = "openai-direct"
     agent.session_id = "sess-123"
     agent.quiet_mode = True
     agent._memory_store = None
@@ -234,6 +235,7 @@ def test_review_fork_inherits_prefill_and_provider_routing():
     ), "fork prefill aliases the parent's dicts (needs deepcopy)"
     assert init_kwargs.get("providers_allowed") == agent.providers_allowed
     assert init_kwargs.get("provider_sort") == agent.provider_sort
+    assert init_kwargs.get("requested_provider") == agent.requested_provider
 
 
 def test_review_fork_pins_session_start_and_session_id():

--- a/tests/run_agent/test_background_review_cost_controls.py
+++ b/tests/run_agent/test_background_review_cost_controls.py
@@ -11,7 +11,10 @@ Pure-function / config-driven; no live model calls.
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from agent import background_review as br
+from hermes_cli import runtime_provider as _runtime_provider  # noqa: F401
 
 
 def _msg(role, content, tool_calls=None):
@@ -26,8 +29,14 @@ def _msg(role, content, tool_calls=None):
 # ---------------------------------------------------------------------------
 
 class _FakeAgent:
-    def __init__(self, provider="openai-codex", model="gpt-5.5"):
+    def __init__(
+        self,
+        provider="openai-codex",
+        model="gpt-5.5",
+        requested_provider=None,
+    ):
         self.provider = provider
+        self.requested_provider = requested_provider or provider
         self.model = model
         self._credential_pool: Any = None
         self.request_overrides = {}
@@ -96,6 +105,152 @@ def test_routing_same_model_as_parent_is_not_routed():
     with patch("hermes_cli.config.load_config", return_value=cfg), patch("hermes_cli.config.load_config_readonly", return_value=cfg):
         rt = br._resolve_review_runtime(agent)
     assert rt["routed"] is False  # same model/provider → keep full-replay path
+
+
+@pytest.mark.parametrize(
+    "task_provider",
+    ("litellm-local", "custom:litellm-local"),
+)
+def test_routing_same_custom_alias_inherits_live_parent_credential(task_provider):
+    """A named custom alias resolving to ``custom`` is still the parent route.
+
+    In a multiplex process, config interpolation may have captured the default
+    profile's process-global key before this profile's scope was installed.
+    The review must recognize the requested alias and inherit the live parent
+    credential instead of explicitly forwarding that stale expanded value.
+    """
+    from agent import secret_scope
+
+    agent = _FakeAgent(
+        provider="custom",
+        requested_provider="litellm-local",
+        model="MiniMax-M3",
+    )
+    task = {
+        "provider": task_provider,
+        "model": "MiniMax-M3",
+        "api_key": "wrong-default-profile-key",
+        "key_env": "LITELLM_MASTER_KEY",
+    }
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope(
+        {"LITELLM_MASTER_KEY": "scoped-profile-key"}
+    )
+    try:
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider"
+        ) as resolve_runtime, patch(
+            "agent.secret_scope.get_secret"
+        ) as get_secret:
+            rt = br._resolve_review_runtime(agent, task)
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(False)
+
+    assert rt["routed"] is False
+    assert rt["requested_provider"] == "litellm-local"
+    assert rt["api_key"] == "parent-key"
+    resolve_runtime.assert_not_called()
+    get_secret.assert_not_called()
+
+
+def test_distinct_review_provider_uses_scoped_key_env_credential():
+    """A different provider remains routed even when its model name matches."""
+    from agent import secret_scope
+
+    agent = _FakeAgent(
+        provider="custom",
+        requested_provider="litellm-local",
+        model="MiniMax-M3",
+    )
+    task = {
+        "provider": "other-proxy",
+        "model": "MiniMax-M3",
+        "api_key": "wrong-default-profile-key",
+        "key_env": "LITELLM_MASTER_KEY",
+    }
+    routed = {
+        "provider": "custom",
+        "requested_provider": "other-proxy",
+        "model": "MiniMax-M3",
+        "api_key": "scoped-profile-key",
+        "base_url": "http://127.0.0.1:4001/v1",
+        "api_mode": "chat_completions",
+    }
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope(
+        {"LITELLM_MASTER_KEY": "scoped-profile-key"}
+    )
+    try:
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=routed,
+        ) as resolve_runtime:
+            rt = br._resolve_review_runtime(agent, task)
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(False)
+
+    assert rt["routed"] is True
+    assert rt["requested_provider"] == "other-proxy"
+    assert rt["model"] == "MiniMax-M3"
+    resolve_runtime.assert_called_once_with(
+        requested="other-proxy",
+        target_model="MiniMax-M3",
+        explicit_api_key="scoped-profile-key",
+        explicit_base_url=None,
+    )
+
+
+def test_distinct_review_provider_real_resolution_uses_profile_scope(
+    tmp_path,
+    monkeypatch,
+):
+    """Exercise config expansion through the real custom-provider resolver."""
+    from agent import secret_scope
+
+    hermes_home = tmp_path / "profile"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        """
+providers:
+  other-proxy:
+    api: http://127.0.0.1:4001/v1
+    key_env: LITELLM_MASTER_KEY
+    default_model: MiniMax-M3
+auxiliary:
+  background_review:
+    provider: other-proxy
+    model: MiniMax-M3
+    api_key: ${LITELLM_MASTER_KEY}
+    key_env: LITELLM_MASTER_KEY
+""".lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("LITELLM_MASTER_KEY", "wrong-default-profile-key")
+    agent = _FakeAgent(
+        provider="custom",
+        requested_provider="litellm-local",
+        model="MiniMax-M3",
+    )
+
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope(
+        {"LITELLM_MASTER_KEY": "scoped-profile-key"}
+    )
+    try:
+        rt = br._resolve_review_runtime(agent)
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(False)
+
+    assert rt["routed"] is True
+    assert rt["provider"] == "custom"
+    assert rt["requested_provider"] == "other-proxy"
+    assert rt["model"] == "MiniMax-M3"
+    assert rt["api_key"] == "scoped-profile-key"
+    assert rt["base_url"] == "http://127.0.0.1:4001/v1"
 
 
 def test_routing_resolution_failure_falls_back_to_parent():


### PR DESCRIPTION
## Summary

- recognize the live parent route through both requested and resolved provider identities
- inherit the parent runtime credential for same-provider/model review forks
- resolve distinct-route key_env credentials through the active profile secret scope
- preserve requested-provider identity on the spawned review agent

## Security invariant

A multiplexed profile must never forward a process-global credential captured from another profile. Named custom-provider aliases that resolve to custom must inherit the live parent credential when they identify the same route, while explicit separate providers remain independently routed.

## Verification

- 41 focused and neighboring background-review tests passed
- real temp-profile config and custom-provider resolution passed with a conflicting process-global value and scoped profile value
- repository-wide Ruff passed
- compileall, diff check, and staged gitleaks scan passed

The full repository suite was attempted, but the fallback repository venv lacks pytest-asyncio and unrelated async test files fail before this change is exercised.