### PR TITLE
fix(cli): insert mapped character instead of raw modifyOtherKeys sequence

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -83,13 +83,15 @@ try:
         install_ignored_terminal_sequences,
         install_modify_other_keys_aliases,
         install_shift_enter_alias,
+        install_vt100_single_char_data_fix,
     )
     install_shift_enter_alias()
     install_ctrl_enter_alias()
     install_cmd_backspace_alias()
     install_modify_other_keys_aliases()
     install_ignored_terminal_sequences()
-    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_modify_other_keys_aliases, install_ignored_terminal_sequences
+    install_vt100_single_char_data_fix()
+    del install_shift_enter_alias, install_ctrl_enter_alias, install_cmd_backspace_alias, install_modify_other_keys_aliases, install_ignored_terminal_sequences, install_vt100_single_char_data_fix
 except Exception:
     pass
 import threading

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -495,6 +495,42 @@ def install_modify_other_keys_aliases() -> int:
     return changed
 
 
+def install_vt100_single_char_data_fix() -> int:
+    """Make single-character key mappings insert the character, not the raw
+    escape sequence.
+
+    prompt_toolkit's ``Vt100Parser._call_handler`` passes the *raw matched
+    sequence* as the KeyPress ``data`` for every ANSI_SEQUENCES hit, and the
+    self-insert binding inserts ``event.data``.  So any mapping that resolves
+    to a plain character (Shift+letter -> ``ESC[27;2;70~`` -> ``'F'``,
+    Shift+Space -> ``' '``, kitty keypad digits, Alt+letter tuples) inserts
+    the literal escape text into the prompt buffer — Shift+F types
+    ``[27;2;70~``.  Rewriting ``data`` to the character itself for
+    single-char string keys fixes every such mapping at the source
+    (normal typing is unaffected: key and data are already identical).
+
+    Idempotent: patches ``Vt100Parser._call_handler`` once per process.
+
+    Returns the number of patches applied (0 or 1).
+    """
+    try:
+        from prompt_toolkit.input.vt100_parser import Vt100Parser
+    except Exception:
+        return 0
+    if getattr(Vt100Parser, "_hermes_single_char_data_fix", False):
+        return 0
+    _orig_call_handler = Vt100Parser._call_handler
+
+    def _call_handler(parser, key, insert_text):
+        if isinstance(key, str) and len(key) == 1 and key != insert_text:
+            insert_text = key
+        return _orig_call_handler(parser, key, insert_text)
+
+    Vt100Parser._call_handler = _call_handler
+    Vt100Parser._hermes_single_char_data_fix = True
+    return 1
+
+
 def install_ignored_terminal_sequences() -> int:
     """Map terminal-emitted noise sequences to ``Keys.Ignore`` so they
     are consumed by the VT100 parser before they reach key bindings or

--- a/tests/cli/test_cli_shift_letter_data_fix.py
+++ b/tests/cli/test_cli_shift_letter_data_fix.py
@@ -1,0 +1,72 @@
+"""Verify the modifyOtherKeys / CSI-u single-character data fix.
+
+When Ghostty runs in xterm modifyOtherKeys mode (which Hermes enables for
+Ghostty terminals), Shift+letters arrive as ``ESC[27;2;<cp>~`` sequences
+instead of plain characters.  ``install_modify_other_keys_aliases()`` maps
+them to single-character string keys (``'F'``, ``' '``), but
+prompt_toolkit's ``Vt100Parser._call_handler`` attaches the *raw matched
+sequence* as the KeyPress ``data``, and the self-insert binding inserts
+``event.data`` — so Shift+F typed literal ``[27;2;70~`` into the prompt.
+
+``install_vt100_single_char_data_fix()`` rewrites ``data`` to the character
+for single-char string keys, fixing every such mapping at the source.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.keys import Keys
+
+from hermes_cli.pt_input_extras import install_modify_other_keys_aliases
+from hermes_cli.pt_input_extras import install_vt100_single_char_data_fix
+
+
+@pytest.fixture(autouse=True)
+def _ensure_aliases_installed():
+    """Make every test idempotent — install the aliases once per test run."""
+    install_modify_other_keys_aliases()
+    install_vt100_single_char_data_fix()
+
+
+def _parse(byte_seq: str):
+    out = []
+    parser = Vt100Parser(out.append)
+    for ch in byte_seq:
+        parser.feed(ch)
+    parser.flush()
+    return [(kp.key, kp.data) for kp in out]
+
+
+def test_install_returns_one_then_zero():
+    """Idempotency — running install twice should not report a second change."""
+    install_vt100_single_char_data_fix()
+    assert install_vt100_single_char_data_fix() == 0
+
+
+def test_shift_letter_inserts_the_character_not_the_escape_sequence():
+    """Shift+F under modifyOtherKeys must type 'F', not '[27;2;70~'."""
+    assert _parse("\x1b[27;2;70~") == [("F", "F")]
+
+
+def test_shift_space_inserts_a_space():
+    """Shift+Space must type a space, not the raw sequence."""
+    assert _parse("\x1b[27;2;32~") == [(" ", " ")]
+
+
+def test_alt_letter_inserts_the_letter():
+    """Alt+letter previously died (empty data); it must type the letter."""
+    keypresses = _parse("\x1b[27;3;97~")
+    assert keypresses[0][0] is Keys.Escape
+    assert keypresses[1] == ("a", "a")
+
+
+def test_plain_letter_unchanged():
+    """Normal typing is untouched — key and data are already identical."""
+    assert _parse("F") == [("F", "F")]
+
+
+def test_enum_keys_unchanged():
+    """Ctrl+C still parses to Keys.ControlC (its own binding, not self-insert)."""
+    assert _parse("\x1b[99;5u")[0][0] is Keys.ControlC


### PR DESCRIPTION
## Summary

Typing Shift+letters in the Hermes CLI prompt on Ghostty (xterm modifyOtherKeys mode, which Hermes enables for Ghostty terminals via `_is_ghostty_terminal`) inserts literal escape text like `[27;2;70~` instead of the character. Same root cause kills Alt+letter combos (dead keys, empty data) and Shift+Space.

**Root cause:** `install_modify_other_keys_aliases()` maps `ESC[27;2;<cp>~` to single-character string keys (`'F'`, `' '`), but prompt_toolkit's `Vt100Parser._call_handler` attaches the *raw matched sequence* as the `KeyPress.data`, and the `self-insert` binding inserts `event.data` — so the escape text lands in the buffer.

**Fix:** new `install_vt100_single_char_data_fix()` (hermes_cli/pt_input_extras.py) rewrites `data` to the mapped character for single-char string keys, called from the cli.py startup block. Fixes Shift+letter, Shift+Space, and dead Alt+letter at the source. Normal typing (key == data already) and enum keys (Ctrl+C) are untouched.

## Test Plan

- New `tests/cli/test_cli_shift_letter_data_fix.py`: 6 tests — Shift+F → `('F','F')`, Shift+Space → `(' ',' ')`, Alt+a → Escape + `('a','a')`, plain `F` unchanged, Ctrl+C → `Keys.ControlC`, idempotency.
- `pytest tests/cli/test_cli_shift_letter_data_fix.py tests/cli/test_cli_shift_enter_newline.py tests/cli/test_cli_cmd_backspace.py` → 22 passed.
- Verified live in the CLI before this PR (real Ghostty session): Shift+letters type clean.