### PR TITLE
fix(cli): honor HERMES_DISABLE_EXTENDED_KEYS to skip the extended-keyboard push

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4280,7 +4280,10 @@ def _enable_extended_enter_keys(output=None, env: Optional[Mapping[str, str]] = 
     for terminals where the re-encoding is not decodable — CJK IME
     composition under WezTerm/WSL2 commits two characters at a time and
     arrow keys stop moving the cursor (#91624); same mechanism family as
-    the unmapped CSI-u reports (#86866, #87631, #88221, #90640).
+    the unmapped CSI-u reports (#86866, #87631, #88221, #90640). Truthy
+    spellings are ``1/true/yes/on`` (case-insensitive); any other value —
+    including ``0``, ``false``, ``off``, and empty — deliberately does NOT
+    opt out, unlike tools that treat any non-empty value as true.
     """
     if env is None:
         env = os.environ

--- a/cli.py
+++ b/cli.py
@@ -4274,7 +4274,18 @@ def _enable_extended_enter_keys(output=None, env: Optional[Mapping[str, str]] = 
 
     The exit reset sequence pops/resets both modes, so this is safe across
     normal exits, Ctrl+C, and SIGTERM cleanup.
+
+    ``HERMES_DISABLE_EXTENDED_KEYS=1`` skips the push entirely, so the
+    terminal keeps sending raw key bytes as before v0.20.4. Escape hatch
+    for terminals where the re-encoding is not decodable — CJK IME
+    composition under WezTerm/WSL2 commits two characters at a time and
+    arrow keys stop moving the cursor (#91624); same mechanism family as
+    the unmapped CSI-u reports (#86866, #87631, #88221, #90640).
     """
+    if env is None:
+        env = os.environ
+    if (env.get("HERMES_DISABLE_EXTENDED_KEYS") or "").strip().lower() in {"1", "true", "yes", "on"}:
+        return False
     if not _terminal_supports_extended_enter_keys(env):
         return False
     # Ghostty exception: only modifyOtherKeys — see _is_ghostty_terminal.

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -211,6 +211,61 @@ def test_non_ghostty_terminals_still_push_kitty_protocol():
     assert b"\x1b[>4;2m" in out.written
 
 
+@pytest.mark.parametrize(
+    "flag",
+    ["1", "true", "TRUE", "yes", "on", " 1 "],
+)
+def test_disable_extended_keys_env_skips_protocol_push(flag):
+    """HERMES_DISABLE_EXTENDED_KEYS restores pre-v0.20.4 raw key bytes (#91624).
+
+    CJK IME composition under WezTerm/WSL2 commits two characters per commit
+    and arrow keys die once the terminal re-encodes keys; the flag must skip
+    the push even on an allowlisted terminal.
+    """
+    import cli as cli_mod
+
+    out = _FakeOutput()
+    result = cli_mod._enable_extended_enter_keys(
+        output=out,
+        env={"TERM_PROGRAM": "WezTerm", "TERM": "xterm-256color",
+             "HERMES_DISABLE_EXTENDED_KEYS": flag},
+    )
+    assert result is False
+    assert out.written == b""
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["0", "", "false", "off"],
+)
+def test_disable_extended_keys_falsy_values_keep_the_push(flag):
+    """Falsy spellings must not opt out — only explicit enable-words do."""
+    import cli as cli_mod
+
+    out = _FakeOutput()
+    result = cli_mod._enable_extended_enter_keys(
+        output=out,
+        env={"TERM_PROGRAM": "WezTerm", "TERM": "xterm-256color",
+             "HERMES_DISABLE_EXTENDED_KEYS": flag},
+    )
+    assert result is True
+    assert b"\x1b[>1u" in out.written
+
+
+def test_disable_extended_keys_absent_keeps_default_push():
+    """Without the flag the push happens exactly as before — no behavior change."""
+    import cli as cli_mod
+
+    out = _FakeOutput()
+    result = cli_mod._enable_extended_enter_keys(
+        output=out,
+        env={"TERM_PROGRAM": "WezTerm", "TERM": "xterm-256color"},
+    )
+    assert result is True
+    assert b"\x1b[>1u" in out.written
+    assert b"\x1b[>4;2m" in out.written
+
+
 @pytest.mark.linux_only
 def test_proc_version_microsoft_marker_preserves_newline():
     """WSL detection via /proc when env vars are scrubbed (sudo etc.).


### PR DESCRIPTION
## What does this PR do?

Adds an official `HERMES_DISABLE_EXTENDED_KEYS` opt-out for the v0.20.4 extended-keyboard push (`_enable_extended_enter_keys()`). When the flag is set, the CLI never writes the Kitty `CSI >1u` / xterm `modifyOtherKeys` push, so the terminal keeps sending raw key bytes exactly as before v0.20.4.

This is the minimal, non-invasive escape hatch for terminals where the protocol push is not survivable: under WezTerm + WSL2 + a Chinese IME, the re-encoded commit is decoded as **two Han characters per commit** and arrow keys stop moving the cursor (#91624) — the same over-aggressive-push mechanism family as the unmapped CSI-u reports (#86866, #87631, #88221, #90640). The default behavior is unchanged for every terminal without the flag.

The gate reads the env through the function's existing `env` parameter (so it also covers the post-recovery re-push at `cli.py:8579` and the startup push), parses truthy spellings case-insensitively (`1/true/yes/on`), and mirrors the repo's existing `HERMES_DISABLE_WINDOWS_UTF8` opt-out precedent.

## Related Issue

Fixes #91624

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — `_enable_extended_enter_keys()`: short-circuit to `False` before the terminal allowlist check when `HERMES_DISABLE_EXTENDED_KEYS` is truthy; docstring documents the escape hatch and the issue family it serves.
- `tests/cli/test_ctrl_enter_newline.py` — three regression tests (11 parametrized cases): truthy spellings skip the push on an allowlisted terminal (nothing written), falsy spellings and the absent flag keep the exact pre-change dual-protocol push.

## How to Test

1. Automated: `.venv/bin/python -m pytest tests/cli/test_ctrl_enter_newline.py tests/cli/test_modify_other_keys_aliases.py tests/cli/test_cli_shift_enter_newline.py tests/cli/test_cli_terminal_shortcuts.py tests/cli/test_cli_cmd_backspace.py -q` — should pass (observed result: 308 passed, 2 platform-skipped on macOS arm64).
2. Manual (issue's environment, WezTerm + WSL2 + Chinese IME): `HERMES_DISABLE_EXTENDED_KEYS=1 hermes` — IME should commit one character per keypress and arrow keys should move the cursor again, per the workaround verification in #91624.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted input-domain suites: 308 passed, 0 failures)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring documents the new flag)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (env var, not a config key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (fix targets Windows/WSL2 terminals; gate is platform-neutral)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
