### PR TITLE
fix: classify 'failed to read request body' as image_too_large for shrink-on-reject

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -242,6 +242,12 @@ _IMAGE_TOO_LARGE_PATTERNS = [
     "image dimensions exceed",  # Anthropic: "image dimensions exceed max allowed size: 8000 pixels"
     "dimensions exceed max allowed size",  # Anthropic dimension-cap (wording variant)
     "max allowed size: 8000",  # Anthropic dimension-cap (explicit pixel ceiling)
+    # Some providers (Ollama Cloud) reject oversized request bodies with a
+    # generic "failed to read request body" 400 instead of a specific
+    # image-size message.  Route to shrink-on-reject so the image gets
+    # downscaled and retried.  If no image parts are present, the shrink
+    # function returns False and the original error surfaces unchanged.
+    "failed to read request body",
     # "request_too_large" on a request known to contain an image → image is
     # the likely culprit; we still try the shrink path before giving up.
 ]

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1127,5 +1127,20 @@ class TestExpandedOverflowPatterns:
         result = classify_api_error(e, provider="openrouter", model="m")
         assert result.reason == FailoverReason.context_overflow
 
+    def test_400_failed_to_read_request_body_is_image_too_large(self):
+        """Some providers (Ollama Cloud) reject oversized request bodies
+        with a generic 'failed to read request body' 400 instead of a
+        specific image-size message.  Must route to image_too_large so the
+        shrink-on-reject path fires and downscales the image for retry."""
+        e = Exception(
+            "Error code: 400 - "
+            "{'error': {'message': 'failed to read request body "
+            "(ref: 19ccdbf6-f526-4f9c-bd50-2f167acca31e)', "
+            "'type': 'invalid_request_error', 'param': None, 'code': None}}"
+        )
+        result = classify_api_error(e, provider="ollama-cloud", model="qwen3.5:cloud")
+        assert result.reason == FailoverReason.image_too_large
+        assert result.retryable is True
+
 
 


### PR DESCRIPTION
## Problem

Some providers return a generic HTTP 400 `failed to read request body` when the request body exceeds their size limit, instead of a specific `image exceeds` message. This is most common with large image attachments (e.g. a 14MB wallpaper image base64-encoded to ~19MB).

Previously this was classified as `format_error` (non-retryable), so the shrink-on-reject path never fired. The agent gave up immediately instead of downscaling the image and retrying.

## Fix

Add `"failed to read request body"` to `_IMAGE_TOO_LARGE_PATTERNS` so it routes to `image_too_large`. The existing shrink function (`try_shrink_image_parts_in_messages`) returns `False` when no image parts are present, so non-image requests that happen to hit this error are unaffected — the original error surfaces unchanged.

## Testing

- New test: `test_400_failed_to_read_request_body_is_image_too_large`
- All 76 error classifier tests pass (75 existing + 1 new)
- No regressions in existing pattern matching