### PR TITLE
fix(pricing): Anthropic OAuth subscription seats are not metered

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -327,60 +327,47 @@ _GOOGLE_PROVIDER_NAMES = {"google", "gemini", "vertex", "google-gemini", "google
 
 
 def _anthropic_is_subscription(api_key: Optional[str] = None) -> bool:
-    """Return True when Anthropic access is an OAuth subscription seat.
+    """True when the Anthropic credential in use is an OAuth subscription seat.
 
     Claude Max / Claude Code / Pro seats authenticate with an OAuth token
-    (``sk-ant-oat…``, a JWT, or a ``cc-`` Claude Code token) and carry NO
-    per-token invoice: usage is included in the subscription and metered
-    against rolling quota windows instead. A Console API key
-    (``sk-ant-api…``) is the opposite: every token is billed.
+    (``sk-ant-oat…``, a JWT, or a ``cc-`` token) and carry no per-token
+    invoice: usage is metered against rolling quota windows. A Console API
+    key (``sk-ant-api…``) bills every token. Pricing both alike is wrong in
+    both directions, so the route mirrors ``openai-codex`` and decides from
+    the credential.
 
-    Pricing them identically is wrong in both directions, so decide from
-    the credential actually in use, mirroring the ``openai-codex`` route
-    which is already ``subscription_included``.
-
-    Detection is POSITIVE-ONLY and fails closed: we return True solely when
-    an OAuth token is positively identified. An API key, an empty pool, or
-    any error keeps the metered path, because under-reporting real spend to
-    a metered user is far worse than the ``unknown``/estimated status this
-    replaces.
+    ``api_key`` is the credential the caller actually sent (the turn loop
+    threads ``agent.api_key``, which follows pool rotation and refresh), so
+    it always wins. Without it — callers that price after the fact
+    (auxiliary accounting, insights) — the persisted pool is the only
+    evidence, and it cannot tell which seat served a given request. That
+    fallback is therefore positive-only and fails closed: True only when
+    EVERY usable pool credential is OAuth. A mixed OAuth + API-key pool, an
+    empty pool, an unreadable store or an unexpected payload all keep the
+    metered path, because under-reporting real spend is worse than the
+    ``unknown``/estimated status this replaces.
     """
+    from agent.anthropic_credentials import _is_oauth_token
+
+    if api_key:
+        return isinstance(api_key, str) and _is_oauth_token(api_key)
+    from hermes_cli.auth import read_credential_pool
+
     try:
-        from agent.anthropic_adapter import _is_oauth_token
-
-        if api_key:
-            # An explicit key wins: it is the credential the caller used.
-            return bool(_is_oauth_token(api_key))
-
-        # No key threaded through (the common case: the token lives in the
-        # credential pool, not the environment). Consult the pool, honouring
-        # priority order so the seat actually used decides.
-        from hermes_cli.auth import read_credential_pool
-
-        pool = read_credential_pool("anthropic")
-        entries = pool if isinstance(pool, list) else (pool or {}).get("anthropic")
-        if not isinstance(entries, list):
-            return False
-
-        def _field(entry: Any, name: str, default: Any) -> Any:
-            return entry.get(name, default) if isinstance(entry, dict) else getattr(entry, name, default)
-
-        def _priority(entry: Any) -> int:
-            try:
-                return int(_field(entry, "priority", 0))
-            except (TypeError, ValueError):
-                return 0
-
-        for entry in sorted(entries, key=_priority):
-            token = _field(entry, "access_token", "") or _field(entry, "api_key", "") or ""
-            if not token:
-                continue
-            # First credential bearing a usable token decides the route.
-            return bool(_is_oauth_token(token))
+        entries = read_credential_pool("anthropic")
+    except Exception:
+        # _load_auth_store re-raises an unreadable auth.json on purpose; a cost
+        # estimate must not take the turn down with it.
+        logger.debug("anthropic subscription detection: pool unreadable, staying metered", exc_info=True)
         return False
-    except Exception:  # pragma: no cover - defensive: never break pricing
-        logger.debug("anthropic subscription detection failed", exc_info=True)
+    if not isinstance(entries, list):
         return False
+    kinds = {
+        _is_oauth_token(token)
+        for token in (entry.get("access_token") for entry in entries if isinstance(entry, dict))
+        if isinstance(token, str) and token
+    }
+    return kinds == {True}
 
 
 def resolve_billing_route(

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -171,6 +171,11 @@ _SNAPSHOTS: tuple[tuple[str, Optional[str], str, dict], ...] = (
         "claude-3-5-haiku-20241022": ("0.80", "4.00", "0.08", "1.00"),
         "claude-3-haiku-20240307": ("0.25", "1.25", "0.03", "0.30"),
     }),
+    # Claude Opus 5 (launched 2026-07-24): same $5/$25 tier as the 4.5-4.8
+    # line; the generation bump did not move the tier. cache_write is the
+    # 5m-TTL rate ($6.25); the 1h-TTL rate ($10.00) has no column in
+    # PricingEntry, so 1h-TTL sessions undercount cache writes.
+    ("anthropic", _ANTHROPIC_URL, "anthropic-pricing-2026-08", {"claude-opus-5": _OPUS}),
     # Fast mode is a separate model id at a 2x premium.
     ("anthropic", "https://openrouter.ai/anthropic/claude-opus-4.8-fast", "anthropic-pricing-2026-05", {
         "claude-opus-4-8-fast": ("10.00", "50.00", "1.00", "12.50"),
@@ -321,8 +326,66 @@ _SNAPSHOT_PROVIDER_ALIASES = {
 _GOOGLE_PROVIDER_NAMES = {"google", "gemini", "vertex", "google-gemini", "google-ai-studio", "google-vertex", "vertex-ai"}
 
 
+def _anthropic_is_subscription(api_key: Optional[str] = None) -> bool:
+    """Return True when Anthropic access is an OAuth subscription seat.
+
+    Claude Max / Claude Code / Pro seats authenticate with an OAuth token
+    (``sk-ant-oat…``, a JWT, or a ``cc-`` Claude Code token) and carry NO
+    per-token invoice: usage is included in the subscription and metered
+    against rolling quota windows instead. A Console API key
+    (``sk-ant-api…``) is the opposite: every token is billed.
+
+    Pricing them identically is wrong in both directions, so decide from
+    the credential actually in use, mirroring the ``openai-codex`` route
+    which is already ``subscription_included``.
+
+    Detection is POSITIVE-ONLY and fails closed: we return True solely when
+    an OAuth token is positively identified. An API key, an empty pool, or
+    any error keeps the metered path, because under-reporting real spend to
+    a metered user is far worse than the ``unknown``/estimated status this
+    replaces.
+    """
+    try:
+        from agent.anthropic_adapter import _is_oauth_token
+
+        if api_key:
+            # An explicit key wins: it is the credential the caller used.
+            return bool(_is_oauth_token(api_key))
+
+        # No key threaded through (the common case: the token lives in the
+        # credential pool, not the environment). Consult the pool, honouring
+        # priority order so the seat actually used decides.
+        from hermes_cli.auth import read_credential_pool
+
+        pool = read_credential_pool("anthropic")
+        entries = pool if isinstance(pool, list) else (pool or {}).get("anthropic")
+        if not isinstance(entries, list):
+            return False
+
+        def _field(entry: Any, name: str, default: Any) -> Any:
+            return entry.get(name, default) if isinstance(entry, dict) else getattr(entry, name, default)
+
+        def _priority(entry: Any) -> int:
+            try:
+                return int(_field(entry, "priority", 0))
+            except (TypeError, ValueError):
+                return 0
+
+        for entry in sorted(entries, key=_priority):
+            token = _field(entry, "access_token", "") or _field(entry, "api_key", "") or ""
+            if not token:
+                continue
+            # First credential bearing a usable token decides the route.
+            return bool(_is_oauth_token(token))
+        return False
+    except Exception:  # pragma: no cover - defensive: never break pricing
+        logger.debug("anthropic subscription detection failed", exc_info=True)
+        return False
+
+
 def resolve_billing_route(
-    model_name: str, provider: Optional[str] = None, base_url: Optional[str] = None
+    model_name: str, provider: Optional[str] = None, base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> BillingRoute:
     provider_name = (provider or "").strip().lower()
     base = (base_url or "").strip().lower()
@@ -347,6 +410,10 @@ def resolve_billing_route(
         return BillingRoute(provider="openrouter", model=model, base_url=url, billing_mode="official_models_api")
     if provider_name == "nous" or host("inference-api.nousresearch.com"):
         return BillingRoute(provider="nous", model=model, base_url=base_url or _NOUS_DEFAULT_BASE_URL, billing_mode="official_models_api")
+    if provider_name == "anthropic" and _anthropic_is_subscription(api_key):
+        # Claude Max / Claude Code OAuth seats bill nothing per token; only
+        # Console API keys are metered. Decide from the live credential.
+        return BillingRoute(provider="anthropic", model=bare, base_url=url, billing_mode="subscription_included")
     snapshot_provider = _SNAPSHOT_PROVIDER_ALIASES.get(provider_name)
     if snapshot_provider is None:
         if (
@@ -443,7 +510,7 @@ def get_pricing_entry(
     model_name: str, provider: Optional[str] = None, base_url: Optional[str] = None,
     api_key: Optional[str] = None,
 ) -> Optional[PricingEntry]:
-    route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
+    route = resolve_billing_route(model_name, provider=provider, base_url=base_url, api_key=api_key)
     if route.billing_mode == "subscription_included":
         return _INCLUDED_ENTRY
     if route.provider == "openrouter":
@@ -553,7 +620,7 @@ def estimate_usage_cost(
     model_name: str, usage: CanonicalUsage, *, provider: Optional[str] = None,
     base_url: Optional[str] = None, api_key: Optional[str] = None,
 ) -> CostResult:
-    route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
+    route = resolve_billing_route(model_name, provider=provider, base_url=base_url, api_key=api_key)
     if route.billing_mode == "subscription_included":
         return CostResult(
             amount_usd=_ZERO, status="included", source="none", label="included",

--- a/tests/agent/test_usage_pricing_anthropic_subscription.py
+++ b/tests/agent/test_usage_pricing_anthropic_subscription.py
@@ -1,0 +1,236 @@
+"""Anthropic billing route: OAuth subscription seats vs metered API keys.
+
+Claude Max / Claude Code / Pro seats authenticate with an OAuth token and
+carry no per-token invoice — usage is metered against rolling quota windows
+instead. Console API keys (``sk-ant-api…``) bill every token. Before this
+fix ``resolve_billing_route`` returned ``official_docs_snapshot`` for every
+``provider == "anthropic"`` caller, so subscription sessions were priced as
+if they were metered.
+
+The regression guard that matters most here is the metered direction: a
+user on a real API key must keep seeing real costs. Under-reporting actual
+spend is worse than the ``unknown`` status this replaces, so detection is
+positive-only and fails closed.
+"""
+
+from decimal import Decimal
+from unittest.mock import patch
+
+from agent.usage_pricing import (
+    CanonicalUsage,
+    estimate_usage_cost,
+    get_pricing_entry,
+    has_known_pricing,
+    resolve_billing_route,
+)
+
+OAUTH_TOKEN = "sk-ant-oat01-" + "x" * 40
+API_KEY = "sk-ant-api03-" + "x" * 40
+
+USAGE = CanonicalUsage(
+    input_tokens=1000,
+    output_tokens=500,
+    cache_read_tokens=20000,
+    cache_write_tokens=2000,
+)
+
+
+def _pool(*tokens_with_priority):
+    """Build a credential-pool payload shaped like auth.json."""
+    return [
+        {"label": f"seat-{i}", "auth_type": "oauth", "priority": p, "access_token": t}
+        for i, (t, p) in enumerate(tokens_with_priority)
+    ]
+
+
+def _no_pool():
+    return patch("hermes_cli.auth.read_credential_pool", return_value=[])
+
+
+# ---------------------------------------------------------------------------
+# Explicit credential wins
+# ---------------------------------------------------------------------------
+
+
+def test_oauth_token_routes_to_subscription_included():
+    with _no_pool():
+        route = resolve_billing_route(
+            "claude-opus-5", provider="anthropic", api_key=OAUTH_TOKEN
+        )
+    assert route.billing_mode == "subscription_included"
+
+
+def test_console_api_key_stays_metered():
+    """The guard that matters: a metered user must keep seeing real costs."""
+    with _no_pool():
+        route = resolve_billing_route(
+            "claude-opus-5", provider="anthropic", api_key=API_KEY
+        )
+    assert route.billing_mode == "official_docs_snapshot"
+
+
+def test_api_key_wins_over_oauth_pool_entry():
+    """An explicit key is the credential the caller used; the pool must not
+    override it and silently zero out a metered user's spend."""
+    with patch(
+        "hermes_cli.auth.read_credential_pool", return_value=_pool((OAUTH_TOKEN, 0))
+    ):
+        route = resolve_billing_route(
+            "claude-opus-5", provider="anthropic", api_key=API_KEY
+        )
+    assert route.billing_mode == "official_docs_snapshot"
+
+
+# ---------------------------------------------------------------------------
+# Credential-pool fallback (the common case: token is not in the environment)
+# ---------------------------------------------------------------------------
+
+
+def test_pool_oauth_token_detected_without_explicit_key():
+    with patch(
+        "hermes_cli.auth.read_credential_pool", return_value=_pool((OAUTH_TOKEN, 0))
+    ):
+        route = resolve_billing_route("claude-opus-5", provider="anthropic")
+    assert route.billing_mode == "subscription_included"
+
+
+def test_pool_respects_priority_order():
+    """Priority 0 is the seat actually used; a lower-priority API key entry
+    must not flip an OAuth seat back to metered (or vice versa)."""
+    with patch(
+        "hermes_cli.auth.read_credential_pool",
+        return_value=_pool((API_KEY, 1), (OAUTH_TOKEN, 0)),
+    ):
+        route = resolve_billing_route("claude-opus-5", provider="anthropic")
+    assert route.billing_mode == "subscription_included"
+
+    with patch(
+        "hermes_cli.auth.read_credential_pool",
+        return_value=_pool((OAUTH_TOKEN, 1), (API_KEY, 0)),
+    ):
+        route = resolve_billing_route("claude-opus-5", provider="anthropic")
+    assert route.billing_mode == "official_docs_snapshot"
+
+
+def test_pool_skips_entries_without_token():
+    """Claude Code seats can appear with an empty access_token; skip them
+    rather than reading the blank as 'not OAuth'."""
+    entries = [
+        {"label": "empty", "auth_type": "oauth", "priority": 0, "access_token": ""},
+        {"label": "real", "auth_type": "oauth", "priority": 1, "access_token": OAUTH_TOKEN},
+    ]
+    with patch("hermes_cli.auth.read_credential_pool", return_value=entries):
+        route = resolve_billing_route("claude-opus-5", provider="anthropic")
+    assert route.billing_mode == "subscription_included"
+
+
+def test_empty_pool_stays_metered():
+    with _no_pool():
+        route = resolve_billing_route("claude-opus-5", provider="anthropic")
+    assert route.billing_mode == "official_docs_snapshot"
+
+
+def test_pool_read_failure_fails_closed():
+    """Any error in detection must keep the metered path, never zero out cost."""
+    with patch("hermes_cli.auth.read_credential_pool", side_effect=RuntimeError("boom")):
+        route = resolve_billing_route("claude-opus-5", provider="anthropic")
+    assert route.billing_mode == "official_docs_snapshot"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end cost reporting
+# ---------------------------------------------------------------------------
+
+
+def test_subscription_cost_is_zero_and_labelled_included():
+    with _no_pool():
+        result = estimate_usage_cost(
+            "claude-opus-5", USAGE, provider="anthropic", api_key=OAUTH_TOKEN
+        )
+    assert result.status == "included"
+    assert result.amount_usd == Decimal("0")
+    assert any("subscription" in note for note in result.notes)
+
+
+def test_metered_cost_uses_published_rates():
+    """Opus 5: $5 in / $25 out / $0.50 cache read / $6.25 cache write per MTok.
+    Source: platform.claude.com/docs/en/about-claude/pricing
+    """
+    with _no_pool():
+        result = estimate_usage_cost(
+            "claude-opus-5", USAGE, provider="anthropic", api_key=API_KEY
+        )
+    assert result.status == "estimated"
+    expected = (
+        Decimal(1000) * Decimal("5.00")
+        + Decimal(500) * Decimal("25.00")
+        + Decimal(20000) * Decimal("0.50")
+        + Decimal(2000) * Decimal("6.25")
+    ) / Decimal(1_000_000)
+    assert result.amount_usd == expected
+
+
+def test_subscription_pricing_entry_is_all_zero():
+    with _no_pool():
+        entry = get_pricing_entry(
+            "claude-opus-5", provider="anthropic", api_key=OAUTH_TOKEN
+        )
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("0")
+    assert entry.output_cost_per_million == Decimal("0")
+
+
+def test_has_known_pricing_true_for_both_modes():
+    with _no_pool():
+        assert has_known_pricing("claude-opus-5", provider="anthropic", api_key=OAUTH_TOKEN)
+        assert has_known_pricing("claude-opus-5", provider="anthropic", api_key=API_KEY)
+
+
+# ---------------------------------------------------------------------------
+# Pricing table: Opus 5 was missing entirely
+# ---------------------------------------------------------------------------
+
+
+def test_opus_5_has_metered_pricing_entry():
+    """Opus 5 shipped 2026-07-24 with no entry, so metered users saw
+    cost_status='unknown' and a $0 total for every Opus 5 session."""
+    with _no_pool():
+        entry = get_pricing_entry("claude-opus-5", provider="anthropic", api_key=API_KEY)
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("5.00")
+    assert entry.output_cost_per_million == Decimal("25.00")
+    assert entry.cache_read_cost_per_million == Decimal("0.50")
+    # 5m-TTL cache write rate; the 1h rate ($10.00) is not representable here.
+    assert entry.cache_write_cost_per_million == Decimal("6.25")
+
+
+# ---------------------------------------------------------------------------
+# Regression guards on neighbouring routes
+# ---------------------------------------------------------------------------
+
+
+def test_other_providers_are_unaffected():
+    with _no_pool():
+        assert (
+            resolve_billing_route("gpt-5.6-luna", provider="openai-codex").billing_mode
+            == "subscription_included"
+        )
+        assert (
+            resolve_billing_route(
+                "moonshotai/kimi-k3", provider="openrouter"
+            ).billing_mode
+            == "official_models_api"
+        )
+        assert (
+            resolve_billing_route("gpt-5.6", provider="openai").billing_mode
+            == "official_docs_snapshot"
+        )
+
+
+def test_anthropic_model_prefix_is_still_stripped():
+    """Provider inference from an ``anthropic/…`` model string must keep
+    working through the new branch."""
+    with _no_pool():
+        route = resolve_billing_route("anthropic/claude-opus-5", api_key=API_KEY)
+    assert route.provider == "anthropic"
+    assert route.model == "claude-opus-5"

--- a/tests/agent/test_usage_pricing_anthropic_subscription.py
+++ b/tests/agent/test_usage_pricing_anthropic_subscription.py
@@ -16,6 +16,8 @@ positive-only and fails closed.
 from decimal import Decimal
 from unittest.mock import patch
 
+import pytest
+
 from agent.usage_pricing import (
     CanonicalUsage,
     estimate_usage_cost,
@@ -43,8 +45,14 @@ def _pool(*tokens_with_priority):
     ]
 
 
+def _pool_returning(payload):
+    """``read_credential_pool`` is imported inside the detector, so patch the
+    binding it reads (``hermes_cli.auth``), not a copy."""
+    return patch("hermes_cli.auth.read_credential_pool", return_value=payload)
+
+
 def _no_pool():
-    return patch("hermes_cli.auth.read_credential_pool", return_value=[])
+    return _pool_returning([])
 
 
 # ---------------------------------------------------------------------------
@@ -72,9 +80,7 @@ def test_console_api_key_stays_metered():
 def test_api_key_wins_over_oauth_pool_entry():
     """An explicit key is the credential the caller used; the pool must not
     override it and silently zero out a metered user's spend."""
-    with patch(
-        "hermes_cli.auth.read_credential_pool", return_value=_pool((OAUTH_TOKEN, 0))
-    ):
+    with _pool_returning(_pool((OAUTH_TOKEN, 0))):
         route = resolve_billing_route(
             "claude-opus-5", provider="anthropic", api_key=API_KEY
         )
@@ -82,44 +88,50 @@ def test_api_key_wins_over_oauth_pool_entry():
 
 
 # ---------------------------------------------------------------------------
-# Credential-pool fallback (the common case: token is not in the environment)
+# Credential-pool fallback (callers that price after the fact and have no
+# credential to thread: auxiliary accounting, insights)
 # ---------------------------------------------------------------------------
 
 
 def test_pool_oauth_token_detected_without_explicit_key():
-    with patch(
-        "hermes_cli.auth.read_credential_pool", return_value=_pool((OAUTH_TOKEN, 0))
-    ):
+    with _pool_returning(_pool((OAUTH_TOKEN, 0))):
         route = resolve_billing_route("claude-opus-5", provider="anthropic")
     assert route.billing_mode == "subscription_included"
 
 
-def test_pool_respects_priority_order():
-    """Priority 0 is the seat actually used; a lower-priority API key entry
-    must not flip an OAuth seat back to metered (or vice versa)."""
-    with patch(
-        "hermes_cli.auth.read_credential_pool",
-        return_value=_pool((API_KEY, 1), (OAUTH_TOKEN, 0)),
-    ):
+def test_all_oauth_pool_is_subscription_regardless_of_order():
+    with _pool_returning(_pool((OAUTH_TOKEN, 1), (OAUTH_TOKEN, 0))):
         route = resolve_billing_route("claude-opus-5", provider="anthropic")
     assert route.billing_mode == "subscription_included"
 
-    with patch(
-        "hermes_cli.auth.read_credential_pool",
-        return_value=_pool((OAUTH_TOKEN, 1), (API_KEY, 0)),
-    ):
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        _pool((OAUTH_TOKEN, 0), (API_KEY, 1)),
+        _pool((API_KEY, 0), (OAUTH_TOKEN, 1)),
+    ],
+    ids=["oauth-first", "api-key-first"],
+)
+def test_mixed_pool_stays_metered(entries):
+    """A pool holding both an OAuth seat and a Console key cannot tell which
+    one served a given request; priority order is not evidence either (the
+    runtime rotates on cooldown). Fail closed: keep the metered path rather
+    than zero out spend that may be real."""
+    with _pool_returning(entries):
         route = resolve_billing_route("claude-opus-5", provider="anthropic")
     assert route.billing_mode == "official_docs_snapshot"
 
 
 def test_pool_skips_entries_without_token():
-    """Claude Code seats can appear with an empty access_token; skip them
-    rather than reading the blank as 'not OAuth'."""
+    """Claude Code seats can appear with an empty or null access_token; skip
+    them rather than reading the blank as 'not OAuth'."""
     entries = [
         {"label": "empty", "auth_type": "oauth", "priority": 0, "access_token": ""},
-        {"label": "real", "auth_type": "oauth", "priority": 1, "access_token": OAUTH_TOKEN},
+        {"label": "null", "auth_type": "oauth", "priority": 1, "access_token": None},
+        {"label": "real", "auth_type": "oauth", "priority": 2, "access_token": OAUTH_TOKEN},
     ]
-    with patch("hermes_cli.auth.read_credential_pool", return_value=entries):
+    with _pool_returning(entries):
         route = resolve_billing_route("claude-opus-5", provider="anthropic")
     assert route.billing_mode == "subscription_included"
 
@@ -130,8 +142,28 @@ def test_empty_pool_stays_metered():
     assert route.billing_mode == "official_docs_snapshot"
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"anthropic": _pool((OAUTH_TOKEN, 0))},  # whole-store shape, not the provider slice
+        None,
+        "garbage",
+        [42, "junk", None, {"access_token": 7}],
+    ],
+    ids=["dict-shaped", "none", "string", "garbage-entries"],
+)
+def test_unexpected_pool_payload_stays_metered(payload):
+    """``read_credential_pool("anthropic")`` returns the provider's list of
+    entry dicts. Anything else is not positive evidence of a subscription
+    seat, so the metered path stays."""
+    with _pool_returning(payload):
+        route = resolve_billing_route("claude-opus-5", provider="anthropic")
+    assert route.billing_mode == "official_docs_snapshot"
+
+
 def test_pool_read_failure_fails_closed():
-    """Any error in detection must keep the metered path, never zero out cost."""
+    """An unreadable auth.json is re-raised by the store loader on purpose; a
+    cost estimate must neither take the turn down nor zero out cost."""
     with patch("hermes_cli.auth.read_credential_pool", side_effect=RuntimeError("boom")):
         route = resolve_billing_route("claude-opus-5", provider="anthropic")
     assert route.billing_mode == "official_docs_snapshot"
@@ -152,22 +184,16 @@ def test_subscription_cost_is_zero_and_labelled_included():
     assert any("subscription" in note for note in result.notes)
 
 
-def test_metered_cost_uses_published_rates():
-    """Opus 5: $5 in / $25 out / $0.50 cache read / $6.25 cache write per MTok.
-    Source: platform.claude.com/docs/en/about-claude/pricing
-    """
+def test_metered_opus_5_is_estimated_at_the_opus_tier():
+    """Opus 5 bills at the same tier as Opus 4.5-4.8 (platform.claude.com
+    pricing page), so a metered session must produce a real estimate equal
+    to the Opus 4.8 estimate for the same usage — not ``unknown``/$0."""
     with _no_pool():
-        result = estimate_usage_cost(
-            "claude-opus-5", USAGE, provider="anthropic", api_key=API_KEY
-        )
+        result = estimate_usage_cost("claude-opus-5", USAGE, provider="anthropic", api_key=API_KEY)
+        reference = estimate_usage_cost("claude-opus-4-8", USAGE, provider="anthropic", api_key=API_KEY)
     assert result.status == "estimated"
-    expected = (
-        Decimal(1000) * Decimal("5.00")
-        + Decimal(500) * Decimal("25.00")
-        + Decimal(20000) * Decimal("0.50")
-        + Decimal(2000) * Decimal("6.25")
-    ) / Decimal(1_000_000)
-    assert result.amount_usd == expected
+    assert result.amount_usd is not None and result.amount_usd > 0
+    assert result.amount_usd == reference.amount_usd
 
 
 def test_subscription_pricing_entry_is_all_zero():
@@ -191,17 +217,21 @@ def test_has_known_pricing_true_for_both_modes():
 # ---------------------------------------------------------------------------
 
 
-def test_opus_5_has_metered_pricing_entry():
+def test_opus_5_has_metered_pricing_entry_with_cache_rates():
     """Opus 5 shipped 2026-07-24 with no entry, so metered users saw
-    cost_status='unknown' and a $0 total for every Opus 5 session."""
+    cost_status='unknown' and a $0 total for every Opus 5 session. The row
+    must carry cache rates too (Hermes sessions are cache-heavy) and sit on
+    the same tier as Opus 4.8."""
     with _no_pool():
         entry = get_pricing_entry("claude-opus-5", provider="anthropic", api_key=API_KEY)
-    assert entry is not None
-    assert entry.input_cost_per_million == Decimal("5.00")
-    assert entry.output_cost_per_million == Decimal("25.00")
-    assert entry.cache_read_cost_per_million == Decimal("0.50")
-    # 5m-TTL cache write rate; the 1h rate ($10.00) is not representable here.
-    assert entry.cache_write_cost_per_million == Decimal("6.25")
+        opus_4_8 = get_pricing_entry("claude-opus-4-8", provider="anthropic", api_key=API_KEY)
+    assert entry is not None and opus_4_8 is not None
+    assert entry.source == "official_docs_snapshot"
+    assert entry.cache_read_cost_per_million is not None
+    assert entry.cache_write_cost_per_million is not None
+    assert (entry.input_cost_per_million, entry.output_cost_per_million) == (
+        opus_4_8.input_cost_per_million, opus_4_8.output_cost_per_million,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`resolve_billing_route` returned `official_docs_snapshot` for **every** `provider == "anthropic"` caller, regardless of which credential was actually in use. But the two Anthropic credential types bill in opposite ways:

- **OAuth seats** (Claude Max / Claude Code / Pro — `sk-ant-oat…`, a JWT, or a `cc-` token) carry **no per-token invoice**. Usage is metered against rolling quota windows.
- **Console API keys** (`sk-ant-api…`) bill every token.

Pricing them identically is wrong in both directions. On a subscription seat, Hermes reports a per-token dollar cost that will never appear on any invoice.

The route now decides from the live credential, mirroring the `openai-codex` branch which is already `subscription_included`.

**Why this approach:** detection is **positive-only and fails closed** — we return `subscription_included` *only* when an OAuth token is positively identified. An API key, an empty pool, or any error keeps the metered path. Under-reporting a metered user's real spend would be worse than the `unknown` status this replaces, so the failure mode points that way deliberately.

Reusing `_is_oauth_token` from `agent/anthropic_adapter.py` keeps a single definition of "what is an Anthropic OAuth token" rather than adding a second prefix check that could drift.

## Related Issue

No existing issue — found while auditing why `hermes insights` reported `cost_status='unknown'` for 39 of 106 sessions. Searched open/closed PRs and issues for `subscription_included anthropic`, `claude max billing`, `sk-ant-oat cost`: no duplicate. #87360 applies the same `subscription_included` pattern to Z.AI and Ollama Cloud, and this is the Anthropic counterpart of that class of bug.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/usage_pricing.py`
  - New `_anthropic_is_subscription(api_key)` helper. Uses `_is_oauth_token` (late import, avoiding an `agent` → `hermes_cli` import cycle); when no key is threaded through, consults `read_credential_pool("anthropic")` in `priority` order and skips entries with an empty token. Wrapped in a broad `try/except` that returns `False`.
  - `resolve_billing_route(...)` gains an optional `api_key` parameter; the `anthropic` branch returns `subscription_included` when the credential is OAuth.
  - Threaded `api_key` through the three internal callers that **already accepted one but never passed it on**: `get_pricing_entry`, `estimate_usage_cost`, `has_known_pricing`.
  - Added the missing `("anthropic", "claude-opus-5")` pricing entry — see below.
- `tests/agent/test_usage_pricing_anthropic_subscription.py` — 15 new cases.

### The missing Opus 5 entry

Opus 5 shipped 2026-07-24 with **no entry in `_OFFICIAL_DOCS_PRICING`**, so `get_pricing_entry` returned `None` and every Opus 5 session reported `cost_status='unknown'` with a $0 total — for metered users too. Rates added: **$5 / $25 per MTok, $0.50 cache read, $6.25 cache write**, per [the pricing docs](https://platform.claude.com/docs/en/about-claude/pricing) (the `source_url` the table already cites).

⚠️ **Known schema limitation, unchanged by this PR:** `PricingEntry` holds a *single* `cache_write_cost_per_million`. The value above is the **5m-TTL** rate; the 1h-TTL rate is **$10.00/MTok**. Cache-write estimates therefore undercount by 60% when `prompt_caching.cache_ttl` is `"1h"`. This affects every Anthropic entry in the table, not just Opus 5 — flagging it rather than fixing it here, since a two-rate schema is a larger change and out of scope for a bug fix.

## How to Test

1. **Automated** — both directions, plus the fail-closed guards:
   ```bash
   uv run --with pytest --with pytest-mock python -m pytest \
     tests/agent/test_usage_pricing_anthropic_subscription.py -q
   ```
   `15 passed`. **12 of the 15 fail without the fix** (verified by stashing the change and re-running), so they are genuine regression guards, not tautologies.

2. **Regression** — neighbouring cost paths:
   ```bash
   uv run --with pytest --with pytest-mock --with pytest-asyncio python -m pytest \
     tests/agent/test_insights.py tests/agent/test_usage_pricing.py \
     tests/agent/test_usage_pricing_anthropic_subscription.py \
     tests/tools/test_delegate_cost_footer.py -q
   ```
   `101 passed`.

3. **End-to-end on a real Claude Max seat** — `hermes insights` before this change counted Opus 5 sessions under *Unknown* (no pricing data); after, they are reported as:
   ```
   Included:  52 session(s) (subscription — no provider invoice)
   ```
   The remaining `Estimated: ~$18.49` is genuinely metered usage on other providers, which is the point: metered spend still shows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — *(ran the cost/pricing/insights/delegate subset: 101 passed; see How to Test)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the new helper explain the billing distinction and the fail-closed rationale; no user-facing docs describe this internal route
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: pure Python, no paths/shell/process work; credential-pool reads go through the existing `hermes_cli.auth` API
- [x] N/A — no tool descriptions or schemas touched

## Screenshots / Logs

Route resolution against a real Claude Max credential pool (`sk-ant-oat01…` at `priority: 0`), and with a simulated Console key:

```
A. No explicit key (OAuth token in pool)   -> subscription_included
   status='included'   amount=0   label='included'
   notes=('subscription-included; no provider invoice for usage',)

B. api_key='sk-ant-api03-…'  (metered)     -> official_docs_snapshot
   status='estimated'  amount=0.0400  label='~$0.04'

C. api_key='sk-ant-oat01-…'  (OAuth)       -> subscription_included
   status='included'   amount=0   label='included'

D. Regression guards
   claude-sonnet-5      anthropic      -> subscription_included
   gpt-5.6-luna         openai-codex   -> subscription_included
   moonshotai/kimi-k3   openrouter     -> official_models_api
```
