### PR TITLE
fix(gateway): retry failed delivery obligations in-process

### DIFF
--- a/gateway/delivery_ledger.py
+++ b/gateway/delivery_ledger.py
@@ -26,9 +26,17 @@ ambiguous sends):
 - ``attempting``  — crashed mid-await: the platform MAY already have the
   message. Redelivered WITH a visible recovered-reply marker so the
   contract is honest at-least-once, never a silent duplicate.
-- ``failed``      — definitively rejected once; the restart is a natural
-  retry boundary. Also carries the marker.
+- ``failed``      — definitively rejected once. Also carries the marker.
 - ``delivered``   — nothing to do; retention prunes.
+
+``sweep_recoverable()`` only ever claims rows whose owner is DEAD, so it
+recovers crashes and nothing else. A transient platform rejection (a Discord
+5xx) leaves a ``failed`` row owned by a gateway that is still very much
+alive: no sweep touched it, and the turn's output sat undelivered until an
+operator forced a restart. ``sweep_retryable()`` closes that hole — it claims
+``failed`` rows owned by THIS live process once their backoff has elapsed.
+The two sweeps partition the space by owner liveness (dead vs. self), so they
+can never claim the same row, and they share one ``attempts`` budget.
 
 Poison rows cannot spin: attempts are capped, stale rows expire, and both
 transition to ``abandoned`` (kept briefly for inspection, then pruned).
@@ -67,6 +75,21 @@ _MAX_ROWS = 500
 # message (crash mid-send / post-rejection retry). Honest at-least-once.
 RECOVERED_MARKER = (
     "♻️ Recovered reply — the gateway restarted during delivery, "
+    "so this may be a duplicate:\n\n"
+)
+
+# In-process retry backoff, indexed by the number of attempts already made
+# (attempts=0 -> first retry after 30s). A row whose attempts reach
+# MAX_ATTEMPTS is abandoned by the same cap the crash path uses, so the two
+# sweeps share one retry budget and a poison row still cannot spin.
+RETRY_BACKOFF_SECONDS = (30.0, 120.0, 600.0)
+
+# Marker for a live-process retry after a transient platform rejection. The
+# crash wording ("the gateway restarted") would be a lie here: the gateway
+# never went down, the platform refused the send. Still labeled, because a
+# 5xx can hide a delivery that actually landed.
+RETRY_MARKER = (
+    "♻️ Retried delivery — the first send was rejected by the platform, "
     "so this may be a duplicate:\n\n"
 )
 
@@ -320,6 +343,118 @@ def sweep_recoverable(
                     "attempts": attempts + 1,
                 })
     return claimed
+
+
+def sweep_retryable(
+    now: Optional[float] = None,
+    *,
+    deliverable_platforms: Optional[set] = None,
+) -> List[Dict[str, Any]]:
+    """Claim ``failed`` rows still owned by THIS live process, for in-process
+    retry after a transient platform rejection.
+
+    Complements ``sweep_recoverable`` (which only claims rows whose owner is
+    dead, i.e. crash recovery). Without this, a Discord 5xx during the final
+    send left the row ``failed`` with ``attempts=0`` forever: the owning
+    gateway never crashed, so nothing ever re-claimed it and the turn's
+    output was only recoverable by restarting the process.
+
+    Ownership is the partition key. A row is claimed here only when
+    ``owner_pid`` is this pid AND the recorded start time matches, so:
+
+    - rows owned by a dead process stay with ``sweep_recoverable``;
+    - rows owned by a DIFFERENT live gateway are left to that process;
+    - a recycled pid cannot be mistaken for us (start time is checked).
+
+    A row is returned only after ``RETRY_BACKOFF_SECONDS[attempts]`` has
+    elapsed since ``updated_at``, so an outage that lasts minutes is retried
+    on a widening interval rather than hammered. Rows over the attempts cap
+    or the stale cutoff transition to 'abandoned', exactly as in the crash
+    path — the retry budget is shared, never doubled.
+    """
+    now = now if now is not None else time.time()
+    pid, started = _owner_stamp()
+    claimed: List[Dict[str, Any]] = []
+    with _DB_LOCK, _transaction() as conn:
+        rows = conn.execute(
+            """SELECT obligation_id, session_key, platform, chat_id, thread_id,
+                      content, attempts, created_at, updated_at,
+                      owner_pid, owner_started_at
+               FROM delivery_obligations
+               WHERE state='failed' AND owner_pid=?""",
+            (pid,),
+        ).fetchall()
+        for (oid, session_key, platform, chat_id, thread_id, content,
+             attempts, created_at, updated_at, owner_pid,
+             owner_started_at) in rows:
+            if (
+                started is not None
+                and owner_started_at is not None
+                and int(owner_started_at) != int(started)
+            ):
+                # Same pid number, different process (pid reuse after a
+                # crash+respawn). Not ours to retry; the crash path owns it.
+                continue
+            if attempts >= MAX_ATTEMPTS or (now - created_at) > STALE_AFTER_SECONDS:
+                conn.execute(
+                    """UPDATE delivery_obligations
+                       SET state='abandoned', updated_at=? WHERE obligation_id=?""",
+                    (now, oid),
+                )
+                continue
+            if (
+                deliverable_platforms is not None
+                and platform not in deliverable_platforms
+            ):
+                # No adapter for this platform right now — claiming would
+                # spend an attempt on a guaranteed no-op.
+                continue
+            try:
+                backoff = RETRY_BACKOFF_SECONDS[int(attempts)]
+            except (IndexError, TypeError, ValueError):
+                backoff = RETRY_BACKOFF_SECONDS[-1]
+            if (now - updated_at) < backoff:
+                continue  # still cooling down
+            cursor = conn.execute(
+                """UPDATE delivery_obligations
+                   SET state='attempting', attempts=attempts+1, updated_at=?
+                   WHERE obligation_id=? AND state='failed' AND owner_pid=?""",
+                (now, oid, pid),
+            )
+            if cursor.rowcount:
+                claimed.append({
+                    "obligation_id": oid,
+                    "session_key": session_key,
+                    "platform": platform,
+                    "chat_id": chat_id,
+                    "thread_id": thread_id,
+                    "content": content,
+                    # Always ambiguous: the platform rejected the send, but a
+                    # 5xx can hide a message that actually landed.
+                    "needs_marker": True,
+                    "attempts": attempts + 1,
+                })
+    return claimed
+
+
+def retry_sweep_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
+    """Read the ``gateway.delivery_retry_sweep`` config gate (default on).
+
+    Separate from ``ledger_enabled`` so the in-process retry can be turned
+    off without losing crash-recovery redelivery.
+    """
+    try:
+        if config is None:
+            from hermes_cli.config import load_config
+
+            config = load_config()
+        gw = config.get("gateway") or {}
+        value = gw.get("delivery_retry_sweep", True)
+        if isinstance(value, str):
+            return value.strip().lower() not in {"false", "0", "no", "off"}
+        return bool(value)
+    except Exception:
+        return True
 
 
 def _prune(now: Optional[float] = None) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12021,10 +12021,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         try:
             from gateway.delivery_ledger import (
-                RECOVERED_MARKER,
                 ledger_enabled,
-                mark_delivered,
-                mark_failed,
                 sweep_recoverable,
             )
 
@@ -12044,6 +12041,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return 0
         if not claimed:
             return 0
+        from gateway.delivery_ledger import RECOVERED_MARKER as _MARKER
+
+        return await self._deliver_claimed_obligations(
+            claimed, marker=_MARKER, clear_resume=True
+        )
+
+    async def _deliver_claimed_obligations(
+        self, claimed, *, marker: str, clear_resume: bool
+    ) -> int:
+        """Send a batch of ledger rows already claimed by a sweep.
+
+        Shared by the crash-recovery path (``_redeliver_pending_obligations``,
+        marker = RECOVERED_MARKER, clears ``resume_pending``) and the
+        in-process retry path (``_retry_failed_obligations``, marker =
+        RETRY_MARKER, nothing to clear — that session never went pending).
+        Returns the number of confirmed deliveries.
+        """
+        from gateway.delivery_ledger import mark_delivered, mark_failed
 
         redelivered = 0
         for row in claimed:
@@ -12062,7 +12077,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
             content = row["content"]
             if row.get("needs_marker"):
-                content = RECOVERED_MARKER + content
+                content = marker + content
             metadata = (
                 {"thread_id": row["thread_id"]} if row.get("thread_id") else None
             )
@@ -12098,9 +12113,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("delivery ledger update failed", exc_info=True)
 
             # The answer reached (or was owed to) this session — don't ALSO
-            # re-run the turn via the resume path.
+            # re-run the turn via the resume path. Only the crash path needs
+            # this: a retry row belongs to a session that never went pending.
             session_key = row.get("session_key") or ""
-            if session_key:
+            if clear_resume and session_key:
                 try:
                     await self.async_session_store.clear_resume_pending(session_key)
                 except Exception:
@@ -12109,6 +12125,69 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         exc_info=True,
                     )
         return redelivered
+
+    async def _retry_failed_obligations(self) -> int:
+        """Retry final responses this live process failed to deliver.
+
+        Closes the gap ``_redeliver_pending_obligations`` cannot cover: that
+        one only claims rows whose owner is DEAD, so it recovers crashes.
+        When the platform itself rejects the send (a Discord 5xx blip) the
+        gateway stays up, keeps owning the row, and nothing retries — the
+        turn's answer sits ``failed``/``attempts=0`` until someone restarts
+        the process. Observed 2026-08-21: a 503 storm on the final send left
+        a thread showing a stale progress card for ~2h with the completed
+        answer stranded in the ledger.
+
+        Backoff and the attempts cap live in the ledger; this only sends.
+        """
+        try:
+            from gateway.delivery_ledger import (
+                RETRY_MARKER,
+                ledger_enabled,
+                retry_sweep_enabled,
+                sweep_retryable,
+            )
+
+            if not await asyncio.to_thread(ledger_enabled):
+                return 0
+            if not await asyncio.to_thread(retry_sweep_enabled):
+                return 0
+            _deliverable = {getattr(p, "value", str(p)) for p in self.adapters}
+            claimed = await asyncio.to_thread(
+                sweep_retryable, None, deliverable_platforms=_deliverable
+            )
+        except Exception:
+            logger.debug("delivery ledger retry sweep failed", exc_info=True)
+            return 0
+        if not claimed:
+            return 0
+        return await self._deliver_claimed_obligations(
+            claimed, marker=RETRY_MARKER, clear_resume=False
+        )
+
+    async def _delivery_retry_watcher(self, interval: float = 30.0) -> None:
+        """Periodically retry obligations this process failed to deliver.
+
+        A permanent supervised watcher. The sweep is cheap (one indexed
+        SELECT over a table capped at 500 rows) and almost always returns
+        nothing, so a short interval costs little; the real pacing is the
+        per-row backoff in ``sweep_retryable``.
+        """
+        await asyncio.sleep(min(interval, 30.0))  # let startup settle
+        while self._running:
+            try:
+                await asyncio.sleep(interval)
+                if not self._running:
+                    return
+                sent = await self._retry_failed_obligations()
+                if sent:
+                    logger.info(
+                        "delivery retry sweep: redelivered %d obligation(s)", sent
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 - a watcher must never die on one bad pass
+                logger.debug("delivery retry watcher pass failed", exc_info=True)
 
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.
@@ -13231,6 +13310,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # that session) is strictly cheaper and more correct than re-running
         # the whole turn.
         await self._redeliver_pending_obligations()
+        # Crash recovery above only covers rows owned by a DEAD process. Arm
+        # the live-process retry sweep so a transient platform rejection
+        # (Discord 5xx) self-heals instead of stranding the answer until the
+        # next restart.
+        try:
+            self._spawn_supervised(
+                self._delivery_retry_watcher, "delivery_retry_watcher"
+            )
+        except Exception:  # noqa: BLE001 - must never block startup
+            logger.debug("delivery retry watcher failed to arm", exc_info=True)
         self._schedule_resume_pending_sessions()
         await self._finish_startup_restore()
 

--- a/tests/gateway/test_delivery_retry_sweep.py
+++ b/tests/gateway/test_delivery_retry_sweep.py
@@ -1,0 +1,243 @@
+"""Tests for the in-process delivery retry sweep (``sweep_retryable``).
+
+``sweep_recoverable`` only claims rows whose owner process is DEAD, so it
+recovers crashes and nothing else. When the PLATFORM rejects the final send
+(a Discord 5xx blip) the gateway stays alive, keeps owning the row, and the
+answer sat ``failed``/``attempts=0`` until an operator restarted the process.
+
+Contract asserted here:
+- a live-owned ``failed`` row is invisible to ``sweep_recoverable`` (the hole)
+- ``sweep_retryable`` claims it, but only after its backoff has elapsed
+- claiming flips it to ``attempting`` and spends exactly one attempt
+- the two sweeps partition by owner liveness and can never claim one row
+- retries always carry a marker (a 5xx can hide a delivery that landed)
+- the attempts cap / stale cutoff abandon poison rows, budget shared
+- pid reuse by a different process is not mistaken for us
+"""
+
+import os
+import time
+
+import pytest
+
+from gateway import delivery_ledger as dl
+
+
+@pytest.fixture(autouse=True)
+def _fresh_db(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(dl, "_db_path", lambda: home / "state.db")
+    yield
+
+
+def _record(oid="ob-1", platform="discord", **kw):
+    dl.record_obligation(
+        obligation_id=oid,
+        session_key=kw.get("session_key", "agent:main:discord:channel:C1"),
+        platform=platform,
+        chat_id=kw.get("chat_id", "C1"),
+        thread_id=kw.get("thread_id", "1539072364405330062"),
+        content=kw.get("content", "the final answer"),
+    )
+
+
+def _row(oid):
+    with dl._connect() as conn:
+        r = conn.execute(
+            """SELECT state, attempts, owner_pid, owner_started_at
+               FROM delivery_obligations WHERE obligation_id=?""",
+            (oid,),
+        ).fetchone()
+    return None if r is None else {
+        "state": r[0], "attempts": r[1],
+        "owner_pid": r[2], "owner_started_at": r[3],
+    }
+
+
+def _set(oid, **cols):
+    sets = ", ".join(f"{k}=?" for k in cols)
+    with dl._connect() as conn:
+        conn.execute(
+            f"UPDATE delivery_obligations SET {sets} WHERE obligation_id=?",
+            (*cols.values(), oid),
+        )
+        conn.commit()
+
+
+def _fail_and_age(oid, seconds_ago):
+    """Mark failed, then backdate updated_at to simulate elapsed backoff."""
+    dl.mark_failed(oid, "503 Service Unavailable")
+    _set(oid, updated_at=time.time() - seconds_ago)
+
+
+# --------------------------------------------------------------------------
+# The hole this sweep exists to close
+# --------------------------------------------------------------------------
+
+def test_crash_sweep_ignores_failed_row_owned_by_live_process():
+    """Regression for the 2026-08-21 incident: a 503 on the final send left
+    the answer stranded because the OWNING gateway never died."""
+    _record()
+    _fail_and_age("ob-1", 3600)
+
+    assert dl.sweep_recoverable() == []          # crash path cannot see it
+    assert _row("ob-1")["attempts"] == 0         # nothing ever retried it
+
+    claimed = dl.sweep_retryable()               # retry path does
+    assert [c["obligation_id"] for c in claimed] == ["ob-1"]
+
+
+def test_claim_flips_to_attempting_and_spends_one_attempt():
+    _record()
+    _fail_and_age("ob-1", 3600)
+
+    claimed = dl.sweep_retryable()
+
+    assert claimed[0]["attempts"] == 1
+    assert claimed[0]["content"] == "the final answer"
+    assert claimed[0]["chat_id"] == "C1"
+    row = _row("ob-1")
+    assert row["state"] == "attempting"
+    assert row["attempts"] == 1
+
+
+def test_retry_always_carries_marker():
+    """A 5xx can hide a message that actually landed - never a silent dup."""
+    _record()
+    _fail_and_age("ob-1", 3600)
+
+    assert dl.sweep_retryable()[0]["needs_marker"] is True
+
+
+def test_retry_marker_does_not_claim_a_gateway_restart():
+    """The crash wording would be a lie here: the gateway never went down."""
+    assert "restart" not in dl.RETRY_MARKER.lower()
+    assert "duplicate" in dl.RETRY_MARKER.lower()
+
+
+# --------------------------------------------------------------------------
+# Backoff
+# --------------------------------------------------------------------------
+
+def test_row_is_not_claimed_before_backoff_elapses():
+    _record()
+    dl.mark_failed("ob-1", "503")  # updated_at = now
+
+    assert dl.sweep_retryable() == []
+    assert _row("ob-1")["state"] == "failed"     # untouched, still retryable
+
+
+def test_backoff_widens_with_each_attempt():
+    """attempts=1 must wait longer than the first retry did."""
+    _record()
+    _fail_and_age("ob-1", dl.RETRY_BACKOFF_SECONDS[0] + 1)
+    assert dl.sweep_retryable()                  # first retry fires
+
+    # That retry failed too; the second backoff step is longer, so an age
+    # that satisfied step 0 must NOT satisfy step 1.
+    _fail_and_age("ob-1", dl.RETRY_BACKOFF_SECONDS[0] + 1)
+    assert _row("ob-1")["attempts"] == 1
+    assert dl.sweep_retryable() == []
+
+    _fail_and_age("ob-1", dl.RETRY_BACKOFF_SECONDS[1] + 1)
+    assert dl.sweep_retryable()
+
+
+# --------------------------------------------------------------------------
+# Bounds: poison rows cannot spin
+# --------------------------------------------------------------------------
+
+def test_attempts_cap_abandons_instead_of_retrying_forever():
+    _record()
+    _fail_and_age("ob-1", 3600)
+    _set("ob-1", attempts=dl.MAX_ATTEMPTS)
+
+    assert dl.sweep_retryable() == []
+    assert _row("ob-1")["state"] == "abandoned"
+
+
+def test_stale_cutoff_abandons_an_old_row():
+    _record()
+    _fail_and_age("ob-1", 3600)
+    _set("ob-1", created_at=time.time() - dl.STALE_AFTER_SECONDS - 1)
+
+    assert dl.sweep_retryable() == []
+    assert _row("ob-1")["state"] == "abandoned"
+
+
+def test_attempts_budget_is_shared_with_the_crash_path():
+    """Two sweeps, one budget - a row cannot get 3 retries per sweep."""
+    _record()
+    _fail_and_age("ob-1", 3600)
+    _set("ob-1", attempts=dl.MAX_ATTEMPTS - 1)
+
+    assert len(dl.sweep_retryable()) == 1
+    assert _row("ob-1")["attempts"] == dl.MAX_ATTEMPTS
+
+    _fail_and_age("ob-1", 3600)
+    assert dl.sweep_retryable() == []
+    assert _row("ob-1")["state"] == "abandoned"
+
+
+# --------------------------------------------------------------------------
+# Ownership partition
+# --------------------------------------------------------------------------
+
+def test_row_owned_by_another_process_is_left_alone():
+    _record()
+    _fail_and_age("ob-1", 3600)
+    _set("ob-1", owner_pid=os.getpid() + 424242)
+
+    assert dl.sweep_retryable() == []
+    assert _row("ob-1")["state"] == "failed"
+
+
+def test_pid_reuse_by_a_different_process_is_not_mistaken_for_us():
+    """Same pid number, different process start time - not ours to retry."""
+    _record()
+    _fail_and_age("ob-1", 3600)
+    row = _row("ob-1")
+    if row["owner_started_at"] is None:
+        pytest.skip("process start time unavailable on this platform")
+    _set("ob-1", owner_started_at=int(row["owner_started_at"]) + 99999)
+
+    assert dl.sweep_retryable() == []
+    assert _row("ob-1")["state"] == "failed"
+
+
+def test_delivered_and_pending_rows_are_never_retried():
+    _record("ob-pending")
+    _record("ob-delivered")
+    dl.mark_delivered("ob-delivered")
+    _set("ob-pending", updated_at=time.time() - 3600)
+    _set("ob-delivered", updated_at=time.time() - 3600)
+
+    assert dl.sweep_retryable() == []
+
+
+# --------------------------------------------------------------------------
+# Platform filter and config gate
+# --------------------------------------------------------------------------
+
+def test_absent_platform_does_not_burn_an_attempt():
+    _record(platform="discord")
+    _fail_and_age("ob-1", 3600)
+
+    assert dl.sweep_retryable(deliverable_platforms={"slack"}) == []
+    row = _row("ob-1")
+    assert row["attempts"] == 0        # budget preserved for a later pass
+    assert row["state"] == "failed"
+
+    assert dl.sweep_retryable(deliverable_platforms={"discord"})
+
+
+def test_retry_sweep_gate_defaults_on_and_honours_false():
+    assert dl.retry_sweep_enabled({}) is True
+    assert dl.retry_sweep_enabled({"gateway": {}}) is True
+    assert dl.retry_sweep_enabled(
+        {"gateway": {"delivery_retry_sweep": False}}
+    ) is False
+    assert dl.retry_sweep_enabled(
+        {"gateway": {"delivery_retry_sweep": "off"}}
+    ) is False


### PR DESCRIPTION
Fixes #91653.

## Problem

`sweep_recoverable()` only claims delivery obligations whose owner process is **dead**. When the platform rejects the final send but the gateway stays alive, the owning process keeps the row and nothing ever re-claims it: the answer is never delivered. `_redeliver_pending_obligations()` only runs at startup, so without a restart there is no retry at all.

Observed in production on 2026-08-21: a Discord 503 storm hit every attempt of one final send (status-card edit, final message, and the plain-text fallback). The row was left `state='failed' attempts=0` forever, the thread showed a stale progress card for about 2 hours, and recovery needed a manual `/stop` plus a re-prompt. The agent turn itself had finished normally 4 minutes in - only delivery was lost.

## Change

- `sweep_retryable()` claims `failed` rows owned by **this live process** once their per-attempt backoff has elapsed (30s / 120s / 600s).
- The two sweeps partition the space by owner liveness (dead vs. self), so they can never claim the same row. They share the existing attempt ceiling and stale cutoff, so a poisoned row cannot spin forever.
- The send loop is extracted to `_deliver_claimed_obligations()` and reused by both the crash-recovery path and the retry path, so there is one delivery code path, not two.
- A supervised `_delivery_retry_watcher` polls every 30s, gated by the new `gateway.delivery_retry_sweep` config key (default on, separate from `gateway.delivery_ledger`) so the retry can be disabled without losing crash recovery.
- Retried sends carry their own marker, distinct from the crash-recovery marker: a 5xx can hide a send that actually landed, so the message stays labeled instead of arriving as a silent duplicate. Saying "the gateway restarted" here would simply be false.

## Tests

- New `tests/gateway/test_delivery_retry_sweep.py`: 14 tests. This includes a deliberate tripwire asserting that `sweep_recoverable()` **cannot** see a `failed` row owned by a live process - if the two sweeps are ever merged, that test fails and explains why they are separate.
- Existing `tests/gateway/test_delivery_ledger.py`: 17 tests, still green - the crash-recovery path is unchanged.
- Both suites verified against this branch's base (current `main`), run per file.

## Production validation

Beyond unit tests, the mechanism was exercised end to end on a live gateway: a canary obligation was injected with `state='failed'`, `attempts=0`, and `owner_pid` set to the **live** gateway process - the exact scenario nothing used to retry. It was reclaimed and delivered on its own about 50 seconds later, with the retry marker attached and `attempts` incremented to 1.

## Notes

- No change to the crash-recovery semantics or to the ledger schema.
- Backoff values and the 30s poll interval are module constants, easy to tune if you prefer different defaults.
