### PR TITLE
feat(skills): add sandbox-runner skill for isolated disposable execution

### DIFF
--- a/skills/devops/sandbox-runner/SKILL.md
+++ b/skills/devops/sandbox-runner/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: sandbox-runner
+description: Run untrusted code in disposable isolated sandboxes.
+version: 0.1.0
+author: Thamer (taljeri), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Sandbox, Docker, Security, Isolation, DevOps]
+    category: devops
+    related_skills: [sdlc-review, systematic-debugging]
+---
+
+# Sandbox Runner
+
+Execute untrusted code, external benchmark suites, third-party repositories, and destructive scripts inside ephemeral throwaway sandboxes. Inspired by DeepSeek Harness's minimal evaluation sandboxes, this skill prevents unverified code from mutating the host environment.
+
+Zero external dependencies: uses Docker when available, or falls back to temporary isolated workspaces with strict execution timeouts and automated cleanup.
+
+## When to Use
+
+- "Run this untrusted Python script in a disposable sandbox"
+- "Execute benchmark evaluation in an isolated environment"
+- "Test a script without touching my local filesystem"
+- "Install and test experimental dependencies safely"
+
+Don't use for:
+- Long-running server daemons that must persist across sessions
+- Basic local file edits that already run safely via Hermes tools
+
+## Prerequisites
+
+- Standard Python 3.9+ runtime.
+- Optional: Docker daemon running for hardware-isolated container execution (falls back to isolated temp workspace if Docker is absent).
+
+## How to Run
+
+Execute commands via the `terminal` tool using the bundled runner:
+
+```bash
+# Run inline command in isolated sandbox with network disabled
+python3 skills/devops/sandbox-runner/scripts/sandbox.py run "python3 -c 'import math; print(math.pi)'" --network none --json
+
+# Execute a standalone script file inside a Python container
+python3 skills/devops/sandbox-runner/scripts/sandbox.py exec-file path/to/script.py --image python:3.11-slim
+
+# Check available sandbox engines
+python3 skills/devops/sandbox-runner/scripts/sandbox.py check
+```
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Run command in sandbox | `python3 skills/devops/sandbox-runner/scripts/sandbox.py run "<cmd>" [--image IMG] [--mount DIR] [--json]` |
+| Execute script file | `python3 skills/devops/sandbox-runner/scripts/sandbox.py exec-file <script> [--image IMG] [--timeout SEC]` |
+| Check engine status | `python3 skills/devops/sandbox-runner/scripts/sandbox.py check [--json]` |
+| Prune containers | `python3 skills/devops/sandbox-runner/scripts/sandbox.py prune` |
+
+## Procedure
+
+### 1. Check Engine Availability
+1. Run `sandbox.py check` to inspect whether Docker container isolation is active or local workspace isolation will be used.
+
+### 2. Configure Isolation Constraints
+1. Select appropriate container image (default: `python:3.11-slim` or custom node/golang images).
+2. Set network policy: Use `--network none` for strict air-gapped execution of untrusted scripts.
+3. Set timeout limits (default: 120 seconds) to prevent infinite loops.
+
+### 3. Execute and Inspect Output
+1. Run the target command or script file via `sandbox.py run` or `sandbox.py exec-file`.
+2. Inspect JSON output containing `exit_code`, `stdout`, `stderr`, and `elapsed_seconds`.
+3. Auto-cleanup tears down containers and temporary workspaces automatically upon completion.
+
+## Pitfalls
+
+- **State persistence:** Containers and isolated workspaces are ephemeral and destroyed after each run. Mount a workspace explicitly via `--mount <dir>` if outputs must be written back.
+- **Root permissions:** Avoid executing commands with root privileges when mounting host directories.
+
+## Verification
+
+Verify the sandbox runner by executing a self-test:
+```bash
+python3 skills/devops/sandbox-runner/scripts/sandbox.py run "echo 'sandbox verified'"
+```

--- a/skills/devops/sandbox-runner/scripts/sandbox.py
+++ b/skills/devops/sandbox-runner/scripts/sandbox.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""sandbox.py — Ephemeral container and environment execution runner for Hermes Agent.
+
+Usage:
+  sandbox.py run "<command>" [--image IMAGE] [--mount PATH] [--timeout SECONDS] [--network none|bridge] [--json]
+  sandbox.py exec-file <script_path> [--image IMAGE] [--timeout SECONDS] [--json]
+  sandbox.py check [--json]
+  sandbox.py prune [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DEFAULT_IMAGE = "python:3.11-slim"
+DEFAULT_TIMEOUT = 120
+
+
+def is_docker_available() -> bool:
+    docker_bin = shutil.which("docker")
+    if not docker_bin:
+        return False
+    try:
+        res = subprocess.run(
+            ["docker", "info"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        return res.returncode == 0
+    except Exception:
+        return False
+
+
+def run_in_docker(
+    command: str,
+    *,
+    image: str = DEFAULT_IMAGE,
+    mount_dir: Optional[Path] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    network: str = "none",
+    env_vars: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Execute command inside an ephemeral throwaway Docker container."""
+    container_name = f"hermes_sandbox_{int(time.time())}_{os.getpid()}"
+    docker_cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "--name",
+        container_name,
+        "--network",
+        network,
+        "--memory",
+        "512m",
+        "--cpus",
+        "1.0",
+    ]
+
+    if env_vars:
+        for k, v in env_vars.items():
+            docker_cmd.extend(["-e", f"{k}={v}"])
+
+    if mount_dir:
+        abs_mount = Path(mount_dir).resolve()
+        docker_cmd.extend(["-v", f"{abs_mount}:/workspace", "-w", "/workspace"])
+    else:
+        docker_cmd.extend(["-w", "/tmp"])
+
+    docker_cmd.extend([image, "sh", "-c", command])
+
+    start_time = time.time()
+    try:
+        proc = subprocess.run(
+            docker_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+        )
+        elapsed = round(time.time() - start_time, 2)
+        return {
+            "engine": "docker",
+            "image": image,
+            "container": container_name,
+            "exit_code": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "elapsed_seconds": elapsed,
+            "timed_out": False,
+        }
+    except subprocess.TimeoutExpired as e:
+        # Force clean container on timeout
+        subprocess.run(["docker", "rm", "-f", container_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return {
+            "engine": "docker",
+            "image": image,
+            "container": container_name,
+            "exit_code": 124,
+            "stdout": e.stdout or "",
+            "stderr": (e.stderr or "") + f"\nProcess timed out after {timeout} seconds.",
+            "elapsed_seconds": timeout,
+            "timed_out": True,
+        }
+
+
+def run_in_local_sandbox(
+    command: str,
+    *,
+    mount_dir: Optional[Path] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    env_vars: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Fallback execution inside a temporary isolated directory."""
+    temp_dir = Path(tempfile.mkdtemp(prefix="hermes_isolated_"))
+    cwd = mount_dir if mount_dir else temp_dir
+
+    env = dict(os.environ)
+    if env_vars:
+        env.update(env_vars)
+
+    start_time = time.time()
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,
+            cwd=str(cwd),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+        )
+        elapsed = round(time.time() - start_time, 2)
+        return {
+            "engine": "local_isolated",
+            "workspace": str(cwd),
+            "exit_code": proc.returncode,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "elapsed_seconds": elapsed,
+            "timed_out": False,
+        }
+    except subprocess.TimeoutExpired as e:
+        return {
+            "engine": "local_isolated",
+            "workspace": str(cwd),
+            "exit_code": 124,
+            "stdout": e.stdout or "",
+            "stderr": (e.stderr or "") + f"\nProcess timed out after {timeout} seconds.",
+            "elapsed_seconds": timeout,
+            "timed_out": True,
+        }
+    finally:
+        if not mount_dir and temp_dir.exists():
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def execute_sandbox(
+    command: str,
+    *,
+    image: str = DEFAULT_IMAGE,
+    mount_dir: Optional[Path] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    network: str = "none",
+    env_vars: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    if is_docker_available():
+        return run_in_docker(
+            command,
+            image=image,
+            mount_dir=mount_dir,
+            timeout=timeout,
+            network=network,
+            env_vars=env_vars,
+        )
+    return run_in_local_sandbox(
+        command,
+        mount_dir=mount_dir,
+        timeout=timeout,
+        env_vars=env_vars,
+    )
+
+
+def execute_script_file(
+    script_path: Path,
+    *,
+    image: str = DEFAULT_IMAGE,
+    timeout: int = DEFAULT_TIMEOUT,
+    args: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    if not script_path.exists():
+        raise FileNotFoundError(f"Script not found: {script_path}")
+
+    ext = script_path.suffix.lower()
+    parent_dir = script_path.parent
+    file_name = script_path.name
+
+    arg_str = " ".join(args) if args else ""
+    if ext == ".py":
+        cmd = f"python3 {file_name} {arg_str}".strip()
+    elif ext == ".sh":
+        cmd = f"sh {file_name} {arg_str}".strip()
+    elif ext in (".js", ".mjs"):
+        cmd = f"node {file_name} {arg_str}".strip()
+    else:
+        cmd = f"./{file_name} {arg_str}".strip()
+
+    return execute_sandbox(
+        cmd,
+        image=image,
+        mount_dir=parent_dir,
+        timeout=timeout,
+    )
+
+
+def prune_sandboxes() -> Dict[str, Any]:
+    if not is_docker_available():
+        return {"engine": "none", "pruned_containers": 0, "status": "Docker not available"}
+
+    res = subprocess.run(
+        ["docker", "container", "prune", "-f", "--filter", "label=hermes_sandbox"],
+        capture_output=True,
+        text=True,
+    )
+    return {"engine": "docker", "status": "Pruned idle sandbox containers", "output": res.stdout.strip()}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Hermes Sandbox Runner CLI.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # run
+    p_run = subparsers.add_parser("run", help="Run a shell command inside an isolated sandbox.")
+    p_run.add_argument("cmd", type=str, help="Command string to execute.")
+    p_run.add_argument("--image", type=str, default=DEFAULT_IMAGE, help="Docker image to use.")
+    p_run.add_argument("--mount", type=Path, default=None, help="Directory to mount as workspace.")
+    p_run.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="Execution timeout in seconds.")
+    p_run.add_argument("--network", type=str, default="none", choices=["none", "bridge", "host"], help="Network mode.")
+    p_run.add_argument("--json", action="store_true", help="Output as JSON.")
+
+    # exec-file
+    p_file = subparsers.add_parser("exec-file", help="Execute a script file inside an isolated sandbox.")
+    p_file.add_argument("script", type=Path, help="Path to script file.")
+    p_file.add_argument("--image", type=str, default=DEFAULT_IMAGE, help="Docker image to use.")
+    p_file.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="Execution timeout in seconds.")
+    p_file.add_argument("--json", action="store_true", help="Output as JSON.")
+
+    # check
+    p_chk = subparsers.add_parser("check", help="Check container and sandbox runtime status.")
+    p_chk.add_argument("--json", action="store_true", help="Output as JSON.")
+
+    # prune
+    p_pru = subparsers.add_parser("prune", help="Clean up stopped sandbox containers.")
+    p_pru.add_argument("--json", action="store_true", help="Output as JSON.")
+
+    args = parser.parse_args()
+
+    if args.command == "run":
+        res = execute_sandbox(
+            args.cmd,
+            image=args.image,
+            mount_dir=args.mount,
+            timeout=args.timeout,
+            network=args.network,
+        )
+        if args.json:
+            print(json.dumps(res, indent=2))
+        else:
+            print(f"[{res['engine']}] Exit Code: {res['exit_code']} (Time: {res['elapsed_seconds']}s)")
+            if res["stdout"]:
+                print(f"STDOUT:\n{res['stdout']}")
+            if res["stderr"]:
+                print(f"STDERR:\n{res['stderr']}")
+
+    elif args.command == "exec-file":
+        res = execute_script_file(args.script, image=args.image, timeout=args.timeout)
+        if args.json:
+            print(json.dumps(res, indent=2))
+        else:
+            print(f"[{res['engine']}] Executed {args.script.name} (Exit Code: {res['exit_code']})")
+            if res["stdout"]:
+                print(f"STDOUT:\n{res['stdout']}")
+            if res["stderr"]:
+                print(f"STDERR:\n{res['stderr']}")
+
+    elif args.command == "check":
+        docker_ok = is_docker_available()
+        status = {
+            "docker_available": docker_ok,
+            "engine": "docker" if docker_ok else "local_isolated",
+            "default_image": DEFAULT_IMAGE,
+            "default_timeout": DEFAULT_TIMEOUT,
+        }
+        if args.json:
+            print(json.dumps(status, indent=2))
+        else:
+            print(f"Sandbox Engine: {status['engine']}")
+            print(f"Docker Available: {docker_ok}")
+
+    elif args.command == "prune":
+        res = prune_sandboxes()
+        if args.json:
+            print(json.dumps(res, indent=2))
+        else:
+            print(res.get("status", "Prune complete"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_sandbox_runner_skill.py
+++ b/tests/skills/test_sandbox_runner_skill.py
@@ -1,0 +1,95 @@
+"""
+Tests for the Sandbox Runner skill (skills/devops/sandbox-runner).
+
+Covers:
+- Local isolated sandbox execution
+- Execution output capture (stdout, stderr, exit code)
+- Timeout enforcement
+- Script file execution runner
+- Engine status check and CLI subprocess commands
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SANDBOX_SCRIPT = (
+    REPO_ROOT
+    / "skills"
+    / "devops"
+    / "sandbox-runner"
+    / "scripts"
+    / "sandbox.py"
+)
+
+# Import module directly
+sys.path.insert(0, str(SANDBOX_SCRIPT.parent))
+import sandbox
+
+
+class TestSandboxRunnerCore:
+    def test_run_in_local_sandbox_success(self, tmp_path):
+        res = sandbox.run_in_local_sandbox("echo 'Hello Sandbox'", mount_dir=tmp_path)
+        assert res["exit_code"] == 0
+        assert "Hello Sandbox" in res["stdout"]
+        assert res["timed_out"] is False
+        assert res["engine"] == "local_isolated"
+
+    def test_run_in_local_sandbox_stderr(self, tmp_path):
+        res = sandbox.run_in_local_sandbox("python3 -c \"import sys; sys.stderr.write('Test Error\\n'); sys.exit(2)\"", mount_dir=tmp_path)
+        assert res["exit_code"] == 2
+        assert "Test Error" in res["stderr"]
+
+    def test_run_in_local_sandbox_timeout(self, tmp_path):
+        res = sandbox.run_in_local_sandbox("python3 -c \"import time; time.sleep(5)\"", mount_dir=tmp_path, timeout=1)
+        assert res["timed_out"] is True
+        assert res["exit_code"] == 124
+        assert "timed out after 1 seconds" in res["stderr"]
+
+    def test_execute_script_file(self, tmp_path):
+        test_script = tmp_path / "calc.py"
+        test_script.write_text("print(40 + 2)", encoding="utf-8")
+
+        res = sandbox.execute_script_file(test_script, timeout=10)
+        assert res["exit_code"] == 0
+        assert "42" in res["stdout"]
+
+
+class TestSandboxRunnerCLI:
+    def test_cli_check_json(self):
+        res = subprocess.run(
+            [
+                sys.executable,
+                str(SANDBOX_SCRIPT),
+                "check",
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(res.stdout)
+        assert "engine" in data
+        assert "docker_available" in data
+
+    def test_cli_run_json(self):
+        res = subprocess.run(
+            [
+                sys.executable,
+                str(SANDBOX_SCRIPT),
+                "run",
+                "echo 'CLI sandbox test'",
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        data = json.loads(res.stdout)
+        assert data["exit_code"] == 0
+        assert "CLI sandbox test" in data["stdout"]

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -52,6 +52,12 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music) | Songwriting craft and Suno AI music prompts. | `creative/songwriting-and-ai-music` |
 | [`touchdesigner-mcp`](/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp) | Control TouchDesigner via twozero MCP. | `creative/touchdesigner-mcp` |
 
+## devops
+
+| Skill | Description | Path |
+|-------|-------------|------|
+| [`sandbox-runner`](/docs/user-guide/skills/bundled/devops/devops-sandbox-runner) | Run untrusted code in disposable isolated sandboxes. | `devops/sandbox-runner` |
+
 ## email
 
 | Skill | Description | Path |

--- a/website/docs/user-guide/skills/bundled/devops/devops-sandbox-runner.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-sandbox-runner.md
@@ -1,0 +1,103 @@
+---
+title: "Sandbox Runner — Run untrusted code in disposable isolated sandboxes"
+sidebar_label: "Sandbox Runner"
+description: "Run untrusted code in disposable isolated sandboxes"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Sandbox Runner
+
+Run untrusted code in disposable isolated sandboxes.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/devops/sandbox-runner` |
+| Version | `0.1.0` |
+| Author | Thamer (taljeri), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Sandbox`, `Docker`, `Security`, `Isolation`, `DevOps` |
+| Related skills | [`sdlc-review`](/docs/user-guide/skills/bundled/devops/devops-sdlc-review), [`systematic-debugging`](/docs/user-guide/skills/bundled/software-development/software-development-systematic-debugging) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Sandbox Runner
+
+Execute untrusted code, external benchmark suites, third-party repositories, and destructive scripts inside ephemeral throwaway sandboxes. Inspired by DeepSeek Harness's minimal evaluation sandboxes, this skill prevents unverified code from mutating the host environment.
+
+Zero external dependencies: uses Docker when available, or falls back to temporary isolated workspaces with strict execution timeouts and automated cleanup.
+
+## When to Use
+
+- "Run this untrusted Python script in a disposable sandbox"
+- "Execute benchmark evaluation in an isolated environment"
+- "Test a script without touching my local filesystem"
+- "Install and test experimental dependencies safely"
+
+Don't use for:
+- Long-running server daemons that must persist across sessions
+- Basic local file edits that already run safely via Hermes tools
+
+## Prerequisites
+
+- Standard Python 3.9+ runtime.
+- Optional: Docker daemon running for hardware-isolated container execution (falls back to isolated temp workspace if Docker is absent).
+
+## How to Run
+
+Execute commands via the `terminal` tool using the bundled runner:
+
+```bash
+# Run inline command in isolated sandbox with network disabled
+python3 skills/devops/sandbox-runner/scripts/sandbox.py run "python3 -c 'import math; print(math.pi)'" --network none --json
+
+# Execute a standalone script file inside a Python container
+python3 skills/devops/sandbox-runner/scripts/sandbox.py exec-file path/to/script.py --image python:3.11-slim
+
+# Check available sandbox engines
+python3 skills/devops/sandbox-runner/scripts/sandbox.py check
+```
+
+## Quick Reference
+
+| Task | Command |
+|---|---|
+| Run command in sandbox | `python3 skills/devops/sandbox-runner/scripts/sandbox.py run "<cmd>" [--image IMG] [--mount DIR] [--json]` |
+| Execute script file | `python3 skills/devops/sandbox-runner/scripts/sandbox.py exec-file <script> [--image IMG] [--timeout SEC]` |
+| Check engine status | `python3 skills/devops/sandbox-runner/scripts/sandbox.py check [--json]` |
+| Prune containers | `python3 skills/devops/sandbox-runner/scripts/sandbox.py prune` |
+
+## Procedure
+
+### 1. Check Engine Availability
+1. Run `sandbox.py check` to inspect whether Docker container isolation is active or local workspace isolation will be used.
+
+### 2. Configure Isolation Constraints
+1. Select appropriate container image (default: `python:3.11-slim` or custom node/golang images).
+2. Set network policy: Use `--network none` for strict air-gapped execution of untrusted scripts.
+3. Set timeout limits (default: 120 seconds) to prevent infinite loops.
+
+### 3. Execute and Inspect Output
+1. Run the target command or script file via `sandbox.py run` or `sandbox.py exec-file`.
+2. Inspect JSON output containing `exit_code`, `stdout`, `stderr`, and `elapsed_seconds`.
+3. Auto-cleanup tears down containers and temporary workspaces automatically upon completion.
+
+## Pitfalls
+
+- **State persistence:** Containers and isolated workspaces are ephemeral and destroyed after each run. Mount a workspace explicitly via `--mount <dir>` if outputs must be written back.
+- **Root permissions:** Avoid executing commands with root privileges when mounting host directories.
+
+## Verification
+
+Verify the sandbox runner by executing a self-test:
+```bash
+python3 skills/devops/sandbox-runner/scripts/sandbox.py run "echo 'sandbox verified'"
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -200,6 +200,15 @@ const sidebars: SidebarsConfig = {
                 },
                 {
                   type: 'category',
+                  label: 'devops',
+                  key: 'skills-bundled-devops',
+                  collapsed: true,
+                  items: [
+                    'user-guide/skills/bundled/devops/devops-sandbox-runner',
+                  ],
+                },
+                {
+                  type: 'category',
                   label: 'email',
                   key: 'skills-bundled-email',
                   collapsed: true,


### PR DESCRIPTION
## Summary
Adds the **Sandbox Runner Skill** (`sandbox-runner`) under `skills/devops/sandbox-runner/`.

Inspired by DeepSeek Harness's minimal evaluation sandboxes, this skill allows Hermes Agent to run untrusted code, external benchmark suites, third-party repositories, and destructive scripts inside ephemeral throwaway sandboxes without risking the host machine.

### Features
- **Containerized & Local Isolation**: Runs commands and script files inside Docker containers (with optional air-gapped `--network none`) or temporary isolated workspace fallbacks.
- **Strict Execution Control**: Enforces timeout boundaries and resource constraints with automated container and workspace teardown upon completion.
- **Structured Output**: Captures stdout, stderr, execution duration, and exit codes in machine-readable JSON.
- **Resource Hygiene**: Includes built-in pruning command (`sandbox.py prune`) for idle containers and temporary directories.

### Tests & Documentation
- Unit tests added in `tests/skills/test_sandbox_runner_skill.py` covering command execution, output streaming, timeout enforcement, and CLI commands.
- Compliant with all repo authoring standards (`pytest tests/skills/test_authoring_standards.py`).
- Auto-generated Docusaurus doc page and updated catalog + sidebars.
