### PR TITLE
feat(plugins): index hermes-discord-rpc in community seed

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -63,6 +63,18 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "hermes-discord-rpc",
+      "description": "Native Discord Rich Presence (RPC) integration for Hermes Agent — live session, model, token, and tool tracking.",
+      "author": "DarRahman",
+      "tags": ["discord", "rpc", "rich-presence", "presence", "desktop"],
+      "repo": "DarRahman/hermes-discord-presence",
+      "ref": "84900bfe7ab53506d7ed21b252773cffe4da7c22",
+      "homepage": "https://github.com/DarRahman/hermes-discord-presence",
+      "capabilities": ["hooks"],
+      "api_version": 1,
+      "added_at": "2026-08-21"
     }
   ]
 }

--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -70,7 +70,7 @@
       "author": "DarRahman",
       "tags": ["discord", "rpc", "rich-presence", "presence", "desktop"],
       "repo": "DarRahman/hermes-discord-presence",
-      "ref": "84900bfe7ab53506d7ed21b252773cffe4da7c22",
+      "ref": "cd3734c29ffb09fc602f1c18a06afbe3ea843d9a",
       "homepage": "https://github.com/DarRahman/hermes-discord-presence",
       "capabilities": ["hooks"],
       "api_version": 1,


### PR DESCRIPTION
## What does this PR do?

Adds an entry to the community plugin index seed (`hermes_cli/data/plugin_index.json`) for **hermes-discord-rpc** — a zero-daemon, native Discord Rich Presence (RPC) integration for Hermes Agent.

The plugin runs in-process inside Hermes Agent using native lifecycle hooks and displays real-time session titles, active LLM model names, live token consumption, elapsed duration, and agent execution states on the user's Discord profile via local IPC (`pypresence`).

Notable properties:
- **Zero background daemons**: Executes purely in-process via hooks (`pre_llm_call`, `pre_tool_call`, `post_tool_call`, `on_session_end`).
- **Zero setup**: Uses default pre-configured Discord Application ID with customizable override support via `config.yaml`.
- **Contract verified**: Passes `hermes plugins doctor .` with 0 warnings.
- **Repository**: [DarRahman/hermes-discord-presence](https://github.com/DarRahman/hermes-discord-presence) pinned to immutable ref `84900bfe7ab53506d7ed21b252773cffe4da7c22`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/data/plugin_index.json` — appended `hermes-discord-rpc` entry (+12 lines) pinned to commit SHA `84900bfe7ab53506d7ed21b252773cffe4da7c22`.

## How to Test

1. Verify parser loads entry:
   ```bash
   python -c "from hermes_cli.plugin_index import _load_seed_entries; print([e.name for e in _load_seed_entries()])"
   ```
2. Run targeted test suite:
   ```bash
   pytest tests/hermes_cli/test_plugin_index_search.py tests/hermes_cli/test_plugin_packs.py -q
   ```
   Result: `74 passed`.
3. Test installation via CLI:
   ```bash
   hermes plugins install hermes-discord-rpc
   ```

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits (`feat(plugins):`)
- [x] Verified no duplicate entries or open PRs for Discord RPC
- [x] PR touches only `hermes_cli/data/plugin_index.json`
- [x] Targeted test suite passed locally (74/74)
