### PR TITLE
feat(evals): report the interval the harnesses already describe in prose

### DIFF
--- a/contributors/emails/timamikhailov@gmail.com
+++ b/contributors/emails/timamikhailov@gmail.com
@@ -1,0 +1,2 @@
+t1mdurden
+# PR: evals uncertainty layer (evals/_stats.py)

--- a/evals/_stats.py
+++ b/evals/_stats.py
@@ -1,0 +1,168 @@
+"""Uncertainty for the eval harnesses in this tree. Standard library only.
+
+Three of the harnesses here already say in prose what this module computes.
+``evals/readtool/README.md`` states the rule outright — *"3 reps minimum; single-run
+deltas within ±3% are noise, not wins"* — and nothing in the tree decides it. The
+compaction runner already writes the per-question ``scores`` array
+(``evals/compaction/runner.py``) and the reporter reads only the summary percentage,
+so the paired data an interval needs is on disk and thrown away.
+
+Everything here is paired, because that is what these harnesses produce: the same
+question bank across every policy, the same task list across every arm. A paired
+interval is strictly tighter than comparing two independent ones, and it is the
+only form that answers "did this change help", as opposed to "are these two numbers
+different".
+
+No numpy, no scipy — the tree takes no new dependencies for `evals/`, and an
+interval nobody can re-run is worth less than one anybody can.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+__all__ = [
+    "paired_delta_ci",
+    "bootstrap_ci",
+    "wilson",
+    "min_detectable_difference",
+    "separable",
+    "fmt_ci",
+]
+
+# Resampling is seeded so a scorecard is reproducible: the same results directory
+# must print the same interval on two machines and in CI. 10k resamples puts the
+# Monte-Carlo error on a 95% bound well under 0.1 pp, which is finer than any
+# number these harnesses report.
+DEFAULT_REPS = 10_000
+DEFAULT_SEED = 0
+
+
+def _percentile(sorted_vals: list[float], q: float) -> float:
+    """Linear-interpolated percentile, q in [0, 1]. Input must be sorted."""
+    if not sorted_vals:
+        return float("nan")
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    pos = q * (len(sorted_vals) - 1)
+    lo = math.floor(pos)
+    hi = math.ceil(pos)
+    if lo == hi:
+        return sorted_vals[int(pos)]
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * (pos - lo)
+
+
+def bootstrap_ci(
+    values: list[float],
+    *,
+    scale: float = 1.0,
+    reps: int = DEFAULT_REPS,
+    seed: int = DEFAULT_SEED,
+    alpha: float = 0.05,
+) -> tuple[float, float]:
+    """Percentile bootstrap interval for the mean of ``values``, times ``scale``.
+
+    Resamples items, not runs. For the compaction harness an item is a question, so
+    this answers "how much would this policy's recall move on a different question
+    bank of the same size" — which is the question a 15-question exam raises and the
+    scorecard currently answers by not asking.
+    """
+    n = len(values)
+    if n == 0:
+        return (float("nan"), float("nan"))
+    if n == 1:
+        return (values[0] * scale, values[0] * scale)
+    rng = random.Random(seed)
+    means: list[float] = []
+    for _ in range(reps):
+        total = 0.0
+        for _ in range(n):
+            total += values[rng.randrange(n)]
+        means.append(total / n * scale)
+    means.sort()
+    return (_percentile(means, alpha / 2), _percentile(means, 1 - alpha / 2))
+
+
+def paired_delta_ci(
+    a: list[float],
+    b: list[float],
+    *,
+    scale: float = 1.0,
+    reps: int = DEFAULT_REPS,
+    seed: int = DEFAULT_SEED,
+    alpha: float = 0.05,
+) -> tuple[float, float, float]:
+    """Interval on ``mean(a) - mean(b)`` for two arms scored on the SAME items.
+
+    Returns ``(point, lo, hi)``, all multiplied by ``scale``.
+
+    Bootstraps the per-item DIFFERENCE, so any item that is simply hard for both
+    arms contributes nothing to the width — that cancellation is the whole reason
+    to keep the pairing rather than compare two separate intervals.
+
+    Raises on a length mismatch: two arms that were not scored on the same items
+    cannot be compared this way, and silently truncating would produce a confident
+    number about the wrong thing.
+    """
+    if len(a) != len(b):
+        raise ValueError(f"paired arms must be the same length: {len(a)} vs {len(b)}")
+    deltas = [x - y for x, y in zip(a, b)]
+    point = (sum(deltas) / len(deltas)) * scale if deltas else float("nan")
+    lo, hi = bootstrap_ci(deltas, scale=scale, reps=reps, seed=seed, alpha=alpha)
+    return (point, lo, hi)
+
+
+def separable(a: list[float], b: list[float], **kw) -> bool:
+    """True when the paired interval on ``a - b`` excludes zero.
+
+    "Not separable" is not "the same" — it means this many items cannot tell them
+    apart. Report it that way.
+    """
+    _, lo, hi = paired_delta_ci(a, b, **kw)
+    return lo > 0 or hi < 0
+
+
+def wilson(k: int, n: int, z: float = 1.959963984540054) -> tuple[float, float]:
+    """Wilson score interval for a rate, e.g. an ok-rate over tasks.
+
+    Wilson rather than Wald because Wald misbehaves near 0 and 1, and a pass-rate
+    table's interesting rows are exactly the ones near the ends.
+    """
+    if n <= 0:
+        return (0.0, 1.0)
+    p = k / n
+    d = 1 + z * z / n
+    centre = (p + z * z / (2 * n)) / d
+    half = z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / d
+    return (max(0.0, centre - half), min(1.0, centre + half))
+
+
+def min_detectable_difference(n: int, sd_of_differences: float) -> float:
+    """Smallest paired difference this many items could detect, 80% power, α=0.05.
+
+    The prospective number. An interval says whether *these* two arms separated;
+    this says how big a gap would have to be before the harness could ever see one,
+    which is what tells you whether to add items or stop comparing.
+    """
+    if n <= 0 or sd_of_differences <= 0:
+        return float("inf")
+    z_a = 1.959963984540054  # two-sided 0.05
+    z_b = 0.8416212335729143  # power 0.80
+    return (z_a + z_b) * sd_of_differences / math.sqrt(n)
+
+
+def stdev(values: list[float]) -> float:
+    """Sample standard deviation; 0.0 for fewer than two values."""
+    n = len(values)
+    if n < 2:
+        return 0.0
+    mean = sum(values) / n
+    return math.sqrt(sum((v - mean) ** 2 for v in values) / (n - 1))
+
+
+def fmt_ci(lo: float, hi: float, unit: str = "") -> str:
+    """``[lo, hi]`` for a table cell, or ``[n/a]`` when the interval is undefined."""
+    if any(math.isnan(v) for v in (lo, hi)):
+        return "[n/a]"
+    return f"[{lo:+.1f}, {hi:+.1f}]{unit}" if lo < 0 or hi < 0 else f"[{lo:.1f}, {hi:.1f}]{unit}"

--- a/evals/compaction/README.md
+++ b/evals/compaction/README.md
@@ -80,3 +80,11 @@ name.
   does not.
 - `--also-uncompacted` adds a control arm that answers from the full
   original transcript — the recall ceiling.
+- The scorecard carries a 95% paired-bootstrap interval per policy and, below the
+  table, which adjacent pairs the question bank can actually order. Every policy
+  answers the same questions, so the comparison is paired and the per-question
+  `scores` array the runner already writes is all it needs. At 15 questions one
+  answer is 6.7 recall points and the smallest detectable difference is around
+  26 pp — the four-transcript pooled numbers are solid, a single transcript's
+  ordering of two close policies is not. The report says which is which; see
+  `evals/_stats.py`.

--- a/evals/compaction/report.py
+++ b/evals/compaction/report.py
@@ -1,6 +1,12 @@
 """Render a compaction-eval scorecard as a terminal table + markdown.
 
 Usage: python evals/compaction/report.py <results_dir>
+
+Every policy answers the SAME question bank, so the arms are paired and the
+per-question ``scores`` array the runner already writes is enough to say whether an
+ordering is real. Two policies whose paired interval straddles zero are printed as
+tied rather than ranked — at fifteen questions one answer is 6.7 recall points, and
+a table that orders them anyway is reporting the question draw.
 """
 from __future__ import annotations
 
@@ -8,23 +14,40 @@ import json
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from _stats import bootstrap_ci, fmt_ci, min_detectable_difference, paired_delta_ci, stdev  # noqa: E402
+
+# recall_pct = 100 * sum(scores) / (2 * n), so one point of mean item score is 50 pp.
+RECALL_SCALE = 50.0
+
 
 def main():
     out_dir = Path(sys.argv[1])
     card = json.loads((out_dir / "scorecard.json").read_text(encoding="utf-8"))
     card.sort(key=lambda s: -s["recall_pct"])
 
+    scored = [s for s in card if s.get("scores")]
+    n_items = len(scored[0]["scores"]) if scored else 0
+    comparable = all(len(s["scores"]) == n_items for s in scored)
+
     rows = []
     for s in card:
         before = s.get("before_tokens", 0)
         after = s.get("after_tokens", 0)
         kept = f"{100 * after / before:.1f}%" if before else "?"
+        scores = s.get("scores") or []
+        if scores:
+            lo, hi = bootstrap_ci(scores, scale=RECALL_SCALE)
+            ci = fmt_ci(lo, hi)
+        else:
+            ci = "[n/a]"
         rows.append((
-            s["policy"], f"{s['recall_pct']}%", f"{before:,}", f"{after:,}", kept,
+            s["policy"], f"{s['recall_pct']}%", ci, f"{before:,}", f"{after:,}", kept,
             str(s.get("compress_seconds", "-")),
         ))
 
-    headers = ("policy", "recall", "tokens before", "tokens after", "kept", "sec")
+    headers = ("policy", "recall", "95% CI", "tokens before", "tokens after", "kept", "sec")
     widths = [max(len(headers[i]), *(len(r[i]) for r in rows)) for i in range(len(headers))]
     line = "  ".join(h.ljust(widths[i]) for i, h in enumerate(headers))
     print(line)
@@ -32,9 +55,37 @@ def main():
     for r in rows:
         print("  ".join(str(r[i]).ljust(widths[i]) for i in range(len(headers))))
 
+    # ── which adjacent pairs the question bank can actually order ────────────────
+    verdicts: list[str] = []
+    if len(scored) >= 2 and comparable:
+        print()
+        print(f"paired over {n_items} shared questions, ranked order:")
+        for hi_s, lo_s in zip(scored, scored[1:]):
+            point, lo, hi = paired_delta_ci(hi_s["scores"], lo_s["scores"], scale=RECALL_SCALE)
+            sep = lo > 0 or hi < 0
+            verdict = "separated" if sep else "TIED — not orderable at this n"
+            verdicts.append(f"{hi_s['policy']} vs {lo_s['policy']}: {verdict}")
+            print(f"  {hi_s['policy']:<18} vs {lo_s['policy']:<18} "
+                  f"{point:+6.1f} pp  {fmt_ci(lo, hi)}  {verdict}")
+
+        pooled = stdev([a - b for a, b in zip(scored[0]["scores"], scored[-1]["scores"])])
+        mdd = min_detectable_difference(n_items, pooled) * RECALL_SCALE
+        print()
+        print(f"smallest difference {n_items} questions could detect "
+              f"(80% power, two-sided 0.05): {mdd:.1f} pp")
+        print("a gap below that is a question draw, not a result — add questions or "
+              "report the tie.")
+    elif scored and not comparable:
+        print()
+        print("NOTE: policies were scored on question banks of different sizes; "
+              "the paired comparison is skipped rather than run on mismatched arms.")
+
     md = ["| " + " | ".join(headers) + " |", "|" + "|".join("---" for _ in headers) + "|"]
     for r in rows:
         md.append("| " + " | ".join(r) + " |")
+    if verdicts:
+        md += ["", f"Paired over {n_items} shared questions:", ""]
+        md += [f"- {v}" for v in verdicts]
     (out_dir / "scorecard.md").write_text("\n".join(md) + "\n", encoding="utf-8")
     print(f"\nmarkdown -> {out_dir}/scorecard.md")
 

--- a/evals/test_stats.py
+++ b/evals/test_stats.py
@@ -1,0 +1,124 @@
+"""Checks for evals/_stats.py.
+
+The tripwire that matters is the last one: on a synthetic no-effect arm the harness
+must decline to call a win. A statistics helper that always finds a difference is
+worse than no helper, because it launders noise into a scorecard.
+"""
+import math
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _stats import (  # noqa: E402
+    bootstrap_ci,
+    fmt_ci,
+    min_detectable_difference,
+    paired_delta_ci,
+    separable,
+    stdev,
+    wilson,
+)
+
+REPS = 2000  # enough for these assertions, fast enough for the per-file runner
+
+
+def test_wilson_matches_the_longhand_form():
+    """Recomputed from the closed form, so a bug in _stats cannot pass its own test."""
+    for k, n in ((14, 15), (0, 15), (15, 15), (30, 60)):
+        z = 1.959963984540054
+        p = k / n
+        a = 2 * n * p + z * z
+        b = z * math.sqrt(z * z + 4 * n * p * (1 - p))
+        d = 2 * (n + z * z)
+        lo, hi = wilson(k, n)
+        assert abs(lo - (a - b) / d) < 1e-12
+        assert abs(hi - (a + b) / d) < 1e-12
+
+
+def test_wilson_stays_inside_the_unit_interval():
+    assert wilson(0, 15)[0] == 0.0
+    assert wilson(15, 15)[1] == 1.0
+    assert wilson(0, 0) == (0.0, 1.0)
+
+
+def test_paired_delta_is_exact_when_every_item_agrees():
+    """No spread between items means no width: the interval collapses onto the point."""
+    a = [2.0] * 15
+    b = [1.0] * 15
+    point, lo, hi = paired_delta_ci(a, b, reps=REPS)
+    assert point == 1.0
+    assert lo == hi == 1.0
+
+
+def test_paired_delta_refuses_mismatched_arms():
+    """Two arms scored on different items are not a paired comparison."""
+    try:
+        paired_delta_ci([1.0, 2.0], [1.0])
+    except ValueError as exc:
+        assert "same length" in str(exc)
+    else:
+        raise AssertionError("mismatched arms must raise, not truncate")
+
+
+def test_paired_delta_is_deterministic():
+    """Same input, same interval — a scorecard has to be reproducible."""
+    a = [2, 0, 2, 2, 0, 0, 0, 2, 0, 1, 0, 2, 0, 1, 0]
+    b = [0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]
+    first = paired_delta_ci(a, b, reps=REPS)
+    second = paired_delta_ci(a, b, reps=REPS)
+    assert first == second
+
+
+def test_the_no_effect_arm_is_not_called_a_win():
+    """THE TRIPWIRE. Two arms drawn from the same distribution must not separate.
+
+    Built from a real shape: 15 questions scored 0/1/2, the arms differing only by
+    which questions happened to land. A harness that reports a winner here is the
+    failure this module exists to prevent.
+    """
+    a = [2, 0, 2, 0, 1, 0, 2, 0, 0, 1, 2, 0, 0, 1, 0]
+    b = [0, 2, 0, 2, 0, 1, 0, 2, 1, 0, 0, 2, 0, 0, 1]
+    assert sum(a) == sum(b), "fixture should be a true tie in total score"
+    assert not separable(a, b, reps=REPS)
+    point, lo, hi = paired_delta_ci(a, b, reps=REPS)
+    assert lo < 0 < hi, f"a tied pair must straddle zero, got [{lo}, {hi}]"
+
+
+def test_a_real_effect_is_still_detected():
+    """The counterpart: the tripwire must not be a test that never fires."""
+    a = [2] * 14 + [0]
+    b = [0] * 14 + [2]
+    assert separable(a, b, reps=REPS)
+
+
+def test_recall_scale_lands_in_percentage_points():
+    """compaction reports 100*sum/(2n), so the scale for a 0/1/2 item is 50."""
+    a = [2] * 15
+    b = [0] * 15
+    point, _, _ = paired_delta_ci(a, b, scale=50.0, reps=REPS)
+    assert abs(point - 100.0) < 1e-9
+
+
+def test_bootstrap_brackets_the_sample_mean():
+    vals = [2, 0, 2, 2, 0, 0, 0, 2, 0, 1, 0, 2, 0, 1, 0]
+    lo, hi = bootstrap_ci(vals, reps=REPS)
+    assert lo <= sum(vals) / len(vals) <= hi
+
+
+def test_mdd_shrinks_with_n_and_grows_with_spread():
+    assert min_detectable_difference(60, 1.0) < min_detectable_difference(15, 1.0)
+    assert min_detectable_difference(15, 2.0) > min_detectable_difference(15, 1.0)
+    # doubling n divides the detectable difference by sqrt(2)
+    assert abs(
+        min_detectable_difference(30, 1.0) - min_detectable_difference(15, 1.0) / math.sqrt(2)
+    ) < 1e-12
+    assert min_detectable_difference(0, 1.0) == float("inf")
+
+
+def test_stdev_and_formatting():
+    assert stdev([1.0]) == 0.0
+    assert abs(stdev([2.0, 4.0]) - math.sqrt(2)) < 1e-12
+    assert fmt_ci(1.0, 2.0) == "[1.0, 2.0]"
+    assert fmt_ci(-1.0, 2.0) == "[-1.0, +2.0]"
+    assert fmt_ci(float("nan"), 1.0) == "[n/a]"


### PR DESCRIPTION
## What does this PR do?

Three eval harnesses in this tree state a noise rule in prose and none of them computes one.

`evals/readtool/README.md:52` says it outright:

> **3 reps minimum**; single-run deltas within ±3% are noise, not wins.

Nothing in the tree decides that. `grep -rn "stdev\|variance\|bootstrap\|interval\|significan" evals/` returns nothing.

Meanwhile the data an interval needs is already on disk and thrown away. `evals/compaction/runner.py` writes the per-question `scores` array into every policy's summary (`"scores": scored`), and `evals/compaction/report.py` reads only `recall_pct`. Every policy answers the **same** question bank, so the arms are paired — and the scorecard currently ranks four policies off a point estimate over 15 questions, where one answer is 6.7 recall points.

This adds the smallest thing that closes it: one stdlib module and one call site.

## Related Issue

No open issue. I searched open, merged and closed PRs and issues for `statistical significance`, `confidence interval`, `significance test`, `bootstrap`, `wilson` and `evals variance` before writing this.

Adjacent, not overlapping: #91627 (mine) repairs the *pairing* in `browser_use/report.py`. This PR adds the *interval* to `compaction/report.py`. Different file, different defect, either can land without the other.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`evals/_stats.py`** (new, 168 lines) — paired percentile bootstrap on per-item differences, Wilson score interval for rate metrics, and `min_detectable_difference(n, sd)`. Standard library only: `evals/` takes no new dependencies, and an interval nobody can re-run is worth less than one anybody can. Resampling is seeded (`random.Random(0)`, 10k resamples) so the same results directory prints the same interval on two machines and in CI.
- **`evals/compaction/report.py`** — prints a 95% paired-bootstrap CI per policy, then, below the table, which adjacent pairs the question bank can actually order, then the smallest difference that many questions could detect. A pair whose paired interval straddles zero prints `TIED — not orderable at this n` instead of being silently ranked. Mismatched bank sizes skip the paired section rather than comparing arms that were not scored on the same items.
- **`evals/test_stats.py`** (new) — 11 checks.
- **`evals/compaction/README.md`** — six lines describing what the new columns mean.

**The pairing is why this makes results look stronger, not weaker.** A paired interval is strictly tighter than two independent ones, because a question that is hard for every policy contributes nothing to the width.

## How to Test

```bash
scripts/run_tests.sh evals/test_stats.py
python3 evals/compaction/report.py <results_dir>   # any dir with a scorecard.json
```

On score arrays shaped like `results/SCORECARD-2026-08-15.md` (the `acp` transcript: uncompacted 100.0, lean+recovery 80.0, lean 36.7, current 30.0 over 15 questions):

```
policy         recall  95% CI          tokens before  tokens after  kept    sec
-------------------------------------------------------------------------------
uncompacted    100.0%  [100.0, 100.0]  500,000        500,000       100.0%  0
lean_recovery  80.0%   [63.3, 93.3]    500,000        50,000        10.0%   41
lean           36.7%   [16.7, 56.7]    500,000        50,000        10.0%   38
current        30.0%   [13.3, 50.0]    500,000        160,000       32.0%   52

paired over 15 shared questions, ranked order:
  uncompacted        vs lean_recovery       +20.0 pp  [6.7, 36.7]      separated
  lean_recovery      vs lean                +43.3 pp  [20.0, 66.7]     separated
  lean               vs current              +6.7 pp  [-16.7, +30.0]   TIED — not orderable at this n

smallest difference 15 questions could detect (80% power, two-sided 0.05): 26.6 pp
```

The big result survives and gets an interval that supports it. The 6.7 pp gap between two close policies on one transcript comes back tied — which is the honest reading of a 15-question exam, and is consistent with the scorecard's own footnote calling one number *"bank-inflated luck"*. The pooled four-transcript headline is not what this questions; a single transcript's ordering of two neighbours is.

**Tests, and the one that matters.** Wilson is validated against the longhand closed form rather than against itself. `test_the_no_effect_arm_is_not_called_a_win` builds two arms drawn from the same distribution and asserts the harness returns tied — a statistics helper that always finds a difference launders noise into a scorecard. `test_a_real_effect_is_still_detected` is its counterpart, so the tripwire is not a test that never fires. `test_paired_delta_refuses_mismatched_arms` asserts a length mismatch raises instead of truncating.

## What platforms

macOS 15 (arm64), Python 3.14. No platform-specific code — `math`, `random`, `json`, `pathlib` only.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] `contributors/emails/` entry included so the Contributor Attribution Check passes
