### PR TITLE
fix(discord): pass guild_id to slash-command session source

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6379,6 +6379,15 @@ class DiscordAdapter(BasePlatformAdapter):
         )
         return (len(self._skill_entries), self._skill_group_hidden_count)
 
+    def _interaction_guild_id(self, interaction: discord.Interaction) -> Optional[str]:
+        """Resolve guild id from a slash interaction (matches message path)."""
+        guild_id = getattr(interaction, "guild_id", None)
+        if guild_id is None:
+            channel = getattr(interaction, "channel", None)
+            guild = getattr(channel, "guild", None) if channel else None
+            guild_id = getattr(guild, "id", None) if guild else None
+        return str(guild_id) if guild_id else None
+
     def _build_slash_event(self, interaction: discord.Interaction, text: str) -> MessageEvent:
         """Build a MessageEvent from a Discord slash command interaction."""
         is_dm = isinstance(interaction.channel, discord.DMChannel)
@@ -6411,6 +6420,7 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            guild_id=self._interaction_guild_id(interaction),
         )
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
@@ -6505,6 +6515,7 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=interaction.user.display_name,
             thread_id=thread_id,
             chat_topic=chat_topic,
+            guild_id=self._interaction_guild_id(interaction),
         )
 
         _parent_channel = self._thread_parent_channel(getattr(interaction, "channel", None))

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -165,6 +165,7 @@ async def test_run_simple_slash_executes_when_defer_interaction_expired(adapter)
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "/reset"
     assert event.source.chat_id == "123"
+    assert event.source.guild_id == "456"
     interaction.edit_original_response.assert_not_awaited()
     interaction.delete_original_response.assert_not_awaited()
 
@@ -395,7 +396,22 @@ def test_build_slash_event_preserves_thread_context(adapter):
     assert event.source.chat_id == "555"
     assert event.source.chat_type == "thread"
     assert event.source.thread_id == "555"
+    assert event.source.guild_id == "1"
     assert "TestGuild" in event.source.chat_name
+
+
+def test_build_slash_event_uses_interaction_guild_id(adapter):
+    interaction = SimpleNamespace(
+        channel=SimpleNamespace(name="general"),
+        channel_id=123,
+        guild_id=456,
+        user=SimpleNamespace(display_name="Jezza", id=42),
+    )
+
+    event = adapter._build_slash_event(interaction, "/reset")
+
+    assert event.source.guild_id == "456"
+    assert event.source.chat_id == "123"
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes the Discord `/new` and `/reset` (and all other simple slash commands) resolving to the wrong session namespace when `gateway.multiplex_profiles` + `profile_routes` are in use.

`_build_slash_event` in `plugins/platforms/discord/adapter.py` built the `SessionSource` via `self.build_source(...)` without `guild_id`, whereas the regular message path passes it. Since `ProfileRoute.matches` requires both `guild_id` AND `chat_id`, the route never matched — `source.profile` stayed `None`, and `_resolve_profile_for_key` fell back to the active/default profile (`agent:main`) instead of the routed profile (e.g. `agent:work`). Result: `/new` reset the wrong session and the routed profile context never cleared.

This adds `_interaction_guild_id` (resolves `interaction.guild_id`, falling back to `interaction.channel.guild.id` to match the message path) and passes it into `build_source` in `_build_slash_event` and the thread-session path.

## Related Issue

Fixes #91633

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py`
  - Added `_interaction_guild_id(interaction)` helper.
  - `_build_slash_event` now passes `guild_id=self._interaction_guild_id(interaction)`.
  - Thread-session path (`_dispatch_thread_session`) passes the same `guild_id`.
- `tests/gateway/test_discord_slash_commands.py`
  - Assert `event.source.guild_id` in `test_run_simple_slash_executes_when_defer_interaction_expired` and `test_build_slash_event_preserves_thread_context`.
  - Added `test_build_slash_event_uses_interaction_guild_id` covering the `interaction.guild_id` path.

## How to Test

1. Configure `gateway.multiplex_profiles: true` + `profile_routes` entry `{platform: discord, guild_id: G, chat_id: C, profile: work}`.
2. Run `/new` in channel C.
3. Before: reset targets `agent:main:...`. After: reset targets `agent:work:...` and the work conversation clears.

Unit tests:
```
venv/bin/python -m pytest tests/gateway/test_discord_slash_commands.py -q
# 14 passed
```

## Checklist

### Code
- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — none found
- [x] My PR contains only changes related to this fix
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping
- [x] N/A — no config keys, docs, or architecture changed
