### PR TITLE
fix(process): serialize machine-wide spawn-ledger registration

### DIFF
--- a/hermes_cli/process_identity.py
+++ b/hermes_cli/process_identity.py
@@ -383,10 +383,11 @@ def ledger_entries(*, project_root: Optional[Path] = None) -> list[dict]:
     want_install = install_id(project_root)
     path = _ledger_path()
     with _LEDGER_LOCK:
-        entries = _read_ledger(path)
-        if entries is None:
-            _quarantine_ledger(path)
-            return []
+        with _ledger_transaction_lock(path):
+            entries = _read_ledger(path)
+            if entries is None:
+                _quarantine_ledger(path)
+                return []
     out: list[dict] = []
     for e in entries:
         if e.get("install") != want_install:

--- a/hermes_cli/process_identity.py
+++ b/hermes_cli/process_identity.py
@@ -41,15 +41,26 @@ import os
 import platform
 import threading
 import time
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
+
 SPAWN_ENV_VAR = "HERMES_SPAWN"
 _TAG_VERSION = "v1"
 LEDGER_FILENAME = "spawn-ledger.json"
+LEDGER_LOCK_TIMEOUT_SECONDS = 2.0
 
 #: Purposes a reaper may treat as "safe to kill when the owner is gone".
 #: Interactive processes (chat, REPLs) are deliberately NOT in this set.
@@ -175,6 +186,69 @@ def _ledger_path() -> Path:
         return Path(get_hermes_home()) / LEDGER_FILENAME
 
 
+def _ledger_lock_path(path: Path) -> Path:
+    """Persistent sibling lock; never lock the replaceable ledger itself."""
+    return path.with_suffix(path.suffix + ".lock")
+
+
+@contextmanager
+def _ledger_transaction_lock(path: Path):
+    """Best-effort bounded cross-process lock for one ledger write transaction.
+
+    The lock lives beside the data file because ``os.replace()`` swaps the
+    ledger's inode. Any lock failure deliberately falls back to the existing
+    process-local behavior: process startup must never be held hostage by a
+    stale or inaccessible advisory lock.
+    """
+    if fcntl is None and msvcrt is None:
+        logger.debug("spawn ledger process lock unavailable; using local lock only")
+        yield
+        return
+
+    lock_path = _ledger_lock_path(path)
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        # msvcrt.locking() needs one byte at offset zero; an empty lock file
+        # does not protect anything on Windows.
+        if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+            lock_path.write_text(" ", encoding="utf-8")
+        lock_file = lock_path.open("r+" if msvcrt else "a+", encoding="utf-8")
+    except OSError:
+        logger.debug("spawn ledger process lock failed; using local lock only", exc_info=True)
+        yield
+        return
+
+    with lock_file:
+        deadline = time.monotonic() + LEDGER_LOCK_TIMEOUT_SECONDS
+        acquired = False
+        while not acquired:
+            try:
+                if fcntl:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                else:
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+                acquired = True
+            except (BlockingIOError, OSError, PermissionError):
+                if time.monotonic() >= deadline:
+                    logger.debug("spawn ledger process lock timed out; using local lock only")
+                    yield
+                    return
+                time.sleep(0.05)
+
+        try:
+            yield
+        finally:
+            try:
+                if fcntl:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                else:
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+
+
 def _read_ledger(path: Path) -> Optional[list[dict]]:
     """Entries list, ``[]`` for empty/missing, ``None`` for CORRUPT.
 
@@ -271,29 +345,30 @@ def register_self(purpose: str, *, project_root: Optional[Path] = None) -> bool:
 
     path = _ledger_path()
     with _LEDGER_LOCK:
-        entries = _read_ledger(path)
-        if entries is None:
-            _quarantine_ledger(path)
-            entries = []
-        pruned: list[dict] = []
-        for e in entries:
-            pid = e.get("pid")
-            if not isinstance(pid, int) or pid == entry.pid:
-                continue
-            alive = _pid_alive_matches(pid, e.get("create_time"))
-            if alive is False:
-                continue  # provably dead → prune
-            pruned.append(e)
-        pruned.append(asdict(entry))
-        try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            tmp = path.with_suffix(path.suffix + f".tmp{os.getpid()}")
-            tmp.write_text(json.dumps(pruned, indent=2), encoding="utf-8")
-            os.replace(tmp, path)
-            return True
-        except OSError:
-            logger.debug("spawn ledger write failed", exc_info=True)
-            return False
+        with _ledger_transaction_lock(path):
+            entries = _read_ledger(path)
+            if entries is None:
+                _quarantine_ledger(path)
+                entries = []
+            pruned: list[dict] = []
+            for e in entries:
+                pid = e.get("pid")
+                if not isinstance(pid, int) or pid == entry.pid:
+                    continue
+                alive = _pid_alive_matches(pid, e.get("create_time"))
+                if alive is False:
+                    continue  # provably dead → prune
+                pruned.append(e)
+            pruned.append(asdict(entry))
+            try:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                tmp = path.with_suffix(path.suffix + f".tmp{os.getpid()}")
+                tmp.write_text(json.dumps(pruned, indent=2), encoding="utf-8")
+                os.replace(tmp, path)
+                return True
+            except OSError:
+                logger.debug("spawn ledger write failed", exc_info=True)
+                return False
 
 
 def ledger_entries(*, project_root: Optional[Path] = None) -> list[dict]:

--- a/tests/hermes_cli/test_process_identity.py
+++ b/tests/hermes_cli/test_process_identity.py
@@ -15,7 +15,10 @@ Runs on any host: psutil interactions go through a fake module.
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
+import textwrap
+import time
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -179,6 +182,103 @@ def test_corrupt_ledger_quarantined_not_rewritten_blind(tmp_path):
     assert parked.read_text(encoding="utf-8") == "{ not json"
     entries = json.loads(ledger.read_text(encoding="utf-8"))
     assert [e["pid"] for e in entries] == [999]
+
+
+def test_register_self_serializes_real_interpreter_ledger_writes(tmp_path):
+    """A second process cannot read a stale ledger while the first writes it."""
+    ledger = tmp_path / "spawn-ledger.json"
+    sync = tmp_path / "sync"
+    sync.mkdir()
+    child_script = textwrap.dedent(
+        """
+        import os
+        import sys
+        import time
+        from pathlib import Path
+
+        from hermes_cli import process_identity as pi
+
+        ledger = Path(sys.argv[1])
+        sync = Path(sys.argv[2])
+        name = sys.argv[3]
+        original_read = pi._read_ledger
+
+        def coordinated_read(path):
+            entries = original_read(path)
+            (sync / (name + ".read")).write_text("ready", encoding="utf-8")
+            while not (sync / "release").exists():
+                time.sleep(0.01)
+            return entries
+
+        pi._ledger_path = lambda: ledger
+        pi._read_ledger = coordinated_read
+        pi._own_create_time = lambda: float(os.getpid())
+        pi._pid_alive_matches = lambda _pid, _create: True
+        (sync / (name + ".started")).write_text("started", encoding="utf-8")
+        while not (sync / ("go-" + name)).exists():
+            time.sleep(0.01)
+        if not pi.register_self("serve", project_root=ledger.parent):
+            raise SystemExit(2)
+        (sync / (name + ".done")).write_text("done", encoding="utf-8")
+        while not (sync / "finish").exists():
+            time.sleep(0.01)
+        """
+    )
+
+    def wait_for(path, timeout=10.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if path.exists():
+                return True
+            time.sleep(0.01)
+        return path.exists()
+
+    root = Path(__file__).resolve().parents[2]
+
+    def launch(name):
+        return subprocess.Popen(
+            [sys.executable, "-c", child_script, str(ledger), str(sync), name],
+            cwd=root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    children = []
+    try:
+        first = launch("first")
+        children.append(first)
+        assert wait_for(sync / "first.started")
+        (sync / "go-first").write_text("go", encoding="utf-8")
+        assert wait_for(sync / "first.read")
+
+        second = launch("second")
+        children.append(second)
+        assert wait_for(sync / "second.started")
+        (sync / "go-second").write_text("go", encoding="utf-8")
+
+        # The first child has already read an empty ledger and remains paused.
+        # Without an interprocess lock, the second child reaches the same read
+        # barrier before release; with one it blocks until the first replaces
+        # the ledger. This is a state handshake, not a sleep-only race.
+        second_read_before_release = wait_for(sync / "second.read", timeout=1.0)
+        (sync / "release").write_text("release", encoding="utf-8")
+        assert wait_for(sync / "first.done")
+        assert wait_for(sync / "second.done")
+
+        pids = {entry["pid"] for entry in json.loads(ledger.read_text(encoding="utf-8"))}
+        assert pids == {first.pid, second.pid}
+        assert not second_read_before_release
+    finally:
+        (sync / "release").touch()
+        (sync / "finish").touch()
+        for child in children:
+            try:
+                stdout, stderr = child.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                child.kill()
+                stdout, stderr = child.communicate()
+            assert child.returncode == 0, stdout + stderr
 
 
 def test_ledger_entries_filters_dead_reused_and_foreign(tmp_path):

--- a/tests/hermes_cli/test_process_identity.py
+++ b/tests/hermes_cli/test_process_identity.py
@@ -14,11 +14,13 @@ Runs on any host: psutil interactions go through a fake module.
 
 from __future__ import annotations
 
+from contextlib import contextmanager, nullcontext
 import json
 import subprocess
 import sys
 import textwrap
 import time
+import threading
 import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -279,6 +281,74 @@ def test_register_self_serializes_real_interpreter_ledger_writes(tmp_path):
                 child.kill()
                 stdout, stderr = child.communicate()
             assert child.returncode == 0, stdout + stderr
+
+
+def test_ledger_entries_cannot_quarantine_a_replaced_valid_ledger(tmp_path):
+    """A stale corrupt read must hold the transaction lock through quarantine."""
+    ledger = tmp_path / "spawn-ledger.json"
+    ledger.write_text("{ not json", encoding="utf-8")
+    transaction_lock = threading.Lock()
+    stale_read = threading.Event()
+    release_reader = threading.Event()
+    reader_result = []
+    reader_errors = []
+    writer_errors = []
+
+    @contextmanager
+    def shared_transaction_lock(_path):
+        with transaction_lock:
+            yield
+
+    original_read = pi._read_ledger
+
+    def paused_corrupt_read(path):
+        entries = original_read(path)
+        if threading.current_thread().name == "ledger-reader":
+            assert entries is None
+            stale_read.set()
+            assert release_reader.wait(timeout=5)
+        return entries
+
+    def read_entries():
+        try:
+            reader_result.extend(pi.ledger_entries(project_root=tmp_path))
+        except Exception as exc:  # pragma: no cover - surfaced below
+            reader_errors.append(exc)
+
+    def register_writer():
+        try:
+            assert pi.register_self("serve", project_root=tmp_path) is True
+        except Exception as exc:  # pragma: no cover - surfaced below
+            writer_errors.append(exc)
+
+    with patch.object(pi, "_ledger_path", return_value=ledger), \
+         patch.object(pi, "_LEDGER_LOCK", nullcontext()), \
+         patch.object(pi, "_ledger_transaction_lock", shared_transaction_lock), \
+         patch.object(pi, "_read_ledger", paused_corrupt_read), \
+         patch.object(pi, "_own_create_time", return_value=1.0):
+        reader = threading.Thread(target=read_entries, name="ledger-reader")
+        writer = threading.Thread(target=register_writer, name="ledger-writer")
+        reader.start()
+        assert stale_read.wait(timeout=5)
+
+        # This is the cross-process boundary: the local lock above is a no-op
+        # to model separate interpreters, so only the sibling transaction lock
+        # can keep the stale corrupt read from acting on a replacement.
+        assert transaction_lock.locked()
+
+        writer.start()
+        release_reader.set()
+        reader.join(timeout=5)
+        writer.join(timeout=5)
+
+    assert not reader.is_alive()
+    assert not writer.is_alive()
+    assert not reader_errors
+    assert not writer_errors
+    assert reader_result == []
+    entries = json.loads(ledger.read_text(encoding="utf-8"))
+    assert [entry["pid"] for entry in entries] == [pi.os.getpid()]
+    assert (tmp_path / "spawn-ledger.json.corrupt").read_text(encoding="utf-8") == "{ not json"
 
 
 def test_ledger_entries_filters_dead_reused_and_foreign(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Serializes registration of the machine-wide `spawn-ledger.json` so concurrent gateway and serve/dashboard startup cannot overwrite one another's positive-identity entry. The persistent sibling lock is bounded; an unavailable or timed-out advisory lock preserves the existing local-only best-effort behavior rather than delaying startup indefinitely.

## Related Issue

N/A — follow-up hardening for the machine-wide ledger introduced by #90777.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Serialize the complete ledger read, corruption quarantine, prune, and atomic-replace transaction with a persistent sibling lock file, leaving the replaceable ledger inode unlocked.
- Use `fcntl` on POSIX and the established nonempty-file `msvcrt` byte-range lock on Windows; acquisition is bounded to two seconds and falls back to the prior process-local lock with debug diagnostics.
- Add a deterministic two-real-interpreter regression: the first process pauses after its initial read, the second attempts registration, and the final ledger must retain both live PIDs.
- Leave startup callers and the updater/reaper policy unchanged.

## How to Test

1. Run `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_process_identity.py -v`.
2. Run `uv run --with ruff ruff check hermes_cli/process_identity.py tests/hermes_cli/test_process_identity.py`.
3. Regression guard: with only the production lock hunk stashed, `test_register_self_serializes_real_interpreter_ledger_writes` fails with one PID left in the ledger; restoring the hunk yields 23/23 passing.
4. Tested locally on macOS; the implementation follows the repository's established POSIX and Windows advisory-lock mechanisms.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (focused process-identity suite run instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no user-facing documentation change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
