### PR TITLE
fix(auxiliary): resolve keys for bare custom providers

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -709,6 +709,14 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     if not requested_norm:
         return None
 
+    bare_custom_fallback = requested_norm == "custom"
+    first_custom_alias = ""
+
+    def _bare_custom_result() -> Optional[Dict[str, Any]]:
+        if bare_custom_fallback and first_custom_alias:
+            return _get_named_custom_provider(first_custom_alias)
+        return None
+
     # Bare "custom" is normally an incomplete spec — the canonical form is
     # "custom:<name>" — and is otherwise owned by the model.base_url "bare
     # custom" trust path. BUT a user may literally name a ``providers:`` (or
@@ -717,8 +725,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     # config, so such an entry was never matched and resolution fell through to
     # the global default (Codex) — the cause of cron jobs with
     # ``provider: "custom"`` failing with ``auth_unavailable: providers=codex``.
-    # Fall through to the config scan instead; if no entry is literally named
-    # "custom" it still returns None at the end, preserving the trust path.
+    # Fall through to the config scan instead. If no entry is literally named
+    # "custom", recover the first configured endpoint as the same compatibility
+    # fallback used by ``resolve_custom_provider`` for older picker state.
 
     # Raw names should only map to custom providers when they are not already
     # valid built-in providers or aliases. Explicit menu keys like
@@ -768,12 +777,19 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
 
             display_name = entry.get("name", "")
+            candidate_base_url = (
+                entry.get("api") or entry.get("url") or entry.get("base_url") or ""
+            )
+            if candidate_base_url and not first_custom_alias:
+                first_custom_alias = custom_provider_slug(
+                    str(display_name or ep_name), str(ep_name)
+                )
             if requested_norm in custom_provider_aliases(
                 str(display_name or ep_name),
                 str(ep_name),
             ):
                 # Found match by provider key
-                base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
+                base_url = candidate_base_url
                 if base_url:
                     result = {
                         "name": entry.get("name", ep_name),
@@ -813,11 +829,11 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             "Each entry must be prefixed with '-' in YAML. "
             "Run 'hermes doctor' for details."
         )
-        return None
+        return _bare_custom_result()
 
     custom_providers = get_compatible_custom_providers(config)
     if not custom_providers:
-        return None
+        return _bare_custom_result()
 
     for entry in custom_providers:
         if not isinstance(entry, dict):
@@ -827,6 +843,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         if not isinstance(name, str) or not isinstance(base_url, str):
             continue
         provider_key = str(entry.get("provider_key", "") or "").strip()
+        if name.strip() and base_url.strip() and not first_custom_alias:
+            first_custom_alias = custom_provider_slug(name, provider_key)
         if requested_norm not in custom_provider_aliases(name, provider_key):
             continue
         result = {
@@ -852,7 +870,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         _lift_max_output_tokens(entry, result)
         return result
 
-    return None
+    return _bare_custom_result()
 
 
 def has_named_custom_provider(requested_provider: str) -> bool:

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -122,6 +122,39 @@ class TestResolveProviderClientNamedCustom:
         assert client is not None
         # no-key-required should be used
 
+    def test_bare_custom_uses_saved_provider_and_scoped_key(self, tmp_path, monkeypatch):
+        """A picker-persisted bare ``custom`` assignment must retain the saved
+        endpoint identity and resolve its key from the active profile scope."""
+        _write_config(tmp_path, {
+            "model": {"default": "main-model", "provider": "nous"},
+            "custom_providers": [
+                {
+                    "name": "agnes-ai",
+                    "base_url": "https://apihub.agnes-ai.test/v1",
+                    "key_env": "HERMES_CUSTOM_CUSTOM_API_KEY",
+                },
+            ],
+        })
+        monkeypatch.delenv("HERMES_CUSTOM_CUSTOM_API_KEY", raising=False)
+
+        from agent import secret_scope
+        from agent.auxiliary_client import resolve_provider_client
+
+        token = secret_scope.set_secret_scope({
+            "HERMES_CUSTOM_CUSTOM_API_KEY": "scoped-custom-key",
+        })
+        try:
+            client, model = resolve_provider_client(
+                "custom", model="agnes-2.5-flash"
+            )
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        assert client is not None
+        assert model == "agnes-2.5-flash"
+        assert "apihub.agnes-ai.test" in str(client.base_url)
+        assert client.api_key == "scoped-custom-key"
+
 
 
 class TestResolveProviderClientModelNormalization:


### PR DESCRIPTION
## Summary

- recover the configured custom-provider identity when older auxiliary picker state stores only `provider: custom`
- resolve that provider's `key_env` through the active profile secret scope before constructing the auxiliary client
- cover the transport boundary with a regression test that keeps the key out of the process environment

## Root cause

The shared custom-provider catalog already self-healed a bare `custom` selection to the first configured endpoint, but `_get_named_custom_provider()` did not. Auxiliary resolution therefore treated the selection as an anonymous custom endpoint, lost the saved provider's `base_url` and `key_env`, and either returned no client or sent placeholder credentials.

## Tests

- `scripts/run_tests.sh tests/agent/test_auxiliary_named_custom_providers.py -k bare_custom_uses_saved_provider_and_scoped_key -q`
- `scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py -q`

Closes #91683
