### PR TITLE
fix(browser): live Developer Mode revocation + restart-safe artifact TTL

### DIFF
--- a/gateway/browser_control_artifacts.py
+++ b/gateway/browser_control_artifacts.py
@@ -215,6 +215,44 @@ class ArtifactStore:
         self._clock = clock if clock is not None else time.time
         self._lock = threading.RLock()
         self._entries: dict[str, _ArtifactEntry] = {}
+        # Restart-safe retention: receipts live only in memory, so files
+        # left behind by a previous process are unreachable but would
+        # otherwise persist forever. Sweep every artifact-id-shaped file
+        # (plus stale temps) that has no index entry — at construction the
+        # index is empty, so anything on disk is an orphan from a dead
+        # process and past its advertised TTL by definition.
+        self._sweep_orphan_files()
+
+    def _sweep_orphan_files(self) -> int:
+        """Delete on-disk artifact files with no live index entry.
+
+        Called at construction (empty index ⇒ everything on disk is an
+        orphan from a previous process). Only files whose names match the
+        server-minted 32-hex id shape or the ``*.tmp`` staging suffix are
+        touched; anything else in the directory is left alone.
+        """
+        removed = 0
+        try:
+            candidates = list(self._root.iterdir())
+        except OSError:
+            return 0
+        with self._lock:
+            live = set(self._entries)
+        for path in candidates:
+            if not path.is_file():
+                continue
+            name = path.name
+            is_temp = name.endswith(".tmp")
+            if not is_temp and not _ARTIFACT_ID_RE.fullmatch(name):
+                continue
+            if not is_temp and name in live:
+                continue
+            try:
+                path.unlink(missing_ok=True)
+                removed += 1
+            except OSError:
+                continue
+        return removed
 
     # ------------------------------------------------------------------
     # Public API

--- a/gateway/browser_control_broker.py
+++ b/gateway/browser_control_broker.py
@@ -335,17 +335,27 @@ class BrowserControlBroker:
         self._controllers: Dict[ControllerScope, _Controller] = {}
         self._pending: Dict[str, _PendingCommand] = {}
         # Developer Mode gates privileged capabilities (browser_evaluate,
-        # browser_cdp). None defers to the live config on every dispatch so
-        # a mid-process config change is honored without restart; an explicit
-        # bool pins the gate for tests and multi-tenant hosts.
-        if developer_mode is None:
-            developer_mode = browser_control_developer_mode()
-        self._developer_mode = developer_mode is True
+        # browser_cdp). None defers to the live config on every selection so
+        # a mid-process config change is honored without restart — including
+        # REVOKING raw CDP/eval from already-attached controllers; an
+        # explicit bool pins the gate for tests and multi-tenant hosts.
+        self._developer_mode_pinned: Optional[bool] = (
+            None if developer_mode is None else developer_mode is True
+        )
         # Artifact stores keyed by resolved profile id; ``None`` is the
         # default/unscoped store (tests, single-profile hosts). A multiplex
         # listener attaches one store per profile so profile A touching the
         # artifact route first can never pin profile B to A's physical root.
         self._artifact_stores: Dict[Optional[str], Any] = {}
+
+    def _developer_mode_now(self) -> bool:
+        """Current Developer Mode authority (live config unless pinned)."""
+        if self._developer_mode_pinned is not None:
+            return self._developer_mode_pinned
+        try:
+            return browser_control_developer_mode()
+        except Exception:
+            return False
 
     def attach_artifact_store(
         self, store: Any, *, profile_id: Optional[str] = None
@@ -378,14 +388,9 @@ class BrowserControlBroker:
         return self._artifact_stores.get(None)
 
     @property
-    def _artifact_store(self) -> Any:
-        """Back-compat view of the default artifact store (tests)."""
-        return self._artifact_stores.get(None)
-
-    @property
     def developer_mode(self) -> bool:
         """Whether privileged capabilities may be selected/dispatched."""
-        return self._developer_mode
+        return self._developer_mode_now()
 
     # ------------------------------------------------------------------
     # Registration tickets
@@ -534,10 +539,13 @@ class BrowserControlBroker:
         Privileged capabilities (``browser_evaluate``, ``browser_cdp``) are
         additionally gated on Developer Mode: with the gate off they are
         never selectable, even when a controller somehow negotiated them.
+        The gate consults the LIVE flag on every selection (unless pinned at
+        construction), so flipping ``developer_mode`` off in config revokes
+        raw CDP/eval from already-attached controllers without a restart.
         """
         if (
             capability in BROWSER_CONTROL_DEVELOPER_CAPABILITIES
-            and not self._developer_mode
+            and not self._developer_mode_now()
         ):
             return None
         with self._lock:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6978,13 +6978,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 continue
             if msg.get("role") not in {"assistant", "tool"}:
                 continue
-            if _is_compressed_summary_message(msg):
-                projected = cls._message_response(msg)
-                if projected.get("display_kind") == "hidden":
-                    continue
-                out.append(projected)
+            # _message_response projects compaction scaffolding itself and
+            # marks pure handoffs display_kind == "hidden"; classifying here
+            # first would re-run the content classifier (a full content
+            # flatten + prefix scan) a second time per message.
+            projected = cls._message_response(msg)
+            if projected.get("display_kind") == "hidden":
                 continue
-            out.append(cls._message_response(msg))
+            out.append(projected)
         return out
 
     @staticmethod

--- a/tests/gateway/test_browser_control_artifacts.py
+++ b/tests/gateway/test_browser_control_artifacts.py
@@ -660,3 +660,62 @@ def test_multiplex_profiles_get_distinct_stores_regardless_of_touch_order(tmp_pa
     scope_b = _broker_scope(profile_id="profile-b")
     assert broker._artifact_store_for_scope(scope_a) is store_a
     assert broker._artifact_store_for_scope(scope_b) is store_b
+
+
+def test_developer_mode_flip_revokes_privileged_selection_live(monkeypatch):
+    """Turning developer_mode off in config revokes CDP/eval from an
+    already-attached controller without a process restart (and on->off
+    the reverse: enabling unlocks selection for a new negotiation)."""
+    import gateway.browser_control_broker as broker_mod
+
+    flag = {"on": True}
+    monkeypatch.setattr(
+        broker_mod, "browser_control_developer_mode", lambda config=None: flag["on"]
+    )
+    broker = BrowserControlBroker()  # developer_mode=None -> live config
+    scope = _broker_scope(
+        capabilities=frozenset({"browser_evaluate", "browser_cdp", "controller.noop"})
+    )
+    broker.attach(scope, lambda _frame: None)
+
+    assert broker.select(scope, "browser_evaluate") is not None
+    # Revocation: flip the live flag off — the attached controller loses
+    # privileged selection immediately.
+    flag["on"] = False
+    assert broker.select(scope, "browser_evaluate") is None
+    assert broker.select(scope, "browser_cdp") is None
+    # Base capabilities are unaffected by the developer gate.
+    assert broker.select(scope, "controller.noop") is not None
+    # And back on: selection resumes without any rebind.
+    flag["on"] = True
+    assert broker.select(scope, "browser_cdp") is not None
+    # Explicit pin still wins over live config (test/multi-tenant contract).
+    pinned = BrowserControlBroker(developer_mode=False)
+    pinned.attach(scope, lambda _frame: None)
+    assert pinned.select(scope, "browser_evaluate") is None
+
+
+def test_store_construction_sweeps_orphan_files_from_previous_process(tmp_path):
+    """Files left by a dead process (unreachable, past advertised TTL) are
+    removed when a fresh store opens the same root."""
+    root = tmp_path / "root"
+    store = ArtifactStore(root)
+    receipt = store.store(
+        TEXT_BYTES, filename="note.txt", content_type="text/plain", scope=_Scope()
+    )
+    orphan = root / receipt.artifact_id
+    assert orphan.exists()
+    stale_tmp = root / "deadbeef.tmp"
+    stale_tmp.write_bytes(b"partial")
+    unrelated = root / "README"
+    unrelated.write_bytes(b"keep me")
+
+    # Simulate restart: a new store over the same root has an empty index.
+    fresh = ArtifactStore(root)
+    assert not orphan.exists()
+    assert not stale_tmp.exists()
+    assert unrelated.exists()  # non-artifact-shaped names untouched
+    assert fresh.count() == 0
+    # New store works normally afterwards.
+    fresh.store(TEXT_BYTES, filename="new.txt", content_type="text/plain", scope=_Scope())
+    assert fresh.count() == 1


### PR DESCRIPTION
## Summary

Closes the two live review blockers from @andrexibiza's #91535 re-review (Developer Mode revocation, restart-safe artifact TTL) plus the double-classification hot-path finding from the post-merge simplify pass.

Blockers 1 and 2 of that review (artifact scope composition, first-profile-wins store) were already fixed in #91535's merged head — the review was written against pre-fix commit `597bc49c65`; see commits `2b10313973`/`7b2b30f587` on main.

## Changes

- `gateway/browser_control_broker.py`: privileged capability selection (`browser_evaluate`/`browser_cdp`) now consults the LIVE `developer_mode` config on every `select()` — flipping it off revokes raw CDP/eval from already-attached controllers without restart; on→off and off→on both covered. Explicit bool still pins the gate (tests/multi-tenant). Also removes the dead `_artifact_store` back-compat property (zero readers).
- `gateway/browser_control_artifacts.py`: a fresh `ArtifactStore` sweeps orphan artifact-id-shaped files and stale `*.tmp` left by a dead process — receipts are memory-only, so post-restart files were unreachable yet lived forever despite the advertised 300s TTL. Non-artifact-shaped names untouched.
- `gateway/platforms/api_server.py`: `_turn_transcript_messages` classifies each row once via the projection instead of pre-classifying then re-classifying inside `_message_response` (was 2x/3x full-content flatten per row per `run.completed`).

## Validation

| | Result |
|---|---|
| Browser-control suites + router + compaction projection | 113 passed |
| Dev-mode revocation regression | on→off revokes attached controller live; off→on unlocks; pinned-bool contract kept |
| Restart-orphan regression | orphan + stale tmp removed, unrelated file kept, fresh store functional |
| ruff | clean |

Refs #91535 (salvage of #85351 by @abundantbeing); addresses https://github.com/NousResearch/hermes-agent/pull/91535#pullrequestreview (blockers 3–4).
