### PR TITLE
fix(desktop): stop SSH backends from leaking after quit

### DIFF
--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection } from './connection-apply'
+import {
+  applyConnectionChange,
+  commitConnectionFailure,
+  resolveTerminalConnection,
+  teardownSshState
+} from './connection-apply'
 
 function deferred() {
   let resolve!: () => void
@@ -83,6 +88,39 @@ describe('resolveTerminalConnection', () => {
         async () => undefined
       )
     ).rejects.toThrow('not ready')
+  })
+})
+
+describe('teardownSshState', () => {
+  it('terminates the owned remote backend before closing its tunnel and SSH transport', async () => {
+    const events: string[] = []
+
+    const ssh = {
+      cancelForward: async () => events.push('forward'),
+      close: async () => events.push('ssh')
+    }
+
+    await teardownSshState(
+      { ssh, ownershipId: 'owner', localPort: 1234, remotePort: 5678 },
+      { cleanupRemote: async () => events.push('remote') }
+    )
+
+    expect(events).toEqual(['remote', 'forward', 'ssh'])
+  })
+
+  it('still closes the SSH transport when remote cleanup fails', async () => {
+    const close = vi.fn(async () => undefined)
+
+    await teardownSshState(
+      { ssh: { cancelForward: vi.fn(async () => undefined), close }, ownershipId: 'owner' },
+      {
+        cleanupRemote: async () => {
+          throw new Error('remote unavailable')
+        }
+      }
+    )
+
+    expect(close).toHaveBeenCalledOnce()
   })
 })
 

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -54,4 +54,26 @@ async function resolveTerminalConnection(getTarget, ensureBackend) {
   return target
 }
 
-export { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection }
+async function teardownSshState(state, { cleanupRemote }) {
+  try {
+    await cleanupRemote(state.ssh, state.ownershipId)
+  } catch {
+    // Remote teardown is best-effort; always release the local tunnel and SSH transport.
+  }
+
+  try {
+    if (state.localPort && state.remotePort) {
+      await state.ssh.cancelForward(state.localPort, state.remotePort)
+    }
+  } catch {
+    // Best effort; closing the transport below drops any remaining forwards.
+  }
+
+  try {
+    await state.ssh.close()
+  } catch {
+    // The app must still be able to quit when SSH teardown fails.
+  }
+}
+
+export { applyConnectionChange, commitConnectionFailure, resolveTerminalConnection, teardownSshState }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -61,7 +61,7 @@ import {
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
 import { runBootstrap } from './bootstrap-runner'
 import { detectBundleSkew } from './bundle-skew'
-import { applyConnectionChange } from './connection-apply'
+import { applyConnectionChange, teardownSshState } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -9078,19 +9078,9 @@ async function teardownSshConnection(profile) {
 
   terminalIpc.disposeTerminalSessionsForSshScope(scope)
 
-  try {
-    if (state.localPort && state.remotePort) {
-      await state.ssh.cancelForward(state.localPort, state.remotePort)
-    }
-  } catch {
-    // best effort
-  }
-
-  try {
-    await state.ssh.close()
-  } catch {
-    // best effort
-  }
+  await teardownSshState(state, {
+    cleanupRemote: state.remotePlatform === 'Windows' ? async () => {} : remoteLifecycle.disconnect
+  })
 }
 
 // CRITICAL: this must mirror resolveRemoteBackend's precedence, not just return
@@ -9321,6 +9311,7 @@ async function bootstrapSshConnectionInner(profile, sshConfig, reuseToken, sourc
   sshConnections.set(scope, {
     ssh,
     fingerprint,
+    ownershipId: result.ownershipId,
     localPort: result.localPort,
     remotePort: result.remotePort,
     pid: result.pid,
@@ -15170,6 +15161,11 @@ app.on('before-quit', event => {
     return
   }
 
+  // A prevented first quit leaves the renderer alive while teardown runs. Seal
+  // the SSH coordinator before touching any connections so reconnect callbacks
+  // cannot recreate a backend for a registration whose app is already quitting.
+  sshBootstrapCoordinator.shutdown()
+
   if (!backendQuitTeardownDone) {
     event.preventDefault()
     void backendShutdown.run().finally(() => {
@@ -15180,7 +15176,6 @@ app.on('before-quit', event => {
 
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
     event.preventDefault()
-    sshBootstrapCoordinator.cancelAll()
     const scopes = [...sshConnections.keys()]
 
     const pending = Promise.allSettled([
@@ -15188,7 +15183,7 @@ app.on('before-quit', event => {
       ...sshBootstrapCoordinator.promises()
     ])
 
-    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 4_000))]).then(async () => {
+    void Promise.race([pending, new Promise(resolve => setTimeout(resolve, 6_000))]).then(async () => {
       await sshBootstrapCoordinator.forceCleanupAll()
       sshQuitTeardownDone = true
       app.quit()

--- a/apps/desktop/electron/remote-lifecycle.test.ts
+++ b/apps/desktop/electron/remote-lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
   buildSpawnCommand,
   cleanupStale,
   connect,
+  disconnect,
   expandRemotePath,
   fingerprintToken,
   isForwardBindCollision,
@@ -490,6 +491,21 @@ test('cleanupStale kills ONLY a provably-ours pid, always drops the lockfile', a
   })
   assert.ok(ours.calls.some(c => /kill 9\b/.test(c)))
   assert.ok(ours.calls.some(c => /rm -f/.test(c)))
+})
+
+test('disconnect reaps the backend recorded for this desktop ownership', async () => {
+  const lock = ownedLock()
+
+  const ssh = fakeSsh([
+    [/cat .*backend\.lock\.json/, JSON.stringify(lock)],
+    [/kill -0 333/, 'ALIVE\n'],
+    [/print\("OWNED"/, 'OWNED\n']
+  ])
+
+  await disconnect(ssh, OWNERSHIP_ID)
+
+  assert.ok(ssh.calls.some(command => /kill 333\b/.test(command)))
+  assert.ok(ssh.calls.some(command => /rm -f .*backend\.lock\.json/.test(command)))
 })
 
 test('buildSpawnCommand is headless serve, detached, token not in argv', () => {

--- a/apps/desktop/electron/remote-lifecycle.ts
+++ b/apps/desktop/electron/remote-lifecycle.ts
@@ -518,6 +518,17 @@ async function cleanupStale(ssh, ownershipId, lock, pidAlive = true) {
   await removeLockfile(ssh, ownershipId)
 }
 
+async function disconnect(ssh, ownershipId) {
+  const lock = await readLockfile(ssh, ownershipId)
+
+  if (!lock) {
+    return
+  }
+
+  const pidAlive = await remotePidAlive(ssh, lock.pid)
+  await cleanupStale(ssh, ownershipId, lock, pidAlive)
+}
+
 // Detach so the backend survives the SSH channel closing: setsid (Linux)
 // starts a new session; macOS has no setsid, so fall back to nohup (HUP-immune;
 // fd-detachment is already handled by </dev/null + redirect + &).
@@ -960,6 +971,7 @@ export {
   cleanupStale,
   connect,
   DEFAULT_READY_TIMEOUT_MS,
+  disconnect,
   expandRemotePath,
   fingerprintToken,
   isForwardBindCollision,

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 
-import { test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 
@@ -127,6 +127,24 @@ test('cancelAll invalidates every pending scope and exposes promises for quit', 
   gates.forEach(gate => gate.resolve())
   const results = await Promise.allSettled(promises)
   assert.ok(results.every(result => result.status === 'rejected' && (result.reason as any).kind === 'superseded'))
+})
+
+test('shutdown cancels active bootstraps and permanently rejects respawn attempts', async () => {
+  const coordinator = createBootstrapCoordinator()
+  const gate = deferred()
+
+  const active = coordinator.start('primary', 'old', async lease => {
+    await gate.promise
+    lease.assertCurrent()
+  })
+
+  coordinator.shutdown()
+  gate.resolve()
+
+  await expect(active).rejects.toMatchObject({ kind: 'superseded' })
+  const run = vi.fn(async () => undefined)
+  await expect(coordinator.start('primary', 'new', run)).rejects.toMatchObject({ kind: 'superseded' })
+  expect(run).not.toHaveBeenCalled()
 })
 
 test('cancelAndWait drains only the requested scope', async () => {

--- a/apps/desktop/electron/ssh-bootstrap-coordinator.ts
+++ b/apps/desktop/electron/ssh-bootstrap-coordinator.ts
@@ -23,8 +23,16 @@ function createBootstrapCoordinator() {
   const pending = new Map<string, any>()
   const generations = new Map<string, number>()
   const drains = new Map<string, Promise<void>>()
+  let shutdownRequested = false
 
   function start(scope, fingerprint, run) {
+    if (shutdownRequested) {
+      const error: any = new Error('SSH bootstrap was cancelled because Desktop is quitting.')
+      error.kind = 'superseded'
+
+      return Promise.reject(error)
+    }
+
     const current = pending.get(scope)
 
     if (current?.fingerprint === fingerprint) {
@@ -121,6 +129,11 @@ function createBootstrapCoordinator() {
     }
   }
 
+  function shutdown() {
+    shutdownRequested = true
+    cancelAll()
+  }
+
   async function forceCleanupAll() {
     const cleanups = [...active].flatMap(entry => [...entry.forceCleanups])
     await Promise.allSettled(cleanups.map(cleanup => cleanup()))
@@ -130,7 +143,7 @@ function createBootstrapCoordinator() {
     return [...active].map(entry => entry.promise)
   }
 
-  return { active, cancel, cancelAll, cancelAndWait, forceCleanupAll, pending, promises, start }
+  return { active, cancel, cancelAll, cancelAndWait, forceCleanupAll, pending, promises, shutdown, start }
 }
 
 export { createBootstrapCoordinator, sshConfigFingerprint }


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop now terminates the `hermes serve --isolated` backend it owns before closing an SSH connection, including during Cmd+Q teardown. It also permanently seals the SSH bootstrap coordinator once quitting starts so renderer reconnect callbacks cannot respawn a backend for a dead app session.

### Symptom

Quitting Desktop after connecting to a remote gateway over SSH leaves the remote `serve --isolated` process, its ownership lockfile, and SSH transport alive. Repeated sessions accumulate remote processes and memory usage.

### Impact

Affected remote hosts retain roughly 100-300 MB RSS per leaked backend according to the issue report. Repeated Desktop sessions can exhaust a small VPS and trigger OOM kills.

### Bug Cause

**Trigger:** `apps/desktop/electron/main.ts:9073` / `teardownSshConnection()` during connection changes or `before-quit`.

**Causal chain:**
1. SSH bootstrap detaches a remote `serve --isolated` process and records its PID in an ownership-scoped lockfile.
2. Desktop teardown only cancelled the local port forward and closed the SSH transport; it never used that ownership record to terminate the remote process.
3. The first `before-quit` event is prevented while asynchronous teardown runs, leaving the renderer alive long enough for reconnect callbacks to start a new SSH bootstrap.
4. The remote backend and registration therefore survive the owning app session, or are respawned while quit is in progress.

**Why it is wrong:** The ownership record already proves which remote process Desktop may safely terminate, but the clean teardown path ignored it and the bootstrap coordinator had cancellation without a terminal shutdown state.

**Working sibling / contrast:** Failed or superseded SSH startup already calls `cleanupStale()` for a provably owned process. This change applies the same ownership-safe cleanup to normal teardown.

**Ruled out:** OpenSSH `ControlPersist` alone does not explain the leaked `serve` processes. `SshConnection.close()` already attempts to exit the control master, while the remote backend is intentionally detached and requires its own lifecycle cleanup.

### Fix

- Add an ownership-aware remote disconnect path that reads the lockfile, verifies the process, terminates it, and removes its artifacts.
- Run remote cleanup before cancelling forwards and closing the SSH transport, while preserving best-effort local cleanup when the host is unreachable.
- Store the ownership ID with each live SSH connection.
- Add a terminal coordinator shutdown state and engage it before asynchronous quit teardown, preventing post-quit respawns.
- Extend the quit teardown budget to cover the existing bounded remote termination wait.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/remote-lifecycle.ts` - add ownership-safe remote backend disconnect cleanup.
- `apps/desktop/electron/connection-apply.ts` - sequence remote cleanup before local tunnel and transport teardown.
- `apps/desktop/electron/ssh-bootstrap-coordinator.ts` - reject new SSH bootstraps after quit shutdown begins.
- `apps/desktop/electron/main.ts` - retain ownership state and wire cleanup into connection and app quit teardown.
- Desktop electron tests - cover remote reaping, teardown ordering, failure fallback, and respawn rejection.

## How to Test

1. Connect Desktop to a Linux or macOS remote host over SSH and confirm one ownership-scoped `serve --isolated` backend is running.
2. Quit Desktop with Cmd+Q and confirm the owned remote backend and `backend.lock.json` are removed.
3. Run the automated regression tests:

```bash
cd apps/desktop
npx vitest run electron/connection-apply.test.ts electron/ssh-bootstrap-coordinator.test.ts electron/remote-lifecycle.test.ts
npm run typecheck
npx eslint electron/connection-apply.ts electron/connection-apply.test.ts electron/ssh-bootstrap-coordinator.ts electron/ssh-bootstrap-coordinator.test.ts electron/remote-lifecycle.ts electron/remote-lifecycle.test.ts electron/main.ts
```

Local result: 89 passed, 1 skipped; typecheck and ESLint passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop tests and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested the automated behavior on Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A; behavior and ownership contracts are documented in code and tests
- [x] Config example updates are N/A; no config keys changed
- [x] CONTRIBUTING.md and AGENTS.md updates are N/A; no architecture or workflow contract changed
- [x] I've considered cross-platform impact; POSIX remote cleanup is gated away from the separate Windows remote lifecycle
- [x] Tool description and schema updates are N/A; no agent tool behavior changed