### PR TITLE
fix(codex): clamp reasoning effort to Ollama Cloud vocabulary

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -29,6 +29,8 @@ def _cache_scope_from_session_id(session_id: Optional[str]) -> str:
 
 from agent.reasoning_effort import (
     ACTUAL_RELAY_EFFORTS,
+    OLLAMA_CLOUD_EFFORTS,
+    OLLAMA_CLOUD_OVERRIDES,
     XAI_GROK46_EFFORTS,
     XAI_LEGACY_EFFORTS,
     clamp_effort,
@@ -495,6 +497,7 @@ class ResponsesApiTransport(ProviderTransport):
         # repeatedly leaked internal levels like "ultra" to the wire
         # (#89503 class) or clamped one rung below a model's real ceiling
         # (#87279).
+        provider_lower = (params.get("provider") or "").strip().lower()
         if params.get("is_xai_responses", False):
             from agent.model_metadata import is_grok_46_family
 
@@ -504,16 +507,26 @@ class ResponsesApiTransport(ProviderTransport):
                 XAI_GROK46_EFFORTS if is_grok_46_family(model)
                 else XAI_LEGACY_EFFORTS
             )
-        elif (params.get("provider") or "").strip().lower() == "actual":
+            _overrides = None
+        elif provider_lower == "actual":
             # Actual Computer relays to SGLang/vLLM backends:
             # none/low/medium/high/max.
             _supported = ACTUAL_RELAY_EFFORTS
+            _overrides = None
+        elif provider_lower == "ollama-cloud":
+            # Ollama Cloud's OpenAI-compatible endpoint accepts
+            # none/low/medium/high/max and rejects xhigh. Use its declared
+            # vocabulary plus xhigh→max override so reasoning_effort=max
+            # is not downgraded to xhigh and then rejected.
+            _supported = OLLAMA_CLOUD_EFFORTS
+            _overrides = OLLAMA_CLOUD_OVERRIDES
         else:
             # OpenAI/Codex Responses backend — per-model vocabulary
             # (live-verified: "max" is gpt-5.6-only, "minimal" always
             # rejected). #68365 premise confirmed.
             _supported = codex_supported_efforts(model)
-        reasoning_effort = clamp_effort(reasoning_effort, _supported)
+            _overrides = None
+        reasoning_effort = clamp_effort(reasoning_effort, _supported, _overrides)
 
         response_tools = _responses_tools(tools)
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -59,6 +59,49 @@ class TestCodexBuildKwargs:
         assert pck.startswith("pck_")
         assert pck != "cron_job42_20260624_143000"
 
+    def test_ollama_cloud_reasoning_effort_max_stays_max(self, transport):
+        """Ollama Cloud's OpenAI-compatible endpoint accepts 'max' but rejects
+        'xhigh'. The codex transport must use the Ollama Cloud effort vocabulary
+        so a configured reasoning_effort of max is not downgraded to xhigh."""
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=messages,
+            tools=[],
+            reasoning_config={"enabled": True, "effort": "max"},
+            provider="ollama-cloud",
+            base_url="https://ollama.com/v1",
+        )
+        assert kw.get("reasoning") == {"effort": "max", "summary": "auto"}
+
+    def test_ollama_cloud_reasoning_effort_xhigh_clamps_to_max(self, transport):
+        """xhigh is not in Ollama Cloud's accepted effort set; it must be clamped
+        to the strongest accepted level, which is max."""
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=messages,
+            tools=[],
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            provider="ollama-cloud",
+            base_url="https://ollama.com/v1",
+        )
+        assert kw.get("reasoning") == {"effort": "max", "summary": "auto"}
+
+    def test_ollama_cloud_reasoning_effort_high_stays_high(self, transport):
+        """A supported effort level within Ollama Cloud's vocabulary passes through
+        unchanged."""
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash",
+            messages=messages,
+            tools=[],
+            reasoning_config={"enabled": True, "effort": "high"},
+            provider="ollama-cloud",
+            base_url="https://ollama.com/v1",
+        )
+        assert kw.get("reasoning") == {"effort": "high", "summary": "auto"}
+
     def test_cache_key_stable_across_session_ids(self, transport):
         """Same static prefix + different session_id (e.g. two cron fires of the
         same job) must yield the same prompt_cache_key — the whole point of the


### PR DESCRIPTION
## Summary

When `api_mode: codex_responses` is used with the `ollama-cloud` provider, a configured `reasoning_effort: max` is sent to the wire as `xhigh`, which Ollama Cloud's OpenAI-compatible endpoint rejects with `HTTP 400: invalid reasoning value: "xhigh" (must be "high", "medium", "low", "max", or "none")`. Every request then fails on the primary provider and triggers the fallback chain.

## Root cause

`agent/transports/codex.py` resolves the reasoning-effort wire vocabulary in `build_kwargs`. Non-xAI, non-Actual backends all fall through to `codex_supported_efforts(model)`, whose legacy set is `(none, low, medium, high, xhigh)` — it does **not** include `max`. `clamp_effort` therefore downgrades the configured `max` to the nearest weaker supported level, `xhigh`, and that value is rejected by Ollama Cloud (which accepts `none/low/medium/high/max`).

The Ollama Cloud vocabulary and its `xhigh → max` override were already declared in `agent/reasoning_effort.py` (`OLLAMA_CLOUD_EFFORTS` / `OLLAMA_CLOUD_OVERRIDES`), but the codex transport never consulted them.

## Fix

Add an `ollama-cloud` provider branch in the codex transport's effort resolution, using the declared `OLLAMA_CLOUD_EFFORTS` vocabulary plus `OLLAMA_CLOUD_OVERRIDES`:

- `max` stays `max` (previously downgraded to `xhigh` → HTTP 400)
- `xhigh` clamps to `max` (the strongest accepted level)
- `high`/`medium`/`low` pass through unchanged

## Tests

Three new tests in `tests/agent/transports/test_codex_transport.py`:

- `test_ollama_cloud_reasoning_effort_max_stays_max` — the regression test; fails before the fix (asserts `max` is not downgraded)
- `test_ollama_cloud_reasoning_effort_xhigh_clamps_to_max`
- `test_ollama_cloud_reasoning_effort_high_stays_high`

Verified locally: the 3 new tests pass, and the full `test_codex_transport.py` + `test_chat_completions.py` suite (153 tests) plus `test_reasoning_effort_sibling_sites.py` (112 tests) pass with no regressions. Also verified live: after the fix, requests to `https://ollama.com/v1` with `reasoning_effort: max` succeed on the primary provider instead of falling back.
