### PR TITLE
fix(mcp): point atlassian catalog at post-cutover /v1/mcp/authv2 endpoint (#91538)

### DIFF
--- a/apps/desktop/src/lib/mcp-directory.ts
+++ b/apps/desktop/src/lib/mcp-directory.ts
@@ -42,7 +42,7 @@ export const MCP_DIRECTORY: McpDirectoryEntry[] = [
     hosts: ['atlassian.net', 'atlassian.com', 'jira.com'],
     keywords: ['jira', 'confluence', 'atlassian', 'bitbucket'],
     name: 'atlassian',
-    url: 'https://mcp.atlassian.com/v1/sse'
+    url: 'https://mcp.atlassian.com/v1/mcp/authv2'
   },
   {
     description: 'Find, create, and update Linear issues and projects.',

--- a/optional-mcps/atlassian/manifest.yaml
+++ b/optional-mcps/atlassian/manifest.yaml
@@ -13,7 +13,7 @@ source: https://support.atlassian.com/rovo/docs/getting-started-with-the-atlassi
 # exchange, and refresh.
 transport:
   type: http
-  url: https://mcp.atlassian.com/v1/sse
+  url: https://mcp.atlassian.com/v1/mcp/authv2
 
 auth:
   type: oauth


### PR DESCRIPTION
## What does this PR do?

Atlassian decommissioned `https://mcp.atlassian.com/v1/sse` after **June 30, 2026** ([their own notice](https://support.atlassian.com/rovo/docs/getting-started-with-the-atlassian-remote-mcp-server/)). The endpoint now returns 404 on every request, so a catalog-installed `atlassian` server still authenticates fine (the OAuth token exchange hits `/v1/token`, which is alive) but every subsequent handshake / tool call fails with `MCPError: Not Found`, and after retries the server parks itself in the `connecting` state. The repeated `server/discover` fallback attempts in the logs are a red herring — the configured URL is simply stale.

This PR updates both surfaces that ship the stale URL to the vendor's current endpoint `https://mcp.atlassian.com/v1/mcp/authv2`:

- `optional-mcps/atlassian/manifest.yaml` — the approved catalog entry (new installs)
- `apps/desktop/src/lib/mcp-directory.ts` — the legacy fallback directory used by older backends whose catalog response carries no `suggest` field

The new URL was verified live against Atlassian's getting-started doc (it is now the only `v1` endpoint listed) and by the issue reporter E2E: with the override in place, an existing OAuth token was accepted without re-auth and `hermes mcp test atlassian` discovered 40 tools.

**Note on existing installs:** `install_entry()` copies `transport.url` into the user's `config.yaml` at install time, so pre-cutover installs keep the stale URL until they reinstall the entry or run `hermes config set mcp_servers.atlassian.url https://mcp.atlassian.com/v1/mcp/authv2`. An automatic migration of existing configs felt like separate scope — happy to add it if maintainers prefer.

## Related Issue

Fixes #91538

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `optional-mcps/atlassian/manifest.yaml`: `transport.url` → `https://mcp.atlassian.com/v1/mcp/authv2`
- `apps/desktop/src/lib/mcp-directory.ts`: atlassian entry `url` → same endpoint

No other files touched; these are the only two references to the deprecated URL in the tree (`git grep mcp.atlassian.com`).

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_mcp_catalog.py -q` → **25 passed**, including the shipped-catalog sanity tests that parse every manifest under `optional-mcps/` from the real repo directory.
2. E2E (per the issue reporter): install the catalog entry, then `hermes mcp test atlassian` discovers tools instead of parking with `MCPError: Not Found`.
3. Live check of the endpoint doc: https://support.atlassian.com/rovo/docs/getting-started-with-the-atlassian-remote-mcp-server/

On tests: no new test was added for the URL value itself — pinning a live vendor URL in an assertion would be exactly the change-detector test the repo rubric discourages, and the existing shipped-catalog parse/validation tests already cover the manifest's structural contract.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(relevant file: `tests/hermes_cli/test_mcp_catalog.py`, 25/25 green)*
- [ ] I've added tests for my changes *(see note above — data-only change covered by existing catalog validation)*
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no docs referenced the old URL)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (data-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A