### PR TITLE
feat(buzz): continue mentioned reply threads

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -94,7 +94,9 @@ _FETCH_LIMIT = 50
 # Bound on the per-channel de-dupe set (events, not bytes).
 _SEEN_CAP = 500
 # When a reply reaches us before its parent, briefly rewind inbound cursors so
-# the next poll / WebSocket reconnect can retrieve that parent too.
+# the next poll / WebSocket reconnect can retrieve that parent too. Keep the
+# rewind and retention windows separate: reducing either can make a parent
+# unreachable before its deferred child is discarded.
 _PENDING_REPLY_LOOKBACK_SECONDS = 60
 _PENDING_REPLY_MAX_AGE_SECONDS = 60
 # Re-run DM discovery (``dms list`` plus the channels-list fallback) every
@@ -1089,6 +1091,8 @@ class BuzzAdapter(BasePlatformAdapter):
         )
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
         # BUZZ_ALLOW_ALL_USERS centrally as well; empty list = no filter here).
+        # This precedes _defer_thread_reply deliberately: unauthorized events
+        # must never be retained for later delivery when a parent arrives.
         if self._allowed_pubkeys and pubkey not in self._allowed_pubkeys:
             logger.debug("Buzz: ignoring message from unauthorized pubkey %s…", pubkey[:8])
             return
@@ -1283,20 +1287,25 @@ class BuzzAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _reply_to_event_id(event: dict) -> Optional[str]:
-        """Return the direct reply target from Buzz's Nostr ``e`` tag."""
+        """Return the direct reply target from a NIP-10 or legacy ``e`` tag."""
         tags = event.get("tags")
         if not isinstance(tags, list):
             return None
+        legacy_targets = []
+        has_explicit_mention = False
         for tag in tags:
-            if (
-                isinstance(tag, (list, tuple))
-                and len(tag) >= 4
-                and tag[0] == "e"
-                and tag[3] == "reply"
-                and tag[1]
-            ):
+            if not (isinstance(tag, (list, tuple)) and len(tag) >= 2 and tag[0] == "e" and tag[1]):
+                continue
+            marker = str(tag[3]).lower() if len(tag) >= 4 and tag[3] else ""
+            if marker == "reply":
                 return str(tag[1])
-        return None
+            # Legacy NIP-10 events omitted markers. A lone e-tag is their
+            # direct parent; root + reply pairs put the direct parent last.
+            if not marker or marker == "root":
+                legacy_targets.append(str(tag[1]))
+            elif marker == "mention":
+                has_explicit_mention = True
+        return legacy_targets[-1] if legacy_targets and not has_explicit_mention else None
 
     def _remember_mentioned_thread_event(self, channel_id: str, event_id: str) -> None:
         """Record one event in an @mentioned reply tree with a bounded LRU."""

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -25,6 +25,7 @@ Configuration in config.yaml::
             cli_path: ""               # path to the buzz binary (default: PATH, then ~/bin/buzz)
             credentials_file: ""       # JSON file holding the nsec (fallback for BUZZ_PRIVATE_KEY)
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
+            thread_require_mention: false  # continue replies after an @mention
 
 Or via environment variables (overrides config.yaml):
     BUZZ_RELAY_URL, BUZZ_CHANNELS, BUZZ_HOME_CHANNEL, BUZZ_POLL_INTERVAL,
@@ -92,6 +93,10 @@ _CHAT_KIND = 9
 _FETCH_LIMIT = 50
 # Bound on the per-channel de-dupe set (events, not bytes).
 _SEEN_CAP = 500
+# When a reply reaches us before its parent, briefly rewind inbound cursors so
+# the next poll / WebSocket reconnect can retrieve that parent too.
+_PENDING_REPLY_LOOKBACK_SECONDS = 60
+_PENDING_REPLY_MAX_AGE_SECONDS = 60
 # Re-run DM discovery (``dms list`` plus the channels-list fallback) every
 # N poll sweeps to pick up conversations opened mid-run.
 _DM_DISCOVERY_EVERY = 5
@@ -392,6 +397,13 @@ class BuzzAdapter(BasePlatformAdapter):
             _rm_cfg = _rm_raw
         self.require_mention = str(_rm_cfg).strip().lower() not in ("false", "0", "no", "off")
 
+        # When false (the default), a direct reply to a message in a thread
+        # started by an @mention continues to reach the agent without another
+        # @mention. Set true in bot-heavy channels to keep strict mention
+        # gating on every thread reply.
+        _trm_cfg = extra.get("thread_require_mention", False)
+        self.thread_require_mention = str(_trm_cfg).strip().lower() not in ("false", "0", "no", "off")
+
         # Inbound transport: "auto" (WebSocket with poll fallback, default),
         # "websocket" (require WS; fail connect when it can't authenticate),
         # or "poll" (CLI polling only). Env (BUZZ_TRANSPORT) overrides
@@ -435,6 +447,16 @@ class BuzzAdapter(BasePlatformAdapter):
         # classification (see _may_reclassify_as_dm).
         self._channel_meta: Dict[str, dict] = {}
         self._user_names: Dict[str, str] = {}
+        # channel_id -> bounded LRU of events in threads entered by an
+        # explicit @mention. Both user and bot event ids are recorded so a
+        # reply chain remains active regardless of which message is replied to.
+        self._mentioned_thread_events: Dict[str, OrderedDict[str, None]] = {}
+        # channel_id -> bounded LRU of unmentioned direct replies received
+        # before their parent @mention (Nostr delivery is not ordered).
+        self._pending_thread_replies: Dict[
+            str, OrderedDict[str, Tuple[dict, float]]
+        ] = {}
+        self._draining_pending_threads: set[str] = set()
         self._poll_count = 0
 
     @property
@@ -597,6 +619,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 pass
         self._poll_task = None
         self._channel_state = {}
+        self._mentioned_thread_events = {}
+        self._pending_thread_replies = {}
+        self._draining_pending_threads = set()
         self._poll_count = 0
 
     # ── Sending ───────────────────────────────────────────────────────────
@@ -630,6 +655,8 @@ class BuzzAdapter(BasePlatformAdapter):
             # Belt-and-braces echo suppression: the poll loop already skips
             # our own pubkey, but marking the id seen makes de-dupe explicit.
             self._mark_seen(str(chat_id), str(event_id))
+            if reply_target and reply_target in self._mentioned_thread_events.get(str(chat_id), {}):
+                self._remember_mentioned_thread_event(str(chat_id), str(event_id))
         return SendResult(
             success=bool(data.get("accepted", True)),
             message_id=str(event_id) if event_id else None,
@@ -683,8 +710,9 @@ class BuzzAdapter(BasePlatformAdapter):
                 "--file", str(local),
                 "--content", "-",
             ]
-            if reply_to:
-                args += ["--reply-to", str(reply_to)]
+            reply_target = reply_to or (metadata or {}).get("thread_id")
+            if reply_target:
+                args += ["--reply-to", str(reply_target)]
             code, out, err = await self._run_cli(args, input_text=caption or "")
             if code != 0:
                 return SendResult(success=False, error=_cli_error_message(err, code), retryable=code == 2)
@@ -695,6 +723,8 @@ class BuzzAdapter(BasePlatformAdapter):
             event_id = data.get("event_id")
             if event_id:
                 self._mark_seen(str(chat_id), str(event_id))
+                if reply_target and reply_target in self._mentioned_thread_events.get(str(chat_id), {}):
+                    self._remember_mentioned_thread_event(str(chat_id), str(event_id))
             return SendResult(
                 success=bool(data.get("accepted", True)),
                 message_id=str(event_id) if event_id else None,
@@ -795,6 +825,9 @@ class BuzzAdapter(BasePlatformAdapter):
     async def _send_channel_subscription(self, websocket, subscription_id: str, channel_id: str) -> None:
         state = self._channel_state.get(channel_id) or {}
         since = max(int(state.get("last_ts") or time.time()) - 1, 0)
+        pending_since = self._pending_reply_since_for(channel_id)
+        if pending_since is not None:
+            since = min(since, pending_since)
         request = [
             "REQ",
             subscription_id,
@@ -883,8 +916,17 @@ class BuzzAdapter(BasePlatformAdapter):
                                 channel_id = subscriptions.get(subscription_id)
                                 state = self._channel_state.get(channel_id or "")
                                 if channel_id and state is not None:
+                                    pending_since_before = self._pending_reply_since_for(channel_id)
                                     await self._handle_event(channel_id, state, event)
                                     self._trim_seen(state)
+                                    pending_since_after = self._pending_reply_since_for(channel_id)
+                                    if pending_since_after != pending_since_before:
+                                        # A child can arrive before its parent. Replace this
+                                        # live subscription immediately so the rewind is not
+                                        # deferred until a reconnect.
+                                        await self._send_channel_subscription(
+                                            websocket, subscription_id, channel_id
+                                        )
                             elif message[0] == "CLOSED":
                                 detail = message[-1] if len(message) > 2 else "subscription closed"
                                 raise ConnectionError(str(detail))
@@ -993,10 +1035,14 @@ class BuzzAdapter(BasePlatformAdapter):
         if state is None:
             return
         args = ["messages", "get", "--channel", channel_id, "--limit", str(_FETCH_LIMIT)]
-        if state["last_ts"]:
+        since = state["last_ts"]
+        pending_since = self._pending_reply_since_for(channel_id)
+        if pending_since is not None:
+            since = min(since, pending_since)
+        if since:
             # Nostr `since` is inclusive: same-second events are re-fetched
             # and de-duped by id below.
-            args += ["--since", str(state["last_ts"])]
+            args += ["--since", str(since)]
         code, out, err = await self._run_cli(args)
         if code != 0:
             logger.debug(
@@ -1007,13 +1053,16 @@ class BuzzAdapter(BasePlatformAdapter):
             await self._handle_event(channel_id, state, event)
         self._trim_seen(state)
 
-    async def _handle_event(self, channel_id: str, state: dict, event: dict) -> None:
+    async def _handle_event(
+        self, channel_id: str, state: dict, event: dict, *, already_seen: bool = False
+    ) -> None:
         """De-dupe, filter, and dispatch a single ``messages get`` event."""
         event_id = str(event.get("id") or "")
         created_at = int(event.get("created_at") or 0)
-        if not event_id or event_id in state["seen"]:
+        if not event_id or (not already_seen and event_id in state["seen"]):
             return
-        state["seen"][event_id] = None
+        if not already_seen:
+            state["seen"][event_id] = None
         state["last_ts"] = max(state["last_ts"], created_at)
 
         if int(event.get("kind") or 0) != _CHAT_KIND:
@@ -1032,17 +1081,35 @@ class BuzzAdapter(BasePlatformAdapter):
         self._maybe_latch_dm(channel_id, state, event)
 
         is_dm = state["chat_type"] == "dm"
-        # In shared channels, respond only when addressed — unless
-        # require_mention is disabled, in which case respond to every message.
-        # DMs always dispatch.
-        if not is_dm and self.require_mention and not self._is_mentioned(content):
-            return
-
+        is_mentioned = self._is_mentioned(content)
+        reply_to_event_id = self._reply_to_event_id(event)
+        in_mentioned_thread = (
+            bool(reply_to_event_id)
+            and reply_to_event_id in self._mentioned_thread_events.get(channel_id, {})
+        )
         # Adapter-level allow-list (the gateway applies BUZZ_ALLOWED_USERS /
         # BUZZ_ALLOW_ALL_USERS centrally as well; empty list = no filter here).
         if self._allowed_pubkeys and pubkey not in self._allowed_pubkeys:
             logger.debug("Buzz: ignoring message from unauthorized pubkey %s…", pubkey[:8])
             return
+
+        # In shared channels, respond only when addressed — unless
+        # require_mention is disabled, or this is a direct reply in a thread
+        # the agent entered through an @mention. DMs always dispatch. A direct
+        # reply whose parent has not arrived is retained briefly: Nostr relay
+        # delivery does not guarantee parent-before-child ordering.
+        if (
+            not is_dm
+            and self.require_mention
+            and not is_mentioned
+            and (self.thread_require_mention or not in_mentioned_thread)
+        ):
+            if not self.thread_require_mention and reply_to_event_id:
+                self._defer_thread_reply(channel_id, event_id, event)
+            return
+
+        if not is_dm and (is_mentioned or in_mentioned_thread):
+            self._remember_mentioned_thread_event(channel_id, event_id)
 
         # Strip a leading @mention so slash commands (@Chip /whoami ->
         # /whoami) and clean prompts are recognized. DM messages often still
@@ -1059,6 +1126,8 @@ class BuzzAdapter(BasePlatformAdapter):
             message_id=event_id,
             created_at=created_at,
         )
+        if not is_dm and (is_mentioned or in_mentioned_thread):
+            await self._dispatch_pending_thread_replies(channel_id, state)
 
     # ── DM classification (issue #68871) ──────────────────────────────────
     #
@@ -1211,6 +1280,81 @@ class BuzzAdapter(BasePlatformAdapter):
         if state is not None:
             state["seen"][event_id] = None
             self._trim_seen(state)
+
+    @staticmethod
+    def _reply_to_event_id(event: dict) -> Optional[str]:
+        """Return the direct reply target from Buzz's Nostr ``e`` tag."""
+        tags = event.get("tags")
+        if not isinstance(tags, list):
+            return None
+        for tag in tags:
+            if (
+                isinstance(tag, (list, tuple))
+                and len(tag) >= 4
+                and tag[0] == "e"
+                and tag[3] == "reply"
+                and tag[1]
+            ):
+                return str(tag[1])
+        return None
+
+    def _remember_mentioned_thread_event(self, channel_id: str, event_id: str) -> None:
+        """Record one event in an @mentioned reply tree with a bounded LRU."""
+        events = self._mentioned_thread_events.setdefault(channel_id, OrderedDict())
+        events[event_id] = None
+        events.move_to_end(event_id)
+        while len(events) > _SEEN_CAP:
+            events.popitem(last=False)
+
+    def _defer_thread_reply(self, channel_id: str, event_id: str, event: dict) -> None:
+        """Keep an out-of-order direct reply until its parent arrives."""
+        pending = self._pending_thread_replies.setdefault(channel_id, OrderedDict())
+        pending[event_id] = (event, time.monotonic() + _PENDING_REPLY_MAX_AGE_SECONDS)
+        pending.move_to_end(event_id)
+        while len(pending) > _SEEN_CAP:
+            pending.popitem(last=False)
+
+    def _pending_reply_since_for(self, channel_id: str) -> Optional[int]:
+        """Prune expired replies and return the cursor needed to find parents."""
+        pending = self._pending_thread_replies.get(channel_id)
+        if not pending:
+            return None
+        now = time.monotonic()
+        for event_id, (_event, deadline) in list(pending.items()):
+            if deadline <= now:
+                pending.pop(event_id)
+        if not pending:
+            self._pending_thread_replies.pop(channel_id, None)
+            return None
+        return min(
+            max(int(event.get("created_at") or 0) - _PENDING_REPLY_LOOKBACK_SECONDS, 0)
+            for event, _deadline in pending.values()
+        )
+
+    async def _dispatch_pending_thread_replies(self, channel_id: str, state: dict) -> None:
+        """Dispatch pending replies whose parents are now in an active thread."""
+        if channel_id in self._draining_pending_threads:
+            return
+        self._draining_pending_threads.add(channel_id)
+        try:
+            self._pending_reply_since_for(channel_id)
+            pending = self._pending_thread_replies.get(channel_id)
+            while pending:
+                ready_event_id = next(
+                    (
+                        event_id
+                        for event_id, (event, _deadline) in pending.items()
+                        if self._reply_to_event_id(event) in self._mentioned_thread_events.get(channel_id, {})
+                    ),
+                    None,
+                )
+                if ready_event_id is None:
+                    return
+                event, _deadline = pending.pop(ready_event_id)
+                await self._handle_event(channel_id, state, event, already_seen=True)
+            self._pending_thread_replies.pop(channel_id, None)
+        finally:
+            self._draining_pending_threads.discard(channel_id)
 
     async def _dispatch_message(
         self,

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -243,6 +243,105 @@ class TestMentionGating:
         await self._poll_with(adapter, _event("e1", content="hey @Chip can you help?", created_at=10))
         assert len(adapter._dispatched) == 1
 
+    @pytest.mark.asyncio
+    async def test_reply_to_mentioned_message_dispatches_without_another_mention(self, adapter):
+        await self._poll_with(
+            adapter,
+            _event("e1", content="@Chip can you help?", created_at=10),
+            _tagged_event("e2", CHANNEL, content="please continue", reply_to="e1", created_at=11),
+        )
+
+        assert [message["message_id"] for message in adapter._dispatched] == ["e1", "e2"]
+
+    @pytest.mark.asyncio
+    async def test_out_of_order_reply_dispatches_after_its_mentioned_parent_arrives(self, adapter):
+        state = adapter._channel_state[CHANNEL]
+        reply = _tagged_event("e2", CHANNEL, content="please continue", reply_to="e1", created_at=11)
+        mention = _event("e1", content="@Chip can you help?", created_at=10)
+
+        await adapter._handle_event(CHANNEL, state, reply)
+        assert adapter._dispatched == []
+
+        await adapter._handle_event(CHANNEL, state, mention)
+
+        assert [message["message_id"] for message in adapter._dispatched] == ["e1", "e2"]
+
+    @pytest.mark.asyncio
+    async def test_pending_reply_keeps_poll_cursor_behind_possible_parent(self, adapter):
+        cli = _ScriptedCli()
+        cli.script(
+            "messages", "get",
+            [_tagged_event("e2", CHANNEL, content="please continue", reply_to="e1", created_at=20)],
+        )
+        cli.script("messages", "get", [_event("e1", content="@Chip can you help?", created_at=10)])
+        adapter._run_cli = cli
+
+        await adapter._poll_channel(CHANNEL)
+        await adapter._poll_channel(CHANNEL)
+
+        second_poll_args, _ = cli.calls[1]
+        if "--since" in second_poll_args:
+            assert int(second_poll_args[second_poll_args.index("--since") + 1]) <= 10
+        assert [message["message_id"] for message in adapter._dispatched] == ["e1", "e2"]
+
+    @pytest.mark.asyncio
+    async def test_expired_pending_reply_does_not_rewind_poll_cursor(self, adapter, monkeypatch):
+        adapter._channel_state[CHANNEL]["last_ts"] = 100
+        monkeypatch.setattr(_buzz_mod.time, "monotonic", lambda: 0)
+        adapter._defer_thread_reply(
+            CHANNEL,
+            "e2",
+            _tagged_event("e2", CHANNEL, content="please continue", reply_to="e1", created_at=20),
+        )
+        monkeypatch.setattr(_buzz_mod.time, "monotonic", lambda: 61)
+        cli = _ScriptedCli()
+        adapter._run_cli = cli
+
+        await adapter._poll_channel(CHANNEL)
+
+        args, _ = cli.calls[0]
+        assert args[args.index("--since") + 1] == "100"
+
+    @pytest.mark.asyncio
+    async def test_deferred_reply_chain_drains_without_recursion(self, adapter):
+        state = adapter._channel_state[CHANNEL]
+        for index in range(500, 1, -1):
+            await adapter._handle_event(
+                CHANNEL,
+                state,
+                _tagged_event(
+                    f"e{index}",
+                    CHANNEL,
+                    content="continue",
+                    reply_to=f"e{index - 1}",
+                    created_at=index,
+                ),
+            )
+
+        await adapter._handle_event(CHANNEL, state, _event("e1", content="@Chip start", created_at=1))
+
+        assert [message["message_id"] for message in adapter._dispatched] == [
+            f"e{index}" for index in range(1, 501)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_thread_require_mention_keeps_replies_gated(self):
+        adapter = _make_adapter({"thread_require_mention": True})
+        adapter._dispatched = []
+
+        async def capture(**kwargs):
+            adapter._dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        adapter._message_handler = AsyncMock()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 0, "seen": {}}
+        await self._poll_with(
+            adapter,
+            _event("e1", content="@Chip can you help?", created_at=10),
+            _tagged_event("e2", CHANNEL, content="please continue", reply_to="e1", created_at=11),
+        )
+
+        assert [message["message_id"] for message in adapter._dispatched] == ["e1"]
 
     @pytest.mark.asyncio
     async def test_allowlist_blocks_unauthorized(self, adapter):

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -254,6 +254,42 @@ class TestMentionGating:
         assert [message["message_id"] for message in adapter._dispatched] == ["e1", "e2"]
 
     @pytest.mark.asyncio
+    async def test_legacy_lone_reply_tag_continues_mentioned_thread(self, adapter):
+        reply = _event("e2", content="please continue", created_at=11)
+        reply["tags"].append(["e", "e1"])
+        await self._poll_with(
+            adapter,
+            _event("e1", content="@Chip can you help?", created_at=10),
+            reply,
+        )
+
+        assert [message["message_id"] for message in adapter._dispatched] == ["e1", "e2"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_reply_marker_wins_over_preceding_mention_marker(self, adapter):
+        reply = _event("e2", content="please continue", created_at=11)
+        reply["tags"] += [["e", "unrelated", "", "mention"], ["e", "e1", "", "reply"]]
+        await self._poll_with(
+            adapter,
+            _event("e1", content="@Chip can you help?", created_at=10),
+            reply,
+        )
+
+        assert [message["message_id"] for message in adapter._dispatched] == ["e1", "e2"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_root_and_reply_tags_use_last_unmarked_target(self, adapter):
+        reply = _event("e3", content="please continue", created_at=12)
+        reply["tags"] += [["e", "root"], ["e", "e1"]]
+        await self._poll_with(
+            adapter,
+            _event("e1", content="@Chip can you help?", created_at=10),
+            reply,
+        )
+
+        assert [message["message_id"] for message in adapter._dispatched] == ["e1", "e3"]
+
+    @pytest.mark.asyncio
     async def test_out_of_order_reply_dispatches_after_its_mentioned_parent_arrives(self, adapter):
         state = adapter._channel_state[CHANNEL]
         reply = _tagged_event("e2", CHANNEL, content="please continue", reply_to="e1", created_at=11)
@@ -344,10 +380,78 @@ class TestMentionGating:
         assert [message["message_id"] for message in adapter._dispatched] == ["e1"]
 
     @pytest.mark.asyncio
+    async def test_unauthorized_reply_is_neither_dispatched_nor_deferred(self, adapter):
+        adapter._allowed_pubkeys = {OTHER_PUBKEY}
+        await self._poll_with(adapter, _event("e1", content="@Chip can you help?", created_at=10))
+        unauthorized_reply = _tagged_event(
+            "e2", CHANNEL, content="please continue", pubkey="b" * 64, reply_to="missing", created_at=11
+        )
+
+        await self._poll_with(adapter, unauthorized_reply)
+
+        assert [message["message_id"] for message in adapter._dispatched] == ["e1"]
+        assert CHANNEL not in adapter._pending_thread_replies
+
+    @pytest.mark.asyncio
     async def test_allowlist_blocks_unauthorized(self, adapter):
         adapter._allowed_pubkeys = {"b" * 64}
         await self._poll_with(adapter, _event("e1", content="@Chip hello", created_at=10))
         assert adapter._dispatched == []
+
+
+class TestWebSocketThreadReplyRewind:
+
+    @pytest.mark.asyncio
+    async def test_out_of_order_reply_replaces_live_subscription_with_rewind(self, monkeypatch):
+        """A pending child must trigger a fresh REQ before a WS reconnect."""
+        adapter = _make_adapter()
+        adapter._channel_state[CHANNEL] = {"chat_type": "group", "last_ts": 100, "seen": {}}
+        adapter._authenticate_websocket = AsyncMock()
+
+        class ScriptedWebSocket:
+            def __init__(self):
+                self.sent = []
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, traceback):
+                return False
+
+            async def send(self, payload):
+                self.sent.append(json.loads(payload))
+
+            def __aiter__(self):
+                return self._frames()
+
+            async def _frames(self):
+                yield json.dumps([
+                    "EVENT",
+                    "test-subscription",
+                    _tagged_event("e2", CHANNEL, content="continue", reply_to="e1", created_at=20),
+                ])
+                raise asyncio.CancelledError()
+
+        websocket = ScriptedWebSocket()
+
+        async def subscribe(ws):
+            await adapter._send_channel_subscription(ws, "test-subscription", CHANNEL)
+            return {"test-subscription": CHANNEL}
+
+        adapter._subscribe_websocket = subscribe
+        import websockets
+
+        monkeypatch.setattr(websockets, "connect", lambda *_args, **_kwargs: websocket)
+        with pytest.raises(asyncio.CancelledError):
+            await adapter._websocket_loop()
+
+        assert len(websocket.sent) == 2
+        assert websocket.sent[0][0:2] == ["REQ", "test-subscription"]
+        assert websocket.sent[1] == [
+            "REQ",
+            "test-subscription",
+            {"kinds": [9], "#h": [CHANNEL], "since": 0},
+        ]
 
 
 # ── DM classification via p-tags (issue #68871) ──────────────────────────

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -34,6 +34,7 @@ gateway:
         cli_path: ""               # buzz binary (default: PATH, then ~/bin/buzz)
         credentials_file: ""       # JSON file with the nsec (BUZZ_PRIVATE_KEY fallback)
         allowed_users: []          # empty = allow all; hex pubkeys or npubs
+        thread_require_mention: false # continue direct replies after an @mention
 ```
 
 Plus, in `~/.hermes/.env`:
@@ -80,6 +81,7 @@ gateway:
         credentials_file: ""              # JSON file with the nsec (BUZZ_PRIVATE_KEY fallback)
         allowed_users: []                 # empty = allow all if allow_all_users is true; otherwise restrict to listed npubs/hex pubkeys
         require_mention: true             # in channels: only respond when addressed (@name, npub, or hex pubkey); DMs always dispatch regardless
+        thread_require_mention: false      # continue direct replies in a thread entered by an @mention
         allow_all_users: false            # set true for community mode (everyone can chat, only owner is admin); false for private mode (only allowed_users)
 ```
 
@@ -90,6 +92,7 @@ gateway:
 - `poll_interval: 4` — balances inbound latency (up to 4s delay) against relay load. Lower values increase polling frequency; higher values reduce it.
 - `allowed_users: []` + `allow_all_users: false` — private mode by default. Only listed users can interact. Set `allow_all_users: true` for community mode where everyone can chat (admin tier still restricted to the owner).
 - `require_mention: true` — in channels, the agent only responds when addressed. DMs always dispatch regardless of this setting.
+- `thread_require_mention: false` — after an @mention, direct replies in that Buzz reply thread continue without another mention. Set it to `true` in bot-heavy channels to require an explicit mention on every reply.
 
 **Rationale:** Channels are for final results and conversation, not for the agent's internal tool execution log. Users see the final answer, not the steps taken to get there. This matches the behavior on Telegram and email, which already have these defaults.
 
@@ -98,6 +101,7 @@ gateway:
 ## Mentions, channels, and DMs
 
 - In shared channels the agent only responds when **addressed** — by `@name`, its npub, or its hex pubkey. Everything else is ignored.
+- Once addressed, the agent follows direct replies in that reply tree without another mention by default. Set `thread_require_mention: true` to keep strict mention gating inside threads.
 - Direct messages always reach the agent, no mention needed.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -101,7 +101,7 @@ gateway:
 ## Mentions, channels, and DMs
 
 - In shared channels the agent only responds when **addressed** — by `@name`, its npub, or its hex pubkey. Everything else is ignored.
-- Once addressed, the agent follows direct replies in that reply tree without another mention by default. Set `thread_require_mention: true` to keep strict mention gating inside threads.
+- Once addressed, the agent follows direct replies in that reply tree without another mention by default. This in-memory membership is bounded to the 500 most recently active thread events per channel and has no time expiry; set `thread_require_mention: true` to keep strict mention gating inside threads.
 - Direct messages always reach the agent, no mention needed.
 - The agent's own messages are never dispatched back to it (self-echo suppression by pubkey), and every event is de-duplicated by event id against a per-channel high-water mark.
 


### PR DESCRIPTION
## Summary
- Continue direct replies in a Buzz thread after an initial `@mention`, while keeping mentions required elsewhere.
- Add `thread_require_mention: true` for strict per-reply mention gating.
- Handle out-of-order Nostr delivery with bounded, expiring pending replies and rewind poll/WebSocket cursors.
- Document the setting and add regression coverage for continuation, ordering, expiry, and long reply chains.

## Verification
- `scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_websocket.py` (33 passed)
- `.venv/bin/ruff check plugins/platforms/buzz/adapter.py tests/gateway/test_buzz_adapter.py`
- `git diff --check`
- Independent review: passed (no blocking security or logic issues).