### PR TITLE
test: keep existing-profile grant out of unrestricted daemon

### DIFF
--- a/tests/tools/test_computer_use_browser_authorization.py
+++ b/tests/tools/test_computer_use_browser_authorization.py
@@ -356,6 +356,7 @@ def test_unrestricted_daemon_serve_command_unchanged(monkeypatch):
     command = captured["command"]
     assert "--dangerously-bypass-approvals" in command
     assert "--capability-manifest" not in command
+    assert "--grant" not in command
 
 
 # ── standard-mode --grant existing-profile ──────────────────────────────


### PR DESCRIPTION
## Summary
- add a regression assertion that unrestricted cua-driver startup never receives `--grant`
- preserve the separation between approval bypass and existing-profile authorization

## Verification
- `.venv/bin/python -m pytest tests/tools/test_computer_use_browser_authorization.py -q -o addopts=`
- 41 passed