### PR TITLE
feat(gateway): honor disable_link_previews on Discord

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1149,6 +1149,12 @@ platform_toolsets:
 # Platform-specific knobs live under `extra`.
 #
 # platforms:
+#   discord:
+#     extra:
+#       # Suppress Discord's URL preview cards. false (default) keeps them,
+#       # true suppresses on every bot message, "scheduled" suppresses only on
+#       # cron deliveries so interactive chat still gets previews.
+#       disable_link_previews: false
 #   telegram:
 #     reply_to_mode: "first"  # off | first | all
 #     # guest_mode lets explicit @mentions from non-allowlisted groups through.

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1066,6 +1066,48 @@ class DiscordAdapter(BasePlatformAdapter):
 
         return _format_discord_markdown_link(preview.text, preview.url)
 
+    @staticmethod
+    def _coerce_link_preview_mode(value: Any) -> str:
+        """Normalize ``extra.disable_link_previews`` into a suppression mode.
+
+        Accepts the same booleans Telegram does (``true``/``false`` plus the
+        usual string spellings) and adds ``"scheduled"``, which suppresses
+        previews only on scheduled deliveries so interactive chat keeps them.
+
+        Returns one of ``"never"`` (default), ``"scheduled"``, ``"always"``.
+        """
+        if value is None:
+            return "never"
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"scheduled", "cron"}:
+                return "scheduled"
+            if lowered in {"true", "1", "yes", "on", "always"}:
+                return "always"
+            return "never"
+        return "always" if value else "never"
+
+    def _should_suppress_embeds(self, metadata: Optional[Dict[str, Any]]) -> bool:
+        """Whether this outgoing message sets Discord's SUPPRESS_EMBEDS flag.
+
+        Masked links in ``content`` do **not** reliably stop Discord from
+        expanding URLs into preview cards, so suppression has to be requested
+        at the API level per message.
+
+        An explicit ``metadata["suppress_embeds"]`` always wins so callers can
+        override per message.  Otherwise the configured mode decides, and
+        ``"scheduled"`` limits suppression to cron deliveries, which carry
+        ``job_id`` in their route metadata (``cron/scheduler.py``).
+        """
+        if metadata is not None and "suppress_embeds" in metadata:
+            return bool(metadata["suppress_embeds"])
+        mode = getattr(self, "_link_preview_mode", "never")
+        if mode == "always":
+            return True
+        if mode == "scheduled":
+            return bool(metadata and metadata.get("job_id"))
+        return False
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
         self._client: Optional[commands.Bot] = None
@@ -1080,6 +1122,15 @@ class DiscordAdapter(BasePlatformAdapter):
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
+        # Link-preview suppression, mirroring Telegram's
+        # ``platforms.telegram.extra.disable_link_previews``.  Discord expands
+        # bare and masked URLs into preview cards; the only reliable way to stop
+        # it is the SUPPRESS_EMBEDS message flag at send time.
+        self._link_preview_mode: str = self._coerce_link_preview_mode(
+            self.config.extra.get("disable_link_previews")
+            if getattr(self.config, "extra", None)
+            else None
+        )
         # Text batching: merge rapid successive messages (Telegram-style)
         self._text_batch_delay_seconds = env_float("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", 0.6)
         self._text_batch_split_delay_seconds = env_float("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", 2.0)
@@ -3473,6 +3524,14 @@ class DiscordAdapter(BasePlatformAdapter):
             if metadata and metadata.get("thread_id"):
                 thread_id = metadata["thread_id"]
             nonconversational = _metadata_marks_nonconversational(metadata)
+            # Only pass the kwarg when actually suppressing: False is Discord's
+            # default, and omitting it keeps the call signature unchanged for
+            # every existing caller and test double.
+            embed_kwargs = (
+                {"suppress_embeds": True}
+                if self._should_suppress_embeds(metadata)
+                else {}
+            )
             final_delivery = bool(metadata and metadata.get("notify"))
 
             if thread_id:
@@ -3521,6 +3580,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     msg = await channel.send(
                         content=chunk,
                         reference=chunk_reference,
+                        **embed_kwargs,
                     )
                 except Exception as e:
                     err_text = str(e)
@@ -3543,6 +3603,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         msg = await channel.send(
                             content=chunk,
                             reference=None,
+                            **embed_kwargs,
                         )
                     else:
                         raise

--- a/tests/gateway/test_discord_suppress_embeds.py
+++ b/tests/gateway/test_discord_suppress_embeds.py
@@ -1,0 +1,154 @@
+"""Tests for Discord link-preview suppression (``disable_link_previews``).
+
+Discord expands URLs in a bot message into preview cards.  Masked links
+(``[text](url)``) in ``content`` do **not** reliably suppress that — the only
+dependable lever is the SUPPRESS_EMBEDS message flag, which has to be set per
+message at send time.
+
+Telegram already exposes ``platforms.telegram.extra.disable_link_previews``.
+These tests cover the Discord counterpart, including the ``"scheduled"`` mode
+that suppresses only cron deliveries (which carry ``job_id`` in their route
+metadata) so interactive chat keeps its previews.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+def _make_adapter(disable_link_previews=None):
+    extra = {} if disable_link_previews is None else {
+        "disable_link_previews": disable_link_previews
+    }
+    return DiscordAdapter(PlatformConfig(enabled=True, token="***", extra=extra))
+
+
+# --------------------------------------------------------------------------
+# mode coercion
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, "never"),
+        (False, "never"),
+        ("false", "never"),
+        ("off", "never"),
+        ("never", "never"),
+        (True, "always"),
+        ("true", "always"),
+        ("YES", "always"),
+        ("always", "always"),
+        ("scheduled", "scheduled"),
+        ("  Scheduled  ", "scheduled"),
+        ("cron", "scheduled"),
+        ("nonsense", "never"),
+    ],
+)
+def test_mode_coercion(raw, expected):
+    assert DiscordAdapter._coerce_link_preview_mode(raw) == expected
+
+
+# --------------------------------------------------------------------------
+# suppression decision
+# --------------------------------------------------------------------------
+
+
+def test_default_keeps_previews():
+    adapter = _make_adapter()
+    assert adapter._should_suppress_embeds(None) is False
+    assert adapter._should_suppress_embeds({"job_id": "abc123"}) is False
+
+
+def test_always_suppresses_every_message():
+    adapter = _make_adapter(True)
+    assert adapter._should_suppress_embeds(None) is True
+    assert adapter._should_suppress_embeds({}) is True
+    assert adapter._should_suppress_embeds({"job_id": "abc123"}) is True
+
+
+def test_scheduled_suppresses_only_cron_deliveries():
+    adapter = _make_adapter("scheduled")
+    # cron/scheduler.py sets route_metadata = {"job_id": job["id"]}
+    assert adapter._should_suppress_embeds({"job_id": "abc123"}) is True
+    # interactive chat carries no job_id and keeps its previews
+    assert adapter._should_suppress_embeds(None) is False
+    assert adapter._should_suppress_embeds({}) is False
+    assert adapter._should_suppress_embeds({"thread_id": "42"}) is False
+
+
+@pytest.mark.parametrize("configured", [None, True, "scheduled"])
+def test_explicit_metadata_overrides_config(configured):
+    adapter = _make_adapter(configured)
+    assert adapter._should_suppress_embeds({"suppress_embeds": True}) is True
+    assert adapter._should_suppress_embeds(
+        {"suppress_embeds": False, "job_id": "abc123"}
+    ) is False
+
+
+# --------------------------------------------------------------------------
+# the flag actually reaches channel.send()
+# --------------------------------------------------------------------------
+
+
+def _wire_channel(adapter):
+    sent = MagicMock()
+    sent.id = 987654321
+    channel = MagicMock()
+    channel.send = AsyncMock(return_value=sent)
+    client = MagicMock()
+    client.get_channel = MagicMock(return_value=channel)
+    adapter._client = client
+    return channel
+
+
+@pytest.mark.asyncio
+async def test_send_passes_suppress_embeds_for_scheduled_delivery():
+    adapter = _make_adapter("scheduled")
+    channel = _wire_channel(adapter)
+
+    await adapter.send("123", "see <https://example.com>", metadata={"job_id": "abc123"})
+
+    assert channel.send.await_count >= 1
+    assert channel.send.await_args.kwargs["suppress_embeds"] is True
+
+
+@pytest.mark.asyncio
+async def test_send_keeps_previews_for_interactive_message():
+    adapter = _make_adapter("scheduled")
+    channel = _wire_channel(adapter)
+
+    await adapter.send("123", "see https://example.com")
+
+    assert channel.send.await_count >= 1
+    # The kwarg is omitted entirely rather than passed as False, so existing
+    # callers and test doubles keep working unchanged.
+    assert "suppress_embeds" not in channel.send.await_args.kwargs

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -590,6 +590,36 @@ display:
       reasoning_style: subtext   # code | blockquote | subtext
 ```
 
+## Link Previews
+
+Discord expands URLs in bot messages into preview cards. Masked links
+(`[text](url)`) in the message body do **not** reliably suppress them — the
+only dependable lever is Discord's `SUPPRESS_EMBEDS` message flag, which has
+to be set per message when it is sent.
+
+`disable_link_previews` mirrors the Telegram setting of the same name and
+accepts an extra value:
+
+```yaml
+gateway:
+  platforms:
+    discord:
+      extra:
+        disable_link_previews: false        # default — every message keeps its previews
+        # disable_link_previews: true       # suppress on every bot message
+        # disable_link_previews: scheduled  # suppress only on scheduled (cron) deliveries
+```
+
+`scheduled` is the useful middle ground for news digests and other recurring
+jobs: a cron post that cites ten sources no longer buries the channel under ten
+preview cards, while an ordinary chat reply that shares one link still renders
+it. Scheduled deliveries are identified by the `job_id` their route metadata
+carries (see `cron/scheduler.py`).
+
+Callers can override the configured behavior per message by setting
+`suppress_embeds` in the send metadata, which wins over any of the modes above.
+
+
 ## Slash Command Access Control
 
 By default, every allowed user can run every slash command. To split your allowlist into **admins** (full slash command access) and **regular users** (only commands you explicitly enable), add `allow_admin_from` and `user_allowed_commands` to the Discord platform's `extra` block:


### PR DESCRIPTION
## What does this PR do?

Discord expands URLs in bot messages into preview cards. Masked links (`[text](url)`) in the message body do **not** reliably suppress them — the only dependable lever is Discord's `SUPPRESS_EMBEDS` message flag, which has to be set per message at send time.

Telegram already exposes `platforms.telegram.extra.disable_link_previews`. The Discord adapter ignored the key entirely, so there was no supported way to stop preview-card clutter on Discord. This adds it.

It also adds a `"scheduled"` mode, which is the case that motivated the change: a recurring job that cites ten sources buries a channel under ten preview cards, while an ordinary chat reply sharing one link genuinely benefits from the card. `"scheduled"` suppresses only scheduled deliveries — identified by the `job_id` their route metadata already carries (`cron/scheduler.py`) — and leaves interactive chat untouched.

```yaml
gateway:
  platforms:
    discord:
      extra:
        disable_link_previews: false        # default — unchanged behavior
        # disable_link_previews: true       # suppress on every bot message
        # disable_link_previews: scheduled  # suppress only on cron deliveries
```

**Why this approach:**

- **Reuses the existing key name** rather than inventing a Discord-specific one. `true`/`false` behave exactly as they do on Telegram; `"scheduled"` is a superset, so the config stays portable between platforms.
- **The kwarg is passed only when suppressing.** `suppress_embeds=False` is Discord's default, so omitting it leaves the `channel.send()` call signature byte-identical for every existing caller and test double. Passing it unconditionally broke 3 existing tests whose fake `channel.send` stubs have fixed signatures — a good signal that the conditional form is the less invasive one.
- **`metadata["suppress_embeds"]` overrides the configured mode**, so a caller can force either behavior per message.

## Related Issue

Implements the request in #60942.

**Prior art — please read before reviewing this one.** #60975 and #60951 both predate this PR and address the same issue. #60975 in particular covers more delivery sites, including the standalone REST sender (`tools/send_message_tool.py` → `_standalone_send`) that this PR does **not** touch. The only thing unique here is the `"scheduled"` mode described above. See the discussion comment on this PR — I'd defer to #60975 on scope.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/discord/adapter.py`
  - `_coerce_link_preview_mode()` — normalizes the extra into `never` / `scheduled` / `always`, accepting the same boolean spellings Telegram does
  - `_should_suppress_embeds()` — per-message decision; explicit metadata wins, then the configured mode
  - `send()` — builds `embed_kwargs` once and splats it into both `channel.send()` call sites (the main send and the no-reference retry)
- `tests/gateway/test_discord_suppress_embeds.py` — new, 21 tests
- `cli-config.yaml.example` — documents the key under `platforms.discord.extra`
- `website/docs/user-guide/messaging/discord.md` — new "Link Previews" section

Net: **+97 lines** across 3 files, plus the test file. No existing lines removed.

## How to Test

1. Set `gateway.platforms.discord.extra.disable_link_previews: scheduled` in `config.yaml`
2. Restart the gateway
3. Trigger a cron job that posts URLs — `hermes cron run <job_id>` — and confirm no preview cards
4. Send the same URL through interactive chat and confirm the preview card still renders
5. Flip to `true` and confirm both paths suppress; remove the key and confirm both show previews

Unit coverage: `pytest tests/gateway/test_discord_suppress_embeds.py -q` → 21 passed.

**Platforms tested:** Debian 13 (trixie), Python 3.11, discord.py 2.7.1. Running live against a Discord bot delivering 8 scheduled jobs.

## Checklist notes for the maintainers

- `pytest tests/gateway/ -k discord` → **4 failed, 330 passed**. The same 4 fail on a clean `main` checkout at `fcbd1076a9` (`test_discord_send.py` ×3 and `test_send_multiple_images.py` ×1, all `AttributeError: None has no attribute 'File'`, and only when the whole selection runs together — they pass in isolation). Pre-existing test-ordering fragility, unrelated to this change. Before: 4 failed / 309 passed. After: same 4 / 330 passed.
- `ruff check` on both changed Python files: **All checks passed.**
- I did not run `ruff format` — the existing test files in this repo don't satisfy it either, and only `PLW1514` is selected in `pyproject.toml`, so formatting appears not to be enforced.

## Possible follow-ups (deliberately out of scope)

- `edit_message()` takes the same streaming path and could honor the flag too; left alone to keep the PR to one logical change.
- `_coerce_bool_extra()` currently lives on the Telegram adapter. If maintainers want, it could move to `BasePlatformAdapter` so both platforms share one coercion helper — that's a refactor touching Telegram, so it isn't in here.
