### PR TITLE
fix(desktop): keep Routines row switch visible in narrow pane (#91623)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9805,12 +9805,12 @@ function RoutineRow({ job, owner }) {
 
   return jsxs('div', {
     className: cn(
-      'group grid gap-1.5 rounded-lg border border-(--ui-stroke-secondary) p-2.5 transition-colors',
+      'group grid min-w-0 gap-1.5 rounded-lg border border-(--ui-stroke-secondary) p-2.5 transition-colors',
       'hover:border-(--ui-stroke-primary, var(--ui-stroke-secondary))'
     ),
     children: [
       jsxs('div', {
-        className: 'flex items-center gap-2',
+        className: 'flex min-w-0 items-center gap-2',
         children: [
           jsx('span', {
             'aria-hidden': true,
@@ -9831,7 +9831,7 @@ function RoutineRow({ job, owner }) {
               type: 'button',
               disabled: busy,
               className:
-                'flex size-5 items-center justify-center rounded text-(--ui-text-quaternary) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--chrome-action-hover) hover:text-foreground',
+                'flex size-5 shrink-0 items-center justify-center rounded text-(--ui-text-quaternary) opacity-0 transition-opacity group-hover:opacity-100 hover:bg-(--chrome-action-hover) hover:text-foreground',
               onClick: () => act('remove'),
               children: jsx(Codicon, { name: 'trash', className: 'text-[0.75rem]' })
             })
@@ -9839,7 +9839,7 @@ function RoutineRow({ job, owner }) {
         ]
       }),
       jsxs('div', {
-        className: 'flex items-center justify-between gap-2 pl-3.5',
+        className: 'flex min-w-0 items-center justify-between gap-2 pl-3.5',
         children: [
           jsxs('span', {
             className:
@@ -9855,7 +9855,7 @@ function RoutineRow({ job, owner }) {
       legacyUnsafe
         ? jsx('div', {
             className:
-              'rounded-md border border-(--ui-stroke-secondary) px-2 py-1.5 text-[0.65rem] leading-4 text-(--ui-accent)',
+              'min-w-0 rounded-md border border-(--ui-stroke-secondary) px-2 py-1.5 text-[0.65rem] leading-4 text-(--ui-accent)',
             children: 'Paused for security: delete and recreate this legacy cronjob before running it again.'
           })
         : null

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import test from 'node:test'
+import vm from 'node:vm'
 
 // RoutineRow narrow-pane layout contract (#91623):
 // The Routines (Cronjobs) pane docks right at 250px. RoutineRow is a
@@ -11,27 +12,130 @@ import test from 'node:test'
 // Switch + delete button became invisible (title truncation also never
 // engaged). Every grid/flex node in the row's width chain must carry
 // min-w-0 so the title and metadata can actually shrink.
+//
+// These tests render the real RoutineRow (extracted from plugin.js, with
+// the React runtime and SDK components stubbed) and assert the contract on
+// the resulting JSX tree — not on source formatting. Tailwind class order,
+// cn() composition, or whitespace can change freely without false reds; a
+// real regression in the width chain (dropped min-w-0 / shrink-0) fails.
 
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
-test('RoutineRow root grid carries min-w-0 so the row can shrink inside the pane', () => {
-  assert.match(source, /'group grid min-w-0 gap-1\.5 rounded-lg border border-\(--ui-stroke-secondary\) p-2\.5 transition-colors'/)
+function slice(from, to) {
+  const start = source.indexOf(from)
+  const end = source.indexOf(to, start)
+  assert.ok(start >= 0 && end > start, `slice ${JSON.stringify(from)} must remain extractable`)
+  return source.slice(start, end)
+}
+
+function renderRoutineRow(job) {
+  // Real helper logic rides along with the row; only the React runtime,
+  // SDK components, and host bridge are stubbed.
+  const helpers = slice('const BOT_TAG_RE = ', '\nasync function loadRoutines(')
+  const scheduleLabel = slice('function scheduleLabel(', '\nfunction RoutineRow(')
+  const row = slice('function RoutineRow(', '\n// Structured schedule picker')
+
+  const context = {
+    jsx: (type, props) => ({ type, props: props || {} }),
+    jsxs: (type, props) => ({ type, props: props || {} }),
+    useState: initial => [initial, () => {}],
+    cn: (...parts) => parts.filter(Boolean).join(' '),
+    relativeTime: () => 'now',
+    Switch: 'Switch',
+    Tip: 'Tip',
+    Codicon: 'Codicon',
+    host: { request: async () => ({}), notifyError: () => {} },
+    invalidateRoutineOwner: async () => {}
+  }
+  vm.runInNewContext(
+    `${helpers}\n${scheduleLabel}\n${row}\nglobalThis.__row = RoutineRow;`,
+    context
+  )
+  // RoutineRow takes { job, owner } since the bot-owner routing rework;
+  // the width-chain contract does not depend on the owner value.
+  return context.__row({ job, owner: undefined })
+}
+
+// Flatten the JSX tree into nodes. Nodes with a className get
+// { type, tokens } (tokens = the cn()-joined class set); classless nodes
+// (Switch etc.) are still listed so their presence can be asserted.
+function collect(node, acc = []) {
+  if (!node || typeof node !== 'object') {
+    return acc
+  }
+  const { props } = node
+  const entry = { type: node.type }
+  if (typeof props?.className === 'string') {
+    entry.tokens = new Set(props.className.split(/\s+/))
+  }
+  acc.push(entry)
+  const children = props?.children
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      collect(child, acc)
+    }
+  } else {
+    collect(children, acc)
+  }
+  return acc
+}
+
+const hasAll = (el, ...tokens) => !!el.tokens && tokens.every(t => el.tokens.has(t))
+const findRow = (els, ...tokens) => els.find(el => hasAll(el, ...tokens))
+
+const JOB = {
+  job_id: 'j1',
+  name: '[bot:researcher] Daily digest',
+  schedule: 'every 60m',
+  enabled: true,
+  state: 'active',
+  next_run_at: '2026-08-23T00:00:00Z'
+}
+
+test('row root grid carries min-w-0 so the row can shrink inside the pane', () => {
+  const els = collect(renderRoutineRow(JOB))
+  const root = findRow(els, 'grid')
+  assert.ok(root, 'row root must be a grid')
+  assert.ok(hasAll(root, 'min-w-0'), 'row root grid must be min-w-0')
 })
 
 test('title/controls flex line carries min-w-0 (title truncate engages, Switch stays visible)', () => {
-  assert.match(source, /className: 'flex min-w-0 items-center gap-2'/)
-  // The old pinned-width form must not come back.
-  assert.doesNotMatch(source, /jsxs\('div', \{\s*\n\s*className: 'flex items-center gap-2',\s*\n\s*children: \[\s*\n\s*jsx\('span', \{\s*\n\s*'aria-hidden': true,/)
+  const els = collect(renderRoutineRow(JOB))
+  // The title line is the first flex row; the metadata line also uses
+  // justify-between, so require its absence to pin the right line.
+  const line = els.find(el => hasAll(el, 'flex', 'gap-2') && !hasAll(el, 'justify-between'))
+  assert.ok(line, 'title/controls line must be a flex row')
+  assert.ok(hasAll(line, 'min-w-0'), 'title/controls line must be min-w-0')
+
+  const title = findRow(els, 'flex-1', 'truncate')
+  assert.ok(title, 'job title span must be flex-1 truncate')
+  assert.ok(hasAll(title, 'min-w-0'), 'title must carry min-w-0 for truncation to engage')
+
+  assert.ok(els.some(el => el.type === 'Switch'), 'enable/disable Switch must render')
 })
 
 test('metadata line carries min-w-0 so the next-run label can truncate, not clip', () => {
-  assert.match(source, /className: 'flex min-w-0 items-center justify-between gap-2 pl-3\.5'/)
+  const els = collect(renderRoutineRow(JOB))
+  const meta = findRow(els, 'flex', 'justify-between', 'pl-3.5')
+  assert.ok(meta, 'metadata line must be a flex row')
+  assert.ok(hasAll(meta, 'min-w-0'), 'metadata line must be min-w-0')
 })
 
 test('delete button is shrink-0 so the icon is never crushed in narrow panes', () => {
-  assert.match(source, /'flex size-5 shrink-0 items-center justify-center rounded text-\(--ui-text-quaternary\)/)
+  const els = collect(renderRoutineRow(JOB))
+  const del = findRow(els, 'size-5')
+  assert.ok(del, 'delete button must render')
+  assert.ok(hasAll(del, 'shrink-0'), 'delete button must be shrink-0')
 })
 
 test('legacy-routine warning strip carries min-w-0 (same grid item class of bug)', () => {
-  assert.match(source, /'min-w-0 rounded-md border border-\(--ui-stroke-secondary\) px-2 py-1\.5 text-\[0\.65rem\] leading-4 text-\(--ui-accent\)'/)
+  const legacyJob = {
+    ...JOB,
+    prompt_preview:
+      'You are running the scheduled routine "Daily digest" for agent \'researcher\'. Execute it AS that agent...'
+  }
+  const els = collect(renderRoutineRow(legacyJob))
+  const strip = findRow(els, 'px-2', 'py-1.5')
+  assert.ok(strip, 'legacy warning strip must render for legacy jobs')
+  assert.ok(hasAll(strip, 'min-w-0'), 'legacy warning strip must be min-w-0')
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+// RoutineRow narrow-pane layout contract (#91623):
+// The Routines (Cronjobs) pane docks right at 250px. RoutineRow is a
+// display:grid node inside the pane's grid list; grid items default to
+// min-width:auto, so the row could not shrink below its min-content width.
+// A nowrap job title pinned the row at ~284px inside the 250px pane, the
+// overflow-hidden ScrollArea clipped the right edge, and the enable/disable
+// Switch + delete button became invisible (title truncation also never
+// engaged). Every grid/flex node in the row's width chain must carry
+// min-w-0 so the title and metadata can actually shrink.
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+test('RoutineRow root grid carries min-w-0 so the row can shrink inside the pane', () => {
+  assert.match(source, /'group grid min-w-0 gap-1\.5 rounded-lg border border-\(--ui-stroke-secondary\) p-2\.5 transition-colors'/)
+})
+
+test('title/controls flex line carries min-w-0 (title truncate engages, Switch stays visible)', () => {
+  assert.match(source, /className: 'flex min-w-0 items-center gap-2'/)
+  // The old pinned-width form must not come back.
+  assert.doesNotMatch(source, /jsxs\('div', \{\s*\n\s*className: 'flex items-center gap-2',\s*\n\s*children: \[\s*\n\s*jsx\('span', \{\s*\n\s*'aria-hidden': true,/)
+})
+
+test('metadata line carries min-w-0 so the next-run label can truncate, not clip', () => {
+  assert.match(source, /className: 'flex min-w-0 items-center justify-between gap-2 pl-3\.5'/)
+})
+
+test('delete button is shrink-0 so the icon is never crushed in narrow panes', () => {
+  assert.match(source, /'flex size-5 shrink-0 items-center justify-center rounded text-\(--ui-text-quaternary\)/)
+})
+
+test('legacy-routine warning strip carries min-w-0 (same grid item class of bug)', () => {
+  assert.match(source, /'min-w-0 rounded-md border border-\(--ui-stroke-secondary\) px-2 py-1\.5 text-\[0\.65rem\] leading-4 text-\(--ui-accent\)'/)
+})


### PR DESCRIPTION
## What does this PR do?

Fixes the invisible enable/disable **Switch** and **delete button** on Bot Mode Routines (Cronjobs) job rows when the pane is docked right (its default 250px width). The row was pinned at ~284px by a grid `min-width: auto` min-content chain, the pane's `overflow-hidden` ScrollArea clipped the right ~34px, and the title's `text-overflow: ellipsis` never engaged (hard-clipped instead).

**Root cause:** `RoutineRow` is a `display: grid` node inside the pane's grid list. Grid items default to `min-width: auto`, so the row cannot shrink below its min-content width; a nowrap job title's full text width propagates up the chain. The `min-w-0 flex-1 truncate` title never gets to shrink because the flex container's width itself is pinned by the grid.

**Fix:** break the min-content chain — add `min-w-0` to the row root and both flex lines, `shrink-0` to the delete button, and `min-w-0` to the legacy-routine warning strip:

- Row root: `group grid min-w-0 gap-1.5 rounded-lg …`
- Title/controls line: `flex min-w-0 items-center gap-2` (title truncate now engages, Switch stays visible)
- Metadata line: `flex min-w-0 items-center justify-between gap-2 pl-3.5` (next-run truncates instead of clipping — same mechanism as #89534, fixed at the root here)
- Delete button: `flex size-5 shrink-0 …`
- Legacy warning strip: `min-w-0 rounded-md border …`

Verified with a headless browser layout probe: at 250px pane width the row was 284px wide with the switch edge at 256px (clipped); after the fix the row is 213px and the switch edge is at 185px (fully visible). This complements #89557 (which wraps the metadata line but does not break the min-content root cause nor touch the title/switch line).

## Related Issue

Fixes #91623

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` — `RoutineRow`: `min-w-0` on row root + both lines, `shrink-0` on delete button, `min-w-0` on legacy warning strip
- `apps/desktop/src/plugins/hermes-bots/tests/routine-row-min-width.test.mjs` — new regression test asserting the layout contract

## How to Test

1. Run Hermes Desktop in Bot Mode; open the Cronjobs (Routines) pane docked right.
2. Before: the row's Switch and delete button are invisible; long titles hard-clip with no ellipsis.
3. After: the Switch is visible on every row, hover shows the delete button, long titles show `…`.
4. `npm --prefix apps/desktop run check:test:plugins` — all suites pass (58 total, incl. the new one).

## Checklist

- [x] I have read the [CONTRIBUTING.md](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) guidelines
- [x] I have searched existing issues and PRs (duplicate check: #89534/#89557 are the adjacent metadata-line issue; the title/switch-line clipping is unreported — #91623)
- [x] My code follows the project's style and linting rules
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass
