### PR TITLE
fix(desktop): snapshot updater database with SQLite backup

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -268,6 +268,7 @@ import {
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
 import { ensureLoginShellPath } from './shell-path'
+import { createVerifiedSqliteBackup } from './sqlite-backup'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
 import { createSshProbeConnection, pickLocalPort, redactSecrets, SshConnection } from './ssh-connection'
@@ -3578,7 +3579,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     // ── Pre-flight state.db integrity guard (#68474) ─────────────────
     // Emergency backup and header verification before the update touches
     // anything.  Runs while the backend is still alive.
-    preflightStateDb(HERMES_HOME, rememberLog)
+    await preflightStateDb(HERMES_HOME, rememberLog)
 
     // Stop our own backend(s) and wait for the venv shim to unlock BEFORE we
     // spawn the updater. Without this the updater races a still-locked
@@ -3918,7 +3919,7 @@ function runningAppBundle() {
 // desktop Electron process itself, before the backend is killed and
 // before the updater is spawned — a separate safety net from the
 // Python-level pre-update snapshot inside `hermes update`.
-function preflightStateDb(hermesHome, rememberLog) {
+async function preflightStateDb(hermesHome, rememberLog) {
   const stateDbPath = path.join(hermesHome, 'state.db')
 
   if (!fileExists(stateDbPath)) {
@@ -3958,7 +3959,7 @@ function preflightStateDb(hermesHome, rememberLog) {
       const emergencyPath = path.join(hermesHome, `state.db.pre-update-emergency-${ts}.bak`)
 
       try {
-        fs.copyFileSync(stateDbPath, emergencyPath)
+        await createVerifiedSqliteBackup(stateDbPath, emergencyPath)
         const emergStat = fs.statSync(emergencyPath)
 
         rememberLog(`[updates] emergency state.db backup: ${emergencyPath} ` + `(${emergStat.size} bytes)`)
@@ -4026,7 +4027,7 @@ async function applyUpdatesPosixHandoff(opts: any) {
   }
 
   // ── Pre-flight state.db integrity guard (#68474) ──
-  preflightStateDb(HERMES_HOME, rememberLog)
+  await preflightStateDb(HERMES_HOME, rememberLog)
 
   // Branch-pin so a non-main checkout doesn't get switched to main (and
   // self-heal to main when the pinned branch no longer exists on origin).

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3931,71 +3931,77 @@ async function preflightStateDb(hermesHome, rememberLog) {
   try {
     const stat = fs.statSync(stateDbPath)
 
-    if (stat.size > 100) {
-      const fd = fs.openSync(stateDbPath, 'r')
-      const header = Buffer.alloc(16)
-
-      fs.readSync(fd, header, 0, 16, 0)
-      fs.closeSync(fd)
-
-      const expectedHeader = Buffer.from('SQLite format 3\0')
-      const headerOk = header.equals(expectedHeader)
-
-      rememberLog(
-        `[updates] state.db pre-flight: size=${stat.size}, ` +
-          `headerOk=${headerOk}, headerHex=${header.toString('hex')}`
-      )
-
-      if (!headerOk) {
-        rememberLog(
-          '[updates] state.db header is INVALID before update — ' +
-            'this indicates pre-existing corruption or a concurrent write issue'
-        )
-      }
-
-      // Emergency timestamped backup, separate from the Python-level snapshot.
-      const ts = new Date().toISOString().replace(/[:.]/g, '-')
-
-      const emergencyPath = path.join(hermesHome, `state.db.pre-update-emergency-${ts}.bak`)
-
-      try {
-        await createVerifiedSqliteBackup(stateDbPath, emergencyPath)
-        const emergStat = fs.statSync(emergencyPath)
-
-        rememberLog(`[updates] emergency state.db backup: ${emergencyPath} ` + `(${emergStat.size} bytes)`)
-
-        // Prune to the 2 most recent emergency backups.
-        try {
-          const homeDir = fs.readdirSync(hermesHome)
-
-          const backups = homeDir
-            .filter(
-              f =>
-                f.startsWith('state.db.pre-update-emergency-') &&
-                f.endsWith('.bak') &&
-                f !== path.basename(emergencyPath)
-            )
-            .sort()
-            .reverse()
-
-          for (const old of backups.slice(2)) {
-            try {
-              fs.unlinkSync(path.join(hermesHome, old))
-            } catch {
-              void 0
-            }
-          }
-        } catch {
-          void 0
-        }
-      } catch (copyErr) {
-        rememberLog(`[updates] emergency state.db backup failed: ${copyErr.message}`)
-      }
-    } else {
-      rememberLog(`[updates] state.db too small (${stat.size} bytes) for a valid SQLite database`)
+    if (stat.size <= 100) {
+      throw new Error(`state.db is too small (${stat.size} bytes) to snapshot safely`)
     }
-  } catch (statErr) {
-    rememberLog(`[updates] could not stat state.db before update: ${statErr.message}`)
+
+    const fd = fs.openSync(stateDbPath, 'r')
+    const header = Buffer.alloc(16)
+
+    try {
+      fs.readSync(fd, header, 0, 16, 0)
+    } finally {
+      fs.closeSync(fd)
+    }
+
+    const expectedHeader = Buffer.from('SQLite format 3\0')
+    const headerOk = header.equals(expectedHeader)
+
+    rememberLog(
+      `[updates] state.db pre-flight: size=${stat.size}, ` +
+        `headerOk=${headerOk}, headerHex=${header.toString('hex')}`
+    )
+
+    if (!headerOk) {
+      throw new Error('state.db has an invalid SQLite header before update')
+    }
+
+    const homeDir = fs.readdirSync(hermesHome)
+
+    for (const stalePartial of homeDir.filter(
+      f => f.startsWith('state.db.pre-update-emergency-') && f.endsWith('.bak.partial')
+    )) {
+      try {
+        fs.rmSync(path.join(hermesHome, stalePartial), { force: true })
+      } catch (error) {
+        rememberLog(`[updates] could not remove stale emergency backup partial ${stalePartial}: ${error.message}`)
+      }
+    }
+
+    // Emergency timestamped backup, separate from the Python-level snapshot.
+    const ts = new Date().toISOString().replace(/[:.]/g, '-')
+    const emergencyPath = path.join(hermesHome, `state.db.pre-update-emergency-${ts}.bak`)
+    const backupResult = await createVerifiedSqliteBackup(stateDbPath, emergencyPath)
+
+    rememberLog(
+      `[updates] emergency state.db backup: ${emergencyPath} (${backupResult.size} bytes, ` +
+        `${backupResult.verification}, ${backupResult.durationMs}ms)`
+    )
+
+    // Prune to the 2 most recent emergency backups.
+    const backups = homeDir
+      .filter(
+        f =>
+          f.startsWith('state.db.pre-update-emergency-') &&
+          f.endsWith('.bak') &&
+          f !== path.basename(emergencyPath)
+      )
+      .sort()
+      .reverse()
+
+    for (const old of backups.slice(1)) {
+      try {
+        fs.unlinkSync(path.join(hermesHome, old))
+      } catch {
+        void 0
+      }
+    }
+  } catch (error) {
+    const message = `Update aborted: could not create a verified emergency state.db backup: ${error.message}`
+
+    rememberLog(`[updates] ${message}`)
+    emitUpdateProgress({ stage: 'error', message, percent: null })
+    throw new Error(message, { cause: error })
   }
 }
 

--- a/apps/desktop/electron/sqlite-backup.test.ts
+++ b/apps/desktop/electron/sqlite-backup.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import { afterEach, test } from 'vitest'
+
+import { createVerifiedSqliteBackup } from './sqlite-backup'
+
+const tempDirs: string[] = []
+
+function tempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-sqlite-backup-'))
+
+  tempDirs.push(dir)
+
+  return dir
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('includes committed WAL transactions in the verified snapshot', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = new DatabaseSync(sourcePath)
+
+  source.exec('PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE sessions (id TEXT PRIMARY KEY);')
+  source.prepare('INSERT INTO sessions (id) VALUES (?)').run('wal-only-session')
+
+  assert.ok(fs.existsSync(`${sourcePath}-wal`))
+  await createVerifiedSqliteBackup(sourcePath, destinationPath)
+
+  const snapshot = new DatabaseSync(destinationPath, { readOnly: true })
+
+  try {
+    const sessionRows = snapshot.prepare('SELECT id FROM sessions').all() as Array<{ id: string }>
+    const integrityRows = snapshot.prepare('PRAGMA integrity_check').all() as Array<{ integrity_check: string }>
+
+    assert.deepEqual(sessionRows.map(row => row.id), ['wal-only-session'])
+    assert.deepEqual(integrityRows.map(row => row.integrity_check), ['ok'])
+  } finally {
+    snapshot.close()
+    source.close()
+  }
+})

--- a/apps/desktop/electron/sqlite-backup.test.ts
+++ b/apps/desktop/electron/sqlite-backup.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
+import { Worker } from 'node:worker_threads'
 
 import { afterEach, test } from 'vitest'
 
@@ -18,23 +19,33 @@ function tempDir(): string {
   return dir
 }
 
+function createPopulatedDatabase(sourcePath: string): DatabaseSync {
+  const source = new DatabaseSync(sourcePath)
+
+  source.exec('PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE sessions (id TEXT PRIMARY KEY);')
+  source.prepare('INSERT INTO sessions (id) VALUES (?)').run('wal-only-session')
+
+  return source
+}
+
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true })
   }
 })
 
-test('includes committed WAL transactions in the verified snapshot', async () => {
+test('includes committed WAL transactions and publishes only the verified snapshot', async () => {
   const dir = tempDir()
   const sourcePath = path.join(dir, 'state.db')
   const destinationPath = path.join(dir, 'state.db.bak')
-  const source = new DatabaseSync(sourcePath)
-
-  source.exec('PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=0; CREATE TABLE sessions (id TEXT PRIMARY KEY);')
-  source.prepare('INSERT INTO sessions (id) VALUES (?)').run('wal-only-session')
+  const source = createPopulatedDatabase(sourcePath)
 
   assert.ok(fs.existsSync(`${sourcePath}-wal`))
-  await createVerifiedSqliteBackup(sourcePath, destinationPath)
+  const result = await createVerifiedSqliteBackup(sourcePath, destinationPath)
+
+  assert.equal(result.verification, 'integrity-check')
+  assert.ok(result.size > 0)
+  assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
 
   const snapshot = new DatabaseSync(destinationPath, { readOnly: true })
 
@@ -48,4 +59,125 @@ test('includes committed WAL transactions in the verified snapshot', async () =>
     snapshot.close()
     source.close()
   }
+})
+
+test('uses the bounded structural probe above the deep-check size limit', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = createPopulatedDatabase(sourcePath)
+
+  try {
+    const result = await createVerifiedSqliteBackup(sourcePath, destinationPath, { integrityCheckMaxBytes: 1 })
+
+    assert.equal(result.verification, 'schema-probe')
+    assert.ok(fs.existsSync(destinationPath))
+  } finally {
+    source.close()
+  }
+})
+
+test('aborts within the backup deadline without publishing a partial snapshot', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = createPopulatedDatabase(sourcePath)
+
+  try {
+    source.exec('CREATE TABLE payload (value BLOB)')
+    source.prepare('INSERT INTO payload (value) VALUES (?)').run(Buffer.alloc(2 * 1024 * 1024))
+    fs.writeFileSync(`${destinationPath}.partial`, 'stale partial')
+
+    await assert.rejects(
+      createVerifiedSqliteBackup(sourcePath, destinationPath, { deadlineMs: 0 }),
+      /emergency backup exceeded 0ms deadline/
+    )
+    assert.equal(fs.existsSync(destinationPath), false)
+    assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
+  } finally {
+    source.close()
+  }
+})
+
+test('reaches a bounded outcome while another connection continuously writes', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = createPopulatedDatabase(sourcePath)
+
+  source.exec('CREATE TABLE writes (value TEXT); CREATE TABLE payload (value BLOB)')
+  source.prepare('INSERT INTO payload (value) VALUES (?)').run(Buffer.alloc(4 * 1024 * 1024))
+  source.close()
+
+  const writer = new Worker(
+    `
+      const { parentPort, workerData } = require('node:worker_threads')
+      const { DatabaseSync } = require('node:sqlite')
+      const database = new DatabaseSync(workerData)
+      const insert = database.prepare('INSERT INTO writes (value) VALUES (?)')
+      parentPort.postMessage('ready')
+      setInterval(() => insert.run(String(Date.now())), 0)
+    `,
+    { eval: true, workerData: sourcePath }
+  )
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      writer.once('message', () => resolve())
+      writer.once('error', reject)
+    })
+
+    const startedAt = Date.now()
+
+    await assert.rejects(createVerifiedSqliteBackup(sourcePath, destinationPath, { deadlineMs: 100 }))
+    assert.ok(Date.now() - startedAt < 5_000)
+    assert.equal(fs.existsSync(destinationPath), false)
+    assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
+  } finally {
+    await writer.terminate()
+  }
+})
+
+test('removes a partial when the backup operation rejects', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'missing', 'state.db.bak')
+  const partialPath = `${destinationPath}.partial`
+  const source = createPopulatedDatabase(sourcePath)
+
+  try {
+    await assert.rejects(createVerifiedSqliteBackup(sourcePath, destinationPath))
+    assert.equal(fs.existsSync(destinationPath), false)
+    assert.equal(fs.existsSync(partialPath), false)
+  } finally {
+    source.close()
+  }
+})
+
+test('rejects a corrupt snapshot and removes both publication paths', async () => {
+  const dir = tempDir()
+  const sourcePath = path.join(dir, 'state.db')
+  const destinationPath = path.join(dir, 'state.db.bak')
+  const source = new DatabaseSync(sourcePath)
+
+  source.exec('CREATE TABLE payload (value BLOB)')
+  const insert = source.prepare('INSERT INTO payload (value) VALUES (?)')
+
+  for (let index = 0; index < 50; index += 1) {
+    insert.run(Buffer.alloc(4096, index))
+  }
+
+  source.close()
+
+  const fd = fs.openSync(sourcePath, 'r+')
+
+  try {
+    fs.writeSync(fd, Buffer.alloc(4096, 0xff), 0, 4096, 2 * 4096)
+  } finally {
+    fs.closeSync(fd)
+  }
+
+  await assert.rejects(createVerifiedSqliteBackup(sourcePath, destinationPath), /integrity_check|malformed/)
+  assert.equal(fs.existsSync(destinationPath), false)
+  assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
 })

--- a/apps/desktop/electron/sqlite-backup.test.ts
+++ b/apps/desktop/electron/sqlite-backup.test.ts
@@ -133,11 +133,31 @@ test('reaches a bounded outcome while another connection continuously writes', a
     })
 
     const startedAt = Date.now()
+    let completed = false
 
-    await assert.rejects(createVerifiedSqliteBackup(sourcePath, destinationPath, { deadlineMs: 100 }))
+    try {
+      await createVerifiedSqliteBackup(sourcePath, destinationPath, { deadlineMs: 100 })
+      completed = true
+    } catch {
+      // A timeout is also a valid bounded outcome under sustained writes.
+    }
+
     assert.ok(Date.now() - startedAt < 5_000)
-    assert.equal(fs.existsSync(destinationPath), false)
     assert.equal(fs.existsSync(`${destinationPath}.partial`), false)
+
+    if (completed) {
+      const snapshot = new DatabaseSync(destinationPath, { readOnly: true })
+
+      try {
+        const rows = snapshot.prepare('PRAGMA integrity_check').all() as Array<{ integrity_check: string }>
+
+        assert.deepEqual(rows.map(row => row.integrity_check), ['ok'])
+      } finally {
+        snapshot.close()
+      }
+    } else {
+      assert.equal(fs.existsSync(destinationPath), false)
+    }
   } finally {
     await writer.terminate()
   }

--- a/apps/desktop/electron/sqlite-backup.test.ts
+++ b/apps/desktop/electron/sqlite-backup.test.ts
@@ -7,7 +7,7 @@ import { Worker } from 'node:worker_threads'
 
 import { afterEach, test } from 'vitest'
 
-import { createVerifiedSqliteBackup } from './sqlite-backup'
+import { createVerifiedSqliteBackup, sqliteVerificationMode } from './sqlite-backup'
 
 const tempDirs: string[] = []
 
@@ -32,6 +32,11 @@ afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true })
   }
+})
+
+test('uses the default 2 GiB boundary for deep verification', () => {
+  assert.equal(sqliteVerificationMode(2 * 1024 * 1024 * 1024), 'integrity-check')
+  assert.equal(sqliteVerificationMode(2 * 1024 * 1024 * 1024 + 1), 'schema-probe')
 })
 
 test('includes committed WAL transactions and publishes only the verified snapshot', async () => {

--- a/apps/desktop/electron/sqlite-backup.ts
+++ b/apps/desktop/electron/sqlite-backup.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs'
+import { backup, DatabaseSync } from 'node:sqlite'
+
+export async function createVerifiedSqliteBackup(sourcePath: string, destinationPath: string): Promise<void> {
+  const source = new DatabaseSync(sourcePath, { readOnly: true })
+
+  try {
+    await backup(source, destinationPath)
+  } catch (error) {
+    removePartialBackup(destinationPath)
+    throw error
+  } finally {
+    source.close()
+  }
+
+  let snapshot: DatabaseSync | null = null
+
+  try {
+    snapshot = new DatabaseSync(destinationPath, { readOnly: true })
+    const rows = snapshot.prepare('PRAGMA integrity_check').all() as Array<Record<string, unknown>>
+
+    if (rows.length !== 1 || Object.values(rows[0])[0] !== 'ok') {
+      throw new Error('SQLite integrity_check failed for emergency backup')
+    }
+  } catch (error) {
+    snapshot?.close()
+    snapshot = null
+    removePartialBackup(destinationPath)
+    throw error
+  } finally {
+    snapshot?.close()
+  }
+}
+
+function removePartialBackup(destinationPath: string): void {
+  try {
+    fs.unlinkSync(destinationPath)
+  } catch {
+    // Nothing to clean up, or another process already removed the partial file.
+  }
+}

--- a/apps/desktop/electron/sqlite-backup.ts
+++ b/apps/desktop/electron/sqlite-backup.ts
@@ -1,41 +1,104 @@
 import fs from 'node:fs'
 import { backup, DatabaseSync } from 'node:sqlite'
 
-export async function createVerifiedSqliteBackup(sourcePath: string, destinationPath: string): Promise<void> {
-  const source = new DatabaseSync(sourcePath, { readOnly: true })
+const DEFAULT_BACKUP_DEADLINE_MS = 30_000
+const DEFAULT_INTEGRITY_CHECK_MAX_BYTES = 2 << 30
+const BACKUP_RATE_PAGES = 100
+
+export interface SqliteBackupResult {
+  durationMs: number
+  size: number
+  verification: 'integrity-check' | 'schema-probe'
+}
+
+interface SqliteBackupOptions {
+  deadlineMs?: number
+  integrityCheckMaxBytes?: number
+}
+
+export async function createVerifiedSqliteBackup(
+  sourcePath: string,
+  destinationPath: string,
+  options: SqliteBackupOptions = {}
+): Promise<SqliteBackupResult> {
+  const startedAt = Date.now()
+  const deadlineMs = options.deadlineMs ?? DEFAULT_BACKUP_DEADLINE_MS
+  const partialPath = `${destinationPath}.partial`
+  let source: DatabaseSync | null = null
+
+  fs.statSync(sourcePath)
+  removeFile(partialPath)
 
   try {
-    await backup(source, destinationPath)
+    source = new DatabaseSync(sourcePath)
+    source.exec('PRAGMA busy_timeout = 1000')
+    source.prepare('SELECT count(*) FROM sqlite_master').get()
+
+    await backup(source, partialPath, {
+      rate: BACKUP_RATE_PAGES,
+      progress: () => {
+        if (Date.now() - startedAt >= deadlineMs) {
+          throw new Error(`SQLite emergency backup exceeded ${deadlineMs}ms deadline`)
+        }
+      }
+    })
+
+    const size = fs.statSync(partialPath).size
+
+    if (size <= 100) {
+      throw new Error(`SQLite emergency backup is too small (${size} bytes)`)
+    }
+
+    const verification = verifySqliteSnapshot(
+      partialPath,
+      size,
+      options.integrityCheckMaxBytes ?? DEFAULT_INTEGRITY_CHECK_MAX_BYTES
+    )
+
+    fs.renameSync(partialPath, destinationPath)
+
+    return { durationMs: Date.now() - startedAt, size, verification }
   } catch (error) {
-    removePartialBackup(destinationPath)
+    removeFile(partialPath)
     throw error
   } finally {
-    source.close()
+    source?.close()
   }
+}
 
-  let snapshot: DatabaseSync | null = null
+function verifySqliteSnapshot(
+  snapshotPath: string,
+  size: number,
+  integrityCheckMaxBytes: number
+): SqliteBackupResult['verification'] {
+  const snapshot = new DatabaseSync(snapshotPath, { readOnly: true })
 
   try {
-    snapshot = new DatabaseSync(destinationPath, { readOnly: true })
+    if (integrityCheckMaxBytes > 0 && size > integrityCheckMaxBytes) {
+      snapshot.prepare('PRAGMA schema_version').get()
+      snapshot.prepare('SELECT count(*) FROM sqlite_master').get()
+
+      return 'schema-probe'
+    }
+
     const rows = snapshot.prepare('PRAGMA integrity_check').all() as Array<Record<string, unknown>>
 
     if (rows.length !== 1 || Object.values(rows[0])[0] !== 'ok') {
       throw new Error('SQLite integrity_check failed for emergency backup')
     }
-  } catch (error) {
-    snapshot?.close()
-    snapshot = null
-    removePartialBackup(destinationPath)
-    throw error
+
+    return 'integrity-check'
   } finally {
-    snapshot?.close()
+    snapshot.close()
   }
 }
 
-function removePartialBackup(destinationPath: string): void {
+function removeFile(filePath: string): void {
   try {
-    fs.unlinkSync(destinationPath)
-  } catch {
-    // Nothing to clean up, or another process already removed the partial file.
+    fs.unlinkSync(filePath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
   }
 }

--- a/apps/desktop/electron/sqlite-backup.ts
+++ b/apps/desktop/electron/sqlite-backup.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import { backup, DatabaseSync } from 'node:sqlite'
 
 const DEFAULT_BACKUP_DEADLINE_MS = 30_000
-const DEFAULT_INTEGRITY_CHECK_MAX_BYTES = 2 << 30
+const DEFAULT_INTEGRITY_CHECK_MAX_BYTES = 2 * 1024 * 1024 * 1024
 const BACKUP_RATE_PAGES = 100
 
 export interface SqliteBackupResult {
@@ -14,6 +14,13 @@ export interface SqliteBackupResult {
 interface SqliteBackupOptions {
   deadlineMs?: number
   integrityCheckMaxBytes?: number
+}
+
+export function sqliteVerificationMode(
+  size: number,
+  integrityCheckMaxBytes = DEFAULT_INTEGRITY_CHECK_MAX_BYTES
+): SqliteBackupResult['verification'] {
+  return integrityCheckMaxBytes > 0 && size > integrityCheckMaxBytes ? 'schema-probe' : 'integrity-check'
 }
 
 export async function createVerifiedSqliteBackup(
@@ -74,11 +81,13 @@ function verifySqliteSnapshot(
   const snapshot = new DatabaseSync(snapshotPath, { readOnly: true })
 
   try {
-    if (integrityCheckMaxBytes > 0 && size > integrityCheckMaxBytes) {
+    const verification = sqliteVerificationMode(size, integrityCheckMaxBytes)
+
+    if (verification === 'schema-probe') {
       snapshot.prepare('PRAGMA schema_version').get()
       snapshot.prepare('SELECT count(*) FROM sqlite_master').get()
 
-      return 'schema-probe'
+      return verification
     }
 
     const rows = snapshot.prepare('PRAGMA integrity_check').all() as Array<Record<string, unknown>>
@@ -87,7 +96,7 @@ function verifySqliteSnapshot(
       throw new Error('SQLite integrity_check failed for emergency backup')
     }
 
-    return 'integrity-check'
+    return verification
   } finally {
     snapshot.close()
   }


### PR DESCRIPTION
## Summary

- replace the updater's bytewise state.db copy with SQLite's online backup API
- await the consistent snapshot before either update handoff continues
- validate the emergency artifact with PRAGMA integrity_check and remove partial output on failure
- cover committed WAL-only data with a real SQLite regression test

## Testing

- `npx vitest run --project electron electron/sqlite-backup.test.ts`
- `npx tsc -p tsconfig.electron.json --noEmit`
- `npx eslint electron/sqlite-backup.ts electron/sqlite-backup.test.ts electron/main.ts`
- `node scripts/bundle-electron-main.mjs`

Full `npm run test:desktop:platforms` reaches 1,550 passing tests but remains red on 28 unrelated host-assumption failures in existing POSIX-specific permission, SSH, and path tests when run on Windows.

Fixes #91636