### PR TITLE
fix(web): fail over keyless auth rejections

### DIFF
--- a/plugins/web/keyless_mcp.py
+++ b/plugins/web/keyless_mcp.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -61,6 +62,23 @@ def _is_rate_limitish(message: str) -> bool:
     """Heuristic: does an error message look like free-tier throttling?"""
     lowered = (message or "").lower()
     return any(marker in lowered for marker in _RATE_LIMIT_MARKERS)
+
+
+_AUTH_STATUS_RE = re.compile(
+    r"\b(?:http(?:\s+status)?|status(?:\s+code)?|client\s+error|error(?:\s+code)?)"
+    r"\s*[:=']*\s*(?:401|403)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_search_failover_eligible(message: str) -> bool:
+    """Return whether another anonymous vendor may serve the search.
+
+    Rate limits and structured HTTP 401/403 provider rejections are local to
+    one free search endpoint. Free-text markers are deliberately ignored:
+    vendors may echo the query in an otherwise terminal error.
+    """
+    return _is_rate_limitish(message) or bool(_AUTH_STATUS_RE.search(message or ""))
 
 
 def keyless_enabled() -> bool:
@@ -806,8 +824,9 @@ def search_with_failover(name: str, query: str, limit: int = 5) -> Dict[str, Any
     """Keyless search across the vendor ring with next-in-line failover.
 
     Starts at *name* when the user pinned it, otherwise at the round-robin
-    cursor. Rate-limit-shaped errors advance to the next ring vendor;
-    non-throttle errors stop the walk (a malformed query fails everywhere).
+    cursor. Rate limits and anonymous-endpoint auth/policy rejections advance
+    to the next ring vendor; request errors stop the walk (a malformed query
+    fails everywhere).
     The result notes the serving vendor via ``data.served_by`` whenever it
     differs from *name*.
     """
@@ -825,15 +844,15 @@ def search_with_failover(name: str, query: str, limit: int = 5) -> Dict[str, Any
                 result.setdefault("data", {})["served_by"] = vendor
             return result
         last = result
-        if not _is_rate_limitish(result.get("error", "")):
+        if not _is_search_failover_eligible(result.get("error", "")):
             return result
         nxt = order[i + 1] if i + 1 < len(order) else None
         if nxt:
             logger.info(
-                "keyless %s search throttled; failing over to %s", vendor, nxt
+                "keyless %s search unavailable; failing over to %s", vendor, nxt
             )
     last["error"] = (
-        f"{last.get('error', '')} (all keyless vendors throttled: "
+        f"{last.get('error', '')} (all keyless vendors unavailable: "
         f"{', '.join(order)})"
     )
     return last
@@ -843,8 +862,8 @@ def extract_with_failover(name: str, urls: List[str]) -> List[Dict[str, Any]]:
     """Keyless extract across the vendor ring, failing over per-batch.
 
     Advances to the next ring vendor only when EVERY url in a batch comes
-    back with a rate-limit-shaped error — partial failures are page
-    problems, not throttling, and return as-is.
+    back with a rate-limit-shaped error — partial failures and HTTP 403s can
+    be page problems, not provider throttling, and return as-is.
     """
     order = _ring_order(name)
     if not order:

--- a/tests/tools/test_web_keyless_fallback.py
+++ b/tests/tools/test_web_keyless_fallback.py
@@ -441,6 +441,26 @@ class TestKeylessFailover:
         """Pin *name* so the ring starts there deterministically."""
         monkeypatch.setattr(keyless_mcp, "_vendor_pinned", lambda n: n == name)
 
+    @pytest.mark.parametrize(
+        ("message", "expected"),
+        [
+            ("free MCP rate limit", True),
+            ("Client error '403 Forbidden'", True),
+            ("HTTP status 401: unauthorized", True),
+            ("status code=403", True),
+            ("HTTP 2403", False),
+            ("error 4031", False),
+            ("FORBIDDEN", False),
+            ("extract failed for 'forbidden kingdom trailer': connection timeout", False),
+            ("HTTP 400: malformed request", False),
+            ("", False),
+        ],
+    )
+    def test_search_failover_eligibility_requires_structured_status(
+        self, message, expected
+    ):
+        assert keyless_mcp._is_search_failover_eligible(message) is expected
+
     def test_search_fails_over_on_rate_limit(self, monkeypatch):
         self._pin(monkeypatch, "exa")
         monkeypatch.setitem(keyless_mcp._KEYLESS_SEARCHERS, "exa", lambda q, l: self._throttled("Exa"))
@@ -448,6 +468,27 @@ class TestKeylessFailover:
         out = keyless_mcp.search_with_failover("exa", "q", 3)
         assert out["success"] is True
         assert out["data"]["served_by"] == "parallel"
+
+    def test_search_fails_over_on_anonymous_provider_forbidden(self, monkeypatch):
+        self._pin(monkeypatch, "firecrawl")
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_SEARCHERS,
+            "firecrawl",
+            lambda q, l: {
+                "success": False,
+                "error": "Keyless Firecrawl search failed: Client error '403 Forbidden'",
+            },
+        )
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_SEARCHERS,
+            "keenable",
+            lambda q, l: self._ok("keenable"),
+        )
+
+        out = keyless_mcp.search_with_failover("firecrawl", "q")
+
+        assert out["success"] is True
+        assert out["data"]["served_by"] == "keenable"
 
     def test_search_no_failover_on_non_throttle_error(self, monkeypatch):
         self._pin(monkeypatch, "exa")
@@ -473,7 +514,7 @@ class TestKeylessFailover:
             )
         out = keyless_mcp.search_with_failover("exa", "q")
         assert out["success"] is False
-        assert "all keyless vendors throttled" in out["error"]
+        assert "all keyless vendors unavailable" in out["error"]
 
     def test_search_walks_ring_past_multiple_throttles(self, monkeypatch):
         # exa -> parallel -> tavily all throttled; firecrawl serves.
@@ -527,6 +568,31 @@ class TestKeylessFailover:
         monkeypatch.setitem(keyless_mcp._KEYLESS_EXTRACTORS, "parallel", lambda urls: good)
         out = keyless_mcp.extract_with_failover("exa", ["https://a", "https://b"])
         assert out == good
+
+    def test_extract_all_forbidden_stays_on_primary(self, monkeypatch):
+        self._pin(monkeypatch, "firecrawl")
+        forbidden = [
+            {"url": url, "title": "", "content": "", "error": "HTTP 403"}
+            for url in ("https://a", "https://b")
+        ]
+        called = []
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_EXTRACTORS,
+            "firecrawl",
+            lambda urls: forbidden,
+        )
+        monkeypatch.setitem(
+            keyless_mcp._KEYLESS_EXTRACTORS,
+            "keenable",
+            lambda urls: called.append(1) or [],
+        )
+
+        out = keyless_mcp.extract_with_failover(
+            "firecrawl", ["https://a", "https://b"]
+        )
+
+        assert out == forbidden
+        assert not called
 
     def test_extract_partial_failure_stays_on_primary(self, monkeypatch):
         self._pin(monkeypatch, "exa")


### PR DESCRIPTION
Fixes #91609.

The keyless search ring only failed over on rate-limit-shaped errors. When an anonymous endpoint rejected a search with HTTP 401/403, the ring stopped even though another free provider could serve the same query.

Treat structured HTTP 401/403 search failures as provider-local availability failures alongside rate limits. Free-text words such as `forbidden` do not trigger failover, malformed requests remain terminal, and extraction preserves its existing rate-limit-only policy because a page-level 403 is ambiguous.

Validation:
- `scripts/run_tests.sh tests/tools/test_web_keyless_fallback.py tests/tools/test_web_keyless_rescue.py tests/tools/test_web_providers.py tests/tools/test_web_tools_tavily.py -q` — 97 passed
- `git diff --check gh-upstream/main...HEAD`
