### PR TITLE
mcp catalog: add mengram

### DIFF
--- a/optional-mcps/mengram/manifest.yaml
+++ b/optional-mcps/mengram/manifest.yaml
@@ -1,0 +1,46 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: mengram
+description: Remember across sessions — facts, what happened, and the workflows the agent has learned.
+source: https://docs.mengram.io
+
+# Mengram ships a remote MCP server with native OAuth 2.1 + PKCE and Dynamic
+# Client Registration over Streamable HTTP. Discovery is advertised at
+# /.well-known/oauth-authorization-server, and the endpoint itself at
+# /.well-known/oauth-protected-resource, so Hermes's MCP client +
+# mcp_oauth_manager handle the flow — nothing to install locally.
+transport:
+  type: http
+  url: https://mengram.io/mcp/connector
+
+auth:
+  type: oauth
+  # No `provider:` — this is native MCP OAuth (case 1), not a third-party
+  # provider. The MCP client triggers the browser flow on the first probe.
+
+# Tool selection at install time:
+# /mcp/connector is a deliberately small surface — remember, recall,
+# context_for, list_procedures — so `default_enabled` is left unset and the
+# install-time checklist starts with all four pre-checked. The full 30-tool
+# surface lives at /mcp for callers that want it.
+
+# Composer-suggestion triggers (desktop brand pills).
+suggest:
+  keywords:
+    - mengram
+    - memory
+  hosts:
+    - mengram.io
+
+post_install: |
+  On first connection, Hermes will open a browser to authenticate with
+  Mengram. A free account is enough to start.
+
+  After auth, restart your Hermes session so the memory tools are loaded.
+  The agent can then save what matters from a conversation and recall it in
+  later sessions, from any machine.
+
+  You can re-run the tool checklist any time with:
+    hermes mcp configure mengram

--- a/optional-mcps/mengram/manifest.yaml
+++ b/optional-mcps/mengram/manifest.yaml
@@ -27,10 +27,13 @@ auth:
 # surface lives at /mcp for callers that want it.
 
 # Composer-suggestion triggers (desktop brand pills).
+# Brand term only, matching the approved entries: `memory` would fire the pill
+# whenever anyone talks about memory at all, which reads as an upsell wearing
+# an endorsement's clothes rather than a brand match. The host below already
+# covers people who name the site.
 suggest:
   keywords:
     - mengram
-    - memory
   hosts:
     - mengram.io
 


### PR DESCRIPTION
Adds Mengram to `optional-mcps` — persistent memory for the agent: facts, past events, and the workflows it has learned, carried between sessions and across machines.

One `manifest.yaml`, no code.

## Why it fits case 1

Mengram serves a remote MCP server over Streamable HTTP with native OAuth 2.1 + PKCE and Dynamic Client Registration, so `mcp_oauth_manager` handles the whole flow and nothing installs locally — the same shape as the Linear entry.

Discovery is already live:

- `/.well-known/oauth-authorization-server` → issuer, authorize, token, and a `registration_endpoint`, with `S256` in `code_challenge_methods_supported`
- `/.well-known/oauth-protected-resource` → declares `https://mengram.io/mcp/connector` as the resource, `bearer_methods_supported: [header]`, scopes `read`/`write`
- the endpoint answers `401` unauthenticated

## Tool surface

The manifest points at `/mcp/connector`, a deliberately small surface of four tools rather than the full server:

| tool | |
|---|---|
| `remember` | save what matters from a conversation |
| `recall` | semantic recall across memory |
| `context_for` | context pack for a task or person |
| `list_procedures` | learned workflows, with their success/failure record |

`default_enabled` is left unset so the install-time checklist starts with all four pre-checked. The full 30-tool surface stays at `/mcp` for callers that want it.

## Notes

A free account is enough to connect; the `post_install` text says so. Docs at https://docs.mengram.io, source at https://github.com/alibaizhanov/mengram (Apache 2.0).

Happy to adjust the description, keywords, or trim the tool set if you'd rather the catalog entry look different.
