### PR TITLE
fix(desktop): verify packaged build provenance

### DIFF
--- a/apps/desktop/scripts/write-build-stamp.mjs
+++ b/apps/desktop/scripts/write-build-stamp.mjs
@@ -10,6 +10,7 @@
  *     "commit":        "<40-char SHA>",
  *     "branch":        "<branch name>",
  *     "builtAt":       "<ISO 8601 UTC timestamp>",
+ *     "desktopContentHash": "<SHA-256 supplied by hermes desktop>" | null,
  *     "dirty":         true|false,
  *     "source":        "ci" | "local" | "fallback"
  *   }
@@ -114,6 +115,22 @@ export function isFallbackCommit(commit) {
   return typeof commit === "string" && /^0{7,40}$/.test(commit)
 }
 
+export function payloadForStamp(stamp, env = process.env, now = () => new Date()) {
+  const desktopContentHash = env.HERMES_DESKTOP_CONTENT_HASH
+
+  return {
+    schemaVersion: STAMP_SCHEMA_VERSION,
+    commit: stamp.commit,
+    branch: stamp.branch,
+    builtAt: now().toISOString(),
+    desktopContentHash: /^[0-9a-f]{64}$/i.test(desktopContentHash || "")
+      ? desktopContentHash.toLowerCase()
+      : null,
+    dirty: stamp.dirty,
+    source: stamp.source
+  }
+}
+
 function main() {
   const stamp = resolveStamp()
   if (!stamp || !stamp.commit) {
@@ -149,14 +166,7 @@ function main() {
     )
   }
 
-  const payload = {
-    schemaVersion: STAMP_SCHEMA_VERSION,
-    commit: stamp.commit,
-    branch: stamp.branch,
-    builtAt: new Date().toISOString(),
-    dirty: stamp.dirty,
-    source: stamp.source
-  }
+  const payload = payloadForStamp(stamp)
 
   mkdirSync(OUT_DIR, { recursive: true })
   writeFileSync(OUT_FILE, JSON.stringify(payload, null, 2) + "\n", "utf8")

--- a/apps/desktop/scripts/write-build-stamp.test.mjs
+++ b/apps/desktop/scripts/write-build-stamp.test.mjs
@@ -8,6 +8,7 @@ import {
   fromFallback,
   fromLocalGit,
   isFallbackCommit,
+  payloadForStamp,
   resolveStamp
 } from './write-build-stamp.mjs'
 
@@ -17,6 +18,27 @@ test('fromCI reads GITHUB_SHA / GITHUB_REF_NAME', () => {
     { commit: 'a'.repeat(40), branch: 'release', dirty: false, source: 'ci' }
   )
   assert.equal(fromCI({}), null)
+})
+
+test('payloadForStamp embeds a normalized desktop content hash', () => {
+  const stamp = { commit: 'a'.repeat(40), branch: 'main', dirty: false, source: 'local' }
+  const now = () => new Date('2026-08-21T12:00:00.000Z')
+
+  assert.deepEqual(payloadForStamp(stamp, { HERMES_DESKTOP_CONTENT_HASH: 'B'.repeat(64) }, now), {
+    schemaVersion: 1,
+    commit: 'a'.repeat(40),
+    branch: 'main',
+    builtAt: '2026-08-21T12:00:00.000Z',
+    desktopContentHash: 'b'.repeat(64),
+    dirty: false,
+    source: 'local'
+  })
+})
+
+test('payloadForStamp records null when no valid content hash was supplied', () => {
+  const stamp = { commit: 'a'.repeat(40), branch: 'main', dirty: false, source: 'local' }
+
+  assert.equal(payloadForStamp(stamp, { HERMES_DESKTOP_CONTENT_HASH: 'not-a-hash' }).desktopContentHash, null)
 })
 
 test('fromLocalGit returns null when git rev-parse fails', () => {

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6615,6 +6615,32 @@ def _renderer_bundle_dir(desktop_dir: Path, *, source_mode: bool) -> Optional[Pa
     return resources / "app.asar.unpacked" / "dist"
 
 
+def _packaged_desktop_provenance(desktop_dir: Path) -> Optional[dict]:
+    """Read the build provenance shipped beside the packaged Electron app."""
+    executable = _desktop_packaged_executable(desktop_dir)
+    if executable is None:
+        return None
+
+    resources = (
+        executable.parent.parent / "Resources"
+        if sys.platform == "darwin"
+        else executable.parent / "resources"
+    )
+    stamp_path = resources / "install-stamp.json"
+    try:
+        payload = json.loads(stamp_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _packaged_desktop_matches_source(desktop_dir: Path, expected_hash: str) -> bool:
+    """True only when the packaged app proves which desktop source it contains."""
+    provenance = _packaged_desktop_provenance(desktop_dir)
+    packaged_hash = provenance.get("desktopContentHash") if provenance else None
+    return isinstance(packaged_hash, str) and packaged_hash.lower() == expected_hash.lower()
+
+
 # The module files the renderer fetches before any app code runs: Vite emits
 # them as `<script type="module" src>` plus `<link rel="modulepreload" href>`.
 _HTML_TAG_WITH_URL = re.compile(r"""<(?:script|link)\b[^>]*\b(?:src|href)=["']([^"']+)["'][^>]*>""", re.IGNORECASE)
@@ -6695,7 +6721,18 @@ def _desktop_build_needed(desktop_dir: Path, project_root: Path, *, source_mode:
         return True
 
     current_hash = _compute_desktop_content_hash(project_root)
-    return current_hash != saved_hash
+    if current_hash != saved_hash:
+        return True
+
+    # The external stamp describes the source tree, not the app that actually
+    # launches. A skipped/torn packaging leg can update that stamp while leaving
+    # release/**/resources/app.asar on an older renderer. Require the package's
+    # own provenance to carry the same content hash before skipping a rebuild.
+    if not source_mode and not _packaged_desktop_matches_source(desktop_dir, current_hash):
+        print("  ⚠ Packaged desktop provenance is missing or stale; rebuilding it")
+        return True
+
+    return False
 
 
 def _write_desktop_build_stamp(project_root: Path, *, source_mode: bool) -> None:
@@ -7977,6 +8014,8 @@ def cmd_gui(args: argparse.Namespace):
                 print("  → No Developer ID configured; ad-hoc signing this local rebuild "
                       "(CSC_IDENTITY_AUTO_DISCOVERY=false)")
             npm_build_env = _npm_lifecycle_env(env)
+            desktop_content_hash = _compute_desktop_content_hash(PROJECT_ROOT)
+            npm_build_env["HERMES_DESKTOP_CONTENT_HASH"] = desktop_content_hash
             if not source_mode:
                 # A running desktop instance launched from release/win-unpacked
                 # holds Hermes.exe locked on Windows, so the pack can't replace
@@ -8065,6 +8104,20 @@ def cmd_gui(args: argparse.Namespace):
                 ):
                     sys.exit(1)
                 packaged_executable = verified_executable
+
+                # A successful npm/electron-builder exit is not proof that the
+                # package was replaced. Windows locks, interrupted swaps, and
+                # stale release trees can leave a runnable OLD app behind. The
+                # build embeds the source hash in resources/install-stamp.json;
+                # require that exact hash before recording success.
+                if not _packaged_desktop_matches_source(desktop_dir, desktop_content_hash):
+                    print("✗ Desktop package provenance does not match the source just built")
+                    print("  The packaged renderer may be stale; retry with `hermes desktop --force-build`.")
+                    try:
+                        _desktop_stamp_path().unlink(missing_ok=True)
+                    except OSError:
+                        pass
+                    sys.exit(1)
 
             # Build succeeded — write the stamp so next run can skip
             _write_desktop_build_stamp(PROJECT_ROOT, source_mode=source_mode)

--- a/tests/hermes_cli/test_desktop_build_provenance.py
+++ b/tests/hermes_cli/test_desktop_build_provenance.py
@@ -1,0 +1,53 @@
+"""Behavior contracts for packaged Desktop build provenance."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_cli import main as cli_main
+
+
+def _packaged_desktop(desktop_dir: Path, payload: object) -> Path:
+    app_dir = desktop_dir / "release" / "test-unpacked"
+    app_dir.mkdir(parents=True)
+    executable = app_dir / "hermes"
+    executable.write_bytes(b"executable")
+    resources = app_dir / "resources"
+    resources.mkdir()
+    (resources / "install-stamp.json").write_text(json.dumps(payload), encoding="utf-8")
+    return executable
+
+
+def test_packaged_desktop_matches_its_embedded_source_hash(tmp_path: Path) -> None:
+    expected = "a" * 64
+    executable = _packaged_desktop(tmp_path, {"desktopContentHash": expected.upper()})
+
+    with patch.object(cli_main, "_desktop_packaged_executable", return_value=executable):
+        assert cli_main._packaged_desktop_matches_source(tmp_path, expected)
+        assert not cli_main._packaged_desktop_matches_source(tmp_path, "b" * 64)
+
+
+def test_packaged_desktop_without_valid_provenance_fails_closed(tmp_path: Path) -> None:
+    executable = _packaged_desktop(tmp_path, {"commit": "a" * 40})
+
+    with patch.object(cli_main, "_desktop_packaged_executable", return_value=executable):
+        assert not cli_main._packaged_desktop_matches_source(tmp_path, "a" * 64)
+
+
+def test_matching_external_stamp_cannot_hide_a_stale_package(tmp_path: Path) -> None:
+    expected = "a" * 64
+    executable = _packaged_desktop(tmp_path, {"desktopContentHash": "b" * 64})
+    external_stamp = tmp_path / "desktop-build-stamp.json"
+    external_stamp.write_text(
+        json.dumps({"contentHash": expected, "sourceMode": False}), encoding="utf-8"
+    )
+
+    with (
+        patch.object(cli_main, "_desktop_packaged_executable", return_value=executable),
+        patch.object(cli_main, "_renderer_bundle_dir", return_value=None),
+        patch.object(cli_main, "_desktop_stamp_path", return_value=external_stamp),
+        patch.object(cli_main, "_compute_desktop_content_hash", return_value=expected),
+    ):
+        assert cli_main._desktop_build_needed(tmp_path, tmp_path, source_mode=False)

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -47,6 +47,12 @@ def _stable_keychain_detection(monkeypatch):
     monkeypatch.setenv("GNOME_KEYRING_CONTROL", "/run/user/1000/keyring")
 
 
+@pytest.fixture(autouse=True)
+def _successful_pack_build_has_matching_provenance(monkeypatch):
+    """The mocked pack steps in this file represent a complete valid package."""
+    monkeypatch.setattr(cli_main, "_packaged_desktop_matches_source", lambda *_: True)
+
+
 def _ns(**kw):
     defaults = dict(
         skip_build=False,
@@ -102,6 +108,7 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     desktop_dir = root / "apps" / "desktop"
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
     packaged_exe = _make_packaged_executable(root, monkeypatch)
+    desktop_content_hash = "a" * 64
 
     install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
     pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
@@ -110,6 +117,7 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok) as mock_install, \
          patch("hermes_cli.main._desktop_build_needed", return_value=True), \
+         patch("hermes_cli.main._compute_desktop_content_hash", return_value=desktop_content_hash), \
          patch("hermes_cli.main._write_desktop_build_stamp"), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
          patch("hermes_cli.main._desktop_linux_sandbox_fixup", return_value=True), \
@@ -128,6 +136,7 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert install_env is not None and "PATH" in install_env
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
+    assert mock_run.call_args_list[0].kwargs["env"]["HERMES_DESKTOP_CONTENT_HASH"] == desktop_content_hash
     assert mock_run.call_args_list[1].args[0] == [str(packaged_exe)]
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 


### PR DESCRIPTION
## Summary

Fixes #66765.

`hermes desktop` previously trusted an external source-content stamp when deciding whether the packaged Electron app was current. That stamp described the checkout, not the package that would actually launch. A skipped, interrupted, or ineffective packaging step could therefore leave an old renderer in `release/**` while the external stamp said the build was current, causing every later launch to skip rebuilding the stale app.

This was reproduced on Windows with a contributed sidebar plugin: navigation reached the plugin route, but the stale packaged renderer never revealed the page. The checkout already contained the correct route behavior; `hermes desktop --force-build` repaired it.

## What changed

- Embed the current Desktop source-content hash in packaged `resources/install-stamp.json` when packaging through `hermes desktop`.
- Require the package's embedded hash to match the current source hash before skipping a packaged rebuild.
- Verify the packaged hash again after `electron-builder` succeeds and before writing the external success stamp.
- Remove the external success stamp and fail closed if the package does not prove it contains the source just built.
- Keep install-stamp schema v1 compatibility by adding `desktopContentHash` as an optional field. Builds made outside this path record `null` instead of claiming unverified provenance.

This complements package-integrity work such as #82384: renderer parity proves a package is internally coherent; this check proves that package came from the current Desktop source.

## Validation

- Regression test copied onto unmodified `origin/main`: failed as expected, including the old build decision incorrectly skipping a stale package.
- `scripts/run_tests.sh tests/hermes_cli/test_desktop_build_provenance.py tests/hermes_cli/test_gui_command.py -q` — 29 passed, 5 OS-specific skipped.
- Broader targeted Python run — 38 passed, 9 OS-specific skipped.
- `npx vitest run apps/desktop/scripts/write-build-stamp.test.mjs apps/desktop/electron/bundle-skew.test.ts` — 17 passed.
- `venv/bin/python -m hermes_cli.main desktop --force-build --build-only` — completed successfully; packaged provenance matched the computed source hash.
- `npm run check` — passed (Desktop, Electron, web, and JS suites; existing lint warnings only, 0 errors).
- `git diff --check` and `python3 -m py_compile hermes_cli/main.py` — passed.

## Compatibility / expected behavior

Legacy or directly packaged apps without `desktopContentHash` trigger a one-time rebuild when evaluated by `hermes desktop`. That fail-closed self-heal is intentional: missing provenance must not be treated as proof that the package is current.
