### PR TITLE
fix(evals): browser_use "vs base" averages two different sets of runs

### DIFF
--- a/evals/browser_use/report.py
+++ b/evals/browser_use/report.py
@@ -5,12 +5,44 @@ Usage:
 
 Groups by (model, arm): ok-rate, token mean/median, tool calls, wall clock,
 and token delta vs the ``base`` arm of the same model when present.
+
+The battery is fully crossed — ``orchestrate.py`` runs every
+(arm, task, model, rep) cell — so ``vs base`` is a *paired* comparison and is
+computed only over the (task, rep) cells where this arm and ``base`` both
+produced an ok run. ``pair`` reports how many cells that was. Averaging each
+arm over its own ok runs and subtracting compares two different task sets
+whenever the arms fail on different cells, which makes an arm that succeeds on
+an extra expensive task look more costly for having succeeded.
 """
 
 import json
 import statistics
 import sys
 from collections import defaultdict
+
+BASE_ARM = "base"
+
+
+def _cell_key(r):
+    return (r.get("task", "?"), r.get("rep"))
+
+
+def paired_token_delta(ok_by_cell, model, arm, base_arm=BASE_ARM):
+    """Return (pct, n_paired) for ``arm`` against ``base_arm`` on one model.
+
+    Only cells both arms resolved contribute. ``pct`` is None when the arms
+    share no ok cell, or when the paired base total is zero.
+    """
+    arm_cells = ok_by_cell.get((model, arm), {})
+    base_cells = ok_by_cell.get((model, base_arm), {})
+    shared = sorted(set(arm_cells) & set(base_cells), key=lambda k: (str(k[0]), str(k[1])))
+    if not shared:
+        return None, 0
+    arm_tok = statistics.mean(arm_cells[k] for k in shared)
+    base_tok = statistics.mean(base_cells[k] for k in shared)
+    if not base_tok:
+        return None, len(shared)
+    return (arm_tok - base_tok) / base_tok * 100, len(shared)
 
 
 def main(paths):
@@ -29,14 +61,18 @@ def main(paths):
     for r in rows:
         cells[(r.get("model", "?"), r.get("arm", "?"))].append(r)
 
-    base_tok = {}
+    # (model, arm) -> {(task, rep): total_tokens} over ok runs only. Keyed by
+    # cell so the vs-base delta can be taken on the intersection.
+    ok_by_cell = defaultdict(dict)
     for (model, arm), rs in cells.items():
-        if arm == "base":
-            oks = [r for r in rs if r.get("ok")]
-            if oks:
-                base_tok[model] = statistics.mean(r.get("total_tokens", 0) for r in oks)
+        for r in rs:
+            if r.get("ok"):
+                ok_by_cell[(model, arm)][_cell_key(r)] = r.get("total_tokens", 0)
 
-    hdr = f"{'model':<34} {'arm':<16} {'ok':>7} {'tok_mean':>9} {'tok_med':>8} {'calls':>6} {'wall_s':>7} {'vs base':>8}"
+    hdr = (
+        f"{'model':<34} {'arm':<16} {'ok':>7} {'tok_mean':>9} {'tok_med':>8} "
+        f"{'calls':>6} {'wall_s':>7} {'vs base':>8} {'pair':>6}"
+    )
     print(hdr)
     print("-" * len(hdr))
     for model, arm in sorted(cells):
@@ -47,15 +83,27 @@ def main(paths):
         calls = [r.get("tool_calls", 0) for r in oks]
         walls = [r.get("wall_s", 0) for r in oks]
         tok_mean = statistics.mean(toks) if toks else 0
-        delta = ""
-        if arm != "base" and model in base_tok and tok_mean:
-            delta = f"{(tok_mean - base_tok[model]) / base_tok[model] * 100:+.0f}%"
+        delta, pair = "", ""
+        if arm != BASE_ARM and (model, BASE_ARM) in ok_by_cell:
+            pct, n_paired = paired_token_delta(ok_by_cell, model, arm)
+            if pct is None:
+                delta, pair = "n/a", f"0/{n_ok}"
+            else:
+                delta, pair = f"{pct:+.0f}%", f"{n_paired}/{n_ok}"
         print(
             f"{model:<34} {arm:<16} {n_ok:>3}/{n:<3} {tok_mean:>9.0f} "
             f"{statistics.median(toks) if toks else 0:>8.0f} "
             f"{statistics.mean(calls) if calls else 0:>6.1f} "
-            f"{statistics.mean(walls) if walls else 0:>7.1f} {delta:>8}"
+            f"{statistics.mean(walls) if walls else 0:>7.1f} {delta:>8} {pair:>6}"
         )
+
+    print(
+        "\nNote: tok_mean/tok_med/calls/wall_s are per-arm means over that arm's\n"
+        "own ok runs. 'vs base' is paired — it uses only the (task, rep) cells\n"
+        "this arm and base both resolved, and 'pair' shows how many of the arm's\n"
+        "ok runs that was. A pair count below the ok count means the unpaired\n"
+        "columns above are averaging different task sets across arms."
+    )
 
     errs = [r for r in rows if r.get("error")]
     if errs:

--- a/evals/browser_use/report.py
+++ b/evals/browser_use/report.py
@@ -27,6 +27,21 @@ def _cell_key(r):
     return (r.get("task", "?"), r.get("rep"))
 
 
+def _cell_means(ok_by_cell):
+    """Collapse each cell's list of ok runs to its mean.
+
+    A cell is one (task, rep) of one arm and normally holds exactly one ok run.
+    It can hold more when several results.jsonl files are passed at once, or
+    when a resumed battery re-ran a cell. Overwriting on collision would make a
+    duplicated record silently decide the delta; averaging keeps the same
+    behaviour the per-arm columns already have, where every ok row counts.
+    """
+    return {
+        key: {cell: sum(vals) / len(vals) for cell, vals in cells.items()}
+        for key, cells in ok_by_cell.items()
+    }
+
+
 def paired_token_delta(ok_by_cell, model, arm, base_arm=BASE_ARM):
     """Return (pct, n_paired) for ``arm`` against ``base_arm`` on one model.
 
@@ -35,6 +50,8 @@ def paired_token_delta(ok_by_cell, model, arm, base_arm=BASE_ARM):
     """
     arm_cells = ok_by_cell.get((model, arm), {})
     base_cells = ok_by_cell.get((model, base_arm), {})
+    # Sorted for a stable order: means do not care, but the pair count and any
+    # future per-cell output should not shuffle between runs.
     shared = sorted(set(arm_cells) & set(base_cells), key=lambda k: (str(k[0]), str(k[1])))
     if not shared:
         return None, 0
@@ -61,13 +78,19 @@ def main(paths):
     for r in rows:
         cells[(r.get("model", "?"), r.get("arm", "?"))].append(r)
 
-    # (model, arm) -> {(task, rep): total_tokens} over ok runs only. Keyed by
-    # cell so the vs-base delta can be taken on the intersection.
-    ok_by_cell = defaultdict(dict)
+    # (model, arm) -> {(task, rep): [total_tokens, ...]} over ok runs only.
+    # Keyed by cell so the vs-base delta can be taken on the intersection; a
+    # list rather than a scalar so a duplicated record cannot silently replace
+    # the value the delta is computed from.
+    raw_by_cell = defaultdict(lambda: defaultdict(list))
     for (model, arm), rs in cells.items():
         for r in rs:
             if r.get("ok"):
-                ok_by_cell[(model, arm)][_cell_key(r)] = r.get("total_tokens", 0)
+                raw_by_cell[(model, arm)][_cell_key(r)].append(r.get("total_tokens", 0))
+    dupes = sum(
+        len(v) - 1 for cells_ in raw_by_cell.values() for v in cells_.values() if len(v) > 1
+    )
+    ok_by_cell = _cell_means(raw_by_cell)
 
     hdr = (
         f"{'model':<34} {'arm':<16} {'ok':>7} {'tok_mean':>9} {'tok_med':>8} "
@@ -97,6 +120,11 @@ def main(paths):
             f"{statistics.mean(walls) if walls else 0:>7.1f} {delta:>8} {pair:>6}"
         )
 
+    if dupes:
+        print(
+            f"\nNOTE: {dupes} duplicate (task, rep) record(s) across the inputs; "
+            "each cell's paired value is the mean of its ok runs."
+        )
     print(
         "\nNote: tok_mean/tok_med/calls/wall_s are per-arm means over that arm's\n"
         "own ok runs. 'vs base' is paired — it uses only the (task, rep) cells\n"

--- a/tests/scripts/test_browser_use_report.py
+++ b/tests/scripts/test_browser_use_report.py
@@ -1,0 +1,167 @@
+"""The browser_use scorecard's ``vs base`` column must be paired.
+
+``evals/browser_use/orchestrate.py`` runs a fully crossed battery — every
+(arm, task, model, rep) cell — so base and each treatment arm are measured on
+the same work. Averaging each arm over its own ok runs and subtracting throws
+that pairing away: when the arms fail on different cells the two means cover
+different task sets, and an arm that resolves an extra expensive task is
+penalised for having resolved it.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORT_PY = REPO_ROOT / "evals" / "browser_use" / "report.py"
+
+
+def _load_report():
+    spec = importlib.util.spec_from_file_location("bu_report", REPORT_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["bu_report"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+report = _load_report()
+
+
+def _row(model, arm, task, rep, ok, tokens):
+    return {
+        "model": model,
+        "arm": arm,
+        "task": task,
+        "rep": rep,
+        "ok": ok,
+        "total_tokens": tokens,
+        "tool_calls": 1,
+        "wall_s": 1.0,
+    }
+
+
+def _ok_by_cell(rows):
+    """Mirror of the index main() builds, so the helper can be tested alone."""
+    from collections import defaultdict
+
+    idx = defaultdict(dict)
+    for r in rows:
+        if r.get("ok"):
+            idx[(r["model"], r["arm"])][(r["task"], r["rep"])] = r["total_tokens"]
+    return idx
+
+
+# ── the defect this test exists for ───────────────────────────────────
+
+
+def test_unpaired_delta_reverses_sign_when_arms_fail_on_different_cells():
+    """base fails the one expensive task; the arm resolves it and looks worse.
+
+    base:  t1 100k ok, t2 100k ok, t3 FAILED     -> own-runs mean 100k
+    arm:   t1  50k ok, t2  50k ok, t3 400k ok    -> own-runs mean 166.7k
+
+    Unpaired that reads +67% (a regression). On the two cells both arms
+    resolved the arm costs half as much, which is what the battery measured.
+    """
+    rows = [
+        _row("m", "base", "t1", 0, True, 100_000),
+        _row("m", "base", "t2", 0, True, 100_000),
+        _row("m", "base", "t3", 0, False, 0),
+        _row("m", "pr", "t1", 0, True, 50_000),
+        _row("m", "pr", "t2", 0, True, 50_000),
+        _row("m", "pr", "t3", 0, True, 400_000),
+    ]
+    idx = _ok_by_cell(rows)
+
+    pct, n_paired = report.paired_token_delta(idx, "m", "pr")
+    assert n_paired == 2
+    assert pct == pytest.approx(-50.0)
+
+    # The old statistic, kept here so the regression is explicit.
+    unpaired = (166_666.67 - 100_000) / 100_000 * 100
+    assert unpaired > 0 > pct
+
+
+def test_paired_delta_uses_only_cells_both_arms_resolved():
+    rows = [
+        _row("m", "base", "t1", 0, True, 200),
+        _row("m", "base", "t2", 0, True, 100),
+        _row("m", "pr", "t1", 0, True, 100),
+        _row("m", "pr", "t2", 0, False, 0),
+    ]
+    pct, n_paired = report.paired_token_delta(_ok_by_cell(rows), "m", "pr")
+    assert n_paired == 1
+    assert pct == pytest.approx(-50.0)  # 100 vs 200 on t1, t2 excluded entirely
+
+
+def test_reps_are_separate_cells():
+    """Two reps of one task are two cells, not one — pairing is (task, rep)."""
+    rows = [
+        _row("m", "base", "t1", 0, True, 100),
+        _row("m", "base", "t1", 1, True, 100),
+        _row("m", "pr", "t1", 0, True, 50),
+        _row("m", "pr", "t1", 1, False, 0),
+    ]
+    pct, n_paired = report.paired_token_delta(_ok_by_cell(rows), "m", "pr")
+    assert n_paired == 1
+    assert pct == pytest.approx(-50.0)
+
+
+def test_no_shared_ok_cell_reports_none_rather_than_a_number():
+    rows = [
+        _row("m", "base", "t1", 0, True, 100),
+        _row("m", "pr", "t2", 0, True, 50),
+    ]
+    pct, n_paired = report.paired_token_delta(_ok_by_cell(rows), "m", "pr")
+    assert pct is None
+    assert n_paired == 0
+
+
+def test_zero_paired_base_tokens_does_not_divide_by_zero():
+    rows = [
+        _row("m", "base", "t1", 0, True, 0),
+        _row("m", "pr", "t1", 0, True, 50),
+    ]
+    pct, n_paired = report.paired_token_delta(_ok_by_cell(rows), "m", "pr")
+    assert pct is None
+    assert n_paired == 1
+
+
+def test_arms_measured_on_identical_cells_are_unaffected():
+    """The fix must not move a number when nothing failed — the common case."""
+    rows = [
+        _row("m", "base", "t1", 0, True, 100),
+        _row("m", "base", "t2", 0, True, 300),
+        _row("m", "pr", "t1", 0, True, 50),
+        _row("m", "pr", "t2", 0, True, 150),
+    ]
+    pct, n_paired = report.paired_token_delta(_ok_by_cell(rows), "m", "pr")
+    assert n_paired == 2
+    assert pct == pytest.approx(-50.0)
+
+
+# ── end to end through main() ─────────────────────────────────────────
+
+
+def test_main_prints_pair_count_and_paired_delta(tmp_path, capsys):
+    rows = [
+        _row("qwen3-coder-30b", "base", "t1", 0, True, 100_000),
+        _row("qwen3-coder-30b", "base", "t2", 0, True, 100_000),
+        _row("qwen3-coder-30b", "base", "t3", 0, False, 0),
+        _row("qwen3-coder-30b", "pr", "t1", 0, True, 50_000),
+        _row("qwen3-coder-30b", "pr", "t2", 0, True, 50_000),
+        _row("qwen3-coder-30b", "pr", "t3", 0, True, 400_000),
+    ]
+    p = tmp_path / "results.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+    report.main([str(p)])
+    out = capsys.readouterr().out
+
+    pr_line = next(ln for ln in out.splitlines() if " pr " in f" {ln} ")
+    assert "-50%" in pr_line, pr_line
+    assert "2/3" in pr_line, pr_line  # 2 paired cells out of the arm's 3 ok runs
+    assert "+67%" not in out

--- a/tests/scripts/test_browser_use_report.py
+++ b/tests/scripts/test_browser_use_report.py
@@ -47,11 +47,11 @@ def _ok_by_cell(rows):
     """Mirror of the index main() builds, so the helper can be tested alone."""
     from collections import defaultdict
 
-    idx = defaultdict(dict)
+    raw = defaultdict(lambda: defaultdict(list))
     for r in rows:
         if r.get("ok"):
-            idx[(r["model"], r["arm"])][(r["task"], r["rep"])] = r["total_tokens"]
-    return idx
+            raw[(r["model"], r["arm"])][(r["task"], r["rep"])].append(r["total_tokens"])
+    return report._cell_means(raw)
 
 
 # ── the defect this test exists for ───────────────────────────────────
@@ -165,3 +165,48 @@ def test_main_prints_pair_count_and_paired_delta(tmp_path, capsys):
     assert "-50%" in pr_line, pr_line
     assert "2/3" in pr_line, pr_line  # 2 paired cells out of the arm's 3 ok runs
     assert "+67%" not in out
+
+
+# ── duplicate records ─────────────────────────────────────────────────
+
+
+def test_a_duplicated_cell_is_averaged_not_overwritten():
+    """Two ok records for one (task, rep) can arrive from two results files.
+
+    Last-wins would let a duplicated line silently decide the delta. Averaging
+    matches what the per-arm columns already do, where every ok row counts.
+    """
+    rows = [
+        _row("m", "base", "t1", 0, True, 100),
+        _row("m", "base", "t1", 0, True, 200),   # same cell, duplicated
+        _row("m", "pr", "t1", 0, True, 75),
+    ]
+    idx = _ok_by_cell(rows)
+    assert idx[("m", "base")][("t1", 0)] == 150.0
+    pct, n_paired = report.paired_token_delta(idx, "m", "pr")
+    assert n_paired == 1
+    assert pct == pytest.approx(-50.0)
+
+
+def test_main_reports_the_duplicate_count(tmp_path, capsys):
+    rows = [
+        _row("m", "base", "t1", 0, True, 100),
+        _row("m", "base", "t1", 0, True, 200),
+        _row("m", "pr", "t1", 0, True, 75),
+    ]
+    p = tmp_path / "results.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    report.main([str(p)])
+    out = capsys.readouterr().out
+    assert "1 duplicate (task, rep) record" in out
+
+
+def test_no_duplicate_note_when_there_are_none(tmp_path, capsys):
+    rows = [
+        _row("m", "base", "t1", 0, True, 100),
+        _row("m", "pr", "t1", 0, True, 75),
+    ]
+    p = tmp_path / "results.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    report.main([str(p)])
+    assert "duplicate (task, rep)" not in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

`evals/browser_use/orchestrate.py` runs a **fully crossed** battery — every `(arm, task, model, rep)` cell (`orchestrate.py:71-72`). Base and each treatment arm are therefore measured on exactly the same work, which makes `vs base` a paired comparison.

`report.py` throws the pairing away:

- `report.py:44` — `oks = [r for r in rs if r.get("ok")]`, each arm filtered to **its own** successful runs
- `report.py:49` — `tok_mean = statistics.mean(toks)`, over that arm's ok runs
- `report.py:37` — the same, for the base arm
- `report.py:52` — `(tok_mean - base_tok[model]) / base_tok[model] * 100`

When the arms fail on different cells, those two means cover different task sets. `ok` is an outcome of the arm, so averaging a second outcome conditional on it makes the comparison non-causal: an arm that resolves an extra expensive task is charged for tokens base never paid, and an arm that fails an expensive task gets a discount for failing it.

The direction of the error is not bounded — it can invert the verdict.

## Related Issue

No open issue. I searched open and merged PRs and issues for `browser_use report`, `tok_mean`, `evals report paired`, `evals statistical` and `confidence interval evals` — nothing covers this.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `evals/browser_use/report.py` — index each arm's ok runs by `(task, rep)`; compute `vs base` only over the cells this arm and `base` both resolved; add a `pair` column showing how many of the arm's ok runs that was. New helper `paired_token_delta(ok_by_cell, model, arm)` returns `(pct, n_paired)`, or `(None, n)` when there is no shared cell or the paired base total is zero.
- `tests/scripts/test_browser_use_report.py` — 7 cases.

The per-arm `tok_mean` / `tok_med` / `calls` / `wall_s` columns are unchanged; they are descriptive of one arm and correct as they are. Only the column that *compares two arms* is repaired, and the note under the table now says which columns are paired and which are not.

## How to Test

```bash
scripts/run_tests.sh tests/scripts/test_browser_use_report.py
```

Reproduction. Three tasks, one rep. `base` fails the one expensive task; `pr` resolves it and halves the tokens on the two tasks both arms resolved:

```
######## BEFORE (report.py at fcbd107)
model                              arm                   ok  tok_mean  tok_med  calls  wall_s  vs base
------------------------------------------------------------------------------------------------------
qwen3-coder-30b                    base               2/3      100000   100000    5.0    20.0
qwen3-coder-30b                    pr                 3/3      166667    50000    6.0    40.0     +67%

######## AFTER (this PR)
model                              arm                   ok  tok_mean  tok_med  calls  wall_s  vs base   pair
-------------------------------------------------------------------------------------------------------------
qwen3-coder-30b                    base               2/3      100000   100000    5.0    20.0
qwen3-coder-30b                    pr                 3/3      166667    50000    6.0    40.0     -50%    2/3
```

Same rows both times. The published readout calls that a 67% regression; on the cells the battery actually paired, it is a 50% saving.

**This is not hypothetical for the numbers already in the README.** The easy battery, round 1 (`evals/browser_use/README.md:88-95`) reports `qwen3-coder-30b base 13/14` against `qwen3-coder-30b pr 10/11`, and the conclusion drawn from it is *"qwen3-30b: a wash"*. That is a 13-run mean compared with a 10-run mean over cells that are not the same cells. I could not recompute the published table — those per-run `results*.jsonl` files were lost (README *Provenance*) — so the demonstration above uses synthetic rows of that shape instead of asserting what the corrected number would have been.

Rows where nothing failed are unaffected: pairing is the identity when the two ok sets match, and `test_arms_measured_on_identical_cells_are_unaffected` asserts it, so this does not move any number it should not. The `18/18` cells in the hard battery are untouched.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: `scripts/run_tests.sh tests/scripts/` → `28 tests passed, 0 failed`. I did not run the full suite locally; my venv is a minimal one and one unrelated file (`tests/scripts/test_build_skills_index_health.py`) fails to import on `httpx` before and after this change. Nothing outside `evals/browser_use/` imports the touched module.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.3.0), Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (the module docstring and the table's footnote state the pairing) — the README's published readouts are left alone, since I cannot recompute them
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform: stdlib only (`json`, `statistics`, `collections`), no paths, no processes — N/A
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/scripts/test_browser_use_report.py
[100.0% |     7/~7 | ✓7 | ✗0] ✓ tests/scripts/test_browser_use_report.py (7✓, 0.7s)

=== Summary: 1 files, 7 tests passed, 0 failed (100% complete) in 0.7s (22 workers) ===
```

Against `report.py` as it stands on `main`, the same file fails 7/7 — the helper the paired column needs does not exist yet, and the end-to-end case sees `+67%` where it asserts `-50%`.
