### PR TITLE
fix(dashboard): scope webhook API to selected profile

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14194,8 +14194,7 @@ def _webhook_route_summary(name: str, route: Dict[str, Any], base_url: str) -> D
     }
 
 
-@app.get("/api/webhooks")
-async def list_webhooks():
+def _list_webhooks() -> Dict[str, Any]:
     import hermes_cli.webhook as wh
 
     base_url = wh._get_webhook_base_url()
@@ -14210,8 +14209,13 @@ async def list_webhooks():
     }
 
 
-@app.post("/api/webhooks/enable")
-async def enable_webhooks():
+@app.get("/api/webhooks")
+async def list_webhooks(profile: Optional[str] = None):
+    with _config_profile_scope(profile):
+        return _list_webhooks()
+
+
+def _enable_webhooks(profile: Optional[str]) -> Dict[str, Any]:
     try:
         _write_platform_enabled("webhook", True)
     except Exception as exc:
@@ -14221,7 +14225,7 @@ async def enable_webhooks():
             detail="Failed to enable webhook platform.",
         ) from exc
 
-    restart_result = _restart_gateway_after_webhook_enable()
+    restart_result = _restart_gateway_after_webhook_enable(profile)
     return {
         "ok": True,
         "platform": "webhook",
@@ -14231,8 +14235,13 @@ async def enable_webhooks():
     }
 
 
-@app.post("/api/webhooks")
-async def create_webhook(body: WebhookCreate):
+@app.post("/api/webhooks/enable")
+async def enable_webhooks(profile: Optional[str] = None):
+    with _config_profile_scope(profile):
+        return _enable_webhooks(profile)
+
+
+def _create_webhook(body: WebhookCreate) -> Dict[str, Any]:
     import re as _re
     import secrets as _secrets
     import time as _time
@@ -14285,8 +14294,13 @@ async def create_webhook(body: WebhookCreate):
     return summary
 
 
-@app.delete("/api/webhooks/{name}")
-async def delete_webhook(name: str):
+@app.post("/api/webhooks")
+async def create_webhook(body: WebhookCreate, profile: Optional[str] = None):
+    with _config_profile_scope(profile):
+        return _create_webhook(body)
+
+
+def _delete_webhook(name: str) -> Dict[str, bool]:
     import hermes_cli.webhook as wh
 
     key = (name or "").strip().lower()
@@ -14298,8 +14312,13 @@ async def delete_webhook(name: str):
     return {"ok": True}
 
 
-@app.put("/api/webhooks/{name}/enabled")
-async def set_webhook_enabled(name: str, body: WebhookEnabledToggle):
+@app.delete("/api/webhooks/{name}")
+async def delete_webhook(name: str, profile: Optional[str] = None):
+    with _config_profile_scope(profile):
+        return _delete_webhook(name)
+
+
+def _set_webhook_enabled(name: str, body: WebhookEnabledToggle) -> Dict[str, Any]:
     """Enable or disable a webhook route.
 
     Disabled routes stay in the subscriptions file (so they can be
@@ -14316,6 +14335,14 @@ async def set_webhook_enabled(name: str, body: WebhookEnabledToggle):
     subs[key]["enabled"] = bool(body.enabled)
     wh._save_subscriptions(subs)
     return {"ok": True, "name": key, "enabled": bool(body.enabled)}
+
+
+@app.put("/api/webhooks/{name}/enabled")
+async def set_webhook_enabled(
+    name: str, body: WebhookEnabledToggle, profile: Optional[str] = None
+):
+    with _config_profile_scope(profile):
+        return _set_webhook_enabled(name, body)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -50,7 +50,7 @@ def client(monkeypatch, isolated_profiles):
 
 
 def _cfg(home):
-    return yaml.safe_load((home / "config.yaml").read_text()) or {}
+    return yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8")) or {}
 
 
 def _write_jobs(home, jobs):
@@ -86,11 +86,11 @@ class TestProfileScopedEnv:
             json={"key": "FAL_KEY", "value": "test-fal-123", "profile": "worker_beta"},
         )
         assert resp.status_code == 200
-        worker_env = (isolated_profiles["worker_beta"] / ".env").read_text()
+        worker_env = (isolated_profiles["worker_beta"] / ".env").read_text(encoding="utf-8")
         assert "test-fal-123" in worker_env
         default_env_path = isolated_profiles["default"] / ".env"
         if default_env_path.exists():
-            assert "test-fal-123" not in default_env_path.read_text()
+            assert "test-fal-123" not in default_env_path.read_text(encoding="utf-8")
 
 
     def test_env_delete_scoped(self, client, isolated_profiles):
@@ -103,7 +103,41 @@ class TestProfileScopedEnv:
             json={"key": "FAL_KEY", "profile": "worker_beta"},
         )
         assert resp.status_code == 200
-        assert "doomed" not in (isolated_profiles["worker_beta"] / ".env").read_text()
+        assert "doomed" not in (isolated_profiles["worker_beta"] / ".env").read_text(
+            encoding="utf-8"
+        )
+
+
+class TestProfileScopedWebhooks:
+    def test_webhook_actions_stay_in_requested_profile(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        import hermes_cli.web_server as ws
+
+        restart_profiles = []
+        monkeypatch.setattr(
+            ws,
+            "_restart_gateway_after_webhook_enable",
+            lambda profile: restart_profiles.append(profile) or {"restart_started": True},
+        )
+
+        params = {"profile": "worker_beta"}
+        assert client.post("/api/webhooks/enable", params=params).status_code == 200
+        assert restart_profiles == ["worker_beta"]
+        assert _cfg(isolated_profiles["worker_beta"])["platforms"]["webhook"]["enabled"] is True
+        assert "platforms" not in _cfg(isolated_profiles["default"])
+
+        assert client.post(
+            "/api/webhooks", params=params, json={"name": "worker-hook", "deliver": "log"}
+        ).status_code == 200
+        assert client.get("/api/webhooks", params=params).json()["subscriptions"][0]["name"] == "worker-hook"
+        assert not (isolated_profiles["default"] / "webhook_subscriptions.json").exists()
+
+        assert client.put(
+            "/api/webhooks/worker-hook/enabled", params=params, json={"enabled": False}
+        ).json()["enabled"] is False
+        assert client.delete("/api/webhooks/worker-hook", params=params).status_code == 200
+        assert client.get("/api/webhooks", params=params).json()["subscriptions"] == []
 
 
 class TestProfileScopedMcp:
@@ -126,7 +160,7 @@ class TestProfileScopedMcp:
         assert worker_cfg["mcp_servers"]["profile-bearer"]["headers"] == {
             "Authorization": "Bearer ${MCP_PROFILE_BEARER_API_KEY}",
         }
-        assert secret in (isolated_profiles["worker_beta"] / ".env").read_text()
+        assert secret in (isolated_profiles["worker_beta"] / ".env").read_text(encoding="utf-8")
         assert not (isolated_profiles["default"] / ".env").exists()
         assert "profile-bearer" not in _cfg(isolated_profiles["default"]).get(
             "mcp_servers", {}
@@ -664,12 +698,12 @@ class TestProfileScopedTelegramOnboarding:
             (["-p", "worker_beta", "gateway", "restart"], "gateway-restart")
         ]
 
-        worker_env = (isolated_profiles["worker_beta"] / ".env").read_text()
+        worker_env = (isolated_profiles["worker_beta"] / ".env").read_text(encoding="utf-8")
         assert "TELEGRAM_BOT_TOKEN=123456:SECRET" in worker_env
         assert "TELEGRAM_ALLOWED_USERS=123456789" in worker_env
         default_env_path = isolated_profiles["default"] / ".env"
         if default_env_path.exists():
-            assert "TELEGRAM_BOT_TOKEN" not in default_env_path.read_text()
+            assert "TELEGRAM_BOT_TOKEN" not in default_env_path.read_text(encoding="utf-8")
 
         worker_cfg = _cfg(isolated_profiles["worker_beta"])
         default_cfg = _cfg(isolated_profiles["default"])

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -16,6 +16,7 @@ vi.mock("./dashboard-auth-reload", () => ({
 const SESSION_HEADER = "X-Hermes-Session-Token";
 
 beforeEach(() => {
+  setManagementProfile("");
   reloadMocks.attemptDashboardTokenReloadOnce.mockReset();
   reloadMocks.attemptDashboardTokenReloadOnce.mockReturnValue(false);
   reloadMocks.clearDashboardTokenReloadAttempt.mockReset();
@@ -116,6 +117,29 @@ describe("api.getModelOptions", () => {
       "/api/model/options?profile=default&refresh=1&include_unconfigured=1",
       expect.objectContaining({ credentials: "include" }),
     );
+  });
+});
+
+describe("api webhook profile scope", () => {
+  it("sends the selected profile to every webhook endpoint", async () => {
+    vi.stubGlobal("window", {});
+    const fetchMock = jsonFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+    setManagementProfile("worker beta");
+
+    await api.getWebhooks();
+    await api.enableWebhooks();
+    await api.createWebhook({ name: "incoming" });
+    await api.deleteWebhook("incoming");
+    await api.setWebhookEnabled("incoming", false);
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "/api/webhooks?profile=worker%20beta",
+      "/api/webhooks/enable?profile=worker%20beta",
+      "/api/webhooks?profile=worker%20beta",
+      "/api/webhooks/incoming?profile=worker%20beta",
+      "/api/webhooks/incoming/enabled?profile=worker%20beta",
+    ]);
   });
 });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -83,6 +83,7 @@ const PROFILE_SCOPED_PREFIXES = [
   // cancellation, and disconnect must all follow the selected management
   // profile rather than silently targeting the dashboard process's profile.
   "/api/providers/oauth",
+  "/api/webhooks",
   "/api/model/info",
   "/api/model/set",
   "/api/model/auxiliary",


### PR DESCRIPTION
## What changed and why

Per the reporter's 2026-08-13 clarification, the dashboard profile switcher already scopes most management APIs but omitted the webhook family. This change lets all five webhook endpoints accept the selected `profile`, resolves their config and subscription paths in the existing await-safe profile context, and passes the profile through when enabling its gateway. The dashboard API client now adds the selected profile to those calls.

The scope is intentionally limited to webhook management; it does not introduce runtime profile switching or a supervisor process.

## Addressing maintainer feedback

- #13547 remains the related dashboard profile-support feature request; this PR fixes a concrete profile-isolation gap in the existing switcher rather than replacing that broader work.
- #13823 established profile-switcher scoping; this PR extends that established contract to the previously omitted webhook endpoints.

## How to test

1. Select a named profile in the dashboard and open the Webhooks page.
2. Enable webhooks, create a subscription, toggle it, and delete it.
3. Confirm `config.yaml` and `webhook_subscriptions.json` change only under that profile's `HERMES_HOME`.

Automated: `pytest tests/hermes_cli/test_web_server_profile_unification.py tests/hermes_cli/test_dashboard_admin_endpoints.py -q -x --timeout=60` (65 passed).

The required full `pytest tests/ -q -x --timeout=60` run was attempted and stopped during collection at the unrelated existing `tests/gateway/test_teams.py` dependency assertion. Frontend Vitest could not run because this worktree has no `web/node_modules`.

## What platforms tested on

- macOS (local shared Python virtual environment)

Fixes #10674

<!-- autocontrib:worker-id=issue-followup-b933cff1 kind=pr-open -->