### PR TITLE
fix(desktop): keep full model ids for custom / self-hosted sources

### DIFF
--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -11,6 +11,19 @@ describe('model-status-label', () => {
     expect(displayModelName('openai/gpt-5.5')).toBe('GPT-5.5')
   })
 
+  it('keeps full ids for custom / self-hosted model sources', () => {
+    // Custom HF-org / self-hosted prefixes are part of the model's identity
+    // and stay visible, so `esatapedico/...` vs `ggml-org/...` variants of
+    // the same base model never look identical in pickers or the status bar.
+    expect(displayModelName('esatapedico/Qwen3.8-27B-NVFP4-MTP-GGUF')).toBe(
+      'esatapedico/Qwen3.8-27B-NVFP4-MTP-GGUF'
+    )
+    expect(displayModelName('ggml-org/qwen3.8-27b@q4_k_m')).toBe('ggml-org/qwen3.8-27b@q4_k_m')
+    expect(formatModelStatusLabel('esatapedico/Qwen3.8-27B-NVFP4-MTP-GGUF', { reasoningEffort: 'medium' })).toBe(
+      'esatapedico/Qwen3.8-27B-NVFP4-MTP-GGUF · Med'
+    )
+  })
+
   it('strips trailing date-pin snapshots from the display name', () => {
     expect(displayModelName('claude-opus-4-5-20251101')).toBe('Opus 4 5')
     expect(displayModelName('anthropic/claude-haiku-4-5-20251001')).toBe('Haiku 4 5')

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -33,12 +33,35 @@ export function currentPickerSelection(
   }
 }
 
-/** Strip provider prefix and normalize for display. */
+// Well-known provider prefixes that are noise in a display name (the short
+// id after them is unambiguous). Anything else — custom orgs, HF repos,
+// self-hosted variants — keeps its full prefix so distinct model sources
+// (e.g. `esatapedico/Qwen3.8-27B-...` vs `ggml-org/qwen3.8-...`) stay
+// distinguishable in pickers and the status bar.
+const KNOWN_PROVIDER_PREFIXES = new Set([
+  'anthropic', 'openai', 'deepseek', 'google', 'gemini', 'meta', 'mistral',
+  'xai', 'grok', 'amazon', 'cohere', 'nous', 'microsoft', 'azure', 'github',
+  'openrouter', 'together', 'fireworks', 'groq', 'ollama', 'lmstudio',
+])
+
+/** Strip known provider prefix and normalize for display. */
 export function modelBaseId(model: string): string {
   const trimmed = model.trim()
-  const slash = trimmed.lastIndexOf('/')
+  const slash = trimmed.indexOf('/')
 
-  return slash >= 0 ? trimmed.slice(slash + 1) : trimmed
+  if (slash > 0) {
+    const prefix = trimmed.slice(0, slash).toLowerCase()
+
+    // Known aggregator/provider → drop the prefix (it's display noise).
+    if (KNOWN_PROVIDER_PREFIXES.has(prefix)) {
+      return trimmed.slice(slash + 1)
+    }
+
+    // Custom org / HF repo / self-hosted → keep the full id.
+    return trimmed
+  }
+
+  return trimmed
 }
 
 // Trailing model-id variants that should render as a grayed tag beside the
@@ -74,6 +97,13 @@ function prettifyBase(base: string): string {
 export function modelDisplayParts(model: string): { name: string; tag: string } {
   let base = modelBaseId(model)
   let tag = ''
+
+  // Models with an org/provider prefix (e.g. `esatapedico/Qwen3.8-27B-...`)
+  // are shown verbatim — the full id IS the display name, so the user can
+  // tell custom-provider variants apart at a glance.
+  if (base.includes('/')) {
+    return { name: model.trim() || 'No model', tag }
+  }
 
   for (const [pattern, label] of VARIANT_TAGS) {
     if (pattern.test(base)) {


### PR DESCRIPTION
## Problem

Desktop's model display layer (`modelBaseId` in `apps/desktop/src/lib/model-status-label.ts`) stripped the provider prefix from **every** model id. Custom HF-org and self-hosted models collapsed to bare names — e.g. `esatapedico/Qwen3.8-27B-NVFP4-MTP-GGUF` and `ggml-org/qwen3.8-27b` showed as indistinguishable short ids in the model picker, status bar, and session rows. For users running several variants of the same base model on local backends, the picker is unusable.

## Fix

- Add a `KNOWN_PROVIDER_PREFIXES` allowlist (anthropic, openai, deepseek, google, xai, ...) whose prefixes remain display noise and get stripped as before.
- Any other prefix — custom orgs, HF repos, self-hosted variants — keeps the **full id** so distinct model sources stay distinguishable.
- `modelDisplayParts` renders prefixed models verbatim (skips prettify) so the full id is the display name.

## Verification

- `apps/desktop`: `npx vitest run src/lib/model-status-label.test.ts` → **12 passed** (existing tests unchanged + new test asserting custom-org models keep full ids while known providers keep friendly short names).