### PR TITLE
fix(mcp): recover HTTP sessions after notification streams disappear

### DIFF
--- a/tests/tools/test_mcp_http_notification_stream.py
+++ b/tests/tools/test_mcp_http_notification_stream.py
@@ -1,0 +1,85 @@
+"""Regression coverage for silent Streamable HTTP GET loss (#91670).
+
+The MCP SDK retries its optional GET/SSE notification channel internally. If
+those retries are exhausted, the GET task returns normally while the POST
+writer and Hermes session remain alive. POST-based pings can still succeed, so
+Hermes otherwise receives no failure signal and never rebuilds the transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tools.mcp_tool import _HTTPNotificationStreamTracker
+
+
+class _Response:
+    def __init__(self, method: str = "GET", content_type: str = "text/event-stream"):
+        self.request = SimpleNamespace(method=method)
+        self.headers = {"content-type": content_type}
+        self.close_count = 0
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+
+
+@pytest.mark.asyncio
+async def test_unreplaced_notification_stream_close_requests_reconnect():
+    reconnect = asyncio.Event()
+    tracker = _HTTPNotificationStreamTracker(
+        grace_seconds=0.01,
+        on_stalled=reconnect.set,
+    )
+    response = _Response()
+
+    await tracker.response_hook(response)
+    await response.aclose()
+
+    await asyncio.wait_for(reconnect.wait(), timeout=0.5)
+    assert response.close_count == 1
+    tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_replacement_notification_stream_cancels_full_reconnect():
+    reconnect = asyncio.Event()
+    tracker = _HTTPNotificationStreamTracker(
+        grace_seconds=0.05,
+        on_stalled=reconnect.set,
+    )
+    first = _Response()
+    replacement = _Response()
+
+    await tracker.response_hook(first)
+    await first.aclose()
+    await asyncio.sleep(0)
+    await tracker.response_hook(replacement)
+    await asyncio.sleep(0.1)
+
+    assert not reconnect.is_set()
+    tracker.close()
+
+
+@pytest.mark.asyncio
+async def test_non_get_or_non_sse_responses_are_not_tracked():
+    reconnect = asyncio.Event()
+    tracker = _HTTPNotificationStreamTracker(
+        grace_seconds=0.01,
+        on_stalled=reconnect.set,
+    )
+    post = _Response(method="POST")
+    json_get = _Response(content_type="application/json")
+
+    await tracker.response_hook(post)
+    await tracker.response_hook(json_get)
+    await post.aclose()
+    await json_get.aclose()
+    await asyncio.sleep(0.05)
+
+    assert not reconnect.is_set()
+    assert post.close_count == 1
+    assert json_get.close_count == 1
+    tracker.close()

--- a/tests/tools/test_mcp_http_notification_stream.py
+++ b/tests/tools/test_mcp_http_notification_stream.py
@@ -64,6 +64,34 @@ async def test_replacement_notification_stream_cancels_full_reconnect():
 
 
 @pytest.mark.asyncio
+async def test_auxiliary_sse_get_does_not_replace_notification_stream():
+    reconnect = asyncio.Event()
+    tracker = _HTTPNotificationStreamTracker(
+        grace_seconds=0.01,
+        on_stalled=reconnect.set,
+    )
+    notification = _Response()
+    auxiliary = _Response()
+
+    await tracker.response_hook(notification)
+
+    async def finish_auxiliary_get() -> None:
+        await tracker.response_hook(auxiliary)
+        await auxiliary.aclose()
+
+    await asyncio.create_task(finish_auxiliary_get())
+    await asyncio.sleep(0.05)
+
+    assert not reconnect.is_set()
+    assert notification.close_count == 0
+    assert auxiliary.close_count == 1
+
+    await notification.aclose()
+    await asyncio.wait_for(reconnect.wait(), timeout=0.5)
+    tracker.close()
+
+
+@pytest.mark.asyncio
 async def test_non_get_or_non_sse_responses_are_not_tracked():
     reconnect = asyncio.Event()
     tracker = _HTTPNotificationStreamTracker(

--- a/tests/tools/test_mcp_http_notification_stream.py
+++ b/tests/tools/test_mcp_http_notification_stream.py
@@ -17,8 +17,16 @@ from tools.mcp_tool import _HTTPNotificationStreamTracker
 
 
 class _Response:
-    def __init__(self, method: str = "GET", content_type: str = "text/event-stream"):
-        self.request = SimpleNamespace(method=method)
+    def __init__(
+        self,
+        method: str = "GET",
+        content_type: str = "text/event-stream",
+        request_headers: dict[str, str] | None = None,
+    ):
+        self.request = SimpleNamespace(
+            method=method,
+            headers=request_headers or {},
+        )
         self.headers = {"content-type": content_type}
         self.close_count = 0
 
@@ -51,7 +59,7 @@ async def test_replacement_notification_stream_cancels_full_reconnect():
         on_stalled=reconnect.set,
     )
     first = _Response()
-    replacement = _Response()
+    replacement = _Response(request_headers={"Last-Event-ID": "notification-1"})
 
     await tracker.response_hook(first)
     await first.aclose()
@@ -71,9 +79,7 @@ async def test_auxiliary_sse_get_does_not_replace_notification_stream():
         on_stalled=reconnect.set,
     )
     notification = _Response()
-    auxiliary = _Response()
-
-    await tracker.response_hook(notification)
+    auxiliary = _Response(request_headers={"Last-Event-ID": "request-1"})
 
     async def finish_auxiliary_get() -> None:
         await tracker.response_hook(auxiliary)
@@ -83,9 +89,9 @@ async def test_auxiliary_sse_get_does_not_replace_notification_stream():
     await asyncio.sleep(0.05)
 
     assert not reconnect.is_set()
-    assert notification.close_count == 0
     assert auxiliary.close_count == 1
 
+    await tracker.response_hook(notification)
     await notification.aclose()
     await asyncio.wait_for(reconnect.wait(), timeout=0.5)
     tracker.close()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -584,6 +584,90 @@ def _jittered(seconds: float) -> float:
 _DEFAULT_KEEPALIVE_INTERVAL = 180  # seconds between liveness pings
 _MIN_KEEPALIVE_INTERVAL = 5        # clamp floor for configured intervals
 
+
+class _HTTPNotificationStreamTracker:
+    """Escalate an unreplaced Streamable HTTP GET stream to a reconnect.
+
+    The MCP SDK retries the optional GET/SSE notification channel itself. If
+    those retries are exhausted, its GET task returns normally while the POST
+    writer remains alive. Hermes' POST-based keepalive can then keep passing,
+    leaving a half-dead session with no notification channel and no failure
+    visible to the outer transport context.
+
+    A closed GET gets a grace period for the SDK's own cheap reconnect. A new
+    GET response cancels the timer; if none arrives, ``on_stalled`` asks Hermes
+    to rebuild the complete transport.
+    """
+
+    __slots__ = (
+        "_grace_seconds", "_on_stalled", "_generation",
+        "_closed_generation", "_timer", "_closed",
+    )
+
+    def __init__(self, *, grace_seconds: float, on_stalled: Callable[[], None]):
+        self._grace_seconds = grace_seconds
+        self._on_stalled = on_stalled
+        self._generation = 0
+        self._closed_generation: Optional[int] = None
+        self._timer: Optional[asyncio.TimerHandle] = None
+        self._closed = False
+
+    async def response_hook(self, response: Any) -> None:
+        """Track the lifecycle of a GET response carrying an SSE stream."""
+        request = getattr(response, "request", None)
+        if str(getattr(request, "method", "")).upper() != "GET":
+            return
+        content_type = str(getattr(response, "headers", {}).get("content-type", ""))
+        if not content_type.lower().startswith("text/event-stream"):
+            return
+
+        self._generation += 1
+        generation = self._generation
+        self._closed_generation = None
+        self._cancel_timer()
+
+        original_close = response.aclose
+
+        async def tracked_close(*args, **kwargs):
+            try:
+                return await original_close(*args, **kwargs)
+            finally:
+                self._stream_closed(generation)
+
+        response.aclose = tracked_close
+
+    def _stream_closed(self, generation: int) -> None:
+        if (
+            self._closed
+            or generation != self._generation
+            or self._closed_generation == generation
+        ):
+            return
+        self._closed_generation = generation
+        self._timer = asyncio.get_running_loop().call_later(
+            self._grace_seconds, self._fire_if_unreplaced, generation
+        )
+
+    def _fire_if_unreplaced(self, generation: int) -> None:
+        self._timer = None
+        if (
+            self._closed
+            or generation != self._generation
+            or self._closed_generation != generation
+        ):
+            return
+        self._on_stalled()
+
+    def _cancel_timer(self) -> None:
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+
+    def close(self) -> None:
+        """Disarm delayed callbacks when the owning transport exits."""
+        self._closed = True
+        self._cancel_timer()
+
 # Final shutdown gives pending MCP-loop tasks one bounded cancellation cycle
 # before closing their owning loop. Cooperative parked/reconnect waiters finish
 # immediately; cancellation-resistant tasks must not hang process exit.
@@ -3560,11 +3644,33 @@ class MCPServerTask:
                 configured_header_names=_configured_header_names,
             )
 
+            notification_reconnect_grace = max(5.0, float(connect_timeout))
+
+            def _reconnect_stalled_notification_stream() -> None:
+                logger.warning(
+                    "MCP server '%s': HTTP notification stream closed and was "
+                    "not restored within %.0fs; rebuilding the full session "
+                    "(state: connected → degraded)",
+                    self.name, notification_reconnect_grace,
+                )
+                self._reconnect_event.set()
+
+            # Give the SDK's built-in GET reconnect loop one normal connection
+            # timeout to replace the stream before escalating to a full-session
+            # rebuild. POST pings cannot detect this half-dead state (#91670).
+            notification_tracker = _HTTPNotificationStreamTracker(
+                grace_seconds=notification_reconnect_grace,
+                on_stalled=_reconnect_stalled_notification_stream,
+            )
+
             client_kwargs: dict = {
                 "follow_redirects": True,
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
                 "verify": ssl_verify,
-                "event_hooks": {"response": [_strip_auth_on_cross_origin_redirect]},
+                "event_hooks": {"response": [
+                    _strip_auth_on_cross_origin_redirect,
+                    notification_tracker.response_hook,
+                ]},
             }
             if headers:
                 client_kwargs["headers"] = headers
@@ -3607,6 +3713,8 @@ class MCPServerTask:
                 # Streamable-HTTP transport TaskGroup dropped: reconnect
                 # immediately instead of backoff/park (#66092).
                 reason = self._reconnect_or_reraise_group(_eg)
+            finally:
+                notification_tracker.close()
             return reason
         else:
             # Deprecated API (mcp < 1.24.0): manages httpx client internally.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -624,6 +624,15 @@ class _HTTPNotificationStreamTracker:
 
         current_task = asyncio.current_task()
         if self._owner_task is None:
+            request_headers = getattr(request, "headers", {})
+            if any(
+                str(name).lower() == "last-event-id"
+                for name in request_headers
+            ):
+                # A finite request-resumption GET may complete before the
+                # long-lived notification response arrives. It must not claim
+                # ownership of notification-channel health.
+                return
             self._owner_task = current_task
         elif current_task is not self._owner_task:
             # The SDK uses the same client for finite request-resumption GETs.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -601,7 +601,7 @@ class _HTTPNotificationStreamTracker:
 
     __slots__ = (
         "_grace_seconds", "_on_stalled", "_generation",
-        "_closed_generation", "_timer", "_closed",
+        "_closed_generation", "_timer", "_closed", "_owner_task",
     )
 
     def __init__(self, *, grace_seconds: float, on_stalled: Callable[[], None]):
@@ -611,6 +611,7 @@ class _HTTPNotificationStreamTracker:
         self._closed_generation: Optional[int] = None
         self._timer: Optional[asyncio.TimerHandle] = None
         self._closed = False
+        self._owner_task: Optional[asyncio.Task] = None
 
     async def response_hook(self, response: Any) -> None:
         """Track the lifecycle of a GET response carrying an SSE stream."""
@@ -619,6 +620,15 @@ class _HTTPNotificationStreamTracker:
             return
         content_type = str(getattr(response, "headers", {}).get("content-type", ""))
         if not content_type.lower().startswith("text/event-stream"):
+            return
+
+        current_task = asyncio.current_task()
+        if self._owner_task is None:
+            self._owner_task = current_task
+        elif current_task is not self._owner_task:
+            # The SDK uses the same client for finite request-resumption GETs.
+            # Its notification retries stay in one owner task, so only that
+            # task's response family represents notification-channel health.
             return
 
         self._generation += 1


### PR DESCRIPTION
## What does this PR do?

HTTP MCP sessions now recover when their server-initiated GET/SSE notification stream disappears and the SDK cannot restore it. Hermes gives the SDK's lightweight GET reconnect loop one connection timeout to recover, then logs a warning and rebuilds the complete MCP session instead of remaining silently half-connected.

### Symptom

A Streamable HTTP MCP server can connect successfully, lose its persistent notification TCP connection after several minutes, and then remain silent indefinitely without a Hermes retry or diagnostic.

### Impact

Operators lose server-initiated MCP notifications and cannot observe automatic recovery. In the reported deployment, the connection remained absent for more than an hour and only a container recreate restored it.

### Bug Cause

**Trigger:** `tools/mcp_tool.py:3578` / `MCPServerTask._run_http` when the SDK's GET notification task exhausts its internal reconnect attempts.

**Causal chain:**
1. The MCP SDK's GET/SSE task returns normally after its own reconnect attempts fail.
2. The transport task group remains open because the independent POST writer is still alive, while Hermes waits only for shutdown, explicit reconnect, or a failed POST-based keepalive.
3. POST pings can continue succeeding without a GET notification channel, so Hermes receives no exception or lifecycle signal and never rebuilds the session.

**Why it is wrong:** Transport health was inferred only from the shared outer context and POST request path, but Streamable HTTP has an independently failing GET notification channel.

**Working sibling / contrast:** Initial connection and POST failures already reach the retry and parked-state machinery because they raise into `MCPServerTask.run`.

**Ruled out:** The server process restarting is not required for this failure. The reported n8n process remained alive, and the SDK source shows that exhausted GET retries return normally rather than failing the outer transport.

### Fix

Track successful GET/SSE responses on the owned HTTP client. Closing a stream starts a grace timer for the SDK's built-in reconnect; opening a replacement cancels it. If no replacement arrives within one connection timeout, Hermes emits a warning and signals the existing full-session reconnect path. Tracker teardown cancels pending callbacks during normal shutdown.

## Related Issue

Closes #91670

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py` - monitor the Streamable HTTP notification channel and escalate unrecovered closure to a full reconnect.
- `tests/tools/test_mcp_http_notification_stream.py` - cover unreplaced closure, successful SDK replacement, and unrelated response filtering.

## How to Test

1. Run the focused MCP reconnect suite:

```bash
scripts/run_tests.sh tests/tools/test_mcp_http_notification_stream.py tests/tools/test_mcp_transport_group_reconnect.py tests/tools/test_mcp_streamable_http_arity.py tests/tools/test_mcp_capability_gating.py tests/tools/test_mcp_reconnect_log_hygiene.py tests/tools/test_mcp_rapid_drop_budget.py -q
```

2. Connect a Streamable HTTP server whose GET/SSE channel closes, prevent its lightweight GET retries from succeeding, and confirm Hermes logs the degraded transition and rebuilds the full session.
3. Allow the SDK to replace a closed GET/SSE channel within `connect_timeout` and confirm Hermes does not rebuild the full session.

Focused result: 39 passed on Windows 11 with MCP SDK 2.0.0. The broader `tests/tools/test_mcp*.py` run passed 573 tests; three unrelated pre-existing Windows failures remained in image MIME fallback, POSIX mode-bit, and Windows environment tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; model-facing MCP tool schemas are unchanged

## Screenshots / Logs

N/A - regression coverage exercises the lifecycle signal directly.
