### PR TITLE
fix(tools): keep spaced paths in search_files files_only output

### DIFF
--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -130,3 +130,56 @@ class TestSplitToolDiagnostics:
         assert diagnostics == ""
         assert "--" in payload
         assert "a.py-6-after" in payload
+
+    def test_files_only_line_with_spaces_is_payload(self):
+        """A files_only path may contain spaces (#91698).
+
+        The old whitespace-free class classified every spaced path as a tool
+        diagnostic, silently dropping it from search_files output.
+        """
+        out = "plain.md\nmy vault/note with space.md\n"
+        diagnostics, payload = _split_tool_diagnostics(out)
+        assert diagnostics == ""
+        assert "my vault/note with space.md" in payload
+        assert "plain.md" in payload
+
+    def test_error_prefix_line_stays_diagnostics_after_space_relaxation(self):
+        """rg's trailing "error: ..." line must not leak into payload (#91698)."""
+        out = "plain.md\nerror: unclosed character class\n"
+        diagnostics, payload = _split_tool_diagnostics(out)
+        assert "error: unclosed character class" in diagnostics
+        assert payload.strip() == "plain.md"
+
+
+@pytest.fixture
+def spaced_tree(tmp_path):
+    """A tree whose matches all live under a space-containing directory."""
+    vault = tmp_path / "Obsidian Vault"
+    vault.mkdir()
+    (vault / "note with space.md").write_text("needle in vault\n")
+    (tmp_path / "plain.md").write_text("needle plain\n")
+    return tmp_path
+
+
+@pytest.mark.parametrize("method", _METHODS)
+class TestFilesOnlySpacedPaths:
+    """Regression tests for #91698 — files_only must not drop spaced paths."""
+
+    def test_files_only_lists_spaced_paths(self, method, spaced_tree):
+        res = _search(_ops(spaced_tree), method, "needle", spaced_tree,
+                      output_mode="files_only")
+        assert res.error is None
+        assert res.total_count == 2
+        assert any("note with space.md" in f for f in res.files)
+        assert any(f.endswith("plain.md") for f in res.files)
+
+    def test_files_only_all_spaced_directory_not_zero(self, method, tmp_path):
+        vault = tmp_path / "all spaced"
+        vault.mkdir()
+        for i in range(3):
+            (vault / f"note {i}.md").write_text("needle\n")
+        res = _search(_ops(tmp_path), method, "needle", tmp_path,
+                      output_mode="files_only")
+        assert res.error is None
+        assert res.total_count == 3
+        assert len(res.files) == 3

--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -150,6 +150,25 @@ class TestSplitToolDiagnostics:
         assert "error: unclosed character class" in diagnostics
         assert payload.strip() == "plain.md"
 
+    def test_capitalized_and_warning_diagnostic_lines_stay_diagnostics(self):
+        """The diagnostic lookaheads are case-insensitive and also cover rg's
+        "warning: ..." lines — a capitalized wrapper build's ``Error:`` must
+        not land in payload as a phantom result file (review on #91702)."""
+        out = "plain.md\nError: unclosed character class\nwarning: skipped binary file\n"
+        diagnostics, payload = _split_tool_diagnostics(out)
+        assert "Error: unclosed character class" in diagnostics
+        assert "warning: skipped binary file" in diagnostics
+        assert payload.strip() == "plain.md"
+
+    def test_spaced_path_match_line_classifies_as_payload(self):
+        """The relaxed first alternative also carries spaced paths in
+        match/count mode — pin it so a future "tighten for files_only"
+        edit cannot silently re-break match mode (review on #91702)."""
+        out = "my vault/note.md:3:needle\n"
+        diagnostics, payload = _split_tool_diagnostics(out)
+        assert diagnostics == ""
+        assert "my vault/note.md:3:needle" in payload
+
 
 @pytest.fixture
 def spaced_tree(tmp_path):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -404,7 +404,7 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
         # with no tool prefix; neither matches a search-output shape, so they
         # fall through to diagnostics.
         #   match / count : "<path>:<...>"   (has a colon; rg -c uses path:count)
-        #   files_only    : "<path>"         (no whitespace, no leading colon)
+        #   files_only    : "<path>"         (no leading colon — spaces allowed)
         #   context line  : "<path>-<line>-" or the "--" group separator
         if line == "--" or _SEARCH_OUTPUT_RE.match(line):
             payload.append(line)
@@ -415,10 +415,14 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
 
 # A real rg/grep output line starts with a path token and is followed by a
 # ``:`` (match/count), a ``-`` (context), or nothing (files_only). Tool
-# diagnostics ("rg: ...", "grep: ...", "error: ...", indented carets) never
-# match because the path token forbids whitespace and a leading tool prefix
-# like "rg" is followed by ": " (space) which the negated class rejects.
-_SEARCH_OUTPUT_RE = re.compile(r'^([A-Za-z]:)?[^\s:][^\n]*?[:\-]\d|^[^\s:][^\s]*$')
+# diagnostics never match: "rg: ..."/"grep: ..." are caught by the explicit
+# prefix check above, indented caret lines by the non-whitespace anchor, and
+# rg's trailing "error: ..." line by the lookahead. The files_only branch
+# must accept interior spaces — paths may legitimately contain them, and
+# the old whitespace-free class silently dropped every such file (#91698).
+_SEARCH_OUTPUT_RE = re.compile(
+    r'^([A-Za-z]:)?[^\s:][^\n]*?[:\-]\d|^(?!error: )[^\s:][^\n]*$'
+)
 
 
 def _parse_search_context_line(line: str) -> tuple[str, int, str] | None:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -417,11 +417,19 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
 # ``:`` (match/count), a ``-`` (context), or nothing (files_only). Tool
 # diagnostics never match: "rg: ..."/"grep: ..." are caught by the explicit
 # prefix check above, indented caret lines by the non-whitespace anchor, and
-# rg's trailing "error: ..." line by the lookahead. The files_only branch
-# must accept interior spaces — paths may legitimately contain them, and
-# the old whitespace-free class silently dropped every such file (#91698).
+# rg's "error: ..." / "warning: ..." lines by the case-insensitive
+# lookaheads (scoped group; Py3.11+). The files_only branch must accept
+# interior spaces — paths may legitimately contain them, and the old
+# whitespace-free class silently dropped every such file (#91698).
+#
+# Residual accepted risk after the #91698 relaxation: any non-blank line
+# that is not literally an rg/grep diagnostic shape (e.g. stray progress
+# output interleaved on stdout) classifies as payload and may surface as a
+# phantom entry in the result. That trades a silent fake "no results" for
+# a visible odd line — the safer failure direction — but keep it in mind
+# when widening the diagnostic prefixes here.
 _SEARCH_OUTPUT_RE = re.compile(
-    r'^([A-Za-z]:)?[^\s:][^\n]*?[:\-]\d|^(?!error: )[^\s:][^\n]*$'
+    r'^([A-Za-z]:)?[^\s:][^\n]*?[:\-]\d|^(?i:(?!error: )(?!warning: ))[^\s:][^\n]*$'
 )
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes `search_files` silently dropping every file whose path contains a space when `output_mode="files_only"` is used (#91698). A vault under an "Obsidian Vault" directory returned `total_count: 0` with no error — indistinguishable from a no-match search.

Root cause: `_split_tool_diagnostics()` classifies rg/grep output lines by shape via `_SEARCH_OUTPUT_RE`. Its files_only branch was `^[^\s:][^\s]*$` — a whole-line whitespace-free match, chosen so tool diagnostics (which contain spaces) fall through to diagnostics. But paths may legitimately contain spaces, so every spaced path line was misclassified as a tool diagnostic and silently discarded before the files_only parser ever saw it. `content` and `count` modes use the other branch (`path:<line>:…`), which allows interior spaces — matching the issue's observation that only `files_only` is affected.

The fix relaxes the files_only branch to accept interior spaces (`[^\n]*$`) while keeping every known diagnostic shape rejected: `rg: …` / `grep: …` are already caught by the explicit prefix check above the regex, indented caret lines by the non-whitespace anchor, and rg's trailing `error: …` line by a new `^(?!error: )` lookahead — that lookahead is required, because the old whitespace-free class was the only thing keeping `error: …` out of the payload. Both backends (`_search_with_rg` and the `_search_with_grep` fallback) share this splitter, so one regex covers both.

## Related Issue

Fixes #91698

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py` — `_SEARCH_OUTPUT_RE` files_only branch: accept interior spaces (paths may contain them), add `^(?!error: )` lookahead so rg's trailing `error: …` diagnostic still falls through; updated the shape-classification comments to document the new mechanism.
- `tests/tools/test_search_error_guard.py` — two unit tests for the splitter (spaced path is payload; `error: …` stays diagnostics after the relaxation) plus a `TestFilesOnlySpacedPaths` class driven through both real backends: mixed tree lists spaced and plain files (`total_count == 2`), and an all-spaced directory no longer reports zero.

## How to Test

1. Automated: `.venv/bin/python -m pytest tests/tools/test_search_error_guard.py tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_file_ops_cwd_tracking.py -q` — should pass (observed result: 106 passed, 2 platform-skipped on macOS arm64; `rg` and `grep` backends both exercised).
2. Manual (issue reproduction): create `"/tmp/sf_repro/file with space.md"` and `/tmp/sf_repro/plain.md` both containing `needle`, then `search_files` with `output_mode="files_only"` on `/tmp/sf_repro` — both files should be listed (previously the spaced one was missing).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted file-tools suites: 106 passed, 0 failures)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (regex block comments updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (optional Windows drive-letter prefix `[A-Za-z]:` alternative preserved; both POSIX-style spaced paths and plain paths covered by tests)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
