### PR TITLE
fix(desktop): ignore malformed keyboard codes

### DIFF
--- a/apps/desktop/src/lib/keybinds/combo.test.ts
+++ b/apps/desktop/src/lib/keybinds/combo.test.ts
@@ -219,10 +219,35 @@ describe('comboFromEvent — IME composition keydowns never resolve to combos (#
 })
 
 describe('comboFromEvent — malformed keyboard events', () => {
-  it('returns null when both key and code are absent', async () => {
-    const { comboFromEvent } = await loadCombo('Win32')
-    const event = { code: undefined, key: undefined } as unknown as KeyboardEvent
+  // Built as plain objects rather than via `new KeyboardEvent`, because the
+  // constructor coerces `code` to a string ("null", "42") and would hide the
+  // very shapes under test.
+  function malformed(init: Record<string, unknown>): KeyboardEvent {
+    return init as unknown as KeyboardEvent
+  }
 
-    expect(comboFromEvent(event)).toBeNull()
+  it.each([
+    ['both key and code are absent', { code: undefined, key: undefined }],
+    ['code is null', { code: null, key: undefined }],
+    ['code is a number', { code: 42, key: undefined }],
+    ['code is an empty string', { code: '', key: undefined }]
+  ])('returns null when %s', async (_label, init) => {
+    const { comboFromEvent } = await loadCombo('Win32')
+
+    expect(comboFromEvent(malformed(init))).toBeNull()
+  })
+
+  // A junk `code` must make the physical fallback inert without discarding an
+  // otherwise legitimate event: some IME and synthetic keydowns carry an empty
+  // `code` alongside a real `key`, which still has to resolve via the key path.
+  it.each([
+    ['null', null],
+    ['a number', 42],
+    ['an empty string', '']
+  ])('resolves via event.key when code is %s but key is valid', async (_label, code) => {
+    const { comboFromEvent } = await loadCombo('Win32')
+
+    expect(comboFromEvent(malformed({ code, key: 'a' }))).toBe('a')
+    expect(comboFromEvent(malformed({ code, ctrlKey: true, key: 'k' }))).toBe('mod+k')
   })
 })

--- a/apps/desktop/src/lib/keybinds/combo.test.ts
+++ b/apps/desktop/src/lib/keybinds/combo.test.ts
@@ -217,3 +217,12 @@ describe('comboFromEvent — IME composition keydowns never resolve to combos (#
     expect(comboFromEvent(keydown({ code: 'KeyN', isComposing: false, key: 'n', metaKey: true }))).toBe('mod+n')
   })
 })
+
+describe('comboFromEvent — malformed keyboard events', () => {
+  it('returns null when both key and code are absent', async () => {
+    const { comboFromEvent } = await loadCombo('Win32')
+    const event = { code: undefined, key: undefined } as unknown as KeyboardEvent
+
+    expect(comboFromEvent(event)).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/keybinds/combo.ts
+++ b/apps/desktop/src/lib/keybinds/combo.ts
@@ -55,7 +55,11 @@ const MODIFIER_CODES = new Set([
 // Modifier names as reported by `event.key` on a bare modifier keydown.
 const MODIFIER_KEYS = new Set(['Alt', 'Control', 'Meta', 'Shift'])
 
-function baseKeyFromCode(code: string): string | null {
+function baseKeyFromCode(code: unknown): string | null {
+  if (typeof code !== 'string' || !code) {
+    return null
+  }
+
   if (code.startsWith('Key')) {
     return code.slice(3).toLowerCase()
   }


### PR DESCRIPTION
## Problem

Desktop keybind normalization assumes `KeyboardEvent.code` is always a string. Synthetic, legacy, or IME-adjacent renderer events can omit it, causing `baseKeyFromCode()` to call `startsWith()` on `undefined` and throw.

Closes #91611.

## Root Cause

`comboFromEvent()` falls back from `event.key` to `event.code` without a runtime boundary guard. TypeScript DOM types do not protect this renderer event path at runtime.

## Fix

Treat a non-string or empty physical key code as an unavailable fallback. `comboFromEvent()` now returns `null` for an event with neither a usable `key` nor `code`, preserving existing normalization for valid browser events.

## Testing

- Added a regression test for an event with `key: undefined` and `code: undefined`.
- Verified the new test failed before the fix with `TypeError: Cannot read properties of undefined (reading 'startsWith')`.\n- `npm run test:ui -- --run src/lib/keybinds/combo.test.ts` (22 passed)\n- `npm run typecheck`\n- `npm run lint -- src/lib/keybinds/combo.ts src/lib/keybinds/combo.test.ts` (0 errors; existing repository warnings remain)\n\nThe full Desktop UI run executed 5,363 tests; 11 failures were confined to `src/app/skills/index.test.tsx` under the combined jsdom/Canvas environment. The same file passes 11/11 when run independently without this change, so this is not attributed to this PR.