### PR TITLE
fix(kanban): auto-subscribe unattached creates (dashboard, CLI, background) to home channels

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1520,6 +1520,26 @@ def _cmd_heartbeat(args: argparse.Namespace) -> int:
     return 0
 
 
+def _has_origin_session_context() -> bool:
+    """True when a home-eligible delivery channel exists for this create.
+
+    Mirrors tools/kanban_tools._maybe_auto_subscribe: gateway sessions set
+    platform+chat_id and TUI/desktop sessions set HERMES_SESSION_KEY. In
+    those cases the origin path owns the subscription; in a pure CLI/cron
+    process neither is present so the home fallback applies.
+    """
+    try:
+        from gateway.session_context import get_session_env
+        platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+        chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+        if platform and chat_id:
+            return True
+        key = get_session_env("HERMES_SESSION_KEY", "") or os.environ.get("HERMES_SESSION_KEY", "")
+        return bool(key)
+    except Exception:
+        return False
+
+
 def _cmd_assignees(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
         data = kb.known_assignees(conn)
@@ -1587,6 +1607,29 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
         )
+        # Auto-subscribe fallback for unattached creates. The CLI has no
+        # origin session channel of its own (cron, bell scripts, human
+        # terminals), so a task finished by a dispatcher would otherwise
+        # produce a terminal event nobody is subscribed to. Any session
+        # context is left alone: the gateway /kanban handler and TUI poller
+        # register their OWN origin subscription, and adding home rows on
+        # top of those would double-notify when the origin IS a home
+        # channel. Best-effort + idempotent (INSERT OR IGNORE); a broken
+        # home config never fails the create.
+        try:
+            if not _has_origin_session_context():
+                kb.subscribe_task_to_configured_homes(conn, task_id)
+        except Exception as _autosub_exc:
+            # A broken home config must not fail the create, and must not
+            # corrupt --json stdout — log it instead of printing to stderr
+            # (run_slash merges stderr and the gateway comma-joins output).
+            import logging as _logging
+
+            _logging.getLogger(__name__).warning(
+                "kanban: home auto-subscribe skipped for %s: %s",
+                task_id,
+                _autosub_exc,
+            )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -11516,6 +11516,139 @@ def add_notify_sub(
             )
 
 
+# ---------------------------------------------------------------------------
+# Configured home channels — shared auto-subscribe fallback
+# ---------------------------------------------------------------------------
+#
+# Tasks created with NO origin session (CLI, cron, background agents,
+# dispatcher-spawned workers) would otherwise reach terminal states nobody
+# is subscribed to. This is the ONE implementation shared by the dashboard,
+# the tool surface, and the CLI create path.
+
+
+def _home_chat_type(platform: str) -> str:
+    """Best-known chat_type for a home-channel subscription row.
+
+    Discord homes are typically guild text CHANNELS, not DMs — stamping
+    ``dm`` there made the notifier's wake/session resolution resolve the
+    wrong source shape. Telegram/Slack/other homes keep the historical
+    ``dm`` default (private 1:1 chats), which matches how /sethome is used.
+    """
+    return "channel" if (platform or "").lower() == "discord" else "dm"
+
+
+def configured_home_channels() -> list[dict]:
+    """Return every ENABLED platform with a home channel set, fully hydrated.
+
+    Reads the live GatewayConfig so env-var overlays (``TELEGRAM_HOME_CHANNEL``,
+    etc.) are honored alongside config.yaml. Platforms with
+    ``enabled: false`` are DROPPED — a disabled platform has no adapter to
+    deliver through, so subscribing its home would only create dead rows the
+    ownership gate skips every tick. Returns platforms in stable (alphabetical)
+    order. Best-effort: any failure yields [].
+    """
+    try:
+        from gateway.config import load_gateway_config
+
+        gw_cfg = load_gateway_config()
+    except Exception:
+        return []
+    homes: list[dict] = []
+    try:
+        for platform, pcfg in gw_cfg.platforms.items():
+            if not pcfg or not pcfg.home_channel:
+                continue
+            if not getattr(pcfg, "enabled", False):
+                # A disabled platform can never deliver — skip it entirely
+                # rather than writing a subscription row nothing consumes.
+                continue
+            hc = pcfg.home_channel
+            homes.append({
+                "platform": platform.value,
+                "chat_id": hc.chat_id,
+                "thread_id": hc.thread_id or "",
+                "name": hc.name or "Home",
+            })
+        homes.sort(key=lambda h: h["platform"])  # stable order
+    except Exception:
+        return []
+    return homes
+
+
+def subscribe_task_to_configured_homes(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    notifier_profile: Optional[str] = None,
+) -> bool:
+    """Best-effort subscribe a task to every configured home channel.
+
+    Delivery fallback for tasks created with NO origin context (CLI, cron,
+    background agents, dispatcher-spawned workers): without it those tasks
+    reach terminal states nobody is subscribed to. Gated by
+    ``kanban.auto_subscribe_on_create`` (default True) — the same opt-out
+    knob as the gateway/TUI origin path.
+
+    Idempotent — :func:`add_notify_sub` ignores duplicate
+    ``(task_id, platform, chat_id, thread_id)`` rows — so retries and
+    origin+home overlap never duplicate notifications.
+
+    Delivery mode stays passive (``notify``): the fallback targets boards
+    owned by unattended creates, and an active wake against a stale home
+    config would interrupt unrelated conversations.
+
+    Returns True when at least one subscription row was written, False when
+    no eligible homes are configured, the gate is off, or everything failed.
+    Never raises: a broken/stale home-channel configuration must not fail
+    the task creation that is mid-flight.
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        if not cfg_get(cfg, "kanban", "auto_subscribe_on_create", default=True):
+            return False
+    except Exception:
+        # Unreadable config still defaults to on — mirrors the gateway /
+        # tool origin auto-subscribe behaviour.
+        pass
+    homes = configured_home_channels()
+    if not homes:
+        return False
+    if notifier_profile is None:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            notifier_profile = (
+                os.environ.get("HERMES_PROFILE")
+                or get_active_profile_name()
+                or "default"
+            )
+        except Exception:
+            notifier_profile = os.environ.get("HERMES_PROFILE") or "default"
+    subscribed_any = False
+    for home in homes:
+        try:
+            add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform=home["platform"],
+                chat_id=home["chat_id"],
+                thread_id=home["thread_id"] or None,
+                chat_type=_home_chat_type(home["platform"]),
+                notifier_profile=notifier_profile,
+            )
+            subscribed_any = True
+        except Exception as exc:
+            logging.getLogger(__name__).warning(
+                "kanban home auto-subscribe failed for task %s on %s: %s",
+                task_id,
+                home.get("platform", "unknown") if isinstance(home, dict) else "unknown",
+                exc,
+            )
+    return subscribed_any
+
+
 def _notify_profile_filter(
     notifier_profiles: Optional[Iterable[str]],
     *,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -649,6 +649,31 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             project_id=payload.project_id,
             board=board,
         )
+        # Auto-subscribe the new task to every configured home channel.
+        # Gated by kanban.auto_subscribe_on_create (default on) — an operator
+        # who disabled auto-subscription (e.g. opted out via the per-platform
+        # notification toggle) must not get silent re-subscription here.
+        # Best-effort and idempotent: a broken home config must never turn a
+        # successfully persisted task into a misleading HTTP 500.
+        try:
+            from hermes_cli.config import cfg_get, load_config
+
+            _auto_sub_enabled = cfg_get(
+                load_config(), "kanban", "auto_subscribe_on_create", default=True
+            )
+        except Exception:
+            # Unreadable config defaults to on, mirroring every other
+            # auto-subscribe surface.
+            _auto_sub_enabled = True
+        if _auto_sub_enabled:
+            try:
+                _subscribe_task_to_configured_homes(conn, task_id)
+            except Exception as exc:
+                log.warning(
+                    "kanban dashboard auto-subscribe failed for task %s: %s",
+                    task_id,
+                    exc,
+                )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
         # Surface a dispatcher-presence warning so the UI can show a
@@ -2093,6 +2118,19 @@ def _active_profile_name() -> str:
         return get_active_profile_name() or "default"
     except Exception:
         return "default"
+
+
+def _subscribe_task_to_configured_homes(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Delegate to the shared kanban_db helper (idempotent, best-effort).
+
+    Kept as a dashboard-local wrapper so this module has a single integration
+    seam (tests patch this to prove home-fallback failures never fail task
+    creation). Shares ONE implementation with the CLI and tool create paths:
+    ``hermes_cli.kanban_db.subscribe_task_to_configured_homes``.
+    """
+    from hermes_cli import kanban_db as _kb
+
+    return _kb.subscribe_task_to_configured_homes(conn, task_id)
 
 
 def _home_sub_matches(sub: dict, home: dict) -> bool:

--- a/tests/gateway/test_kanban_unattached_home_e2e.py
+++ b/tests/gateway/test_kanban_unattached_home_e2e.py
@@ -1,0 +1,140 @@
+"""E2E: unattached kanban_create → home-channel fallback subscription →
+gateway notifier delivery through a real RecordingAdapter.
+
+Root-cause scenario: a board full of agent/background-created tasks and
+zero kanban_notify_subs rows meant terminal events never reached the
+user's home channel. This test drives the whole chain:
+kanban_create (no session origin) → subscribe_task_to_configured_homes
+→ GatewayRunner._kanban_notifier_watcher → adapter.send().
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+class RecordingAdapter:
+    """Minimal adapter that records sends (same shape as
+    tests/gateway/test_kanban_notifier.py's helper)."""
+
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+
+async def _run_one_notifier_tick(monkeypatch, runner):
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    await runner._kanban_notifier_watcher(interval=1)
+
+
+@pytest.fixture
+def discord_home_env(monkeypatch, tmp_path):
+    """Isolated HERMES_HOME with a single enabled Discord home channel."""
+    from pathlib import Path as _Path
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "disc_fake")
+    monkeypatch.setenv("DISCORD_HOME_CHANNEL", "status-channel")
+    return home
+
+
+@pytest.mark.asyncio
+async def test_unattached_create_reaches_discord_home_via_notifier(
+    monkeypatch,
+    discord_home_env,
+):
+    """Full chain: background/CLI kanban_create with homes configured but no
+    session origin → subscription row exists → watcher claims the terminal
+    event and delivers it through the Discord recording adapter."""
+    import yaml
+
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from hermes_cli import kanban_db as kb
+
+    # Pin an explicit config so load_gateway_config sees exactly one
+    # ENABLED platform (discord) with a home channel.
+    cfg_home = discord_home_env / "config.yaml"
+    cfg_home.write_text(
+        yaml.safe_dump({"platforms": {"discord": {"enabled": True}}}),
+        encoding="utf-8",
+    )
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    # Create the task exactly as an unattached agent would: no platform /
+    # chat_id / session key in the environment.
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "swarm decomposition follow-up",
+        "assignee": "worker1",
+    })
+    import json as _json
+
+    d = _json.loads(out)
+    assert d["ok"] is True, d
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, d["task_id"])
+        assert any(s["platform"] == "discord" for s in subs), (
+            "unattached create must land a discord home subscription"
+        )
+        kb.block_task(conn, d["task_id"], reason="needs human input")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    runner._owns_kanban_dispatcher_lock = lambda: True
+    # The default profile owns the home-fallback row (stamped at create).
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_active_profile_name",
+        lambda self: "default",
+        raising=True,
+    )
+    monkeypatch.setattr(
+        GatewayRunner,
+        "_authorization_adapter",
+        lambda self, plat, profile=None: (
+            adapter if plat == Platform.DISCORD else None
+        ),
+        raising=True,
+    )
+
+    await _run_one_notifier_tick(monkeypatch, runner)
+
+    assert adapter.sent, (
+        "terminal event for the unattached-created task must be delivered "
+        "to the discord home channel"
+    )
+    assert all(m["chat_id"] == "status-channel" for m in adapter.sent)
+    assert any("needs human input" in m["text"] for m in adapter.sent)

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -175,7 +175,151 @@ def test_run_slash_reclaim_running_task(kanban_home):
 
 
 # ---------------------------------------------------------------------------
-# /kanban help / no-args / unknown-action UX (issue #21794)
+# CLI create → configured-home auto-subscription fallback
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def home_channels_env(monkeypatch):
+    """Simulate telegram + discord homes configured via env overlays."""
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "abc:fake")
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "1234567")
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL_THREAD_ID", "42")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "disc_fake")
+    monkeypatch.setenv("DISCORD_HOME_CHANNEL", "9999999")
+
+
+def _cli_sub_keys(task_id):
+    with kb.connect_closing() as conn:
+        subs = kb.list_notify_subs(conn, task_id)
+    return sorted(
+        (s["platform"], s["chat_id"], s.get("thread_id") or "") for s in subs
+    )
+
+
+def test_cli_create_auto_subscribes_configured_homes_when_unattached(
+    kanban_home, home_channels_env,
+):
+    """`hermes kanban create ...` from a plain shell (no gateway/TUI origin
+    session) must land notify subscriptions on every configured home channel
+    so dispatcher-completed tasks reach the board owner."""
+    raw = kc.run_slash(
+        'create "cli-orchestrated task" --assignee alice --json'
+    )
+    task = json.loads(raw)
+    assert task["id"], raw
+
+    assert _cli_sub_keys(task["id"]) == [
+        ("discord", "9999999", ""),
+        ("telegram", "1234567", "42"),
+    ]
+
+
+def test_cli_create_skips_homes_when_gateway_origin_present(
+    kanban_home, home_channels_env, monkeypatch,
+):
+    """A gateway-originated CLI create (session vars set, as the /kanban
+    slash handler does before run_slash) must NOT double-subscribe homes —
+    the origin subscription is owned by the slash handler."""
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-99")
+
+    raw = kc.run_slash(
+        'create "gateway-originated task" --assignee alice --json'
+    )
+    task = json.loads(raw)
+    assert task["id"], raw
+
+    # No home fallback row: the origin subscription is owned by the slash
+    # handler and the CLI must not add duplicate homes on top.
+    assert _cli_sub_keys(task["id"]) == []
+
+
+def test_cli_create_survives_broken_homes_config(
+    kanban_home, home_channels_env, monkeypatch,
+):
+    """A homes-config failure must not fail the CLI create (resilience),
+    and --json stdout must stay clean machine-parseable output."""
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(kb, "subscribe_task_to_configured_homes", _boom)
+    raw = kc.run_slash(
+        'create "resilient create" --assignee alice --json'
+    )
+    task = json.loads(raw)
+    assert task["id"], raw
+
+
+def test_decompose_triage_task_inherits_root_notify_subscriptions(kanban_home):
+    """Swarm decomposition must not lose delivery: every child produced by
+    decompose_triage_task inherits the root task's notify subscriptions
+    (idempotent INSERT OR IGNORE on the subscription primary key), so the
+    originating channel still hears when a fan-out child BLOCKs or
+    completes even though only the root was explicitly subscribed — and a
+    background/CLI-created root gets that subscription from the home
+    fallback in the first place."""
+    conn = kb.connect()
+    try:
+        root = kb.create_task(
+            conn, title="triage root", triage=True, assignee="orchestrator",
+        )
+        _add_full_parent_sub(conn, root)
+
+        child_ids = kb.decompose_triage_task(
+            conn,
+            root,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "first child", "assignee": "worker1"},
+                {
+                    "title": "second child", "assignee": "worker2",
+                    "parents": [0],
+                },
+            ],
+            author="triager",
+            auto_promote=False,
+        )
+        assert child_ids is not None
+
+        subs = [kb.list_notify_subs(conn, cid) for cid in child_ids]
+
+        # The cursor starts caught up: no pre-link history replays.
+        _, old_events = kb.unseen_events_for_sub(
+            conn,
+            task_id=child_ids[0],
+            platform="telegram",
+            chat_id="chat1",
+            thread_id="topic1",
+            kinds=["blocked"],
+        )
+    finally:
+        conn.close()
+
+    assert len(subs) == 2
+    for s in subs:
+        _assert_full_inherited_sub(s)
+    assert old_events == []
+
+
+def _add_full_parent_sub(conn, parent):
+    kb.add_notify_sub(
+        conn, task_id=parent, platform="telegram", chat_id="chat1",
+        thread_id="topic1", user_id="user1",
+        chat_type="dm", notifier_profile="default",
+        delivery_mode="notify+wake",
+        delivery_metadata={"reply_fallback": "general"},
+    )
+
+
+def _assert_full_inherited_sub(subs):
+    assert len(subs) == 1
+    s = subs[0]
+    assert s["platform"] == "telegram"
+    assert s["chat_id"] == "chat1"
+    assert s["thread_id"] == "topic1"
+    assert s["user_id"] == "user1"
+    assert s["chat_type"] == "dm"
+    assert s["delivery_mode"] == "notify+wake"
 
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1230,3 +1230,110 @@ def test_specify_happy_path(client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+
+
+# ---------------------------------------------------------------------------
+# Dashboard auto-subscribe: configured-home fallback on create
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_created_task_subscribes_all_configured_home_channels(
+    client, with_home_channels,
+):
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Notify homes when finished"},
+    )
+    assert response.status_code == 200, response.text
+    task_id = response.json()["task"]["id"]
+
+    with kb.connect() as conn:
+        subscriptions = kb.list_notify_subs(conn, task_id)
+
+    assert {
+        (sub["platform"], sub["chat_id"], sub["thread_id"])
+        for sub in subscriptions
+    } == {
+        ("telegram", "1234567", "42"),
+        ("discord", "9999999", ""),
+    }
+    assert {sub["notifier_profile"] for sub in subscriptions} == {"default"}
+
+
+def test_dashboard_honors_auto_subscribe_gate(
+    client, with_home_channels, kanban_home, monkeypatch,
+):
+    """Security finding: the dashboard create path must honor
+    kanban.auto_subscribe_on_create=false like every other surface."""
+    (kanban_home / "config.yaml").write_text(
+        "gateway:\n  enabled: false\nkanban:\n  auto_subscribe_on_create: false\n",
+        encoding="utf-8",
+    )
+    # The plugin module was loaded at fixture time; reload so nothing cached
+    # matters — the gate is read per-request anyway.
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Gate keeps dashboard quiet"},
+    )
+    assert response.status_code == 200, response.text
+    task_id = response.json()["task"]["id"]
+
+    with kb.connect() as conn:
+        assert kb.list_notify_subs(conn, task_id) == []
+
+
+def test_dashboard_task_persists_when_home_channel_probe_fails(
+    client, monkeypatch, caplog,
+):
+    plugin_api = sys.modules["hermes_dashboard_plugin_kanban_test"]
+    monkeypatch.setattr(
+        plugin_api.kanban_db,
+        "subscribe_task_to_configured_homes",
+        lambda conn, tid: (_ for _ in ()).throw(
+            RuntimeError("broken channels config")
+        ),
+    )
+
+    with caplog.at_level("WARNING"):
+        response = client.post(
+            "/api/plugins/kanban/tasks",
+            json={"title": "Persist despite broken channels config"},
+        )
+
+    assert response.status_code == 200, response.text
+    task_id = response.json()["task"]["id"]
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id) is not None
+    assert "kanban dashboard auto-subscribe failed" in caplog.text
+    assert "broken channels config" in caplog.text
+
+
+def test_dashboard_recreated_task_with_same_id_gets_no_duplicate_subs(
+    client, with_home_channels,
+):
+    """Re-subscribing the same task to the same homes (e.g. a retried
+    request) must not produce duplicate subscription rows —
+    add_notify_sub is idempotent on (task, platform, chat, thread)."""
+    response = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "Idempotent dashboard task"},
+    )
+    assert response.status_code == 200, response.text
+    task_id = response.json()["task"]["id"]
+
+    plugin_api = sys.modules["hermes_dashboard_plugin_kanban_test"]
+    with kb.connect() as conn:
+        # The create endpoint itself must have subscribed (feature presence).
+        initial = kb.list_notify_subs(conn, task_id)
+        assert {s["platform"] for s in initial} == {"telegram", "discord"}
+        # A retried subscribe step for the SAME task adds nothing.
+        plugin_api._subscribe_task_to_configured_homes(conn, task_id)
+        subscriptions = kb.list_notify_subs(conn, task_id)
+
+    keys = sorted(
+        (s["platform"], s["chat_id"], s["thread_id"] or "") for s in subscriptions
+    )
+    assert keys == [
+        ("discord", "9999999", ""),
+        ("telegram", "1234567", "42"),
+    ]

--- a/tests/tools/test_kanban_home_autosubscribe.py
+++ b/tests/tools/test_kanban_home_autosubscribe.py
@@ -1,0 +1,344 @@
+"""Kanban auto-subscribe: unattached/background home-channel fallback.
+
+Covers the root-cause fix for boards where agent/CLI/background-created
+tasks never reached the configured home channels:
+
+  - kanban_create without gateway/TUI origin context (CLI, cron,
+    background agents, dispatcher-spawned workers) falls back to
+    subscribing every ENABLED configured home channel when
+    ``kanban.auto_subscribe_on_create`` is enabled.
+  - Gateway/TUI-originated creates keep their origin subscription and do
+    NOT get duplicate home rows.
+  - Re-running subscribe-to-homes is idempotent (no duplicates).
+  - A missing/broken homes config must not fail task creation.
+  - Platforms with ``enabled: false`` never produce dead subscription rows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers (same shape as the existing tool-surface tests)
+# ---------------------------------------------------------------------------
+
+
+def _list_subs_for_task(task_id):
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        return list(kb.list_notify_subs(conn, task_id))
+    finally:
+        conn.close()
+
+
+def _sub_keys(subs):
+    return sorted((s["platform"], s["chat_id"], s.get("thread_id") or "") for s in subs)
+
+
+@pytest.fixture
+def worker_env(monkeypatch, tmp_path):
+    """Same shape as tests/tools/test_kanban_tools.py::worker_env."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    from pathlib import Path as _Path
+
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="worker-test", assignee="test-worker")
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    return tid
+
+
+@pytest.fixture
+def with_home_channels_env(monkeypatch):
+    """Simulate telegram + discord homes configured via env overlays."""
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "abc:fake")
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "1234567")
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL_THREAD_ID", "42")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "disc_fake")
+    monkeypatch.setenv("DISCORD_HOME_CHANNEL", "9999999")
+
+
+def _clear_session_env(monkeypatch):
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+
+
+def test_unattached_create_subscribes_configured_home_channels(
+    monkeypatch,
+    worker_env,
+    with_home_channels_env,
+):
+    """A kanban_create from a session WITHOUT gateway/TUI delivery context
+    (CLI / cron / background agent / dispatcher-spawned worker) still lands
+    in the configured home channels so orchestration tasks notify."""
+    from tools import kanban_tools as kt
+
+    _clear_session_env(monkeypatch)
+
+    out = kt._handle_create({
+        "title": "background orchestration task",
+        "assignee": "peer",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True, d
+    assert d.get("subscribed") is True, (
+        "unattached create should report subscribed=True via home fallback"
+    )
+
+    subs = _list_subs_for_task(d["task_id"])
+    assert _sub_keys(subs) == [
+        ("discord", "9999999", ""),
+        ("telegram", "1234567", "42"),
+    ]
+    # Home-fallback rows carry the active profile so THIS profile's gateway
+    # notifier owns delivery (the ownership gate drops foreign-profile rows).
+    assert {s["notifier_profile"] for s in subs} == {"test-worker"}
+
+
+def test_unattached_create_homes_disabled_by_config_gate(
+    monkeypatch,
+    worker_env,
+    tmp_path,
+    with_home_channels_env,
+):
+    """kanban.auto_subscribe_on_create=false suppresses the home fallback too —
+    same knob as the gateway/TUI path (explicit opt-out)."""
+    home = tmp_path / "gate-home" / ".hermes"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "gateway:\n  enabled: false\nkanban:\n  auto_subscribe_on_create: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _clear_session_env(monkeypatch)
+
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "gated off",
+        "assignee": "peer",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d.get("subscribed") is False
+    assert _list_subs_for_task(d["task_id"]) == []
+
+
+def test_disabled_platform_home_is_skipped_no_dead_rows(
+    monkeypatch,
+    worker_env,
+    tmp_path,
+):
+    """Security finding: a platform configured ``enabled: false`` has no
+    adapter to deliver through — its home must NOT produce a dead
+    subscription row that the notifier ownership gate would skip forever."""
+    import yaml
+
+    from hermes_cli import kanban_db as kb
+
+    # Isolate config entirely from the shared env-overlay fixtures: the
+    # enabled/disabled split lives in config.yaml alone here.
+    for var in (
+        "TELEGRAM_BOT_TOKEN", "TELEGRAM_HOME_CHANNEL",
+        "TELEGRAM_HOME_CHANNEL_THREAD_ID", "DISCORD_BOT_TOKEN",
+        "DISCORD_HOME_CHANNEL", "SLACK_BOT_TOKEN", "SLACK_HOME_CHANNEL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    home = Path(os.environ["HERMES_HOME"])
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "gateway": {"enabled": False},
+            "platforms": {
+                "telegram": {
+                    "enabled": True,
+                    "home_channel": {
+                        "platform": "telegram",
+                        "chat_id": "1234567",
+                        "name": "Home",
+                        "thread_id": "42",
+                    },
+                },
+                "discord": {
+                    "enabled": False,
+                    "home_channel": {
+                        "platform": "discord",
+                        "chat_id": "9999999",
+                        "name": "Home",
+                    },
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    homes = kb.configured_home_channels()
+    # The invariant under test: disabled platform → no dead row.
+    assert homes == [
+        {"platform": "telegram", "chat_id": "1234567", "thread_id": "42", "name": "Home"},
+    ]
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="no dead rows", assignee="w1")
+        kb.subscribe_task_to_configured_homes(conn, tid)
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+
+    assert {s["platform"] for s in subs} == {"telegram"}
+
+
+def test_gateway_origin_create_does_not_duplicate_home_subscription(
+    monkeypatch,
+    worker_env,
+    with_home_channels_env,
+):
+    """A gateway-session create keeps its ORIGIN subscription. The home
+    fallback must not add a second row for the same platform when the
+    origin already covers it — no duplicate notifications for the chat
+    that created the task."""
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
+    monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "thread-7")
+
+    out = kt._handle_create({
+        "title": "origin wins over home",
+        "assignee": "peer",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+    assert d["subscribed"] is True
+
+    subs = _list_subs_for_task(d["task_id"])
+    keys = _sub_keys(subs)
+    # Exactly ONE telegram row — the origin session, not a home duplicate.
+    tg_rows = [k for k in keys if k[0] == "telegram"]
+    assert tg_rows == [("telegram", "chat-42", "thread-7")]
+    # Discord has no origin here; the home fallback may cover it, but the
+    # critical invariant is: one subscription per (platform, chat, thread).
+    assert len(keys) == len(set(keys))
+    assert all(
+        s["delivery_mode"] == "notify+wake" for s in subs if s["chat_id"] == "chat-42"
+    )
+
+
+def test_tui_origin_create_not_duplicated_by_home_fallback(
+    monkeypatch,
+    worker_env,
+    with_home_channels_env,
+):
+    """TUI-origin creates keep their tui subscription untouched by the
+    home fallback (requirement: preserve origin subscription)."""
+    from tools import kanban_tools as kt
+
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_KEY", "tui-session-abc")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+
+    out = kt._handle_create({
+        "title": "tui create stays tui",
+        "assignee": "peer",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True
+
+    subs = _list_subs_for_task(d["task_id"])
+    tui_rows = [s for s in subs if s["platform"] == "tui"]
+    assert len(tui_rows) == 1
+    assert tui_rows[0]["chat_id"] == "tui-session-abc"
+
+
+def test_subscribe_to_homes_is_idempotent_no_duplicates(
+    monkeypatch,
+    worker_env,
+    with_home_channels_env,
+):
+    """Calling the home-fallback twice for the same task writes no extra
+    rows (INSERT OR IGNORE on the subscription primary key)."""
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="idem potens", assignee="w1")
+        first = kb.subscribe_task_to_configured_homes(conn, tid)
+        count_after_first = len(kb.list_notify_subs(conn, tid))
+        second = kb.subscribe_task_to_configured_homes(conn, tid)
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+
+    assert first is True and second is True
+    assert count_after_first == len(subs) == 2
+    assert _sub_keys(subs) == [
+        ("discord", "9999999", ""),
+        ("telegram", "1234567", "42"),
+    ]
+
+
+def test_discord_home_row_uses_channel_chat_type(monkeypatch, worker_env, with_home_channels_env):
+    """Security finding: Discord homes are guild text CHANNELS — the row must
+    not be stamped chat_type='dm' (wrong wake/session source shape)."""
+    from hermes_cli import kanban_db as kb
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="discord channel type", assignee="w1")
+        kb.subscribe_task_to_configured_homes(conn, tid)
+        subs = {s["platform"]: s for s in kb.list_notify_subs(conn, tid)}
+    finally:
+        conn.close()
+
+    assert subs["discord"]["chat_type"] == "channel"
+    assert subs["telegram"]["chat_type"] == "dm"
+
+
+def test_home_failure_does_not_break_task_creation(
+    monkeypatch,
+    worker_env,
+    with_home_channels_env,
+):
+    """If the homes config explodes mid-create, the task still persists and
+    the create response stays ok=True (resilience requirement)."""
+    from tools import kanban_tools as kt
+
+    _clear_session_env(monkeypatch)
+
+    from tools import kanban_tools as _mod_self
+
+    def _broken_homes(conn, task_id):
+        raise RuntimeError("homes config exploded")
+
+    monkeypatch.setattr(_mod_self, "_subscribe_task_to_configured_homes", _broken_homes)
+
+    out = kt._handle_create({
+        "title": "survives broken homes",
+        "assignee": "peer",
+    })
+    d = json.loads(out)
+    assert d["ok"] is True, d
+    assert d["task_id"]

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1553,7 +1553,14 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
                 or os.environ.get("HERMES_SESSION_KEY", "")
             )
             if not session_key:
-                return False  # CLI / cron / test — no persistent channel
+                # Unattached origin (CLI / cron / background agent /
+                # dispatcher-spawned worker): no persistent channel of its
+                # own, so fall back to the user's CONFIGURED HOME CHANNELS.
+                # Without this, orchestration tasks created outside a chat
+                # produced terminal events nobody was subscribed to (the
+                # 61-task / 0-subscription board root cause). Idempotent and
+                # best-effort; never fails the create.
+                return _subscribe_task_to_configured_homes(conn, task_id)
             platform = "tui"
             chat_id = session_key
         is_gateway_session = platform != "tui"
@@ -1607,6 +1614,19 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             _exc, platform, bool(chat_id),
         )
         return False
+
+
+def _subscribe_task_to_configured_homes(conn: Any, task_id: str) -> bool:
+    """Delegate to the shared kanban_db helper (idempotent, best-effort).
+
+    Kept as a thin tool-local wrapper so the tool surface has a single
+    integration seam (tests patch this to prove home-fallback failures never
+    fail kanban_create). Shares ONE implementation with the dashboard and CLI
+    create paths via ``hermes_cli.kanban_db.subscribe_task_to_configured_homes``.
+    """
+    from hermes_cli import kanban_db as _kb
+
+    return _kb.subscribe_task_to_configured_homes(conn, task_id)
 
 
 def _handle_unblock(args: dict, **kw) -> str:


### PR DESCRIPTION
## Purpose

Kanban tasks created with **no origin session** — from the dashboard, the CLI, cron, background agents, and dispatcher-spawned workers — reached terminal states (completed / blocked / gave-up) that nobody was subscribed to.

**Root cause:** an audit of the live board found **61 tasks with 0 notification subscriptions**. Every unattached create path persisted its task without any notify-subscription rows, so completion/blocking events were silently dropped even when Telegram/Discord/Slack home channels were fully configured.

This change adds ONE shared, idempotent, best-effort helper — `kanban_db.subscribe_task_to_configured_homes()` — gated by `kanban.auto_subscribe_on_create` in `config.yaml` (default on), used by every unattached create surface:

- `plugins/kanban/dashboard/plugin_api.py` — `create_task` honors the gate and delegates via a thin local wrapper; failures log, never turn a persisted task into a misleading HTTP 500
- `tools/kanban_tools._maybe_auto_subscribe()` — unattached tool-origin creates fall back to configured homes; gateway/TUI origin subscriptions still win
- `hermes_cli/kanban._cmd_create` — same fallback when no origin-session context exists; failures logged, `--json` stdout stays clean

Per-task toggles are preserved, so users can opt out after the fact.

## Security review

- **Enabled platforms only:** homes on platforms with `enabled: false` are dropped before subscription — a disabled platform has no adapter, so subscribing its home would only write dead rows.
- **Gate honored everywhere:** all three surfaces check `kanban.auto_subscribe_on_create` before subscribing; unreadable config defaults to on (pre-gate behavior).
- **Discord chat_type fixed:** Discord home rows stamp `chat_type='channel'` instead of the wrong `'dm'`; other homes keep the historical `'dm'`.
- **Delivery stays passive** (`notify`) — no new active-wake behavior.
- **No unrelated watcher changes:** notifier/watcher loops are untouched; the diff is scoped to creation-time subscription only.

## Validation

Focused suites (all green):

- `tests/tools/test_kanban_home_autosubscribe.py` + `tests/gateway/test_kanban_unattached_home_e2e.py` — **9 passed**
- `tests/hermes_cli/test_kanban_cli.py` + `tests/plugins/test_kanban_dashboard_plugin.py` — **50 passed**
- Coverage includes enabled/disabled/missing homes, dashboard gate + resilience + idempotency, unattached CLI/tool fallback, origin preservation, child/background inheritance
- `ruff check` on all 8 changed files — clean
- `git diff --check origin/main...HEAD` — clean
- Rebased onto current `main` (`5259f565d0`) via cherry-pick; merge is conflict-free against the evolved `plugin_api.py`

## Local live E2E evidence (real delivery, real gateway)

Exercised against a temp `HERMES_HOME` with the real gateway delivering to Discord `#hermes-status`:

- **Completion:** task `t_7b83fb9b` driven to `done` — completion message visibly delivered to `#hermes-status`
- **Blocking:** task `t_63d98517` marked `blocked` — blocking message visibly delivered to `#hermes-status`

## Related (not duplicates)

- #84895 — related Kanban notification routing work; different surface/scope
- #56781 — related home-channel configuration; different surface/scope

## Risk

Low and localized to creation-time subscription records. Behavior intentionally changes unattached creates from opt-in to subscribed-by-default when enabled homes are configured; subscription failures are best-effort and cannot fail the underlying create.

## Deployment note

This PR does not merge or deploy anything. Activation requires an authorized merge followed by the normal deployment process.
