### PR TITLE
fix(redact): keep opaque payload scanning linear

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -155,11 +155,14 @@ _SECRET_ENV_NAMES = r"(?:API_?KEY|KEY|TOKEN|SECRET|PASSWORD|PASSWD|PASS|PW|CREDE
 _ENV_ASSIGN_RE = re.compile(
     rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
 )
-# Lowercase env names: only underscore-boundary forms (``openai_key=…``,
-# ``FAL_KEY=…``, ``db_pw=…``) — NOT bare ``password=``/``token=``/``secret=``,
-# which appear in prose, URLs, and form bodies (issue #77484).
+# Lowercase env assignment candidates. The left boundary and possessive key
+# scan keep discovery linear on long opaque values; the replacement callback
+# enforces the underscore-boundary secret-name rule below.
+_LOWER_ENV_SECRET_SUFFIXES = frozenset(
+    {"key", "pass", "pw", "token", "secret", "password", "passwd", "credential", "auth"}
+)
 _ENV_ASSIGN_LOWER_RE = re.compile(
-    rf"([a-z0-9_]+(?:_|^)(?:key|pass|pw|token|secret|password|passwd|credential|auth)(?=[^a-z0-9_]|$))\s*=\s*(['\"]?)(\S+)\2",
+    r"(?<![a-z0-9_])([a-z0-9_]++)\s*+=\s*+(['\"]?)(\S+)\2",
     re.IGNORECASE,
 )
 
@@ -183,9 +186,8 @@ _ENV_ASSIGN_LOWER_RE = re.compile(
 _SECRET_CFG_NAMES = r"(?:api[ _.\-]?key|token|secret|passwd|password|credential|auth)"
 _CFG_VALUE = r"(['\"]?)([^\s&]+?)\2(?=[\s&]|$)"
 # Linear pre-gate for the _CFG_*_RE subs below: a text with no secret keyword
-# can never match either pattern, so the (potentially backtrack-heavy) subs
-# are skipped entirely for such text. See the call site in
-# redact_sensitive_text().
+# can never match either pattern, so the subs are skipped entirely. See the
+# call site in redact_sensitive_text().
 _CFG_SECRET_WORD_RE = re.compile(_SECRET_CFG_NAMES, re.IGNORECASE)
 
 # Programmatic env lookups (``os.getenv(...)``, ``os.environ[...]``,
@@ -195,15 +197,15 @@ _CFG_SECRET_WORD_RE = re.compile(_SECRET_CFG_NAMES, re.IGNORECASE)
 _ENV_LOOKUP_VALUE_RE = re.compile(
     r"^(?:os\.(?:getenv|environ)|process\.env|\$ENV\{)"
 )
-# Namespaced (dotted) key: the secret word may sit anywhere in a dotted path.
-# NOTE(perf): possessive quantifiers (py3.11+) replace the nested quantifier
-# ``(?:[A-Za-z0-9_\-]+\.)+`` (exponential backtracking on long dotted runs).
-# The ``*`` runs bordering {_SECRET_CFG_NAMES} must stay backtrackable
-# (secret words are matchable by the class, e.g. ``app.api.key=…``).
+# Namespaced (dotted) assignment candidate. Keyword validation happens in the
+# replacement callback so this regex never needs ambiguous wildcards around a
+# secret-word alternation. The left boundary makes the engine enter the long
+# key scan only once per key-like run; the possessive key/value scans cannot
+# retry from every character in an opaque base64/hex payload.
 _CFG_DOTTED_RE = re.compile(
-    rf"([A-Za-z0-9_\-]++\.[A-Za-z0-9_.\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_.\-]*+"
-    rf"|[A-Za-z0-9_.\-]*{_SECRET_CFG_NAMES}[A-Za-z0-9_.\-]*\.[A-Za-z0-9_.\-]++)"
-    rf"={_CFG_VALUE}",
+    r"(?<![A-Za-z0-9_.\-])"
+    r"((?=[A-Za-z0-9_.\-]*\.)[A-Za-z0-9_\-][A-Za-z0-9_.\-]*+)"
+    r"=([^\s&]++)",
     re.IGNORECASE,
 )
 # Line-anchored bare key: ``password=…`` / ``export api_key=…`` at start of line.
@@ -868,21 +870,49 @@ def redact_sensitive_text(
             # case). The uppercase regex above is all-caps-only, so it never
             # matches URL params; the lowercase one would (issue #77484).
             if "://" not in text:
-                text = _ENV_ASSIGN_LOWER_RE.sub(_redact_env, text)
+                def _redact_lower_env(m):
+                    # Lowercase/mixed-case env names must use an underscore
+                    # boundary. Bare password=/token=/secret= forms appear in
+                    # prose and are handled only by the anchored config path.
+                    name = m.group(1)
+                    if (
+                        "_" not in name
+                        or name.rsplit("_", 1)[-1].casefold()
+                        not in _LOWER_ENV_SECRET_SUFFIXES
+                    ):
+                        return m.group(0)
+                    return _redact_env(m)
+
+                text = _ENV_ASSIGN_LOWER_RE.sub(_redact_lower_env, text)
             # Lowercase/dotted config keys (issue #16413). Skip URLs entirely —
             # web-URL query params are intentionally passed through (see note
             # near the bottom of this function); _DB_CONNSTR_RE still guards
             # connection-string passwords.
             #
-            # Extra gate: every _CFG_*_RE match requires a secret keyword in
-            # the key, so a text without any secret keyword cannot match —
-            # skipping is exact. This matters because _CFG_DOTTED_RE
-            # backtracks quadratically on long unbroken [A-Za-z0-9_.\-] runs
-            # (e.g. base64/hex blobs in compaction payloads); the linear
-            # keyword scan prevents that pathological path on secret-free
-            # text.
+            # Extra gate: every _CFG_*_RE replacement requires a secret
+            # keyword in the key, so a text without one can be skipped exactly.
             if "://" not in text and _CFG_SECRET_WORD_RE.search(text):
-                text = _CFG_DOTTED_RE.sub(_redact_env, text)
+                def _redact_dotted_config(m):
+                    name, raw_value = m.group(1), m.group(2)
+                    # A dotted path must have a non-empty final segment. The
+                    # regex keeps candidate discovery linear and delegates the
+                    # semantic checks to this callback.
+                    if name.endswith(".") or not _key_has_secret_keyword(name):
+                        return m.group(0)
+                    quote = ""
+                    value = raw_value
+                    if (
+                        len(raw_value) >= 2
+                        and raw_value[0] in "'\""
+                        and raw_value[-1] == raw_value[0]
+                    ):
+                        quote = raw_value[0]
+                        value = raw_value[1:-1]
+                    if _ENV_LOOKUP_VALUE_RE.match(value):
+                        return m.group(0)
+                    return f"{name}={quote}{_mask_token(value)}{quote}"
+
+                text = _CFG_DOTTED_RE.sub(_redact_dotted_config, text)
                 text = _CFG_ANCHORED_RE.sub(_redact_env, text)
 
         # JSON fields: "apiKey": "***"  (skip for code files — false positives)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -677,6 +677,25 @@ class TestConfigKeyRedosResistance:
         assert "Sup3rS3cret!" not in result
         assert ".password=" in result
 
+    def test_secret_keyword_with_large_opaque_payload_completes_fast(self):
+        """A keyword elsewhere must not make config scanning quadratic.
+
+        Tool output can contain a credential assignment followed by a large
+        base64 attachment. The keyword activates assignment scanning, while
+        the unbroken payload made both lowercase-env and dotted-key patterns
+        retry from every character despite not being a config assignment.
+        """
+        import time
+
+        text = "credential=x\n" + "A" * 100_000 + "="
+        t0 = time.perf_counter()
+        result = redact_sensitive_text(text)
+        elapsed = time.perf_counter() - t0
+
+        assert "credential=x" not in result
+        assert result.endswith("A" * 100_000 + "=")
+        assert elapsed < 3.0
+
     def test_yaml_assign_redos_resistance(self):
         """_YAML_ASSIGN_RE must not backtrack excessively on long inputs."""
         import time


### PR DESCRIPTION
## What does this PR do?

Prevents `redact_sensitive_text()` from stalling on mixed tool output that contains a secret-like assignment followed by a large opaque base64 or hex payload.

The existing secret-keyword pre-gate only protected secret-free text. Once a line such as `credential=x` activated assignment scanning, `_ENV_ASSIGN_LOWER_RE` and `_CFG_DOTTED_RE` could retry from every character in a later unbroken payload. A 100 KB synthetic attachment shape did not complete within an 8 second regression timeout on current `main`.

This replaces both ambiguous scans with boundary-anchored candidate patterns using possessive key and value runs. Existing secret-name and word-boundary semantics remain in replacement callbacks, so the performance fix does not broaden what gets redacted.

## Related Issue

No linked issue. This closes a residual case left after the dotted-key ReDoS fixes in #74330 and #76083.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/redact.py`: make lowercase environment assignment discovery linear and preserve the underscore-suffix secret-name contract in the callback.
- `agent/redact.py`: make dotted config assignment discovery linear and preserve keyword, quoting, env-lookup, URL, and final-segment behavior in the callback.
- `tests/agent/test_redact.py`: add a 100 KB mixed credential plus opaque-payload regression that verifies redaction, payload preservation, and bounded runtime.

## How to Test

1. Run the focused test through the repository wrapper:
   ```bash
   HERMES_PYTHON=/path/to/python-with-pytest scripts/run_tests.sh --files 'tests/agent/test_redact.py'
   ```
2. Run the related redaction suites:
   ```bash
   python -m pytest \
     tests/agent/test_redact.py \
     tests/agent/test_compaction_redaction_boundaries.py \
     tests/agent/test_tool_call_arg_no_redaction.py \
     tests/tools/test_terminal_error_redaction.py \
     tests/tools/test_terminal_tool_exception_redaction.py \
     tests/tools/test_kanban_redaction.py \
     tests/tools/test_browser_type_redaction.py \
     tests/test_redaction_registry.py \
     tests/monitoring/test_export_redaction.py \
     tests/hermes_cli/test_redact_config_bridge.py \
     tests/gateway/test_tui_approval_redaction.py \
     tests/gateway/test_telegram_error_redaction.py \
     tests/gateway/test_pii_redaction.py \
     tests/gateway/test_approval_prompt_redaction.py \
     tests/acp_adapter/test_acp_logging_redaction.py -q
   ```
3. Optionally benchmark `redact_sensitive_text("credential=x\n" + "A" * n + "=")` across increasing values of `n`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3, Python 3.11, 3.12, and 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Verification

- Baseline regression on current `main`: 100 KB synthetic payload exceeded an 8 second external timeout.
- Fixed regression: 100 KB completed in 0.085 seconds, 1 MB completed in 0.940 seconds on Python 3.12.
- Python compatibility smoke proof: 100 KB completed in 0.155 seconds on Python 3.11 and 0.139 seconds on Python 3.13.
- Repository test wrapper: 98 passed, 0 failed.
- Related redaction suites: 176 passed, 0 failed.
- Behavior parity: 1,584 structured assignment cases and 20,000 deterministic fuzz strings produced zero output differences against pre-fix `main`.
- `ruff check agent/redact.py tests/agent/test_redact.py`: passed.
- `python -m py_compile agent/redact.py tests/agent/test_redact.py`: passed.
