### PR TITLE
feat: add Codex usage forecast command

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -28,6 +28,8 @@ class AccountUsageWindow:
     used_percent: Optional[float] = None
     reset_at: Optional[datetime] = None
     detail: Optional[str] = None
+    window_seconds: Optional[int] = None
+    reset_after_seconds: Optional[int] = None
 
 
 @dataclass(frozen=True)
@@ -117,6 +119,59 @@ def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, mark
         lines.append(detail)
     if snapshot.unavailable_reason:
         lines.append(f"Unavailable: {snapshot.unavailable_reason}")
+    return lines
+
+
+def _format_duration(seconds: float) -> str:
+    total_minutes = max(0, int(seconds // 60))
+    hours, minutes = divmod(total_minutes, 60)
+    if hours:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+
+def render_codex_usage_lines(
+    snapshot: Optional[AccountUsageSnapshot], *, markdown: bool = False
+) -> list[str]:
+    """Render Codex limits plus a linear end-of-window usage forecast.
+
+    The forecast uses the average burn rate since the backend window began;
+    it does not claim to predict bursty future work.
+    """
+    if not snapshot:
+        return []
+    lines = render_account_usage_lines(snapshot, markdown=markdown)
+    lines[0] = f"📈 {'**' if markdown else ''}Codex usage{'**' if markdown else ''}"
+    insert_at = 3
+    for window in snapshot.windows:
+        used = window.used_percent
+        duration = window.window_seconds
+        remaining_time = window.reset_after_seconds
+        if used is None or not duration or remaining_time is None:
+            insert_at += 1
+            continue
+        elapsed = duration - remaining_time
+        if used <= 0 or elapsed <= 0:
+            insert_at += 1
+            continue
+        rate = float(used) / elapsed
+        seconds_to_exhaustion = max(0.0, (100.0 - float(used)) / rate)
+        if seconds_to_exhaustion < remaining_time:
+            forecast = (
+                "At current average pace: exhausted in "
+                f"{_format_duration(seconds_to_exhaustion)} (before reset)"
+            )
+        else:
+            projected_used = min(100.0, float(used) + rate * remaining_time)
+            forecast = (
+                "At current average pace: "
+                f"~{projected_used:.0f}% used at reset "
+                f"(~{max(0.0, 100.0 - projected_used):.0f}% remaining)"
+            )
+        # Insert directly after this window's rendered line. Account lines
+        # begin with header + provider, hence the offset of two.
+        lines.insert(insert_at, forecast)
+        insert_at += 2
     return lines
 
 
@@ -535,6 +590,16 @@ def _fetch_codex_account_usage(
                 label=label,
                 used_percent=float(used),
                 reset_at=_parse_dt(window.get("reset_at")),
+                window_seconds=(
+                    int(window["limit_window_seconds"])
+                    if isinstance(window.get("limit_window_seconds"), (int, float))
+                    else None
+                ),
+                reset_after_seconds=(
+                    int(window["reset_after_seconds"])
+                    if isinstance(window.get("reset_after_seconds"), (int, float))
+                    else None
+                ),
             )
         )
     details: list[str] = []

--- a/cli.py
+++ b/cli.py
@@ -12113,6 +12113,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._handle_usage_command(cmd_original)
+        elif canonical == "codex-usage":
+            self._show_codex_usage()
         elif canonical == "subscription":
             self._show_subscription()
         elif canonical == "topup":
@@ -13437,6 +13439,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print(f"  Unknown /usage subcommand: {' '.join(parts[1:])}. Try /usage or /usage reset [--force].")
             return
         self._show_usage()
+
+    def _show_codex_usage(self):
+        """Show ChatGPT Codex quota windows and a linear burn-rate forecast."""
+        from agent.account_usage import (
+            fetch_account_usage,
+            render_codex_usage_lines,
+        )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            try:
+                snapshot = pool.submit(
+                    fetch_account_usage, "openai-codex"
+                ).result(timeout=15.0)
+            except Exception:
+                snapshot = None
+        lines = render_codex_usage_lines(snapshot)
+        if not lines:
+            print(
+                "  Codex usage is unavailable. Sign in with "
+                "`hermes auth add openai-codex` and try again."
+            )
+            return
+        print()
+        for line in lines:
+            print(f"  {line}")
+        print()
 
     def _usage_reset(self, force: bool = False):
         """`/usage reset [--force]` — redeem one banked Codex reset credit."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17573,6 +17573,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
+        if canonical == "codex-usage":
+            return await self._handle_codex_usage_command(event)
+
         if canonical == "topup":
             return await self._handle_topup_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5453,6 +5453,19 @@ class GatewaySlashCommandsMixin:
             return "\n".join(parts)
         return t("gateway.usage.no_data")
 
+    async def _handle_codex_usage_command(self, event: MessageEvent) -> str:
+        """Show ChatGPT Codex quota windows and a linear burn-rate forecast."""
+        from agent.account_usage import render_codex_usage_lines
+
+        snapshot = await asyncio.to_thread(fetch_account_usage, "openai-codex")
+        lines = render_codex_usage_lines(snapshot, markdown=True)
+        if not lines:
+            return (
+                "Codex usage is unavailable. Sign in with "
+                "`hermes auth add openai-codex` and try again."
+            )
+        return "\n".join(lines)
+
     async def _handle_insights_command(self, event: MessageEvent) -> str:
         """Handle /insights command -- show usage insights and analytics."""
         args = event.get_command_args().strip()

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -366,6 +366,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, busy_policy="dispatch"),
     CommandDef("usage", "Show token usage and rate limits; `reset` redeems a banked Codex limit reset", "Info",
                args_hint="[reset [--force]]"),
+    CommandDef("codex-usage", "Show Codex quota, reset times, and linear exhaustion forecast", "Info"),
     CommandDef("subscription", "View your Nous plan and change it in the browser", "Info",
                cli_only=True, aliases=("upgrade",)),
     CommandDef("topup", "Show your Nous balance and manage billing on the portal", "Info"),
@@ -1366,7 +1367,7 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #     (session export is an interactive surface; platform is a rare
 #     informational lookup) — without this entry /save tips the registry
 #     past the 50-cap and silently clamps /platform, breaking parity.
-_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "pause", "whoami", "platform"})
+_SLACK_VIA_HERMES_ONLY = frozenset({"topup", "codex-usage", "moa", "debug", "egress", "init", "version", "diff", "update", "heartbeat", "refine", "pause", "whoami", "platform"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -40,6 +40,8 @@ def codex_usage_payload():
             "primary_window": {
                 "used_percent": 21,
                 "reset_at": 1779846359,
+                "limit_window_seconds": 18_000,
+                "reset_after_seconds": 9_000,
             },
             "secondary_window": {
                 "used_percent": 4,
@@ -74,8 +76,56 @@ def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_
     assert snapshot.plan == "Plus"
     assert [w.label for w in snapshot.windows] == ["Session", "Weekly"]
     assert snapshot.windows[0].used_percent == 21
+    assert snapshot.windows[0].window_seconds == 18_000
+    assert snapshot.windows[0].reset_after_seconds == 9_000
     assert calls[0]["url"] == "https://chatgpt.com/backend-api/wham/usage"
     assert calls[0]["headers"]["Authorization"] == "Bearer live-agent-token"
+
+
+def test_codex_usage_forecast_projects_exhaustion_before_reset():
+    snapshot = account_usage.AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=account_usage._parse_dt(1_800_000_000),
+        plan="Plus",
+        windows=(
+            account_usage.AccountUsageWindow(
+                label="Session",
+                used_percent=60,
+                reset_at=account_usage._parse_dt(1_800_007_200),
+                window_seconds=19_800,
+                reset_after_seconds=9_000,
+            ),
+        ),
+    )
+
+    lines = account_usage.render_codex_usage_lines(snapshot)
+
+    assert lines[0] == "📈 Codex usage"
+    assert "Session: 40% remaining (60% used)" in lines[2]
+    assert "At current average pace: exhausted in 2h 0m" in lines[3]
+    assert "before reset" in lines[3]
+
+
+def test_codex_usage_forecast_projects_remaining_quota_at_reset():
+    snapshot = account_usage.AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=account_usage._parse_dt(1_800_000_000),
+        windows=(
+            account_usage.AccountUsageWindow(
+                label="Weekly",
+                used_percent=20,
+                reset_at=account_usage._parse_dt(1_800_009_000),
+                window_seconds=18_000,
+                reset_after_seconds=9_000,
+            ),
+        ),
+    )
+
+    lines = account_usage.render_codex_usage_lines(snapshot)
+
+    assert "~40% used at reset (~60% remaining)" in lines[3]
 
 
 def test_codex_usage_falls_back_to_native_credential_pool(monkeypatch, codex_usage_payload):

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -234,6 +234,32 @@ class TestCLIStatusBar:
 
 
 class TestCLIUsageReport:
+    def test_show_codex_usage_prints_forecast(self, monkeypatch, capsys):
+        from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow, _parse_dt
+
+        snapshot = AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=_parse_dt(1_800_000_000),
+            windows=(
+                AccountUsageWindow(
+                    label="Session",
+                    used_percent=60,
+                    reset_at=_parse_dt(1_800_009_000),
+                    window_seconds=19_800,
+                    reset_after_seconds=9_000,
+                ),
+            ),
+        )
+        monkeypatch.setattr("agent.account_usage.fetch_account_usage", lambda provider: snapshot)
+        cli_obj = _make_cli()
+
+        cli_obj._show_codex_usage()
+
+        output = capsys.readouterr().out
+        assert "40% remaining" in output
+        assert "exhausted in 2h 0m" in output
+
     def test_show_usage_omits_cost_reporting(self, capsys):
         cli_obj = _attach_agent(
             _make_cli(),

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -112,6 +112,33 @@ class TestUsageCachedAgent:
 class TestUsageAccountSection:
     """Account-limits section appended to /usage output (PR #2486)."""
 
+    @pytest.mark.asyncio
+    async def test_codex_usage_command_renders_quota_and_forecast(self, monkeypatch):
+        from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow, _parse_dt
+
+        runner = _make_runner(SK)
+        snapshot = AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=_parse_dt(1_800_000_000),
+            plan="Plus",
+            windows=(
+                AccountUsageWindow(
+                    label="Session",
+                    used_percent=60,
+                    reset_at=_parse_dt(1_800_009_000),
+                    window_seconds=19_800,
+                    reset_after_seconds=9_000,
+                ),
+            ),
+        )
+        monkeypatch.setattr("gateway.slash_commands.fetch_account_usage", lambda provider: snapshot)
+
+        result = await runner._handle_codex_usage_command(MagicMock())
+
+        assert "40% remaining" in result
+        assert "exhausted in 2h 0m" in result
+
 
     @pytest.mark.asyncio
     async def test_usage_command_uses_persisted_provider_when_agent_not_running(self, monkeypatch):

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -99,6 +99,13 @@ class TestResolveCommand:
         assert not ctx.cli_only and not ctx.gateway_only
         assert "context" in GATEWAY_KNOWN_COMMANDS
 
+    def test_codex_usage_command_is_available_everywhere(self):
+        command = resolve_command("codex-usage")
+        assert command is not None
+        assert command.name == "codex-usage"
+        assert not command.cli_only and not command.gateway_only
+        assert "codex-usage" in GATEWAY_KNOWN_COMMANDS
+
 
 
 


### PR DESCRIPTION
## Summary
- add `/codex-usage` on CLI and gateway surfaces
- show remaining Codex quota and reset countdowns
- linearly project exhaustion or remaining quota at reset from the current window average

## Verification
- `90 passed` across account usage, gateway usage command, command registry, and CLI usage tests
- live authenticated Codex usage fetch/render verified locally
- `py_compile` and `git diff --check` pass