### PR TITLE
fix(bot-mode): friendly labels for hour/day interval schedules

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -8608,10 +8608,14 @@ function scheduleLabel(schedule) {
     return `Once (${bare[1]}${bare[2]})`
   }
 
-  const match = /^every (\d+)m$/.exec(schedule || '')
+  // composeSchedule emits h/d intervals directly ('every 1h', 'every 2d') —
+  // normalize every unit to minutes so those get friendly labels too instead
+  // of falling through to the raw schedule string.
+  const match = /^every (\d+)([mhd])$/.exec(schedule || '')
 
   if (match) {
-    const minutes = Number(match[1])
+    const n = Number(match[1])
+    const minutes = match[2] === 'h' ? n * 60 : match[2] === 'd' ? n * 1440 : n
 
     if (minutes % 1440 === 0) {
       const d = minutes / 1440

--- a/apps/desktop/src/plugins/hermes-bots/tests/schedule-label.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/schedule-label.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const pluginSource = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function load() {
+  const values = new Map()
+  const atom = initial => {
+    const slot = { get: () => values.get(slot), set: value => values.set(slot, value) }
+    values.set(slot, initial)
+    return slot
+  }
+  const context = {
+    atom, PALETTE_AREA: 'palette', COMPOSER_AREAS: { middleware: 'middleware' },
+    document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
+    host: {
+      request: async () => ({ jobs: [] }),
+      state: {
+        profile: { listen: () => undefined },
+        gateway: { listen: () => undefined }
+      }
+    }
+  }
+  const source = pluginSource
+    .replace(/^import\s+\*\s+as\s+sdk\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^import\s+\{[\s\S]*?\}\s+from '@hermes\/plugin-sdk'\r?\n/m, '')
+    .replace(/^const \{ McpTab, ToolsetConfigPanel \} = sdk\r?\n/m, '')
+    .replace(/^import .* from 'react'\r?\n/m, '')
+    .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
+    .replace('export default {', 'globalThis.plugin = {')
+    .concat('\nglobalThis.__sched = { scheduleLabel, composeSchedule };\n')
+  vm.runInNewContext(source, context, { filename: 'plugin.js' })
+  return context
+}
+
+test('unit: minute intervals keep their existing labels', () => {
+  const { __sched } = load()
+  assert.equal(__sched.scheduleLabel('every 45m'), 'Every 45m')
+  assert.equal(__sched.scheduleLabel('every 60m'), 'Hourly')
+  assert.equal(__sched.scheduleLabel('every 1440m'), 'Daily')
+  assert.equal(__sched.scheduleLabel('every 2880m'), 'Every 2 days')
+})
+
+test("unit: hour/day intervals composeSchedule emits get friendly labels, not the raw string", () => {
+  const { __sched } = load()
+  // 'hourly' frequency in the picker emits exactly 'every 1h'
+  assert.equal(__sched.scheduleLabel('every 1h'), 'Hourly')
+  assert.equal(__sched.scheduleLabel('every 2h'), 'Every 2h')
+  assert.equal(__sched.scheduleLabel('every 1d'), 'Daily')
+  assert.equal(__sched.scheduleLabel('every 3d'), 'Every 3 days')
+})
+
+test('integration: every schedule the picker can emit round-trips to a friendly label', () => {
+  const { __sched } = load()
+  const states = [
+    { freq: 'hourly' },
+    { freq: 'interval', intervalN: '2', intervalUnit: 'h' },
+    { freq: 'interval', intervalN: '30', intervalUnit: 'm' },
+    { freq: 'interval', intervalN: '2', intervalUnit: 'd' }
+  ]
+  for (const state of states) {
+    const schedule = __sched.composeSchedule({ time: '9:0', ...state })
+    const label = __sched.scheduleLabel(schedule)
+    assert.notEqual(label, schedule, `raw schedule leaked into the label for ${JSON.stringify(state)}`)
+  }
+})
+
+test('unit: cron and once schedules are untouched', () => {
+  const { __sched } = load()
+  assert.equal(__sched.scheduleLabel('30m'), 'Once (30m)')
+  assert.equal(__sched.scheduleLabel('once in 2h'), 'Once (2h)')
+  assert.equal(__sched.scheduleLabel('0 9 * * *'), '0 9 * * *')
+})


### PR DESCRIPTION
## Symptom

Create a routine in the Bots pane with the picker's own **"Every hour"** frequency: the routine row chip shows the raw schedule string `every 1h` instead of "Hourly". Same for day intervals — "Interval: 2 days" renders as `every 2d` instead of "Every 2 days".

## Cause

`scheduleLabel()` only matches minute-granularity intervals:

```js
const match = /^every (\d+)m$/.exec(schedule || '')
```

but `composeSchedule()` (same file) emits hour/day units directly:

```js
case 'hourly':   return 'every 1h'
case 'interval': return `every ${n}${state.intervalUnit || 'h'}`  // m|h|d
```

so two of the picker's own outputs fall through to the raw-string fallback.

## Fix

Match `m|h|d` and normalize to minutes before the existing `%1440`/`%60` labeling arithmetic. No behavior change for minute intervals, cron lines, or once-schedules.

## Tests

New `tests/schedule-label.test.mjs` (same vm-extraction harness as the neighboring tests):
- minute intervals keep existing labels (45m / 60m / 1440m / 2880m)
- `every 1h` → "Hourly", `every 2d` → "Every 2 days", etc.
- round-trip property: every schedule shape the picker can emit produces a label ≠ the raw string
- once/cron schedules untouched

`node --test tests/*.test.mjs`: **383 pass, 0 fail** (379 existing + 4 new).

*(Found while installing the archived NousResearch/Hermes-Bot-Mode repo — its issues are closed, and this plugin now lives in-tree, so reporting the fix directly here.)*