### PR TITLE
fix(desktop): show loading feedback while "Show earlier" backfills

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -241,16 +241,20 @@ function ChatRuntimeBoundary({
 
   const [windowPages, setWindowPages] = useState(1)
   const [windowSessionKey, setWindowSessionKey] = useState(runtimeId)
+  const [expandingWindow, setExpandingWindow] = useState(false)
   // Sticky-cut continuity across flushes (advanceTranscriptWindow). A ref, not
   // state: it is derived from `messages` and must never trigger a render.
   const windowStateRef = useRef<null | TranscriptWindowState>(null)
 
   // Reset the window on session swap during RENDER, so a large expand from the
-  // previous chat can't leak into the next one's first paint (#55191).
+  // previous chat can't leak into the next one's first paint (#55191). A
+  // backfill still in flight for the PREVIOUS session must not paint this
+  // one's button as loading either.
   if (windowSessionKey !== runtimeId) {
     setWindowSessionKey(runtimeId)
     setWindowPages(1)
     windowStateRef.current = null
+    setExpandingWindow(false)
   }
 
   const { messages: windowedMessages, windowed } = useMemo(() => {
@@ -277,6 +281,13 @@ function ChatRuntimeBoundary({
     // something older to show. Fire-and-forget: the prepend lands through the
     // session-state write path and re-renders this boundary.
     if (!windowStateRef.current?.window.windowed && runtimeId && storedId && transcriptBackfillAvailable(storedId)) {
+      // Loading state for the click itself: fire-and-forget otherwise leaves
+      // a click that resolves to "nothing more" indistinguishable from a
+      // dead control — the request completes, possiblyTruncated corrects
+      // itself, and the button just vanishes with no sign anything happened
+      // (#90473). Tracked here, not in transcript-backfill.ts: it is about
+      // THIS click's affordance, not the fetch itself.
+      setExpandingWindow(true)
       void backfillOlderTranscriptPage({
         storedSessionId: storedId,
         // Stale-response guard: a session switch remounts/re-keys this view;
@@ -290,7 +301,7 @@ function ChatRuntimeBoundary({
             return merged === state.messages ? state : { ...state, messages: merged }
           })
         }
-      })
+      }).finally(() => setExpandingWindow(false))
     }
 
     setWindowPages(pages => pages + 1)
@@ -298,7 +309,10 @@ function ChatRuntimeBoundary({
 
   const olderAvailable = windowed || restBackfillAvailable
 
-  const transcriptWindow = useMemo(() => ({ olderAvailable, expandWindow }), [expandWindow, olderAvailable])
+  const transcriptWindow = useMemo(
+    () => ({ olderAvailable, expandWindow, expandingWindow }),
+    [expandWindow, olderAvailable, expandingWindow]
+  )
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
     messageRepository: runtimeMessageRepository,

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -19,6 +19,7 @@ import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
 import { usePaneLifecycle } from '@/components/pane-shell/pane-visibility'
 import { useI18n } from '@/i18n'
+import { Loader2 } from '@/lib/icons'
 import { messagePaintWeight } from '@/lib/render-weight'
 import { cn } from '@/lib/utils'
 import {
@@ -397,7 +398,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     targetScrollTop: resolveThreadScrollTarget
   })
 
-  const { olderAvailable, expandWindow } = useTranscriptWindow()
+  const { olderAvailable, expandWindow, expandingWindow } = useTranscriptWindow()
 
   useEffect(() => {
     $mountedTranscriptPanes.set($mountedTranscriptPanes.get() + 1)
@@ -776,11 +777,18 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
           >
             {(hiddenCount > 0 || olderAvailable) && (
               <button
-                className="mx-auto mb-(--conversation-turn-gap) rounded-full border border-border/65 bg-(--composer-fill) px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
+                aria-busy={expandingWindow}
+                // Loading swaps the visible label for a spinner (matches
+                // mcp-setup-tool.tsx's working-state buttons) — kept as the
+                // accessible name in both states so a screen reader doesn't
+                // read this control as unlabeled while it fetches.
+                aria-label={t.assistant.thread.showEarlier}
+                className="mx-auto mb-(--conversation-turn-gap) rounded-full border border-border/65 bg-(--composer-fill) px-3 py-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-70"
+                disabled={expandingWindow}
                 onClick={showEarlier}
                 type="button"
               >
-                {t.assistant.thread.showEarlier}
+                {expandingWindow ? <Loader2 aria-hidden className="mx-auto size-3 animate-spin" /> : t.assistant.thread.showEarlier}
               </button>
             )}
             {rows}

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-window.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-window.test.ts
@@ -1,6 +1,18 @@
+import { renderHook } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
-import { resolveShowEarlierAction } from './transcript-window'
+import { resolveShowEarlierAction, useTranscriptWindow } from './transcript-window'
+
+describe('useTranscriptWindow', () => {
+  it('defaults expandingWindow to false outside a Provider', () => {
+    // A "Show earlier" click never shows a loading state before the boundary
+    // above sets up the real value — no Provider must never read as "loading".
+    const { result } = renderHook(() => useTranscriptWindow())
+
+    expect(result.current.olderAvailable).toBe(false)
+    expect(result.current.expandingWindow).toBe(false)
+  })
+})
 
 describe('resolveShowEarlierAction', () => {
   it('spends the already-materialized DOM page first', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
@@ -5,11 +5,18 @@ export interface TranscriptWindowValue {
   olderAvailable: boolean
   /** Pull one more page of older messages out of the session store. */
   expandWindow: () => void
+  /** A REST backfill triggered by expandWindow() is in flight. The DOM-budget
+   *  path (already-materialized content) never sets this — only the fetch. A
+   *  click that resolves to "nothing more" is otherwise silent (#90473): the
+   *  request completes, the flag that made the control visible corrects
+   *  itself, and the button just vanishes with no sign a click did anything. */
+  expandingWindow: boolean
 }
 
 const TranscriptWindowContext = createContext<TranscriptWindowValue>({
   olderAvailable: false,
-  expandWindow: () => {}
+  expandWindow: () => {},
+  expandingWindow: false
 })
 
 export function TranscriptWindowProvider({ children, value }: { children: ReactNode; value: TranscriptWindowValue }) {


### PR DESCRIPTION
## What does this PR do?

**Scope note added after opening this PR:** #87686 and #87972 (open) independently diagnosed a more direct root cause for "Show earlier does nothing" — a render-phase budget cap (regression from `62eefff697`) that reverts the DOM budget increase on the very next render, for every click, regardless of whether there's more to load. That is very likely the PRIMARY explanation for the dead-button reports on #90473, not the mechanism below. This PR is now better understood as a smaller, complementary fix, not the main one — see #87972's description for the likely real fix.

What this PR actually addresses: `expandWindow()`'s REST backfill (triggered by clicking "Show earlier") is explicitly fire-and-forget — no loading state, no outcome feedback. When the click resolves to "nothing more" (which happens whenever `possiblyTruncated`'s "last page came back full → probably more" heuristic is a false positive — e.g. a session's message count sitting on an exact page boundary), the request completes, the flag that made the control visible corrects itself, and the button just vanishes with no sign anything happened. That gap is real and independent of the render-budget-cap bug above — it will still apply once #87686/#87972 land, whenever a click legitimately exhausts both the DOM budget and the store window and falls through to the network path.

This was reported on #90473 after #90928 merged (a visible-button/no-op-click report, and a separate reconnect/cold-hydration reproduction) — at the time I read both as describing this mechanism; #87686/#87972 make a stronger case that the DOM-budget-cap bug is what most users actually hit first, since "Show earlier" spends the DOM budget before ever reaching the network path this PR covers.

This is the narrow fix either way — not the broader redesign #80680's analysis describes (dedicated display-history projection, reverse pagination, compression-lineage reconstruction), which needs an architectural decision this PR doesn't make.

## Related Issue

Related to #90473 (does not close it — the open discussion covers more than this piece; #90928 already addresses the backend reachability portion).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx` — add `expandingWindow: boolean` to `TranscriptWindowValue`, defaulted `false`.
- `apps/desktop/src/app/chat/index.tsx` — track it around the backfill fetch in `expandWindow()` (set true before, `.finally()` false after); reset on session swap alongside the existing `windowPages` reset (`#55191`'s pattern) so a fetch in flight for a previous session can't paint a stale loading state on a different one.
- `apps/desktop/src/components/assistant-ui/thread/list.tsx` — the button disables and swaps its label for a spinner while pending, matching the existing working-state pattern in `mcp-setup-tool.tsx` elsewhere in this codebase. Kept an `aria-label` constant across both states so the accessible name doesn't disappear while loading (a small correction on the reference pattern, which doesn't have one either).
- `apps/desktop/src/components/assistant-ui/thread/transcript-window.test.ts` — covers the new context default.

## How to Test

1. Open a long session where the store window is already fully materialized but the REST tail was truncated (`possiblyTruncated: true` with nothing actually older — e.g. total message count sitting on an exact multiple of the page limit).
2. Click "Show earlier". Before this change: nothing visibly happens until the button silently vanishes. After: the button shows a spinner and disables for the duration of the fetch.
3. `npm run typecheck`, `npx eslint` on the four changed files, `npm run test:ui` — all clean (see below).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits (`fix(desktop): ...`)
- [x] I searched for existing PRs/issues first — this thread (#90473, #80680, #80141, #69640, #52816) and #90928 specifically to avoid overlapping its scope
- [x] My PR contains only changes related to this fix
- [x] Tests: this is a JS/TS-only change (no Python touched), so the Python `pytest tests/ -q` checklist item doesn't apply — ran the JS-equivalent instead: `npm run typecheck` (clean, all 3 tsconfig projects), `npx eslint` on the changed files (clean), and `npm run test:ui` (full project: **562 files, 5363 tests, 0 failures** — differential-clean, nothing existing broken)
- [x] Added a test for the change (context default)
- [x] Platform: verified on macOS (Node 22.23.2, this repo's own `engine-strict` requirement)

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas touched
- [x] Cross-platform: this is a pure React/TS state + JSX change (no OS-specific API), so no platform-specific impact expected

## Screenshots / Logs

```
Test Files  562 passed (562)
     Tests  5363 passed (5363)
```
