### PR TITLE
ci: exact-object certification for #90250 history

### DIFF
--- a/apps/desktop/electron/backend-child.ts
+++ b/apps/desktop/electron/backend-child.ts
@@ -1,103 +1,84 @@
 /**
- * backend-child.ts
+ * Fail-closed lifecycle control for desktop-owned backend children.
  *
- * Windows-aware teardown for the desktop's managed backend child process.
+ * A numeric PID is observation, never destructive authority. This module only
+ * signals a retained ChildProcess-style owner whose lifecycle fields still say
+ * it is live. Persisted or reconstructed `{ pid }` records are intentionally
+ * rejected. If no owner survives, callers must leave residue and abort the
+ * operation rather than rediscovering and killing by PID (#89614).
  *
- * Node's `child.kill()` only signals the direct child. On Windows a backend
- * that spawned its own grandchildren (a `hermes` REPL, a pty terminal
- * session, the gateway) survives a plain SIGTERM and keeps files (e.g. the
- * venv shim) locked. So on Windows we tree-kill via `forceKillProcessTree`.
- *
- * On POSIX the backend IS spawned into its own session/process-group
- * (start_new_session=True), so `child.kill('SIGTERM')` would only reach the
- * backend and orphan its MCP grandchildren (the leak in #serve-orphans). We
- * signal the whole group via `process.kill(-pid, ...)` instead, falling back
- * to the direct child if the group send fails.
- *
- * Extracted into its own dependency-free module (no electron import) so the
- * tree-kill / group-kill branching can be asserted directly with a fake child
- * object and spy kill functions, instead of grepping main.ts source text for
- * the function body.
+ * Tree-wide force-stop belongs in a platform authority created at spawn time:
+ * a retained Windows Job Object handle or a retained POSIX process-group
+ * owner. Until that authority lands, direct-child shutdown plus abort-on-lock
+ * is the safe P1 policy.
  */
-
-export interface StopBackendChildDeps {
-  /** Defaults to the real platform check; injectable for tests. */
-  isWindows?: boolean
-  /** Windows tree-kill implementation (real: taskkill /T /F via execFileSync). */
-  forceKillProcessTree: (pid: number) => void
-  /**
-   * POSIX group-signal implementation. Real: process.kill(-pgid, signal).
-   * Injectable so the negative-pid group send is asserted in tests without a
-   * live process group. Defaults to process.kill.
-   */
-  killGroup?: (pgid: number, signal: string) => void
-}
-
-export interface StopBackendTreesForUpdateDeps {
-  /** Synchronous Windows taskkill /T /F implementation. */
-  forceKillProcessTree: (pid: number) => void
-  /** Clears and stops the desktop's pooled backends. */
-  stopAllPoolBackends: () => void
-}
 
 export interface BackendProcessRoot {
   pid?: number | null
+  exitCode?: null | number
+  signalCode?: null | string
 }
 
 export interface KillableChild extends BackendProcessRoot {
   killed?: boolean
-  kill: (signal: string) => void
+  /** Accepts NodeJS.Signals (e.g. 'SIGTERM', 'SIGKILL') to match ChildProcess.kill. */
+  kill: (signal?: NodeJS.Signals | number | null) => unknown
+}
+
+export interface StopBackendTreesForUpdateDeps {
+  /** Stops pooled backends through their retained ChildProcess owners. */
+  stopAllPoolBackends: () => Promise<void> | void
 }
 
 /**
- * Stop a managed child process, choosing the right strategy for the platform.
- * No-ops silently if `child` is falsy, already killed, or the kill attempt
- * throws (the process may already be gone) -- mirrors the original inline
- * best-effort semantics in main.ts.
+ * True only for a retained owner with a positive PID and explicit live
+ * lifecycle state. Missing lifecycle fields mean there is no authority, not
+ * that a legacy PID should be trusted.
  */
-export function stopBackendChild(child: KillableChild | null | undefined, deps: StopBackendChildDeps) {
-  if (!child || child.killed) {
-    return
+export function isLiveProcessRoot(root: BackendProcessRoot | null | undefined): boolean {
+  return Boolean(
+    root &&
+      Number.isInteger(root.pid) &&
+      (root.pid as number) > 0 &&
+      root.exitCode === null &&
+      root.signalCode === null
+  )
+}
+
+function signalRetainedChild(child: KillableChild | null | undefined, signal: NodeJS.Signals): boolean {
+  if (!child || !isLiveProcessRoot(child) || typeof child.kill !== 'function') {
+    return false
   }
-
-  const isWindows = deps.isWindows ?? process.platform === 'win32'
-  const killGroup = deps.killGroup ?? ((pgid: number, signal: string) => process.kill(pgid, signal))
-
   try {
-    if (isWindows && Number.isInteger(child.pid)) {
-      deps.forceKillProcessTree(child.pid as number)
-    } else if (Number.isInteger(child.pid)) {
-      // POSIX: pgid == pid (start_new_session). Signal the whole group so MCP
-      // grandchildren die too; fall back to the direct child on failure.
-      try {
-        killGroup(-(child.pid as number), 'SIGTERM')
-      } catch {
-        child.kill('SIGTERM')
-      }
-    } else {
-      child.kill('SIGTERM')
-    }
+    return child.kill(signal) !== false
   } catch {
-    // Already gone.
+    return false
   }
 }
 
-/**
- * Stop every backend tree owned by a Windows Desktop update hand-off.
- *
- * Tree-kill the primary root while its PID is still live, then delegate pool
- * teardown to the existing routine that tree-kills each pooled root exactly
- * once before mutating its registry. In particular, do not signal the primary
- * first: if that root exits before taskkill /T runs, Windows can no longer
- * enumerate its MCP grandchildren and they survive with the venv locked.
- */
-export function stopBackendTreesForUpdate(
-  primary: BackendProcessRoot | null | undefined,
-  deps: StopBackendTreesForUpdateDeps
-): void {
-  if (primary && Number.isInteger(primary.pid)) {
-    deps.forceKillProcessTree(primary.pid as number)
+/** Graceful stop through the retained owner only. */
+export function stopBackendChild(child: KillableChild | null | undefined): boolean {
+  if (!child || child.killed) {
+    return false
   }
+  return signalRetainedChild(child, 'SIGTERM')
+}
 
-  deps.stopAllPoolBackends()
+/** Forced direct-child stop through the same retained owner only. */
+export function forceStopBackendChild(child: KillableChild | null | undefined): boolean {
+  return signalRetainedChild(child, 'SIGKILL')
+}
+
+/**
+ * Begin update teardown without ever converting ownership into a PID.
+ * Descendants that survive direct-child shutdown keep the shim locked; the
+ * caller must then abort the update. That residue is deliberate containment
+ * until a retained Job Object/process-group authority owns the full tree.
+ */
+export async function stopBackendTreesForUpdate(
+  primary: KillableChild | null | undefined,
+  deps: StopBackendTreesForUpdateDeps
+): Promise<void> {
+  stopBackendChild(primary)
+  await deps.stopAllPoolBackends()
 }

--- a/apps/desktop/electron/backend-stale-pid.test.ts
+++ b/apps/desktop/electron/backend-stale-pid.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+
+import { test } from 'vitest'
+
+import { forceStopBackendChild, isLiveProcessRoot, stopBackendChild, stopBackendTreesForUpdate } from './backend-child'
+
+const live = (pid: number, kill: (signal: NodeJS.Signals) => unknown = () => true) => ({
+  exitCode: null,
+  kill,
+  killed: false,
+  pid,
+  signalCode: null
+})
+const exited = (pid: number, kill: (signal: NodeJS.Signals) => unknown = () => true, code = 0) => ({
+  exitCode: code,
+  kill,
+  killed: false,
+  pid,
+  signalCode: null
+})
+const signalled = (pid: number, kill: (signal: NodeJS.Signals) => unknown = () => true, signalCode = 'SIGTERM') => ({
+  exitCode: null,
+  kill,
+  killed: true,
+  pid,
+  signalCode
+})
+
+test('only an explicit live retained owner is actionable', () => {
+  assert.equal(isLiveProcessRoot(live(4242)), true)
+  // THE regression: exitCode 0 with a populated pid is the shape Node leaves
+  // behind, and it used to pass every `Number.isInteger(pid)` guard.
+  assert.equal(isLiveProcessRoot(exited(4242)), false)
+  assert.equal(isLiveProcessRoot(signalled(4242)), false)
+  // A pid-only legacy record is observation, not authority.
+  assert.equal(isLiveProcessRoot({ pid: 4242 }), false, 'a pid-only legacy record is observation, not authority')
+  assert.equal(isLiveProcessRoot({ exitCode: null, pid: 0, signalCode: null }), false)
+  // A negative pid would be a POSIX process-GROUP id. taskkill has no such
+  // notion, so letting one through would pass a nonsense argument to it.
+  assert.equal(isLiveProcessRoot({ exitCode: null, pid: -991, signalCode: null }), false)
+})
+
+test('a reaped owner with a still-populated pid is never signalled', () => {
+  const signals: string[] = []
+  const child = exited(4242, signal => signals.push(signal))
+  // exited() has killed=false but exitCode=0 so isLiveProcessRoot is false;
+  // signalRetainedChild must refuse to call kill() entirely.
+  assert.equal(stopBackendChild(child), false)
+  assert.deepEqual(signals, [])
+})
+
+test('null / undefined child is a no-op', () => {
+  assert.equal(stopBackendChild(null), false)
+  assert.equal(stopBackendChild(undefined), false)
+  assert.equal(forceStopBackendChild(null), false)
+  assert.equal(forceStopBackendChild(undefined), false)
+})
+
+test('already-killed child is a no-op', () => {
+  const signals: string[] = []
+  const child = signalled(4242, signal => signals.push(signal))
+  assert.equal(stopBackendChild(child), false)
+  assert.deepEqual(signals, [])
+})
+
+test('graceful stop signals the retained owner and never accepts a pid mutator', () => {
+  const signals: string[] = []
+  const child = live(1234, signal => signals.push(signal))
+  assert.equal(stopBackendChild(child), true)
+  assert.deepEqual(signals, ['SIGTERM'])
+})
+
+test('forceful stop sends SIGKILL through the retained owner', () => {
+  const signals: string[] = []
+  const child = live(5678, signal => signals.push(signal))
+  assert.equal(forceStopBackendChild(child), true)
+  assert.deepEqual(signals, ['SIGKILL'])
+})
+
+test('child.kill throwing is swallowed (best-effort retained-owner signal)', () => {
+  const child = live(9, () => {
+    throw new Error('EPERM')
+  })
+  assert.equal(stopBackendChild(child), false)
+})
+
+test('stopBackendTreesForUpdate delegates to stopBackendChild then pool', async () => {
+  const calls: string[] = []
+  const poolChild = live(2001, signal => calls.push(`pool:${signal}`))
+  const primaryChild = live(2002, signal => calls.push(`primary:${signal}`))
+  await stopBackendTreesForUpdate(primaryChild, {
+    stopAllPoolBackends: () => {
+      calls.push('pool-stopped')
+    }
+  })
+  // primary gets SIGTERM via stopBackendChild, then pool callback fires.
+  assert.deepEqual(calls, ['primary:SIGTERM', 'pool-stopped'])
+})
+
+test('stopBackendTreesForUpdate with no pool callback still signals primary', async () => {
+  const signals: string[] = []
+  const primaryChild = live(3003, signal => signals.push(signal))
+  await stopBackendTreesForUpdate(primaryChild, {
+    stopAllPoolBackends: () => undefined
+  })
+  assert.deepEqual(signals, ['SIGTERM'])
+})
+
+test('pid-only child (no kill fn) is refused', () => {
+  const signals: string[] = []
+  const pidOnly = { exitCode: null, pid: 9999, signalCode: null }
+  assert.equal(stopBackendChild(pidOnly as any), false)
+  assert.deepEqual(signals, [])
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,7 +31,11 @@ import {
 } from 'electron'
 
 import { classifyActiveRuntime } from './active-runtime-state'
-import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
+import {
+  forceStopBackendChild as forceStopBackendChildImpl,
+  stopBackendChild as stopBackendChildImpl,
+  stopBackendTreesForUpdate
+} from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
@@ -3039,31 +3043,6 @@ function isShimLocked(shimPath) {
   }
 }
 
-// Force-kill the entire process TREE rooted at each PID. Node's child.kill()
-// only signals the direct child, so on Windows a backend `hermes.exe` that
-// spawned its own grandchildren (a `hermes` REPL, a pty terminal session, the
-// gateway) would survive and keep the venv shim locked. taskkill /T /F reaps
-// the whole tree synchronously. Windows-only: this is called solely from the
-// Windows shim-unlock path, and the backend is NOT spawned detached (so it's
-// not a process-group leader — a POSIX negative-pgid kill would be meaningless
-// here anyway). POSIX teardown stays with the existing before-quit SIGTERM.
-function forceKillProcessTree(pid) {
-  if (!IS_WINDOWS) {
-    return
-  }
-
-  if (!Number.isInteger(pid) || pid <= 0) {
-    return
-  }
-
-  try {
-    execFileSync('taskkill', ['/PID', String(pid), '/T', '/F'], hiddenWindowsChildOptions({ stdio: 'ignore' }))
-  } catch {
-    // Already gone, or no permission — best effort; the unlock wait below is
-    // the real gate.
-  }
-}
-
 function writeBackendOwnership(contents) {
   fs.mkdirSync(path.dirname(DESKTOP_BACKEND_OWNERSHIP_PATH), { recursive: true })
   const tempPath = `${DESKTOP_BACKEND_OWNERSHIP_PATH}.${process.pid}.tmp`
@@ -3205,46 +3184,14 @@ async function stopOwnedBackend(identity) {
     return
   }
 
-  if (IS_WINDOWS) {
-    forceKillProcessTree(identity.pid)
-  } else {
-    try {
-      process.kill(-identity.pid, 'SIGTERM')
-    } catch {
-      try {
-        process.kill(identity.pid, 'SIGTERM')
-      } catch {
-        return
-      }
-    }
-
-    const deadline = Date.now() + 1500
-
-    while (Date.now() < deadline) {
-      if ((await processIdentityMatches(identity)) !== true) {
-        return
-      }
-
-      await new Promise(resolve => setTimeout(resolve, 50))
-    }
-
-    // Revalidate immediately before escalation so PID reuse cannot target a
-    // replacement process.
-    if ((await processIdentityMatches(identity)) === true) {
-      try {
-        process.kill(-identity.pid, 'SIGKILL')
-      } catch {
-        process.kill(identity.pid, 'SIGKILL')
-      }
-    }
-  }
-
-  await new Promise(resolve => setTimeout(resolve, 50))
-  const remaining = await processIdentityMatches(identity)
-
-  if (remaining !== false) {
-    throw new Error(`Backend PID ${identity.pid} did not stop cleanly.`)
-  }
+  // Persisted identity is evidence that the process still looks like Hermes;
+  // it is not the retained capability that created/adopted that process. Keep
+  // the ownership record so a later authority-aware recovery can report it,
+  // but never turn the PID back into kill authority (#89614).
+  throw Object.assign(
+    new Error(`Refusing to stop backend PID ${identity.pid}: no retained process authority.`),
+    { code: 'NO_PROCESS_AUTHORITY' }
+  )
 }
 
 const backendOwnership = createBackendOwnership({
@@ -3368,10 +3315,8 @@ async function releaseBackendLock(updateRoot, tag) {
 
   const hermesProcess = backendConnectionState.getProcess()
 
-  stopBackendTreesForUpdate(hermesProcess, {
-    forceKillProcessTree,
-    stopAllPoolBackends
-  })
+  await stopBackendTreesForUpdate(hermesProcess, { stopAllPoolBackends })
+  await waitForBackendExit(hermesProcess)
 
   const shim = venvHermesShimPath(updateRoot)
   const deadlineMs = Date.now() + 15000
@@ -3383,27 +3328,9 @@ async function releaseBackendLock(updateRoot, tag) {
       return { unlocked: true }
     }
 
-    // A supervised backend can respawn between kill and check (grandchildren,
-    // pool entries registered mid-teardown). Re-collect and re-kill each pass
-    // instead of trusting the initial sweep.
-    const stragglers = []
-
-    const currentHermesProcess = backendConnectionState.getProcess()
-
-    if (currentHermesProcess && Number.isInteger(currentHermesProcess.pid)) {
-      stragglers.push(currentHermesProcess.pid)
-    }
-
-    for (const entry of backendPool.values()) {
-      if (entry.process && Number.isInteger(entry.process.pid)) {
-        stragglers.push(entry.process.pid)
-      }
-    }
-
-    for (const pid of stragglers) {
-      forceKillProcessTree(pid)
-    }
-
+    // The lock is observation only. Descendants or foreign processes may
+    // remain after retained-child shutdown; never rediscover authority from
+    // their PIDs. The timeout below aborts before replacement (#89614).
     await new Promise(r => setTimeout(r, 300))
   }
 
@@ -9512,7 +9439,7 @@ function resetBootProgressForReconnect() {
 }
 
 function stopBackendChild(child) {
-  stopBackendChildImpl(child, { forceKillProcessTree, isWindows: IS_WINDOWS })
+  stopBackendChildImpl(child)
 }
 
 // Soft gateway-mode apply: tear down the primary without resetting boot UI or
@@ -9611,19 +9538,7 @@ async function waitForBackendExit(child, timeoutMs = 5000) {
     return
   }
 
-  try {
-    if (IS_WINDOWS && Number.isInteger(child.pid)) {
-      forceKillProcessTree(child.pid)
-    } else if (Number.isInteger(child.pid)) {
-      try {
-        process.kill(-child.pid, 'SIGKILL')
-      } catch {
-        child.kill('SIGKILL')
-      }
-    } else {
-      child.kill('SIGKILL')
-    }
-  } catch {
+  if (!forceStopBackendChildImpl(child)) {
     return
   }
 

--- a/apps/desktop/electron/windows-child-options.test.ts
+++ b/apps/desktop/electron/windows-child-options.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { stopBackendChild, stopBackendTreesForUpdate } from './backend-child'
+import { forceStopBackendChild, isLiveProcessRoot, stopBackendChild, stopBackendTreesForUpdate } from './backend-child'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
 test('hiddenWindowsChildOptions adds windowsHide:true on Windows when unset', () => {
@@ -43,126 +43,104 @@ function makeChild(overrides: Partial<{ pid: number | null; killed: boolean }> =
   return {
     calls,
     child: {
-      kill: (signal: string) => {
+      exitCode: null,
+      kill: (signal: NodeJS.Signals) => {
         calls.push(signal)
       },
       killed: overrides.killed ?? false,
-      pid: 'pid' in overrides ? overrides.pid : 1234
+      pid: 'pid' in overrides ? overrides.pid : 1234,
+      signalCode: null
     }
   }
 }
 
-test('stopBackendChild tree-kills on Windows when the child has a pid', () => {
-  const { child, calls } = makeChild({ pid: 4242 })
-  const treeKillCalls: number[] = []
-
-  stopBackendChild(child, {
-    forceKillProcessTree: (pid: number) => treeKillCalls.push(pid),
-    isWindows: true
-  })
-
-  assert.deepEqual(treeKillCalls, [4242])
-  assert.deepEqual(calls, [], 'SIGTERM must not be sent when the Windows tree-kill path is taken')
-})
-
-test('stopBackendChild group-SIGTERMs on POSIX (negative pgid) when the child has a pid', () => {
-  const { child, calls } = makeChild({ pid: 4242 })
-  const treeKillCalls: number[] = []
-  const groupKills: Array<[number, string]> = []
-
-  stopBackendChild(child, {
-    forceKillProcessTree: (pid: number) => treeKillCalls.push(pid),
-    isWindows: false,
-    killGroup: (pgid, signal) => groupKills.push([pgid, signal])
-  })
-
-  assert.deepEqual(groupKills, [[-4242, 'SIGTERM']], 'must signal the whole process group')
-  assert.deepEqual(calls, [], 'direct child.kill must not run when the group send succeeds')
-  assert.deepEqual(treeKillCalls, [], 'tree-kill must not run off Windows')
-})
-
-test('stopBackendChild falls back to direct SIGTERM on POSIX when the group send throws', () => {
+test('stopBackendChild signals the retained owner via kill on any platform', () => {
   const { child, calls } = makeChild({ pid: 4242 })
 
-  stopBackendChild(child, {
-    forceKillProcessTree: () => {},
-    isWindows: false,
-    killGroup: () => {
-      throw new Error('ESRCH: no such process group')
-    }
-  })
+  const result = stopBackendChild(child)
 
-  assert.deepEqual(calls, ['SIGTERM'], 'must fall back to signalling the direct child')
-})
-
-test('stopBackendChild falls back to SIGTERM on Windows when the pid is not an integer', () => {
-  const { child, calls } = makeChild({ pid: null })
-  const treeKillCalls: number[] = []
-
-  stopBackendChild(child, {
-    forceKillProcessTree: (pid: number) => treeKillCalls.push(pid),
-    isWindows: true
-  })
-
+  assert.equal(result, true, 'must signal a live retained owner')
   assert.deepEqual(calls, ['SIGTERM'])
-  assert.deepEqual(treeKillCalls, [])
+})
+
+test('stopBackendChild never tree-kills by PID (fail-closed: pid is observation only)', () => {
+  // The old API accepted a forceKillProcessTree dep; the new fail-closed API
+  // has no such parameter — stopBackendChild only calls child.kill.
+  const { child } = makeChild({ pid: 4242 })
+
+  assert.equal(stopBackendChild(child), true)
+  // No PID-based tree-kill path exists anymore.
+})
+
+test('stopBackendChild falls back to direct kill when group signal is unavailable (no-op throw)', () => {
+  // With the new API, there is no group-signal path; stopBackendChild simply
+  // calls child.kill directly. A throwing kill is swallowed.
+  const signals: string[] = []
+  const child = {
+    exitCode: null,
+    kill: () => {
+      signals.push('SIGTERM')
+    },
+    killed: false,
+    pid: 99,
+    signalCode: null
+  }
+
+  assert.equal(stopBackendChild(child), true)
+  assert.deepEqual(signals, ['SIGTERM'])
+})
+
+test('stopBackendChild no longer accepts a pid-only legacy record', () => {
+  // { pid: 99 } without lifecycle fields is observation, not authority.
+  assert.equal(stopBackendChild({ pid: 99 } as any), false)
 })
 
 test('stopBackendChild is a no-op for an already-killed child', () => {
   const { child, calls } = makeChild({ killed: true })
-  const treeKillCalls: number[] = []
 
-  stopBackendChild(child, {
-    forceKillProcessTree: (pid: number) => treeKillCalls.push(pid),
-    isWindows: true
-  })
-
+  assert.equal(stopBackendChild(child), false)
   assert.deepEqual(calls, [])
-  assert.deepEqual(treeKillCalls, [])
 })
 
 test('stopBackendChild is a no-op for a null/undefined child', () => {
-  const treeKillCalls: number[] = []
+  assert.equal(stopBackendChild(null), false)
+  assert.equal(stopBackendChild(undefined), false)
+  assert.equal(forceStopBackendChild(null), false)
+  assert.equal(forceStopBackendChild(undefined), false)
+})
 
-  assert.doesNotThrow(() => {
-    stopBackendChild(null, { forceKillProcessTree: (pid: number) => treeKillCalls.push(pid), isWindows: true })
-    stopBackendChild(undefined, { forceKillProcessTree: (pid: number) => treeKillCalls.push(pid), isWindows: true })
-  })
-  assert.deepEqual(treeKillCalls, [])
+test('forceStopBackendChild sends SIGKILL through the retained owner', () => {
+  const { child, calls } = makeChild({ pid: 9999 })
+
+  assert.equal(forceStopBackendChild(child), true)
+  assert.deepEqual(calls, ['SIGKILL'])
 })
 
 test('stopBackendChild swallows errors thrown by the kill strategy', () => {
   const child = {
+    exitCode: null,
     kill: () => {
       throw new Error('ESRCH: no such process')
     },
     killed: false,
-    pid: 99
+    pid: 999,
+    signalCode: null
   }
 
-  assert.doesNotThrow(() => {
-    stopBackendChild(child, {
-      forceKillProcessTree: () => {},
-      isWindows: false
-    })
-  })
+  assert.equal(stopBackendChild(child), false)
 })
 
-test('Windows update tree-kills captured roots without pre-signalling the primary backend', () => {
-  const primary = makeChild({ pid: 101 })
-  const pooled = makeChild({ pid: 202 })
+test('update teardown signals the retained primary owner only, no PID tree-kill', async () => {
   const events: string[] = []
+  const primary = makeChild({ pid: 101 })
 
-  stopBackendTreesForUpdate(primary.child, {
-    forceKillProcessTree: pid => events.push(`tree:${pid}`),
+  await stopBackendTreesForUpdate(primary.child, {
     stopAllPoolBackends: () => {
       events.push('pool-stop')
-      // Production stopAllPoolBackends() already tree-kills every pool root.
-      events.push(`tree:${pooled.child.pid}`)
     }
   })
 
-  assert.deepEqual(events, ['tree:101', 'pool-stop', 'tree:202'])
-  assert.deepEqual(primary.calls, [], 'the primary root must not be signalled before taskkill /T sees it')
-  assert.deepEqual(pooled.calls, [])
+  // primary gets SIGTERM via stopBackendChild; pool callback fires.
+  assert.deepEqual(events, ['pool-stop'])
+  assert.deepEqual(primary.calls, ['SIGTERM'])
 })


### PR DESCRIPTION
## Disposition

Closed after proving the exact-SHA limitation that required the final topology repair on [#90250](https://github.com/NousResearch/hermes-agent/pull/90250).

This temporary **DO NOT MERGE** lane reran the first historical #90250 object, `8f60d098d2c21e72f86868c44697c83a94f546c9`, against the current merge composition. Fresh Docker and Nix passed, but Desktop lint failed deterministically on unused imports contained in that immutable commit. A rerun therefore could not make the same SHA green.

#90250 now carries the complete final tree as one current-main commit, while all 21 original development SHAs remain preserved in its PR body and Notion provenance record. No implementation or attribution was discarded; only intrinsically red intermediate objects were removed from the active commit list.

No merge, review, reviewer request, or maintainer notification is attached to this certification lane.