### PR TITLE
fix(gateway): distinguish OSError from auth failure in provider resolution

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1368,6 +1368,30 @@ class _ProviderAuthResolutionError(RuntimeError):
     """
 
 
+def _classify_provider_resolution_error(exc: Exception) -> tuple[str, str]:
+    """
+    Classify a provider resolution failure to avoid misleading diagnostics.
+
+    Returns (log_prefix, user_message_prefix).
+
+    When an OSError/IOError is found in the __cause__ chain, the error is an
+    I/O failure (disk full, quota exceeded, permission denied), not an
+    authentication failure. Return distinct prefixes so logs and user messages
+    don't mislead operators into chasing credentials when the disk is full.
+
+    See #91656: a disk-full OSError was surfaced to the user as "Provider
+    authentication failed" because every exception from resolve_runtime_provider()
+    was unconditionally wrapped as _ProviderAuthResolutionError. This helper
+    inspects the root cause before choosing the wording.
+    """
+    current = exc
+    while current is not None:
+        if isinstance(current, (OSError, IOError)):
+            return ("Provider resolution failed", "⚠️ Provider resolution failed")
+        current = getattr(current, '__cause__', None)
+    return ("Provider authentication failed", "⚠️ Provider authentication failed")
+
+
 class APIServerAdapter(BasePlatformAdapter):
     """
     OpenAI-compatible HTTP API server adapter.
@@ -6546,11 +6570,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     # all (raw aiohttp 500, no JSON body).  Handling it
                     # here, once, covers every _run_agent() caller;
                     # /v1/runs has its own branch in its executor.
-                    logger.warning("Provider authentication failed for session=%s: %s",
-                                   session_id or "", exc)
+                    log_prefix, user_prefix = _classify_provider_resolution_error(exc)
+                    logger.warning("%s for session=%s: %s",
+                                   log_prefix, session_id or "", exc)
                     return (
                         {
-                            "final_response": f"⚠️ Provider authentication failed: {exc}",
+                            "final_response": f"{user_prefix}: {exc}",
                             "messages": [],
                             "api_calls": 0,
                             "tools": [],
@@ -7037,8 +7062,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 # message the other endpoints give a provider auth/credential
                 # failure, instead of falling through to the generic
                 # except-Exception branch below.
-                logger.warning("Provider authentication failed for run=%s: %s", run_id, exc)
-                error_msg = f"⚠️ Provider authentication failed: {exc}"
+                log_prefix, user_prefix = _classify_provider_resolution_error(exc)
+                logger.warning("%s for run=%s: %s", log_prefix, run_id, exc)
+                error_msg = f"{user_prefix}: {exc}"
                 self._set_run_status(
                     run_id,
                     "failed",

--- a/tests/gateway/test_api_server_classify_error.py
+++ b/tests/gateway/test_api_server_classify_error.py
@@ -1,0 +1,82 @@
+"""
+Tests for _classify_provider_resolution_error in api_server.py.
+
+This helper was added in #91656 to distinguish disk-full / I/O errors from
+genuine provider authentication failures, so logs and user messages don't
+mislead operators into chasing credentials when the disk is full.
+"""
+
+import errno
+
+import pytest
+
+from gateway.platforms.api_server import _classify_provider_resolution_error
+
+
+class TestClassifyProviderResolutionError:
+    """Verify OSError/IOError in the __cause__ chain is detected and classified distinctly."""
+
+    def test_plain_runtime_error_is_auth_failure(self):
+        """
+        A plain RuntimeError with no I/O error in the chain → auth failure.
+        """
+        exc = RuntimeError("Invalid API key")
+        log_prefix, user_prefix = _classify_provider_resolution_error(exc)
+        assert log_prefix == "Provider authentication failed"
+        assert user_prefix == "⚠️ Provider authentication failed"
+
+    def test_oserror_at_root_is_io_failure(self):
+        """
+        RuntimeError wrapping an OSError (disk full) → I/O failure.
+        """
+        os_err = OSError(errno.ENOSPC, "No space left on device")
+        wrapper = RuntimeError("Provider resolution failed")
+        wrapper.__cause__ = os_err
+        log_prefix, user_prefix = _classify_provider_resolution_error(wrapper)
+        assert log_prefix == "Provider resolution failed"
+        assert user_prefix == "⚠️ Provider resolution failed"
+
+    def test_oserror_deep_in_chain(self):
+        """
+        OSError buried several levels deep in __cause__ chain → I/O failure.
+        """
+        inner = OSError(errno.EDQUOT, "Disk quota exceeded")
+        middle = ValueError("Invalid config format")
+        middle.__cause__ = inner
+        outer = RuntimeError("Boom")
+        outer.__cause__ = middle
+        log_prefix, user_prefix = _classify_provider_resolution_error(outer)
+        assert log_prefix == "Provider resolution failed"
+        assert user_prefix == "⚠️ Provider resolution failed"
+
+    def test_ioerror_variant(self):
+        """
+        IOError is treated the same as OSError (both are I/O failures).
+        """
+        io_err = IOError(errno.EACCES, "Permission denied")
+        wrapper = RuntimeError("Failed to resolve")
+        wrapper.__cause__ = io_err
+        log_prefix, user_prefix = _classify_provider_resolution_error(wrapper)
+        assert log_prefix == "Provider resolution failed"
+        assert user_prefix == "⚠️ Provider resolution failed"
+
+    def test_unrelated_exception_types_are_auth_failure(self):
+        """
+        Other exception types (ValueError, KeyError) → auth failure.
+        """
+        inner = KeyError("missing_key")
+        outer = RuntimeError("Config error")
+        outer.__cause__ = inner
+        log_prefix, user_prefix = _classify_provider_resolution_error(outer)
+        assert log_prefix == "Provider authentication failed"
+        assert user_prefix == "⚠️ Provider authentication failed"
+
+    def test_none_cause_chain_terminates_safely(self):
+        """
+        Walking the __cause__ chain when it ends with None → no crash.
+        """
+        exc = RuntimeError("No cause")
+        # Explicitly no __cause__ set (the default)
+        log_prefix, user_prefix = _classify_provider_resolution_error(exc)
+        assert log_prefix == "Provider authentication failed"
+        assert user_prefix == "⚠️ Provider authentication failed"


### PR DESCRIPTION
Fixes #91656. `resolve_runtime_provider()` failures were unconditionally reported as "Provider authentication failed", even when the root cause was an `OSError` (disk full, quota, permission denied). Added `_classify_provider_resolution_error()` to walk the `__cause__` chain and use a distinct "Provider resolution failed" wording for I/O errors, applied at both call sites in `api_server.py`.

Tests: `tests/gateway/test_api_server_classify_error.py` (new, 6 cases). Reverting the helper makes the import fail immediately, confirming the test is tied to the fix. Full file: `tests/gateway/test_api_server.py` passes except one pre-existing failure (`test_health_detailed_returns_ok`) that also fails on `main` without this change.

AI assistance was used, mostly because my English is not perfect. I reviewed the changes and ran the tests above.
