### PR TITLE
fix(gateway): dedup STT input by content, not just cache path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24669,6 +24669,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         seen = set()
         audio_paths = [p for p in audio_paths if p not in seen and not seen.add(p)]
+        # Content-identity dedup (#91513): the same physical voice can enter
+        # one turn through BOTH the current-media and replied-to-media routes,
+        # each download getting its own local cache path — so path identity
+        # misses it and the STT provider is billed twice for the same bytes.
+        # Hash the file contents (order-preserving first-wins); an unreadable
+        # path falls back to path identity and never collapses with another
+        # unreadable path.
+        import hashlib
+
+        content_seen: set = set()
+        content_deduped: List[str] = []
+        for p in audio_paths:
+            try:
+                h = hashlib.sha256()
+                with open(p, "rb") as f:
+                    for chunk in iter(lambda: f.read(65536), b""):
+                        h.update(chunk)
+                key = ("sha256", h.hexdigest())
+            except OSError:
+                key = ("path", p)
+            if key in content_seen:
+                logger.debug(
+                    "Skipping duplicate audio content (same bytes via a "
+                    "different cache path): %s", p,
+                )
+                continue
+            content_seen.add(key)
+            content_deduped.append(p)
+        audio_paths = content_deduped
         if not getattr(self.config, "stt_enabled", True):
             notes = []
             for path in audio_paths:

--- a/tests/gateway/test_stt_content_dedup.py
+++ b/tests/gateway/test_stt_content_dedup.py
@@ -1,0 +1,112 @@
+"""Content-identity dedup at the gateway STT boundary (#91513).
+
+The same Telegram voice can reach one turn through both the current-media
+and replied-to-media routes; each download gets its own local cache path,
+so the old path-only dedup transcribed (and billed) it twice. The gateway
+must collapse identical audio BYTES across distinct paths, keep distinct
+audio distinct, and never merge unreadable paths.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.session import SessionSource
+
+
+def _make_runner() -> "GatewayRunner":  # type: ignore[name-defined]
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+    return runner
+
+
+_SOURCE = SessionSource(platform="telegram", chat_id="1", chat_type="dm")
+
+
+def _fake_transcribe(transcript: str = "hello world"):
+    return patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": transcript, "provider": "whisper"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_bytes_different_paths_transcribed_once(tmp_path):
+    """Two cache paths with identical audio bytes -> one STT call (#91513)."""
+    a = tmp_path / "audio_A.ogg"
+    b = tmp_path / "audio_B.ogg"
+    payload = b"same-voice-bytes" * 4
+    a.write_bytes(payload)
+    b.write_bytes(payload)
+
+    runner = _make_runner()
+    with _fake_transcribe() as mock_transcribe:
+        enriched, transcripts = await runner._enrich_message_with_transcription(
+            "check this", [str(a), str(b)]
+        )
+
+    assert mock_transcribe.call_count == 1, (
+        "identical bytes via distinct cache paths must be transcribed once"
+    )
+    assert transcripts == ["hello world"]
+
+
+@pytest.mark.asyncio
+async def test_different_bytes_both_transcribed(tmp_path):
+    """Distinct audio files must remain distinct after dedup."""
+    a = tmp_path / "audio_A.ogg"
+    b = tmp_path / "audio_B.ogg"
+    a.write_bytes(b"voice-one" * 4)
+    b.write_bytes(b"voice-two" * 4)
+
+    runner = _make_runner()
+    with _fake_transcribe() as mock_transcribe:
+        enriched, transcripts = await runner._enrich_message_with_transcription(
+            "check this", [str(a), str(b)]
+        )
+
+    assert mock_transcribe.call_count == 2
+    assert transcripts == ["hello world", "hello world"]
+
+
+@pytest.mark.asyncio
+async def test_repeated_identical_path_still_once(tmp_path):
+    """The pre-existing path dedup behavior is preserved."""
+    a = tmp_path / "audio_A.ogg"
+    a.write_bytes(b"voice" * 4)
+
+    runner = _make_runner()
+    with _fake_transcribe() as mock_transcribe:
+        await runner._enrich_message_with_transcription(
+            "check this", [str(a), str(a)]
+        )
+
+    assert mock_transcribe.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_unreadable_paths_do_not_collapse_or_crash(tmp_path):
+    """Missing/unreadable paths fall back to path identity: no crash, and two
+    distinct unreadable paths are never merged into one another."""
+    missing_a = str(tmp_path / "missing_A.ogg")
+    missing_b = str(tmp_path / "missing_B.ogg")
+
+    runner = _make_runner()
+    with _fake_transcribe() as mock_transcribe:
+        enriched, transcripts = await runner._enrich_message_with_transcription(
+            "check this", [missing_a, missing_b]
+        )
+
+    # Two distinct unreadable paths must never merge with each other (the
+    # dedup key falls back to path identity). The mock always succeeds, so
+    # both attempted transcriptions "succeed" — the call count is the
+    # no-accidental-collapse proof.
+    assert mock_transcribe.call_count == 2
+    assert transcripts == ["hello world", "hello world"]


### PR DESCRIPTION
## What does this PR do?

Stops the same physical voice from being transcribed (and billed) twice in one user turn. A Telegram voice can reach the startup batch through BOTH the current-media path and the replied-to-media path; the adapter caches each download under its own local path, so the existing path-only dedup in `_enrich_message_with_transcription()` did not recognize the identical bytes — the STT provider was charged twice and the agent received the same transcript twice (#91513; observed: two cached files with identical SHA-256, size, and duration but distinct generated paths).

The fix adds content-identity deduplication at the shared gateway boundary, before STT: hash each file's bytes (order-preserving, first occurrence wins). Unreadable/missing paths fall back to path identity and never collapse with one another; distinct audio files remain distinct; the pre-existing repeated-path behavior is unchanged. This guards every adapter and merge path, not just the Telegram replied-media route.

## Related Issue

Fixes #91513

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: In `_enrich_message_with_transcription()`, after the existing path dedup, hash each audio file's content (streamed SHA-256) and drop later entries whose bytes were already seen, with a comment explaining the dual-route cache-path failure mode. Unreadable paths keep path identity so two broken paths never merge.
- `tests/gateway/test_stt_content_dedup.py`: New regression suite with the four cases from the issue — identical bytes via distinct paths → one transcription; distinct bytes → both transcribed; repeated identical path → still one; two unreadable paths → attempted independently (no accidental collapse, no crash).

## How to Test

1. In a Telegram DM topic, start a turn with a short text, then during the startup-media grace window send an update whose current voice and `reply_to_message.voice` are the same file
2. Before the fix the logs show two "Cached ... audio" entries, two STT calls, and the same transcript prepended twice; after the fix the duplicate content is dropped at the boundary and one transcript is prepended (Observed result: `test_same_bytes_different_paths_transcribed_once` fails on unpatched main with 2 STT calls and passes with this patch)
3. Two genuinely different voice notes in one turn still both transcribe (Observed result: `test_different_bytes_both_transcribed` passes, 2 calls)
4. `scripts/run_tests.sh tests/gateway/test_stt_content_dedup.py tests/gateway/test_telegram_audio_vs_voice.py -q` → should pass (Observed result: 6 passed locally)
5. `scripts/run_tests.sh tests/gateway/test_stt_config.py -q` → should pass (Observed result: 4 passed locally)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
