### PR TITLE
fix(weixin): recognize "prepare failed" errmsg as stale-session ret=-2

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -118,12 +118,13 @@ MESSAGE_DEDUP_TTL_SECONDS = 300
 def _is_stale_session_ret(
     ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
 ) -> bool:
-    """True when iLink returns ret=-2 / errcode=-2 with 'unknown error',
-    which is a stale-session signal (same as errcode=-14) rather than
-    a genuine rate limit."""
+    """True when iLink returns ret=-2 / errcode=-2 with 'unknown error'
+    or 'prepare failed', which are stale-session signals (same as
+    errcode=-14) rather than a genuine rate limit."""
     if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
         return False
-    return (errmsg or "").lower() == "unknown error"
+    msg = (errmsg or "").lower()
+    return msg == "unknown error" or msg == "prepare failed"
 
 
 MEDIA_IMAGE = 1

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -497,12 +497,44 @@ class TestWeixinVoiceSending:
 
 
 class TestIsStaleSessionRet:
-    """Regression test for #17228: distinguish stale-session ret=-2 from rate-limit ret=-2."""
+    """Regression test for #17228: distinguish stale-session ret=-2 from rate-limit ret=-2.
 
+    Covers the 'unknown error' variant fixed for #17228 and the
+    'prepare failed' variant observed on zh-CN / WSL2 setups (follow-up
+    to #18100): both are stale-session signals misreported under the
+    generic ret=-2 rate-limit code.
+    """
+
+
+    def test_ret_minus_2_unknown_error_is_stale(self):
+        # The original #17228 variant: stale context_token surfaces as
+        # errmsg="unknown error" under the generic -2 code.
+        assert weixin._is_stale_session_ret(-2, None, "unknown error") is True
+
+    def test_errcode_minus_2_prepare_failed_is_stale(self):
+        # Follow-up variant: iLink also reports stale sessions as
+        # errmsg="prepare failed" (observed on cron-initiated pushes).
+        assert weixin._is_stale_session_ret(None, -2, "prepare failed") is True
+
+    def test_prepare_failed_is_case_insensitive(self):
+        assert weixin._is_stale_session_ret(-2, None, "Prepare Failed") is True
+
+    def test_prepare_failed_with_non_rate_limit_code_is_not_stale(self):
+        # The helper only disambiguates -2; other codes are handled
+        # elsewhere (e.g. SESSION_EXPIRED_ERRCODE for -14).
+        assert weixin._is_stale_session_ret(0, None, "prepare failed") is False
+        assert weixin._is_stale_session_ret(None, -14, "prepare failed") is False
 
     def test_ret_minus_2_with_freq_limit_is_not_stale(self):
         # Genuine rate limit — must NOT be treated as stale session.
         assert weixin._is_stale_session_ret(-2, None, "freq limit") is False
+
+    def test_ret_minus_2_with_empty_errmsg_is_not_stale(self):
+        # Empty/None errmsg stays a genuine rate limit here; the empty-errmsg
+        # stale variant is tracked separately in #18100 and is intentionally
+        # out of scope for this helper change.
+        assert weixin._is_stale_session_ret(-2, None, None) is False
+        assert weixin._is_stale_session_ret(-2, None, "") is False
 
 
     def test_errcode_minus_14_is_not_matched_here(self):


### PR DESCRIPTION
# PR 描述：fix(weixin): recognize "prepare failed" errmsg as stale-session ret=-2

## Summary

The Weixin iLink adapter's `_is_stale_session_ret` helper currently
recognizes `errmsg="unknown error"` as a stale-session signal under the
generic `ret=-2` rate-limit code (the fix for #17228). A second errmsg
variant — `"prepare failed"` — reports the same underlying condition
(stale/invalid `context_token`) but is still misclassified as a genuine
rate limit, sending the adapter into pointless rate-limit backoff retries
that can never succeed.

This PR adds `"prepare failed"` to the stale-session errmsg match and
fills the missing positive-path regression tests for both variants.

## Problem

Observed on a zh-CN / WSL2 setup (2026-08-20), cron-initiated pushes to a
chat with no recent user activity fail with:

```
WARNING gateway.platforms.weixin: [Weixin] send chunk failed to=o9cq8... attempt=1/3,
retrying in 30.00s: Weixin send failed: iLink sendmessage rate limited: ret=-2 errcode=None errmsg=prepare failed
```

The adapter treats this as a transient rate limit: it backs off and
retries up to N times with the same stale `context_token`, every retry
fails identically, and the message is silently dropped. The correct
behavior — already implemented for `errcode=-14` and for the
`ret=-2 "unknown error"` variant (#17228) — is to recognize the session
as stale, clear the cached `context_token`, refresh it, and retry once.

## Root cause

iLink aliases at least three distinct failure conditions under the
generic business-level `ret=-2` code:

| Condition | errmsg observed | Current handling |
|---|---|---|
| Genuine rate limit | `"freq limit"` | backoff + retry (correct) |
| Stale context_token | `"unknown error"` | stale-session path (#17228, fixed) |
| Stale context_token | `"prepare failed"` | backoff + retry (**wrong** — this PR) |
| Stale context_token | *(empty)* | open question (#18100) |

Which variant a given client sees appears to depend on setup/locale
(the `prepare failed` observation is from zh-CN / WSL2), consistent with
the note in #18100 that locale may matter for which errmsg iLink returns.

## Changes

- `gateway/platforms/weixin.py` — `_is_stale_session_ret`: also match
  `errmsg == "prepare failed"` (case-insensitive, same as the existing
  match); docstring updated.
- `tests/gateway/test_weixin.py` — `TestIsStaleSessionRet`: add positive
  tests for both the original `"unknown error"` variant (previously
  untested) and the new `"prepare failed"` variant, plus case-insensitivity;
  add an explicit negative test pinning that empty errmsg stays classified
  as a rate limit here (the empty-errmsg stale variant remains tracked in
  #18100 and intentionally out of scope).

## Relation to prior issues

- #17228 introduced `_is_stale_session_ret` for the `"unknown error"`
  variant. This PR extends the same mechanism to the `"prepare failed"`
  variant of the identical underlying condition.
- #18100 reports a third variant (empty errmsg) and remains open; this PR
  deliberately does not change empty-errmsg handling and pins current
  behavior in a test so the follow-up decision is explicit.

## Why classifying "prepare failed" as stale is safe

Both call sites bound the effect of a misclassification:

- **Send path** (`_send_text_with_retry`): the stale branch strips the
  cached `context_token` and retries **once** without it, guarded by
  `retried_without_token` — no loop. If the token was actually still
  valid (i.e. `"prepare failed"` ever meant something else), the single
  extra attempt fails and control falls through to the existing
  rate-limit backoff path unchanged.
- **Poll path** (`_poll_loop`): the stale branch pauses 10 minutes and
  continues — strictly gentler than the failure counter/backoff it
  replaces.

Empirically, the rate-limit path is a dead end for this condition: on
2026-08-21 three independent cron-initiated pushes failed all 3 retries
under rate-limit backoff with identical `ret=-2 errmsg=prepare failed`
responses — retrying with the same stale token cannot succeed, so the
only behavior change for real occurrences is from guaranteed-drop to
the established recovery path.

Exact-match on `"prepare failed"` is kept deliberately (no substring
match): it cannot swallow a genuine rate-limit message, and any future
variant should be added explicitly with its own test.

## Testing

```
pytest tests/gateway/test_weixin.py::TestIsStaleSessionRet -v
→ 6 passed
```

Full-file run: all `TestIsStaleSessionRet` tests pass; the 4 failing
voice tests (`TestWeixinVoiceAlwaysDownloaded`,
`TestWeixinVoiceGatewayHandoff`) fail identically on clean `main`
without this change (pre-existing, unrelated).
