### PR TITLE
fix(tui): never transfer the shared launch SessionDB to one agent

### DIFF
--- a/tests/tui_gateway/test_session_db_ownership_teardown.py
+++ b/tests/tui_gateway/test_session_db_ownership_teardown.py
@@ -241,6 +241,19 @@ def test_transfer_is_refused_for_the_shared_launch_handle(monkeypatch):
     assert agent._owns_session_db is False
 
 
+def test_get_db_returns_the_cached_instance(monkeypatch):
+    """The identity defense (``db is _get_db()``) only works while _get_db
+    hands out ONE process-wide instance. Pin the caching semantics: once a
+    handle exists, repeated calls return the same object rather than
+    constructing per-call wrappers (review finding on #91631)."""
+    sentinel = types.SimpleNamespace(closed=0)
+    monkeypatch.setattr(server, "_db", sentinel)
+    monkeypatch.setattr(server, "_db_error", None)
+
+    assert server._get_db() is sentinel
+    assert server._get_db() is server._get_db()
+
+
 # ---------------------------------------------------------------------------
 # 3. The deferred builder — _start_agent_build
 # ---------------------------------------------------------------------------

--- a/tests/tui_gateway/test_session_db_ownership_teardown.py
+++ b/tests/tui_gateway/test_session_db_ownership_teardown.py
@@ -227,6 +227,20 @@ def test_transfer_is_refused_for_missing_operands(agent, db):
     assert server._transfer_db_to_agent(agent, db) is False
 
 
+def test_transfer_is_refused_for_the_shared_launch_handle(monkeypatch):
+    """Defense in depth for #91610: identity alone passes for the SHARED
+    launch handle — a launch-profile agent IS holding it — so ownership
+    would make session.close() tear down the process-wide database under
+    every other session. The transfer must refuse it even when a caller
+    invokes the transfer incorrectly."""
+    shared = _RecordingDB()
+    monkeypatch.setattr(server, "_get_db", lambda: shared)
+    agent = types.SimpleNamespace(_session_db=shared, _owns_session_db=False)
+
+    assert server._transfer_db_to_agent(agent, shared) is False
+    assert agent._owns_session_db is False
+
+
 # ---------------------------------------------------------------------------
 # 3. The deferred builder — _start_agent_build
 # ---------------------------------------------------------------------------

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -333,3 +333,42 @@ def test_resume_never_closes_shared_launch_db(profile_dbs, monkeypatch):
     assert resp["error"]["code"] == 4007
     assert profile_dbs == []  # no dedicated handle was opened
     assert shared.closed == 0
+
+
+def test_resume_eager_never_transfers_shared_launch_db(profile_dbs, monkeypatch):
+    """Regression #91610: an eager resume in the LAUNCH profile resolves the
+    shared ``_get_db()`` handle and used to transfer ownership to the agent
+    unconditionally — session.close() then closed the process-wide database
+    under every unrelated session. The transfer must be gated on owns_db."""
+    shared = _RecordingDB(db_path="launch")
+    shared.rows["s1"] = {"id": "s1", "cwd": ""}
+    monkeypatch.setattr(server, "_get_db", lambda: shared)
+
+    def _fake_make_agent(sid, key, session_db=None, **_kwargs):
+        agent = types.SimpleNamespace(model="test")
+        agent._session_db = session_db  # the agent IS holding the shared handle
+        agent._owns_session_db = False
+        return agent
+
+    def _fake_init_session(sid, key, agent, history, session_db=None, **_kwargs):
+        with server._sessions_lock:
+            server._sessions[sid] = {"agent": agent, "session_key": key}
+
+    monkeypatch.setattr(server, "_make_agent", _fake_make_agent)
+    monkeypatch.setattr(server, "_init_session", _fake_init_session)
+    monkeypatch.setattr(server, "_set_session_context", lambda _target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(
+        server, "_stored_session_runtime_overrides", lambda _found: {}
+    )
+    monkeypatch.setattr(server, "_session_info", lambda agent, *a: {"model": "test"})
+
+    resp = _resume(session_id="s1", eager_build=True)
+
+    assert resp["result"]["session_key"] == "s1"
+    agent = server._sessions.get(resp["result"]["session_id"], {}).get("agent")
+    assert agent is not None
+    # Ownership never transferred: closing this one session must not own the
+    # process-wide handle, and the shared handle stays open for others.
+    assert agent._owns_session_db is False
+    assert shared.closed == 0

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -861,7 +861,14 @@ def _(rid, params: dict) -> dict:
                     # leaves the old leak, which is survivable; closing under a
                     # live session is the permanent "Cannot operate on a closed
                     # database" break this patch exists to avoid.
-                    _transfer_db_to_agent(agent, db)
+                    #
+                    # The transfer itself is gated on owns_db: with no
+                    # non-launch profile selected this path resolved db to the
+                    # SHARED launch handle (_get_db()), and transferring it
+                    # made session.close() tear down the process-wide
+                    # database under every unrelated session (#91610).
+                    if owns_db:
+                        _transfer_db_to_agent(agent, db)
                     owns_db = False
                 finally:
                     if init_home_token is not None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1477,6 +1477,10 @@ def _transfer_db_to_agent(agent, db) -> bool:
         # explicitly even if a caller invokes the transfer incorrectly; the
         # caller's own `owns_db` gate is the first line of defense.
         if db is _get_db():
+            logger.warning(
+                "Refused transfer of the shared launch SessionDB to a session "
+                "agent — the caller's owns_db gate should have prevented this."
+            )
             return False
         agent._owns_session_db = True
         return True

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1470,6 +1470,14 @@ def _transfer_db_to_agent(agent, db) -> bool:
     try:
         if getattr(agent, "_session_db", None) is not db:
             return False
+        # Defense in depth (#91610): the shared launch handle must never
+        # transfer. Identity alone passes for it — a launch-profile agent IS
+        # holding that handle — and ownership would make session.close() tear
+        # down the process-wide database every other session shares. Refuse it
+        # explicitly even if a caller invokes the transfer incorrectly; the
+        # caller's own `owns_db` gate is the first line of defense.
+        if db is _get_db():
+            return False
         agent._owns_session_db = True
         return True
     except Exception:


### PR DESCRIPTION
## What does this PR do?

Stops one session's close from tearing down the process-wide SessionDB. The eager `session.resume` path called `_transfer_db_to_agent(agent, db)` unconditionally — but with no non-launch profile selected, `db` resolves to the **shared launch handle** (`_get_db()`), so the transfer succeeded on identity alone (the agent IS holding that handle) and set `_owns_session_db=True`. `session.close` then closed the shared handle, and every unrelated session's writes failed with `'NoneType' object has no attribute 'execute'` until the backend was restarted (#91610). This directly violated `_transfer_db_to_agent`'s own documented contract ("Never called for the shared launch handle ... stays at `_owns_session_db` False"), an invariant introduced with the ownership lifecycle in #81071.

Two layers, matching the issue's minimal-fix direction plus its defense-in-depth suggestion:

- The eager-resume call site gates the transfer on `owns_db` — only a handle this path opened (a dedicated profile handle) may transfer. The unconditional `owns_db = False` drop stays exactly as before (the finally must not close under a live registered session, per the existing comment).
- `_transfer_db_to_agent` now refuses `db is _get_db()` even when a caller invokes it incorrectly, protecting the other call sites (branch sessions, deferred builds, compute host).

## Related Issue

Fixes #91610

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_session.py`: In the eager resume ownership-transfer block, call `_transfer_db_to_agent` only when `owns_db` is true, with a comment explaining the shared-handle failure mode; the unconditional drop is unchanged.
- `tui_gateway/server.py`: `_transfer_db_to_agent` refuses the shared launch handle (`db is _get_db()`) before setting ownership — defense in depth per the issue.
- `tests/tui_gateway/test_session_resume_db_ownership.py`: `test_resume_eager_never_transfers_shared_launch_db` — an eager launch-profile resume whose agent holds the shared handle completes registration, leaves `_owns_session_db` false, and the shared handle's `close()` is never called.
- `tests/tui_gateway/test_session_db_ownership_teardown.py`: `test_transfer_is_refused_for_the_shared_launch_handle` — the defense-in-depth refusal (identity matches, still refused).

## How to Test

1. In the launch/default profile, eagerly resume a stored session (`eager_build: true`), then close it
2. Before the fix, the agent ends up with `_owns_session_db=True` for the shared handle and closing it kills the process-wide database — every other chat fails with `'NoneType' object has no attribute 'execute'`; after the fix the close leaves the shared handle open and other sessions keep writing (Observed result: both new regression tests fail on unpatched main — the transfer marks the shared handle / ownership flips to True — and pass with this patch)
3. Dedicated profile handles still transfer (no regression in the leak fix from #81071): the pre-existing `test_resume_keeps_profile_db_open_after_ownership_transfer` still passes
4. `scripts/run_tests.sh tests/tui_gateway/test_session_resume_db_ownership.py tests/tui_gateway/test_session_db_ownership_teardown.py -q` → should pass (Observed result: 25 passed locally)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
