### PR TITLE
fix(api): stop failed session turns from reporting success

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2542,6 +2542,28 @@ class APIServerAdapter(BasePlatformAdapter):
         persisted = self._runtime_request_from_persisted_session_lock(session, body)
         return persisted or runtime_request
 
+    @staticmethod
+    def _agent_failure_details(
+        result: Any,
+    ) -> Optional[tuple[str, Dict[str, bool]]]:
+        """Return a redacted native-session failure, if the turn failed."""
+        if not isinstance(result, dict):
+            return None
+        completed = bool(result.get("completed", True))
+        partial = bool(result.get("partial"))
+        failed = bool(result.get("failed"))
+        raw_error = result.get("error")
+        if not failed and (completed or not raw_error):
+            return None
+        message = _redact_api_error_text(
+            raw_error or "Agent run did not complete successfully."
+        )
+        return message, {
+            "completed": completed,
+            "partial": partial,
+            "failed": failed,
+        }
+
     @classmethod
     def _sanitize_runtime_metadata(
         cls,
@@ -3814,6 +3836,22 @@ class APIServerAdapter(BasePlatformAdapter):
             **agent_overrides,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
+        failure = self._agent_failure_details(result)
+        if failure is not None:
+            error_message, failure_state = failure
+            error_body = _openai_error(
+                error_message,
+                err_type="server_error",
+                code="agent_failed",
+            )
+            error_body["error"]["hermes"] = failure_state
+            error_headers = {
+                "X-Hermes-Session-Id": effective_session_id or session_id,
+                "X-Hermes-Completed": "false",
+            }
+            if gateway_session_key:
+                error_headers["X-Hermes-Session-Key"] = gateway_session_key
+            return web.json_response(error_body, status=502, headers=error_headers)
         final_response = _resolve_media_to_data_urls(result.get("final_response", "") if isinstance(result, dict) else "")
         headers = {"X-Hermes-Session-Id": effective_session_id or session_id}
         if gateway_session_key:
@@ -4006,6 +4044,23 @@ class APIServerAdapter(BasePlatformAdapter):
                         else ""
                     ),
                 )
+                failure = self._agent_failure_details(result)
+                if failure is not None:
+                    error_message, failure_state = failure
+                    self._set_run_status(
+                        run_id,
+                        "failed",
+                        session_id=effective_session_id,
+                        error=error_message,
+                        last_event="error",
+                    )
+                    await queue.put(_event_payload("error", {
+                        "message": error_message,
+                        "code": "agent_failed",
+                        "hermes": failure_state,
+                        "runtime": effective_runtime,
+                    }))
+                    return
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
@@ -6536,6 +6591,9 @@ class APIServerAdapter(BasePlatformAdapter):
                             "messages": [],
                             "api_calls": 0,
                             "tools": [],
+                            "completed": False,
+                            "failed": True,
+                            "error": str(exc),
                         },
                         {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                     )

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1055,6 +1055,70 @@ class TestChatCompletionsEndpoint:
 
 
     @pytest.mark.asyncio
+    async def test_session_chat_returns_error_for_failed_agent_result(self, adapter):
+        app = _create_app(adapter)
+        failure = {
+            "final_response": "HTTP 400: requested model is invalid",
+            "completed": False,
+            "failed": True,
+            "error": "HTTP 400: requested model is invalid",
+            "messages": [],
+            "api_calls": 1,
+        }
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_get_existing_session_or_404", return_value=({"id": "s1"}, None)),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(adapter, "_run_agent", new=AsyncMock(return_value=(failure, {}))),
+            ):
+                resp = await cli.post(
+                    "/api/sessions/s1/chat",
+                    json={"message": "hi"},
+                )
+                assert resp.status == 502
+                data = await resp.json()
+
+        assert data["error"]["message"] == "HTTP 400: requested model is invalid"
+        assert data["error"]["code"] == "agent_failed"
+        assert data["error"]["hermes"] == {
+            "completed": False,
+            "partial": False,
+            "failed": True,
+        }
+        assert "message" not in data
+
+    @pytest.mark.asyncio
+    async def test_session_chat_stream_emits_error_for_failed_agent_result(self, adapter):
+        app = _create_app(adapter)
+        failure = {
+            "final_response": "HTTP 404: model not found",
+            "completed": False,
+            "failed": True,
+            "error": "HTTP 404: model not found",
+            "messages": [],
+            "api_calls": 1,
+        }
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_get_existing_session_or_404", return_value=({"id": "s1"}, None)),
+                patch.object(adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(adapter, "_run_agent", new=AsyncMock(return_value=(failure, {}))),
+            ):
+                resp = await cli.post(
+                    "/api/sessions/s1/chat/stream",
+                    json={"message": "hi"},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+        assert "event: error" in body
+        assert '"code": "agent_failed"' in body
+        assert "HTTP 404: model not found" in body
+        assert "event: assistant.completed" not in body
+        assert "event: run.completed" not in body
+
+
+    @pytest.mark.asyncio
     async def test_stream_task_done_callback_enqueues_eos_for_chat_completions(self, adapter):
         """Regression guard for #24451: completion callback must signal SSE EOS."""
         app = _create_app(adapter)


### PR DESCRIPTION
## What does this PR do?

Native API session turns no longer report upstream provider failures as successful assistant and run completions. Synchronous requests now return a redacted 502 error envelope, while streaming requests emit an error event and retain a failed run state, so clients can distinguish failed turns from completed responses.

### Symptom

When an upstream model request fails, `/api/sessions/{id}/chat` can return the provider error text as an ordinary assistant message, and `/api/sessions/{id}/chat/stream` can emit `assistant.completed` followed by `run.completed`.

### Impact

Clients consuming the native session API can persist or display an upstream failure as a successful assistant response. This masks routing and provider failures and prevents callers from applying normal error handling.

### Bug Cause

**Trigger:** `gateway/platforms/api_server.py` in `_handle_session_chat` and `_handle_session_chat_stream` when `_run_agent` returns a structured failure result.

**Causal chain:**
1. A provider rejects the selected model or authentication and the agent returns `failed=True`, `completed=False`, and an error.
2. Both native session handlers consume the result without checking its completion state.
3. The synchronous endpoint serializes `final_response` as a normal message, while the streaming endpoint emits `assistant.completed` and `run.completed`.

**Why it is wrong:** The handlers treat every returned dictionary as a completed turn even though the agent result contract distinguishes failures from successful completion.

**Working sibling / contrast:** Successful agent results still use the existing message and completion event paths. The fix handles both synchronous and streaming native session endpoints at their shared failure boundary.

**Ruled out:** Default and request-level model resolution are not changed here. Current main already normalizes the advertised display alias and forwards explicit model/provider overrides; real-environment verification confirmed those routes before exercising the failure contract.

### Fix

Detect incomplete or failed agent results before success serialization. Return a redacted `agent_failed` 502 response for synchronous turns, emit an `error` event and persist a failed run for streaming turns, and mark provider-authentication resolution failures with the same structured result fields.

## Related Issue

Closes #91546

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` - map structured agent failures to native HTTP and SSE error contracts.
- `tests/gateway/test_api_server.py` - cover synchronous and streaming failure responses and prevent false completion events.

## How to Test

1. Configure the API server with a working provider, then request an invalid model to produce a real upstream 4xx response.
2. POST to `/api/sessions/{id}/chat` and verify a redacted HTTP 502 response with `code: agent_failed`.
3. POST to `/api/sessions/{id}/chat/stream` and verify an `error` event, a failed run state, and no `assistant.completed` or `run.completed` event.
4. Automated tests already run locally (154 passed): `scripts/run_tests.sh tests/gateway/test_api_server.py -q`.

## Checklist

### Code

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched existing PRs to avoid duplicates
- [x] The PR contains only changes related to this fix
- [x] The repository test entry passed all 154 tests in the relevant test file
- [x] Regression tests cover the bug
- [x] Tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A because the native API now exposes its existing failure semantics
- [x] Configuration example updates are N/A because no keys changed
- [x] Architecture or workflow documentation updates are N/A
- [x] Cross-platform impact was considered; the change is platform-independent HTTP and SSE handling
- [x] Tool description or schema updates are N/A