### PR TITLE
fix(cli): preserve borrowed one-shot session ownership

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1379,7 +1379,7 @@ def _notify_single_query_session_finalize(cli, *, reason: str = "shutdown") -> N
 
 
 def _flush_one_shot_session_store(cli) -> None:
-    """Durably flush + finalize the one-shot session row before process exit.
+    """Durably flush the one-shot session row before process exit.
 
     The quiet/one-shot ``-q`` / ``-Q`` paths (including resume-or-create of a
     titled session via ``-c <name> --create-if-missing``, the Bot Mode
@@ -1392,16 +1392,17 @@ def _flush_one_shot_session_store(cli) -> None:
       write-lock contention (e.g. a busy multiplex gateway sharing state.db)
       was silently lost — the reply reached stdout and agent.log but the
       resumed session's stored history never changed (#88583);
-    - the resumed/created titled session row was left dangling open
-      (``ended_at``/``end_reason`` NULL) on every one-shot exit;
+    - CLI-owned resumed/created rows were left dangling open
+      (``ended_at``/``end_reason`` NULL) on one-shot exit;
     - queued async token-accounting deltas relied on interpreter-exit hooks,
       which the kanban SIGTERM path's ``os._exit(0)`` skips entirely.
 
     Idempotent and best-effort: ``_persist_session`` dedupes via the
     per-message ``_DB_PERSISTED_MARKER`` stamps (already-written turns are
     not re-written) and ``end_session`` no-ops on an already-ended row.
-    Sessions handed off to the gateway are owned by the gateway process and
-    are left strictly alone (#88234).
+    Sessions handed off to the gateway are left strictly alone (#88234).
+    A resumed row created by another surface is still flushed, but remains
+    open for that surface to own and continue.
     """
     agent = getattr(cli, "agent", None)
     if agent is None:
@@ -1430,6 +1431,19 @@ def _flush_one_shot_session_store(cli) -> None:
         db.flush_token_counts()
     except Exception:
         logger.debug("one-shot token-count drain failed", exc_info=True)
+    # A fresh CLI session is ours regardless of its source override (cron and
+    # Kanban launch CLI workers this way). A resumed row is ours only when it
+    # originated in the CLI. WebUI/desktop/messaging rows can remain live on
+    # their owning surface while a one-shot CLI turn borrows them; ending such
+    # a row here strands that owner behind a stale cli_close boundary.
+    if getattr(cli, "_resumed", False):
+        try:
+            row = db.get_session(session_id)
+        except Exception:
+            logger.debug("one-shot session ownership lookup failed", exc_info=True)
+            return
+        if not row or (row.get("source") or "").strip().lower() != "cli":
+            return
     try:
         db.end_session(session_id, "cli_close")
     except Exception:

--- a/tests/cli/test_oneshot_resumed_session_persist.py
+++ b/tests/cli/test_oneshot_resumed_session_persist.py
@@ -12,7 +12,8 @@ next turn and ends the session with ``cli_close`` on quit).
 The fix routes every one-shot exit (quiet ``-Q -q``, human ``-q``, and the
 kanban SIGTERM path) through ``cli._flush_one_shot_session_store``: a final
 ``_persist_session`` retry (idempotent via the per-message persisted
-markers), a token-count drain, and ``end_session(..., "cli_close")``.
+markers), a token-count drain, and ``end_session(..., "cli_close")`` for
+CLI-owned rows only.
 """
 
 from __future__ import annotations
@@ -54,10 +55,11 @@ def _make_agent(session_db, session_id="oneshot-88583"):
     return agent
 
 
-def _fake_cli(agent):
+def _fake_cli(agent, *, resumed=False):
     return SimpleNamespace(
         agent=agent,
         session_id=agent.session_id,
+        _resumed=resumed,
         conversation_history=[],
         _session_db=agent._session_db,
         _release_active_session=lambda: None,
@@ -119,7 +121,7 @@ class TestOneShotDurableFlush:
                     {"role": "user", "content": "hi"},
                     {"role": "assistant", "content": "hello"},
                 ]
-                fake = _fake_cli(agent)
+                fake = _fake_cli(agent, resumed=True)
                 monkeypatch.setattr(cli_mod, "_run_cleanup", lambda **kw: None)
                 monkeypatch.setattr(
                     cli_mod, "_notify_single_query_session_finalize", lambda _c: None
@@ -130,6 +132,62 @@ class TestOneShotDurableFlush:
                 sess = db.get_session(agent.session_id)
                 assert sess["ended_at"] is not None
                 assert sess["end_reason"] == "cli_close"
+            finally:
+                db.close()
+
+    @pytest.mark.parametrize("source", ["webui", "telegram"])
+    def test_flush_keeps_borrowed_cross_surface_session_open(self, source):
+        """A one-shot CLI borrower persists its turn without ending its owner."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            try:
+                session_id = f"borrowed-{source}"
+                db.create_session(session_id, source=source)
+                agent = _make_agent(db, session_id=session_id)
+                agent._session_messages = [
+                    {"role": "user", "content": "borrowed one-shot turn"},
+                    {"role": "assistant", "content": "persisted reply"},
+                ]
+
+                with patch.object(db, "flush_token_counts", wraps=db.flush_token_counts) as flush:
+                    cli_mod._flush_one_shot_session_store(
+                        _fake_cli(agent, resumed=True)
+                    )
+
+                assert [m["content"] for m in db.get_messages(session_id)] == [
+                    "borrowed one-shot turn",
+                    "persisted reply",
+                ]
+                assert flush.call_count >= 1
+                session = db.get_session(session_id)
+                assert session is not None
+                assert session["source"] == source
+                assert session["ended_at"] is None
+                assert session["end_reason"] is None
+            finally:
+                db.close()
+
+    @pytest.mark.parametrize("source", ["cron", "kanban"])
+    def test_flush_closes_fresh_cli_owned_source_override(self, source):
+        """A source override does not transfer ownership of a fresh CLI row."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "state.db")
+            try:
+                session_id = f"fresh-{source}"
+                db.create_session(session_id, source=source)
+                agent = _make_agent(db, session_id=session_id)
+
+                cli_mod._flush_one_shot_session_store(
+                    _fake_cli(agent, resumed=False)
+                )
+
+                session = db.get_session(session_id)
+                assert session is not None
+                assert session["end_reason"] == "cli_close"
             finally:
                 db.close()
 


### PR DESCRIPTION
## Bug Description

A one-shot CLI turn that resumed a live session created by another surface (for example `source=webui` or a messaging gateway) durably persisted its turn, then unconditionally ended the shared row with `end_reason=cli_close`. The owning surface could continue appending messages after that stale end boundary, which breaks lifecycle/lineage consumers.

Regression introduced by 56de3c142 while fixing #88583.

## Root Cause

`_flush_one_shot_session_store()` correctly retries transcript persistence and token accounting for every one-shot exit, but treated every resumed row as CLI-owned when deciding whether to call `end_session(..., "cli_close")`. A direct `--resume` can borrow a row whose durable `source` belongs to WebUI, desktop, or a gateway.

## Fix

- Preserve the durability and token-drain steps for every non-handoff, persistence-enabled one-shot.
- End a resumed row only when its durable source is `cli`.
- Continue ending fresh CLI-created one-shot rows even when an internal source override labels them `cron` or `kanban`.
- Fail safe when ownership cannot be read: keep the resumed row open rather than create a false terminal boundary.
- Keep gateway-handoff and first-end-reason behavior unchanged.

## How to Verify

1. Seed an open `source=webui` session in an isolated `HERMES_HOME`.
2. Run a real one-shot CLI `--resume` turn against a local OpenAI-compatible SSE server.
3. Confirm the user/assistant turn and token counts persist while `ended_at` and `end_reason` remain null.
4. Confirm a CLI-owned resumed row still ends as `cli_close`.

## Test Plan

- [x] RED on current base: both `webui` and `telegram` borrowed-session cases ended as `cli_close`.
- [x] GREEN: `scripts/run_tests.sh tests/cli/test_oneshot_resumed_session_persist.py tests/cli/test_handoff_cleanup_race.py tests/test_lazy_session_regressions.py -q` (24 passed).
- [x] Isolated-`HERMES_HOME` subprocess E2E: 4 messages persisted, token totals flushed, `source=webui`, `ended_at=null`, `end_reason=null`.
- [x] `git diff --check origin/main...HEAD`.

## Risk Assessment

Low — the change is confined to the terminal disposition step of one-shot CLI cleanup. Persistence and token flushing occur before the ownership check exactly as before; explicit gateway handoffs still short-circuit the entire helper; `SessionDB.end_session()` remains first-reason-wins.
