### PR TITLE
fix(slack): bound Socket Mode reconnect teardown

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1080,6 +1080,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
+        self._socket_stop_timeout_s = 10.0
         # Monotonic timestamp of the most recent Socket Mode handler (re)start,
         # used to grant a grace window for the first ping/pong after connect.
         self._socket_handler_started_monotonic: Optional[float] = None
@@ -1339,10 +1340,28 @@ class SlackAdapter(BasePlatformAdapter):
                 return
 
             logger.warning("[Slack] Socket Mode unhealthy (%s); reconnecting", reason)
-            await self._stop_socket_mode_handler()
+            try:
+                await asyncio.wait_for(
+                    self._stop_socket_mode_handler(),
+                    timeout=self._socket_stop_timeout_s,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[Slack] Timed out closing stale Socket Mode handler after %.1fs; "
+                    "starting a replacement",
+                    self._socket_stop_timeout_s,
+                )
+            except Exception as exc:  # pragma: no cover - defensive recovery
+                logger.warning(
+                    "[Slack] Error closing stale Socket Mode handler: %s; "
+                    "starting a replacement",
+                    exc,
+                    exc_info=True,
+                )
 
             try:
                 self._start_socket_mode_handler()
+                logger.info("[Slack] Socket Mode replacement started")
             except Exception as exc:  # pragma: no cover - defensive logging
                 logger.error(
                     "[Slack] Socket Mode reconnect failed: %s", exc, exc_info=True

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1340,6 +1340,7 @@ class SlackAdapter(BasePlatformAdapter):
                 return
 
             logger.warning("[Slack] Socket Mode unhealthy (%s); reconnecting", reason)
+            stale_task = self._socket_mode_task
             try:
                 await asyncio.wait_for(
                     self._stop_socket_mode_handler(),
@@ -1351,6 +1352,8 @@ class SlackAdapter(BasePlatformAdapter):
                     "starting a replacement",
                     self._socket_stop_timeout_s,
                 )
+                if stale_task is not None and not stale_task.done():
+                    stale_task.cancel()
             except Exception as exc:  # pragma: no cover - defensive recovery
                 logger.warning(
                     "[Slack] Error closing stale Socket Mode handler: %s; "

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -313,3 +313,64 @@ class TestSocketModeRestart:
         )
 
         adapter._start_socket_mode_handler.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_restart_cancels_stale_task_on_teardown_timeout(self, adapter):
+        """Stale socket task must be cancelled if teardown times out."""
+        stale_task = asyncio.create_task(asyncio.sleep(float("inf")))
+        adapter._socket_mode_task = stale_task
+
+        never = asyncio.Event()
+
+        async def _hang_forever():
+            await never.wait()
+
+        adapter._stop_socket_mode_handler = AsyncMock(side_effect=_hang_forever)
+        adapter._start_socket_mode_handler = MagicMock()
+        adapter._socket_stop_timeout_s = 0.01
+
+        await asyncio.wait_for(
+            adapter._restart_socket_mode("transport disconnected"), timeout=0.2
+        )
+        await asyncio.sleep(0.01)  # allow cancellation to propagate
+
+        assert stale_task.cancelled(), "stale socket task should be cancelled after teardown timeout"
+
+    @pytest.mark.asyncio
+    async def test_restart_starts_replacement_when_stop_raises(self, adapter):
+        """An error in _stop_socket_mode_handler must not prevent starting a replacement."""
+        adapter._stop_socket_mode_handler = AsyncMock(
+            side_effect=RuntimeError("session exploded")
+        )
+        adapter._start_socket_mode_handler = MagicMock()
+        adapter._socket_stop_timeout_s = 0.1
+
+        await asyncio.wait_for(
+            adapter._restart_socket_mode("transport disconnected"), timeout=0.5
+        )
+
+        adapter._start_socket_mode_handler.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_lock_released_after_timeout_so_second_restart_runs(self, adapter):
+        """Reconnect lock must be released after a teardown timeout."""
+        call_count = 0
+
+        async def _hang_once():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                await asyncio.sleep(float("inf"))
+
+        adapter._stop_socket_mode_handler = AsyncMock(side_effect=_hang_once)
+        adapter._start_socket_mode_handler = MagicMock()
+        adapter._socket_stop_timeout_s = 0.01
+
+        await asyncio.wait_for(
+            adapter._restart_socket_mode("transport disconnected"), timeout=0.2
+        )
+        await asyncio.wait_for(
+            adapter._restart_socket_mode("second reason"), timeout=0.2
+        )
+
+        assert adapter._start_socket_mode_handler.call_count == 2

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -295,3 +295,21 @@ class TestSocketModeRestart:
         await adapter._socket_watchdog_loop()
 
         assert reasons == ["transport disconnected"]
+
+    @pytest.mark.asyncio
+    async def test_restart_starts_replacement_when_old_handler_close_hangs(self, adapter):
+        """A wedged close_async must not wedge the reconnect lock forever."""
+        never = asyncio.Event()
+
+        async def _hang_forever():
+            await never.wait()
+
+        adapter._stop_socket_mode_handler = AsyncMock(side_effect=_hang_forever)
+        adapter._start_socket_mode_handler = MagicMock()
+        adapter._socket_stop_timeout_s = 0.01
+
+        await asyncio.wait_for(
+            adapter._restart_socket_mode("transport disconnected"), timeout=0.2
+        )
+
+        adapter._start_socket_mode_handler.assert_called_once_with()


### PR DESCRIPTION
## Why

Slack Socket Mode can enter a zombie state after a transient network/DNS outage. The watchdog correctly detects `transport disconnected`, but `_restart_socket_mode()` waits forever if the stale handler's `close_async()` never returns. No replacement websocket is created, even though the log says `reconnecting`.

Observed production sequence:

```text
Socket Mode connected
Socket Mode unhealthy (transport disconnected); reconnecting
# no replacement, no further inbound events
```

The process and TCP socket remain alive, which makes the gateway look healthy while every Slack mention is silently lost.

## Fix

- Bound stale-handler teardown with `asyncio.wait_for`.
- If teardown times out or raises, log it and start a replacement handler anyway.
- Log successful replacement startup.
- Keep task cancellation ordering inside `_stop_socket_mode_handler()` unchanged.

## Regression test

The new async test makes `_stop_socket_mode_handler()` hang forever and proves `_restart_socket_mode()` returns within a bounded interval and starts exactly one replacement.

## Verification

```text
169 Slack adapter tests passed
ruff check passed
```

No platform config, message routing, or normal clean-teardown behavior changes.