### PR TITLE
fix(telegram): rebuild after cancellation-shielded stop

### DIFF
--- a/contributors/emails/gc@erek.ai
+++ b/contributors/emails/gc@erek.ai
@@ -1,0 +1,1 @@
+goodchang77

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2990,14 +2990,26 @@ class TelegramAdapter(BasePlatformAdapter):
                     # the gateway silently drops messages for hours.
                     # Bounding stop() lets the reconnect ladder always advance.
                     # Refs: NousResearch/hermes-agent#58270
-                    await asyncio.wait_for(app.updater.stop(), timeout=_UPDATER_STOP_TIMEOUT)
+                    await _await_with_thread_deadline(
+                        app.updater.stop(), timeout=_UPDATER_STOP_TIMEOUT
+                    )
                 except asyncio.TimeoutError:
-                    logger.warning(
+                    message = (
+                        "Telegram updater.stop() did not finish before the network-"
+                        "recovery deadline; rebuilding the adapter instead of reusing "
+                        "an Updater whose lifecycle lock may still be held."
+                    )
+                    logger.error(
                         "[%s] updater.stop() timed out during network-error "
-                        "reconnect (likely CLOSE-WAIT socket); forcing drain "
-                        "and restart without clean stop",
+                        "reconnect (likely CLOSE-WAIT socket); escalating to fresh-"
+                        "adapter recovery",
                         self.name,
                     )
+                    self._set_fatal_error(
+                        "telegram_network_error", message, retryable=True
+                    )
+                    await self._handoff_polling_fatal_error()
+                    return
         except Exception:
             pass
 

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -207,6 +207,70 @@ async def test_reconnect_continues_if_drain_hangs(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_reconnect_stop_deadline_does_not_wait_for_cancel_cleanup(monkeypatch):
+    """A cancellation-resistant PTB stop must not freeze the retry ladder.
+
+    ``asyncio.wait_for`` waits for the cancelled coroutine to finish.  AnyIO's
+    cancellation-shielded httpcore cleanup can therefore leave ``stop()``
+    pending forever after the timeout fires: the gateway process stays alive,
+    but no later Telegram retry runs.  The wall-clock deadline must abandon
+    that task and escalate to a fresh adapter without reusing the Updater.
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 1
+
+    release_stop = asyncio.Event()
+    stop_cancelled = asyncio.Event()
+    lifecycle_lock = asyncio.Lock()
+
+    async def _cancellation_resistant_stop():
+        async with lifecycle_lock:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                stop_cancelled.set()
+                await release_stop.wait()
+
+    async def _start_polling_with_same_lock(*args, **kwargs):
+        async with lifecycle_lock:
+            return None
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock(side_effect=_cancellation_resistant_stop)
+    mock_updater.start_polling = AsyncMock(side_effect=_start_polling_with_same_lock)
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    mock_app.bot = MagicMock()
+    mock_app.bot._request = ()
+    adapter._app = mock_app
+    adapter._notify_fatal_error = AsyncMock()
+
+    monkeypatch.setattr(tg_adapter, "_UPDATER_STOP_TIMEOUT", 0.01)
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        recovery = asyncio.create_task(
+            adapter._handle_polling_network_error(Exception("Timed out"))
+        )
+        done, _ = await asyncio.wait({recovery}, timeout=0.2)
+
+    try:
+        assert recovery in done, (
+            "reconnect remained blocked waiting for cancellation-shielded "
+            "updater.stop() cleanup"
+        )
+        assert stop_cancelled.is_set()
+        assert adapter.has_fatal_error
+        adapter._notify_fatal_error.assert_awaited_once()
+        mock_updater.start_polling.assert_not_awaited()
+    finally:
+        release_stop.set()
+        if not recovery.done():
+            recovery.cancel()
+        await asyncio.gather(recovery, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_heartbeat_force_escalates_wedged_recovery_task(monkeypatch):
     """#66377: the heartbeat is an independent, cause-agnostic watchdog.
 
@@ -549,12 +613,12 @@ async def test_handle_polling_network_error_updater_stop_timeout():
 
     When the underlying TCP connection is in CLOSE-WAIT, PTB's polling task is
     blocked on epoll on the dead socket.  updater.stop() awaits that task and
-    therefore hangs indefinitely.  The fix wraps stop() in asyncio.wait_for()
-    with a 15-second timeout so the reconnect always advances.
+    therefore hangs indefinitely.  The wall-clock deadline abandons the stop
+    task and escalates to fresh-adapter recovery instead of calling
+    start_polling() while PTB's shared lifecycle lock may still be held.
 
-    This test simulates the hang by making stop() sleep forever and verifies
-    that _drain_polling_connections() and start_polling() are still called
-    after the timeout fires.
+    This test simulates the hang by making stop() outlive the deadline and
+    verifies that the current Updater is not drained or restarted afterward.
     Refs: NousResearch/hermes-agent#58270
     """
     adapter = _make_adapter()
@@ -571,6 +635,7 @@ async def test_handle_polling_network_error_updater_stop_timeout():
     app.updater.stop = _hanging_stop
     app.updater.start_polling = AsyncMock()
     adapter._app = app
+    adapter._notify_fatal_error = AsyncMock()
 
     drain_called = []
 
@@ -594,9 +659,13 @@ async def test_handle_polling_network_error_updater_stop_timeout():
     with patch.object(_mod, "_UPDATER_STOP_TIMEOUT", 0.05):
         await adapter._handle_polling_network_error(OSError("CLOSE-WAIT test"))
 
-    # The reconnect ladder must have advanced past the hung stop().
-    assert drain_called, "_drain_polling_connections was not called after stop() timeout"
-    assert start_polling_called, "start_polling was not called after stop() timeout"
+    # A timed-out stop may still hold PTB's lifecycle lock. Reusing this
+    # Updater would wedge start_polling() behind it, so recovery must hand the
+    # runner a retryable fatal and rebuild the adapter instead.
+    assert adapter.has_fatal_error
+    adapter._notify_fatal_error.assert_awaited_once()
+    assert not drain_called
+    assert not start_polling_called
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- bound Telegram `updater.stop()` with the existing wall-clock deadline helper during network recovery
- escalate a cancellation-shielded stop timeout to retryable fatal recovery so the runner rebuilds a fresh adapter
- avoid reusing an `Updater` that may still hold PTB's lifecycle lock
- add regression coverage where `stop()` swallows cancellation while holding the same lock required by `start_polling()`

## Problem

`asyncio.wait_for()` cancels the inner coroutine on timeout and then waits for cancellation to finish. If PTB/AnyIO/httpcore cleanup is cancellation-shielded, `updater.stop()` can remain pending forever. The gateway process stays alive, but Telegram polling never advances and messages are silently missed.

Simply abandoning `stop()` and restarting the same `Updater` is unsafe because PTB serializes `stop()` and `start_polling()` with the same lifecycle lock. This change therefore hands recovery back to `GatewayRunner`, which disposes the stale adapter and creates a fresh one.

## Tests

- `uv run --with pytest-asyncio pytest tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_telegram_start_polling_timeout.py tests/gateway/test_telegram_closewait_limits_31599.py tests/gateway/test_telegram_polling_health_confirmation.py -o addopts= -q`
  - 26 passed
- `uv run --with ruff ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_network_reconnect.py`
  - passed
- `git diff --check`
  - passed

## Incident evidence

Observed in production after a Telegram `Bad Gateway`: reconnect attempts entered timeout handling while the gateway process remained alive but stopped making polling progress. Restarting the gateway recovered service. The added test reproduces the cancellation-resistant lifecycle-lock behavior without external network dependencies.