### PR TITLE
fix(approval): git restore and git checkout -- <path> discard uncommitted work unprompted

### DIFF
--- a/tests/tools/test_git_worktree_destructive.py
+++ b/tests/tools/test_git_worktree_destructive.py
@@ -44,6 +44,19 @@ _DESTROYS_UNCOMMITTED_WORK = [
     # git checkout forced
     "git checkout -f",
     "git checkout --force main",
+    # git switch — the modern replacement for the branch half of checkout.
+    # `--discard-changes` is aliased `-f` / `--force`.
+    "git switch --discard-changes main",
+    "git switch -f main",
+    "git switch --force main",
+    # flags that overwrite the working tree without ever spelling `--`
+    "git checkout --pathspec-from-file=paths.txt",
+    "git restore --pathspec-from-file=paths.txt",
+    "git checkout --ours -- app.py",
+    "git checkout --theirs app.py",
+    # a path that merely CONTAINS the text of the exemption flag must not
+    # suppress the prompt for the whole segment
+    "git restore -- ./--staged",
     # still caught when it is not the first command in the line
     "cd /repo && git restore .",
     "git fetch && git checkout -- .",
@@ -60,6 +73,10 @@ _MUST_NOT_PROMPT = [
     "git checkout --track origin/x",
     "git checkout -t origin/x",
     "git switch main",
+    "git switch -c feature/x",
+    "git switch --create feature/x",
+    "git switch --track origin/x",
+    "git restore --staged --pathspec-from-file=paths.txt",
     # ordinary read-only or additive git
     "git status",
     "git log --oneline",
@@ -102,3 +119,40 @@ def test_restore_and_checkout_report_distinct_descriptions():
     assert restore_desc != checkout_desc
     assert "restore" in restore_desc.lower()
     assert "checkout" in checkout_desc.lower()
+
+
+def test_glued_pathspec_spellings_are_not_gated_because_git_rejects_them():
+    """`git checkout --"$f"` is one shell word, and git errors on it.
+
+    Verified against git itself: in a repo with a modified `f.py`,
+    `git checkout --"f.py"` prints `error: unknown option 'f.py'` and leaves the
+    file modified. The shell glues `--` to the expansion, so git never sees the
+    `--` separator followed by a pathspec. Gating the glued form would add a
+    prompt on a command that discards nothing, which is why the pattern
+    requires whitespace on both sides of `--`.
+    """
+    for command in ('git checkout --"$f"', "git checkout --'app.py'", "git checkout --app.py"):
+        assert detect_dangerous_command(command)[0] is False, command
+    # The spaced form -- the one git actually honours -- is gated.
+    assert detect_dangerous_command('git checkout -- "$f"')[0] is True
+
+
+def test_non_ascii_whitespace_still_reaches_the_patterns():
+    """Every fixture above uses plain ASCII spaces.
+
+    If `_normalize_command_for_detection` ever stops folding NBSP and friends,
+    every pattern in this file silently stops matching and the suite stays
+    green. This pins the normalization contract the patterns depend on.
+    """
+    assert detect_dangerous_command("git\u00a0restore .")[0] is True      # NBSP after `git`
+    assert detect_dangerous_command("git restore\u00a0.")[0] is True      # NBSP before the pathspec
+
+
+def test_the_residual_this_does_not_cover_is_stated():
+    """A file named exactly `--staged`, after the `--` separator, is
+    indistinguishable from the flag by regex alone and still suppresses.
+
+    Recorded rather than hidden: if this ever starts returning True, the
+    pattern grew a real tokenizer and this test should be deleted, not fixed.
+    """
+    assert detect_dangerous_command("git restore -- --staged")[0] is False

--- a/tests/tools/test_git_worktree_destructive.py
+++ b/tests/tools/test_git_worktree_destructive.py
@@ -1,0 +1,104 @@
+"""`git restore` and `git checkout -- <path>` destroy uncommitted work too.
+
+`DANGEROUS_PATTERNS` has a block headed *"Git destructive operations that can
+lose uncommitted work or rewrite shared history"* (tools/approval.py, just above
+the `git reset --hard` entry). It covers `reset --hard`, `push --force`,
+`clean -f` and `branch -D` — and neither of the two other commands that
+overwrite the working tree from the index.
+
+Nothing recovers from either. The reflog holds commits; it does not hold
+unstaged edits.
+
+The gating is deliberately narrow on the `checkout` side. `git checkout <branch>`
+refuses rather than discards when it would lose changes, and `git checkout -b`
+creates; prompting on those would prompt on the most common git command there
+is. Only a pathspec (`--`, or a bare `.`) or `-f`/`--force` is matched.
+
+On the `restore` side the exclusion is `--staged` without `--worktree`, which is
+the unstage idiom and touches only the index. Short-flag spellings are treated
+as dangerous on purpose: `_normalize_command_for_detection` lowercases before
+matching, and git distinguishes `-S` (`--staged`) from `-s` (`--source`) by case
+alone, so after folding they are the same token. Failing closed there costs one
+prompt; failing open costs the file.
+"""
+
+import pytest
+
+from tools.approval import detect_dangerous_command
+
+
+_DESTROYS_UNCOMMITTED_WORK = [
+    # git restore — working tree is the default target
+    "git restore .",
+    "git restore src/",
+    "git restore src/app.py",
+    "git restore --source=HEAD~1 app.py",
+    "git restore -- .",
+    # --staged AND --worktree restores both, so the worktree is in scope
+    "git restore --staged --worktree app.py",
+    # git checkout with an explicit pathspec
+    "git checkout -- .",
+    "git checkout -- src/app.py",
+    "git checkout HEAD~1 -- app.py",
+    "git checkout .",
+    # git checkout forced
+    "git checkout -f",
+    "git checkout --force main",
+    # still caught when it is not the first command in the line
+    "cd /repo && git restore .",
+    "git fetch && git checkout -- .",
+]
+
+_MUST_NOT_PROMPT = [
+    # --staged alone restores the index only: the unstage idiom. Already
+    # treated as benign by tests/tools/test_self_repo_guard.py.
+    "git restore --staged pyproject.toml",
+    "git restore --staged .",
+    # switching branches refuses rather than discards
+    "git checkout main",
+    "git checkout -b feature/x",
+    "git checkout --track origin/x",
+    "git checkout -t origin/x",
+    "git switch main",
+    # ordinary read-only or additive git
+    "git status",
+    "git log --oneline",
+    "git diff",
+    "git add -A",
+    "git commit -m 'msg'",
+    "git stash",
+    "git fetch --all",
+]
+
+
+@pytest.mark.parametrize("command", _DESTROYS_UNCOMMITTED_WORK)
+def test_commands_that_overwrite_the_working_tree_are_dangerous(command):
+    is_dangerous, key, description = detect_dangerous_command(command)
+    assert is_dangerous is True, f"{command!r} discards uncommitted work unprompted"
+    assert description, f"{command!r} matched with no description"
+
+
+@pytest.mark.parametrize("command", _MUST_NOT_PROMPT)
+def test_non_destructive_git_is_not_dangerous(command):
+    is_dangerous, key, description = detect_dangerous_command(command)
+    assert is_dangerous is False, f"false positive on {command!r}: {description}"
+
+
+def test_the_siblings_this_matches_the_gating_of_still_fire():
+    """Controls: the two entries this block was modelled on.
+
+    If either of these stops matching, the new patterns are not the reason the
+    suite is green.
+    """
+    assert detect_dangerous_command("git reset --hard")[0] is True
+    assert detect_dangerous_command("git clean -fdx")[0] is True
+
+
+def test_restore_and_checkout_report_distinct_descriptions():
+    """A shared description would make the approval key collide, and an
+    approval keyed on the description is granted per category."""
+    _, _, restore_desc = detect_dangerous_command("git restore .")
+    _, _, checkout_desc = detect_dangerous_command("git checkout -- .")
+    assert restore_desc != checkout_desc
+    assert "restore" in restore_desc.lower()
+    assert "checkout" in checkout_desc.lower()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1050,6 +1050,32 @@ DANGEROUS_PATTERNS = [
     # later command in the same script.
     (r'\bgit\s+branch\b[^;|&\n]*?(?:-d\b|--delete\b)[^;|&\n]*?(?:-f\b|--force\b)', "git branch force delete (long flags)"),
     (r'\bgit\s+branch\b[^;|&\n]*?(?:-f\b|--force\b)[^;|&\n]*?(?:-d\b|--delete\b)', "git branch force delete (long flags, force-first)"),
+    # The two remaining ways to destroy uncommitted work, which the block
+    # above names in its own heading and does not cover. `git reset --hard`
+    # and `git clean -f` are gated; `git restore <pathspec>` and
+    # `git checkout -- <pathspec>` do the same thing to the working tree and
+    # were not. Neither is recoverable: the reflog holds commits, not
+    # unstaged edits.
+    #
+    # `git restore` writes the WORKING TREE unless `--staged` is given
+    # alone -- `--staged` restores only the index (the unstage idiom), and
+    # `--staged --worktree` together restore both. So: dangerous unless the
+    # segment carries `--staged` without `--worktree`. Only the long
+    # spellings are excluded, deliberately: `_normalize_command_for_detection`
+    # lowercases before matching, and git's short flags distinguish `-S`
+    # (--staged) from `-s` (--source) by case alone, so a short-flag spelling
+    # is indistinguishable after folding and is treated as dangerous. Failing
+    # closed there costs one prompt on `git restore -S f`; failing open costs
+    # the file.
+    (r'\bgit\s+restore\b(?:(?![^\n;|&`]*--staged)|(?=[^\n;|&`]*--worktree))', "git restore (discards uncommitted working-tree changes)"),
+    # `git checkout` only overwrites the working tree when it is given a
+    # pathspec or forced, so match those three spellings and nothing else --
+    # `git checkout <branch>` and `git checkout -b <new>` refuse rather than
+    # discard, and gating them would prompt on the single most common git
+    # command there is. `--` is git's explicit pathspec separator; a bare `.`
+    # operand is a pathspec (a ref cannot be named `.`); `-f`/`--force` is
+    # documented as "throw away local modifications".
+    (r'\bgit\s+checkout\b(?:[^\n;|&`]*?\s--\s|[^\n;|&`]*?\s--force\b|[^\n;|&`]*?\s-f\b|\s+\.(?:\s|$))', "git checkout with pathspec or --force (discards uncommitted working-tree changes)"),
     # Script execution after chmod +x — catches the two-step pattern where
     # a script is first made executable then immediately run. The script
     # content may contain dangerous commands that individual patterns miss.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1067,7 +1067,12 @@ DANGEROUS_PATTERNS = [
     # is indistinguishable after folding and is treated as dangerous. Failing
     # closed there costs one prompt on `git restore -S f`; failing open costs
     # the file.
-    (r'\bgit\s+restore\b(?:(?![^\n;|&`]*--staged)|(?=[^\n;|&`]*--worktree))', "git restore (discards uncommitted working-tree changes)"),
+    # `--staged` and `--worktree` must be their own tokens: a bare substring
+    # scan lets a path that merely CONTAINS the text suppress the prompt for
+    # the whole segment (`git restore -- ./--staged`). Residual, stated rather
+    # than hidden: a file named exactly `--staged` after the `--` separator is
+    # still indistinguishable from the flag by regex alone.
+    (r'\bgit\s+restore\b(?:(?![^\n;|&`]*\s--staged\b)|(?=[^\n;|&`]*\s--worktree\b))', "git restore (discards uncommitted working-tree changes)"),
     # `git checkout` only overwrites the working tree when it is given a
     # pathspec or forced, so match those three spellings and nothing else --
     # `git checkout <branch>` and `git checkout -b <new>` refuse rather than
@@ -1075,7 +1080,16 @@ DANGEROUS_PATTERNS = [
     # command there is. `--` is git's explicit pathspec separator; a bare `.`
     # operand is a pathspec (a ref cannot be named `.`); `-f`/`--force` is
     # documented as "throw away local modifications".
-    (r'\bgit\s+checkout\b(?:[^\n;|&`]*?\s--\s|[^\n;|&`]*?\s--force\b|[^\n;|&`]*?\s-f\b|\s+\.(?:\s|$))', "git checkout with pathspec or --force (discards uncommitted working-tree changes)"),
+    # `--pathspec-from-file` reads the pathspec from a file, and `--ours` /
+    # `--theirs` write a conflicted path back over the working tree; all three
+    # overwrite without ever spelling `--`.
+    (r'\bgit\s+checkout\b(?:[^\n;|&`]*?\s--\s|[^\n;|&`]*?\s(?:--force|--pathspec-from-file|--ours|--theirs)\b|[^\n;|&`]*?\s-f\b|\s+\.(?:\s|$))', "git checkout with pathspec or --force (discards uncommitted working-tree changes)"),
+    # `git switch` is git's modern replacement for the branch half of
+    # `checkout`, and `--discard-changes` (aliased `-f`/`--force`) is
+    # documented as "throw away local modifications". An agent steered away
+    # from `checkout -f` reaches for this one. Plain `git switch <branch>` and
+    # `git switch -c <new>` refuse rather than discard and stay ungated.
+    (r'\bgit\s+switch\b[^\n;|&`]*?\s(?:--discard-changes|--force|-f)\b', "git switch --discard-changes (discards uncommitted working-tree changes)"),
     # Script execution after chmod +x — catches the two-step pattern where
     # a script is first made executable then immediately run. The script
     # content may contain dangerous commands that individual patterns miss.


### PR DESCRIPTION
## What does this PR do?

`DANGEROUS_PATTERNS` carries a block headed *"Git destructive operations that can lose uncommitted work or rewrite shared history"*. It gates `git reset --hard`, `git push --force`, `git clean -f` and `git branch -D` — and neither of the two other commands that overwrite the working tree from the index.

Measured on this tree, `./.venv/bin/python`:

```
BEFORE
  True   'git reset --hard'          git reset --hard (destroys uncommitted changes)
  True   'git clean -fdx'            git clean with force (deletes untracked files)
  False  'git restore .'
  False  'git restore src/'
  False  'git checkout -- .'
  False  'git checkout HEAD~1 -- f.py'
  False  'git checkout .'
  False  'git checkout -f'
```

Nothing recovers from any of those four. The reflog holds commits; it does not hold unstaged edits. `git restore .` and `git reset --hard` destroy the same bytes and only one of them prompts.

## Related Issue

No open issue. Searched open and merged PRs and issues for `git restore`, `git checkout uncommitted`, `destroys uncommitted changes` and `DANGEROUS_PATTERNS git` — nothing covers this gap. The nearest is closed PR #6961 (*"close 4 DANGEROUS_PATTERNS gaps"*), which covered heredoc, pgrep, git `--force` and chmod+exec, not these.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/approval.py` — two entries in `DANGEROUS_PATTERNS`, immediately after the existing git block, with the reasoning inline.
- `tests/tools/test_git_worktree_destructive.py` — new file, 30 cases.

**The gating is deliberately narrow**, because the cost of over-matching here is a prompt on an everyday command.

`git restore` writes the **working tree** unless `--staged` is given alone: `--staged` restores only the index (the unstage idiom), and `--staged --worktree` restores both. So it is dangerous unless the segment carries `--staged` without `--worktree`. Only the long spellings are excluded, on purpose — `_normalize_command_for_detection` lowercases before matching, and git distinguishes `-S` (`--staged`) from `-s` (`--source`) by case alone, so a short-flag spelling is indistinguishable after folding and is treated as dangerous. Failing closed there costs one prompt on `git restore -S f`; failing open costs the file. `git restore --staged pyproject.toml` — already asserted benign by `tests/tools/test_self_repo_guard.py:172` — stays benign.

`git checkout` overwrites the working tree only when given a pathspec or forced, so exactly three spellings match: `--` (git's explicit pathspec separator), a bare `.` operand (a ref cannot be named `.`), and `-f`/`--force` (*"throw away local modifications"*). **`git checkout <branch>` and `git checkout -b <new>` are untouched** — they refuse rather than discard, and gating them would prompt on the most common git command there is.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_git_worktree_destructive.py
```

12 of 12 destructive spellings now prompt:

```
git restore .                       git checkout -- .
git restore src/                    git checkout -- src/app.py
git restore src/app.py              git checkout HEAD~1 -- app.py
git restore --source=HEAD~1 app.py  git checkout .
git restore -- .                    git checkout -f
git restore --staged --worktree f   git checkout --force main
```

0 of 14 non-destructive ones regress:

```
git restore --staged pyproject.toml   git checkout main        git status
git restore --staged .                git checkout -b feature/x  git log --oneline
git switch main                       git checkout --track origin/x   git diff
git add -A    git commit -m 'msg'     git checkout -t origin/x   git stash
git fetch --all
```

The test keeps `git reset --hard` and `git clean -fdx` as controls, so a green suite cannot be green for the wrong reason.

## Scope

Per `SECURITY.md` §2.4 the approval gate is an in-process heuristic and not a security boundary; this is not filed as a vulnerability and claims no containment. It adds two spellings to a category the block already names in its own heading.

One judgement call worth stating for the reviewer: this means `git restore <path>` now prompts, where it did not before. That is the same treatment `git reset --hard` already gets for the same consequence, and the unstage idiom is excluded — but if the maintainers would rather `restore` stay silent, dropping that one entry leaves the `checkout` half standing on its own.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: `scripts/run_tests.sh` over the 30 test files in `tests/` that touch the approval module or the shell denylists gives `1218 tests passed, 22 failed` before *and* after this change, byte-identical failure set (pre-existing missing-dependency failures in my minimal local venv). I did not run the full suite locally.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.3.0), Python 3.14

### Documentation & Housekeeping

- [x] Documentation — the reasoning for each pattern's boundaries is inline above it, matching the style of the `git reset --h` abbreviation note and the `git branch -d --force` note in the same block
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — two regexes, no paths, no processes
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/tools/test_git_worktree_destructive.py
=== Summary: 1 files, 30 tests passed, 0 failed (100% complete) in 0.7s (22 workers) ===
```
