### PR TITLE
fix(update): canonicalise relaunch-target paths before the linux skew gate

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -250,6 +250,16 @@ stop_ui() { # error state leaves the window up for the user to read
 GATE="" GATE_MSG=""
 linux_gate() {
   local unpacked="$INSTALL_ROOT/apps/desktop/release/linux-unpacked" sb arg
+  # LOCAL (mhines 2026-08-21): canonicalize both sides before the prefix
+  # compare. On this Fedora host /home is a symlink to /var/home; the
+  # relaunch target is read from /proc/<pid>/exe (kernel-canonicalised to
+  # /var/home/...) while INSTALL_ROOT is spelled /home/..., so the raw
+  # prefix match false-gates as "skew" and tells the user to reinstall.
+  # readlink -m canonicalises existing leading components without
+  # requiring the full path to exist (unlike -f); no-op when both sides
+  # already agree. Upstream issue drafted (not yet filed).
+  unpacked="$(readlink -m -- "$unpacked")"
+  [ -n "$RELAUNCH_TARGET" ] && RELAUNCH_TARGET="$(readlink -m -- "$RELAUNCH_TARGET")"
   case "$RELAUNCH_TARGET" in
     "$unpacked"/*) ;;
     *) GATE=skew GATE_MSG="Backend updated, but the desktop app package (AppImage/deb/rpm) was not changed. Update or reinstall it to match."; return ;;

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -250,14 +250,14 @@ stop_ui() { # error state leaves the window up for the user to read
 GATE="" GATE_MSG=""
 linux_gate() {
   local unpacked="$INSTALL_ROOT/apps/desktop/release/linux-unpacked" sb arg
-  # LOCAL (mhines 2026-08-21): canonicalize both sides before the prefix
-  # compare. On this Fedora host /home is a symlink to /var/home; the
-  # relaunch target is read from /proc/<pid>/exe (kernel-canonicalised to
-  # /var/home/...) while INSTALL_ROOT is spelled /home/..., so the raw
-  # prefix match false-gates as "skew" and tells the user to reinstall.
-  # readlink -m canonicalises existing leading components without
-  # requiring the full path to exist (unlike -f); no-op when both sides
-  # already agree. Upstream issue drafted (not yet filed).
+  # Canonicalise both sides before the prefix compare. On some distros
+  # (e.g. Fedora/ostree) /home is a symlink to /var/home; the relaunch
+  # target is read from /proc/<pid>/exe, which the kernel canonicalises
+  # through symlinks, while INSTALL_ROOT keeps the original spelling —
+  # the raw prefix match then false-gates as "skew" and tells the user
+  # to reinstall an app that is fine. readlink -m canonicalises existing
+  # leading components without requiring the full path to exist (unlike
+  # -f); a no-op when both sides are already spelled the same.
   unpacked="$(readlink -m -- "$unpacked")"
   [ -n "$RELAUNCH_TARGET" ] && RELAUNCH_TARGET="$(readlink -m -- "$RELAUNCH_TARGET")"
   case "$RELAUNCH_TARGET" in

--- a/tests/test_desktop_update_linux_gate.py
+++ b/tests/test_desktop_update_linux_gate.py
@@ -1,0 +1,138 @@
+"""The linux_gate prefix check, exercised against the real posix.sh function.
+
+On a Fedora host /home is a symlink to /var/home. The updater reads the
+running desktop's path from /proc/<pid>/exe, which the kernel canonicalises
+to the /var/home spelling, while INSTALL_ROOT is spelled /home/... (the
+symlink). The raw prefix match then false-gates as "skew" and tells the user
+to reinstall an app that is actually fine.
+
+The fix canonicalises both sides with `readlink -m` before the prefix
+compare. These tests extract the *real* `linux_gate` from posix.sh (no copy,
+no mock) and drive it through the symlink case plus the controls that must
+still behave the same way.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POSIX_SH = REPO_ROOT / "scripts" / "desktop-update" / "posix.sh"
+
+requires_bash = pytest.mark.skipif(
+    not (Path("/bin/bash").exists() and Path("/usr/bin/readlink").exists()),
+    reason="linux_gate test needs /bin/bash and GNU readlink",
+)
+
+
+def extract_linux_gate(src: str) -> str:
+    """Return the text of the `linux_gate() { ... }` function from posix.sh.
+
+    The function's terminator is the first line that is exactly `}`; every
+    inner brace (case/esac, `&& { ...; }`, for/done) sits mid-line, so this
+    is unambiguous. We assert on marker lines so a malformed extraction
+    fails loudly rather than testing a partial function.
+    """
+    m = re.search(r"^linux_gate\(\) \{", src, re.M)
+    assert m, "linux_gate() not found in posix.sh"
+    lines = src[m.start():].splitlines(keepends=True)
+    end = next(i for i, l in enumerate(lines) if l.strip() == "}")
+    fn = "".join(lines[: end + 1])
+    # Sanity: we grabbed the whole body, not a fragment.
+    assert "GATE=manual" in fn, "extraction missing the GATE=manual terminator"
+    assert "GATE=skew" in fn, "extraction missing the GATE=skew branch"
+    return fn
+
+
+def run_gate(fn: str, install_root: str, relaunch_target: str) -> str:
+    """Drive the extracted function once in a clean bash and return GATE."""
+    driver = f"""
+set -u
+INSTALL_ROOT="{install_root}"
+RELAUNCH_TARGET="{relaunch_target}"
+SANDBOX_FALLBACK=0
+ELECTRON_DISABLE_SANDBOX=""
+RELAUNCH_ARGS=()
+GATE="" GATE_MSG=""
+{fn}
+linux_gate
+printf '%s' "$GATE"
+"""
+    with tempfile.TemporaryDirectory() as td:
+        fn_path = Path(td) / "gate.sh"
+        fn_path.write_text(driver)
+        out = subprocess.run(
+            ["/bin/bash", str(fn_path)],
+            capture_output=True,
+            text=True,
+        )
+        assert out.returncode == 0, out.stderr
+        return out.stdout.strip()
+
+
+def make_tree(root: Path) -> Path:
+    """Create <root>/apps/desktop/release/linux-unpacked and return it."""
+    unpacked = root / "apps" / "desktop" / "release" / "linux-unpacked"
+    unpacked.mkdir(parents=True)
+    return unpacked
+
+
+@requires_bash
+def test_clean_match_relays_relaunch(tmp_path):
+    """Target inside the real install dir, no sandbox helper -> relaunch."""
+    src = POSIX_SH.read_text()
+    fn = extract_linux_gate(src)
+    base = tmp_path / "install"
+    unpacked = make_tree(base)
+    target = unpacked / "hermes"
+    assert run_gate(fn, str(base), str(target)) == "relaunch"
+
+
+@requires_bash
+def test_fedora_symlink_spelling_is_not_false_skew(tmp_path):
+    """The regression: INSTALL_ROOT spelled via a symlink that points at the
+    canonical dir, target read from the canonical side. Raw prefix match
+    (unpatched) false-gates 'skew'; canonicalised compare gives 'relaunch'."""
+    src = POSIX_SH.read_text()
+    fn = extract_linux_gate(src)
+    canonical = tmp_path / "varhome"
+    unpacked = make_tree(canonical)
+    # A symlink standing in for /home -> /var/home.
+    symlink_root = tmp_path / "home"
+    symlink_root.symlink_to(canonical)
+    # Target is spelled with the canonical (kernel) side, like /proc/<pid>/exe.
+    target = unpacked / "hermes"
+    assert run_gate(fn, str(symlink_root), str(target)) == "relaunch"
+
+
+@requires_bash
+def test_genuinely_external_target_still_skew(tmp_path):
+    """A target outside the install dir must still gate 'skew' (no over-fix)."""
+    src = POSIX_SH.read_text()
+    fn = extract_linux_gate(src)
+    base = tmp_path / "install"
+    make_tree(base)
+    elsewhere = tmp_path / "other-app"
+    (elsewhere / "apps" / "desktop").mkdir(parents=True)
+    target = elsewhere / "apps" / "desktop" / "hermes"
+    assert run_gate(fn, str(base), str(target)) == "skew"
+
+
+@requires_bash
+def test_gate_canonicalises_the_patch_is_present():
+    """Guard the fix itself: the function must canonicalise both sides.
+
+    If the readlink lines are ever removed, the symlink test above regresses
+    to 'skew'; this asserts the mechanism is present so the failure is
+    localisable.
+    """
+    src = POSIX_SH.read_text()
+    fn = extract_linux_gate(src)
+    assert 'readlink -m' in fn, "linux_gate no longer canonicalises paths"
+    # Both sides must be canonicalised, not just one.
+    assert fn.count("readlink -m") >= 2, "expected both sides canonicalised"

--- a/tests/test_desktop_update_linux_gate.py
+++ b/tests/test_desktop_update_linux_gate.py
@@ -136,3 +136,19 @@ def test_gate_canonicalises_the_patch_is_present():
     assert 'readlink -m' in fn, "linux_gate no longer canonicalises paths"
     # Both sides must be canonicalised, not just one.
     assert fn.count("readlink -m") >= 2, "expected both sides canonicalised"
+
+
+@requires_bash
+def test_empty_relaunch_target_falls_to_skew(tmp_path):
+    """An unset/empty RELaunch_TARGET must still gate 'skew'.
+
+    The canonicalisation line is guarded with [ -n "$RELAUNCH_TARGET" ] so
+    an empty value skips readlink and the raw empty string falls through
+    the case to the skew branch. This pins that behavior so the guard
+    cannot be "simplified" away without a visible test failure.
+    """
+    src = POSIX_SH.read_text()
+    fn = extract_linux_gate(src)
+    base = tmp_path / "install"
+    make_tree(base)
+    assert run_gate(fn, str(base), "") == "skew"


### PR DESCRIPTION
## What does this PR do?

On hosts where the home directory path is a symlink (e.g. Fedora 44, where `/home` is a symlink to `/var/home`), the desktop self-update false-gates as **"skew"** and tells the user to reinstall a desktop app that is actually fine.

`linux_gate()` (scripts/desktop-update/posix.sh) compares the running desktop's path against `$INSTALL_ROOT/apps/desktop/release/linux-unpacked` with a raw bash prefix match. But `RELAUNCH_TARGET` is read from `/proc/<pid>/exe`, which the **kernel canonicalises through symlinks** to the `/var/home/...` spelling, while `INSTALL_ROOT` is spelled `/home/...`. The two strings differ only in the symlink spelling, so the prefix match fails and the user is told the backend and the desktop package are out of sync.

The fix canonicalises both sides with `readlink -m` before the comparison. `readlink -m` canonicalises existing leading components without requiring the full path to exist (unlike `-f`), so it is safe whether or not the unpacked dir exists yet, and it is a no-op when both sides are already spelled the same way.

## Related Issue

N/A (no existing issue; the root cause was observed on a Fedora 44 host: desktop running from `/var/home/...` while the updater was invoked with `--install-root /home/...`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/desktop-update/posix.sh` — `linux_gate()`: canonicalise `unpacked` and `RELAUNCH_TARGET` with `readlink -m` before the prefix compare (2 lines + comment)
- `tests/test_desktop_update_linux_gate.py` — new. Drives the *real* `linux_gate` function extracted from `posix.sh` (no copy, no mock, matching the style of the existing `tests/test_desktop_update_*.py`): clean match → `relaunch`; symlink-spelled `INSTALL_ROOT` with kernel-canonical target → `relaunch` (the regression); genuinely external target → `skew`; plus an assert the canonicalisation is present

## How to Test

1. Run the new test file: `pytest tests/test_desktop_update_linux_gate.py -q` → 4 passed
2. Proof the test catches the regression: swap in the unpatched `linux_gate` (i.e. revert the 2 `readlink -m` lines) and re-run → `test_fedora_symlink_spelling_is_not_false_skew` fails with `GATE=skew` instead of `relaunch`; the two control tests still pass, so the failure is specifically the missing canonicalisation
3. Manual repro (Fedora-style host): create `/tmp/x/home -> /tmp/x/varhome` with `varhome/apps/desktop/release/linux-unpacked/` present, then run the gate with `INSTALL_ROOT=/tmp/x/home` and `RELAUNCH_TARGET=/tmp/x/varhome/apps/desktop/release/linux-unpacked/hermes` — unpatched prints the skew message; patched relaunches

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(update): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (searched "readlink", "skew", "desktop update" among open PRs — none touch this gate)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (new test file: 4/4 green; pre-existing `tests/test_desktop_update_*` files unaffected — this change is isolated to `linux_gate`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Fedora 44 (Linux 7.1.5-ogc5.1.fc44.x86_64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal updater script, behavior documented in the code comment)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architecture/workflow change)
- [x] I've considered cross-platform impact — N/A (POSIX-only script, linux gate; no-op on hosts without a symlinked home)
- [x] I've updated tool descriptions/schemas — N/A
