### PR TITLE
fix(desktop): keep background approvals on their owning gateway

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/approval-routing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/approval-routing.test.tsx
@@ -1,0 +1,36 @@
+import { act, cleanup, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as gatewayStore from '@/store/gateway'
+import { clearAllPrompts } from '@/store/prompts'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+describe('approval gateway ownership', () => {
+  afterEach(() => {
+    cleanup()
+    clearAllPrompts()
+    vi.restoreAllMocks()
+  })
+
+  it('acknowledges a background approval through its source profile runtime', async () => {
+    const request = vi.spyOn(gatewayStore, 'requestGatewayForAgent').mockResolvedValue({ acknowledged: true })
+    const stream: MessageStreamHarness = renderMessageStream('active-session')
+
+    act(() =>
+      stream.handleEvent({
+        payload: { command: 'rm -rf /tmp/x', description: 'dangerous', request_id: 'req-1' },
+        profile: 'worker',
+        session_id: 'background-session',
+        type: 'approval.request'
+      })
+    )
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(null, 'worker', 'approval.received', {
+        request_id: 'req-1',
+        session_id: 'background-session'
+      })
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -1,8 +1,9 @@
 import { translateNow } from '@/i18n'
 import { normalizeChoices, normalizeQuestions, setClarifyRequest, warnDroppedChoices } from '@/store/clarify'
-import { $gateway } from '@/store/gateway'
+import { requestGatewayForAgent } from '@/store/gateway'
 import { setMcpSetupRequest } from '@/store/mcp-setup'
 import { dispatchNativeNotification } from '@/store/native-notifications'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { receiveApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import { requestScrollToBottom } from '@/store/thread-scroll'
 
@@ -191,7 +192,17 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     const command = typeof payload?.command === 'string' ? payload.command : ''
     const description = typeof payload?.description === 'string' ? payload.description : 'dangerous command'
 
-    void receiveApprovalRequest($gateway.get(), {
+    const ownerGateway = {
+      request: (method: string, params: Record<string, unknown>) =>
+        requestGatewayForAgent(
+          event.connectionId ?? null,
+          normalizeProfileKey(event.profile ?? $activeGatewayProfile.get()),
+          method,
+          params
+        )
+    }
+
+    void receiveApprovalRequest(ownerGateway, {
       // false only when a tirith warning forbids it; backend omits the field otherwise.
       allowPermanent: payload?.allow_permanent !== false,
       choices: Array.isArray(payload?.choices)

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGateway } from '@/hermes'
 import { $gateway } from '@/store/gateway'
-import { $approvalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
+import { $approvalRequest, clearAllPrompts, receiveApprovalRequest, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
 
 import { PendingApprovalFallback, PendingToolApproval } from './approval'
@@ -86,6 +86,30 @@ describe('PendingToolApproval', () => {
       expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
     })
     expect($approvalRequest.get()).toBeNull()
+  })
+
+  it('responds through the gateway that delivered a background approval', async () => {
+    const activeRequest = mockGateway()
+    const ownerRequest = vi.fn().mockResolvedValue({ resolved: true })
+
+    $activeSessionId.set('sess-1')
+    await receiveApprovalRequest(
+      { request: ownerRequest },
+      { command: 'rm -rf /tmp/x', description: 'dangerous command', requestId: 'req-1', sessionId: 'sess-1' }
+    )
+    ownerRequest.mockClear()
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Run/ }))
+
+    await waitFor(() => {
+      expect(ownerRequest).toHaveBeenCalledWith('approval.respond', {
+        choice: 'once',
+        request_id: 'req-1',
+        session_id: 'sess-1'
+      })
+    })
+    expect(activeRequest).not.toHaveBeenCalled()
   })
 
   it('reveals the full command inline when the Command toggle is clicked', () => {

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -106,7 +106,8 @@ const isMac = typeof navigator !== 'undefined' && /Mac|iP(hone|ad|od)/.test(navi
 const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline' }> = ({ request, surface }) => {
   const { t } = useI18n()
   const copy = t.assistant.approval
-  const gateway = useStore($gateway)
+  const activeGateway = useStore($gateway)
+  const gateway = request.gateway ?? activeGateway
   const [submitting, setSubmitting] = useState<ApprovalChoice | null>(null)
   // "Always allow" persists the pattern to ~/.hermes/config.yaml permanently, so
   // it goes through a confirm step rather than firing straight from the menu.
@@ -143,7 +144,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
       setSubmitting(choice)
 
       try {
-        await gateway.request<{ resolved?: boolean }>('approval.respond', {
+        await gateway.request('approval.respond', {
           choice,
           request_id: request.requestId,
           session_id: request.sessionId ?? undefined

--- a/apps/desktop/src/store/native-notifications.test.ts
+++ b/apps/desktop/src/store/native-notifications.test.ts
@@ -324,6 +324,27 @@ describe('respondToApprovalAction', () => {
     expect($approvalRequest.get()).toBeNull()
   })
 
+  it('responds through the gateway that owns the approval request', async () => {
+    const ownerRequest = vi.fn().mockResolvedValue({ resolved: true })
+    setActiveSessionId('bg')
+    setApprovalRequest({
+      command: 'rm -rf /',
+      description: 'dangerous',
+      gateway: { request: ownerRequest },
+      requestId: 'req-bg',
+      sessionId: 'bg'
+    })
+
+    await respondToApprovalAction('bg', 'approve')
+
+    expect(ownerRequest).toHaveBeenCalledWith('approval.respond', {
+      choice: 'once',
+      request_id: 'req-bg',
+      session_id: 'bg'
+    })
+    expect(request).not.toHaveBeenCalled()
+  })
+
   it('rejects via approval.respond {choice: "deny"}', async () => {
     await respondToApprovalAction('bg', 'reject')
     expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'deny', session_id: 'bg' })

--- a/apps/desktop/src/store/native-notifications.ts
+++ b/apps/desktop/src/store/native-notifications.ts
@@ -5,7 +5,7 @@ import { persistString, storedString } from '@/lib/storage'
 
 import { $gateway } from './gateway'
 import { withinNativeNotifyBaseline } from './notify-baseline'
-import { clearApprovalRequest } from './prompts'
+import { clearApprovalRequest, sessionApprovalRequest } from './prompts'
 import { $activeSessionId } from './session'
 
 export type { HermesOpenTarget }
@@ -352,15 +352,20 @@ export async function respondToApprovalAction(sessionId: null | string, actionId
     return
   }
 
-  const gateway = $gateway.get()
+  const approval = sessionApprovalRequest(sessionId).get()
+  const gateway = approval?.gateway ?? $gateway.get()
 
   if (!gateway) {
     return
   }
 
   try {
-    await gateway.request('approval.respond', { choice, session_id: sessionId ?? undefined })
-    clearApprovalRequest(sessionId)
+    await gateway.request('approval.respond', {
+      choice,
+      ...(approval?.requestId ? { request_id: approval.requestId } : {}),
+      session_id: sessionId ?? undefined
+    })
+    clearApprovalRequest(sessionId, approval?.requestId)
   } catch {
     // Leave the prompt parked so the user can still resolve it in-app.
   }

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -76,11 +76,15 @@ export interface ApprovalRequest extends KeyedPrompt {
   choices?: string[]
   command: string
   description: string
+  // The exact runtime connection that emitted this request. Background
+  // profiles can keep streaming while another gateway is active, so approval
+  // controls must not rediscover ownership from the current foreground route.
+  gateway?: ApprovalGateway
   requestId?: string
   smartDenied?: boolean
 }
 
-interface ApprovalGateway {
+export interface ApprovalGateway {
   request: (method: string, params: Record<string, unknown>) => Promise<unknown>
 }
 
@@ -116,7 +120,7 @@ export const setApprovalRequest = approval.set
 export const clearApprovalRequest = approval.clear
 
 export async function receiveApprovalRequest(gateway: ApprovalGateway | null, request: ApprovalRequest): Promise<void> {
-  setApprovalRequest(request)
+  setApprovalRequest(gateway ? { ...request, gateway } : request)
 
   if (gateway && request.requestId && request.sessionId) {
     await gateway.request('approval.received', {


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop approvals raised by a background profile now stay bound to the gateway runtime that owns the pending request. Without this fix, clicking Run or Reject can send `approval.respond` to the foreground gateway, which returns `4001 session not found` and leaves the agent blocked until timeout.

### Symptom

In a multi-profile Desktop session, an approval from a background runtime can remain visible, but responding to it immediately fails with `4001 session not found` when another local gateway is active.

### Impact

The user cannot approve or deny the pending command. The affected agent remains blocked until the approval times out.

### Bug Cause

**Trigger:** `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts` handles `approval.request` while a different profile gateway is active.

**Causal chain:**
1. A background profile runtime emits `approval.request` through its secondary gateway connection.
2. Desktop parks the request by session ID but discards the source gateway identity, and both the inline controls and native notification later read the current global `$gateway`.
3. `approval.respond` reaches the foreground runtime, whose in-memory session map does not own that runtime session ID, so it returns `4001` before resolving the request.

**Why it is wrong:** Runtime session IDs and pending approval queues are process-owned. A foreground route change must not retarget an authoritative response for a request emitted by another runtime.

**Working sibling / contrast:** Source-scoped Desktop RPCs already use `requestGatewayForAgent(connectionId, profile, ...)` to retain the owning registered connection and profile without foregrounding it.

**Ruled out:** Resolving only by `request_id` inside the incorrectly selected gateway cannot fix the cross-runtime case because `tools/approval.py` stores pending queues in process memory under the owning session key.

### Fix

The approval event handler now creates a source-scoped gateway requester from the event's connection and profile and stores it with the parked approval. Inline actions, reconnect replay, and native notification actions reuse that owner requester; notification responses also carry the exact `request_id` when available. Legacy requests without an owner still fall back to the active gateway.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts` - bind incoming approvals to their source gateway route.
- `apps/desktop/src/store/prompts.ts` - retain the owner requester with each parked approval.
- `apps/desktop/src/components/assistant-ui/tool/approval.tsx` - send inline responses and replay through the owner requester.
- `apps/desktop/src/store/native-notifications.ts` - route notification actions to the owner and preserve request correlation.
- Desktop Vitest coverage - verify source-profile acknowledgement and both response surfaces.

## How to Test

1. Start two local Desktop profile runtimes and make runtime A raise a dangerous-command approval while runtime B is the foreground gateway.
2. Click Run or Reject on A's parked approval.
3. Confirm the response reaches runtime A, resolves the exact request ID, and no `4001 session not found` is returned.
4. Automated checks already run locally:

```bash
cd apps/desktop
npx vitest run src/components/assistant-ui/tool/approval.test.tsx src/store/native-notifications.test.ts src/app/session/hooks/use-message-stream/approval-routing.test.tsx
npm run typecheck
npx eslint src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts src/app/session/hooks/use-message-stream/approval-routing.test.tsx src/components/assistant-ui/tool/approval.tsx src/components/assistant-ui/tool/approval.test.tsx src/store/prompts.ts src/store/native-notifications.ts src/store/native-notifications.test.ts
```

Result: 43 tests passed; typecheck and targeted lint passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop test entry and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the automated path on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not applicable
- [x] Config example update is not applicable
- [x] Contributor guide update is not applicable
- [x] I've considered cross-platform impact; the routing logic is platform-independent
- [x] Tool schema updates are not applicable
