### PR TITLE
fix(desktop): grey out unavailable/locked models in the model menu

### DIFF
--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -106,3 +106,53 @@ describe('the catalog owns model curation', () => {
     expect($modelVisibilityOpen.get()).toBe(true)
   })
 })
+
+describe('unavailable models are inert', () => {
+  it('greys out and disables a provider without usable credentials', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          models: ['gemini-3.1-pro'],
+          name: 'Google',
+          slug: 'google',
+          authenticated: false,
+          warning: 'Add an API key to use Google models'
+        }
+      ]
+    })
+
+    const select = renderMenu()
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    // The provider's warning is surfaced on the row.
+    expect(screen.getByText(/Add an API key/)).toBeTruthy()
+
+    // Clicking the unauthenticated row must not commit a selection.
+    fireEvent.click(screen.getByText(/Gemini 3\.1 Pro/i))
+    expect(select).not.toHaveBeenCalled()
+  })
+
+  it('disables a tier-locked model but leaves its siblings selectable', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        {
+          models: ['gemini-3.1-pro', 'gemini-2.5-flash'],
+          name: 'Google',
+          slug: 'google',
+          unavailable_models: ['gemini-3.1-pro']
+        }
+      ]
+    })
+
+    const select = renderMenu()
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    // The locked model is inert…
+    fireEvent.click(screen.getByText(/Gemini 3\.1 Pro/i))
+    expect(select).not.toHaveBeenCalled()
+
+    // …while the available sibling still selects normally.
+    fireEvent.click(screen.getByText(/Gemini 2\.5 Flash/i))
+    expect(select).toHaveBeenCalledWith('gemini-2.5-flash', 'google')
+  })
+})

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -192,6 +192,15 @@ export function ModelCatalogMenu({
   )
 
   const selectFamily = async (family: ModelFamily, provider: ModelOptionProvider) => {
+    // Unavailable rows (provider not authenticated, or the model locked for the
+    // account's tier) are inert — no switch and no preset write on any path
+    // (click, keyboard commit, or the hover edit submenu).
+    const providerUnavailable = provider.authenticated === false
+    const modelLocked = provider.unavailable_models?.includes(family.id) ?? false
+    if (providerUnavailable || modelLocked) {
+      return
+    }
+
     const caps = provider.capabilities?.[family.id]
     const preset = controller.presetFor(provider.slug, family.id)
 
@@ -405,6 +414,14 @@ export function ModelCatalogMenu({
                     const name = modelDisplayParts(family.id).name
                     const caps = group.provider.capabilities?.[family.id]
 
+                    // A row is unavailable when the provider has no usable
+                    // credentials (authenticated === false) or this specific
+                    // model is locked for the account's tier (Nous free-tier
+                    // gating). Gray it out and make it inert.
+                    const providerUnavailable = group.provider.authenticated === false
+                    const modelLocked = group.provider.unavailable_models?.includes(family.id) ?? false
+                    const isUnavailable = providerUnavailable || modelLocked
+
                     // Effective settings for this row: the live choice when it's
                     // the active model, otherwise its remembered preset. Row
                     // label AND submenu read from these so they never disagree.
@@ -429,8 +446,10 @@ export function ModelCatalogMenu({
                     // Clicking the row commits the model and closes; the edit
                     // submenu (reasoning/fast) is reached by HOVER, so you can
                     // tweak those without the click dismissing everything.
+                    const rowKey = `${group.provider.slug}:${family.id}`
+                    const rowKbProps = kbRowProps(rowKey)
                     const activate = () => {
-                      if (!isCurrent) {
+                      if (!isCurrent && !isUnavailable) {
                         void selectFamily(family, group.provider)
                       }
 
@@ -438,8 +457,14 @@ export function ModelCatalogMenu({
                     }
 
                     return (
-                      <DropdownMenuSub key={`${group.provider.slug}:${family.id}`}>
+                      <DropdownMenuSub key={rowKey}>
                         <DropdownMenuSubTrigger
+                          {...rowKbProps}
+                          className={cn(
+                            rowKbProps.className,
+                            isUnavailable && 'text-(--ui-text-tertiary) opacity-50'
+                          )}
+                          disabled={isUnavailable}
                           hideChevron
                           onClick={activate}
                           onKeyDown={event => {
@@ -447,14 +472,18 @@ export function ModelCatalogMenu({
                               activate()
                             }
                           }}
-                          {...kbRowProps(`${group.provider.slug}:${family.id}`)}
                         >
                           <span className="min-w-0 flex-1 truncate">
                             <HighlightMatches query={search} text={name} />
                             {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
+                            {providerUnavailable && group.provider.warning ? (
+                              <span className="text-(--ui-text-tertiary) ml-1">({group.provider.warning})</span>
+                            ) : null}
                           </span>
                           {isCurrent ? (
                             <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" />
+                          ) : modelLocked ? (
+                            <Codicon className="ml-auto text-(--ui-text-tertiary)" name="lock" size="0.625rem" />
                           ) : null}
                         </DropdownMenuSubTrigger>
                         <ModelEditSubmenu


### PR DESCRIPTION
## What does this PR do?

The desktop model catalog menu does not grey out models the account cannot actually use. The backend already reports three fields on every provider in the model catalog — `authenticated` (false when the provider has no usable credentials), `unavailable_models` (models locked to a higher account tier, e.g. Nous free-tier gating), and `warning` (a human hint) — and the `ModelOptionProvider` type already declares them. But the catalog menu's renderer never consumed them, so an unauthenticated provider or a tier-locked model looked identical to a selectable one, and clicking it would let the session switch to a model it can't use.

This PR renders such rows greyed-out and inert:

- an unauthenticated provider's row is `disabled` and surfaces its `warning` inline,
- a tier-locked model row is `disabled` and shows a lock icon,
- `selectFamily` early-returns, so **no** path (mouse click, keyboard commit, or the hover edit submenu) can select an unavailable model.

## Related Issue

Fixes # — (no existing issue found; this is a UI gap surfaced by a downstream user)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/shell/model-catalog-menu.tsx` — compute `providerUnavailable` / `modelLocked` / `isUnavailable` per row; guard `selectFamily`; grey-out + disable the trigger; render the provider warning and a lock icon.
- `apps/desktop/src/app/shell/model-catalog-menu.test.tsx` — two new tests: (1) an unauthenticated provider's row is inert and shows its warning; (2) a tier-locked model is inert while its sibling stays selectable.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/shell/model-catalog-menu.test.tsx` — 5 tests pass.
2. `cd apps/desktop && npx tsc --noEmit -p tsconfig.json` — no type errors.
3. (Manual) With a Nous account on the free tier, open the composer model menu: paid models show a lock icon, are greyed out, and cannot be selected; the current model still shows its check mark.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (N/A — change is renderer-only; ran the desktop vitest suite: 674 files / 6938 tests pass)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no doc/config surface changes)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure renderer/CSS + icon change, platform-agnostic)
