### PR TITLE
fix(cli): do not force headless serve when Desktop spawned the backend (#91495)

### DIFF
--- a/contributors/emails/paula@smfworks.com
+++ b/contributors/emails/paula@smfworks.com
@@ -1,0 +1,2 @@
+smfworks
+# SMF Works contributor

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11235,6 +11235,17 @@ def _is_electron_packaged_web_dist(path: str) -> bool:
     return "app.asar" in path.replace("\\", "/")
 
 
+def _should_force_serve_headless(headless_backend: bool) -> bool:
+    """Whether ``hermes serve`` should export HERMES_SERVE_HEADLESS=1.
+
+    Standalone ``serve`` is headless. Desktop spawns the same command with
+    ``HERMES_DESKTOP=1`` plus a packaged ``HERMES_WEB_DIST`` and session
+    token; forcing headless there 404s ``/`` and never mounts ``/api/ws``
+    (#91495).
+    """
+    return bool(headless_backend) and os.environ.get("HERMES_DESKTOP") != "1"
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
     _token_file = getattr(args, "ssh_session_token_file", None)
@@ -11443,7 +11454,7 @@ def cmd_dashboard(args):
         logger.debug("terminal config → env bridge failed for dashboard/serve",
                      exc_info=True)
 
-    if _headless_backend:
+    if _should_force_serve_headless(_headless_backend):
         # Don't build the SPA, and tell mount_spa() (read at web_server import
         # below) to disable it even if a stray dist exists. Set it first.
         os.environ["HERMES_SERVE_HEADLESS"] = "1"

--- a/tests/hermes_cli/test_serve_command.py
+++ b/tests/hermes_cli/test_serve_command.py
@@ -48,3 +48,21 @@ def test_serve_is_a_headless_backend_but_dashboard_is_not():
     # build; only `serve` carries it.
     assert getattr(_parser().parse_args(["serve"]), "headless_backend", False) is True
     assert getattr(_parser().parse_args(["dashboard"]), "headless_backend", False) is False
+
+
+def test_desktop_spawned_serve_does_not_force_headless(monkeypatch):
+    """#91495: Desktop launches `hermes serve` with HERMES_DESKTOP=1.
+
+    Forcing HERMES_SERVE_HEADLESS=1 then 404s `/` and never mounts `/api/ws`,
+    so the desktop WebSocket probe rejects the session token.
+    Standalone `hermes serve` (no HERMES_DESKTOP) stays strictly headless.
+    """
+    from hermes_cli.main import _should_force_serve_headless
+
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    assert _should_force_serve_headless(True) is False
+    assert _should_force_serve_headless(False) is False
+
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    assert _should_force_serve_headless(True) is True
+    assert _should_force_serve_headless(False) is False


### PR DESCRIPTION
## Summary

Desktop fails to start with `WebSocket (/api/ws) rejected the session token` because `hermes serve` unconditionally sets `HERMES_SERVE_HEADLESS=1`. That 404s `/` with "Headless backend: web UI disabled" so the desktop never reads the bootstrap token.

Standalone `hermes serve` stays headless. When `HERMES_DESKTOP=1`, skip the env export so the packaged SPA + `/api/ws` stay mounted. Ready sentinel remains `HERMES_BACKEND_READY` (`headless=_headless_backend` is unchanged).

## Test Plan

- [x] `tests/hermes_cli/test_serve_command.py` — 3 passed (desktop exempt / standalone still forced / dashboard not headless)
- [x] ruff clean

Closes #91495