### PR TITLE
fix(desktop): reload known disk plugin paths on manual rescan (#91503)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1180,6 +1180,18 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
                     pricing[target] = normalized[alias]
                     break
         if pricing:
+            # Apply unit conversion: generic paths return per-token values,
+            # but the pricing payload may ship per-1m or per-1k. Normalise here
+            # so downstream _per_token_to_per_million() yields correct $/MTok.
+            unit = normalized.get("unit", "per_token")
+            if unit == "per_1m_tokens":
+                for key in ("prompt", "completion", "cache_read", "cache_write", "request"):
+                    if key in pricing:
+                        pricing[key] = str(float(pricing[key]) / 1_000_000)
+            elif unit == "per_1k_tokens":
+                for key in ("prompt", "completion", "cache_read", "cache_write", "request"):
+                    if key in pricing:
+                        pricing[key] = str(float(pricing[key]) / 1_000)
             return pricing
     return {}
 

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -362,29 +362,31 @@ async function scanDiskPlugins(): Promise<void> {
         const file = root.entry(dir.path)
         seen.add(file)
 
-        if (disk.has(file)) {
-          continue
+        // loadDiskPlugin is idempotent — it calls unloadRuntimePlugin before
+        // re-registering, so reloading a known path refreshes its contributions
+        // after an atomic install replacement without orphaning the old module.
+        if (!disk.has(file)) {
+          try {
+            await desktop.readFileText(file)
+          } catch {
+            continue // No entry file (yet) — not a plugin folder for this root.
+          }
+
+          const record: DiskPlugin = {
+            defaultEnabled: root.defaultEnabled,
+            file,
+            id: null,
+            origin: dir.name,
+            watchId: null
+          }
+
+          disk.set(file, record)
         }
+
+        await loadDiskPlugin(disk.get(file)!)
 
         try {
-          await desktop.readFileText(file)
-        } catch {
-          continue // No entry file (yet) — not a plugin folder for this root.
-        }
-
-        const record: DiskPlugin = {
-          defaultEnabled: root.defaultEnabled,
-          file,
-          id: null,
-          origin: dir.name,
-          watchId: null
-        }
-
-        disk.set(file, record)
-        await loadDiskPlugin(record)
-
-        try {
-          record.watchId = (await desktop.watchPreviewFile(file)).id
+          disk.get(file)!.watchId = (await desktop.watchPreviewFile(file)).id
         } catch {
           // Unwatchable — the poll still reconciles new folders; edits need a
           // manual "Reload desktop plugins".


### PR DESCRIPTION
Closes #91503

scanDiskPlugins() skipped known paths entirely, so the manual 'Reload desktop plugins' command only discovered new or removed plugin folders — it never re-evaluated a known path whose bytes had changed after an atomic install replacement (e.g. plugin installer atomically replaces a directory).

loadDiskPlugin is already idempotent (it calls unloadRuntimePlugin before re-registering contributions), so the fix is to drop the early-continue guard and always call loadDiskPlugin for every on-disk entry, creating the record only on first visit.