### PR TITLE
fix(doctor): stop warning on valid Vertex publisher model names

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1409,6 +1409,9 @@ def run_doctor(args):
                 "lmstudio",
                 "nous",
                 "nvidia",
+                # Vertex AI model IDs include the publisher namespace
+                # (for example google/gemini-3.7-flash).
+                "vertex",
                 # Fireworks' native model IDs are slash-form
                 # (accounts/fireworks/models/... and .../routers/...), so a "/"
                 # is expected, not an aggregator vendor prefix.

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -560,6 +560,7 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
         ("kimi-coding", "kimi-k2"),
         ("nvidia", "qwen/qwen3.5-122b-a10b"),
         ("moa", "anthropic/claude-sonnet-4.6"),
+        ("vertex", "google/gemini-3.7-flash"),
     ],
 )
 def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
@@ -600,7 +601,7 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
     out = buf.getvalue()
     assert f"model.provider '{provider}' is not a recognised provider" not in out
     assert f"model.provider '{provider}' is unknown" not in out
-    if provider in {"ai-gateway", "opencode-zen", "kilocode", "nvidia"}:
+    if provider in {"ai-gateway", "opencode-zen", "kilocode", "nvidia", "vertex"}:
         assert (
             f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider}'"
             not in out


### PR DESCRIPTION
## What does this PR do?

Stops `hermes doctor` from warning that valid Vertex AI publisher-qualified model names such as `google/gemini-3.7-flash` should drop their publisher prefix. Vertex requires this publisher/model form, so the previous guidance could lead users to replace a valid configuration with an invalid model ID.

### Symptom

With `model.provider: vertex` and `model.default: google/gemini-3.7-flash`, doctor reports that vendor-prefixed slugs belong to aggregators and recommends removing `google/`.

### Impact

Vertex AI users receive a false-positive configuration issue and an incorrect remediation instruction.

### Bug Cause

**Trigger:** `hermes_cli/doctor.py:1402` / `providers_accepting_vendor_slugs`

**Causal chain:**
1. Doctor reads a Vertex model ID containing `/`.
2. Its provider policy allow-list does not include `vertex`.
3. The generic vendor-slug branch classifies the required publisher namespace as an aggregator prefix and emits the warning.

**Why it is wrong:** Vertex AI model IDs use publisher-qualified names, so `/` is valid for this native provider.

**Working sibling / contrast:** Existing providers with required slash-form IDs, including Fireworks and DeepInfra, are already represented in the same policy allow-list.

**Ruled out:** Provider recognition is not the failure. The existing runtime doctor test confirms `vertex` resolves as a known provider; only the slash-form policy assertion failed before this fix.

### Fix

Treat Vertex as a provider that accepts publisher/model IDs and extend the real `run_doctor` provider-policy test with the reported configuration.

## Related Issue

Closes #91669

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py` - accept publisher-qualified model IDs for Vertex AI.
- `tests/hermes_cli/test_doctor.py` - cover `vertex` with `google/gemini-3.7-flash` through `run_doctor`.

## How to Test

1. Configure `model.provider: vertex` and `model.default: google/gemini-3.7-flash`.
2. Run `hermes doctor` and confirm the vendor/model slug warning is absent.
3. Run the automated doctor tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q
```

Result: 57 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the repo test entry on the relevant test file and all 57 tests pass.
- [x] I've added a regression test for the fix.
- [x] I've tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation update is N/A; this corrects an existing diagnostic policy.
- [x] `cli-config.yaml.example` update is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed.
- [x] Cross-platform impact was considered; the policy and test are platform-independent.
- [x] Tool description/schema updates are N/A; no model tool behavior changed.
