### PR TITLE
fix(kanban): make manual ready approval durable

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2584,6 +2584,14 @@ DEFAULT_CONFIG = {
         # decomposition is manual via `hermes kanban decompose <id>` or
         # the dashboard's Decompose button.
         "auto_decompose": True,
+        # Promote dependency-free decomposed children immediately. When false,
+        # each child receives a durable task-level hold that only the native
+        # ``kanban promote`` action clears.
+        "auto_promote_children": True,
+        # Apply the same durable manual Ready approval gate to single-task
+        # Triage specification (and decomposer fanout=false fallback). Off by
+        # default so existing automatic workflows retain their behaviour.
+        "require_manual_ready_approval": False,
         # Max triage tasks to decompose per dispatcher tick. Prevents a
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -63,6 +63,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "body": t.body,
         "assignee": t.assignee,
         "status": t.status,
+        "manual_ready_gate": t.manual_ready_gate,
         "priority": t.priority,
         "tenant": t.tenant,
         "workspace_kind": t.workspace_kind,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1141,6 +1141,9 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Durable hold set by manual-governance Triage flows. Automatic
+    # recomputation cannot promote the task while this is true.
+    manual_ready_gate: bool = False
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1234,6 +1237,10 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            manual_ready_gate=(
+                bool(row["manual_ready_gate"])
+                if "manual_ready_gate" in keys else False
             ),
         )
 
@@ -1422,7 +1429,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Durable product-owner gate. Automatic dependency/recompute passes must
+    -- leave this task in todo until an explicit promote action clears it.
+    manual_ready_gate    INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2678,6 +2688,17 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
+
+    if "manual_ready_gate" not in cols:
+        # Existing tasks retain automatic promotion. Only manual-governance
+        # creation/specification paths opt new rows into this durable hold.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "manual_ready_gate",
+            "manual_ready_gate INTEGER NOT NULL DEFAULT 0",
+        )
+
 
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
@@ -4544,12 +4565,14 @@ def recompute_ready(
     promoted = 0
     with write_txn(conn):
         todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
+            "SELECT id, status, consecutive_failures, max_retries, manual_ready_gate "
             "FROM tasks WHERE status IN ('todo', 'blocked')"
         ).fetchall()
         for row in todo_rows:
             task_id = row["id"]
             cur_status = row["status"]
+            if bool(row["manual_ready_gate"]):
+                continue
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):
                 # Worker / operator asked for explicit human intervention — do not
                 # silently auto-recover.  ``unblock_task`` is the only
@@ -6777,7 +6800,7 @@ def promote_task(
     force: bool = False,
     dry_run: bool = False,
 ) -> tuple[bool, Optional[str]]:
-    """Manually promote a `todo` or `blocked` task to `ready`.
+    """Manually promote a `todo`, `blocked`, or `scheduled` task to `ready`.
 
     Mirrors the automatic promotion done by ``recompute_ready`` but
     drives it from a deliberate operator action with an audit-trail
@@ -6785,46 +6808,55 @@ def promote_task(
     state (`done`/`archived`) unless ``force=True``. Does NOT change
     assignee or claim state. Returns ``(True, None)`` on success and
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
-    promotion would succeed without mutating state.
+    promotion would succeed without mutating state. Callers must not hold an
+    outer transaction; this function owns its atomic ``write_txn`` boundary.
     """
-    row = conn.execute(
-        "SELECT status FROM tasks WHERE id = ?", (task_id,)
-    ).fetchone()
-    if row is None:
-        return False, f"task {task_id} not found"
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            return False, f"task {task_id} not found"
 
-    cur_status = row["status"]
-    if cur_status not in ("todo", "blocked"):
-        return False, (
-            f"task {task_id} is {cur_status!r}; promote only applies to "
-            f"'todo' or 'blocked'"
-        )
-
-    if not force:
-        parents = conn.execute(
-            "SELECT t.id, t.status FROM tasks t "
-            "JOIN task_links l ON l.parent_id = t.id "
-            "WHERE l.child_id = ?",
-            (task_id,),
-        ).fetchall()
-        unsatisfied = [
-            p["id"] for p in parents
-            if p["status"] not in ("done", "archived")
-        ]
-        if unsatisfied:
+        cur_status = row["status"]
+        if cur_status not in ("todo", "blocked", "scheduled"):
             return False, (
-                f"unsatisfied parent dependencies: "
-                f"{', '.join(unsatisfied)} (use --force to override)"
+                f"task {task_id} is {cur_status!r}; promote only applies to "
+                f"'todo', 'blocked', or 'scheduled'"
             )
 
-    if dry_run:
-        return True, None
+        if not force:
+            parents = conn.execute(
+                "SELECT t.id, t.status FROM tasks t "
+                "JOIN task_links l ON l.parent_id = t.id "
+                "WHERE l.child_id = ?",
+                (task_id,),
+            ).fetchall()
+            unsatisfied = [
+                p["id"] for p in parents
+                if p["status"] not in ("done", "archived")
+            ]
+            if unsatisfied:
+                return False, (
+                    f"unsatisfied parent dependencies: "
+                    f"{', '.join(unsatisfied)} (use --force to override)"
+                )
 
-    with write_txn(conn):
+        if dry_run:
+            return True, None
+
+        _reclaim_dangling_run(
+            conn,
+            task_id,
+            statuses=(cur_status,),
+            now=int(time.time()),
+            note="invariant recovery on manual promotion",
+        )
         upd = conn.execute(
-            "UPDATE tasks SET status = 'ready' "
-            "WHERE id = ? AND status IN ('todo', 'blocked')",
-            (task_id,),
+            "UPDATE tasks SET status = 'ready', manual_ready_gate = 0, "
+            "current_run_id = NULL "
+            "WHERE id = ? AND status = ?",
+            (task_id, cur_status),
         )
         if upd.rowcount != 1:
             return False, f"task {task_id} status changed during promotion"
@@ -6900,7 +6932,7 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     now = int(time.time())
     with write_txn(conn):
         current = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?",
+            "SELECT status, manual_ready_gate FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         resume_status = (
@@ -6913,7 +6945,11 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             note="invariant recovery on unblock",
         )
         # Re-gate on parent completion before restoring the source phase.
-        landing_status = _landing_status_after_parents(conn, task_id)
+        landing_status = (
+            "todo"
+            if current and bool(current["manual_ready_gate"])
+            else _landing_status_after_parents(conn, task_id)
+        )
         new_status = (
             "review"
             if landing_status == "ready" and resume_status == "review"
@@ -7194,6 +7230,7 @@ def specify_triage_task(
     body: Optional[str] = None,
     assignee: Optional[str] = None,
     author: Optional[str] = None,
+    require_manual_ready_approval: bool = False,
 ) -> bool:
     """Flesh out a triage task and promote it to ``todo``.
 
@@ -7221,8 +7258,11 @@ def specify_triage_task(
         ).fetchone()
         if existing is None:
             return False
-        sets: list[str] = ["status = 'todo'"]
-        params: list[Any] = []
+        sets: list[str] = [
+            "status = 'todo'",
+            "manual_ready_gate = ?",
+        ]
+        params: list[Any] = [1 if require_manual_ready_approval else 0]
         changed_fields: list[str] = []
         if title is not None and title.strip() != (existing["title"] or ""):
             sets.append("title = ?")
@@ -7266,7 +7306,10 @@ def specify_triage_task(
             conn,
             task_id,
             "specified",
-            {"changed_fields": changed_fields} if changed_fields else None,
+            {
+                "changed_fields": changed_fields,
+                "manual_ready_gate": bool(require_manual_ready_approval),
+            },
         )
     # Outside the write_txn above, so we don't nest BEGIN IMMEDIATE — the
     # ready-promotion pass opens its own IMMEDIATE txn. This runs the same
@@ -7419,8 +7462,8 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, manual_ready_gate) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
@@ -7431,6 +7474,7 @@ def decompose_triage_task(
                     tenant,
                     now,
                     (author or "decomposer"),
+                    0 if auto_promote else 1,
                 ),
             )
             _append_event(

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -295,6 +295,9 @@ def decompose_task(
     default_assignee = _resolve_default_assignee(cfg)
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
     auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
+    require_manual_ready_approval = bool(
+        kanban_cfg.get("require_manual_ready_approval", False)
+    )
     roster, valid_names = _build_roster()
 
     try:
@@ -369,6 +372,7 @@ def decompose_task(
                 body=body_val,
                 assignee=assignee_val,
                 author=audit_author,
+                require_manual_ready_approval=require_manual_ready_approval,
             )
         if not ok:
             return DecomposeOutcome(

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -50,6 +50,17 @@ HERMES_KANBAN_SPECIFY_MAX_TOKENS = max(
 logger = logging.getLogger(__name__)
 
 
+def _require_manual_ready_approval() -> bool:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+    except Exception:
+        return False
+    kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+    return bool(kanban_cfg.get("require_manual_ready_approval", False))
+
+
 _SYSTEM_PROMPT = """You are the Kanban triage specifier for the Hermes Agent board.
 A user dropped a rough idea into the Triage column. Your job is to turn it
 into a concrete, actionable task spec that an autonomous worker can pick up
@@ -239,6 +250,7 @@ def specify_task(
             title=new_title,
             body=new_body,
             author=author or _profile_author(),
+            require_manual_ready_approval=_require_manual_ready_approval(),
         )
     if not ok:
         # Race: someone else promoted / archived the task between our

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1992,6 +1992,30 @@
               settings.auto_decompose
                 ? "The dispatcher decomposes new triage tasks automatically."
                 : "Triage tasks stay in triage until you click ⚗ Decompose."),
+            h("label", { className: "flex items-center gap-2 text-xs h-8" },
+              h(Checkbox, {
+                checked: !!settings.auto_promote_children,
+                onCheckedChange: function (checked) {
+                  saveSettings({ auto_promote_children: checked === true });
+                },
+              }),
+              "Auto-promote decomposed children",
+            ),
+            h("div", { className: "text-[10px] text-muted-foreground" },
+              settings.auto_promote_children
+                ? "Children become Ready automatically as dependencies allow."
+                : "Decomposed children stay in Todo until an explicit Promote action."),
+            h("label", { className: "flex items-center gap-2 text-xs h-8" },
+              h(Checkbox, {
+                checked: !!settings.require_manual_ready_approval,
+                onCheckedChange: function (checked) {
+                  saveSettings({ require_manual_ready_approval: checked === true });
+                },
+              }),
+              "Require manual Ready approval",
+            ),
+            h("div", { className: "text-[10px] text-muted-foreground" },
+              "Specified single tasks stay in Todo until an explicit Promote action."),
           ),
         ) : h("div", { className: "text-xs text-muted-foreground" },
           "Loading…"),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -927,7 +927,15 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 # status set. "Changes requested" (review -> ready) goes through
                 # reopen_review_task via _reopen_if_review.
                 current = kanban_db.get_task(conn, task_id)
-                if current and current.status in ("blocked", "scheduled"):
+                if (
+                    current
+                    and current.manual_ready_gate
+                    and current.status in ("todo", "blocked", "scheduled")
+                ):
+                    ok, _ = kanban_db.promote_task(
+                        conn, task_id, actor="dashboard"
+                    )
+                elif current and current.status in ("blocked", "scheduled"):
                     ok = kanban_db.unblock_task(conn, task_id)
                 else:
                     reopened = _reopen_if_review(conn, task_id, current)
@@ -1176,11 +1184,13 @@ def _set_status_direct(
 
         cur = conn.execute(
             "UPDATE tasks SET status = ?, "
+            "  manual_ready_gate = CASE WHEN ? = 'ready' THEN 0 ELSE manual_ready_gate END, "
             "  claim_lock = CASE WHEN ? = 'running' THEN claim_lock ELSE NULL END, "
             "  claim_expires = CASE WHEN ? = 'running' THEN claim_expires ELSE NULL END, "
             "  worker_pid = CASE WHEN ? = 'running' THEN worker_pid ELSE NULL END "
             "WHERE id = ?",
             (
+                effective_status,
                 effective_status,
                 effective_status,
                 effective_status,
@@ -1360,7 +1370,15 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         )
                     elif s == "ready":
                         cur = kanban_db.get_task(conn, tid)
-                        if cur and cur.status in ("blocked", "scheduled"):
+                        if (
+                            cur
+                            and cur.manual_ready_gate
+                            and cur.status in ("todo", "blocked", "scheduled")
+                        ):
+                            ok, _ = kanban_db.promote_task(
+                                conn, tid, actor="dashboard-bulk"
+                            )
+                        elif cur and cur.status in ("blocked", "scheduled"):
                             ok = kanban_db.unblock_task(conn, tid)
                         else:
                             reopened = _reopen_if_review(conn, tid, cur)
@@ -2773,6 +2791,7 @@ class OrchestrationSettingsBody(BaseModel):
     default_assignee: Optional[str] = None
     auto_decompose: Optional[bool] = None
     auto_promote_children: Optional[bool] = None
+    require_manual_ready_approval: Optional[bool] = None
 
 
 @router.get("/orchestration")
@@ -2789,6 +2808,9 @@ def get_orchestration_settings():
     explicit_default = (kanban_cfg.get("default_assignee") or "").strip()
     auto_decompose = bool(kanban_cfg.get("auto_decompose", True))
     auto_promote_children = bool(kanban_cfg.get("auto_promote_children", True))
+    require_manual_ready_approval = bool(
+        kanban_cfg.get("require_manual_ready_approval", False)
+    )
 
     # Resolve fallbacks the same way the decomposer does.
     resolved_orch = explicit_orch
@@ -2812,6 +2834,7 @@ def get_orchestration_settings():
         "default_assignee": explicit_default,
         "auto_decompose": auto_decompose,
         "auto_promote_children": auto_promote_children,
+        "require_manual_ready_approval": require_manual_ready_approval,
         "resolved_orchestrator_profile": resolved_orch,
         "resolved_default_assignee": resolved_default,
         "active_profile": active_default,
@@ -2879,6 +2902,11 @@ def set_orchestration_settings(payload: OrchestrationSettingsBody):
 
     if payload.auto_promote_children is not None:
         kanban_section["auto_promote_children"] = bool(payload.auto_promote_children)
+
+    if payload.require_manual_ready_approval is not None:
+        kanban_section["require_manual_ready_approval"] = bool(
+            payload.require_manual_ready_approval
+        )
 
     try:
         save_config(cfg)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -57,6 +57,19 @@ def test_kanban_list_json_includes_session_id(kanban_home):
     )
 
 
+def test_kanban_list_json_exposes_manual_ready_gate(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="held", assignee="patch")
+        conn.execute(
+            "UPDATE tasks SET status = 'todo', manual_ready_gate = 1 WHERE id = ?",
+            (task_id,),
+        )
+
+    payload = json.loads(kc.run_slash("list --json"))
+    task = next(row for row in payload if row["id"] == task_id)
+    assert task["manual_ready_gate"] is True
+
+
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):
     with kb.connect_closing() as conn:
         parent_id = kb.create_task(conn, title="parent task")

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -754,8 +754,7 @@ def test_default_spawn_does_not_auto_load_any_skill(kanban_home, monkeypatch):
 
 
 def test_legacy_db_without_skills_column_migrates(tmp_path):
-    """_migrate_add_optional_columns is idempotent and adds skills
-    when absent. Run it twice on a pared-down schema to confirm."""
+    """Optional columns migrate idempotently with safe legacy defaults."""
     import sqlite3
     db_path = tmp_path / "legacy.db"
     conn = sqlite3.connect(str(db_path))
@@ -795,6 +794,7 @@ def test_legacy_db_without_skills_column_migrates(tmp_path):
     kb._migrate_add_optional_columns(conn)
     after = {r[1] for r in conn.execute("PRAGMA table_info(tasks)")}
     assert "skills" in after, f"migration did not add skills column: {after}"
+    assert "manual_ready_gate" in after
 
     # Idempotent: running again must not raise.
     kb._migrate_add_optional_columns(conn)
@@ -806,6 +806,7 @@ def test_legacy_db_without_skills_column_migrates(tmp_path):
     keys = set(row.keys())
     assert "skills" in keys
     assert row["skills"] is None
+    assert row["manual_ready_gate"] == 0
     conn.close()
 
 

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -123,6 +123,34 @@ def test_migration_is_idempotent(tmp_path, monkeypatch):
         assert len(conn.execute("SELECT * FROM task_events").fetchall()) == 2
 
 
+def test_manual_ready_gate_migration_is_idempotent_and_default_safe(tmp_path):
+    db_path = tmp_path / "pre-manual-ready-gate.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(kb.SCHEMA_SQL)
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('legacy-task', 'Legacy', 'todo', 1000)"
+    )
+    conn.execute("ALTER TABLE tasks DROP COLUMN manual_ready_gate")
+    conn.commit()
+
+    kb._migrate_add_optional_columns(conn)
+    conn.commit()
+    kb._migrate_add_optional_columns(conn)
+    conn.commit()
+
+    columns = {
+        row["name"]: row for row in conn.execute("PRAGMA table_info(tasks)")
+    }
+    assert columns["manual_ready_gate"]["notnull"] == 1
+    assert columns["manual_ready_gate"]["dflt_value"] == "0"
+    task = kb.get_task(conn, "legacy-task")
+    assert task is not None
+    assert task.manual_ready_gate is False
+    conn.close()
+
+
 def test_unseen_events_for_sub_survives_migrated_db(tmp_path, monkeypatch):
     """The crash that motivated #35096 — ``int(None)`` on a NULL cursor — is
     gone after migration; the notifier query returns an integer cursor."""

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -68,6 +68,43 @@ def test_decompose_creates_children_and_promotes_root(kanban_home):
     assert c1.assignee == "engineer"
 
 
+def test_manual_decompose_children_stay_todo_across_recompute_passes(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn, title="review before dispatch")
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "groom first", "assignee": "patch"},
+                {"title": "groom dependent", "assignee": "patch", "parents": [0]},
+            ],
+            author="product-owner",
+            auto_promote=False,
+        )
+        assert child_ids is not None
+        first_id, dependent_id = child_ids
+        first = kb.get_task(conn, first_id)
+        dependent = kb.get_task(conn, dependent_id)
+        assert first is not None and first.status == "todo"
+        assert dependent is not None and dependent.status == "todo"
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.recompute_ready(conn) == 0
+        first = kb.get_task(conn, first_id)
+        assert first is not None and first.status == "todo"
+
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (first_id,))
+        assert kb.recompute_ready(conn) == 0
+        dependent = kb.get_task(conn, dependent_id)
+        assert dependent is not None and dependent.status == "todo"
+
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (dependent_id,))
+        assert kb.recompute_ready(conn) == 0
+        dependent = kb.get_task(conn, dependent_id)
+        assert dependent is not None and dependent.status == "blocked"
+
+
 def test_decompose_records_audit_comment_and_event(kanban_home):
     with kb.connect() as conn:
         tid = _create_triage(conn)

--- a/tests/hermes_cli/test_kanban_promote.py
+++ b/tests/hermes_cli/test_kanban_promote.py
@@ -87,6 +87,46 @@ def _promote_ns(task_id, *, ids=None, reason=None, force=False,
     )
 
 
+def test_promote_clears_manual_ready_gate_and_allows_one_claim(conn):
+    child = kb.create_task(conn, title="held child", assignee="patch")
+    conn.execute(
+        "UPDATE tasks SET status = 'todo', manual_ready_gate = 1 WHERE id = ?",
+        (child,),
+    )
+
+    ok, err = kb.promote_task(conn, child, actor="product-owner")
+    assert ok and err is None
+    task = kb.get_task(conn, child)
+    assert task is not None
+    assert task.status == "ready"
+    assert task.manual_ready_gate is False
+
+    claimed = kb.claim_task(conn, child, claimer="test-claim")
+    assert claimed is not None
+    assert kb.claim_task(conn, child, claimer="duplicate-claim") is None
+    ok, err = kb.promote_task(conn, child, actor="product-owner")
+    assert ok is False
+    assert "promote only applies" in (err or "")
+    events = [event.kind for event in kb.list_events(conn, child)]
+    assert events.count("promoted_manual") == 1
+
+
+def test_promote_scheduled_manual_gate_is_supported(conn):
+    child = kb.create_task(conn, title="scheduled hold", assignee="patch")
+    conn.execute(
+        "UPDATE tasks SET status = 'scheduled', manual_ready_gate = 1 WHERE id = ?",
+        (child,),
+    )
+
+    ok, err = kb.promote_task(conn, child, actor="product-owner")
+
+    assert ok is True and err is None
+    task = kb.get_task(conn, child)
+    assert task is not None
+    assert task.status == "ready"
+    assert task.manual_ready_gate is False
+
+
 def test_cli_promote_bulk_ids_promotes_all(kanban_home, capsys):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent")

--- a/tests/hermes_cli/test_kanban_specify_db.py
+++ b/tests/hermes_cli/test_kanban_specify_db.py
@@ -52,6 +52,25 @@ def test_specify_promotes_triage_to_todo(kanban_home):
     assert "**Goal**" in (task.body or "")
 
 
+def test_specify_can_require_manual_ready_approval(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn, title="needs product review")
+        ok = kb.specify_triage_task(
+            conn,
+            tid,
+            title="Specified but held",
+            body="Complete execution contract.",
+            author="product-owner",
+            require_manual_ready_approval=True,
+        )
+        assert ok is True
+        assert kb.recompute_ready(conn) == 0
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "todo"
+        assert task.manual_ready_gate is True
+
+
 def test_specify_rejects_blank_title(kanban_home):
     with kb.connect() as conn:
         tid = _create_triage(conn, title="rough")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -177,6 +177,190 @@ def test_tenant_filter(client):
     assert total == 1
 
 
+def test_orchestration_settings_expose_manual_ready_approval(client):
+    response = client.get("/api/plugins/kanban/orchestration")
+    assert response.status_code == 200
+    assert response.json()["auto_promote_children"] is True
+    assert response.json()["require_manual_ready_approval"] is False
+
+    response = client.put(
+        "/api/plugins/kanban/orchestration",
+        json={
+            "auto_promote_children": False,
+            "require_manual_ready_approval": True,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["auto_promote_children"] is False
+    assert response.json()["require_manual_ready_approval"] is True
+
+
+def test_dashboard_ready_action_clears_manual_gate(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "held for product review", "assignee": "patch"},
+    ).json()["task"]
+    with kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET status = 'todo', manual_ready_gate = 1 WHERE id = ?",
+            (created["id"],),
+        )
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{created['id']}",
+        json={"status": "ready"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["manual_ready_gate"] is False
+    with kb.connect() as conn:
+        events = [event.kind for event in kb.list_events(conn, created["id"])]
+    assert events.count("promoted_manual") == 1
+
+
+def test_dashboard_ready_action_preserves_legacy_non_gated_transition(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "ordinary todo", "assignee": "patch"},
+    ).json()["task"]
+    with kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET status = 'todo', manual_ready_gate = 0 WHERE id = ?",
+            (created["id"],),
+        )
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{created['id']}",
+        json={"status": "ready"},
+    )
+
+    assert response.status_code == 200, response.text
+    with kb.connect() as conn:
+        events = [event.kind for event in kb.list_events(conn, created["id"])]
+    assert events.count("promoted_manual") == 0
+    assert events.count("status") == 1
+
+
+def test_dashboard_direct_ready_transition_defensively_clears_stale_gate(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "archived with stale gate", "assignee": "patch"},
+    ).json()["task"]
+    with kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET status = 'archived', manual_ready_gate = 1 WHERE id = ?",
+            (created["id"],),
+        )
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{created['id']}",
+        json={"status": "ready"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["task"]["manual_ready_gate"] is False
+
+
+@pytest.mark.parametrize("parked_status", ["blocked", "scheduled"])
+def test_dashboard_ready_action_clears_gate_from_parked_status(client, parked_status):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "parked manual gate", "assignee": "patch"},
+    ).json()["task"]
+    with kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET status = ?, manual_ready_gate = 1 WHERE id = ?",
+            (parked_status, created["id"]),
+        )
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{created['id']}",
+        json={"status": "ready"},
+    )
+    assert response.status_code == 200, response.text
+    task = response.json()["task"]
+    assert task["status"] == "ready"
+    assert task["manual_ready_gate"] is False
+
+
+def test_dashboard_bulk_ready_clears_gate_from_blocked(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "bulk parked manual gate", "assignee": "patch"},
+    ).json()["task"]
+    with kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', manual_ready_gate = 1 WHERE id = ?",
+            (created["id"],),
+        )
+
+    response = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [created["id"]], "status": "ready"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["results"] == [{"id": created["id"], "ok": True}]
+    with kb.connect() as conn:
+        task = kb.get_task(conn, created["id"])
+    assert task is not None
+    assert task.status == "ready"
+    assert task.manual_ready_gate is False
+
+
+def test_dashboard_bulk_ready_preserves_legacy_non_gated_transition(client):
+    created = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "ordinary bulk todo", "assignee": "patch"},
+    ).json()["task"]
+    with kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET status = 'todo', manual_ready_gate = 0 WHERE id = ?",
+            (created["id"],),
+        )
+
+    response = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [created["id"]], "status": "ready"},
+    )
+
+    assert response.status_code == 200, response.text
+    with kb.connect() as conn:
+        events = [event.kind for event in kb.list_events(conn, created["id"])]
+    assert events.count("promoted_manual") == 0
+    assert events.count("status") == 1
+
+
+@pytest.mark.parametrize("parked_status", ["blocked", "scheduled"])
+def test_dashboard_ready_dependency_failure_is_atomic(client, parked_status):
+    parent = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "unfinished parent", "assignee": "planner"},
+    ).json()["task"]
+    child = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "held child", "assignee": "patch", "parents": [parent["id"]]},
+    ).json()["task"]
+    with kb.connect() as conn:
+        conn.execute(
+            "UPDATE tasks SET status = ?, manual_ready_gate = 1 WHERE id = ?",
+            (parked_status, child["id"]),
+        )
+        before_events = len(kb.list_events(conn, child["id"]))
+
+    response = client.patch(
+        f"/api/plugins/kanban/tasks/{child['id']}",
+        json={"status": "ready"},
+    )
+
+    assert response.status_code == 409
+    with kb.connect() as conn:
+        task = kb.get_task(conn, child["id"])
+        after_events = len(kb.list_events(conn, child["id"]))
+    assert task is not None
+    assert task.status == parked_status
+    assert task.manual_ready_gate is True
+    assert after_events == before_events
+
+
 def test_dashboard_markdown_html_is_sanitized_before_render():
     """Markdown rendering must sanitize HTML before dangerouslySetInnerHTML."""
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -601,6 +601,8 @@ The kanban board has two ways to handle a task you drop into the Triage column:
 
 Flip between the two modes from the **Orchestration: Auto/Manual** pill at the top of the kanban page (emerald = Auto, muted gray = Manual), or by editing `config.yaml` directly. Both modes coexist with `hermes kanban specify` — that's still available as a single-task spec rewrite when you don't want fan-out.
 
+Ready approval is a separate control from decomposition. Set `kanban.auto_promote_children: false` to leave every decomposed child in `todo` behind a durable manual gate; dispatcher ticks and completed dependencies do not clear that gate. Set `kanban.require_manual_ready_approval: true` to apply the same gate to a single task produced by **✨ Specify** (including the decomposer's no-fan-out fallback). In either case, explicitly move the card to Ready in the dashboard or run `hermes kanban promote <id>` after review. That native promotion clears the gate and makes the task claimable. Both settings default to automatic behavior for backward compatibility, and existing tasks migrate with no gate.
+
 The decomposer's routing decisions depend on profile descriptions, which is a per-profile labeling primitive you set with `hermes profile create --description "..."`, `hermes profile describe <name> --text "..."`, `hermes profile describe <name> --auto` (LLM-generates from the profile's installed skills + model), or the dashboard's per-profile editor in the expanded **Orchestration settings** panel. Profiles without a description still appear in the roster — they're routable by name, just less precisely. The decomposer NEVER lands a child task with `assignee=None`: when the LLM picks an unknown profile, the child gets routed to `kanban.default_assignee` (or the active default profile if that's unset).
 
 `kanban.orchestrator_profile` does not load that profile's prompt, skills, or custom logic into the decomposition call. It controls who owns the root/orchestration task after fan-out. To change the decomposer's model/provider, configure `auxiliary.kanban_decomposer`. To use a profile's custom task-splitting logic instead of the built-in decomposer, switch to Manual mode and have that profile create or decompose tasks explicitly.
@@ -610,6 +612,8 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | Key | Default | Purpose |
 |---|---|---|
 | `auto_decompose` | `true` | Dispatcher auto-runs the built-in decomposer for Triage tasks every tick. It does not gate profile-driven `kanban_create` calls or creator wake turns. |
+| `auto_promote_children` | `true` | Promote decomposed children as dependencies allow. When `false`, each child stays in `todo` behind a durable gate until an explicit dashboard Ready action or `hermes kanban promote <id>`. |
+| `require_manual_ready_approval` | `false` | Apply the durable manual Ready gate to single-task **Specify** results and no-fan-out decomposition fallbacks. |
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |


### PR DESCRIPTION
## Summary
- persist a per-task manual Ready gate for decomposed and specified Triage work
- make automatic recompute/dispatcher passes respect the gate until explicit native promotion
- expose the gate through CLI/dashboard/config and document the Product Owner workflow
- preserve legacy automatic and dashboard transitions for non-gated tasks

## Verification
- RED reproduced dispatcher recompute bypass and dashboard single/bulk legacy-route regressions
- `scripts/run_tests.sh` focused changed paths: 95 passed
- full relevant Kanban suite: 379 passed, 0 failed, 1 Windows-only skipped
- ruff changed Python files: passed
- py_compile, `node --check`, and `git diff --check`: passed
- two fresh exact-diff independent reviews: PASS, P0/P1/P2 = 0

## Compatibility / migration
- additive `manual_ready_gate INTEGER NOT NULL DEFAULT 0` migration is idempotent and default-safe
- existing tasks and automatic-mode users retain automatic promotion
- direct dashboard Ready writes defensively clear stale gates

## Risk / rollback
Risk is limited to manual-governance tasks being intentionally held in Todo until explicit promotion. Roll back by reverting commit f5047d948e; the additive column can remain safely at its default without a database rewrite.