### PR TITLE
fix: route cron failures to alert delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -342,6 +342,19 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     return f"⚠️ Cron '{job_name}' failed: {cleaned}"
 
 
+def _failure_delivery_job(job: dict) -> dict:
+    """Use cron.failure_deliver only for failed scheduler-run notifications."""
+    try:
+        failure_deliver = (load_config().get("cron") or {}).get("failure_deliver")
+    except Exception:
+        failure_deliver = None
+    if not isinstance(failure_deliver, str) or not failure_deliver.strip():
+        return job
+    routed_job = dict(job)
+    routed_job["deliver"] = failure_deliver.strip()
+    return routed_job
+
+
 class CronPromptInjectionBlocked(Exception):
     """Raised by _build_job_prompt when the fully-assembled prompt trips the
     injection scanner. Caught in run_job so the operator sees a clean
@@ -6697,9 +6710,10 @@ def _run_one_job_body(
                 )
 
             if should_deliver:
+                delivery_job = _failure_delivery_job(job) if not success else job
                 unresolved_origin = (
-                    _normalize_deliver_value(job.get("deliver", "local")) == "origin"
-                    and not _resolve_delivery_targets(job)
+                    _normalize_deliver_value(delivery_job.get("deliver", "local")) == "origin"
+                    and not _resolve_delivery_targets(delivery_job)
                 )
                 try:
                     with _side_effect_fence() as owns_delivery:
@@ -6707,7 +6721,7 @@ def _run_one_job_body(
                             raise _FireClaimLostDuringSideEffect
                         delivery_attempted = True
                         delivery_error = _deliver_result(
-                            job,
+                            delivery_job,
                             deliver_content,
                             adapters=adapters,
                             loop=loop,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -13,6 +13,7 @@ from cron.scheduler import (
     SILENT_MARKER,
     _build_job_prompt,
     _deliver_result,
+    _failure_delivery_job,
     _merge_mcp_into_per_job_toolsets,
     _resolve_cron_enabled_toolsets,
     _resolve_delivery_target,
@@ -68,6 +69,25 @@ class TestSummarizeCronFailureForDelivery:
         assert "No model was invoked" in summary
         assert "provider timeout" not in summary
         assert "fallback chain" not in summary.lower()
+
+
+class TestFailureDeliveryJob:
+    def test_uses_failure_delivery_without_mutating_normal_job(self):
+        job = {"id": "job-1", "deliver": "origin"}
+        with patch(
+            "cron.scheduler.load_config",
+            return_value={"cron": {"failure_deliver": "discord:alerts"}},
+        ):
+            routed = _failure_delivery_job(job)
+
+        assert routed == {"id": "job-1", "deliver": "discord:alerts"}
+        assert job == {"id": "job-1", "deliver": "origin"}
+
+    @pytest.mark.parametrize("config", [{}, {"cron": {}}, {"cron": {"failure_deliver": "  "}}])
+    def test_keeps_job_delivery_when_failure_route_is_not_configured(self, config):
+        job = {"id": "job-1", "deliver": "origin"}
+        with patch("cron.scheduler.load_config", return_value=config):
+            assert _failure_delivery_job(job) is job
 
 
 class TestPerJobToolsetMcpMerge:


### PR DESCRIPTION
## What does this PR do?

Adds an optional `cron.failure_deliver` configuration value. When a scheduled run fails, Hermes sends the failure notification to this destination while leaving the job's normal `deliver` target unchanged for successful runs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that improves failed-run notification routing)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `_failure_delivery_job()` in `cron/scheduler.py`.
- Read the optional `cron.failure_deliver` setting only for failed scheduler-run notifications.
- Copy the job payload before changing its delivery target, preserving normal scheduler state and successful-job delivery.
- Add regression coverage for configured and unset/blank values.

## Why core rather than a plugin?

The decision belongs to the scheduler's failed-run notification path. A post-delivery hook would be less reliable and cannot guarantee independent routing before ordinary delivery handling. The feature is generic and does not encode a platform credential, channel identifier, or user-specific policy.

## Configuration

```yaml
cron:
  failure_deliver: discord:<channel-id>
```

When unset, empty, or invalid, existing delivery behavior is preserved.

## How to Test

```bash
PYTHONPATH="$PWD" python -m pytest tests/cron/test_scheduler.py -o 'addopts=' -q
ruff check cron/scheduler.py tests/cron/test_scheduler.py
```

Result on macOS arm64: `107 passed`; Ruff passed.

## Checklist

- [x] I have read the Contributing Guide.
- [x] This PR contains only the focused scheduler routing change and its tests.
- [x] I added tests for the changed behavior.
- [x] Successful-job delivery remains unchanged.
- [x] No credentials, private paths, channel IDs, or user-specific settings are included.
