### PR TITLE
fix(email): preserve reply-all recipients and configured CC

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -33,7 +33,7 @@ from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
-from email.utils import formatdate
+from email.utils import formatdate, getaddresses
 from email import encoders
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -558,6 +558,24 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_port = _esecret_int("EMAIL_SMTP_PORT", 587)
         self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 15)
 
+        # Optional reply-all policy. Disabled by default to preserve existing
+        # privacy semantics. ``reply_cc`` is always applied when configured;
+        # ``reply_all`` additionally preserves To/Cc participants from the
+        # incoming message. The agent and primary recipient are excluded and
+        # addresses are deduplicated case-insensitively.
+        self._reply_all = is_truthy_value(extra.get("reply_all"), default=False)
+        raw_reply_cc = extra.get("reply_cc", [])
+        if isinstance(raw_reply_cc, str):
+            raw_reply_cc = [raw_reply_cc]
+        self._reply_cc: List[str] = []
+        seen_reply_cc: set[str] = set()
+        if isinstance(raw_reply_cc, (list, tuple, set)):
+            for _, address in getaddresses([str(value) for value in raw_reply_cc]):
+                normalized = address.strip().lower()
+                if normalized and normalized not in seen_reply_cc:
+                    seen_reply_cc.add(normalized)
+                    self._reply_cc.append(normalized)
+
         # Skip attachments — configured via config.yaml:
         #   platforms:
         #     email:
@@ -602,8 +620,8 @@ class EmailAdapter(BasePlatformAdapter):
         self._last_fetch_failed: bool = False
         self._last_fetch_error: str = ""
 
-        # Map chat_id (sender email) -> last subject + message-id for threading
-        self._thread_context: Dict[str, Dict[str, str]] = {}
+        # Map chat_id (sender email) -> subject/message-id/recipient context.
+        self._thread_context: Dict[str, Dict[str, Any]] = {}
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
@@ -949,6 +967,19 @@ class EmailAdapter(BasePlatformAdapter):
         subject = _decode_header_value(msg.get("Subject", "(no subject)"))
         message_id = msg.get("Message-ID", "")
         in_reply_to = msg.get("In-Reply-To", "")
+
+        def _recipient_addresses(header: str) -> List[str]:
+            addresses: List[str] = []
+            seen: set[str] = set()
+            for _, address in getaddresses(msg.get_all(header, [])):
+                normalized = address.strip().lower()
+                if normalized and normalized not in seen:
+                    seen.add(normalized)
+                    addresses.append(normalized)
+            return addresses
+
+        to_addrs = _recipient_addresses("To")
+        cc_addrs = _recipient_addresses("Cc")
         # Skip automated/noreply senders before any processing
         msg_headers = dict(msg.items())
         if _is_automated_sender(sender_addr, msg_headers):
@@ -975,6 +1006,8 @@ class EmailAdapter(BasePlatformAdapter):
             "subject": subject,
             "message_id": message_id,
             "in_reply_to": in_reply_to,
+            "to_addrs": to_addrs,
+            "cc_addrs": cc_addrs,
             "body": body,
             "attachments": attachments,
             "date": msg.get("Date", ""),
@@ -1104,6 +1137,8 @@ class EmailAdapter(BasePlatformAdapter):
         self._thread_context[sender_addr] = {
             "subject": subject,
             "message_id": msg_data["message_id"],
+            "to_addrs": list(msg_data.get("to_addrs", [])),
+            "cc_addrs": list(msg_data.get("cc_addrs", [])),
         }
 
         source = self.build_source(
@@ -1155,6 +1190,35 @@ class EmailAdapter(BasePlatformAdapter):
             return self._address.rsplit("@", 1)[-1] or "localhost"
         return "localhost"
 
+    def _reply_cc_addresses(self, to_addr: str) -> List[str]:
+        """Return policy-approved reply Cc recipients for ``to_addr``."""
+        ctx = self._thread_context.get(to_addr, {})
+        if not ctx:
+            return []
+        candidates: List[str] = []
+        if self._reply_all:
+            candidates.extend(ctx.get("to_addrs", []))
+            candidates.extend(ctx.get("cc_addrs", []))
+        candidates.extend(self._reply_cc)
+
+        excluded = {self._address.strip().lower(), to_addr.strip().lower()}
+        recipients: List[str] = []
+        seen: set[str] = set()
+        for _, address in getaddresses([str(value) for value in candidates]):
+            normalized = address.strip().lower()
+            if not normalized or normalized in excluded or normalized in seen:
+                continue
+            seen.add(normalized)
+            recipients.append(normalized)
+        return recipients
+
+    def _apply_reply_recipients(self, msg: MIMEMultipart, to_addr: str) -> None:
+        """Set primary and optional Cc recipients on an outgoing reply."""
+        msg["To"] = to_addr
+        cc_addrs = self._reply_cc_addresses(to_addr)
+        if cc_addrs:
+            msg["Cc"] = ", ".join(cc_addrs)
+
     def _send_email(
         self,
         to_addr: str,
@@ -1164,7 +1228,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
         msg["From"] = self._address
-        msg["To"] = to_addr
+        self._apply_reply_recipients(msg, to_addr)
 
         # Thread context for reply
         ctx = self._thread_context.get(to_addr, {})
@@ -1279,7 +1343,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
-        msg["To"] = to_addr
+        self._apply_reply_recipients(msg, to_addr)
 
         ctx = self._thread_context.get(to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")
@@ -1359,7 +1423,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
-        msg["To"] = to_addr
+        self._apply_reply_recipients(msg, to_addr)
 
         ctx = self._thread_context.get(to_addr, {})
         subject = ctx.get("subject", "Hermes Agent")

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -18,6 +18,8 @@ from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
 from email import encoders
+from email.utils import getaddresses
+
 from unittest.mock import patch, MagicMock, AsyncMock, ANY
 
 from gateway.platforms.base import SendResult
@@ -84,6 +86,35 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertIn("world", result)
         self.assertNotIn("<p>", result)
         self.assertNotIn("<b>", result)
+
+
+class TestReplyAllRecipientParsing(unittest.TestCase):
+    """Incoming To/Cc participants are preserved for reply-all policy."""
+
+    def test_parse_fetched_message_extracts_to_and_cc_addresses(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        msg = MIMEText("Hello", "plain", "utf-8")
+        msg["From"] = "CEO <ceo@test.com>"
+        msg["To"] = "Hermes <hermes@test.com>, Pico <pico@test.com>"
+        msg["Cc"] = "Other <other@test.com>, PICO@test.com"
+        msg["Subject"] = "Team thread"
+        msg["Message-ID"] = "<original@test.com>"
+
+        parsed = adapter._parse_fetched_message(b"1", msg.as_bytes())
+
+        assert parsed is not None
+        self.assertEqual(parsed["to_addrs"], ["hermes@test.com", "pico@test.com"])
+        self.assertEqual(parsed["cc_addrs"], ["other@test.com", "pico@test.com"])
 
 
 class TestExtractTextBody(unittest.TestCase):
@@ -348,7 +379,7 @@ class TestThreadContext(unittest.TestCase):
         else:
             os.environ["EMAIL_ALLOW_ALL_USERS"] = self._prev_allow_all
 
-    def _make_adapter(self):
+    def _make_adapter(self, extra=None):
         from gateway.config import PlatformConfig
         with patch.dict(os.environ, {
             "EMAIL_ADDRESS": "hermes@test.com",
@@ -357,7 +388,7 @@ class TestThreadContext(unittest.TestCase):
             "EMAIL_SMTP_HOST": "smtp.test.com",
         }):
             from plugins.platforms.email.adapter import EmailAdapter
-            adapter = EmailAdapter(PlatformConfig(enabled=True))
+            adapter = EmailAdapter(PlatformConfig(enabled=True, extra=extra or {}))
         return adapter
 
 
@@ -381,6 +412,87 @@ class TestThreadContext(unittest.TestCase):
             self.assertEqual(send_call["In-Reply-To"], "<original@test.com>")
             self.assertEqual(send_call["References"], "<original@test.com>")
             self.assertIn("Date", send_call)
+
+    def test_reply_all_preserves_participants_and_configured_cc(self):
+        adapter = self._make_adapter({
+            "reply_all": True,
+            "reply_cc": ["pico@test.com", "hermes@test.com", "ceo@test.com"],
+        })
+        adapter._thread_context["ceo@test.com"] = {
+            "subject": "Team question",
+            "message_id": "<team@test.com>",
+            "to_addrs": ["hermes@test.com", "pico@test.com"],
+            "cc_addrs": ["other@test.com", "PICO@test.com"],
+        }
+
+        mock_server = MagicMock()
+        with patch.object(adapter, "_connect_smtp", return_value=mock_server):
+            adapter._send_email("ceo@test.com", "Concise answer.", None)
+
+        sent = mock_server.send_message.call_args[0][0]
+        cc_addresses = [
+            address.lower()
+            for _, address in getaddresses(sent.get_all("Cc", []))
+        ]
+        self.assertEqual(sent["To"], "ceo@test.com")
+        self.assertEqual(cc_addresses, ["pico@test.com", "other@test.com"])
+        self.assertNotIn("hermes@test.com", cc_addresses)
+        self.assertNotIn("ceo@test.com", cc_addresses)
+
+    def test_reply_all_string_false_keeps_dynamic_cc_disabled(self):
+        adapter = self._make_adapter({"reply_all": "false"})
+        adapter._thread_context["ceo@test.com"] = {
+            "subject": "Private question",
+            "message_id": "<private@test.com>",
+            "to_addrs": ["hermes@test.com", "pico@test.com"],
+            "cc_addrs": ["other@test.com"],
+        }
+
+        mock_server = MagicMock()
+        with patch.object(adapter, "_connect_smtp", return_value=mock_server):
+            adapter._send_email("ceo@test.com", "Private answer.", None)
+
+        sent = mock_server.send_message.call_args[0][0]
+        self.assertIsNone(sent.get("Cc"))
+
+    def test_configured_cc_does_not_apply_without_reply_context(self):
+        adapter = self._make_adapter({"reply_cc": ["pico@test.com"]})
+
+        mock_server = MagicMock()
+        with patch.object(adapter, "_connect_smtp", return_value=mock_server):
+            adapter._send_email("ceo@test.com", "Proactive brief.", None)
+
+        sent = mock_server.send_message.call_args[0][0]
+        self.assertIsNone(sent.get("Cc"))
+
+    def test_attachment_reply_applies_configured_cc(self):
+        import tempfile
+
+        adapter = self._make_adapter({"reply_cc": ["pico@test.com"]})
+        adapter._thread_context["ceo@test.com"] = {
+            "subject": "Attached report",
+            "message_id": "<attachment@test.com>",
+        }
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as handle:
+            handle.write(b"report")
+            file_path = handle.name
+
+        try:
+            mock_server = MagicMock()
+            with patch.object(adapter, "_connect_smtp", return_value=mock_server):
+                adapter._send_email_with_attachment(
+                    "ceo@test.com", "See attached.", file_path
+                )
+
+            sent = mock_server.send_message.call_args[0][0]
+            cc_addresses = [
+                address.lower()
+                for _, address in getaddresses(sent.get_all("Cc", []))
+            ]
+            self.assertEqual(cc_addresses, ["pico@test.com"])
+        finally:
+            os.unlink(file_path)
 
 
 class TestSendMethods(unittest.TestCase):

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -122,6 +122,34 @@ Replies are sent via SMTP with proper email threading:
 - **Message-ID** generated with the agent's domain
 - Responses are sent as plain text (UTF-8)
 
+#### Optional reply-all and always-Cc policy
+
+Replies target only the sender by default. Opt into preserving participants
+from the incoming message with `reply_all`, and/or add addresses that must
+always be copied with `reply_cc`:
+
+```yaml
+platforms:
+  email:
+    extra:
+      reply_all: true
+      reply_cc:
+        - operator@example.com
+```
+
+`reply_all` copies the incoming message's To/Cc participants. `reply_cc` is
+applied even when `reply_all` is off, but only to replies with inbound thread
+context; proactive sends and cron deliveries are unchanged. The agent's own
+address and the primary reply recipient are excluded automatically, and
+duplicate addresses are removed case-insensitively. Both settings are opt-in
+so existing installations keep their current privacy behaviour.
+
+:::warning
+`reply_all` trusts the incoming To/Cc headers. Enable it only when
+`EMAIL_ALLOWED_USERS` contains trusted senders who are allowed to choose the
+reply audience. Use `reply_cc` alone when you only need a fixed operator copy.
+:::
+
 ### File Attachments
 
 The agent can send file attachments in replies. Include `MEDIA:/path/to/file` in the response and the file is attached to the outgoing email.


### PR DESCRIPTION
## Summary
- add opt-in `platforms.email.extra.reply_all` to preserve incoming To/Cc participants on gateway replies
- add opt-in `platforms.email.extra.reply_cc` for a fixed operator copy
- exclude the agent and primary recipient, deduplicate case-insensitively, and keep proactive/cron sends unchanged
- apply the same recipient policy to text and attachment replies
- document the privacy boundary and trusted-sender requirement

## Why
The Email gateway currently replies only to the sender. In a multi-participant executive thread, other participants silently disappear from subsequent agent replies.

## Safety
Both settings default off, preserving existing behavior. `reply_all` is explicitly documented as trusting incoming recipient headers and should be used only with a strict `EMAIL_ALLOWED_USERS` list.

## Validation
- RED/GREEN regression tests for To/Cc parsing, dynamic reply-all, configured CC, case-insensitive dedupe, bot/primary-recipient exclusion, string-false parsing, proactive-send isolation, and attachment replies
- `67 passed` across the Email gateway test set
- `ruff check` passed
- `git diff --check` passed
- full upstream CI requested via this PR