### PR TITLE
fix(agent): keep large Codex requests from reconnecting at 120s

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1572,7 +1572,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     _ttfb_disable_above,
                 )
                 _ttfb_timeout = _large_request_ttfb_timeout
-        _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 120.0)
+        # Scaling above is the default policy for large contexts. Keep the
+        # independent maximum opt-in so its implicit default cannot undo that
+        # policy; operators may still set a finite ceiling explicitly.
+        _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 0.0)
         if _ttfb_cap > 0 and _ttfb_timeout > _ttfb_cap:
             logger.info(
                 "Capping openai-codex no-byte TTFB timeout from %.0fs to %.0fs "

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -148,6 +148,74 @@ def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):
     assert "codex_ttfb_kill" not in closes
 
 
+@pytest.mark.parametrize(
+    ("estimated_tokens", "env", "expected_enabled", "expected_timeout"),
+    [
+        (1_000, {}, True, 120.0),
+        (100_001, {}, True, 180.0),
+        (100_001, {"HERMES_CODEX_TTFB_MAX_SECONDS": "120"}, True, 120.0),
+        (100_001, {"HERMES_CODEX_TTFB_STRICT": "1"}, True, 120.0),
+        (100_001, {"HERMES_CODEX_TTFB_TIMEOUT_SECONDS": "0"}, False, 0.0),
+    ],
+)
+def test_ttfb_timeout_policy(
+    tmp_path,
+    monkeypatch,
+    estimated_tokens,
+    env,
+    expected_enabled,
+    expected_timeout,
+):
+    """Default scaling survives unless an operator explicitly overrides it."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    for name in (
+        "HERMES_CODEX_TTFB_MAX_SECONDS",
+        "HERMES_CODEX_TTFB_STRICT",
+        "HERMES_CODEX_TTFB_TIMEOUT_SECONDS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    monkeypatch.setattr(
+        h, "estimate_request_context_tokens", lambda _kwargs: estimated_tokens
+    )
+    response = SimpleNamespace(ok=True)
+    monkeypatch.setattr(agent, "_run_codex_stream", lambda *_args, **_kwargs: response)
+    observed: dict[str, object] = {}
+
+    class HeartbeatThread:
+        def __init__(self, *, target, daemon):
+            self._polls = 0
+            self._target = target
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+        def is_alive(self):
+            self._polls += 1
+            if self._polls == 101:
+                self._target()
+                return False
+            return True
+
+    def capture_policy(**kwargs):
+        observed.update(kwargs)
+        return ""
+
+    monkeypatch.setattr(h.threading, "Thread", HeartbeatThread)
+    monkeypatch.setattr(h, "_codex_wait_notice_recovery", capture_policy)
+
+    assert h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"}) is response
+    assert observed["ttfb_enabled"] is expected_enabled
+    assert observed["ttfb_timeout"] == expected_timeout
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Large OpenAI Codex requests can legitimately need more than 120 seconds to produce their first SSE event. Hermes already scales the no-byte timeout to 180 seconds above 100K estimated tokens, but an implicit 120-second maximum immediately erased that allowance and could reconnect a healthy request during prefill.

### Symptom

With no TTFB environment overrides, one request logs both a scale from 120s to 180s and an immediate cap from 180s back to 120s.

### Impact

OpenAI Codex requests above 100K estimated tokens can be reconnected at 120 seconds even though the built-in policy classified them for a 180-second first-byte allowance. This can discard healthy in-progress prefill work and repeat a large request unnecessarily.

### Bug Cause

**Trigger:** `agent/chat_completion_helpers.py` in `interruptible_api_call`, when an OpenAI Codex request is estimated above 100K tokens and no `HERMES_CODEX_TTFB_*` overrides are set.

**Causal chain:**
1. The default no-byte timeout starts at 120 seconds.
2. Large-context scaling raises it to the 180-second built-in idle allowance.
3. `HERMES_CODEX_TTFB_MAX_SECONDS` independently defaults to 120 seconds and immediately clamps the scaled value.
4. The watchdog therefore reconnects at 120 seconds instead of preserving the large-context allowance.

**Why it is wrong:** The implicit cap contradicts the built-in scaling policy, so the scale-up branch has no behavioral effect for requests above 100K tokens.

**Working sibling / contrast:** Small requests correctly retain the 120-second default. An explicitly configured maximum also correctly caps large requests and remains supported.

**Ruled out:** The post-first-event idle watchdog and the absolute hard timeout are separate policies. Neither changes the no-byte timeout before the first SSE event.

### Fix

Make the independent TTFB maximum opt-in by defaulting it to zero, while preserving explicit finite caps. Add behavior-level regression coverage for small and large defaults, an explicit maximum, strict mode, and a disabled watchdog.

## Related Issue

Closes #91621

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` - stop the implicit maximum from undoing large-context TTFB scaling.
- `tests/agent/test_codex_ttfb_watchdog.py` - cover the effective timeout policy through the real request path.

## How to Test

1. Run the focused Codex TTFB watchdog suite:

```bash
scripts/run_tests.sh tests/agent/test_codex_ttfb_watchdog.py -q
```

2. Verify the default >100K-token case observes 180 seconds, while an explicit `HERMES_CODEX_TTFB_MAX_SECONDS=120` case observes 120 seconds.
3. Verify strict mode remains at 120 seconds and timeout zero disables the watchdog.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - this corrects an existing internal timeout interaction.
- [x] `cli-config.yaml.example` update: N/A - no config key was added or changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed.
- [x] Cross-platform impact considered: the timeout policy is platform-independent.
- [x] Tool descriptions/schemas update: N/A - no model tool behavior changed.

## Screenshots / Logs

The regression test reproduces the original default interaction by observing the effective no-byte timeout through `interruptible_api_call`.
