### PR TITLE
fix(desktop): self-heal a deleted profile, and ad-hoc sign the macOS bundle

### DIFF
--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -19,16 +19,62 @@
  *   - packager.appInfo.productFilename: the exe basename (e.g. 'Hermes')
  */
 
+import { execFile } from 'node:child_process'
 import path from 'node:path'
+import { promisify } from 'node:util'
 
 import { stampExeIdentity } from './set-exe-identity.mjs'
 
+const run = promisify(execFile)
+
+/**
+ * Re-sign the macOS bundle ad-hoc when electron-builder left it unsigned.
+ *
+ * Without a Developer ID, electron-builder skips signing and the bundle keeps
+ * Electron's own linker-signed signature — which our resources invalidate
+ * ("code has no resources but signature indicates they must be present"), and
+ * whose identifier is the generic `Electron`. macOS binds a keychain ACL to a
+ * VERIFIED code identity, so an invalid signature means "Always Allow" on the
+ * safeStorage prompt can never stick: every launch and every token read
+ * re-prompts for the login keychain password.
+ *
+ * An ad-hoc signature is enough to fix that — it yields a stable identity
+ * (com.nousresearch.hermes) with sealed resources. We only touch a bundle that
+ * FAILS verification, so a real Developer ID signature is never clobbered.
+ */
+async function adhocSignMac(appPath) {
+  try {
+    await run('codesign', ['--verify', '--deep', '--strict', appPath])
+
+    return
+  } catch {
+    // Unsigned or invalid — fall through and ad-hoc sign.
+  }
+
+  await run('codesign', ['--force', '--deep', '--sign', '-', appPath])
+  await run('codesign', ['--verify', '--deep', '--strict', appPath])
+}
+
 export default async function afterPack(context) {
+  const productName = context.packager?.appInfo?.productFilename || 'Hermes'
+
+  if (context.electronPlatformName === 'darwin') {
+    const appPath = path.join(context.appOutDir, `${productName}.app`)
+
+    try {
+      await adhocSignMac(appPath)
+    } catch (err) {
+      // Never fail the build; the cost is the recurring keychain prompt.
+      console.warn(`[after-pack] ad-hoc codesign failed (${err.message}); expect repeated keychain prompts`)
+    }
+
+    return
+  }
+
   if (context.electronPlatformName !== 'win32') {
     return
   }
 
-  const productName = context.packager?.appInfo?.productFilename || 'Hermes'
   const exe = path.join(context.appOutDir, `${productName}.exe`)
   const desktopRoot = path.resolve(import.meta.dirname, '..')
 

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -26,6 +26,7 @@ const {
   ensureGatewayProfile,
   invalidateProfileListFetches,
   prewarmProfileBackend,
+  refreshActiveProfile,
   refreshProfiles
 } = await import('./profile')
 
@@ -114,6 +115,44 @@ describe('ensureGatewayProfile → $connection sync (#46651)', () => {
     expect(getConnection).not.toHaveBeenCalled()
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
     expect($connection.get()?.mode).toBe('remote')
+  })
+})
+
+describe('stale profile self-heal', () => {
+  // The remote dropped `teacher`, but a restored session / saved route still
+  // points at it. Without a guard every profile-scoped call answers
+  // 404 `Profile 'teacher' does not exist.` and the app wedges.
+  it('activates default instead of a profile the backend does not report', async () => {
+    $profiles.set([profile('default', true), profile('hermes-cardinal')])
+    $activeGatewayProfile.set('hermes-cardinal')
+    getConnection.mockResolvedValue(localConn())
+
+    await ensureGatewayProfile('teacher')
+
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('default')
+    expect(ensureGatewayForProfile).not.toHaveBeenCalledWith('teacher')
+    expect($activeGatewayProfile.get()).toBe('default')
+  })
+
+  it('drops an already-active profile once the real list omits it', async () => {
+    $activeGatewayProfile.set('teacher')
+    getConnection.mockResolvedValue(localConn())
+    vi.mocked(getProfiles).mockResolvedValueOnce({
+      profiles: [profile('default', true), profile('hermes-cardinal')]
+    })
+
+    await refreshActiveProfile()
+
+    expect($activeGatewayProfile.get()).toBe('default')
+  })
+
+  it('leaves the target alone while the profile list is still empty', async () => {
+    // Pre-list boot: an unfetched list must not be read as "nothing exists".
+    getConnection.mockResolvedValue(remoteConn())
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('vps-remote')
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -157,6 +157,7 @@ export async function refreshActiveProfile(): Promise<void> {
 
   try {
     await refreshProfiles()
+    await reconcileGatewayProfile()
   } catch {
     // Leave the cached list in place.
   }
@@ -188,6 +189,27 @@ export async function switchProfile(name: string): Promise<void> {
 // eviction fallbacks (idle reap, connection removal, profile delete) can never
 // leave this naming a profile the active socket no longer serves (#89206).
 export const $activeGatewayProfile = atom<string>('default')
+
+// True when `key` is a profile the backend actually reports. "default" is the
+// root home so it always passes, and an empty list means "not fetched yet" —
+// neither is second-guessed, so a pre-list boot behaves exactly as before.
+function profileIsKnown(key: string): boolean {
+  const profiles = $profiles.get()
+
+  return (
+    key === 'default' || profiles.length === 0 || profiles.some(entry => normalizeProfileKey(entry.name) === key)
+  )
+}
+
+// Drop an active profile the backend no longer has. A profile deleted or
+// renamed on the remote otherwise stays pinned here, and every profile-scoped
+// REST call 404s `Profile 'x' does not exist` — unhandled, so the whole app
+// wedges behind a name nothing can serve. Fall back to the root home.
+async function reconcileGatewayProfile(): Promise<void> {
+  if (!profileIsKnown(normalizeProfileKey($activeGatewayProfile.get()))) {
+    await ensureGatewayProfile('default')
+  }
+}
 
 // Profile for the NEXT new chat (chosen via the new-chat picker). null = primary
 // / default, so single-profile users are unaffected.
@@ -319,7 +341,11 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     return
   }
 
-  const target = normalizeProfileKey(profile)
+  const requested = normalizeProfileKey(profile)
+  // A stale target — a restored session, saved route, or plugin pointing at a
+  // profile the backend no longer has — would pin every profile-scoped request
+  // to a 404. Activate the root home instead of a name that doesn't exist.
+  const target = profileIsKnown(requested) ? requested : 'default'
 
   if (normalizeProfileKey($activeGatewayProfile.get()) === target && $gateway.get()) {
     return

--- a/contributors/emails/info@pmcardinal.com
+++ b/contributors/emails/info@pmcardinal.com
@@ -1,0 +1,2 @@
+cardinalconseils
+# PR #2 (dashboard-auth: process-global provider scope)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -2397,7 +2397,14 @@ class PluginContext:
             )
             return
         registry_name = provider.name
-        scope = self._manager.scope_key
+        # The dashboard auth gate is process-global: one HTTP listener serves
+        # every profile, and its middleware runs under whatever home the
+        # current request is scoped to (``--open-profile``, ``?profile=``).
+        # Registering per-home means the gate looks the provider up under a
+        # home it was never registered against and fails closed -- 503 on
+        # /api/auth/providers, "Sign-in unavailable", and valid sessions
+        # rejected as expired. Register globally so every scope sees it.
+        scope = None
         previous = snapshot_registration(registry_name, scope=scope)
         try:
             register_provider(provider, scope=scope)

--- a/tests/test_dashboard_auth_provider_scope.py
+++ b/tests/test_dashboard_auth_provider_scope.py
@@ -1,0 +1,87 @@
+"""Dashboard-auth providers must stay visible under every home scope.
+
+One dashboard process serves every profile: it is launched with
+``--open-profile`` and handles ``?profile=<name>`` requests, each of which runs
+under ``set_hermes_home_override``. The auth gate reads the provider registry
+inside that override.
+
+Registering the provider per-home therefore broke the gate — it looked the
+provider up under a home it was never registered against, found nothing, and
+failed closed: ``/api/auth/providers`` 503, ``/login`` "Sign-in unavailable",
+and valid sessions rejected as ``invalid_or_expired_session``.
+"""
+
+from hermes_cli.dashboard_auth import registry
+from hermes_constants import (
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+
+
+class _StubProvider:
+    """Minimal provider satisfying ``assert_protocol_compliance``."""
+
+    name = "stub"
+    display_name = "Stub"
+    supports_password = True
+    supports_session = True
+
+    # Never called here — this test is about registry visibility, not auth.
+    def start_login(self, redirect_uri):  # pragma: no cover
+        raise NotImplementedError
+
+    def complete_login(self, *a, **kw):  # pragma: no cover
+        raise NotImplementedError
+
+    def verify_session(self, *a, **kw):  # pragma: no cover
+        raise NotImplementedError
+
+    def refresh_session(self, *a, **kw):  # pragma: no cover
+        raise NotImplementedError
+
+    def revoke_session(self, *a, **kw):  # pragma: no cover
+        raise NotImplementedError
+
+
+def test_provider_visible_under_a_different_home_override(tmp_path):
+    launch_home = tmp_path / "launch"
+    other_profile = tmp_path / "profiles" / "other"
+    launch_home.mkdir(parents=True)
+    other_profile.mkdir(parents=True)
+
+    provider = _StubProvider()
+    # scope=None is what PluginContext.register_dashboard_auth_provider uses:
+    # the gate is process-global, so the registration must be too.
+    registry.register_provider(provider, scope=None)
+    try:
+        assert provider in registry.list_providers()
+
+        # A profile-scoped request: the gate now runs under another home.
+        token = set_hermes_home_override(str(other_profile))
+        try:
+            assert provider in registry.list_providers(), (
+                "provider vanished under a profile-scoped home override"
+            )
+            assert registry.get_provider("stub") is provider
+            assert provider in registry.list_session_providers()
+        finally:
+            reset_hermes_home_override(token)
+    finally:
+        registry.clear_providers()
+
+
+def test_per_home_registration_is_invisible_to_other_scopes(tmp_path):
+    """Guards the regression itself: scoping this registry by home is what broke."""
+    other_profile = tmp_path / "profiles" / "other"
+    other_profile.mkdir(parents=True)
+
+    provider = _StubProvider()
+    registry.register_provider(provider, scope=str(tmp_path / "launch"))
+    try:
+        token = set_hermes_home_override(str(other_profile))
+        try:
+            assert provider not in registry.list_providers()
+        finally:
+            reset_hermes_home_override(token)
+    finally:
+        registry.clear_providers()


### PR DESCRIPTION
Two independent desktop bug fixes found while debugging a remote gateway that had lost a profile. Happy to split into separate PRs if preferred.

## 1. A profile deleted on the backend wedges the app

When the desktop runs in app-global remote mode, `pathWithGlobalRemoteProfile` appends `?profile=<name>` to every profile-scoped REST call. If that profile no longer exists on the backend, `_resolve_profile_dir` answers `404 {"detail":"Profile 'x' does not exist."}` on the ~58 endpoints behind `_profile_scope()` — config, env, skills, toolsets, model, analytics, media.

Nothing reconciled the active profile against the real list: `ensureGatewayProfile` accepted any name, and `adoptPrimaryProfile` only fell back when the preference was *absent*, never when it was *stale*. A restored session (`hermes.desktop.lastSessionId.<profile>` in localStorage) re-pinned the dead name on every boot, so the app stayed wedged with unhandled rejections.

Fix — one predicate, two entry points, both in `src/store/profile.ts`:

- `profileIsKnown()` — `default` always passes (it's the root home), and an **empty** list means "not fetched yet" and also passes, so pre-list boot behaves exactly as before.
- `ensureGatewayProfile()` routes an unknown target to `default` instead of activating a name nothing can serve. This is the funnel every path uses — session restore, saved routes, plugins, slash commands, rail clicks.
- `refreshActiveProfile()` reconciles once the real list lands, so a profile that disappears server-side self-heals on the next boot.

Deliberately *not* calling `window.hermesDesktop.profile.set()` from the guard — that tears down the primary backend and reloads the window, which would loop.

## 2. macOS keychain re-prompts forever without a Developer ID

With no signing identity, electron-builder skips signing and the bundle keeps Electron's linker-signed signature — which the app's own resources invalidate:

```
Signature=adhoc, linker-signed   Identifier=Electron   Sealed Resources=none
codesign --verify → "code has no resources but signature indicates they must be present"
```

macOS binds a keychain ACL to a *verified* code identity, so with an invalid signature "Always Allow" on the `safeStorage` prompt can never stick — every launch and every token read re-prompts for the login keychain password. Clicking "Always Allow" genuinely does nothing.

Ad-hoc signing in the existing `afterPack` hook yields a stable identity (`com.nousresearch.hermes`) with sealed resources, which is enough for the ACL to hold. Only bundles that **fail** verification are touched, so a real Developer ID signature is never clobbered, and a failure warns rather than failing the build.

## Testing

- 3 new cases in `src/store/profile.test.ts` (unknown target → `default`; active profile dropped once the real list omits it; empty list leaves the target alone).
- Full desktop suite: **4342 passed, 1 failed, 2 skipped**. The single failure is `electron/git-review-ops.test.ts` → "reviewList caps the file payload returned to the renderer", which passes **9/9 in isolation on both this branch and the base commit** — a pre-existing flake under parallel load, unrelated to these changes.
- `tsc -p . --noEmit` and `eslint` clean.
- macOS: verified `codesign --verify --deep --strict` passes after the hook, and no-ops on an already-valid bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)