### PR TITLE
feat: add Skillven publish provider to Hermes CLI

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1465,8 +1465,8 @@ def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> No
 
 
 def do_publish(skill_path: str, target: str = "github", repo: str = "",
-               console: Optional[Console] = None) -> None:
-    """Publish a local skill to a registry (GitHub PR or ClawHub submission)."""
+               registry: str = "", console: Optional[Console] = None) -> None:
+    """Publish a local skill to a registry (GitHub PR, ClawHub, or Skillven submission)."""
     from tools.skills_hub import GitHubAuth, SKILLS_DIR
     from tools.skills_guard import scan_skill, format_scan_report
 
@@ -1478,6 +1478,21 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
         path = SKILLS_DIR / path
     if not path.exists() or not (path / "SKILL.md").exists():
         c.print(f"[bold red]Error:[/] No SKILL.md found at {path}\n")
+        return
+
+    if target == "skillven":
+        # Skillven's SKILL.md is frontmatter-free (see skillven_publish), so it
+        # can't go through the frontmatter/description validation block below —
+        # run the shared scan here and delegate before that block runs.
+        from hermes_cli.skillven_publish import do_skillven_publish
+
+        c.print(f"[bold]Scanning '{path.name}' before publish...[/]")
+        result = scan_skill(path, source="self")
+        c.print(format_scan_report(result))
+        if result.verdict == "dangerous":
+            c.print("[bold red]Cannot publish a skill with DANGEROUS verdict.[/]\n")
+            return
+        do_skillven_publish(path, registry=registry, scan_result=result, console=c)
         return
 
     # Validate the skill
@@ -1771,6 +1786,7 @@ def skills_command(args) -> None:
             args.skill_path,
             target=getattr(args, "to", "github"),
             repo=getattr(args, "repo", ""),
+            registry=getattr(args, "registry", "") or "",
         )
     elif action == "snapshot":
         snap_action = getattr(args, "snapshot_action", None)

--- a/hermes_cli/skillven_publish.py
+++ b/hermes_cli/skillven_publish.py
@@ -1,0 +1,368 @@
+"""Skillven registry publish provider for ``hermes skills publish --to skillven``.
+
+Footprint Ladder rung-2 (CLI capability, no new core tool). Orchestration lives
+in ``do_skillven_publish``; the bundle builder and HTTP client are kept in this
+standalone module per the task's "small private helper or separate module"
+requirement so ``hermes_cli/skills_hub.py`` only gets a thin dispatch branch.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+import httpx
+import yaml
+
+DEFAULT_REGISTRY = "https://api.skillven.com"
+TOKEN_ENV_VAR = "SKILLVEN_PUBLISH_TOKEN"
+
+# Mirrors Skillven's documented publish-API bundle contract exactly.
+MAX_FILE_BYTES = 1 * 1024 * 1024
+MAX_BUNDLE_BYTES = 4 * 1024 * 1024
+MAX_BUNDLE_FILE_COUNT = 64
+MAX_PATH_DEPTH = 8
+MAX_PATH_LEN = 255
+
+REQUIRED_METADATA_FIELDS = (
+    "name",
+    "version",
+    "description",
+    "license",
+    "compatible_agents",
+    "required_tools",
+    "permissions",
+    "risk_level",
+)
+_METADATA_STRING_FIELDS = ("name", "version", "description", "license", "risk_level")
+_METADATA_LIST_FIELDS = ("compatible_agents", "required_tools", "permissions")
+_RISK_LEVELS = {"low", "medium", "high"}
+
+
+class SkillvenPublishError(Exception):
+    """Any Skillven publish failure. Message text is always safe to print — never token/body dumps."""
+
+
+@dataclass
+class SkillvenBundle:
+    metadata: dict
+    files: list  # list[tuple[str, bytes]] — (posix-relative path, content)
+
+
+def _validate_relative_path(root: Path, rel: Path) -> Path:
+    """Reject absolute paths, ``..`` escapes, NUL bytes, and symlinks under ``root``."""
+    raw = str(rel)
+    if "\x00" in raw:
+        raise SkillvenPublishError(f"Rejected path containing a NUL byte: {raw!r}")
+    if rel.is_absolute():
+        raise SkillvenPublishError(f"Rejected absolute path in bundle: {rel}")
+    if ".." in rel.parts:
+        raise SkillvenPublishError(f"Rejected path escaping the skill directory: {rel}")
+
+    full = root / rel
+    if full.is_symlink():
+        raise SkillvenPublishError(f"Rejected symlink in bundle: {rel}")
+
+    resolved_root = root.resolve()
+    resolved = full.resolve()
+    try:
+        resolved.relative_to(resolved_root)
+    except ValueError:
+        raise SkillvenPublishError(
+            f"Rejected path escaping the skill directory: {rel}"
+        ) from None
+    return resolved
+
+
+def _collect_bundle_files(root: Path) -> list:
+    """Return sorted relative Paths of allowed regular files under ``root``."""
+    root = root.resolve()
+    out = []
+    for full in sorted(root.rglob("*")):
+        if full.is_dir():
+            continue
+        rel = full.relative_to(root)
+        _validate_relative_path(root, rel)
+        if not full.is_file():
+            raise SkillvenPublishError(f"Rejected non-regular file in bundle: {rel}")
+        out.append(rel)
+    return out
+
+
+def _load_metadata(root: Path) -> dict:
+    meta_path = root / "metadata.yaml"
+    if not meta_path.exists():
+        raise SkillvenPublishError(
+            "metadata.yaml is required for --to skillven but was not found."
+        )
+    try:
+        data = yaml.safe_load(meta_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        raise SkillvenPublishError(f"metadata.yaml is not valid YAML: {exc}") from None
+    if not isinstance(data, dict):
+        raise SkillvenPublishError("metadata.yaml must contain a YAML mapping.")
+
+    missing = [f for f in REQUIRED_METADATA_FIELDS if f not in data]
+    if missing:
+        raise SkillvenPublishError(
+            "metadata.yaml is missing required field(s): " + ", ".join(missing)
+        )
+    for field in _METADATA_STRING_FIELDS:
+        if not isinstance(data.get(field), str) or not data[field].strip():
+            raise SkillvenPublishError(
+                f"metadata.yaml field '{field}' must be a non-empty string."
+            )
+    for field in _METADATA_LIST_FIELDS:
+        if not isinstance(data.get(field), list):
+            raise SkillvenPublishError(f"metadata.yaml field '{field}' must be a list.")
+    if data["risk_level"] not in _RISK_LEVELS:
+        raise SkillvenPublishError(
+            f"metadata.yaml field 'risk_level' must be one of: {', '.join(sorted(_RISK_LEVELS))}."
+        )
+    return data
+
+
+def _check_skill_md_frontmatter_free(skill_md_text: str) -> None:
+    text = skill_md_text.lstrip("﻿")
+    if re.match(r"^\s*---\s*\n", text):
+        raise SkillvenPublishError(
+            "SKILL.md for --to skillven must not contain YAML frontmatter; "
+            "Skillven renders frontmatter from metadata.yaml at publish time."
+        )
+
+
+def _check_bundle_limits(files: list) -> None:
+    if len(files) > MAX_BUNDLE_FILE_COUNT:
+        raise SkillvenPublishError(
+            f"Too many files in bundle (> {MAX_BUNDLE_FILE_COUNT}): {len(files)}"
+        )
+    total = 0
+    for rel, content in files:
+        if len(rel.encode("utf-8")) > MAX_PATH_LEN:
+            raise SkillvenPublishError(f"Path too long (> {MAX_PATH_LEN} bytes): {rel}")
+        if len(rel.split("/")) > MAX_PATH_DEPTH:
+            raise SkillvenPublishError(
+                f"Path too deep (> {MAX_PATH_DEPTH} segments): {rel}"
+            )
+        if len(content) > MAX_FILE_BYTES:
+            raise SkillvenPublishError(
+                f"File too large (> {MAX_FILE_BYTES} bytes): {rel}"
+            )
+        total += len(content)
+    if total > MAX_BUNDLE_BYTES:
+        raise SkillvenPublishError(
+            f"Bundle too large (> {MAX_BUNDLE_BYTES} bytes): {total} bytes"
+        )
+
+
+def build_skillven_payload(root) -> dict:
+    """Build the exact JSON-able payload sent to both the preview and publish endpoints."""
+    root = Path(root)
+    skill_md_path = root / "SKILL.md"
+    if not skill_md_path.exists():
+        raise SkillvenPublishError("SKILL.md is required but was not found.")
+    _check_skill_md_frontmatter_free(skill_md_path.read_text(encoding="utf-8"))
+
+    metadata = _load_metadata(root)
+
+    rel_paths = _collect_bundle_files(root)
+    if Path("SKILL.md") not in rel_paths or Path("metadata.yaml") not in rel_paths:
+        raise SkillvenPublishError(
+            "Bundle must include both SKILL.md and metadata.yaml."
+        )
+
+    files = [(rel.as_posix(), (root / rel).read_bytes()) for rel in rel_paths]
+    _check_bundle_limits(files)
+
+    payload_files = [
+        {"path": rel, "content_base64": base64.b64encode(content).decode("ascii")}
+        for rel, content in files
+    ]
+    return {"metadata": metadata, "files": payload_files}
+
+
+def get_publish_token() -> str:
+    from agent.secret_scope import get_secret
+
+    token = get_secret(TOKEN_ENV_VAR)
+    if not token:
+        raise SkillvenPublishError(
+            f"{TOKEN_ENV_VAR} is not set. Add it to your .env (never commit it), then retry: "
+            "hermes skills publish <path> --to skillven"
+        )
+    return token
+
+
+def _confirm(prompt: str) -> bool:
+    try:
+        resp = input(f"{prompt} [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return False
+    return resp in {"y", "yes"}
+
+
+class SkillvenClient:
+    """Thin Skillven HTTP wrapper. ``transport`` is injectable for tests (httpx.MockTransport)."""
+
+    def __init__(
+        self, registry: str, token: str, *, transport=None, timeout: float = 30.0
+    ):
+        self._client = httpx.Client(
+            base_url=registry.rstrip("/"),
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=timeout,
+            transport=transport,
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    def preview(self, payload: dict) -> dict:
+        return self._request("POST", "/v1/skills/preview", payload)
+
+    def publish(self, payload: dict) -> dict:
+        return self._request("POST", "/v1/skills", payload)
+
+    def get_version(self, name: str, version: str) -> dict:
+        return self._request("GET", f"/v1/skills/{name}/versions/{version}", None)
+
+    def _request(self, method: str, path: str, payload: Optional[dict]) -> dict:
+        try:
+            resp = self._client.request(method, path, json=payload)
+        except httpx.TimeoutException:
+            raise SkillvenPublishError(
+                "Skillven request timed out. Please retry."
+            ) from None
+        except httpx.HTTPError:
+            raise SkillvenPublishError(
+                "Network error contacting the Skillven registry."
+            ) from None
+
+        if resp.status_code == 401:
+            raise SkillvenPublishError(
+                "Skillven rejected the token as invalid (401). Check SKILLVEN_PUBLISH_TOKEN."
+            )
+        if resp.status_code == 403:
+            raise SkillvenPublishError(
+                "Skillven denied the request (403): you may not own this skill name."
+            )
+        if resp.status_code == 409:
+            raise SkillvenPublishError(
+                "Skillven reports this name/version already exists (409 duplicate version)."
+            )
+        if resp.status_code >= 400:
+            code, message = self._safe_error_fields(resp)
+            raise SkillvenPublishError(
+                f"Skillven returned {resp.status_code} ({code}): {message}"
+            )
+
+        try:
+            return resp.json()
+        except ValueError:
+            raise SkillvenPublishError(
+                "Skillven returned an invalid (non-JSON) response."
+            ) from None
+
+    @staticmethod
+    def _safe_error_fields(resp: httpx.Response):
+        try:
+            data = resp.json()
+        except ValueError:
+            return ("unknown", "no further details")
+        if not isinstance(data, dict):
+            return ("unknown", "no further details")
+        code = data.get("code") or data.get("error") or "unknown"
+        message = data.get("message") or "no further details"
+        return (str(code)[:200], str(message)[:500])
+
+
+def do_skillven_publish(
+    path,
+    *,
+    registry: str,
+    scan_result,
+    console,
+    confirm: Optional[Callable[[str], bool]] = None,
+    client_factory: Optional[Callable[[str, str], SkillvenClient]] = None,
+) -> None:
+    """Preview -> confirm -> publish -> read-back. Caller must have already run
+    ``scan_skill(path, source="self")``; a dangerous verdict is re-checked here
+    defensively so this function never reaches the network without it."""
+    if scan_result is None or getattr(scan_result, "verdict", None) == "dangerous":
+        console.print("[bold red]Cannot publish a skill with DANGEROUS verdict.[/]\n")
+        return
+
+    registry = (registry or DEFAULT_REGISTRY).rstrip("/")
+    confirm = confirm or _confirm
+    client_factory = client_factory or SkillvenClient
+
+    try:
+        payload = build_skillven_payload(path)
+        token = get_publish_token()
+    except SkillvenPublishError as exc:
+        console.print(f"[bold red]Error:[/] {exc}\n")
+        return
+
+    metadata = payload["metadata"]
+    name, version = metadata["name"], metadata["version"]
+
+    client = client_factory(registry, token)
+    try:
+        try:
+            preview = client.preview(payload)
+        except SkillvenPublishError as exc:
+            console.print(f"[bold red]Preview failed:[/] {exc}\n")
+            return
+
+        warnings = preview.get("warnings") or []
+        if not preview.get("preview") or not preview.get("installable") or warnings:
+            console.print(
+                "[bold red]Skillven preview did not pass; aborting before any real publish.[/]"
+            )
+            for w in warnings[:20]:
+                console.print(f"  [yellow]- {w}[/]")
+            return
+
+        console.print(f"[bold]Skillven preview OK[/] for '{name}' v{version}")
+        console.print(f"  files: {len(payload['files'])}")
+        console.print(
+            f"  license: {metadata.get('license')}  risk_level: {metadata.get('risk_level')}"
+        )
+
+        if not confirm(f"Publish '{name}' v{version} to Skillven ({registry})?"):
+            console.print("[yellow]Aborted — no real publish sent.[/]\n")
+            return
+
+        try:
+            published = client.publish(payload)
+        except SkillvenPublishError as exc:
+            console.print(f"[bold red]Publish failed:[/] {exc}\n")
+            return
+
+        pub_name = published.get("name", name)
+        pub_version = published.get("version", version)
+        console.print("[bold green]Published to Skillven[/]")
+        console.print(f"  name: {pub_name}")
+        console.print(f"  version: {pub_version}")
+        console.print(f"  installable: {published.get('installable')}")
+        console.print(
+            f"  source_skill_md_sha256: {published.get('source_skill_md_sha256')}"
+        )
+        console.print(f"  files: {len(published.get('files', payload['files']))}")
+
+        try:
+            confirmed = client.get_version(pub_name, pub_version)
+            console.print(
+                f"[bold]Read-back confirmed:[/] version={confirmed.get('version')} "
+                f"installable={confirmed.get('installable')}\n"
+            )
+        except SkillvenPublishError as exc:
+            console.print(
+                f"[yellow]Warning:[/] could not read back published version: {exc}\n"
+            )
+    finally:
+        client.close()

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -277,10 +277,18 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
     )
     skills_publish.add_argument("skill_path", help="Path to skill directory")
     skills_publish.add_argument(
-        "--to", default="github", choices=["github", "clawhub"], help="Target registry"
+        "--to",
+        default="github",
+        choices=["github", "clawhub", "skillven"],
+        help="Target registry",
     )
     skills_publish.add_argument(
         "--repo", default="", help="Target GitHub repo (e.g. openai/skills)"
+    )
+    skills_publish.add_argument(
+        "--registry",
+        default="",
+        help="Registry base URL override (e.g. for --to skillven)",
     )
 
     skills_snapshot = skills_subparsers.add_parser(

--- a/tests/hermes_cli/test_skills_publish_skillven.py
+++ b/tests/hermes_cli/test_skills_publish_skillven.py
@@ -1,0 +1,226 @@
+"""RED-first tests for the Skillven publish provider (Hermes Agent 18-B).
+
+Covers: parser accepts ``--to skillven`` + ``--registry``, and ``do_publish``
+dispatches to the skillven path without touching github/clawhub behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_cli.skillven_publish as skillven_publish_mod
+import hermes_cli.skills_hub as skills_hub_mod
+from hermes_cli.subcommands.skills import build_skills_parser
+
+
+class _FakeConsole:
+    def __init__(self):
+        self.lines: list[str] = []
+
+    def print(self, msg=""):
+        self.lines.append(str(msg))
+
+
+def _write_frontmatter_skill(tmp_path, name="demo", description="A demo skill."):
+    root = tmp_path / "skill"
+    root.mkdir()
+    (root / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\nBody\n", encoding="utf-8"
+    )
+    return root
+
+
+def _build_parser():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_skills_parser(sub, cmd_skills=lambda args: None)
+    return parser
+
+
+def test_publish_parser_accepts_skillven_target_and_registry():
+    parser = _build_parser()
+    ns = parser.parse_args([
+        "skills",
+        "publish",
+        "/tmp/my-skill",
+        "--to",
+        "skillven",
+        "--registry",
+        "https://staging.skillven.example",
+    ])
+    assert ns.to == "skillven"
+    assert ns.registry == "https://staging.skillven.example"
+
+
+def test_publish_parser_registry_defaults_empty():
+    parser = _build_parser()
+    ns = parser.parse_args(["skills", "publish", "/tmp/my-skill", "--to", "github"])
+    assert ns.registry == ""
+
+
+def test_publish_parser_still_rejects_unknown_target():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["skills", "publish", "/tmp/my-skill", "--to", "bogus"])
+
+
+# ---------------------------------------------------------------------------
+# do_publish dispatch: skillven runs the shared scan first, always (spec item 2)
+# ---------------------------------------------------------------------------
+
+
+def test_do_publish_skillven_runs_common_scan_then_delegates(tmp_path, monkeypatch):
+    from tools import skills_guard
+
+    root = tmp_path / "skill"
+    root.mkdir()
+    (root / "SKILL.md").write_text("# Demo\n\nNo frontmatter.\n", encoding="utf-8")
+
+    scanned = []
+    monkeypatch.setattr(
+        skills_guard,
+        "scan_skill",
+        lambda path, source: (
+            scanned.append((path, source)) or SimpleNamespace(verdict="safe")
+        ),
+    )
+    monkeypatch.setattr(skills_guard, "format_scan_report", lambda result: "scan ok")
+
+    delegated = []
+    monkeypatch.setattr(
+        skillven_publish_mod,
+        "do_skillven_publish",
+        lambda path, **kw: delegated.append((path, kw)),
+    )
+
+    console = _FakeConsole()
+    skills_hub_mod.do_publish(
+        str(root), target="skillven", registry="https://example.test", console=console
+    )
+
+    assert scanned and scanned[0][1] == "self"
+    assert len(delegated) == 1
+    delegated_path, kwargs = delegated[0]
+    assert delegated_path == root
+    assert kwargs["registry"] == "https://example.test"
+    assert kwargs["scan_result"].verdict == "safe"
+
+
+def test_do_publish_skillven_dangerous_scan_blocks_without_delegating(
+    tmp_path, monkeypatch
+):
+    from tools import skills_guard
+
+    root = tmp_path / "skill"
+    root.mkdir()
+    (root / "SKILL.md").write_text("# Demo\n\nNo frontmatter.\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        skills_guard,
+        "scan_skill",
+        lambda path, source: SimpleNamespace(verdict="dangerous"),
+    )
+    monkeypatch.setattr(
+        skills_guard, "format_scan_report", lambda result: "scan dangerous"
+    )
+
+    delegated = []
+    monkeypatch.setattr(
+        skillven_publish_mod,
+        "do_skillven_publish",
+        lambda path, **kw: delegated.append((path, kw)),
+    )
+
+    console = _FakeConsole()
+    skills_hub_mod.do_publish(str(root), target="skillven", console=console)
+
+    assert delegated == []
+    assert any("DANGEROUS" in line for line in console.lines)
+
+
+# ---------------------------------------------------------------------------
+# skills_command dispatch forwards --registry (spec item 1)
+# ---------------------------------------------------------------------------
+
+
+def test_skills_command_publish_forwards_registry(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        skills_hub_mod,
+        "do_publish",
+        lambda *a, **kw: captured.update(kw) or captured.setdefault("args", a),
+    )
+    ns = argparse.Namespace(
+        skills_action="publish",
+        skill_path="/tmp/x",
+        to="skillven",
+        repo="",
+        registry="https://staging.example",
+    )
+    skills_hub_mod.skills_command(ns)
+
+    assert captured["registry"] == "https://staging.example"
+    assert captured["target"] == "skillven"
+
+
+# ---------------------------------------------------------------------------
+# github/clawhub regression: unchanged behavior (spec item 9)
+# ---------------------------------------------------------------------------
+
+
+def test_do_publish_clawhub_message_unchanged(tmp_path, monkeypatch):
+    from tools import skills_guard
+
+    root = _write_frontmatter_skill(tmp_path)
+    monkeypatch.setattr(
+        skills_guard,
+        "scan_skill",
+        lambda path, source: SimpleNamespace(verdict="safe"),
+    )
+    monkeypatch.setattr(skills_guard, "format_scan_report", lambda result: "scan ok")
+
+    console = _FakeConsole()
+    skills_hub_mod.do_publish(str(root), target="clawhub", console=console)
+
+    assert any("not yet supported" in line for line in console.lines)
+
+
+def test_do_publish_github_still_requires_repo(tmp_path, monkeypatch):
+    from tools import skills_guard
+
+    root = _write_frontmatter_skill(tmp_path)
+    monkeypatch.setattr(
+        skills_guard,
+        "scan_skill",
+        lambda path, source: SimpleNamespace(verdict="safe"),
+    )
+    monkeypatch.setattr(skills_guard, "format_scan_report", lambda result: "scan ok")
+
+    console = _FakeConsole()
+    skills_hub_mod.do_publish(str(root), target="github", console=console)
+
+    assert any("--repo required" in line for line in console.lines)
+
+
+def test_do_publish_still_rejects_missing_description_for_github(tmp_path, monkeypatch):
+    from tools import skills_guard
+
+    root = tmp_path / "skill"
+    root.mkdir()
+    (root / "SKILL.md").write_text("---\nname: demo\n---\nBody\n", encoding="utf-8")
+    monkeypatch.setattr(
+        skills_guard,
+        "scan_skill",
+        lambda path, source: SimpleNamespace(verdict="safe"),
+    )
+    monkeypatch.setattr(skills_guard, "format_scan_report", lambda result: "scan ok")
+
+    console = _FakeConsole()
+    skills_hub_mod.do_publish(
+        str(root), target="github", repo="owner/repo", console=console
+    )
+
+    assert any("must have a 'description'" in line for line in console.lines)

--- a/tests/hermes_cli/test_skillven_publish.py
+++ b/tests/hermes_cli/test_skillven_publish.py
@@ -1,0 +1,508 @@
+"""RED-first tests for hermes_cli/skillven_publish.py (Hermes Agent 18-B).
+
+Covers bundle validation, payload building, token resolution, the HTTP
+client's preview/publish/read-back calls, and the do_skillven_publish
+orchestration (scan gate, preview gate, confirmation gate, no secret leaks).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import yaml
+
+from hermes_cli import skillven_publish
+
+
+class _FakeConsole:
+    def __init__(self):
+        self.lines: list[str] = []
+
+    def print(self, msg=""):
+        self.lines.append(str(msg))
+
+
+def _write_bundle(
+    tmp_path,
+    *,
+    name="demo-skill",
+    version="1.0.0",
+    extra_files=None,
+    skill_md=None,
+    metadata_overrides=None,
+):
+    root = tmp_path / "skill"
+    root.mkdir()
+    (root / "SKILL.md").write_text(
+        skill_md or "# Demo Skill\n\nBody text with no frontmatter.\n",
+        encoding="utf-8",
+    )
+    metadata = {
+        "name": name,
+        "version": version,
+        "description": "A demo skill for tests.",
+        "license": "MIT",
+        "compatible_agents": ["claude", "hermes"],
+        "required_tools": [],
+        "permissions": [],
+        "risk_level": "low",
+    }
+    if metadata_overrides:
+        metadata.update(metadata_overrides)
+    (root / "metadata.yaml").write_text(yaml.safe_dump(metadata), encoding="utf-8")
+    if extra_files:
+        for rel, content in extra_files.items():
+            p = root / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content, encoding="utf-8")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Bundle building / validation (spec items 2, 3)
+# ---------------------------------------------------------------------------
+
+
+def test_build_skillven_payload_includes_all_files_base64_encoded(tmp_path):
+    root = _write_bundle(
+        tmp_path, extra_files={"reference/notes.md": "reference content"}
+    )
+
+    payload = skillven_publish.build_skillven_payload(root)
+
+    paths = sorted(f["path"] for f in payload["files"])
+    assert paths == ["SKILL.md", "metadata.yaml", "reference/notes.md"]
+    by_path = {f["path"]: f["content_base64"] for f in payload["files"]}
+    assert (
+        base64.b64decode(by_path["reference/notes.md"]).decode() == "reference content"
+    )
+    assert payload["metadata"]["name"] == "demo-skill"
+    assert payload["metadata"]["version"] == "1.0.0"
+
+
+def test_build_skillven_payload_requires_metadata_yaml(tmp_path):
+    root = tmp_path / "skill"
+    root.mkdir()
+    (root / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+
+    with pytest.raises(skillven_publish.SkillvenPublishError, match="metadata.yaml"):
+        skillven_publish.build_skillven_payload(root)
+
+
+def test_build_skillven_payload_requires_skill_md(tmp_path):
+    root = tmp_path / "skill"
+    root.mkdir()
+    (root / "metadata.yaml").write_text(yaml.safe_dump({"name": "x"}), encoding="utf-8")
+
+    with pytest.raises(skillven_publish.SkillvenPublishError):
+        skillven_publish.build_skillven_payload(root)
+
+
+def test_build_skillven_payload_rejects_frontmatter_skill_md(tmp_path):
+    root = _write_bundle(tmp_path, skill_md="---\nname: demo\n---\nBody\n")
+
+    with pytest.raises(skillven_publish.SkillvenPublishError, match="frontmatter"):
+        skillven_publish.build_skillven_payload(root)
+
+
+def test_build_skillven_payload_rejects_incomplete_metadata(tmp_path):
+    root = _write_bundle(tmp_path)
+    (root / "metadata.yaml").write_text(
+        yaml.safe_dump({"name": "demo-skill"}), encoding="utf-8"
+    )
+
+    with pytest.raises(skillven_publish.SkillvenPublishError, match="missing"):
+        skillven_publish.build_skillven_payload(root)
+
+
+def test_collect_bundle_files_rejects_symlink(tmp_path):
+    root = _write_bundle(tmp_path)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("secret", encoding="utf-8")
+    (root / "link.txt").symlink_to(outside)
+
+    with pytest.raises(skillven_publish.SkillvenPublishError, match="symlink"):
+        skillven_publish.build_skillven_payload(root)
+
+
+def test_validate_relative_path_rejects_escape_absolute_and_nul(tmp_path):
+    root = tmp_path
+
+    with pytest.raises(skillven_publish.SkillvenPublishError):
+        skillven_publish._validate_relative_path(root, Path("../escape.txt"))
+    with pytest.raises(skillven_publish.SkillvenPublishError):
+        skillven_publish._validate_relative_path(root, Path("/etc/passwd"))
+    with pytest.raises(skillven_publish.SkillvenPublishError):
+        skillven_publish._validate_relative_path(root, Path("bad\x00name"))
+
+
+def test_check_bundle_limits_rejects_oversize_file(tmp_path):
+    with pytest.raises(skillven_publish.SkillvenPublishError, match="too large"):
+        skillven_publish._check_bundle_limits([
+            ("SKILL.md", b"x" * (skillven_publish.MAX_FILE_BYTES + 1))
+        ])
+
+
+def test_check_bundle_limits_allows_file_exactly_max_bytes():
+    skillven_publish._check_bundle_limits([
+        ("SKILL.md", b"x" * skillven_publish.MAX_FILE_BYTES)
+    ])
+
+
+def test_check_bundle_limits_allows_bundle_exactly_max_bytes():
+    files = [(f"f{i}.bin", b"x" * skillven_publish.MAX_FILE_BYTES) for i in range(4)]
+    assert sum(len(c) for _, c in files) == skillven_publish.MAX_BUNDLE_BYTES
+
+    skillven_publish._check_bundle_limits(files)
+
+
+def test_check_bundle_limits_rejects_bundle_over_max_bytes():
+    files = [(f"f{i}.bin", b"x" * skillven_publish.MAX_FILE_BYTES) for i in range(4)]
+    files.append(("extra.bin", b"x"))
+    assert sum(len(c) for _, c in files) == skillven_publish.MAX_BUNDLE_BYTES + 1
+
+    with pytest.raises(skillven_publish.SkillvenPublishError, match="too large"):
+        skillven_publish._check_bundle_limits(files)
+
+
+def test_check_bundle_limits_allows_max_file_count():
+    files = [(f"f{i}.txt", b"x") for i in range(skillven_publish.MAX_BUNDLE_FILE_COUNT)]
+
+    skillven_publish._check_bundle_limits(files)
+
+
+def test_check_bundle_limits_rejects_over_max_file_count():
+    files = [
+        (f"f{i}.txt", b"x") for i in range(skillven_publish.MAX_BUNDLE_FILE_COUNT + 1)
+    ]
+
+    with pytest.raises(skillven_publish.SkillvenPublishError, match="(?i)too many files"):
+        skillven_publish._check_bundle_limits(files)
+
+
+def test_check_bundle_limits_allows_max_path_depth():
+    path = "/".join(f"d{i}" for i in range(skillven_publish.MAX_PATH_DEPTH - 1)) + "/file.md"
+    assert len(path.split("/")) == skillven_publish.MAX_PATH_DEPTH
+
+    skillven_publish._check_bundle_limits([(path, b"x")])
+
+
+def test_check_bundle_limits_rejects_over_max_path_depth():
+    path = "/".join(f"d{i}" for i in range(skillven_publish.MAX_PATH_DEPTH)) + "/file.md"
+    assert len(path.split("/")) == skillven_publish.MAX_PATH_DEPTH + 1
+
+    with pytest.raises(skillven_publish.SkillvenPublishError, match="(?i)too deep"):
+        skillven_publish._check_bundle_limits([(path, b"x")])
+
+
+# ---------------------------------------------------------------------------
+# Token resolution (spec item 4)
+# ---------------------------------------------------------------------------
+
+
+def test_get_publish_token_missing_raises_without_network(monkeypatch):
+    monkeypatch.delenv("SKILLVEN_PUBLISH_TOKEN", raising=False)
+
+    with pytest.raises(
+        skillven_publish.SkillvenPublishError, match="SKILLVEN_PUBLISH_TOKEN"
+    ):
+        skillven_publish.get_publish_token()
+
+
+def test_get_publish_token_reads_secret_env_var(monkeypatch):
+    monkeypatch.setenv("SKILLVEN_PUBLISH_TOKEN", "tkn-abc")
+
+    assert skillven_publish.get_publish_token() == "tkn-abc"
+
+
+# ---------------------------------------------------------------------------
+# SkillvenClient HTTP mapping (spec items 5, 6)
+# ---------------------------------------------------------------------------
+
+
+def test_client_attaches_bearer_token_header():
+    captured = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request.headers.get("authorization"))
+        return httpx.Response(
+            200, json={"preview": True, "installable": True, "warnings": []}
+        )
+
+    client = skillven_publish.SkillvenClient(
+        "https://example.test", "tkn-secret", transport=httpx.MockTransport(handler)
+    )
+    client.preview({"metadata": {}, "files": []})
+
+    assert captured == ["Bearer tkn-secret"]
+
+
+@pytest.mark.parametrize(
+    "status,expected_snippet",
+    [(401, "invalid"), (403, "own"), (409, "duplicate")],
+)
+def test_client_maps_known_error_codes_to_specific_safe_messages(
+    status, expected_snippet
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status, json={"code": "x", "message": "server detail", "secret": "leak-me"}
+        )
+
+    client = skillven_publish.SkillvenClient(
+        "https://example.test", "tkn-secret", transport=httpx.MockTransport(handler)
+    )
+
+    with pytest.raises(skillven_publish.SkillvenPublishError) as exc_info:
+        client.preview({"metadata": {}, "files": []})
+
+    msg = str(exc_info.value)
+    assert expected_snippet in msg.lower()
+    assert "leak-me" not in msg
+    assert "tkn-secret" not in msg
+
+
+def test_client_does_not_dump_full_response_body_on_5xx():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            500,
+            json={
+                "code": "internal",
+                "message": "boom",
+                "stack_trace": "TOKEN_LEAK tkn-secret",
+            },
+        )
+
+    client = skillven_publish.SkillvenClient(
+        "https://example.test", "tkn-secret", transport=httpx.MockTransport(handler)
+    )
+
+    with pytest.raises(skillven_publish.SkillvenPublishError) as exc_info:
+        client.preview({"metadata": {}, "files": []})
+
+    msg = str(exc_info.value)
+    assert "internal" in msg
+    assert "boom" in msg
+    assert "TOKEN_LEAK" not in msg
+    assert "tkn-secret" not in msg
+
+
+def test_client_maps_timeout_to_safe_message():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.TimeoutException("timed out", request=request)
+
+    client = skillven_publish.SkillvenClient(
+        "https://example.test", "tkn-secret", transport=httpx.MockTransport(handler)
+    )
+
+    with pytest.raises(skillven_publish.SkillvenPublishError, match="(?i)time"):
+        client.preview({"metadata": {}, "files": []})
+
+
+def test_client_maps_network_error_to_safe_message():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    client = skillven_publish.SkillvenClient(
+        "https://example.test", "tkn-secret", transport=httpx.MockTransport(handler)
+    )
+
+    with pytest.raises(skillven_publish.SkillvenPublishError, match="(?i)network"):
+        client.preview({"metadata": {}, "files": []})
+
+
+# ---------------------------------------------------------------------------
+# do_skillven_publish orchestration (spec items 2, 5, 6, 7)
+# ---------------------------------------------------------------------------
+
+
+def test_do_skillven_publish_aborts_before_any_client_when_scan_dangerous(tmp_path):
+    root = _write_bundle(tmp_path)
+    created = []
+
+    def factory(registry, token):
+        created.append((registry, token))
+        raise AssertionError("client must not be created for a dangerous scan verdict")
+
+    console = _FakeConsole()
+    skillven_publish.do_skillven_publish(
+        root,
+        registry="https://example.test",
+        scan_result=SimpleNamespace(verdict="dangerous"),
+        console=console,
+        client_factory=factory,
+    )
+
+    assert created == []
+
+
+def test_do_skillven_publish_aborts_when_preview_has_warnings(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLVEN_PUBLISH_TOKEN", "tkn-secret")
+    root = _write_bundle(tmp_path)
+    published = []
+
+    class FakeClient:
+        def __init__(self, registry, token):
+            pass
+
+        def preview(self, payload):
+            return {"preview": True, "installable": True, "warnings": ["needs review"]}
+
+        def publish(self, payload):
+            published.append(payload)
+            return {}
+
+        def get_version(self, name, version):
+            return {}
+
+        def close(self):
+            pass
+
+    console = _FakeConsole()
+    skillven_publish.do_skillven_publish(
+        root,
+        registry="https://example.test",
+        scan_result=SimpleNamespace(verdict="safe"),
+        console=console,
+        client_factory=lambda r, t: FakeClient(r, t),
+        confirm=lambda prompt: True,
+    )
+
+    assert published == []
+
+
+def test_do_skillven_publish_aborts_when_not_installable(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLVEN_PUBLISH_TOKEN", "tkn-secret")
+    root = _write_bundle(tmp_path)
+    published = []
+
+    class FakeClient:
+        def __init__(self, registry, token):
+            pass
+
+        def preview(self, payload):
+            return {"preview": True, "installable": False, "warnings": []}
+
+        def publish(self, payload):
+            published.append(payload)
+            return {}
+
+        def get_version(self, name, version):
+            return {}
+
+        def close(self):
+            pass
+
+    console = _FakeConsole()
+    skillven_publish.do_skillven_publish(
+        root,
+        registry="https://example.test",
+        scan_result=SimpleNamespace(verdict="safe"),
+        console=console,
+        client_factory=lambda r, t: FakeClient(r, t),
+        confirm=lambda prompt: True,
+    )
+
+    assert published == []
+
+
+def test_do_skillven_publish_aborts_when_user_declines(tmp_path, monkeypatch):
+    monkeypatch.setenv("SKILLVEN_PUBLISH_TOKEN", "tkn-secret")
+    root = _write_bundle(tmp_path)
+    published = []
+
+    class FakeClient:
+        def __init__(self, registry, token):
+            pass
+
+        def preview(self, payload):
+            return {"preview": True, "installable": True, "warnings": []}
+
+        def publish(self, payload):
+            published.append(payload)
+            return {}
+
+        def get_version(self, name, version):
+            return {}
+
+        def close(self):
+            pass
+
+    console = _FakeConsole()
+    skillven_publish.do_skillven_publish(
+        root,
+        registry="https://example.test",
+        scan_result=SimpleNamespace(verdict="safe"),
+        console=console,
+        client_factory=lambda r, t: FakeClient(r, t),
+        confirm=lambda prompt: False,
+    )
+
+    assert published == []
+
+
+def test_do_skillven_publish_approved_sends_preview_then_publish_same_payload_no_leak(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("SKILLVEN_PUBLISH_TOKEN", "tkn-secret-value")
+    root = _write_bundle(tmp_path)
+
+    seen = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if request.url.path == "/v1/skills/preview":
+            return httpx.Response(
+                200, json={"preview": True, "installable": True, "warnings": []}
+            )
+        if request.url.path == "/v1/skills" and request.method == "POST":
+            body = json.loads(request.content.decode())
+            return httpx.Response(
+                200,
+                json={
+                    "name": body["metadata"]["name"],
+                    "version": body["metadata"]["version"],
+                    "installable": True,
+                    "source_skill_md_sha256": "deadbeef",
+                    "files": body["files"],
+                },
+            )
+        if request.url.path.startswith("/v1/skills/") and request.method == "GET":
+            return httpx.Response(200, json={"version": "1.0.0", "installable": True})
+        return httpx.Response(404, json={"code": "not_found", "message": "no route"})
+
+    console = _FakeConsole()
+    skillven_publish.do_skillven_publish(
+        root,
+        registry="https://example.test",
+        scan_result=SimpleNamespace(verdict="safe"),
+        console=console,
+        client_factory=lambda r, t: skillven_publish.SkillvenClient(
+            r, t, transport=httpx.MockTransport(handler)
+        ),
+        confirm=lambda prompt: True,
+    )
+
+    assert [r.url.path for r in seen] == [
+        "/v1/skills/preview",
+        "/v1/skills",
+        "/v1/skills/demo-skill/versions/1.0.0",
+    ]
+    assert all(
+        r.headers.get("authorization") == "Bearer tkn-secret-value" for r in seen
+    )
+
+    preview_body = json.loads(seen[0].content.decode())
+    publish_body = json.loads(seen[1].content.decode())
+    assert preview_body == publish_body
+
+    output = "\n".join(console.lines)
+    assert "tkn-secret-value" not in output
+    assert "demo-skill" in output
+    assert "1.0.0" in output
+    assert "deadbeef" in output


### PR DESCRIPTION
Adds the Skillven target to the Hermes skills publish CLI. It runs the existing security scan, validates the Skillven bundle, calls preview, requires explicit confirmation, publishes, and verifies the version. Personal Publish Token is read through secret_scope and never logged. Focused tests: 38 passed; skills hub/parser regression: 4 passed; ruff and CLI help passed. Full suite has 43 unrelated pre-existing environment failures documented.