### PR TITLE
fix(ci): shared pytest basetemp prune race no longer manufactures FLAKY retries

### DIFF
--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -45,8 +45,10 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, Future
@@ -378,9 +380,43 @@ def _run_one_file_once(
     file_timeout: float,
 ) -> Tuple[Path, int, str, dict[str, int], float]:
     """Single attempt of a per-file pytest subprocess (see _run_one_file)."""
-    cmd = [sys.executable, "-m", "pytest", str(file), *pytest_args]
-    
+    # Private --basetemp per subprocess: without it, every concurrent pytest
+    # process shares /tmp/pytest-of-<user>/ and runs the numbered-root
+    # retention pruning (keep-last-3) against its siblings' live roots. Under
+    # 8-way parallelism a sibling's pruning can delete a root between another
+    # process creating it and its first tmp_path use, which surfaces as
+    #   FileNotFoundError: /tmp/pytest-of-runner/pytest-NNN
+    # at fixture setup (seen on CI run 32498702748, slice 9). A per-process
+    # basetemp bypasses the shared numbered-root machinery entirely. A
+    # user-supplied --basetemp in pytest_args comes later on the command
+    # line and therefore wins.
+    basetemp = tempfile.mkdtemp(prefix="hermes-pytest-")
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        str(file),
+        f"--basetemp={basetemp}",
+        *pytest_args,
+    ]
+
     subproc_start = time.monotonic()
+    try:
+        return _launch_and_collect(
+            cmd, file, repo_root, file_timeout, subproc_start
+        )
+    finally:
+        shutil.rmtree(basetemp, ignore_errors=True)
+
+
+def _launch_and_collect(
+    cmd: List[str],
+    file: Path,
+    repo_root: Path,
+    file_timeout: float,
+    subproc_start: float,
+) -> Tuple[Path, int, str, dict[str, int], float]:
+    """Launch one pytest subprocess and collect its result (see _run_one_file_once)."""
     # launch the pytest process
     proc = subprocess.Popen(
         cmd,

--- a/tests/test_run_tests_parallel_basetemp.py
+++ b/tests/test_run_tests_parallel_basetemp.py
@@ -1,0 +1,97 @@
+"""Each per-file pytest subprocess must get a private --basetemp.
+
+Without one, every concurrent pytest process shares
+``/tmp/pytest-of-<user>/`` and runs keep-last-3 numbered-root retention
+pruning against its siblings' live roots. Under parallel CI load a
+sibling's pruning deletes a root between another process creating it and
+its first ``tmp_path`` use, failing fixture setup with
+``FileNotFoundError: /tmp/pytest-of-runner/pytest-NNN`` (CI runs
+32498702748 slice 9, 32499632201 slice 7).
+
+These tests capture the constructed command via a fake Popen — no real
+pytest subprocess is launched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location(
+        "run_tests_parallel_under_test",
+        REPO_ROOT / "scripts" / "run_tests_parallel.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _FakePopen:
+    captured_cmds: list[list[str]] = []
+
+    def __init__(self, cmd, **kwargs):
+        type(self).captured_cmds.append(list(cmd))
+        self.pid = 999999
+        self.returncode = 0
+
+    def communicate(self, timeout=None):
+        return ("1 passed in 0.01s\n", None)
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+    def poll(self):
+        return 0
+
+
+def _captured_cmd(mod, pytest_args):
+    _FakePopen.captured_cmds.clear()
+    mod.subprocess.Popen, real = _FakePopen, mod.subprocess.Popen
+    try:
+        mod._run_one_file_once(
+            Path("tests/test_example.py"), pytest_args, REPO_ROOT, 60.0
+        )
+    finally:
+        mod.subprocess.Popen = real
+    assert len(_FakePopen.captured_cmds) == 1
+    return _FakePopen.captured_cmds[0]
+
+
+def test_private_basetemp_injected():
+    mod = _load_runner()
+    cmd = _captured_cmd(mod, ["-q"])
+    basetemps = [a for a in cmd if a.startswith("--basetemp=")]
+    assert len(basetemps) == 1, cmd
+    assert "hermes-pytest-" in basetemps[0]
+    # Cleaned up after the run (rmtree in the finally).
+    leftover = basetemps[0].split("=", 1)[1]
+    assert not Path(leftover).exists()
+
+
+def test_user_supplied_basetemp_comes_later_and_wins():
+    mod = _load_runner()
+    cmd = _captured_cmd(mod, ["--basetemp=/tmp/user-choice"])
+    basetemps = [a for a in cmd if a.startswith("--basetemp=")]
+    assert len(basetemps) == 2, cmd
+    # pytest uses the LAST occurrence; the user's must come after ours.
+    assert basetemps[-1] == "--basetemp=/tmp/user-choice"
+
+
+def test_no_shared_pytest_of_root_used():
+    """The injected basetemp never lives under the shared pytest-of parent."""
+    mod = _load_runner()
+    cmd = _captured_cmd(mod, [])
+    ours = next(a for a in cmd if a.startswith("--basetemp="))
+    assert "pytest-of" not in ours
+
+
+if __name__ == "__main__":
+    sys.exit(0)


### PR DESCRIPTION
## Summary
Per-file pytest subprocesses no longer share `/tmp/pytest-of-<user>/`, killing the fixture-setup `FileNotFoundError` flake class that was retrying green in CI.

Root cause: every concurrent per-file pytest process defaulted to the same basetemp parent, where pytest's keep-last-3 numbered-root retention pruning runs in *every* session. Under 8-way CI parallelism a sibling's pruning deleted a freshly created `pytest-NNN` root before its owner's first `tmp_path` use — fixture setup then failed with `FileNotFoundError: /tmp/pytest-of-runner/pytest-NNN`, and the retry (in an emptier window) passed, laundering the failure into a `⚠ FLAKY` frame.

Observed three times in one day, three different victim files (the victim is whoever loses the race, so per-test patching is impossible — this is the class fix at the runner):
- run [32498702748](https://github.com/NousResearch/hermes-agent/actions/runs/32498702748) slice 9 — `tests/tui_gateway/test_slash_worker_sys_path.py`
- run [32499632201](https://github.com/NousResearch/hermes-agent/actions/runs/32499632201) slice 7 — `tests/run_agent/test_tool_call_incremental_persistence.py` (12 of 13 tests errored at setup)

## Changes
- `scripts/run_tests_parallel.py`: each subprocess gets a private `--basetemp` (`tempfile.mkdtemp`, removed in a `finally`); a user-supplied `--basetemp` comes later on the command line and wins
- `tests/test_run_tests_parallel_basetemp.py`: 3 tests — injection, user-override ordering, never-under-`pytest-of`; verified to fail without the fix (sabotage run: 3/3 red)

## Validation
| Check | Result |
|---|---|
| New tests, 5 consecutive runs | 3 passed × 5 |
| Sabotage (fix reverted) | 3/3 failed |
| Runner over 2 victim files, 5 consecutive runs | 5 tests passed × 5, 0 leftover `/tmp/hermes-pytest-*` dirs |
| Existing runner suites (`test_run_tests_parallel*.py`) | 12 passed, 1 skipped |

## Infographic

![Private basetemp per test process](https://v3b.fal.media/files/b/0aa73f66/HCy492S5TXUDlN56wZo1I_LxFZWwvD.png)
