### PR TITLE
fix(providers): honor a regional config base_url under the OpenRouter pool

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -513,6 +513,26 @@ def _resolve_runtime_from_pool_entry(
                 cfg_base_url = ""
         base_url = cfg_base_url or base_url or "https://api.anthropic.com"
     elif provider == "openrouter":
+        # An explicitly configured regional endpoint (e.g.
+        # eu.openrouter.ai) must survive credential-pool resolution: the
+        # pool supplies AUTHENTICATION, not routing. Only apply the
+        # config override when the pool entry itself carries no
+        # endpoint-specific base_url (i.e. it fell back to the default
+        # openrouter.ai), and only when the configured URL stays on
+        # OpenRouter's own domain — the pooled OpenRouter credential
+        # must not follow the user to an unrelated host (#91591).
+        cfg_provider_or = str(model_cfg.get("provider") or "").strip().lower()
+        if cfg_provider_or == "openrouter":
+            cfg_base_url_or = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+            entry_url_is_default = (
+                not base_url or base_url.rstrip("/") == OPENROUTER_BASE_URL.rstrip("/")
+            )
+            if (
+                cfg_base_url_or
+                and entry_url_is_default
+                and base_url_host_matches(cfg_base_url_or, "openrouter.ai")
+            ):
+                base_url = cfg_base_url_or
         base_url = base_url or OPENROUTER_BASE_URL
     elif provider == "xai":
         api_mode = "codex_responses"

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -527,8 +527,16 @@ def _resolve_runtime_from_pool_entry(
             entry_url_is_default = (
                 not base_url or base_url.rstrip("/") == OPENROUTER_BASE_URL.rstrip("/")
             )
+            # https-only: the pooled OpenRouter credential rides this URL,
+            # so an explicit plaintext-http override is never honored.
+            # Bare hosts (no scheme) stay honored — every client treats a
+            # scheme-less base_url as https.
+            cfg_scheme_or = (
+                urlparse(cfg_base_url_or).scheme.lower() if "://" in cfg_base_url_or else ""
+            )
             if (
                 cfg_base_url_or
+                and cfg_scheme_or in {"", "https"}
                 and entry_url_is_default
                 and base_url_host_matches(cfg_base_url_or, "openrouter.ai")
             ):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -439,6 +439,122 @@ def test_resolve_runtime_provider_auto_uses_openrouter_pool(monkeypatch):
     assert resolved.get("credential_pool") is not None
 
 
+def test_resolve_runtime_provider_openrouter_pool_keeps_regional_config_base_url(monkeypatch):
+    """Regression #91591: the OpenRouter credential pool supplies
+    AUTHENTICATION, not routing. With `provider: openrouter` and an
+    explicit regional base_url (eu.openrouter.ai) in config, pool
+    resolution used to silently replace it with the default
+    openrouter.ai endpoint."""
+    _fake_pool_key = "k" + "-" * 10  # placeholder-shaped, not a usable secret
+
+    class _Entry:
+        access_token = _fake_pool_key
+        source = "manual"
+        base_url = "https://openrouter.ai/api/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://eu.openrouter.ai/api/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["base_url"] == "https://eu.openrouter.ai/api/v1"
+    # The pool still authenticates — only the endpoint routing is honored.
+    assert resolved["api_key"] == _fake_pool_key
+    assert resolved["source"] == "manual"
+
+
+def test_resolve_runtime_provider_openrouter_pool_rejects_off_domain_config_url(monkeypatch):
+    """FAIL-CLOSED: a config base_url NOT on openrouter.ai must not receive
+    the pooled OpenRouter credential — the regional override is only honored
+    while it stays on OpenRouter's own domain."""
+    class _Entry:
+        access_token = "k" + "-" * 10
+        source = "manual"
+        base_url = "https://openrouter.ai/api/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://evil.example/api/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["base_url"] == rp.OPENROUTER_BASE_URL
+
+
+def test_resolve_runtime_provider_openrouter_pool_entry_url_wins_over_config(monkeypatch):
+    """A pool entry that carries its own endpoint-specific base_url (e.g. a
+    configured mirror) outranks the config default — the override only
+    applies when the entry fell back to the plain default endpoint."""
+    class _Entry:
+        access_token = "k" + "-" * 10
+        source = "manual"
+        base_url = "https://mirror.openrouter.ai/api/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://eu.openrouter.ai/api/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["base_url"] == "https://mirror.openrouter.ai/api/v1"
+
+
 def test_resolve_runtime_provider_openrouter_explicit_api_key_skips_pool(monkeypatch):
     class _Entry:
         access_token = "pool-key"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -519,6 +519,78 @@ def test_resolve_runtime_provider_openrouter_pool_rejects_off_domain_config_url(
     assert resolved["base_url"] == rp.OPENROUTER_BASE_URL
 
 
+def test_resolve_runtime_provider_openrouter_pool_rejects_plaintext_http_override(monkeypatch):
+    """FAIL-CLOSED: an on-domain but plaintext-http override is not honored —
+    the pooled OpenRouter credential must never ride a cleartext URL
+    (review finding on this fix)."""
+    class _Entry:
+        access_token = "k" + "-" * 10
+        source = "manual"
+        base_url = "https://openrouter.ai/api/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "http://eu.openrouter.ai/api/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["base_url"] == rp.OPENROUTER_BASE_URL
+
+
+def test_resolve_runtime_provider_openrouter_pool_host_match_is_case_insensitive(monkeypatch):
+    """Pins the helper's case-insensitivity: URL hostnames are case-insensitive
+    per RFC 3986 and ``base_url_hostname`` lowercases them, so an
+    upper-cased regional host still gets its override honored."""
+    class _Entry:
+        access_token = "k" + "-" * 10
+        source = "manual"
+        base_url = "https://openrouter.ai/api/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://EU.OpenRouter.AI/api/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["base_url"] == "https://EU.OpenRouter.AI/api/v1"
+
+
 def test_resolve_runtime_provider_openrouter_pool_entry_url_wins_over_config(monkeypatch):
     """A pool entry that carries its own endpoint-specific base_url (e.g. a
     configured mirror) outranks the config default — the override only


### PR DESCRIPTION
## What does this PR do?

Stops the OpenRouter credential pool from silently replacing an explicitly configured regional endpoint. `_resolve_runtime_from_pool_entry`'s openrouter branch took the pool entry's base_url (the default `openrouter.ai/api/v1`) and never consulted config, so with

```yaml
model:
  provider: openrouter
  base_url: https://eu.openrouter.ai/api/v1
```

and the API key supplied by the OpenRouter credential pool, runtime resolution returned `base_url: https://openrouter.ai/api/v1` — OpenRouter generation logs confirmed the calls landed on the global route while direct calls to the EU endpoint took the EU route (#91591).

The fix treats the pool as supplying AUTHENTICATION, not routing: when config declares `provider: openrouter` with an explicit `base_url` AND the pool entry itself carries no endpoint-specific URL (it fell back to the plain default), the configured endpoint wins. Two guards keep this fail-closed:

- The configured URL must host-match `openrouter.ai` (mirroring the #28660 env-key host gates) — the pooled OpenRouter credential never follows a config URL to an unrelated host.
- A pool entry that carries its own endpoint-specific base_url (e.g. a configured mirror) still outranks the config default.

Explicit api_key paths (which skip the pool entirely) and default configs are unchanged.

## Related Issue

Fixes #91591

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py`: In `_resolve_runtime_from_pool_entry`'s `openrouter` branch, honor `model.base_url` from config when `model.provider == "openrouter"`, the entry URL is empty/default, and the configured URL host-matches `openrouter.ai`; with a comment explaining the authentication-not-routing contract and the credential-domain guard.
- `tests/hermes_cli/test_runtime_provider_resolution.py`: Three regression tests — regional config URL survives pool resolution (pool key still authenticates), off-domain config URL is rejected (falls back to the default endpoint; the pooled credential is not redirected), and an entry-specific mirror URL still wins over the config default.

## How to Test

1. Configure `provider: openrouter` with `base_url: https://eu.openrouter.ai/api/v1` and supply the API key through the OpenRouter credential pool
2. Before the fix, runtime resolution reports `base_url: https://openrouter.ai/api/v1` and OpenRouter logs show the global route; after the fix the runtime reports the EU endpoint and the pool key still authenticates (Observed result: `test_resolve_runtime_provider_openrouter_pool_keeps_regional_config_base_url` fails on unpatched main — base_url is the default — and passes with this patch)
3. A config base_url pointing off openrouter.ai does not receive the pooled credential (Observed result: `test_resolve_runtime_provider_openrouter_pool_rejects_off_domain_config_url` passes, default endpoint retained)
4. `scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py -q` → should pass (Observed result: 64 passed locally, including all 9 pre-existing openrouter tests)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
