### PR TITLE
fix(gateway): close Host in the Shell RCE vulnerability

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1086,16 +1086,14 @@ class GatewaySlashCommandsMixin:
         # the same owner — fail closed.
         return False
 
-    def _resume_caller_is_admin(self, source: SessionSource) -> bool:
-        """Whether *source* is an EXPLICITLY-configured admin allowed to make a
-        cross-origin /resume or /sessions listing.
+    def _caller_is_explicit_admin(self, source: SessionSource) -> bool:
+        """Whether *source* is an explicitly configured gateway admin.
 
         Deliberately stricter than ``SlashAccessPolicy.is_admin()``: that returns
         True for every allowed caller when slash gating is DISABLED (so commands
-        stay runnable by default), but cross-ORIGIN DATA ACCESS must require a
-        real, configured admin. Otherwise the default (no admin list) config
-        would treat every gateway caller as cross-origin-capable and re-open the
-        enumeration IDOR.
+        stay runnable by default). Security-sensitive operations must require a
+        real configured admin instead of treating backward-compatible unrestricted
+        slash access as administrative identity.
         """
         try:
             from gateway.slash_access import policy_for_source
@@ -1104,6 +1102,10 @@ class GatewaySlashCommandsMixin:
             return bool(policy.enabled and uid and policy.is_admin(uid))
         except Exception:
             return False
+
+    def _resume_caller_is_admin(self, source: SessionSource) -> bool:
+        """Whether *source* may access cross-origin session data as an admin."""
+        return self._caller_is_explicit_admin(source)
 
     async def _resume_target_allowed(
         self, source: SessionSource, target_id: str, allow_override: bool = False
@@ -2795,6 +2797,21 @@ class GatewaySlashCommandsMixin:
             if not gate_arg or gate_lower == "list":
                 return mgr.render_gates()
             if gate_lower.startswith("add "):
+                # SECURITY: a gate is persisted and later executed with
+                # shell=True at a turn boundary. Letting an allowed but
+                # non-admin gateway sender choose that string is authenticated
+                # remote code execution under the Hermes process account.
+                # Backward-compatible slash access treats every allowed sender
+                # as unrestricted when no admin list is set, but that must not
+                # silently grant host-shell authority. Require a real
+                # scope-specific admin entry for this one mutation; listing and
+                # removing gates remain available for recovery.
+                if not self._caller_is_explicit_admin(event.source):
+                    return (
+                        "⛔ /goal gate add requires an explicitly configured "
+                        "gateway admin (allow_admin_from for DMs or "
+                        "group_allow_admin_from for groups)."
+                    )
                 command = gate_arg[len("add"):].strip()
                 try:
                     gate = mgr.add_gate(command)

--- a/tests/gateway/test_goal_gate_access.py
+++ b/tests/gateway/test_goal_gate_access.py
@@ -1,0 +1,131 @@
+"""Gateway authorization tests for shell-backed goal quality gates."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+def _source(user_id: str = "user-1", *, chat_type: str = "dm") -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        user_id=user_id,
+        chat_id=f"{chat_type}-1",
+        chat_type=chat_type,
+    )
+
+
+def _runner(*, admins=(), group_admins=()):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                extra={
+                    "allow_admin_from": list(admins),
+                    "group_allow_admin_from": list(group_admins),
+                },
+            )
+        }
+    )
+    manager = MagicMock()
+    manager.add_gate.return_value = SimpleNamespace(
+        command="touch /tmp/host-in-the-shell",
+        max_retries=3,
+        timeout_seconds=300,
+    )
+    runner._get_goal_manager_for_event = AsyncMock(
+        return_value=(manager, SimpleNamespace(session_id="session-1"))
+    )
+    return runner, manager
+
+
+def _event(user_id: str = "user-1", *, chat_type: str = "dm"):
+    event = MagicMock()
+    event.source = _source(user_id, chat_type=chat_type)
+    event.get_command_args.return_value = (
+        "gate add touch /tmp/host-in-the-shell"
+    )
+    return event
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("admins", "user_id"),
+    [
+        ((), "user-1"),
+        (("admin-1",), "user-1"),
+    ],
+)
+async def test_gateway_gate_add_requires_explicit_admin(admins, user_id):
+    """Allowed chat users must not turn /goal into an unrestricted host shell."""
+    from gateway.run import GatewayRunner
+
+    runner, manager = _runner(admins=admins)
+
+    result = await GatewayRunner._handle_goal_command(runner, _event(user_id))
+
+    assert "explicitly configured gateway admin" in result
+    manager.add_gate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gateway_explicit_admin_can_add_goal_gate():
+    """The fix preserves the documented quality-gate capability for operators."""
+    from gateway.run import GatewayRunner
+
+    runner, manager = _runner(admins=("admin-1",))
+
+    result = await GatewayRunner._handle_goal_command(runner, _event("admin-1"))
+
+    assert "Gate added" in result
+    manager.add_gate.assert_called_once_with(
+        "touch /tmp/host-in-the-shell"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_group_gate_add_uses_group_admin_scope():
+    """DM admin status must not silently grant host-shell access in groups."""
+    from gateway.run import GatewayRunner
+
+    runner, manager = _runner(
+        admins=("dm-admin",),
+        group_admins=("group-admin",),
+    )
+
+    denied = await GatewayRunner._handle_goal_command(
+        runner,
+        _event("dm-admin", chat_type="group"),
+    )
+    allowed = await GatewayRunner._handle_goal_command(
+        runner,
+        _event("group-admin", chat_type="group"),
+    )
+
+    assert "explicitly configured gateway admin" in denied
+    assert "Gate added" in allowed
+    manager.add_gate.assert_called_once_with(
+        "touch /tmp/host-in-the-shell"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_non_admin_can_still_list_goal_gates():
+    """Non-admins retain read-only visibility into the active goal's gates."""
+    from gateway.run import GatewayRunner
+
+    runner, manager = _runner(admins=("admin-1",))
+    manager.render_gates.return_value = "- 1. $ scripts/run_tests.sh"
+    event = _event("user-1")
+    event.get_command_args.return_value = "gate list"
+
+    result = await GatewayRunner._handle_goal_command(runner, event)
+
+    assert result == "- 1. $ scripts/run_tests.sh"
+    manager.render_gates.assert_called_once_with()

--- a/website/docs/user-guide/features/goals.md
+++ b/website/docs/user-guide/features/goals.md
@@ -71,7 +71,11 @@ What you'll see:
 | `/goal gate remove <N>` | Remove the Nth gate (1-based). |
 | `/goal gate clear` | Remove all gates. |
 
-Works identically on the CLI and every gateway platform (Telegram, Discord, Slack, Matrix, Signal, WhatsApp, SMS, iMessage, Webhook, API server, and the web dashboard).
+Goal controls work on the CLI and every gateway platform (Telegram, Discord, Slack, Matrix, Signal, WhatsApp, SMS, iMessage, Webhook, API server, and the web dashboard).
+
+Quality-gate creation is currently exposed by the classic CLI and messaging gateway. The TUI and Desktop can execute gates already persisted on a resumed session but do not expose `gate add`.
+
+Because a quality gate executes a shell command on the Hermes host, gateway users may add gates only when their ID is explicitly listed in `allow_admin_from` for DMs or `group_allow_admin_from` for groups. Listing and removing gates remain available to other allowed gateway users; local CLI behavior is unchanged.
 
 ## Completion contracts
 


### PR DESCRIPTION
## What does this PR do?

This fixes the **Host in the Shell vulnerability** — the name used in this PR for an authenticated remote-code-execution path in gateway goal quality gates.

An allowed gateway user could send `/goal gate add <command>`. Hermes persisted that caller-controlled string and later executed it with `shell=True` under the Hermes process account. When no slash-admin list was configured—the backward-compatible default—every allowed chat user was treated as unrestricted, so a non-admin could reach the host shell without terminal approval.

The fix keeps ordinary slash commands backward compatible while requiring a real, scope-specific gateway admin entry for the one operation that creates executable host state.

### Behavior by surface

| Surface | Before | After |
|---|---|---|
| Messaging gateway, no admin list configured | Any allowed user could add an arbitrary shell gate | `gate add` is denied |
| Messaging gateway, allowed non-admin | Could add an arbitrary shell gate | `gate add` is denied |
| Messaging gateway, explicit DM admin | Could add a gate | Still allowed through `allow_admin_from` |
| Messaging gateway, explicit group admin | Could add a gate | Still allowed through `group_allow_admin_from` |
| Classic CLI | Could add and run gates locally | Unchanged |
| Ink TUI / Desktop | Cannot create gates through `gate add`; can execute an already-persisted gate | Unchanged |

## Related Issue

No public issue. Security finding: the **Host in the Shell vulnerability**.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extract the existing strict explicit-admin check so session-data access and shell-backed gate creation share one fail-closed policy.
- Require `allow_admin_from` for DM gate creation and `group_allow_admin_from` for group gate creation.
- Preserve read-only gate listing and existing local CLI/TUI/Desktop behavior.
- Document the host-shell boundary and current surface behavior.
- Add behavioral regression coverage for default-open slash access, configured non-admins, DM admins, group admins, and non-admin gate listing.

## How to Test

1. Configure an allowed gateway user without a matching explicit admin entry.
2. Send `/goal gate add touch /tmp/host-in-the-shell`; Hermes should deny it and persist no gate.
3. Add the same user to the scope-appropriate admin list and retry; Hermes should add the gate.
4. Run the focused suites below.

## Verification

- [x] RED: the new authorization test failed in both vulnerable cases before the implementation.
- [x] `scripts/run_tests.sh tests/gateway/test_goal_gate_access.py -q`
- [x] `scripts/run_tests.sh tests/gateway/test_resume_command.py tests/gateway/test_goal*.py tests/gateway/test_slash_access.py tests/gateway/test_slash_access_dispatch.py tests/tui_gateway/test_goal_command.py tests/hermes_cli/test_goal_gates.py -q` — 87 passed
- [x] `python -m compileall -q gateway/slash_commands.py tests/gateway/test_goal_gate_access.py`
- [x] `git diff --check`

## Security notes

This is authenticated RCE, not shell injection: the gateway sender controls the complete gate command, and the goal engine later executes it with `shell=True`. The vulnerable principal is an allowed chat user who has not been explicitly trusted as a gateway admin.

Explicit gateway admins retain gate creation because those IDs are the operator-configured host-trust boundary. The change does not globally flip slash access to fail-closed and does not remove quality gates from the local CLI.

## Checklist

### Code

- [x] I've read the Contributing Guide and repository instructions
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the full repository test suite
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] I've updated the relevant goals documentation
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the policy is platform-independent
- [x] Tool description/schema update is N/A
