### PR TITLE
feat(docker): support Railway image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -419,7 +419,6 @@ COPY --chmod=0755 docker/entrypoint-dispatch.sh /opt/hermes/docker/entrypoint-di
 # every other consumer.
 ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
 RUN mkdir -p /opt/data
-VOLUME [ "/opt/data" ]
 
 # The image ENTRYPOINT is a tiny dispatcher rather than `/init` directly.
 # When the image really owns PID 1 (normal Docker / Podman), the dispatcher

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -166,6 +166,12 @@ Or if you have already opened a terminal in your running container (via Docker D
 
 The `/opt/data` volume is the single source of truth for all Hermes state. It maps to your host's `~/.hermes/` directory and contains:
 
+:::warning Mount persistent storage explicitly
+The image does not declare a Dockerfile `VOLUME`, because some hosted builders (including Railway) reject that instruction. Always mount durable storage at `/opt/data` when running Hermes: use `-v ~/.hermes:/opt/data` with `docker run`, keep the repository's Compose volume mapping, or attach a Railway Volume with `/opt/data` as its mount path.
+
+Without an explicit mount, Hermes writes to the container's writable layer. That data is lost when the container is replaced or redeployed.
+:::
+
 | Path | Contents |
 |------|----------|
 | `.env` | API keys and secrets |


### PR DESCRIPTION
## What does this PR do?

Railway can build the repository Dockerfile without rejecting its `VOLUME` instruction. The image still creates `/opt/data`, while operators now receive explicit guidance to attach persistent storage at that path because container-local data does not survive replacement or redeployment.

## Related Issue

Closes #91560

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `Dockerfile` - remove the image-declared `/opt/data` volume that Railway's builder rejects.
- `website/docs/user-guide/docker.md` - document explicit Docker, Compose, and Railway persistence mounts and the unmounted-container data-loss boundary.

## How to Test

1. Build the repository Dockerfile with a builder that rejects Dockerfile `VOLUME` instructions, such as Railway.
2. Confirm Docker Compose still mounts the host data directory at `/opt/data`.
3. Confirm the built image creates `/opt/data` without declaring it as an image volume.

Local validation:

```text
PASS: Dockerfile declares no VOLUME instruction
PASS: both Compose files parse and every deployment file retains an explicit /opt/data mount
npx npm@11.17.0 run build:fast -> success
```

The local Podman build parsed the Dockerfile and advanced through cached image layers, then stopped at the existing s6-overlay download step because the local build VM did not trust the network certificate issuer.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested the changed Docker and documentation surfaces on Windows 11 with Podman and Docusaurus

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] `cli-config.yaml.example` is N/A because this change adds no configuration keys
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because this change does not alter architecture or workflows
- [x] I've considered cross-platform impact; explicit volume mounts remain the deployment contract on every platform
- [x] Tool descriptions and schemas are N/A because this change does not alter model tools
