### PR TITLE
feat(whatsapp): add guarded group creation

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -153,7 +153,7 @@ def gui_toolset_label(label: str) -> str:
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a"}
+_DEFAULT_OFF_TOOLSETS = {"homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search", "a2a", "whatsapp_group_admin"}
 
 
 # Config-only capabilities: they appear in `hermes tools` for provider/API-key
@@ -216,6 +216,7 @@ def _homeassistant_credentials_present() -> bool:
 _TOOLSET_PLATFORM_RESTRICTIONS: Dict[str, Set[str]] = {
     "discord": {"discord"},
     "discord_admin": {"discord"},
+    "whatsapp_group_admin": {"whatsapp"},
 }
 
 

--- a/plugins/platforms/whatsapp/__init__.py
+++ b/plugins/platforms/whatsapp/__init__.py
@@ -1,3 +1,27 @@
-from .adapter import register
+"""WhatsApp platform plugin.
+
+Keep this module import-light: deferred plugin discovery imports it to register
+client tools without materializing the gateway adapter.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def register(ctx) -> None:
+    try:
+        from .tools import register_tools
+
+        register_tools(ctx)
+    except Exception:
+        logger.warning("WhatsApp: failed to register group admin tool", exc_info=True)
+
+    from .adapter import register as register_platform
+
+    register_platform(ctx)
+
 
 __all__ = ["register"]

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -60,6 +60,42 @@ logger = logging.getLogger(__name__)
 # Inbound owner-typed WhatsApp text is prefixed at MessageEvent construction so
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
+_GROUP_ADMIN_JID = re.compile(
+    r"^(?P<identifier>[0-9]{1,32})(?::[0-9]{1,3})?@(?:s\.whatsapp\.net|c\.us|lid)$",
+    re.IGNORECASE,
+)
+
+
+def _group_admin_identifiers(extra: dict[str, Any]) -> set[str]:
+    """Return exact configured user principals in Hermes' canonical ID space."""
+    from gateway.whatsapp_identity import canonical_whatsapp_identifier
+
+    result: set[str] = set()
+    configured = extra.get("group_admin_users", [])
+    if isinstance(configured, str):
+        configured = configured.split(",")
+    if not isinstance(configured, list):
+        return result
+    for raw in configured:
+        value = str(raw).strip()
+        if not _GROUP_ADMIN_JID.fullmatch(value):
+            continue
+        canonical = canonical_whatsapp_identifier(value)
+        if canonical:
+            result.add(canonical)
+    return result
+
+
+def _is_group_admin_source(source: Any, extra: dict[str, Any]) -> bool:
+    """Authorize only an exact configured principal in its direct-message chat."""
+    if getattr(source, "chat_type", None) != "dm":
+        return False
+    from gateway.whatsapp_identity import canonical_whatsapp_identifier
+
+    user = canonical_whatsapp_identifier(getattr(source, "user_id", ""))
+    chat = canonical_whatsapp_identifier(getattr(source, "chat_id", ""))
+    admins = _group_admin_identifiers(extra)
+    return bool(user and chat and user == chat and user in admins)
 
 
 def _listener_pids_on_port(port: int) -> list:
@@ -487,6 +523,30 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
 
+    def toolsets_for_source(self, source) -> Optional[list[str]]:
+        """Expose group administration only to an exact configured DM owner.
+
+        Resolve the platform's ordinary toolsets first so this per-source
+        override cannot accidentally drop existing capabilities. The group
+        toolset is default-off and platform-restricted; authorized DMs add it
+        for this turn, while every other source has it removed even if someone
+        hand-edited it into the platform list.
+        """
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.tools_config import _get_platform_tools
+
+            configured = set(_get_platform_tools(load_config() or {}, "whatsapp"))
+        except Exception:
+            configured = set()
+        configured.discard("whatsapp_group_admin")
+        if _is_group_admin_source(source, self.config.extra):
+            configured.add("whatsapp_group_admin")
+        # GatewayRunner historically treats [] as "no override". no_mcp is a
+        # recognized zero-capability sentinel and preserves an explicit empty
+        # selection without falling back to a hand-edited unsafe list.
+        return sorted(configured) if configured else ["no_mcp"]
+
     def _coerce_float_extra(self, key: str, default: float) -> float:
         """Read a float from ``config.extra``, guarding against bad/non-finite values.
 
@@ -715,10 +775,27 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "WHATSAPP_DEBUG", "WHATSAPP_FORWARD_OWNER_MESSAGES",
                 "WHATSAPP_REPLY_PREFIX", "WHATSAPP_MAX_MESSAGE_LENGTH",
                 "WHATSAPP_CHUNK_DELAY_MS", "WHATSAPP_SEND_TIMEOUT_MS",
+                # Fail-closed, loopback-only group administration. The token
+                # is injected into the child environment and is never placed
+                # in argv or logs.
+                "WHATSAPP_GROUP_CONTROL_TOKEN",
             ):
                 _v = _wenv(_key)
                 if _v:
                     bridge_env[_key] = _v
+            # Behavioral group-control policy is configured in config.yaml;
+            # only the bearer credential lives in .env. The bridge receives
+            # these values as an internal transport detail.
+            _group_participants = self.config.extra.get("group_allowed_participants", [])
+            if isinstance(_group_participants, str):
+                _group_participants = _group_participants.split(",")
+            if isinstance(_group_participants, list) and _group_participants:
+                bridge_env["WHATSAPP_GROUP_ALLOWED_PARTICIPANTS"] = ",".join(
+                    str(value).strip() for value in _group_participants if str(value).strip()
+                )
+            _group_state = self.config.extra.get("group_operation_state")
+            if _group_state:
+                bridge_env["WHATSAPP_GROUP_OPERATION_STATE"] = str(_group_state)
             # Pass the profile-aware cache directories so the bridge writes
             # media where the Python side reads it.  Without these the bridge
             # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges

--- a/plugins/platforms/whatsapp/plugin.yaml
+++ b/plugins/platforms/whatsapp/plugin.yaml
@@ -9,6 +9,8 @@ description: >
   Supports DM/group policies, mention gating, free-response chats, and
   per-user allowlists.
 author: NousResearch
+provides_tools:
+  - whatsapp_create_group
 requires_env:
   - name: WHATSAPP_ENABLED
     description: "Enable the WhatsApp adapter (requires the Node.js bridge running)"
@@ -31,3 +33,7 @@ optional_env:
     description: "Display name for the WhatsApp home channel"
     prompt: "Home channel display name"
     password: false
+  - name: WHATSAPP_GROUP_CONTROL_TOKEN
+    description: "Private bearer token for the loopback-only group control endpoint"
+    prompt: "Group control token (empty disables group creation)"
+    password: true

--- a/plugins/platforms/whatsapp/tools.py
+++ b/plugins/platforms/whatsapp/tools.py
@@ -1,0 +1,249 @@
+"""Fail-closed WhatsApp group administration tool.
+
+The model-facing tool is only one half of the authorization boundary.  The
+WhatsApp adapter exposes its toolset solely to exact configured DM principals,
+and the loopback Node bridge independently authenticates the call, enforces the
+participant allowlist, and persists idempotency state.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+_CONTROL = re.compile(r"[\x00-\x1f\x7f]")
+_JID = re.compile(
+    r"^(?:[0-9]{1,32})(?::[0-9]{1,3})?@(s\.whatsapp\.net|c\.us|lid)$",
+    re.IGNORECASE,
+)
+_OPERATION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{7,63}$")
+_TOOLSET = "whatsapp_group_admin"
+
+
+def _wenv(name: str, default: str = "") -> str:
+    from agent.secret_scope import UnscopedSecretError, get_secret
+
+    try:
+        value = get_secret(name)
+    except UnscopedSecretError:
+        import os
+
+        value = os.getenv(name)
+    return value if value is not None else default
+
+
+def _normalize_jid(value: object) -> str | None:
+    raw = str(value or "").strip()
+    if len(raw) > 96 or _CONTROL.search(raw):
+        return None
+    match = _JID.fullmatch(raw)
+    if not match:
+        return None
+    local, domain = raw.rsplit("@", 1)
+    local = local.split(":", 1)[0]
+    domain = "s.whatsapp.net" if domain.lower() == "c.us" else domain.lower()
+    return f"{local}@{domain}"
+
+
+def _group_config_value(name: str) -> list[object]:
+    try:
+        from hermes_cli.config import load_config
+
+        extra = (
+            (((load_config() or {}).get("gateway") or {}).get("platforms") or {})
+            .get("whatsapp", {})
+            .get("extra", {})
+        )
+        value = extra.get(name, []) if isinstance(extra, dict) else []
+    except Exception:
+        return []
+    if isinstance(value, str):
+        return value.split(",")
+    return value if isinstance(value, list) else []
+
+
+def _jid_allowlist(name: str) -> set[str]:
+    values = {
+        normalized
+        for item in _group_config_value(name)
+        if (normalized := _normalize_jid(item)) is not None
+    }
+    return values
+
+
+def _check_available() -> bool:
+    token = _wenv("WHATSAPP_GROUP_CONTROL_TOKEN").strip()
+    return bool(
+        token
+        and 32 <= len(token) <= 512
+        and _jid_allowlist("group_admin_users")
+        and _jid_allowlist("group_allowed_participants")
+    )
+
+
+def _bridge_port() -> int:
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config() or {}
+        raw = (
+            (
+                ((config.get("gateway") or {}).get("platforms") or {}).get("whatsapp")
+                or {}
+            )
+            .get("extra", {})
+            .get("bridge_port", 3000)
+        )
+        port = int(raw)
+    except (TypeError, ValueError, AttributeError):
+        port = 3000
+    return port if 1 <= port <= 65535 else 3000
+
+
+def _validated_request(args: dict[str, Any]) -> dict[str, Any] | None:
+    subject = str(args.get("subject") or "").strip()
+    confirmation = str(args.get("confirmed_subject") or "")
+    operation_id = str(args.get("operation_id") or "").strip()
+    raw_participants = args.get("participants")
+    raw_confirmed_participants = args.get("confirmed_participants")
+    if (
+        not subject
+        or len(subject) > 100
+        or _CONTROL.search(subject)
+        or confirmation != subject
+        or not _OPERATION_ID.fullmatch(operation_id)
+        or not isinstance(raw_participants, list)
+        or not isinstance(raw_confirmed_participants, list)
+        or not 1 <= len(raw_participants) <= 50
+    ):
+        return None
+
+    participants: list[str] = []
+    for value in raw_participants:
+        normalized = _normalize_jid(value)
+        if normalized is None or normalized in participants:
+            return None
+        participants.append(normalized)
+    confirmed_participants = [
+        _normalize_jid(value) for value in raw_confirmed_participants
+    ]
+    if confirmed_participants != participants:
+        return None
+    if not set(participants).issubset(_jid_allowlist("group_allowed_participants")):
+        return None
+    return {
+        "subject": subject,
+        "confirmedSubject": confirmation,
+        "operationId": operation_id,
+        "participants": participants,
+        "confirmedParticipants": confirmed_participants,
+    }
+
+
+async def whatsapp_create_group(args: dict[str, Any], **_kwargs: Any) -> str:
+    request = _validated_request(args)
+    token = _wenv("WHATSAPP_GROUP_CONTROL_TOKEN").strip()
+    if request is None or not _check_available():
+        return json.dumps({
+            "success": False,
+            "error": "Group creation is unavailable or the confirmed request is invalid.",
+        })
+
+    try:
+        import aiohttp
+
+        timeout = aiohttp.ClientTimeout(total=25)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                f"http://127.0.0.1:{_bridge_port()}/groups/create",
+                json=request,
+                headers={"Authorization": f"Bearer {token}"},
+            ) as response:
+                try:
+                    body = await response.json()
+                except Exception:
+                    body = {}
+                if response.status not in {200, 201} or not isinstance(body, dict):
+                    return json.dumps({
+                        "success": False,
+                        "error": "The WhatsApp bridge rejected the group request.",
+                        "status": response.status,
+                    })
+                return json.dumps({
+                    "success": body.get("success") is True,
+                    "status": str(body.get("status") or "created")[:32],
+                    "operation_id": request["operationId"],
+                    "subject": request["subject"],
+                    "group_id": str(body.get("groupId") or "")[:128] or None,
+                })
+    except Exception:
+        return json.dumps({
+            "success": False,
+            "error": "The local WhatsApp group control service is unavailable.",
+        })
+
+
+_SCHEMA = {
+    "name": "whatsapp_create_group",
+    "description": (
+        "Create one WhatsApp group after the operator explicitly confirms the exact "
+        "subject and participants. Use a stable unique operation_id for retries. "
+        "Never guess participant identifiers or retry an uncertain operation with a new ID."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "subject": {
+                "type": "string",
+                "description": "Exact WhatsApp group subject, 1-100 characters.",
+            },
+            "participants": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+                "maxItems": 50,
+                "description": "Exact allowlisted WhatsApp user JIDs to add.",
+            },
+            "operation_id": {
+                "type": "string",
+                "description": "Stable 8-64 character idempotency key for this exact request.",
+            },
+            "confirmed_subject": {
+                "type": "string",
+                "description": "Repeat the exact subject only after the operator confirms it and the participant list.",
+            },
+            "confirmed_participants": {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": 1,
+                "maxItems": 50,
+                "description": "Repeat the exact participant JID list only after the operator confirms it.",
+            },
+        },
+        "required": [
+            "subject",
+            "participants",
+            "operation_id",
+            "confirmed_subject",
+            "confirmed_participants",
+        ],
+        "additionalProperties": False,
+    },
+}
+
+
+def register_tools(ctx) -> None:
+    ctx.register_tool(
+        name="whatsapp_create_group",
+        toolset=_TOOLSET,
+        schema=_SCHEMA,
+        handler=whatsapp_create_group,
+        check_fn=_check_available,
+        requires_env=[
+            "WHATSAPP_GROUP_CONTROL_TOKEN",
+        ],
+        is_async=True,
+        description=_SCHEMA["description"],
+        emoji="👥",
+    )

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -34,6 +34,12 @@ import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
+  GroupOperationStore,
+  authorizeGroupControl,
+  executeGroupCreate,
+  parseParticipantAllowlist,
+} from './group_control.js';
+import {
   buildPollPayload,
   createReconnectScheduler,
   createVersionResolver,
@@ -86,6 +92,20 @@ const SEND_READ_RECEIPTS =
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
+const GROUP_CONTROL_TOKEN = String(process.env.WHATSAPP_GROUP_CONTROL_TOKEN || '').trim();
+const GROUP_ALLOWED_PARTICIPANTS = parseParticipantAllowlist(
+  process.env.WHATSAPP_GROUP_ALLOWED_PARTICIPANTS || '',
+);
+const GROUP_OPERATION_STATE = process.env.WHATSAPP_GROUP_OPERATION_STATE
+  || path.join(path.dirname(SESSION_DIR), 'group-operations.json');
+const GROUP_CONTROL_ENABLED = Boolean(
+  GROUP_CONTROL_TOKEN
+  && GROUP_CONTROL_TOKEN.length >= 32
+  && GROUP_CONTROL_TOKEN.length <= 512
+  && GROUP_ALLOWED_PARTICIPANTS.size > 0
+);
+const groupOperationStore = new GroupOperationStore(GROUP_OPERATION_STATE);
+let groupControlQueue = Promise.resolve();
 // Cache directories: the Python gateway passes the profile-aware paths via
 // env (HERMES_HOME-aware, new cache/ layout).  Fall back to the legacy
 // hardcoded locations for bridges launched outside the gateway.
@@ -780,7 +800,7 @@ async function startSocket() {
 
 // HTTP server
 const app = express();
-app.use(express.json());
+app.use(express.json({ limit: '16kb' }));
 
 // Host-header validation — defends against DNS rebinding.
 // The bridge binds loopback-only (127.0.0.1) but a victim browser on
@@ -1103,6 +1123,38 @@ app.get('/chat/:id', async (req, res) => {
   });
 });
 
+// Authenticated, disabled-by-default group administration. This endpoint is
+// deliberately absent from ordinary send APIs and remains loopback-only with
+// the rest of the bridge. Requests are serialized so subject checks and
+// idempotency reservations cannot race each other.
+app.post('/groups/create', async (req, res) => {
+  if (!GROUP_CONTROL_ENABLED) {
+    return res.status(404).json({ error: 'Group control is disabled' });
+  }
+  if (!authorizeGroupControl(req.headers.authorization, GROUP_CONTROL_TOKEN)) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const run = async () => executeGroupCreate({
+    body: req.body,
+    allowedParticipants: GROUP_ALLOWED_PARTICIPANTS,
+    store: groupOperationStore,
+    listGroups: () => sock.groupFetchAllParticipating(),
+    createGroup: (subject, participants) => sock.groupCreate(subject, participants),
+  });
+  const task = groupControlQueue.then(run, run);
+  groupControlQueue = task.catch(() => {});
+  try {
+    const result = await task;
+    return res.status(result.httpStatus).json(result.body);
+  } catch {
+    return res.status(500).json({ error: 'Group control failed' });
+  }
+});
+
 // Health check
 app.get('/health', (req, res) => {
   res.json({
@@ -1111,6 +1163,7 @@ app.get('/health', (req, res) => {
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
+    groupControlEnabled: GROUP_CONTROL_ENABLED,
   });
 });
 

--- a/scripts/whatsapp-bridge/group_control.js
+++ b/scripts/whatsapp-bridge/group_control.js
@@ -1,0 +1,244 @@
+import { createHash, timingSafeEqual } from 'crypto';
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+  fsyncSync,
+} from 'fs';
+import path from 'path';
+
+const CONTROL = /[\x00-\x1f\x7f]/;
+const JID = /^(\d{1,32})(?::\d{1,3})?@(s\.whatsapp\.net|c\.us|lid)$/i;
+const OPERATION_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{7,63}$/;
+const SCHEMA_VERSION = 1;
+const MAX_OPERATIONS = 256;
+
+export function normalizeParticipantJid(value) {
+  const raw = String(value || '').trim();
+  if (!raw || raw.length > 96 || CONTROL.test(raw)) return null;
+  const match = raw.match(JID);
+  if (!match) return null;
+  const domain = match[2].toLowerCase() === 'c.us' ? 's.whatsapp.net' : match[2].toLowerCase();
+  return `${match[1]}@${domain}`;
+}
+
+export function parseParticipantAllowlist(raw) {
+  const result = new Set();
+  for (const value of String(raw || '').split(',')) {
+    if (!value.trim()) continue;
+    const normalized = normalizeParticipantJid(value);
+    if (!normalized) return new Set();
+    result.add(normalized);
+  }
+  return result;
+}
+
+export function authorizeGroupControl(header, expectedToken) {
+  const prefix = 'Bearer ';
+  const supplied = String(header || '');
+  const expected = String(expectedToken || '');
+  if (expected.length < 32 || expected.length > 512 || !supplied.startsWith(prefix)) return false;
+  const actual = supplied.slice(prefix.length);
+  const actualBuffer = Buffer.from(actual, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  if (actualBuffer.length !== expectedBuffer.length) return false;
+  return timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+export function validateGroupCreatePayload(body, allowedParticipants) {
+  const subject = String(body?.subject || '').trim();
+  const confirmedSubject = String(body?.confirmedSubject || '');
+  const operationId = String(body?.operationId || '').trim();
+  if (
+    !subject || subject.length > 100 || CONTROL.test(subject)
+    || confirmedSubject !== subject
+    || !OPERATION_ID.test(operationId)
+    || !Array.isArray(body?.participants)
+    || !Array.isArray(body?.confirmedParticipants)
+    || body.participants.length < 1
+    || body.participants.length > 50
+    || !(allowedParticipants instanceof Set)
+    || allowedParticipants.size < 1
+  ) return null;
+
+  const participants = [];
+  for (const raw of body.participants) {
+    const participant = normalizeParticipantJid(raw);
+    if (!participant || !allowedParticipants.has(participant) || participants.includes(participant)) {
+      return null;
+    }
+    participants.push(participant);
+  }
+  const confirmedParticipants = body.confirmedParticipants.map(normalizeParticipantJid);
+  if (
+    confirmedParticipants.length !== participants.length
+    || confirmedParticipants.some((participant, index) => participant !== participants[index])
+  ) return null;
+  const payloadHash = createHash('sha256')
+    .update(JSON.stringify({ subject, participants }))
+    .digest('hex');
+  return { subject, confirmedSubject, operationId, participants, confirmedParticipants, payloadHash };
+}
+
+function validateState(value) {
+  if (!value || value.schemaVersion !== SCHEMA_VERSION || !Array.isArray(value.operations)) {
+    throw new Error('Group operation state is invalid');
+  }
+  for (const operation of value.operations) {
+    if (
+      !operation || !OPERATION_ID.test(String(operation.operationId || ''))
+      || !/^[a-f0-9]{64}$/.test(String(operation.payloadHash || ''))
+      || !['pending', 'created', 'uncertain'].includes(operation.status)
+      || typeof operation.subject !== 'string' || !operation.subject
+      || !Number.isFinite(operation.createdAt) || !Number.isFinite(operation.updatedAt)
+      || (operation.groupId !== undefined && !String(operation.groupId).endsWith('@g.us'))
+    ) throw new Error('Group operation state is invalid');
+  }
+  return value;
+}
+
+export class GroupOperationStore {
+  constructor(filePath, { now = () => Date.now() } = {}) {
+    if (!filePath) throw new Error('Group operation state path is required');
+    this.filePath = filePath;
+    this.now = now;
+  }
+
+  load() {
+    if (!existsSync(this.filePath)) return { schemaVersion: SCHEMA_VERSION, operations: [] };
+    return validateState(JSON.parse(readFileSync(this.filePath, 'utf8')));
+  }
+
+  save(state) {
+    validateState(state);
+    const directory = path.dirname(this.filePath);
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    chmodSync(directory, 0o700);
+    const temporary = `${this.filePath}.${process.pid}.tmp`;
+    let descriptor;
+    try {
+      descriptor = openSync(temporary, 'wx', 0o600);
+      writeFileSync(descriptor, `${JSON.stringify(state, null, 2)}\n`);
+      fsyncSync(descriptor);
+      closeSync(descriptor);
+      descriptor = undefined;
+      renameSync(temporary, this.filePath);
+      chmodSync(this.filePath, 0o600);
+      const directoryDescriptor = openSync(directory, 'r');
+      try { fsyncSync(directoryDescriptor); } finally { closeSync(directoryDescriptor); }
+    } finally {
+      if (descriptor !== undefined) closeSync(descriptor);
+      if (existsSync(temporary)) unlinkSync(temporary);
+    }
+  }
+
+  recordPending(request) {
+    const state = this.load();
+    const existing = state.operations.find(item => item.operationId === request.operationId);
+    if (existing) return { existing };
+    const now = this.now();
+    const operation = {
+      operationId: request.operationId,
+      payloadHash: request.payloadHash,
+      subject: request.subject,
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    };
+    if (state.operations.length >= MAX_OPERATIONS) {
+      throw new Error('Group operation state is at capacity');
+    }
+    state.operations.push(operation);
+    this.save(state);
+    return { operation };
+  }
+
+  finish(operationId, status, groupId = null) {
+    const state = this.load();
+    const operation = state.operations.find(item => item.operationId === operationId);
+    if (!operation) throw new Error('Group operation is missing');
+    operation.status = status;
+    operation.updatedAt = this.now();
+    if (groupId) operation.groupId = String(groupId).slice(0, 128);
+    this.save(state);
+    return operation;
+  }
+}
+
+function existingOperationResponse(existing, request) {
+  if (existing.payloadHash !== request.payloadHash) {
+    return { httpStatus: 409, body: { success: false, status: 'conflict', error: 'Operation ID is already bound to a different request.' } };
+  }
+  if (existing.status === 'created' && existing.groupId) {
+    return { httpStatus: 200, body: { success: true, status: 'created', groupId: existing.groupId } };
+  }
+  return { httpStatus: 409, body: { success: false, status: 'uncertain', error: 'This operation is pending or uncertain and will not be retried automatically.' } };
+}
+
+function withTimeout(promise, timeoutMs) {
+  let timer;
+  return Promise.race([
+    Promise.resolve(promise),
+    new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error('Group control timed out')), timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(timer));
+}
+
+export async function executeGroupCreate({
+  body,
+  allowedParticipants,
+  store,
+  listGroups,
+  createGroup,
+  now = () => Date.now(),
+  minimumIntervalMs = 30_000,
+  operationTimeoutMs = 10_000,
+}) {
+  const request = validateGroupCreatePayload(body, allowedParticipants);
+  if (!request) {
+    return { httpStatus: 400, body: { success: false, status: 'invalid', error: 'Group request is invalid.' } };
+  }
+
+  const state = store.load();
+  const existing = state.operations.find(item => item.operationId === request.operationId);
+  if (existing) return existingOperationResponse(existing, request);
+  const recentAttempt = state.operations.find(
+    item => Number.isFinite(item.createdAt) && now() - item.createdAt < minimumIntervalMs,
+  );
+  if (recentAttempt) {
+    return { httpStatus: 429, body: { success: false, status: 'rate-limited', error: 'Group creation is temporarily rate limited.' } };
+  }
+
+  let groups;
+  try {
+    groups = await withTimeout(listGroups(), operationTimeoutMs);
+  } catch {
+    return { httpStatus: 503, body: { success: false, status: 'unavailable', error: 'Existing groups could not be verified.' } };
+  }
+  if (Object.values(groups || {}).some(group => group?.subject === request.subject)) {
+    return { httpStatus: 409, body: { success: false, status: 'subject-exists', error: 'A group with this exact subject already exists.' } };
+  }
+
+  const reserved = store.recordPending(request);
+  if (reserved.existing) return existingOperationResponse(reserved.existing, request);
+  try {
+    const created = await withTimeout(
+      createGroup(request.subject, request.participants),
+      operationTimeoutMs,
+    );
+    const groupId = String(created?.id || '').trim();
+    if (!groupId || !groupId.endsWith('@g.us')) throw new Error('Group result is invalid');
+    store.finish(request.operationId, 'created', groupId);
+    return { httpStatus: 201, body: { success: true, status: 'created', groupId } };
+  } catch {
+    store.finish(request.operationId, 'uncertain');
+    return { httpStatus: 502, body: { success: false, status: 'uncertain', error: 'Group creation result is uncertain and will not be retried automatically.' } };
+  }
+}

--- a/scripts/whatsapp-bridge/group_control.js
+++ b/scripts/whatsapp-bridge/group_control.js
@@ -142,7 +142,15 @@ export class GroupOperationStore {
     const state = this.load();
     const existing = state.operations.find(item => item.operationId === request.operationId);
     if (existing) return { existing };
+    const reserved = state.operations.find(
+      item => item.subject === request.subject || item.payloadHash === request.payloadHash,
+    );
+    if (reserved) return { reserved };
     const now = this.now();
+    const recentAttempt = state.operations.find(
+      item => Number.isFinite(item.createdAt) && now - item.createdAt < request.minimumIntervalMs,
+    );
+    if (recentAttempt) return { rateLimited: true };
     const operation = {
       operationId: request.operationId,
       payloadHash: request.payloadHash,
@@ -181,6 +189,10 @@ function existingOperationResponse(existing, request) {
   return { httpStatus: 409, body: { success: false, status: 'uncertain', error: 'This operation is pending or uncertain and will not be retried automatically.' } };
 }
 
+function reservedOperationResponse() {
+  return { httpStatus: 409, body: { success: false, status: 'reserved', error: 'This group subject or participant payload is already bound to another operation and will not be retried.' } };
+}
+
 function withTimeout(promise, timeoutMs) {
   let timer;
   return Promise.race([
@@ -209,6 +221,10 @@ export async function executeGroupCreate({
   const state = store.load();
   const existing = state.operations.find(item => item.operationId === request.operationId);
   if (existing) return existingOperationResponse(existing, request);
+  const reservedOperation = state.operations.find(
+    item => item.subject === request.subject || item.payloadHash === request.payloadHash,
+  );
+  if (reservedOperation) return reservedOperationResponse();
   const recentAttempt = state.operations.find(
     item => Number.isFinite(item.createdAt) && now() - item.createdAt < minimumIntervalMs,
   );
@@ -226,8 +242,12 @@ export async function executeGroupCreate({
     return { httpStatus: 409, body: { success: false, status: 'subject-exists', error: 'A group with this exact subject already exists.' } };
   }
 
-  const reserved = store.recordPending(request);
+  const reserved = store.recordPending({ ...request, minimumIntervalMs });
   if (reserved.existing) return existingOperationResponse(reserved.existing, request);
+  if (reserved.reserved) return reservedOperationResponse();
+  if (reserved.rateLimited) {
+    return { httpStatus: 429, body: { success: false, status: 'rate-limited', error: 'Group creation is temporarily rate limited.' } };
+  }
   try {
     const created = await withTimeout(
       createGroup(request.subject, request.participants),

--- a/scripts/whatsapp-bridge/group_control.test.mjs
+++ b/scripts/whatsapp-bridge/group_control.test.mjs
@@ -22,7 +22,7 @@ const request = {
   confirmedParticipants: ['15550001111:2@c.us'],
 };
 
-const token = '0123456789abcdef0123456789abcdef';
+const token = '0123456789abcdef'.repeat(2);
 assert.equal(authorizeGroupControl(`Bearer ${token}`, token), true);
 assert.equal(authorizeGroupControl('Bearer short', 'short'), false);
 assert.equal(authorizeGroupControl('', token), false);

--- a/scripts/whatsapp-bridge/group_control.test.mjs
+++ b/scripts/whatsapp-bridge/group_control.test.mjs
@@ -22,10 +22,10 @@ const request = {
   confirmedParticipants: ['15550001111:2@c.us'],
 };
 
-const token = '0123456789abcdef'.repeat(2);
-assert.equal(authorizeGroupControl(`Bearer ${token}`, token), true);
+const credential = 'x'.repeat(32);
+assert.equal(authorizeGroupControl(`Bearer ${credential}`, credential), true);
 assert.equal(authorizeGroupControl('Bearer short', 'short'), false);
-assert.equal(authorizeGroupControl('', token), false);
+assert.equal(authorizeGroupControl('', credential), false);
 assert.deepEqual([...allowed], ['15550001111@s.whatsapp.net', '998877@lid']);
 assert.deepEqual(
   validateGroupCreatePayload(request, allowed).participants,

--- a/scripts/whatsapp-bridge/group_control.test.mjs
+++ b/scripts/whatsapp-bridge/group_control.test.mjs
@@ -1,0 +1,148 @@
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  GroupOperationStore,
+  authorizeGroupControl,
+  executeGroupCreate,
+  parseParticipantAllowlist,
+  validateGroupCreatePayload,
+} from './group_control.js';
+
+const allowed = parseParticipantAllowlist(
+  '15550001111@s.whatsapp.net,998877@lid',
+);
+const request = {
+  subject: 'Codex Blockers',
+  confirmedSubject: 'Codex Blockers',
+  operationId: 'codex-blockers-001',
+  participants: ['15550001111:2@c.us'],
+  confirmedParticipants: ['15550001111:2@c.us'],
+};
+
+const token = '0123456789abcdef0123456789abcdef';
+assert.equal(authorizeGroupControl(`Bearer ${token}`, token), true);
+assert.equal(authorizeGroupControl('Bearer short', 'short'), false);
+assert.equal(authorizeGroupControl('', token), false);
+assert.deepEqual([...allowed], ['15550001111@s.whatsapp.net', '998877@lid']);
+assert.deepEqual(
+  validateGroupCreatePayload(request, allowed).participants,
+  ['15550001111@s.whatsapp.net'],
+);
+assert.equal(
+  validateGroupCreatePayload({ ...request, confirmedSubject: 'different' }, allowed),
+  null,
+);
+assert.equal(
+  validateGroupCreatePayload({ ...request, confirmedParticipants: ['998877@lid'] }, allowed),
+  null,
+);
+assert.equal(
+  validateGroupCreatePayload(
+    { ...request, participants: ['17770000000@s.whatsapp.net'] },
+    allowed,
+  ),
+  null,
+);
+console.log('  ✓ group control authentication and exact allowlists fail closed');
+
+const root = mkdtempSync(path.join(tmpdir(), 'hermes-group-control-'));
+try {
+  let now = 1_000_000;
+  const statePath = path.join(root, 'private', 'operations.json');
+  const store = new GroupOperationStore(statePath, { now: () => now });
+  let creates = 0;
+  const created = await executeGroupCreate({
+    body: request,
+    allowedParticipants: allowed,
+    store,
+    now: () => now,
+    listGroups: async () => ({}),
+    createGroup: async (subject, participants) => {
+      creates += 1;
+      assert.equal(subject, 'Codex Blockers');
+      assert.deepEqual(participants, ['15550001111@s.whatsapp.net']);
+      return { id: '120363001234567890@g.us' };
+    },
+  });
+  assert.equal(created.httpStatus, 201);
+  assert.equal(created.body.groupId, '120363001234567890@g.us');
+  assert.equal(statSync(path.dirname(statePath)).mode & 0o777, 0o700);
+  assert.equal(statSync(statePath).mode & 0o777, 0o600);
+
+  const replay = await executeGroupCreate({
+    body: request,
+    allowedParticipants: allowed,
+    store,
+    now: () => now,
+    listGroups: async () => { throw new Error('must not re-check'); },
+    createGroup: async () => { throw new Error('must not recreate'); },
+  });
+  assert.equal(replay.httpStatus, 200);
+  assert.equal(replay.body.groupId, created.body.groupId);
+  assert.equal(creates, 1);
+
+  const changedReplay = await executeGroupCreate({
+    body: { ...request, subject: 'Changed', confirmedSubject: 'Changed' },
+    allowedParticipants: allowed,
+    store,
+    now: () => now,
+    listGroups: async () => ({}),
+    createGroup: async () => ({ id: 'unused@g.us' }),
+  });
+  assert.equal(changedReplay.httpStatus, 409);
+  assert.equal(changedReplay.body.status, 'conflict');
+  console.log('  ✓ created operations persist privately and replay idempotently');
+
+  now += 30_001;
+  const duplicateSubject = await executeGroupCreate({
+    body: { ...request, operationId: 'codex-blockers-002' },
+    allowedParticipants: allowed,
+    store,
+    now: () => now,
+    listGroups: async () => ({ existing: { subject: 'Codex Blockers' } }),
+    createGroup: async () => ({ id: 'unused@g.us' }),
+  });
+  assert.equal(duplicateSubject.httpStatus, 409);
+  assert.equal(duplicateSubject.body.status, 'subject-exists');
+
+  const uncertain = await executeGroupCreate({
+    body: {
+      subject: 'Operations',
+      confirmedSubject: 'Operations',
+      operationId: 'operations-group-001',
+      participants: ['998877@lid'],
+      confirmedParticipants: ['998877@lid'],
+    },
+    allowedParticipants: allowed,
+    store,
+    now: () => now,
+    minimumIntervalMs: 0,
+    listGroups: async () => ({}),
+    createGroup: async () => { throw new Error('network result unknown'); },
+  });
+  assert.equal(uncertain.httpStatus, 502);
+  assert.equal(uncertain.body.status, 'uncertain');
+  const uncertainReplay = await executeGroupCreate({
+    body: {
+      subject: 'Operations',
+      confirmedSubject: 'Operations',
+      operationId: 'operations-group-001',
+      participants: ['998877@lid'],
+      confirmedParticipants: ['998877@lid'],
+    },
+    allowedParticipants: allowed,
+    store,
+    now: () => now,
+    minimumIntervalMs: 0,
+    listGroups: async () => ({}),
+    createGroup: async () => ({ id: 'must-not-run@g.us' }),
+  });
+  assert.equal(uncertainReplay.httpStatus, 409);
+  assert.equal(uncertainReplay.body.status, 'uncertain');
+  console.log('  ✓ duplicate subjects and uncertain operations never create twice');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/scripts/whatsapp-bridge/group_control.test.mjs
+++ b/scripts/whatsapp-bridge/group_control.test.mjs
@@ -106,7 +106,7 @@ try {
     createGroup: async () => ({ id: 'unused@g.us' }),
   });
   assert.equal(duplicateSubject.httpStatus, 409);
-  assert.equal(duplicateSubject.body.status, 'subject-exists');
+  assert.equal(duplicateSubject.body.status, 'reserved');
 
   const uncertain = await executeGroupCreate({
     body: {
@@ -142,6 +142,52 @@ try {
   });
   assert.equal(uncertainReplay.httpStatus, 409);
   assert.equal(uncertainReplay.body.status, 'uncertain');
+
+  const uncertainNewId = await executeGroupCreate({
+    body: {
+      subject: 'Operations',
+      confirmedSubject: 'Operations',
+      operationId: 'operations-group-002',
+      participants: ['998877@lid'],
+      confirmedParticipants: ['998877@lid'],
+    },
+    allowedParticipants: allowed,
+    store,
+    now: () => now + 30_001,
+    minimumIntervalMs: 0,
+    listGroups: async () => ({}),
+    createGroup: async () => ({ id: 'must-not-run@g.us' }),
+  });
+  assert.equal(uncertainNewId.httpStatus, 409);
+  assert.equal(uncertainNewId.body.status, 'reserved');
+
+  const raceStore = new GroupOperationStore(path.join(root, 'race.json'));
+  let raceCreates = 0;
+  let releaseLists;
+  const listsReady = new Promise(resolve => { releaseLists = resolve; });
+  let listCalls = 0;
+  const attempt = operationId => executeGroupCreate({
+    body: { ...request, operationId },
+    allowedParticipants: allowed,
+    store: raceStore,
+    minimumIntervalMs: 0,
+    listGroups: async () => {
+      listCalls += 1;
+      if (listCalls === 2) releaseLists();
+      await listsReady;
+      return {};
+    },
+    createGroup: async () => {
+      raceCreates += 1;
+      return { id: '120363001234567891@g.us' };
+    },
+  });
+  const race = await Promise.all([
+    attempt('codex-blockers-race-1'),
+    attempt('codex-blockers-race-2'),
+  ]);
+  assert.equal(raceCreates, 1);
+  assert.deepEqual(race.map(result => result.httpStatus).sort(), [201, 409]);
   console.log('  ✓ duplicate subjects and uncertain operations never create twice');
 } finally {
   rmSync(root, { recursive: true, force: true });

--- a/tests/gateway/test_whatsapp_group_admin.py
+++ b/tests/gateway/test_whatsapp_group_admin.py
@@ -1,0 +1,204 @@
+"""Authorization and request tests for native WhatsApp group creation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from types import SimpleNamespace
+
+from gateway.config import PlatformConfig
+from plugins.platforms.whatsapp import adapter as adapter_module
+from plugins.platforms.whatsapp import tools
+
+
+def _env(monkeypatch, **values):
+    monkeypatch.setattr(
+        tools,
+        "_wenv",
+        lambda name, default="": values.get(name, default),
+    )
+
+
+def _config(monkeypatch, *, admins=(), participants=()):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "gateway": {
+                "platforms": {
+                    "whatsapp": {
+                        "extra": {
+                            "group_admin_users": list(admins),
+                            "group_allowed_participants": list(participants),
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+
+def test_group_request_requires_exact_confirmation_and_allowlisted_jids(monkeypatch):
+    _config(
+        monkeypatch,
+        participants=("15550001111@s.whatsapp.net", "998877@lid"),
+    )
+    valid = {
+        "subject": "Codex Blockers",
+        "confirmed_subject": "Codex Blockers",
+        "operation_id": "codex-blockers-001",
+        "participants": ["15550001111:2@c.us", "998877@lid"],
+        "confirmed_participants": ["15550001111:2@c.us", "998877@lid"],
+    }
+    assert tools._validated_request(valid) == {
+        "subject": "Codex Blockers",
+        "confirmedSubject": "Codex Blockers",
+        "operationId": "codex-blockers-001",
+        "participants": ["15550001111@s.whatsapp.net", "998877@lid"],
+        "confirmedParticipants": ["15550001111@s.whatsapp.net", "998877@lid"],
+    }
+    assert tools._validated_request({**valid, "confirmed_subject": "different"}) is None
+    assert (
+        tools._validated_request({**valid, "confirmed_participants": ["998877@lid"]})
+        is None
+    )
+    assert (
+        tools._validated_request({
+            **valid,
+            "participants": ["17770000000@s.whatsapp.net"],
+        })
+        is None
+    )
+    assert tools._validated_request({**valid, "operation_id": "short"}) is None
+
+
+def test_tool_availability_fails_closed_without_each_private_boundary(monkeypatch):
+    complete = {
+        "WHATSAPP_GROUP_CONTROL_TOKEN": "0123456789abcdef0123456789abcdef",
+    }
+    _config(
+        monkeypatch,
+        admins=("15550001111@s.whatsapp.net",),
+        participants=("15550001111@s.whatsapp.net",),
+    )
+    _env(monkeypatch, **complete)
+    assert tools._check_available() is True
+    _env(monkeypatch, WHATSAPP_GROUP_CONTROL_TOKEN="")
+    assert tools._check_available() is False
+    _env(monkeypatch, **complete)
+    _config(monkeypatch, participants=())
+    assert tools._check_available() is False
+    _config(monkeypatch, participants=("15550001111@s.whatsapp.net",))
+    assert tools._check_available() is False
+
+
+def test_group_tool_sends_token_only_in_header_and_redacts_participants(monkeypatch):
+    values = {
+        "WHATSAPP_GROUP_CONTROL_TOKEN": "0123456789abcdef0123456789abcdef",
+    }
+    _env(monkeypatch, **values)
+    _config(
+        monkeypatch,
+        admins=("15550001111@s.whatsapp.net",),
+        participants=("15550001111@s.whatsapp.net",),
+    )
+    monkeypatch.setattr(tools, "_bridge_port", lambda: 3123)
+    captured = {}
+
+    class Response:
+        status = 201
+
+        async def json(self):
+            return {"success": True, "status": "created", "groupId": "12036300@g.us"}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+    class Session:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        def post(self, url, **kwargs):
+            captured.update(url=url, **kwargs)
+            return Response()
+
+    fake_aiohttp = SimpleNamespace(
+        ClientSession=Session,
+        ClientTimeout=lambda **kwargs: kwargs,
+    )
+    monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+    result = json.loads(
+        asyncio.run(
+            tools.whatsapp_create_group({
+                "subject": "Codex Blockers",
+                "confirmed_subject": "Codex Blockers",
+                "operation_id": "codex-blockers-001",
+                "participants": ["15550001111@s.whatsapp.net"],
+                "confirmed_participants": ["15550001111@s.whatsapp.net"],
+            })
+        )
+    )
+    assert result == {
+        "success": True,
+        "status": "created",
+        "operation_id": "codex-blockers-001",
+        "subject": "Codex Blockers",
+        "group_id": "12036300@g.us",
+    }
+    assert captured["url"] == "http://127.0.0.1:3123/groups/create"
+    assert captured["headers"] == {
+        "Authorization": "Bearer 0123456789abcdef0123456789abcdef"
+    }
+    assert "0123456789abcdef0123456789abcdef" not in json.dumps(captured["json"])
+    assert "participants" not in json.dumps(result)
+
+
+def test_adapter_exposes_admin_toolset_only_to_exact_direct_principal(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"platform_toolsets": {"whatsapp": ["web"]}},
+    )
+    monkeypatch.setattr(
+        "gateway.whatsapp_identity.canonical_whatsapp_identifier",
+        lambda value: str(value or "").split(":", 1)[0].split("@", 1)[0],
+    )
+    adapter = adapter_module.WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "session_name": "test",
+                "group_admin_users": ["15550001111@s.whatsapp.net"],
+            },
+        )
+    )
+
+    owner = SimpleNamespace(
+        chat_type="dm",
+        user_id="15550001111:2@s.whatsapp.net",
+        chat_id="15550001111@s.whatsapp.net",
+    )
+    stranger = SimpleNamespace(
+        chat_type="dm",
+        user_id="17770000000@s.whatsapp.net",
+        chat_id="17770000000@s.whatsapp.net",
+    )
+    group = SimpleNamespace(
+        chat_type="group",
+        user_id="15550001111@s.whatsapp.net",
+        chat_id="12036300@g.us",
+    )
+
+    assert "whatsapp_group_admin" in adapter.toolsets_for_source(owner)
+    assert "whatsapp_group_admin" not in adapter.toolsets_for_source(stranger)
+    assert "whatsapp_group_admin" not in adapter.toolsets_for_source(group)
+    assert "web" in adapter.toolsets_for_source(owner)
+    assert "web" in adapter.toolsets_for_source(stranger)

--- a/tests/gateway/test_whatsapp_group_admin.py
+++ b/tests/gateway/test_whatsapp_group_admin.py
@@ -20,6 +20,9 @@ def _env(monkeypatch, **values):
     )
 
 
+_TEST_TOKEN = "0123456789abcdef" * 2
+
+
 def _config(monkeypatch, *, admins=(), participants=()):
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
@@ -74,7 +77,7 @@ def test_group_request_requires_exact_confirmation_and_allowlisted_jids(monkeypa
 
 def test_tool_availability_fails_closed_without_each_private_boundary(monkeypatch):
     complete = {
-        "WHATSAPP_GROUP_CONTROL_TOKEN": "0123456789abcdef0123456789abcdef",
+        "WHATSAPP_GROUP_CONTROL_TOKEN": _TEST_TOKEN,
     }
     _config(
         monkeypatch,
@@ -94,7 +97,7 @@ def test_tool_availability_fails_closed_without_each_private_boundary(monkeypatc
 
 def test_group_tool_sends_token_only_in_header_and_redacts_participants(monkeypatch):
     values = {
-        "WHATSAPP_GROUP_CONTROL_TOKEN": "0123456789abcdef0123456789abcdef",
+        "WHATSAPP_GROUP_CONTROL_TOKEN": _TEST_TOKEN,
     }
     _env(monkeypatch, **values)
     _config(
@@ -155,10 +158,8 @@ def test_group_tool_sends_token_only_in_header_and_redacts_participants(monkeypa
         "group_id": "12036300@g.us",
     }
     assert captured["url"] == "http://127.0.0.1:3123/groups/create"
-    assert captured["headers"] == {
-        "Authorization": "Bearer 0123456789abcdef0123456789abcdef"
-    }
-    assert "0123456789abcdef0123456789abcdef" not in json.dumps(captured["json"])
+    assert captured["headers"] == {"Authorization": f"Bearer {_TEST_TOKEN}"}
+    assert _TEST_TOKEN not in json.dumps(captured["json"])
     assert "participants" not in json.dumps(result)
 
 

--- a/tests/gateway/test_whatsapp_group_admin.py
+++ b/tests/gateway/test_whatsapp_group_admin.py
@@ -20,7 +20,7 @@ def _env(monkeypatch, **values):
     )
 
 
-_TEST_TOKEN = "0123456789abcdef" * 2
+_TEST_CREDENTIAL = "x" * 32
 
 
 def _config(monkeypatch, *, admins=(), participants=()):
@@ -77,7 +77,7 @@ def test_group_request_requires_exact_confirmation_and_allowlisted_jids(monkeypa
 
 def test_tool_availability_fails_closed_without_each_private_boundary(monkeypatch):
     complete = {
-        "WHATSAPP_GROUP_CONTROL_TOKEN": _TEST_TOKEN,
+        "WHATSAPP_GROUP_CONTROL_TOKEN": _TEST_CREDENTIAL,
     }
     _config(
         monkeypatch,
@@ -97,7 +97,7 @@ def test_tool_availability_fails_closed_without_each_private_boundary(monkeypatc
 
 def test_group_tool_sends_token_only_in_header_and_redacts_participants(monkeypatch):
     values = {
-        "WHATSAPP_GROUP_CONTROL_TOKEN": _TEST_TOKEN,
+        "WHATSAPP_GROUP_CONTROL_TOKEN": _TEST_CREDENTIAL,
     }
     _env(monkeypatch, **values)
     _config(
@@ -158,8 +158,8 @@ def test_group_tool_sends_token_only_in_header_and_redacts_participants(monkeypa
         "group_id": "12036300@g.us",
     }
     assert captured["url"] == "http://127.0.0.1:3123/groups/create"
-    assert captured["headers"] == {"Authorization": f"Bearer {_TEST_TOKEN}"}
-    assert _TEST_TOKEN not in json.dumps(captured["json"])
+    assert captured["headers"] == {"Authorization": f"Bearer {_TEST_CREDENTIAL}"}
+    assert _TEST_CREDENTIAL not in json.dumps(captured["json"])
     assert "participants" not in json.dumps(result)
 
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -240,6 +240,36 @@ Set `text_batch_delay_seconds: 0` to dispatch each message immediately (disables
 
 ---
 
+## Optional Group Creation
+
+Hermes can create a WhatsApp group through a disabled-by-default administrative
+tool. Enable it only for exact direct-message principals and a bounded set of
+participants:
+
+```yaml
+# ~/.hermes/config.yaml
+gateway:
+  platforms:
+    whatsapp:
+      extra:
+        group_admin_users:
+          - "15551234567@s.whatsapp.net"
+        group_allowed_participants:
+          - "15551234567@s.whatsapp.net"
+```
+
+Generate a private bearer credential (for example with
+`openssl rand -base64 32`) and store it as `WHATSAPP_GROUP_CONTROL_TOKEN` in
+`~/.hermes/.env`. Restart the gateway after both settings are present.
+
+The tool is exposed only when the sender and DM chat resolve to the same exact
+configured admin. It is never exposed in group chats. Every request must repeat
+the exact subject and participant list as confirmation and supply a stable
+idempotency key. An ambiguous or timed-out create is recorded as uncertain and
+is not retried automatically.
+
+---
+
 ## Troubleshooting
 
 | Problem | Solution |


### PR DESCRIPTION
## What does this PR do?

Adds a disabled-by-default WhatsApp group-creation tool at the plugin edge. It is exposed only to exact configured DM principals and calls a loopback-only bridge endpoint with a private bearer token, exact participant allowlisting, explicit request confirmation, rate limiting, and persistent idempotency.

This is a focused, current-architecture alternative for the group-create portion of #12605, whose broader WhatsApp Ultimate setup is marked incomplete. It does not add storage, dependencies, or general group administration.

## Type of Change

- [x] ✨ New feature
- [x] 🔒 Security-sensitive authorization boundary
- [x] ✅ Tests
- [x] 📝 Documentation update

## Changes Made

- Register a default-off, WhatsApp-restricted plugin toolset.
- Gate the tool per exact direct-message source; group sessions never receive it.
- Add a loopback authenticated create endpoint with confirmed payloads and exact allowlists.
- Persist pending/created/uncertain operations before the irreversible call and never auto-retry uncertain outcomes.
- Keep behavioral settings in config.yaml; only the bearer credential lives in .env.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_whatsapp_group_admin.py tests/gateway/test_whatsapp_group_gating.py tests/hermes_cli/test_tools_config.py`
2. `node --test scripts/whatsapp-bridge/*.test.mjs`
3. Configure exact admin/participant JIDs and a 32+ character token as documented, restart the gateway, and verify `/health` reports `groupControlEnabled: true`.

## Validation

- 65 focused Python tests pass through the repository test wrapper.
- 23 bridge tests pass.
- Ruff check and `git diff --check` pass.
- Tested locally on macOS; no new dependency was added.

## Checklist

- [x] Read CONTRIBUTING.md and AGENTS.md
- [x] Conventional commit
- [x] Searched open and merged PRs; overlap with #12605 is called out above
- [x] Focused change only
- [x] Added behavior tests
- [x] Updated WhatsApp documentation and tool schema
- [x] Considered cross-platform file/process behavior

Full repository test suite was not run locally; the focused CI-parity wrapper and bridge suite above are green.