### PR TITLE
chore: AUTHOR_MAP troy.rowe@re-source.au -> troyrowe-resource

### DIFF
--- a/contributors/emails/troy.rowe@re-source.au
+++ b/contributors/emails/troy.rowe@re-source.au
@@ -1,0 +1,2 @@
+troyrowe-resource
+# PR #90261 salvage


### PR DESCRIPTION
## Summary
Adds the email → login mapping for @troyrowe-resource ahead of salvaging PR #90261 (server-injected parameter 400 classifier).

## Changes
- `contributors/emails/troy.rowe@re-source.au` → `troyrowe-resource`

Needed so `check-attribution` passes on the salvage PR.