### PR TITLE
feat(memory): let cloned profiles share one Honcho AI peer

### DIFF
--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -154,6 +154,22 @@ class MemoryProvider(ABC):
         """
         return ""
 
+    def clone_profile(
+        self,
+        profile_name: str,
+        *,
+        source_dir,
+        profile_dir,
+        clone_all: bool = False,
+    ) -> object | None:
+        """Apply provider-owned state when Hermes clones a profile.
+
+        Providers that keep identity or connection state outside config.yaml
+        may override this hook. The default is intentionally a no-op so older
+        and third-party providers remain compatible.
+        """
+        return None
+
     def system_prompt_block(self) -> str:
         """Return text to include in the system prompt.
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10409,13 +10409,15 @@ def cmd_profile(args):
                         f"Cloned config, .env, SOUL.md, and skills from {source_label}."
                     )
 
-            # Auto-clone Honcho config for the new profile (only with clone operations)
+            # create_profile() applies provider-specific clone integration for
+            # every surface; report the resulting Honcho peer in the CLI.
             if clone_config or clone_all:
                 try:
-                    from plugins.memory.honcho.cli import clone_honcho_for_profile
+                    from plugins.memory.honcho.cli import cloned_profile_ai_peer
 
-                    if clone_honcho_for_profile(name):
-                        print(f"Honcho config cloned (peer: {name})")
+                    ai_peer = cloned_profile_ai_peer(name)
+                    if ai_peer:
+                        print(f"Honcho config cloned (peer: {ai_peer})")
                 except Exception:
                     pass  # Honcho plugin not installed or not configured
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10415,7 +10415,15 @@ def cmd_profile(args):
                 try:
                     from plugins.memory.honcho.cli import cloned_profile_ai_peer
 
-                    ai_peer = cloned_profile_ai_peer(name)
+                    honcho_path = profile_dir / "honcho.json" if clone_all else None
+                    ai_peer = cloned_profile_ai_peer(
+                        name,
+                        config_path=(
+                            honcho_path
+                            if honcho_path and honcho_path.exists()
+                            else None
+                        ),
+                    )
                     if ai_peer:
                         print(f"Honcho config cloned (peer: {ai_peer})")
                 except Exception:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1262,6 +1262,17 @@ def create_profile(
     # unit-generation paths handle gateway lifecycle.
     _maybe_register_gateway_service(canon)
 
+    # Profile creation is shared by the CLI, REST/Desktop, and Bot Mode RPC.
+    # Keep the existing Honcho clone integration here so every clone surface
+    # applies the same memory identity policy.
+    if source_dir is not None:
+        try:
+            from plugins.memory.honcho.cli import clone_honcho_for_profile
+
+            clone_honcho_for_profile(canon)
+        except Exception:
+            pass  # Honcho plugin not installed or not configured
+
     return profile_dir
 
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1263,23 +1263,20 @@ def create_profile(
     _maybe_register_gateway_service(canon)
 
     # Profile creation is shared by the CLI, REST/Desktop, and Bot Mode RPC.
-    # Keep the existing Honcho clone integration here so every clone surface
-    # applies the same memory identity policy.
+    # Let the selected memory provider apply its own clone-time identity state
+    # without coupling this core profile module to a specific plugin.
     if source_dir is not None:
         try:
-            from plugins.memory.honcho.cli import clone_honcho_for_profile
+            from plugins.memory import clone_memory_provider_profile
 
-            # Full clones carry a profile-local Honcho config that wins over
-            # the shared default config at runtime. Update that copied file;
-            # config-only clones continue accumulating shared host blocks in
-            # the launch profile's config as before.
-            honcho_path = profile_dir / "honcho.json" if clone_all else None
-            clone_honcho_for_profile(
+            clone_memory_provider_profile(
                 canon,
-                config_path=honcho_path if honcho_path and honcho_path.exists() else None,
+                source_dir=source_dir,
+                profile_dir=profile_dir,
+                clone_all=clone_all,
             )
         except Exception:
-            pass  # Honcho plugin not installed or not configured
+            pass  # provider clone integration is best-effort
 
     return profile_dir
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1269,7 +1269,15 @@ def create_profile(
         try:
             from plugins.memory.honcho.cli import clone_honcho_for_profile
 
-            clone_honcho_for_profile(canon)
+            # Full clones carry a profile-local Honcho config that wins over
+            # the shared default config at runtime. Update that copied file;
+            # config-only clones continue accumulating shared host blocks in
+            # the launch profile's config as before.
+            honcho_path = profile_dir / "honcho.json" if clone_all else None
+            clone_honcho_for_profile(
+                canon,
+                config_path=honcho_path if honcho_path and honcho_path.exists() else None,
+            )
         except Exception:
             pass  # Honcho plugin not installed or not configured
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1276,7 +1276,11 @@ def create_profile(
                 clone_all=clone_all,
             )
         except Exception:
-            pass  # provider clone integration is best-effort
+            logger.debug(
+                "Memory provider profile-clone integration failed for '%s'",
+                canon,
+                exc_info=True,
+            )
 
     return profile_dir
 

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -39,7 +39,8 @@ import logging
 import sys
 from pathlib import Path
 from typing import List, Optional, Tuple, TYPE_CHECKING
-from hermes_cli.config import cfg_get
+from hermes_cli.config import cfg_get, load_config_readonly
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
 if TYPE_CHECKING:
     from agent.memory_provider import MemoryProvider
@@ -383,15 +384,16 @@ def clone_memory_provider_profile(
     provider_names: list[str] = []
     config_path = source_dir / "config.yaml"
     if config_path.exists():
+        token = set_hermes_home_override(source_dir)
         try:
-            import yaml
-
-            config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            config = load_config_readonly()
             configured = cfg_get(config, "memory", "provider") or None
             if configured:
                 provider_names.append(configured)
         except Exception:
             pass
+        finally:
+            reset_hermes_home_override(token)
 
     for candidate, provider_dir in _iter_provider_dirs():
         manifest_path = provider_dir / "plugin.yaml"

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -366,6 +366,62 @@ def load_memory_provider(
         return None
 
 
+def clone_memory_provider_profile(
+    profile_name: str,
+    *,
+    source_dir: Path,
+    profile_dir: Path,
+    clone_all: bool = False,
+) -> object | None:
+    """Run the cloned profile's configured memory-provider hook.
+
+    The provider normally comes from the source config.yaml. Legacy provider
+    installs that predate ``memory.provider`` may declare a
+    ``profile_clone_config`` marker in plugin.yaml; this keeps profile creation
+    generic while preserving their existing clone behavior.
+    """
+    provider_name = None
+    config_path = source_dir / "config.yaml"
+    if config_path.exists():
+        try:
+            import yaml
+
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            provider_name = cfg_get(config, "memory", "provider") or None
+        except Exception:
+            pass
+
+    if not provider_name:
+        for candidate, provider_dir in _iter_provider_dirs():
+            manifest_path = provider_dir / "plugin.yaml"
+            if not manifest_path.exists():
+                continue
+            try:
+                import yaml
+
+                manifest = yaml.safe_load(
+                    manifest_path.read_text(encoding="utf-8-sig")
+                ) or {}
+                marker = manifest.get("profile_clone_config")
+            except Exception:
+                continue
+            if isinstance(marker, str) and marker and (source_dir / marker).exists():
+                provider_name = candidate
+                break
+
+    if not provider_name:
+        return None
+    provider = load_memory_provider(provider_name, register_skills=False)
+    if provider is None:
+        return None
+    return provider.clone_profile(
+        profile_name,
+        source_dir=source_dir,
+        profile_dir=profile_dir,
+        clone_all=clone_all,
+    )
+
+
 def _load_provider_from_entry_point(
     entry_point,
     *,

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -375,51 +375,53 @@ def clone_memory_provider_profile(
 ) -> object | None:
     """Run the cloned profile's configured memory-provider hook.
 
-    The provider normally comes from the source config.yaml. Legacy provider
-    installs that predate ``memory.provider`` may declare a
-    ``profile_clone_config`` marker in plugin.yaml; this keeps profile creation
-    generic while preserving their existing clone behavior.
+    The active provider comes from the source config.yaml. Providers with
+    legacy out-of-band state may also declare ``profile_clone: true`` in
+    plugin.yaml so their hook can probe that state without coupling profile
+    creation to a provider-specific filename or resolver.
     """
-    provider_name = None
+    provider_names: list[str] = []
     config_path = source_dir / "config.yaml"
     if config_path.exists():
         try:
             import yaml
 
             config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-            provider_name = cfg_get(config, "memory", "provider") or None
+            configured = cfg_get(config, "memory", "provider") or None
+            if configured:
+                provider_names.append(configured)
         except Exception:
             pass
 
-    if not provider_name:
-        for candidate, provider_dir in _iter_provider_dirs():
-            manifest_path = provider_dir / "plugin.yaml"
-            if not manifest_path.exists():
-                continue
-            try:
-                import yaml
+    for candidate, provider_dir in _iter_provider_dirs():
+        manifest_path = provider_dir / "plugin.yaml"
+        if not manifest_path.exists():
+            continue
+        try:
+            import yaml
 
-                manifest = yaml.safe_load(
-                    manifest_path.read_text(encoding="utf-8-sig")
-                ) or {}
-                marker = manifest.get("profile_clone_config")
-            except Exception:
-                continue
-            if isinstance(marker, str) and marker and (source_dir / marker).exists():
-                provider_name = candidate
-                break
+            manifest = yaml.safe_load(
+                manifest_path.read_text(encoding="utf-8-sig")
+            ) or {}
+        except Exception:
+            continue
+        if manifest.get("profile_clone") is True and candidate not in provider_names:
+            provider_names.append(candidate)
 
-    if not provider_name:
-        return None
-    provider = load_memory_provider(provider_name, register_skills=False)
-    if provider is None:
-        return None
-    return provider.clone_profile(
-        profile_name,
-        source_dir=source_dir,
-        profile_dir=profile_dir,
-        clone_all=clone_all,
-    )
+    results = []
+    for provider_name in provider_names:
+        provider = load_memory_provider(provider_name, register_skills=False)
+        if provider is None:
+            continue
+        result = provider.clone_profile(
+            profile_name,
+            source_dir=source_dir,
+            profile_dir=profile_dir,
+            clone_all=clone_all,
+        )
+        if result is not None:
+            results.append(result)
+    return results or None
 
 
 def _load_provider_from_entry_point(

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -526,16 +526,16 @@ def _load_provider_from_dir(
     if cached_file and Path(cached_file).resolve() == init_file.resolve():
         mod = cached
     else:
-        if cached_file:
-            # User-installed providers are profile-scoped, so two profiles may
-            # install different implementations under the same provider name.
-            # Remove the prior package and its relative-import submodules before
-            # loading the implementation resolved for this profile.
-            for loaded_name in list(sys.modules):
-                if loaded_name == module_name or loaded_name.startswith(
-                    f"{module_name}."
-                ):
-                    sys.modules.pop(loaded_name, None)
+        # A synthetic package shell has no __file__, but CLI discovery may
+        # already have loaded descendants such as ``<provider>.cli`` from a
+        # different profile. Whenever the exact full package is not reusable,
+        # clear the package and every descendant before loading this profile's
+        # implementation.
+        for loaded_name in list(sys.modules):
+            if loaded_name == module_name or loaded_name.startswith(
+                f"{module_name}."
+            ):
+                sys.modules.pop(loaded_name, None)
 
         # Handle relative imports within the plugin
         # First ensure the parent packages are registered

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -522,9 +522,21 @@ def _load_provider_from_dir(
     # discover_plugin_cli_commands() for relative-import support has no
     # __file__; only reuse modules that were actually loaded from disk.
     cached = sys.modules.get(module_name)
-    if cached is not None and getattr(cached, "__file__", None):
+    cached_file = getattr(cached, "__file__", None) if cached is not None else None
+    if cached_file and Path(cached_file).resolve() == init_file.resolve():
         mod = cached
     else:
+        if cached_file:
+            # User-installed providers are profile-scoped, so two profiles may
+            # install different implementations under the same provider name.
+            # Remove the prior package and its relative-import submodules before
+            # loading the implementation resolved for this profile.
+            for loaded_name in list(sys.modules):
+                if loaded_name == module_name or loaded_name.startswith(
+                    f"{module_name}."
+                ):
+                    sys.modules.pop(loaded_name, None)
+
         # Handle relative imports within the plugin
         # First ensure the parent packages are registered
         for parent in ("plugins", "plugins.memory"):

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -31,6 +31,7 @@ Usage:
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import importlib.machinery
 import importlib.metadata
@@ -512,7 +513,17 @@ def _load_provider_from_dir(
     # Use a separate namespace for user-installed plugins so they don't
     # collide with bundled providers in sys.modules.
     _is_bundled = _MEMORY_PLUGINS_DIR in provider_dir.parents or provider_dir.parent == _MEMORY_PLUGINS_DIR
-    module_name = f"plugins.memory.{name}" if _is_bundled else f"{_USER_NAMESPACE}.{name}"
+    if _is_bundled:
+        module_name = f"plugins.memory.{name}"
+    else:
+        # The same provider name may be installed by multiple profiles in one
+        # long-lived process. Give each resolved directory its own package so
+        # retained provider instances and lazy relative imports cannot cross
+        # profile boundaries through sys.modules.
+        path_key = hashlib.sha256(
+            str(provider_dir.resolve()).encode("utf-8")
+        ).hexdigest()[:16]
+        module_name = f"{_USER_NAMESPACE}.{name}_{path_key}"
     init_file = provider_dir / "__init__.py"
 
     if not init_file.exists():
@@ -526,11 +537,8 @@ def _load_provider_from_dir(
     if cached_file and Path(cached_file).resolve() == init_file.resolve():
         mod = cached
     else:
-        # A synthetic package shell has no __file__, but CLI discovery may
-        # already have loaded descendants such as ``<provider>.cli`` from a
-        # different profile. Whenever the exact full package is not reusable,
-        # clear the package and every descendant before loading this profile's
-        # implementation.
+        # Clear an incomplete or mismatched package in this directory-specific
+        # namespace before retrying the load, including relative submodules.
         for loaded_name in list(sys.modules):
             if loaded_name == module_name or loaded_name.startswith(
                 f"{module_name}."

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -381,49 +381,70 @@ def clone_memory_provider_profile(
     plugin.yaml so their hook can probe that state without coupling profile
     creation to a provider-specific filename or resolver.
     """
-    provider_names: list[str] = []
-    config_path = source_dir / "config.yaml"
-    if config_path.exists():
-        token = set_hermes_home_override(source_dir)
-        try:
-            config = load_config_readonly()
-            configured = cfg_get(config, "memory", "provider") or None
-            if configured:
-                provider_names.append(configured)
-        except Exception:
-            pass
-        finally:
-            reset_hermes_home_override(token)
+    token = set_hermes_home_override(source_dir)
+    try:
+        provider_names: list[str] = []
+        config_path = source_dir / "config.yaml"
+        if config_path.exists():
+            try:
+                config = load_config_readonly()
+                configured = cfg_get(config, "memory", "provider") or None
+                if configured:
+                    provider_names.append(configured)
+            except Exception:
+                logger.debug(
+                    "Failed to read memory provider from clone source %s",
+                    source_dir,
+                    exc_info=True,
+                )
 
-    for candidate, provider_dir in _iter_provider_dirs():
-        manifest_path = provider_dir / "plugin.yaml"
-        if not manifest_path.exists():
-            continue
-        try:
-            import yaml
+        for candidate, provider_dir in _iter_provider_dirs():
+            manifest_path = provider_dir / "plugin.yaml"
+            if not manifest_path.exists():
+                continue
+            try:
+                import yaml
 
-            manifest = yaml.safe_load(
-                manifest_path.read_text(encoding="utf-8-sig")
-            ) or {}
-        except Exception:
-            continue
-        if manifest.get("profile_clone") is True and candidate not in provider_names:
-            provider_names.append(candidate)
+                manifest = yaml.safe_load(
+                    manifest_path.read_text(encoding="utf-8-sig")
+                ) or {}
+                if not isinstance(manifest, dict):
+                    raise TypeError("plugin manifest must be a mapping")
+            except Exception:
+                logger.debug(
+                    "Failed to inspect profile-clone manifest for memory provider '%s'",
+                    candidate,
+                    exc_info=True,
+                )
+                continue
+            if manifest.get("profile_clone") is True and candidate not in provider_names:
+                provider_names.append(candidate)
 
-    results = []
-    for provider_name in provider_names:
-        provider = load_memory_provider(provider_name, register_skills=False)
-        if provider is None:
-            continue
-        result = provider.clone_profile(
-            profile_name,
-            source_dir=source_dir,
-            profile_dir=profile_dir,
-            clone_all=clone_all,
-        )
-        if result is not None:
-            results.append(result)
-    return results or None
+        results = []
+        for provider_name in provider_names:
+            provider = load_memory_provider(provider_name, register_skills=False)
+            if provider is None:
+                continue
+            try:
+                result = provider.clone_profile(
+                    profile_name,
+                    source_dir=source_dir,
+                    profile_dir=profile_dir,
+                    clone_all=clone_all,
+                )
+            except Exception:
+                logger.debug(
+                    "Memory provider '%s' failed to clone profile '%s'",
+                    provider_name,
+                    profile_name,
+                    exc_info=True,
+                )
+                continue
+            if result is not None:
+                results.append(result)
+        return results or None
+    finally:
+        reset_hermes_home_override(token)
 
 
 def _load_provider_from_entry_point(

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -163,6 +163,7 @@ For every key, resolution order is: **host block > root > env var > default**.
 | `workspace` | string | host key | Honcho workspace ID. Shared environment — all profiles in the same workspace can see the same user identity and related memories |
 | `peerName` | string | — | User peer identity |
 | `aiPeer` | string | host key | AI peer identity |
+| `shareAiPeerAcrossProfiles` | bool | `false` | Root-only opt-in. When cloning a Hermes profile, inherit the default host's `aiPeer` instead of creating a profile-specific AI peer |
 
 ### Identity Mapping (Gateway Multi-User)
 

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -163,7 +163,7 @@ For every key, resolution order is: **host block > root > env var > default**.
 | `workspace` | string | host key | Honcho workspace ID. Shared environment — all profiles in the same workspace can see the same user identity and related memories |
 | `peerName` | string | — | User peer identity |
 | `aiPeer` | string | host key | AI peer identity |
-| `shareAiPeerAcrossProfiles` | bool | `false` | Root-only opt-in. When cloning a Hermes profile, inherit the default host's `aiPeer` instead of creating a profile-specific AI peer |
+| `shareAiPeerAcrossProfiles` | bool | `false` | Root-only opt-in. When cloning a Hermes profile, inherit the default host's effective `aiPeer` instead of creating a profile-specific AI peer. If neither the host nor root config sets `aiPeer`, Honcho's canonical host fallback (`hermes` for the default profile) is shared. |
 
 ### Identity Mapping (Gateway Multi-User)
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -275,6 +275,32 @@ class HonchoMemoryProvider(MemoryProvider):
             pass
         return paths
 
+    def clone_profile(
+        self,
+        profile_name: str,
+        *,
+        source_dir,
+        profile_dir,
+        clone_all: bool = False,
+    ) -> object | None:
+        """Clone Honcho identity state for a new Hermes profile."""
+        from plugins.memory.honcho.cli import (
+            clone_honcho_for_profile,
+            cloned_profile_ai_peer,
+        )
+
+        config_path = profile_dir / "honcho.json" if clone_all else None
+        if config_path is not None and not config_path.exists():
+            config_path = None
+        if not clone_honcho_for_profile(profile_name, config_path=config_path):
+            return None
+        return {
+            "ai_peer": cloned_profile_ai_peer(
+                profile_name,
+                config_path=config_path,
+            ),
+        }
+
     def __init__(self, query_rewriter: Optional[Callable[[str], str]] = None):
         self._manager = None   # HonchoSessionManager
         self._config = None    # HonchoClientConfig

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shutil
 import threading
 import time
 from typing import Any, Callable, Dict, List, Optional
@@ -288,11 +289,37 @@ class HonchoMemoryProvider(MemoryProvider):
             clone_honcho_for_profile,
             cloned_profile_ai_peer,
         )
+        from plugins.memory.honcho.client import (
+            resolve_active_host,
+            resolve_config_path,
+        )
+        from hermes_cli.profiles import get_active_profile_name
 
-        config_path = profile_dir / "honcho.json" if clone_all else None
-        if config_path is not None and not config_path.exists():
-            config_path = None
-        if not clone_honcho_for_profile(profile_name, config_path=config_path):
+        source_config_path = resolve_config_path()
+        source_host = resolve_active_host()
+        source_is_named = get_active_profile_name() != "default"
+        target_config_path = profile_dir / "honcho.json"
+
+        if clone_all and target_config_path.exists():
+            config_path = target_config_path
+        elif source_is_named and source_config_path == source_dir / "honcho.json":
+            # A named profile's local Honcho config is invisible to its clone.
+            # Copy it before adding the target host so provider-owned identity
+            # state follows config-only clones without mutating the source.
+            shutil.copy2(source_config_path, target_config_path)
+            config_path = target_config_path
+        else:
+            # Named profiles may resolve a shared default/global store; update
+            # that exact fallback so the target can see its new host block.
+            # The default profile keeps the legacy no-path flow, which reads a
+            # global config but migrates writes into ~/.hermes/honcho.json.
+            config_path = source_config_path if source_is_named else None
+
+        if not clone_honcho_for_profile(
+            profile_name,
+            config_path=config_path,
+            source_host=source_host,
+        ):
             return None
         return {
             "ai_peer": cloned_profile_ai_peer(

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -28,7 +28,7 @@ def clone_honcho_for_profile(
 
     Returns True if a host block was created, False if Honcho isn't configured.
     """
-    cfg = _read_config(config_path)
+    cfg = _read_config() if config_path is None else _read_config(config_path)
     if not cfg:
         return False
 
@@ -77,7 +77,10 @@ def clone_honcho_for_profile(
     new_block["enabled"] = default_block.get("enabled", True)
 
     cfg.setdefault("hosts", {})[new_host] = new_block
-    _write_config(cfg, path=config_path)
+    if config_path is None:
+        _write_config(cfg)
+    else:
+        _write_config(cfg, path=config_path)
 
     # Eagerly create the peer in Honcho so it exists before first message.
     # Preserve the historical one-argument call for ambient configs (and
@@ -95,7 +98,7 @@ def cloned_profile_ai_peer(
     config_path: Path | None = None,
 ) -> str | None:
     """Return the AI peer stored for a cloned profile, if one exists."""
-    cfg = _read_config(config_path)
+    cfg = _read_config() if config_path is None else _read_config(config_path)
     block = cfg.get("hosts", {}).get(profile_host_key(profile_name), {})
     ai_peer = block.get("aiPeer") if isinstance(block, dict) else None
     return ai_peer if isinstance(ai_peer, str) and ai_peer else None
@@ -113,10 +116,13 @@ def _ensure_peer_exists(
     """
     try:
         from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client
-        hcfg = HonchoClientConfig.from_global_config(
-            host=host_key,
-            config_path=config_path,
-        )
+        if config_path is None:
+            hcfg = HonchoClientConfig.from_global_config(host=host_key)
+        else:
+            hcfg = HonchoClientConfig.from_global_config(
+                host=host_key,
+                config_path=config_path,
+            )
         if not hcfg.enabled or not (hcfg.api_key or hcfg.base_url):
             return False
         client = get_honcho_client(hcfg)

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -61,11 +61,14 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
     if peer_name:
         new_block["peerName"] = peer_name
 
-    # AI peer is profile-specific; workspace is shared so all profiles
-    # see the same user context, sessions, and project history.
-    # Use the bare profile name as the peer identity (not the host key)
-    # because Honcho's peer ID pattern is ^[a-zA-Z0-9_-]+$ (no dots).
-    new_block["aiPeer"] = profile_name
+    # AI peers stay profile-specific unless the operator explicitly opted
+    # into one shared AI identity for cloned single-operator profiles.
+    if cfg.get("shareAiPeerAcrossProfiles") is True:
+        new_block["aiPeer"] = default_block.get("aiPeer") or cfg.get("aiPeer") or HOST
+    else:
+        # Use the bare profile name as the peer identity (not the host key)
+        # because Honcho's peer ID pattern is ^[a-zA-Z0-9_-]+$ (no dots).
+        new_block["aiPeer"] = profile_name
     new_block["workspace"] = default_block.get("workspace") or cfg.get("workspace") or HOST
     new_block["enabled"] = default_block.get("enabled", True)
 
@@ -75,6 +78,14 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
     # Eagerly create the peer in Honcho so it exists before first message
     _ensure_peer_exists(new_host)
     return True
+
+
+def cloned_profile_ai_peer(profile_name: str) -> str | None:
+    """Return the AI peer stored for a cloned profile, if one exists."""
+    cfg = _read_config()
+    block = cfg.get("hosts", {}).get(profile_host_key(profile_name), {})
+    ai_peer = block.get("aiPeer") if isinstance(block, dict) else None
+    return ai_peer if isinstance(ai_peer, str) and ai_peer else None
 
 
 def _ensure_peer_exists(host_key: str | None = None) -> bool:

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -15,7 +15,11 @@ from plugins.memory.honcho.client import _host_block, profile_host_key, resolve_
 from hermes_cli.config import cfg_get
 
 
-def clone_honcho_for_profile(profile_name: str) -> bool:
+def clone_honcho_for_profile(
+    profile_name: str,
+    *,
+    config_path: Path | None = None,
+) -> bool:
     """Auto-clone Honcho config for a new profile from the default host block.
 
     Called during profile creation. If Honcho is configured on the default
@@ -24,7 +28,7 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
 
     Returns True if a host block was created, False if Honcho isn't configured.
     """
-    cfg = _read_config()
+    cfg = _read_config(config_path)
     if not cfg:
         return False
 
@@ -73,22 +77,35 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
     new_block["enabled"] = default_block.get("enabled", True)
 
     cfg.setdefault("hosts", {})[new_host] = new_block
-    _write_config(cfg)
+    _write_config(cfg, path=config_path)
 
-    # Eagerly create the peer in Honcho so it exists before first message
-    _ensure_peer_exists(new_host)
+    # Eagerly create the peer in Honcho so it exists before first message.
+    # Preserve the historical one-argument call for ambient configs (and
+    # third-party monkeypatches); only bind a path for copied local configs.
+    if config_path is None:
+        _ensure_peer_exists(new_host)
+    else:
+        _ensure_peer_exists(new_host, config_path=config_path)
     return True
 
 
-def cloned_profile_ai_peer(profile_name: str) -> str | None:
+def cloned_profile_ai_peer(
+    profile_name: str,
+    *,
+    config_path: Path | None = None,
+) -> str | None:
     """Return the AI peer stored for a cloned profile, if one exists."""
-    cfg = _read_config()
+    cfg = _read_config(config_path)
     block = cfg.get("hosts", {}).get(profile_host_key(profile_name), {})
     ai_peer = block.get("aiPeer") if isinstance(block, dict) else None
     return ai_peer if isinstance(ai_peer, str) and ai_peer else None
 
 
-def _ensure_peer_exists(host_key: str | None = None) -> bool:
+def _ensure_peer_exists(
+    host_key: str | None = None,
+    *,
+    config_path: Path | None = None,
+) -> bool:
     """Create the AI peer in Honcho if it doesn't already exist.
 
     Idempotent -- safe to call multiple times. Returns True if the peer
@@ -96,7 +113,10 @@ def _ensure_peer_exists(host_key: str | None = None) -> bool:
     """
     try:
         from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client
-        hcfg = HonchoClientConfig.from_global_config(host=host_key)
+        hcfg = HonchoClientConfig.from_global_config(
+            host=host_key,
+            config_path=config_path,
+        )
         if not hcfg.enabled or not (hcfg.api_key or hcfg.base_url):
             return False
         client = get_honcho_client(hcfg)
@@ -271,8 +291,8 @@ def _local_config_path() -> Path:
     return get_hermes_home() / "honcho.json"
 
 
-def _read_config() -> dict:
-    path = _config_path()
+def _read_config(path: Path | None = None) -> dict:
+    path = path or _config_path()
     if path.exists():
         try:
             return json.loads(path.read_text(encoding="utf-8"))

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -19,10 +19,11 @@ def clone_honcho_for_profile(
     profile_name: str,
     *,
     config_path: Path | None = None,
+    source_host: str = HOST,
 ) -> bool:
-    """Auto-clone Honcho config for a new profile from the default host block.
+    """Clone Honcho config for a new profile from the selected source host.
 
-    Called during profile creation. If Honcho is configured on the default
+    Called during profile creation. If Honcho is configured for the source
     host, creates a new host block for the profile with inherited settings
     and auto-derived workspace/aiPeer.
 
@@ -33,9 +34,9 @@ def clone_honcho_for_profile(
         return False
 
     hosts = cfg.get("hosts", {})
-    default_block = hosts.get(HOST, {})
+    default_block = hosts.get(source_host, {})
 
-    # No default host block and no root-level API key = Honcho not configured
+    # No source host block and no root-level API key = Honcho not configured
     has_key = bool(cfg.get("apiKey") or os.environ.get("HONCHO_API_KEY"))
     if not default_block and not has_key:
         return False
@@ -68,12 +69,16 @@ def clone_honcho_for_profile(
     # AI peers stay profile-specific unless the operator explicitly opted
     # into one shared AI identity for cloned single-operator profiles.
     if cfg.get("shareAiPeerAcrossProfiles") is True:
-        new_block["aiPeer"] = default_block.get("aiPeer") or cfg.get("aiPeer") or HOST
+        new_block["aiPeer"] = (
+            default_block.get("aiPeer") or cfg.get("aiPeer") or source_host
+        )
     else:
         # Use the bare profile name as the peer identity (not the host key)
         # because Honcho's peer ID pattern is ^[a-zA-Z0-9_-]+$ (no dots).
         new_block["aiPeer"] = profile_name
-    new_block["workspace"] = default_block.get("workspace") or cfg.get("workspace") or HOST
+    new_block["workspace"] = (
+        default_block.get("workspace") or cfg.get("workspace") or source_host
+    )
     new_block["enabled"] = default_block.get("enabled", True)
 
     cfg.setdefault("hosts", {})[new_host] = new_block

--- a/plugins/memory/honcho/plugin.yaml
+++ b/plugins/memory/honcho/plugin.yaml
@@ -5,3 +5,4 @@ pip_dependencies:
   - honcho-ai
 hooks:
   - on_session_end
+profile_clone_config: honcho.json

--- a/plugins/memory/honcho/plugin.yaml
+++ b/plugins/memory/honcho/plugin.yaml
@@ -5,4 +5,4 @@ pip_dependencies:
   - honcho-ai
 hooks:
   - on_session_end
-profile_clone_config: honcho.json
+profile_clone: true

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -203,6 +203,26 @@ class TestCreateProfile:
         honcho = json.loads((profile_dir / "honcho.json").read_text())
         assert honcho["hosts"]["hermes_coder"]["aiPeer"] == "shared-assistant"
 
+    def test_clone_preserves_legacy_global_honcho_integration(self, profile_env, monkeypatch):
+        default_home = profile_env / ".hermes"
+        (default_home / "config.yaml").write_text("model: test")
+        global_honcho = profile_env / ".honcho" / "config.json"
+        global_honcho.parent.mkdir()
+        global_honcho.write_text(json.dumps({
+            "apiKey": "***",
+            "shareAiPeerAcrossProfiles": True,
+            "hosts": {"hermes": {"aiPeer": "shared-assistant"}},
+        }))
+        monkeypatch.setattr(
+            "plugins.memory.honcho.cli._ensure_peer_exists",
+            lambda host_key=None: True,
+        )
+
+        create_profile("coder", clone_config=True, no_alias=True)
+
+        honcho = json.loads((default_home / "honcho.json").read_text())
+        assert honcho["hosts"]["hermes_coder"]["aiPeer"] == "shared-assistant"
+
 
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -175,6 +175,34 @@ class TestCreateProfile:
         honcho = json.loads((default_home / "honcho.json").read_text())
         assert honcho["hosts"]["hermes_coder"]["aiPeer"] == "shared-assistant"
 
+    def test_clone_all_updates_copied_honcho_config(self, profile_env, monkeypatch):
+        default_home = profile_env / ".hermes"
+        (default_home / "honcho.json").write_text(json.dumps({
+            "apiKey": "***",
+            "shareAiPeerAcrossProfiles": True,
+            "hosts": {
+                "hermes": {
+                    "aiPeer": "shared-assistant",
+                    "peerName": "eri",
+                    "workspace": "shared",
+                },
+            },
+        }))
+        monkeypatch.setattr(
+            "plugins.memory.honcho.cli._ensure_peer_exists",
+            lambda host_key=None, **kwargs: True,
+        )
+
+        profile_dir = create_profile(
+            "coder",
+            clone_from="default",
+            clone_all=True,
+            no_alias=True,
+        )
+
+        honcho = json.loads((profile_dir / "honcho.json").read_text())
+        assert honcho["hosts"]["hermes_coder"]["aiPeer"] == "shared-assistant"
+
 
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -151,6 +151,30 @@ class TestCreateProfile:
         assert (profile_dir / ".env").read_text().strip() == "KEY=val"
         assert (profile_dir / "SOUL.md").read_text() == "Be helpful."
 
+    def test_clone_config_runs_memory_provider_profile_clone(self, profile_env, monkeypatch):
+        default_home = profile_env / ".hermes"
+        (default_home / "config.yaml").write_text("model: test")
+        (default_home / "honcho.json").write_text(json.dumps({
+            "apiKey": "***",
+            "shareAiPeerAcrossProfiles": True,
+            "hosts": {
+                "hermes": {
+                    "aiPeer": "shared-assistant",
+                    "peerName": "eri",
+                    "workspace": "shared",
+                },
+            },
+        }))
+        monkeypatch.setattr(
+            "plugins.memory.honcho.cli._ensure_peer_exists",
+            lambda host_key=None: True,
+        )
+
+        create_profile("coder", clone_config=True, no_alias=True)
+
+        honcho = json.loads((default_home / "honcho.json").read_text())
+        assert honcho["hosts"]["hermes_coder"]["aiPeer"] == "shared-assistant"
+
 
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -18,6 +18,8 @@ from unittest.mock import patch, MagicMock
 import pytest
 import yaml
 
+import plugins.memory.honcho.cli as honcho_cli
+
 from hermes_cli import profiles
 from hermes_cli.profiles import (
     normalize_profile_name,
@@ -166,7 +168,7 @@ class TestCreateProfile:
             },
         }))
         monkeypatch.setattr(
-            "plugins.memory.honcho.cli._ensure_peer_exists",
+            honcho_cli, "_ensure_peer_exists",
             lambda host_key=None: True,
         )
 
@@ -189,7 +191,7 @@ class TestCreateProfile:
             },
         }))
         monkeypatch.setattr(
-            "plugins.memory.honcho.cli._ensure_peer_exists",
+            honcho_cli, "_ensure_peer_exists",
             lambda host_key=None, **kwargs: True,
         )
 
@@ -214,7 +216,7 @@ class TestCreateProfile:
             "hosts": {"hermes": {"aiPeer": "shared-assistant"}},
         }))
         monkeypatch.setattr(
-            "plugins.memory.honcho.cli._ensure_peer_exists",
+            honcho_cli, "_ensure_peer_exists",
             lambda host_key=None: True,
         )
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -248,6 +248,46 @@ class TestCreateProfile:
         assert "Memory provider profile-clone integration failed for 'coder'" in caplog.text
         assert "RuntimeError: provider clone failed" in caplog.text
 
+    def test_clone_from_named_profile_copies_local_honcho_identity(
+        self, profile_env, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_HONCHO_HOST", raising=False)
+        source_dir = create_profile("source", no_alias=True)
+        (source_dir / "config.yaml").write_text(
+            "memory:\n  provider: honcho\n",
+            encoding="utf-8",
+        )
+        source_honcho = {
+            "apiKey": "***",
+            "shareAiPeerAcrossProfiles": True,
+            "hosts": {
+                "hermes_source": {
+                    "aiPeer": "source-assistant",
+                    "workspace": "source-workspace",
+                },
+            },
+        }
+        source_honcho_path = source_dir / "honcho.json"
+        source_honcho_path.write_text(json.dumps(source_honcho), encoding="utf-8")
+        monkeypatch.setattr(
+            honcho_cli,
+            "_ensure_peer_exists",
+            lambda host_key=None, **kwargs: True,
+        )
+
+        target_dir = create_profile(
+            "target",
+            clone_from="source",
+            clone_config=True,
+            no_alias=True,
+        )
+
+        target_honcho = json.loads((target_dir / "honcho.json").read_text())
+        target_block = target_honcho["hosts"]["hermes_target"]
+        assert target_block["aiPeer"] == "source-assistant"
+        assert target_block["workspace"] == "source-workspace"
+        assert json.loads(source_honcho_path.read_text()) == source_honcho
+
 
 # ===================================================================
 # TestNoSkillsOptOut

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -18,6 +18,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 import yaml
 
+import plugins.memory as memory_plugins
 import plugins.memory.honcho.cli as honcho_cli
 
 from hermes_cli import profiles
@@ -225,8 +226,27 @@ class TestCreateProfile:
         honcho = json.loads((default_home / "honcho.json").read_text())
         assert honcho["hosts"]["hermes_coder"]["aiPeer"] == "shared-assistant"
 
+    def test_clone_logs_memory_provider_hook_failure(
+        self, profile_env, monkeypatch, caplog
+    ):
+        default_home = profile_env / ".hermes"
+        (default_home / "config.yaml").write_text("model: test")
 
+        def fail_clone(*args, **kwargs):
+            raise RuntimeError("provider clone failed")
 
+        monkeypatch.setattr(
+            memory_plugins,
+            "clone_memory_provider_profile",
+            fail_clone,
+        )
+
+        with caplog.at_level("DEBUG", logger="hermes_cli.profiles"):
+            profile_dir = create_profile("coder", clone_config=True, no_alias=True)
+
+        assert profile_dir.is_dir()
+        assert "Memory provider profile-clone integration failed for 'coder'" in caplog.text
+        assert "RuntimeError: provider clone failed" in caplog.text
 
 
 # ===================================================================

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -3,6 +3,8 @@
 from types import SimpleNamespace
 import json
 
+import pytest
+
 
 class TestResolveApiKey:
     """Test _resolve_api_key with various config shapes."""
@@ -303,6 +305,39 @@ class TestCloneHonchoForProfile:
         assert "runtimePeerPrefix" not in new_block
         assert "pinUserPeer" not in new_block
         assert "pinPeerName" not in new_block
+
+    def test_opt_in_shares_default_ai_peer_with_cloned_profile(self, monkeypatch, tmp_path):
+        cfg = {
+            "apiKey": "***",
+            "shareAiPeerAcrossProfiles": True,
+            "hosts": {
+                "hermes": {
+                    "aiPeer": "shared-assistant",
+                    "peerName": "eri",
+                },
+            },
+        }
+        honcho_cli, written = self._setup_clone_env(monkeypatch, tmp_path, cfg)
+
+        ok = honcho_cli.clone_honcho_for_profile("coder")
+
+        assert ok is True
+        assert written["cfg"]["hosts"]["hermes_coder"]["aiPeer"] == "shared-assistant"
+
+    @pytest.mark.parametrize("configured", [None, False])
+    def test_shared_ai_peer_is_opt_in(self, monkeypatch, tmp_path, configured):
+        cfg = {
+            "apiKey": "***",
+            "hosts": {"hermes": {"aiPeer": "shared-assistant"}},
+        }
+        if configured is not None:
+            cfg["shareAiPeerAcrossProfiles"] = configured
+        honcho_cli, written = self._setup_clone_env(monkeypatch, tmp_path, cfg)
+
+        ok = honcho_cli.clone_honcho_for_profile("coder")
+
+        assert ok is True
+        assert written["cfg"]["hosts"]["hermes_coder"]["aiPeer"] == "coder"
 
 
 class TestSetupWizardDeploymentShape:

--- a/tests/plugins/memory/test_discovery_sources.py
+++ b/tests/plugins/memory/test_discovery_sources.py
@@ -219,3 +219,51 @@ def test_activation_is_not_gated_on_plugins_enabled(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
     assert memory_plugins.load_memory_provider("gatedmem") is not None
+
+
+def test_profile_clone_resolves_provider_through_canonical_config_loader(
+    tmp_path, monkeypatch
+):
+    source_dir = tmp_path / "source"
+    profile_dir = tmp_path / "profile"
+    source_dir.mkdir()
+    profile_dir.mkdir()
+    (source_dir / "config.yaml").write_text(
+        "memory:\n  provider: ${CLONE_MEMORY_PROVIDER}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLONE_MEMORY_PROVIDER", "custommem")
+    monkeypatch.setattr(memory_plugins, "_iter_provider_dirs", lambda: [])
+
+    calls = []
+
+    class Provider:
+        def clone_profile(self, profile_name, **kwargs):
+            calls.append((profile_name, kwargs))
+            return "cloned"
+
+    monkeypatch.setattr(
+        memory_plugins,
+        "load_memory_provider",
+        lambda name, **kwargs: Provider() if name == "custommem" else None,
+    )
+
+    from hermes_constants import get_hermes_home
+
+    ambient_home = get_hermes_home()
+    result = memory_plugins.clone_memory_provider_profile(
+        "coder",
+        source_dir=source_dir,
+        profile_dir=profile_dir,
+    )
+
+    assert result == ["cloned"]
+    assert calls == [(
+        "coder",
+        {
+            "source_dir": source_dir,
+            "profile_dir": profile_dir,
+            "clone_all": False,
+        },
+    )]
+    assert get_hermes_home() == ambient_home

--- a/tests/plugins/memory/test_discovery_sources.py
+++ b/tests/plugins/memory/test_discovery_sources.py
@@ -404,3 +404,65 @@ def test_profile_clone_isolates_bad_manifests_and_failing_hooks(
     assert result == ["working-cloned"]
     assert "profile-clone manifest for memory provider 'malformed'" in caplog.text
     assert "Memory provider 'failing' failed to clone profile 'coder'" in caplog.text
+
+
+def test_profile_clone_reloads_same_named_provider_from_source_profile(
+    tmp_path, monkeypatch
+):
+    provider_name = "sameprofilemem"
+    marker_source = """\
+from agent.memory_provider import MemoryProvider
+
+
+class Provider(MemoryProvider):
+    @property
+    def name(self):
+        return "sameprofilemem"
+
+    def is_available(self):
+        return True
+
+    def initialize(self, *args, **kwargs):
+        pass
+
+    def get_tool_schemas(self):
+        return []
+
+    def clone_profile(self, profile_name, **kwargs):
+        (kwargs["profile_dir"] / "provider-origin.txt").write_text(ORIGIN)
+
+
+def register(ctx):
+    ctx.register_memory_provider(Provider())
+"""
+    ambient_dir = tmp_path / "ambient" / "plugins" / provider_name
+    source_dir = tmp_path / "source"
+    source_provider_dir = source_dir / "plugins" / provider_name
+    profile_dir = tmp_path / "profile"
+    ambient_dir.mkdir(parents=True)
+    source_provider_dir.mkdir(parents=True)
+    profile_dir.mkdir()
+    (ambient_dir / "__init__.py").write_text(
+        f'ORIGIN = "ambient"\n{marker_source}',
+        encoding="utf-8",
+    )
+    (source_provider_dir / "__init__.py").write_text(
+        f'ORIGIN = "source"\n{marker_source}',
+        encoding="utf-8",
+    )
+    (source_dir / "config.yaml").write_text(
+        f"memory:\n  provider: {provider_name}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", tmp_path / "bundled")
+
+    ambient_provider = memory_plugins._load_provider_from_dir(ambient_dir)
+    assert ambient_provider is not None
+
+    memory_plugins.clone_memory_provider_profile(
+        "coder",
+        source_dir=source_dir,
+        profile_dir=profile_dir,
+    )
+
+    assert (profile_dir / "provider-origin.txt").read_text() == "source"

--- a/tests/plugins/memory/test_discovery_sources.py
+++ b/tests/plugins/memory/test_discovery_sources.py
@@ -315,3 +315,92 @@ def test_profile_clone_runs_provider_declared_by_manifest(tmp_path, monkeypatch)
             "clone_all": True,
         },
     )]
+
+
+def test_profile_clone_loads_provider_from_explicit_source_profile(
+    tmp_path, monkeypatch
+):
+    source_dir = tmp_path / "source"
+    profile_dir = tmp_path / "profile"
+    source_dir.mkdir()
+    profile_dir.mkdir()
+    (source_dir / "config.yaml").write_text(
+        "memory:\n  provider: sourceclone\n",
+        encoding="utf-8",
+    )
+    provider_dir = source_dir / "plugins" / "sourceclone"
+    provider_dir.mkdir(parents=True)
+    (provider_dir / "__init__.py").write_text(
+        PROVIDER_SOURCE.format(name="sourceclone").replace(
+            "    def get_tool_schemas(self):\n        return []\n",
+            "    def get_tool_schemas(self):\n"
+            "        return []\n\n"
+            "    def clone_profile(self, profile_name, **kwargs):\n"
+            "        (kwargs['profile_dir'] / 'sourceclone.txt').write_text(profile_name)\n"
+            "        return 'source-cloned'\n",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", tmp_path / "bundled")
+
+    from hermes_constants import get_hermes_home
+
+    ambient_home = get_hermes_home()
+    result = memory_plugins.clone_memory_provider_profile(
+        "coder",
+        source_dir=source_dir,
+        profile_dir=profile_dir,
+    )
+
+    assert result == ["source-cloned"]
+    assert (profile_dir / "sourceclone.txt").read_text() == "coder"
+    assert get_hermes_home() == ambient_home
+
+
+def test_profile_clone_isolates_bad_manifests_and_failing_hooks(
+    tmp_path, monkeypatch, caplog
+):
+    source_dir = tmp_path / "source"
+    profile_dir = tmp_path / "profile"
+    source_dir.mkdir()
+    profile_dir.mkdir()
+
+    provider_dirs = []
+    for name, manifest in (
+        ("malformed", "- not-a-mapping\n"),
+        ("failing", "profile_clone: true\n"),
+        ("working", "profile_clone: true\n"),
+    ):
+        provider_dir = tmp_path / name
+        provider_dir.mkdir()
+        (provider_dir / "plugin.yaml").write_text(manifest, encoding="utf-8")
+        provider_dirs.append((name, provider_dir))
+    monkeypatch.setattr(memory_plugins, "_iter_provider_dirs", lambda: provider_dirs)
+
+    class FailingProvider:
+        def clone_profile(self, profile_name, **kwargs):
+            raise RuntimeError("broken clone hook")
+
+    class WorkingProvider:
+        def clone_profile(self, profile_name, **kwargs):
+            return "working-cloned"
+
+    def load_provider(name, **kwargs):
+        if name == "failing":
+            return FailingProvider()
+        if name == "working":
+            return WorkingProvider()
+        return None
+
+    monkeypatch.setattr(memory_plugins, "load_memory_provider", load_provider)
+
+    with caplog.at_level("DEBUG", logger="plugins.memory"):
+        result = memory_plugins.clone_memory_provider_profile(
+            "coder",
+            source_dir=source_dir,
+            profile_dir=profile_dir,
+        )
+
+    assert result == ["working-cloned"]
+    assert "profile-clone manifest for memory provider 'malformed'" in caplog.text
+    assert "Memory provider 'failing' failed to clone profile 'coder'" in caplog.text

--- a/tests/plugins/memory/test_discovery_sources.py
+++ b/tests/plugins/memory/test_discovery_sources.py
@@ -267,3 +267,51 @@ def test_profile_clone_resolves_provider_through_canonical_config_loader(
         },
     )]
     assert get_hermes_home() == ambient_home
+
+
+def test_profile_clone_runs_provider_declared_by_manifest(tmp_path, monkeypatch):
+    source_dir = tmp_path / "source"
+    profile_dir = tmp_path / "profile"
+    provider_dir = tmp_path / "legacy-memory"
+    source_dir.mkdir()
+    profile_dir.mkdir()
+    provider_dir.mkdir()
+    (provider_dir / "plugin.yaml").write_text(
+        "name: legacy-memory\nprofile_clone: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        memory_plugins,
+        "_iter_provider_dirs",
+        lambda: [("legacy-memory", provider_dir)],
+    )
+
+    calls = []
+
+    class Provider:
+        def clone_profile(self, profile_name, **kwargs):
+            calls.append((profile_name, kwargs))
+            return "legacy-cloned"
+
+    monkeypatch.setattr(
+        memory_plugins,
+        "load_memory_provider",
+        lambda name, **kwargs: Provider() if name == "legacy-memory" else None,
+    )
+
+    result = memory_plugins.clone_memory_provider_profile(
+        "coder",
+        source_dir=source_dir,
+        profile_dir=profile_dir,
+        clone_all=True,
+    )
+
+    assert result == ["legacy-cloned"]
+    assert calls == [(
+        "coder",
+        {
+            "source_dir": source_dir,
+            "profile_dir": profile_dir,
+            "clone_all": True,
+        },
+    )]

--- a/tests/plugins/memory/test_discovery_sources.py
+++ b/tests/plugins/memory/test_discovery_sources.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import importlib.metadata
 import sys
 import textwrap
+import types
 from pathlib import Path
 
 import pytest
@@ -466,3 +467,58 @@ def register(ctx):
     )
 
     assert (profile_dir / "provider-origin.txt").read_text() == "source"
+
+
+def test_profile_clone_evicts_cli_discovery_package_descendants(
+    tmp_path, monkeypatch
+):
+    provider_name = "syntheticprofilemem"
+    source_dir = tmp_path / "source"
+    profile_dir = tmp_path / "profile"
+    provider_dir = source_dir / "plugins" / provider_name
+    provider_dir.mkdir(parents=True)
+    profile_dir.mkdir()
+    (source_dir / "config.yaml").write_text(
+        f"memory:\n  provider: {provider_name}\n",
+        encoding="utf-8",
+    )
+    (provider_dir / "helper.py").write_text(
+        'ORIGIN = "source"\n',
+        encoding="utf-8",
+    )
+    (provider_dir / "__init__.py").write_text(
+        "from agent.memory_provider import MemoryProvider\n"
+        "from .helper import ORIGIN\n\n"
+        "class Provider(MemoryProvider):\n"
+        "    @property\n"
+        "    def name(self):\n"
+        f"        return {provider_name!r}\n\n"
+        "    def is_available(self):\n"
+        "        return True\n\n"
+        "    def initialize(self, *args, **kwargs):\n"
+        "        pass\n\n"
+        "    def get_tool_schemas(self):\n"
+        "        return []\n\n"
+        "    def clone_profile(self, profile_name, **kwargs):\n"
+        "        (kwargs['profile_dir'] / 'synthetic-origin.txt').write_text(ORIGIN)\n\n"
+        "def register(ctx):\n"
+        "    ctx.register_memory_provider(Provider())\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(memory_plugins, "_MEMORY_PLUGINS_DIR", tmp_path / "bundled")
+
+    module_name = f"{memory_plugins._USER_NAMESPACE}.{provider_name}"
+    synthetic_package = types.ModuleType(module_name)
+    synthetic_package.__path__ = [str(tmp_path / "ambient" / provider_name)]
+    ambient_helper = types.ModuleType(f"{module_name}.helper")
+    ambient_helper.ORIGIN = "ambient"
+    monkeypatch.setitem(sys.modules, module_name, synthetic_package)
+    monkeypatch.setitem(sys.modules, f"{module_name}.helper", ambient_helper)
+
+    memory_plugins.clone_memory_provider_profile(
+        "coder",
+        source_dir=source_dir,
+        profile_dir=profile_dir,
+    )
+
+    assert (profile_dir / "synthetic-origin.txt").read_text() == "source"

--- a/tests/plugins/memory/test_discovery_sources.py
+++ b/tests/plugins/memory/test_discovery_sources.py
@@ -429,8 +429,14 @@ class Provider(MemoryProvider):
     def get_tool_schemas(self):
         return []
 
+    def current_origin(self):
+        from .helper import ORIGIN
+        return ORIGIN
+
     def clone_profile(self, profile_name, **kwargs):
-        (kwargs["profile_dir"] / "provider-origin.txt").write_text(ORIGIN)
+        (kwargs["profile_dir"] / "provider-origin.txt").write_text(
+            self.current_origin()
+        )
 
 
 def register(ctx):
@@ -443,12 +449,14 @@ def register(ctx):
     ambient_dir.mkdir(parents=True)
     source_provider_dir.mkdir(parents=True)
     profile_dir.mkdir()
-    (ambient_dir / "__init__.py").write_text(
-        f'ORIGIN = "ambient"\n{marker_source}',
+    (ambient_dir / "__init__.py").write_text(marker_source, encoding="utf-8")
+    (ambient_dir / "helper.py").write_text('ORIGIN = "ambient"\n', encoding="utf-8")
+    (source_provider_dir / "__init__.py").write_text(
+        marker_source,
         encoding="utf-8",
     )
-    (source_provider_dir / "__init__.py").write_text(
-        f'ORIGIN = "source"\n{marker_source}',
+    (source_provider_dir / "helper.py").write_text(
+        'ORIGIN = "source"\n',
         encoding="utf-8",
     )
     (source_dir / "config.yaml").write_text(
@@ -467,9 +475,10 @@ def register(ctx):
     )
 
     assert (profile_dir / "provider-origin.txt").read_text() == "source"
+    assert ambient_provider.current_origin() == "ambient"
 
 
-def test_profile_clone_evicts_cli_discovery_package_descendants(
+def test_profile_clone_ignores_cli_discovery_package_descendants(
     tmp_path, monkeypatch
 ):
     provider_name = "syntheticprofilemem"

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -128,7 +128,17 @@ class MyMemoryProvider(MemoryProvider):
 | `on_session_end(messages)` | Conversation ends | Final extraction/flush |
 | `on_pre_compress(messages)` | Before context compression | Save insights before discard |
 | `on_memory_write(action, target, content)` | Built-in memory writes | Mirror to your backend |
+| `clone_profile(profile_name, *, source_dir, profile_dir, clone_all=False)` | After a profile clone is created | Copy or reconcile provider-owned identity/connection state |
 | `shutdown()` | Process exit | Clean up connections |
+
+`clone_profile()` has a no-op default for compatibility. Hermes invokes it for
+the provider selected by the source profile's `memory.provider`. A directory
+provider that must inspect legacy state even when it is not selected can also
+declare `profile_clone: true` in `plugin.yaml`; Hermes then invokes its hook on
+profile clones. Keep the hook idempotent and treat `source_dir` and
+`profile_dir` as the authoritative profile roots. `clone_all=True` means the
+source tree was copied in full before the hook runs, so update the copied state
+in `profile_dir` rather than the source.
 
 ## Config Schema
 
@@ -215,6 +225,9 @@ version: 1.0.0
 description: "Short description of what this provider does."
 hooks:
   - on_session_end    # list hooks you implement
+# Optional: run clone_profile() even when this provider is not selected, for
+# legacy provider state stored outside config.yaml.
+profile_clone: true
 ```
 
 ## Threading Contract


### PR DESCRIPTION
## What does this PR do?

Adds an explicit, disabled-by-default Honcho option for single-operator profile fleets that need cloned profiles to retain one shared AI identity. Profile clones now apply the same Honcho integration through the shared creation path used by the CLI, Desktop REST endpoint, and Bot Mode RPC.

### Motivation

Honcho profile cloning already shares the workspace and user peer, but always replaces the AI peer with the new profile name. Operators who intentionally use one AI peer across a Bot fleet must manually repair every new clone or allow AI-side representations and conclusions to diverge.

### Behavior

Set `shareAiPeerAcrossProfiles: true` at the root of `honcho.json` to make new profile clones inherit the default host block's `aiPeer`. When the option is missing or false, clones keep the existing profile-specific AI peer behavior. Existing profiles, workspace selection, user-peer mapping, and session naming are unchanged.

### Implementation

`clone_honcho_for_profile()` resolves the shared peer from the default host block, then the root `aiPeer`, when the strict boolean opt-in is enabled. The existing Honcho clone integration now runs inside `create_profile()`, so all clone surfaces share one behavior, while the CLI reports the actual resulting peer. Behavior tests cover both flag states and the shared profile-creation path.

## Related Issue

Closes #91577

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/memory/honcho/cli.py` - add the opt-in clone policy and expose the cloned peer for CLI reporting.
- `hermes_cli/profiles.py` and `hermes_cli/main.py` - centralize clone integration across profile creation surfaces and report the resolved peer.
- `plugins/memory/honcho/README.md` - document the root-level option.
- `tests/honcho_plugin/test_cli.py` and `tests/hermes_cli/test_profiles.py` - cover opt-in, default behavior, and shared creation flow.

## How to Test

1. Configure a default Honcho host with `aiPeer: shared-assistant` and root `shareAiPeerAcrossProfiles: true`.
2. Clone a profile through the CLI or Desktop/Bot Mode profile creation path and confirm its generated host block uses `shared-assistant`.
3. Remove the option or set it to false, clone another profile, and confirm its AI peer matches the new profile name.
4. Run:

```bash
scripts/run_tests.sh tests/honcho_plugin/test_cli.py -k "opt_in_shares_default_ai_peer or shared_ai_peer_is_opt_in" -q
scripts/run_tests.sh tests/hermes_cli/test_profiles.py -k "clone_config_runs_memory_provider_profile_clone" -q
```

The targeted checks pass with 4 tests on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because this option belongs to `honcho.json`
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no contribution workflow changed
- [x] I've considered cross-platform impact; the implementation uses platform-independent JSON and Python paths
- [x] Tool descriptions and schemas are N/A because no model tool changed
