### PR TITLE
fix(models): list claude-opus-5 in the curated Anthropic catalog

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -194,6 +194,47 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://openai.com/index/previewing-gpt-5-6-sol/",
         pricing_version="openai-gpt-5.6-2026-07",
     ),
+    # ── Anthropic Claude Opus 5 ──────────────────────────────────────────
+    # Same $5/$25 base pricing as the 4.6-4.8 line. Fast-mode variant is a
+    # separate model ID with 2x premium. Dated snapshot 20260723 shares
+    # base pricing.
+    # Source: https://platform.claude.com/docs/en/about-claude/pricing
+    (
+        "anthropic",
+        "claude-opus-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-07",
+    ),
+    (
+        "anthropic",
+        "claude-opus-5-20260723",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("5.00"),
+        output_cost_per_million=Decimal("25.00"),
+        cache_read_cost_per_million=Decimal("0.50"),
+        cache_write_cost_per_million=Decimal("6.25"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-07",
+    ),
+    (
+        "anthropic",
+        "claude-opus-5-fast",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("10.00"),
+        output_cost_per_million=Decimal("50.00"),
+        cache_read_cost_per_million=Decimal("1.00"),
+        cache_write_cost_per_million=Decimal("12.50"),
+        source="official_docs_snapshot",
+        source_url="https://openrouter.ai/anthropic/claude-opus-5-fast",
+        pricing_version="anthropic-pricing-2026-07",
+    ),
     # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
     # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate
     # model ID with 2x premium (vs the 6x premium on older Opus generations).

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -445,6 +445,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "anthropic": [
         "claude-fable-5",
+        "claude-opus-5",
         "claude-sonnet-5",
         "claude-opus-4-8",
         "claude-opus-4-7",

--- a/tests/hermes_cli/test_anthropic_picker_curated.py
+++ b/tests/hermes_cli/test_anthropic_picker_curated.py
@@ -33,6 +33,28 @@ def test_anthropic_curated_alias_survives_when_live_omits_it():
     assert result[:len(curated)] == list(curated)
 
 
+def test_anthropic_curated_opus_5_listed_for_oauth_subscriptions():
+    """Opus 5 stays in the picker when the live models endpoint 401s.
+
+    Subscription OAuth tokens are rejected by Anthropic's platform-API
+    /v1/models endpoint, so Claude Pro/Max users always fall back to the
+    curated list — it must carry the current flagship (claude-opus-5),
+    mirroring OPENROUTER_MODELS / opencode-zen which already list it.
+    """
+    curated = M._PROVIDER_MODELS["anthropic"]
+    assert "claude-opus-5" in curated
+
+    with patch.object(M, "_fetch_anthropic_models", return_value=None):
+        result = M.provider_model_ids("anthropic")
+
+    assert "claude-opus-5" in result
+    # And when live succeeds, curated-first merge keeps it too.
+    live = ["claude-opus-4-8", "claude-sonnet-4-6"]
+    with patch.object(M, "_fetch_anthropic_models", return_value=live):
+        merged = M.provider_model_ids("anthropic")
+    assert "claude-opus-5" in merged
+
+
 def test_anthropic_merge_dedupes_overlap_and_appends_live_only():
     """Models in both lists appear once; live-only models are appended."""
     live = [


### PR DESCRIPTION
## Summary

- `claude-opus-5` was missing from the curated `_PROVIDER_MODELS["anthropic"]` list in `hermes_cli/models.py` — it is present in `OPENROUTER_MODELS`, the `nous` catalog, `opencode-zen`, and `reasoning_timeouts.py`, but absent from the one list native-Anthropic pickers render.
- Anthropic's `/v1/models` endpoint **401s subscription OAuth tokens** (Claude Pro/Max), so for subscription users the picker always falls back to the curated list — hiding the current flagship entirely. (The model itself works fine when addressed directly.)
- Adds official-docs pricing entries for `claude-opus-5`, `claude-opus-5-fast` (2x), and the `claude-opus-5-20260723` dated snapshot — same $5/$25 line as 4.6-4.8, per the OpenRouter model metadata.
- Adds a regression test pinning the curated-list fallback path for OAuth subscriptions (extends `tests/hermes_cli/test_anthropic_picker_curated.py`).

## Root cause chain

1. Claude Max OAuth setup succeeds (`hermes auth add anthropic --type oauth`) and inference works — sessions run on `claude-opus-5`.
2. The model picker calls `provider_model_ids("anthropic")`, which tries the live `/v1/models` fetch first.
3. The platform-API endpoint rejects subscription tokens with HTTP 401 → `_fetch_anthropic_models()` returns `None`.
4. Fallback returns the curated list verbatim — which never added Opus 5.

## Test plan

- [x] `pytest tests/hermes_cli/test_anthropic_picker_curated.py` — 4 passed (3 existing + 1 new)
- [x] `pytest tests/agent/test_usage_pricing.py tests/agent/test_anthropic_thinking_disable.py tests/agent/test_anthropic_billing_guidance.py` — 78 passed
- [x] Broader sweep (adapter, request-client-reuse, aux client, error classifier, reasoning floor, model_normalize): 541 passed, 9 pre-existing env failures (identical on clean base with changes stashed — scratch-venv dependency/mock quirks, not from this change)

🤖 This PR was created with [Hermes Agent](https://github.com/NousResearch/hermes-agent)