### PR TITLE
fix(models): keep reasoning available under metadata-only overrides

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -1231,10 +1231,17 @@ def get_model_capabilities(
     else:
         # Unknown model — derive sensible defaults. The override will
         # patch whichever fields it specifies; the rest stay at defaults
-        # that are safe for agentic use (tools on, vision/reasoning off).
+        # that are safe for agentic use (tools on, vision off). Reasoning
+        # defaults ON for the permissive-unknown stance: a no-catalog model
+        # with NO override resolves to None and every consumer already
+        # treats that as "unknown; don't restrict" (inventory documents
+        # reasoning=True as the safe default; OpenRouter capability parsing
+        # mirrors the same permissive stance). Definitive False here made
+        # any metadata-only override (e.g. just context_window) silently
+        # disable the effort dial for uncatalogued models (#91608).
         supports_tools = True
         supports_vision = False
-        supports_reasoning = False
+        supports_reasoning = True
         context_window = 200000
         max_output_tokens = 8192
         model_family = ""

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -1068,6 +1068,30 @@ class TestModelOverrides:
         assert caps is not None
         assert caps.context_window != 1000
 
+    def test_caps_metadata_only_override_keeps_reasoning_available(self):
+        """Regression #91608: a metadata-only override (just context_window)
+        for an uncatalogued model must not disable the unrelated reasoning
+        capability — reasoning availability stays identical to the
+        no-override path (None → consumers' permissive default)."""
+        overrides = {
+            "zai": {
+                "glm-5.3": {"context_window": 131072},
+            },
+        }
+        with self._setup_overrides(overrides), \
+             patch("agent.models_dev.fetch_models_dev", return_value={}):
+            caps = get_model_capabilities("zai", "glm-5.3")
+        assert caps is not None
+        assert caps.context_window == 131072
+        # Unspecified capability stays permissive, not definitive False.
+        assert caps.supports_reasoning is True
+        # Explicit false still wins when the override declares it.
+        overrides["zai"]["glm-5.3"]["supports_reasoning"] = False
+        with self._setup_overrides(overrides), \
+             patch("agent.models_dev.fetch_models_dev", return_value={}):
+            caps_off = get_model_capabilities("zai", "glm-5.3")
+        assert caps_off.supports_reasoning is False
+
     def test_caps_no_override_no_catalog_returns_none(self):
         with self._setup_overrides({}), \
              patch("agent.models_dev.fetch_models_dev", return_value={}):


### PR DESCRIPTION
## What does this PR do?

Stops a metadata-only `model_overrides` entry from silently disabling reasoning for uncatalogued models. For a model missing from models.dev, `get_model_capabilities()`'s unknown-model branch set `supports_reasoning=False` definitively — so adding an unrelated override like

```yaml
model_overrides:
  zai:
    glm-5.3:
      context_window: 131072
```

flipped Desktop's capability result from "unknown; do not restrict" to a hard `supports_reasoning=False`: the reasoning menu disappeared and showed "No options for this model" (#91608; the reporter verified that adding an explicit `supports_reasoning: true` restored the effort controls).

Without any override the same model resolves to `None`, and every consumer already treats `None` as permissive — `inventory.py::_apply_capabilities` documents `reasoning = True` as the safe default, and the OpenRouter capability parsing in `models.py` mirrors the same permissive-unknown stance. The unknown-model branch now defaults `supports_reasoning=True` so unspecified capabilities inherit exactly that behavior; an explicit `supports_reasoning: false` in the override still wins. Vision stays off (safe routing default for unknown models) and catalog-hit models are untouched.

## Related Issue

Fixes #91608

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/models_dev.py`: In `get_model_capabilities()`'s unknown-model branch, default `supports_reasoning` to `True` with a comment explaining the permissive-unknown contract (consumers' `None` handling) and the #91608 failure mode.
- `tests/agent/test_models_dev.py`: `test_caps_metadata_only_override_keeps_reasoning_available` — a context-window-only override for an uncatalogued model keeps reasoning available (identical to the no-override path), and an explicit `supports_reasoning: false` in the same override still wins.

## How to Test

1. Use an uncatalogued model (e.g. `zai/glm-5.3`) with a `model_overrides` entry containing only `context_window`
2. Before the fix, `get_model_capabilities` returns `supports_reasoning=False` and Desktop shows "No options for this model" for the reasoning menu; after the fix reasoning stays available and the override's `context_window` still applies (Observed result: the new regression test fails on unpatched main — `supports_reasoning` comes back `False` — and passes with this patch)
3. Setting `supports_reasoning: false` explicitly in the override still disables it (covered in the same test)
4. `scripts/run_tests.sh tests/agent/test_models_dev.py -q` → should pass (Observed result: 69 passed locally, including the pre-existing override/caps tests)
5. `scripts/run_tests.sh tests/hermes_cli/test_inventory_pricing.py -q` → should pass (Observed result: 26 passed locally)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
