### PR TITLE
fix(gateway): keep launchd force installs truthful

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4726,7 +4726,21 @@ def _launchd_fallback_to_detached(reason: str, *, exit_on_failure: bool = True) 
     return False
 
 
-def generate_launchd_plist() -> str:
+def _launchd_plist_run_at_load(plist_path: Path | None = None) -> bool:
+    """Return the installed launchd RunAtLoad value, defaulting to enabled."""
+    import plistlib
+
+    path = plist_path or get_launchd_plist_path()
+    try:
+        with path.open("rb") as fh:
+            data = plistlib.load(fh)
+        value = data.get("RunAtLoad") if isinstance(data, dict) else None
+        return bool(value) if isinstance(value, bool) else True
+    except (OSError, ValueError, TypeError, plistlib.InvalidFileException):
+        return True
+
+
+def generate_launchd_plist(*, start_on_login: bool | None = None) -> str:
     # Stable cwd anchor — never the volatile source checkout. See
     # _stable_service_working_dir() for the rationale (same rot risk applies
     # to launchd's WorkingDirectory as to systemd's).
@@ -4753,6 +4767,8 @@ def generate_launchd_plist() -> str:
     )
 
     err_path = log_dir / "gateway.error.log"
+    run_at_load = _launchd_plist_run_at_load() if start_on_login is None else start_on_login
+    run_at_load_xml = "<true/>" if run_at_load else "<false/>"
 
     # Build ProgramArguments array, including --profile when using a named profile.
     # The stderr wrapper preserves launchd's restart semantics while adding
@@ -4819,7 +4835,7 @@ def generate_launchd_plist() -> str:
     </array>
     
     <key>RunAtLoad</key>
-    <true/>
+    {run_at_load_xml}
     
     <key>KeepAlive</key>
     <true/>
@@ -5068,7 +5084,7 @@ def refresh_launchd_plist_if_needed() -> bool:
     return True
 
 
-def launchd_install(force: bool = False):
+def launchd_install(force: bool = False, *, start_on_login: bool | None = None):
     plist_path = get_launchd_plist_path()
 
     if plist_path.exists() and not force:
@@ -5082,19 +5098,36 @@ def launchd_install(force: bool = False):
         return
 
     plist_path.parent.mkdir(parents=True, exist_ok=True)
-    new_plist = generate_launchd_plist()
+    new_plist = generate_launchd_plist(start_on_login=start_on_login)
     if _refuse_temp_home_service_write(new_plist, "launchd plist"):
         return
     print(f"Installing launchd service to: {plist_path}")
     plist_path.write_text(new_plist, encoding="utf-8")
 
-    try:
-        _launchctl_bootstrap(
-            _launchd_domain(), plist_path, get_launchd_label(), timeout=30
+    label = get_launchd_label()
+    domain = _launchd_domain()
+    if force:
+        # `launchctl bootstrap` returns EIO (5) when the label is already
+        # loaded. A forced reinstall is explicitly asking to replace the
+        # existing job, so boot it out before bootstrapping instead of first
+        # misreporting an unsupported launchd domain and falling back to a bare
+        # background process (#91549).
+        subprocess.run(
+            ["launchctl", "bootout", f"{domain}/{label}"],
+            check=False,
+            timeout=90,
         )
+        _wait_for_gateway_exit(timeout=_get_restart_drain_timeout(), force_after=None)
+
+    try:
+        _launchctl_bootstrap(domain, plist_path, label, timeout=30)
     except subprocess.CalledProcessError as e:
         if not _launchctl_domain_unsupported(e.returncode):
             raise
+        try:
+            plist_path.unlink(missing_ok=True)
+        except OSError:
+            pass
         _launchd_fallback_to_detached(f"launchctl bootstrap exit {e.returncode}")
         return
 
@@ -7748,7 +7781,7 @@ def _gateway_command_inner(args):
             if start_now:
                 systemd_start(system=system)
         elif is_macos():
-            launchd_install(force)
+            launchd_install(force, start_on_login=getattr(args, "start_on_login", None))
         elif is_windows():
             from hermes_cli import gateway_windows
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -262,6 +262,30 @@ class TestGeneratedSystemdUnits:
 
         assert "SoftResourceLimits" not in plist
 
+    def test_launchd_plist_honors_no_start_on_login(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+
+        plist = plistlib.loads(
+            gateway_cli.generate_launchd_plist(start_on_login=False).encode()
+        )
+
+        assert plist["RunAtLoad"] is False
+        assert plist["KeepAlive"] is True
+
+    def test_launchd_plist_preserves_installed_run_at_load(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_bytes(plistlib.dumps({"RunAtLoad": False}))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        plist = plistlib.loads(gateway_cli.generate_launchd_plist().encode())
+
+        assert plist["RunAtLoad"] is False
+
 
 
 class TestGatewayStopCleanup:
@@ -2043,6 +2067,119 @@ class TestLaunchctlBootstrapEioRetry:
         with pytest.raises(subprocess.CalledProcessError) as excinfo:
             gateway_cli._launchctl_bootstrap(self.DOMAIN, self.PLIST, self.LABEL)
         assert excinfo.value.returncode == 5
+
+
+class TestLaunchdInstallForce:
+    def test_force_boots_out_existing_label_before_bootstrap(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway"
+        )
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_refuse_temp_home_service_write",
+            lambda definition, kind: False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda timeout, force_after=None: calls.append(["wait", timeout, force_after])
+            or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, **kwargs: calls.append(cmd)
+            or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchctl_bootstrap",
+            lambda domain, path, label, timeout=30: calls.append(
+                ["bootstrap", domain, str(path), label, timeout]
+            ),
+        )
+
+        gateway_cli.launchd_install(force=True, start_on_login=False)
+
+        assert calls[:3] == [
+            ["launchctl", "bootout", "gui/501/ai.hermes.gateway"],
+            ["wait", 0, None],
+            ["bootstrap", "gui/501", str(plist_path), "ai.hermes.gateway", 30],
+        ]
+        plist = plistlib.loads(plist_path.read_bytes())
+        assert plist["RunAtLoad"] is False
+
+    def test_unsupported_launchd_fallback_removes_plist(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(
+            gateway_cli,
+            "_refuse_temp_home_service_write",
+            lambda definition, kind: False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchctl_bootstrap",
+            lambda *a, **k: (_ for _ in ()).throw(
+                subprocess.CalledProcessError(5, ["launchctl", "bootstrap"])
+            ),
+        )
+        monkeypatch.setattr(gateway_cli, "_spawn_detached_gateway", lambda: True)
+
+        gateway_cli.launchd_install(force=False, start_on_login=False)
+
+        assert not plist_path.exists()
+        out = capsys.readouterr().out
+        assert "Started gateway as a background process instead" in out
+        assert "will NOT auto-start at login" in out
+
+    def test_gateway_install_passes_start_on_login_to_launchd(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(gateway_cli, "is_managed", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_container", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "launchd_install",
+            lambda force=False, *, start_on_login=None: captured.update(
+                {"force": force, "start_on_login": start_on_login}
+            ),
+        )
+
+        args = SimpleNamespace(
+            gateway_command="install",
+            force=True,
+            system=False,
+            run_as_user=None,
+            start_now=None,
+            start_on_login=False,
+            elevated_handoff=False,
+        )
+
+        gateway_cli._gateway_command_inner(args)
+
+        assert captured == {"force": True, "start_on_login": False}
 
 
 class TestRetryLaunchctlBootstrapUntilRegistered:


### PR DESCRIPTION
Summary
On macOS, gateway install ignored the install-time start-on-login flag in the launchd path and treated a forced reinstall like a fresh bootstrap. If the launchd label was already loaded, bootstrap could report EIO and the CLI could fall back to a detached process while leaving a plist whose RunAtLoad state contradicted the printed fallback guarantee. This change passes the CLI start-on-login choice into launchd plist generation, boots out an existing label before a forced bootstrap, preserves an installed RunAtLoad setting across plist refreshes, and removes the plist when launchd cannot supervise and the detached fallback is used.

Changes
hermes_cli/gateway.py: adds RunAtLoad preservation/override support, passes --no-start-on-login through macOS install, pre-bootouts force installs, waits for the previous gateway to exit before bootstrap, and removes the plist before detached fallback messaging.
tests/hermes_cli/test_gateway_service.py: adds regressions for RunAtLoad false plists, preserving installed RunAtLoad, force bootout-before-bootstrap ordering, fallback plist cleanup, and CLI flag propagation.

How to Test
python -m pytest tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway_service_paths.py tests/hermes_cli/test_service_manager.py -q
# ✅ 97/97 passed, 3 skipped

Checklist
- [x] Tests pass — 97/97 targeted, 3 skipped
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (macOS launchd path; Linux/WSL2/Windows/Termux unaffected)
- [x] profile-safe paths used — existing get_hermes_home/display_hermes_home paths preserved
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

Risk & Impact
Low. The change is limited to macOS launchd install semantics and preserves existing defaults unless --no-start-on-login is supplied or a prior plist already disabled RunAtLoad.
Type: Bug fix
Closes: #91549

Notes
- ruff check . passed with pre-existing invalid # noqa warnings only.
- ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py passed.
- python scripts/check-windows-footguns.py --diff upstream/main passed.
- scripts/run_tests.sh is blocked in this Termux environment by per-file runner PermissionError across 3158 files; targeted regressions pass.
