### PR TITLE
fix(desktop): keep session tab strips visible

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { forceLoneHeaderForPanes } from './lone-header'
+import { forceLoneHeaderForPanes, resolveZoneHeaderHidden } from './lone-header'
 
 describe('forceLoneHeaderForPanes', () => {
   const chrome =
@@ -33,5 +33,64 @@ describe('forceLoneHeaderForPanes', () => {
 
   it('leaves standing side chrome (files / sessions) headerless', () => {
     expect(forceLoneHeaderForPanes(['files'], chrome('right'), noCollapse)).toBe(false)
+  })
+})
+
+describe('resolveZoneHeaderHidden', () => {
+  it('keeps a lone session workspace strip visible', () => {
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: false,
+        headerVeto: false,
+        persistedHidden: undefined,
+        sessionStrip: true,
+        shownCount: 1
+      })
+    ).toBe(false)
+  })
+
+  it('ignores a persisted hide for session strips', () => {
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: true,
+        headerVeto: false,
+        persistedHidden: true,
+        sessionStrip: true,
+        shownCount: 2
+      })
+    ).toBe(false)
+  })
+
+  it('still honors a full-page header veto', () => {
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: false,
+        headerVeto: true,
+        persistedHidden: false,
+        sessionStrip: true,
+        shownCount: 1
+      })
+    ).toBe(true)
+  })
+
+  it('preserves explicit and automatic hiding for non-session zones', () => {
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: true,
+        headerVeto: false,
+        persistedHidden: true,
+        sessionStrip: false,
+        shownCount: 1
+      })
+    ).toBe(true)
+    expect(
+      resolveZoneHeaderHidden({
+        forceLoneHeader: false,
+        headerVeto: false,
+        persistedHidden: undefined,
+        sessionStrip: false,
+        shownCount: 1
+      })
+    ).toBe(true)
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/lone-header.ts
@@ -33,3 +33,24 @@ export function forceLoneHeaderForPanes(
 
   return shown.length === 1 && isCollapsePane(shown[0])
 }
+
+export interface ZoneHeaderVisibilityInput {
+  forceLoneHeader: boolean
+  headerVeto: boolean
+  persistedHidden?: boolean
+  sessionStrip: boolean
+  shownCount: number
+}
+
+/** Resolve header visibility without letting the chat switcher become a dead end. */
+export function resolveZoneHeaderHidden(input: ZoneHeaderVisibilityInput): boolean {
+  if (input.headerVeto) {
+    return true
+  }
+
+  if (input.sessionStrip) {
+    return false
+  }
+
+  return input.persistedHidden ?? (input.shownCount <= 1 && !input.forceLoneHeader)
+}

--- a/apps/desktop/src/components/pane-shell/tree/renderer/session-strip-visibility.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/session-strip-visibility.test.tsx
@@ -1,0 +1,67 @@
+import { useStore } from '@nanostores/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+import { stubResizeObserver } from '@/test/jsdom'
+
+import { group } from '../model'
+import { $layoutTree } from '../store'
+
+import { TreeGroup } from './tree-group'
+
+function LiveTreeGroup() {
+  useStore($layoutTree)
+
+  return <TreeGroup node={$layoutTree.get() as never} parentAxis="column" />
+}
+
+beforeAll(() => {
+  stubResizeObserver()
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+let disposePane: (() => void) | undefined
+
+afterEach(() => {
+  cleanup()
+  disposePane?.()
+  disposePane = undefined
+})
+
+const groupNode = () =>
+  $layoutTree.get() as { headerHidden?: boolean; minimized?: boolean; panes: string[] }
+
+const doubleTap = (target: Element) => {
+  for (let i = 0; i < 2; i++) {
+    fireEvent.pointerDown(target, { button: 0, clientX: 10, clientY: 10, pointerType: 'mouse' })
+    fireEvent.pointerUp(window, { button: 0, clientX: 10, clientY: 10, pointerType: 'mouse' })
+  }
+}
+
+describe('session strip visibility', () => {
+  it('undoes the first-tap collapse without persisting a header hide', () => {
+    const paneId = 'session-tile:test'
+    disposePane = registry.register({
+      area: 'panes',
+      data: { placement: 'main' },
+      id: paneId,
+      render: () => null,
+      title: 'Session'
+    })
+    $layoutTree.set(group([paneId], { active: paneId, id: 'grp-session' }))
+    render(<LiveTreeGroup />)
+
+    const strip = globalThis.document.querySelector<HTMLElement>('[data-zone-tabstrip="grp-session"]')
+    expect(strip).toBeTruthy()
+
+    doubleTap(strip!)
+
+    expect(groupNode().minimized).not.toBe(true)
+    expect(groupNode().headerHidden).not.toBe(true)
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tool-panel-close.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tool-panel-close.test.tsx
@@ -101,6 +101,7 @@ describe('right-clicking a tool panel tab', () => {
     openContextMenu(tab!)
 
     expect(await screen.findByRole('menuitem', { name: /^close$/i })).toBeTruthy()
+    expect(await screen.findByRole('menuitem', { name: /^hide header$/i })).toBeTruthy()
   })
 
   it('offers Close while the zone is MINIMIZED to its rail', async () => {
@@ -116,6 +117,18 @@ describe('right-clicking a tool panel tab', () => {
     openContextMenu(tabEl('logs')!)
 
     expect(await screen.findByRole('menuitem', { name: /^close$/i })).toBeTruthy()
+  })
+})
+
+describe('right-clicking the session workspace tab', () => {
+  it('does not offer the dead-end Hide header action', async () => {
+    declareDefaultTree(group(['workspace'], { active: 'workspace', id: 'grp-main' }))
+    render(<TreeGroup node={zoneAt(0)} parentAxis="row" />)
+
+    openContextMenu(tabEl('workspace')!)
+
+    expect(await screen.findByRole('menu')).toBeTruthy()
+    expect(screen.queryByRole('menuitem', { name: /^hide header$/i })).toBeNull()
   })
 })
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -35,6 +35,16 @@ function terminalGroup(minimized: boolean): GroupNode {
   }
 }
 
+function workspaceGroup(): GroupNode {
+  return {
+    active: 'workspace',
+    headerHidden: true,
+    id: 'workspace-zone',
+    panes: ['workspace'],
+    type: 'group'
+  }
+}
+
 const toggle = (label: string) =>
   globalThis.document.querySelector<HTMLButtonElement>(
     `[data-tree-group="terminal-zone"] button[aria-label="${label}"]`
@@ -72,5 +82,20 @@ describe('TreeGroup', () => {
     render(<TreeGroup node={terminalGroup(true)} parentAxis="column" />)
 
     expect(toggle('Restore').querySelector('i')!.className).toContain('codicon-chevron-up')
+  })
+
+  it('keeps the session strip visible for a lone workspace with persisted hide', () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { placement: 'main', uncloseable: true },
+      id: 'workspace',
+      render: () => <div>Workspace</div>,
+      title: 'Workspace'
+    })
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+
+    render(<TreeGroup node={workspaceGroup()} parentAxis="row" />)
+
+    expect(globalThis.document.querySelector('[data-tree-group="workspace-zone"][data-zone-header]')).not.toBeNull()
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -72,7 +72,7 @@ import {
 } from '../tab-selection'
 
 import { type DoubleTapContext, startPaneDrag } from './drag-session'
-import { forceLoneHeaderForPanes } from './lone-header'
+import { forceLoneHeaderForPanes, resolveZoneHeaderHidden } from './lone-header'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
 
@@ -82,6 +82,7 @@ import { paneChrome } from './track-model'
  *  a pane with no domain menu of its own (the file tree, a terminal, the main
  *  tab on a fresh draft) falls through to this one. */
 function ZoneMenu({
+  canHideHeader = true,
   children,
   closable,
   minimizable = true,
@@ -90,6 +91,8 @@ function ZoneMenu({
   nodeId,
   targetPane
 }: {
+  /** False for chat switchers, whose strip is the only session-tab recovery surface. */
+  canHideHeader?: boolean
   children: ReactNode
   /** The pane the menu closes (the right-clicked chip / the active pane);
    *  undefined = not closable (the main zone). */
@@ -155,12 +158,13 @@ function ZoneMenu({
             </>
           )
         })()}
-        <kit.Separator />
-        {renderActionItem(kit, {
-          icon: headerHidden ? 'eye' : 'eye-closed',
-          label: headerHidden ? t.zones.showHeader : t.zones.hideHeader,
-          onSelect: () => setTreeGroupHeaderHidden(nodeId, !headerHidden)
-        })}
+        {(canHideHeader || minimizable) && <kit.Separator />}
+        {canHideHeader &&
+          renderActionItem(kit, {
+            icon: headerHidden ? 'eye' : 'eye-closed',
+            label: headerHidden ? t.zones.showHeader : t.zones.hideHeader,
+            onSelect: () => setTreeGroupHeaderHidden(nodeId, !headerHidden)
+          })}
         {minimizable &&
           renderActionItem(kit, {
             // Same action-direction contract as the strip button below: the
@@ -263,16 +267,25 @@ export function TreeGroup({
   //    tile in its own zone is unclosable (the "3rd tile has no tab" trap);
   //  - a TOOL PANEL (terminal/logs — a collapse pane) dragged out of the main
   //    stack, else it's a dead zone with no tab to grab or ✕ to close.
-  // The uncloseable workspace and side chrome (sessions/files) keep the clean
-  // no-tab default. Double-click toggles it either way; a minimized group
-  // always shows its header (it IS the header).
+  // The session switcher (workspace + session tiles) always keeps its strip:
+  // hiding the only session navigation surface is an inescapable dead end.
+  // Standing side chrome (sessions/files) keeps the clean no-tab default. A
+  // minimized group always shows its header (it IS the header).
   // Session-tile ids force the header even before chrome registers — cycling
   // onto a freshly-split tile used to land headerless ("name card missing").
   const forceLoneHeader = forceLoneHeaderForPanes(shown, id => paneChrome(paneFor(id)), isCollapsePane)
+  const sessionStrip = shown.some(isSessionStripPane)
+  const canHideHeader = !sessionStrip
 
   // A full-page view (headerVeto) suppresses the strip while it's the active
   // pane — a page is not a tab-able surface; the bar returns with the chat.
-  const headerHidden = paneChrome(active).headerVeto || (node.headerHidden ?? (shown.length <= 1 && !forceLoneHeader))
+  const headerHidden = resolveZoneHeaderHidden({
+    forceLoneHeader,
+    headerVeto: Boolean(paneChrome(active).headerVeto),
+    persistedHidden: node.headerHidden,
+    sessionStrip,
+    shownCount: shown.length
+  })
 
   // A group collapses ALONG its parent split's axis. In a row that means the
   // WIDTH collapses — a full-width horizontal header would strand a tall
@@ -298,6 +311,11 @@ export function TreeGroup({
     key: `hide-header-${node.id}`,
     onDoubleTap: () => {
       setTreeGroupMinimized(node.id, false)
+
+      if (!canHideHeader) {
+        return
+      }
+
       setTreeGroupHeaderHidden(node.id, true)
     }
   }
@@ -347,6 +365,7 @@ export function TreeGroup({
 
   // Same menu on the header strip and the edit veil — one prop bag.
   const zoneMenu = {
+    canHideHeader,
     closable,
     headerHidden,
     minimizable,
@@ -357,9 +376,9 @@ export function TreeGroup({
 
   // NO body double-click toggle: virtualized content (the thread) recreates
   // its nodes between clicks, so the gesture was hopelessly unreliable. The
-  // bar's lifecycle is explicit instead — gaining a tab sticky-shows it
-  // (insertAtGroup pins headerHidden false), the main tab's context menu
-  // hides it, and full-page views veto it via paneChrome.headerVeto.
+  // bar's lifecycle is explicit instead — the session switcher stays visible,
+  // tool/side zones may hide from their own strip, and full-page views veto it
+  // via paneChrome.headerVeto.
 
   return (
     <div


### PR DESCRIPTION
## What does this PR do?

Keeps the Desktop session-tab strip visible for every chat switcher zone (`workspace` and `session-tile:*`). Today a lone workspace auto-hides its strip, and a persisted `headerHidden: true` can make that state survive restarts. Because the only **Show header** action lives in the hidden strip, the user is left with no in-app recovery path.

This rebased successor to #89225 keeps that navigation surface available while addressing its review feedback:

- reuses the existing `isSessionStripPane` classifier instead of introducing a second pane-id authority;
- preserves `paneChrome.headerVeto` for full-page views;
- removes **Hide header** only from session switcher zones, while tool/side zones retain it;
- compensates the first tap's minimize before refusing a session-strip double-tap hide, so minimizable session tiles do not collapse.

The change is complementary to #91514 / #86278, which prevent tab double-clicks from forwarding the strip-hide gesture. This PR owns the remaining lone-workspace, persisted-state, menu, and strip-background paths.

Co-authored with and based on the policy work in #89225 by @leonphull; this branch updates the implementation to current `main` and incorporates the blocking review feedback.

## Related Issue

Fixes #89350
Related: #79518, #89225, #91514

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `renderer/lone-header.ts`: centralize header visibility precedence for session vs non-session zones.
- `renderer/tree-group.tsx`: keep session strips visible, omit their dead-end hide action, and refuse persisted/double-tap hiding while preserving minimize compensation.
- Renderer tests: cover lone workspace, persisted hide, full-page veto, non-session policy, context-menu behavior, and the synthesized double-tap path.

## How to Test

1. Start Desktop with a layout containing only `workspace` in `grp-main` and no explicit `headerHidden`; confirm the workspace tab and `+` remain visible.
2. Start with `grp-main.headerHidden: true`; confirm the session strip still renders and **Hide header** is absent from its context menu.
3. Double-tap the strip background of a minimizable `session-tile:*` zone; confirm the zone is not left minimized and `headerHidden: true` is not persisted.
4. Open a full-page view; confirm `headerVeto` still suppresses the strip.
5. Open a lone tool zone such as terminal; confirm its existing **Hide header** action still works.

Automated verification:

- `vitest run --project ui src/components/pane-shell/tree`: 24 files, 125 tests passed.
- Sabotage run with the session-strip resolver disabled: 3 new regressions fail; restoring the fix returns the suite to green.
- `npm run typecheck`: clean.
- `npm run lint`: 0 errors (repository baseline warnings only).
- `npm run build`: production renderer + Electron bundles built successfully.
- `git diff --check`: clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Desktop test suite; Python tests are unaffected by this renderer-only change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 packaged Desktop plus jsdom/Vitest regression suite

### Documentation & Housekeeping

- [x] Documentation update N/A — renderer behavior and inline policy comments updated
- [x] `cli-config.yaml.example` N/A — no config change
- [x] `CONTRIBUTING.md` / `AGENTS.md` N/A — no architecture or workflow change
- [x] Cross-platform impact considered — pure renderer policy, no OS-specific API
- [x] Tool descriptions/schemas N/A — no tool change

## Screenshots / Logs

Live packaged Windows reproduction showed `grp-main` containing only `workspace` with no `headerHidden`; the left strip was absent while another session group still displayed tabs. Setting `grp-main.headerHidden = false` through DevTools restored the workspace tab and `New session tab` affordance immediately. The regression suite now enforces that state without requiring DevTools recovery.
