### PR TITLE
fix(skills): include grounded citations hub support files

### DIFF
--- a/skills/research/grounded-citations/SKILL.md
+++ b/skills/research/grounded-citations/SKILL.md
@@ -23,6 +23,7 @@ For high-stakes work the same ledger doubles as a fact-checking chain: verbatim
 quotes are attached to each source (rejected unless they literally appear in
 the fetched page text), claims from model knowledge are flagged `[unverified]`,
 and `verify --evidence` fails any draft whose cited sources carry no evidence.
+The design rationale and threat model live in `references/grounding-rationale.md`.
 
 This skill covers answers in chat, written documents (markdown, PDF, docx,
 slides), and research reports. It does not cover academic BibTeX pipelines —
@@ -46,9 +47,11 @@ Mention a URL only if the user would plausibly want the link.
 
 ## Prerequisites
 
-None beyond the standard toolset. `scripts/sources.py` is stdlib-only Python 3.
-Retrieval comes from whatever is configured: `web_search`, `web_extract`,
-`browser_navigate`, or `terminal` (curl, CLIs).
+None beyond the standard toolset. `scripts/sources.py` is stdlib-only Python 3
+and imports the sibling helper `scripts/_hermes_home.py` so profile-scoped Hub
+installs resolve `$HERMES_HOME` without a repository checkout. Retrieval comes
+from whatever is configured: `web_search`, `web_extract`, `browser_navigate`, or
+`terminal` (curl, CLIs).
 
 Ledger location: `$HERMES_HOME/cache/citations/ledger.json` (profile-aware).
 Override per task with `--ledger <path>` or `HERMES_CITATION_LEDGER`.

--- a/tests/skills/test_grounded_citations_hub_package.py
+++ b/tests/skills/test_grounded_citations_hub_package.py
@@ -1,0 +1,74 @@
+"""Hub packaging regressions for the grounded-citations bundled skill."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+from pathlib import Path
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2] / "skills" / "research" / "grounded-citations"
+)
+
+
+def _referenced_paths() -> set[str]:
+    from tools.skills_hub import _referenced_support_paths
+
+    body = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    referenced = _referenced_support_paths(body)
+    assert referenced is not None
+    return referenced
+
+
+def test_skill_md_references_all_hub_required_support_files() -> None:
+    """Hub installs only download support files referenced from SKILL.md."""
+    assert {
+        "scripts/sources.py",
+        "scripts/_hermes_home.py",
+        "references/citation-formats.md",
+        "references/grounding-rationale.md",
+    }.issubset(_referenced_paths())
+
+
+def test_hub_referenced_package_imports_from_profile_install(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A Hub-installed file subset includes every runtime dependency."""
+    referenced = _referenced_paths()
+
+    installed = tmp_path / "profile" / "skills" / "research" / "grounded-citations"
+    installed.mkdir(parents=True)
+    (installed / "SKILL.md").write_text(
+        (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    for rel_path in referenced:
+        src = SKILL_DIR / rel_path
+        dst = installed / rel_path
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+    home = tmp_path / "profile"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.syspath_prepend(str(installed / "scripts"))
+    sys.modules.pop("_hermes_home", None)
+
+    spec = importlib.util.spec_from_file_location(
+        "installed_grounded_citations_sources",
+        installed / "scripts" / "sources.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    ledger_path = module.resolve_ledger_path()
+    assert ledger_path == home / "cache" / "citations" / "ledger.json"
+    entries = module.add_sources(ledger_path, ["https://example.com"])
+    assert entries[0]["id"] == 1
+    assert (
+        json.loads(ledger_path.read_text(encoding="utf-8"))["sources"][0]["url"]
+        == "https://example.com"
+    )


### PR DESCRIPTION
Summary
Hub installs only include support files explicitly referenced from SKILL.md. The grounded-citations skill referenced scripts/sources.py and citation-formats.md, but sources.py imports a sibling _hermes_home.py helper and the skill also ships grounding-rationale.md; profile-scoped Hub installs therefore omitted a required runtime helper and sources.py failed with ModuleNotFoundError. This updates the skill instructions to reference every runtime support file and adds a regression that builds the Hub-referenced subset in an isolated profile and imports/runs the ledger code from that subset.

Changes
skills/research/grounded-citations/SKILL.md: explicitly references scripts/_hermes_home.py and references/grounding-rationale.md so Hub packaging includes them.
tests/skills/test_grounded_citations_hub_package.py: adds package-completeness regressions for _referenced_support_paths and an isolated profile install subset that imports sources.py and writes a ledger.

How to Test
python -m pytest tests/skills/test_grounded_citations_skill.py tests/skills/test_grounded_citations_hub_package.py -q
# ✅ 49/49 passed

Checklist
- [x] Tests pass — 49/49 targeted
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — get_hermes_home behavior preserved by the shipped helper
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

Risk & Impact
Low. This only adds explicit support-file references and tests the Hub-installed subset; runtime code is unchanged.
Type: Bug fix
Closes: #91542

Notes
- ruff check . passed.
- python scripts/check-windows-footguns.py --diff upstream/main passed.
- scripts/run_tests.sh is blocked in this Termux environment by per-file runner PermissionError across 3158 files; targeted regressions pass.
