### PR TITLE
fix(a2a): deliver inbound inline media

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18170,7 +18170,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     image_paths.append(path)
                 # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT
                 # MessageType.VOICE = voice message (Opus/OGG) — always STT
-                if event.message_type == MessageType.AUDIO:
+                if event.message_type == MessageType.AUDIO and _event_media_is_audio(event, i):
                     audio_file_paths.append(path)
                 elif not _pending_stt_prepared and _event_media_is_stt_input(event, i):
                     audio_paths.append(path)

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -147,14 +147,14 @@ def _cache_inline_raw_media(parts: list[dict]) -> list[CachedMedia]:
 def _message_type_for_media(cached_media: list[CachedMedia]) -> MessageType:
     """Match the shared gateway precedence for mixed attachments."""
     kinds = {item.kind for item in cached_media}
+    if "audio" in kinds:
+        return MessageType.AUDIO
     if "document" in kinds:
         return MessageType.DOCUMENT
     if "image" in kinds:
         return MessageType.PHOTO
     if "video" in kinds:
         return MessageType.VIDEO
-    if "audio" in kinds:
-        return MessageType.AUDIO
     return MessageType.TEXT
 
 

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -30,6 +30,8 @@ Bind safety: with no token configured, the server binds 127.0.0.1 only.
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import json
 import logging
 import os
@@ -48,10 +50,12 @@ from typing import Any, Dict, Optional
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    CachedMedia,
     MessageEvent,
     MessageType,
     ProcessingOutcome,
     SendResult,
+    cache_media_bytes,
 )
 from gateway.config import Platform
 
@@ -63,7 +67,95 @@ _DEFAULT_PORT = 9900
 _ORPHAN_TIMEOUT = 300  # seconds before a pending task is considered orphaned
 _WATCHDOG_INTERVAL = 60  # seconds between orphaned task watchdog runs
 _MAX_BODY = 1_048_576  # 1MB max request body — prevents DoS via memory exhaustion
+_MAX_INLINE_RAW_PARTS = 16
 _SSE_KEEPALIVE = 5  # seconds between SSE keepalive comments
+
+
+class _InlineMediaLimitError(ValueError):
+    pass
+
+
+def _inline_raw_parts(params: dict) -> list[dict]:
+    """Return bounded inline raw FileParts from an inbound message."""
+    message = params.get("message", params)
+    parts = message.get("parts", []) if isinstance(message, dict) else []
+    inline_parts: list[dict] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        raw = part.get("raw")
+        if not isinstance(raw, str) or not raw:
+            continue
+        if len(inline_parts) >= _MAX_INLINE_RAW_PARTS:
+            raise _InlineMediaLimitError(
+                f"inline raw FileParts accepts at most {_MAX_INLINE_RAW_PARTS} attachments"
+            )
+        inline_parts.append(part)
+    return inline_parts
+
+
+def _decode_protojson_bytes(raw: str) -> bytes:
+    """Strictly decode ProtoJSON bytes with either base64 alphabet."""
+    if raw.endswith("="):
+        if len(raw) % 4:
+            raise binascii.Error("invalid base64 padding")
+        padded = raw
+    else:
+        if "=" in raw or len(raw) % 4 == 1:
+            raise binascii.Error("invalid base64 padding")
+        padded = raw + "=" * (-len(raw) % 4)
+    return base64.b64decode(padded, altchars=b"-_", validate=True)
+
+
+def _cache_inline_raw_media(parts: list[dict]) -> list[CachedMedia]:
+    """Decode and cache inline raw FileParts without fetching URLs."""
+    cached_media: list[CachedMedia] = []
+
+    for part in parts:
+        raw = part.get("raw")
+        if not isinstance(raw, str):
+            continue
+
+        filename = str(part.get("filename") or part.get("name") or "")
+        media_type = str(part.get("mediaType") or part.get("mimeType") or "")
+        try:
+            data = _decode_protojson_bytes(raw)
+        except (binascii.Error, ValueError):
+            logger.warning("A2A: skipping malformed inline FilePart %r", filename)
+            continue
+        if not data:
+            logger.warning("A2A: skipping empty inline FilePart %r", filename)
+            continue
+
+        try:
+            cached = cache_media_bytes(
+                data,
+                filename=filename,
+                mime_type=media_type,
+            )
+        except Exception as exc:
+            logger.warning("A2A: failed to cache inline FilePart %r: %s", filename, exc)
+            continue
+        if cached is None:
+            logger.warning("A2A: inline FilePart %r failed media validation", filename)
+            continue
+        cached_media.append(cached)
+
+    return cached_media
+
+
+def _message_type_for_media(cached_media: list[CachedMedia]) -> MessageType:
+    """Match the shared gateway precedence for mixed attachments."""
+    kinds = {item.kind for item in cached_media}
+    if "document" in kinds:
+        return MessageType.DOCUMENT
+    if "image" in kinds:
+        return MessageType.PHOTO
+    if "video" in kinds:
+        return MessageType.VIDEO
+    if "audio" in kinds:
+        return MessageType.AUDIO
+    return MessageType.TEXT
 
 
 def _reply_timeout() -> float:
@@ -701,6 +793,7 @@ class A2AAdapter(BasePlatformAdapter):
         the future the caller must wait on. Runs on an HTTP worker thread.
         """
         agent = agent or self._agents[""]
+        inline_raw_parts = _inline_raw_parts(params)
         text = protocol.extract_text(params)
         context_id = protocol.extract_context_id(params) or protocol.new_context_id()
         task_id = protocol.new_task_id()
@@ -759,11 +852,12 @@ class A2AAdapter(BasePlatformAdapter):
                 created_at=rec["created_iso"],
             ), None
 
+        cached_media = _cache_inline_raw_media(inline_raw_parts)
         fut = self._add_pending(task_id, context_id)
 
         event = MessageEvent(
             text=framed,
-            message_type=MessageType.TEXT,
+            message_type=_message_type_for_media(cached_media),
             source=self.build_source(
                 chat_id=context_id,
                 chat_name=f"a2a:{peer}",
@@ -772,6 +866,8 @@ class A2AAdapter(BasePlatformAdapter):
                 user_name=peer,
             ),
             message_id=task_id,
+            media_urls=[item.path for item in cached_media],
+            media_types=[item.media_type for item in cached_media],
         )
 
         try:
@@ -949,7 +1045,10 @@ class A2AAdapter(BasePlatformAdapter):
                 return (protocol.STATE_FAILED, "[agent did not reply in time]")
 
     def _rpc_message_send(self, req_id: Any, params: dict, peer: str, agent: Optional[dict] = None, v1_response: bool = False) -> dict:
-        terminal, pending = self._prepare_task(params, peer, agent=agent)
+        try:
+            terminal, pending = self._prepare_task(params, peer, agent=agent)
+        except _InlineMediaLimitError as exc:
+            return protocol.jsonrpc_error(req_id, protocol.ERR_INVALID_PARAMS, str(exc))
         if terminal is not None:
             result = protocol.send_message_response(terminal) if v1_response else terminal
             return protocol.jsonrpc_result(req_id, result)
@@ -998,6 +1097,12 @@ class A2AAdapter(BasePlatformAdapter):
     def _rpc_message_stream(self, handler, req_id: Any, params: dict, peer: str, agent: Optional[dict] = None) -> None:
         """Handle message/stream as an SSE response of JSON-RPC-wrapped
         StreamResponse events (A2A v1.0 §9.4)."""
+        try:
+            _inline_raw_parts(params)
+        except _InlineMediaLimitError as exc:
+            handler._json(200, protocol.jsonrpc_error(
+                req_id, protocol.ERR_INVALID_PARAMS, str(exc)))
+            return
         protocol.metrics.streams_started += 1
         self._sse_headers(handler)
 

--- a/tests/gateway/test_telegram_audio_vs_voice.py
+++ b/tests/gateway/test_telegram_audio_vs_voice.py
@@ -116,6 +116,41 @@ async def test_audio_attachment_context_note_format():
     assert "ask the user what they'd like" not in result.lower()
 
 
+@pytest.mark.asyncio
+async def test_mixed_audio_and_document_route_by_attachment_mime():
+    """An AUDIO message must not label its document attachment as audio."""
+    runner = _make_runner(stt_enabled=True)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm")
+    event = MessageEvent(
+        text="Compare these files",
+        message_type=MessageType.AUDIO,
+        source=source,
+        media_urls=[
+            "/tmp/cache_12345_my_song.mp3",
+            "/tmp/cache_67890_notes.pdf",
+        ],
+        media_types=["audio/mpeg", "application/pdf"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("audio files must not enter STT"),
+    ):
+        with patch(
+            "tools.credential_files.to_agent_visible_cache_path",
+            side_effect=lambda path: path,
+        ):
+            result = await runner._prepare_inbound_message_text(
+                event=event,
+                source=source,
+                history=[],
+            )
+
+    assert result.lower().count("audio file attachment") == 1
+    assert "my_song.mp3" in result
+    assert "document: 'notes.pdf'" in result
+
+
 # ---------------------------------------------------------------------------
 # 3. STT disabled still results in no transcription for audio file attachments
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_audio_vs_voice.py
+++ b/tests/gateway/test_telegram_audio_vs_voice.py
@@ -117,18 +117,17 @@ async def test_audio_attachment_context_note_format():
 
 
 @pytest.mark.asyncio
-async def test_mixed_audio_and_document_route_by_attachment_mime():
+async def test_mixed_audio_and_document_route_by_attachment_mime(tmp_path):
     """An AUDIO message must not label its document attachment as audio."""
     runner = _make_runner(stt_enabled=True)
     source = SessionSource(platform=Platform.TELEGRAM, chat_id="1", chat_type="dm")
+    audio_path = tmp_path / "cache_12345_my_song.mp3"
+    document_path = tmp_path / "cache_67890_notes.pdf"
     event = MessageEvent(
         text="Compare these files",
         message_type=MessageType.AUDIO,
         source=source,
-        media_urls=[
-            "/tmp/cache_12345_my_song.mp3",
-            "/tmp/cache_67890_notes.pdf",
-        ],
+        media_urls=[str(audio_path), str(document_path)],
         media_types=["audio/mpeg", "application/pdf"],
     )
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1163,6 +1163,35 @@ class TestInlineRawMediaRoundTrip:
             document_bytes,
         ]
 
+    def test_audio_takes_precedence_in_mixed_inline_files(self, monkeypatch):
+        """Mixed audio remains agent-visible while documents keep their own path."""
+        audio_bytes = b"ID3\x04\x00\x00\x00\x00\x00\x00inline A2A audio"
+        document_bytes = b"inline A2A document"
+        event = _round_trip_parts(
+            monkeypatch,
+            [
+                protocol.text_part("Compare these files"),
+                protocol.file_part(
+                    raw=base64.b64encode(audio_bytes).decode("ascii"),
+                    filename="sample.mp3",
+                    media_type="audio/mpeg",
+                ),
+                protocol.file_part(
+                    raw=base64.b64encode(document_bytes).decode("ascii"),
+                    filename="notes.txt",
+                    media_type="text/plain",
+                ),
+            ],
+            "ctx-mixed-audio-document",
+        )
+
+        assert event.message_type is MessageType.AUDIO
+        assert event.media_types == ["audio/mpeg", "text/plain"]
+        assert [Path(path).read_bytes() for path in event.media_urls] == [
+            audio_bytes,
+            document_bytes,
+        ]
+
     def test_malformed_inline_base64_is_skipped(self, monkeypatch):
         """Malformed base64 never becomes a cached attachment or fails the task."""
         event = _round_trip_parts(

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -10,6 +10,7 @@ with a mocked agent handler.
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import hmac
 import json
@@ -20,11 +21,22 @@ import urllib.error
 import urllib.request
 from concurrent.futures import Future
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from gateway.platforms.base import MessageType
 from plugins.platforms.a2a import protocol, security, tools
+
+
+_PNG_1X1_STANDARD_UNPADDED = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII"
+)
+_PNG_1X1_URLSAFE_UNPADDED = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk-A8AAQUBAScY42YAAAAASUVORK5CYII"
+)
+_PNG_1X1 = base64.b64decode(_PNG_1X1_STANDARD_UNPADDED + "=")
 
 
 def _free_port() -> int:
@@ -948,6 +960,38 @@ def _send_body(text, ctx="", extra_params=None):
     return {"jsonrpc": "2.0", "id": "1", "method": "message/send", "params": params}
 
 
+def _round_trip_parts(monkeypatch, parts, context_id):
+    """Send A2A parts through the live HTTP adapter and return its event."""
+    monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
+    monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
+    received = {}
+
+    def reply_fn(event):
+        received["event"] = event
+        return "got it"
+
+    adapter, base = _make_live_adapter(monkeypatch, reply_fn=reply_fn)
+
+    async def run():
+        assert await adapter.connect() is True
+        try:
+            message = protocol.message_with_parts(
+                protocol.ROLE_USER,
+                parts,
+                context_id=context_id,
+            )
+            response = await asyncio.to_thread(_post_json, base + "/", {
+                "jsonrpc": "2.0", "id": "1", "method": "message/send",
+                "params": {"message": message},
+            })
+            assert response["result"]["status"]["state"] == protocol.STATE_COMPLETED
+            return received["event"]
+        finally:
+            await adapter.disconnect()
+
+    return asyncio.run(run())
+
+
 @pytest.mark.integration
 class TestInboundRoundTrip:
     def test_live_server_card_and_message_send(self, monkeypatch):
@@ -992,47 +1036,214 @@ class TestInboundRoundTrip:
 
         asyncio.run(run())
 
+
+class TestInlineRawMediaRoundTrip:
     def test_mixed_parts_delivered_to_agent(self, monkeypatch):
-        """A message with text + file + data Parts delivers all content to the
-        agent — file URLs and data JSON are rendered into the text stream."""
+        """URL FileParts stay text-only and are never fetched."""
+        requests_received = []
+
+        class CountingHandler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                requests_received.append(self.path)
+                self.send_response(200)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            def do_HEAD(self):
+                self.do_GET()
+
+            def log_message(self, format, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), CountingHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            file_url = f"http://127.0.0.1:{server.server_port}/report.pdf"
+            event = _round_trip_parts(
+                monkeypatch,
+                [
+                    protocol.text_part("Please process these:"),
+                    protocol.file_part(
+                        url=file_url,
+                        filename="report.pdf",
+                        media_type="application/pdf",
+                    ),
+                    protocol.data_part({"title": "Q3", "pages": 42}, "application/json"),
+                ],
+                "ctx-mixed",
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+        assert "Please process these:" in event.text
+        assert file_url in event.text
+        assert "report.pdf" in event.text
+        assert "Q3" in event.text
+        assert "42" in event.text
+        assert event.media_urls == []
+        assert event.media_types == []
+        assert requests_received == []
+
+    def test_inline_raw_image_delivered_as_media_attachment(self, monkeypatch):
+        """A2A raw image Parts reach the normal gateway media pipeline."""
+        image_bytes = _PNG_1X1
+        event = _round_trip_parts(
+            monkeypatch,
+            [
+                protocol.text_part("Describe this image"),
+                protocol.file_part(
+                    raw=base64.b64encode(image_bytes).decode("ascii"),
+                    filename="sample.png",
+                    media_type="image/png",
+                ),
+            ],
+            "ctx-inline-image",
+        )
+
+        assert "Describe this image" in event.text
+        assert event.message_type is MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+        assert Path(event.media_urls[0]).read_bytes() == image_bytes
+
+    @pytest.mark.parametrize(
+        "raw",
+        [_PNG_1X1_STANDARD_UNPADDED, _PNG_1X1_URLSAFE_UNPADDED],
+        ids=["standard-unpadded", "urlsafe-unpadded"],
+    )
+    def test_protojson_raw_base64_variants_are_accepted(self, monkeypatch, raw):
+        """ProtoJSON bytes accept standard/URL-safe base64 without padding."""
+        event = _round_trip_parts(
+            monkeypatch,
+            [
+                protocol.text_part("Describe this image"),
+                protocol.file_part(
+                    raw=raw,
+                    filename="sample.png",
+                    media_type="image/png",
+                ),
+            ],
+            f"ctx-{raw[:8]}",
+        )
+
+        assert event.message_type is MessageType.PHOTO
+        assert event.media_types == ["image/png"]
+        assert len(event.media_urls) == 1
+        assert Path(event.media_urls[0]).read_bytes() == _PNG_1X1
+
+    def test_multiple_inline_raw_files_preserve_attachment_order(self, monkeypatch):
+        """Every inline raw FilePart reaches the event in wire order."""
+        image_bytes = _PNG_1X1
+        document_bytes = b"inline A2A document"
+        event = _round_trip_parts(
+            monkeypatch,
+            [
+                protocol.text_part("Compare these files"),
+                protocol.file_part(
+                    raw=base64.b64encode(image_bytes).decode("ascii"),
+                    filename="sample.png",
+                    media_type="image/png",
+                ),
+                protocol.file_part(
+                    raw=base64.b64encode(document_bytes).decode("ascii"),
+                    filename="notes.txt",
+                    media_type="text/plain",
+                ),
+            ],
+            "ctx-multiple-inline-files",
+        )
+
+        assert event.message_type is MessageType.DOCUMENT
+        assert event.media_types == ["image/png", "text/plain"]
+        assert [Path(path).read_bytes() for path in event.media_urls] == [
+            image_bytes,
+            document_bytes,
+        ]
+
+    def test_malformed_inline_base64_is_skipped(self, monkeypatch):
+        """Malformed base64 never becomes a cached attachment or fails the task."""
+        event = _round_trip_parts(
+            monkeypatch,
+            [
+                protocol.text_part("Handle the caption"),
+                protocol.file_part(
+                    raw="not-valid-base64!",
+                    filename="broken.png",
+                    media_type="image/png",
+                ),
+            ],
+            "ctx-malformed-inline-image",
+        )
+
+        assert event.message_type is MessageType.TEXT
+        assert event.media_urls == []
+        assert event.media_types == []
+
+    def test_invalid_inline_image_bytes_are_not_cached(self, monkeypatch):
+        """A claimed image must pass the shared magic-byte validation."""
+        event = _round_trip_parts(
+            monkeypatch,
+            [
+                protocol.text_part("Handle the caption"),
+                protocol.file_part(
+                    raw=base64.b64encode(b"not an image").decode("ascii"),
+                    filename="fake.png",
+                    media_type="image/png",
+                ),
+            ],
+            "ctx-invalid-inline-image",
+        )
+
+        assert event.message_type is MessageType.TEXT
+        assert event.media_urls == []
+        assert event.media_types == []
+
+    @pytest.mark.parametrize("method", ["message/send", "message/stream"])
+    def test_too_many_inline_raw_parts_return_invalid_params(self, monkeypatch, method):
+        """One request cannot amplify into unbounded cache files or warnings."""
         monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
         monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
-
-        received = {}
-
-        def reply_fn(event):
-            received["text"] = event.text
-            return "got it"
-
-        adapter, base = _make_live_adapter(monkeypatch, reply_fn=reply_fn)
+        adapter, base = _make_live_adapter(monkeypatch)
+        parts = [
+            protocol.file_part(
+                raw="YQ==",
+                filename=f"part-{index}.txt",
+                media_type="text/plain",
+            )
+            for index in range(17)
+        ]
 
         async def run():
             assert await adapter.connect() is True
-            msg = protocol.message_with_parts(
-                protocol.ROLE_USER,
-                [
-                    protocol.text_part("Please process these:"),
-                    protocol.file_part(url="https://example.com/report.pdf",
-                                       filename="report.pdf", media_type="application/pdf"),
-                    protocol.data_part({"title": "Q3", "pages": 42}, "application/json"),
-                ],
-                context_id="ctx-mixed",
-            )
-            resp = await asyncio.to_thread(_post_json, base + "/", {
-                "jsonrpc": "2.0", "id": "1", "method": "message/send",
-                "params": {"message": msg},
-            })
-            assert resp["result"]["status"]["state"] == "TASK_STATE_COMPLETED"
-            # The agent received all three parts rendered into text
-            assert "Please process these:" in received["text"]
-            assert "https://example.com/report.pdf" in received["text"]
-            assert "report.pdf" in received["text"]
-            assert "Q3" in received["text"]
-            assert "42" in received["text"]
-            await adapter.disconnect()
+            try:
+                message = protocol.message_with_parts(
+                    protocol.ROLE_USER,
+                    parts,
+                    context_id="ctx-too-many-inline-parts",
+                )
+                response = await asyncio.to_thread(
+                    _post_json,
+                    base + "/",
+                    {
+                        "jsonrpc": "2.0",
+                        "id": "1",
+                        "method": method,
+                        "params": {"message": message},
+                    },
+                )
+                assert response["error"]["code"] == protocol.ERR_INVALID_PARAMS
+                assert "at most 16" in response["error"]["message"]
+            finally:
+                await adapter.disconnect()
 
         asyncio.run(run())
 
+
+@pytest.mark.integration
+class TestInboundProtocolRoundTrip:
     def test_push_config_crud_over_http(self, monkeypatch):
         """Full push notification config CRUD over real HTTP."""
         monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
@@ -1364,16 +1575,37 @@ class TestMultiAgentRouting:
             "agents": {"dev": {"profile": "dev", "tenant": "dev"}}
         }))
         agent = adapter._agents["dev"]
+        document_bytes = b"routed A2A document"
+        monkeypatch.setattr(
+            "plugins.platforms.a2a.adapter.cache_media_bytes",
+            lambda *_args, **_kwargs: pytest.fail("routed media must not use the parent cache"),
+        )
 
         def fake_forward(agent_arg, peer, context_id, framed_text):
             assert agent_arg["slug"] == "dev"
             assert peer == "peer-x"
             assert "hello" in framed_text
+            assert "[file: notes.txt]" in framed_text
+            assert "saved at:" not in framed_text
             return "dev reply", protocol.STATE_COMPLETED
 
         adapter._forward_to_profile = fake_forward  # type: ignore
         terminal, pending = adapter._prepare_task(
-            {"tenant": "dev", "message": protocol.text_message(protocol.ROLE_USER, "hello", context_id="ctx-dev")},
+            {
+                "tenant": "dev",
+                "message": protocol.message_with_parts(
+                    protocol.ROLE_USER,
+                    [
+                        protocol.text_part("hello"),
+                        protocol.file_part(
+                            raw=base64.b64encode(document_bytes).decode("ascii"),
+                            filename="notes.txt",
+                            media_type="text/plain",
+                        ),
+                    ],
+                    context_id="ctx-dev",
+                ),
+            },
             "peer-x",
             agent=agent,
         )


### PR DESCRIPTION
## What does this PR do?

A2A `message/send` currently flattens inline `raw` FileParts into a text-only byte-count note, so the gateway never receives an attachment and vision-capable models cannot see inbound images.

This change strictly decodes inline base64 FileParts, passes their bytes through the existing unified media cache, and populates `MessageEvent.media_urls` / `media_types` using the cache's validated metadata. URL-referenced FileParts remain text-only and are never fetched, so this does not add an SSRF surface.

## Related Issue

Addresses the inline-`raw` portion of #90588; URL-referenced FileParts remain text-only and are not fetched.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Strictly decode ProtoJSON `raw` bytes in standard or URL-safe base64, with optional padding.
- Reuse `cache_media_bytes()` for size limits, image magic-byte validation, cache paths, MIME metadata, and media classification.
- Populate `MessageEvent.media_urls`, `media_types`, and the message-level media type, including mixed attachments.
- Prioritize audio for mixed A2A attachments, while the gateway routes audio, documents, images, and video by each attachment's own MIME.
- Bound each request to 16 inline raw attachments and reject excess parts with `INVALID_PARAMS` before decoding or caching.
- Keep routed-profile requests on their existing text-only path; local cache paths are never forwarded across profile/container boundaries.
- Keep URL FileParts text-only; no URL downloads, redirects, or remote fetch policy are introduced.
- Add normal-CI live HTTP regressions for a valid PNG, ProtoJSON base64 variants, mixed image/document order, malformed base64, invalid image bytes, send/stream attachment limits, and a request-counted URL no-fetch invariant.

## How to Test

1. Run the complete A2A plugin suite:
   ```bash
   scripts/run_tests.sh tests/plugins/test_a2a_plugin.py -m 'not integration'
   scripts/run_tests.sh tests/plugins/test_a2a_plugin.py -m integration
   scripts/run_tests.sh tests/plugins/test_a2a_phase23.py tests/plugins/test_a2a_schema_registration.py
   scripts/run_tests.sh tests/gateway/test_telegram_audio_vs_voice.py tests/gateway/test_mixed_attachment_routing.py
   uv run --no-project --with ruff==0.15.10 ruff check plugins/platforms/a2a/adapter.py gateway/run.py tests/plugins/test_a2a_plugin.py tests/gateway/test_telegram_audio_vs_voice.py
   uv run --no-project scripts/check-windows-footguns.py --diff origin/main
   ```
   Local result: 116 default A2A tests, 9 integration tests, 46 adjacent A2A tests, and 5 gateway audio/mixed-routing tests passed; Ruff passed. The Windows checker reports two pre-existing bare `Path.read_text()` calls in `test_a2a_plugin.py`; both are present in `origin/main` and neither line is part of this PR's diff.
2. Send an A2A `message/send` request containing a text Part plus an inline `raw` PNG FilePart.
3. Verify the dispatched `MessageEvent` is `PHOTO`, has one cached path in `media_urls`, and records `image/png` in `media_types`.

Manual smoke (Debian 13 / Python 3.11): ran `/tmp/hermes-90588-dbcf695-venv/bin/hermes gateway run --force` with isolated `HOME` / `HERMES_HOME` and a localhost-only fake OpenAI-compatible endpoint, then sent a real JSON-RPC `message/send` containing an inline PNG. Result: `TASK_STATE_COMPLETED` + `SMOKE_OK`; the model request contained `data:image/png;base64,...`, and the cached PNG was byte-identical to the input. No user profile, credentials, or external model endpoint was used.

Full repository suite (clean `HOME`, isolated Python 3.11): `scripts/run_tests.sh` completed with exit 1 — 36,154 passed, 68 failed, and 308 skipped across 3,158 files. After installing the relevant project-declared lazy extras, 62 of those failures no longer reproduced; a one-worker rerun removed 2 more load-sensitive failures and left 4 failures in 3 files: `tests/test_hermes_state.py` (1), `tests/test_install_macos_launcher.py` (1), and `tests/test_mcp_serve.py` (2). A targeted — not full-suite A/B — run of those files on the then-current `origin/main` (`b2c4f1f`) with its own isolated venv reproduced failures in the same three files (326 passed, 3 failed); the mtime-sensitive EventBridge failure varied between runs. This confirms a baseline problem at the affected-file level, not that all 68 initial failures were pre-existing. None of those files is changed by this PR. The full-suite checklist remains unchecked because the complete run did not exit 0.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 / Linux, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and covered by code comments/tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture/workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib base64 plus existing cross-platform cache helpers
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changes

## Screenshots / Logs

Not applicable. The regression is covered by live A2A HTTP round-trip tests.
