### PR TITLE
fix: allow safe Obsidian links in Desktop

### DIFF
--- a/apps/desktop/electron/external-url-policy.test.ts
+++ b/apps/desktop/electron/external-url-policy.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { isAllowedShellExternalProtocol } from './external-url-policy'
+
+describe('external URL protocol policy', () => {
+  it('allows web, mail, and Obsidian handoffs', () => {
+    expect(isAllowedShellExternalProtocol('http:')).toBe(true)
+    expect(isAllowedShellExternalProtocol('https:')).toBe(true)
+    expect(isAllowedShellExternalProtocol('mailto:')).toBe(true)
+    expect(isAllowedShellExternalProtocol('obsidian:')).toBe(true)
+  })
+
+  it('rejects arbitrary custom and executable protocols', () => {
+    expect(isAllowedShellExternalProtocol('javascript:')).toBe(false)
+    expect(isAllowedShellExternalProtocol('vscode:')).toBe(false)
+    expect(isAllowedShellExternalProtocol('unknown-app:')).toBe(false)
+  })
+})

--- a/apps/desktop/electron/external-url-policy.ts
+++ b/apps/desktop/electron/external-url-policy.ts
@@ -1,0 +1,9 @@
+const SHELL_EXTERNAL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'obsidian:'])
+
+/**
+ * Protocols Electron may hand to the operating system after a user click.
+ * Keep this list deliberately narrow: custom schemes can launch applications.
+ */
+export function isAllowedShellExternalProtocol(protocol: string): boolean {
+  return SHELL_EXTERNAL_PROTOCOLS.has(protocol.toLowerCase())
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -141,6 +141,7 @@ import {
   terminalScriptExtension,
   tuiResumeArgs
 } from './external-terminal'
+import { isAllowedShellExternalProtocol } from './external-url-policy'
 import { type FaviconIo, resolveFavicon } from './favicon'
 import { findGitBash as _findGitBash } from './find-git-bash'
 import {
@@ -1589,7 +1590,7 @@ function openExternalUrl(rawUrl) {
     return true
   }
 
-  if (!['http:', 'https:', 'mailto:'].includes(parsed.protocol)) {
+  if (!isAllowedShellExternalProtocol(parsed.protocol)) {
     return false
   }
 

--- a/apps/desktop/src/components/assistant-ui/markdown-text.obsidian.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.obsidian.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MarkdownTextContent } from './markdown-text'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+
+const OBSIDIAN_URL =
+  'obsidian://open?vault=PG%20Vault&file=Social%20Media%2FDrafts%2F2026-08-21-americana-vin-fiz-parts-train.md'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+
+  if (initialHermesDesktop) {
+    desktopWindow.hermesDesktop = initialHermesDesktop
+  } else {
+    delete desktopWindow.hermesDesktop
+  }
+})
+
+describe('MarkdownTextContent Obsidian links', () => {
+  it('preserves an Obsidian URI and hands a user click to the desktop shell', async () => {
+    const openExternal = vi.fn().mockResolvedValue(undefined)
+
+    desktopWindow.hermesDesktop = { openExternal } as unknown as Window['hermesDesktop']
+
+    render(<MarkdownTextContent isRunning={false} text={`[Open the canonical draft](${OBSIDIAN_URL})`} />)
+
+    const link = await screen.findByRole('link', { name: 'Open the canonical draft' })
+
+    expect(link.getAttribute('href')).toBe(OBSIDIAN_URL)
+    expect(screen.queryByText('[blocked]')).toBeNull()
+
+    fireEvent.click(link)
+
+    expect(openExternal).toHaveBeenCalledOnce()
+    expect(openExternal).toHaveBeenCalledWith(OBSIDIAN_URL)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -20,6 +20,7 @@ import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/extern
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
+import { obsidianHrefFromMarkdownHref, remarkObsidianLinks } from '@/lib/obsidian-link'
 import {
   downloadGatewayMediaFile,
   isFileMediaPath,
@@ -56,6 +57,8 @@ import { paragraphPlainText, TranscriptDirectiveLeaf, useIsClaimedDirective } fr
 // `singleDollarTextMath: true` enables `$x^2$` for inline math (de-facto
 // LLM convention). The default false-setting only accepts `$$...$$`.
 const mathPlugin = createMemoizedMathPlugin({ singleDollarTextMath: true })
+
+const markdownRemarkPlugins = [remarkObsidianLinks]
 
 // `@streamdown/code` statically imports ALL of shiki (every grammar + theme —
 // the single largest chunk in the renderer), so it must never sit on the
@@ -255,6 +258,25 @@ function childrenToText(children: unknown): string {
 }
 
 function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a'>) {
+  const obsidianHref = obsidianHrefFromMarkdownHref(href)
+
+  if (obsidianHref) {
+    return (
+      <a
+        className={cn('ref wrap-anywhere', className)}
+        href={obsidianHref}
+        onClick={event => {
+          event.preventDefault()
+          openExternalLink(obsidianHref)
+        }}
+        rel="noopener noreferrer"
+        {...props}
+      >
+        {children}
+      </a>
+    )
+  }
+
   const mediaPath = mediaPathFromMarkdownHref(href)
 
   if (mediaPath) {
@@ -682,6 +704,7 @@ function MarkdownTextSurface({
         parseMarkdownIntoBlocksFn={parseMarkdownIntoBlocksCached}
         plugins={plugins}
         preprocess={preprocessWithTailRepair}
+        remarkPlugins={markdownRemarkPlugins}
       />
     </ErrorBoundary>
   )

--- a/apps/desktop/src/lib/obsidian-link.test.ts
+++ b/apps/desktop/src/lib/obsidian-link.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { obsidianHrefFromMarkdownHref, remarkObsidianLinks } from './obsidian-link'
+
+const OBSIDIAN_URL =
+  'obsidian://open?vault=PG%20Vault&file=Social%20Media%2FDrafts%2F2026-08-21-americana-vin-fiz-parts-train.md'
+
+describe('Obsidian Markdown link transport', () => {
+  it('encodes an Obsidian link as an inert fragment and restores it exactly', () => {
+    const link = { type: 'link', url: OBSIDIAN_URL, children: [{ type: 'text' }] }
+    const tree = { type: 'root', children: [link] }
+
+    remarkObsidianLinks()(tree)
+
+    expect(link.url).toMatch(/^#obsidian:/)
+    expect(obsidianHrefFromMarkdownHref(link.url)).toBe(OBSIDIAN_URL)
+  })
+
+  it('ignores normal links and rejects malformed or spoofed fragments', () => {
+    const link = { type: 'link', url: 'https://example.com', children: [] }
+
+    remarkObsidianLinks()({ type: 'root', children: [link] })
+
+    expect(link.url).toBe('https://example.com')
+    expect(obsidianHrefFromMarkdownHref('#obsidian:not-a-custom-uri')).toBeNull()
+    expect(obsidianHrefFromMarkdownHref('#obsidian:%E0%A4%A')).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/obsidian-link.ts
+++ b/apps/desktop/src/lib/obsidian-link.ts
@@ -1,0 +1,39 @@
+type MarkdownNode = {
+  children?: MarkdownNode[]
+  type?: string
+  url?: string
+}
+
+const OBSIDIAN_FRAGMENT_PREFIX = '#obsidian:'
+
+/**
+ * Carry Markdown-authored Obsidian URIs through rehype-sanitize as inert
+ * fragments. The renderer restores them only for an explicit user click.
+ */
+export function remarkObsidianLinks() {
+  return (tree: MarkdownNode) => {
+    const walk = (node: MarkdownNode) => {
+      if (node.type === 'link' && node.url && /^obsidian:/i.test(node.url)) {
+        node.url = `${OBSIDIAN_FRAGMENT_PREFIX}${encodeURIComponent(node.url)}`
+      }
+
+      node.children?.forEach(walk)
+    }
+
+    walk(tree)
+  }
+}
+
+export function obsidianHrefFromMarkdownHref(href?: string): string | null {
+  if (!href?.startsWith(OBSIDIAN_FRAGMENT_PREFIX)) {
+    return null
+  }
+
+  try {
+    const decoded = decodeURIComponent(href.slice(OBSIDIAN_FRAGMENT_PREFIX.length))
+
+    return /^obsidian:/i.test(decoded) ? decoded : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

- preserve Markdown-authored `obsidian://` links through Desktop's sanitized Markdown pipeline
- hand Obsidian links to the OS only after an explicit user click
- add `obsidian:` to Electron's narrow external-protocol allowlist while continuing to reject arbitrary custom schemes
- cover the renderer transport/click path and Electron protocol policy with targeted tests

## Why

Hermes Desktop currently renders a valid Obsidian deep link such as:

```markdown
[Open the canonical draft](obsidian://open?vault=PG%20Vault&file=Social%20Media%2FDrafts%2Fexample.md)
```

as plain text followed by `[blocked]`. This prevents scheduled-job outputs from linking directly to synced Obsidian notes.

The fix does not relax custom protocols generally. The Markdown layer carries only `obsidian:` links through sanitization as inert fragments, restores them in the dedicated link component, and Electron independently checks the final protocol before calling `shell.openExternal`.

## Tests

- `NODE_OPTIONS=--max-old-space-size=512 npx vitest run --project ui src/lib/obsidian-link.test.ts --maxWorkers=1 --no-file-parallelism`
- `NODE_OPTIONS=--max-old-space-size=256 npx vitest run --project electron electron/external-url-policy.test.ts --maxWorkers=1 --no-file-parallelism`
- `NODE_OPTIONS=--max-old-space-size=512 npx vitest run --project ui src/components/assistant-ui/markdown-text.obsidian.test.tsx --maxWorkers=1 --no-file-parallelism`
- targeted ESLint for all new and changed support/test files
