### PR TITLE
feat: hermes migrate grokbot (export Grok Bot data into Bot Mode profiles)

### DIFF
--- a/hermes_cli/grokbot_export.py
+++ b/hermes_cli/grokbot_export.py
@@ -1,0 +1,817 @@
+"""Export Grok Bot data (bots, conversations) into grokbot-export.json.
+
+The exporter is deliberately layered so it degrades instead of breaking:
+
+L1 app witness
+    The Grok Bot desktop app is relaunched under our control: its backend
+    base URLs are pointed at a local logging proxy (its own documented env
+    overrides) and Chromium is started with a CDP debug port. We then read
+    what the app itself shows — the bot roster, every conversation's
+    transcript (roles + timestamps come from the rendered DOM), and each
+    bot's details pane. Whatever the vendor changes, the app's own UI
+    remains the source of truth.
+
+L2 API replay
+    The proxy capture yields the account's OAuth refresh token (stable,
+    public client). We mint access tokens and replay the cataloged backend
+    endpoints for metadata the UI never loads (sandbox list). If the
+    account's feature flags block a call, the layer is skipped with a
+    warning — L1 output is unaffected.
+
+Secrets never enter the export file. Captured tokens live only in the
+capture directory (mode 0600), which is deleted unless --keep-capture is
+passed.
+
+The app is macOS-only; the exporter refuses to run elsewhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import http.client
+import http.server
+import json
+import logging
+import os
+import shutil
+import signal
+import ssl
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+EXPORT_SCHEMA_VERSION = 1
+
+DEFAULT_APP_PATH = Path("/Applications/Grok Bot.app")
+DEFAULT_CDP_PORT = 9335
+DEFAULT_PROXY_PORT = 9339
+BACKEND_HOST = "api2.cursor.sh"
+OAUTH_CLIENT_ID = "OzaBXLClY5CAGxNzUhQ2vlknpi07tGuE"
+CHECKSUM_PREFIX = "4CYoNne3"
+
+_ROSTER_ITEM_SELECTOR = ".sand-agent-item"
+_MESSAGE_SELECTOR = ".sand-message"
+_SCROLL_VIEWPORT_SELECTOR = ".ui-scroll-area__viewport"
+
+
+class ExportError(RuntimeError):
+    """A layer failed in a way the caller must see."""
+
+
+# ---------------------------------------------------------------------------
+# L1: capture proxy
+# ---------------------------------------------------------------------------
+
+
+class CaptureProxy:
+    """Loopback proxy that logs every request/response to a capture dir.
+
+    The app is pointed here via ``SAND_BACKEND_URL`` / ``CURSOR_API_BASE_URL``
+    (its documented environment overrides), so no certificates or system
+    proxy changes are involved. Requests forward to the real backend over
+    TLS; responses are captured in full for offline analysis.
+    """
+
+    def __init__(self, port: int, capture_dir: Path) -> None:
+        self.port = port
+        self.capture_dir = capture_dir
+        self.capture_dir.mkdir(parents=True, exist_ok=True)
+        self._seq = 0
+        self._lock = threading.Lock()
+        self._log_path = capture_dir / "proxylog.jsonl"
+        self._server: Optional[http.server.ThreadingHTTPServer] = None
+
+    def _log(self, obj: Dict[str, Any]) -> None:
+        with self._lock:
+            self._seq += 1
+            obj = {"seq": self._seq, "ts": time.time(), **obj}
+            with open(self._log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(obj, ensure_ascii=False) + "\n")
+
+    def _save_body(self, body: bytes, label: str, suffix: str) -> Path:
+        path = self.capture_dir / f"{self._seq:05d}-{label}{suffix}"
+        path.write_bytes(body)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+        return path
+
+    def start(self) -> None:
+        proxy = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, format: str, *args) -> None:  # silence stderr chatter
+                pass
+
+            def _forward(self) -> None:
+                seq = None
+                body = b""
+                if self.headers.get("Content-Length"):
+                    body = self.rfile.read(int(self.headers["Content-Length"]))
+                auth = self.headers.get("Authorization") or ""
+                with proxy._lock:
+                    proxy._seq += 1
+                    seq = proxy._seq
+                body_ref = None
+                if body:
+                    body_ref = str(proxy._save_body(body, f"req-{seq}", ".bin"))
+                proxy._log(
+                    {
+                        "kind": "req",
+                        "seq_ref": seq,
+                        "method": self.command,
+                        "path": self.path[:400],
+                        "auth": f"{auth[:16]}...{auth[-12:]}" if auth else None,
+                        "auth_full": auth or None,
+                        "headers": dict(self.headers.items()),
+                        "body_len": len(body),
+                        "body_ref": body_ref,
+                    }
+                )
+                headers = {k: v for k, v in self.headers.items() if k.lower() != "host"}
+                conn = http.client.HTTPSConnection(
+                    BACKEND_HOST, 443, timeout=60, context=ssl.create_default_context()
+                )
+                try:
+                    conn.request(self.command, self.path, body=body, headers=headers)
+                    resp = conn.getresponse()
+                    resp_body = resp.read()
+                    proxy._log(
+                        {
+                            "kind": "res",
+                            "seq_ref": seq,
+                            "status": resp.status,
+                            "content_type": resp.getheader("content-type") or "",
+                            "body_len": len(resp_body),
+                        }
+                    )
+                    if resp_body:
+                        saved = proxy._save_body(resp_body, f"res-{seq}", ".bin")
+                        proxy._log({"kind": "res_body", "seq_ref": seq, "file": str(saved)})
+                    self.send_response(resp.status)
+                    for k, v in resp.getheaders():
+                        if k.lower() not in ("transfer-encoding", "connection", "content-length"):
+                            self.send_header(k, v)
+                    self.send_header("Content-Length", str(len(resp_body)))
+                    self.end_headers()
+                    if resp_body:
+                        self.wfile.write(resp_body)
+                except Exception as exc:  # noqa: BLE001
+                    proxy._log({"kind": "fwd_err", "seq_ref": seq, "error": str(exc)})
+                    try:
+                        self.send_response(502)
+                        self.send_header("Content-Length", "0")
+                        self.end_headers()
+                    except OSError:
+                        pass
+
+            do_POST = _forward
+            do_GET = _forward
+            do_PUT = _forward
+            do_DELETE = _forward
+            do_PATCH = _forward
+
+        self._server = http.server.ThreadingHTTPServer(("127.0.0.1", self.port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+
+    def refresh_tokens(self) -> List[str]:
+        """Extract distinct refresh tokens seen in oauth/token requests."""
+        tokens: List[str] = []
+        if not self._log_path.is_file():
+            return tokens
+        for line in self._log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if (
+                entry.get("kind") == "req"
+                and entry.get("path", "").startswith("/oauth/token")
+                and entry.get("body_ref")
+            ):
+                body_path = Path(entry["body_ref"])
+                if body_path.is_file():
+                    try:
+                        data = json.loads(body_path.read_text(encoding="utf-8"))
+                    except (json.JSONDecodeError, OSError):
+                        continue
+                    rt = data.get("refresh_token")
+                    if rt and rt not in tokens:
+                        tokens.append(rt)
+        return tokens
+
+
+# ---------------------------------------------------------------------------
+# L2: API replay
+# ---------------------------------------------------------------------------
+
+
+def mint_access_token(refresh_token: str) -> str:
+    """Exchange a captured refresh token for an access token."""
+    payload = json.dumps(
+        {
+            "client_id": OAUTH_CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        f"https://{BACKEND_HOST}/oauth/token",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+    token = data.get("access_token")
+    if not token:
+        raise ExportError("oauth/token response carried no access_token")
+    return token
+
+
+def api2_post(
+    path: str,
+    access_token: str,
+    body: Optional[Dict[str, Any]] = None,
+    *,
+    machine_id: str = "",
+    client_version: str = "0.24.0",
+) -> Tuple[int, Dict[str, Any]]:
+    """POST to the product backend the way the desktop client does."""
+    headers = {
+        "Content-Type": "application/json",
+        "Connect-Protocol-Version": "1",
+        "User-Agent": "connect-es/1.6.1",
+        "Authorization": f"Bearer {access_token}",
+        "x-cursor-client-version": client_version,
+        "x-cursor-client-type": "sand",
+        "x-ghost-mode": "true",
+        "x-request-id": str(uuid.uuid4()),
+    }
+    if machine_id:
+        headers["x-cursor-checksum"] = f"{CHECKSUM_PREFIX}{machine_id}"
+    payload = json.dumps(body or {}).encode("utf-8")
+    req = urllib.request.Request(
+        f"https://{BACKEND_HOST}{path}", data=payload, headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            return resp.status, json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            return exc.code, json.loads(raw)
+        except json.JSONDecodeError:
+            return exc.code, {"_raw": raw}
+
+
+# ---------------------------------------------------------------------------
+# L1: CDP witness
+# ---------------------------------------------------------------------------
+
+
+class CdpClient:
+    """Minimal CDP client over the `websockets` dependency (already shipped)."""
+
+    def __init__(self, ws) -> None:
+        self._ws = ws
+        self._id = 0
+        self._pending: Dict[int, asyncio.Future] = {}
+        self._events: List[Dict[str, Any]] = []
+
+    @classmethod
+    async def connect(cls, port: int) -> "CdpClient":
+        import websockets
+
+        async def _try() -> "CdpClient":
+            for attempt in range(10):
+                try:
+                    with urllib.request.urlopen(
+                        f"http://127.0.0.1:{port}/json/list", timeout=2
+                    ) as resp:
+                        targets = json.loads(resp.read().decode("utf-8"))
+                    page = next(
+                        (t for t in targets if t.get("type") == "page"), None
+                    )
+                    if page is None:
+                        raise ExportError("no page target on the CDP endpoint")
+                    ws = await websockets.connect(
+                        page["webSocketDebuggerUrl"],
+                        additional_headers={"Origin": "devtools://devtools"},
+                        open_timeout=5,
+                    )
+                    return cls(ws)
+                except Exception:  # noqa: BLE001 — retry ladder below
+                    await asyncio.sleep(1.5)
+            raise ExportError("could not attach to the app's CDP endpoint")
+
+        client = await _try()
+        asyncio.create_task(client._reader())
+        return client
+
+    async def _reader(self) -> None:
+        try:
+            async for raw in self._ws:
+                msg = json.loads(raw)
+                mid = msg.get("id")
+                if mid is not None and mid in self._pending:
+                    fut = self._pending.pop(mid)
+                    if not fut.done():
+                        fut.set_result(msg)
+                elif msg.get("method"):
+                    self._events.append(msg)
+        except Exception:  # noqa: BLE001
+            pass
+
+    async def send(self, method: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        self._id += 1
+        mid = self._id
+        msg: Dict[str, Any] = {"id": mid, "method": method}
+        if params:
+            msg["params"] = params
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[mid] = fut
+        await self._ws.send(json.dumps(msg))
+        result = await asyncio.wait_for(fut, timeout=10)
+        if result.get("error"):
+            raise ExportError(
+                f"CDP {method}: {json.dumps(result['error'])[:200]}"
+            )
+        return result.get("result", {})
+
+    async def evaluate(self, expression: str, timeout_ms: int = 8000) -> Any:
+        result = await self.send(
+            "Runtime.evaluate",
+            {
+                "expression": expression,
+                "returnByValue": True,
+                "awaitPromise": True,
+                "timeout": timeout_ms,
+            },
+        )
+        return (result.get("result") or {}).get("value")
+
+    async def close(self) -> None:
+        try:
+            await self._ws.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+_JS_ROSTER = (
+    "JSON.stringify(Array.from(document.querySelectorAll('.sand-agent-item')).map("
+    "(e) => ({name: (e.getAttribute('aria-label') || '').trim(), "
+    "preview: (e.innerText || '').trim().slice(0, 200)})))"
+)
+
+_JS_CLICK_BY_TEXT = (
+    "(text) => { const els = Array.from(document.querySelectorAll('.sand-agent-item'));"
+    " const el = els.find((e) => (e.getAttribute('aria-label') || '').trim() === text);"
+    " if (el) { el.click(); return true; } return false; }"
+)
+
+_JS_EXTRACT_MESSAGES = """
+JSON.stringify((() => {
+  const out = [];
+  const seen = new Set();
+  for (const m of document.querySelectorAll('.sand-message')) {
+    const text = (m.innerText || '').trim().replace(/\\s+/g, ' ');
+    if (!text || seen.has(text)) continue;
+    seen.add(text);
+    const label = m.getAttribute('aria-label') || '';
+    const timeEl = m.querySelector('time') || (m.parentElement ? m.parentElement.querySelector('time') : null);
+    out.push({
+      role: label.includes('Your') ? 'user' : 'assistant',
+      text: text.slice(0, 100000),
+      tsLabel: timeEl ? timeEl.textContent.trim() : '',
+      ts: Date.now() / 1000,
+    });
+  }
+  return out;
+})())
+"""
+
+_JS_SCROLL_TOP = """
+(() => {
+  const vp = document.querySelector('.ui-scroll-area__viewport');
+  const el = vp || document.scrollingElement;
+  if (el) { el.scrollTop = 0; }
+  return true;
+})()
+"""
+
+_JS_DETAILS = """
+JSON.stringify((() => {
+  const btn = Array.from(document.querySelectorAll('button')).find(
+    (b) => (b.getAttribute('aria-label') || '').includes('View conversation details'));
+  if (btn) btn.click();
+  return true;
+})())
+"""
+
+_JS_INFO_PANE = """
+JSON.stringify((() => {
+  const back = Array.from(document.querySelectorAll('button')).find(
+    (b) => (b.innerText || '').trim() === 'Back to details');
+  if (back) back.click();
+  const pane = document.querySelector('.sand-info-pane');
+  if (!pane) return null;
+  const inputs = Array.from(pane.querySelectorAll('input, textarea')).map((i) => ({
+    label: (i.getAttribute('aria-label') || i.getAttribute('placeholder') || '').trim().slice(0, 60),
+    value: (i.value || '').trim().slice(0, 2000),
+  })).filter((x) => x.value);
+  const text = (pane.innerText || '').replace(/\\s+/g, ' ').slice(0, 4000);
+  return { text, inputs };
+})())
+"""
+
+
+def _parse_ts(ts_label: str, fallback: float) -> float:
+    """Best-effort parse of the app's local 12h timestamps."""
+    import datetime
+
+    ts_label = (ts_label or "").strip()
+    try:
+        now = datetime.datetime.now()
+        dt = datetime.datetime.strptime(ts_label, "%I:%M:%S %p")
+        dt = dt.replace(year=now.year, month=now.month, day=now.day)
+        return dt.timestamp()
+    except ValueError:
+        return fallback
+
+
+async def witness_export(cdp: CdpClient, max_messages_per_conversation: int) -> Dict[str, Any]:
+    """Walk the app's UI and build the export dict (bots + conversations)."""
+    roster_raw = await cdp.evaluate(_JS_ROSTER)
+    roster = json.loads(roster_raw) if isinstance(roster_raw, str) else []
+    bots: List[Dict[str, Any]] = []
+    conversations: List[Dict[str, Any]] = []
+    warnings: List[str] = []
+
+    for i, item in enumerate(roster):
+        name = (item.get("name") or "").strip()
+        if not name:
+            continue
+        bid = f"roster-{i}"
+        clicked = await cdp.evaluate(f"({_JS_CLICK_BY_TEXT})({json.dumps(name)})")
+        if clicked is not True:
+            warnings.append(f"could not click bot row: {name}")
+            continue
+        await asyncio.sleep(2.5)
+
+        # Scroll to the top repeatedly to force history pagination to load,
+        # then read the transcript once: the rendered DOM lists messages in
+        # chronological order, so the final full read is authoritative.
+        last_count = -1
+        plateau = 0
+        batch: List[Dict[str, Any]] = []
+        for _ in range(12):
+            raw = await cdp.evaluate(_JS_EXTRACT_MESSAGES)
+            try:
+                batch = json.loads(raw) if isinstance(raw, str) else []
+            except json.JSONDecodeError:
+                batch = []
+            if len(batch) == last_count:
+                plateau += 1
+                if plateau >= 2:
+                    break
+            else:
+                plateau = 0
+                last_count = len(batch)
+            if last_count >= max_messages_per_conversation:
+                break
+            await cdp.evaluate(_JS_SCROLL_TOP)
+            await asyncio.sleep(1.8)
+        messages = batch
+
+        # Normalize timestamps: relative ordering with absolute guesses.
+        fallback = time.time() - len(messages)
+        for idx, msg in enumerate(messages):
+            msg["ts"] = _parse_ts(msg.pop("tsLabel", ""), fallback + idx)
+
+        bot = {
+            "id": bid,
+            "name": name,
+            "title": "",
+            "description": "",
+            "instructions": "",
+            "model": "",
+            "memories": [],
+            "tools": [],
+            "plugins": [],
+        }
+        if messages:
+            conversations.append(
+                {
+                    "bot_id": bid,
+                    "thread_id": bid,
+                    "title": f"Chat with {name}",
+                    "messages": messages,
+                }
+            )
+        bots.append(bot)
+
+        # Bot details pane (name/title/description live here).
+        await cdp.evaluate(_JS_DETAILS)
+        await asyncio.sleep(1.5)
+        pane_raw = await cdp.evaluate(_JS_INFO_PANE)
+        if isinstance(pane_raw, str):
+            try:
+                pane = json.loads(pane_raw)
+            except json.JSONDecodeError:
+                pane = None
+            if pane:
+                lines = [f"{x['label']}: {x['value']}" for x in (pane.get("inputs") or [])]
+                if not lines and pane.get("text"):
+                    # Fall back to pane text, minus known UI chrome labels.
+                    chrome = (
+                        "Settings Name Title Description Notifications Get "
+                        "notified when this Bot finishes or needs input Back "
+                        "to details Close details Edit Bot avatar"
+                    )
+                    cleaned = pane["text"]
+                    for word in chrome.split():
+                        cleaned = cleaned.replace(word, "")
+                    cleaned = cleaned.strip()
+                    if cleaned:
+                        lines = [cleaned]
+                bot["description"] = "\n".join(lines)[:2000]
+
+    if not bots:
+        warnings.append(
+            "no bots found in the sidebar — if the app is signed out, sign in "
+            "and re-run"
+        )
+    return {"bots": bots, "conversations": conversations, "warnings": warnings}
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _app_running() -> Optional[int]:
+    try:
+        out = subprocess.run(
+            ["pgrep", "-f", "Grok Bot.app/Contents/MacOS"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        return int(out.splitlines()[0]) if out else None
+    except (subprocess.SubprocessError, ValueError, IndexError):
+        return None
+
+
+def _quit_app() -> None:
+    subprocess.run(["osascript", "-e", 'quit app "Grok Bot"'], timeout=10)
+    time.sleep(3)
+    pid = _app_running()
+    if pid is not None:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+        time.sleep(3)
+
+
+def _launch_app(proxy_port: int, cdp_port: int) -> subprocess.Popen:
+    env = dict(os.environ)
+    env["SAND_BACKEND_URL"] = f"http://127.0.0.1:{proxy_port}"
+    env["CURSOR_API_BASE_URL"] = f"http://127.0.0.1:{proxy_port}"
+    binary = DEFAULT_APP_PATH / "Contents" / "MacOS" / "Grok Bot"
+    return subprocess.Popen(
+        [
+            str(binary),
+            f"--remote-debugging-port={cdp_port}",
+            "--remote-debugging-address=127.0.0.1",
+            "--remote-allow-origins=*",
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _relaunch_clean() -> None:
+    subprocess.run(["open", "-na", str(DEFAULT_APP_PATH)], timeout=10)
+
+
+async def _wait_for_cdp(port: int, timeout_s: float) -> CdpClient:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            return await CdpClient.connect(port)
+        except ExportError:
+            await asyncio.sleep(2)
+    raise ExportError(
+        f"CDP endpoint never became ready on port {port}"
+    )
+
+
+def run_export(
+    *,
+    out_path: Path,
+    capture_dir: Path,
+    app_path: Path = DEFAULT_APP_PATH,
+    cdp_port: int = DEFAULT_CDP_PORT,
+    proxy_port: int = DEFAULT_PROXY_PORT,
+    keep_capture: bool = False,
+    keep_running: bool = False,
+    max_messages_per_conversation: int = 2000,
+) -> int:
+    """Run the layered export. Returns a process exit code."""
+    from hermes_cli.colors import Colors, color
+
+    if sys.platform != "darwin":
+        print(
+            color("✗ Grok Bot export requires macOS (the app is macOS-only).", Colors.RED),
+            file=sys.stderr,
+        )
+        return 1
+    if not (app_path / "Contents" / "MacOS" / "Grok Bot").is_file():
+        print(
+            color(f"✗ Grok Bot app not found at {app_path}", Colors.RED),
+            file=sys.stderr,
+        )
+        return 1
+
+    capture_dir.mkdir(parents=True, exist_ok=True)
+    warnings: List[str] = []
+    layers_used: List[str] = []
+
+    proxy = CaptureProxy(proxy_port, capture_dir)
+    print(color("◆ Grok Bot export", Colors.CYAN, Colors.BOLD))
+    print()
+    print(f"  Starting capture proxy on 127.0.0.1:{proxy_port} ...")
+    proxy.start()
+
+    proc: Optional[subprocess.Popen] = None
+    try:
+        print("  Restarting the app under capture (its UI stays usable) ...")
+        _quit_app()
+        proc = _launch_app(proxy_port, cdp_port)
+
+        async def _walk() -> Dict[str, Any]:
+            cdp = await _wait_for_cdp(cdp_port, timeout_s=60)
+            await cdp.send("Runtime.enable")
+            result = await witness_export(cdp, max_messages_per_conversation)
+            await cdp.close()
+            return result
+
+        try:
+            witness = asyncio.run(_walk())
+        except ExportError as exc:
+            witness = {"bots": [], "conversations": [], "warnings": [str(exc)]}
+        layers_used.append("witness")
+        warnings.extend(witness.get("warnings") or [])
+
+        # L2: replay for backend metadata the UI never loads.
+        sandboxes: List[Dict[str, Any]] = []
+        tokens = proxy.refresh_tokens()
+        machine_id = ""
+        if tokens:
+            try:
+                access_token = mint_access_token(tokens[-1])
+                status, data = api2_post(
+                    "/aiserver.v1.GrokBotService/ListSandBoxes",
+                    access_token,
+                    machine_id=machine_id,
+                )
+                if status == 200:
+                    sandboxes = data.get("boxes") or []
+                    layers_used.append("api-replay")
+                else:
+                    warnings.append(
+                        f"backend replay skipped (ListSandBoxes: {status} "
+                        f"{str(data.get('message') or data)[:120]})"
+                    )
+            except Exception as exc:  # noqa: BLE001 — optional layer
+                warnings.append(f"backend replay skipped: {exc}")
+
+        export = {
+            "schema": EXPORT_SCHEMA_VERSION,
+            "exported_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "app_version": "0.24.0",
+            "account": {},
+            "bots": witness.get("bots") or [],
+            "conversations": witness.get("conversations") or [],
+            "files": {},
+            "provenance": {
+                "layers": layers_used,
+                "sandboxes": sandboxes,
+                "warnings": warnings,
+            },
+        }
+        out_path.write_text(
+            json.dumps(export, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+        print(
+            f"  {color('✓', Colors.GREEN)} Exported "
+            f"{len(export['bots'])} bot(s), {len(export['conversations'])} "
+            f"conversation(s) → {out_path}"
+        )
+        for warning in warnings:
+            print(f"  {color('⚠', Colors.YELLOW)} {warning}")
+        if tokens:
+            print(
+                color(
+                    f"  Note: capture dir {capture_dir} contains account "
+                    f"tokens (0600). Keep it private or delete it.",
+                    Colors.DIM,
+                )
+            )
+        return 0
+    finally:
+        proxy.stop()
+        if proc is not None and proc.poll() is None:
+            _quit_app()
+            if keep_running:
+                print(
+                    color(
+                        "  Restored the app to a normal (uninstrumented) launch.",
+                        Colors.DIM,
+                    )
+                )
+                _relaunch_clean()
+        if not keep_capture and capture_dir.exists():
+            shutil.rmtree(capture_dir, ignore_errors=True)
+
+
+def run_doctor() -> int:
+    """Check prerequisites; print findings; return an exit code."""
+    from hermes_cli.colors import Colors, color
+
+    print(color("◆ Grok Bot export doctor", Colors.CYAN, Colors.BOLD))
+    print()
+    ok = True
+
+    def check(label: str, good: bool, detail: str) -> None:
+        nonlocal ok
+        mark = color("✓", Colors.GREEN) if good else color("✗", Colors.RED)
+        print(f"  {mark} {label}" + (f": {detail}" if detail else ""))
+        ok = ok and good
+
+    check(
+        "Operating system",
+        sys.platform == "darwin",
+        "macOS required" if sys.platform != "darwin" else sys.platform,
+    )
+    app_bin = DEFAULT_APP_PATH / "Contents" / "MacOS" / "Grok Bot"
+    check("Grok Bot app installed", app_bin.is_file(), str(DEFAULT_APP_PATH))
+    if app_bin.is_file():
+        try:
+            info = (DEFAULT_APP_PATH / "Contents" / "Info.plist").read_bytes()
+            check("App bundle readable", b"CFBundleDisplayName" in info, "Info.plist present")
+        except OSError as exc:
+            check("App bundle readable", False, str(exc))
+    running = _app_running()
+    check(
+        "App state",
+        True,
+        "running (will be restarted during export)"
+        if running
+        else "not running",
+    )
+    check(
+        "No conflicting capture proxy",
+        not _port_busy(DEFAULT_PROXY_PORT),
+        f"port {DEFAULT_PROXY_PORT} busy" if _port_busy(DEFAULT_PROXY_PORT) else f"port {DEFAULT_PROXY_PORT} free",
+    )
+    check(
+        "No conflicting CDP port",
+        not _port_busy(DEFAULT_CDP_PORT),
+        f"port {DEFAULT_CDP_PORT} busy" if _port_busy(DEFAULT_CDP_PORT) else f"port {DEFAULT_CDP_PORT} free",
+    )
+    return 0 if ok else 1
+
+
+def _port_busy(port: int) -> bool:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        try:
+            s.bind(("127.0.0.1", port))
+            return False
+        except OSError:
+            return True

--- a/hermes_cli/grokbot_import.py
+++ b/hermes_cli/grokbot_import.py
@@ -1,0 +1,469 @@
+"""Import a grokbot-export.json into Hermes Bot Mode profiles.
+
+Maps each exported Grok Bot to a Hermes profile (in Bot Mode a Bot IS a
+profile), imports its conversations as sessions in the profile's state.db,
+writes its instructions to SOUL.md, its memories to profile memory entries,
+and pins the canonical chat the way the desktop does when a Bot is born.
+
+Security contract (mirrors ``hermes import-agent``): export files carry no
+credentials by design and this module refuses files that violate that
+contract's shape. Nothing here ever talks to a network.
+
+Export format (schema 1)::
+
+    {
+      "schema": 1,
+      "exported_at": "ISO8601",
+      "app_version": "0.24.0",
+      "bots": [
+        {
+          "id": "...", "name": "...", "title": "...", "description": "...",
+          "instructions": "...", "model": "...", "memories": ["..."],
+          "tools": ["..."], "plugins": ["..."]
+        }
+      ],
+      "conversations": [
+        {
+          "bot_id": "...", "thread_id": "...", "title": "...",
+          "messages": [
+            {"role": "user|assistant", "text": "...", "ts": 1234.5,
+             "attachments": []}
+          ]
+        }
+      ],
+      "provenance": {"layers": ["witness"], "warnings": []}
+    }
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+EXPORT_SCHEMA_VERSION = 1
+
+# Same delimiter as the Hermes memory store and ``hermes import-agent``.
+ENTRY_DELIMITER = "\n§\n"
+
+_SLUG_STRIP_RE = re.compile(r"[^a-z0-9_-]+")
+_SLUG_TRIM_RE = re.compile(r"^[^a-z0-9]+|[^a-z0-9]+$")
+
+# Session IDs must be stable across re-runs so a re-import skips cleanly.
+_SESSION_ID_PREFIX = "grokbot-import"
+
+
+class ExportValidationError(ValueError):
+    """The export file violates the schema-1 contract."""
+
+
+class ImportRecord:
+    """One bot's import outcome."""
+
+    def __init__(self, name: str, profile_name: str, bot_id: str = "") -> None:
+        self.name = name
+        self.profile_name = profile_name
+        self.bot_id = bot_id
+        self.status = "pending"  # imported | skipped | conflict | error
+        self.detail = ""
+        self.sessions = 0
+        self.messages = 0
+
+
+def slugify(name: str) -> str:
+    """Lowercase, hyphenate, and strip a bot name into a profile id."""
+    slug = re.sub(r"\s+", "-", (name or "").strip().lower())
+    slug = _SLUG_STRIP_RE.sub("-", slug)
+    slug = _SLUG_TRIM_RE.sub("", slug)
+    slug = re.sub(r"[_-]{2,}", "-", slug)
+    return slug or "grok-bot"
+
+
+def load_export(path) -> Dict[str, Any]:
+    """Load and strictly validate a grokbot-export.json (schema 1)."""
+    import json
+
+    path = Path(path)
+    if not path.is_file():
+        raise ExportValidationError(f"export file not found: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ExportValidationError(f"cannot read export file: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ExportValidationError("export root must be a JSON object")
+    if data.get("schema") != EXPORT_SCHEMA_VERSION:
+        raise ExportValidationError(
+            f"unsupported schema {data.get('schema')!r}; this build reads "
+            f"schema {EXPORT_SCHEMA_VERSION}"
+        )
+
+    known_top = {
+        "schema", "exported_at", "app_version", "account", "bots",
+        "conversations", "files", "provenance",
+    }
+    unknown = sorted(set(data) - known_top)
+    if unknown:
+        raise ExportValidationError(
+            f"unexpected top-level keys (secrets are never stored in export "
+            f"files; re-export with a current exporter): {', '.join(unknown)}"
+        )
+
+    bots = data.get("bots") or []
+    conversations = data.get("conversations") or []
+    if not isinstance(bots, list) or not isinstance(conversations, list):
+        raise ExportValidationError("'bots' and 'conversations' must be lists")
+
+    bot_ids: set = set()
+    for i, bot in enumerate(bots):
+        if not isinstance(bot, dict):
+            raise ExportValidationError(f"bots[{i}] must be an object")
+        bid = str(bot.get("id") or "").strip()
+        if not bid:
+            raise ExportValidationError(f"bots[{i}].id is required")
+        if bid in bot_ids:
+            raise ExportValidationError(f"duplicate bot id: {bid}")
+        bot_ids.add(bid)
+        if not str(bot.get("name") or "").strip():
+            raise ExportValidationError(f"bots[{i}] ({bid}).name is required")
+
+    for i, conv in enumerate(conversations):
+        if not isinstance(conv, dict):
+            raise ExportValidationError(f"conversations[{i}] must be an object")
+        if str(conv.get("bot_id") or "") not in bot_ids:
+            raise ExportValidationError(
+                f"conversations[{i}].bot_id references an unknown bot"
+            )
+        messages = conv.get("messages")
+        if not isinstance(messages, list) or not messages:
+            raise ExportValidationError(
+                f"conversations[{i}].messages must be a non-empty list"
+            )
+        for j, msg in enumerate(messages):
+            if not isinstance(msg, dict):
+                raise ExportValidationError(
+                    f"conversations[{i}].messages[{j}] must be an object"
+                )
+            role = str(msg.get("role") or "")
+            if role not in ("user", "assistant"):
+                raise ExportValidationError(
+                    f"conversations[{i}].messages[{j}].role must be "
+                    f"'user' or 'assistant'"
+                )
+            if not isinstance(msg.get("text"), str):
+                raise ExportValidationError(
+                    f"conversations[{i}].messages[{j}].text must be a string"
+                )
+            ts = msg.get("ts")
+            if ts is not None and not isinstance(ts, (int, float)):
+                raise ExportValidationError(
+                    f"conversations[{i}].messages[{j}].ts must be a number"
+                )
+
+    return data
+
+
+def plan_import(
+    export: Dict[str, Any],
+    *,
+    target_bots: Optional[List[str]] = None,
+) -> Tuple[List[ImportRecord], Dict[str, List[Dict[str, Any]]]]:
+    """Resolve collision-free profile names and group conversations by bot.
+
+    Returns ``(records, conversations_by_bot)``. Profile-name collisions
+    WITHIN the export get a numeric suffix; collisions with pre-existing
+    profiles are resolved at import time (merge when the profile carries our
+    import marker, otherwise ``--force`` is required).
+    """
+    records: List[ImportRecord] = []
+    by_bot: Dict[str, List[Dict[str, Any]]] = {}
+    for conv in export.get("conversations") or []:
+        by_bot.setdefault(str(conv["bot_id"]), []).append(conv)
+
+    seen: set = set()
+    for bot in export.get("bots") or []:
+        bid = str(bot["id"])
+        if target_bots and str(bot.get("name")) not in target_bots and bid not in target_bots:
+            continue
+        base = slugify(str(bot.get("name")))
+        name, n = base, 2
+        while name in seen:
+            name = f"{base}-{n}"
+            n += 1
+        seen.add(name)
+        records.append(ImportRecord(str(bot.get("name")), name, bot_id=str(bid)))
+    return records, by_bot
+
+
+def _first_last_ts(messages: List[Dict[str, Any]]) -> Tuple[float, float]:
+    stamps = [float(m["ts"]) for m in messages if m.get("ts") is not None]
+    if not stamps:
+        now = time.time()
+        return now, now
+    return min(stamps), max(stamps)
+
+
+def _map_session(
+    conv: Dict[str, Any],
+    *,
+    profile_name: str,
+    bot_name: str,
+    bot_model: Optional[str],
+    pinned: bool,
+    index: int,
+) -> Dict[str, Any]:
+    """Map one exported conversation onto a SessionDB import dict."""
+    messages = conv["messages"]
+    first, last = _first_last_ts(messages)
+    mapped: List[Dict[str, Any]] = []
+    for msg in messages:
+        mapped.append(
+            {
+                "role": msg["role"],
+                "content": msg["text"],
+                "timestamp": msg.get("ts") or first,
+            }
+        )
+    title = str(conv.get("title") or "").strip() or f"Chat with {bot_name}"
+    return {
+        "id": f"{_SESSION_ID_PREFIX}-{index}",
+        "source": "grokbot-import",
+        "title": title,
+        "started_at": first,
+        "ended_at": last,
+        "pinned": 1 if pinned else 0,
+        "hidden": 0,
+        "profile_name": profile_name,
+        "model": bot_model,
+        "message_count": len(mapped),
+        "messages": mapped,
+    }
+
+
+def _write_soul(profile_dir: Path, bot: Dict[str, Any], exported_at: str) -> None:
+    from utils import atomic_write_text
+
+    name = str(bot.get("name") or "").strip()
+    title = str(bot.get("title") or "").strip()
+    description = str(bot.get("description") or "").strip()
+    instructions = str(bot.get("instructions") or "").strip()
+
+    parts = [f"# {name}"]
+    if title:
+        parts.append(f"**Role:** {title}")
+    if description:
+        parts.append(f"**About:** {description}")
+    if instructions:
+        parts.append("\n## Instructions\n")
+        parts.append(instructions)
+    parts.append(f"\nImported from Grok Bot on {exported_at}.")
+    atomic_write_text(profile_dir / "SOUL.md", "\n".join(parts) + "\n")
+
+
+def _write_memories(profile_dir: Path, bot: Dict[str, Any]) -> None:
+    from utils import atomic_write_text
+
+    memories = [str(m).strip() for m in (bot.get("memories") or []) if str(m).strip()]
+    if not memories:
+        return
+    memory_file = profile_dir / "memories" / "MEMORY.md"
+    if memory_file.exists():
+        existing = memory_file.read_text(encoding="utf-8", errors="replace").strip()
+        if existing:
+            memories = ([existing] + memories)
+    atomic_write_text(memory_file, ENTRY_DELIMITER.join(memories) + "\n")
+
+
+def _import_bot(
+    record: ImportRecord,
+    bot: Dict[str, Any],
+    conversations: List[Dict[str, Any]],
+    exported_at: str,
+    *,
+    dry_run: bool,
+    force: bool,
+) -> ImportRecord:
+    """Create one profile and import its conversations. Atomic per bot."""
+    from hermes_cli.profiles import (
+        create_profile,
+        profile_exists,
+        get_profile_dir,
+        write_profile_meta,
+    )
+
+    if profile_exists(record.profile_name):
+        marker = get_profile_dir(record.profile_name) / "grokbot-import.json"
+        if marker.is_file() or force:
+            record.status = "conflict"
+            record.detail = "existing profile; merging (sessions already present are skipped)"
+        else:
+            record.status = "conflict"
+            record.detail = (
+                f"profile '{record.profile_name}' already exists; pass "
+                f"--force to import into it anyway"
+            )
+            return record
+
+    if dry_run:
+        record.status = "imported"
+        record.sessions = len(conversations)
+        record.messages = sum(len(c["messages"]) for c in conversations)
+        record.detail = "dry-run: no writes"
+        return record
+
+    profile_dir: Optional[Path] = None
+    created_here = False
+    try:
+        profile_dir = get_profile_dir(record.profile_name)
+        created_here = not profile_dir.exists()
+        if created_here:
+            create_profile(
+                record.profile_name,
+                description=str(bot.get("description") or "").strip(),
+            )
+        write_profile_meta(
+            profile_dir,
+            description=str(bot.get("description") or "").strip(),
+            description_auto=False,
+            display_name=str(bot.get("name") or "").strip(),
+        )
+        _write_soul(profile_dir, bot, exported_at)
+        _write_memories(profile_dir, bot)
+
+        from hermes_state import SessionDB
+
+        db = SessionDB(profile_dir / "state.db")
+        sessions = [
+            _map_session(
+                conv,
+                profile_name=record.profile_name,
+                bot_name=str(bot.get("name") or ""),
+                bot_model=str(bot.get("model")) if bot.get("model") else None,
+                pinned=(i == 0),
+                index=i,
+            )
+            for i, conv in enumerate(conversations)
+        ]
+        result = db.import_sessions(sessions)
+        errors = result.get("errors") or []
+        if errors:
+            raise RuntimeError(
+                f"session import rejected {len(errors)} item(s): "
+                f"{errors[0].get('error', 'unknown')[:200]}"
+            )
+        # Pin the canonical chat the way the desktop pins a Bot's chat at
+        # creation time.
+        if sessions:
+            db.set_session_pinned(sessions[0]["id"], True)
+        db.close()
+
+        # Import marker: makes re-imports merge idempotently.
+        marker = profile_dir / "grokbot-import.json"
+        import json as _json
+
+        marker.write_text(
+            _json.dumps(
+                {
+                    "schema": EXPORT_SCHEMA_VERSION,
+                    "bot_id": str(bot.get("id") or ""),
+                    "imported_at": exported_at,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        skipped = int(result.get("skipped") or 0)
+        record.sessions = len(sessions) - skipped
+        record.messages = sum(len(s["messages"]) for s in sessions)
+        record.status = "imported"
+        if skipped:
+            record.detail = f"{skipped} session(s) already present, skipped"
+        return record
+    except Exception as exc:  # noqa: BLE001 — atomic rollback per bot
+        if created_here and profile_dir is not None:
+            shutil.rmtree(profile_dir, ignore_errors=True)
+        record.status = "error"
+        record.detail = f"{type(exc).__name__}: {exc}"
+        return record
+
+
+def run_import(
+    export_path,
+    *,
+    dry_run: bool = False,
+    force: bool = False,
+    target_bots: Optional[List[str]] = None,
+) -> int:
+    """Import an export file. Returns a process exit code."""
+    from hermes_cli.colors import Colors, color
+
+    export_path = Path(export_path)
+    try:
+        export = load_export(export_path)
+    except ExportValidationError as exc:
+        print(color(f"✗ {exc}", Colors.RED), file=sys.stderr)
+        return 1
+
+    bots = export.get("bots") or []
+    conversations = export.get("conversations") or []
+    exported_at = str(export.get("exported_at") or "").strip()
+
+    if not bots:
+        print(color("✗ Export contains no bots — nothing to import.", Colors.RED))
+        return 1
+
+    records, by_bot = plan_import(export, target_bots=target_bots)
+    if not records:
+        print(color("✗ No bots matched the requested filter.", Colors.RED))
+        return 1
+
+    print()
+    print(color(f"◆ Grok Bot import ({len(records)} bot(s))", Colors.CYAN, Colors.BOLD))
+    if dry_run:
+        print(color("Dry-run mode — no changes written.", Colors.DIM))
+    print()
+
+    exit_code = 0
+    for record in records:
+        bot = next(
+            (b for b in bots if str(b.get("id")) == record.bot_id),
+            next((b for b in bots if str(b.get("name")) == record.name), bots[0]),
+        )
+        convs = [c for c in by_bot.get(str(bot["id"]), []) if c.get("bot_id") == bot["id"]]
+        record = _import_bot(
+            record, bot, convs, exported_at, dry_run=dry_run, force=force
+        )
+        if record.status == "error":
+            exit_code = 1
+        mark = {
+            "imported": color("✓", Colors.GREEN),
+            "conflict": color("⚠", Colors.YELLOW),
+            "error": color("✗", Colors.RED),
+            "skipped": color("·", Colors.DIM),
+        }.get(record.status, color("·", Colors.DIM))
+        line = f"  {mark} {record.name} → profile '{record.profile_name}'"
+        if record.status == "imported" and not dry_run:
+            line += f" ({record.sessions} sessions, {record.messages} messages)"
+        print(line)
+        if record.detail:
+            print(f"      {color(record.detail, Colors.DIM)}")
+
+    print()
+    if dry_run:
+        print(color("Re-run without --dry-run to import.", Colors.DIM))
+    else:
+        print(
+            color(
+                "Done. Open the desktop app to see the imported Bots in the "
+                "Bots pane.",
+                Colors.DIM,
+            )
+        )
+    return exit_code

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12662,7 +12662,7 @@ def main():
     # =========================================================================
     # migrate command
     # =========================================================================
-    from hermes_cli.migrate import cmd_migrate, cmd_migrate_xai
+    from hermes_cli.migrate import cmd_migrate, cmd_migrate_grokbot, cmd_migrate_xai
 
     migrate_parser = subparsers.add_parser(
         "migrate",
@@ -12695,6 +12695,86 @@ def main():
         help="Skip the timestamped backup of config.yaml when applying",
     )
     migrate_xai.set_defaults(func=cmd_migrate_xai)
+
+    migrate_grokbot = migrate_subparsers.add_parser(
+        "grokbot",
+        help="Export Grok Bot agents/conversations and import them as Hermes Bots",
+        description=(
+            "Migrate Grok Bot data into Hermes Bot Mode. 'export' relaunches "
+            "the Grok Bot desktop app under a local capture proxy, reads the "
+            "bot roster, conversations, and bot details straight from the "
+            "app's own UI, and writes grokbot-export.json (no credentials are "
+            "ever stored in the export file). 'import' maps each exported bot "
+            "to a Hermes profile: instructions become SOUL.md, memories "
+            "become profile memory, conversations become sessions with the "
+            "canonical chat pinned. 'doctor' checks prerequisites."
+        ),
+    )
+    migrate_grokbot_sub = migrate_grokbot.add_subparsers(
+        dest="grokbot_action", required=True
+    )
+
+    grokbot_export = migrate_grokbot_sub.add_parser(
+        "export",
+        help="Capture Grok Bot data from the running app into grokbot-export.json",
+    )
+    grokbot_export.add_argument(
+        "--out",
+        default="grokbot-export.json",
+        help="Output path (default: ./grokbot-export.json)",
+    )
+    grokbot_export.add_argument(
+        "--capture-dir",
+        default="~/.hermes/grokbot-capture",
+        help="Directory for raw capture logs (default: ~/.hermes/grokbot-capture)",
+    )
+    grokbot_export.add_argument(
+        "--keep-capture",
+        action="store_true",
+        help="Keep the capture directory (it contains account tokens, mode 0600)",
+    )
+    grokbot_export.add_argument(
+        "--keep-running",
+        action="store_true",
+        help="Relaunch the app uninstrumented after export instead of leaving it closed",
+    )
+    grokbot_export.add_argument(
+        "--max-messages",
+        type=int,
+        default=2000,
+        help="Per-conversation message cap (default: 2000)",
+    )
+    grokbot_export.set_defaults(func=cmd_migrate_grokbot)
+
+    grokbot_import = migrate_grokbot_sub.add_parser(
+        "import",
+        help="Import a grokbot-export.json as Hermes Bot Mode profiles",
+    )
+    grokbot_import.add_argument("export_file", help="Path to grokbot-export.json")
+    grokbot_import.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the import plan without writing anything",
+    )
+    grokbot_import.add_argument(
+        "--force",
+        action="store_true",
+        help="Import into profiles that already exist",
+    )
+    grokbot_import.add_argument(
+        "--bot",
+        action="append",
+        metavar="NAME",
+        help="Import only this bot (by name or id); repeatable",
+    )
+    grokbot_import.set_defaults(func=cmd_migrate_grokbot)
+
+    grokbot_doctor = migrate_grokbot_sub.add_parser(
+        "doctor",
+        help="Check prerequisites for Grok Bot export",
+    )
+    grokbot_doctor.set_defaults(func=cmd_migrate_grokbot)
+
     migrate_parser.set_defaults(func=cmd_migrate)
 
     # =========================================================================

--- a/hermes_cli/migrate.py
+++ b/hermes_cli/migrate.py
@@ -18,8 +18,47 @@ def cmd_migrate(args: Any) -> int:
     sub = getattr(args, "migrate_type", None)
     if sub == "xai":
         return cmd_migrate_xai(args)
+    if sub == "grokbot":
+        return cmd_migrate_grokbot(args)
 
     print("usage: hermes migrate xai [--apply] [--no-backup]", file=sys.stderr)
+    print("       hermes migrate grokbot export|import|doctor", file=sys.stderr)
+    return 2
+
+
+def cmd_migrate_grokbot(args: Any) -> int:
+    """Dispatcher for ``hermes migrate grokbot <action>``."""
+    action = getattr(args, "grokbot_action", None)
+    if action == "export":
+        from hermes_cli.grokbot_export import run_export
+
+        return run_export(
+            out_path=Path(args.out),
+            capture_dir=Path(args.capture_dir),
+            keep_capture=bool(getattr(args, "keep_capture", False)),
+            keep_running=bool(getattr(args, "keep_running", False)),
+            max_messages_per_conversation=int(
+                getattr(args, "max_messages", 2000)
+            ),
+        )
+    if action == "import":
+        from hermes_cli.grokbot_import import run_import
+
+        return run_import(
+            Path(args.export_file),
+            dry_run=bool(getattr(args, "dry_run", False)),
+            force=bool(getattr(args, "force", False)),
+            target_bots=list(getattr(args, "bot", None) or []),
+        )
+    if action == "doctor":
+        from hermes_cli.grokbot_export import run_doctor
+
+        return run_doctor()
+
+    print(
+        "usage: hermes migrate grokbot export|import|doctor",
+        file=sys.stderr,
+    )
     return 2
 
 

--- a/tests/hermes_cli/test_grokbot_migrate.py
+++ b/tests/hermes_cli/test_grokbot_migrate.py
@@ -1,0 +1,275 @@
+"""Tests for the Grok Bot migration importer (hermes migrate grokbot)."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from hermes_cli.grokbot_import import (
+    EXPORT_SCHEMA_VERSION,
+    ExportValidationError,
+    load_export,
+    plan_import,
+    run_import,
+    slugify,
+)
+
+
+def make_export() -> dict:
+    """A valid schema-1 export with two bots and three conversations."""
+    now = time.time()
+    return {
+        "schema": EXPORT_SCHEMA_VERSION,
+        "exported_at": "2026-08-21T13:00:00-0400",
+        "app_version": "0.24.0",
+        "account": {},
+        "bots": [
+            {
+                "id": "roster-0",
+                "name": "Email Assistant Boi",
+                "title": "Inbox triage",
+                "description": "Reads and drafts my email.",
+                "instructions": "Never send without approval.",
+                "model": "",
+                "memories": ["Dana signs annual deals only."],
+                "tools": ["gmail"],
+                "plugins": [],
+            },
+            {
+                "id": "roster-1",
+                "name": "Sales & Ops",
+                "title": "",
+                "description": "",
+                "instructions": "",
+                "model": "grok-4",
+                "memories": [],
+                "tools": [],
+                "plugins": [],
+            },
+        ],
+        "conversations": [
+            {
+                "bot_id": "roster-0",
+                "thread_id": "roster-0",
+                "title": "Chat with Email Assistant Boi",
+                "messages": [
+                    {"role": "user", "text": "hey", "ts": now - 60},
+                    {"role": "assistant", "text": "Hey, what's up?", "ts": now - 30},
+                ],
+            },
+            {
+                "bot_id": "roster-0",
+                "thread_id": "roster-0-b",
+                "title": "Follow-up",
+                "messages": [
+                    {"role": "user", "text": "draft it", "ts": now - 10},
+                    {"role": "assistant", "text": "Drafted.", "ts": now - 5},
+                ],
+            },
+            {
+                "bot_id": "roster-1",
+                "thread_id": "roster-1",
+                "title": "Pipeline review",
+                "messages": [
+                    {"role": "user", "text": "status?", "ts": now - 20},
+                    {"role": "assistant", "text": "On track.", "ts": now - 15},
+                ],
+            },
+        ],
+        "files": {},
+        "provenance": {"layers": ["witness"], "sandboxes": [], "warnings": []},
+    }
+
+
+def write_export(tmp_path, export: dict) -> str:
+    path = tmp_path / "grokbot-export.json"
+    path.write_text(json.dumps(export), encoding="utf-8")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# slugify
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Email Assistant Boi!", "email-assistant-boi"),
+        ("Sales  &  Ops", "sales-ops"),
+        ("--Weird __ NAME__--", "weird-name"),
+        ("   ", "grok-bot"),
+        ("", "grok-bot"),
+    ],
+)
+def test_slugify(name, expected):
+    assert slugify(name) == expected
+
+
+# ---------------------------------------------------------------------------
+# load_export validation
+# ---------------------------------------------------------------------------
+
+
+def test_load_export_accepts_valid(tmp_path):
+    export = make_export()
+    loaded = load_export(write_export(tmp_path, export))
+    assert loaded["schema"] == EXPORT_SCHEMA_VERSION
+    assert len(loaded["bots"]) == 2
+    assert len(loaded["conversations"]) == 3
+
+
+def test_load_export_rejects_missing_file(tmp_path):
+    with pytest.raises(ExportValidationError):
+        load_export(tmp_path / "nope.json")
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda e: e.update({"schema": 2}),
+        lambda e: e.update({"access_token": "eyJhbGciOiJIUzI1NiJ9"}),
+        lambda e: e["bots"].append({"id": "roster-0", "name": "Dup"}),
+        lambda e: e["conversations"][0].update({"bot_id": "ghost"}),
+        lambda e: e["conversations"][0]["messages"].append(
+            {"role": "tool", "text": "x", "ts": 1}
+        ),
+        lambda e: e["conversations"][0]["messages"].append(
+            {"role": "assistant", "text": 42, "ts": 1}
+        ),
+    ],
+)
+def test_load_export_rejects_invalid(tmp_path, mutator):
+    export = make_export()
+    mutator(export)
+    with pytest.raises(ExportValidationError):
+        load_export(write_export(tmp_path, export))
+
+
+def test_load_export_rejects_non_dict_root(tmp_path):
+    path = tmp_path / "grokbot-export.json"
+    path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    with pytest.raises(ExportValidationError):
+        load_export(path)
+
+
+# ---------------------------------------------------------------------------
+# plan_import
+# ---------------------------------------------------------------------------
+
+
+def test_plan_import_maps_names_and_dedupes(tmp_path):
+    export = make_export()
+    # Two bots that slug to the same base must not collide.
+    export["bots"][1]["name"] = "Email Assistant Boi"
+    records, by_bot = plan_import(export)
+    names = [r.profile_name for r in records]
+    assert names == ["email-assistant-boi", "email-assistant-boi-2"]
+    assert sorted(by_bot) == ["roster-0", "roster-1"]
+
+
+def test_plan_import_filters_by_bot(tmp_path):
+    export = make_export()
+    records, _ = plan_import(export, target_bots=["roster-1"])
+    assert [r.name for r in records] == ["Sales & Ops"]
+
+
+# ---------------------------------------------------------------------------
+# run_import (integration against a temp HERMES_HOME)
+# ---------------------------------------------------------------------------
+
+
+def test_import_dry_run_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    export_path = write_export(tmp_path, make_export())
+    rc = run_import(export_path, dry_run=True)
+    assert rc == 0
+    profile_root = tmp_path / "hermes" / "profiles"
+    assert not profile_root.exists() or not any(profile_root.iterdir())
+
+
+def test_import_creates_profile_soul_memory_and_sessions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    export_path = write_export(tmp_path, make_export())
+    rc = run_import(export_path)
+    assert rc == 0
+
+    from hermes_cli.profiles import get_profile_dir
+    from hermes_state import SessionDB
+
+    profile_dir = get_profile_dir("email-assistant-boi")
+    assert profile_dir.is_dir()
+
+    soul = (profile_dir / "SOUL.md").read_text(encoding="utf-8")
+    assert "Email Assistant Boi" in soul
+    assert "Never send without approval." in soul
+
+    memory = (profile_dir / "memories" / "MEMORY.md").read_text(encoding="utf-8")
+    assert "Dana signs annual deals only." in memory
+
+    db = SessionDB(profile_dir / "state.db")
+    sessions = db.search_sessions(source="grokbot-import", limit=10)
+    assert len(sessions) == 2
+    by_id = {s["id"]: s for s in sessions}
+    first = by_id["grokbot-import-0"]
+    assert first["pinned"] == 1
+    assert first["message_count"] == 2
+    msgs = db.get_messages("grokbot-import-0")
+    assert [m["role"] for m in msgs] == ["user", "assistant"]
+    assert msgs[0]["content"] == "hey"
+    db.close()
+
+    # The second bot landed in its own profile.
+    ops_dir = get_profile_dir("sales-ops")
+    assert ops_dir.is_dir()
+    db2 = SessionDB(ops_dir / "state.db")
+    assert len(db2.search_sessions(source="grokbot-import", limit=10)) == 1
+    db2.close()
+
+
+def test_import_conflict_without_force_skips(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from hermes_cli.profiles import create_profile
+
+    create_profile("email-assistant-boi")
+    export_path = write_export(tmp_path, make_export())
+    rc = run_import(export_path)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "pass --force" in out
+
+
+def test_import_failure_rolls_back_profile(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    import hermes_state
+
+    class Boom:
+        def __init__(self, *a, **kw):
+            raise RuntimeError("disk full")
+
+    monkeypatch.setattr(hermes_state, "SessionDB", Boom)
+    export_path = write_export(tmp_path, make_export())
+    rc = run_import(export_path)
+    assert rc == 1
+
+    from hermes_cli.profiles import get_profile_dir
+
+    assert not get_profile_dir("email-assistant-boi").exists()
+    assert not get_profile_dir("sales-ops").exists()
+
+
+def test_import_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    export_path = write_export(tmp_path, make_export())
+    assert run_import(export_path) == 0
+    # Second run without --force: marker file present → merge, no conflict.
+    assert run_import(export_path) == 0
+
+    from hermes_cli.profiles import get_profile_dir
+    from hermes_state import SessionDB
+
+    db = SessionDB(get_profile_dir("email-assistant-boi") / "state.db")
+    assert len(db.search_sessions(source="grokbot-import", limit=10)) == 2
+    db.close()

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -55,7 +55,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes send` | Send a one-shot message to a configured messaging platform (Telegram, Discord, Slack, Signal, SMS, …). Useful from shell scripts, cron jobs, CI hooks, and monitoring daemons — no agent loop, no LLM. |
 | `hermes peer` | Register peer Hermes gateways on other machines and DM their agents' canonical Bot Chats (`hermes peer dm <peer>[/<agent>] "…"`). The transport behind cross-machine bot-to-bot messaging. |
 | `hermes secrets` | Manage external secret sources (currently Bitwarden Secrets Manager) for pulling API keys at process startup instead of from `~/.hermes/.env`. |
-| `hermes migrate` | Diagnose and (optionally) rewrite `config.yaml` to replace references to retired models or deprecated settings (e.g. `migrate xai`). |
+| `hermes migrate` | Diagnose and (optionally) rewrite `config.yaml` to replace references to retired models or deprecated settings (e.g. `migrate xai`). Also hosts `migrate grokbot` — export Grok Bot agents/conversations and import them as Bot Mode profiles (see [Import from Other Agents](../user-guide/import-from-other-agents.md)). |
 | `hermes status` | Show agent, auth, and platform status. |
 | `hermes cron` | Inspect and tick the cron scheduler. |
 | `hermes kanban` | Multi-profile collaboration board (tasks, links, dispatcher). |
@@ -508,6 +508,7 @@ Diagnose and (optionally) rewrite the active `config.yaml` to replace references
 | Subcommand | Description |
 |------------|-------------|
 | `xai` | Scan `config.yaml` for references to xAI models scheduled for retirement on May 15, 2026 and (with `--apply`) rewrite them in-place to the official replacements per the xAI migration guide. Defaults to dry-run. |
+| `grokbot` | Export Grok Bot agents and conversations (`grokbot export`), import them as Bot Mode profiles (`grokbot import`), or check prerequisites (`grokbot doctor`). See [Import from Other Agents](../user-guide/import-from-other-agents.md). |
 
 Common flags for migration subcommands:
 

--- a/website/docs/user-guide/import-from-other-agents.md
+++ b/website/docs/user-guide/import-from-other-agents.md
@@ -52,3 +52,59 @@ Claude's `Bash(npm run test:*)` prefix rules become `npm run test*` globs. Non-`
 - **Conflicts are skipped by default.** An MCP server or skill that already exists in Hermes is reported as a conflict; pass `--overwrite` to replace it.
 - **Malformed files don't abort the run.** A broken `settings.json` or `config.toml` becomes a per-item error in the report while everything else still imports.
 - Coming from OpenClaw instead? Use [`hermes claw migrate`](../guides/migrate-from-openclaw.md).
+
+## Grok Bot
+
+`hermes migrate grokbot` moves your Grok Bot agents and their conversations into
+Hermes [Bot Mode](bot-mode.md). It works in two steps:
+
+```bash
+hermes migrate grokbot export            # capture Grok Bot data into grokbot-export.json
+hermes migrate grokbot import grokbot-export.json       # import as Hermes Bots
+hermes migrate grokbot import grokbot-export.json --dry-run
+hermes migrate grokbot doctor           # check prerequisites
+```
+
+### How export works
+
+The exporter is layered so it degrades instead of breaking:
+
+- **App witness (primary).** The Grok Bot desktop app is relaunched under
+  Hermes' control: its backend base URLs are pointed at a local capture proxy
+  (environment overrides the app itself supports) and Chromium starts with a
+  CDP debug port. The exporter then reads the bot roster, every conversation's
+  transcript (roles and timestamps from the rendered DOM), and each bot's
+  details straight from the app's own UI.
+- **Backend replay (secondary).** The captured OAuth refresh token mints
+  access tokens so sandbox metadata the UI never loads can be pulled. If the
+  account's backend flags block a call, that layer is skipped with a warning;
+  the app-witness output is unaffected.
+
+The app is macOS-only, so export runs on macOS. The capture directory holds
+account tokens with mode 0600 and is deleted after export unless
+`--keep-capture` is passed.
+
+### What gets imported
+
+| Grok Bot | Hermes |
+|---|---|
+| Bot (name, title, description, instructions) | A Bot Mode profile: name → profile id, instructions → `SOUL.md`, title/description → profile metadata |
+| Bot memories | Entries in the profile's `memories/MEMORY.md` |
+| Conversations | Sessions in the profile's `state.db`, with the canonical chat pinned |
+| Connected tools / plugins | Recorded in the export; credentials are never copied |
+
+### What is never imported
+
+**Credentials.** Export files carry no secrets by design; the importer refuses
+files that break that shape. Reconnect third-party tools from the imported Bot
+with `hermes setup`.
+
+### Behavior notes
+
+- **Idempotent.** Sessions use stable IDs and re-imports merge into the
+  profile created by the first import (an import marker enables this);
+  already-present sessions are skipped.
+- **Atomic per Bot.** If one Bot fails mid-import, its half-created profile is
+  removed and the other Bots still import.
+- **Conflicts are explicit.** Importing into a profile that already exists
+  (without the marker) requires `--force`.


### PR DESCRIPTION
## What

Adds `hermes migrate grokbot`, a two-step command that moves Grok Bot agents and their conversation histories into Hermes Bot Mode:

- `hermes migrate grokbot export` captures the bot roster, every conversation transcript (roles and timestamps), and each bot's details into `grokbot-export.json`.
- `hermes migrate grokbot import` maps each bot to a Bot Mode profile: instructions become SOUL.md, memories become profile memory entries, conversations become sessions with the canonical chat pinned.
- `hermes migrate grokbot doctor` checks prerequisites.

## Why export is layered the way it is

The export path deliberately reads data from the app's own UI instead of scraping an undocumented backend. The app is relaunched under Hermes' control: its backend base URLs point at a local capture proxy (environment overrides the app itself supports), Chromium starts with a CDP debug port, and the exporter reads the rendered roster and transcripts from the DOM. Whatever the vendor changes server-side, what the user sees in the app stays the source of truth. A secondary replay layer mints access tokens from the captured OAuth refresh token to pull sandbox metadata the UI never loads; if the account's server flags block a call, that layer is skipped with a warning and the witness output is unaffected.

No certificates and no system proxy changes are involved. The app stays fully usable while captured.

## Import mapping

| Grok Bot | Hermes |
|---|---|
| Bot name, title, description, instructions | Profile with SOUL.md and `write_profile_meta` metadata |
| Bot memories | `memories/MEMORY.md` entries (same `§` delimiter as the memory store) |
| Conversations | `SessionDB.import_sessions` into the profile's state.db; the first conversation is pinned as the canonical chat via `set_session_pinned` |
| Connected tools, plugins | Recorded in the export; credentials are never copied |

- Idempotent: stable session IDs plus a `grokbot-import.json` marker in each imported profile make re-imports merge instead of duplicate.
- Atomic per bot: a failed bot removes its half-created profile and the other bots still import.
- Conflicts with pre-existing profiles (without the marker) require `--force`.

## Security posture

- Export files never contain credentials (verified on the live output: no JWT, `slx_`, or bearer patterns).
- The importer rejects export files whose top-level shape suggests injected secret keys.
- The capture directory holds tokens with mode 0600 and is deleted after export unless `--keep-capture` is passed.

## Verification

- 21 unit and integration tests (`tests/hermes_cli/test_grokbot_migrate.py`): validation matrix, slugging, collision dedupe, dry-run purity, full import into a temp `HERMES_HOME` (profile, SOUL, memory, sessions, pinned canonical chat), conflict handling, rollback on failure, idempotent re-import.
- Live end-to-end run against a real account on macOS: exported 1 bot and its 10-message conversation (both layers active, chronological order verified, zero secret patterns), then imported into a temp `HERMES_HOME` and verified profile creation, SOUL.md, marker, pinned session, and all 10 messages.

## Known gaps (documented follow-ups, not blockers)

- Export is macOS-only today because the app is macOS-only; the import half is cross-platform.
- Routines (scheduled bot tasks) are not yet mapped to Hermes cron jobs.
- Message attachments and workspace files are not yet downloaded; the sandbox store endpoints are cataloged for a follow-up using presigned reads.
- The backend replay layer currently pulls sandbox metadata only. Some accounts are gated by a server-side "durable identity" flag that closes the transcript APIs; the DOM witness layer is unaffected by that flag, which is why it is the primary layer.