### PR TITLE
feat(gateway): pass sender context (opt-in) to plugin slash command handlers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3508,6 +3508,56 @@ def _strip_response_attachments_for_direct_send(response: str, adapter) -> str:
     return cleaned.strip()
 
 
+def _invoke_plugin_command_handler(handler, raw_args: str, source):
+    """Invoke a plugin slash-command handler, passing sender context when asked.
+
+    Handlers are registered with the signature ``fn(raw_args: str)``. A
+    handler that declares a second positional parameter (conventionally
+    named ``context``) additionally receives a dict with the invoking
+    sender's identity::
+
+        {
+            "user_id":   source.user_id,
+            "user_name": source.user_name,
+            "chat_id":   source.chat_id,
+            "chat_type": source.chat_type,
+            "platform":  source.platform.value,
+        }
+
+    The arity check is opt-in and fully backward compatible: one-parameter
+    handlers are called exactly as before. Handlers wrapped with
+    ``functools.partial``/decorators that hide their signature fall back to
+    the legacy one-argument call.
+    """
+    try:
+        import inspect
+
+        params = list(inspect.signature(handler).parameters.values())
+        positional = [
+            p
+            for p in params
+            if p.kind
+            in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD, p.VAR_POSITIONAL)
+            and p.default is p.empty
+        ]
+        has_varargs = any(p.kind is p.VAR_POSITIONAL for p in params)
+        wants_context = has_varargs or len(positional) >= 2
+    except (TypeError, ValueError):
+        wants_context = False
+
+    if not wants_context:
+        return handler(raw_args)
+
+    context = {
+        "user_id": getattr(source, "user_id", None),
+        "user_name": getattr(source, "user_name", None),
+        "chat_id": getattr(source, "chat_id", None),
+        "chat_type": getattr(source, "chat_type", None),
+        "platform": getattr(getattr(source, "platform", None), "value", None),
+    }
+    return handler(raw_args, context)
+
+
 def _skill_slug_from_frontmatter(skill_md: Path) -> tuple[str | None, str | None]:
     """Derive the /command slug and declared frontmatter name from a SKILL.md.
 
@@ -17776,7 +17826,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
                     user_args = event.get_command_args().strip()
-                    result = plugin_handler(user_args)
+                    result = _invoke_plugin_command_handler(plugin_handler, user_args, source)
                     if asyncio.iscoroutine(result):
                         result = await result
                     return str(result) if result else None

--- a/tests/gateway/test_plugin_command_context.py
+++ b/tests/gateway/test_plugin_command_context.py
@@ -1,0 +1,182 @@
+"""Tests for sender-context passing to plugin slash command handlers.
+
+Plugin slash command handlers historically receive only ``raw_args``. A
+handler that declares a second positional parameter (``context``) receives a
+dict with the invoking sender's identity — this is what lets identity/RBAC
+plugins implement commands like ``/rbac whoami``. One-parameter handlers must
+keep working exactly as before (opt-in, backward compatible).
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u42",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    return runner
+
+
+def _patch_plugin_command(monkeypatch, name: str, handler):
+    import gateway.run as gateway_run
+    from hermes_cli import plugins as plugins_mod
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        plugins_mod,
+        "get_plugin_command_handler",
+        lambda cmd: handler if cmd == name else None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_receives_sender_context(monkeypatch):
+    """A two-parameter handler gets (raw_args, context) with sender identity."""
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("plugin command leaked to the agent")
+    )
+
+    captured = {}
+
+    def _handler(raw_args, context):
+        captured["raw_args"] = raw_args
+        captured["context"] = context
+        return "ok"
+
+    _patch_plugin_command(monkeypatch, "myident", _handler)
+
+    result = await runner._handle_message(_make_event("/myident verbose"))
+
+    assert result == "ok"
+    assert captured["raw_args"] == "verbose"
+    ctx = captured["context"]
+    assert ctx["user_id"] == "u42"
+    assert ctx["user_name"] == "tester"
+    assert ctx["chat_id"] == "c1"
+    assert ctx["chat_type"] == "dm"
+    assert ctx["platform"] == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_one_param_handler_unchanged(monkeypatch):
+    """Legacy one-parameter handlers must keep working (backward compat)."""
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("plugin command leaked to the agent")
+    )
+
+    captured = {}
+
+    def _handler(raw_args):
+        captured["raw_args"] = raw_args
+        return "legacy ok"
+
+    _patch_plugin_command(monkeypatch, "ping", _handler)
+
+    result = await runner._handle_message(_make_event("/ping hello"))
+
+    assert result == "legacy ok"
+    assert captured["raw_args"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_async_handler_with_context(monkeypatch):
+    """Async two-parameter handlers are awaited and receive context."""
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("plugin command leaked to the agent")
+    )
+
+    captured = {}
+
+    async def _handler(raw_args, context):
+        captured["context"] = context
+        return f"user={context['user_id']}"
+
+    _patch_plugin_command(monkeypatch, "myident", _handler)
+
+    result = await runner._handle_message(_make_event("/myident"))
+
+    assert result == "user=u42"
+    assert captured["context"]["platform"] == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_plugin_command_lambda_one_arg_still_legacy(monkeypatch):
+    """A lambda registered as handler keeps the legacy one-arg call."""
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("plugin command leaked to the agent")
+    )
+
+    _patch_plugin_command(monkeypatch, "metricas", lambda args: f"metrics {args}")
+
+    result = await runner._handle_message(_make_event("/metricas dias:7"))
+
+    assert result == "metrics dias:7"

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -1187,6 +1187,21 @@ def register(ctx):
     ctx.register_command("check", handler=_handle_check, description="Run async check")
 ```
 
+**Sender context (opt-in):** A handler that declares a **second positional parameter** (conventionally named `context`) additionally receives a dict with the invoking sender's identity — platform, user id, chat id, etc. This is what lets identity/RBAC plugins implement commands like `/myplugin whoami` that answer differently per user:
+
+```python
+def _handle_whoami(raw_args: str, context: dict) -> str:
+    return (
+        f"You are {context['user_name'] or context['user_id']} "
+        f"on {context['platform']} (chat {context['chat_id']})"
+    )
+
+def register(ctx):
+    ctx.register_command("whoami", handler=_handle_whoami, description="Show your identity")
+```
+
+`context` keys (in gateway sessions): `user_id`, `user_name`, `chat_id`, `chat_type`, `platform`. One-parameter handlers keep working exactly as before — the extra argument is only passed when the handler asks for it, so existing plugins are unaffected.
+
 ### Dispatch tools from slash commands
 
 Slash command handlers that need to orchestrate tools (spawn a subagent via `delegate_task`, call `file_edit`, etc.) should use `ctx.dispatch_tool()` instead of reaching into framework internals. The parent-agent context (workspace hints, spinner, model inheritance) is wired up automatically.


### PR DESCRIPTION
## What does this PR do?

Lets plugin slash command handlers (registered via `ctx.register_command()`) receive the **invoking sender's identity** — opt-in via a second positional parameter.

Today a handler only gets `fn(raw_args: str)`: it has no way to know who invoked the command, so per-user responses (e.g. an RBAC plugin's `/myplugin whoami`) are impossible. With this change, a handler declared as `fn(raw_args, context)` additionally receives:

```python
{
    "user_id":   source.user_id,
    "user_name": source.user_name,
    "chat_id":   source.chat_id,
    "chat_type": source.chat_type,
    "platform":  source.platform.value,
}
```

The arity check uses `inspect.signature` at dispatch time. One-parameter handlers are called exactly as before — **fully backward compatible**, existing plugins unaffected. Handlers that hide their signature (some decorators/partials) safely fall back to the legacy one-argument call.

## Related Issue

Fixes #91526

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: new `_invoke_plugin_command_handler()` helper — inspects the handler's signature, builds the sender-context dict from `source`, and calls the handler with 1 or 2 args accordingly. The plugin slash command dispatch site in `_handle_message` now routes through it.
- `tests/gateway/test_plugin_command_context.py`: 4 new tests — context passed to a 2-param handler, legacy 1-param handler unchanged, async 2-param handler, lambda legacy path.
- `website/docs/developer-guide/plugins/index.md`: new "Sender context (opt-in)" section in the plugin developer guide, with example and key reference.

## How to Test

1. Register a plugin command with a two-parameter handler: `def handler(raw_args, context): return context["user_id"]` via `ctx.register_command("myident", handler=handler)`.
2. In a gateway session (Telegram/Discord), run `/myident` — the response shows your user id.
3. A one-parameter handler (`lambda args: ...`) keeps working unchanged — covered by `tests/gateway/test_plugin_command_context.py` (4 tests, all passing) plus the full `tests/gateway/` suite (no regressions: the 8 failures there are pre-existing on `main`, identical list with and without this change).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (RPi 5, Debian trixie)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
tests/gateway/test_plugin_command_context.py::test_plugin_command_receives_sender_context PASSED
tests/gateway/test_plugin_command_context.py::test_plugin_command_one_param_handler_unchanged PASSED
tests/gateway/test_plugin_command_context.py::test_plugin_command_async_handler_with_context PASSED
tests/gateway/test_plugin_command_context.py::test_plugin_command_lambda_one_arg_still_legacy PASSED
```
