### PR TITLE
fix(desktop): authenticate registered remote gateways

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -249,6 +249,18 @@ import {
 } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import {
+  clearRegistryAuthScope,
+  createDraftRegistryAuthScope,
+  mintRegistryAuthTicket,
+  promoteRegistryAuthScope,
+  registryAuthPartition,
+  registryAuthStorageKey,
+  saveWithRegistryAuthPromotion,
+  serializeRegistryAuthFailure,
+  validateRegistryAuthScope,
+  verifyTokenRegistryAuth
+} from './registry-auth'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
   RemoteLivenessTracker,
@@ -5141,6 +5153,7 @@ const RENDER_TITLE_BLOCKED_RESOURCES = new Set([
 
 let linkTitleSession = null
 let oauthSession = null
+const registryOauthSessions = new Map<string, any>()
 let renderTitleInFlight = 0
 const renderTitleQueue = []
 
@@ -5929,8 +5942,13 @@ async function gatewayAuthProviders(baseUrl, headers = {}) {
 // see the 404 that identifies a backend predating /api/health (the auth gate
 // answers before the SPA catch-all). `probeIsCredentialed` tells
 // waitForHermesReady how to read a 401 — rejected session vs gated route.
-async function buildReadinessHealthProbe(baseUrl, authMode, token) {
-  const nativeAt = authMode === 'oauth' ? await ensureNativeAccessToken(baseUrl).catch(() => null) : null
+async function buildReadinessHealthProbe(
+  baseUrl: string,
+  authMode: string | undefined,
+  token: string | null | undefined,
+  authScope?: string
+) {
+  const nativeAt = authMode === 'oauth' ? await ensureNativeAccessToken(baseUrl, authScope).catch(() => null) : null
   const probeAuth = resolveReadinessProbeAuth(authMode, nativeAt, token)
 
   if (probeAuth.kind === 'bearer') {
@@ -5945,7 +5963,7 @@ async function buildReadinessHealthProbe(baseUrl, authMode, token) {
 
   if (probeAuth.kind === 'cookie') {
     return {
-      probeHealth: (url, options: any = {}) => fetchJsonViaOauthSession(url, options),
+      probeHealth: (url: string, options: any = {}) => fetchJsonViaOauthSession(url, { ...options, authScope }),
       probeIsCredentialed: true
     }
   }
@@ -5960,8 +5978,15 @@ async function buildReadinessHealthProbe(baseUrl, authMode, token) {
   return { probeHealth: fetchPublicJson, probeIsCredentialed: false }
 }
 
-async function waitForHermes(baseUrl, token, signal?, authMode?, headers = {}) {
-  const { probeHealth, probeIsCredentialed } = await buildReadinessHealthProbe(baseUrl, authMode, token)
+async function waitForHermes(
+  baseUrl: string,
+  token: string | null | undefined,
+  signal?: AbortSignal,
+  authMode?: string,
+  headers: Record<string, string> = {},
+  authScope?: string
+) {
+  const { probeHealth, probeIsCredentialed } = await buildReadinessHealthProbe(baseUrl, authMode, token, authScope)
 
   return waitForHermesReady(baseUrl, {
     token,
@@ -6733,7 +6758,21 @@ function installMediaPermissions() {
 
 const OAUTH_SESSION_PARTITION = 'persist:hermes-remote-oauth'
 
-function getOauthSession() {
+function getOauthSession(authScope?: string) {
+  if (authScope) {
+    const scope = validateRegistryAuthScope(authScope)
+    const existing = registryOauthSessions.get(scope)
+
+    if (existing || !app.isReady()) {
+      return existing || null
+    }
+
+    const scopedSession = session.fromPartition(registryAuthPartition(scope))
+    registryOauthSessions.set(scope, scopedSession)
+
+    return scopedSession
+  }
+
   if (oauthSession || !app.isReady()) {
     return oauthSession
   }
@@ -6791,8 +6830,8 @@ function warmOauthCookieStore() {
 // connection-config.ts (cookiesHaveSession / cookiesHaveLiveSession). See
 // that module for details.
 
-async function hasOauthSessionCookie(baseUrl) {
-  const sess = getOauthSession()
+async function hasOauthSessionCookie(baseUrl: string, authScope?: string) {
+  const sess = getOauthSession(authScope)
 
   if (!sess) {
     return false
@@ -6824,8 +6863,8 @@ async function hasOauthSessionCookie(baseUrl) {
 // the next authenticated request. Gating on the AT alone forces a needless full
 // re-login every ~15 min. Used for the Settings "connected" indicator and as a
 // cheap early-out before attempting a network round-trip in resolveRemoteBackend.
-async function hasLiveOauthSession(baseUrl) {
-  const sess = getOauthSession()
+async function hasLiveOauthSession(baseUrl: string, authScope?: string) {
+  const sess = getOauthSession(authScope)
 
   if (!sess) {
     return false
@@ -6874,8 +6913,8 @@ async function hasLiveOauthSession(baseUrl) {
   return readLive()
 }
 
-async function clearOauthSession(baseUrl) {
-  const sess = getOauthSession()
+async function clearOauthSession(baseUrl: string | undefined, authScope?: string) {
+  const sess = getOauthSession(authScope)
 
   if (!sess) {
     return
@@ -6914,7 +6953,10 @@ async function clearOauthSession(baseUrl) {
 //     ``/auth/login`` → portal ``/oauth/authorize`` (auto-approves org members)
 //     → ``/auth/callback``, which sets the gateway cookie with NO interactive
 //     prompt. This is the per-agent cloud cascade (decisions.md Q5).
-function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
+function openOauthLoginWindow(
+  baseUrl: string,
+  { silent = false, authScope = undefined as string | undefined } = {}
+) {
   return new Promise((resolve, reject) => {
     if (!app.isReady()) {
       reject(new Error('Desktop is not ready to start an OAuth login.'))
@@ -6922,7 +6964,7 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
       return
     }
 
-    const sess = getOauthSession()
+    const sess = getOauthSession(authScope)
 
     if (!sess) {
       reject(new Error('OAuth session partition is unavailable.'))
@@ -6970,7 +7012,7 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
         return
       }
 
-      if (await hasOauthSessionCookie(baseUrl)) {
+      if (await hasOauthSessionCookie(baseUrl, authScope)) {
         finish(null)
       }
     }
@@ -7055,7 +7097,7 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
 // authed REST against a gated gateway, including minting WS tickets.
 function fetchJsonViaOauthSession(url, options: any = {}) {
   return new Promise((resolve, reject) => {
-    const sess = getOauthSession()
+    const sess = getOauthSession(options.authScope)
 
     if (!sess) {
       reject(new Error('OAuth session partition is unavailable.'))
@@ -7208,40 +7250,47 @@ function _nativeTokenStoreIo(): NativeTokenStoreIo {
   }
 }
 
-function _persistNativeTokens(baseUrl: string, tokens: NativeTokenSet | null) {
-  persistNativeTokenSet(baseUrl, tokens, _nativeTokenStoreIo())
+function nativeTokenStorageKey(baseUrl: string, authScope?: string): string {
+  return authScope ? registryAuthStorageKey(authScope, baseUrl) : baseUrl
 }
 
-function _loadNativeTokens(baseUrl: string): NativeTokenSet | null {
-  const cached = _nativeTokens.get(baseUrl)
+function _persistNativeTokens(storageKey: string, tokens: NativeTokenSet | null) {
+  persistNativeTokenSet(storageKey, tokens, _nativeTokenStoreIo())
+}
+
+function _loadNativeTokens(baseUrl: string, authScope?: string): NativeTokenSet | null {
+  const storageKey = nativeTokenStorageKey(baseUrl, authScope)
+  const cached = _nativeTokens.get(storageKey)
 
   if (cached) {
     return cached
   }
 
-  const tokens = loadNativeTokenSet(baseUrl, _nativeTokenStoreIo())
+  const tokens = loadNativeTokenSet(storageKey, _nativeTokenStoreIo())
 
   if (tokens) {
-    _nativeTokens.set(baseUrl, tokens)
+    _nativeTokens.set(storageKey, tokens)
   }
 
   return tokens
 }
 
-function _storeNativeTokens(baseUrl: string, tokens: NativeTokenSet) {
-  _nativeTokens.set(baseUrl, tokens)
-  _persistNativeTokens(baseUrl, tokens)
+function _storeNativeTokens(baseUrl: string, tokens: NativeTokenSet, authScope?: string) {
+  const storageKey = nativeTokenStorageKey(baseUrl, authScope)
+  _nativeTokens.set(storageKey, tokens)
+  _persistNativeTokens(storageKey, tokens)
 }
 
-function _clearNativeTokens(baseUrl: string) {
-  _nativeTokens.delete(baseUrl)
-  _persistNativeTokens(baseUrl, null)
+function _clearNativeTokens(baseUrl: string, authScope?: string) {
+  const storageKey = nativeTokenStorageKey(baseUrl, authScope)
+  _nativeTokens.delete(storageKey)
+  _persistNativeTokens(storageKey, null)
 }
 
 // True when we hold native bearer tokens for this gateway (the native-flow
 // analogue of hasLiveOauthSession's cookie check).
-function hasNativeSession(baseUrl: string): boolean {
-  return _loadNativeTokens(baseUrl) !== null
+function hasNativeSession(baseUrl: string, authScope?: string): boolean {
+  return _loadNativeTokens(baseUrl, authScope) !== null
 }
 
 // POST JSON WITHOUT the OAuth cookie partition — used for the native token +
@@ -7259,8 +7308,8 @@ function postJsonNoAuth(url: string, body: unknown, opts: any = {}) {
 // Return a valid native access token for baseUrl, refreshing via
 // /auth/native/refresh if the stored one is at/near expiry. Returns null when
 // there are no tokens or the refresh is terminally rejected (caller re-logins).
-async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> {
-  const tokens = _loadNativeTokens(baseUrl)
+async function ensureNativeAccessToken(baseUrl: string, authScope?: string): Promise<string | null> {
+  const tokens = _loadNativeTokens(baseUrl, authScope)
 
   if (!tokens) {
     return null
@@ -7272,7 +7321,7 @@ async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> 
 
   if (!tokens.refreshToken) {
     // Access token expired and no RT to rotate — force re-login.
-    _clearNativeTokens(baseUrl)
+    _clearNativeTokens(baseUrl, authScope)
 
     return null
   }
@@ -7285,20 +7334,167 @@ async function ensureNativeAccessToken(baseUrl: string): Promise<string | null> 
     )
 
     const rotated = parseTokenResponse(body)
-    _storeNativeTokens(baseUrl, rotated)
+    _storeNativeTokens(baseUrl, rotated, authScope)
 
     return rotated.accessToken
   } catch (error: any) {
     // A 401 means the RT is dead (session_expired) — drop tokens so the UI
     // prompts a fresh native login. A 503/transient keeps them for a retry.
     if (error && error.statusCode === 401) {
-      _clearNativeTokens(baseUrl)
+      _clearNativeTokens(baseUrl, authScope)
 
       return null
     }
 
     throw error
   }
+}
+
+async function copyRegistryOauthCookies(fromScope: string, toScope: string, baseUrl: string): Promise<void> {
+  const source = getOauthSession(fromScope)
+  const target = getOauthSession(toScope)
+
+  if (!source || !target) {
+    throw new Error('Registered gateway authentication session is unavailable.')
+  }
+
+  const cookies = await source.cookies.get({ url: baseUrl })
+  await Promise.all(
+    cookies.map((cookie: any) => {
+      const scheme = cookie.secure ? 'https' : 'http'
+      const cookieUrl = `${scheme}://${cookie.domain.replace(/^\./, '')}${cookie.path || '/'}`
+      const { hostOnly: _hostOnly, session: _session, ...details } = cookie
+
+      return target.cookies.set({ ...details, url: cookieUrl })
+    })
+  )
+}
+
+function moveRegistryNativeTokens(fromStorageKey: string, toStorageKey: string): void {
+  const tokens = _nativeTokens.get(fromStorageKey) || loadNativeTokenSet(fromStorageKey, _nativeTokenStoreIo())
+
+  if (!tokens) {
+    return
+  }
+
+  _nativeTokens.set(toStorageKey, tokens)
+  _persistNativeTokens(toStorageKey, tokens)
+}
+
+function registryAuthLifecycleDeps() {
+  return {
+    clearCookies: (scope: string, baseUrl: string) => clearOauthSession(baseUrl, scope),
+    clearNativeTokens: (storageKey: string) => {
+      _nativeTokens.delete(storageKey)
+      _persistNativeTokens(storageKey, null)
+    },
+    copyCookies: copyRegistryOauthCookies,
+    moveNativeTokens: moveRegistryNativeTokens
+  }
+}
+
+function registryAuthPayload(payload: any): {
+  baseUrl: string
+  headers: Record<string, string>
+  scope: string
+} {
+  const scope = validateRegistryAuthScope(payload?.scope)
+  const incomingHeaders = decryptRemoteHeaders(payload?.headers)
+
+  const storedHeaders = scope.startsWith('draft-')
+    ? {}
+    : decryptRemoteHeaders(readDesktopConnectionsRegistry().connections.find((connection: any) => connection.id === scope)?.headers)
+
+  return {
+    baseUrl: normalizeRemoteBaseUrl(payload?.url),
+    headers: { ...storedHeaders, ...incomingHeaders },
+    scope
+  }
+}
+
+async function loginRegistryAuthScope(payload: any) {
+  const { baseUrl, scope } = registryAuthPayload(payload)
+  let statusBody: any = null
+
+  try {
+    statusBody = await fetchPublicJson(`${baseUrl}/api/status`, { timeoutMs: 8_000 })
+  } catch {
+    // Compatibility fallback: older gateways may not expose native-flow
+    // discovery but still support the embedded cookie login.
+  }
+
+  if (resolveLoginStrategy(statusBody) === 'native') {
+    try {
+      const tokens = await runNativeLogin(baseUrl, {
+        openExternal: url => shell.openExternal(url),
+        postJson: (url, body, opts) => postJsonNoAuth(url, body, opts),
+        rememberLog
+      })
+
+      _storeNativeTokens(baseUrl, tokens, scope)
+
+      return { ok: true, baseUrl, connected: true }
+    } catch (error) {
+      rememberLog(
+        `[native-oauth] scoped native login failed (${error instanceof Error ? error.message : String(error)}); ` +
+          'falling back to embedded flow'
+      )
+    }
+  }
+
+  await openOauthLoginWindow(baseUrl, { authScope: scope })
+
+  return { ok: true, baseUrl, connected: await hasOauthSessionCookie(baseUrl, scope) }
+}
+
+async function verifyRegistryAuthScope(payload: any) {
+  const { baseUrl, headers, scope } = registryAuthPayload(payload)
+  const authMode = normAuthMode(payload?.authMode)
+  let status: any
+
+  if (authMode === 'oauth') {
+    const nativeAt = await ensureNativeAccessToken(baseUrl, scope).catch(() => null)
+    status = nativeAt
+      ? await fetchJson(`${baseUrl}/api/status`, null, { bearer: nativeAt, headers, timeoutMs: 8_000 })
+      : await fetchJsonViaOauthSession(`${baseUrl}/api/status`, {
+          authScope: scope,
+          headers,
+          timeoutMs: 8_000
+        })
+
+    const ticket = await mintRegistryAuthTicket(scope, baseUrl, headers, mintGatewayWsTicket)
+    const wsUrl = buildGatewayWsUrlWithTicket(baseUrl, ticket)
+    const probe = await probeGatewayWebSocket(wsUrl, { WebSocketImpl: globalThis.WebSocket, headers })
+
+    if (!probe.ok) {
+      throw new Error(`The authenticated gateway WebSocket readiness check failed: ${probe.reason}`)
+    }
+  } else {
+    const candidateToken = typeof payload?.token === 'string' ? payload.token.trim() : ''
+
+    const storedToken = scope.startsWith('draft-')
+      ? ''
+      : decryptDesktopSecret(
+          readDesktopConnectionsRegistry().connections.find((connection: any) => connection.id === scope)?.token
+        ) || ''
+
+    const token = candidateToken || storedToken
+
+    const verified = await verifyTokenRegistryAuth({
+      baseUrl,
+      headers,
+      token,
+      readStatus: (url, value, requestHeaders) =>
+        fetchJson(url, value, { headers: requestHeaders, timeoutMs: 8_000 }) as Promise<{ version?: null | string }>,
+      resolveWebSocketUrl: (url, value) => resolveTestWsUrl(url, 'token', value),
+      probeWebSocket: (url, requestHeaders) =>
+        probeGatewayWebSocket(url, { WebSocketImpl: globalThis.WebSocket, headers: requestHeaders })
+    })
+
+    status = verified
+  }
+
+  return { ok: true, baseUrl, version: status?.version || null }
 }
 
 // OAuth-session download that streams the response body straight to a
@@ -7554,9 +7750,9 @@ async function saveGatewayFileViaDataUrl(connection, profile, filePath, ctx: any
 // falling back to the OAuth cookie partition otherwise.
 // Throws (with statusCode 401) if the session cookie is missing/expired —
 // callers treat that as "needs re-login".
-async function mintGatewayWsTicket(baseUrl, headers = {}) {
+async function mintGatewayWsTicket(baseUrl: string, headers: Record<string, string> = {}, authScope?: string) {
   // Native flow: mint the ticket with the bearer token, no cookie involved.
-  const nativeAt = await ensureNativeAccessToken(baseUrl).catch(() => null)
+  const nativeAt = await ensureNativeAccessToken(baseUrl, authScope).catch(() => null)
 
   if (nativeAt) {
     const body = (await fetchJson(`${baseUrl}/api/auth/ws-ticket`, null, {
@@ -7578,7 +7774,8 @@ async function mintGatewayWsTicket(baseUrl, headers = {}) {
   const body = (await fetchJsonViaOauthSession(`${baseUrl}/api/auth/ws-ticket`, {
     method: 'POST',
     timeoutMs: 8_000,
-    headers
+    headers,
+    authScope
   })) as any
 
   const ticket = body?.ticket
@@ -8632,7 +8829,20 @@ async function saveRegistryConnection(input: any = {}) {
     throw new Error('Remote gateway session token is required.')
   }
 
-  writeDesktopConnectionsRegistry(upsertConnection(registry, entry))
+  await saveWithRegistryAuthPromotion({
+    baseUrl: entry.url ? normalizeRemoteBaseUrl(entry.url) : '',
+    connectionId: entry.id,
+    draftScope: typeof input.authDraftScope === 'string' ? input.authDraftScope : undefined,
+    persist: () => writeDesktopConnectionsRegistry(upsertConnection(registry, entry)),
+    promote: async (draftScope, connectionId, baseUrl) => {
+      if (entry.kind !== 'remote') {
+        throw new Error('Draft gateway authentication can only be promoted for a remote connection.')
+      }
+
+      await promoteRegistryAuthScope(draftScope, connectionId, baseUrl, registryAuthLifecycleDeps())
+      registryOauthSessions.delete(draftScope)
+    }
+  })
 
   // A dial-material edit (endpoint/auth/ssh routing — NOT a label rename)
   // leaves pooled backends under `conn:<id>::*` and renderer sockets pointing
@@ -8936,7 +9146,8 @@ async function buildRemoteConnection(
   remoteHost?,
   remoteKind = 'url',
   remoteIdentity?,
-  headers?
+  headers?,
+  authScope?: string
 ) {
   const baseUrl = normalizeRemoteBaseUrl(rawUrl)
   const remoteHeaders = decryptRemoteHeaders(headers)
@@ -8962,7 +9173,7 @@ async function buildRemoteConnection(
     // into "not signed in" even though mintGatewayWsTicket would succeed with
     // the stored bearer.
     if (
-      !oauthSessionIsLive(hasNativeSession(baseUrl), await hasLiveOauthSession(baseUrl)) &&
+      !oauthSessionIsLive(hasNativeSession(baseUrl, authScope), await hasLiveOauthSession(baseUrl, authScope)) &&
       oauthGuardMayHardFail(await gatewayAuthProviders(baseUrl, remoteHeaders))
     ) {
       const err = new Error(
@@ -8977,7 +9188,9 @@ async function buildRemoteConnection(
     let ticket
 
     try {
-      ticket = await mintGatewayWsTicket(baseUrl, remoteHeaders)
+      ticket = authScope
+        ? await mintRegistryAuthTicket(authScope, baseUrl, remoteHeaders, mintGatewayWsTicket)
+        : await mintGatewayWsTicket(baseUrl, remoteHeaders)
     } catch (error) {
       throw gatewayTicketFailure(
         error,
@@ -8998,6 +9211,7 @@ async function buildRemoteConnection(
       remoteHost: host || undefined,
       remoteIdentity,
       remoteKind,
+      authScope,
       headers: remoteHeaders,
       // No static token in OAuth mode; REST is cookie-authed via the partition.
       token: null,
@@ -10145,10 +10359,18 @@ async function connectRegistryBackend(source, profile, key, poolEntry) {
     undefined,
     source.kind === 'cloud' ? 'cloud' : 'url',
     undefined,
-    source.headers
+    source.headers,
+    source.id
   )
 
-  await waitForHermes(connection.baseUrl, connection.token, undefined, connection.authMode, connection.headers)
+  await waitForHermes(
+    connection.baseUrl,
+    connection.token,
+    undefined,
+    connection.authMode,
+    connection.headers,
+    source.id
+  )
   poolEntry.remoteBaseUrl = connection.baseUrl
 
   return {
@@ -12642,6 +12864,70 @@ ipcMain.handle('hermes:connection-config:test', async (_event, payload) => testD
 // the registry lands separately; these handlers only manage the persisted
 // list, so they are safe to ship ahead of the switchover.
 ipcMain.handle('hermes:connections:list', async () => sanitizeConnectionsRegistry())
+ipcMain.handle('hermes:connections:auth:create-draft', async () => ({
+  ok: true,
+  scope: createDraftRegistryAuthScope()
+}))
+ipcMain.handle('hermes:connections:auth:probe', async (_event, payload) => {
+  try {
+    const { baseUrl, scope } = registryAuthPayload(payload)
+
+    return { ...(await probeRemoteAuthMode(baseUrl)), scope }
+  } catch (error) {
+    return serializeRegistryAuthFailure(error, error instanceof Error ? error.message : 'Could not inspect gateway auth.')
+  }
+})
+ipcMain.handle('hermes:connections:auth:login', async (_event, payload) => {
+  try {
+    return await loginRegistryAuthScope(payload)
+  } catch (error) {
+    return serializeRegistryAuthFailure(error, error instanceof Error ? error.message : 'Could not sign in to the gateway.')
+  }
+})
+ipcMain.handle('hermes:connections:auth:verify', async (_event, payload) => {
+  try {
+    return await verifyRegistryAuthScope(payload)
+  } catch (error) {
+    return serializeRegistryAuthFailure(
+      error,
+      error instanceof Error ? error.message : 'Could not verify the gateway session.'
+    )
+  }
+})
+ipcMain.handle('hermes:connections:auth:status', async (_event, payload) => {
+  try {
+    const { baseUrl, scope } = registryAuthPayload(payload)
+    const connected = hasNativeSession(baseUrl, scope) || (await hasLiveOauthSession(baseUrl, scope))
+
+    return { ok: true, baseUrl, connected }
+  } catch (error) {
+    return serializeRegistryAuthFailure(error, error instanceof Error ? error.message : 'Could not read gateway auth status.')
+  }
+})
+ipcMain.handle('hermes:connections:auth:clear', async (_event, payload) => {
+  try {
+    const { baseUrl, scope } = registryAuthPayload(payload)
+    await clearRegistryAuthScope(scope, baseUrl, registryAuthLifecycleDeps())
+    registryOauthSessions.delete(scope)
+
+    return { ok: true, baseUrl, connected: false }
+  } catch (error) {
+    return serializeRegistryAuthFailure(error, error instanceof Error ? error.message : 'Could not clear gateway auth.')
+  }
+})
+ipcMain.handle('hermes:connections:auth:promote', async (_event, payload) => {
+  try {
+    const baseUrl = normalizeRemoteBaseUrl(payload?.url)
+    const draftScope = validateRegistryAuthScope(payload?.draftScope)
+    const connectionId = validateRegistryAuthScope(payload?.connectionId)
+    await promoteRegistryAuthScope(draftScope, connectionId, baseUrl, registryAuthLifecycleDeps())
+    registryOauthSessions.delete(draftScope)
+
+    return { ok: true, baseUrl, scope: connectionId }
+  } catch (error) {
+    return serializeRegistryAuthFailure(error, error instanceof Error ? error.message : 'Could not save gateway auth.')
+  }
+})
 ipcMain.handle('hermes:connections:save', async (_event, payload) => {
   const saved = await saveRegistryConnection(payload)
 
@@ -12649,11 +12935,19 @@ ipcMain.handle('hermes:connections:save', async (_event, payload) => {
 })
 ipcMain.handle('hermes:connections:remove', async (_event, id) => {
   const key = String(id || '')
-  const registry = removeConnection(readDesktopConnectionsRegistry(), key)
+  const current = readDesktopConnectionsRegistry()
+  const removed = current.connections.find((connection: any) => connection.id === key)
+  const registry = removeConnection(current, key)
   writeDesktopConnectionsRegistry(registry)
   // Tear down anything the removed connection still had running: pooled
   // backends under its composite keys and any ssh tunnel scopes it owned.
   await stopRegistryConnectionBackends(key)
+
+  if (removed?.url) {
+    await clearRegistryAuthScope(key, normalizeRemoteBaseUrl(removed.url), registryAuthLifecycleDeps())
+    registryOauthSessions.delete(key)
+  }
+
   // And the renderer side: without this push, secondaries scoped to the
   // removed connection keep their WebSocket open (remote/cloud have no local
   // process to kill) and stream ghost events until page reload.
@@ -12748,7 +13042,7 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
   // Same HTTP+WS two-leg check as testDesktopConnectionConfig: HTTP alone is
   // a false positive when the WebSocket leg is blocked.
   const wsUrl = await resolveTestWsUrl(baseUrl, authMode, token, {
-    mintTicket: url => mintGatewayWsTicket(url, testHeaders)
+    mintTicket: (url: string) => mintRegistryAuthTicket(entry.id, url, testHeaders, mintGatewayWsTicket)
   })
 
   if (wsUrl && typeof globalThis.WebSocket === 'function') {
@@ -13000,7 +13294,13 @@ ipcMain.handle('hermes:gateway:ws-url-for', async (_event, payload) => {
     const connection: any = await ensureRegistryBackend(connectionId, profile)
 
     if (connection.authMode === 'oauth') {
-      const ticket = await mintGatewayWsTicket(connection.baseUrl, connection.headers)
+      const ticket = await mintRegistryAuthTicket(
+        connection.authScope || connectionId,
+        connection.baseUrl,
+        connection.headers,
+        mintGatewayWsTicket
+      )
+
       const wsUrl = buildGatewayWsUrlWithTicket(connection.baseUrl, ticket)
 
       rememberRemoteWsHeaders(wsUrl, connection.headers)
@@ -13108,7 +13408,7 @@ async function fetchJsonForBackend(
       throw new Error('File uploads are not supported against OAuth-gated remote backends yet.')
     }
 
-    const nativeAt = await ensureNativeAccessToken(descriptor.baseUrl).catch(() => null)
+    const nativeAt = await ensureNativeAccessToken(descriptor.baseUrl, descriptor.authScope).catch(() => null)
 
     if (nativeAt) {
       return fetchJson(url, null, {
@@ -13124,7 +13424,8 @@ async function fetchJsonForBackend(
       method: opts.method,
       body: opts.body,
       timeoutMs: opts.timeoutMs,
-      headers: descriptor.headers
+      headers: descriptor.headers,
+      authScope: descriptor.authScope
     })
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -204,7 +204,14 @@ import {
   tokenNeedsRefresh
 } from './native-oauth'
 import { runNativeLogin } from './native-oauth-login'
-import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
+import {
+  loadNativeTokenSet,
+  type NativeTokenStoreIo,
+  persistNativeTokenSet,
+  restoreNativeTokenSecret,
+  snapshotNativeTokenSecret,
+  type StoredTokenSecret
+} from './native-token-store'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import {
   createParentStartMarkerResolver,
@@ -250,14 +257,30 @@ import {
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import {
-  clearRegistryAuthScope,
+  authenticatedRegistryStatus,
+  type AuthenticatedRegistryStatusDependencies,
+  clearRegistryAuthCredentialsTransactionally,
   createDraftRegistryAuthScope,
+  createRegistryAuthTargetConnectionId,
   mintRegistryAuthTicket,
-  promoteRegistryAuthScope,
+  promoteAndPersistRegistryAuth,
+  readDurableRegistryAuthStatus,
+  registryAuthCandidateBinding,
+  RegistryAuthCleanupRetryQueue,
+  type RegistryAuthCredentialLifecycle,
+  type RegistryAuthCredentialSnapshot,
   registryAuthPartition,
+  RegistryAuthReadinessAuthority,
+  registryAuthReadinessRequired,
   registryAuthStorageKey,
-  saveWithRegistryAuthPromotion,
+  removeRegistryConnectionTransactionally,
+  resolveRegistryAuthCandidateHeaders,
+  resolveRegistryAuthScopeAuthority,
+  runStructuredRegistryTest,
+  saveVerifiedRegistryConnection,
   serializeRegistryAuthFailure,
+  teardownRemovedRegistryConnection,
+  testAuthenticatedRegistryConnection,
   validateRegistryAuthScope,
   verifyTokenRegistryAuth
 } from './registry-auth'
@@ -5154,6 +5177,7 @@ const RENDER_TITLE_BLOCKED_RESOURCES = new Set([
 let linkTitleSession = null
 let oauthSession = null
 const registryOauthSessions = new Map<string, any>()
+const registryAuthReadiness = new RegistryAuthReadinessAuthority()
 let renderTitleInFlight = 0
 const renderTitleQueue = []
 
@@ -7277,14 +7301,23 @@ function _loadNativeTokens(baseUrl: string, authScope?: string): NativeTokenSet 
 
 function _storeNativeTokens(baseUrl: string, tokens: NativeTokenSet, authScope?: string) {
   const storageKey = nativeTokenStorageKey(baseUrl, authScope)
-  _nativeTokens.set(storageKey, tokens)
   _persistNativeTokens(storageKey, tokens)
+  _nativeTokens.set(storageKey, tokens)
 }
 
 function _clearNativeTokens(baseUrl: string, authScope?: string) {
   const storageKey = nativeTokenStorageKey(baseUrl, authScope)
-  _nativeTokens.delete(storageKey)
   _persistNativeTokens(storageKey, null)
+  _nativeTokens.delete(storageKey)
+}
+
+function clearNativeTokensBestEffort(baseUrl: string, authScope?: string): void {
+  try {
+    _clearNativeTokens(baseUrl, authScope)
+  } catch {
+    // persistNativeTokenSet already records the durable-write failure. Automatic
+    // expiry cleanup deliberately remains best-effort so callers can re-login.
+  }
 }
 
 // True when we hold native bearer tokens for this gateway (the native-flow
@@ -7321,7 +7354,7 @@ async function ensureNativeAccessToken(baseUrl: string, authScope?: string): Pro
 
   if (!tokens.refreshToken) {
     // Access token expired and no RT to rotate — force re-login.
-    _clearNativeTokens(baseUrl, authScope)
+    clearNativeTokensBestEffort(baseUrl, authScope)
 
     return null
   }
@@ -7341,7 +7374,7 @@ async function ensureNativeAccessToken(baseUrl: string, authScope?: string): Pro
     // A 401 means the RT is dead (session_expired) — drop tokens so the UI
     // prompts a fresh native login. A 503/transient keeps them for a retry.
     if (error && error.statusCode === 401) {
-      _clearNativeTokens(baseUrl, authScope)
+      clearNativeTokensBestEffort(baseUrl, authScope)
 
       return null
     }
@@ -7350,69 +7383,191 @@ async function ensureNativeAccessToken(baseUrl: string, authScope?: string): Pro
   }
 }
 
-async function copyRegistryOauthCookies(fromScope: string, toScope: string, baseUrl: string): Promise<void> {
-  const source = getOauthSession(fromScope)
-  const target = getOauthSession(toScope)
+type RegistryNativeTokenSnapshot = {
+  cached?: NativeTokenSet
+  hasCached: boolean
+  stored?: StoredTokenSecret
+}
 
-  if (!source || !target) {
+type ElectronRegistryAuthCredentialSnapshot = RegistryAuthCredentialSnapshot & {
+  cookies: readonly any[]
+  nativeTokens: RegistryNativeTokenSnapshot
+}
+
+function registryCookieUrl(cookie: any): string {
+  const scheme = cookie.secure ? 'https' : 'http'
+
+  return `${scheme}://${String(cookie.domain || '').replace(/^\./, '')}${cookie.path || '/'}`
+}
+
+function registryOauthSession(scope: string) {
+  const scopedSession = getOauthSession(scope)
+
+  if (!scopedSession) {
     throw new Error('Registered gateway authentication session is unavailable.')
   }
 
-  const cookies = await source.cookies.get({ url: baseUrl })
+  return scopedSession
+}
+
+async function readRegistryOauthCookies(scope: string, baseUrl: string): Promise<any[]> {
+  const cookies = await registryOauthSession(scope).cookies.get({ url: baseUrl })
+
+  return cookies.map((cookie: any) => ({ ...cookie }))
+}
+
+async function removeRegistryOauthCookies(scope: string, baseUrl: string): Promise<void> {
+  const scopedSession = registryOauthSession(scope)
+  const cookies = await scopedSession.cookies.get({ url: baseUrl })
+  await Promise.all(cookies.map((cookie: any) => scopedSession.cookies.remove(registryCookieUrl(cookie), cookie.name)))
+}
+
+async function writeRegistryOauthCookies(scope: string, cookies: readonly any[]): Promise<void> {
+  const scopedSession = registryOauthSession(scope)
   await Promise.all(
-    cookies.map((cookie: any) => {
-      const scheme = cookie.secure ? 'https' : 'http'
-      const cookieUrl = `${scheme}://${cookie.domain.replace(/^\./, '')}${cookie.path || '/'}`
+    cookies.map(cookie => {
       const { hostOnly: _hostOnly, session: _session, ...details } = cookie
 
-      return target.cookies.set({ ...details, url: cookieUrl })
+      return scopedSession.cookies.set({ ...details, url: registryCookieUrl(cookie) })
     })
   )
 }
 
-function moveRegistryNativeTokens(fromStorageKey: string, toStorageKey: string): void {
-  const tokens = _nativeTokens.get(fromStorageKey) || loadNativeTokenSet(fromStorageKey, _nativeTokenStoreIo())
+function snapshotRegistryNativeTokens(scope: string, baseUrl: string): RegistryNativeTokenSnapshot {
+  const storageKey = registryAuthStorageKey(scope, baseUrl)
+  const cached = _nativeTokens.get(storageKey)
 
-  if (!tokens) {
-    return
+  return {
+    cached: cached ? { ...cached } : undefined,
+    hasCached: _nativeTokens.has(storageKey),
+    stored: snapshotNativeTokenSecret(storageKey, _nativeTokenStoreIo())
   }
-
-  _nativeTokens.set(toStorageKey, tokens)
-  _persistNativeTokens(toStorageKey, tokens)
 }
 
-function registryAuthLifecycleDeps() {
-  return {
-    clearCookies: (scope: string, baseUrl: string) => clearOauthSession(baseUrl, scope),
-    clearNativeTokens: (storageKey: string) => {
-      _nativeTokens.delete(storageKey)
-      _persistNativeTokens(storageKey, null)
-    },
-    copyCookies: copyRegistryOauthCookies,
-    moveNativeTokens: moveRegistryNativeTokens
+function restoreRegistryNativeTokens(
+  scope: string,
+  baseUrl: string,
+  snapshot: RegistryNativeTokenSnapshot
+): void {
+  const storageKey = registryAuthStorageKey(scope, baseUrl)
+  restoreNativeTokenSecret(storageKey, snapshot.stored, _nativeTokenStoreIo())
+
+  if (snapshot.hasCached && snapshot.cached) {
+    _nativeTokens.set(storageKey, { ...snapshot.cached })
+  } else {
+    _nativeTokens.delete(storageKey)
   }
+}
+
+async function snapshotRegistryAuthCredentials(
+  scope: string,
+  baseUrl: string
+): Promise<ElectronRegistryAuthCredentialSnapshot> {
+  return {
+    cookies: await readRegistryOauthCookies(scope, baseUrl),
+    nativeTokens: snapshotRegistryNativeTokens(scope, baseUrl)
+  }
+}
+
+async function restoreRegistryAuthCredentials(
+  scope: string,
+  baseUrl: string,
+  rawSnapshot: RegistryAuthCredentialSnapshot
+): Promise<void> {
+  const snapshot = rawSnapshot as ElectronRegistryAuthCredentialSnapshot
+  await removeRegistryOauthCookies(scope, baseUrl)
+  await writeRegistryOauthCookies(scope, snapshot.cookies)
+  restoreRegistryNativeTokens(scope, baseUrl, snapshot.nativeTokens)
+}
+
+async function clearRegistryAuthCredentialsExact(scope: string, baseUrl: string): Promise<void> {
+  await removeRegistryOauthCookies(scope, baseUrl)
+  const storageKey = registryAuthStorageKey(scope, baseUrl)
+  _persistNativeTokens(storageKey, null)
+  _nativeTokens.delete(storageKey)
+}
+
+const registryAuthCleanupRetries = new RegistryAuthCleanupRetryQueue()
+
+function reportRegistryAuthCleanupFailure(_error: unknown): void {
+  rememberLog('[registry-auth] credential cleanup failed; retained for retry')
+}
+
+function registryAuthCredentialLifecycle(): RegistryAuthCredentialLifecycle {
+  const lifecycle: RegistryAuthCredentialLifecycle = {
+    snapshot: snapshotRegistryAuthCredentials,
+    replace: async (fromScope, toScope, baseUrl) => {
+      const source = await snapshotRegistryAuthCredentials(fromScope, baseUrl)
+      await clearRegistryAuthCredentialsExact(toScope, baseUrl)
+      await writeRegistryOauthCookies(toScope, source.cookies)
+      restoreRegistryNativeTokens(toScope, baseUrl, source.nativeTokens)
+    },
+    restore: restoreRegistryAuthCredentials,
+    clear: (scope, baseUrl) =>
+      clearRegistryAuthCredentialsTransactionally({
+        clear: () => clearRegistryAuthCredentialsExact(scope, baseUrl),
+        restore: snapshot => restoreRegistryAuthCredentials(scope, baseUrl, snapshot),
+        snapshot: () => snapshotRegistryAuthCredentials(scope, baseUrl)
+      })
+  }
+
+  return lifecycle
+}
+
+async function retryRegistryAuthCleanup(lifecycle = registryAuthCredentialLifecycle()): Promise<void> {
+  await registryAuthCleanupRetries.retry(lifecycle, reportRegistryAuthCleanupFailure)
 }
 
 function registryAuthPayload(payload: any): {
   baseUrl: string
+  connectionId: string
+  generation: number
   headers: Record<string, string>
   scope: string
 } {
-  const scope = validateRegistryAuthScope(payload?.scope)
-  const incomingHeaders = decryptRemoteHeaders(payload?.headers)
+  const scopeAuthority = resolveRegistryAuthScopeAuthority({
+    authority: registryAuthReadiness,
+    baseUrl: payload?.url,
+    registry: readDesktopConnectionsRegistry(),
+    scope: payload?.scope
+  })
 
-  const storedHeaders = scope.startsWith('draft-')
+  const storedHeaders = scopeAuthority.scope.startsWith('draft-')
     ? {}
-    : decryptRemoteHeaders(readDesktopConnectionsRegistry().connections.find((connection: any) => connection.id === scope)?.headers)
+    : decryptRemoteHeaders(
+        readDesktopConnectionsRegistry().connections.find(
+          (connection: any) => connection.id === scopeAuthority.connectionId
+        )?.headers
+      )
 
   return {
-    baseUrl: normalizeRemoteBaseUrl(payload?.url),
-    headers: { ...storedHeaders, ...incomingHeaders },
-    scope
+    ...scopeAuthority,
+    headers: resolveRegistryAuthCandidateHeaders(payload?.headers, storedHeaders) as Record<string, string>
+  }
+}
+
+function readAuthenticatedRegistryStatus(input: {
+  authMode: 'oauth' | 'token'
+  baseUrl: string
+  headers: Record<string, string>
+  scope: string
+  token?: string | null
+}) {
+  return authenticatedRegistryStatus(input, registryAuthStatusDependencies())
+}
+
+function registryAuthStatusDependencies(): AuthenticatedRegistryStatusDependencies<any> {
+  return {
+    readNativeAccessToken: ensureNativeAccessToken,
+    readBearerStatus: (url, bearer, headers) => fetchJson(url, null, { bearer, headers, timeoutMs: 8_000 }),
+    readOauthStatus: (url, scope, headers) =>
+      fetchJsonViaOauthSession(url, { authScope: scope, headers, timeoutMs: 8_000 }),
+    readTokenStatus: (url, token, headers) => fetchJson(url, token, { headers, timeoutMs: 8_000 })
   }
 }
 
 async function loginRegistryAuthScope(payload: any) {
+  await retryRegistryAuthCleanup()
   const { baseUrl, scope } = registryAuthPayload(payload)
   let statusBody: any = null
 
@@ -7448,19 +7603,14 @@ async function loginRegistryAuthScope(payload: any) {
 }
 
 async function verifyRegistryAuthScope(payload: any) {
-  const { baseUrl, headers, scope } = registryAuthPayload(payload)
+  await retryRegistryAuthCleanup()
+  const { baseUrl, connectionId, generation, headers, scope } = registryAuthPayload(payload)
   const authMode = normAuthMode(payload?.authMode)
   let status: any
+  let token = ''
 
   if (authMode === 'oauth') {
-    const nativeAt = await ensureNativeAccessToken(baseUrl, scope).catch(() => null)
-    status = nativeAt
-      ? await fetchJson(`${baseUrl}/api/status`, null, { bearer: nativeAt, headers, timeoutMs: 8_000 })
-      : await fetchJsonViaOauthSession(`${baseUrl}/api/status`, {
-          authScope: scope,
-          headers,
-          timeoutMs: 8_000
-        })
+    status = await readAuthenticatedRegistryStatus({ authMode, baseUrl, headers, scope })
 
     const ticket = await mintRegistryAuthTicket(scope, baseUrl, headers, mintGatewayWsTicket)
     const wsUrl = buildGatewayWsUrlWithTicket(baseUrl, ticket)
@@ -7475,10 +7625,12 @@ async function verifyRegistryAuthScope(payload: any) {
     const storedToken = scope.startsWith('draft-')
       ? ''
       : decryptDesktopSecret(
-          readDesktopConnectionsRegistry().connections.find((connection: any) => connection.id === scope)?.token
+          readDesktopConnectionsRegistry().connections.find(
+            (connection: any) => connection.id === connectionId
+          )?.token
         ) || ''
 
-    const token = candidateToken || storedToken
+    token = candidateToken || storedToken
 
     const verified = await verifyTokenRegistryAuth({
       baseUrl,
@@ -7494,7 +7646,19 @@ async function verifyRegistryAuthScope(payload: any) {
     status = verified
   }
 
-  return { ok: true, baseUrl, version: status?.version || null }
+  const readinessCapability = registryAuthReadiness.issue(
+    registryAuthCandidateBinding({
+      authMode,
+      baseUrl,
+      connectionId,
+      generation,
+      headers,
+      scope,
+      token
+    })
+  )
+
+  return { ok: true, baseUrl, readinessCapability, version: status?.version || null }
 }
 
 // OAuth-session download that streams the response body straight to a
@@ -8407,7 +8571,7 @@ function decryptRemoteHeaders(headers) {
  * normalizeRemoteHeaders at the registry/config layer.
  */
 function encryptIncomingRemoteHeaders(raw, existing, options: { allowPlainText?: boolean } = {}) {
-  const out = {}
+  const encryptedCandidate: Record<string, unknown> = {}
   const stored = normalizeRemoteHeaders(existing)
 
   for (const [name, value] of Object.entries(raw || {})) {
@@ -8421,26 +8585,24 @@ function encryptIncomingRemoteHeaders(raw, existing, options: { allowPlainText?:
       const trimmed = value.trim()
 
       if (trimmed) {
-        out[key] = encryptDesktopSecret(trimmed, { allowPlainText: options.allowPlainText === true })
+        encryptedCandidate[key] = encryptDesktopSecret(trimmed, { allowPlainText: options.allowPlainText === true })
       }
 
       continue
     }
 
     if (value === null) {
-      if (stored[key]) {
-        out[key] = stored[key]
-      }
+      encryptedCandidate[key] = null
 
       continue
     }
 
     if (value && typeof value === 'object') {
-      out[key] = value
+      encryptedCandidate[key] = value
     }
   }
 
-  return out
+  return resolveRegistryAuthCandidateHeaders(encryptedCandidate, stored)
 }
 
 function rememberRemoteWsHeaders(wsUrl, headers = {}) {
@@ -8829,20 +8991,57 @@ async function saveRegistryConnection(input: any = {}) {
     throw new Error('Remote gateway session token is required.')
   }
 
-  await saveWithRegistryAuthPromotion({
-    baseUrl: entry.url ? normalizeRemoteBaseUrl(entry.url) : '',
-    connectionId: entry.id,
-    draftScope: typeof input.authDraftScope === 'string' ? input.authDraftScope : undefined,
-    persist: () => writeDesktopConnectionsRegistry(upsertConnection(registry, entry)),
-    promote: async (draftScope, connectionId, baseUrl) => {
-      if (entry.kind !== 'remote') {
-        throw new Error('Draft gateway authentication can only be promoted for a remote connection.')
-      }
+  const persist = () => writeDesktopConnectionsRegistry(upsertConnection(registry, entry))
+  const draftScope = typeof input.authDraftScope === 'string' ? input.authDraftScope : undefined
 
-      await promoteRegistryAuthScope(draftScope, connectionId, baseUrl, registryAuthLifecycleDeps())
+  if (entry.kind === 'remote') {
+    const scopeAuthority = resolveRegistryAuthScopeAuthority({
+      authority: registryAuthReadiness,
+      baseUrl: entry.url,
+      registry,
+      scope: draftScope || entry.id
+    })
+
+    const binding = registryAuthCandidateBinding({
+      authMode: entry.authMode,
+      baseUrl: scopeAuthority.baseUrl,
+      connectionId: scopeAuthority.connectionId,
+      generation: scopeAuthority.generation,
+      headers: decryptRemoteHeaders(entry.headers),
+      scope: scopeAuthority.scope,
+      token: decryptDesktopSecret(entry.token) || ''
+    })
+
+    const lifecycle = registryAuthCredentialLifecycle()
+    await registryAuthCleanupRetries.retry(lifecycle, reportRegistryAuthCleanupFailure)
+    await saveVerifiedRegistryConnection({
+      authority: registryAuthReadiness,
+      binding,
+      capability: typeof input.authReadinessCapability === 'string' ? input.authReadinessCapability : undefined,
+      connectionId: entry.id,
+      persist: draftScope
+        ? () =>
+            promoteAndPersistRegistryAuth({
+              baseUrl: scopeAuthority.baseUrl,
+              cleanupRetries: registryAuthCleanupRetries,
+              fromScope: draftScope,
+              lifecycle,
+              onCleanupFailure: reportRegistryAuthCleanupFailure,
+              persist,
+              toScope: entry.id
+            })
+        : persist,
+      readinessRequired: registryAuthReadinessRequired(existing, entry)
+    })
+
+    if (draftScope) {
       registryOauthSessions.delete(draftScope)
     }
-  })
+
+    registryAuthReadiness.invalidateScope(scopeAuthority.scope)
+  } else {
+    persist()
+  }
 
   // A dial-material edit (endpoint/auth/ssh routing — NOT a label rename)
   // leaves pooled backends under `conn:<id>::*` and renderer sockets pointing
@@ -12864,10 +13063,25 @@ ipcMain.handle('hermes:connection-config:test', async (_event, payload) => testD
 // the registry lands separately; these handlers only manage the persisted
 // list, so they are safe to ship ahead of the switchover.
 ipcMain.handle('hermes:connections:list', async () => sanitizeConnectionsRegistry())
-ipcMain.handle('hermes:connections:auth:create-draft', async () => ({
-  ok: true,
-  scope: createDraftRegistryAuthScope()
-}))
+ipcMain.handle('hermes:connections:auth:create-draft', async (_event, payload) => {
+  const scope = createDraftRegistryAuthScope()
+  const requestedOwner = typeof payload?.ownerConnectionId === 'string' ? payload.ownerConnectionId : undefined
+
+  const owner = requestedOwner
+    ? readDesktopConnectionsRegistry().connections.find(
+        (connection: any) => connection.id === requestedOwner && connection.kind === 'remote'
+      )?.id
+    : undefined
+
+  if (requestedOwner && !owner) {
+    throw new Error('The draft target does not identify a registered remote connection.')
+  }
+
+  const targetConnectionId = owner || createRegistryAuthTargetConnectionId()
+  registryAuthReadiness.registerDraft(scope, targetConnectionId)
+
+  return { ok: true, scope, targetConnectionId }
+})
 ipcMain.handle('hermes:connections:auth:probe', async (_event, payload) => {
   try {
     const { baseUrl, scope } = registryAuthPayload(payload)
@@ -12896,36 +13110,37 @@ ipcMain.handle('hermes:connections:auth:verify', async (_event, payload) => {
 })
 ipcMain.handle('hermes:connections:auth:status', async (_event, payload) => {
   try {
-    const { baseUrl, scope } = registryAuthPayload(payload)
-    const connected = hasNativeSession(baseUrl, scope) || (await hasLiveOauthSession(baseUrl, scope))
+    await retryRegistryAuthCleanup()
+    const { baseUrl, connectionId, headers, scope } = registryAuthPayload(payload)
+    const entry = readDesktopConnectionsRegistry().connections.find((connection: any) => connection.id === connectionId)
 
-    return { ok: true, baseUrl, connected }
+    if (!entry || entry.kind !== 'remote') {
+      throw new Error('The registered gateway authentication scope does not identify a remote connection.')
+    }
+
+    return await readDurableRegistryAuthStatus({
+      authMode: normAuthMode(entry.authMode),
+      baseUrl,
+      headers,
+      scope,
+      token: decryptDesktopSecret(entry.token)
+    }, registryAuthStatusDependencies())
   } catch (error) {
     return serializeRegistryAuthFailure(error, error instanceof Error ? error.message : 'Could not read gateway auth status.')
   }
 })
 ipcMain.handle('hermes:connections:auth:clear', async (_event, payload) => {
   try {
+    const lifecycle = registryAuthCredentialLifecycle()
+    await retryRegistryAuthCleanup(lifecycle)
     const { baseUrl, scope } = registryAuthPayload(payload)
-    await clearRegistryAuthScope(scope, baseUrl, registryAuthLifecycleDeps())
+    await lifecycle.clear(scope, baseUrl)
     registryOauthSessions.delete(scope)
+    registryAuthReadiness.invalidateScope(scope)
 
     return { ok: true, baseUrl, connected: false }
   } catch (error) {
     return serializeRegistryAuthFailure(error, error instanceof Error ? error.message : 'Could not clear gateway auth.')
-  }
-})
-ipcMain.handle('hermes:connections:auth:promote', async (_event, payload) => {
-  try {
-    const baseUrl = normalizeRemoteBaseUrl(payload?.url)
-    const draftScope = validateRegistryAuthScope(payload?.draftScope)
-    const connectionId = validateRegistryAuthScope(payload?.connectionId)
-    await promoteRegistryAuthScope(draftScope, connectionId, baseUrl, registryAuthLifecycleDeps())
-    registryOauthSessions.delete(draftScope)
-
-    return { ok: true, baseUrl, scope: connectionId }
-  } catch (error) {
-    return serializeRegistryAuthFailure(error, error instanceof Error ? error.message : 'Could not save gateway auth.')
   }
 })
 ipcMain.handle('hermes:connections:save', async (_event, payload) => {
@@ -12937,23 +13152,40 @@ ipcMain.handle('hermes:connections:remove', async (_event, id) => {
   const key = String(id || '')
   const current = readDesktopConnectionsRegistry()
   const removed = current.connections.find((connection: any) => connection.id === key)
-  const registry = removeConnection(current, key)
-  writeDesktopConnectionsRegistry(registry)
-  // Tear down anything the removed connection still had running: pooled
-  // backends under its composite keys and any ssh tunnel scopes it owned.
-  await stopRegistryConnectionBackends(key)
+  const lifecycle = registryAuthCredentialLifecycle()
 
-  if (removed?.url) {
-    await clearRegistryAuthScope(key, normalizeRemoteBaseUrl(removed.url), registryAuthLifecycleDeps())
+  try {
+    await retryRegistryAuthCleanup(lifecycle)
+    const registry = removeConnection(current, key)
+    const baseUrl = removed?.url ? normalizeRemoteBaseUrl(removed.url) : undefined
+
+    await removeRegistryConnectionTransactionally({
+      credentials: baseUrl
+        ? {
+            clear: () => lifecycle.clear(key, baseUrl),
+            restore: snapshot => lifecycle.restore(key, baseUrl, snapshot),
+            snapshot: () => lifecycle.snapshot(key, baseUrl)
+          }
+        : undefined,
+      persistRemoval: () => writeDesktopConnectionsRegistry(registry)
+    })
+
     registryOauthSessions.delete(key)
+    await teardownRemovedRegistryConnection({
+      authority: registryAuthReadiness,
+      scope: key,
+      stopBackends: () => stopRegistryConnectionBackends(key)
+    })
+
+    // And the renderer side: without this push, secondaries scoped to the
+    // removed connection keep their WebSocket open (remote/cloud have no local
+    // process to kill) and stream ghost events until page reload.
+    broadcastConnectionsChanged({ connectionId: key, reason: 'removed' })
+
+    return { ok: true, registry: sanitizeConnectionsRegistry(registry) }
+  } catch (error) {
+    return serializeRegistryAuthFailure(error, 'Could not remove the registered gateway connection.')
   }
-
-  // And the renderer side: without this push, secondaries scoped to the
-  // removed connection keep their WebSocket open (remote/cloud have no local
-  // process to kill) and stream ghost events until page reload.
-  broadcastConnectionsChanged({ connectionId: key, reason: 'removed' })
-
-  return { ok: true, registry: sanitizeConnectionsRegistry(registry) }
 })
 ipcMain.handle('hermes:connections:set-primary', async (_event, id) => {
   const registry = setPrimaryConnection(readDesktopConnectionsRegistry(), String(id || ''))
@@ -12973,9 +13205,10 @@ ipcMain.handle('hermes:connections:set-last-used', async (_event, id) => {
 
   return { ok: true, registry: sanitizeConnectionsRegistry(registry) }
 })
-ipcMain.handle('hermes:connections:test', async (_event, id) => {
-  const registry = readDesktopConnectionsRegistry()
-  const entry = registry.connections.find(c => c.id === String(id || ''))
+ipcMain.handle('hermes:connections:test', async (_event, id) =>
+  runStructuredRegistryTest(async () => {
+    const registry = readDesktopConnectionsRegistry()
+    const entry = registry.connections.find(c => c.id === String(id || ''))
 
   if (!entry) {
     throw new Error(`No connection with id "${String(id || '')}".`)
@@ -12997,9 +13230,18 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
       sshInventoryAttemptedAt.delete(entry.id)
       sshRosterCache.delete(entry.id)
       await probeSshProfileInventory(entry)
+
+      return result
     }
 
-    return result
+    return {
+      ...result,
+      ...serializeRegistryAuthFailure(
+        new Error(result?.error || 'SSH connection test failed.'),
+        result?.error || 'SSH connection test failed.'
+      ),
+      reachable: false
+    }
   }
 
   // Remote/cloud/local probe built DIRECTLY from the registry entry. Routing
@@ -13009,10 +13251,10 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
   // credential transmission + a false "reachable"), and testing the local
   // entry would probe whatever v1's global mode points at instead of the
   // app-managed local backend.
-  let baseUrl
-  let token = null
-  let authMode = 'token'
-  let testHeaders = {}
+  let baseUrl: string
+  let token: null | string = null
+  let authMode: 'oauth' | 'token' = 'token'
+  let testHeaders: Record<string, string> = {}
 
   if (entry.kind === 'local') {
     const local = await startHermes()
@@ -13033,31 +13275,30 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
     }
   }
 
-  const status = (await fetchJson(`${baseUrl}/api/status`, token, { timeoutMs: 8_000, headers: testHeaders })) as any
-
-  // The Test button is the cheapest moment to (re)learn this backend's stable
-  // identity for the same-backend roster collapse + Settings hint.
-  rememberConnectionInstallId(entry.id, status)
-
-  // Same HTTP+WS two-leg check as testDesktopConnectionConfig: HTTP alone is
-  // a false positive when the WebSocket leg is blocked.
-  const wsUrl = await resolveTestWsUrl(baseUrl, authMode, token, {
-    mintTicket: (url: string) => mintRegistryAuthTicket(entry.id, url, testHeaders, mintGatewayWsTicket)
-  })
-
-  if (wsUrl && typeof globalThis.WebSocket === 'function') {
-    const probe = await probeGatewayWebSocket(wsUrl, { WebSocketImpl: globalThis.WebSocket, headers: testHeaders })
-
-    if (!probe.ok) {
-      throw new Error(
-        `Reached the gateway over HTTP, but the live WebSocket (/api/ws) connection failed: ${probe.reason} ` +
-          'The HTTP check can pass while the WebSocket is blocked by a proxy, firewall, or gateway auth/origin guard.'
-      )
-    }
-  }
-
-  return { ok: true, baseUrl, version: status?.version || null }
-})
+    return testAuthenticatedRegistryConnection(
+      {
+        authMode,
+        baseUrl,
+        headers: testHeaders,
+        scope: entry.kind === 'local' ? 'local' : entry.id,
+        token
+      },
+      {
+        ...registryAuthStatusDependencies(),
+        onStatus: status => {
+          rememberConnectionInstallId(entry.id, status)
+        },
+        resolveWebSocketUrl: (url, mode, value) =>
+          resolveTestWsUrl(url, mode, value, {
+            mintTicket: (ticketUrl: string) =>
+              mintRegistryAuthTicket(entry.id, ticketUrl, testHeaders, mintGatewayWsTicket)
+          }),
+        probeWebSocket: (url, headers) =>
+          probeGatewayWebSocket(url, { WebSocketImpl: globalThis.WebSocket, headers })
+      }
+    )
+  }, 'Could not test the registered gateway connection.')
+)
 
 // ── Union agent roster + registry ws-url + fan-out updates (phase 3-5) ─────
 

--- a/apps/desktop/electron/native-token-store.test.ts
+++ b/apps/desktop/electron/native-token-store.test.ts
@@ -21,7 +21,13 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import { type NativeTokenSet, parseStoredTokenSet, parseTokenResponse } from './native-oauth'
-import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
+import {
+  loadNativeTokenSet,
+  type NativeTokenStoreIo,
+  persistNativeTokenSet,
+  restoreNativeTokenSecret,
+  snapshotNativeTokenSecret
+} from './native-token-store'
 
 const GATEWAY = 'https://gw.example.com'
 
@@ -284,28 +290,128 @@ test('a non-Error decryption failure keeps its detail in the log', () => {
   assert.match(disk.logs[0], /keychain exploded/)
 })
 
-test('an unwritable store file is logged rather than thrown', () => {
+test('an unwritable store file propagates failure to the transaction boundary', () => {
   const disk = createFakeDisk(null, {
     writeStoreText: () => {
       throw new Error('EACCES: permission denied')
     }
   })
 
-  assert.doesNotThrow(() => persistNativeTokenSet(GATEWAY, TOKENS, disk.io))
+  assert.throws(() => persistNativeTokenSet(GATEWAY, TOKENS, disk.io), /EACCES: permission denied/)
   assert.match(disk.logs[0], /failed to persist tokens: EACCES/)
 })
 
-test('a non-Error write failure keeps its detail in the log', () => {
+test('a non-Error write failure is logged and propagated intact', () => {
   const disk = createFakeDisk(null, {
     writeStoreText: () => {
       throw 'disk went away'
     }
   })
 
-  // `(error as Error).message` on a thrown string reads as undefined and loses
-  // the only diagnostic there was.
-  assert.doesNotThrow(() => persistNativeTokenSet(GATEWAY, TOKENS, disk.io))
+  assert.throws(
+    () => persistNativeTokenSet(GATEWAY, TOKENS, disk.io),
+    error => error === 'disk went away'
+  )
   assert.equal(disk.logs[0], '[native-oauth] failed to persist tokens: disk went away')
+})
+
+test('an encrypted token envelope snapshots and restores exactly without decrypting it', () => {
+  const original = { encoding: 'safeStorage', value: 'opaque-original-bytes' }
+  const replacement = { encoding: 'safeStorage', value: 'opaque-replacement-bytes' }
+  const disk = createFakeDisk(JSON.stringify({ [GATEWAY]: original }))
+
+  const snapshot = snapshotNativeTokenSecret(GATEWAY, disk.io)
+  restoreNativeTokenSecret(GATEWAY, replacement, disk.io)
+  restoreNativeTokenSecret(GATEWAY, snapshot, disk.io)
+
+  assert.deepEqual(JSON.parse(disk.fileText()!)[GATEWAY], original)
+})
+
+test('restoring an encrypted envelope propagates persistence failure', () => {
+  const disk = createFakeDisk('{}', {
+    writeStoreText: () => {
+      throw new Error('restore write failed')
+    }
+  })
+
+  assert.throws(
+    () => restoreNativeTokenSecret(GATEWAY, { encoding: 'safeStorage', value: 'opaque' }, disk.io),
+    /restore write failed/
+  )
+})
+
+test('transactional restore does not write when the authoritative store read fails', () => {
+  const before = JSON.stringify({
+    'registry:gateway-b': { encoding: 'safeStorage', value: 'unrelated-opaque-envelope' }
+  })
+
+  const disk = createFakeDisk(before)
+  let readInjected = false
+  let writes = 0
+
+  const io: NativeTokenStoreIo = {
+    ...disk.io,
+    readStoreText: () => {
+      readInjected = true
+      throw new Error('EIO: token store unavailable')
+    },
+    writeStoreText: () => {
+      writes += 1
+    }
+  }
+
+  assert.throws(
+    () => restoreNativeTokenSecret('registry:gateway-a', { encoding: 'safeStorage', value: 'restored' }, io),
+    /EIO: token store unavailable/
+  )
+  assert.equal(readInjected, true, 'the injected authoritative read failure must execute')
+  assert.equal(writes, 0, 'restore must not truncate or replace the store after an unreadable snapshot')
+  assert.equal(disk.fileText(), before, 'the unrelated gateway entry must remain byte-for-byte intact')
+})
+
+test('transactional restore does not truncate a malformed store or invent an empty replacement', () => {
+  const malformed = '{not json'
+  const disk = createFakeDisk(malformed)
+  let writes = 0
+
+  const io: NativeTokenStoreIo = {
+    ...disk.io,
+    writeStoreText: () => {
+      writes += 1
+    }
+  }
+
+  assert.throws(
+    () => restoreNativeTokenSecret('registry:gateway-a', undefined, io),
+    /Unexpected token|JSON/i
+  )
+  assert.equal(writes, 0, 'malformed authoritative state must never be replaced with an empty map')
+  assert.equal(disk.fileText(), malformed)
+})
+
+test('ordinary startup load remains tolerant of native-token store I/O failure', () => {
+  let readInjected = false
+
+  const disk = createFakeDisk('{}', {
+    readStoreText: () => {
+      readInjected = true
+      throw new Error('EIO: token store unavailable')
+    }
+  })
+
+  assert.equal(loadNativeTokenSet(GATEWAY, disk.io), null)
+  assert.equal(readInjected, true, 'the injected tolerant startup read must execute')
+  assert.deepEqual(disk.logs, [])
+})
+
+test('an authoritative envelope snapshot propagates store read failure', () => {
+  const disk = createFakeDisk('{}', {
+    readStoreText: () => {
+      throw new Error('EIO: token store unavailable')
+    }
+  })
+
+  assert.throws(() => snapshotNativeTokenSecret(GATEWAY, disk.io), /EIO: token store unavailable/)
 })
 
 test('an unusable keychain fails the write loudly and writes nothing', () => {

--- a/apps/desktop/electron/native-token-store.ts
+++ b/apps/desktop/electron/native-token-store.ts
@@ -66,6 +66,59 @@ function readStore(io: NativeTokenStoreIo): Record<string, any> {
   }
 }
 
+function readStoreForTransaction(io: NativeTokenStoreIo): Record<string, any> {
+  try {
+    const parsed = JSON.parse(io.readStoreText())
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('Native token store is not an object map.')
+    }
+
+    return parsed
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return {}
+    }
+
+    throw error
+  }
+}
+
+function writeStore(store: Record<string, any>, io: NativeTokenStoreIo): void {
+  try {
+    io.writeStoreText(JSON.stringify(store))
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+
+    io.rememberLog?.(`[native-oauth] failed to persist tokens: ${detail}`)
+    throw error
+  }
+}
+
+/** Snapshot the opaque encrypted envelope without decrypting or re-encrypting it. */
+export function snapshotNativeTokenSecret(storageKey: string, io: NativeTokenStoreIo): StoredTokenSecret | undefined {
+  const secret = readStoreForTransaction(io)[storageKey]
+
+  return secret && typeof secret === 'object' && !Array.isArray(secret) ? { ...secret } : undefined
+}
+
+/** Restore an exact encrypted envelope (or its prior absence) transactionally. */
+export function restoreNativeTokenSecret(
+  storageKey: string,
+  secret: StoredTokenSecret | undefined,
+  io: NativeTokenStoreIo
+): void {
+  const store = readStoreForTransaction(io)
+
+  if (secret) {
+    store[storageKey] = { ...secret }
+  } else {
+    delete store[storageKey]
+  }
+
+  writeStore(store, io)
+}
+
 /**
  * A gateway URL safe to write into a log line.
  *
@@ -118,13 +171,7 @@ export function persistNativeTokenSet(baseUrl: string, tokens: NativeTokenSet | 
     delete store[baseUrl]
   }
 
-  try {
-    io.writeStoreText(JSON.stringify(store))
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error)
-
-    io.rememberLog?.(`[native-oauth] failed to persist tokens: ${detail}`)
-  }
+  writeStore(store, io)
 }
 
 /**

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -149,13 +149,13 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   connections: {
     list: () => ipcRenderer.invoke('hermes:connections:list'),
     auth: {
-      createDraft: () => ipcRenderer.invoke('hermes:connections:auth:create-draft'),
+      createDraft: (payload?: { ownerConnectionId?: string }) =>
+        ipcRenderer.invoke('hermes:connections:auth:create-draft', payload),
       probe: payload => ipcRenderer.invoke('hermes:connections:auth:probe', payload),
       login: payload => ipcRenderer.invoke('hermes:connections:auth:login', payload),
       verify: payload => ipcRenderer.invoke('hermes:connections:auth:verify', payload),
       status: payload => ipcRenderer.invoke('hermes:connections:auth:status', payload),
-      clear: payload => ipcRenderer.invoke('hermes:connections:auth:clear', payload),
-      promote: payload => ipcRenderer.invoke('hermes:connections:auth:promote', payload)
+      clear: payload => ipcRenderer.invoke('hermes:connections:auth:clear', payload)
     },
     save: payload => ipcRenderer.invoke('hermes:connections:save', payload),
     remove: id => ipcRenderer.invoke('hermes:connections:remove', id),

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -148,6 +148,15 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   // v2 multi-connection registry: named agent sources (local / remote / cloud / ssh).
   connections: {
     list: () => ipcRenderer.invoke('hermes:connections:list'),
+    auth: {
+      createDraft: () => ipcRenderer.invoke('hermes:connections:auth:create-draft'),
+      probe: payload => ipcRenderer.invoke('hermes:connections:auth:probe', payload),
+      login: payload => ipcRenderer.invoke('hermes:connections:auth:login', payload),
+      verify: payload => ipcRenderer.invoke('hermes:connections:auth:verify', payload),
+      status: payload => ipcRenderer.invoke('hermes:connections:auth:status', payload),
+      clear: payload => ipcRenderer.invoke('hermes:connections:auth:clear', payload),
+      promote: payload => ipcRenderer.invoke('hermes:connections:auth:promote', payload)
+    },
     save: payload => ipcRenderer.invoke('hermes:connections:save', payload),
     remove: id => ipcRenderer.invoke('hermes:connections:remove', id),
     setPrimary: id => ipcRenderer.invoke('hermes:connections:set-primary', id),

--- a/apps/desktop/electron/registry-auth.test.ts
+++ b/apps/desktop/electron/registry-auth.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  clearRegistryAuthScope,
+  createDraftRegistryAuthScope,
+  mintRegistryAuthTicket,
+  promoteRegistryAuthScope,
+  registryAuthPartition,
+  registryAuthStorageKey,
+  saveWithRegistryAuthPromotion,
+  serializeRegistryAuthFailure,
+  validateRegistryAuthScope,
+  verifyTokenRegistryAuth
+} from './registry-auth'
+
+test('registry auth scopes accept durable connection ids and stable draft ids', () => {
+  assert.equal(validateRegistryAuthScope('homelab-2'), 'homelab-2')
+  const draft = createDraftRegistryAuthScope(() => '76f9d14d-2f10-4ccb-9bb8-089935501512')
+  assert.equal(draft, 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512')
+  assert.equal(validateRegistryAuthScope(draft), draft)
+})
+
+test('registry auth scopes reject partition injection and reserved local identity', () => {
+  for (const value of ['', 'local', '../other', 'same host', 'persist:shared', 'draft-not-a-uuid']) {
+    assert.throws(() => validateRegistryAuthScope(value), /scope/i)
+  }
+})
+
+test('same-host registered connections receive distinct persistent cookie partitions', () => {
+  assert.equal(registryAuthPartition('gateway-a'), 'persist:hermes-registry-auth-gateway-a')
+  assert.equal(registryAuthPartition('gateway-b'), 'persist:hermes-registry-auth-gateway-b')
+  assert.notEqual(registryAuthPartition('gateway-a'), registryAuthPartition('gateway-b'))
+})
+
+test('native token ownership is connection scoped rather than URL scoped', () => {
+  const url = 'https://gateway.example.test'
+  assert.equal(registryAuthStorageKey('gateway-a', url), 'registry:gateway-a')
+  assert.equal(registryAuthStorageKey('gateway-b', url), 'registry:gateway-b')
+  assert.notEqual(registryAuthStorageKey('gateway-a', url), registryAuthStorageKey('gateway-b', url))
+})
+
+test('readiness and runtime mint separate tickets in the validated connection scope', async () => {
+  const calls: string[] = []
+
+  const mint = async (baseUrl: string, headers: Record<string, string>, scope: string) => {
+    calls.push(`${scope}:${baseUrl}:${headers['X-Access']}`)
+
+    return `ticket-${calls.length}`
+  }
+
+  const readiness = await mintRegistryAuthTicket(
+    'gateway-a',
+    'https://gateway.example.test',
+    { 'X-Access': 'secret' },
+    mint
+  )
+
+  const runtime = await mintRegistryAuthTicket(
+    'gateway-a',
+    'https://gateway.example.test',
+    { 'X-Access': 'secret' },
+    mint
+  )
+
+  assert.equal(readiness, 'ticket-1')
+  assert.equal(runtime, 'ticket-2')
+  assert.deepEqual(calls, [
+    'gateway-a:https://gateway.example.test:secret',
+    'gateway-a:https://gateway.example.test:secret'
+  ])
+})
+
+test('auth rejection crosses IPC as a structured serializable result', () => {
+  const rejection = Object.assign(new Error('session expired'), { statusCode: 401 })
+  assert.deepEqual(serializeRegistryAuthFailure(rejection, 'Could not verify the gateway session.'), {
+    error: 'Could not verify the gateway session.',
+    kind: 'auth-required',
+    ok: false
+  })
+})
+
+test('transport failures stay distinct from auth rejection and expose sanitized fallback text', () => {
+  const failure = serializeRegistryAuthFailure(new Error('socket timed out'), 'Gateway transport verification failed.')
+  assert.deepEqual(failure, {
+    error: 'Gateway transport verification failed.',
+    kind: 'transport-error',
+    ok: false
+  })
+})
+
+test('removing or abandoning a scope clears only its cookie jar and native token key', async () => {
+  const clearedCookies: string[] = []
+  const clearedTokens: string[] = []
+  await clearRegistryAuthScope('gateway-a', 'https://same.example.test:9119', {
+    clearCookies: async scope => clearedCookies.push(scope),
+    clearNativeTokens: key => clearedTokens.push(key)
+  })
+  assert.deepEqual(clearedCookies, ['gateway-a'])
+  assert.deepEqual(clearedTokens, ['registry:gateway-a'])
+})
+
+test('failed draft promotion does not persist a ready-looking registry row', async () => {
+  let saved = false
+
+  await assert.rejects(
+    saveWithRegistryAuthPromotion({
+      baseUrl: 'https://gateway.example.test',
+      connectionId: 'gateway-a',
+      draftScope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512',
+      persist: () => {
+        saved = true
+      },
+      promote: async () => {
+        throw new Error('promotion failed')
+      }
+    }),
+    /promotion failed/
+  )
+  assert.equal(saved, false)
+})
+
+test('candidate token readiness authenticates HTTP and the real websocket leg', async () => {
+  const calls: string[] = []
+
+  const result = await verifyTokenRegistryAuth({
+    baseUrl: 'https://gateway.example.test',
+    headers: { 'X-Access': 'secret' },
+    probeWebSocket: async (url, headers) => {
+      calls.push(`ws:${url}:${headers['X-Access']}`)
+
+      return { ok: true }
+    },
+    readStatus: async (url, token, headers) => {
+      calls.push(`http:${url}:${token}:${headers['X-Access']}`)
+
+      return { version: '1.2.3' }
+    },
+    resolveWebSocketUrl: async (url, token) => `${url.replace('https:', 'wss:')}/api/ws?token=${token}`,
+    token: 'candidate-secret'
+  })
+
+  assert.deepEqual(result, { version: '1.2.3' })
+  assert.deepEqual(calls, [
+    'http:https://gateway.example.test/api/status:candidate-secret:secret',
+    'ws:wss://gateway.example.test/api/ws?token=candidate-secret:secret'
+  ])
+})
+
+test('candidate token readiness rejects a failed websocket leg', async () => {
+  await assert.rejects(
+    verifyTokenRegistryAuth({
+      baseUrl: 'https://gateway.example.test',
+      headers: {},
+      probeWebSocket: async () => ({ ok: false, reason: 'upgrade rejected' }),
+      readStatus: async () => ({ version: '1.2.3' }),
+      resolveWebSocketUrl: async () => 'wss://gateway.example.test/api/ws?token=candidate',
+      token: 'candidate'
+    }),
+    /WebSocket readiness check failed: upgrade rejected/
+  )
+})
+
+test('saving a draft promotes credentials into the durable connection scope then clears the draft', async () => {
+  const calls: string[] = []
+  const draft = 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512'
+  await promoteRegistryAuthScope(draft, 'homelab', 'https://same.example.test:9119', {
+    clearCookies: async scope => calls.push(`clear-cookies:${scope}`),
+    clearNativeTokens: key => calls.push(`clear-token:${key}`),
+    copyCookies: async (from, to) => calls.push(`copy-cookies:${from}->${to}`),
+    moveNativeTokens: (from, to) => calls.push(`move-token:${from}->${to}`)
+  })
+  assert.deepEqual(calls, [
+    `copy-cookies:${draft}->homelab`,
+    `move-token:registry:${draft}->registry:homelab`,
+    `clear-cookies:${draft}`,
+    `clear-token:registry:${draft}`
+  ])
+})

--- a/apps/desktop/electron/registry-auth.test.ts
+++ b/apps/desktop/electron/registry-auth.test.ts
@@ -1,19 +1,272 @@
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { test } from 'vitest'
 
 import {
+  authenticatedRegistryStatus,
+  clearRegistryAuthCredentialsTransactionally,
   clearRegistryAuthScope,
   createDraftRegistryAuthScope,
+  createRegistryAuthTargetConnectionId,
   mintRegistryAuthTicket,
+  promoteAndPersistRegistryAuth,
   promoteRegistryAuthScope,
+  readDurableRegistryAuthStatus,
+  registryAuthCandidateBinding,
+  RegistryAuthCleanupRetryQueue,
+  type RegistryAuthCredentialSnapshot,
   registryAuthPartition,
+  RegistryAuthReadinessAuthority,
+  registryAuthReadinessRequired,
   registryAuthStorageKey,
+  removeRegistryConnectionTransactionally,
+  resolveRegistryAuthCandidateHeaders,
+  resolveRegistryAuthScopeAuthority,
+  revokeRegistryAuthScope,
+  runStructuredRegistryTest,
+  saveVerifiedRegistryConnection,
   saveWithRegistryAuthPromotion,
   serializeRegistryAuthFailure,
+  teardownRemovedRegistryConnection,
+  testAuthenticatedRegistryConnection,
   validateRegistryAuthScope,
   verifyTokenRegistryAuth
 } from './registry-auth'
+
+function readinessBinding(overrides: Partial<Parameters<typeof registryAuthCandidateBinding>[0]> = {}) {
+  return registryAuthCandidateBinding({
+    authMode: 'oauth',
+    baseUrl: 'https://gateway.example.test:9119/',
+    connectionId: 'gateway-a',
+    generation: 3,
+    headers: { 'X-Access': 'secret' },
+    scope: 'gateway-a',
+    token: '',
+    ...overrides
+  })
+}
+
+test('readiness capability is accepted exactly once', () => {
+  let now = 1_000
+
+  const authority = new RegistryAuthReadinessAuthority({
+    now: () => now,
+    randomToken: () => 'capability-1',
+    ttlMs: 60_000
+  })
+
+  const binding = readinessBinding()
+  const capability = authority.issue(binding)
+
+  assert.equal(capability, 'capability-1')
+  authority.consume(capability, binding)
+  assert.throws(() => authority.consume(capability, binding), /used|unknown/i)
+  now += 1
+})
+
+test('readiness capability rejects missing and expired proof', () => {
+  let now = 1_000
+
+  const authority = new RegistryAuthReadinessAuthority({
+    now: () => now,
+    randomToken: () => 'capability-1',
+    ttlMs: 60_000
+  })
+
+  const binding = readinessBinding()
+
+  assert.throws(() => authority.consume(undefined, binding), /readiness/i)
+  const capability = authority.issue(binding)
+  now += 60_000
+  assert.throws(() => authority.consume(capability, binding), /expired/i)
+})
+
+test('readiness capability binds every canonical candidate field and burns on mismatch', () => {
+  const changedBindings = [
+    readinessBinding({ scope: 'gateway-b' }),
+    readinessBinding({ baseUrl: 'https://gateway.example.test:9120' }),
+    readinessBinding({ authMode: 'token' }),
+    readinessBinding({ headers: { 'X-Access': 'different' } }),
+    readinessBinding({ token: 'different' }),
+    readinessBinding({ connectionId: 'gateway-b' }),
+    readinessBinding({ generation: 4 })
+  ]
+
+  for (const [index, changed] of changedBindings.entries()) {
+    const capability = `capability-${index}`
+    const authority = new RegistryAuthReadinessAuthority({ randomToken: () => capability })
+    const original = readinessBinding()
+    authority.issue(original)
+    assert.throws(() => authority.consume(capability, changed), /does not match/i)
+    assert.throws(() => authority.consume(capability, original), /used|unknown/i)
+  }
+})
+
+test('draft scope authority binds verification and save to its native target connection id', async () => {
+  const draft = 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512'
+  const targetConnectionId = createRegistryAuthTargetConnectionId(() => '76f9d14d-2f10-4ccb-9bb8-089935501512')
+  const authority = new RegistryAuthReadinessAuthority({ randomToken: () => 'capability-1' })
+  authority.registerDraft(draft, targetConnectionId)
+
+  const scopeAuthority = resolveRegistryAuthScopeAuthority({
+    authority,
+    baseUrl: 'https://gateway.example.test:9119',
+    registry: { connections: [] },
+    scope: draft
+  })
+
+  const binding = readinessBinding({ scope: draft, connectionId: targetConnectionId })
+  const capability = authority.issue(binding)
+
+  assert.equal(scopeAuthority.connectionId, targetConnectionId)
+  await assert.rejects(
+    saveVerifiedRegistryConnection({
+      authority,
+      binding,
+      capability,
+      connectionId: 'renderer-chosen-id',
+      persist: () => undefined
+    }),
+    /target|connection/i
+  )
+})
+
+test('invalidating a scope revokes its capabilities and draft authority', () => {
+  const draft = 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512'
+  const authority = new RegistryAuthReadinessAuthority({ randomToken: () => 'capability-1' })
+  authority.registerDraft(draft, 'gateway-a')
+  const binding = readinessBinding({ scope: draft, connectionId: 'gateway-a' })
+  const capability = authority.issue(binding)
+
+  assert.equal(authority.ownsDraft(draft, 'gateway-a'), true)
+  authority.invalidateScope(draft)
+  assert.equal(authority.ownsDraft(draft, 'gateway-a'), false)
+  assert.throws(() => authority.consume(capability, binding), /used|unknown/i)
+})
+
+test('label-only existing remote save preserves auth without consuming readiness', async () => {
+  const existing = {
+    authMode: 'token' as const,
+    headers: { 'X-Access': { encrypted: 'saved-header' } },
+    id: 'gateway-a',
+    kind: 'remote' as const,
+    label: 'Old label',
+    token: { encrypted: 'saved-token' },
+    url: 'https://gateway.example.test:9119'
+  }
+
+  const renamed = { ...existing, label: 'New label' }
+  const authority = new RegistryAuthReadinessAuthority()
+  let persisted = false
+
+  assert.equal(registryAuthReadinessRequired(existing, renamed), false)
+  await saveVerifiedRegistryConnection({
+    authority,
+    binding: readinessBinding(),
+    capability: undefined,
+    connectionId: renamed.id,
+    persist: () => {
+      persisted = true
+    },
+    readinessRequired: false
+  })
+
+  assert.equal(persisted, true)
+  assert.deepEqual(renamed.token, existing.token)
+  assert.deepEqual(renamed.headers, existing.headers)
+})
+
+test('label-only save rejects draft promotion without matching readiness', async () => {
+  const authority = new RegistryAuthReadinessAuthority()
+
+  const binding = readinessBinding({
+    connectionId: 'gateway-a',
+    scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512'
+  })
+
+  let persisted = false
+  let promoted = false
+
+  await assert.rejects(
+    saveVerifiedRegistryConnection({
+      authority,
+      binding,
+      capability: undefined,
+      connectionId: 'gateway-a',
+      persist: () => {
+        persisted = true
+      },
+      promote: async () => {
+        promoted = true
+      },
+      readinessRequired: false
+    }),
+    /readiness/i
+  )
+
+  assert.equal(promoted, false)
+  assert.equal(persisted, false)
+})
+
+test('verified save rejects missing and stale readiness capabilities before persistence', async () => {
+  const authority = new RegistryAuthReadinessAuthority({ randomToken: () => 'capability-1' })
+  const binding = readinessBinding()
+  let persisted = false
+
+  const deps = {
+    authority,
+    binding,
+    connectionId: binding.connectionId,
+    persist: () => {
+      persisted = true
+    }
+  }
+
+  await assert.rejects(saveVerifiedRegistryConnection({ capability: undefined, ...deps }), /readiness/i)
+  const staleCapability = authority.issue(readinessBinding({ generation: 2 }))
+  await assert.rejects(saveVerifiedRegistryConnection({ capability: staleCapability, ...deps }), /readiness|match/i)
+  assert.equal(persisted, false)
+})
+
+test('durable scope authority rejects caller URL mismatch, orphan ids, and same-host port changes', () => {
+  const authority = new RegistryAuthReadinessAuthority()
+
+  const registry = {
+    connections: [
+      { id: 'gateway-a', kind: 'remote', url: 'https://gateway.example.test:9119' },
+      { id: 'gateway-b', kind: 'remote', url: 'https://gateway.example.test:9120' }
+    ]
+  }
+
+  assert.throws(
+    () => resolveRegistryAuthScopeAuthority({ authority, baseUrl: registry.connections[1].url, registry, scope: 'gateway-a' }),
+    /match|scope|url/i
+  )
+  assert.throws(
+    () => resolveRegistryAuthScopeAuthority({ authority, baseUrl: registry.connections[0].url, registry, scope: 'orphan' }),
+    /registered|remote/i
+  )
+  assert.throws(
+    () => resolveRegistryAuthScopeAuthority({ authority, baseUrl: 'https://gateway.example.test:9120', registry, scope: 'gateway-a' }),
+    /match|scope|url/i
+  )
+})
+
+test('candidate binding normalizes URL and fingerprints secrets canonically', () => {
+  const first = readinessBinding({ headers: { 'X-Z': 'last', 'x-a': 'first' } })
+
+  const second = readinessBinding({
+    baseUrl: 'https://gateway.example.test:9119',
+    headers: { 'X-A': 'first', 'x-z': 'last' }
+  })
+
+  assert.deepEqual(first, second)
+  assert.equal(JSON.stringify(first).includes('first'), false)
+  assert.equal(JSON.stringify(first).includes('last'), false)
+})
 
 test('registry auth scopes accept durable connection ids and stable draft ids', () => {
   assert.equal(validateRegistryAuthScope('homelab-2'), 'homelab-2')
@@ -77,7 +330,8 @@ test('auth rejection crosses IPC as a structured serializable result', () => {
   assert.deepEqual(serializeRegistryAuthFailure(rejection, 'Could not verify the gateway session.'), {
     error: 'Could not verify the gateway session.',
     kind: 'auth-required',
-    ok: false
+    ok: false,
+    statusCode: 401
   })
 })
 
@@ -86,8 +340,48 @@ test('transport failures stay distinct from auth rejection and expose sanitized 
   assert.deepEqual(failure, {
     error: 'Gateway transport verification failed.',
     kind: 'transport-error',
-    ok: false
+    ok: false,
+    statusCode: null
   })
+})
+
+test('removing a connection invalidates its generation and outstanding capabilities', async () => {
+  const authority = new RegistryAuthReadinessAuthority({ randomToken: () => 'capability-1' })
+  const binding = readinessBinding()
+  const capability = authority.issue(binding)
+
+  await revokeRegistryAuthScope('gateway-a', 'https://gateway.example.test:9119', authority, {
+    clearCookies: async () => undefined,
+    clearNativeTokens: () => undefined
+  })
+
+  assert.equal(authority.generationForScope('gateway-a'), 1)
+  assert.throws(() => authority.consume(capability, binding), /used|unknown/i)
+})
+
+test('removal revokes authority even when backend teardown fails after deletion', async () => {
+  const authority = new RegistryAuthReadinessAuthority({ randomToken: () => 'capability-1' })
+  const binding = readinessBinding()
+  const capability = authority.issue(binding)
+  let credentialClears = 0
+
+  await assert.rejects(
+    teardownRemovedRegistryConnection({
+      authority,
+      clearCredentials: async () => {
+        credentialClears += 1
+      },
+      scope: 'gateway-a',
+      stopBackends: async () => {
+        throw new Error('backend stop failed')
+      }
+    }),
+    /backend stop failed/
+  )
+
+  assert.equal(credentialClears, 1)
+  assert.equal(authority.generationForScope('gateway-a'), 1)
+  assert.throws(() => authority.consume(capability, binding), /used|unknown/i)
 })
 
 test('removing or abandoning a scope clears only its cookie jar and native token key', async () => {
@@ -119,6 +413,776 @@ test('failed draft promotion does not persist a ready-looking registry row', asy
     /promotion failed/
   )
   assert.equal(saved, false)
+})
+
+type FakeCredentialState = { cookies: string[]; nativeTokens: null | string }
+type FakeCredentialFailure =
+  | 'destination-snapshot'
+  | 'destination-clear'
+  | 'cookie-copy'
+  | 'native-token-copy'
+  | 'source-clear'
+
+type FakeCredentialStore = ReturnType<typeof createFakeCredentialStore>
+
+function createFakeCredentialStore(failAt?: FakeCredentialFailure) {
+  let failure = failAt
+  const draft = 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512'
+  const destination = 'gateway-a'
+
+  const states = new Map<string, FakeCredentialState>([
+    [draft, { cookies: ['draft-cookie'], nativeTokens: 'draft-token' }],
+    [destination, { cookies: ['old-cookie'], nativeTokens: 'old-token' }]
+  ])
+
+  const events: string[] = []
+  const read = (scope: string): FakeCredentialState => structuredClone(states.get(scope)!)
+  const write = (scope: string, state: FakeCredentialState) => states.set(scope, structuredClone(state))
+
+  return {
+    destination,
+    draft,
+    events,
+    lifecycle: {
+      snapshot: async (scope: string) => {
+        events.push(`snapshot:${scope}`)
+
+        if (scope === destination && failure === 'destination-snapshot') {throw new Error('destination snapshot failed')}
+
+        return read(scope)
+      },
+      replace: async (fromScope: string, toScope: string) => {
+        const source = read(fromScope)
+        events.push(`clear:${toScope}`)
+        write(toScope, { cookies: [], nativeTokens: null })
+
+        if (failure === 'destination-clear') {throw new Error('destination clear failed')}
+        events.push(`copy-cookies:${fromScope}->${toScope}`)
+
+        if (failure === 'cookie-copy') {throw new Error('cookie copy failed')}
+        write(toScope, { ...read(toScope), cookies: [...source.cookies] })
+        events.push(`copy-native:${fromScope}->${toScope}`)
+
+        if (failure === 'native-token-copy') {throw new Error('native token copy failed')}
+        write(toScope, { ...read(toScope), nativeTokens: source.nativeTokens })
+      },
+      restore: async (scope: string, _baseUrl: string, snapshot: RegistryAuthCredentialSnapshot) => {
+        events.push(`restore:${scope}`)
+        write(scope, snapshot as FakeCredentialState)
+      },
+      clear: async (scope: string) => {
+        events.push(`clear:${scope}`)
+
+        if (scope === draft && failure === 'source-clear') {throw new Error('source clear failed')}
+        write(scope, { cookies: [], nativeTokens: null })
+      }
+    },
+    allowFailures: () => { failure = undefined },
+    read
+  }
+}
+
+async function attemptFakePromotion(store: FakeCredentialStore, persist: () => unknown = () => undefined) {
+  return promoteAndPersistRegistryAuth({
+    baseUrl: 'https://gateway.example.test',
+    fromScope: store.draft,
+    toScope: store.destination,
+    lifecycle: store.lifecycle,
+    persist
+  })
+}
+
+test('destination snapshot failure leaves both scopes untouched and skips registry persistence', async () => {
+  const store = createFakeCredentialStore('destination-snapshot')
+  const destinationBefore = store.read(store.destination)
+  const sourceBefore = store.read(store.draft)
+  let registryWritten = false
+
+  await assert.rejects(attemptFakePromotion(store, () => { registryWritten = true }), /destination snapshot failed/)
+
+  assert.deepEqual(store.read(store.destination), destinationBefore)
+  assert.deepEqual(store.read(store.draft), sourceBefore)
+  assert.equal(registryWritten, false)
+})
+
+test('destination clear failure restores previous durable credentials and skips registry persistence', async () => {
+  const store = createFakeCredentialStore('destination-clear')
+  const destinationBefore = store.read(store.destination)
+  const sourceBefore = store.read(store.draft)
+  let registryWritten = false
+
+  await assert.rejects(attemptFakePromotion(store, () => { registryWritten = true }), /destination clear failed/)
+
+  assert.deepEqual(store.read(store.destination), destinationBefore)
+  assert.deepEqual(store.read(store.draft), sourceBefore)
+  assert.equal(registryWritten, false)
+  assert.ok(store.events.includes(`restore:${store.destination}`))
+})
+
+test('cookie-copy failure restores the exact destination snapshot and retains source credentials', async () => {
+  const store = createFakeCredentialStore('cookie-copy')
+  const destinationBefore = store.read(store.destination)
+  const sourceBefore = store.read(store.draft)
+  let registryWritten = false
+
+  await assert.rejects(attemptFakePromotion(store, () => { registryWritten = true }), /cookie copy failed/)
+
+  assert.ok(
+    store.events.includes(`copy-cookies:${store.draft}->${store.destination}`),
+    'the injected cookie-copy boundary must execute'
+  )
+  assert.deepEqual(store.read(store.destination), destinationBefore)
+  assert.deepEqual(store.read(store.draft), sourceBefore)
+  assert.equal(registryWritten, false)
+})
+
+test('native-token-copy failure rolls back cookies and tokens to the exact destination snapshot', async () => {
+  const store = createFakeCredentialStore('native-token-copy')
+  const destinationBefore = store.read(store.destination)
+  const sourceBefore = store.read(store.draft)
+  let registryWritten = false
+
+  await assert.rejects(attemptFakePromotion(store, () => { registryWritten = true }), /native token copy failed/)
+
+  assert.ok(
+    store.events.includes(`copy-native:${store.draft}->${store.destination}`),
+    'the injected native-token-copy boundary must execute'
+  )
+  assert.deepEqual(store.read(store.destination), destinationBefore)
+  assert.deepEqual(store.read(store.draft), sourceBefore)
+  assert.equal(registryWritten, false)
+})
+
+test('registry persistence failure restores destination and retains draft credentials', async () => {
+  const store = createFakeCredentialStore()
+  const destinationBefore = store.read(store.destination)
+  const sourceBefore = store.read(store.draft)
+
+  await assert.rejects(
+    attemptFakePromotion(store, () => {
+      store.events.push('persist')
+      throw new Error('registry write failed')
+    }),
+    /registry write failed/
+  )
+
+  assert.deepEqual(store.read(store.destination), destinationBefore)
+  assert.deepEqual(store.read(store.draft), sourceBefore)
+  assert.ok(store.events.includes(`restore:${store.destination}`))
+})
+
+test('promotion preserves simultaneous registry-write and destination-restore failures as uncertain state', async () => {
+  const primary = new Error('registry write failed')
+  const rollback = new Error('destination restore failed')
+  const store = createFakeCredentialStore()
+  let restoreInjected = false
+
+  const lifecycle = {
+    ...store.lifecycle,
+    restore: async () => {
+      restoreInjected = true
+      throw rollback
+    }
+  }
+
+  await assert.rejects(
+    promoteAndPersistRegistryAuth({
+      baseUrl: 'https://gateway.example.test',
+      fromScope: store.draft,
+      lifecycle,
+      persist: () => {
+        throw primary
+      },
+      toScope: store.destination
+    }),
+    error => {
+      assert.ok(error instanceof AggregateError)
+      assert.deepEqual(error.errors, [primary, rollback])
+      assert.equal((error as AggregateError & { stateUncertain?: boolean }).stateUncertain, true)
+
+      return true
+    }
+  )
+  assert.equal(restoreInjected, true, 'the injected rollback failure must execute')
+})
+
+test('promotion rethrows a lone registry-write failure unchanged after successful restore', async () => {
+  const primary = new Error('registry write failed')
+  const store = createFakeCredentialStore()
+  let restoreExecuted = false
+
+  const lifecycle = {
+    ...store.lifecycle,
+    restore: async (...args: Parameters<typeof store.lifecycle.restore>) => {
+      restoreExecuted = true
+      await store.lifecycle.restore(...args)
+    }
+  }
+
+  await assert.rejects(
+    promoteAndPersistRegistryAuth({
+      baseUrl: 'https://gateway.example.test',
+      fromScope: store.draft,
+      lifecycle,
+      persist: () => {
+        throw primary
+      },
+      toScope: store.destination
+    }),
+    error => error === primary
+  )
+  assert.equal(restoreExecuted, true, 'the successful restore hook must execute')
+})
+
+test('transactional credential clear preserves simultaneous clear and restore failures as uncertain state', async () => {
+  const primary = new Error('credential clear failed')
+  const rollback = new Error('credential restore failed')
+  let clearInjected = false
+  let restoreInjected = false
+
+  await assert.rejects(
+    clearRegistryAuthCredentialsTransactionally({
+      clear: async () => {
+        clearInjected = true
+        throw primary
+      },
+      restore: async () => {
+        restoreInjected = true
+        throw rollback
+      },
+      snapshot: async () => ({ cookies: [], nativeTokens: undefined })
+    }),
+    error => {
+      assert.ok(error instanceof AggregateError)
+      assert.deepEqual(error.errors, [primary, rollback])
+      assert.equal((error as AggregateError & { stateUncertain?: boolean }).stateUncertain, true)
+
+      return true
+    }
+  )
+  assert.equal(clearInjected, true, 'the injected clear failure must execute')
+  assert.equal(restoreInjected, true, 'the injected restore failure must execute')
+})
+
+test('transactional credential clear rethrows a lone clear failure unchanged after successful restore', async () => {
+  const primary = new Error('credential clear failed')
+  let restoreExecuted = false
+
+  await assert.rejects(
+    clearRegistryAuthCredentialsTransactionally({
+      clear: async () => {
+        throw primary
+      },
+      restore: async () => {
+        restoreExecuted = true
+      },
+      snapshot: async () => ({ cookies: [] })
+    }),
+    error => error === primary
+  )
+  assert.equal(restoreExecuted, true, 'the successful restore hook must execute')
+})
+
+test('successful promotion replaces destination exactly, persists before clearing source, and then clears draft', async () => {
+  const store = createFakeCredentialStore()
+  const sourceBefore = store.read(store.draft)
+
+  const result = await attemptFakePromotion(store, () => {
+    store.events.push('persist')
+
+    return 'saved'
+  })
+
+  assert.equal(result, 'saved')
+  assert.deepEqual(store.read(store.destination), sourceBefore)
+  assert.deepEqual(store.read(store.draft), { cookies: [], nativeTokens: null })
+  assert.ok(store.events.indexOf('persist') < store.events.lastIndexOf(`clear:${store.draft}`))
+})
+
+test('source cleanup failure after persistence keeps durable credentials and queues a retry', async () => {
+  const store = createFakeCredentialStore('source-clear')
+  const sourceBefore = store.read(store.draft)
+  const retries = new RegistryAuthCleanupRetryQueue()
+
+  const result = await promoteAndPersistRegistryAuth({
+    baseUrl: 'https://gateway.example.test',
+    cleanupRetries: retries,
+    fromScope: store.draft,
+    toScope: store.destination,
+    lifecycle: store.lifecycle,
+    persist: () => {
+      store.events.push('persist')
+
+      return 'saved'
+    }
+  })
+
+  assert.equal(result, 'saved')
+  assert.deepEqual(store.read(store.destination), sourceBefore)
+  assert.deepEqual(store.read(store.draft), sourceBefore)
+  assert.equal(retries.size, 1)
+  assert.equal(store.events.includes(`restore:${store.destination}`), false)
+
+  store.allowFailures()
+  await retries.retry(store.lifecycle)
+  assert.deepEqual(store.read(store.draft), { cookies: [], nativeTokens: null })
+  assert.equal(retries.size, 0)
+})
+
+test('source cleanup failures are reported while remaining retryable', async () => {
+  const store = createFakeCredentialStore('source-clear')
+  const retries = new RegistryAuthCleanupRetryQueue()
+  const failures: unknown[] = []
+
+  await promoteAndPersistRegistryAuth({
+    baseUrl: 'https://gateway.example.test',
+    cleanupRetries: retries,
+    fromScope: store.draft,
+    lifecycle: store.lifecycle,
+    onCleanupFailure: error => failures.push(error),
+    persist: () => 'saved',
+    toScope: store.destination
+  })
+
+  assert.equal(retries.size, 1)
+  assert.match(String(failures[0]), /source clear failed/)
+
+  await retries.retry(store.lifecycle, error => failures.push(error))
+  assert.equal(retries.size, 1)
+  assert.equal(failures.length, 2)
+})
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+function readMainSource(): string {
+  return fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+}
+
+function mainSourceSlice(startMarker: string, endMarker: string): string {
+  const source = readMainSource()
+  const start = source.indexOf(startMarker)
+  const end = source.indexOf(endMarker, start + startMarker.length)
+  assert.notEqual(start, -1, `${startMarker} should exist in main.ts`)
+  assert.notEqual(end, -1, `${endMarker} should follow ${startMarker} in main.ts`)
+
+  return source.slice(start, end)
+}
+
+test('authoritative header candidates retain only explicit null entries and replace renamed values', () => {
+  const stored = { 'CF-Access-Client-Secret': 'stored-secret', 'X-Old-Access': 'old-secret' }
+
+  assert.deepEqual(resolveRegistryAuthCandidateHeaders({}, stored), {})
+  assert.deepEqual(resolveRegistryAuthCandidateHeaders({ 'CF-Access-Client-Secret': null }, stored), {
+    'CF-Access-Client-Secret': 'stored-secret'
+  })
+  assert.deepEqual(resolveRegistryAuthCandidateHeaders({ 'X-New-Access': 'replacement-secret' }, stored), {
+    'X-New-Access': 'replacement-secret'
+  })
+})
+
+test('authenticated durable status uses the exact scoped native bearer and candidate headers', async () => {
+  const calls: unknown[][] = []
+
+  const status = await authenticatedRegistryStatus(
+    {
+      authMode: 'oauth',
+      baseUrl: 'https://gateway.example.test',
+      headers: { 'CF-Access-Client-Secret': 'candidate-secret' },
+      scope: 'gateway-a'
+    },
+    {
+      readNativeAccessToken: async (baseUrl, scope) => {
+        calls.push(['native', baseUrl, scope])
+
+        return 'native-access-token'
+      },
+      readBearerStatus: async (url, bearer, headers) => {
+        calls.push(['bearer', url, bearer, headers])
+
+        return { version: '0.20.4' }
+      },
+      readOauthStatus: async () => {
+        throw new Error('cookie status must not run when native auth is available')
+      },
+      readTokenStatus: async () => {
+        throw new Error('token status must not run for OAuth')
+      }
+    }
+  )
+
+  assert.deepEqual(status, { version: '0.20.4' })
+  assert.deepEqual(calls, [
+    ['native', 'https://gateway.example.test', 'gateway-a'],
+    [
+      'bearer',
+      'https://gateway.example.test/api/status',
+      'native-access-token',
+      { 'CF-Access-Client-Secret': 'candidate-secret' }
+    ]
+  ])
+})
+
+test('authenticated durable status uses the exact scoped OAuth cookie session when native auth is absent', async () => {
+  const calls: unknown[][] = []
+  await authenticatedRegistryStatus(
+    { authMode: 'oauth', baseUrl: 'https://gateway.example.test', headers: {}, scope: 'gateway-a' },
+    {
+      readNativeAccessToken: async () => null,
+      readBearerStatus: async () => {
+        throw new Error('bearer status must not run without native auth')
+      },
+      readOauthStatus: async (url, scope, headers) => {
+        calls.push([url, scope, headers])
+
+        return { version: 'cookie' }
+      },
+      readTokenStatus: async () => {
+        throw new Error('token status must not run for OAuth')
+      }
+    }
+  )
+
+  assert.deepEqual(calls, [['https://gateway.example.test/api/status', 'gateway-a', {}]])
+})
+
+test('durable authenticated status classifies revoked bearer and cookie sessions as auth-required', async () => {
+  for (const nativeToken of ['revoked-native-token', null] as const) {
+    const calls: string[] = []
+
+    const result = await readDurableRegistryAuthStatus(
+      { authMode: 'oauth', baseUrl: 'https://gateway.example.test', headers: {}, scope: 'gateway-a' },
+      {
+        readNativeAccessToken: async () => nativeToken,
+        readBearerStatus: async () => {
+          calls.push('bearer')
+          throw Object.assign(new Error('revoked bearer'), { statusCode: 401 })
+        },
+        readOauthStatus: async () => {
+          calls.push('cookie')
+          throw Object.assign(new Error('revoked cookie'), { statusCode: 403 })
+        },
+        readTokenStatus: async () => {
+          throw new Error('token status must not run for OAuth')
+        }
+      }
+    )
+
+    assert.deepEqual(result, {
+      error: 'Could not read gateway auth status.',
+      kind: 'auth-required',
+      ok: false,
+      statusCode: nativeToken ? 401 : 403
+    })
+    assert.deepEqual(calls, [nativeToken ? 'bearer' : 'cookie'])
+  }
+})
+
+test('durable authenticated status classifies 5xx and timeout failures as transport errors', async () => {
+  const failures = [
+    Object.assign(new Error('upstream unavailable'), { statusCode: 503 }),
+    new Error('Timed out connecting to Hermes backend after 8000ms')
+  ]
+
+  for (const failure of failures) {
+    let statusCalls = 0
+
+    const result = await readDurableRegistryAuthStatus(
+      {
+        authMode: 'token',
+        baseUrl: 'https://gateway.example.test',
+        headers: { 'X-Access': 'secret' },
+        scope: 'gateway-a',
+        token: 'durable-token'
+      },
+      {
+        readNativeAccessToken: async () => null,
+        readBearerStatus: async () => ({ version: 'unexpected' }),
+        readOauthStatus: async () => ({ version: 'unexpected' }),
+        readTokenStatus: async () => {
+          statusCalls += 1
+          throw failure
+        }
+      }
+    )
+
+    assert.equal(statusCalls, 1, 'the authenticated durable status hook must execute')
+    assert.deepEqual(result, {
+      error: 'Could not read gateway auth status.',
+      kind: 'transport-error',
+      ok: false,
+      statusCode: 'statusCode' in failure ? 503 : null
+    })
+  }
+})
+
+test('Registry Test runs authenticated HTTP before the live WebSocket leg', async () => {
+  const calls: unknown[][] = []
+
+  const result = await testAuthenticatedRegistryConnection(
+    {
+      authMode: 'token',
+      baseUrl: 'https://gateway.example.test',
+      headers: { 'X-Access': 'secret' },
+      scope: 'gateway-a',
+      token: 'durable-token'
+    },
+    {
+      onStatus: status => {
+        calls.push(['status', status])
+      },
+      readNativeAccessToken: async () => null,
+      readBearerStatus: async () => ({ version: 'unexpected' }),
+      readOauthStatus: async () => ({ version: 'unexpected' }),
+      readTokenStatus: async (url, token, headers) => {
+        calls.push(['http', url, token, headers])
+
+        return { version: '0.20.4' }
+      },
+      resolveWebSocketUrl: async (baseUrl, authMode, token) => {
+        calls.push(['resolve-ws', baseUrl, authMode, token])
+
+        return 'wss://gateway.example.test/api/ws?token=durable-token'
+      },
+      probeWebSocket: async (url, headers) => {
+        calls.push(['ws', url, headers])
+
+        return { ok: true }
+      }
+    }
+  )
+
+  assert.deepEqual(result, { baseUrl: 'https://gateway.example.test', ok: true, version: '0.20.4' })
+  assert.deepEqual(calls, [
+    ['http', 'https://gateway.example.test/api/status', 'durable-token', { 'X-Access': 'secret' }],
+    ['status', { version: '0.20.4' }],
+    ['resolve-ws', 'https://gateway.example.test', 'token', 'durable-token'],
+    ['ws', 'wss://gateway.example.test/api/ws?token=durable-token', { 'X-Access': 'secret' }]
+  ])
+})
+
+test('Registry Test returns structured auth failure and skips WebSocket after HTTP rejection', async () => {
+  let httpCalls = 0
+  let wsCalls = 0
+
+  const result = await testAuthenticatedRegistryConnection(
+    { authMode: 'oauth', baseUrl: 'https://gateway.example.test', headers: {}, scope: 'gateway-a' },
+    {
+      readNativeAccessToken: async () => 'revoked-token',
+      readBearerStatus: async () => {
+        httpCalls += 1
+        throw Object.assign(new Error('revoked'), { statusCode: 401 })
+      },
+      readOauthStatus: async () => ({ version: 'unexpected' }),
+      readTokenStatus: async () => ({ version: 'unexpected' }),
+      resolveWebSocketUrl: async () => {
+        wsCalls += 1
+
+        return 'wss://gateway.example.test/api/ws'
+      },
+      probeWebSocket: async () => {
+        wsCalls += 1
+
+        return { ok: true }
+      }
+    }
+  )
+
+  assert.equal(httpCalls, 1, 'the authenticated HTTP hook must execute')
+  assert.equal(wsCalls, 0)
+  assert.deepEqual(result, {
+    error: 'Could not test the registered gateway connection.',
+    kind: 'auth-required',
+    ok: false,
+    statusCode: 401
+  })
+})
+
+test('Registry Test returns structured transport failure when WebSocket fails after HTTP success', async () => {
+  const calls: string[] = []
+
+  const result = await testAuthenticatedRegistryConnection(
+    { authMode: 'token', baseUrl: 'https://gateway.example.test', headers: {}, scope: 'gateway-a', token: 'token' },
+    {
+      readNativeAccessToken: async () => null,
+      readBearerStatus: async () => ({ version: 'unexpected' }),
+      readOauthStatus: async () => ({ version: 'unexpected' }),
+      readTokenStatus: async () => {
+        calls.push('http')
+
+        return { version: '0.20.4' }
+      },
+      resolveWebSocketUrl: async () => {
+        calls.push('resolve-ws')
+
+        return 'wss://gateway.example.test/api/ws'
+      },
+      probeWebSocket: async () => {
+        calls.push('ws')
+
+        return { ok: false, reason: 'upgrade rejected' }
+      }
+    }
+  )
+
+  assert.deepEqual(calls, ['http', 'resolve-ws', 'ws'])
+  assert.deepEqual(result, {
+    error: 'Could not test the registered gateway connection.',
+    kind: 'transport-error',
+    ok: false,
+    statusCode: null
+  })
+})
+
+test('structured registry Test catches auth, 5xx, and timeout failures', async () => {
+  const cases = [
+    [Object.assign(new Error('revoked'), { statusCode: 401 }), 'auth-required', 401],
+    [Object.assign(new Error('upstream unavailable'), { statusCode: 503 }), 'transport-error', 503],
+    [new Error('Timed out connecting to Hermes backend after 8000ms'), 'transport-error', null]
+  ] as const
+
+  for (const [failure, kind, statusCode] of cases) {
+    const result = await runStructuredRegistryTest(async () => {
+      throw failure
+    }, 'Connection test failed.')
+
+    assert.deepEqual(result, { error: 'Connection test failed.', kind, ok: false, statusCode })
+  }
+})
+
+test('Electron save wiring uses the atomic lifecycle and drains deferred cleanup', () => {
+  const save = mainSourceSlice('async function saveRegistryConnection(', '\nfunction readActiveDesktopProfile(')
+
+  assert.match(save, /registryAuthCleanupRetries\.retry\(lifecycle/)
+  assert.match(save, /promoteAndPersistRegistryAuth\(\{/)
+  assert.match(save, /fromScope: draftScope/)
+  assert.match(save, /toScope: entry\.id/)
+  assert.doesNotMatch(save, /promoteRegistryAuthScope\(/)
+})
+
+test('removal cleanup failure leaves the registry row intact', async () => {
+  const row = { id: 'gateway-a' }
+  const rows = [row]
+  let clearInjected = false
+  let persistCalled = false
+
+  await assert.rejects(
+    removeRegistryConnectionTransactionally({
+      credentials: {
+        clear: async () => {
+          clearInjected = true
+          throw new Error('credential cleanup failed')
+        },
+        restore: async () => undefined,
+        snapshot: async () => ({ cookies: ['old-cookie'] })
+      },
+      persistRemoval: () => {
+        persistCalled = true
+        rows.splice(0, 1)
+      }
+    }),
+    /credential cleanup failed/
+  )
+  assert.equal(clearInjected, true, 'the injected cleanup failure must execute')
+  assert.equal(persistCalled, false)
+  assert.deepEqual(rows, [row])
+})
+
+test('registry-write failure restores credentials and leaves the registry row intact', async () => {
+  const primary = new Error('registry write failed')
+  const row = { id: 'gateway-a' }
+  const rows = [row]
+  let restoreExecuted = false
+
+  await assert.rejects(
+    removeRegistryConnectionTransactionally({
+      credentials: {
+        clear: async () => undefined,
+        restore: async snapshot => {
+          restoreExecuted = true
+          assert.deepEqual(snapshot, { cookies: ['old-cookie'] })
+        },
+        snapshot: async () => ({ cookies: ['old-cookie'] })
+      },
+      persistRemoval: () => {
+        throw primary
+      }
+    }),
+    error => error === primary
+  )
+  assert.equal(restoreExecuted, true, 'the successful restoration hook must execute')
+  assert.deepEqual(rows, [row])
+})
+
+test('removal preserves simultaneous registry-write and credential-restore failures as uncertain state', async () => {
+  const primary = new Error('registry write failed')
+  const rollback = new Error('credential restore failed')
+  let writeInjected = false
+  let restoreInjected = false
+
+  await assert.rejects(
+    removeRegistryConnectionTransactionally({
+      credentials: {
+        clear: async () => undefined,
+        restore: async () => {
+          restoreInjected = true
+          throw rollback
+        },
+        snapshot: async () => ({ cookies: ['old-cookie'] })
+      },
+      persistRemoval: () => {
+        writeInjected = true
+        throw primary
+      }
+    }),
+    error => {
+      assert.ok(error instanceof AggregateError)
+      assert.deepEqual(error.errors, [primary, rollback])
+      assert.equal((error as AggregateError & { stateUncertain?: boolean }).stateUncertain, true)
+
+      return true
+    }
+  )
+  assert.equal(writeInjected, true, 'the injected registry-write failure must execute')
+  assert.equal(restoreInjected, true, 'the injected restoration failure must execute')
+})
+
+test('successful removal clears credentials before deleting the registry row', async () => {
+  const events: string[] = []
+
+  const result = await removeRegistryConnectionTransactionally({
+    credentials: {
+      clear: async () => { events.push('clear') },
+      restore: async () => { events.push('restore') },
+      snapshot: async () => {
+        events.push('snapshot')
+
+        return { cookies: ['old-cookie'] }
+      }
+    },
+    persistRemoval: () => {
+      events.push('delete-row')
+
+      return 'removed'
+    }
+  })
+
+  assert.equal(result, 'removed')
+  assert.deepEqual(events, ['snapshot', 'clear', 'delete-row'])
+})
+
+test('Electron native-token cache changes only after durable persistence succeeds', () => {
+  const store = mainSourceSlice('function _storeNativeTokens(', '\nfunction _clearNativeTokens(')
+  const clear = mainSourceSlice('function _clearNativeTokens(', '\n// True when we hold native bearer tokens')
+
+  assert.ok(store.indexOf('_persistNativeTokens(') < store.indexOf('_nativeTokens.set('))
+  assert.ok(clear.indexOf('_persistNativeTokens(') < clear.indexOf('_nativeTokens.delete('))
+})
+
+test('automatic terminal token cleanup explicitly chooses best-effort persistence policy', () => {
+  const ensure = mainSourceSlice('async function ensureNativeAccessToken(', '\ntype RegistryNativeTokenSnapshot =')
+
+  assert.match(ensure, /clearNativeTokensBestEffort\(baseUrl, authScope\)/)
+  assert.doesNotMatch(ensure, /_clearNativeTokens\(baseUrl, authScope\)/)
 })
 
 test('candidate token readiness authenticates HTTP and the real websocket leg', async () => {

--- a/apps/desktop/electron/registry-auth.ts
+++ b/apps/desktop/electron/registry-auth.ts
@@ -1,0 +1,143 @@
+import { isGatewayAuthRejection } from './connection-config'
+
+const DURABLE_SCOPE_RE = /^(?!draft-)[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/
+const DRAFT_SCOPE_RE = /^draft-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export type RegistryAuthFailureKind = 'auth-required' | 'transport-error'
+
+export interface RegistryAuthFailure {
+  error: string
+  kind: RegistryAuthFailureKind
+  ok: false
+}
+
+export function validateRegistryAuthScope(rawScope: unknown): string {
+  const scope = String(rawScope ?? '').trim()
+
+  if (scope === 'local' || (!DURABLE_SCOPE_RE.test(scope) && !DRAFT_SCOPE_RE.test(scope))) {
+    throw new Error('A valid registered gateway authentication scope is required.')
+  }
+
+  return scope
+}
+
+export function createDraftRegistryAuthScope(randomUuid: () => string = () => crypto.randomUUID()): string {
+  return validateRegistryAuthScope(`draft-${randomUuid()}`)
+}
+
+export function registryAuthPartition(scope: unknown): string {
+  return `persist:hermes-registry-auth-${validateRegistryAuthScope(scope)}`
+}
+
+export function registryAuthStorageKey(scope: unknown, _baseUrl: unknown): string {
+  return `registry:${validateRegistryAuthScope(scope)}`
+}
+
+export async function mintRegistryAuthTicket(
+  rawScope: unknown,
+  baseUrl: string,
+  headers: Record<string, string>,
+  mintTicket: (baseUrl: string, headers: Record<string, string>, scope: string) => Promise<string>
+): Promise<string> {
+  return mintTicket(baseUrl, headers, validateRegistryAuthScope(rawScope))
+}
+
+interface RegistryAuthCleanupDependencies {
+  clearCookies: (scope: string, baseUrl: string) => Promise<unknown>
+  clearNativeTokens: (storageKey: string) => unknown
+}
+
+interface RegistryAuthPromotionDependencies extends RegistryAuthCleanupDependencies {
+  copyCookies: (fromScope: string, toScope: string, baseUrl: string) => Promise<unknown>
+  moveNativeTokens: (fromStorageKey: string, toStorageKey: string) => unknown
+}
+
+export async function clearRegistryAuthScope(
+  rawScope: unknown,
+  baseUrl: string,
+  deps: RegistryAuthCleanupDependencies
+): Promise<void> {
+  const scope = validateRegistryAuthScope(rawScope)
+  await deps.clearCookies(scope, baseUrl)
+  deps.clearNativeTokens(registryAuthStorageKey(scope, baseUrl))
+}
+
+export async function promoteRegistryAuthScope(
+  rawFromScope: unknown,
+  rawToScope: unknown,
+  baseUrl: string,
+  deps: RegistryAuthPromotionDependencies
+): Promise<void> {
+  const fromScope = validateRegistryAuthScope(rawFromScope)
+  const toScope = validateRegistryAuthScope(rawToScope)
+  await deps.copyCookies(fromScope, toScope, baseUrl)
+  deps.moveNativeTokens(registryAuthStorageKey(fromScope, baseUrl), registryAuthStorageKey(toScope, baseUrl))
+  await clearRegistryAuthScope(fromScope, baseUrl, deps)
+}
+
+export interface RegistryAuthPromotionSaveOptions<T> {
+  baseUrl: string
+  connectionId: string
+  draftScope?: string
+  persist: () => T
+  promote: (draftScope: string, connectionId: string, baseUrl: string) => Promise<void>
+}
+
+export async function saveWithRegistryAuthPromotion<T>(options: RegistryAuthPromotionSaveOptions<T>): Promise<T> {
+  if (options.draftScope) {
+    await options.promote(
+      validateRegistryAuthScope(options.draftScope),
+      validateRegistryAuthScope(options.connectionId),
+      options.baseUrl
+    )
+  }
+
+  return options.persist()
+}
+
+interface VerifyTokenRegistryAuthOptions {
+  baseUrl: string
+  headers: Record<string, string>
+  token: string
+  readStatus: (
+    url: string,
+    token: string,
+    headers: Record<string, string>
+  ) => Promise<{ version?: null | string }>
+  resolveWebSocketUrl: (baseUrl: string, token: string) => Promise<null | string> | null | string
+  probeWebSocket: (
+    url: string,
+    headers: Record<string, string>
+  ) => Promise<{ ok: boolean; reason?: string }>
+}
+
+export async function verifyTokenRegistryAuth(options: VerifyTokenRegistryAuthOptions): Promise<{ version: null | string }> {
+  const token = options.token.trim()
+
+  if (!token) {
+    throw new Error('Remote gateway session token is required.')
+  }
+
+  const status = await options.readStatus(`${options.baseUrl}/api/status`, token, options.headers)
+  const wsUrl = await options.resolveWebSocketUrl(options.baseUrl, token)
+
+  if (!wsUrl) {
+    throw new Error('The gateway WebSocket readiness URL could not be resolved.')
+  }
+
+  const probe = await options.probeWebSocket(wsUrl, options.headers)
+
+  if (!probe.ok) {
+    throw new Error(`The authenticated gateway WebSocket readiness check failed: ${probe.reason || 'connection failed'}`)
+  }
+
+  return { version: status.version || null }
+}
+
+export function serializeRegistryAuthFailure(error: unknown, displayText: string): RegistryAuthFailure {
+  return {
+    error: displayText,
+    kind: isGatewayAuthRejection(error) ? 'auth-required' : 'transport-error',
+    ok: false
+  }
+}

--- a/apps/desktop/electron/registry-auth.ts
+++ b/apps/desktop/electron/registry-auth.ts
@@ -1,14 +1,413 @@
-import { isGatewayAuthRejection } from './connection-config'
+import { createHash, randomBytes } from 'node:crypto'
+
+import { isGatewayAuthRejection, normalizeRemoteBaseUrl } from './connection-config'
+import { connectionDialFieldsChanged, type RegistryConnection } from './connection-registry'
 
 const DURABLE_SCOPE_RE = /^(?!draft-)[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/
 const DRAFT_SCOPE_RE = /^draft-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export type RegistryAuthFailureKind = 'auth-required' | 'transport-error'
 
+export interface RegistryAuthCandidateBinding {
+  authMode: 'oauth' | 'token'
+  baseUrl: string
+  connectionId: string
+  generation: number
+  headersFingerprint: string
+  scope: string
+  tokenFingerprint: string
+}
+
+interface RegistryAuthCandidateInput {
+  authMode: unknown
+  baseUrl: unknown
+  connectionId: unknown
+  generation: unknown
+  headers?: Record<string, string>
+  scope: unknown
+  token?: string
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+export function fingerprintRegistryAuthCandidate(
+  headers: Record<string, string> = {},
+  token = ''
+): Pick<RegistryAuthCandidateBinding, 'headersFingerprint' | 'tokenFingerprint'> {
+  const canonicalHeaders = Object.entries(headers)
+    .map(([name, value]) => [name.toLowerCase(), String(value)] as const)
+    .sort(([leftName, leftValue], [rightName, rightValue]) =>
+      leftName.localeCompare(rightName) || leftValue.localeCompare(rightValue)
+    )
+
+  return {
+    headersFingerprint: sha256(JSON.stringify(canonicalHeaders)),
+    tokenFingerprint: sha256(token)
+  }
+}
+
+export function registryAuthCandidateBinding(input: RegistryAuthCandidateInput): RegistryAuthCandidateBinding {
+  const authMode = String(input.authMode || '').trim().toLowerCase()
+
+  if (authMode !== 'oauth' && authMode !== 'token') {
+    throw new Error('A valid registered gateway authentication mode is required.')
+  }
+
+  const generation = Number(input.generation)
+
+  if (!Number.isSafeInteger(generation) || generation < 0) {
+    throw new Error('A valid registered gateway authentication generation is required.')
+  }
+
+  return {
+    authMode,
+    baseUrl: normalizeRemoteBaseUrl(input.baseUrl),
+    connectionId: validateRegistryAuthScope(input.connectionId),
+    generation,
+    ...fingerprintRegistryAuthCandidate(input.headers, input.token || ''),
+    scope: validateRegistryAuthScope(input.scope)
+  }
+}
+
+interface RegistryAuthReadinessAuthorityOptions {
+  now?: () => number
+  randomToken?: () => string
+  ttlMs?: number
+}
+
+export class RegistryAuthReadinessAuthority {
+  private readonly capabilities = new Map<string, RegistryAuthCandidateBinding & { expiresAt: number }>()
+  private readonly drafts = new Map<string, string>()
+  private readonly generations = new Map<string, number>()
+  private readonly now: () => number
+  private readonly randomToken: () => string
+  private readonly ttlMs: number
+
+  constructor(options: RegistryAuthReadinessAuthorityOptions = {}) {
+    this.now = options.now || Date.now
+    this.randomToken = options.randomToken || (() => randomBytes(32).toString('base64url'))
+    this.ttlMs = options.ttlMs ?? 60_000
+  }
+
+  issue(binding: RegistryAuthCandidateBinding): string {
+    const capability = this.randomToken()
+    this.capabilities.set(capability, { ...binding, expiresAt: this.now() + this.ttlMs })
+
+    return capability
+  }
+
+  registerDraft(rawScope: unknown, targetConnectionId: string): void {
+    const scope = validateRegistryAuthScope(rawScope)
+
+    if (!DRAFT_SCOPE_RE.test(scope)) {
+      throw new Error('A valid draft gateway authentication scope is required.')
+    }
+
+    this.drafts.set(scope, validateRegistryAuthScope(targetConnectionId))
+    this.generations.set(scope, 0)
+  }
+
+  ownsDraft(rawScope: unknown, ownerConnectionId?: string): boolean {
+    const scope = validateRegistryAuthScope(rawScope)
+
+    if (!this.drafts.has(scope)) {
+      return false
+    }
+
+    const owner = this.drafts.get(scope)
+
+    return ownerConnectionId === undefined || owner === ownerConnectionId
+  }
+
+  draftOwner(rawScope: unknown): string {
+    const scope = validateRegistryAuthScope(rawScope)
+
+    if (!this.drafts.has(scope)) {
+      throw new Error('The draft gateway authentication scope is not registered.')
+    }
+
+    return this.drafts.get(scope)!
+  }
+
+  generationForScope(rawScope: unknown): number {
+    const scope = validateRegistryAuthScope(rawScope)
+
+    return this.generations.get(scope) || 0
+  }
+
+  invalidateScope(rawScope: unknown): void {
+    const scope = validateRegistryAuthScope(rawScope)
+
+    for (const [capability, record] of this.capabilities) {
+      if (record.scope === scope) {
+        this.capabilities.delete(capability)
+      }
+    }
+
+    this.drafts.delete(scope)
+    this.generations.set(scope, this.generationForScope(scope) + 1)
+  }
+
+  consume(capability: string | undefined, binding: RegistryAuthCandidateBinding): void {
+    const record = capability ? this.capabilities.get(capability) : undefined
+
+    if (capability) {
+      this.capabilities.delete(capability)
+    }
+
+    if (!record) {
+      throw new Error('A valid readiness capability is required; it is unknown or already used.')
+    }
+
+    if (record.expiresAt <= this.now()) {
+      throw new Error('The readiness capability has expired.')
+    }
+
+    const { expiresAt: _expiresAt, ...recordBinding } = record
+
+    if (JSON.stringify(recordBinding) !== JSON.stringify(binding)) {
+      throw new Error('The readiness capability does not match the connection candidate.')
+    }
+  }
+}
+
+export interface RegistryAuthScopeAuthority {
+  baseUrl: string
+  connectionId: string
+  generation: number
+  scope: string
+}
+
+interface RegistryAuthRegistryRow {
+  id: string
+  kind: string
+  url?: string
+}
+
+export function resolveRegistryAuthScopeAuthority(options: {
+  authority: RegistryAuthReadinessAuthority
+  baseUrl: unknown
+  registry: { connections: RegistryAuthRegistryRow[] }
+  scope: unknown
+}): RegistryAuthScopeAuthority {
+  const scope = validateRegistryAuthScope(options.scope)
+  const callerBaseUrl = normalizeRemoteBaseUrl(options.baseUrl)
+
+  if (DRAFT_SCOPE_RE.test(scope)) {
+    const ownerConnectionId = options.authority.draftOwner(scope)
+
+    return {
+      baseUrl: callerBaseUrl,
+      connectionId: ownerConnectionId || scope,
+      generation: options.authority.generationForScope(scope),
+      scope
+    }
+  }
+
+  const connection = options.registry.connections.find(row => row.id === scope)
+
+  if (!connection || connection.kind !== 'remote' || !connection.url) {
+    throw new Error('The registered gateway authentication scope does not identify a remote connection.')
+  }
+
+  const storedBaseUrl = normalizeRemoteBaseUrl(connection.url)
+
+  if (storedBaseUrl !== callerBaseUrl) {
+    throw new Error('The caller URL does not match the registered gateway authentication scope.')
+  }
+
+  return {
+    baseUrl: storedBaseUrl,
+    connectionId: connection.id,
+    generation: options.authority.generationForScope(scope),
+    scope
+  }
+}
+
+export async function saveVerifiedRegistryConnection<T>(options: {
+  authority: RegistryAuthReadinessAuthority
+  binding: RegistryAuthCandidateBinding
+  capability?: string
+  connectionId: string
+  persist: () => Promise<T> | T
+  promote?: () => Promise<void>
+  readinessRequired?: boolean
+}): Promise<T> {
+  if (options.readinessRequired !== false || options.promote) {
+    options.authority.consume(options.capability, options.binding)
+
+    if (validateRegistryAuthScope(options.connectionId) !== options.binding.connectionId) {
+      throw new Error('The readiness capability target does not match the saved connection.')
+    }
+  }
+
+  if (options.promote) {
+    await options.promote()
+  }
+
+  return options.persist()
+}
+
+export function registryAuthReadinessRequired(
+  existing: RegistryConnection | null | undefined,
+  candidate: RegistryConnection
+): boolean {
+  return !existing || connectionDialFieldsChanged(existing, candidate)
+}
+
 export interface RegistryAuthFailure {
   error: string
   kind: RegistryAuthFailureKind
   ok: false
+  statusCode: number | null
+}
+
+export function resolveRegistryAuthCandidateHeaders<T>(
+  rawCandidate: unknown,
+  storedHeaders: Record<string, T>
+): Record<string, string | T> {
+  if (!rawCandidate || typeof rawCandidate !== 'object' || Array.isArray(rawCandidate)) {
+    return { ...storedHeaders }
+  }
+
+  const candidate: Record<string, string | T> = {}
+
+  for (const [rawName, value] of Object.entries(rawCandidate)) {
+    const name = rawName.trim()
+
+    if (!name) {
+      continue
+    }
+
+    if (value === null) {
+      if (storedHeaders[name] !== undefined) {
+        candidate[name] = storedHeaders[name]
+      }
+
+      continue
+    }
+
+    if (typeof value === 'string' && value.trim()) {
+      candidate[name] = value.trim()
+    } else if (value && typeof value === 'object') {
+      candidate[name] = value as T
+    }
+  }
+
+  return candidate
+}
+
+export interface AuthenticatedRegistryStatusInput {
+  authMode: 'oauth' | 'token'
+  baseUrl: string
+  headers: Record<string, string>
+  scope: string
+  token?: string | null
+}
+
+export interface AuthenticatedRegistryStatusDependencies<T> {
+  readBearerStatus: (url: string, bearer: string, headers: Record<string, string>) => Promise<T>
+  readNativeAccessToken: (baseUrl: string, scope: string) => Promise<null | string>
+  readOauthStatus: (url: string, scope: string, headers: Record<string, string>) => Promise<T>
+  readTokenStatus: (url: string, token: string, headers: Record<string, string>) => Promise<T>
+}
+
+export async function authenticatedRegistryStatus<T>(
+  input: AuthenticatedRegistryStatusInput,
+  dependencies: AuthenticatedRegistryStatusDependencies<T>
+): Promise<T> {
+  const baseUrl = normalizeRemoteBaseUrl(input.baseUrl)
+  const url = `${baseUrl}/api/status`
+
+  if (input.authMode === 'oauth') {
+    const bearer = await dependencies.readNativeAccessToken(baseUrl, validateRegistryAuthScope(input.scope))
+
+    return bearer
+      ? dependencies.readBearerStatus(url, bearer, input.headers)
+      : dependencies.readOauthStatus(url, input.scope, input.headers)
+  }
+
+  const token = String(input.token || '').trim()
+
+  if (!token) {
+    throw new Error('Remote gateway session token is required.')
+  }
+
+  return dependencies.readTokenStatus(url, token, input.headers)
+}
+
+export async function readDurableRegistryAuthStatus<T>(
+  input: AuthenticatedRegistryStatusInput,
+  dependencies: AuthenticatedRegistryStatusDependencies<T>
+): Promise<{ baseUrl: string; connected: true; ok: true } | RegistryAuthFailure> {
+  const baseUrl = normalizeRemoteBaseUrl(input.baseUrl)
+
+  try {
+    await authenticatedRegistryStatus({ ...input, baseUrl }, dependencies)
+
+    return { baseUrl, connected: true, ok: true }
+  } catch (error) {
+    return serializeRegistryAuthFailure(error, 'Could not read gateway auth status.')
+  }
+}
+
+interface AuthenticatedRegistryConnectionTestDependencies<T extends { version?: null | string }>
+  extends AuthenticatedRegistryStatusDependencies<T> {
+  onStatus?: (status: T) => void
+  probeWebSocket: (url: string, headers: Record<string, string>) => Promise<{ ok: boolean; reason?: string }>
+  resolveWebSocketUrl: (
+    baseUrl: string,
+    authMode: 'oauth' | 'token',
+    token: null | string,
+    headers: Record<string, string>,
+    scope: string
+  ) => Promise<null | string> | null | string
+}
+
+export async function testAuthenticatedRegistryConnection<T extends { version?: null | string }>(
+  input: AuthenticatedRegistryStatusInput,
+  dependencies: AuthenticatedRegistryConnectionTestDependencies<T>
+): Promise<{ baseUrl: string; ok: true; version: null | string } | RegistryAuthFailure> {
+  const baseUrl = normalizeRemoteBaseUrl(input.baseUrl)
+
+  return runStructuredRegistryTest(async () => {
+    const status = await authenticatedRegistryStatus({ ...input, baseUrl }, dependencies)
+
+    dependencies.onStatus?.(status)
+
+    const wsUrl = await dependencies.resolveWebSocketUrl(
+      baseUrl,
+      input.authMode,
+      input.token || null,
+      input.headers,
+      input.scope
+    )
+
+    if (!wsUrl) {
+      throw new Error('The gateway WebSocket readiness URL could not be resolved.')
+    }
+
+    const probe = await dependencies.probeWebSocket(wsUrl, input.headers)
+
+    if (!probe.ok) {
+      throw new Error(`The authenticated gateway WebSocket readiness check failed: ${probe.reason || 'connection failed'}`)
+    }
+
+    return { baseUrl, ok: true as const, version: status.version || null }
+  }, 'Could not test the registered gateway connection.')
+}
+
+export async function runStructuredRegistryTest<T extends object>(
+  operation: () => Promise<T>,
+  failureText: string
+): Promise<T | RegistryAuthFailure> {
+  try {
+    return await operation()
+  } catch (error) {
+    return serializeRegistryAuthFailure(error, failureText)
+  }
 }
 
 export function validateRegistryAuthScope(rawScope: unknown): string {
@@ -23,6 +422,10 @@ export function validateRegistryAuthScope(rawScope: unknown): string {
 
 export function createDraftRegistryAuthScope(randomUuid: () => string = () => crypto.randomUUID()): string {
   return validateRegistryAuthScope(`draft-${randomUuid()}`)
+}
+
+export function createRegistryAuthTargetConnectionId(randomUuid: () => string = () => crypto.randomUUID()): string {
+  return validateRegistryAuthScope(`gateway-${randomUuid()}`)
 }
 
 export function registryAuthPartition(scope: unknown): string {
@@ -40,6 +443,150 @@ export async function mintRegistryAuthTicket(
   mintTicket: (baseUrl: string, headers: Record<string, string>, scope: string) => Promise<string>
 ): Promise<string> {
   return mintTicket(baseUrl, headers, validateRegistryAuthScope(rawScope))
+}
+
+export interface RegistryAuthCredentialSnapshot {
+  cookies: readonly unknown[]
+  nativeTokens?: unknown
+}
+
+export interface RegistryAuthCredentialLifecycle {
+  snapshot: (scope: string, baseUrl: string) => Promise<RegistryAuthCredentialSnapshot>
+  replace: (fromScope: string, toScope: string, baseUrl: string) => Promise<void>
+  restore: (scope: string, baseUrl: string, snapshot: RegistryAuthCredentialSnapshot) => Promise<void>
+  clear: (scope: string, baseUrl: string) => Promise<void>
+}
+
+export class RegistryAuthCleanupRetryQueue {
+  private readonly pending = new Map<string, { baseUrl: string; scope: string }>()
+
+  get size(): number {
+    return this.pending.size
+  }
+
+  record(scope: string, baseUrl: string): void {
+    const validatedScope = validateRegistryAuthScope(scope)
+    this.pending.set(`${validatedScope}\n${baseUrl}`, { baseUrl, scope: validatedScope })
+  }
+
+  async retry(lifecycle: RegistryAuthCredentialLifecycle, onFailure?: (error: unknown) => void): Promise<void> {
+    for (const [key, entry] of this.pending) {
+      try {
+        await lifecycle.clear(entry.scope, entry.baseUrl)
+        this.pending.delete(key)
+      } catch (error) {
+        onFailure?.(error)
+        // Keep the Electron-memory entry for the next lifecycle call.
+      }
+    }
+  }
+}
+
+const defaultRegistryAuthCleanupRetries = new RegistryAuthCleanupRetryQueue()
+
+export class RegistryAuthRollbackError extends AggregateError {
+  readonly stateUncertain = true
+
+  constructor(primaryError: unknown, rollbackError: unknown, message: string) {
+    super([primaryError, rollbackError], message)
+    this.name = 'RegistryAuthRollbackError'
+  }
+}
+
+async function restoreRegistryAuthAfterFailure(
+  primaryError: unknown,
+  restore: () => Promise<void>,
+  aggregateMessage: string
+): Promise<never> {
+  try {
+    await restore()
+  } catch (rollbackError) {
+    throw new RegistryAuthRollbackError(primaryError, rollbackError, aggregateMessage)
+  }
+
+  throw primaryError
+}
+
+export async function clearRegistryAuthCredentialsTransactionally(options: {
+  clear: () => Promise<void>
+  restore: (snapshot: RegistryAuthCredentialSnapshot) => Promise<void>
+  snapshot: () => Promise<RegistryAuthCredentialSnapshot>
+}): Promise<void> {
+  const before = await options.snapshot()
+
+  try {
+    await options.clear()
+  } catch (error) {
+    return restoreRegistryAuthAfterFailure(
+      error,
+      () => options.restore(before),
+      'Registry authentication credential cleanup failed and its rollback also failed; credential state is uncertain.'
+    )
+  }
+}
+
+export async function removeRegistryConnectionTransactionally<T>(options: {
+  credentials?: {
+    clear: () => Promise<void>
+    restore: (snapshot: RegistryAuthCredentialSnapshot) => Promise<void>
+    snapshot: () => Promise<RegistryAuthCredentialSnapshot>
+  }
+  persistRemoval: () => Promise<T> | T
+}): Promise<T> {
+  const credentialsBefore = options.credentials ? await options.credentials.snapshot() : undefined
+
+  if (options.credentials) {
+    await options.credentials.clear()
+  }
+
+  try {
+    return await options.persistRemoval()
+  } catch (error) {
+    if (!options.credentials || !credentialsBefore) {
+      throw error
+    }
+
+    return restoreRegistryAuthAfterFailure(
+      error,
+      () => options.credentials!.restore(credentialsBefore),
+      'Registry connection removal failed and its credential rollback also failed; credential state is uncertain.'
+    )
+  }
+}
+
+export async function promoteAndPersistRegistryAuth<T>(options: {
+  baseUrl: string
+  cleanupRetries?: RegistryAuthCleanupRetryQueue
+  fromScope: unknown
+  lifecycle: RegistryAuthCredentialLifecycle
+  onCleanupFailure?: (error: unknown) => void
+  persist: () => Promise<T> | T
+  toScope: unknown
+}): Promise<T> {
+  const fromScope = validateRegistryAuthScope(options.fromScope)
+  const toScope = validateRegistryAuthScope(options.toScope)
+  const destinationBefore = await options.lifecycle.snapshot(toScope, options.baseUrl)
+  let result: T
+
+  try {
+    await options.lifecycle.replace(fromScope, toScope, options.baseUrl)
+    result = await options.persist()
+  } catch (error) {
+    return restoreRegistryAuthAfterFailure(
+      error,
+      () => options.lifecycle.restore(toScope, options.baseUrl, destinationBefore),
+      'Registry authentication promotion failed and its credential rollback also failed; credential state is uncertain.'
+    )
+  }
+
+  try {
+    await options.lifecycle.clear(fromScope, options.baseUrl)
+  } catch (error) {
+    ;(options.cleanupRetries || defaultRegistryAuthCleanupRetries).record(fromScope, options.baseUrl)
+    options.onCleanupFailure?.(error)
+  }
+
+  return result
 }
 
 interface RegistryAuthCleanupDependencies {
@@ -60,6 +607,61 @@ export async function clearRegistryAuthScope(
   const scope = validateRegistryAuthScope(rawScope)
   await deps.clearCookies(scope, baseUrl)
   deps.clearNativeTokens(registryAuthStorageKey(scope, baseUrl))
+}
+
+export async function revokeRegistryAuthScope(
+  rawScope: unknown,
+  baseUrl: string,
+  authority: RegistryAuthReadinessAuthority,
+  deps: RegistryAuthCleanupDependencies
+): Promise<void> {
+  const scope = validateRegistryAuthScope(rawScope)
+
+  try {
+    await clearRegistryAuthScope(scope, baseUrl, deps)
+  } finally {
+    authority.invalidateScope(scope)
+  }
+}
+
+export async function teardownRemovedRegistryConnection(options: {
+  authority: RegistryAuthReadinessAuthority
+  clearCredentials?: () => Promise<void>
+  scope: unknown
+  stopBackends: () => Promise<void>
+}): Promise<void> {
+  const scope = validateRegistryAuthScope(options.scope)
+  let cleanupFailure: { error: unknown } | undefined
+  let stopFailure: { error: unknown } | undefined
+
+  try {
+    await options.stopBackends()
+  } catch (error) {
+    stopFailure = { error }
+  } finally {
+    try {
+      await options.clearCredentials?.()
+    } catch (error) {
+      cleanupFailure = { error }
+    } finally {
+      options.authority.invalidateScope(scope)
+    }
+  }
+
+  if (cleanupFailure) {
+    if (stopFailure) {
+      throw new AggregateError(
+        [stopFailure.error, cleanupFailure.error],
+        'Connection backend teardown and registry authentication cleanup both failed.'
+      )
+    }
+
+    throw cleanupFailure.error
+  }
+
+  if (stopFailure) {
+    throw stopFailure.error
+  }
 }
 
 export async function promoteRegistryAuthScope(
@@ -135,9 +737,12 @@ export async function verifyTokenRegistryAuth(options: VerifyTokenRegistryAuthOp
 }
 
 export function serializeRegistryAuthFailure(error: unknown, displayText: string): RegistryAuthFailure {
+  const rawStatusCode = error && typeof error === 'object' ? Number((error as { statusCode?: unknown }).statusCode) : NaN
+
   return {
     error: displayText,
     kind: isGatewayAuthRejection(error) ? 'auth-required' : 'transport-error',
-    ok: false
+    ok: false,
+    statusCode: Number.isInteger(rawStatusCode) ? rawStatusCode : null
   }
 }

--- a/apps/desktop/src/app/settings/connections-registry.test.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.test.tsx
@@ -1,12 +1,14 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DesktopConnectionsRegistry } from '@/global'
+import { $notifications } from '@/store/notifications'
 import { $connection } from '@/store/session'
 
 import {
   ConnectionsRegistrySection,
   findDuplicateConnection,
+  isConnectionAuthRejection,
   normalizeGatewayUrl,
   sameBackendPeerLabel,
   sshCompositeKey
@@ -18,6 +20,12 @@ const remove = vi.fn()
 const setLaunchMode = vi.fn()
 const setPrimary = vi.fn()
 const test = vi.fn()
+const createDraft = vi.fn()
+const authProbe = vi.fn()
+const authLogin = vi.fn()
+const authVerify = vi.fn()
+const authStatus = vi.fn()
+const authClear = vi.fn()
 
 const registry: DesktopConnectionsRegistry = {
   connections: [
@@ -38,6 +46,7 @@ const registry: DesktopConnectionsRegistry = {
 }
 
 beforeEach(() => {
+  $notifications.set([])
   $connection.set({
     baseUrl: 'http://homelab.lan:9119',
     connectionId: 'homelab',
@@ -55,9 +64,34 @@ beforeEach(() => {
   setLaunchMode.mockResolvedValue({ ok: true, registry: { ...registry, launchMode: 'last-used' } })
   setPrimary.mockResolvedValue({ ok: true, registry: { ...registry, primary: 'homelab' } })
   test.mockResolvedValue({ ok: true, reachable: true })
+
+  createDraft.mockResolvedValue({ ok: true, scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512' })
+  authProbe.mockResolvedValue({
+    authMode: 'token',
+    baseUrl: 'http://homelab.lan:9119',
+    error: null,
+    providers: [],
+    reachable: true,
+    scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512',
+    version: '0.20.4'
+  })
+  authLogin.mockResolvedValue({ baseUrl: 'http://homelab.lan:9119', connected: true, ok: true })
+  authVerify.mockResolvedValue({ baseUrl: 'http://homelab.lan:9119', ok: true, version: '0.20.4' })
+  authStatus.mockResolvedValue({ baseUrl: 'http://homelab.lan:9119', connected: false, ok: true })
+  authClear.mockResolvedValue({ baseUrl: 'http://homelab.lan:9119', connected: false, ok: true })
   Object.defineProperty(window, 'hermesDesktop', {
     configurable: true,
-    value: { connections: { list, remove, save, setLaunchMode, setPrimary, test } }
+    value: {
+      connections: {
+        auth: { clear: authClear, createDraft, login: authLogin, probe: authProbe, status: authStatus, verify: authVerify },
+        list,
+        remove,
+        save,
+        setLaunchMode,
+        setPrimary,
+        test
+      }
+    }
   })
 })
 
@@ -79,29 +113,393 @@ describe('ConnectionsRegistrySection', () => {
     expect(list).toHaveBeenCalledTimes(1)
   })
 
-  it('opens the add-connection editor and saves with a required label', async () => {
+  it('creates one draft and keeps a new remote disabled until current discovery and readiness succeed', async () => {
     render(<ConnectionsRegistrySection />)
 
     await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
     fireEvent.click(screen.getByText('Add connection'))
+    await waitFor(() => expect(createDraft).toHaveBeenCalledTimes(1))
 
-    // Save is disabled until a label is present.
-    const saveButton = screen.getByText('Save connection').closest('button')!
-    expect(saveButton.disabled).toBe(true)
-
+    const saveButton = screen.getByText('Save connection').closest('button') as HTMLButtonElement
     fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'Spark box' } })
     fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
       target: { value: 'http://spark.lan:9119' }
     })
-    expect(saveButton.disabled).toBe(false)
+
+    expect(saveButton.disabled).toBe(true)
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('shows an actionable unreachable discovery error and keeps save disabled', async () => {
+    authProbe.mockResolvedValueOnce({
+      authMode: 'token',
+      baseUrl: 'https://offline.example.test',
+      error: 'Connection refused. Check the gateway URL and network access.',
+      providers: [],
+      reachable: false,
+      scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512',
+      version: null
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'Offline' } })
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'https://offline.example.test' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+
+    expect(await screen.findByText('Connection refused. Check the gateway URL and network access.')).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('shows a malformed URL discovery error and keeps save disabled', async () => {
+    authProbe.mockResolvedValueOnce({ error: 'Enter a valid HTTP or HTTPS gateway URL.', ok: false })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'Malformed' } })
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'not-a-url' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+
+    expect(await screen.findByText('Enter a valid HTTP or HTTPS gateway URL.')).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('keeps save disabled when login connects but websocket readiness fails', async () => {
+    authProbe.mockResolvedValueOnce({
+      authMode: 'oauth',
+      baseUrl: 'https://gateway.example.test',
+      error: null,
+      providers: [{ name: 'nous', displayName: 'Nous Research', supportsPassword: false }],
+      reachable: true,
+      scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512',
+      version: '0.20.4'
+    })
+    authVerify.mockResolvedValueOnce({
+      error: 'The authenticated gateway WebSocket readiness check failed: upgrade rejected',
+      kind: 'transport-error',
+      ok: false
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'Nous gateway' } })
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'https://gateway.example.test' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with Nous Research' }))
+
+    expect(
+      await screen.findByText('The authenticated gateway WebSocket readiness check failed: upgrade rejected')
+    ).toBeTruthy()
+    expect((screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement).disabled).toBe(true)
+    expect($connection.get()?.connectionId).toBe('homelab')
+  })
+
+  it('detects password authentication and requires sign-in before saving a remote gateway', async () => {
+    authProbe.mockResolvedValueOnce({
+      authMode: 'oauth',
+      baseUrl: 'http://100.110.110.95:9119',
+      error: null,
+      providers: [{ name: 'basic', displayName: 'Username & Password', supportsPassword: true }],
+      reachable: true,
+      version: '0.20.4'
+    })
+    authLogin.mockResolvedValueOnce({
+      baseUrl: 'http://100.110.110.95:9119',
+      connected: true,
+      ok: true
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'PopCorn VPS' } })
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'http://100.110.110.95:9119' }
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+
+    await waitFor(() => expect(authProbe).toHaveBeenCalledWith(expect.objectContaining({ url: 'http://100.110.110.95:9119' })))
+    expect(screen.queryByPlaceholderText('Paste session token')).toBeNull()
+    const signIn = screen.getByRole('button', { name: 'Sign in' })
+    const saveButton = screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement
+    expect(saveButton.disabled).toBe(true)
+
+    fireEvent.click(signIn)
+
+    await waitFor(() => expect(authLogin).toHaveBeenCalledWith(expect.objectContaining({ url: 'http://100.110.110.95:9119' })))
+    await waitFor(() => expect(saveButton.disabled).toBe(false))
     fireEvent.click(saveButton)
 
-    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
-    expect(save.mock.calls[0][0]).toMatchObject({
-      kind: 'remote',
-      label: 'Spark box',
-      url: 'http://spark.lan:9119'
+    await waitFor(() =>
+      expect(save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authMode: 'oauth',
+          kind: 'remote',
+          label: 'PopCorn VPS',
+          url: 'http://100.110.110.95:9119'
+        })
+      )
+    )
+  })
+
+  it('uses provider-generic OAuth copy without changing the active local connection', async () => {
+    $connection.set({ ...$connection.get()!, connectionId: 'local', mode: 'local' })
+    authProbe.mockResolvedValueOnce({
+      authMode: 'oauth',
+      baseUrl: 'https://gateway.example.test',
+      error: null,
+      providers: [{ name: 'nous', displayName: 'Nous Research', supportsPassword: false }],
+      reachable: true,
+      version: '0.20.4'
     })
+    authLogin.mockResolvedValueOnce({
+      baseUrl: 'https://gateway.example.test',
+      connected: true,
+      ok: true
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'Nous gateway' } })
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'https://gateway.example.test' }
+    })
+    expect($connection.get()?.connectionId).toBe('local')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    const signIn = await screen.findByRole('button', { name: 'Sign in with Nous Research' })
+    expect($connection.get()?.connectionId).toBe('local')
+
+    fireEvent.click(signIn)
+    const saveButton = screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement
+    await waitFor(() => expect(saveButton.disabled).toBe(false))
+    expect($connection.get()?.connectionId).toBe('local')
+
+    fireEvent.click(saveButton)
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect($connection.get()?.connectionId).toBe('local')
+    expect(setPrimary).not.toHaveBeenCalled()
+  })
+
+  it('uses every backend-provided display name for mixed OAuth providers', async () => {
+    authProbe.mockResolvedValueOnce({
+      authMode: 'oauth',
+      baseUrl: 'https://gateway.example.test',
+      error: null,
+      providers: [
+        { name: 'password', displayName: 'Password', supportsPassword: true },
+        { name: 'enterprise-oidc', displayName: 'Enterprise SSO', supportsPassword: false }
+      ],
+      reachable: true,
+      version: '0.20.4'
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'https://gateway.example.test' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+
+    expect(await screen.findByRole('button', { name: 'Sign in with Password / Enterprise SSO' })).toBeTruthy()
+  })
+
+  it('keeps a cancelled OAuth login unsigned-in and warns without saving', async () => {
+    $connection.set({ ...$connection.get()!, connectionId: 'local', mode: 'local' })
+    authProbe.mockResolvedValueOnce({
+      authMode: 'oauth',
+      baseUrl: 'https://gateway.example.test',
+      error: null,
+      providers: [{ name: 'nous', displayName: 'Nous Research', supportsPassword: false }],
+      reachable: true,
+      version: '0.20.4'
+    })
+    authLogin.mockResolvedValueOnce({ connected: false, ok: true })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'Nous gateway' } })
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'https://gateway.example.test' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+
+    const signIn = await screen.findByRole('button', { name: 'Sign in with Nous Research' })
+    const saveButton = screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement
+    fireEvent.click(signIn)
+
+    await waitFor(() => expect(authLogin).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://gateway.example.test' })))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Sign in with Nous Research' })).toBeTruthy())
+    expect(saveButton.disabled).toBe(true)
+    expect(save).not.toHaveBeenCalled()
+    expect($connection.get()?.connectionId).toBe('local')
+    expect($notifications.get()).toEqual([
+      expect.objectContaining({
+        kind: 'warning',
+        message: 'The login window closed before authentication finished.',
+        title: 'Sign-in incomplete'
+      })
+    ])
+  })
+
+  it('ignores a stale auth probe after the editor URL changes', async () => {
+    $connection.set({ ...$connection.get()!, connectionId: 'local', mode: 'local' })
+    let resolveProbe!: (result: Awaited<ReturnType<typeof window.hermesDesktop.connections.auth.probe>>) => void
+    authProbe.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveProbe = resolve
+        })
+    )
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    const urlInput = screen.getByPlaceholderText('http://homelab.lan:9119') as HTMLInputElement
+    fireEvent.change(urlInput, { target: { value: 'https://gateway-a.example.test' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    await waitFor(() => expect(authProbe).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://gateway-a.example.test' })))
+
+    fireEvent.change(urlInput, { target: { value: 'https://gateway-b.example.test' } })
+    await act(async () => {
+      resolveProbe({
+        authMode: 'oauth',
+        baseUrl: 'https://gateway-a.example.test',
+        error: null,
+        providers: [{ name: 'nous', displayName: 'Nous Research', supportsPassword: false }],
+        reachable: true,
+        scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512',
+        version: '0.20.4'
+      })
+    })
+
+    expect(urlInput.value).toBe('https://gateway-b.example.test')
+    expect(screen.getByRole('button', { name: 'Detect authentication' })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Sign in with Nous Research' })).toBeNull()
+    expect($connection.get()?.connectionId).toBe('local')
+  })
+
+  it('ignores a stale successful login after the editor URL changes', async () => {
+    $connection.set({ ...$connection.get()!, connectionId: 'local', mode: 'local' })
+    authProbe.mockResolvedValueOnce({
+      authMode: 'oauth',
+      baseUrl: 'https://gateway-a.example.test',
+      error: null,
+      providers: [{ name: 'nous', displayName: 'Nous Research', supportsPassword: false }],
+      reachable: true,
+      version: '0.20.4'
+    })
+    let resolveLogin!: (result: Awaited<ReturnType<typeof window.hermesDesktop.connections.auth.login>>) => void
+    authLogin.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveLogin = resolve
+        })
+    )
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'Nous gateway' } })
+    const urlInput = screen.getByPlaceholderText('http://homelab.lan:9119') as HTMLInputElement
+    fireEvent.change(urlInput, { target: { value: 'https://gateway-a.example.test' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Sign in with Nous Research' }))
+    await waitFor(() => expect(authLogin).toHaveBeenCalledWith(expect.objectContaining({ url: 'https://gateway-a.example.test' })))
+
+    fireEvent.change(urlInput, { target: { value: 'https://gateway-b.example.test' } })
+    await act(async () => {
+      resolveLogin({ baseUrl: 'https://gateway-a.example.test', connected: true, ok: true })
+    })
+
+    expect(urlInput.value).toBe('https://gateway-b.example.test')
+    expect((screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByRole('button', { name: 'Detect authentication' })).toBeTruthy()
+    expect(save).not.toHaveBeenCalled()
+    expect($connection.get()?.connectionId).toBe('local')
+  })
+
+  it('requires candidate-token websocket readiness before enabling save', async () => {
+    list.mockResolvedValueOnce({
+      ...registry,
+      connections: [
+        registry.connections[0],
+        { ...registry.connections[1], authMode: 'oauth', tokenPreview: null, tokenSet: false }
+      ]
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+
+    await waitFor(() => expect(authProbe).toHaveBeenCalledWith(expect.objectContaining({ url: 'http://homelab.lan:9119' })))
+    const saveButton = screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement
+    expect(saveButton.disabled).toBe(true)
+
+    fireEvent.change(screen.getByPlaceholderText('Paste session token'), { target: { value: 'new-token' } })
+    expect(saveButton.disabled).toBe(true)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    const verifyButton = await screen.findByRole('button', { name: 'Verify connection' })
+    fireEvent.click(verifyButton)
+
+    await waitFor(() =>
+      expect(authVerify).toHaveBeenCalledWith(
+        expect.objectContaining({ authMode: 'token', scope: 'homelab', token: 'new-token' })
+      )
+    )
+    await waitFor(() => expect(saveButton.disabled).toBe(false))
+  })
+
+  it('invalidates an existing OAuth sign-in when its URL changes', async () => {
+    list.mockResolvedValueOnce({
+      ...registry,
+      connections: [
+        registry.connections[0],
+        { ...registry.connections[1], authMode: 'oauth', tokenPreview: null, tokenSet: false }
+      ]
+    })
+    authProbe.mockResolvedValueOnce({
+      authMode: 'oauth',
+      baseUrl: 'http://new-homelab.lan:9119',
+      error: null,
+      providers: [{ name: 'basic', displayName: 'Username & Password', supportsPassword: true }],
+      reachable: true,
+      version: '0.20.4'
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'http://new-homelab.lan:9119' }
+    })
+    const saveButton = screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement
+    expect(saveButton.disabled).toBe(true)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+
+    await waitFor(() => expect(authProbe).toHaveBeenCalledWith(expect.objectContaining({ url: 'http://new-homelab.lan:9119' })))
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeTruthy()
+    expect(saveButton.disabled).toBe(true)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }))
+    await waitFor(() => expect(authLogin).toHaveBeenCalledWith(expect.objectContaining({ url: 'http://new-homelab.lan:9119' })))
+    await waitFor(() => expect(saveButton.disabled).toBe(false))
   })
 
   it('offers every kind on create and disables Local while the managed entry exists', async () => {
@@ -128,6 +526,10 @@ describe('ConnectionsRegistrySection', () => {
     fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
       target: { value: 'HTTP://HOMELAB.LAN:9119/' }
     })
+    fireEvent.change(screen.getByPlaceholderText('Paste session token'), { target: { value: 'candidate' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Verify connection' }))
+    await waitFor(() => expect(authVerify).toHaveBeenCalled())
     fireEvent.click(screen.getByText('Save connection').closest('button')!)
 
     await waitFor(() =>
@@ -286,6 +688,70 @@ describe('ConnectionsRegistrySection', () => {
     expect(search.closest<HTMLElement>('.border-t')?.style.minHeight).toBe('')
   })
 
+  it('uses durable status and scopes reauthentication and sign-out to the edited connection', async () => {
+    $connection.set({ ...$connection.get()!, connectionId: 'local', mode: 'local' })
+    list.mockResolvedValueOnce({
+      ...registry,
+      connections: [
+        registry.connections[0],
+        { ...registry.connections[1], authMode: 'oauth', tokenPreview: null, tokenSet: false }
+      ]
+    })
+    test.mockResolvedValueOnce({ error: 'Authentication required', kind: 'auth-required', ok: false })
+    authStatus.mockResolvedValueOnce({ baseUrl: 'http://homelab.lan:9119', connected: true, ok: true })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getAllByText('Test')[1])
+
+    await waitFor(() => expect(test).toHaveBeenCalledWith('homelab'))
+    expect(screen.getByText('Homelab')).toBeTruthy()
+    expect($connection.get()?.connectionId).toBe('local')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    await waitFor(() =>
+      expect(authStatus).toHaveBeenCalledWith(expect.objectContaining({ scope: 'homelab' }))
+    )
+    expect(await screen.findByRole('button', { name: 'Reauthenticate' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Sign out' })).toBeTruthy()
+    expect($connection.get()?.connectionId).toBe('local')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reauthenticate' }))
+    await waitFor(() =>
+      expect(authLogin).toHaveBeenCalledWith(expect.objectContaining({ scope: 'homelab' }))
+    )
+    await waitFor(() =>
+      expect(authVerify).toHaveBeenCalledWith(expect.objectContaining({ authMode: 'oauth', scope: 'homelab' }))
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out' }))
+    await waitFor(() =>
+      expect(authClear).toHaveBeenCalledWith(expect.objectContaining({ scope: 'homelab' }))
+    )
+    expect($connection.get()?.connectionId).toBe('local')
+  })
+
+  it('clears its owned draft scope when a new remote editor is cancelled', async () => {
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    await waitFor(() => expect(createDraft).toHaveBeenCalledTimes(1))
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'https://draft.example.test' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() =>
+      expect(authClear).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512',
+          url: 'https://draft.example.test'
+        })
+      )
+    )
+  })
+
   it('tests a connection through the bridge', async () => {
     render(<ConnectionsRegistrySection />)
 
@@ -293,6 +759,43 @@ describe('ConnectionsRegistrySection', () => {
     fireEvent.click(screen.getAllByText('Test')[0])
 
     await waitFor(() => expect(test).toHaveBeenCalled())
+  })
+})
+
+describe('connection auth rejection classification', () => {
+  it('matches direct and Electron-serialized 401/403 errors only', () => {
+    expect(isConnectionAuthRejection({ statusCode: 401 })).toBe(true)
+    expect(isConnectionAuthRejection({ statusCode: 403 })).toBe(true)
+    expect(
+      isConnectionAuthRejection(
+        new Error("Error invoking remote method 'hermes:connections:test': Error: 401: Authentication required")
+      )
+    ).toBe(true)
+    expect(
+      isConnectionAuthRejection(
+        new Error("Error invoking remote method 'hermes:connections:test': Error: 403: Forbidden")
+      )
+    ).toBe(true)
+    expect(
+      isConnectionAuthRejection(
+        new Error(
+          "Error invoking remote method 'hermes:connections:test': Error: Reached the gateway over HTTP, but the OAuth session was rejected while minting a WebSocket ticket. Open Settings → Gateway and sign in again."
+        )
+      )
+    ).toBe(true)
+    expect(
+      isConnectionAuthRejection(
+        new Error("Error invoking remote method 'hermes:connections:test': Error: 500: unavailable")
+      )
+    ).toBe(false)
+    expect(
+      isConnectionAuthRejection(
+        new Error(
+          "Error invoking remote method 'hermes:connections:test': Error: 500: upstream echoed: OAuth session was rejected while minting a WebSocket ticket"
+        )
+      )
+    ).toBe(false)
+    expect(isConnectionAuthRejection(new Error('Timed out connecting to Hermes backend after 8000ms'))).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/settings/connections-registry.test.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.test.tsx
@@ -27,6 +27,33 @@ const authVerify = vi.fn()
 const authStatus = vi.fn()
 const authClear = vi.fn()
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let consumed = false
+
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise
+  })
+
+  return {
+    consume: () => {
+      consumed = true
+
+      return promise
+    },
+    resolve,
+    wasConsumed: () => consumed
+  }
+}
+
+function draftResult(index: number) {
+  return {
+    ok: true as const,
+    scope: `draft-00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+    targetConnectionId: `gateway-00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
+  }
+}
+
 const registry: DesktopConnectionsRegistry = {
   connections: [
     { id: 'local', kind: 'local', label: 'This device', tokenPreview: null, tokenSet: false },
@@ -65,7 +92,11 @@ beforeEach(() => {
   setPrimary.mockResolvedValue({ ok: true, registry: { ...registry, primary: 'homelab' } })
   test.mockResolvedValue({ ok: true, reachable: true })
 
-  createDraft.mockResolvedValue({ ok: true, scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512' })
+  createDraft.mockResolvedValue({
+    ok: true,
+    scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512',
+    targetConnectionId: 'gateway-76f9d14d-2f10-4ccb-9bb8-089935501512'
+  })
   authProbe.mockResolvedValue({
     authMode: 'token',
     baseUrl: 'http://homelab.lan:9119',
@@ -76,7 +107,12 @@ beforeEach(() => {
     version: '0.20.4'
   })
   authLogin.mockResolvedValue({ baseUrl: 'http://homelab.lan:9119', connected: true, ok: true })
-  authVerify.mockResolvedValue({ baseUrl: 'http://homelab.lan:9119', ok: true, version: '0.20.4' })
+  authVerify.mockResolvedValue({
+    baseUrl: 'http://homelab.lan:9119',
+    ok: true,
+    readinessCapability: 'readiness-capability-1',
+    version: '0.20.4'
+  })
   authStatus.mockResolvedValue({ baseUrl: 'http://homelab.lan:9119', connected: false, ok: true })
   authClear.mockResolvedValue({ baseUrl: 'http://homelab.lan:9119', connected: false, ok: true })
   Object.defineProperty(window, 'hermesDesktop', {
@@ -244,6 +280,8 @@ describe('ConnectionsRegistrySection', () => {
       expect(save).toHaveBeenCalledWith(
         expect.objectContaining({
           authMode: 'oauth',
+          authReadinessCapability: 'readiness-capability-1',
+          id: 'gateway-76f9d14d-2f10-4ccb-9bb8-089935501512',
           kind: 'remote',
           label: 'PopCorn VPS',
           url: 'http://100.110.110.95:9119'
@@ -502,6 +540,65 @@ describe('ConnectionsRegistrySection', () => {
     await waitFor(() => expect(saveButton.disabled).toBe(false))
   })
 
+  it('preflights plaintext consent without spending the readiness capability', async () => {
+    list.mockResolvedValueOnce({ ...registry, secureTokenStorage: false })
+    authProbe.mockResolvedValueOnce({
+      authMode: 'token',
+      baseUrl: 'https://keyringless.example.test',
+      error: null,
+      providers: [],
+      reachable: true,
+      scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512',
+      version: '0.20.4'
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'Keyringless gateway' } })
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'https://keyringless.example.test' }
+    })
+    fireEvent.change(screen.getByPlaceholderText('Paste session token'), { target: { value: 'candidate-token' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Verify connection' }))
+    await waitFor(
+      () => expect((screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement).disabled).toBe(false)
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save connection' }))
+
+    expect(await screen.findByRole('button', { name: 'Save as plain text' })).toBeTruthy()
+    expect(save).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save as plain text' }))
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowPlainTextToken: true,
+        authReadinessCapability: 'readiness-capability-1',
+        token: 'candidate-token'
+      })
+    )
+  })
+
+  it('saves a label-only existing remote edit without verification or a readiness capability', async () => {
+    render(<ConnectionsRegistrySection />)
+
+    await waitFor(() => expect(screen.getByText('Homelab')).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.change(screen.getByDisplayValue('Homelab'), { target: { value: 'Renamed homelab' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save connection' }))
+
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'homelab', kind: 'remote', label: 'Renamed homelab' })
+    )
+    expect(save.mock.calls[0][0]).not.toHaveProperty('authReadinessCapability')
+    expect(save.mock.calls[0][0]).not.toHaveProperty('token')
+    expect(authVerify).not.toHaveBeenCalled()
+  })
+
   it('offers every kind on create and disables Local while the managed entry exists', async () => {
     render(<ConnectionsRegistrySection />)
 
@@ -752,6 +849,231 @@ describe('ConnectionsRegistrySection', () => {
     )
   })
 
+  it('clears a late draft result after cancel instead of adopting it', async () => {
+    const pendingDraft = deferred<ReturnType<typeof draftResult>>()
+    createDraft.mockImplementationOnce(() => pendingDraft.consume())
+    render(<ConnectionsRegistrySection />)
+
+    await screen.findByText('Homelab')
+    fireEvent.click(screen.getByText('Add connection'))
+    expect(createDraft).toHaveBeenCalledTimes(1)
+    expect(pendingDraft.wasConsumed()).toBe(true)
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'https://gateway-a.example.test' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await act(async () => pendingDraft.resolve(draftResult(1)))
+
+    await waitFor(() =>
+      expect(authClear).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: draftResult(1).scope, url: 'https://gateway-a.example.test' })
+      )
+    )
+    expect(screen.queryByRole('button', { name: 'Save connection' })).toBeNull()
+  })
+
+  it('clears the A draft when switching to B and gives B a distinct scope', async () => {
+    const pendingA = deferred<ReturnType<typeof draftResult>>()
+    createDraft
+      .mockImplementationOnce(() => pendingA.consume())
+      .mockResolvedValueOnce(draftResult(2))
+      .mockResolvedValueOnce(draftResult(3))
+    render(<ConnectionsRegistrySection />)
+
+    await screen.findByText('Homelab')
+    fireEvent.click(screen.getByText('Add connection'))
+    const urlInput = screen.getByPlaceholderText('http://homelab.lan:9119')
+    fireEvent.change(urlInput, { target: { value: 'https://gateway-a.example.test' } })
+    expect(createDraft).toHaveBeenCalledTimes(2)
+    expect(pendingA.wasConsumed()).toBe(true)
+    fireEvent.change(urlInput, { target: { value: 'https://gateway-b.example.test' } })
+
+    await act(async () => pendingA.resolve(draftResult(1)))
+
+    await waitFor(() => expect(createDraft).toHaveBeenCalledTimes(3))
+    await waitFor(() =>
+      expect(authClear).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: draftResult(1).scope, url: 'https://gateway-a.example.test' })
+      )
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    await waitFor(() =>
+      expect(authProbe).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: draftResult(3).scope, url: 'https://gateway-b.example.test' })
+      )
+    )
+  })
+
+  it('rotates draft ownership for every A to B to A endpoint generation', async () => {
+    createDraft
+      .mockResolvedValueOnce(draftResult(1))
+      .mockResolvedValueOnce(draftResult(2))
+      .mockResolvedValueOnce(draftResult(3))
+      .mockResolvedValueOnce(draftResult(4))
+    render(<ConnectionsRegistrySection />)
+
+    await screen.findByText('Homelab')
+    fireEvent.click(screen.getByText('Add connection'))
+    await waitFor(() => expect(createDraft).toHaveBeenCalledTimes(1))
+    const urlInput = screen.getByPlaceholderText('http://homelab.lan:9119')
+    fireEvent.change(urlInput, { target: { value: 'https://gateway-a.example.test' } })
+    await waitFor(() => expect(createDraft).toHaveBeenCalledTimes(2))
+    fireEvent.change(urlInput, { target: { value: 'https://gateway-b.example.test' } })
+    await waitFor(() => expect(createDraft).toHaveBeenCalledTimes(3))
+    fireEvent.change(urlInput, { target: { value: 'https://gateway-a.example.test' } })
+    await waitFor(() => expect(createDraft).toHaveBeenCalledTimes(4))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    await waitFor(() =>
+      expect(authProbe).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: draftResult(4).scope, url: 'https://gateway-a.example.test' })
+      )
+    )
+    expect(authClear).toHaveBeenCalledWith(expect.objectContaining({ scope: draftResult(2).scope }))
+    expect(authClear).toHaveBeenCalledWith(expect.objectContaining({ scope: draftResult(3).scope }))
+  })
+
+  it('invalidates readiness and rotates the draft across a same-host port change', async () => {
+    createDraft
+      .mockResolvedValueOnce(draftResult(1))
+      .mockResolvedValueOnce(draftResult(2))
+      .mockResolvedValueOnce(draftResult(3))
+    authProbe.mockResolvedValueOnce({
+      authMode: 'token',
+      baseUrl: 'https://same.example.test:9119',
+      error: null,
+      providers: [],
+      reachable: true,
+      scope: draftResult(2).scope,
+      version: '0.20.4'
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await screen.findByText('Homelab')
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'Port gateway' } })
+    const urlInput = screen.getByPlaceholderText('http://homelab.lan:9119')
+    fireEvent.change(urlInput, { target: { value: 'https://same.example.test:9119' } })
+    await waitFor(() => expect(createDraft).toHaveBeenCalledTimes(2))
+    fireEvent.change(screen.getByPlaceholderText('Paste session token'), { target: { value: 'candidate' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Verify connection' }))
+    await waitFor(() =>
+      expect((screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement).disabled).toBe(false)
+    )
+
+    fireEvent.change(urlInput, { target: { value: 'https://same.example.test:9120' } })
+
+    await waitFor(() => expect(createDraft).toHaveBeenCalledTimes(3))
+    expect((screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement).disabled).toBe(true)
+    expect(authClear).toHaveBeenCalledWith(expect.objectContaining({ scope: draftResult(2).scope }))
+  })
+
+  it('does not let a stale verify result restore readiness after an auth mutation', async () => {
+    const pendingVerify = deferred<Awaited<ReturnType<typeof window.hermesDesktop.connections.auth.verify>>>()
+    authVerify.mockImplementationOnce(() => pendingVerify.consume())
+    authProbe.mockResolvedValueOnce({
+      authMode: 'token',
+      baseUrl: 'https://stale.example.test',
+      error: null,
+      providers: [],
+      reachable: true,
+      scope: draftResult(2).scope,
+      version: '0.20.4'
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await screen.findByText('Homelab')
+    fireEvent.click(screen.getByText('Add connection'))
+    fireEvent.change(screen.getByPlaceholderText('Homelab'), { target: { value: 'Stale verify' } })
+    fireEvent.change(screen.getByPlaceholderText('http://homelab.lan:9119'), {
+      target: { value: 'https://stale.example.test' }
+    })
+    fireEvent.change(screen.getByPlaceholderText('Paste session token'), { target: { value: 'first-token' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Verify connection' }))
+    await waitFor(() =>
+      expect(authVerify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: 'draft-76f9d14d-2f10-4ccb-9bb8-089935501512',
+          token: 'first-token',
+          url: 'https://stale.example.test'
+        })
+      )
+    )
+    expect(authVerify).toHaveBeenCalledTimes(1)
+    expect(pendingVerify.wasConsumed()).toBe(true)
+
+    fireEvent.change(screen.getByPlaceholderText('Paste session token'), { target: { value: 'second-token' } })
+    await act(async () =>
+      pendingVerify.resolve({
+        baseUrl: 'https://stale.example.test',
+        ok: true,
+        readinessCapability: 'stale-capability',
+        version: '0.20.4'
+      })
+    )
+
+    expect((screen.getByRole('button', { name: 'Save connection' }) as HTMLButtonElement).disabled).toBe(true)
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it('clears the sole stored access header name authoritatively in probe, verify, and save', async () => {
+    const oldHeaderName = 'CF-Access-Client-Secret'
+    list.mockResolvedValueOnce({
+      ...registry,
+      connections: [registry.connections[0], { ...registry.connections[1], headerNames: [oldHeaderName] }]
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await screen.findByText('Homelab')
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    await waitFor(() => expect(authStatus).toHaveBeenCalledTimes(1))
+    fireEvent.change(screen.getByDisplayValue(oldHeaderName), { target: { value: '' } })
+    fireEvent.change(screen.getByPlaceholderText('Paste session token'), { target: { value: 'replacement-token' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    await waitFor(() => expect(authProbe).toHaveBeenCalledTimes(1))
+    expect(authProbe.mock.calls[0][0].headers).toEqual({})
+    expect(authProbe.mock.calls[0][0].headers).not.toHaveProperty(oldHeaderName)
+    fireEvent.click(await screen.findByRole('button', { name: 'Verify connection' }))
+
+    await waitFor(() => expect(authVerify).toHaveBeenCalledTimes(1))
+    expect(authVerify.mock.calls[0][0].headers).toEqual({})
+    expect(authVerify.mock.calls[0][0].headers).not.toHaveProperty(oldHeaderName)
+    fireEvent.click(screen.getByRole('button', { name: 'Save connection' }))
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0].headers).toEqual({})
+    expect(save.mock.calls[0][0].headers).not.toHaveProperty(oldHeaderName)
+  })
+
+  it('renames a stored header authoritatively for verification and save', async () => {
+    list.mockResolvedValueOnce({
+      ...registry,
+      connections: [registry.connections[0], { ...registry.connections[1], headerNames: ['X-Old-Access'] }]
+    })
+    render(<ConnectionsRegistrySection />)
+
+    await screen.findByText('Homelab')
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    await waitFor(() => expect(authStatus).toHaveBeenCalledTimes(1))
+    fireEvent.change(screen.getByDisplayValue('X-Old-Access'), { target: { value: 'X-New-Access' } })
+    fireEvent.change(screen.getByPlaceholderText('Saved — leave blank to keep'), {
+      target: { value: 'replacement-secret' }
+    })
+    fireEvent.change(screen.getByPlaceholderText('Paste session token'), { target: { value: 'replacement-token' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Detect authentication' }))
+    await waitFor(() => expect(authProbe).toHaveBeenCalledTimes(1))
+    expect(authProbe.mock.calls[0][0].headers).toEqual({ 'X-New-Access': 'replacement-secret' })
+    fireEvent.click(await screen.findByRole('button', { name: 'Verify connection' }))
+
+    await waitFor(() => expect(authVerify).toHaveBeenCalledTimes(1))
+    expect(authVerify.mock.calls[0][0].headers).toEqual({ 'X-New-Access': 'replacement-secret' })
+    fireEvent.click(screen.getByRole('button', { name: 'Save connection' }))
+    await waitFor(() => expect(save).toHaveBeenCalledTimes(1))
+    expect(save.mock.calls[0][0].headers).toEqual({ 'X-New-Access': 'replacement-secret' })
+  })
+
   it('tests a connection through the bridge', async () => {
     render(<ConnectionsRegistrySection />)
 
@@ -763,38 +1085,23 @@ describe('ConnectionsRegistrySection', () => {
 })
 
 describe('connection auth rejection classification', () => {
-  it('matches direct and Electron-serialized 401/403 errors only', () => {
+  it('uses structured kind and statusCode fields without inspecting renderer error prose', () => {
+    expect(isConnectionAuthRejection({ kind: 'auth-required' })).toBe(true)
     expect(isConnectionAuthRejection({ statusCode: 401 })).toBe(true)
     expect(isConnectionAuthRejection({ statusCode: 403 })).toBe(true)
     expect(
       isConnectionAuthRejection(
         new Error("Error invoking remote method 'hermes:connections:test': Error: 401: Authentication required")
       )
-    ).toBe(true)
-    expect(
-      isConnectionAuthRejection(
-        new Error("Error invoking remote method 'hermes:connections:test': Error: 403: Forbidden")
-      )
-    ).toBe(true)
+    ).toBe(false)
     expect(
       isConnectionAuthRejection(
         new Error(
           "Error invoking remote method 'hermes:connections:test': Error: Reached the gateway over HTTP, but the OAuth session was rejected while minting a WebSocket ticket. Open Settings → Gateway and sign in again."
         )
       )
-    ).toBe(true)
-    expect(
-      isConnectionAuthRejection(
-        new Error("Error invoking remote method 'hermes:connections:test': Error: 500: unavailable")
-      )
     ).toBe(false)
-    expect(
-      isConnectionAuthRejection(
-        new Error(
-          "Error invoking remote method 'hermes:connections:test': Error: 500: upstream echoed: OAuth session was rejected while minting a WebSocket ticket"
-        )
-      )
-    ).toBe(false)
+    expect(isConnectionAuthRejection({ kind: 'transport-error', statusCode: 500 })).toBe(false)
     expect(isConnectionAuthRejection(new Error('Timed out connecting to Hermes backend after 8000ms'))).toBe(false)
   })
 })

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -6,6 +6,7 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { Input } from '@/components/ui/input'
 import type {
   DesktopConnectionKind,
+  DesktopConnectionProbeResult,
   DesktopConnectionsRegistry,
   DesktopRegistryConnection,
   DesktopRegistryConnectionInput
@@ -16,6 +17,7 @@ import {
   connectionMatchesQuery,
   sortConnectionsForDisplay
 } from '@/lib/connection-display'
+import { deriveRemoteAuthProviderShape } from '@/lib/desktop-remote-auth'
 import { triggerHaptic } from '@/lib/haptics'
 import { Cloud, Globe, Loader2, Monitor, Pencil, Plus, RefreshCw, SearchIcon, Terminal, Trash2 } from '@/lib/icons'
 import { $activeConnectionId, setConnectionsRegistry } from '@/store/connections'
@@ -115,6 +117,37 @@ export function sshCompositeKey(composite: string): string {
   }
 
   return `${user}@${host}:${port}`
+}
+
+const CONNECTION_TEST_IPC_ERROR_PREFIX = "Error invoking remote method 'hermes:connections:test': Error: "
+
+const WS_TICKET_AUTH_REJECTION_MESSAGE =
+  'Reached the gateway over HTTP, but the OAuth session was rejected while minting a WebSocket ticket. ' +
+  'Open Settings → Gateway and sign in again.'
+
+/**
+ * Electron's invoke bridge preserves a main-process throw as a renderer Error
+ * message (for example, `Error invoking remote method '…': Error: 401: …`),
+ * but does not preserve custom Error fields. Accept the field when present in
+ * direct/test callers; otherwise match a leading serialized status or the
+ * complete Electron-wrapped WebSocket-ticket auth rejection.
+ */
+export function isConnectionAuthRejection(error: unknown): boolean {
+  const statusCode =
+    error && typeof error === 'object' && 'statusCode' in error
+      ? Number((error as { statusCode?: unknown }).statusCode)
+      : null
+
+  if (statusCode === 401 || statusCode === 403) {
+    return true
+  }
+
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : ''
+
+  return (
+    /^(?:Error invoking remote method 'hermes:connections:test': Error: )?(?:401|403):(?:\s|$)/.test(message) ||
+    message === `${CONNECTION_TEST_IPC_ERROR_PREFIX}${WS_TICKET_AUTH_REJECTION_MESSAGE}`
+  )
 }
 
 /**
@@ -233,6 +266,20 @@ export function ConnectionsRegistrySection() {
   const [launchModeBusy, setLaunchModeBusy] = useState(false)
   const [updatingAll, setUpdatingAll] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
+  const [authProbe, setAuthProbe] = useState<DesktopConnectionProbeResult | null>(null)
+  const [authProbeBusy, setAuthProbeBusy] = useState(false)
+  const [authSignedIn, setAuthSignedIn] = useState(false)
+  const [authSigningIn, setAuthSigningIn] = useState(false)
+  const [authVerifying, setAuthVerifying] = useState(false)
+  const [authError, setAuthError] = useState<null | string>(null)
+  const [authProbeGeneration, setAuthProbeGeneration] = useState<null | number>(null)
+  const [authReadyGeneration, setAuthReadyGeneration] = useState<null | number>(null)
+  const [authScope, setAuthScope] = useState<null | string>(null)
+  const authScopeRef = useRef<{ owned: boolean; scope: null | string }>({ owned: false, scope: null })
+  const authDraftPromise = useRef<null | Promise<null | string>>(null)
+  const authGeneration = useRef(0)
+  const [reauthIds, setReauthIds] = useState<Set<string>>(() => new Set())
+  const authProbeSeq = useRef(0)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const pendingSearchTopRef = useRef<null | number>(null)
   // Inline duplicate rejection from the save path (dedupe is also enforced in
@@ -241,7 +288,57 @@ export function ConnectionsRegistrySection() {
 
   const bridge = window.hermesDesktop?.connections
 
+  const { isPassword: isPasswordProvider, providerLabel } = deriveRemoteAuthProviderShape(
+    authProbe?.providers,
+    t.install.identityProvider
+  )
+
   const hasLocal = Boolean(registry?.connections.some(c => c.kind === 'local'))
+
+  const editingExistingTokenEntry = Boolean(
+    editor?.id &&
+      registry?.connections.some(
+        connection =>
+          connection.id === editor.id && connection.kind === 'remote' && (connection.authMode ?? 'token') === 'token'
+      )
+  )
+
+  const originalEditorConnection = editor?.id
+    ? registry?.connections.find(connection => connection.id === editor.id)
+    : undefined
+
+  const remoteEndpointChanged = Boolean(
+    editor?.kind === 'remote' &&
+      editor.id &&
+      normalizeGatewayUrl(editor.url) !== normalizeGatewayUrl(originalEditorConnection?.url || '')
+  )
+
+  const headersChanged = Boolean(
+    editor?.kind === 'remote' &&
+      (editor.headers.some(row => row.value.trim()) ||
+        editor.headers.map(row => row.name.trim()).filter(Boolean).join('\n') !==
+          (originalEditorConnection?.headerNames || []).join('\n'))
+  )
+
+  const remoteAuthChanged = Boolean(
+    editor?.kind === 'remote' &&
+      (editor.token.trim() ||
+        editor.authMode !== (originalEditorConnection?.authMode || 'token') ||
+        headersChanged)
+  )
+
+  const remoteNeedsReadiness = Boolean(
+    editor?.kind === 'remote' && (!editor.id || remoteEndpointChanged || remoteAuthChanged)
+  )
+
+  const authProbeIsCurrent = Boolean(
+    editor?.kind === 'remote' &&
+      authProbe?.reachable &&
+      authProbeGeneration === authGeneration.current &&
+      normalizeGatewayUrl(authProbe.baseUrl) === normalizeGatewayUrl(editor.url)
+  )
+
+  const authReady = authProbeIsCurrent && authReadyGeneration === authGeneration.current
 
   const publishRegistry = useCallback((next: DesktopConnectionsRegistry) => {
     setRegistry(next)
@@ -270,9 +367,358 @@ export function ConnectionsRegistrySection() {
     void load()
   }, [load])
 
+  const editorAuthHeaders = (current: EditorState): Record<string, string> =>
+    Object.fromEntries(
+      current.headers
+        .map(row => [row.name.trim(), row.value.trim()] as const)
+        .filter(([name, value]) => Boolean(name && value))
+    )
+
+  const setAuthScopeState = (scope: null | string, owned: boolean) => {
+    authScopeRef.current = { owned, scope }
+    setAuthScope(scope)
+  }
+
+  const invalidateReadiness = (clearProbe = false) => {
+    authGeneration.current += 1
+    setAuthReadyGeneration(null)
+    setAuthError(null)
+
+    if (clearProbe) {
+      authProbeSeq.current += 1
+      setAuthProbe(null)
+      setAuthProbeGeneration(null)
+      setAuthProbeBusy(false)
+    }
+  }
+
+  const resetEditorAuth = useCallback((signedIn = false) => {
+    authProbeSeq.current += 1
+    authGeneration.current += 1
+    setAuthProbe(null)
+    setAuthProbeGeneration(null)
+    setAuthProbeBusy(false)
+    setAuthSignedIn(signedIn)
+    setAuthSigningIn(false)
+    setAuthVerifying(false)
+    setAuthError(null)
+    setAuthReadyGeneration(null)
+  }, [])
+
+  const clearOwnedDraft = async (url: string) => {
+    const current = authScopeRef.current
+
+    if (!current.owned || !current.scope) {
+      return
+    }
+
+    setAuthScopeState(null, false)
+
+    if (url.trim()) {
+      await bridge?.auth.clear({ scope: current.scope, url, headers: {} })
+    }
+  }
+
+  const createOwnedDraft = async () => {
+    if (authScopeRef.current.owned && authScopeRef.current.scope) {
+      return authScopeRef.current.scope
+    }
+
+    if (authDraftPromise.current) {
+      return authDraftPromise.current
+    }
+
+    const pending = (async () => {
+      const result = await bridge?.auth.createDraft()
+
+      if (result?.ok) {
+        setAuthScopeState(result.scope, true)
+
+        return result.scope
+      }
+
+      if (result && !result.ok) {
+        setAuthError(result.error)
+      }
+
+      return null
+    })()
+
+    authDraftPromise.current = pending
+
+    try {
+      return await pending
+    } finally {
+      if (authDraftPromise.current === pending) {
+        authDraftPromise.current = null
+      }
+    }
+  }
+
+  const readDurableAuthStatus = async (next: EditorState, seq: number) => {
+    if (!next.id || next.kind !== 'remote') {
+      return
+    }
+
+    const result = await bridge?.auth.status({
+      scope: next.id,
+      url: next.url,
+      headers: editorAuthHeaders(next)
+    })
+
+    if (seq !== authGeneration.current || !result) {
+      return
+    }
+
+    if (result.ok) {
+      setAuthSignedIn(result.connected)
+    } else {
+      setAuthError(result.error)
+    }
+  }
+
   const openEditor = (next: EditorState | null) => {
+    const previousUrl = editor?.url || ''
     setDupeError(null)
+    void clearOwnedDraft(previousUrl)
+    resetEditorAuth()
+    setAuthScopeState(null, false)
     setEditor(next)
+
+    if (!next || next.kind !== 'remote') {
+      return
+    }
+
+    if (next.id) {
+      setAuthScopeState(next.id, false)
+      const seq = authGeneration.current
+      void readDurableAuthStatus(next, seq)
+    } else {
+      void createOwnedDraft()
+    }
+  }
+
+  const ensureScopeForUrl = async (current: EditorState, nextUrl: string) => {
+    if (!current.id) {
+      return authScopeRef.current.scope || createOwnedDraft()
+    }
+
+    const original = registry?.connections.find(connection => connection.id === current.id)?.url || ''
+    const changed = normalizeGatewayUrl(nextUrl) !== normalizeGatewayUrl(original)
+
+    if (changed) {
+      if (!authScopeRef.current.owned) {
+        setAuthScopeState(null, false)
+
+        return createOwnedDraft()
+      }
+
+      return authScopeRef.current.scope
+    }
+
+    if (authScopeRef.current.owned) {
+      await clearOwnedDraft(current.url)
+    }
+
+    setAuthScopeState(current.id, false)
+    const seq = authGeneration.current
+    void readDurableAuthStatus({ ...current, url: nextUrl }, seq)
+
+    return current.id
+  }
+
+  const probeEditorAuth = async () => {
+    const url = editor?.url.trim()
+
+    if (!editor || editor.kind !== 'remote' || !url || !bridge?.auth) {
+      return
+    }
+
+    const scope = authScopeRef.current.scope || (await createOwnedDraft())
+
+    if (!scope) {
+      return
+    }
+
+    const seq = ++authProbeSeq.current
+    const generation = authGeneration.current
+    setAuthProbeBusy(true)
+    setAuthError(null)
+
+    try {
+      const result = await bridge.auth.probe({ scope, url, headers: editorAuthHeaders(editor) })
+
+      if (seq !== authProbeSeq.current || generation !== authGeneration.current) {
+        return
+      }
+
+      if (!('reachable' in result)) {
+        setAuthProbe(null)
+        setAuthError(result.error)
+
+        return
+      }
+
+      setAuthProbe(result)
+      setAuthProbeGeneration(generation)
+
+      if (!result.reachable) {
+        setAuthError(result.error || t.settings.gateway.probeError)
+
+        return
+      }
+
+      if (normalizeGatewayUrl(result.baseUrl) !== normalizeGatewayUrl(url)) {
+        setAuthError('The gateway response did not match the current URL. Detect authentication again.')
+
+        return
+      }
+
+      setEditor(current =>
+        current && normalizeGatewayUrl(current.url) === normalizeGatewayUrl(url)
+          ? { ...current, authMode: result.authMode === 'oauth' ? 'oauth' : 'token' }
+          : current
+      )
+    } catch (err) {
+      if (seq === authProbeSeq.current) {
+        const message = err instanceof Error ? err.message : t.settings.gateway.probeError
+        setAuthError(message)
+        notifyError(err, t.settings.gateway.probeError)
+      }
+    } finally {
+      if (seq === authProbeSeq.current) {
+        setAuthProbeBusy(false)
+      }
+    }
+  }
+
+  const verifyEditorAuth = async (current = editor) => {
+    const url = current?.url.trim()
+    const scope = authScopeRef.current.scope
+
+    if (!current || current.kind !== 'remote' || !url || !scope || !bridge?.auth) {
+      return false
+    }
+
+    const generation = authGeneration.current
+    setAuthVerifying(true)
+    setAuthError(null)
+
+    try {
+      const result = await bridge.auth.verify({
+        authMode: current.authMode,
+        scope,
+        token: current.token.trim() || undefined,
+        url,
+        headers: editorAuthHeaders(current)
+      })
+
+      if (generation !== authGeneration.current) {
+        return false
+      }
+
+      if (!result.ok) {
+        setAuthReadyGeneration(null)
+        setAuthError(result.error)
+
+        if (result.kind === 'auth-required' && current.id) {
+          setReauthIds(ids => new Set(ids).add(current.id!))
+          setAuthSignedIn(false)
+        }
+
+        return false
+      }
+
+      setAuthReadyGeneration(generation)
+
+      return true
+    } catch (err) {
+      if (generation === authGeneration.current) {
+        setAuthReadyGeneration(null)
+        setAuthError(err instanceof Error ? err.message : s.testFailed)
+      }
+
+      return false
+    } finally {
+      if (generation === authGeneration.current) {
+        setAuthVerifying(false)
+      }
+    }
+  }
+
+  const signInEditorAuth = async () => {
+    const url = editor?.url.trim()
+    const scope = authScopeRef.current.scope
+
+    if (!editor || editor.kind !== 'remote' || !url || !scope || !bridge?.auth) {
+      return
+    }
+
+    const generation = authGeneration.current
+    setAuthSigningIn(true)
+    setAuthError(null)
+
+    try {
+      const result = await bridge.auth.login({ scope, url, headers: editorAuthHeaders(editor) })
+
+      if (generation !== authGeneration.current) {
+        return
+      }
+
+      if (!result.ok) {
+        setAuthError(result.error)
+
+        return
+      }
+
+      if (!result.connected) {
+        notify({
+          kind: 'warning',
+          title: t.boot.failure.signInIncompleteTitle,
+          message: t.boot.failure.signInIncompleteMessage
+        })
+
+        return
+      }
+
+      setAuthSignedIn(true)
+      const verified = await verifyEditorAuth(editor)
+
+      if (verified && editor.id) {
+        setReauthIds(current => {
+          const next = new Set(current)
+          next.delete(editor.id!)
+
+          return next
+        })
+      }
+    } catch (err) {
+      if (generation === authGeneration.current) {
+        setAuthError(err instanceof Error ? err.message : s.signInFailed)
+        notifyError(err, s.signInFailed)
+      }
+    } finally {
+      if (generation === authGeneration.current) {
+        setAuthSigningIn(false)
+      }
+    }
+  }
+
+  const signOutEditorAuth = async () => {
+    const url = editor?.url.trim()
+    const scope = authScopeRef.current.scope
+
+    if (!editor || !url || !scope || !bridge?.auth) {
+      return
+    }
+
+    invalidateReadiness()
+    setAuthSignedIn(false)
+    const result = await bridge.auth.clear({ scope, url, headers: editorAuthHeaders(editor) })
+
+    if (!result.ok) {
+      setAuthError(result.error)
+    }
   }
 
   const save = useCallback(
@@ -315,6 +761,10 @@ export function ConnectionsRegistrySection() {
           payload.url = editor.url
           payload.authMode = editor.authMode
 
+          if (authScopeRef.current.owned && authScopeRef.current.scope) {
+            payload.authDraftScope = authScopeRef.current.scope
+          }
+
           if (editor.token.trim()) {
             payload.token = editor.token.trim()
           }
@@ -344,6 +794,8 @@ export function ConnectionsRegistrySection() {
 
         const result = await bridge.save(payload)
         publishRegistry(result.registry)
+        setAuthScopeState(null, false)
+        resetEditorAuth()
         setEditor(null)
         setPlainTextConfirm(false)
       } catch (err) {
@@ -367,7 +819,7 @@ export function ConnectionsRegistrySection() {
         setSaving(false)
       }
     },
-    [bridge, editor, publishRegistry, registry?.connections, registry?.secureTokenStorage, s]
+    [bridge, editor, publishRegistry, registry?.connections, registry?.secureTokenStorage, resetEditorAuth, s]
   )
 
   const remove = useCallback(async () => {
@@ -443,9 +895,17 @@ export function ConnectionsRegistrySection() {
         if (reachable) {
           notify({ title: conn.label, message: s.testOk })
         } else {
+          if (result.kind === 'auth-required') {
+            setReauthIds(current => new Set(current).add(conn.id))
+          }
+
           notifyError(new Error(result.error || conn.label), s.testFailed)
         }
       } catch (err) {
+        if (isConnectionAuthRejection(err)) {
+          setReauthIds(current => new Set(current).add(conn.id))
+        }
+
         notifyError(err, s.testFailed)
       } finally {
         setTestingId(null)
@@ -654,8 +1114,16 @@ export function ConnectionsRegistrySection() {
                 disabled={Boolean(editor.id) || (kind === 'local' && hasLocal)}
                 key={kind}
                 onClick={() => {
+                  const next = { ...editor, kind }
                   setDupeError(null)
-                  setEditor({ ...editor, kind })
+                  void clearOwnedDraft(editor.url)
+                  resetEditorAuth()
+                  setAuthScopeState(null, false)
+                  setEditor(next)
+
+                  if (kind === 'remote') {
+                    void createOwnedDraft()
+                  }
                 }}
                 size="sm"
                 variant={editor.kind === kind ? 'default' : 'outline'}
@@ -687,8 +1155,12 @@ export function ConnectionsRegistrySection() {
               action={
                 <Input
                   onChange={e => {
+                    const url = e.target.value
+                    const next = { ...editor, url }
                     setDupeError(null)
-                    setEditor({ ...editor, url: e.target.value })
+                    resetEditorAuth()
+                    setEditor(next)
+                    void ensureScopeForUrl(editor, url)
                   }}
                   placeholder="http://homelab.lan:9119"
                   value={editor.url}
@@ -700,37 +1172,90 @@ export function ConnectionsRegistrySection() {
 
           {editor.kind === 'remote' && (
             <>
-              <ListRow
-                action={
-                  <div className="flex gap-2">
-                    {(['token', 'oauth'] as const).map(mode => (
-                      <Button
-                        key={mode}
-                        onClick={() => setEditor({ ...editor, authMode: mode })}
-                        size="sm"
-                        variant={editor.authMode === mode ? 'default' : 'outline'}
-                      >
-                        {mode === 'token' ? t.settings.gateway.tokenTitle : 'OAuth'}
-                      </Button>
-                    ))}
-                  </div>
-                }
-                title={t.settings.gateway.authTitle}
-              />
+              {!authProbeIsCurrent && (
+                <ListRow
+                  action={
+                    <Button
+                      disabled={authProbeBusy || !editor.url.trim()}
+                      onClick={() => void probeEditorAuth()}
+                      size="sm"
+                      variant="outline"
+                    >
+                      {authProbeBusy ? t.settings.gateway.probing : s.detectAuthentication}
+                    </Button>
+                  }
+                  title={t.settings.gateway.authTitle}
+                />
+              )}
               {editor.authMode === 'token' && (
                 <ListRow
                   action={
-                    <Input
-                      onChange={e => setEditor({ ...editor, token: e.target.value })}
-                      placeholder={t.settings.gateway.pasteSessionToken}
-                      type="password"
-                      value={editor.token}
-                    />
+                    <div className="flex items-center gap-2">
+                      <Input
+                        onChange={e => {
+                          invalidateReadiness()
+                          setEditor({ ...editor, token: e.target.value })
+                        }}
+                        placeholder={t.settings.gateway.pasteSessionToken}
+                        type="password"
+                        value={editor.token}
+                      />
+                      {authProbeIsCurrent ? (
+                        <Button
+                          disabled={
+                            authVerifying || (!editor.token.trim() && (!editingExistingTokenEntry || remoteAuthChanged))
+                          }
+                          onClick={() => void verifyEditorAuth()}
+                          size="sm"
+                          variant="outline"
+                        >
+                          {authVerifying ? t.common.connecting : 'Verify connection'}
+                        </Button>
+                      ) : null}
+                    </div>
                   }
                   description={t.settings.gateway.tokenDesc}
                   title={t.settings.gateway.tokenTitle}
                 />
               )}
+              {authProbeIsCurrent && editor.authMode === 'oauth' && (!editor.id || remoteEndpointChanged) && (
+                <ListRow
+                  action={
+                    <Button disabled={authSigningIn || authSignedIn} onClick={() => void signInEditorAuth()} size="sm">
+                      {authSignedIn
+                        ? t.settings.gateway.signedIn
+                        : authSigningIn
+                          ? t.common.connecting
+                          : isPasswordProvider
+                            ? t.settings.gateway.signIn
+                            : t.settings.gateway.signInWith(providerLabel)}
+                    </Button>
+                  }
+                  title={t.settings.gateway.authTitle}
+                />
+              )}
+              {editor.id && editor.authMode === 'oauth' && !remoteEndpointChanged ? (
+                <div className="flex justify-end gap-2">
+                  <Button
+                    disabled={authSigningIn || authVerifying}
+                    onClick={() => void signInEditorAuth()}
+                    size="sm"
+                    variant="outline"
+                  >
+                    Reauthenticate
+                  </Button>
+                  {authSignedIn ? (
+                    <Button
+                      disabled={authSigningIn || authVerifying}
+                      onClick={() => void signOutEditorAuth()}
+                      size="sm"
+                      variant="outline"
+                    >
+                      {t.settings.gateway.signOut}
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
             </>
           )}
 
@@ -744,29 +1269,34 @@ export function ConnectionsRegistrySection() {
                 <div className="flex items-center gap-2" key={index}>
                   <Input
                     className="flex-1"
-                    onChange={e =>
+                    onChange={e => {
+                      invalidateReadiness()
                       setEditor({
                         ...editor,
                         headers: editor.headers.map((h, i) => (i === index ? { ...h, name: e.target.value } : h))
                       })
-                    }
+                    }}
                     placeholder="CF-Access-Client-Id"
                     value={row.name}
                   />
                   <Input
                     className="flex-1"
-                    onChange={e =>
+                    onChange={e => {
+                      invalidateReadiness()
                       setEditor({
                         ...editor,
                         headers: editor.headers.map((h, i) => (i === index ? { ...h, value: e.target.value } : h))
                       })
-                    }
+                    }}
                     placeholder={row.stored ? s.headerValueSaved : s.headerValuePlaceholder}
                     type="password"
                     value={row.value}
                   />
                   <Button
-                    onClick={() => setEditor({ ...editor, headers: editor.headers.filter((_, i) => i !== index) })}
+                    onClick={() => {
+                      invalidateReadiness()
+                      setEditor({ ...editor, headers: editor.headers.filter((_, i) => i !== index) })
+                    }}
                     size="sm"
                     variant="ghost"
                   >
@@ -776,9 +1306,10 @@ export function ConnectionsRegistrySection() {
               ))}
               <div>
                 <Button
-                  onClick={() =>
+                  onClick={() => {
+                    invalidateReadiness()
                     setEditor({ ...editor, headers: [...editor.headers, { name: '', stored: false, value: '' }] })
-                  }
+                  }}
                   size="sm"
                   variant="outline"
                 >
@@ -805,12 +1336,27 @@ export function ConnectionsRegistrySection() {
           )}
 
           {dupeError ? <p className="text-xs text-destructive">{dupeError}</p> : null}
+          {authError ? <p className="text-xs text-destructive">{authError}</p> : null}
 
           <div className="flex justify-end gap-2">
             <Button disabled={saving} onClick={() => openEditor(null)} size="sm" variant="ghost">
               {s.cancel}
             </Button>
-            <Button disabled={saving || !editor.label.trim()} onClick={() => void save()} size="sm">
+            <Button
+              disabled={
+                saving ||
+                !editor.label.trim() ||
+                ((editor.kind === 'remote' || editor.kind === 'cloud') && !editor.url.trim()) ||
+                (remoteNeedsReadiness && !authReady) ||
+                (editor.kind === 'remote' && editor.authMode === 'oauth' && !authSignedIn) ||
+                (editor.kind === 'remote' &&
+                  authProbe?.authMode === 'token' &&
+                  !editor.token.trim() &&
+                  !editingExistingTokenEntry)
+              }
+              onClick={() => void save()}
+              size="sm"
+            >
               {saving ? s.saving : s.save}
             </Button>
           </div>

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -119,35 +119,16 @@ export function sshCompositeKey(composite: string): string {
   return `${user}@${host}:${port}`
 }
 
-const CONNECTION_TEST_IPC_ERROR_PREFIX = "Error invoking remote method 'hermes:connections:test': Error: "
-
-const WS_TICKET_AUTH_REJECTION_MESSAGE =
-  'Reached the gateway over HTTP, but the OAuth session was rejected while minting a WebSocket ticket. ' +
-  'Open Settings → Gateway and sign in again.'
-
-/**
- * Electron's invoke bridge preserves a main-process throw as a renderer Error
- * message (for example, `Error invoking remote method '…': Error: 401: …`),
- * but does not preserve custom Error fields. Accept the field when present in
- * direct/test callers; otherwise match a leading serialized status or the
- * complete Electron-wrapped WebSocket-ticket auth rejection.
- */
 export function isConnectionAuthRejection(error: unknown): boolean {
+  const kind =
+    error && typeof error === 'object' && 'kind' in error ? (error as { kind?: unknown }).kind : null
+
   const statusCode =
     error && typeof error === 'object' && 'statusCode' in error
       ? Number((error as { statusCode?: unknown }).statusCode)
       : null
 
-  if (statusCode === 401 || statusCode === 403) {
-    return true
-  }
-
-  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : ''
-
-  return (
-    /^(?:Error invoking remote method 'hermes:connections:test': Error: )?(?:401|403):(?:\s|$)/.test(message) ||
-    message === `${CONNECTION_TEST_IPC_ERROR_PREFIX}${WS_TICKET_AUTH_REJECTION_MESSAGE}`
-  )
+  return kind === 'auth-required' || statusCode === 401 || statusCode === 403
 }
 
 /**
@@ -275,9 +256,28 @@ export function ConnectionsRegistrySection() {
   const [authProbeGeneration, setAuthProbeGeneration] = useState<null | number>(null)
   const [authReadyGeneration, setAuthReadyGeneration] = useState<null | number>(null)
   const [authScope, setAuthScope] = useState<null | string>(null)
-  const authScopeRef = useRef<{ owned: boolean; scope: null | string }>({ owned: false, scope: null })
-  const authDraftPromise = useRef<null | Promise<null | string>>(null)
+
+  const authScopeRef = useRef<{
+    editorGeneration: number
+    normalizedUrl: string
+    owned: boolean
+    scope: null | string
+  }>({ editorGeneration: 0, normalizedUrl: '', owned: false, scope: null })
+
+  const authDraftPromises = useRef(
+    new Set<{
+      cleanupUrl: string
+      editorGeneration: number
+      normalizedUrl: string
+      promise: Promise<null | string>
+    }>()
+  )
+
+  const authTargetConnectionId = useRef<null | string>(null)
   const authGeneration = useRef(0)
+  const editorRef = useRef<EditorState | null>(null)
+  editorRef.current = editor
+  const authReadinessCapability = useRef<null | string>(null)
   const [reauthIds, setReauthIds] = useState<Set<string>>(() => new Set())
   const authProbeSeq = useRef(0)
   const searchInputRef = useRef<HTMLInputElement>(null)
@@ -367,22 +367,29 @@ export function ConnectionsRegistrySection() {
     void load()
   }, [load])
 
-  const editorAuthHeaders = (current: EditorState): Record<string, string> =>
+  const editorAuthHeaders = (current: EditorState): Record<string, null | string> =>
     Object.fromEntries(
       current.headers
-        .map(row => [row.name.trim(), row.value.trim()] as const)
-        .filter(([name, value]) => Boolean(name && value))
+        .map(row => [row.name.trim(), row.value.trim() || (row.stored ? null : '')] as const)
+        .filter(([name]) => Boolean(name))
     )
 
-  const setAuthScopeState = (scope: null | string, owned: boolean) => {
-    authScopeRef.current = { owned, scope }
+  const setAuthScopeState = (
+    scope: null | string,
+    owned: boolean,
+    normalizedUrl = normalizeGatewayUrl(editorRef.current?.url || ''),
+    editorGeneration = authGeneration.current
+  ) => {
+    authScopeRef.current = { editorGeneration, normalizedUrl, owned, scope }
     setAuthScope(scope)
   }
 
   const invalidateReadiness = (clearProbe = false) => {
     authGeneration.current += 1
+    authReadinessCapability.current = null
     setAuthReadyGeneration(null)
     setAuthError(null)
+    authScopeRef.current = { ...authScopeRef.current, editorGeneration: authGeneration.current }
 
     if (clearProbe) {
       authProbeSeq.current += 1
@@ -395,6 +402,7 @@ export function ConnectionsRegistrySection() {
   const resetEditorAuth = useCallback((signedIn = false) => {
     authProbeSeq.current += 1
     authGeneration.current += 1
+    authReadinessCapability.current = null
     setAuthProbe(null)
     setAuthProbeGeneration(null)
     setAuthProbeBusy(false)
@@ -405,53 +413,97 @@ export function ConnectionsRegistrySection() {
     setAuthReadyGeneration(null)
   }, [])
 
-  const clearOwnedDraft = async (url: string) => {
-    const current = authScopeRef.current
-
-    if (!current.owned || !current.scope) {
+  const clearDraft = async (
+    draft: Pick<typeof authScopeRef.current, 'normalizedUrl' | 'owned' | 'scope'>,
+    fallbackUrl = ''
+  ) => {
+    if (!draft.owned || !draft.scope) {
       return
     }
 
-    setAuthScopeState(null, false)
+    if (authScopeRef.current.scope === draft.scope) {
+      setAuthScopeState(null, false)
+    }
 
-    if (url.trim()) {
-      await bridge?.auth.clear({ scope: current.scope, url, headers: {} })
+    const url = draft.normalizedUrl || normalizeGatewayUrl(fallbackUrl)
+
+    if (url) {
+      await bridge?.auth.clear({ scope: draft.scope, url, headers: {} })
     }
   }
 
-  const createOwnedDraft = async () => {
-    if (authScopeRef.current.owned && authScopeRef.current.scope) {
-      return authScopeRef.current.scope
+  const clearOwnedDraft = async (fallbackUrl: string) => clearDraft(authScopeRef.current, fallbackUrl)
+
+  const createOwnedDraft = async (
+    ownerConnectionId?: string,
+    normalizedUrl = normalizeGatewayUrl(editorRef.current?.url || ''),
+    editorGeneration = authGeneration.current
+  ) => {
+    const current = authScopeRef.current
+
+    if (
+      current.owned &&
+      current.scope &&
+      current.editorGeneration === editorGeneration &&
+      current.normalizedUrl === normalizedUrl
+    ) {
+      return current.scope
     }
 
-    if (authDraftPromise.current) {
-      return authDraftPromise.current
+    const existingPending = [...authDraftPromises.current].find(
+      pending => pending.editorGeneration === editorGeneration && pending.normalizedUrl === normalizedUrl
+    )
+
+    if (existingPending) {
+      return existingPending.promise
     }
 
-    const pending = (async () => {
-      const result = await bridge?.auth.createDraft()
+    const pending = {
+      cleanupUrl: '',
+      editorGeneration,
+      normalizedUrl,
+      promise: Promise.resolve<null | string>(null)
+    }
 
-      if (result?.ok) {
-        setAuthScopeState(result.scope, true)
+    pending.promise = (async () => {
+      const result = await bridge?.auth.createDraft(ownerConnectionId ? { ownerConnectionId } : undefined)
 
-        return result.scope
+      if (!result?.ok) {
+        if (result && editorGeneration === authGeneration.current) {
+          setAuthError(result.error)
+        }
+
+        return null
       }
 
-      if (result && !result.ok) {
-        setAuthError(result.error)
+      const currentEditor = editorRef.current
+
+      const stillCurrent =
+        editorGeneration === authGeneration.current &&
+        currentEditor?.kind === 'remote' &&
+        normalizeGatewayUrl(currentEditor.url) === normalizedUrl
+
+      if (!stillCurrent) {
+        await clearDraft(
+          { normalizedUrl: pending.cleanupUrl || normalizedUrl, owned: true, scope: result.scope },
+          currentEditor?.url || ''
+        )
+
+        return null
       }
 
-      return null
+      setAuthScopeState(result.scope, true, normalizedUrl, editorGeneration)
+      authTargetConnectionId.current = result.targetConnectionId
+
+      return result.scope
     })()
 
-    authDraftPromise.current = pending
+    authDraftPromises.current.add(pending)
 
     try {
-      return await pending
+      return await pending.promise
     } finally {
-      if (authDraftPromise.current === pending) {
-        authDraftPromise.current = null
-      }
+      authDraftPromises.current.delete(pending)
     }
   }
 
@@ -473,54 +525,70 @@ export function ConnectionsRegistrySection() {
     if (result.ok) {
       setAuthSignedIn(result.connected)
     } else {
+      setAuthSignedIn(false)
       setAuthError(result.error)
     }
   }
 
   const openEditor = (next: EditorState | null) => {
-    const previousUrl = editor?.url || ''
+    const previous = authScopeRef.current
+    const previousUrl = editorRef.current?.url || ''
     setDupeError(null)
-    void clearOwnedDraft(previousUrl)
     resetEditorAuth()
-    setAuthScopeState(null, false)
+    editorRef.current = next
+    setAuthScopeState(null, false, normalizeGatewayUrl(next?.url || ''))
+    authTargetConnectionId.current = null
     setEditor(next)
+    void clearDraft(previous, previousUrl)
+
+    for (const pending of authDraftPromises.current) {
+      pending.cleanupUrl ||= normalizeGatewayUrl(previousUrl || next?.url || '')
+    }
 
     if (!next || next.kind !== 'remote') {
       return
     }
 
     if (next.id) {
-      setAuthScopeState(next.id, false)
+      setAuthScopeState(next.id, false, normalizeGatewayUrl(next.url))
+      authTargetConnectionId.current = next.id
       const seq = authGeneration.current
       void readDurableAuthStatus(next, seq)
     } else {
-      void createOwnedDraft()
+      void createOwnedDraft(undefined, normalizeGatewayUrl(next.url), authGeneration.current)
     }
   }
 
   const ensureScopeForUrl = async (current: EditorState, nextUrl: string) => {
-    if (!current.id) {
-      return authScopeRef.current.scope || createOwnedDraft()
-    }
+    const previousNormalizedUrl = normalizeGatewayUrl(current.url)
+    const normalizedUrl = normalizeGatewayUrl(nextUrl)
 
-    const original = registry?.connections.find(connection => connection.id === current.id)?.url || ''
-    const changed = normalizeGatewayUrl(nextUrl) !== normalizeGatewayUrl(original)
-
-    if (changed) {
-      if (!authScopeRef.current.owned) {
-        setAuthScopeState(null, false)
-
-        return createOwnedDraft()
-      }
-
+    if (normalizedUrl === previousNormalizedUrl) {
       return authScopeRef.current.scope
     }
 
-    if (authScopeRef.current.owned) {
-      await clearOwnedDraft(current.url)
+    const previous = authScopeRef.current
+
+    for (const pending of authDraftPromises.current) {
+      pending.cleanupUrl ||= previousNormalizedUrl || normalizedUrl
     }
 
-    setAuthScopeState(current.id, false)
+    void clearDraft(previous, previousNormalizedUrl || normalizedUrl)
+    setAuthScopeState(null, false, normalizedUrl)
+
+    if (!current.id) {
+      return createOwnedDraft(undefined, normalizedUrl, authGeneration.current)
+    }
+
+    const original = registry?.connections.find(connection => connection.id === current.id)?.url || ''
+    const changed = normalizedUrl !== normalizeGatewayUrl(original)
+
+    if (changed) {
+      return createOwnedDraft(current.id, normalizedUrl, authGeneration.current)
+    }
+
+    setAuthScopeState(current.id, false, normalizedUrl)
+    authTargetConnectionId.current = current.id
     const seq = authGeneration.current
     void readDurableAuthStatus({ ...current, url: nextUrl }, seq)
 
@@ -618,6 +686,7 @@ export function ConnectionsRegistrySection() {
       }
 
       if (!result.ok) {
+        authReadinessCapability.current = null
         setAuthReadyGeneration(null)
         setAuthError(result.error)
 
@@ -629,11 +698,13 @@ export function ConnectionsRegistrySection() {
         return false
       }
 
+      authReadinessCapability.current = result.readinessCapability
       setAuthReadyGeneration(generation)
 
       return true
     } catch (err) {
       if (generation === authGeneration.current) {
+        authReadinessCapability.current = null
         setAuthReadyGeneration(null)
         setAuthError(err instanceof Error ? err.message : s.testFailed)
       }
@@ -744,6 +815,18 @@ export function ConnectionsRegistrySection() {
         return
       }
 
+      if (
+        !allowPlainTextToken &&
+        registry?.secureTokenStorage === false &&
+        editor.kind === 'remote' &&
+        editor.authMode === 'token' &&
+        editor.token.trim()
+      ) {
+        setPlainTextConfirm(true)
+
+        return
+      }
+
       setDupeError(null)
       setSaving(true)
 
@@ -755,6 +838,8 @@ export function ConnectionsRegistrySection() {
 
         if (editor.id) {
           payload.id = editor.id
+        } else if (editor.kind === 'remote' && authTargetConnectionId.current) {
+          payload.id = authTargetConnectionId.current
         }
 
         if (editor.kind === 'remote' || editor.kind === 'cloud') {
@@ -763,6 +848,10 @@ export function ConnectionsRegistrySection() {
 
           if (authScopeRef.current.owned && authScopeRef.current.scope) {
             payload.authDraftScope = authScopeRef.current.scope
+          }
+
+          if (editor.kind === 'remote' && authReadinessCapability.current) {
+            payload.authReadinessCapability = authReadinessCapability.current
           }
 
           if (editor.token.trim()) {
@@ -774,17 +863,16 @@ export function ConnectionsRegistrySection() {
           }
 
           // Authoritative header map: typed value → new secret; empty value on
-          // a stored row → null (keep saved secret); a removed row is simply
-          // absent, which clears it server-side.
+          // a stored row → null (keep saved secret); a removed or blank-name row
+          // is absent. Always send the map (including {}) so Electron cannot
+          // inherit credentials from the previously stored connection.
           const headerEntries = editor.headers
             .map(row => ({ name: row.name.trim(), stored: row.stored, value: row.value.trim() }))
             .filter(row => row.name)
 
-          if (headerEntries.length > 0 || editor.headers.length === 0) {
-            payload.headers = Object.fromEntries(
-              headerEntries.map(row => [row.name, row.value ? row.value : row.stored ? null : ''])
-            )
-          }
+          payload.headers = Object.fromEntries(
+            headerEntries.map(row => [row.name, row.value ? row.value : row.stored ? null : ''])
+          )
         } else if (editor.kind === 'ssh') {
           // The composite host string (user@host:port) is the single source
           // of truth — never send separate user/port (see editorFromConnection).
@@ -792,6 +880,10 @@ export function ConnectionsRegistrySection() {
           payload.keyPath = editor.keyPath || undefined
         }
 
+        // Readiness proof is one-shot renderer state: forward the value captured
+        // above exactly once and burn the local copy before crossing IPC.
+        authReadinessCapability.current = null
+        setAuthReadyGeneration(null)
         const result = await bridge.save(payload)
         publishRegistry(result.registry)
         setAuthScopeState(null, false)
@@ -799,21 +891,6 @@ export function ConnectionsRegistrySection() {
         setEditor(null)
         setPlainTextConfirm(false)
       } catch (err) {
-        // Keyring-less machine and the user hasn't consented to plain-text
-        // storage yet: raise the same opt-in dialog the connection-mode form
-        // uses instead of dead-ending the save.
-        if (
-          !allowPlainTextToken &&
-          registry?.secureTokenStorage === false &&
-          editor.kind === 'remote' &&
-          editor.authMode === 'token' &&
-          editor.token.trim()
-        ) {
-          setPlainTextConfirm(true)
-
-          return
-        }
-
         notifyError(err, s.saveFailed)
       } finally {
         setSaving(false)
@@ -895,7 +972,7 @@ export function ConnectionsRegistrySection() {
         if (reachable) {
           notify({ title: conn.label, message: s.testOk })
         } else {
-          if (result.kind === 'auth-required') {
+          if (isConnectionAuthRejection(result)) {
             setReauthIds(current => new Set(current).add(conn.id))
           }
 
@@ -1115,14 +1192,20 @@ export function ConnectionsRegistrySection() {
                 key={kind}
                 onClick={() => {
                   const next = { ...editor, kind }
+                  const previous = authScopeRef.current
                   setDupeError(null)
-                  void clearOwnedDraft(editor.url)
                   resetEditorAuth()
-                  setAuthScopeState(null, false)
+                  editorRef.current = next
+                  setAuthScopeState(null, false, normalizeGatewayUrl(next.url))
                   setEditor(next)
+                  void clearDraft(previous, editor.url)
+
+                  for (const pending of authDraftPromises.current) {
+                    pending.cleanupUrl ||= normalizeGatewayUrl(editor.url)
+                  }
 
                   if (kind === 'remote') {
-                    void createOwnedDraft()
+                    void createOwnedDraft(undefined, normalizeGatewayUrl(next.url), authGeneration.current)
                   }
                 }}
                 size="sm"
@@ -1159,6 +1242,7 @@ export function ConnectionsRegistrySection() {
                     const next = { ...editor, url }
                     setDupeError(null)
                     resetEditorAuth()
+                    editorRef.current = next
                     setEditor(next)
                     void ensureScopeForUrl(editor, url)
                   }}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -139,6 +139,15 @@ declare global {
       // together (local + any number of remote/cloud/ssh instances).
       connections: {
         list: () => Promise<DesktopConnectionsRegistry>
+        auth: {
+          createDraft: () => Promise<DesktopRegistryAuthDraftResult>
+          probe: (payload: DesktopRegistryAuthScopeRequest) => Promise<DesktopRegistryAuthProbeResult>
+          login: (payload: DesktopRegistryAuthScopeRequest) => Promise<DesktopRegistryAuthSessionResult>
+          verify: (payload: DesktopRegistryAuthVerifyRequest) => Promise<DesktopRegistryAuthVerifyResult>
+          status: (payload: DesktopRegistryAuthScopeRequest) => Promise<DesktopRegistryAuthSessionResult>
+          clear: (payload: DesktopRegistryAuthScopeRequest) => Promise<DesktopRegistryAuthSessionResult>
+          promote: (payload: DesktopRegistryAuthPromotionRequest) => Promise<DesktopRegistryAuthPromotionResult>
+        }
         save: (
           payload: DesktopRegistryConnectionInput
         ) => Promise<{ ok: boolean; connection: DesktopRegistryConnection; registry: DesktopConnectionsRegistry }>
@@ -791,6 +800,7 @@ export interface DesktopConnectionTestResult {
     | 'unknown'
     | null
   error?: string | null
+  kind?: 'auth-required' | 'transport-error'
   host?: string
   remoteHermesPath?: string
   remoteHermesVersion?: string
@@ -856,6 +866,8 @@ export interface DesktopRegistryConnectionInput {
   // Plaintext token to store (encrypted at rest); omit to keep the saved one.
   token?: string
   allowPlainTextToken?: boolean
+  // Owned draft scope promoted atomically before the registry row is persisted.
+  authDraftScope?: string
   // Extra gateway headers for remote/cloud entries (access proxies such as
   // Cloudflare Access). The map is authoritative when present: name → new
   // plaintext value (encrypted at rest), or null to keep the stored secret
@@ -915,6 +927,44 @@ export interface DesktopSshResolveResult {
 export interface DesktopSshHostsResult {
   hosts: string[]
 }
+
+export interface DesktopRegistryAuthScopeRequest {
+  scope: string
+  url: string
+  headers?: Record<string, string>
+}
+
+export interface DesktopRegistryAuthVerifyRequest extends DesktopRegistryAuthScopeRequest {
+  authMode: 'oauth' | 'token'
+  // Candidate token is verified in main and is never echoed to the renderer.
+  token?: string
+}
+
+export interface DesktopRegistryAuthPromotionRequest {
+  connectionId: string
+  draftScope: string
+  url: string
+}
+
+export interface DesktopRegistryAuthFailure {
+  error: string
+  kind: 'auth-required' | 'transport-error'
+  ok: false
+}
+
+export type DesktopRegistryAuthDraftResult = { ok: true; scope: string } | DesktopRegistryAuthFailure
+export type DesktopRegistryAuthProbeResult =
+  | (DesktopConnectionProbeResult & { scope: string })
+  | DesktopRegistryAuthFailure
+export type DesktopRegistryAuthSessionResult =
+  | { baseUrl: string; connected: boolean; ok: true }
+  | DesktopRegistryAuthFailure
+export type DesktopRegistryAuthVerifyResult =
+  | { baseUrl: string; ok: true; version: string | null }
+  | DesktopRegistryAuthFailure
+export type DesktopRegistryAuthPromotionResult =
+  | { baseUrl: string; ok: true; scope: string }
+  | DesktopRegistryAuthFailure
 
 export interface DesktopAuthProvider {
   name: string

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -140,13 +140,12 @@ declare global {
       connections: {
         list: () => Promise<DesktopConnectionsRegistry>
         auth: {
-          createDraft: () => Promise<DesktopRegistryAuthDraftResult>
+          createDraft: (payload?: { ownerConnectionId?: string }) => Promise<DesktopRegistryAuthDraftResult>
           probe: (payload: DesktopRegistryAuthScopeRequest) => Promise<DesktopRegistryAuthProbeResult>
           login: (payload: DesktopRegistryAuthScopeRequest) => Promise<DesktopRegistryAuthSessionResult>
           verify: (payload: DesktopRegistryAuthVerifyRequest) => Promise<DesktopRegistryAuthVerifyResult>
           status: (payload: DesktopRegistryAuthScopeRequest) => Promise<DesktopRegistryAuthSessionResult>
           clear: (payload: DesktopRegistryAuthScopeRequest) => Promise<DesktopRegistryAuthSessionResult>
-          promote: (payload: DesktopRegistryAuthPromotionRequest) => Promise<DesktopRegistryAuthPromotionResult>
         }
         save: (
           payload: DesktopRegistryConnectionInput
@@ -801,6 +800,7 @@ export interface DesktopConnectionTestResult {
     | null
   error?: string | null
   kind?: 'auth-required' | 'transport-error'
+  statusCode?: number | null
   host?: string
   remoteHermesPath?: string
   remoteHermesVersion?: string
@@ -868,6 +868,8 @@ export interface DesktopRegistryConnectionInput {
   allowPlainTextToken?: boolean
   // Owned draft scope promoted atomically before the registry row is persisted.
   authDraftScope?: string
+  // Opaque, one-time proof returned by auth.verify for this exact candidate.
+  authReadinessCapability?: string
   // Extra gateway headers for remote/cloud entries (access proxies such as
   // Cloudflare Access). The map is authoritative when present: name → new
   // plaintext value (encrypted at rest), or null to keep the stored secret
@@ -931,7 +933,7 @@ export interface DesktopSshHostsResult {
 export interface DesktopRegistryAuthScopeRequest {
   scope: string
   url: string
-  headers?: Record<string, string>
+  headers?: Record<string, null | string>
 }
 
 export interface DesktopRegistryAuthVerifyRequest extends DesktopRegistryAuthScopeRequest {
@@ -940,19 +942,17 @@ export interface DesktopRegistryAuthVerifyRequest extends DesktopRegistryAuthSco
   token?: string
 }
 
-export interface DesktopRegistryAuthPromotionRequest {
-  connectionId: string
-  draftScope: string
-  url: string
-}
 
 export interface DesktopRegistryAuthFailure {
   error: string
   kind: 'auth-required' | 'transport-error'
   ok: false
+  statusCode: number | null
 }
 
-export type DesktopRegistryAuthDraftResult = { ok: true; scope: string } | DesktopRegistryAuthFailure
+export type DesktopRegistryAuthDraftResult =
+  | { ok: true; scope: string; targetConnectionId: string }
+  | DesktopRegistryAuthFailure
 export type DesktopRegistryAuthProbeResult =
   | (DesktopConnectionProbeResult & { scope: string })
   | DesktopRegistryAuthFailure
@@ -960,10 +960,7 @@ export type DesktopRegistryAuthSessionResult =
   | { baseUrl: string; connected: boolean; ok: true }
   | DesktopRegistryAuthFailure
 export type DesktopRegistryAuthVerifyResult =
-  | { baseUrl: string; ok: true; version: string | null }
-  | DesktopRegistryAuthFailure
-export type DesktopRegistryAuthPromotionResult =
-  | { baseUrl: string; ok: true; scope: string }
+  | { baseUrl: string; ok: true; readinessCapability: string; version: string | null }
   | DesktopRegistryAuthFailure
 
 export interface DesktopAuthProvider {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -729,6 +729,8 @@ export const en: Translations = {
         `“${label}” will be removed from this app. The instance itself is not touched — you can add it again any time.`,
       makePrimary: 'Make primary',
       testConnection: 'Test',
+      detectAuthentication: 'Detect authentication',
+      signInFailed: 'Gateway sign-in failed',
       testOk: 'Reachable',
       testFailed: 'Connection test failed',
       saveFailed: 'Could not save the connection',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -615,6 +615,8 @@ export interface Translations {
       removeConfirmDesc: (label: string) => string
       makePrimary: string
       testConnection: string
+      detectAuthentication: string
+      signInFailed: string
       testOk: string
       testFailed: string
       saveFailed: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -933,6 +933,8 @@ export const zh: Translations = {
       removeConfirmDesc: (label: string) => `“${label}”将从本应用移除。实例本身不受影响——你可以随时重新添加。`,
       makePrimary: '设为主连接',
       testConnection: '测试',
+      detectAuthentication: '检测认证方式',
+      signInFailed: '网关登录失败',
       testOk: '可访问',
       testFailed: '连接测试失败',
       saveFailed: '无法保存连接',


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop can authenticate a self-hosted remote gateway from the primary **Remote gateway** connection flow, but **Registered gateways → Add connection** previously exposed only the legacy static session-token path.

That forced users to replace their local agent connection in order to sign into a password/OAuth/OIDC-gated remote backend. This draft adds capability-driven authentication for registered secondary gateways while keeping **This device** available.

The implementation currently includes:

- backend auth-provider discovery for registered remotes;
- Basic/password, OAuth and OIDC-compatible sign-in routing;
- connection-scoped cookie partitions and native-token ownership;
- Electron-issued draft scopes and final connection IDs;
- one-time, 60-second readiness capabilities bound to scope, URL, auth mode, headers, token fingerprint and generation;
- authenticated HTTP plus real WebSocket readiness before save;
- failure-atomic credential promotion/removal with rollback and error preservation;
- race-safe renderer draft rotation and stale-result rejection;
- structured auth/transport failures instead of renderer error-prose parsing;
- exact authoritative header removal/rename semantics;
- legacy session-token compatibility.

This is intentionally opened as a **Draft PR** to get maintainer feedback on the native auth ownership model before further hardening.

## Related Issue

No matching issue or PR was found after searching the repository for registered/secondary gateway authentication.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [ ] ✨ New feature
- [x] ✅ Tests

## Changes Made

- `apps/desktop/src/app/settings/connections-registry.tsx`
  - auth discovery, login, verification, reauthentication and race-safe draft lifecycle for registered gateways.
- `apps/desktop/electron/registry-auth.ts`
  - native readiness authority, scope ownership, transactional credential lifecycle and structured results.
- `apps/desktop/electron/main.ts`
  - scoped Electron sessions/tokens, IPC wiring, authenticated HTTP/WS checks and registry persistence.
- `apps/desktop/electron/preload.ts` / `apps/desktop/src/global.d.ts`
  - narrow typed bridge additions.
- Focused Electron and renderer regression coverage.

## Known blockers / feedback requested

A final independent whole-branch review found six issues that should be resolved before this draft becomes ready for merge:

1. **Production draft-promotion wiring:** a label-only edit can still route draft promotion through `persist` rather than the readiness-guarded `promote` parameter.
2. **Hermes Cloud compatibility:** Cloud registry connections currently receive a scoped auth ID without a migration/login path from the legacy global Cloud OAuth store.
3. **Access-proxy headers:** candidate headers are not consistently forwarded during native auth discovery and preliminary login status requests.
4. **Removal failure contract:** Electron can return a structured removal failure, while the renderer currently assumes a success-shaped registry result.
5. **In-flight native login cancellation:** renderer generation guards ignore stale results but do not cancel the native login window or clean credentials written after cancellation.
6. **Partition cleanup/navigation guard:** cookie cleanup is origin-filtered rather than full partition cleanup, persistent partitions can remain on disk, and the login window lacks an explicit navigation restriction for the expected provider flow.

Maintainer feedback requested:

- Should Hermes Cloud retain the legacy global auth partition until an explicit migration exists, or move to connection-scoped auth in this PR?
- Is a dedicated Electron-owned auth-session manager the preferred home for login cancellation and partition destruction?
- Should registered-gateway auth discovery share the primary remote flow's adapter directly, or remain a registry-specific native seam?

## How to Test

1. Keep **This device** active.
2. Open **Settings → Gateways → Registered gateways → Add connection**.
3. Add a gated self-hosted gateway.
4. Detect advertised auth providers and complete sign-in.
5. Verify authenticated HTTP and `/api/ws` readiness.
6. Save and switch repeatedly between local and remote connections.
7. Edit headers, sign out, reauthenticate and remove the secondary connection.

Automated verification run on macOS Apple Silicon:

```text
Focused renderer/Electron auth suites: 184/184 passed
Desktop TypeScript typecheck: passed
Targeted ESLint: passed
Full UI suite: 5,319 passed
Desktop Electron/platform suite: 1,569 passed, 3 skipped
Desktop build: passed
macOS arm64 packaged bundle: built; ad-hoc signature verified
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages use Conventional Commits
- [x] I searched existing issues and PRs
- [x] The branch has a common ancestor with current upstream `main`
- [x] The PR contains only Desktop registered-gateway auth changes
- [x] Regression tests were added
- [x] Tested on macOS Apple Silicon

### Documentation & Housekeeping

- [x] No configuration keys or user-facing environment variables added
- [x] No plaintext credentials added
- [x] Cross-platform impact considered; native behavior remains behind Electron abstractions
- [x] No local planning files, build artifacts, PopCorn files or package-lock noise included

## Screenshots / Logs

A screenshot can be added after the maintainers confirm the desired final auth UX and partition ownership model.
