### PR TITLE
fix(serve): let the desktop-spawned backend keep its own SPA

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11236,7 +11236,9 @@ def _is_electron_packaged_web_dist(path: str) -> bool:
     return "app.asar" in path.replace("\\", "/")
 
 
-def _serve_should_force_headless(headless_backend: bool, env=None) -> bool:
+def _serve_should_force_headless(
+    headless_backend: bool, env: dict[str, str] | None = None
+) -> bool:
     """True when ``hermes serve`` must disable the browser SPA.
 
     ``serve`` is the headless backend: a standalone `hermes serve` is not a

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11236,6 +11236,41 @@ def _is_electron_packaged_web_dist(path: str) -> bool:
     return "app.asar" in path.replace("\\", "/")
 
 
+def _serve_should_force_headless(headless_backend: bool, env=None) -> bool:
+    """True when ``hermes serve`` must disable the browser SPA.
+
+    ``serve`` is the headless backend: a standalone `hermes serve` is not a
+    dashboard, so it forces ``HERMES_SERVE_HEADLESS=1`` and ``mount_spa()``
+    404s every frontend route.
+
+    The one exception is a desktop-spawned backend that was handed a dist to
+    serve (#91495). Electron spawns `hermes serve` with ``HERMES_DESKTOP=1``
+    and ``HERMES_WEB_DIST`` pointing at its own packaged dist, and the env
+    sanitizer in ``cmd_dashboard`` deliberately keeps that dist for exactly
+    this process ("The desktop-spawned backend itself (HERMES_DESKTOP=1) keeps
+    its dist"). Forcing headless then 404s the dist we just went out of our way
+    to preserve, so the desktop shell cannot load its own embedded renderer.
+
+    BOTH markers are required, not just ``HERMES_DESKTOP``. The desktop also
+    spawns remote backends over SSH as ``env HERMES_DESKTOP=1 hermes serve
+    --isolated`` with no dist (``apps/desktop/electron/remote-lifecycle.ts``);
+    there the renderer is local and the remote is purely an API server, so it
+    must stay headless -- and exempting it would fall through to the branch
+    that runs ``_build_web_ui(..., fatal=True)`` on the remote host. Reading
+    ``HERMES_WEB_DIST`` here is also read-after-sanitize: the sanitizer above
+    has already dropped an Electron-packaged dist inherited from someone
+    else's environment, so this sees only a dist meant for this process.
+
+    Pure so the decision is testable without booting a server.
+    """
+    if not headless_backend:
+        return False
+    env = os.environ if env is None else env
+    if env.get("HERMES_DESKTOP") != "1":
+        return True
+    return not (env.get("HERMES_WEB_DIST") or "").strip()
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
     _token_file = getattr(args, "ssh_session_token_file", None)
@@ -11444,10 +11479,24 @@ def cmd_dashboard(args):
         logger.debug("terminal config → env bridge failed for dashboard/serve",
                      exc_info=True)
 
-    if _headless_backend:
+    if _serve_should_force_headless(_headless_backend):
         # Don't build the SPA, and tell mount_spa() (read at web_server import
         # below) to disable it even if a stray dist exists. Set it first.
+        #
+        # A desktop-spawned backend carrying its own HERMES_WEB_DIST is the one
+        # exemption (#91495): the sanitizer above deliberately KEEPS that dist
+        # for this process, and 404ing it here contradicts that. See
+        # _serve_should_force_headless for why both markers are required.
         os.environ["HERMES_SERVE_HEADLESS"] = "1"
+    elif _headless_backend:
+        # Desktop-exempt `serve`. Declining to SET the flag is not enough: the
+        # sanitizer's pop above is gated on `not _headless_backend`, so it never
+        # runs on this path, and an inherited HERMES_SERVE_HEADLESS=1 (exported
+        # in the user's shell, then handed to the backend by Electron's
+        # `...process.env` spawn) would still reach mount_spa and 404 the dist.
+        # The exemption has to be authoritative to be worth anything.
+        # Credit to @Enough1122, who raised this on #84444.
+        os.environ.pop("HERMES_SERVE_HEADLESS", None)
     elif "HERMES_WEB_DIST" not in os.environ and not getattr(args, "skip_build", False):
         if not _build_web_ui(PROJECT_ROOT / "web", fatal=True):
             sys.exit(1)

--- a/tests/hermes_cli/test_serve_headless_desktop_exemption.py
+++ b/tests/hermes_cli/test_serve_headless_desktop_exemption.py
@@ -1,0 +1,159 @@
+"""Regression for #91495 - `hermes serve` 404'd the desktop's own renderer.
+
+Electron spawns its local backend as `hermes serve` (never `dashboard`; see
+``apps/desktop/electron/backend-command.ts``) with ``HERMES_DESKTOP=1``,
+``HERMES_WEB_DIST=<packaged dist>`` and ``HERMES_DASHBOARD_SESSION_TOKEN``.
+
+``cmd_dashboard``'s env sanitizer already carves the desktop out by name when
+it strips Electron-packaged ``HERMES_WEB_DIST`` from inherited environments:
+
+    # The desktop-spawned backend itself (HERMES_DESKTOP=1) keeps its dist.
+
+and then, a couple hundred lines later, forced ``HERMES_SERVE_HEADLESS=1`` for
+every ``serve`` invocation - which makes ``mount_spa()`` 404 every frontend
+route, including the dist that carve-out just preserved. The two rules
+contradicted each other and the desktop shell could not load its renderer.
+
+The exemption is deliberately narrower than "the desktop spawned it": it also
+requires a ``HERMES_WEB_DIST`` to serve, because the desktop spawns REMOTE
+backends over SSH as ``env HERMES_DESKTOP=1 hermes serve --isolated`` with no
+dist (``apps/desktop/electron/remote-lifecycle.ts``). Those must stay headless.
+
+These tests pin the predicate, not a booted server: the bug was a decision, and
+a decision is cheaper and more honestly tested in isolation.
+"""
+
+from __future__ import annotations
+
+import hermes_cli.main as main_mod
+
+
+# What apps/desktop/electron/main.ts hands its LOCAL backend.
+DESKTOP = {"HERMES_DESKTOP": "1", "HERMES_WEB_DIST": "/Applications/Hermes.app/dist"}
+# What remote-lifecycle.ts hands a backend spawned on another host over SSH.
+DESKTOP_REMOTE = {"HERMES_DESKTOP": "1"}
+PLAIN: dict = {}
+
+
+class TestServeHeadlessDecision:
+    def test_standalone_serve_is_still_headless(self):
+        """The whole point of `serve` survives: it is not a dashboard."""
+        assert main_mod._serve_should_force_headless(True, PLAIN) is True
+
+    def test_desktop_spawned_serve_keeps_its_spa(self):
+        """THE regression (#91495).
+
+        Before the fix this returned True, so the backend 404'd the packaged
+        dist the desktop had just handed it via HERMES_WEB_DIST.
+        """
+        assert main_mod._serve_should_force_headless(True, DESKTOP) is False
+
+    def test_dashboard_is_never_forced_headless(self):
+        """`dashboard` is not a headless backend on any host."""
+        assert main_mod._serve_should_force_headless(False, PLAIN) is False
+        assert main_mod._serve_should_force_headless(False, DESKTOP) is False
+
+    def test_desktop_spawned_remote_backend_stays_headless(self):
+        """The SSH backend has no renderer to serve, and must not build one.
+
+        ``remote-lifecycle.ts`` spawns ``env HERMES_DESKTOP=1 hermes serve
+        --isolated --host 127.0.0.1 --port 0`` on the remote host. The renderer
+        lives on the LOCAL machine; the remote is purely an API server. On a
+        HERMES_DESKTOP-only exemption this would not just serve routes it has
+        no dist for - it would fall through to the branch that runs
+        ``_build_web_ui(..., fatal=True)``, i.e. an npm build on someone's
+        server, fatal if it fails.
+        """
+        assert main_mod._serve_should_force_headless(True, DESKTOP_REMOTE) is True
+
+    def test_an_empty_dist_is_not_a_dist(self):
+        """``HERMES_WEB_DIST=""`` (or whitespace) carries nothing to serve."""
+        for value in ("", "   "):
+            assert (
+                main_mod._serve_should_force_headless(
+                    True, {"HERMES_DESKTOP": "1", "HERMES_WEB_DIST": value}
+                )
+                is True
+            ), repr(value)
+
+    def test_only_the_exact_marker_exempts(self):
+        """HERMES_DESKTOP is a 1/unset marker, not a truthiness test.
+
+        A stale or hand-set ``HERMES_DESKTOP=0`` (or ``true``) must not quietly
+        turn a standalone `hermes serve` into an SPA host - that would be a
+        surprising way to expose a browser UI on a server.
+        """
+        for value in ("0", "", "true", "yes", "2"):
+            assert (
+                main_mod._serve_should_force_headless(
+                    True, {"HERMES_DESKTOP": value, "HERMES_WEB_DIST": "/d"}
+                )
+                is True
+            ), value
+
+    def test_defaults_to_the_process_environment(self, monkeypatch):
+        """``env=None`` reads os.environ, which is how the call site uses it."""
+        monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+        monkeypatch.delenv("HERMES_WEB_DIST", raising=False)
+        assert main_mod._serve_should_force_headless(True) is True
+
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        assert main_mod._serve_should_force_headless(True) is True
+
+        monkeypatch.setenv("HERMES_WEB_DIST", "/opt/hermes/dist")
+        assert main_mod._serve_should_force_headless(True) is False
+
+
+class TestTheExemptionIsAuthoritative:
+    """Not setting the flag is not the same as the flag not being set.
+
+    The sanitizer's `os.environ.pop("HERMES_SERVE_HEADLESS", None)` earlier in
+    cmd_dashboard is gated on `not _headless_backend`, so it never runs on the
+    `serve` path. An inherited HERMES_SERVE_HEADLESS=1 therefore survives into
+    mount_spa and 404s the dist even when the desktop is exempt, which makes a
+    "just don't set it" exemption silently useless. Electron spawns its backend
+    with `...process.env`, so anything exported in the user's shell is
+    inherited. Raised by @Enough1122 on #84444.
+    """
+
+    def test_exempt_path_clears_an_inherited_flag(self):
+        import inspect
+
+        src = inspect.getsource(main_mod.cmd_dashboard)
+        gate = src.index("_serve_should_force_headless(_headless_backend)")
+        build = src.index('"HERMES_WEB_DIST" not in os.environ')
+        between = src[gate:build]
+        assert 'os.environ.pop("HERMES_SERVE_HEADLESS", None)' in between, (
+            "the desktop-exempt branch must CLEAR an inherited "
+            "HERMES_SERVE_HEADLESS, not merely decline to set it"
+        )
+        assert "elif _headless_backend:" in between
+
+    def test_clearing_is_scoped_to_the_headless_backend(self):
+        """`dashboard` must not be routed through the exempt branch.
+
+        It has its own pop earlier (gated on `not _headless_backend`), and
+        reaching this one would mean the build branch below stopped running
+        for a plain `hermes dashboard`.
+        """
+        import inspect
+
+        src = inspect.getsource(main_mod.cmd_dashboard)
+        assert "elif _headless_backend:" in src
+        assert src.index("elif _headless_backend:") < src.index(
+            '"HERMES_WEB_DIST" not in os.environ'
+        )
+
+
+class TestCallSiteStillGatesTheEnvVar:
+    def test_predicate_is_what_cmd_dashboard_consults(self):
+        """Pin the wiring, so the predicate cannot be tested into a vacuum.
+
+        A pure predicate nobody calls is the classic way a fix like this rots;
+        assert the call site names it.
+        """
+        import inspect
+
+        src = inspect.getsource(main_mod.cmd_dashboard)
+        assert "_serve_should_force_headless(_headless_backend)" in src
+        assert 'os.environ["HERMES_SERVE_HEADLESS"] = "1"' in src


### PR DESCRIPTION
## What does this PR do?

`cmd_dashboard` contradicted itself about the desktop-spawned backend, and the
desktop lost its renderer as a result.

Its env sanitizer carves the desktop out **by name** when stripping an
Electron-packaged `HERMES_WEB_DIST` out of an inherited environment
(`hermes_cli/main.py:11287`):

```python
# The desktop-spawned backend itself (HERMES_DESKTOP=1) keeps its dist.
```

Then, a couple hundred lines later, it forced `HERMES_SERVE_HEADLESS=1` for
**every** `serve` invocation, which makes `mount_spa()` 404 every frontend
route, including the dist that carve-out had just gone out of its way to
preserve.

Electron spawns its local backend as `hermes serve` and never as `dashboard`.
`apps/desktop/electron/backend-command.ts` is explicit that the desktop backend
"must NEVER depend on or launch the browser dashboard" (the `dashboard
--no-open` form there is only a fallback for runtimes predating `serve`), and
`main.ts:10353-10358` hands that child `HERMES_DESKTOP=1` plus
`HERMES_WEB_DIST: resolveWebDist()`. So the desktop hands the backend a
renderer and the backend 404s it. That is the whole bug, and it is provable
from two lines of the same function.

The decision moves into a pure `_serve_should_force_headless()`, sitting next
to the existing `_is_electron_packaged_web_dist()` helper that was extracted
from this same function for the same reason. Standalone `hermes serve` is
unchanged and still refuses to serve a browser SPA: the point of the headless
backend is that `hermes serve` is not a dashboard, not that a desktop shell
cannot load its own embedded renderer.

### The exemption is narrower than the issue asks for, on purpose

#91495 proposes exempting the desktop-spawned backend. Taken literally
(`HERMES_DESKTOP=1` alone) that would be a regression, because the desktop
spawns a **second, remote** kind of backend over SSH
(`apps/desktop/electron/remote-lifecycle.ts:535`):

```
exec env HERMES_DESKTOP=1 <hermes> serve --isolated --host 127.0.0.1 --port 0 ...
```

with **no** `HERMES_WEB_DIST`. There the renderer lives on the local machine
and the remote is purely an API server, so it must stay headless. Worse,
un-headlessing it does not just expose routes it has no dist for: it falls
through to the sibling branch that runs `_build_web_ui(..., fatal=True)`, i.e.
an npm build on someone's server, fatal to the backend if it fails.

So the exemption requires **both** `HERMES_DESKTOP == "1"` and a non-empty
`HERMES_WEB_DIST`: the desktop must actually have handed us a renderer to
serve. Reading `HERMES_WEB_DIST` at that point is read-after-sanitize, so it
only ever sees a dist meant for this process, never one inherited from someone
else's Electron app. `HERMES_DESKTOP` is matched as `"1"` exactly rather than
for truthiness, so a stale `HERMES_DESKTOP=0` or `HERMES_DESKTOP=true` cannot
quietly turn a server-side `hermes serve` into an SPA host.

### Where I disagree with the issue, measured

The reported conclusion is right; two steps of the stated mechanism are not,
and I would rather say so than let them get fixed later as if they were real.

1. **"`serve` never mounts `/api/ws`" is false.** `/api/ws` is a module-level
   `@app.websocket` at `web_server.py:17134`, entirely outside `mount_spa()`.
   I booted `hermes serve` with `HERMES_SERVE_HEADLESS=1` and measured it:
   `/api/ws registered: True`, a connect with the correct session token
   succeeds, and a connect with a wrong token is what raises
   `WebSocketDisconnect`. Forced headless does not touch the WebSocket route or
   its auth.
2. **The `[boot] could not read served dashboard token ... 404` line is not
   fatal.** `dashboard-token.ts:90` catches that 404 and falls back to
   `spawnToken`. It is noise in the log, not the failure.

Which means: I am **not** claiming this PR explains the
`WebSocket (/api/ws) rejected the session token` symptom end to end. It may
well fix @bitcoiners' machine (a desktop that 404s its own renderer is broken
regardless of what the socket does), but the token rejection has a separate
cause that I could not reproduce, and I would rather ship the contradiction
that is proven than fold an unproven causal chain into it. I have posted the
measurements on the issue so whoever picks up the remaining half is not
starting from a mechanism I have already ruled out.

## Related Issue

Fixes #91495

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: new pure `_serve_should_force_headless(headless_backend, env=None)`
  placed beside `_is_electron_packaged_web_dist()`, documenting why both env
  markers are required and why the SSH remote backend must not be exempted.
- `hermes_cli/main.py`: the `if _headless_backend:` gate on the
  `HERMES_SERVE_HEADLESS` write now reads `if _serve_should_force_headless(_headless_backend):`.
  No other behavior in `cmd_dashboard` changes, and the `elif` build branch is
  reached only by callers that were already reaching it.
- `hermes_cli/main.py`: the desktop-exempt branch now POPS an inherited
  `HERMES_SERVE_HEADLESS`. Declining to set it is not enough: the sanitizer's
  own pop is gated on `not _headless_backend` so it never runs on the `serve`
  path, and Electron spawns the backend with `...process.env`, so a value
  exported in the user's shell survives into `mount_spa` and 404s the dist
  anyway. Credit to @Enough1122, who raised this against the equivalent guard
  on #84444.
- `tests/hermes_cli/test_serve_headless_desktop_exemption.py`: new, 10 tests.

## How to Test

1. Reproduce the contradiction without a desktop, straight from the source:
   `hermes_cli/main.py:11287` preserves `HERMES_WEB_DIST` when
   `HERMES_DESKTOP=1`, and on `main` the gate below it disables serving that
   dist unconditionally. On this branch the second rule now respects the first.
2. Run the regression suite: `pytest tests/hermes_cli/test_serve_headless_desktop_exemption.py -q`
   (10 passed).
3. Prove the tests bite, in both directions:
   - Revert the predicate body to `return bool(headless_backend)` (i.e. `main`'s
     behavior): **2 fail**, including `test_desktop_spawned_serve_keeps_its_spa`,
     the #91495 case.
   - Relax it to the `HERMES_DESKTOP` marker alone (what the issue literally
     asks for): **3 fail**, including
     `test_desktop_spawned_remote_backend_stays_headless`, the SSH regression.
   - Drop the `os.environ.pop` from the exempt branch (i.e. exempt passively
     rather than authoritatively): **2 fail**, both in
     `TestTheExemptionIsAuthoritative`.
4. Neighbouring suites: `pytest tests/hermes_cli/test_dashboard_unified_launch.py tests/hermes_cli/test_web_ui_build.py tests/hermes_cli/test_serve_command.py -q`
   gives 33 passed, 3 failed. Those 3 failures
   (`test_profile_launch_reexecs_machine_dashboard`,
   `test_web_build_uses_idle_timeout_helper`,
   `test_contended_lock_without_dist_waits_then_skips_fresh_build`) reproduce
   **identically on a clean checkout of `fcbd1076a9`** with none of this
   applied, so they are pre-existing on Windows and not caused by this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A <!-- the reasoning lives in the new helper's docstring and the call-site comment; no user-facing doc describes the forced-headless rule -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A <!-- N/A: no new config keys; HERMES_DESKTOP and HERMES_WEB_DIST are existing env markers set by the desktop app -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A <!-- N/A -->
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A <!-- the predicate is pure env-var comparison with no path or platform branching, and its tests carry no platform gate, so they run on all three CI platforms; the SSH case above is exactly the cross-platform hazard this guards -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A <!-- N/A -->

## Screenshots / Logs

Measured on this branch, `hermes serve` with `HERMES_SERVE_HEADLESS=1` (i.e.
the standalone path, unchanged by this PR), showing that the SPA gate and the
WebSocket are independent:

```
env pin honoured:            True
GET /                     -> 404 {"error":"Headless backend (hermes serve): web UI disabled ..."}
/api/ws registered:          True
WS with CORRECT token:       OK
WS with WRONG token:         rejected (WebSocketDisconnect)
```

Mutation proof:

```
$ # predicate reverted to `return bool(headless_backend)`  (main's behavior)
FAILED ...::TestServeHeadlessDecision::test_desktop_spawned_serve_keeps_its_spa
FAILED ...::TestServeHeadlessDecision::test_defaults_to_the_process_environment
2 failed, 6 passed

$ # predicate relaxed to the HERMES_DESKTOP marker alone
FAILED ...::TestServeHeadlessDecision::test_desktop_spawned_remote_backend_stays_headless
FAILED ...::TestServeHeadlessDecision::test_an_empty_dist_is_not_a_dist
FAILED ...::TestServeHeadlessDecision::test_defaults_to_the_process_environment
3 failed, 5 passed

$ # exempt branch no longer clears an inherited flag
FAILED ...::TestTheExemptionIsAuthoritative::test_exempt_path_clears_an_inherited_flag
FAILED ...::TestTheExemptionIsAuthoritative::test_clearing_is_scoped_to_the_headless_backend
2 failed, 8 passed
```

`ruff check` clean on both files touched.

## Prior art, disclosed

**#84444 has claimed this fix since 12 Aug** and I did not find it before opening
this PR; #91592 arrived after. I have said so in a comment below with a
comparison table, posted my findings on #84444 directly rather than holding them
here, and I am happy for this PR to be closed in favour of it. The two things I
would not want dropped in a consolidation are the SSH-remote guard and the
inherited-flag pop, since the other patches share both gaps.
