### PR TITLE
fix(a2a): make reply deadline config-native

### DIFF
--- a/plugins/platforms/a2a/README.md
+++ b/plugins/platforms/a2a/README.md
@@ -19,6 +19,7 @@ gateway:
       enabled: true
       extra:
         port: 9900
+        reply_timeout: 900  # optional; default 300 seconds
 
 # peers you want to call (outbound):
 a2a_agents:
@@ -83,7 +84,7 @@ via `tasks/get`.
 | `A2A_ALLOW_ALL_USERS` | `false` | Allow any authed peer (dev only). |
 | `A2A_RATE_LIMIT` | `60` | Requests/minute per identity. |
 | `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20). |
-| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply. |
+| `A2A_REPLY_TIMEOUT` | `300` | Legacy environment fallback for the reply timeout; prefer `gateway.platforms.a2a.extra.reply_timeout`. |
 | `A2A_PUSH_SECRET` | bearer token | HMAC secret for push signing. |
 | `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict skills on the Agent Card. |
 

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 import sqlite3
@@ -61,17 +62,24 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_PORT = 9900
 _ORPHAN_TIMEOUT = 300  # seconds before a pending task is considered orphaned
+_ORPHAN_GRACE = 60  # slack beyond reply/route deadlines
 _WATCHDOG_INTERVAL = 60  # seconds between orphaned task watchdog runs
 _MAX_BODY = 1_048_576  # 1MB max request body — prevents DoS via memory exhaustion
 _SSE_KEEPALIVE = 5  # seconds between SSE keepalive comments
 
 
-def _reply_timeout() -> float:
-    """Seconds to wait for the agent to answer an inbound task."""
+def _parse_reply_timeout(value: Any, fallback: float = 300.0) -> float:
+    """Return a finite positive reply timeout or the safe fallback."""
     try:
-        return max(1.0, float(os.getenv("A2A_REPLY_TIMEOUT", "300")))
+        parsed = float(value)
     except (ValueError, TypeError):
-        return 300.0
+        return fallback
+    return parsed if math.isfinite(parsed) and parsed >= 1.0 else fallback
+
+
+def _reply_timeout() -> float:
+    """Legacy environment bridge for the inbound reply timeout."""
+    return _parse_reply_timeout(os.getenv("A2A_REPLY_TIMEOUT", "300"))
 
 
 def _default_agent_name() -> str:
@@ -344,6 +352,10 @@ class A2AAdapter(BasePlatformAdapter):
 
         extra = getattr(config, "extra", {}) or {}
         self.port = int(os.getenv("A2A_PORT") or extra.get("port", _DEFAULT_PORT))
+        self.reply_timeout = _parse_reply_timeout(
+            extra.get("reply_timeout", _reply_timeout()),
+            fallback=_reply_timeout(),
+        )
         self.host = security.resolve_bind_host()
         self.agent_name = _default_agent_name()
         self._advertised_toolsets = [
@@ -467,12 +479,28 @@ class A2AAdapter(BasePlatformAdapter):
 
     # ── Orphaned task watchdog ─────────────────────────────────────────────
 
+    def _orphan_timeout_for(self, rec: dict) -> int:
+        """Keep orphan cleanup behind both inbound and routed deadlines."""
+        agent = self._agents.get(str(rec.get("agent_slug") or "")) or {}
+        try:
+            route_timeout = float(agent.get("timeout") or 0)
+        except (TypeError, ValueError):
+            route_timeout = 0
+        return int(max(
+            _ORPHAN_TIMEOUT,
+            self.reply_timeout + _ORPHAN_GRACE,
+            route_timeout + _ORPHAN_GRACE,
+        ))
+
     def _watchdog_loop(self) -> None:
         """Background thread that fails orphaned tasks (keeps them queryable)."""
         while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL):
             try:
-                for tid in self.tasks.fail_orphans(_ORPHAN_TIMEOUT):
-                    logger.warning("A2A: orphaned task %s marked failed (timeout %ds)", tid, _ORPHAN_TIMEOUT)
+                for tid in self.tasks.fail_orphans(
+                    _ORPHAN_TIMEOUT,
+                    timeout_for=self._orphan_timeout_for,
+                ):
+                    logger.warning("A2A: orphaned task %s marked failed", tid)
                     protocol.metrics.tasks_failed += 1
             except Exception:
                 logger.debug("A2A: watchdog error", exc_info=True)
@@ -933,7 +961,7 @@ class A2AAdapter(BasePlatformAdapter):
         raises, the client is gone and we stop waiting.
         """
         fut: Future = pending["future"]
-        deadline = pending["started"] + _reply_timeout()
+        deadline = pending["started"] + self.reply_timeout
         while True:
             try:
                 return fut.result(timeout=_SSE_KEEPALIVE if keepalive else max(0.0, deadline - time.time()))
@@ -1041,7 +1069,7 @@ class A2AAdapter(BasePlatformAdapter):
             if fut is None:
                 self._sse_write(handler, protocol.sse_done())
                 return
-            deadline = time.time() + _reply_timeout()
+            deadline = time.time() + self.reply_timeout
             while True:
                 try:
                     state, reply = fut.result(timeout=_SSE_KEEPALIVE)

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -30,7 +30,7 @@ from collections import OrderedDict, defaultdict, deque
 from concurrent.futures import Future
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 PROTOCOL_VERSION = "1.0"
 
@@ -748,14 +748,25 @@ class TaskStore:
             return page, next_offset, total
         return page, next_offset
 
-    def fail_orphans(self, timeout_seconds: int = 300) -> list[str]:
+    def fail_orphans(
+        self,
+        timeout_seconds: int = 300,
+        timeout_for: Optional[Callable[[dict], float]] = None,
+    ) -> list[str]:
         with self._lock:
             now = time.time()
-            stale = [
-                tid for tid, rec in self._tasks.items()
-                if rec["state"] not in TERMINAL_STATES
-                and now - rec["created_at"] > timeout_seconds
-            ]
+            stale = []
+            for tid, rec in self._tasks.items():
+                if rec["state"] in TERMINAL_STATES:
+                    continue
+                limit = float(timeout_seconds)
+                if timeout_for is not None:
+                    try:
+                        limit = max(limit, float(timeout_for(rec)))
+                    except (TypeError, ValueError):
+                        pass
+                if now - rec["created_at"] > limit:
+                    stale.append(tid)
         failed = []
         for tid in stale:
             if self.complete(tid, STATE_FAILED, "[task orphaned — no reply produced]"):

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -16,6 +16,7 @@ import json
 import os
 import socket
 import threading
+import time
 import urllib.error
 import urllib.request
 from concurrent.futures import Future
@@ -24,7 +25,77 @@ from types import SimpleNamespace
 
 import pytest
 
+from plugins.platforms.a2a import adapter as a2a_adapter
 from plugins.platforms.a2a import protocol, security, tools
+
+
+def test_reply_timeout_can_be_configured_without_environment(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    adapter = a2a_adapter.A2AAdapter(
+        PlatformConfig(enabled=True, extra={"reply_timeout": 900})
+    )
+
+    assert adapter.reply_timeout == 900.0
+
+
+def test_non_finite_reply_timeout_falls_back_safely(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    adapter = a2a_adapter.A2AAdapter(
+        PlatformConfig(enabled=True, extra={"reply_timeout": "inf"})
+    )
+
+    assert adapter.reply_timeout == 300.0
+
+
+def test_reply_wait_uses_configured_timeout(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    adapter = a2a_adapter.A2AAdapter(
+        PlatformConfig(enabled=True, extra={"reply_timeout": 900})
+    )
+
+    class CapturingFuture:
+        timeout = 0.0
+
+        def result(self, timeout):
+            self.timeout = timeout
+            return protocol.STATE_COMPLETED, "alive"
+
+    future = CapturingFuture()
+    state, reply = adapter._await_reply({"future": future, "started": time.time()})
+
+    assert (state, reply) == (protocol.STATE_COMPLETED, "alive")
+    assert 890 < future.timeout <= 900
+
+
+def test_orphan_watchdog_outlives_routed_agent_timeout(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    adapter = a2a_adapter.A2AAdapter(PlatformConfig(enabled=True, extra={
+        "reply_timeout": 900,
+        "agents": {"slow": {"profile": "slow", "timeout": 1800}},
+    }))
+
+    assert adapter._orphan_timeout_for({"agent_slug": "slow"}) > 1800
+
+
+def test_task_store_uses_per_task_orphan_timeout():
+    store = protocol.TaskStore()
+    store.create("task-slow", "ctx", "peer", agent_slug="slow")
+    store._tasks["task-slow"]["created_at"] = time.time() - 500
+
+    failed = store.fail_orphans(300, timeout_for=lambda rec: 1860)
+
+    assert failed == []
+    record = store.get("task-slow")
+    assert record is not None
+    assert record["state"] == protocol.STATE_SUBMITTED
 
 
 def _free_port() -> int:

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -27,6 +27,7 @@ gateway:
       enabled: true
       extra:
         port: 9900
+        reply_timeout: 900  # optional; default 300 seconds
 ```
 
 The outbound client tools ship as the `a2a` toolset, **off by default** — enable it per platform:
@@ -102,7 +103,7 @@ Secure by default; every widening step is explicit:
 | `A2A_ALLOW_ALL_USERS` | `false` | Allow any authenticated peer (dev only) |
 | `A2A_RATE_LIMIT` | `60` | Requests/minute per identity |
 | `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20) |
-| `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply |
+| `A2A_REPLY_TIMEOUT` | `300` | Legacy environment fallback for the reply timeout; prefer `gateway.platforms.a2a.extra.reply_timeout` |
 | `A2A_PUSH_SECRET` | bearer token | HMAC secret for push-notification signing |
 | `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict which skills appear on the Agent Card |
 


### PR DESCRIPTION
## Problem

Hermes A2A has a five-minute inbound reply deadline controlled only through an environment variable. Behavioral timeout configuration belongs in `config.yaml`, and raising only the reply deadline can leave the fixed orphan watchdog free to fail a still-running routed profile first. That produces disagreement between the direct response and persisted task state.

## Change

- add `gateway.platforms.a2a.extra.reply_timeout` as the preferred profile-safe configuration path while preserving `A2A_REPLY_TIMEOUT` as a legacy fallback
- reject invalid and non-finite timeout values with the safe 300-second fallback
- use the configured deadline for synchronous replies and task subscriptions
- derive each orphan deadline from both the inbound reply timeout and the routed agent timeout, plus 60 seconds of grace
- let `TaskStore.fail_orphans` accept a per-task timeout resolver without permitting it to shorten the existing floor
- document the config key on both A2A reference surfaces

The default remains 300 seconds, avoiding a global increase in long-lived synchronous request workers. Deployments that need long turns can opt into 900 seconds per profile.

This overlaps the watchdog symptom in #90158 but additionally supplies the config-native deadline, applies it to reply/subscription waits, rejects non-finite values, and keeps ordinary and routed task deadlines consistent.

## Verification

- four regression slices were observed red before their implementations
- `scripts/run_tests.sh tests/plugins/test_a2a_plugin.py` — 111 passed
- `git diff --check` — clean

## Risk and rollback

Only explicitly configured profiles get a longer request lifetime. Removing `reply_timeout` restores the 300-second default; reverting the commit restores the environment-only behavior.
