### PR TITLE
fix(tui): preserve full model catalog after saving key

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -14329,8 +14329,62 @@ def test_model_save_key_uses_credential_lifecycle_and_picker_context(monkeypatch
     build_payload.assert_called_once_with(
         picker_ctx,
         picker_hints=True,
-        max_models=50,
     )
+
+
+def test_model_save_key_returns_full_provider_catalog(monkeypatch):
+    """Newly-authenticated providers must not be capped at 50 models."""
+    env_var = "TEST_LARGE_PROVIDER_API_KEY"
+    full_models = [f"model-{index:03}" for index in range(1, 121)]
+    picker_ctx = object()
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.PROVIDER_REGISTRY",
+        {
+            "large-provider": types.SimpleNamespace(
+                name="Large Provider",
+                auth_type="api_key",
+                api_key_env_vars=(env_var,),
+            )
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+    monkeypatch.setattr(
+        "hermes_cli.credential_lifecycle.save_provider_env_credential",
+        Mock(),
+    )
+    monkeypatch.setattr(server, "_model_picker_context", lambda _agent: picker_ctx)
+
+    def build_payload(_ctx, *, picker_hints, max_models=None):
+        models = full_models[:max_models] if max_models is not None else full_models
+        return {
+            "providers": [
+                {"slug": "other-provider", "models": ["other-model"]},
+                {
+                    "slug": "large-provider",
+                    "name": "Large Provider",
+                    "models": models,
+                    "total_models": len(full_models),
+                },
+            ]
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.inventory.build_models_payload",
+        build_payload,
+    )
+
+    resp = server._methods["model.save_key"](
+        104,
+        {"slug": "large-provider", "api_key": "test-key"},
+    )
+
+    provider = resp["result"]["provider"]
+    assert provider["slug"] == "large-provider"
+    assert len(provider["models"]) == 120
+    assert "model-051" in provider["models"]
+    assert provider["models"][-1] == "model-120"
+    assert len(provider["models"]) == len(set(provider["models"]))
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -545,6 +545,7 @@ def _(rid, params: dict) -> dict:
         session = _sessions.get(params.get("session_id", ""))
         agent = session.get("agent") if session else None
         ctx = _model_picker_context(agent)
+        # Newly authenticated providers need their complete catalog for TUI search.
         payload = build_models_payload(
             ctx,
             picker_hints=True,

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -546,7 +546,8 @@ def _(rid, params: dict) -> dict:
         agent = session.get("agent") if session else None
         ctx = _model_picker_context(agent)
         payload = build_models_payload(
-            ctx, picker_hints=True, max_models=50,
+            ctx,
+            picker_hints=True,
         )
         provider_data = next(
             (p for p in payload["providers"] if p["slug"] == slug), None


### PR DESCRIPTION
## Summary

Preserve the complete provider model catalog returned by `model.save_key` instead of applying the 50-model preview cap.

## Problem

Issue #42270 describes large provider catalogs, including NVIDIA NIM, losing models after the first 50 in the TUI picker.

On current `main`, the normal picker and prewarm paths already retain the complete catalog, but the `model.save_key` transition still requested `max_models=50`.

The TUI replaces the provider in local state with this response, so models after that cap cannot be searched until a later refresh.

## Fix

Remove the remaining catalog cap from the save-key response path.

Add an offline 120-model regression test covering models beyond position 50, provider selection, and duplicate prevention.

## Tests

- `scripts/run_tests.sh tests/test_tui_gateway_server.py -k model_save_key -q` — 2 passed
- `scripts/run_tests.sh tests/test_tui_gateway_server.py tests/hermes_cli/test_inventory.py tests/hermes_cli/test_picker_prewarm.py tests/hermes_cli/test_model_catalog.py -q` — 626 passed
- `ruff check --no-cache tui_gateway/methods_complete.py tests/test_tui_gateway_server.py`
- `ruff format --check --no-cache --range=530-560 tui_gateway/methods_complete.py`
- `ruff format --check --no-cache --range=14280-14410 tests/test_tui_gateway_server.py`
- `git diff --check origin/main...HEAD`

Refs #42270
