### PR TITLE
fix(native-compaction): retain image-only user content

### DIFF
--- a/agent/native_compaction.py
+++ b/agent/native_compaction.py
@@ -170,10 +170,11 @@ def _approx_tokens(text: str) -> int:
 
 
 def _extract_item_text(item: Any) -> Optional[str]:
-    """Extract measurable text from string, list content, output_text, or nested metadata text.
+    """Extract measurable text from message content and fallback fields.
 
-    Returns None when the item carries no measurable text.
-    Handles string content, multipart lists (input_text/text/output_text), and fallback keys.
+    Returns None when the item carries no measurable text. Handles string
+    content, multipart lists (input_text/text/output_text), and nested
+    metadata text.
     """
     if not isinstance(item, dict):
         return None
@@ -203,6 +204,30 @@ def _extract_item_text(item: Any) -> Optional[str]:
         return text if text.strip() else None
 
     return None
+
+
+def _has_retainable_image_content(item: Any) -> bool:
+    """Return True for a converted Responses message with a valid image part.
+
+    The pruning boundary receives normalized Responses items, so only the
+    adapter-owned ``input_image`` shape is authority here. Unknown, malformed,
+    or empty multipart placeholders must not become durable history merely
+    because their list is non-empty.
+    """
+    if not isinstance(item, dict):
+        return False
+    content = item.get("content")
+    if not isinstance(content, list):
+        return False
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        if str(part.get("type") or "").strip().lower() != "input_image":
+            continue
+        image_url = part.get("image_url")
+        if isinstance(image_url, str) and image_url.strip():
+            return True
+    return False
 
 
 def _is_summary_item(item: Any) -> bool:
@@ -249,7 +274,8 @@ def prune_pre_checkpoint_items(
     - Retained user messages are kept verbatim within
       ``retained_user_token_budget``; the boundary message is head-truncated
       when it only partially fits (string content only) — goals are usually
-      stated up front, so the head is the valuable end.
+      stated up front, so the head is the valuable end. A recognized
+      image-only user message is retained whole at one-token cost.
     - Compression summary messages (``_is_summary_item``, the canonical
       ``agent.context_compressor`` provenance check) are retained whole
       within ``retained_summary_token_budget``. A summary is never
@@ -360,14 +386,11 @@ def prune_pre_checkpoint_items(
             continue
 
         text = _extract_item_text(item)
+        has_retainable_image = is_user and _has_retainable_image_content(item)
+        if text is None and not has_retainable_image:
+            continue
         if text is None:
-            continue
-        # Image-only user messages have empty text but non-empty content —
-        # main retains them at 1-token cost (images count as zero, matching
-        # Codex's retention accounting). Don't skip them just because text
-        # is falsy.
-        if not text and not is_user:
-            continue
+            text = ""
 
         if is_summary:
             result = _try_retain_summary(text)

--- a/tests/run_agent/test_native_compaction_nontext_retention.py
+++ b/tests/run_agent/test_native_compaction_nontext_retention.py
@@ -1,0 +1,83 @@
+"""Regression coverage for image-only user content across native compaction."""
+
+from agent.codex_responses_adapter import _chat_messages_to_responses_input
+from agent.native_compaction import _extract_item_text, prune_pre_checkpoint_items
+
+
+_IMAGE_URL = "data:image/png;base64,AAAA"
+_CHAT_IMAGE_PART = {"type": "image_url", "image_url": {"url": _IMAGE_URL}}
+_RESPONSES_IMAGE_PART = {"type": "input_image", "image_url": _IMAGE_URL}
+_CHECKPOINT = {"type": "compaction", "encrypted_content": "blob_cp"}
+
+
+def test_extract_item_text_remains_text_only_for_image_content():
+    image_only = {"content": [_RESPONSES_IMAGE_PART]}
+
+    assert _extract_item_text(image_only) is None
+    assert _extract_item_text({"content": []}) is None
+
+
+def test_image_only_user_message_survives_pre_checkpoint_pruning_verbatim():
+    image_only = {"role": "user", "content": [_RESPONSES_IMAGE_PART]}
+    items = [
+        image_only,
+        _CHECKPOINT,
+        {"role": "user", "content": "after checkpoint"},
+    ]
+
+    pruned = prune_pre_checkpoint_items(items, retained_user_token_budget=1)
+
+    assert pruned == [
+        _CHECKPOINT,
+        image_only,
+        {"role": "user", "content": "after checkpoint"},
+    ]
+    assert pruned[1] is image_only
+
+
+def test_image_only_user_message_still_obeys_retention_budget():
+    image_only = {"role": "user", "content": [_RESPONSES_IMAGE_PART]}
+
+    assert prune_pre_checkpoint_items(
+        [image_only, _CHECKPOINT],
+        retained_user_token_budget=0,
+    ) == [_CHECKPOINT]
+
+
+def test_malformed_or_unknown_multipart_is_not_retained():
+    invalid_contents = [
+        [{}],
+        [{"type": "input_image", "image_url": ""}],
+        [{"type": "unknown", "value": "not an attachment"}],
+    ]
+
+    for content in invalid_contents:
+        malformed = {"role": "user", "content": content}
+        assert prune_pre_checkpoint_items(
+            [malformed, _CHECKPOINT],
+            retained_user_token_budget=1,
+        ) == [_CHECKPOINT]
+
+
+def test_adapter_preserves_image_only_user_message_across_checkpoint():
+    messages = [
+        {"role": "user", "content": [_CHAT_IMAGE_PART]},
+        {
+            "role": "assistant",
+            "content": "checkpoint turn",
+            "codex_reasoning_items": [_CHECKPOINT],
+        },
+        {"role": "user", "content": "after checkpoint"},
+    ]
+
+    converted = _chat_messages_to_responses_input(
+        messages,
+        native_compaction_eligible=True,
+    )
+
+    assert converted == [
+        _CHECKPOINT,
+        {"role": "user", "content": [_RESPONSES_IMAGE_PART]},
+        {"role": "assistant", "content": "checkpoint turn"},
+        {"role": "user", "content": "after checkpoint"},
+    ]


### PR DESCRIPTION
## Problem

#91477 repaired native-compaction summary provenance, but pre-checkpoint pruning still dropped an image-only user message. The normalized Responses item has a valid `input_image` part and no measurable text, so the text-only extraction path returned `None` and pruning discarded the message before retention accounting.

## Repair

- Keep `_extract_item_text()` text-only.
- Grant retention authority only to the adapter-owned normalized `input_image` shape with a non-empty string `image_url`.
- Retain the original user-message object verbatim at one-token cost and preserve the explicit retention budget.
- Reject empty, malformed, and unknown multipart placeholders instead of treating any non-empty list as durable history.
- Do not claim file-only support: the current chat-to-Responses adapter does not emit `input_file`.

## Proof

The regression suite proves text extraction remains text-only, valid image-only user content survives a replayed compaction checkpoint verbatim, zero budget still drops it, malformed or unknown multipart content is not promoted, and the production `_chat_messages_to_responses_input()` path carries the image-only message across the checkpoint.

## Exact green object

The branch contains **one commit only**. Superseded red objects are no longer part of the PR history.

- Head: [`039e26994fa5b7f37a387721055519b531c32f5b`](https://github.com/andrexibiza/hermes-agent/commit/039e26994fa5b7f37a387721055519b531c32f5b)
- Tested base: [`2584b7c4eca82ada05f16eba08936d157b483329`](https://github.com/NousResearch/hermes-agent/commit/2584b7c4eca82ada05f16eba08936d157b483329)
- GitHub merge candidate: [`24c2bc4e5cd456799729b51b20a1c4b2295ad764`](https://github.com/NousResearch/hermes-agent/commit/24c2bc4e5cd456799729b51b20a1c4b2295ad764)
- [CI 32508623713](https://github.com/NousResearch/hermes-agent/actions/runs/32508623713) — success
- [Docker 32508622727](https://github.com/NousResearch/hermes-agent/actions/runs/32508622727) — success
- [Nix 32508622749](https://github.com/NousResearch/hermes-agent/actions/runs/32508622749) — success
- Topology — one commit, two intended files, open, non-draft, mergeable

The final object republishes the identical source tree after an unrelated focus-redraw timing failure on the superseded object; there is no source delta between the two objects.

## Interlocks

#90976 → merged #91477 → #91557. This is a distinct post-merge regression repair, not a reopening or repeat review of #90975.