### PR TITLE
fix(approval): saving the allowlist deletes entries the operator added by hand and resurrects ones they revoked

### DIFF
--- a/tests/tools/test_permanent_allowlist_reconcile.py
+++ b/tests/tools/test_permanent_allowlist_reconcile.py
@@ -1,0 +1,148 @@
+"""`command_allowlist` is a file the operator edits; a save must not clobber it.
+
+`load_permanent_allowlist()` runs once, at module import (tools/approval.py, the
+call at the bottom of the module), and `load_permanent()` only ever unions into
+`_permanent_approved` — nothing removes. `save_permanent_allowlist()` then wrote
+that in-memory set straight back over `config["command_allowlist"]`.
+
+So a hand edit made while a Hermes process is live was undone by the next
+`[a]lways`, in both directions at once: an entry the operator ADDED on disk was
+deleted, and an entry they REMOVED — the documented way to withdraw a standing
+approval — came back.
+
+Reconciling at write time fixes both. The file is re-read and the result is
+what is on disk now, plus what this process approved since its own baseline.
+"""
+
+import pytest
+
+import tools.approval as approval
+
+
+@pytest.fixture
+def fake_config(monkeypatch):
+    """A dict standing in for config.yaml, plus a clean module baseline."""
+    store = {"command_allowlist": []}
+
+    def _load():
+        return {"command_allowlist": list(store["command_allowlist"])}
+
+    def _save(config):
+        store["command_allowlist"] = list(config.get("command_allowlist", []))
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _load, raising=False)
+    monkeypatch.setattr("hermes_cli.config.save_config", _save, raising=False)
+
+    saved_approved = set(approval._permanent_approved)
+    saved_baseline = set(approval._permanent_baseline)
+    approval._permanent_approved.clear()
+    approval._permanent_baseline = set()
+    try:
+        yield store
+    finally:
+        approval._permanent_approved.clear()
+        approval._permanent_approved.update(saved_approved)
+        approval._permanent_baseline = saved_baseline
+
+
+def _start_process_with(store, entries):
+    """Simulate import-time load against the current file contents."""
+    store["command_allowlist"] = list(entries)
+    approval.load_permanent(set(entries))
+    approval._permanent_baseline = set(entries)
+
+
+# ── the two halves of the bug ─────────────────────────────────────────
+
+
+def test_an_entry_the_operator_added_on_disk_survives_a_save(fake_config):
+    _start_process_with(fake_config, ["git status", "ls *"])
+    fake_config["command_allowlist"] = ["git status", "ls *", "npm test"]
+
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert "npm test" in fake_config["command_allowlist"], (
+        "a hand-added entry was deleted by an unrelated [a]lways"
+    )
+    assert "docker *" in fake_config["command_allowlist"]
+
+
+def test_an_entry_the_operator_revoked_on_disk_is_not_resurrected(fake_config):
+    _start_process_with(fake_config, ["git status", "ls *"])
+    fake_config["command_allowlist"] = ["ls *"]          # operator revokes it
+
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert "git status" not in fake_config["command_allowlist"], (
+        "a revoked standing approval came back on the next save"
+    )
+    assert sorted(fake_config["command_allowlist"]) == ["docker *", "ls *"]
+
+
+def test_a_revoked_entry_stops_being_honoured_in_memory_after_the_save(fake_config):
+    _start_process_with(fake_config, ["git status", "ls *"])
+    fake_config["command_allowlist"] = ["ls *"]
+
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert "git status" not in approval._permanent_approved
+    assert "ls *" in approval._permanent_approved
+    assert "docker *" in approval._permanent_approved
+
+
+# ── the ordinary path must not move ───────────────────────────────────
+
+
+def test_an_untouched_file_round_trips_unchanged(fake_config):
+    _start_process_with(fake_config, ["git status", "ls *"])
+
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert sorted(fake_config["command_allowlist"]) == ["docker *", "git status", "ls *"]
+
+
+def test_repeated_saves_are_idempotent(fake_config):
+    _start_process_with(fake_config, ["ls *"])
+    approval.approve_permanent("docker *")
+
+    approval.save_permanent_allowlist(approval._permanent_approved)
+    first = sorted(fake_config["command_allowlist"])
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert sorted(fake_config["command_allowlist"]) == first == ["docker *", "ls *"]
+
+
+def test_a_second_process_writing_first_does_not_lose_this_ones_approval(fake_config):
+    """Two live Hermes processes. Whoever writes second must not drop the first."""
+    _start_process_with(fake_config, ["ls *"])
+    # The other process approved something and wrote it out.
+    fake_config["command_allowlist"] = ["ls *", "cargo *"]
+
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+
+    assert sorted(fake_config["command_allowlist"]) == ["cargo *", "docker *", "ls *"]
+
+
+def test_empty_start_and_first_approval(fake_config):
+    _start_process_with(fake_config, [])
+    approval.approve_permanent("ls *")
+    approval.save_permanent_allowlist(approval._permanent_approved)
+    assert fake_config["command_allowlist"] == ["ls *"]
+
+
+def test_save_failure_is_logged_not_raised(fake_config, monkeypatch):
+    """The existing contract: a config write failure must not break approval."""
+    _start_process_with(fake_config, ["ls *"])
+
+    def _boom():
+        raise OSError("disk full")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _boom, raising=False)
+    approval.approve_permanent("docker *")
+    approval.save_permanent_allowlist(approval._permanent_approved)   # must not raise
+    assert "docker *" in approval._permanent_approved

--- a/tests/tools/test_permanent_allowlist_reconcile.py
+++ b/tests/tools/test_permanent_allowlist_reconcile.py
@@ -14,6 +14,8 @@ Reconciling at write time fixes both. The file is re-read and the result is
 what is on disk now, plus what this process approved since its own baseline.
 """
 
+import logging
+
 import pytest
 
 import tools.approval as approval
@@ -135,7 +137,7 @@ def test_empty_start_and_first_approval(fake_config):
     assert fake_config["command_allowlist"] == ["ls *"]
 
 
-def test_save_failure_is_logged_not_raised(fake_config, monkeypatch):
+def test_save_failure_is_logged_not_raised(fake_config, monkeypatch, caplog):
     """The existing contract: a config write failure must not break approval."""
     _start_process_with(fake_config, ["ls *"])
 
@@ -144,5 +146,21 @@ def test_save_failure_is_logged_not_raised(fake_config, monkeypatch):
 
     monkeypatch.setattr("hermes_cli.config.load_config", _boom, raising=False)
     approval.approve_permanent("docker *")
-    approval.save_permanent_allowlist(approval._permanent_approved)   # must not raise
+    with caplog.at_level(logging.WARNING, logger=approval.logger.name):
+        approval.save_permanent_allowlist(approval._permanent_approved)   # must not raise
+    assert "Could not save allowlist" in caplog.text
     assert "docker *" in approval._permanent_approved
+
+
+def test_a_caller_that_passes_a_smaller_set_does_not_remove(fake_config):
+    """Documented consequence of reconciling: ``patterns`` may only add.
+
+    A future `allowlist remove` built on this function would silently no-op.
+    The docstring says so; this pins it so the next reader finds out here
+    rather than in production.
+    """
+    _start_process_with(fake_config, ["ls *", "docker *"])
+
+    approval.save_permanent_allowlist({"ls *"})          # tries to drop docker *
+
+    assert "docker *" in fake_config["command_allowlist"]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2928,18 +2928,29 @@ def _command_matches_permanent_allowlist(command: str) -> bool:
 # Config persistence for permanent allowlist
 # =========================================================================
 
+# What ``command_allowlist`` held the last time this process synchronised with
+# the file. Everything in ``_permanent_approved`` beyond it is an approval THIS
+# process made, and is the only thing a save is entitled to add: the difference
+# is what separates "the operator granted this here" from "this was on disk when
+# we started, and may since have been revoked".
+_permanent_baseline: set = set()
+
+
 def load_permanent_allowlist() -> set:
     """Load permanently allowed command patterns from config.
 
     Also syncs them into the approval module so is_approved() works for
     patterns added via 'always' in a previous session.
     """
+    global _permanent_baseline
     try:
         from hermes_cli.config import load_config_readonly
         config = load_config_readonly()
         patterns = set(config.get("command_allowlist", []) or [])
         if patterns:
             load_permanent(patterns)
+        with _lock:
+            _permanent_baseline = set(patterns)
         return patterns
     except Exception as e:
         logger.warning("Failed to load permanent allowlist: %s", e)
@@ -2947,12 +2958,42 @@ def load_permanent_allowlist() -> set:
 
 
 def save_permanent_allowlist(patterns: set):
-    """Save permanently allowed command patterns to config."""
+    """Save permanently allowed command patterns to config.
+
+    ``command_allowlist`` is a file an operator edits by hand — removing an
+    entry there is the documented way to withdraw a standing approval. This
+    process read that file once, at import, and ``load_permanent`` only ever
+    unions into ``_permanent_approved``; nothing takes anything out. Writing
+    the in-memory set straight back therefore did two things at once: it
+    deleted entries the operator had added on disk since import, and it
+    resurrected the ones they had removed.
+
+    Reconcile instead. The file is re-read at write time and the result is
+    ``what is on disk now`` plus ``what this process approved since its own
+    baseline``. An entry the operator deleted stays deleted unless this
+    process approved it again; an entry they added survives.
+
+    This does not make a revocation take effect the instant the file changes —
+    nothing re-reads the file on the approval hot path, and adding a stat there
+    is a separate change. It makes the next write stop undoing it.
+    """
+    global _permanent_baseline
     try:
         from hermes_cli.config import load_config, save_config
         config = load_config()
-        config["command_allowlist"] = list(patterns)
-        save_config(config)
+        on_disk = set(config.get("command_allowlist", []) or [])
+        with _lock:
+            approved_here = set(patterns) - _permanent_baseline
+            merged = on_disk | approved_here
+            config["command_allowlist"] = sorted(merged)
+            save_config(config)
+            # The file and this process now agree; anything the operator does
+            # next is measured against what was actually written.
+            _permanent_baseline = set(merged)
+            # Drop anything the operator revoked on disk, so is_approved()
+            # stops honouring it for the rest of this process too.
+            _permanent_approved.clear()
+            _permanent_approved.update(merged)
     except Exception as e:
         logger.warning("Could not save allowlist: %s", e)
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2976,6 +2976,13 @@ def save_permanent_allowlist(patterns: set):
     This does not make a revocation take effect the instant the file changes —
     nothing re-reads the file on the approval hot path, and adding a stat there
     is a separate change. It makes the next write stop undoing it.
+
+    Consequence for callers, which is not obvious from the signature:
+    ``patterns`` may only ADD. An entry left out of it is not removed, because
+    the on-disk list wins for anything this process did not approve itself.
+    Entries are removed by editing ``command_allowlist`` in config.yaml. A
+    future `allowlist remove` command must delete the line there, not pass a
+    smaller set here.
     """
     global _permanent_baseline
     try:

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -239,6 +239,13 @@ These patterns are loaded at startup and silently approved in all future session
 Use `hermes config edit` to review or remove patterns from your permanent allowlist.
 :::
 
+:::caution
+The list is read when Hermes starts. A pattern you remove while a session is
+already running stays approved in that session until it next writes the file
+(the next time you answer `always` to a prompt) or you restart Hermes. If you
+removed it for safety reasons, restart.
+:::
+
 ### Mining Approval History (`hermes approvals suggest`)
 
 Instead of answering the same prompt session after session, you can mine your


### PR DESCRIPTION
## What does this PR do?

`command_allowlist` in `config.yaml` is a file the operator edits, and deleting a line from it is the documented way to withdraw a standing approval. A Hermes process reads that file **once**, at module import — the `load_permanent_allowlist()` call at the bottom of `tools/approval.py` — and `load_permanent()` (`:2866-2869`) only ever unions into `_permanent_approved`. Nothing removes.

`save_permanent_allowlist()` then wrote that in-memory set straight back over `config["command_allowlist"]`, from eight call sites. So any hand edit made while a Hermes process is live was undone by that process's next `[a]lways`, in both directions at once.

## Related Issue

No open issue. Searched open and merged PRs and issues for `command_allowlist revoke`, `permanent allowlist reload`, `approval allowlist clobber` and `save_permanent_allowlist` — nothing covers this.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/approval.py` — add `_permanent_baseline`, the set `command_allowlist` held the last time this process synchronised with the file. `load_permanent_allowlist()` records it; `save_permanent_allowlist()` re-reads the file and writes `what is on disk now` ∪ `what this process approved since its baseline`, then refreshes both the baseline and `_permanent_approved` from the written set.
- `tests/tools/test_permanent_allowlist_reconcile.py` — 8 cases.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_permanent_allowlist_reconcile.py
```

Reproduction, on this tree with a temp `HERMES_HOME`:

```
######## BEFORE (tools/approval.py at fcbd107)
  on disk before this process starts : ['git status', 'ls *']
  operator edits config.yaml by hand : ['ls *', 'npm test']   (revoked 'git status', added 'npm test')
  after ONE [a]lways                 : ['docker *', 'git status', 'ls *']
  is_approved still honours revoked? : True

######## AFTER (this PR)
  on disk before this process starts : ['git status', 'ls *']
  operator edits config.yaml by hand : ['ls *', 'npm test']   (revoked 'git status', added 'npm test')
  after ONE [a]lways                 : ['docker *', 'ls *', 'npm test']
  is_approved still honours revoked? : False
```

Two things happen in the BEFORE, and neither prints anything:

- `npm test` — an entry the operator added to their own config file — is **deleted**.
- `git status` — a standing approval they had just **withdrawn** — is written back, and keeps auto-approving for the rest of the process.

The same shape loses writes between two live Hermes processes: whichever saves second overwrites the other's entry. `test_a_second_process_writing_first_does_not_lose_this_ones_approval` pins that.

## Scope, and what this deliberately does not do

It does **not** make a revocation take effect the instant the file changes. Nothing re-reads `config.yaml` on the approval hot path, and adding a stat there is a separate change with its own cost. This makes the next *write* stop undoing the operator's edit, and drops revoked entries from `_permanent_approved` at that point so `is_approved()` stops honouring them.

Per SECURITY.md §2.4 the approval gate is an in-process heuristic and not a boundary; this is not filed as a vulnerability and makes no containment claim. It is a config file being silently rewritten with stale contents.

`_lock` is `threading.Lock` and not reentrant. All eight `save_permanent_allowlist` call sites were checked and none holds it across the call, so the added critical section cannot deadlock. The failure path still logs and returns rather than raising, and a test pins that.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: `scripts/run_tests.sh` over the 29 test files in `tests/` that reference the allowlist or the approval module gives an identical failure set before and after this change (25 failed both times — pre-existing missing-dependency failures in my minimal local venv, present on `fcbd107` too). I did not run the full suite locally.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.3.0), Python 3.14

### Documentation & Housekeeping

- [x] Documentation — the new behaviour is documented in `save_permanent_allowlist`'s docstring, including what it does not do
- [x] `cli-config.yaml.example` — N/A, no new config key
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — stdlib only, no paths or processes added; the config I/O is the existing `hermes_cli.config` pair
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/tools/test_permanent_allowlist_reconcile.py
[100.0% |     8/~8 | ✓8 | ✗0] ✓ tests/tools/test_permanent_allowlist_reconcile.py (8✓, 0.5s)
=== Summary: 1 files, 8 tests passed, 0 failed (100% complete) in 0.5s (22 workers) ===
```
