### PR TITLE
fix(update): keep Windows Hermes commands available after UI updates

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3181,7 +3181,7 @@ def _ensure_fhs_path_guard() -> None:
         print("    (reload your shell or run 'source ~/.bashrc' to pick it up)")
 
 def _ensure_acp_launcher() -> None:
-    """Self-heal: install a ``hermes-acp`` launcher next to the ``hermes`` one.
+    """Self-heal the launchers exposed on the user's PATH.
 
     Mirrors the launcher block in ``scripts/install.sh`` so existing installs
     gain the ACP command on ``hermes update`` without a reinstall.  ACP hosts
@@ -3195,14 +3195,34 @@ def _ensure_acp_launcher() -> None:
     (venv wrapper, FHS symlink, pipx/pip console script) without having to
     reconstruct interpreter/entrypoint paths.
 
-    No-op on Windows (install.ps1 copies ``hermes.exe`` + ``hermes-acp.exe``
-    into ``$InstallDir\bin`` and puts THAT on the user PATH — never the whole
-    ``venv\Scripts`` dir, which would shadow the user's ``python`` (#83797) —
-    so ``hermes-acp.exe`` already resolves) and wherever a ``hermes-acp`` is
-    already present next to the ``hermes`` command.  Unwritable directories
-    (e.g. ``/usr/local/bin`` as non-root) are skipped silently.  Idempotent.
+    On Windows, mirror ``install.ps1`` by copying ``hermes.exe`` and
+    ``hermes-acp.exe`` from the project venv into ``$InstallDir\bin``.  The
+    installer puts that dedicated directory on PATH instead of the whole
+    ``venv\Scripts`` directory, which would shadow the user's ``python``
+    (#83797).  Updates refresh the venv without rerunning the installer's PATH
+    setup, so recreate or refresh those copies here.
+
+    On POSIX, install the ``hermes-acp`` delegating shim wherever a ``hermes``
+    command is already present.  Unwritable directories are skipped silently.
+    Idempotent on every platform.
     """
     if _m().sys.platform == "win32":
+        scripts_dir = _m()._venv_scripts_dir()
+        if scripts_dir is None:
+            return
+        bin_dir = _m().PROJECT_ROOT / "bin"
+        try:
+            bin_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return
+        for name in ("hermes.exe", "hermes-acp.exe"):
+            source = scripts_dir / name
+            target = bin_dir / name
+            try:
+                if source.is_file():
+                    shutil.copy2(source, target)
+            except OSError:
+                continue
         return
     for bin_dir in (Path.home() / ".local" / "bin", Path("/usr/local/bin")):
         hermes_cmd = bin_dir / "hermes"

--- a/tests/hermes_cli/test_ensure_acp_launcher_windows.py
+++ b/tests/hermes_cli/test_ensure_acp_launcher_windows.py
@@ -1,0 +1,41 @@
+"""Native Windows coverage for the dedicated PATH launcher copies."""
+
+import pytest
+
+from hermes_cli import main as hermes_main
+from hermes_cli.main import _ensure_acp_launcher
+
+pytestmark = pytest.mark.windows_only
+
+
+def test_restores_dedicated_bin_launchers(tmp_path, monkeypatch):
+    scripts_dir = tmp_path / "venv" / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    launchers = {
+        "hermes.exe": b"updated hermes launcher",
+        "hermes-acp.exe": b"updated acp launcher",
+    }
+    for name, content in launchers.items():
+        (scripts_dir / name).write_bytes(content)
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+
+    _ensure_acp_launcher()
+
+    for name, content in launchers.items():
+        assert (tmp_path / "bin" / name).read_bytes() == content
+
+
+def test_refreshes_stale_bin_launchers(tmp_path, monkeypatch):
+    scripts_dir = tmp_path / "venv" / "Scripts"
+    scripts_dir.mkdir(parents=True)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for name in ("hermes.exe", "hermes-acp.exe"):
+        (scripts_dir / name).write_bytes(f"updated {name}".encode())
+        (bin_dir / name).write_bytes(b"stale launcher")
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+
+    _ensure_acp_launcher()
+
+    for name in ("hermes.exe", "hermes-acp.exe"):
+        assert (bin_dir / name).read_bytes() == f"updated {name}".encode()


### PR DESCRIPTION
## What does this PR do?

Windows users who update Hermes from the Desktop UI keep working `hermes` and `hermes-acp` commands in new terminals. The shared post-update self-heal now restores the dedicated `bin` launcher copies from the refreshed project venv, preserving the installer contract without adding all of `venv/Scripts` to PATH.

### Symptom

After a successful Desktop UI update, `<install>/bin` can be missing while User PATH still points to it. A new cmd window then reports that `hermes` is not recognized, even though the updated launchers remain available under `venv/Scripts`.

### Impact

Affected native Windows installs lose the globally resolvable `hermes` and `hermes-acp` commands after an otherwise successful UI update. Users must invoke the venv launcher by absolute path or manually recreate the dedicated launcher copies.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd.py:3205` / `_ensure_acp_launcher()` returns immediately on Windows.

**Causal chain:**
1. The Desktop updater refreshes the checkout and project venv without rerunning the PowerShell installer's `Set-PathVariable` block.
2. The common post-update launcher self-heal runs, but its Windows branch exits without recreating `<install>/bin`.
3. User PATH continues to target the missing dedicated bin directory, so cmd cannot resolve either Hermes launcher.

**Why it is wrong:** The Windows installer deliberately exposes copied launchers from `<install>/bin`, not the entire venv Scripts directory. Treating Windows as a no-op assumes those copies can never disappear during later update flows.

**Working sibling / contrast:** `scripts/install.ps1` creates the dedicated bin directory and copies both `hermes.exe` and `hermes-acp.exe` from `venv/Scripts` during a fresh install.

**Ruled out:** The venv dependency update is not the failure: both launchers remain executable directly from `venv/Scripts` after the reported update.

### Fix

On Windows, `_ensure_acp_launcher()` now resolves the active project venv, creates the dedicated bin directory when needed, and refreshes both launcher copies independently. Native Windows tests cover both a missing bin directory and stale existing copies.

## Related Issue

Closes #91563

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` - mirror the PowerShell installer launcher-copy contract in the shared post-update self-heal.
- `tests/hermes_cli/test_ensure_acp_launcher_windows.py` - cover missing and stale dedicated launcher copies on native Windows.

## How to Test

1. Run the native Windows launcher regression and installer PATH-contract tests.
2. Confirm all three tests pass.

```bash
scripts/run_tests.sh tests/hermes_cli/test_ensure_acp_launcher_windows.py tests/hermes_cli/test_windows_native_docs.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are updated
- [x] Config examples are N/A because no config keys changed
- [x] Contributor or architecture documentation is N/A because no workflow changed
- [x] Cross-platform impact was considered; the POSIX launcher branch is unchanged
- [x] Tool descriptions and schemas are N/A because no tool behavior changed

## Screenshots / Logs

Automated result: 3 passed, 0 failed across the native Windows launcher and installer PATH-contract test files.
