### PR TITLE
fix(agent): guard merged assistant compaction handoffs (salvage #85394)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -7978,7 +7978,6 @@ def reference_handoff_would_drive_next_model_call(
     for index, message in enumerate(messages):
         if not is_compaction_summary_message(message):
             continue
-        previous = messages[index - 1] if index > 0 else None
         merged_completed_assistant = (
             isinstance(message, dict)
             and message.get("role") == "assistant"
@@ -7986,17 +7985,17 @@ def reference_handoff_would_drive_next_model_call(
                 message.get("content")
             )
             == "merged"
-            and isinstance(previous, dict)
-            and previous.get("role") == "assistant"
-            and previous.get("finish_reason") == "stop"
+            and message.get("finish_reason") == "stop"
+            and not message.get("tool_calls")
         )
         if (
             _handoff_carries_live_user_content(message)
             and not merged_completed_assistant
         ):
             # Embedded live ask — this row is not a sole-handoff driver. A
-            # merged assistant carrier after a completed stop preserves the
-            # assistant's own prose/tool_calls, not a fresh user request.
+            # completed merged assistant carrier preserves the assistant's own
+            # prose, not a fresh user request. A carrier with pending tool_calls
+            # remains live regardless of an earlier completed assistant turn.
             continue
         last_driving_handoff = index
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -7978,8 +7978,25 @@ def reference_handoff_would_drive_next_model_call(
     for index, message in enumerate(messages):
         if not is_compaction_summary_message(message):
             continue
-        if _handoff_carries_live_user_content(message):
-            # Embedded live ask — this row is not a sole-handoff driver.
+        previous = messages[index - 1] if index > 0 else None
+        merged_completed_assistant = (
+            isinstance(message, dict)
+            and message.get("role") == "assistant"
+            and ContextCompressor.classify_summary_content(
+                message.get("content")
+            )
+            == "merged"
+            and isinstance(previous, dict)
+            and previous.get("role") == "assistant"
+            and previous.get("finish_reason") == "stop"
+        )
+        if (
+            _handoff_carries_live_user_content(message)
+            and not merged_completed_assistant
+        ):
+            # Embedded live ask — this row is not a sole-handoff driver. A
+            # merged assistant carrier after a completed stop preserves the
+            # assistant's own prose/tool_calls, not a fresh user request.
             continue
         last_driving_handoff = index
 

--- a/tests/agent/test_reference_handoff_active_turn.py
+++ b/tests/agent/test_reference_handoff_active_turn.py
@@ -14,8 +14,11 @@ from agent.context_compressor import (
     COMPRESSED_SUMMARY_HAS_USER_TURN_KEY,
     COMPRESSED_SUMMARY_METADATA_KEY,
     COMPRESSION_CONTINUATION_USER_CONTENT,
+    ContextCompressor,
     HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
+    _MERGED_PRIOR_CONTEXT_HEADER,
+    _MERGED_SUMMARY_DELIMITER,
     _SUMMARY_END_MARKER,
     is_compaction_summary_message,
     is_user_originated_turn,
@@ -34,6 +37,24 @@ def _standalone_handoff(task: str = "finish the already-done refactor") -> dict:
             f"{SUMMARY_PREFIX}\n{HISTORICAL_TASK_HEADING}\n"
             f"User asked: '{task}'\n\n{_SUMMARY_END_MARKER}"
         ),
+        COMPRESSED_SUMMARY_METADATA_KEY: True,
+        COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: True,
+    }
+
+
+def _merged_assistant_carrier() -> dict:
+    """Production merge-into-tail shape: assistant role/tool_calls survive."""
+    return {
+        "role": "assistant",
+        "content": (
+            f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+            "Refactor complete.\n\n"
+            f"{_MERGED_SUMMARY_DELIMITER}\n"
+            f"{SUMMARY_PREFIX}\n{HISTORICAL_TASK_HEADING}\n"
+            "User asked: 'finish the already-done refactor'\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        ),
+        "tool_calls": [{"id": "stale-c1", "function": {"name": "terminal"}}],
         COMPRESSED_SUMMARY_METADATA_KEY: True,
         COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: True,
     }
@@ -73,6 +94,70 @@ class TestReferenceHandoffWouldDriveNextModelCall:
                 "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
             },
             {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        ]
+        assert reference_handoff_would_drive_next_model_call(messages) is False
+
+    def test_merged_assistant_carrier_after_completed_stop_drives(self):
+        """Completed assistant prose/tool_calls on the carrier are not a user ask."""
+        messages = [
+            {"role": "user", "content": "please finish the refactor"},
+            {
+                "role": "assistant",
+                "content": "Refactor complete.",
+                "finish_reason": "stop",
+            },
+            _merged_assistant_carrier(),
+        ]
+        assert reference_handoff_would_drive_next_model_call(messages) is True
+
+    def test_merged_assistant_carrier_without_completed_stop_stays_in_flight(self):
+        messages = [
+            {"role": "user", "content": "please finish the refactor"},
+            _merged_assistant_carrier(),
+        ]
+        assert reference_handoff_would_drive_next_model_call(messages) is False
+
+    def test_standalone_assistant_handoff_after_stop_uses_existing_guard(self):
+        handoff = _standalone_handoff()
+        handoff["role"] = "assistant"
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Refactor complete.",
+                "finish_reason": "stop",
+            },
+            handoff,
+        ]
+        assert ContextCompressor.classify_summary_content(handoff["content"]) == (
+            "standalone"
+        )
+        assert reference_handoff_would_drive_next_model_call(messages) is True
+
+    def test_real_user_after_merged_assistant_carrier_does_not_drive(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Refactor complete.",
+                "finish_reason": "stop",
+            },
+            _merged_assistant_carrier(),
+            {"role": "user", "content": "start a different task"},
+        ]
+        assert reference_handoff_would_drive_next_model_call(messages) is False
+
+    def test_distinct_tool_call_after_merged_carrier_stays_in_flight(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Refactor complete.",
+                "finish_reason": "stop",
+            },
+            _merged_assistant_carrier(),
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "live-c2", "function": {"name": "terminal"}}],
+            },
         ]
         assert reference_handoff_would_drive_next_model_call(messages) is False
 

--- a/tests/agent/test_reference_handoff_active_turn.py
+++ b/tests/agent/test_reference_handoff_active_turn.py
@@ -42,9 +42,11 @@ def _standalone_handoff(task: str = "finish the already-done refactor") -> dict:
     }
 
 
-def _merged_assistant_carrier() -> dict:
-    """Production merge-into-tail shape: assistant role/tool_calls survive."""
-    return {
+def _merged_assistant_carrier(
+    *, finish_reason: str = "stop", tool_calls: list[dict] | None = None
+) -> dict:
+    """Production merge-into-tail shape with the carrier's completion state."""
+    carrier = {
         "role": "assistant",
         "content": (
             f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
@@ -54,10 +56,13 @@ def _merged_assistant_carrier() -> dict:
             "User asked: 'finish the already-done refactor'\n\n"
             f"{_SUMMARY_END_MARKER}"
         ),
-        "tool_calls": [{"id": "stale-c1", "function": {"name": "terminal"}}],
+        "finish_reason": finish_reason,
         COMPRESSED_SUMMARY_METADATA_KEY: True,
         COMPRESSED_SUMMARY_HAS_USER_TURN_KEY: True,
     }
+    if tool_calls is not None:
+        carrier["tool_calls"] = tool_calls
+    return carrier
 
 
 class TestReferenceHandoffWouldDriveNextModelCall:
@@ -97,23 +102,27 @@ class TestReferenceHandoffWouldDriveNextModelCall:
         ]
         assert reference_handoff_would_drive_next_model_call(messages) is False
 
-    def test_merged_assistant_carrier_after_completed_stop_drives(self):
-        """Completed assistant prose/tool_calls on the carrier are not a user ask."""
+    def test_completed_merged_assistant_carrier_drives_without_adjacent_stop(self):
+        """The carrier's own stop marks preserved assistant prose as completed."""
         messages = [
+            {"role": "system", "content": "system"},
             {"role": "user", "content": "please finish the refactor"},
-            {
-                "role": "assistant",
-                "content": "Refactor complete.",
-                "finish_reason": "stop",
-            },
             _merged_assistant_carrier(),
         ]
         assert reference_handoff_would_drive_next_model_call(messages) is True
 
-    def test_merged_assistant_carrier_without_completed_stop_stays_in_flight(self):
+    def test_live_tool_call_carrier_after_completed_stop_stays_in_flight(self):
+        """Pending tool_calls on the carrier are live even after an earlier stop."""
         messages = [
-            {"role": "user", "content": "please finish the refactor"},
-            _merged_assistant_carrier(),
+            {
+                "role": "assistant",
+                "content": "Earlier turn complete.",
+                "finish_reason": "stop",
+            },
+            _merged_assistant_carrier(
+                finish_reason="tool_calls",
+                tool_calls=[{"id": "live-c1", "function": {"name": "terminal"}}],
+            ),
         ]
         assert reference_handoff_would_drive_next_model_call(messages) is False
 


### PR DESCRIPTION
## Summary

A completed merged assistant compaction carrier can no longer become the active turn and re-drive the model after its work already finished (extends the #80622 guard to the merged-carrier shape it missed).

Salvage of #85394 by @abundantbeing — both commits cherry-picked with authorship preserved.

## Changes

- `agent/context_compressor.py`: `reference_handoff_would_drive_next_model_call` now treats a merged assistant carrier with its own completed `finish_reason="stop"` and no pending `tool_calls` as reference-only. A carrier with pending tool_calls stays live; standalone handoffs, force-user-leading carriers, and real user turns after the carrier are unchanged.
- `tests/agent/test_reference_handoff_active_turn.py`: +5 tests covering the completed merged carrier, live tool-call carrier, standalone-after-stop, user-after-carrier, and distinct tool-call-after-carrier shapes.

## Validation

| | Before (main) | After |
|---|---|---|
| Completed merged carrier drives next model call | True (bug) | False |
| Live tool-call carrier stays in flight | ✓ | ✓ |
| Non-normalized finish_reason (`end_turn`) | pre-PR behavior | pre-PR behavior (fail-safe) |

- 20/20 in the focused active-turn suite; mutation check confirmed (revert prod file → RED, restore → GREEN)
- Side-by-side E2E main vs branch verified the fix flips exactly the bug case and nothing else
- ruff clean

Closes #85394. Credit: @abundantbeing (authorship preserved via cherry-pick).
Refs #42768 (remaining merged-assistant active-turn leak).
