### PR TITLE
fix(desktop): refresh readiness on OAuth success so a stale credential failure clears while unfocused

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts
@@ -2,6 +2,7 @@ import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getStatus } from '@/hermes'
+import { $desktopOnboarding } from '@/store/onboarding'
 
 import { deferred } from '../../../test/deferred'
 
@@ -25,6 +26,7 @@ beforeEach(() => {
   vi.mocked(getStatus)
     .mockReset()
     .mockResolvedValue({} as never)
+  $desktopOnboarding.set({ ...$desktopOnboarding.get(), flow: { status: 'idle' } })
 })
 
 afterEach(() => {
@@ -222,5 +224,61 @@ describe('useStatusSnapshot', () => {
       await vi.advanceTimersByTimeAsync(1)
     })
     expect(requestGatewayMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('clears a stale readiness failure when OAuth completes while unfocused', async () => {
+    let healthy = false
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'setup.runtime_check') {
+        return (healthy ? { ok: true } : { error: 'No usable credentials found for nous.', ok: false }) as never
+      }
+
+      return { provider_configured: healthy } as never
+    }) as unknown as GatewayRequester
+
+    // Focused: seed the authoritative credential failure.
+    const { result } = renderHook(() => useStatusSnapshot('open', requestGateway))
+    await flushAsync()
+    expect(result.current.inferenceStatus).toMatchObject({ ready: false, source: 'runtime_check' })
+
+    // User leaves Hermes for the browser to complete OAuth; no focus event fires.
+    vi.mocked(document.hasFocus).mockReturnValue(false)
+    healthy = true
+
+    // OAuth completes: the onboarding flow transitions to success while unfocused.
+    await act(async () => {
+      $desktopOnboarding.set({
+        ...$desktopOnboarding.get(),
+        flow: { status: 'success', provider: { id: 'nous', name: 'Nous' } as never }
+      })
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    // The stale failure is replaced by the healthy result without a focus event.
+    expect(result.current.inferenceStatus).toMatchObject({ ready: true, source: 'runtime_check' })
+  })
+
+  it('does not force a background poll on non-success onboarding transitions while unfocused', async () => {
+    const requestGateway = vi.fn(
+      async (method: string) => (method === 'setup.runtime_check' ? { ok: true } : { provider_configured: true }) as never
+    ) as unknown as GatewayRequester
+
+    vi.mocked(document.hasFocus).mockReturnValue(false)
+    renderHook(() => useStatusSnapshot('open', requestGateway))
+    await flushAsync()
+    expect(requestGateway).not.toHaveBeenCalled()
+
+    // A non-success flow change (e.g. entering the polling state) must not
+    // trigger the focus-bypassing refresh — only auth success does.
+    await act(async () => {
+      $desktopOnboarding.set({
+        ...$desktopOnboarding.get(),
+        flow: { status: 'starting', provider: { id: 'nous', name: 'Nous' } as never }
+      })
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(requestGateway).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
+++ b/apps/desktop/src/app/shell/hooks/use-status-snapshot.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { getStatus } from '@/hermes'
 import { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
+import { $desktopOnboarding } from '@/store/onboarding'
 import type { StatusResponse } from '@/types/hermes'
 
 // Statusbar health is ambient chrome, not live data — nothing the user acts on
@@ -42,11 +43,13 @@ export function useStatusSnapshot(
       }
     }
 
-    const refresh = async () => {
+    const refresh = async (force = false) => {
       // macOS commonly leaves an occluded BrowserWindow `visible`; focus is
       // the missing signal that prevents status + readiness RPCs while the
-      // user is working in another app.
-      if (document.visibilityState !== 'visible' || !document.hasFocus()) {
+      // user is working in another app. `force` overrides the gate for a
+      // user-initiated auth transition, which must not leave a known-stale
+      // readiness result on screen just because the window is unfocused.
+      if (!force && (document.visibilityState !== 'visible' || !document.hasFocus())) {
         scheduleRefresh()
 
         return
@@ -99,12 +102,36 @@ export function useStatusSnapshot(
       }
     }
 
+    // An OAuth sign-in updates backend readiness, but ambient polling is
+    // skipped while the window is unfocused — so a stale credential failure can
+    // linger indefinitely if the user stays in the browser after completing the
+    // flow. Watch the onboarding store for the auth-success transition and force
+    // one readiness refresh that bypasses the focus gate. This does not resume
+    // background polling: the forced refresh reschedules the normal (focus-gated)
+    // cadence in its `finally`.
+    let lastFlowStatus = $desktopOnboarding.get().flow.status
+
+    const unsubscribeOnboarding = $desktopOnboarding.listen(state => {
+      const status = state.flow.status
+      const becameSuccess = status === 'success' && lastFlowStatus !== 'success'
+      lastFlowStatus = status
+
+      if (becameSuccess && !cancelled) {
+        if (timer !== undefined) {
+          window.clearTimeout(timer)
+        }
+
+        void refresh(true)
+      }
+    })
+
     document.addEventListener('visibilitychange', onReturn)
     window.addEventListener('focus', onReturn)
     void refresh()
 
     return () => {
       cancelled = true
+      unsubscribeOnboarding()
       document.removeEventListener('visibilitychange', onReturn)
       window.removeEventListener('focus', onReturn)
 


### PR DESCRIPTION
## What does this PR do?

After an OAuth sign-in completes, Hermes Desktop could keep showing the old `No … credentials found` readiness failure while the window was unfocused. The status hook polls every 60s but skips the status + runtime-readiness request whenever the window lacks focus, so if the user stays in the browser after the OAuth redirect, every poll is skipped and the stale negative can remain on screen indefinitely — the backend is already healthy.

This wires the OAuth-completion signal into the readiness hook: when the onboarding flow transitions to `success`, the hook forces a single readiness refresh that bypasses the focus gate. Avoiding background health traffic while unfocused is still correct for ambient polling, but a user-initiated authentication transition should not leave a known-stale failure visible. The forced refresh is bounded — it runs once and then restores the normal focus-gated cadence, so no background polling is reintroduced.

## Related Issue

Fixes #91613

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/shell/hooks/use-status-snapshot.ts`: add a `force` parameter to `refresh()` that overrides the visibility/focus gate for a user-initiated auth transition; subscribe to `$desktopOnboarding` and, on the `flow.status → 'success'` (OAuth completion) transition, force one readiness refresh independent of focus; unsubscribe on effect cleanup.
- `apps/desktop/src/app/shell/hooks/use-status-snapshot.test.ts`: add a regression test that seeds a failed readiness snapshot, simulates a successful OAuth completion while `document.hasFocus()` is `false`, and asserts the stale failure is replaced without a focus event; add a guard test that non-success onboarding transitions do not force a background poll while unfocused.

## How to Test

1. Open the provider/Gateway setup panel from an unauthenticated state so `setup.runtime_check` returns a credential failure and the status bar shows the readiness failure.
2. Complete the provider OAuth flow in the browser and leave Hermes unfocused after the redirect completes.
3. Before the fix: the old failure stays visible even though the runtime check now returns `ok: true`, until you refocus or reopen the panel. After the fix: the readiness indicator refreshes to healthy on OAuth completion without needing a focus event.
4. Automated: `cd apps/desktop && npx vitest run src/app/shell/hooks/use-status-snapshot.test.ts` — 9 passing. The new "clears a stale readiness failure when OAuth completes while unfocused" test fails on the unpatched hook and passes with the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (desktop vitest/jsdom suite)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ npx vitest run src/app/shell/hooks/use-status-snapshot.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)
```
