### PR TITLE
fix(desktop): refresh externally updated session tiles

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -2,8 +2,16 @@ import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { $changeEventsAvailable, notifySessionsChanged, resetLiveSync } from '@/store/live-sync'
-import { $activeSessionId, $selectedStoredSessionId, setBusy, setMessagingSessions, setSessions } from '@/store/session'
+import {
+  $activeSessionId,
+  $selectedStoredSessionId,
+  setBusy,
+  setCronSessions,
+  setMessagingSessions,
+  setSessions
+} from '@/store/session'
 import {
   $attentionSessionIds,
   $stalledSessionIds,
@@ -15,6 +23,7 @@ import {
 import {
   type ActiveTranscriptRefreshDeps,
   reconcileActiveTranscript,
+  reconcileOpenTranscripts,
   rehydrateLiveSessionStatuses,
   resolveActiveTranscriptSession,
   useBackgroundSync,
@@ -91,6 +100,7 @@ function useSyncHarness({
     freshDraftReady: false,
     gatewayState: 'open',
     refreshActiveTranscript,
+    refreshSessionTiles: vi.fn(async () => undefined),
     refreshCronJobs: vi.fn(),
     refreshCurrentModel: vi.fn(),
     refreshHermesConfig: vi.fn(),
@@ -128,6 +138,7 @@ afterEach(() => {
   $activeSessionId.set(null)
   $selectedStoredSessionId.set(null)
   setSessions([])
+  setCronSessions([])
   setMessagingSessions([])
   setBusy(false)
   vi.clearAllMocks()
@@ -157,6 +168,37 @@ describe('active transcript refresh', () => {
         text: 'external answer'
       })
     )
+  })
+
+  it('refreshes session tiles alongside the primary transcript when sessions.changed ticks', async () => {
+    $changeEventsAvailable.set(true)
+    const refreshActiveTranscript = vi.fn(async () => undefined)
+    const refreshSessionTiles = vi.fn(async () => undefined)
+
+    renderHook(() =>
+      useBackgroundSync({
+        activeConnectionId: 'local',
+        activeGatewayProfile: 'default',
+        activeIsMessaging: false,
+        activeSessionId: ACTIVE_RUNTIME_ID,
+        activeStoredSessionId: ACTIVE_STORED_ID,
+        freshDraftReady: false,
+        gatewayState: 'open',
+        refreshActiveTranscript,
+        refreshSessionTiles,
+        refreshCronJobs: vi.fn(),
+        refreshCurrentModel: vi.fn(),
+        refreshHermesConfig: vi.fn(),
+        refreshMessagingSessions: vi.fn(),
+        refreshSessions: vi.fn(),
+        requestGateway: vi.fn(async () => ({ sessions: [] })) as never
+      })
+    )
+
+    act(() => notifySessionsChanged())
+
+    await waitFor(() => expect(refreshSessionTiles).toHaveBeenCalledTimes(1))
+    expect(refreshActiveTranscript).toHaveBeenCalledTimes(1)
   })
 
   it('does not add a periodic transcript poll to local/Desktop sessions', async () => {
@@ -237,7 +279,143 @@ describe('active transcript refresh', () => {
   })
 })
 
+describe('reconcileOpenTranscripts', () => {
+  it('hydrates every idle session tile through its own runtime cache', async () => {
+    const fixtureState = createClientSessionState('fixture')
+
+    const states = new Map([
+      ['runtime-a', createClientSessionState('stored-a')],
+      ['runtime-b', createClientSessionState('stored-b-tip')]
+    ])
+
+    const updateSessionState = vi.fn((runtimeId: string, updater: (state: typeof fixtureState) => typeof fixtureState) => {
+      const current = states.get(runtimeId)!
+      const next = updater(current)
+      states.set(runtimeId, next)
+
+      return next
+    })
+
+    const storedBMessages = [
+      { content: 'question for stored-b', role: 'user', timestamp: 1 },
+      { content: 'external answer for stored-b', role: 'assistant', timestamp: 2 }
+    ]
+
+    const signatureRef = {
+      current: new Map([['work:stored-b:runtime-old', sessionMessagesSignature(storedBMessages as never)]])
+    }
+
+    vi.mocked(getLatestSessionMessages).mockImplementation(async storedSessionId =>
+      ({
+        messages: [
+          { content: `question for ${storedSessionId}`, role: 'user', timestamp: 1 },
+          { content: `external answer for ${storedSessionId}`, role: 'assistant', timestamp: 2 }
+        ],
+        session_id: storedSessionId
+      }) as never
+    )
+
+    await reconcileOpenTranscripts({
+      requestSequenceRefs: { current: new Map() },
+      signatureRef,
+      targets: () => [
+        {
+          currentStoredSessionId: () => states.get('runtime-a')?.storedSessionId,
+          isBusy: () => false,
+          isCurrent: () => true,
+          profile: 'default',
+          runtimeSessionId: 'runtime-a',
+          storedSessionId: 'stored-a'
+        },
+        {
+          currentStoredSessionId: () => states.get('runtime-b')?.storedSessionId,
+          isBusy: () => false,
+          isCurrent: () => true,
+          profile: 'work',
+          runtimeSessionId: 'runtime-b',
+          storedSessionId: 'stored-b'
+        }
+      ],
+      updateSessionState
+    })
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-a', 'default')
+    expect(getLatestSessionMessages).toHaveBeenCalledWith('stored-b', 'work')
+    expect(updateSessionState).toHaveBeenCalledWith('runtime-b', expect.any(Function), 'stored-b-tip')
+    expect(signatureRef.current.has('work:stored-b:runtime-old')).toBe(false)
+    expect(signatureRef.current.has('work:stored-b:runtime-b')).toBe(true)
+    expect(states.get('runtime-a')?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'external answer for stored-a'
+    })
+    expect(states.get('runtime-b')?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'external answer for stored-b'
+    })
+  })
+
+  it('does not clobber a tile that is busy or closes during its read', async () => {
+    const updateSessionState = vi.fn()
+    const staleSequenceRef = { current: 3 }
+
+    const requestSequenceRefs = {
+      current: new Map<string, { current: number }>([['default:closed:runtime-closed', staleSequenceRef]])
+    }
+
+    let current = true
+    let resolve: ((value: unknown) => void) | undefined
+
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+
+    const refresh = reconcileOpenTranscripts({
+      requestSequenceRefs,
+      signatureRef: { current: new Map() },
+      targets: () => [
+        {
+          currentStoredSessionId: () => 'stored-a',
+          isBusy: () => false,
+          isCurrent: () => current,
+          runtimeSessionId: 'runtime-a',
+          storedSessionId: 'stored-a'
+        },
+        {
+          currentStoredSessionId: () => 'stored-b',
+          isBusy: () => true,
+          isCurrent: () => true,
+          runtimeSessionId: 'runtime-b',
+          storedSessionId: 'stored-b'
+        }
+      ],
+      updateSessionState: updateSessionState as never
+    })
+
+    current = false
+    resolve?.(transcript('stale tile answer'))
+    await refresh
+
+    expect(getLatestSessionMessages).toHaveBeenCalledTimes(1)
+    expect(updateSessionState).not.toHaveBeenCalled()
+    expect(staleSequenceRef.current).toBe(4)
+    expect(requestSequenceRefs.current.has('default:closed:runtime-closed')).toBe(false)
+  })
+})
+
 describe('reconcileActiveTranscript', () => {
+  it('resolves and hydrates a cron-only session from the cron sessions store', async () => {
+    setCronSessions([{ id: ACTIVE_STORED_ID, profile: 'cron-profile', source: 'cron' } as never])
+    const fixture = makeRefresh(resolveActiveTranscriptSession)
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('cron answer') as never)
+
+    await fixture.refresh()
+
+    expect(getLatestSessionMessages).toHaveBeenCalledWith(ACTIVE_STORED_ID, 'cron-profile')
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)?.parts[0]).toMatchObject({
+      text: 'cron answer'
+    })
+  })
+
   it('resolves and hydrates a messaging session from the messaging sessions store', async () => {
     setMessagingSessions([{ id: ACTIVE_STORED_ID, profile: 'messaging-profile', source: 'telegram' } as never])
     const fixture = makeRefresh(resolveActiveTranscriptSession)

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -21,6 +21,7 @@ function render(activeGatewayProfile: string, activeConnectionId: string, refres
         freshDraftReady: false,
         gatewayState: 'open',
         refreshActiveTranscript: noop,
+        refreshSessionTiles: noop,
         refreshCronJobs: noop,
         refreshCurrentModel: noop,
         refreshHermesConfig: noop,

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -9,9 +9,11 @@ import { sessionMessagesSignature } from '@/lib/session-signatures'
 import { $changeEventsAvailable, $cronChangeTick, $sessionsChangeTick } from '@/store/live-sync'
 import { $onBattery, batteryPollInterval } from '@/store/power'
 import { refreshActiveProfile } from '@/store/profile'
+import { $projectTree } from '@/store/projects'
 import {
   $activeSessionId,
   $busy,
+  $cronSessions,
   $currentCwd,
   $messagingSessions,
   $selectedStoredSessionId,
@@ -25,6 +27,7 @@ import {
   SESSION_WATCHDOG_TIMEOUT_MS,
   setSessionStalled
 } from '@/store/session-states'
+import type { SessionInfo } from '@/types/hermes'
 
 import type { ClientSessionState } from '../../types'
 import type { GatewayRequester } from '../types'
@@ -33,11 +36,21 @@ interface ActiveTranscriptSession {
   profile?: string | null
 }
 
-/** Resolve an active transcript from either local recents or messaging slices. */
+/** Resolve an open transcript from recents, messaging, or the project tree. */
 export function resolveActiveTranscriptSession(storedSessionId: string): ActiveTranscriptSession | undefined {
+  const match = (session: SessionInfo) => sessionMatchesStoredId(session, storedSessionId)
+
   return (
-    $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId)) ??
-    $messagingSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+    $sessions.get().find(match) ??
+    $cronSessions.get().find(match) ??
+    $messagingSessions.get().find(match) ??
+    $projectTree
+      .get()
+      .flatMap(project => [
+        ...project.repos.flatMap(repo => repo.groups.flatMap(group => group.sessions)),
+        ...(project.previewSessions ?? [])
+      ])
+      .find(match)
   )
 }
 
@@ -48,11 +61,28 @@ export interface ActiveTranscriptRefreshDeps {
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   resolveSession: (storedSessionId: string) => ActiveTranscriptSession | null | undefined
   signatureRef: MutableRefObject<Map<string, string>>
+  updateStoredSessionId?: () => null | string | undefined
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
     storedSessionId?: string | null
   ) => ClientSessionState
+}
+
+export interface OpenTranscriptTarget {
+  currentStoredSessionId: () => null | string | undefined
+  isBusy: () => boolean
+  isCurrent: () => boolean
+  profile?: string | null
+  runtimeSessionId: string
+  storedSessionId: string
+}
+
+export interface OpenTranscriptRefreshDeps {
+  requestSequenceRefs: MutableRefObject<Map<string, MutableRefObject<number>>>
+  signatureRef: MutableRefObject<Map<string, string>>
+  targets: () => readonly OpenTranscriptTarget[]
+  updateSessionState: ActiveTranscriptRefreshDeps['updateSessionState']
 }
 
 /** Reconcile one persisted transcript snapshot into the currently viewed session. */
@@ -63,6 +93,7 @@ export async function reconcileActiveTranscript({
   resolveSession,
   selectedStoredSessionIdRef,
   signatureRef,
+  updateStoredSessionId,
   updateSessionState
 }: ActiveTranscriptRefreshDeps): Promise<void> {
   const storedSessionId = selectedStoredSessionIdRef.current
@@ -93,7 +124,7 @@ export async function reconcileActiveTranscript({
       return
     }
 
-    const signatureKey = `${stored.profile ?? 'default'}:${storedSessionId}`
+    const signatureKey = `${stored.profile ?? 'default'}:${storedSessionId}:${runtimeSessionId}`
     const signature = sessionMessagesSignature(latest.messages)
 
     if (signatureRef.current.get(signatureKey) === signature) {
@@ -112,11 +143,86 @@ export async function reconcileActiveTranscript({
         // them (see transcript-backfill).
         messages: preserveLocalAssistantErrors(graftRefreshedTailOntoBackfill(messages, state.messages), state.messages)
       }),
-      storedSessionId
+      updateStoredSessionId ? updateStoredSessionId() : storedSessionId
     )
   } catch {
     // Non-fatal: the next change event or manual resume can hydrate the view.
   }
+}
+
+/** Reconcile every open chat surface through the guarded primary path. */
+export async function reconcileOpenTranscripts({
+  requestSequenceRefs,
+  signatureRef,
+  targets,
+  updateSessionState
+}: OpenTranscriptRefreshDeps): Promise<void> {
+  const uniqueTargets = new Map<string, OpenTranscriptTarget>()
+
+  for (const target of targets()) {
+    if (target.isCurrent()) {
+      uniqueTargets.set(target.runtimeSessionId, target)
+    }
+  }
+
+  const requestKeyFor = (target: OpenTranscriptTarget) =>
+    `${target.profile ?? 'default'}:${target.storedSessionId}:${target.runtimeSessionId}`
+
+  const activeRequestKeys = new Set([...uniqueTargets.values()].map(requestKeyFor))
+
+  for (const [key, requestSequenceRef] of requestSequenceRefs.current) {
+    if (!activeRequestKeys.has(key)) {
+      // Invalidate an in-flight read before releasing its sequence entry. If a
+      // tile later reopens under the same ids, that old response must not land.
+      requestSequenceRef.current += 1
+      requestSequenceRefs.current.delete(key)
+    }
+  }
+
+  for (const key of signatureRef.current.keys()) {
+    if (!activeRequestKeys.has(key)) {
+      signatureRef.current.delete(key)
+    }
+  }
+
+  await Promise.all(
+    [...uniqueTargets.values()].map(target => {
+      const requestKey = requestKeyFor(target)
+      let requestSequenceRef = requestSequenceRefs.current.get(requestKey)
+
+      if (!requestSequenceRef) {
+        requestSequenceRef = { current: 0 }
+        requestSequenceRefs.current.set(requestKey, requestSequenceRef)
+      }
+
+      return reconcileActiveTranscript({
+        activeSessionIdRef: {
+          get current() {
+            return target.isCurrent() ? target.runtimeSessionId : null
+          },
+          set current(_value: string | null) {}
+        },
+        busyRef: {
+          get current() {
+            return target.isBusy()
+          },
+          set current(_value: boolean) {}
+        },
+        requestSequenceRef,
+        resolveSession: storedSessionId =>
+          target.isCurrent() && storedSessionId === target.storedSessionId ? { profile: target.profile } : undefined,
+        selectedStoredSessionIdRef: {
+          get current() {
+            return target.isCurrent() ? target.storedSessionId : null
+          },
+          set current(_value: string | null) {}
+        },
+        signatureRef,
+        updateStoredSessionId: target.currentStoredSessionId,
+        updateSessionState
+      })
+    })
+  )
 }
 
 // Cron sessions are written by a background scheduler tick, messaging turns by
@@ -292,6 +398,7 @@ interface BackgroundSyncParams {
   freshDraftReady: boolean
   gatewayState: string
   refreshActiveTranscript: () => Promise<unknown> | unknown
+  refreshSessionTiles: () => Promise<unknown> | unknown
   refreshCronJobs: () => Promise<unknown> | unknown
   refreshCurrentModel: (force?: boolean) => Promise<unknown> | unknown
   refreshHermesConfig: () => Promise<unknown> | unknown
@@ -360,6 +467,7 @@ export function useBackgroundSync({
   freshDraftReady,
   gatewayState,
   refreshActiveTranscript,
+  refreshSessionTiles,
   refreshCronJobs,
   refreshCurrentModel,
   refreshHermesConfig,
@@ -512,6 +620,7 @@ export function useBackgroundSync({
       void refreshSessions()
       void refreshMessagingSessions()
       requestActiveTranscriptRefresh(true)
+      void refreshSessionTiles()
     }
 
     const unsubscribe = $sessionsChangeTick.listen(() => {
@@ -534,7 +643,14 @@ export function useBackgroundSync({
         window.clearTimeout(timer)
       }
     }
-  }, [changeEventsAvailable, gatewayState, refreshMessagingSessions, refreshSessions, requestActiveTranscriptRefresh])
+  }, [
+    changeEventsAvailable,
+    gatewayState,
+    refreshMessagingSessions,
+    refreshSessions,
+    refreshSessionTiles,
+    requestActiveTranscriptRefresh
+  ])
 
   // Keep the cron-jobs section live without a user action (scheduler ticks in
   // the background). cron.changed (jobs.json moved: CRUD or a scheduler tick's

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -71,6 +71,7 @@ import {
   setMessages
 } from '@/store/session'
 import { requestForSessionProfile } from '@/store/session-request-router'
+import { $sessionTiles } from '@/store/session-states'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
 import { isAuxiliaryWindow, isHudWindow } from '@/store/windows'
@@ -114,6 +115,7 @@ import { usePreviewRouting } from '../session/hooks/use-preview-routing'
 import { usePromptActions } from '../session/hooks/use-prompt-actions'
 import { useRouteResume } from '../session/hooks/use-route-resume'
 import { useSessionActions } from '../session/hooks/use-session-actions'
+import { resolveSessionProfile } from '../session/hooks/use-session-actions/utils'
 import { useSessionListActions } from '../session/hooks/use-session-list-actions'
 import { useSessionStateCache } from '../session/hooks/use-session-state-cache'
 import { startWorkspaceSession } from '../session/workspace-session-target'
@@ -132,6 +134,7 @@ import { UpdatesOverlay } from '../updates-overlay'
 import { ContribWiringContext } from './context'
 import {
   reconcileActiveTranscript,
+  reconcileOpenTranscripts,
   resolveActiveTranscriptSession,
   useBackgroundSync
 } from './hooks/use-background-sync'
@@ -173,7 +176,9 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const billingSettingsSeenRef = useRef(0)
   const cronReviewSeenRef = useRef(0)
   const activeTranscriptSignatureRef = useRef(new Map<string, string>())
+  const tileTranscriptSignatureRef = useRef(new Map<string, string>())
   const activeTranscriptRequestSequenceRef = useRef(0)
+  const openTranscriptRequestSequenceRefs = useRef(new Map<string, { current: number }>())
   // Stable identity for the whole callback surface (see WiringActions). Mutated
   // in place each render so memoized surfaces never re-render on churn.
   const actionsRef = useRef<WiringActions | null>(null)
@@ -428,6 +433,58 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       }),
     [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, updateSessionState]
   )
+
+  const refreshSessionTiles = useCallback(async () => {
+    const tiles = await Promise.all(
+      $sessionTiles.get().map(async tile => {
+        const runtimeSessionId = tile.runtimeId
+
+        if (!runtimeSessionId) {
+          return null
+        }
+
+        const storedSessionId = tile.storedSessionId
+        const cachedProfile = resolveActiveTranscriptSession(storedSessionId)?.profile?.trim()
+        const profile = cachedProfile || (await resolveSessionProfile(storedSessionId).catch(() => undefined))
+
+        if (!profile) {
+          return null
+        }
+
+        return { profile, runtimeSessionId, storedSessionId }
+      })
+    )
+
+    return reconcileOpenTranscripts({
+      requestSequenceRefs: openTranscriptRequestSequenceRefs,
+      signatureRef: tileTranscriptSignatureRef,
+      targets: () =>
+        tiles.flatMap(tile =>
+          tile
+            ? [
+                {
+                  currentStoredSessionId: () =>
+                    sessionStateByRuntimeIdRef.current.get(tile.runtimeSessionId)?.storedSessionId,
+                  isBusy: () => Boolean(sessionStateByRuntimeIdRef.current.get(tile.runtimeSessionId)?.busy),
+                  isCurrent: () =>
+                    sessionStateByRuntimeIdRef.current.has(tile.runtimeSessionId) &&
+                    $sessionTiles
+                      .get()
+                      .some(
+                        current =>
+                          current.storedSessionId === tile.storedSessionId &&
+                          current.runtimeId === tile.runtimeSessionId
+                      ),
+                  profile: tile.profile,
+                  runtimeSessionId: tile.runtimeSessionId,
+                  storedSessionId: tile.storedSessionId
+                }
+              ]
+            : []
+        ),
+      updateSessionState
+    })
+  }, [sessionStateByRuntimeIdRef, updateSessionState])
 
   const { handleGatewayEvent } = useMessageStream({
     activeGatewayProfile,
@@ -807,6 +864,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     freshDraftReady,
     gatewayState,
     refreshActiveTranscript,
+    refreshSessionTiles,
     refreshCronJobs,
     refreshCurrentModel,
     refreshHermesConfig,


### PR DESCRIPTION
## What does this PR do?

Extends Desktop's existing event-driven transcript reconciliation to session tiles.

A stored conversation can be open as either the primary workspace chat or a `session-tile:*` pane. `sessions.changed` already refreshed the primary transcript after another process appended to `state.db`, but tiled chats only hydrated on resume and listened to their own live gateway stream. A Hermex/WebUI, CLI, cron, or messaging turn could therefore persist into the same session while the visible Desktop tile stayed stale.

This keeps the existing architecture: the gateway's coarse `sessions.changed` nudge, the existing 10-second coalescing path, and `reconcileActiveTranscript`. It adds no timer, transport, broker, or WebUI-specific integration.

## Related Issue

Addresses the session-tile variant of #42962 and the cross-process event gap described in #58671.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Refresh every open idle session tile alongside the primary transcript on the existing coalesced `sessions.changed` path.
- Reuse the authoritative transcript conversion, tail grafting, local-error preservation, stale-response guard, and runtime-cache update path.
- Preserve auto-compression ownership by reading through the tile's durable/root ID while committing into the runtime cache's current stored tip.
- Scope transcript signatures by runtime and keep tile signatures separate from the primary cache, so moving the same stored session between surfaces cannot suppress hydration.
- Resolve cron-only rows and fail closed through the existing cross-profile ownership resolver when a cached row lacks a profile.
- Invalidate and prune stale tile request/signature entries when targets close or rebind.

## How to Test

Reproduction before the fix:

1. Open a stored session in Desktop as a session tile/tab and leave it idle.
2. Resume that exact stored session from another process/frontend (Hermex/WebUI or `hermes chat --resume <id> -q "..."`).
3. Confirm the new turns are persisted into the same `state.db` session.
4. Observe that the already-open tile remains stale while switching/reopening hydrates it.

After this change, the existing `sessions.changed` nudge refreshes the tile without switching or reopening it.

Automated verification on macOS:

- `npm run test:ui -- --run src/app/contrib` — 66 passed
- `npm run test:ui -- --run src/app/contrib/hooks/use-session-tile-delegate.test.ts src/app/chat/session-tile-actions.test.ts` — 8 passed
- `npm run typecheck` — passed
- focused ESLint on the changed background-sync files — passed
- `git diff --check` — passed

A full `npm run test:ui` run completed with 5,330 passing and 15 failures in unrelated suites. The largest failure group (`src/app/skills/index.test.tsx`) reproduces in isolation on current `main` (11/11 failures, overlapping `act()`/duplicate mount symptoms); no failed test imports or exercises the files changed here.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository `AGENTS.md` guidance
- [x] My commit message follows Conventional Commits
- [x] I searched existing issues/PRs; the primary-view fix landed via #86299/#86588, but no tile variant was found
- [x] My PR contains only changes related to this bug
- [x] I've added regression coverage for tile hydration, busy/closed targets, runtime rotation, cron rows, runtime-scoped signatures, and cleanup
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update N/A — no user-facing setting or workflow changes
- [x] Config example update N/A
- [x] Architecture-guide update N/A — extends the existing sync contract
- [x] Cross-platform impact considered — renderer/gateway logic is platform-independent
- [x] Tool schema update N/A

## Screenshots / Logs

No visual change. The observable contract is that an externally persisted turn appears in an already-open session tile without a tab switch or restart.
