### PR TITLE
docs(plugins): clarify that the plugins.enabled gate is per-profile

### DIFF
--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -149,6 +149,8 @@ User plugins at `~/.hermes/plugins/model-providers/<name>/` and `~/.hermes/plugi
 
 **General plugins and user-installed backends are disabled by default** — discovery finds them (so they show up in `hermes plugins` and `/plugins`), but nothing with hooks or tools loads until you add the plugin's name to `plugins.enabled` in `~/.hermes/config.yaml`. This stops third-party code from running without your explicit consent.
 
+> **`plugins.enabled` is per-profile.** Each profile has its own `config.yaml` (`~/.hermes/profiles/<name>/config.yaml`), and the gate reads the *active profile's* config — a plugin enabled in the default profile is invisible to every other profile. If you use multiple profiles, add the plugin to each one's `plugins.enabled` (or run `hermes plugins enable <name>` while that profile is active). This is opt-in working as designed: consent to run third-party code is per-workspace, not machine-wide. Bundled platform plugins are the exception — several categories bypass this gate entirely (see "What bypasses the gate" below).
+
 ```yaml
 plugins:
   enabled:


### PR DESCRIPTION
## Summary

One-paragraph docs clarification in `website/docs/user-guide/features/plugins.md`, right where the opt-in gate is explained: **`plugins.enabled` is read from the active profile's `config.yaml`**, so a plugin enabled in the default profile is invisible to every other profile.

Found this the hard way with a user plugin (quota) that worked on the default profile but silently didn't load under a different profile — nothing in the docs mentions that the gate is profile-scoped, and the existing text points at `~/.hermes/config.yaml` as if it were one global file.

## Changes

- New callout after the opt-in paragraph: each profile has its own config (`~/.hermes/profiles/<name>/config.yaml`), enable per profile (or run `hermes plugins enable <name>` while that profile is active), and why it's designed that way (consent to third-party code is per-workspace).
- Notes bundled platform plugins remain the global exception, pointing at the existing bypass section.

No code changes.