### PR TITLE
fix(desktop): resolve Windows SSH Python runtime path

### DIFF
--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -36,8 +36,12 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
     '$hermes=$candidates|Where-Object{Test-Path -LiteralPath $_ -PathType Leaf}|Select-Object -First 1',
     'if(-not $hermes){throw "Hermes is not installed on the remote Windows host."}',
     'if($explicit -and $hermes -ne $explicit){throw "The configured Hermes path is not an executable file."}',
-    '$python=Join-Path (Split-Path $hermes) "python.exe"',
-    'if(-not (Test-Path -LiteralPath $python -PathType Leaf)){throw "The remote Hermes Python runtime was not found."}',
+    '# Try the standard installer layout (venv\\Scripts) first, then fall back to sibling path',
+    '$pythonCandidates=@()',
+    '$pythonCandidates+=(Join-Path $hermesHome "hermes-agent\\venv\\Scripts\\python.exe")',
+    '$pythonCandidates+=(Join-Path (Split-Path $hermes) "python.exe")',
+    '$python=$pythonCandidates|Where-Object{Test-Path -LiteralPath $_ -PathType Leaf}|Select-Object -First 1',
+    'if(-not $python){throw "The remote Hermes Python runtime was not found."}',
     '[ordered]@{os="Windows";arch=$env:PROCESSOR_ARCHITECTURE;hermesHome=$hermesHome;hermesPath=$hermes;python=$python}|ConvertTo-Json -Compress'
   ].join(';')
 

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -36,7 +36,6 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
     '$hermes=$candidates|Where-Object{Test-Path -LiteralPath $_ -PathType Leaf}|Select-Object -First 1',
     'if(-not $hermes){throw "Hermes is not installed on the remote Windows host."}',
     'if($explicit -and $hermes -ne $explicit){throw "The configured Hermes path is not an executable file."}',
-    '# Try the standard installer layout (venv\\Scripts) first, then fall back to sibling path',
     '$pythonCandidates=@()',
     '$pythonCandidates+=(Join-Path $hermesHome "hermes-agent\\venv\\Scripts\\python.exe")',
     '$pythonCandidates+=(Join-Path (Split-Path $hermes) "python.exe")',


### PR DESCRIPTION
## Summary

Fix Windows Desktop SSH platform detection for the standard Windows installer layout.

`probeWindowsRemote()` currently assumes `python.exe` is a sibling of the resolved `hermes.exe`. With the official installer, PATH resolves `hermes.exe` from `hermes-agent\bin`, while the Python runtime lives under `hermes-agent\venv\Scripts`.

This change:
- resolves `python.exe` from `hermes-agent\venv\Scripts\python.exe` first
- falls back to the sibling `python.exe` path for custom/dev layouts
- preserves explicit `remoteHermesPath` precedence

Fixes #91479

## Validation

- `cd apps/desktop && npx tsc -p tsconfig.electron.json --noEmit`
- `git diff --check`

Native Windows end-to-end SSH verification was not performed in the current environment.