### PR TITLE
fix(kanban): split worker liveness and progress leases

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -521,6 +521,32 @@ def _managed_values(
 _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S = 30.0
 
 
+def _note_verified_tool_progress(
+    tool_name: str | None, result: Any, tool_args: dict[str, Any],
+) -> None:
+    """Record a VERIFIED tool execution as progress on the kanban board.
+
+    Separate from ``agent._touch_activity``, the LIVENESS clock: that one is
+    stamped by stream chunks, API waits and the in-flight ticker above, so a
+    worker reasoning in a loop keeps it fresh forever. Progress is stamped
+    exactly once per tool call, after the call returned, with its observed
+    result — the bridge itself refuses refused/failed/read-only/bookkeeping
+    calls, so "a tool was attempted" never counts and the in-flight ticker
+    deliberately does not feed it.
+
+    Gated on the dispatcher-spawned-worker env var before importing anything,
+    so a normal chat session pays nothing. Best-effort: a bridge failure must
+    never break the agent loop.
+    """
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return
+    try:
+        from tools.kanban_tools import note_tool_progress_from_env
+        note_tool_progress_from_env(tool_name, result, tool_args=tool_args)
+    except Exception:
+        pass
+
+
 def _run_tool_activity_heartbeat(
     agent,
     stop_event: threading.Event,
@@ -709,10 +735,16 @@ def _run_agent_tool_execution_middleware(
         )
         _hb_thread.start()
         try:
-            return execute(final_args)
+            result = execute(final_args)
         finally:
             _hb_stop.set()
             _hb_thread.join(timeout=2.0)
+        # Kanban progress lease: every tool — sequential and concurrent —
+        # funnels through this middleware, and only here is the call known
+        # to have been dispatched (not refused) with an observed result. A
+        # raised tool never reaches this line.
+        _note_verified_tool_progress(function_name, result, final_args)
+        return result
 
     def _hermes_pipeline(relay_args: dict[str, Any]) -> Any:
         request_result = apply_tool_request_middleware(

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -16,6 +16,7 @@ NO_EFFECT_TOOL_NAMES = frozenset({
     "read_file", "search_files", "session_search", "skill_view", "skills_list",
     "web_extract", "web_search", "vision_analyze", "browser_snapshot",
     "browser_get_images", "browser_console", "read_terminal",
+    "kanban_show", "kanban_list", "kanban_attachments",
 })
 
 

--- a/apps/desktop/src/plugins/kanban/completion-notify.test.ts
+++ b/apps/desktop/src/plugins/kanban/completion-notify.test.ts
@@ -451,6 +451,22 @@ describe('terminal kinds beyond completed', () => {
     expect(hostMock.notify.mock.calls[2][0]).toMatchObject({ kind: 'warning', message: 't103' })
   })
 
+  it('no_progress_deferred notifies with a warning toast and the task id (claim held, still running)', async () => {
+    const m = await loadModule()
+    m.bindCompletionNotify(makeRest(() => 100) as never)
+
+    const fired = await m.onKanbanEventsFrame('smoke', [
+      ev(101, 'no_progress_deferred', { progress_age_seconds: 3000, timeout_seconds: 2700 })
+    ])
+
+    expect(fired).toBe(true)
+    expect(lastNotify()).toMatchObject({
+      kind: 'warning',
+      title: 'No observable progress — claim held, worker still running',
+      message: 't101'
+    })
+  })
+
   it('silent kinds (status/archived/unblocked) advance the cursor but never notify', async () => {
     const m = await loadModule()
     m.bindCompletionNotify(makeRest(() => 100) as never)

--- a/apps/desktop/src/plugins/kanban/completion-notify.ts
+++ b/apps/desktop/src/plugins/kanban/completion-notify.ts
@@ -8,7 +8,9 @@
  * mark. Notifies on the same terminal kinds the gateway watcher pings
  * (gateway/kanban_watchers.py): 'completed' (kanban_db.complete_task —
  * payload: summary + artifacts), 'blocked' (payload: reason), 'gave_up'
- * (payload: error), 'crashed', 'timed_out', and 'block_loop_detected'
+ * (payload: error), 'crashed', 'timed_out', 'no_progress_deferred' (the
+ * worker is alive but its progress lease expired; the dispatcher holds the
+ * claim and the task keeps running), and 'block_loop_detected'
  * (payload: reason — the routed-to-triage human handoff).
  *
  * Two delivery doors, complementary by design:
@@ -51,6 +53,7 @@ const TERMINAL_NOTIFY = new Map<string, { titleKey: string; toast: ToastKind }>(
   ['completed', { titleKey: 'notify.completedTitle', toast: 'success' }],
   ['crashed', { titleKey: 'notify.crashedTitle', toast: 'error' }],
   ['gave_up', { titleKey: 'notify.gaveUpTitle', toast: 'error' }],
+  ['no_progress_deferred', { titleKey: 'notify.noProgressDeferredTitle', toast: 'warning' }],
   ['timed_out', { titleKey: 'notify.timedOutTitle', toast: 'warning' }]
 ])
 

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -193,6 +193,7 @@ type KanbanMessages = {
     gaveUpTitle: string
     crashedTitle: string
     timedOutTitle: string
+    noProgressDeferredTitle: string
     openKanban: string
     artifacts: (n: number) => string
   }
@@ -395,6 +396,7 @@ export const en: KanbanMessages = {
     gaveUpTitle: 'Task gave up',
     crashedTitle: 'Worker crashed — will retry',
     timedOutTitle: 'Task timed out — will retry',
+    noProgressDeferredTitle: 'No observable progress — claim held, worker still running',
     openKanban: 'Open Kanban',
     artifacts: (n: number) => `${n} artifacts`
   }
@@ -596,6 +598,7 @@ const ja: KanbanMessages = {
     gaveUpTitle: 'タスクを断念しました',
     crashedTitle: 'ワーカーがクラッシュ — 再試行します',
     timedOutTitle: 'タスクがタイムアウト — 再試行します',
+    noProgressDeferredTitle: '観測可能な進捗なし — クレームを保持、ワーカーは実行中',
     openKanban: 'かんばんを開く',
     artifacts: (n: number) => `成果物 ${n} 件`
   }
@@ -794,6 +797,7 @@ const zh: KanbanMessages = {
     gaveUpTitle: '任务已放弃',
     crashedTitle: '工作单元崩溃 — 将重试',
     timedOutTitle: '任务超时 — 将重试',
+    noProgressDeferredTitle: '无可观测进展 — 保留认领，worker 仍在运行',
     openKanban: '打开看板',
     artifacts: (n: number) => `${n} 个产物`
   }
@@ -992,6 +996,7 @@ const zhHant: KanbanMessages = {
     gaveUpTitle: '任務已放棄',
     crashedTitle: '工作單元當機 — 將重試',
     timedOutTitle: '任務逾時 — 將重試',
+    noProgressDeferredTitle: '無可觀測進展 — 保留認領，worker 仍在執行',
     openKanban: '開啟看板',
     artifacts: (n: number) => `${n} 個產物`
   }

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -314,6 +314,16 @@ model:
 # Disable this only when every review is performed manually from the dashboard.
 kanban:
   review_dispatch: true
+  # Progress lease: report a running task whose worker is alive but has shown
+  # no observable progress for this long. "Progress" means a verified tool
+  # execution or a board state transition — things the worker does, not things
+  # it says. Raw stream tokens and kanban_heartbeat renew liveness only
+  # (whatever the heartbeat's note says), so a slow single model call is
+  # unaffected while a reasoning-only loop is bounded. Detection records a
+  # no_progress_deferred event and holds the claim; it never terminates or
+  # requeues the worker. 0 disables; values under 60 are refused with a warning
+  # and fall back to the default.
+  no_progress_timeout_seconds: 2700
 
 # =============================================================================
 # Terminal Tool Configuration

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -26,6 +26,23 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+def _resolve_no_progress_timeout_seconds(
+    kanban_cfg: dict[str, Any],
+    kb: Any,
+) -> int:
+    """Resolve ``kanban.no_progress_timeout_seconds`` through the DB layer.
+
+    The gateway deliberately owns no validity rules of its own: the DB
+    parser is the single definition of a valid progress bound (bools,
+    non-integers, negatives and sub-minute windows fall back to the default
+    with a WARNING, 0 disables), so a gateway tick cannot drift from a CLI
+    or daemon tick.
+    """
+    return kb.resolve_no_progress_timeout_seconds(
+        kanban_cfg.get("no_progress_timeout_seconds")
+    )
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -239,7 +256,12 @@ class GatewayKanbanWatchersMixin:
         # but is not a block (see kanban_db.request_review); the task is not
         # archived, so the subscription stays alive and later review
         # cycles keep notifying.
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "status", "archived", "unblocked", "block_loop_detected", "review_requested")
+        # ``no_progress_deferred`` is claimed and delivered so a subscriber
+        # learns the worker is alive but idle — but it is NOT a terminal
+        # outcome: the card is still running under a held claim, nothing
+        # was terminated or requeued, so it never wakes the creator (see
+        # _WAKE_KINDS below).
+        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out", "no_progress_deferred", "status", "archived", "unblocked", "block_loop_detected", "review_requested")
         # Subscriptions are removed only when the task reaches the irreversible
         # archived status. ``done`` is reversible in review/controller flows,
         # so removing its subscription would silence a later reopen. We used
@@ -602,6 +624,19 @@ class GatewayKanbanWatchersMixin:
                             msg = (
                                 f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
                                 f"(max_runtime={limit}s); will retry"
+                            )
+                        elif kind == "no_progress_deferred":
+                            _age = _limit = 0
+                            if ev.payload:
+                                try:
+                                    _age = int(ev.payload.get("progress_age_seconds") or 0)
+                                    _limit = int(ev.payload.get("timeout_seconds") or 0)
+                                except (TypeError, ValueError):
+                                    pass
+                            msg = (
+                                f"⏳ {board_tag}{tag}Kanban {sub['task_id']} no observable "
+                                f"progress for {_age}s (limit {_limit}s); claim held, "
+                                f"worker still running"
                             )
                         elif kind == "status":
                             new_status = ""
@@ -1360,6 +1395,20 @@ class GatewayKanbanWatchersMixin:
             )
             stale_timeout_seconds = 0
 
+        # kanban.no_progress_timeout_seconds — the PROGRESS lease bound.
+        # Unlike stale detection this is ON by default: a worker that is
+        # demonstrably alive but produces no verified tool execution and
+        # no board transition renews its claim forever otherwise. The
+        # detector only records a ``no_progress_deferred`` receipt and holds
+        # the claim; it never terminates or requeues. 0 disables.
+        no_progress_timeout_seconds = _resolve_no_progress_timeout_seconds(
+            kanban_cfg, _kb,
+        )
+        logger.info(
+            "kanban dispatcher: no_progress_timeout_seconds=%s",
+            no_progress_timeout_seconds or "disabled",
+        )
+
         # kanban.reconcile_orphans (config.yaml, default true): each tick,
         # requeue 'running' cards whose claim bookkeeping is broken (no
         # valid claim, dead/gone worker) — the zombie-card reconciliation
@@ -1500,6 +1549,7 @@ class GatewayKanbanWatchersMixin:
                     max_in_progress=max_in_progress,
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
+                    no_progress_timeout_seconds=no_progress_timeout_seconds,
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
                     reconcile_orphans=reconcile_orphans,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2690,6 +2690,31 @@ DEFAULT_CONFIG = {
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
+        # No-progress detection (progress lease). A running task whose
+        # worker is alive — streaming, reasoning, heartbeating — but has
+        # produced NO observable progress for this many seconds is reported:
+        # the dispatcher records a durable ``no_progress_deferred`` event
+        # and holds the claim. It does not terminate the worker, requeue
+        # the task or count a failure — the card keeps running and the
+        # existing crash / stale / max-runtime paths and manual reclaim
+        # remain the recovery levers.
+        #
+        # "Progress" is deterministic, never something the model asserts
+        # about itself: a verified tool execution (dispatched, able to
+        # change the task's world, and successful — seen by the tool
+        # middleware), a durable board transition, or the claim itself.
+        # Raw stream tokens, API waits and `kanban_heartbeat` — whatever
+        # its note says — renew LIVENESS (`last_heartbeat_at`) but never
+        # progress, so a slow single model call is untouched while a
+        # reasoning-only loop is bounded.
+        #
+        # Default 45 min: wider than any plausible single model call
+        # (extended thinking and provider backoff included). Set 0 to
+        # disable. Values in 1..59, booleans and unparseable values are
+        # refused (a WARNING is logged and the default is used): a
+        # sub-minute progress bound would flag healthy workers, so it is a
+        # units slip rather than an intent.
+        "no_progress_timeout_seconds": 2700,
         # Orphaned-card reconciliation: each dispatcher tick, requeue
         # 'running' cards whose claim bookkeeping is broken (claim_lock or
         # claim_expires NULL with a dead/gone worker) — zombies invisible

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2643,6 +2643,13 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             _kanban_cfg.get("max_in_progress_per_profile")
         )
         max_in_progress = _coerce_positive_int(_kanban_cfg.get("max_in_progress"))
+        # Progress-lease bound. Same resolution the gateway-embedded
+        # dispatcher and the standalone daemon use (one validated parser:
+        # 0 disables, invalid values fall back to the default), so a tick
+        # behaves identically whichever surface ran it.
+        no_progress_timeout_seconds = kb.resolve_no_progress_timeout_seconds(
+            _kanban_cfg.get("no_progress_timeout_seconds")
+        )
         # Memory-derived default when unset (OOF-30/OOF-77) — same
         # fallback the gateway-embedded dispatcher applies, so behaviour
         # matches regardless of which path runs the tick.
@@ -2658,6 +2665,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         max_in_progress_per_profile = None
         max_in_progress = None
         max_spawn = getattr(args, "max", None)
+        no_progress_timeout_seconds = kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS
     with kb.connect_closing() as conn:
         res = kb.dispatch_once(
             conn,
@@ -2667,6 +2675,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            no_progress_timeout_seconds=no_progress_timeout_seconds,
         )
     if getattr(args, "json", False):
         print(json.dumps({
@@ -2674,6 +2683,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "crashed": res.crashed,
             "timed_out": res.timed_out,
             "stale": res.stale,
+            "no_progress_deferred": res.no_progress_deferred,
             "auto_blocked": res.auto_blocked,
             "promoted": res.promoted,
             "spawned": [
@@ -2699,6 +2709,12 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     print(f"Stale:        {len(res.stale)}")
     if res.stale:
         print(f"  {', '.join(res.stale)}")
+    # Progress-lease expiries are detected and held, never reclaimed here:
+    # the card stays running under its claim. Say so, or a held card reads
+    # as an idle tick.
+    print(f"No progress (deferred): {len(res.no_progress_deferred)}")
+    if res.no_progress_deferred:
+        print(f"  {', '.join(res.no_progress_deferred)}  (claim held, still running)")
     print(f"Auto-blocked: {len(res.auto_blocked)}")
     if res.auto_blocked:
         print(f"  {', '.join(res.auto_blocked)}")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -336,6 +336,7 @@ def _fire_dispatch_tick_hook(
             result.reconciled_orphans,
             result.crashed,
             result.stale,
+            result.no_progress_deferred,
             result.timed_out,
             result.auto_blocked,
             result.rate_limited,
@@ -374,7 +375,158 @@ DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 # bridges chunk-level liveness into ``last_heartbeat_at`` via #31752,
 # so any genuinely active worker keeps its heartbeat fresh as a side
 # effect of normal API traffic.
+#
+# That bridge is exactly why this threshold cannot detect the *no-progress*
+# case: a worker reasoning in a loop is talking to its provider constantly,
+# so its heartbeat never goes stale. Liveness and progress are separate
+# leases — see the progress lease block below.
 DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS = 60 * 60
+
+# ---------------------------------------------------------------------------
+# Progress lease
+# ---------------------------------------------------------------------------
+# A running claim carries two INDEPENDENT leases:
+#
+#   liveness (last_heartbeat_at + claim_expires)
+#       "the worker process and its provider are responsive." Renewed by any
+#       agent activity, raw stream tokens and API waits included. This is
+#       what carries a slow-but-healthy single tool-free model call.
+#
+#   progress (tasks.last_progress_at — the one authoritative column)
+#       "something observable happened OUTSIDE the model's token stream."
+#       Stamped only by deterministic events the model cannot author directly:
+#         * the claim that started the attempt,
+#         * a VERIFIED tool execution seen by the centralized tool middleware
+#           (tools.kanban_tools.note_tool_progress_from_env, driven from
+#           agent/tool_executor.py): dispatched, side-effect-capable, and its
+#           result a success — a refused, failed, read-only or bookkeeping
+#           call is not evidence,
+#         * a durable board state transition (``PROGRESS_EVENT_KINDS``).
+#
+# Text a model writes is NOT one of them. ``kanban_heartbeat(note=...)``
+# renews liveness and records the note as commentary; it never touches this
+# lease, however specific the note sounds, because nothing checks the note
+# against the world. See ``PROGRESS_RENEWAL_SOURCES``.
+#
+# Detection only. ``detect_no_progress_running`` reports an expired progress
+# lease with a durable ``no_progress_deferred`` receipt and holds the claim
+# for a bounded grace. It never signals a process, requeues the card or
+# counts a failure: releasing a claim beside a worker we cannot prove we own
+# is the duplicate-worker bug, and the dispatcher holds no settlement
+# authority over any worker here. Turning a detected expiry into a reclaim
+# is a separate, narrower change layered on this one.
+#
+# Default 45 minutes: comfortably longer than any plausible single tool-free
+# model call (extended thinking and provider backoff included), and short
+# enough to bound a reasoning-only loop. ``kanban.no_progress_timeout_seconds``
+# configures it; 0 disables detection.
+DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS = 45 * 60
+
+# Smallest progress window that can mean what it says. A single model call
+# routinely runs past a minute with nothing else happening, so any value in
+# 1..59 would report healthy workers on the very next tick. In practice such
+# a value is a units slip (45 "minutes" written into a seconds field), not an
+# intent, so it is refused rather than obeyed.
+MIN_NO_PROGRESS_TIMEOUT_SECONDS = 60
+
+# How long a detected no-progress expiry holds the claim, and therefore how
+# often the ``no_progress_deferred`` receipt may be re-issued for the same
+# run while the condition persists. The stale ``last_progress_at`` is left
+# alone on purpose (clearing it would reset the very clock that detected the
+# problem), so the condition re-detects every tick; the receipt is bounded
+# to one per grace window so it stays auditable rather than becoming noise.
+NO_PROGRESS_DEFER_GRACE_SECONDS = 15 * 60
+
+# ``record_progress`` sources. The claim and board transitions stamp the
+# column inline (they already hold the write txn), so the single callable
+# entry point is the tool middleware.
+PROGRESS_SOURCE_TOOL = "tool_invocation"
+
+# The allowlist IS the class boundary, enforced inside ``record_progress``
+# rather than at its call sites, so a future caller cannot re-open a
+# model-authored path by accident. There is deliberately NO source for
+# model-authored text: a deterministic, verified evidence mechanism gets its
+# own source constant here — and its own verification — rather than a string.
+PROGRESS_RENEWAL_SOURCES = frozenset({PROGRESS_SOURCE_TOOL})
+
+# Event kinds that constitute a durable board state transition. Deliberately
+# EXCLUDES lease bookkeeping (``heartbeat``, ``claim_extended``, ``claimed``,
+# ``spawned``) and dispatcher recovery receipts (``reclaimed``, ``stale``,
+# ``timed_out``, ``crashed``, ``reclaim_deferred``, ``no_progress_deferred``)
+# — counting those would make the guard renew itself.
+PROGRESS_EVENT_KINDS = frozenset({
+    "completed",
+    "review_requested",
+    "changes_requested",
+    "review_reopened",
+    "blocked",
+    "unblocked",
+    "commented",
+    "attached",
+    "attachment_removed",
+    "linked",
+    "unlinked",
+    "edited",
+    "decomposed",
+    "specified",
+})
+
+
+def resolve_no_progress_timeout_seconds(
+    value: Any = None,
+    *,
+    default: int = DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS,
+) -> int:
+    """Coerce a ``kanban.no_progress_timeout_seconds`` config value.
+
+    ``None`` / missing -> ``default``. ``0`` is an explicit "disable". Every
+    rejected value falls back to ``default`` rather than to 0: a typo in
+    config.yaml must not silently switch detection off. Each rejection is
+    logged at WARNING so a misconfigured board is visible, not merely ignored.
+
+    Rejected: booleans (``True`` is an ``int`` in Python, so a YAML
+    ``no_progress_timeout_seconds: true`` would otherwise resolve to a
+    one-second bound), anything unparseable, non-finite floats (``.inf`` and
+    ``.nan`` are real YAML scalars; ``int(float("inf"))`` raises
+    ``OverflowError``, which is not a ``ValueError``), negatives, and values
+    in ``1..MIN_NO_PROGRESS_TIMEOUT_SECONDS - 1``.
+
+    Every dispatch entry point (gateway watcher, ``hermes kanban dispatch``,
+    the standalone daemon, the dashboard nudge) resolves through here, so
+    there is exactly one definition of a valid progress bound.
+    """
+    if value is None:
+        return int(default)
+    if isinstance(value, bool):
+        _log.warning(
+            "kanban: no_progress_timeout_seconds=%r is a boolean, not a "
+            "duration; using default %ds", value, default,
+        )
+        return int(default)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError, OverflowError):
+        _log.warning(
+            "kanban: no_progress_timeout_seconds=%r is not a finite integer; "
+            "using default %ds", value, default,
+        )
+        return int(default)
+    if parsed < 0:
+        _log.warning(
+            "kanban: no_progress_timeout_seconds=%d is negative; using "
+            "default %ds", parsed, default,
+        )
+        return int(default)
+    if 0 < parsed < MIN_NO_PROGRESS_TIMEOUT_SECONDS:
+        _log.warning(
+            "kanban: no_progress_timeout_seconds=%ds is below the %ds "
+            "minimum — a single model call routinely takes longer (did you "
+            "mean minutes?); using default %ds",
+            parsed, MIN_NO_PROGRESS_TIMEOUT_SECONDS, default,
+        )
+        return int(default)
+    return parsed
+
 
 # Grace added to a claim when a reclaim is deferred because the previous
 # host-local worker is still alive after a termination attempt. Releasing the
@@ -1085,7 +1237,12 @@ class Task:
     # just spawn). Pre-rename column: ``last_spawn_error``.
     last_failure_error: Optional[str] = None
     max_runtime_seconds: Optional[int] = None
+    # Liveness lease — "process/provider responsive". Bumped by ordinary API
+    # traffic (stream chunks included) via the runtime-activity bridge.
     last_heartbeat_at: Optional[int] = None
+    # Progress lease — "something observable happened outside the token
+    # stream". See ``PROGRESS_EVENT_KINDS`` / :func:`record_progress`.
+    last_progress_at: Optional[int] = None
     current_run_id: Optional[int] = None
     workflow_template_id: Optional[str] = None
     current_step_key: Optional[str] = None
@@ -1193,6 +1350,9 @@ class Task:
             ),
             last_heartbeat_at=(
                 row["last_heartbeat_at"] if "last_heartbeat_at" in keys else None
+            ),
+            last_progress_at=(
+                row["last_progress_at"] if "last_progress_at" in keys else None
             ),
             current_run_id=(
                 row["current_run_id"] if "current_run_id" in keys else None
@@ -1363,6 +1523,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     last_failure_error   TEXT,
     max_runtime_seconds  INTEGER,
     last_heartbeat_at    INTEGER,
+    -- Progress lease: last time something observable happened outside the
+    -- worker's token stream — the claim, a verified tool execution, or a
+    -- durable board transition (PROGRESS_EVENT_KINDS). Independent of the
+    -- liveness lease above; NULL on rows that predate it (readers fall back
+    -- to the active run's started_at). The one authoritative column.
+    last_progress_at     INTEGER,
     -- Pointer into task_runs for the currently-active run (NULL if no
     -- run is in-flight). Denormalised for cheap reads.
     current_run_id       INTEGER,
@@ -2597,6 +2763,16 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     if "last_heartbeat_at" not in cols:
         _add_column_if_missing(
             conn, "tasks", "last_heartbeat_at", "last_heartbeat_at INTEGER"
+        )
+    if "last_progress_at" not in cols:
+        # Progress lease (see SCHEMA_SQL). Existing rows get NULL rather than
+        # ``now``: backfilling a timestamp would hand every in-flight worker
+        # a lease it never earned, including one already wedged in a
+        # reasoning loop at upgrade time. Readers COALESCE NULL to the active
+        # run's ``started_at``, so a legitimately-running pre-upgrade worker
+        # is measured from when its attempt began.
+        _add_column_if_missing(
+            conn, "tasks", "last_progress_at", "last_progress_at INTEGER"
         )
     if "current_run_id" not in cols:
         _add_column_if_missing(
@@ -4319,6 +4495,108 @@ def _append_event(
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
     )
+    # A durable board transition IS progress evidence, whichever surface
+    # produced it (worker tool, CLI, dashboard). Routing it through the one
+    # funnel every transition already passes keeps the rule in a single
+    # place instead of sprinkled across a dozen mutators. Lease bookkeeping
+    # and dispatcher recovery receipts are excluded — see PROGRESS_EVENT_KINDS.
+    if kind in PROGRESS_EVENT_KINDS:
+        _stamp_progress(conn, task_id, now)
+
+
+def _stamp_progress(conn: sqlite3.Connection, task_id: str, now: int) -> None:
+    """Write ``tasks.last_progress_at``. Caller holds the write transaction.
+
+    Tolerates only a missing column: a state transition on a board that
+    somehow predates the additive migration must not be taken down by its
+    progress lease. Any other error is the caller's transaction to handle.
+    """
+    try:
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = ? WHERE id = ?",
+            (now, task_id),
+        )
+    except sqlite3.OperationalError as exc:
+        if "no such column" not in str(exc):
+            raise
+        _log.debug(
+            "kanban: progress lease column missing on this board; skipping "
+            "stamp for %s", task_id,
+        )
+
+
+def record_progress(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    source: Any,
+    expected_run_id: Optional[int] = None,
+    claim_lock: Optional[str] = None,
+) -> dict[str, Any]:
+    """Renew the PROGRESS lease for ``task_id`` and return a receipt.
+
+    ``source`` must be in :data:`PROGRESS_RENEWAL_SOURCES`; anything else is
+    refused with ``reason="unsupported_source"`` and writes nothing —
+    including values that are not even hashable, which would otherwise make
+    the frozenset membership test raise instead of refuse. That check is the
+    class boundary and lives here rather than at the call sites. There is no
+    ``note`` parameter: free text a model writes is commentary and must not
+    be able to move a lease, because nothing validates it against the world.
+
+    Only a running task can make progress, and only the attempt that owns
+    it: ``expected_run_id`` must match the task's active run and
+    ``claim_lock`` (when given) its claim, so a worker whose run was reclaimed
+    or whose claim was taken over cannot resurrect the lease of whatever
+    replaced it.
+
+    Progress stamps a column and never appends an event — a tool call every
+    few seconds for hours would otherwise bloat ``task_events``. Board
+    transitions are the durable record and stamp inline from
+    :func:`_append_event`. Never raises on a normal miss; the receipt
+    (``recorded``, ``reason``, ``source``, ``run_id``, ``last_progress_at``)
+    is advisory.
+    """
+    now = int(time.time())
+    receipt: dict[str, Any] = {
+        "recorded": False,
+        "reason": "not_running",
+        "source": source,
+        "run_id": None,
+        "last_progress_at": None,
+    }
+    try:
+        supported = source in PROGRESS_RENEWAL_SOURCES
+    except TypeError:
+        # An unhashable source is by definition not on the allowlist.
+        supported = False
+    if not supported:
+        receipt["reason"] = "unsupported_source"
+        return receipt
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, current_run_id, claim_lock FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None or row["status"] != "running":
+            return receipt
+        if expected_run_id is None or not claim_lock:
+            receipt["reason"] = "authority_required"
+            return receipt
+        run_id = row["current_run_id"]
+        if expected_run_id is not None and (
+            run_id is None or int(run_id) != int(expected_run_id)
+        ):
+            receipt["reason"] = "superseded"
+            return receipt
+        if claim_lock is not None and row["claim_lock"] != claim_lock:
+            receipt["reason"] = "claim_mismatch"
+            return receipt
+        receipt["run_id"] = int(run_id) if run_id is not None else None
+        _stamp_progress(conn, task_id, now)
+        receipt["recorded"] = True
+        receipt["reason"] = "recorded"
+        receipt["last_progress_at"] = now
+    return receipt
 
 
 def _end_run(
@@ -4678,15 +4956,19 @@ def claim_task(
         cur = conn.execute(
             """
             UPDATE tasks
-               SET status        = 'running',
-                   claim_lock    = ?,
-                   claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
+               SET status           = 'running',
+                   claim_lock       = ?,
+                   claim_expires    = ?,
+                   started_at       = COALESCE(started_at, ?),
+                   -- The claim itself is a state transition: the attempt
+                   -- starts with a fresh progress lease, so a worker gets
+                   -- the full no-progress window to do something.
+                   last_progress_at = ?
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, now, now, task_id),
         )
         if cur.rowcount != 1:
             return None
@@ -4778,15 +5060,18 @@ def claim_review_task(
         cur = conn.execute(
             """
             UPDATE tasks
-               SET status        = 'running',
-                   claim_lock    = ?,
-                   claim_expires = ?,
-                   started_at    = COALESCE(started_at, ?)
+               SET status           = 'running',
+                   claim_lock       = ?,
+                   claim_expires    = ?,
+                   started_at       = COALESCE(started_at, ?),
+                   -- Same as claim_task: a review attempt starts with a
+                   -- fresh progress lease.
+                   last_progress_at = ?
              WHERE id = ?
                AND status = 'review'
                AND claim_lock IS NULL
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, now, now, task_id),
         )
         if cur.rowcount != 1:
             return None
@@ -8058,6 +8343,14 @@ class DispatchResult:
     stale: list[str] = field(default_factory=list)
     """Task ids reclaimed because no progress (heartbeat) was seen
     within ``dispatch_stale_timeout_seconds``."""
+    no_progress_deferred: list[str] = field(default_factory=list)
+    """Task ids whose PROGRESS lease expired this tick — no verified tool
+    execution and no board transition within
+    ``kanban.no_progress_timeout_seconds`` — and were reported with a
+    durable ``no_progress_deferred`` receipt. The card keeps its status,
+    claim, PID and run and nothing is signalled, requeued or counted as a
+    failure; the claim is held for ``NO_PROGRESS_DEFER_GRACE_SECONDS``. See
+    :func:`detect_no_progress_running`."""
     respawn_guarded: list[tuple[str, str]] = field(default_factory=list)
     """Tasks skipped by the respawn guard, as ``(task_id, reason)`` pairs.
 
@@ -8675,6 +8968,185 @@ def detect_stale_running(
         # spawn_failed / timed_out / crashed counters.
 
     return reclaimed
+
+
+# Liveness classification carried on the no-progress receipt, so an operator
+# can tell whether the worker was chattering with its provider the whole time
+# (a reasoning loop: ``fresh``) or had gone quiet as well (``stale``). Matches
+# the liveness backstop used by ``release_stale_claims`` so the two agree.
+_NO_PROGRESS_LIVENESS_FRESH_SECONDS = DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
+
+
+def detect_no_progress_running(
+    conn: sqlite3.Connection,
+    *,
+    no_progress_timeout_seconds: int = DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS,
+) -> list[str]:
+    """Report ``running`` tasks whose PROGRESS lease expired. Detection only.
+
+    ``release_stale_claims`` and ``detect_stale_running`` both key off
+    ``last_heartbeat_at``, which the runtime-activity bridge keeps fresh from
+    raw stream tokens — so a worker that reasoned for thousands of tokens
+    with zero tool calls and zero board transitions renewed its claim
+    forever. This pass keys off ``tasks.last_progress_at`` instead.
+
+    A task is a candidate when ``now - COALESCE(tasks.last_progress_at,
+    run.started_at, tasks.started_at)`` exceeds the timeout. The COALESCE is
+    the migration path: a run claimed before the progress lease existed is
+    measured from when its attempt began, never treated as infinitely stale.
+
+    Classification, not overlap. This runs after the crash, stale and
+    max-runtime passes in a dispatcher tick and skips a host-local task whose
+    PID is already gone: that is a *dead* worker and ``detect_crashed_workers``
+    owns it (it carries exit-code forensics this pass cannot see).
+
+    For each expiry this pass emits a durable ``no_progress_deferred`` event
+    and holds the claim for :data:`NO_PROGRESS_DEFER_GRACE_SECONDS` — and
+    does nothing else. Status, claim lock, worker pid, the active run and the
+    failure counter are left exactly as they were; no signal is sent and the
+    card is never requeued. The dispatcher holds no settlement authority over
+    any worker here — missing, custom-spawned, remote or otherwise — so every
+    expiry is the same safe-defer case, not an error. Releasing a claim beside
+    a worker we cannot prove we own is the duplicate-worker bug this refuses
+    to reintroduce; the settling path is a separate, narrower change.
+
+    The stale ``last_progress_at`` is deliberately left alone (clearing it
+    would reset the clock that detected the problem), so the condition
+    re-detects every tick; the receipt is re-issued at most once per grace
+    window per run, which keeps the hold bounded and auditable. The task id
+    is returned only on the ticks a receipt was written.
+
+    ``no_progress_timeout_seconds <= 0`` disables the pass entirely.
+    """
+    if no_progress_timeout_seconds <= 0:
+        return []
+
+    now = int(time.time())
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    deferred: list[str] = []
+
+    rows = conn.execute(
+        "SELECT t.id, t.worker_pid, t.claim_lock, t.claim_expires, "
+        "       t.current_run_id, t.last_heartbeat_at, t.last_progress_at, "
+        "       COALESCE(t.last_progress_at, r.started_at, t.started_at) "
+        "           AS progress_at "
+        "FROM tasks t "
+        "LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.status = 'running'"
+    ).fetchall()
+
+    for row in rows:
+        if (
+            row["progress_at"] is None
+            or row["claim_lock"] is None
+            or row["claim_expires"] is None
+        ):
+            # Broken claim bookkeeping — reconcile_orphaned_running owns it.
+            # Holding such a row would invent a ``claim_expires`` where
+            # there was none and hand it to the TTL path later, beside a
+            # possibly-live process.
+            continue
+        progress_age = now - int(row["progress_at"])
+        if progress_age <= no_progress_timeout_seconds:
+            continue
+
+        tid = row["id"]
+        lock = row["claim_lock"]
+        pid = row["worker_pid"]
+        host_local = lock.startswith(host_prefix)
+        if host_local and pid and not _pid_alive(pid):
+            # Dead, not wedged. Leave the forensics to the crash path.
+            continue
+
+        run_id = row["current_run_id"]
+        # Bounded receipt: one per grace window per run. The window is read
+        # from the durable event log, so it survives restarts and is shared
+        # by every dispatcher that can tick this board.
+        recent = conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? AND kind = 'no_progress_deferred' "
+            "  AND run_id IS ? AND created_at > ? LIMIT 1",
+            (tid, run_id, now - NO_PROGRESS_DEFER_GRACE_SECONDS),
+        ).fetchone()
+        if recent is not None:
+            continue
+
+        last_hb = row["last_heartbeat_at"]
+        hb_age = (now - int(last_hb)) if last_hb is not None else None
+        if hb_age is None:
+            liveness = "never"
+        elif hb_age <= _NO_PROGRESS_LIVENESS_FRESH_SECONDS:
+            liveness = "fresh"
+        else:
+            liveness = "stale"
+
+        hold_until = now + NO_PROGRESS_DEFER_GRACE_SECONDS
+        with write_txn(conn):
+            # Hold the claim for the grace: a floor, never a reset, so a live
+            # worker's own renewals are not brought forward. CAS on the
+            # claim and run we classified so a concurrent transition wins.
+            cur = conn.execute(
+                "UPDATE tasks "
+                "   SET claim_expires = MAX(COALESCE(claim_expires, 0), ?) "
+                " WHERE id = ? AND status = 'running' "
+                "   AND claim_lock IS ? AND current_run_id IS ?",
+                (hold_until, tid, row["claim_lock"], run_id),
+            )
+            if cur.rowcount != 1:
+                continue
+            if run_id is not None:
+                conn.execute(
+                    "UPDATE task_runs "
+                    "   SET claim_expires = MAX(COALESCE(claim_expires, 0), ?) "
+                    " WHERE id = ?",
+                    (hold_until, int(run_id)),
+                )
+            claim_expires_now = conn.execute(
+                "SELECT claim_expires FROM tasks WHERE id = ?", (tid,),
+            ).fetchone()["claim_expires"]
+            _append_event(
+                conn, tid, "no_progress_deferred",
+                {
+                    "classification": "no_progress",
+                    # This dispatcher holds no settlement authority over
+                    # any worker; every expiry is the safe-defer case.
+                    "reason": "authority_unavailable",
+                    "progress_age_seconds": int(progress_age),
+                    "timeout_seconds": int(no_progress_timeout_seconds),
+                    "last_progress_at": (
+                        int(row["last_progress_at"])
+                        if row["last_progress_at"] is not None else None
+                    ),
+                    "last_heartbeat_at": (
+                        int(last_hb) if last_hb is not None else None
+                    ),
+                    "heartbeat_age_seconds": (
+                        int(hb_age) if hb_age is not None else None
+                    ),
+                    "liveness": liveness,
+                    "worker_pid": int(pid) if pid else None,
+                    "claim_lock": row["claim_lock"],
+                    "host_local": host_local,
+                    "claim_expires_was": (
+                        int(row["claim_expires"])
+                        if row["claim_expires"] is not None else None
+                    ),
+                    "claim_expires_now": int(claim_expires_now),
+                    "grace_seconds": NO_PROGRESS_DEFER_GRACE_SECONDS,
+                },
+                run_id=run_id,
+            )
+            deferred.append(tid)
+        _log.warning(
+            "kanban: task %s has shown no observable progress for %ss "
+            "(limit %ss; liveness %s); holding the claim for %ss and "
+            "deferring — no settlement authority, nothing signalled or "
+            "requeued",
+            tid, int(progress_age), int(no_progress_timeout_seconds),
+            liveness, NO_PROGRESS_DEFER_GRACE_SECONDS,
+        )
+
+    return deferred
 
 
 def reconcile_orphaned_running(
@@ -9694,6 +10166,21 @@ def resolve_max_in_progress(configured: Optional[int]) -> Optional[int]:
     return derive_default_max_in_progress()
 
 
+def configured_kanban_setting(key: str) -> Any:
+    """Read one raw ``kanban.<key>`` value from config.yaml, or None.
+
+    Shared by the dispatch entry points that do not already hold a loaded
+    config (the standalone daemon, the dashboard nudge). Fails open: an
+    unreadable config must not take down a dispatcher tick, it just falls
+    back to the caller's default.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        return (load_config_readonly() or {}).get("kanban", {}).get(key)
+    except Exception:
+        return None
+
+
 def configured_max_in_progress() -> Optional[int]:
     """Read ``kanban.max_in_progress`` from config, or None when unset/invalid.
 
@@ -9815,6 +10302,7 @@ def dispatch_once(
     max_in_progress: Optional[int] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stale_timeout_seconds: int = 0,
+    no_progress_timeout_seconds: int = DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS,
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
@@ -9850,6 +10338,7 @@ def dispatch_once(
             max_in_progress=max_in_progress,
             failure_limit=failure_limit,
             stale_timeout_seconds=stale_timeout_seconds,
+            no_progress_timeout_seconds=no_progress_timeout_seconds,
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
@@ -9870,6 +10359,7 @@ def dispatch_once(
                 max_in_progress=max_in_progress,
                 failure_limit=failure_limit,
                 stale_timeout_seconds=stale_timeout_seconds,
+                no_progress_timeout_seconds=no_progress_timeout_seconds,
                 board=board,
                 default_assignee=default_assignee,
                 max_in_progress_per_profile=max_in_progress_per_profile,
@@ -9897,6 +10387,7 @@ def _dispatch_once_locked(
     max_in_progress: Optional[int] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stale_timeout_seconds: int = 0,
+    no_progress_timeout_seconds: int = DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS,
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
@@ -9908,6 +10399,10 @@ def _dispatch_once_locked(
       1. Reclaim stale running tasks (TTL expired).
       2. Reclaim stale running tasks (no recent heartbeat).
       3. Reclaim crashed running tasks (host-local PID no longer alive).
+      3b. Report running tasks whose PROGRESS lease expired (after the
+          crash / stale / max-runtime passes; detection only, see
+          ``detect_no_progress_running`` — bounded by
+          ``no_progress_timeout_seconds``, 0 disables).
       3. Promote todo -> ready where all parents are done.
       4. For each ready task with an assignee, atomically claim and call
          ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
@@ -9969,6 +10464,14 @@ def _dispatch_once_locked(
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
+    # Progress-lease detection runs AFTER every settling pass above so each
+    # recovery path keeps its own case: a dead pid is a crash, an absent
+    # heartbeat is stale, a blown runtime cap is timed_out. What is left is
+    # a worker that is alive-or-remote and has produced nothing observable.
+    # This pass only records and holds; it never signals or requeues.
+    result.no_progress_deferred = detect_no_progress_running(
+        conn, no_progress_timeout_seconds=no_progress_timeout_seconds,
+    )
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
     # Count tasks already running so max_spawn enforces concurrency rather
@@ -10978,12 +11481,20 @@ def run_daemon(
             max_in_progress = resolve_max_in_progress(
                 configured_max_in_progress()
             )
+            # Same for the progress-lease bound: the standalone daemon must
+            # honour kanban.no_progress_timeout_seconds exactly like the
+            # gateway and the CLI, or the systemd deployment would be the
+            # one surface where the lease is measured differently.
+            no_progress_timeout_seconds = resolve_no_progress_timeout_seconds(
+                configured_kanban_setting("no_progress_timeout_seconds")
+            )
             with contextlib.closing(connect()) as conn:
                 res = dispatch_once(
                     conn,
                     max_spawn=max_spawn,
                     max_in_progress=max_in_progress,
                     failure_limit=failure_limit,
+                    no_progress_timeout_seconds=no_progress_timeout_seconds,
                 )
             if on_tick is not None:
                 try:

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -1078,6 +1078,76 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     )]
 
 
+def _rule_no_progress_deferred(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """The dispatcher reported this running attempt's PROGRESS lease as
+    expired (``no_progress_deferred``): the worker was alive — streaming,
+    reasoning, heartbeating — but produced no verified tool execution and
+    no board transition for ``kanban.no_progress_timeout_seconds``. The
+    dispatcher holds the claim and does nothing else, so without this
+    surface the card simply looks busy.
+
+    Scoped to the CURRENT attempt: receipts for a previous run (a retried
+    card) are history, and a receipt that predates the attempt's latest
+    progress (``tasks.last_progress_at``) has been superseded by real work.
+    """
+    if _task_field(task, "status") != "running":
+        return []
+    run_id = _task_field(task, "current_run_id")
+    if run_id is None:
+        return []
+    receipts = [
+        ev for ev in events
+        if _event_kind(ev) == "no_progress_deferred"
+        and _task_field(ev, "run_id") == run_id
+    ]
+    if not receipts:
+        return []
+    latest = receipts[-1]
+    last_progress = _task_field(task, "last_progress_at")
+    if last_progress is not None and int(last_progress) >= _event_ts(latest):
+        return []
+    payload = _parse_payload(latest)
+    age = _positive_int(payload.get("progress_age_seconds"), 0)
+    limit = _positive_int(payload.get("timeout_seconds"), 0)
+    liveness = str(payload.get("liveness") or "unknown")
+    task_id = _task_field(task, "id")
+    actions: list[DiagnosticAction] = []
+    if task_id:
+        actions.append(DiagnosticAction(
+            kind="cli_hint",
+            label=f"Check logs: hermes kanban log {task_id}",
+            payload={"command": f"hermes kanban log {task_id}"},
+            suggested=True,
+        ))
+    actions.extend(_generic_recovery_actions(task, running=True))
+    return [Diagnostic(
+        kind="no_progress_deferred",
+        severity="warning",
+        title=(
+            f"No observable progress for {age}s (limit {limit}s) — claim held"
+        ),
+        detail=(
+            f"The worker's liveness heartbeat is {liveness}, but no verified "
+            f"tool execution and no board transition has renewed its progress "
+            f"lease within kanban.no_progress_timeout_seconds ({limit}s). The "
+            f"dispatcher recorded the condition and is holding the claim; it "
+            f"has not terminated or requeued the worker. Check the worker log "
+            f"for a reasoning loop, steer it with a comment, or reclaim it."
+        ),
+        actions=actions,
+        first_seen_at=_event_ts(receipts[0]),
+        last_seen_at=_event_ts(latest),
+        count=len(receipts),
+        run_id=int(run_id),
+        data={
+            "progress_age_seconds": age,
+            "timeout_seconds": limit,
+            "liveness": liveness,
+            "receipts": len(receipts),
+        },
+    )]
+
+
 # Registry — order matters: rules higher on the list render first when
 # severity ties. Add new rules here.
 _RULES: list[RuleFn] = [
@@ -1090,6 +1160,7 @@ _RULES: list[RuleFn] = [
     _rule_stuck_in_blocked,
     _rule_block_unblock_cycling,
     _rule_stranded_in_ready,
+    _rule_no_progress_deferred,
 ]
 
 
@@ -1105,6 +1176,7 @@ DIAGNOSTIC_KINDS = (
     "stuck_in_blocked",
     "block_unblock_cycling",
     "stranded_in_ready",
+    "no_progress_deferred",
 )
 
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -344,10 +344,14 @@ VALID_HOOKS: Set[str] = {
     # Kwargs: board: str | None, profile_name: str, dry_run: bool,
     #   outcome: "ok" | "skipped_locked" | "idle",
     #   result: hermes_cli.kanban_db.DispatchResult (spawned, reclaimed,
-    #     promoted, reconciled_orphans, crashed, stale, timed_out,
-    #     auto_blocked, rate_limited, auto_assigned_default,
+    #     promoted, reconciled_orphans, crashed, stale, no_progress_deferred,
+    #     timed_out, auto_blocked, rate_limited, auto_assigned_default,
     #     respawn_guarded, skipped_per_profile_capped, skipped_unassigned,
-    #     skipped_nonspawnable, skipped_locked).
+    #     skipped_nonspawnable, skipped_locked). ``no_progress_deferred``
+    #     carries the running tasks whose progress lease expired this tick
+    #     and were reported with a ``no_progress_deferred`` receipt while
+    #     keeping their claim (see kanban_db.detect_no_progress_running);
+    #     a tick whose only action was such a receipt reports outcome="ok".
     #   Privacy: result carries task ids, assignees, and workspace paths.
     "on_kanban_dispatch_tick",
     # Gateway platform-boundary observer hooks (#64176). Observer-only; each

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2289,6 +2289,15 @@ def dispatch(
     try:
         result = kanban_db.dispatch_once(
             conn, dry_run=dry_run, max_spawn=max_n, board=board,
+            # Same progress bound the gateway/CLI/daemon ticks resolve, so a
+            # dashboard nudge cannot behave differently from a scheduled tick.
+            no_progress_timeout_seconds=(
+                kanban_db.resolve_no_progress_timeout_seconds(
+                    kanban_db.configured_kanban_setting(
+                        "no_progress_timeout_seconds"
+                    )
+                )
+            ),
         )
         # DispatchResult is a dataclass.
         try:

--- a/tests/agent/test_tool_result_classification.py
+++ b/tests/agent/test_tool_result_classification.py
@@ -29,3 +29,6 @@ def test_side_effect_classification_keeps_session_mutations():
     assert tool_may_have_side_effect("mcp_unknown") is True
     assert tool_may_have_side_effect("read_file") is False
     assert tool_may_have_side_effect("web_search") is False
+    assert tool_may_have_side_effect("kanban_show") is False
+    assert tool_may_have_side_effect("kanban_list") is False
+    assert tool_may_have_side_effect("kanban_attachments") is False

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -26,3 +26,60 @@ def test_mixin_defines_kanban_methods():
         assert hasattr(GatewayKanbanWatchersMixin, m), f"mixin missing {m}"
 
 
+
+
+def test_gateway_resolves_no_progress_timeout_through_the_db_parser():
+    """The gateway deliberately owns no validity rules of its own — the DB
+    layer is the single definition of a valid progress bound. Drive the real
+    ``kanban_db`` parser and assert exact resolved values for every branch so
+    a drifting second copy (or a swallowed fallback) cannot hide here."""
+    from gateway.kanban_watchers import _resolve_no_progress_timeout_seconds
+    from hermes_cli import kanban_db as real_kb
+
+    default = real_kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS
+    assert default == 45 * 60
+    cases = [
+        ({}, default),                                        # unset
+        ({"no_progress_timeout_seconds": None}, default),     # explicit null
+        ({"no_progress_timeout_seconds": 0}, 0),              # disabled
+        ({"no_progress_timeout_seconds": 60}, 60),            # the minimum
+        ({"no_progress_timeout_seconds": 3600}, 3600),        # ordinary
+        ({"no_progress_timeout_seconds": "600"}, 600),        # YAML string
+        ({"no_progress_timeout_seconds": True}, default),     # bool is not 1s
+        ({"no_progress_timeout_seconds": False}, default),
+        ({"no_progress_timeout_seconds": 45}, default),       # units slip
+        ({"no_progress_timeout_seconds": 59}, default),
+        ({"no_progress_timeout_seconds": -1}, default),
+        ({"no_progress_timeout_seconds": "abc"}, default),
+        ({"no_progress_timeout_seconds": []}, default),
+        ({"no_progress_timeout_seconds": float("inf")}, default),
+        ({"no_progress_timeout_seconds": float("nan")}, default),
+    ]
+    for cfg, expected in cases:
+        assert _resolve_no_progress_timeout_seconds(cfg, real_kb) == expected, cfg
+
+
+def test_gateway_dispatcher_passes_the_no_progress_timeout_to_every_tick():
+    """Source-level contract for the watcher loop: the resolved bound is
+    threaded into ``dispatch_once`` so a gateway tick cannot behave
+    differently from a CLI or daemon tick."""
+    from gateway import kanban_watchers
+
+    src = inspect.getsource(kanban_watchers.GatewayKanbanWatchersMixin._kanban_dispatcher_watcher)
+    assert "_resolve_no_progress_timeout_seconds(" in src
+    assert "no_progress_timeout_seconds=no_progress_timeout_seconds" in src
+
+
+def test_no_progress_deferred_is_delivered_but_never_wakes_the_creator():
+    """A deferred receipt must reach subscribers (dropping it would let a
+    held card look healthy), but the task is still running, so it is not a
+    terminal outcome and must not synthesise a creator turn the way
+    ``crashed`` / ``timed_out`` do."""
+    from gateway import kanban_watchers
+
+    src = inspect.getsource(kanban_watchers.GatewayKanbanWatchersMixin._kanban_notifier_watcher)
+    terminal = next(line for line in src.splitlines() if "TERMINAL_KINDS = (" in line)
+    wake = next(line for line in src.splitlines() if "_WAKE_KINDS = (" in line)
+    assert '"no_progress_deferred"' in terminal
+    assert '"no_progress_deferred"' not in wake
+    assert 'kind == "no_progress_deferred"' in src

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -94,3 +94,84 @@ def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypat
     )
 
 
+@pytest.mark.parametrize(
+    "configured, expected_key",
+    [
+        (600, 600),
+        (0, 0),
+        ("banana", "default"),
+        (True, "default"),
+        (45, "default"),
+    ],
+)
+def test_cli_dispatch_passes_the_resolved_no_progress_timeout(
+    isolated_kanban_home, monkeypatch, configured, expected_key,
+):
+    """``hermes kanban dispatch`` must resolve ``kanban.no_progress_timeout_seconds``
+    through the same validated parser the gateway and daemon use: zero
+    disables, invalid values fall back to the default (never to 0)."""
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"no_progress_timeout_seconds": configured}},
+    )
+    captured = {}
+    monkeypatch.setattr(
+        kanban_db, "dispatch_once",
+        lambda conn, **kw: (captured.update(kw), kanban_db.DispatchResult())[1],
+    )
+    args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=False)
+    kb_cli._cmd_dispatch(args)
+
+    expected = (
+        kanban_db.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS
+        if expected_key == "default" else expected_key
+    )
+    assert captured.get("no_progress_timeout_seconds") == expected
+
+
+def test_cli_dispatch_without_config_uses_the_same_default(isolated_kanban_home, monkeypatch):
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+    captured = {}
+    monkeypatch.setattr(
+        kanban_db, "dispatch_once",
+        lambda conn, **kw: (captured.update(kw), kanban_db.DispatchResult())[1],
+    )
+    kb_cli._cmd_dispatch(argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=False))
+    assert captured.get("no_progress_timeout_seconds") == (
+        kanban_db.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS
+    )
+
+
+def test_cli_dispatch_reports_deferred_no_progress_in_json_and_text(
+    isolated_kanban_home, monkeypatch, capsys,
+):
+    """The detected/deferred outcome must reach the operator on both output
+    shapes; dropping it would make a held card look like an idle tick."""
+    import json as _json
+
+    from hermes_cli import kanban as kb_cli
+    from hermes_cli import kanban_db
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"kanban": {}})
+    monkeypatch.setattr(
+        kanban_db, "dispatch_once",
+        lambda conn, **kw: kanban_db.DispatchResult(no_progress_deferred=["t_held"]),
+    )
+
+    kb_cli._cmd_dispatch(argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=True))
+    payload = _json.loads(capsys.readouterr().out)
+    assert payload["no_progress_deferred"] == ["t_held"]
+
+    kb_cli._cmd_dispatch(argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=False))
+    text = capsys.readouterr().out
+    assert "No progress (deferred): 1" in text
+    assert "t_held" in text

--- a/tests/hermes_cli/test_kanban_progress_lease.py
+++ b/tests/hermes_cli/test_kanban_progress_lease.py
@@ -1,0 +1,1127 @@
+"""Progress lease vs liveness lease on the Kanban board (commit A: detection).
+
+A dispatcher-spawned worker could hold its claim forever while doing nothing:
+``AIAgent._touch_activity`` fires on every stream chunk and API wait, and the
+runtime bridge renews ``tasks.last_heartbeat_at`` + ``claim_expires`` from it.
+Every watchdog keyed off that one clock, so a worker reasoning in a loop with
+zero tool calls and zero board transitions renewed its own lease indefinitely.
+
+The fix splits the claim into two independent leases:
+
+* **liveness** (``last_heartbeat_at`` + ``claim_expires``) — "the process and
+  its provider are responsive". Renewed by any agent activity, stream tokens
+  included. Unchanged.
+* **progress** (``tasks.last_progress_at``, one authoritative column) —
+  "something observable happened outside the model's token stream". Stamped
+  by the claim, by a *verified* tool execution seen by the tool middleware,
+  and by durable board transitions (``PROGRESS_EVENT_KINDS``). Never by
+  model-authored text, ``kanban_heartbeat`` notes included.
+
+This commit only DETECTS an expired progress lease. ``detect_no_progress_running``
+records a durable ``no_progress_deferred`` receipt, holds the claim for a
+bounded grace and leaves status / claim / PID / run / failure accounting
+exactly as they were. It never signals, requeues or counts a failure: the
+authority to do that is a separate, later change. These tests pin that
+boundary as hard as they pin the lease split.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _host() -> str:
+    return kb._claimer_id().split(":", 1)[0]
+
+
+def _running_task(conn, *, title="t", assignee="a", pid=4242, claimer=None):
+    """Create + claim a task on this host, with a worker pid recorded."""
+    tid = kb.create_task(conn, title=title, assignee=assignee)
+    kb.claim_task(conn, tid, claimer=claimer or f"{_host()}:worker")
+    if pid is not None:
+        kb._set_worker_pid(conn, tid, pid)
+    return tid
+
+
+def _cols(conn, table):
+    return {r["name"] for r in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _row(conn, tid):
+    return conn.execute("SELECT * FROM tasks WHERE id = ?", (tid,)).fetchone()
+
+
+def _run_row(conn, tid):
+    return conn.execute(
+        "SELECT r.* FROM task_runs r JOIN tasks t ON t.current_run_id = r.id "
+        "WHERE t.id = ?",
+        (tid,),
+    ).fetchone()
+
+
+def _events(conn, tid, kind):
+    return [
+        json.loads(r["payload"]) if r["payload"] else {}
+        for r in conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = ? "
+            "ORDER BY id",
+            (tid, kind),
+        )
+    ]
+
+
+def _age_progress(conn, tid, seconds, *, heartbeat_age=0):
+    """Fresh liveness, stale progress: the reasoning-loop shape."""
+    now = int(time.time())
+    conn.execute(
+        "UPDATE tasks SET last_heartbeat_at = ?, last_progress_at = ?, "
+        "claim_expires = ? WHERE id = ?",
+        (now - heartbeat_age, now - seconds, now + 900, tid),
+    )
+    conn.commit()
+
+
+def _record_owned_progress(conn, tid):
+    row = _row(conn, tid)
+    return kb.record_progress(
+        conn,
+        tid,
+        source=kb.PROGRESS_SOURCE_TOOL,
+        expected_run_id=row["current_run_id"],
+        claim_lock=row["claim_lock"],
+    )
+
+
+def _forbid_signals(monkeypatch):
+    """Commit A must never reach for a process. Any attempt is a test failure."""
+    def _boom(*_a, **_kw):
+        raise AssertionError("no-progress detection must never signal a worker")
+
+    monkeypatch.setattr(kb, "_terminate_reclaimed_worker", _boom)
+    monkeypatch.setattr(kb.os, "kill", _boom, raising=False)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+
+
+def _stub_operator_reclaim(monkeypatch):
+    """``reclaim_task`` is an operator action that legitimately signals; in
+    tests it must never touch a real pid, so its termination helper is a
+    no-op that reports a non-local worker."""
+    monkeypatch.setattr(
+        kb, "_terminate_reclaimed_worker",
+        lambda *a, **kw: {"prev_pid": None, "host_local": False,
+                          "termination_attempted": False, "terminated": False,
+                          "sigkill": False},
+    )
+
+
+def _snapshot(conn, tid):
+    row = _row(conn, tid)
+    run = _run_row(conn, tid)
+    return {
+        "status": row["status"],
+        "claim_lock": row["claim_lock"],
+        "worker_pid": row["worker_pid"],
+        "current_run_id": row["current_run_id"],
+        "consecutive_failures": row["consecutive_failures"],
+        "last_progress_at": row["last_progress_at"],
+        "run_status": run["status"],
+        "run_outcome": run["outcome"],
+        "run_ended_at": run["ended_at"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema + migration + dataclass
+# ---------------------------------------------------------------------------
+
+def test_fresh_schema_carries_one_authoritative_progress_column(kanban_home):
+    """``tasks.last_progress_at`` is the single source of truth; the run
+    history table is deliberately not widened for it."""
+    with kb.connect() as conn:
+        assert "last_progress_at" in _cols(conn, "tasks")
+        assert "last_progress_at" not in _cols(conn, "task_runs")
+
+
+def test_migration_adds_the_progress_lease_and_preserves_rows(kanban_home):
+    """A board that predates the lease migrates in place: additive, rows and
+    the in-flight claim preserved, legacy rows NULL (never backfilled to
+    'now', which would gift a wedged pre-upgrade worker a lease it never
+    earned)."""
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        other = kb.create_task(conn, title="queued", assignee="a")
+        conn.execute("ALTER TABLE tasks DROP COLUMN last_progress_at")
+        conn.commit()
+        assert "last_progress_at" not in _cols(conn, "tasks")
+
+        kb._migrate_add_optional_columns(conn)
+
+        assert "last_progress_at" in _cols(conn, "tasks")
+        assert _row(conn, tid)["status"] == "running"
+        assert _row(conn, tid)["claim_lock"] == f"{_host()}:worker"
+        assert _row(conn, tid)["last_progress_at"] is None
+        assert _row(conn, other)["status"] in {"ready", "todo"}
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 2
+
+
+def test_migration_is_idempotent(kanban_home):
+    with kb.connect() as conn:
+        kb._migrate_add_optional_columns(conn)
+        kb._migrate_add_optional_columns(conn)
+        assert "last_progress_at" in _cols(conn, "tasks")
+
+
+def test_reopening_a_legacy_board_migrates_it(kanban_home):
+    """Restart path: ``connect()`` on an un-migrated board adds the column."""
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        conn.execute("ALTER TABLE tasks DROP COLUMN last_progress_at")
+        conn.commit()
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    with kb.connect() as conn:
+        assert "last_progress_at" in _cols(conn, "tasks")
+        assert kb.get_task(conn, tid).last_progress_at is None
+
+
+def test_task_dataclass_exposes_the_progress_lease(kanban_home):
+    """``asdict(Task)`` is what the dashboard and CLI serialise — the field
+    has to be on the dataclass or no surface can ever show it. The run
+    dataclass stays as it was: one authoritative column."""
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        task = kb.get_task(conn, tid)
+        assert task.last_progress_at is not None
+        run = kb.get_run(conn, task.current_run_id)
+        assert not hasattr(run, "last_progress_at")
+
+
+def test_legacy_row_reads_as_none(kanban_home):
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = NULL WHERE id = ?", (tid,)
+        )
+        conn.commit()
+        assert kb.get_task(conn, tid).last_progress_at is None
+
+
+# ---------------------------------------------------------------------------
+# Claim stamps both leases
+# ---------------------------------------------------------------------------
+
+def test_claim_stamps_liveness_and_progress(kanban_home):
+    """The claim is itself a transition: the attempt starts with a fresh
+    progress lease (and, as before, a fresh claim TTL)."""
+    before = int(time.time())
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="t", assignee="a")
+        assert _row(conn, tid)["last_progress_at"] is None
+        kb.claim_task(conn, tid, claimer=f"{_host()}:worker")
+        row = _row(conn, tid)
+        assert row["last_progress_at"] >= before
+        assert row["claim_expires"] > before
+
+
+def test_review_claim_stamps_the_progress_lease(kanban_home):
+    before = int(time.time())
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        assert kb.request_review(
+            conn, tid, summary="done, please review",
+            expected_run_id=_row(conn, tid)["current_run_id"],
+        )
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = NULL WHERE id = ?", (tid,)
+        )
+        conn.commit()
+        assert kb.get_task(conn, tid).status == "review"
+        claimed = kb.claim_review_task(conn, tid, claimer=f"{_host()}:reviewer")
+        assert claimed is not None and claimed.status == "running"
+        assert _row(conn, tid)["last_progress_at"] >= before
+
+
+def test_reclaim_then_reclaim_starts_a_fresh_lease(kanban_home, monkeypatch):
+    """A second attempt is measured from its own claim, not the previous
+    attempt's last action."""
+    _stub_operator_reclaim(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 9000)
+        assert kb.reclaim_task(conn, tid, reason="operator") is True
+        before = int(time.time())
+        kb.claim_task(conn, tid, claimer=f"{_host()}:worker")
+        assert _row(conn, tid)["last_progress_at"] >= before
+
+
+# ---------------------------------------------------------------------------
+# Liveness never renews progress
+# ---------------------------------------------------------------------------
+
+def test_stream_activity_renews_liveness_but_not_progress(kanban_home):
+    """THE regression. ``heartbeat_claim`` / ``heartbeat_worker`` are the
+    liveness bridge that ``_touch_activity`` drives on every stream chunk.
+    They must move ``last_heartbeat_at`` and ``claim_expires`` — and leave
+    ``last_progress_at`` exactly where it was."""
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        stale = int(time.time()) - 9000
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = ?, last_heartbeat_at = ?, "
+            "claim_expires = ? WHERE id = ?",
+            (stale, stale, stale, tid),
+        )
+        conn.commit()
+
+        for _ in range(5):  # thousands of tokens, no tools
+            assert kb.heartbeat_claim(conn, tid, claimer=f"{_host()}:worker")
+            assert kb.heartbeat_worker(conn, tid)
+
+        row = _row(conn, tid)
+        assert row["last_heartbeat_at"] > stale, "liveness must renew"
+        assert row["claim_expires"] > stale, "claim TTL must renew"
+        assert row["last_progress_at"] == stale, (
+            "raw stream/API activity must NOT renew the progress lease"
+        )
+
+
+def test_heartbeat_notes_never_renew_progress(kanban_home):
+    """The note is free text the model writes. A/B/A/B defeats a
+    previous-note dedupe; twenty unique notes defeat any 'is it new?' test.
+    Neither may move the lease — the boundary is the class of the signal,
+    not its content."""
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        stale = int(time.time()) - 9000
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = ? WHERE id = ?", (stale, tid)
+        )
+        conn.commit()
+        notes = [("compiling A" if i % 2 == 0 else "compiling B") for i in range(8)]
+        notes += [f"step {i}: analysed subsystem {i}, chose approach {i}" for i in range(20)]
+        for note in notes:
+            assert kb.heartbeat_worker(conn, tid, note=note)
+        assert _row(conn, tid)["last_progress_at"] == stale
+        # ...and the commentary is still recorded for humans.
+        assert len(_events(conn, tid, "heartbeat")) == len(notes)
+
+
+def test_lease_bookkeeping_events_do_not_renew_progress(kanban_home):
+    """``heartbeat`` / ``claim_extended`` / ``claimed`` / recovery receipts are
+    bookkeeping, not work. If they renewed progress the guard would renew
+    itself."""
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        stale = int(time.time()) - 9000
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = ? WHERE id = ?", (stale, tid)
+        )
+        conn.commit()
+        with kb.write_txn(conn):
+            for kind in (
+                "heartbeat", "claim_extended", "claimed", "spawned",
+                "reclaim_deferred", "no_progress_deferred", "stale",
+                "reclaimed", "timed_out", "crashed", "respawn_guarded",
+            ):
+                kb._append_event(conn, tid, kind, {"reason": "test"})
+        assert _row(conn, tid)["last_progress_at"] == stale
+
+
+# ---------------------------------------------------------------------------
+# Durable board transitions and verified tool execution renew progress
+# ---------------------------------------------------------------------------
+
+def test_progress_event_kinds_is_the_transition_allowlist():
+    """Pinned so a bookkeeping kind cannot drift in and a transition cannot
+    silently drop out."""
+    assert kb.PROGRESS_EVENT_KINDS == frozenset({
+        "completed", "review_requested", "changes_requested",
+        "review_reopened", "blocked", "unblocked", "commented", "attached",
+        "attachment_removed", "linked", "unlinked", "edited", "decomposed",
+        "specified",
+    })
+    for bookkeeping in (
+        "heartbeat", "claimed", "claim_extended", "spawned", "promoted",
+        "reclaimed", "reclaim_deferred", "no_progress_deferred", "stale",
+        "timed_out", "crashed", "gave_up", "spawn_failed", "status",
+    ):
+        assert bookkeeping not in kb.PROGRESS_EVENT_KINDS, bookkeeping
+
+
+def test_board_transition_renews_progress(kanban_home):
+    """A durable board transition is progress evidence in its own right,
+    whichever surface produced it (worker tool, CLI, dashboard)."""
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        stale = int(time.time()) - 9000
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = ? WHERE id = ?", (stale, tid)
+        )
+        conn.commit()
+        kb.add_comment(conn, tid, author="worker", body="hotspot: a.py — churn")
+        assert _row(conn, tid)["last_progress_at"] > stale
+
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = ? WHERE id = ?", (stale, tid)
+        )
+        conn.commit()
+        # ``linked`` is recorded on the child side of the edge.
+        parent = kb.create_task(conn, title="parent", assignee="a")
+        kb.link_tasks(conn, parent, tid)
+        assert _row(conn, tid)["last_progress_at"] > stale
+
+
+def test_verified_tool_execution_renews_progress(kanban_home):
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        stale = int(time.time()) - 9000
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = ? WHERE id = ?", (stale, tid)
+        )
+        conn.commit()
+        run_id = _row(conn, tid)["current_run_id"]
+
+        receipt = kb.record_progress(
+            conn, tid, source=kb.PROGRESS_SOURCE_TOOL,
+            expected_run_id=run_id, claim_lock=f"{_host()}:worker",
+        )
+
+        assert receipt["recorded"] is True
+        assert receipt["reason"] == "recorded"
+        assert receipt["run_id"] == run_id
+        assert _row(conn, tid)["last_progress_at"] > stale
+        assert _row(conn, tid)["last_progress_at"] == receipt["last_progress_at"]
+
+
+def test_record_progress_admits_only_the_verified_tool_source(kanban_home):
+    """Enforced inside ``record_progress``, not at its call sites, so a future
+    caller that invents a model-driven source gets a refusal rather than a
+    lease renewal. Unhashable sources are refused, never raised."""
+    assert kb.PROGRESS_RENEWAL_SOURCES == frozenset({kb.PROGRESS_SOURCE_TOOL})
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        stale = int(time.time()) - 9000
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = ? WHERE id = ?", (stale, tid)
+        )
+        conn.commit()
+        for bogus in ("checkpoint", "heartbeat", "note", "model", "", None, ["tool"]):
+            receipt = kb.record_progress(conn, tid, source=bogus)
+            assert receipt["recorded"] is False, bogus
+            assert receipt["reason"] == "unsupported_source", bogus
+        assert _row(conn, tid)["last_progress_at"] == stale
+
+
+def test_record_progress_is_bound_to_task_run_and_claim(kanban_home):
+    """A worker whose run was reclaimed, or whose claim was taken over, must
+    not resurrect the lease of whatever replaced it."""
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        stale = int(time.time()) - 9000
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = ? WHERE id = ?", (stale, tid)
+        )
+        conn.commit()
+        run_id = _row(conn, tid)["current_run_id"]
+        lock = f"{_host()}:worker"
+
+        wrong_run = kb.record_progress(
+            conn, tid, source=kb.PROGRESS_SOURCE_TOOL,
+            expected_run_id=run_id + 1000, claim_lock=lock,
+        )
+        assert wrong_run["recorded"] is False
+        assert wrong_run["reason"] == "superseded"
+
+        wrong_claim = kb.record_progress(
+            conn, tid, source=kb.PROGRESS_SOURCE_TOOL,
+            expected_run_id=run_id, claim_lock=f"{_host()}:someone-else",
+        )
+        assert wrong_claim["recorded"] is False
+        assert wrong_claim["reason"] == "claim_mismatch"
+
+        missing = kb.record_progress(
+            conn, "t_does_not_exist", source=kb.PROGRESS_SOURCE_TOOL,
+        )
+        assert missing["recorded"] is False
+        assert missing["reason"] == "not_running"
+
+        queued = kb.create_task(conn, title="queued", assignee="a")
+        parked = kb.record_progress(conn, queued, source=kb.PROGRESS_SOURCE_TOOL)
+        assert parked["recorded"] is False
+        assert parked["reason"] == "not_running"
+
+        assert _row(conn, tid)["last_progress_at"] == stale
+
+
+def test_tool_progress_requires_the_complete_worker_authority_tuple(kanban_home):
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        stale = int(time.time()) - 9000
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = ? WHERE id = ?", (stale, tid)
+        )
+        conn.commit()
+        row = _row(conn, tid)
+
+        for kwargs in (
+            {},
+            {"expected_run_id": row["current_run_id"]},
+            {"claim_lock": row["claim_lock"]},
+        ):
+            receipt = kb.record_progress(
+                conn, tid, source=kb.PROGRESS_SOURCE_TOOL, **kwargs,
+            )
+            assert receipt["recorded"] is False
+            assert receipt["reason"] == "authority_required"
+            assert _row(conn, tid)["last_progress_at"] == stale
+
+
+def test_progress_never_writes_an_event_row(kanban_home):
+    """Progress is a column stamp only — a tool call every few seconds for
+    hours must not bloat ``task_events``, and no ``progress`` event exists
+    to be mined for 'the worker said it did something'."""
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        before = conn.execute("SELECT COUNT(*) FROM task_events").fetchone()[0]
+        for _ in range(5):
+            _record_owned_progress(conn, tid)
+        after = conn.execute("SELECT COUNT(*) FROM task_events").fetchone()[0]
+        assert after == before
+        assert _events(conn, tid, "progress") == []
+
+
+# ---------------------------------------------------------------------------
+# Detection: expiry is deferred, never settled, in this commit
+# ---------------------------------------------------------------------------
+
+def test_expired_progress_lease_is_deferred_not_reclaimed(kanban_home, monkeypatch):
+    """The reproduced incident at the DB layer: PID alive, heartbeat seconds
+    old, progress lease hours old. The detector reports it with a durable
+    receipt and holds the claim — and changes nothing else."""
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        before = _snapshot(conn, tid)
+        now = int(time.time())
+
+        deferred = kb.detect_no_progress_running(
+            conn, no_progress_timeout_seconds=2700,
+        )
+
+        assert deferred == [tid]
+        after = _snapshot(conn, tid)
+        assert after == before, "status/claim/pid/run/failure count must be untouched"
+        assert after["status"] == "running"
+        assert after["consecutive_failures"] == 0
+        assert after["run_outcome"] is None and after["run_ended_at"] is None
+
+        receipts = _events(conn, tid, "no_progress_deferred")
+        assert len(receipts) == 1
+        payload = receipts[0]
+        assert payload["classification"] == "no_progress"
+        assert payload["reason"] == "authority_unavailable"
+        assert payload["progress_age_seconds"] >= 7200
+        assert payload["timeout_seconds"] == 2700
+        assert payload["heartbeat_age_seconds"] <= 60
+        assert payload["liveness"] == "fresh"
+        assert payload["worker_pid"] == 4242
+        assert payload["claim_lock"] == f"{_host()}:worker"
+        assert payload["host_local"] is True
+        assert payload["grace_seconds"] == kb.NO_PROGRESS_DEFER_GRACE_SECONDS
+        assert payload["claim_expires_now"] >= now + kb.NO_PROGRESS_DEFER_GRACE_SECONDS
+
+        # The claim is held for the grace window, on the task AND its run.
+        assert _row(conn, tid)["claim_expires"] >= now + kb.NO_PROGRESS_DEFER_GRACE_SECONDS
+        assert _run_row(conn, tid)["claim_expires"] >= now + kb.NO_PROGRESS_DEFER_GRACE_SECONDS
+
+        # Nothing that belongs to settlement happened.
+        assert _events(conn, tid, "no_progress") == []
+        assert _events(conn, tid, "reclaimed") == []
+        assert _events(conn, tid, "reclaim_deferred") == []
+        assert kb.list_comments(conn, tid) == []
+        run = conn.execute(
+            "SELECT status, outcome FROM task_runs WHERE task_id = ?", (tid,)
+        ).fetchall()
+        assert [(r["status"], r["outcome"]) for r in run] == [("running", None)]
+
+
+def test_holding_the_claim_never_shortens_it(kanban_home, monkeypatch):
+    """A live worker renews its own claim well past the grace; the hold is a
+    floor, not a reset, so it cannot bring a healthy claim forward."""
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        far = int(time.time()) + 10 * kb.NO_PROGRESS_DEFER_GRACE_SECONDS
+        conn.execute("UPDATE tasks SET claim_expires = ? WHERE id = ?", (far, tid))
+        conn.commit()
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == [tid]
+        assert _row(conn, tid)["claim_expires"] == far
+
+
+def test_deferred_receipt_fires_once_per_grace_window(kanban_home, monkeypatch):
+    """The stale lease is left alone on purpose (clearing it would reset the
+    clock that detected the problem), so the condition re-detects every
+    tick. The receipt is bounded: one per grace window per run."""
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == [tid]
+        for _ in range(5):
+            assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == []
+        assert len(_events(conn, tid, "no_progress_deferred")) == 1
+        assert _row(conn, tid)["status"] == "running"
+
+        # Once the grace has elapsed, the still-expired lease is reported again.
+        conn.execute(
+            "UPDATE task_events SET created_at = created_at - ? "
+            "WHERE task_id = ? AND kind = 'no_progress_deferred'",
+            (kb.NO_PROGRESS_DEFER_GRACE_SECONDS + 1, tid),
+        )
+        conn.commit()
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == [tid]
+        assert len(_events(conn, tid, "no_progress_deferred")) == 2
+        assert _row(conn, tid)["status"] == "running"
+        assert _row(conn, tid)["consecutive_failures"] == 0
+
+
+def test_the_receipt_window_is_per_run(kanban_home, monkeypatch):
+    """A recent receipt for a previous attempt must not suppress the first
+    receipt of the attempt that replaced it."""
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == [tid]
+        _stub_operator_reclaim(monkeypatch)
+        assert kb.reclaim_task(conn, tid, reason="operator") is True
+        _forbid_signals(monkeypatch)
+        kb.claim_task(conn, tid, claimer=f"{_host()}:worker")
+        kb._set_worker_pid(conn, tid, 4343)
+        _age_progress(conn, tid, 7200)
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == [tid]
+        assert len(_events(conn, tid, "no_progress_deferred")) == 2
+
+
+def test_progress_resumed_clears_the_condition(kanban_home, monkeypatch):
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == [tid]
+        _record_owned_progress(conn, tid)
+        conn.execute(
+            "UPDATE task_events SET created_at = created_at - ? "
+            "WHERE task_id = ? AND kind = 'no_progress_deferred'",
+            (kb.NO_PROGRESS_DEFER_GRACE_SECONDS + 1, tid),
+        )
+        conn.commit()
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == []
+        assert len(_events(conn, tid, "no_progress_deferred")) == 1
+
+
+def test_expiry_never_changes_spawnability_or_failure_count(kanban_home, monkeypatch):
+    """Through a full dispatcher tick: the deferred card stays ``running``,
+    nothing is spawned for it, and the circuit breaker never moves."""
+    _forbid_signals(monkeypatch)
+    spawned: list = []
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 9000)
+        for _ in range(3):
+            result = kb.dispatch_once(
+                conn,
+                spawn_fn=lambda task, *a, **kw: spawned.append(task.id),
+                no_progress_timeout_seconds=60,
+            )
+            assert tid not in spawned
+            assert result.auto_blocked == []
+            assert result.crashed == [] and result.stale == [] and result.timed_out == []
+            assert result.reclaimed == 0
+        task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        assert task.consecutive_failures == 0
+        assert task.claim_lock == f"{_host()}:worker"
+        assert task.worker_pid == 4242
+        assert kb.has_spawnable_ready(conn) is False
+
+
+def test_slow_healthy_api_call_is_not_reported(kanban_home, monkeypatch):
+    """A single long tool-free API call keeps its claim: liveness carries it
+    and the progress lease has not yet expired."""
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 1800)
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=2700) == []
+        assert _events(conn, tid, "no_progress_deferred") == []
+
+
+def test_detection_is_disabled_when_timeout_is_zero(kanban_home, monkeypatch):
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        conn.execute(
+            "UPDATE tasks SET last_heartbeat_at = ?, last_progress_at = 1 WHERE id = ?",
+            (int(time.time()), tid),
+        )
+        conn.commit()
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=0) == []
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=-5) == []
+        assert _events(conn, tid, "no_progress_deferred") == []
+
+
+def test_legacy_rows_are_measured_from_the_run_start(kanban_home, monkeypatch):
+    """A run claimed before the upgrade has ``last_progress_at IS NULL``. It
+    is measured from its own start — never treated as infinitely stale."""
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        now = int(time.time())
+        conn.execute(
+            "UPDATE tasks SET last_progress_at = NULL, last_heartbeat_at = ? "
+            "WHERE id = ?",
+            (now, tid),
+        )
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE task_id = ?", (now - 60, tid),
+        )
+        conn.commit()
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=2700) == []
+
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE task_id = ?", (now - 9000, tid),
+        )
+        conn.commit()
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=2700) == [tid]
+        assert _events(conn, tid, "no_progress_deferred")[0]["last_progress_at"] is None
+
+
+def test_dead_host_local_worker_is_left_to_the_crash_path(kanban_home, monkeypatch):
+    """Classification, not overlap: a dead PID is a crash, and the crash path
+    owns it (exit-code forensics this pass cannot see)."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == []
+        assert _events(conn, tid, "no_progress_deferred") == []
+
+
+def test_remote_and_custom_spawn_claims_are_safely_deferred(kanban_home, monkeypatch):
+    """No authority record exists in this commit, so a remote claim and a
+    custom-spawn claim (no pid) are ordinary safe-defer cases — the same
+    receipt, not an error, not a reclaim."""
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        remote = _running_task(conn, title="remote", pid=None, claimer="otherhost:worker")
+        custom = _running_task(conn, title="custom", pid=None)
+        for tid in (remote, custom):
+            _age_progress(conn, tid, 7200)
+        deferred = kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60)
+        assert sorted(deferred) == sorted([remote, custom])
+        for tid, host_local in ((remote, False), (custom, True)):
+            payload = _events(conn, tid, "no_progress_deferred")[0]
+            assert payload["host_local"] is host_local
+            assert payload["worker_pid"] is None
+            assert payload["reason"] == "authority_unavailable"
+            assert kb.get_task(conn, tid).status == "running"
+
+
+def test_orphaned_running_rows_are_left_to_reconciliation(kanban_home, monkeypatch):
+    """A ``running`` card with no valid claim is ``reconcile_orphaned_running``'s
+    case. Holding it would invent a ``claim_expires`` where there was none and
+    hand the row to the TTL path later — beside a possibly-live process."""
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        no_lock = _running_task(conn, title="no-lock")
+        no_expiry = _running_task(conn, title="no-expiry", pid=4343)
+        for tid in (no_lock, no_expiry):
+            _age_progress(conn, tid, 7200)
+        conn.execute("UPDATE tasks SET claim_lock = NULL WHERE id = ?", (no_lock,))
+        conn.execute("UPDATE tasks SET claim_expires = NULL WHERE id = ?", (no_expiry,))
+        conn.commit()
+
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == []
+
+        assert _row(conn, no_lock)["claim_lock"] is None
+        assert _row(conn, no_expiry)["claim_expires"] is None
+        for tid in (no_lock, no_expiry):
+            assert _events(conn, tid, "no_progress_deferred") == []
+
+
+def test_only_running_tasks_are_candidates(kanban_home, monkeypatch):
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        kb.block_task(conn, tid, reason="need creds")
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == []
+        assert _events(conn, tid, "no_progress_deferred") == []
+
+
+def test_stale_liveness_is_reported_truthfully(kanban_home, monkeypatch):
+    """The receipt records liveness separately from progress so an operator
+    can tell a reasoning loop (fresh) from a wedged process (stale)."""
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200, heartbeat_age=5000)
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == [tid]
+        payload = _events(conn, tid, "no_progress_deferred")[0]
+        assert payload["liveness"] == "stale"
+        assert payload["heartbeat_age_seconds"] >= 5000
+
+        never = _running_task(conn, title="never", pid=4343)
+        conn.execute(
+            "UPDATE tasks SET last_heartbeat_at = NULL, last_progress_at = ? WHERE id = ?",
+            (int(time.time()) - 7200, never),
+        )
+        conn.commit()
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == [never]
+        assert _events(conn, never, "no_progress_deferred")[0]["liveness"] == "never"
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher wiring
+# ---------------------------------------------------------------------------
+
+def test_dispatch_tick_runs_the_detector_after_the_existing_passes(
+    kanban_home, monkeypatch,
+):
+    """The detector is classification AFTER the crash / stale / max-runtime
+    passes, so each recovery path keeps its own case."""
+    _forbid_signals(monkeypatch)
+    order: list[str] = []
+
+    def _wrap(name):
+        real = getattr(kb, name)
+
+        def _inner(*a, **kw):
+            order.append(name)
+            return real(*a, **kw)
+        return _inner
+
+    for name in (
+        "release_stale_claims", "detect_stale_running", "detect_crashed_workers",
+        "enforce_max_runtime", "detect_no_progress_running", "recompute_ready",
+    ):
+        monkeypatch.setattr(kb, name, _wrap(name))
+
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        result = kb.dispatch_once(
+            conn, spawn_fn=lambda *a, **kw: None, no_progress_timeout_seconds=2700,
+        )
+    assert result.no_progress_deferred == [tid]
+    assert order.index("detect_no_progress_running") > order.index("detect_crashed_workers")
+    assert order.index("detect_no_progress_running") > order.index("detect_stale_running")
+    assert order.index("detect_no_progress_running") > order.index("enforce_max_runtime")
+    assert order.index("detect_no_progress_running") < order.index("recompute_ready")
+
+
+def test_dispatch_tick_defaults_to_the_validated_default(kanban_home, monkeypatch):
+    """On by default, with a window wide enough for legitimate long model
+    calls; the default is the same object every entry point resolves to."""
+    assert kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS == 45 * 60
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS + 600)
+        result = kb.dispatch_once(conn, spawn_fn=lambda *a, **kw: None)
+        assert result.no_progress_deferred == [tid]
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_dispatch_tick_below_the_default_window_is_quiet(kanban_home, monkeypatch):
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS - 600)
+        result = kb.dispatch_once(conn, spawn_fn=lambda *a, **kw: None)
+        assert result.no_progress_deferred == []
+
+
+def test_dispatch_result_carries_the_deferred_list_by_default():
+    result = kb.DispatchResult()
+    assert result.no_progress_deferred == []
+
+
+def test_dispatch_tick_hook_classifies_a_deferred_only_tick_as_ok(monkeypatch):
+    """A tick whose only action was a deferred receipt did something (a
+    durable write); it must not be reported as idle."""
+    from hermes_cli import lifecycle
+
+    calls: list[dict] = []
+    monkeypatch.setattr(kb, "_kanban_observer_consumed", lambda _name: True)
+    monkeypatch.setattr(
+        lifecycle, "invoke_hook", lambda name, **kw: calls.append({"name": name, **kw}),
+    )
+
+    kb._fire_dispatch_tick_hook(kb.DispatchResult(), board="b", dry_run=False)
+    kb._fire_dispatch_tick_hook(
+        kb.DispatchResult(no_progress_deferred=["t_1"]), board="b", dry_run=False,
+    )
+    outcomes = [c["outcome"] for c in calls if c["name"] == "on_kanban_dispatch_tick"]
+    assert outcomes == ["idle", "ok"]
+    assert calls[-1]["result"].no_progress_deferred == ["t_1"]
+
+
+def test_dispatch_tick_hook_e2e_deferred_only_tick_is_not_idle(kanban_home, monkeypatch):
+    """Through ``dispatch_once``: the only thing that happened this tick was
+    a deferred receipt, and every dispatcher-health subscriber must be told
+    the tick acted — this is precisely the incident being watched for."""
+    from hermes_cli import lifecycle
+
+    seen: list[dict] = []
+    monkeypatch.setattr(kb, "_kanban_observer_consumed", lambda _name: True)
+    monkeypatch.setattr(
+        lifecycle, "invoke_hook", lambda name, **kw: seen.append({"hook": name, **kw}),
+    )
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        result = kb.dispatch_once(
+            conn, spawn_fn=lambda *a, **kw: None, max_spawn=0,
+            no_progress_timeout_seconds=2700,
+        )
+    assert result.no_progress_deferred == [tid]
+    ticks = [s for s in seen if s.get("hook") == "on_kanban_dispatch_tick"]
+    assert ticks and ticks[-1]["outcome"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Configuration: one validated default, zero disables, every entry point
+# ---------------------------------------------------------------------------
+
+def test_resolve_no_progress_timeout_seconds_contract(caplog):
+    d = kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS
+    assert kb.MIN_NO_PROGRESS_TIMEOUT_SECONDS == 60
+    assert kb.resolve_no_progress_timeout_seconds(None) == d
+    assert kb.resolve_no_progress_timeout_seconds(0) == 0          # explicit off
+    assert kb.resolve_no_progress_timeout_seconds("0") == 0
+    assert kb.resolve_no_progress_timeout_seconds(60) == 60         # the minimum
+    assert kb.resolve_no_progress_timeout_seconds(900) == 900
+    assert kb.resolve_no_progress_timeout_seconds("900") == 900     # YAML string
+    assert kb.resolve_no_progress_timeout_seconds(900.0) == 900
+    # Every rejection falls back to the DEFAULT, never to 0: a typo must not
+    # silently switch the guard off — and each one is logged at WARNING.
+    with caplog.at_level("WARNING"):
+        for bad in (True, False, -5, "-5", 1, 30, 45, 59, "banana", [], {},
+                    float("inf"), float("-inf"), float("nan")):
+            caplog.clear()
+            assert kb.resolve_no_progress_timeout_seconds(bad) == d, bad
+            assert "no_progress_timeout_seconds" in caplog.text, bad
+
+
+def test_config_default_and_example_expose_the_timeout(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli.config import DEFAULT_CONFIG, load_config
+
+    assert DEFAULT_CONFIG["kanban"]["no_progress_timeout_seconds"] == (
+        kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS
+    )
+    assert load_config()["kanban"]["no_progress_timeout_seconds"] == (
+        kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS
+    )
+
+    repo_root = Path(__file__).resolve().parents[2]
+    example = (repo_root / "cli-config.yaml.example").read_text(encoding="utf-8")
+    assert (
+        f"no_progress_timeout_seconds: {kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS}"
+        in example
+    )
+
+
+def test_user_config_override_propagates(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (home / "config.yaml").write_text(
+        "kanban:\n  no_progress_timeout_seconds: 600\n", encoding="utf-8",
+    )
+    from hermes_cli.config import load_config
+
+    assert kb.resolve_no_progress_timeout_seconds(
+        load_config()["kanban"]["no_progress_timeout_seconds"]
+    ) == 600
+
+
+def test_configured_setting_reader_fails_open(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"kanban": {"no_progress_timeout_seconds": 600}},
+    )
+    assert kb.configured_kanban_setting("no_progress_timeout_seconds") == 600
+
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", _boom)
+    assert kb.configured_kanban_setting("no_progress_timeout_seconds") is None
+    assert kb.resolve_no_progress_timeout_seconds(
+        kb.configured_kanban_setting("no_progress_timeout_seconds")
+    ) == kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS
+
+
+@pytest.mark.parametrize(
+    "configured, expected",
+    [(600, 600), (0, 0), ("banana", "default"), (None, "default")],
+)
+def test_standalone_daemon_passes_the_resolved_timeout(monkeypatch, configured, expected):
+    """The deprecated ``--force`` daemon is still a dispatch entry point; it
+    must resolve the bound exactly like the gateway and the CLI."""
+    if expected == "default":
+        expected = kb.DEFAULT_NO_PROGRESS_TIMEOUT_SECONDS
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"kanban": {"no_progress_timeout_seconds": configured}},
+    )
+    monkeypatch.setattr(kb, "resolve_max_in_progress", lambda _c: None)
+    monkeypatch.setattr(kb, "connect", lambda *a, **kw: type(
+        "_Conn", (), {"close": lambda self: None},
+    )())
+    captured: dict = {}
+    stop = threading.Event()
+
+    def _fake_dispatch_once(conn, **kwargs):
+        captured.update(kwargs)
+        stop.set()
+        return kb.DispatchResult()
+
+    monkeypatch.setattr(kb, "dispatch_once", _fake_dispatch_once)
+    kb.run_daemon(interval=0.01, stop_event=stop)
+    assert captured.get("no_progress_timeout_seconds") == expected
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+def test_diagnostics_surface_a_deferred_no_progress_receipt(kanban_home, monkeypatch):
+    from hermes_cli import kanban_diagnostics as kd
+
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=2700) == [tid]
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+        runs = kb.list_runs(conn, tid)
+
+    assert "no_progress_deferred" in kd.DIAGNOSTIC_KINDS
+    diags = [
+        d for d in kd.compute_task_diagnostics(task, events, runs)
+        if d.kind == "no_progress_deferred"
+    ]
+    assert len(diags) == 1
+    diag = diags[0]
+    assert diag.severity == "warning"
+    assert diag.run_id == task.current_run_id
+    assert "no observable progress" in diag.title.lower()
+    assert diag.data["progress_age_seconds"] >= 7200
+    assert diag.data["timeout_seconds"] == 2700
+    assert any(a.kind == "reclaim" for a in diag.actions)
+    assert any(
+        a.kind == "cli_hint" and f"hermes kanban log {tid}" in a.payload.get("command", "")
+        for a in diag.actions
+    )
+
+
+def test_diagnostics_drop_the_receipt_once_progress_resumes(kanban_home, monkeypatch):
+    from hermes_cli import kanban_diagnostics as kd
+
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == [tid]
+        _record_owned_progress(conn, tid)
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+        runs = kb.list_runs(conn, tid)
+    assert [
+        d for d in kd.compute_task_diagnostics(task, events, runs)
+        if d.kind == "no_progress_deferred"
+    ] == []
+
+
+def test_diagnostics_ignore_receipts_from_a_previous_attempt(kanban_home, monkeypatch):
+    from hermes_cli import kanban_diagnostics as kd
+
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=60) == [tid]
+        _stub_operator_reclaim(monkeypatch)
+        assert kb.reclaim_task(conn, tid, reason="operator") is True
+        kb.claim_task(conn, tid, claimer=f"{_host()}:worker")
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+        runs = kb.list_runs(conn, tid)
+    assert [
+        d for d in kd.compute_task_diagnostics(task, events, runs)
+        if d.kind == "no_progress_deferred"
+    ] == []
+
+
+def test_diagnostics_read_raw_rows_as_the_dashboard_passes_them(kanban_home, monkeypatch):
+    """The dashboard feeds the rule engine raw ``sqlite3.Row`` objects whose
+    ``payload`` is still a JSON string; the rule must read the receipt
+    either way."""
+    from hermes_cli import kanban_diagnostics as kd
+
+    _forbid_signals(monkeypatch)
+    with kb.connect() as conn:
+        tid = _running_task(conn)
+        _age_progress(conn, tid, 7200)
+        assert kb.detect_no_progress_running(conn, no_progress_timeout_seconds=2700) == [tid]
+        task_row = conn.execute("SELECT * FROM tasks WHERE id = ?", (tid,)).fetchone()
+        event_rows = conn.execute(
+            "SELECT * FROM task_events WHERE task_id = ? ORDER BY id", (tid,),
+        ).fetchall()
+        run_rows = conn.execute(
+            "SELECT * FROM task_runs WHERE task_id = ? ORDER BY id", (tid,),
+        ).fetchall()
+    diags = [
+        d for d in kd.compute_task_diagnostics(task_row, event_rows, run_rows)
+        if d.kind == "no_progress_deferred"
+    ]
+    assert len(diags) == 1
+    assert diags[0].data["progress_age_seconds"] >= 7200
+    assert diags[0].data["timeout_seconds"] == 2700
+    assert diags[0].to_dict()["run_id"] == task_row["current_run_id"]

--- a/tests/tools/test_kanban_progress_bridge.py
+++ b/tests/tools/test_kanban_progress_bridge.py
@@ -1,0 +1,812 @@
+"""Runtime → board progress/liveness bridge (tools/kanban_tools.py).
+
+``AIAgent._touch_activity`` fires on every stream chunk, every API wait and
+every retry notice, and bridges into the kanban board so a dispatcher-spawned
+worker is not reclaimed mid-flight. That bridge renewed the *only* lease the
+watchdogs looked at, so a worker that reasoned for thousands of tokens with
+zero tool calls held its claim forever.
+
+These tests pin the split:
+
+* stream/API activity            → liveness only
+* VERIFIED tool execution        → progress (via the tool middleware): the
+  call was dispatched (not refused), it is a tool that can change the task's
+  world (not read-only, not agent bookkeeping) and its result is a success
+* failed / refused / read-only / bookkeeping tool calls → nothing
+* ``kanban_heartbeat``           → liveness + commentary, NEVER progress: its
+  note is free text the model writes, so gating the lease on it would be a
+  spelling test, not a guard
+* a durable board transition through the worker toolset → progress
+
+Everything runs against real imports and a temp ``HERMES_HOME``.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools import kanban_tools as kt
+
+
+@pytest.fixture
+def worker_env(monkeypatch, tmp_path):
+    """A dispatcher-spawned worker: isolated home, claimed running task,
+    the env vars the dispatcher pins at spawn time."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="worker-test", assignee="test-worker")
+        host = kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, tid, claimer=f"{host}:worker")
+        run_id = kb.get_task(conn, tid).current_run_id
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", f"{host}:worker")
+    _reset_rate_limits(monkeypatch)
+    return tid
+
+
+def _reset_rate_limits(monkeypatch):
+    """The bridges rate-limit their DB writes; tests drive them back-to-back."""
+    monkeypatch.setattr(kt, "_auto_heartbeat_last_attempt", None, raising=False)
+    monkeypatch.setattr(kt, "_auto_progress_last_attempt", None, raising=False)
+    monkeypatch.setattr(kt, "_AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS", 0.0)
+    monkeypatch.setattr(kt, "_AUTO_PROGRESS_MIN_INTERVAL_SECONDS", 0.0, raising=False)
+
+
+def _lease(tid):
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        return conn.execute(
+            "SELECT last_heartbeat_at, last_progress_at, claim_expires "
+            "FROM tasks WHERE id = ?",
+            (tid,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+def _rewind(tid, *, heartbeat, progress):
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET last_heartbeat_at = ?, last_progress_at = ? "
+            "WHERE id = ?",
+            (heartbeat, progress, tid),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+OK_TERMINAL = json.dumps({"exit_code": 0, "stdout": "ok", "stderr": ""})
+FAILED_TERMINAL = json.dumps({"exit_code": 1, "stdout": "", "stderr": "boom"})
+OK_WRITE = json.dumps({"success": True, "bytes_written": 42, "path": "a.py"})
+FAILED_WRITE = json.dumps({"error": "Permission denied: a.py"})
+
+
+# ---------------------------------------------------------------------------
+# Liveness bridge: unchanged, and it never touches progress
+# ---------------------------------------------------------------------------
+
+def test_stream_activity_renews_liveness_only(worker_env):
+    """Reproduces the masking: thousands of stream tokens keep the claim
+    alive but must leave the progress lease untouched."""
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+
+    for _ in range(10):
+        kt.heartbeat_current_worker_from_env()
+
+    row = _lease(worker_env)
+    assert row["last_heartbeat_at"] > old
+    assert row["last_progress_at"] == old
+
+
+def _activity_stub():
+    """Minimal object carrying only what ``_touch_activity`` reads."""
+    import run_agent as _ra
+
+    class _Stub:
+        session_id = ""
+        _session_db = None
+        _last_activity_ts = 0.0
+        _last_activity_desc = ""
+        _last_activity_provenance = None
+        _session_activity_last_persist_mono = 0.0
+
+    stub = _Stub()
+    stub._touch_activity = _ra.AIAgent._touch_activity.__get__(stub)
+    stub._persist_session_activity_if_due = (
+        _ra.AIAgent._persist_session_activity_if_due.__get__(stub)
+    )
+    return stub
+
+
+def test_touch_activity_stream_chunk_does_not_renew_progress(worker_env):
+    """E2E through the real ``AIAgent._touch_activity``: the exact call the
+    streaming path makes on every chunk."""
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+
+    agent = _activity_stub()
+    for _ in range(20):
+        agent._touch_activity("receiving stream response")
+        agent._touch_activity("waiting for non-streaming API response")
+
+    row = _lease(worker_env)
+    assert row["last_heartbeat_at"] > old, "liveness must still be bridged"
+    assert row["last_progress_at"] == old, (
+        "stream tokens must never renew the progress lease"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Progress bridge: only a verified tool execution counts
+# ---------------------------------------------------------------------------
+
+def test_verified_tool_success_renews_progress(worker_env):
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+
+    assert kt.note_tool_progress_from_env("terminal", OK_TERMINAL) is True
+    assert _lease(worker_env)["last_progress_at"] > old
+
+    _rewind(worker_env, heartbeat=old, progress=old)
+    assert kt.note_tool_progress_from_env("write_file", OK_WRITE) is True
+    assert _lease(worker_env)["last_progress_at"] > old
+
+
+@pytest.mark.parametrize(
+    "tool_name, result",
+    [
+        ("terminal", FAILED_TERMINAL),
+        ("write_file", FAILED_WRITE),
+        ("patch", json.dumps({"success": False, "error": "hunk failed"})),
+        ("execute_code", "Error executing tool 'execute_code': boom"),
+        ("terminal", json.dumps({"error": "Tool execution cancelled by user interrupt",
+                                 "status": "cancelled"})),
+    ],
+)
+def test_failed_tool_call_does_not_renew_progress(worker_env, tool_name, result):
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+
+    ok, reason = kt.tool_call_is_progress_evidence(tool_name, result)
+    assert (ok, reason) == (False, "failed")
+    assert kt.note_tool_progress_from_env(tool_name, result) is False
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+def test_refused_tool_call_does_not_renew_progress(worker_env):
+    """A call blocked by scope/plugin/guardrail policy never ran."""
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+
+    ok, reason = kt.tool_call_is_progress_evidence(
+        "terminal", json.dumps({"error": "blocked"}), blocked=True,
+    )
+    assert (ok, reason) == (False, "refused")
+    assert kt.note_tool_progress_from_env("terminal", OK_TERMINAL, blocked=True) is False
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+def test_unobserved_result_does_not_renew_progress(worker_env):
+    """'A tool was attempted' is not evidence; only an observed success is."""
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    assert kt.tool_call_is_progress_evidence("terminal", None) == (False, "unverified")
+    assert kt.note_tool_progress_from_env("terminal") is False
+    assert kt.note_tool_progress_from_env("terminal", None) is False
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+@pytest.mark.parametrize(
+    "tool_name", ["read_file", "search_files", "web_search", "web_extract",
+                  "session_search", "browser_snapshot", "read_terminal",
+                  "kanban_show", "kanban_list", "kanban_attachments"],
+)
+def test_read_only_tool_does_not_renew_progress(worker_env, tool_name):
+    """Reading cannot change the task's world, so a loop of reads is still a
+    loop. The classification is the one the interrupt-safety code already
+    uses (``agent.tool_result_classification.NO_EFFECT_TOOL_NAMES``)."""
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+
+    ok, reason = kt.tool_call_is_progress_evidence(tool_name, json.dumps({"content": "x"}))
+    assert (ok, reason) == (False, "read_only")
+    assert kt.note_tool_progress_from_env(tool_name, json.dumps({"content": "x"})) is False
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+@pytest.mark.parametrize("tool_name", ["kanban_heartbeat", "todo", "memory"])
+def test_bookkeeping_tool_does_not_renew_progress(worker_env, tool_name):
+    """Tools whose only effect is the agent's own state (the lease, its todo
+    list, its memory store) can be called at will by a looping model and
+    say nothing about the task."""
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+
+    ok, reason = kt.tool_call_is_progress_evidence(tool_name, json.dumps({"ok": True}))
+    assert (ok, reason) == (False, "non_task")
+    assert kt.note_tool_progress_from_env(tool_name, json.dumps({"ok": True})) is False
+    assert _lease(worker_env)["last_progress_at"] == old
+    assert tool_name in kt.NON_PROGRESS_TOOL_NAMES
+
+
+def test_progress_evidence_predicate_is_strict_in_order(worker_env):
+    """Refusal beats classification beats result: a blocked read-only call
+    reports ``refused``, and a successful mutating call is ``verified``."""
+    assert kt.tool_call_is_progress_evidence("read_file", "x", blocked=True) == (False, "refused")
+    assert kt.tool_call_is_progress_evidence("terminal", OK_TERMINAL) == (True, "verified")
+    assert kt.tool_call_is_progress_evidence("patch", json.dumps({"success": True})) == (True, "verified")
+    # Multimodal results are dicts, not strings — a success shape.
+    assert kt.tool_call_is_progress_evidence(
+        "browser_navigate", {"_multimodal": True, "text": "ok"},
+    ) == (True, "verified")
+
+
+@pytest.mark.parametrize(
+    "tool_name, action",
+    [
+        ("process", "list"), ("process", "poll"), ("process", "log"),
+        ("process", "wait"),
+        ("computer_use", "capture"), ("computer_use", "cua_browser_state"),
+        ("cronjob", "list"), ("delegate_task", "list"),
+    ],
+)
+def test_read_only_action_of_a_multiplexed_tool_is_not_progress(
+    worker_env, tool_name, action,
+):
+    assert kt.tool_call_is_progress_evidence(
+        tool_name, {"status": "ok"}, tool_args={"action": action},
+    ) == (False, "read_only")
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"_multimodal": True, "error": "permission denied", "status": "error"},
+        {"ok": False, "action": "click", "message": "No active window"},
+        {"ok": False, "status": "refused", "code": "typed_browser_unavailable"},
+        {"effect": "suspected_noop"},
+        {"success": False},
+        {"verified": False},
+        {"exit_code": 1},
+    ],
+)
+def test_mapping_and_multimodal_failures_are_not_progress(worker_env, result):
+    assert kt.tool_call_is_progress_evidence("computer_use", result) == (
+        False, "failed",
+    )
+
+
+def test_bridge_is_inert_outside_a_worker(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    _reset_rate_limits(monkeypatch)
+    assert kt.note_tool_progress_from_env("terminal", OK_TERMINAL) is False
+
+
+def test_wrong_run_cannot_renew_progress(worker_env, monkeypatch):
+    """A worker whose run was reclaimed must not resurrect the lease of the
+    run that replaced it."""
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "999999")
+    kt.note_tool_progress_from_env("terminal", OK_TERMINAL)
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+def test_wrong_claim_cannot_renew_progress(worker_env, monkeypatch):
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "otherhost:intruder")
+    kt.note_tool_progress_from_env("terminal", OK_TERMINAL)
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+def test_wrong_task_cannot_renew_progress(worker_env, monkeypatch):
+    """The env names a task this process does not own (not running, or a
+    different card): nothing moves, on either card."""
+    from hermes_cli import kanban_db as kb
+
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    conn = kb.connect()
+    try:
+        other = kb.create_task(conn, title="someone else's", assignee="x")
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", other)
+    kt.note_tool_progress_from_env("terminal", OK_TERMINAL)
+    assert _lease(worker_env)["last_progress_at"] == old
+    assert _lease(other)["last_progress_at"] is None
+
+
+def test_non_dispatcher_owned_context_cannot_renew_progress(worker_env):
+    """A cron job fired in-process from a worker inherits the worker's env
+    but does not own its task; its tool calls are not the worker's work."""
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    with non_dispatcher_owned_context():
+        assert kt.note_tool_progress_from_env("terminal", OK_TERMINAL) is False
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+def test_bridge_never_raises(monkeypatch, tmp_path):
+    """A bridge failure must never break the agent loop."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_does_not_exist")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "nope"))
+    _reset_rate_limits(monkeypatch)
+    assert kt.note_tool_progress_from_env("terminal", OK_TERMINAL) in (True, False)
+    assert kt.note_tool_progress_from_env("terminal", object()) in (True, False)
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter: thread-safe, independent of the liveness limiter
+# ---------------------------------------------------------------------------
+
+def test_progress_write_is_rate_limited(worker_env, monkeypatch):
+    """A tool call every few seconds for hours must not become a DB write
+    every few seconds for hours — and a failed call must not consume the
+    window a later success needs."""
+    monkeypatch.setattr(kt, "_AUTO_PROGRESS_MIN_INTERVAL_SECONDS", 3600.0)
+    assert kt.note_tool_progress_from_env("terminal", FAILED_TERMINAL) is False
+    assert kt.note_tool_progress_from_env("terminal", OK_TERMINAL) is True
+    assert kt.note_tool_progress_from_env("terminal", OK_TERMINAL) is False
+
+
+@pytest.mark.parametrize("uptime", [0.0, 1.0, 3599.999])
+def test_progress_limiter_admits_the_first_event_at_any_uptime(
+    worker_env, monkeypatch, uptime,
+):
+    """None is the never-attempted sentinel; every float is a real stamp. A
+    worker launched right after boot must not lose its first event merely
+    because monotonic uptime is smaller than the window."""
+    monkeypatch.setattr(kt, "_AUTO_PROGRESS_MIN_INTERVAL_SECONDS", 3600.0)
+    monkeypatch.setattr(time, "monotonic", lambda: uptime)
+    assert kt.note_tool_progress_from_env("terminal", OK_TERMINAL) is True
+    assert kt._auto_progress_last_attempt == uptime
+    assert kt.note_tool_progress_from_env("terminal", OK_TERMINAL) is False
+
+
+@pytest.mark.parametrize("uptime", [0.0, 1.0, 3599.999])
+def test_heartbeat_limiter_admits_the_first_event_at_any_uptime(
+    worker_env, monkeypatch, uptime,
+):
+    monkeypatch.setattr(kt, "_AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS", 3600.0)
+    monkeypatch.setattr(time, "monotonic", lambda: uptime)
+    assert kt.heartbeat_current_worker_from_env() is True
+    assert kt._auto_heartbeat_last_attempt == uptime
+    assert kt.heartbeat_current_worker_from_env() is False
+
+
+def test_progress_limiter_state_is_guarded_by_a_lock(worker_env, monkeypatch):
+    """Concurrent tool calls complete on worker threads and all touch the
+    module-level limiter timestamp. Read-compare-write without a lock lets
+    two threads both observe the old value and both write, which is how a
+    limiter silently stops limiting."""
+    assert isinstance(kt._auto_progress_lock, type(threading.Lock()))
+    monkeypatch.setattr(kt, "_AUTO_PROGRESS_MIN_INTERVAL_SECONDS", 3600.0)
+
+    admitted: list[bool] = []
+    barrier = threading.Barrier(8)
+
+    def _hit():
+        barrier.wait()
+        admitted.append(kt.note_tool_progress_from_env("terminal", OK_TERMINAL))
+
+    threads = [threading.Thread(target=_hit) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert sum(1 for a in admitted if a) == 1, admitted
+
+
+def test_a_recent_liveness_write_never_suppresses_a_progress_stamp(worker_env, monkeypatch):
+    monkeypatch.setattr(kt, "_AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS", 3600.0)
+    monkeypatch.setattr(kt, "_AUTO_PROGRESS_MIN_INTERVAL_SECONDS", 3600.0)
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    assert kt.heartbeat_current_worker_from_env() is True
+    assert kt.note_tool_progress_from_env("terminal", OK_TERMINAL) is True
+    row = _lease(worker_env)
+    assert row["last_heartbeat_at"] > old and row["last_progress_at"] > old
+
+
+def test_limiter_sentinel_is_none_on_fresh_import():
+    import subprocess
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[2]
+    probe = (
+        "from tools import kanban_tools as kt; "
+        "assert kt._auto_progress_last_attempt is None; "
+        "assert kt._auto_heartbeat_last_attempt is None"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], cwd=repo_root,
+        capture_output=True, text=True, timeout=60, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# The tool executor is the verified middleware
+# ---------------------------------------------------------------------------
+
+def _make_agent(monkeypatch):
+    """Minimal AIAgent-like stub (mirrors tests/run_agent/test_tool_activity_heartbeat.py)."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "")
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "")
+    import run_agent as _ra
+
+    class _Stub:
+        _interrupt_requested = False
+        _interrupt_message = None
+        log_prefix = ""
+        quiet_mode = True
+        verbose_logging = False
+        log_prefix_chars = 200
+        _checkpoint_mgr = MagicMock(enabled=False)
+        tool_progress_callback = None
+        tool_start_callback = None
+        tool_complete_callback = None
+        tool_progress_mode = "off"
+        _todo_store = MagicMock()
+        _session_db = None
+        valid_tool_names = set()
+        _turns_since_memory = 0
+        _iters_since_skill = 0
+        _current_tool = None
+        _last_activity = 0.0
+        session_id = ""
+        _current_turn_id = ""
+        _current_api_request_id = ""
+
+        def __init__(self):
+            self._tool_worker_threads: set = set()
+            self._tool_worker_threads_lock = threading.Lock()
+            self._active_children_lock = threading.Lock()
+
+        def _touch_activity(self, desc):
+            self._last_activity = time.time()
+
+        def _vprint(self, msg, force=False):
+            pass
+
+        def _safe_print(self, msg):
+            pass
+
+        def _should_emit_quiet_tool_messages(self):
+            return False
+
+        def _should_start_quiet_spinner(self):
+            return False
+
+        def _has_stream_consumers(self):
+            return False
+
+        def _tool_result_content_for_active_model(self, name, result):
+            return result
+
+        def _record_file_mutation_result(self, *a, **kw):
+            pass
+
+        def _apply_pending_steer_to_tool_results(self, *a, **kw):
+            pass
+
+    stub = _Stub()
+    stub._subdirectory_hints = MagicMock()
+    stub._subdirectory_hints.check_tool_call = lambda *a, **kw: None
+    stub._flush_messages_to_session_db = lambda *a, **kw: None
+    stub._append_guardrail_observation = lambda name, result, *a, **kw: result
+    stub.interrupt = _ra.AIAgent.interrupt.__get__(stub)
+    stub.clear_interrupt = _ra.AIAgent.clear_interrupt.__get__(stub)
+    stub._guardrail_block_result = lambda d: json.dumps({"error": "blocked"})
+    stub._tool_guardrails = MagicMock(
+        before_call=lambda name, args: MagicMock(allows_execution=True)
+    )
+    return stub
+
+
+def _run_middleware(
+    agent, *, function_name, execute, scope_block=None, function_args=None,
+):
+    import agent.tool_executor as te
+
+    return te._run_agent_tool_execution_middleware(
+        agent,
+        function_name=function_name,
+        function_args=function_args or {"command": "true"},
+        effective_task_id="task",
+        tool_call_id="tc1",
+        execute=execute,
+        scope_block=scope_block,
+        display_index=1,
+    )
+
+
+def test_executor_notes_progress_for_a_verified_success(worker_env, monkeypatch):
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    agent = _make_agent(monkeypatch)
+
+    managed = _run_middleware(
+        agent, function_name="terminal", execute=lambda _args: OK_TERMINAL,
+    )
+    assert managed.dispatched is True and managed.blocked is False
+    assert _lease(worker_env)["last_progress_at"] > old
+
+
+def test_executor_does_not_note_progress_for_a_failed_result(worker_env, monkeypatch):
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    agent = _make_agent(monkeypatch)
+
+    managed = _run_middleware(
+        agent, function_name="terminal", execute=lambda _args: FAILED_TERMINAL,
+    )
+    assert managed.dispatched is True
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+def test_executor_does_not_note_progress_when_the_tool_raises(worker_env, monkeypatch):
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    agent = _make_agent(monkeypatch)
+
+    def _boom(_args):
+        raise RuntimeError("tool exploded")
+
+    with pytest.raises(RuntimeError):
+        _run_middleware(agent, function_name="terminal", execute=_boom)
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+def test_executor_does_not_note_progress_for_a_refused_call(worker_env, monkeypatch):
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    agent = _make_agent(monkeypatch)
+    calls: list = []
+
+    managed = _run_middleware(
+        agent, function_name="terminal",
+        execute=lambda _args: calls.append(1) or OK_TERMINAL,
+        scope_block="terminal is not available in this scope",
+    )
+    assert managed.blocked is True and calls == []
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+def test_executor_does_not_note_progress_for_a_read_only_tool(worker_env, monkeypatch):
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    agent = _make_agent(monkeypatch)
+    _run_middleware(
+        agent, function_name="read_file",
+        execute=lambda _args: json.dumps({"content": "hello"}),
+    )
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+def test_executor_passes_action_args_to_progress_classifier(worker_env, monkeypatch):
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    agent = _make_agent(monkeypatch)
+    _run_middleware(
+        agent,
+        function_name="process",
+        function_args={"action": "poll", "session_id": "proc_1"},
+        execute=lambda _args: json.dumps({"status": "running"}),
+    )
+    assert _lease(worker_env)["last_progress_at"] == old
+
+
+def test_executor_bridge_is_inert_outside_a_worker_and_never_raises(monkeypatch, tmp_path):
+    import agent.tool_executor as te
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    te._note_verified_tool_progress("terminal", OK_TERMINAL, {})  # no env: no-op
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_does_not_exist")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "nope"))
+    te._note_verified_tool_progress("terminal", OK_TERMINAL, {})  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# kanban_heartbeat: liveness + commentary, NEVER progress
+# ---------------------------------------------------------------------------
+
+def test_heartbeat_tool_renews_liveness_and_records_the_note_but_never_progress(worker_env):
+    """A/B/A/B defeats a previous-note dedupe; twenty unique notes defeat any
+    'is this new?' test. It must not matter — no note renews progress."""
+    from hermes_cli import kanban_db as kb
+
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+
+    notes = [("compiling module A" if i % 2 == 0 else "compiling module B") for i in range(8)]
+    notes += [f"step {i}: analysed subsystem {i} and chose approach {i}" for i in range(20)]
+    notes.append("wrote migrations/003_users.sql; ran pytest -q; 41 passed")
+    for note in notes:
+        d = json.loads(kt._handle_heartbeat({"note": note}))
+        assert d.get("ok") is True, note
+        assert _lease(worker_env)["last_progress_at"] == old, note
+    assert _lease(worker_env)["last_heartbeat_at"] > old
+
+    conn = kb.connect()
+    try:
+        recorded = [
+            json.loads(r["payload"])["note"]
+            for r in conn.execute(
+                "SELECT payload FROM task_events WHERE task_id = ? "
+                "AND kind = 'heartbeat' AND payload IS NOT NULL ORDER BY id",
+                (worker_env,),
+            )
+        ]
+    finally:
+        conn.close()
+    assert recorded == notes
+
+
+def test_heartbeat_schema_says_liveness_only(worker_env):
+    """The schema is the contract the model reads. It must not tell the
+    model that writing a good enough note keeps the claim."""
+    desc = kt.KANBAN_HEARTBEAT_SCHEMA["description"].lower()
+    note_desc = (
+        kt.KANBAN_HEARTBEAT_SCHEMA["parameters"]["properties"]["note"]["description"].lower()
+    )
+    assert "liveness" in desc
+    assert "progress" in desc
+    for lure in ("renews the progress", "renews progress", "evidence"):
+        assert lure not in desc + " " + note_desc, lure
+
+
+# ---------------------------------------------------------------------------
+# Board transitions through the worker toolset
+# ---------------------------------------------------------------------------
+
+def test_worker_comment_renews_progress(worker_env):
+    old = int(time.time()) - 9000
+    _rewind(worker_env, heartbeat=old, progress=old)
+    kt._handle_comment({"task_id": worker_env, "body": "hotspot: a.py — churn"})
+    assert _lease(worker_env)["last_progress_at"] > old
+
+
+# ---------------------------------------------------------------------------
+# E2E: agent activity -> board leases -> dispatcher decision
+# ---------------------------------------------------------------------------
+
+def _dispatch(monkeypatch):
+    """One real dispatcher tick beside a live (mocked) host-local worker.
+    Any attempt to signal a process fails the test."""
+    from hermes_cli import kanban_db as kb
+
+    def _boom(*_a, **_kw):
+        raise AssertionError("no-progress detection must never signal a worker")
+
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: True)
+    monkeypatch.setattr(kb, "_terminate_reclaimed_worker", _boom)
+    monkeypatch.setattr(kb.os, "kill", _boom, raising=False)
+    conn = kb.connect()
+    try:
+        return kb.dispatch_once(conn, spawn_fn=lambda *a, **kw: None)
+    finally:
+        conn.close()
+
+
+def _set_pid(tid, pid=4242):
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        kb._set_worker_pid(conn, tid, pid)
+    finally:
+        conn.close()
+
+
+def _configured_limit():
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.config import load_config
+    return kb.resolve_no_progress_timeout_seconds(
+        (load_config().get("kanban") or {}).get("no_progress_timeout_seconds")
+    )
+
+
+def test_e2e_reasoning_only_worker_is_detected_and_deferred(worker_env, monkeypatch):
+    """The reproduced incident, end to end: a worker streams for a long time,
+    calls no tool, transitions nothing — and the dispatcher records exactly
+    that, holds the claim, and touches nothing else."""
+    from hermes_cli import kanban_db as kb
+
+    _set_pid(worker_env)
+    agent = _activity_stub()
+    for _ in range(50):
+        agent._touch_activity("receiving stream response")
+
+    now = int(time.time())
+    _rewind(worker_env, heartbeat=now, progress=now - _configured_limit() - 60)
+
+    result = _dispatch(monkeypatch)
+    assert result.no_progress_deferred == [worker_env]
+    assert result.crashed == [] and result.stale == [] and result.timed_out == []
+    assert result.auto_blocked == [] and result.reclaimed == 0
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task.status == "running"
+        assert task.consecutive_failures == 0
+        assert task.worker_pid == 4242
+        assert task.claim_expires >= now + kb.NO_PROGRESS_DEFER_GRACE_SECONDS
+        runs = conn.execute(
+            "SELECT status, outcome FROM task_runs WHERE task_id = ?", (worker_env,),
+        ).fetchall()
+        assert [(r["status"], r["outcome"]) for r in runs] == [("running", None)]
+        receipts = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'no_progress_deferred'",
+            (worker_env,),
+        ).fetchall()
+        assert len(receipts) == 1
+        payload = json.loads(receipts[0]["payload"])
+        assert payload["liveness"] == "fresh"
+        assert payload["reason"] == "authority_unavailable"
+        assert kb.list_comments(conn, worker_env) == []
+    finally:
+        conn.close()
+
+
+def test_e2e_worker_with_a_verified_tool_call_is_not_reported(worker_env, monkeypatch):
+    """Same elapsed wall-clock, one real verified tool call: quiet."""
+    from hermes_cli import kanban_db as kb
+
+    _set_pid(worker_env)
+    now = int(time.time())
+    _rewind(worker_env, heartbeat=now, progress=now - _configured_limit() - 60)
+
+    import agent.tool_executor as te
+    te._note_verified_tool_progress("terminal", OK_TERMINAL, {})
+
+    result = _dispatch(monkeypatch)
+    assert result.no_progress_deferred == []
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, worker_env).status == "running"
+    finally:
+        conn.close()
+
+
+def test_e2e_worker_with_only_failed_tool_calls_is_reported(worker_env, monkeypatch):
+    _set_pid(worker_env)
+    now = int(time.time())
+    _rewind(worker_env, heartbeat=now, progress=now - _configured_limit() - 60)
+
+    import agent.tool_executor as te
+    for _ in range(5):
+        te._note_verified_tool_progress("terminal", FAILED_TERMINAL, {})
+
+    assert _dispatch(monkeypatch).no_progress_deferred == [worker_env]

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -262,6 +262,34 @@ class TestFormatKanbanEventText:
         text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
         assert "timed out" in text
 
+    def test_no_progress_deferred_is_a_claimed_kind_that_renders(self):
+        """A deferred progress-lease receipt must reach the TUI subscriber —
+        and say truthfully that the claim is held, not that the task was
+        reclaimed or the worker terminated."""
+        from tui_gateway import server as _server
+
+        assert "no_progress_deferred" in _server._KANBAN_NOTIFY_KINDS
+        assert "no_progress_deferred" not in _server._KANBAN_SILENT_KINDS
+        ev = SimpleNamespace(
+            kind="no_progress_deferred",
+            payload={"progress_age_seconds": 3000, "timeout_seconds": 2700},
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "main")
+        assert "t_abc123" in text
+        assert "no observable progress" in text
+        assert "3000s" in text and "2700s" in text
+        assert "claim held" in text
+        assert "[main]" in text and "@worker" in text
+        for untrue in ("terminated", "requeue", "will retry", "reclaimed"):
+            assert untrue not in text, untrue
+
+    def test_no_progress_deferred_with_bad_payload_does_not_raise(self):
+        ev = SimpleNamespace(kind="no_progress_deferred", payload={"progress_age_seconds": "x"})
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "no observable progress" in text
+        ev = SimpleNamespace(kind="no_progress_deferred", payload=None)
+        assert "no observable progress" in _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+
 
 class TestNotificationPollerLoopKanbanWiring:
     """Drive a real TUI subscription through ``_notification_poller_loop``.

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -31,7 +31,8 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Optional
+import threading
+from typing import Any, Mapping, Optional
 
 from agent.redact import redact_sensitive_text
 from hermes_cli.goals import judge_goal
@@ -295,7 +296,7 @@ def _goal_mode_handoff_rejection(task, evidence: str) -> Optional[str]:
 #     explicit tool which carries a model-supplied note.
 
 _AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS = 60.0
-_auto_heartbeat_last_attempt: float = 0.0
+_auto_heartbeat_last_attempt: Optional[float] = None
 
 
 def heartbeat_current_worker_from_env() -> bool:
@@ -325,7 +326,11 @@ def heartbeat_current_worker_from_env() -> bool:
         return False
     import time as _time
     now = _time.monotonic()
-    if (now - _auto_heartbeat_last_attempt) < _AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS:
+    if (
+        _auto_heartbeat_last_attempt is not None
+        and (now - _auto_heartbeat_last_attempt)
+        < _AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS
+    ):
         return False
     _auto_heartbeat_last_attempt = now
     try:
@@ -354,6 +359,186 @@ def heartbeat_current_worker_from_env() -> bool:
         return True
     except Exception:
         logger.debug("auto-heartbeat: bridge failed", exc_info=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Verified tool execution → board-PROGRESS bridge
+# ---------------------------------------------------------------------------
+# The liveness bridge above proves the provider is answering, not that the
+# worker is accomplishing anything — conflating the two is what let a worker
+# reason for thousands of tokens with zero tool calls while renewing its claim
+# indefinitely. Progress is a separate lease (``tasks.last_progress_at``) and
+# this bridge is its only callable renewal path. The tool executor calls it
+# once per tool call, AFTER the call returned, with the observed result.
+#
+# Only a VERIFIED execution counts, and the verification is done here rather
+# than trusted from the caller:
+#   * refused  — the call was blocked by scope/plugin/guardrail policy and
+#                never ran;
+#   * non_task — tools whose only effect is the agent's own state (the lease
+#                itself, its todo list, its memory store). A looping model can
+#                call these at will and they say nothing about the task;
+#   * read_only — tools that cannot change the task's world (the same
+#                classification the interrupt-safety code uses); a loop of
+#                reads is still a loop;
+#   * failed   — a non-zero exit, an error payload, a raised tool: the attempt
+#                proved nothing landed;
+#   * unverified — no observed result at all ("a tool was attempted" is not
+#                evidence).
+# Everything else is ``verified``. Same best-effort contract as the liveness
+# bridge: never raise into the agent loop, no-op outside a dispatcher-owned
+# worker, one DB write per ``_AUTO_PROGRESS_MIN_INTERVAL_SECONDS``.
+
+NON_PROGRESS_TOOL_NAMES = frozenset({"kanban_heartbeat", "todo", "memory"})
+
+# Multiplexed tools need their selected action as well as their name. These
+# actions only observe/control-plane state; repeating them is still a loop.
+NON_PROGRESS_TOOL_ACTIONS = {
+    "process": frozenset({"list", "poll", "log", "wait"}),
+    "computer_use": frozenset({
+        "capture", "list_apps", "list_windows", "wait", "cua_browser_state",
+    }),
+    "cronjob": frozenset({"list"}),
+    "delegate_task": frozenset({"list"}),
+}
+
+_AUTO_PROGRESS_MIN_INTERVAL_SECONDS = 20.0
+# ``None`` is the never-attempted sentinel (a worker launched in the first
+# limiter window after boot must not lose its first stamp to a small
+# monotonic uptime); every float is a real stamp.
+_auto_progress_last_attempt: Optional[float] = None
+# Concurrent tool calls complete on worker threads and all touch this
+# timestamp. Read-compare-write without a lock lets two threads both observe
+# the old value and both write, which is how a limiter silently stops
+# limiting. Its own lock and its own timestamp: a recent liveness write must
+# never suppress a progress stamp.
+_auto_progress_lock = threading.Lock()
+
+
+def tool_call_is_progress_evidence(
+    tool_name: Optional[str],
+    result: Any,
+    *,
+    tool_args: Optional[Mapping[str, Any]] = None,
+    blocked: bool = False,
+) -> tuple[bool, str]:
+    """Classify one completed tool call. Returns ``(counts, reason)``.
+
+    Pure and side-effect free so the boundary can be asserted directly.
+    Order matters: a refused call is ``refused`` whatever the tool, a
+    bookkeeping or read-only tool is never evidence however it succeeded,
+    and only a side-effect-capable tool's SUCCESS is ``verified``.
+    """
+    if blocked:
+        return False, "refused"
+    name = tool_name or ""
+    if name in NON_PROGRESS_TOOL_NAMES:
+        return False, "non_task"
+    action = str((tool_args or {}).get("action") or "").strip()
+    if action and action in NON_PROGRESS_TOOL_ACTIONS.get(name, ()):
+        return False, "read_only"
+    from agent.tool_result_classification import tool_may_have_side_effect
+    if not tool_may_have_side_effect(name):
+        return False, "read_only"
+    if result is None:
+        return False, "unverified"
+    from agent.display import _detect_tool_failure
+    try:
+        failed, _suffix = _detect_tool_failure(name, result)
+    except Exception:
+        # An unclassifiable result is not evidence.
+        return False, "unverified"
+    if failed:
+        return False, "failed"
+    # Stricter than the CLI's failure tag, which for some tools keys off a
+    # single field (terminal: exit_code): a payload that SAYS it errored,
+    # was blocked or was cancelled proves nothing landed, whatever else it
+    # carries.
+    data: Any = result if isinstance(result, Mapping) else None
+    if isinstance(result, str):
+        from utils import safe_json_loads
+        data = safe_json_loads(result)
+    if isinstance(data, Mapping):
+        status = str(data.get("status") or "").lower()
+        effect = str(data.get("effect") or "").lower()
+        exit_code = data.get("exit_code")
+        if (
+            data.get("error")
+            or data.get("ok") is False
+            or data.get("success") is False
+            or data.get("verified") is False
+            or status in {
+                "blocked", "cancelled", "error", "failed", "refused", "timeout",
+            }
+            or effect in {"suspected_noop", "refused"}
+            or (isinstance(exit_code, int) and exit_code != 0)
+        ):
+            return False, "failed"
+    return True, "verified"
+
+
+def note_tool_progress_from_env(
+    tool_name: Optional[str],
+    result: Any = None,
+    *,
+    tool_args: Optional[Mapping[str, Any]] = None,
+    blocked: bool = False,
+) -> bool:
+    """Renew the kanban PROGRESS lease for a verified tool execution.
+
+    ``tool_name`` and ``result`` describe the call that just completed;
+    ``blocked`` says the middleware refused it. Only a call that
+    :func:`tool_call_is_progress_evidence` accepts reaches the board, and
+    only for the task / run / claim this process was spawned for
+    (``HERMES_KANBAN_TASK`` / ``HERMES_KANBAN_RUN_ID`` /
+    ``HERMES_KANBAN_CLAIM_LOCK``): the DB layer refuses a superseded run or
+    a foreign claim, so a reclaimed worker cannot resurrect the lease of the
+    attempt that replaced it. A delegate_task child or an in-process cron
+    job does not own the task and is ignored even with the env present.
+
+    Returns True when a progress write was attempted, False when the call
+    was skipped (not a worker, not evidence, rate-limited, or a swallowed
+    error). Informational — callers must not branch on it.
+    """
+    global _auto_progress_last_attempt
+    tid = _default_task_id(None)
+    if not tid:
+        return False
+    counts, _reason = tool_call_is_progress_evidence(
+        tool_name, result, tool_args=tool_args, blocked=blocked,
+    )
+    if not counts:
+        return False
+
+    import time as _time
+    with _auto_progress_lock:
+        now = _time.monotonic()
+        if (
+            _auto_progress_last_attempt is not None
+            and now - _auto_progress_last_attempt
+            < _AUTO_PROGRESS_MIN_INTERVAL_SECONDS
+        ):
+            return False
+        _auto_progress_last_attempt = now
+
+    try:
+        kb, conn = _connect()
+        try:
+            kb.record_progress(
+                conn, tid,
+                source=kb.PROGRESS_SOURCE_TOOL,
+                expected_run_id=_worker_run_id(tid),
+                claim_lock=os.environ.get("HERMES_KANBAN_CLAIM_LOCK") or None,
+            )
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        return True
+    except Exception:
+        logger.debug("auto-progress: bridge failed", exc_info=True)
         return False
 
 
@@ -1982,8 +2167,10 @@ KANBAN_HEARTBEAT_SCHEMA = {
     "description": (
         "Signal that you're still alive during a long operation "
         "(training, encoding, large crawls). Call every few minutes so "
-        "humans see liveness separately from PID checks. Pure side "
-        "effect — no work changes."
+        "humans see liveness separately from PID checks. Renews LIVENESS "
+        "only: the separate progress lease moves only when you actually "
+        "run a tool that changes something or move the card, never on a "
+        "heartbeat or its note. Pure side effect — no work changes."
     ),
     "parameters": {
         "type": "object",
@@ -1995,8 +2182,9 @@ KANBAN_HEARTBEAT_SCHEMA = {
             "note": {
                 "type": "string",
                 "description": (
-                    "Optional short note describing current progress. "
-                    "Shown in the event log."
+                    "Optional short note on what you are waiting for. "
+                    "Recorded in the event log for humans to read; it has "
+                    "no effect on any lease."
                 ),
             },
             "board": _board_schema_prop(),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9903,7 +9903,7 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
 # event behind an unclaimed row.
 _KANBAN_NOTIFY_KINDS = (
     "completed", "blocked", "gave_up", "crashed", "timed_out",
-    "status", "archived", "unblocked",
+    "no_progress_deferred", "status", "archived", "unblocked",
 )
 _KANBAN_SILENT_KINDS = frozenset({"archived", "unblocked"})
 _KANBAN_POLL_SECONDS = 5.0
@@ -10045,6 +10045,20 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
         except (TypeError, ValueError):
             pass
         return f"⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry"
+    if kind == "no_progress_deferred":
+        # Detection only: the worker is alive but has shown no verified
+        # progress, and the dispatcher is holding the claim. Nothing was
+        # terminated or requeued — say exactly that.
+        age = limit = 0
+        try:
+            age = int(payload.get("progress_age_seconds") or 0)
+            limit = int(payload.get("timeout_seconds") or 0)
+        except (TypeError, ValueError):
+            pass
+        return (
+            f"⏳ {board_tag}{tag}Kanban {task_id} no observable progress for "
+            f"{age}s (limit {limit}s); claim held, worker still running"
+        )
     if kind == "status":
         return f"🔄 {board_tag}{tag}Kanban {task_id} → {payload.get('status') or ''}"
     return None

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -140,7 +140,7 @@ Registered when the agent is either (a) spawned by the kanban dispatcher (`HERME
 | `kanban_block` | Block the current task on a question for the user — the dispatcher pauses, surfaces the question, and resumes once a human replies. | `HERMES_KANBAN_TASK` or `kanban` toolset |
 | `kanban_request_review` | Hand the implementation to a reviewer with `summary`, optional structured `metadata`, and an optional reviewer profile. Moves the same task to `review`; it is not a block and does not affect block-loop accounting. | `HERMES_KANBAN_TASK` or `kanban` toolset |
 | `kanban_request_changes` | Reviewer verdict for an actively claimed review run. Closes the review run, reapplies parent gating, and routes the task back to the original implementer without using a block. | `HERMES_KANBAN_TASK` or `kanban` toolset |
-| `kanban_heartbeat` | Send a progress heartbeat during a long-running operation so the dispatcher knows the worker is still alive. | `HERMES_KANBAN_TASK` or `kanban` toolset |
+| `kanban_heartbeat` | Signal during a long-running operation that the worker is still alive. Renews the liveness lease only — the separate progress lease moves on verified tool executions and board transitions, never on a heartbeat or its note. | `HERMES_KANBAN_TASK` or `kanban` toolset |
 | `kanban_comment` | Add a comment to the task thread without changing its state — useful for surfacing intermediate findings. | `HERMES_KANBAN_TASK` or `kanban` toolset |
 | `kanban_create` | Fan out child tasks from the current task. Used by orchestrators and follow-up-spawning workers. | `HERMES_KANBAN_TASK` or `kanban` toolset |
 | `kanban_link` | Link tasks with a parent → child dependency edge. | `HERMES_KANBAN_TASK` or `kanban` toolset |

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -300,7 +300,7 @@ parent, missing input, unmet capability) before unblocking, or raise
 | `kanban_request_review` | Start same-card review with a durable `summary`, optional `metadata`, and optional reviewer profile. The task moves to `review`; this is not a block. | `summary` |
 | `kanban_request_changes` | Reviewer verdict from an active review run. Closes that run, reapplies parent gating, and routes the task to its original implementer without block-loop accounting. | `reason` |
 | `kanban_block` | Stop work and route by why: `kind=dependency` (waits in `todo`, auto-resumes), `needs_input`/`capability`/`transient` (surface to a human). Repeated same-kind re-blocks auto-escalate to `triage`. | `reason` |
-| `kanban_heartbeat` | Signal liveness during long operations. Pure side-effect. | — |
+| `kanban_heartbeat` | Signal liveness during long operations. Renews the liveness lease only — never the progress lease, whatever its note says. Pure side-effect. | — |
 | `kanban_comment` | Append a durable note to the task thread. | `task_id`, `body` |
 | `kanban_attach` | Attach a file to a task by passing its bytes inline (base64); stored under the task's attachments dir (25 MB cap). | file bytes + name |
 | `kanban_attach_url` | Attach a file to a task by URL. | `url` |
@@ -398,7 +398,7 @@ Every profile that works kanban tasks automatically gets the worker lifecycle �
 
 1. On spawn, call `kanban_show()` to read title + body + parent handoffs + prior attempts + full comment thread.
 2. `cd $HERMES_KANBAN_WORKSPACE` (via the terminal tool) and do the work there.
-3. Call `kanban_heartbeat(note="...")` every few minutes during long operations. **If your work may run longer than 1 hour, call `kanban_heartbeat` at least once an hour** — the dispatcher reclaims tasks that have been running past `kanban.dispatch_stale_timeout_seconds` (default 4 h) with no heartbeat in the last hour, on the assumption the worker crashed without cleanup. A reclaim is benign (the task goes back to `ready` for re-dispatch without a failure-counter tick) but you lose your current run's progress.
+3. Call `kanban_heartbeat(note="...")` every few minutes during long operations. **If your work may run longer than 1 hour, call `kanban_heartbeat` at least once an hour** — the dispatcher reclaims tasks that have been running past `kanban.dispatch_stale_timeout_seconds` (default 4 h) with no heartbeat in the last hour, on the assumption the worker crashed without cleanup. A reclaim is benign (the task goes back to `ready` for re-dispatch without a failure-counter tick) but you lose your current run's progress. A heartbeat renews *liveness* only; see [Liveness vs. progress](#liveness-vs-progress-no-progress-detection) for the separate progress lease.
 4. Complete with `kanban_complete(summary="...", metadata={...})`, or `kanban_block(reason="...")` if stuck.
 
 That final `kanban_complete` / `kanban_block` call is part of the worker
@@ -802,6 +802,26 @@ kanban:
   auto_promote_children: false
   default_workdir: ~/work/active-project
 ```
+
+### Liveness vs. progress (no-progress detection)
+
+A running claim carries two independent leases:
+
+| Lease | Column | Renewed by |
+|-------|--------|------------|
+| **Liveness** — "the worker and its provider are responsive" | `last_heartbeat_at` + `claim_expires` | Any agent activity: stream tokens, API waits, the in-flight tool ticker, and `kanban_heartbeat` (with or without a note). |
+| **Progress** — "something observable happened outside the model's token stream" | `last_progress_at` | The claim itself; a *verified* tool execution (dispatched, able to change the task's world, and successful — read-only tools, refused or failed calls, and agent-bookkeeping tools like `todo`/`memory`/`kanban_heartbeat` never count); a durable board transition (comment, attach, link, block, complete, review). |
+
+Nothing the model *writes* renews progress — a `kanban_heartbeat` note is recorded as commentary and has no effect on any lease — so a slow single model call survives on liveness while a reasoning-only loop is bounded.
+
+When a running task's progress lease is older than `kanban.no_progress_timeout_seconds` (default `2700`, 45 minutes; `0` disables; values under 60 are refused with a warning and fall back to the default), the dispatcher **detects and reports** it: it writes a durable `no_progress_deferred` event (with the progress age, the liveness age, the pid and claim it observed) and holds the claim for a bounded grace (15 minutes), re-issuing the receipt at most once per grace window while the condition persists. It does **not** terminate the worker, requeue the task, or count a failure — the card keeps its status, claim, PID and run, and the existing crash / stale / max-runtime paths and manual `hermes kanban reclaim` remain the recovery levers. The receipt surfaces as a `no_progress_deferred` line in `hermes kanban dispatch` output, a `no_progress_deferred` diagnostic on `hermes kanban show` and the dashboard, and a passive notification to gateway / TUI / desktop subscribers (it never wakes the creating agent, because the task is still running).
+
+```yaml
+kanban:
+  no_progress_timeout_seconds: 2700   # 0 disables detection
+```
+
+The same validated value is used by the gateway-embedded dispatcher, `hermes kanban dispatch`, the standalone daemon and the dashboard's dispatch nudge, so a tick behaves identically whichever surface ran it.
 
 ### Scheduled task starts (`scheduled_at`)
 


### PR DESCRIPTION
## Summary

Split Kanban worker **liveness** from deterministic **progress** without claiming universal process authority.

- model streaming, API waits, in-flight tool heartbeats, and `kanban_heartbeat` commentary renew liveness only;
- claims, successful side-effect-capable tool execution, and durable board transitions renew progress;
- failed/refused/unverified tools, exact read-only tools, read-only multiplexed actions, and multimodal failure payloads do not renew progress;
- default 45-minute no-progress detection emits a bounded `no_progress_deferred` receipt while retaining the exact task status, claim, PID, and run;
- this PR never signals, requeues, clears authority, or counts failure on progress expiry;
- the timeout and passive receipt propagate through CLI, gateway, standalone daemon, dashboard, diagnostics, Desktop/TUI notification surfaces, config, and docs.

## Why the scope changed

Review correctly showed that automatic requeue is inseparable from process-scope authority. The previous head and a contributed consolidation attempt tried to solve both together, but created Windows recovery/review deadlocks, upgrade fences, uncached platform probes under SQLite writer transactions, and sibling status-transition release gaps.

This rewrite keeps the reviewer-approved causal half and removes the unsafe authority expansion. Automatic settlement belongs in a separate PR with an explicit platform/upgrade contract; unsupported authority must never become permission to start a duplicate worker.

The existing PR thread, reviews, and contributor audit remain attached. The offered commit `6c5bf42d3ebff2d67231a0c069f92c30744aefad` was audited and credited in the discussion but is not applied wholesale.

## Invariants

- `tasks.last_progress_at` is the single persisted progress clock; migration is additive and leaves legacy rows `NULL`.
- A claim stamps both liveness and progress.
- Tool progress requires the complete task/run/claim tuple; stale or foreign workers cannot renew a successor.
- Board transition kinds are explicitly allowlisted; lease/recovery receipts cannot renew themselves.
- Read-only `kanban_show`, `kanban_list`, attachments listing, process list/poll/log/wait, capture/state inspection, cron list, and delegation list remain non-progress.
- Mapping and multimodal results with `ok:false`, `error`, failed/refused status/effect, false verification/success, or nonzero exit never count.
- Expiry classification runs after existing stale/crash/max-runtime passes and is detection-only.
- `0` explicitly disables detection; malformed, negative, boolean, non-finite, and sub-minute values fall back to the validated default consistently.
- Notifications are passive; a deferred receipt does not wake or spawn work.

## TDD and verification

- Clean-base RED: **106 failed / 0 new passed** across the new behavioral witnesses.
- Exact-head focused canonical runner: **150 passed / 0 failed**.
- Exact-head hosted Python suite: **36,972 passed / 0 failed / 351 skipped** across 3,206 files.
- Patch-identical pre-final-rebase broad Kanban/middleware/dashboard regression: **479 passed / 0 failed / 1 platform skip**.
- Desktop completion notification: **29 passed**; Desktop typecheck passed.
- Changed Python Ruff and compileall: passed.
- Windows-footgun scan: passed on every changed Python file.
- `git diff --check`: passed.
- Mutation/sabotage witness: allowing heartbeat commentary or failed tool results to count caused ten committed witnesses to fail; restoring the invariant returned the suite green.
- Independent reviews found read-only-action and real `computer_use` failure-shape bypasses; both were closed with behavioral tests.

## Explicit boundary

This PR detects and reports deterministic no-progress. It does **not** claim that a PID, hostname, or unsupported platform is safe to terminate, and it does not automatically requeue a worker. A future settlement change must prove exact task/run/claim/process-group authority and full quiescence before releasing the claim.

## Deployment

Source-only PR. No live board, database, dispatcher, gateway, or Hermes runtime was modified or deployed.
