### PR TITLE
fix(tui): save config to the same Hermes-home override the load path uses (#91587)

### DIFF
--- a/contributors/emails/paula@smfworks.com
+++ b/contributors/emails/paula@smfworks.com
@@ -1,0 +1,2 @@
+smfworks
+# SMF Works contributor

--- a/tests/tui_gateway/test_save_cfg_home_override.py
+++ b/tests/tui_gateway/test_save_cfg_home_override.py
@@ -1,0 +1,41 @@
+"""Regression for #91587: _save_cfg must write the same home _load_cfg_raw reads.
+
+_load_cfg_raw honors get_hermes_home_override(); _save_cfg used to ignore it
+and dump into the launch-profile _hermes_home. That breaks the documented
+read→mutate→_save_cfg pair whenever a session override is active.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tui_gateway import server
+
+
+def test_save_cfg_writes_override_home_not_launch_home(tmp_path, monkeypatch):
+    launch_home = tmp_path / "launch"
+    profile_home = tmp_path / "profile"
+    launch_home.mkdir()
+    profile_home.mkdir()
+    (launch_home / "config.yaml").write_text("model:\n  default: launch-model\n", encoding="utf-8")
+    (profile_home / "config.yaml").write_text("model:\n  default: profile-model\n", encoding="utf-8")
+
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    monkeypatch.setattr(server, "_cfg_cache", None)
+    monkeypatch.setattr(server, "_cfg_mtime", None)
+    monkeypatch.setattr(server, "_cfg_path", None)
+
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        raw = server._load_cfg_raw()
+        assert raw["model"]["default"] == "profile-model"
+        raw["model"]["default"] = "updated-profile"
+        server._save_cfg(raw)
+    finally:
+        reset_hermes_home_override(token)
+
+    profile = yaml.safe_load((profile_home / "config.yaml").read_text(encoding="utf-8"))
+    launch = yaml.safe_load((launch_home / "config.yaml").read_text(encoding="utf-8"))
+    assert profile["model"]["default"] == "updated-profile"
+    assert launch["model"]["default"] == "launch-model"

--- a/tests/tui_gateway/test_save_cfg_home_override.py
+++ b/tests/tui_gateway/test_save_cfg_home_override.py
@@ -39,3 +39,19 @@ def test_save_cfg_writes_override_home_not_launch_home(tmp_path, monkeypatch):
     launch = yaml.safe_load((launch_home / "config.yaml").read_text(encoding="utf-8"))
     assert profile["model"]["default"] == "updated-profile"
     assert launch["model"]["default"] == "launch-model"
+
+
+def test_cfg_home_and_watcher_home_share_override(tmp_path, monkeypatch):
+    launch_home = tmp_path / "launch"
+    profile_home = tmp_path / "profile"
+    launch_home.mkdir()
+    profile_home.mkdir()
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        assert server._cfg_home() == profile_home
+        assert server._watcher_home() == profile_home
+    finally:
+        reset_hermes_home_override(token)
+    assert server._cfg_home() == launch_home
+    assert server._watcher_home() == launch_home

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3295,6 +3295,19 @@ def _load_dashboard_process_isolation_config(cfg: dict | None = None) -> dict[st
     }
 
 
+def _cfg_home() -> Path:
+    """Hermes home used by the ``_load_cfg_raw`` / ``_save_cfg`` pair.
+
+    Honors the context-local profile override so a resumed remote session
+    reads and writes ITS config.yaml. Without this, the documented
+    read→mutate→save round-trip dumps a profile's config into the launch
+    home (#91587).
+    """
+    override = get_hermes_home_override()
+    home = override if isinstance(override, str) and override else _hermes_home
+    return Path(home)
+
+
 def _load_cfg_raw() -> dict:
     """Read the active profile's config.yaml EXACTLY as written (write-back primitive).
 
@@ -3310,9 +3323,7 @@ def _load_cfg_raw() -> dict:
         # remote profile loads ITS config (model, skills, prompt); otherwise the
         # launch profile's _hermes_home. Cache is keyed on the resolved path, so
         # profiles don't clobber each other.
-        override = get_hermes_home_override()
-        home = override if isinstance(override, str) and override else _hermes_home
-        p = Path(home) / "config.yaml"
+        p = _cfg_home() / "config.yaml"
         mtime = p.stat().st_mtime if p.exists() else None
         with _cfg_lock:
             if _cfg_cache is not None and _cfg_mtime == mtime and _cfg_path == p:
@@ -3382,7 +3393,7 @@ def _save_cfg(cfg: dict):
 
     from utils import atomic_roundtrip_yaml_save
 
-    path = _hermes_home / "config.yaml"
+    path = _cfg_home() / "config.yaml"
     # Comment-, ordering-, and Unicode-preserving full-state write.
     # Replaces the previous `yaml.safe_dump(cfg, f)` (and later
     # `atomic_config_write`, which is not comment-preserving) which clobbered

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3753,8 +3753,7 @@ def _skin_sig() -> tuple[str, float | None]:
     """(active skin name, its user-file mtime). Built-ins have no file, so only
     their name moves; a user skin's mtime lets an in-place color edit repaint too."""
     name = str((_load_cfg().get("display") or {}).get("skin") or "default")
-    override = get_hermes_home_override()
-    home = override if isinstance(override, str) and override else _hermes_home
+    home = _cfg_home()
     try:
         mtime: float | None = (Path(home) / "skins" / f"{name}.yaml").stat().st_mtime
     except OSError:
@@ -3797,8 +3796,7 @@ def _broadcast_skin_if_changed() -> None:
 
 def _watcher_home() -> Path:
     """Active profile home for the change watcher's signature probes."""
-    override = get_hermes_home_override()
-    return Path(override if isinstance(override, str) and override else _hermes_home)
+    return _cfg_home()
 
 
 def _pet_sig() -> tuple:


### PR DESCRIPTION
## Summary

`_load_cfg_raw()` honors `get_hermes_home_override()` so a resumed profile reads ITS `config.yaml`. `_save_cfg()` hardcoded `_hermes_home`, so the documented read→mutate→save pair dumped a profile's config into the launch home.

Both paths now share `_cfg_home()`.

## Test Plan

- [x] `tests/tui_gateway/test_save_cfg_home_override.py` — RED then GREEN
- [x] existing `_save_cfg` comment/order tests + config loader e2e — 5 passed
- [x] ruff clean

Closes #91587