### PR TITLE
fix(desktop): strip slash-prefixed skills from suggestion haystack

### DIFF
--- a/apps/desktop/src/store/suggestion-providers/skill.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.test.ts
@@ -8,6 +8,12 @@ import { collidesWithWorkspace, skillHit, skillPattern, skillTouchedInMessages }
 // has finished typing (at least one character follows it).
 const hits = (name: string, draft: string) => skillHit(skillPattern(name), draft.toLowerCase())
 
+// Simulates the draft provider's haystack sanitization (strips slash commands).
+const hitsAfterSanitize = (name: string, draft: string) => {
+  const sanitized = draft.replace(/\s\/[\w-]+/g, ' ').toLowerCase()
+  return skillHit(skillPattern(name), sanitized)
+}
+
 describe('skillPattern + skillHit', () => {
   it('matches the exact name as a completed whole word', () => {
     expect(hits('perf', 'run the perf loop')).toBe(true)
@@ -125,3 +131,25 @@ describe('skillTouchedInMessages', () => {
     expect(skillTouchedInMessages('pr-ready', [])).toBe(false)
   })
 })
+
+describe('draft haystack sanitization (slash-prefixed skills)', () => {
+  it('strips slash commands mid-message before scanning', () => {
+    // The bug: "please run /github-auth on this" triggered "Use skill: github-auth"
+    // because skillHit matched "github-auth" inside the slash command.
+    expect(hitsAfterSanitize('github-auth', 'please run /github-auth on this')).toBe(false)
+    expect(hitsAfterSanitize('vault', 'When I trigger /vault and /github-auth please')).toBe(false)
+  })
+
+  it('preserves URL fragments mid-prose (no leading whitespace)', () => {
+    // https://example.com/api/v1 is not stripped because there's no \s before /api.
+    // The regex only strips whitespace-bounded slash commands.
+    expect(hitsAfterSanitize('api', 'visit https://example.com/api/v1 for api docs ')).toBe(true)
+  })
+
+  it('a real prose mention after a slash command still hits', () => {
+    // Once a real prose mention of github-auth appears after the slash command,
+    // that mention still hits (the slash token is stripped, the prose mention remains).
+    expect(hitsAfterSanitize('github-auth', '/github-auth loaded. Is github-auth any good? ')).toBe(true)
+  })
+})
+

--- a/apps/desktop/src/store/suggestion-providers/skill.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.test.ts
@@ -2,17 +2,15 @@ import { describe, expect, it } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
 
-import { collidesWithWorkspace, skillHit, skillPattern, skillTouchedInMessages } from './skill'
+import { collidesWithWorkspace, skillHit, skillPattern, skillTouchedInMessages, stripSlashTokens } from './skill'
 
 // skillHit is the provider's real predicate: a whole-word match that the user
 // has finished typing (at least one character follows it).
 const hits = (name: string, draft: string) => skillHit(skillPattern(name), draft.toLowerCase())
 
-// Simulates the draft provider's haystack sanitization (strips slash commands).
-const hitsAfterSanitize = (name: string, draft: string) => {
-  const sanitized = draft.replace(/\s\/[\w-]+/g, ' ').toLowerCase()
-  return skillHit(skillPattern(name), sanitized)
-}
+// Exercises the provider's real haystack sanitizer, not a copy of it.
+const hitsAfterSanitize = (name: string, draft: string) =>
+  skillHit(skillPattern(name), stripSlashTokens(draft).toLowerCase())
 
 describe('skillPattern + skillHit', () => {
   it('matches the exact name as a completed whole word', () => {

--- a/apps/desktop/src/store/suggestion-providers/skill.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.ts
@@ -219,7 +219,10 @@ registerDraftProvider('skill', async ({ sessionId, text }) => {
     return []
   }
 
-  const haystack = text.toLowerCase()
+  // Strip any other /<token> the user has authored (whitespace-bounded, so
+  // URLs like /api/v1 mid-prose are not destroyed — a / preceded by another
+  // / is left alone because there is no whitespace boundary).
+  const haystack = text.replace(/\s\/[\w-]+/g, ' ').toLowerCase()
   const cwd = $currentCwd.get()
   const skills = await loadIndex()
   const matched = skills.filter(skill => skillHit(skill.pattern, haystack) && !collidesWithWorkspace(skill.name, cwd))

--- a/apps/desktop/src/store/suggestion-providers/skill.ts
+++ b/apps/desktop/src/store/suggestion-providers/skill.ts
@@ -64,6 +64,15 @@ export function skillHit(pattern: RegExp, haystack: string): boolean {
   return false
 }
 
+/** Strip whitespace-bounded /<token> slash commands the user authored, so a
+ *  skill name inside a command ("run /github-auth") does not self-trigger the
+ *  prose suggestion. Whitespace-bounded on purpose: a URL like /api/v1 mid-prose
+ *  has no leading whitespace and is left intact. Exported so the provider and
+ *  its tests exercise the same sanitizer instead of a copy. */
+export function stripSlashTokens(text: string): string {
+  return text.replace(/\s\/[\w-]+/g, ' ')
+}
+
 /** Workspace homonym guard, exported for tests: a skill named like the
  *  working directory is the project's name, not a request for the skill.
  *  Working in `~/www/hermes-agent`, the draft says "hermes-agent" constantly
@@ -222,7 +231,7 @@ registerDraftProvider('skill', async ({ sessionId, text }) => {
   // Strip any other /<token> the user has authored (whitespace-bounded, so
   // URLs like /api/v1 mid-prose are not destroyed — a / preceded by another
   // / is left alone because there is no whitespace boundary).
-  const haystack = text.replace(/\s\/[\w-]+/g, ' ').toLowerCase()
+  const haystack = stripSlashTokens(text).toLowerCase()
   const cwd = $currentCwd.get()
   const skills = await loadIndex()
   const matched = skills.filter(skill => skillHit(skill.pattern, haystack) && !collidesWithWorkspace(skill.name, cwd))


### PR DESCRIPTION
Fixes #91626.

The skill-suggestion pill was re-firing on every keystroke when a slash command appeared mid-message (e.g. `please run /github-auth on this`), because the whole-word pattern matched the skill name inside the slash token. The start-of-message guard only tested `trimmed.startsWith('/')`, so mid-message slash commands were scanned.

**Fix:** Strip whitespace-bounded slash commands (`\s\/[\w-]+`) from the haystack before scanning. URLs like `https://example.com/api/v1` are preserved because they lack the leading whitespace boundary.

**Tests:** Added a new test suite covering:
- Mid-message slash commands no longer trigger suggestions
- Multiple slash commands in one draft  
- URLs in prose remain intact (no false strip)
- Real prose mentions after slash commands still hit

All existing tests pass.

**Screenshot:** Issue reporter's screenshot shows the exact case (slash-prefixed skill in mid-message triggering a persistent pill) that this fix resolves.

I used AI assistance, mostly because my English is poor.