### PR TITLE
fix(discord): suppress link-preview embeds and keep it across streaming edits

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1188,6 +1188,7 @@ platform_toolsets:
 #   auto_thread: true                # Auto-create thread on @mention (default: true)
 #   free_response_channels: ""       # Channel IDs where no mention is needed
 #   reactions: true                  # Show processing reactions (default: true)
+#   suppress_link_previews: true     # Hide URL preview embeds on bot messages (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1157,6 +1157,17 @@ class DiscordAdapter(BasePlatformAdapter):
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
+        # Link-preview suppression. Discord unfurls URLs in bot messages into
+        # preview cards; the dependable lever is the per-message SUPPRESS_EMBEDS
+        # flag, set at send time via ``channel.send(suppress_embeds=...)``. The
+        # streaming edit path uses ``PartialMessage.edit(content=...)``, which
+        # sends no ``flags`` field and so preserves the suppression across every
+        # mid-stream edit (Discord only regenerates the embed when an edit
+        # actively clears the flag). Defaults on; operators who want previews
+        # set ``extra.suppress_link_previews: false``.
+        self._suppress_link_previews: bool = self._coerce_suppress_link_previews(
+            self.config.extra.get("suppress_link_previews", True)
+        )
         # In-memory cache of the bot's last message ID per channel, used by
         # history backfill to skip the full scan on hot paths.  Falls back to
         # scanning channel.history() on cache miss (cold start / restart).
@@ -1172,6 +1183,18 @@ class DiscordAdapter(BasePlatformAdapter):
         # Mirrors the Telegram #58563 fix. Entries are dropped on finalize.
         self._last_overflow_preview: Dict[tuple, str] = {}
         self._warned_fail_closed_default = False
+
+    @staticmethod
+    def _coerce_suppress_link_previews(value: Any) -> bool:
+        """Coerce ``extra.suppress_link_previews`` to a bool (default on).
+
+        YAML already yields a real bool, but env/JSON overrides can arrive as
+        strings; treat the usual falsey spellings as off and everything else
+        (including a missing key, which arrives as the ``True`` default) as on.
+        """
+        if isinstance(value, str):
+            return value.strip().lower() not in ("false", "0", "no", "off", "")
+        return bool(value)
 
     def _config_value(
         self, key: str, default: Any, *, env_key: Optional[str] = None
@@ -3521,6 +3544,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     msg = await channel.send(
                         content=chunk,
                         reference=chunk_reference,
+                        suppress_embeds=self._suppress_link_previews,
                     )
                 except Exception as e:
                     err_text = str(e)
@@ -3543,6 +3567,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         msg = await channel.send(
                             content=chunk,
                             reference=None,
+                            suppress_embeds=self._suppress_link_previews,
                         )
                     else:
                         raise
@@ -3788,6 +3813,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 self._last_overflow_preview.pop(_preview_key, None)
 
             try:
+                # PartialMessage.edit sends no ``flags`` field, so a link-preview
+                # embed suppressed at send time (see ``suppress_embeds`` on the
+                # send path) stays suppressed across these streaming edits —
+                # Discord only regenerates the embed when an edit clears the
+                # SUPPRESS_EMBEDS flag, which this content-only edit never does.
                 await msg.edit(content=formatted)
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = formatted
@@ -3902,7 +3932,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 # overflow continuations stay threaded.
                 reference = self._message_reference_from_ids(prev_msg.id, channel)
             try:
-                sent = await channel.send(content=chunk, reference=reference)
+                sent = await channel.send(
+                    content=chunk,
+                    reference=reference,
+                    suppress_embeds=self._suppress_link_previews,
+                )
             except Exception as send_err:
                 # Drop the reply anchor and retry once — a deleted/expired
                 # anchor (10008) or system-message reply (50035) shouldn't lose
@@ -3912,7 +3946,11 @@ class DiscordAdapter(BasePlatformAdapter):
                     self.name, send_err,
                 )
                 try:
-                    sent = await channel.send(content=chunk, reference=None)
+                    sent = await channel.send(
+                        content=chunk,
+                        reference=None,
+                        suppress_embeds=self._suppress_link_previews,
+                    )
                 except Exception as retry_err:
                     logger.warning(
                         "[%s] Overflow split: stopped at %d/%d chunks delivered: %s",

--- a/tests/gateway/test_discord_edit_message_overflow.py
+++ b/tests/gateway/test_discord_edit_message_overflow.py
@@ -61,7 +61,7 @@ def _wire_channel(adapter, *, original_msg, send_side_effect=None):
     records every ``channel.send`` call."""
     sends = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, suppress_embeds=False):
         sends.append({"content": content, "reference": reference})
         if send_side_effect is not None:
             res = send_side_effect(len(sends), content, reference)

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -687,7 +687,7 @@ async def test_discord_send_does_not_cache_nonconversational_status_as_history_b
     """Automated status notifications should not move the backfill boundary."""
 
     class SendingChannel(FakeTextChannel):
-        async def send(self, content, reference=None):
+        async def send(self, content, reference=None, suppress_embeds=False):
             return SimpleNamespace(id=222)
 
     channel = SendingChannel(channel_id=777)

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -116,7 +116,7 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
     sent_msgs = [SimpleNamespace(id=1001), SimpleNamespace(id=1002)]
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, suppress_embeds=False):
         send_calls.append({"content": content, "reference": reference})
         if len(send_calls) == 1:
             raise RuntimeError(

--- a/tests/gateway/test_discord_split_cap.py
+++ b/tests/gateway/test_discord_split_cap.py
@@ -80,7 +80,7 @@ class TestSendCap:
         adapter = _make_adapter()
         sends = []
 
-        async def fake_send(*, content, reference=None):
+        async def fake_send(*, content, reference=None, suppress_embeds=False):
             sends.append(content)
             return SimpleNamespace(id=9000 + len(sends))
 
@@ -140,7 +140,7 @@ class TestEditOverflowCap:
         async def fake_edit(*, content):
             edits.append(content)
 
-        async def fake_send(*, content, reference=None):
+        async def fake_send(*, content, reference=None, suppress_embeds=False):
             sends.append(content)
             return SimpleNamespace(id=9000 + len(sends))
 

--- a/tests/gateway/test_discord_suppress_link_previews.py
+++ b/tests/gateway/test_discord_suppress_link_previews.py
@@ -1,0 +1,173 @@
+"""Regression tests for Discord link-preview suppression (issue #91657).
+
+Discord unfurls URLs in bot messages into preview cards.  The dependable lever
+is the per-message ``SUPPRESS_EMBEDS`` flag, set at send time via
+``channel.send(suppress_embeds=...)``.  The adapter exposes this as
+``extra.suppress_link_previews`` (default **on**) so streamed answers that cite
+links (docs lookups, search results, PR links) don't clutter the channel with
+embeds.
+
+The streaming edit path edits through ``PartialMessage.edit(content=...)``,
+which — in the pinned discord.py 2.7.1 — sends no ``flags`` field, so it
+*preserves* a suppression applied at send time (Discord only regenerates the
+embed when an edit actively clears the flag).  These tests pin both halves:
+the send carries the flag per config, and the streaming edit never passes a
+``suppress``/``flags`` keyword that could clear it.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+MAX = DiscordAdapter.MAX_MESSAGE_LENGTH  # 2000
+
+
+def _make_adapter(suppress_link_previews=None):
+    extra = {}
+    if suppress_link_previews is not None:
+        extra["suppress_link_previews"] = suppress_link_previews
+    return DiscordAdapter(PlatformConfig(enabled=True, token="***", extra=extra))
+
+
+def _wire_channel(adapter, *, original_msg=None):
+    """Fake client whose channel records every ``channel.send`` call (kwargs
+    included) and returns ``original_msg`` from ``get_partial_message``."""
+    sends = []
+
+    async def fake_send(*, content, reference=None, suppress_embeds=False):
+        sends.append({"content": content, "suppress_embeds": suppress_embeds})
+        return SimpleNamespace(id=9000 + len(sends))
+
+    channel = SimpleNamespace(
+        id=555,
+        get_partial_message=MagicMock(return_value=original_msg),
+        send=AsyncMock(side_effect=fake_send),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _cid: channel,
+        fetch_channel=AsyncMock(return_value=channel),
+    )
+    return channel, sends
+
+
+# --------------------------------------------------------------------------- #
+# Config coercion — default on, override off, string spellings
+# --------------------------------------------------------------------------- #
+
+
+class TestConfig:
+    def test_defaults_on_when_key_absent(self):
+        assert _make_adapter()._suppress_link_previews is True
+
+    def test_explicit_true(self):
+        assert _make_adapter(True)._suppress_link_previews is True
+
+    def test_explicit_false(self):
+        assert _make_adapter(False)._suppress_link_previews is False
+
+    @pytest.mark.parametrize("raw", ["false", "False", "0", "no", "off", ""])
+    def test_string_falsey_spellings_disable(self, raw):
+        assert _make_adapter(raw)._suppress_link_previews is False
+
+    @pytest.mark.parametrize("raw", ["true", "yes", "on", "1"])
+    def test_string_truthy_spellings_enable(self, raw):
+        assert _make_adapter(raw)._suppress_link_previews is True
+
+
+# --------------------------------------------------------------------------- #
+# Send path — the flag rides on channel.send per config
+# --------------------------------------------------------------------------- #
+
+
+class TestSendSuppression:
+    @pytest.mark.asyncio
+    async def test_send_suppresses_by_default(self):
+        adapter = _make_adapter()
+        _, sends = _wire_channel(adapter)
+        result = await adapter.send("555", "see https://example.com for docs")
+        assert result.success is True
+        assert len(sends) == 1
+        assert sends[0]["suppress_embeds"] is True
+
+    @pytest.mark.asyncio
+    async def test_send_keeps_previews_when_disabled(self):
+        adapter = _make_adapter(False)
+        _, sends = _wire_channel(adapter)
+        result = await adapter.send("555", "see https://example.com for docs")
+        assert result.success is True
+        assert sends[0]["suppress_embeds"] is False
+
+    @pytest.mark.asyncio
+    async def test_overflow_continuations_carry_the_flag(self):
+        # A finalized oversized edit splits into a first-chunk edit plus
+        # continuation channel.send() calls — those continuations are part of
+        # the same streamed reply and must stay suppressed too.
+        adapter = _make_adapter()
+        partial = SimpleNamespace(
+            id=42,
+            edit=AsyncMock(),
+            to_reference=MagicMock(return_value=SimpleNamespace(kind="ref")),
+        )
+        _, sends = _wire_channel(adapter, original_msg=partial)
+        result = await adapter.edit_message("555", "42", "link " * 1200, finalize=True)
+        assert result.success is True
+        assert sends, "expected overflow continuations"
+        assert all(s["suppress_embeds"] is True for s in sends)
+
+
+# --------------------------------------------------------------------------- #
+# Edit path — the content-only edit never clears the flag
+# --------------------------------------------------------------------------- #
+
+
+class TestEditPreservesSuppression:
+    @pytest.mark.asyncio
+    async def test_streaming_edit_sends_no_suppress_or_flags_kwarg(self):
+        """The streaming edit must not pass ``suppress``/``flags`` to
+        ``PartialMessage.edit``.  Passing ``suppress=False`` (or ``flags`` with
+        the bit cleared) is exactly what makes Discord regenerate the embed
+        mid-stream; a content-only edit leaves the send-time suppression intact.
+        """
+        adapter = _make_adapter()
+        edit_calls = []
+
+        async def record_edit(**kwargs):
+            edit_calls.append(kwargs)
+
+        msg = SimpleNamespace(id=42, edit=AsyncMock(side_effect=record_edit))
+        _wire_channel(adapter, original_msg=msg)
+
+        result = await adapter.edit_message("555", "42", "streamed https://example.com")
+        assert result.success is True
+        assert len(edit_calls) == 1
+        assert edit_calls[0] == {"content": "streamed https://example.com"}
+        assert "suppress" not in edit_calls[0]
+        assert "flags" not in edit_calls[0]

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -337,6 +337,7 @@ discord:
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
+  suppress_link_previews: true    # Hide URL preview embeds on bot messages (default: true)
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
@@ -378,6 +379,25 @@ In **multi-bot threads** where users address one bot per turn, this default beco
 discord:
   require_mention: true
   thread_require_mention: true    # multi-bot setup
+```
+
+#### `discord.suppress_link_previews`
+
+**Type:** boolean — **Default:** `true`
+
+Discord unfurls URLs in bot messages into preview cards. Streamed answers that
+cite links — documentation lookups, search results, PR links — otherwise end up
+wrapped in unwanted embeds. When enabled (the default), the bot sets Discord's
+`SUPPRESS_EMBEDS` flag on the messages it sends, so no preview card is
+generated. Because the flag is set at send time and the streaming edit path
+never clears it, the suppression holds across the mid-stream edits the bot makes
+while a reply streams in.
+
+Set `suppress_link_previews: false` if you *want* preview cards on bot messages.
+
+```yaml
+discord:
+  suppress_link_previews: false   # keep URL preview embeds
 ```
 
 #### `discord.free_response_channels`


### PR DESCRIPTION
## What does this PR do?

Discord expands URLs in bot messages into link-preview embed cards. Streamed answers that cite links — documentation lookups, search results, PR links — end up wrapped in unwanted preview cards, which is exactly the clutter the bot should avoid.

The dependable lever for hiding these cards is Discord's per-message `SUPPRESS_EMBEDS` flag, which has to be set at send time. The Discord adapter never set it, so there was no supported way to stop preview-card clutter.

This adds a `suppress_link_previews` config key (default **on**) and sets `suppress_embeds` on the adapter's outgoing conversational messages. Because the flag is applied at send time and the streaming edit path edits through `PartialMessage.edit(content=...)` — which sends no `flags` field — the suppression survives every mid-stream edit the bot makes while a reply streams in (Discord only regenerates the embed when an edit actively clears the flag). Operators who want previews can set `suppress_link_previews: false`.

## Related Issue

Fixes #91657

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py`: read `extra.suppress_link_previews` (default `True`) into `self._suppress_link_previews` via a new `_coerce_suppress_link_previews` helper (accepts bool or string spellings); pass `suppress_embeds=self._suppress_link_previews` on the conversational send paths (main chunked send + reply-reference retry, and the overflow-split continuation sends + their retry). The streaming edit path stays a content-only `PartialMessage.edit`, with a comment noting it must stay that way so it never clears the flag.
- `tests/gateway/test_discord_suppress_link_previews.py` (new): regression tests for config defaulting on, explicit off, string coercion, the flag riding on `channel.send`, overflow continuations carrying the flag, and the streaming edit passing no `suppress`/`flags` kwarg that could clear suppression.
- `tests/gateway/test_discord_edit_message_overflow.py`, `tests/gateway/test_discord_send.py`, `tests/gateway/test_discord_free_response.py`, `tests/gateway/test_discord_split_cap.py`: updated the fake `channel.send` signatures to accept the new `suppress_embeds` keyword.
- `website/docs/user-guide/messaging/discord.md`, `cli-config.yaml.example`: document the `suppress_link_previews` key.

## How to Test

1. Leave Discord defaults (or set `discord.suppress_link_previews: true`). Have the bot stream a reply that contains a URL. The message arrives with no link-preview card, and the card does not appear as streaming continues to edit the message. Set `discord.suppress_link_previews: false` and repeat — the preview card is kept.
2. `pytest tests/gateway/test_discord_suppress_link_previews.py -q`
3. `pytest tests/gateway/test_discord_send.py tests/gateway/test_discord_edit_message_overflow.py tests/gateway/test_discord_split_cap.py tests/gateway/test_discord_free_response.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live check against a Discord bot in a test guild (message ids elided):

```
send (suppress_link_previews on)     -> flags=4 (SUPPRESS_EMBEDS)  embeds=0
3x streaming edit + finalize         -> flags=4                    embeds=0
send with suppress_link_previews off -> flags=0                    embeds=1 (preview kept)
```
