### PR TITLE
fix(gateway): dedupe identical audio before STT

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,6 +28,7 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import faulthandler
+import hashlib
 import inspect
 import json
 import logging
@@ -3236,6 +3237,62 @@ async def _probe_audio_duration(path: str) -> Optional[str]:
         pass
 
     return None
+
+
+def _deduplicate_audio_paths(audio_paths: List[str]) -> tuple[List[str], List[str]]:
+    """Preserve order while removing repeated paths and identical audio files.
+
+    Content hashing is limited to files that share a byte size. Missing or
+    unreadable paths retain path-only identity so a failed probe cannot drop a
+    distinct attachment.
+    """
+    unique_paths: List[str] = []
+    duplicate_paths: List[str] = []
+    seen_paths = set()
+    size_buckets: Dict[int, List[tuple[str, Optional[bytes]]]] = {}
+
+    def _digest(path: str) -> Optional[bytes]:
+        try:
+            with open(path, "rb") as audio_file:
+                return hashlib.file_digest(audio_file, "sha256").digest()
+        except (OSError, ValueError):
+            return None
+
+    for path in audio_paths:
+        if path in seen_paths:
+            duplicate_paths.append(path)
+            continue
+        seen_paths.add(path)
+
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            unique_paths.append(path)
+            continue
+
+        bucket = size_buckets.setdefault(size, [])
+        if not bucket:
+            bucket.append((path, None))
+            unique_paths.append(path)
+            continue
+
+        current_digest = _digest(path)
+        is_duplicate = False
+        for index, (prior_path, prior_digest) in enumerate(bucket):
+            if prior_digest is None:
+                prior_digest = _digest(prior_path)
+                bucket[index] = (prior_path, prior_digest)
+            if current_digest is not None and current_digest == prior_digest:
+                is_duplicate = True
+                break
+
+        if is_duplicate:
+            duplicate_paths.append(path)
+            continue
+        bucket.append((path, current_digest))
+        unique_paths.append(path)
+
+    return unique_paths, duplicate_paths
 
 
 def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
@@ -24667,8 +24724,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 list if every clip failed or STT is disabled. Callers can use
                 this to echo transcripts back to the user before the agent loop.
         """
-        seen = set()
-        audio_paths = [p for p in audio_paths if p not in seen and not seen.add(p)]
+        audio_paths, duplicate_paths = await asyncio.to_thread(
+            _deduplicate_audio_paths, audio_paths
+        )
+        for path in duplicate_paths:
+            logger.info("Skipping duplicate audio attachment before STT: %s", path)
         if not getattr(self.config, "stt_enabled", True):
             notes = []
             for path in audio_paths:

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -1,7 +1,7 @@
 """Gateway STT config tests — honor stt.enabled: false from config.yaml."""
 
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 import yaml
@@ -93,5 +93,144 @@ async def test_enrich_message_with_transcription_guards_empty_transcript():
     assert "empty or inaudible" in result
     assert '""' not in result
     assert transcripts == []
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_dedupes_identical_audio_content(tmp_path):
+    """Distinct cache paths containing the same audio bytes get one STT call (#91513)."""
+    from gateway.run import GatewayRunner
+
+    current_audio = tmp_path / "current.ogg"
+    replied_audio = tmp_path / "replied.ogg"
+    current_audio.write_bytes(b"same telegram voice bytes")
+    replied_audio.write_bytes(b"same telegram voice bytes")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "one transcript", "provider": "local_command"},
+    ) as transcribe:
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "caption", [str(current_audio), str(replied_audio)]
+        )
+
+    transcribe.assert_called_once_with(str(current_audio), None, "gateway")
+    assert result.count('"one transcript"') == 1
+    assert transcripts == ["one transcript"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_offloads_content_deduplication(tmp_path):
+    """Hashing cached audio must not block the gateway event loop (#91513)."""
+    from gateway.run import GatewayRunner, _deduplicate_audio_paths
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"telegram voice bytes")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    with (
+        patch(
+            "gateway.run.asyncio.to_thread",
+            new_callable=AsyncMock,
+            side_effect=[
+                ([str(audio)], []),
+                {"success": True, "transcript": "one", "provider": "local_command"},
+            ],
+        ) as to_thread,
+        patch("tools.transcription_tools.transcribe_audio") as transcribe,
+    ):
+        _result, transcripts = await runner._enrich_message_with_transcription(
+            "", [str(audio)]
+        )
+
+    assert to_thread.await_args_list[0] == call(_deduplicate_audio_paths, [str(audio)])
+    assert to_thread.await_args_list[1] == call(transcribe, str(audio), None, "gateway")
+    assert transcripts == ["one"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_keeps_distinct_audio_content(tmp_path):
+    """Content deduplication must not collapse two genuinely different clips."""
+    from gateway.run import GatewayRunner
+
+    first_audio = tmp_path / "first.ogg"
+    second_audio = tmp_path / "second.ogg"
+    first_audio.write_bytes(b"first telegram voice")
+    second_audio.write_bytes(b"second telegram voice")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=[
+            {"success": True, "transcript": "first", "provider": "local_command"},
+            {"success": True, "transcript": "second", "provider": "local_command"},
+        ],
+    ) as transcribe:
+        result, transcripts = await runner._enrich_message_with_transcription(
+            "caption", [str(first_audio), str(second_audio)]
+        )
+
+    assert transcribe.call_args_list == [
+        call(str(first_audio), None, "gateway"),
+        call(str(second_audio), None, "gateway"),
+    ]
+    assert result.count('"first"') == 1
+    assert result.count('"second"') == 1
+    assert transcripts == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_keeps_distinct_unreadable_paths():
+    """A failed identity probe falls back to path identity instead of dropping audio."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    paths = ["/missing/first.ogg", "/missing/second.ogg"]
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=[
+            {"success": True, "transcript": "first", "provider": "local_command"},
+            {"success": True, "transcript": "second", "provider": "local_command"},
+        ],
+    ) as transcribe:
+        _result, transcripts = await runner._enrich_message_with_transcription("", paths)
+
+    assert transcribe.call_args_list == [
+        call(paths[0], None, "gateway"),
+        call(paths[1], None, "gateway"),
+    ]
+    assert transcripts == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_dedupes_repeated_unreadable_path():
+    """The existing exact-path guard still applies when content cannot be read."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner._has_setup_skill = lambda: False
+
+    path = "/missing/repeated.ogg"
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "one", "provider": "local_command"},
+    ) as transcribe:
+        _result, transcripts = await runner._enrich_message_with_transcription("", [path, path])
+
+    transcribe.assert_called_once_with(path, None, "gateway")
+    assert transcripts == ["one"]
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents one physical audio file from being transcribed more than once in a single gateway turn when different attachment paths cache identical bytes.

Telegram can materialize one voice message through both the current-media and replied-to-media paths during startup batching. Those downloads receive different generated cache names, so the previous exact-path deduplication did not catch them. The gateway then paid for two STT calls and prepended the same transcript twice.

This change deduplicates audio immediately before the shared STT boundary:

- repeated path strings are removed as before;
- equal-size files are compared by SHA-256 while preserving input order;
- unreadable paths retain path-only identity and are not accidentally collapsed;
- hashing is offloaded with `asyncio.to_thread()` so large media cannot block the gateway event loop;
- distinct audio clips remain distinct.

The fix is platform-neutral and intentionally leaves reply metadata/context intact. It only suppresses duplicate audio processing.

## Related Issue

Fixes #91513

Related: #61455 / #67248 handle repeated processing of one pending event across interrupt paths; this PR covers distinct local paths for identical content already present in one STT input list.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - add ordered path/content deduplication for audio attachments;
  - compare content only inside equal-size buckets;
  - offload filesystem reads and hashing from the event loop;
  - log each skipped duplicate before STT.
- `tests/gateway/test_stt_config.py`
  - cover distinct paths with identical bytes;
  - cover distinct audio content;
  - cover unreadable distinct paths and repeated unreadable paths;
  - verify deduplication and STT both run through `asyncio.to_thread()`.

## How to Test

1. Run the focused STT suite:
   ```bash
   uv run --extra dev pytest -o 'addopts=' tests/gateway/test_stt_config.py -q
   ```
2. Run adjacent Telegram/STT gateway coverage:
   ```bash
   uv run --extra dev pytest -o 'addopts=' \
     tests/gateway/test_stt_transcript_echo_config.py \
     tests/gateway/test_telegram_audio_vs_voice.py \
     tests/gateway/test_busy_session_ack.py \
     tests/gateway/test_telegram_group_gating.py -q
   ```
3. Run static checks:
   ```bash
   uv run --extra dev ruff check gateway/run.py tests/gateway/test_stt_config.py
   uv run python -m py_compile gateway/run.py tests/gateway/test_stt_config.py
   git diff --check
   ```

Observed results:

- RED before implementation: identical bytes under two paths produced two `transcribe_audio` calls.
- Focused suite: `9 passed`.
- Adjacent suites: `37 passed`.
- Ruff, `py_compile`, and diff check: passed.
- Independent review: PASS after moving hashing behind `asyncio.to_thread()`.

The repository-wide `scripts/run_tests.sh` was started but stopped after unrelated baseline/environment failures appeared during collection and early execution, including missing optional `acp` and existing `test_coding_context.py` failures. The focused and adjacent gateway suites above are clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. The regression is asserted through STT call count and transcript output tests; no private chat content, IDs, tokens, or cache paths are included.
