### PR TITLE
fix(desktop): stop gating edit-menu Paste on the clipboard probe (#91553)

### DIFF
--- a/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
@@ -290,22 +290,12 @@ describe('AppContextMenu', () => {
     expect(item('Select all').getAttribute('data-disabled')).not.toBeNull()
   })
 
-  it('grays out paste until the clipboard reports text', async () => {
-    const readClipboard = vi.fn().mockResolvedValue('clip content')
-
-    installBridge({ readClipboard: readClipboard as unknown as Window['hermesDesktop']['readClipboard'] })
-    mountMenu()
-    const host = attach('<textarea>text</textarea>')
-
-    fireEvent.contextMenu(host.querySelector('textarea')!)
-
-    // The clipboard read is async — the item enables when it lands.
-    const pasteItem = (await screen.findByText('Paste')).closest('[data-slot="dropdown-menu-item"]')!
-
-    await waitFor(() => expect(pasteItem.getAttribute('data-disabled')).toBeNull())
-  })
-
-  it('keeps paste grayed out on an empty clipboard', async () => {
+  it('keeps paste clickable even when the clipboard probe reports empty', async () => {
+    // #91553: the dom paste action runs webContents.paste() in main — the
+    // same path Ctrl+V takes, which resolves the system clipboard itself.
+    // A renderer-side probe that comes back empty (as the Win32
+    // clipboard.readText() bridge can while that path succeeds) must not
+    // gray the item out; pasting on a truly empty clipboard is a no-op.
     const readClipboard = vi.fn().mockResolvedValue('')
 
     installBridge({ readClipboard: readClipboard as unknown as Window['hermesDesktop']['readClipboard'] })
@@ -316,8 +306,19 @@ describe('AppContextMenu', () => {
 
     const pasteItem = (await screen.findByText('Paste')).closest('[data-slot="dropdown-menu-item"]')!
 
-    await waitFor(() => expect(readClipboard).toHaveBeenCalled())
-    expect(pasteItem.getAttribute('data-disabled')).not.toBeNull()
+    expect(pasteItem.getAttribute('data-disabled')).toBeNull()
+  })
+
+  it('keeps paste clickable when the bridge has no clipboard read at all', async () => {
+    installBridge()
+    mountMenu()
+    const host = attach('<textarea>text</textarea>')
+
+    fireEvent.contextMenu(host.querySelector('textarea')!)
+
+    const pasteItem = (await screen.findByText('Paste')).closest('[data-slot="dropdown-menu-item"]')!
+
+    expect(pasteItem.getAttribute('data-disabled')).toBeNull()
   })
 
   it('offers the window verbs on bare chrome', async () => {

--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -306,8 +306,13 @@ function domSections(open: Extract<OpenContextMenu, { kind: 'dom' }>, t: Transla
     // SELECTION, so they need selected text — not just field content.
     // Inputs and textareas carry their selection on the element (Chrome
     // never reflects it into window.getSelection()); contenteditable uses
-    // the document selection the resolver captured. Paste needs a
-    // non-empty clipboard, select all needs the field to hold anything.
+    // the document selection the resolver captured. Select all needs the
+    // field to hold anything. Paste is intentionally NOT gated on a
+    // clipboard probe: its action is webContents.paste() in main — the
+    // same path Ctrl+V takes — which resolves the system clipboard itself,
+    // while the renderer-side readClipboard probe can report empty on
+    // Windows even when that path succeeds (#91553). Pasting with an
+    // empty clipboard is a harmless no-op, so the item fails open.
     const formField =
       target.editable instanceof HTMLInputElement || target.editable instanceof HTMLTextAreaElement
         ? target.editable
@@ -337,7 +342,6 @@ function domSections(open: Extract<OpenContextMenu, { kind: 'dom' }>, t: Transla
         shortcut={EDIT_SHORTCUTS.copy}
       />,
       <Item
-        disabled={!open.clipboardHasText}
         key="edit-paste"
         label={copy.edit.paste}
         onSelect={() => editableCommand('paste')}

--- a/apps/desktop/src/app/context-menu/store.ts
+++ b/apps/desktop/src/app/context-menu/store.ts
@@ -51,9 +51,6 @@ export type OpenContextMenu =
       y: number
       target: ContextMenuDomTarget
       spellcheck: SpellcheckContext | null
-      /** Whether the clipboard held text when the menu opened (grays out
-       *  Paste). Arrives async right after open; false until then. */
-      clipboardHasText: boolean
     }
   | {
       kind: 'guest'
@@ -67,7 +64,12 @@ export type OpenContextMenu =
       x: number
       y: number
       terminal: TerminalMenuHandle
-      /** Same async clipboard fact as the dom shape, for the paste item. */
+      /** Whether the clipboard held text when the menu opened (grays out
+       *  Paste). Arrives async right after open; false until then. Unlike
+       *  the dom menu — whose paste runs webContents.paste() in main and
+       *  must NOT depend on this probe (#91553) — the terminal paste item
+       *  inserts the readClipboard() text itself, so its gate and its
+       *  action share one mechanism. */
       clipboardHasText: boolean
     }
 
@@ -75,17 +77,18 @@ export type OpenContextMenu =
  *  menus can never be open at once. */
 export const $contextMenu = atom<null | OpenContextMenu>(null)
 
-/** Read the clipboard and flag the OPEN menu when text is available. The
- *  read is an IPC round-trip, so the menu opens first (empty-clipboard
- *  verdict) and the flag lands a tick later — same late-fact pattern as
- *  spellcheck. Guarded by identity: a stale read never flags a newer menu. */
-function probeClipboard(opened: OpenContextMenu): void {
+/** Read the clipboard and flag the OPEN terminal menu when text is
+ *  available. The read is an IPC round-trip, so the menu opens first
+ *  (empty-clipboard verdict) and the flag lands a tick later — same
+ *  late-fact pattern as spellcheck. Guarded by identity: a stale read
+ *  never flags a newer menu. */
+function probeClipboard(opened: Extract<OpenContextMenu, { kind: 'terminal' }>): void {
   void window.hermesDesktop
     ?.readClipboard?.()
     .then((text: string) => {
       const current = $contextMenu.get()
 
-      if (current === opened && (current.kind === 'dom' || current.kind === 'terminal') && text) {
+      if (current === opened && current.kind === 'terminal' && text) {
         $contextMenu.set({ ...current, clipboardHasText: true })
       }
     })
@@ -93,13 +96,7 @@ function probeClipboard(opened: OpenContextMenu): void {
 }
 
 export function openDomContextMenu(x: number, y: number, target: ContextMenuDomTarget): void {
-  const opened: OpenContextMenu = { kind: 'dom', x, y, target, spellcheck: null, clipboardHasText: false }
-
-  $contextMenu.set(opened)
-
-  if (target.editable) {
-    probeClipboard(opened)
-  }
+  $contextMenu.set({ kind: 'dom', x, y, target, spellcheck: null })
 }
 
 export function openGuestContextMenu(x: number, y: number, params: GuestMenuParams, guest: GuestMenuHandle): void {


### PR DESCRIPTION
## What does this PR do?

On Windows, the desktop context menu's **Paste** item stays grayed out even when the clipboard holds text — while Ctrl+V pastes the same text fine (#91553).

Root cause: the dom menu gated Paste on a renderer-side probe (`readClipboard()` → main-process `clipboard.readText()`, `store.ts`), but the item's action never consumes that probe — `editableCommand('paste')` dispatches **`webContents.paste()`** in main, the same Chromium path Ctrl+V takes, which resolves the system clipboard itself. When the Win32 `clipboard.readText()` bridge returns empty (or the IPC rejects — errors were swallowed by `.catch(() => undefined)`), the item was disabled for the whole menu lifetime even though pasting would have worked. The gate tested one mechanism; the action uses another.

### Fix — fail open

- Drop the `disabled={!open.clipboardHasText}` gate from the dom Paste item. Pasting with an empty clipboard is a harmless no-op (`webContents.paste()` does nothing), and this matches Chromium's own context menu, which keeps Paste enabled for editables.
- Remove the now-unused `clipboardHasText` fact from the `'dom'` menu shape and stop probing on dom open — opening an editable menu no longer makes the clipboard IPC round-trip at all.
- **Keep** the gate on the terminal paste item: its action inserts the `readClipboard()` text into the PTY directly, so there the probe and the action share one mechanism and the gate stays honest.

## Related Issue

Fixes #91553

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/context-menu/app-context-menu.tsx` — remove the probe gate from the dom Paste item; update the verb-availability comment to record why Paste is intentionally ungated
- `apps/desktop/src/app/context-menu/store.ts` — drop `clipboardHasText` from the `'dom'` variant; narrow `probeClipboard` to terminal menus only
- `apps/desktop/src/app/context-menu/app-context-menu.test.tsx` — replace the two probe-gating tests (one of which asserted the buggy behavior) with fail-open invariants: paste stays clickable when the probe reports empty, and when the bridge has no clipboard read at all

## How to Test

1. `cd apps/desktop && npx vitest run src/app/context-menu/app-context-menu.test.tsx` → **34 passed** (includes the two new fail-open regression tests).
2. Manual repro from the issue: copy text anywhere, right-click the chat composer in Hermes Desktop on Windows → Paste is now clickable and pastes; with an empty clipboard it is still clickable and is a no-op.
3. Terminal pane right-click behavior is unchanged (gate kept, covered by existing tests).

`tsc -p . --noEmit` on the renderer project reports no errors in the touched files (the only two diagnostics are pre-existing `Cannot find module 'blobatar/*'` resolution failures from a stale local node_modules, unrelated to this change).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(relevant suite: the desktop context-menu vitest file, 34/34 green)*
- [x] I've added tests for my changes *(two fail-open regression tests replacing the probe-gating pair)*
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior comment updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — yes: the gate removal is platform-uniform; macOS/Linux lose nothing (their probes worked, but gating a working action on them bought nothing)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A