### PR TITLE
fix(bot-mode): let group approval choices resume blocked members

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5502,6 +5502,27 @@ async function answerGroupClarify(entry, member, answers) {
   }
 }
 
+/** Submit one closed-set approval choice immediately. The ref-backed lock is
+ *  taken before the RPC starts, so two clicks in the same React render cannot
+ *  emit duplicate approval.respond requests. A failed request releases the
+ *  lock without clearing the mirrored card, allowing an explicit retry. */
+async function submitGroupApprovalChoice(entry, member, choice, pendingRef, onSending) {
+  if (!member || pendingRef.current) {
+    return false
+  }
+
+  pendingRef.current = true
+  onSending(true)
+
+  try {
+    await answerGroupClarify(entry, member, choice)
+    return true
+  } finally {
+    pendingRef.current = false
+    onSending(false)
+  }
+}
+
 /** One member turn, gateway-native: submit the room delta as a prompt into
  *  the member's per-group session, then poll the session until a NEW
  *  assistant message lands (or timeout → pass). While the session visibly
@@ -10016,6 +10037,7 @@ function GroupClarifyCard({ entry, members }) {
   const [drafts, setDrafts] = useState({})
   const [picked, setPicked] = useState({})
   const [sending, setSending] = useState(false)
+  const approvalPendingRef = useRef(false)
   const questions = entry.questions && entry.questions.length
     ? entry.questions.map((q, i) => ({
         qid: q?.qid ?? q?.id ?? `q${i}`,
@@ -10037,15 +10059,29 @@ function GroupClarifyCard({ entry, members }) {
 
   const allAnswered = questions.every(q => answerFor(q))
 
-  const submit = async () => {
-    if (!member || sending || !allAnswered) {
+  const submit = async approvalChoice => {
+    if (!member || (!isApproval && (sending || !allAnswered))) {
       return
     }
 
-    setSending(true)
+    if (!isApproval) {
+      setSending(true)
+    }
 
     try {
-      if (isApproval || !(entry.questions && entry.questions.length)) {
+      if (isApproval) {
+        const submitted = await submitGroupApprovalChoice(
+          entry,
+          member,
+          approvalChoice,
+          approvalPendingRef,
+          setSending
+        )
+
+        if (!submitted) {
+          return
+        }
+      } else if (!(entry.questions && entry.questions.length)) {
         await answerGroupClarify(entry, member, answerFor(questions[0]))
       } else {
         const answers = {}
@@ -10059,7 +10095,7 @@ function GroupClarifyCard({ entry, members }) {
 
       // Echo the exchange into the room log so the thread reads complete.
       const summary = isApproval
-        ? `${answerFor(questions[0])} — ${entry.command || entry.question || 'command approval'}`
+        ? `${approvalChoice} — ${entry.command || entry.question || 'command approval'}`
         : questions
             .map(q => (questions.length > 1 ? `${q.question}: ${answerFor(q)}` : answerFor(q)))
             .join('\n')
@@ -10067,7 +10103,9 @@ function GroupClarifyCard({ entry, members }) {
     } catch (err) {
       host.notify({ kind: 'error', message: `Could not send the answer to @${botHandle(entry.member, member)}: ${err?.message || err}` })
     } finally {
-      setSending(false)
+      if (!isApproval) {
+        setSending(false)
+      }
     }
   }
 
@@ -10114,8 +10152,16 @@ function GroupClarifyCard({ entry, members }) {
                         'h-6 px-2 text-[0.7rem]',
                         isApproval && choice === 'deny' && !chosen && 'text-destructive'
                       ),
+                      disabled: sending || !member,
                       onClick: () => {
                         setDrafts(prev => ({ ...prev, [q.qid]: '' }))
+
+                        if (isApproval) {
+                          setPicked(prev => ({ ...prev, [q.qid]: [choice] }))
+                          void submit(choice)
+                          return
+                        }
+
                         setPicked(prev => {
                           const current = prev[q.qid] || []
                           const next = q.multiSelect
@@ -10157,15 +10203,17 @@ function GroupClarifyCard({ entry, members }) {
           ]
         }, `q:${q.qid}`)
       ),
-      jsx('div', {
-        className: 'flex justify-end',
-        children: jsx(Button, {
-          size: 'sm',
-          disabled: sending || !allAnswered || !member,
-          onClick: () => void submit(),
-          children: sending ? 'Sending…' : isApproval ? 'Respond' : 'Answer'
-        })
-      })
+      isApproval
+        ? null
+        : jsx('div', {
+            className: 'flex justify-end',
+            children: jsx(Button, {
+              size: 'sm',
+              disabled: sending || !allAnswered || !member,
+              onClick: () => void submit(),
+              children: sending ? 'Sending…' : 'Answer'
+            })
+          })
     ]
   })
 }

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -196,7 +196,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, submitGroupApprovalChoice: typeof submitGroupApprovalChoice === "function" ? submitGroupApprovalChoice : undefined, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -1809,6 +1809,120 @@ test('answerGroupClarify routes approvals through approval.respond with session 
   )
   assert.equal(gc.clarifyResponds.length, 0, 'approvals never touch the clarify wire')
   assert.equal(Object.keys(gc.$groupClarify.get()).length, 0)
+})
+
+test('approval choices submit immediately for every server choice', async () => {
+  for (const choice of ['once', 'session', 'always', 'deny']) {
+    const gc = load(() => '(pass)')
+    const member = { name: 'research', title: '' }
+
+    gc.syncGroupClarify('Core', member, {
+      session_id: 'rt-research-1',
+      pending_approval: { ...APPROVAL_PAYLOAD, choices: ['once', 'session', 'always', 'deny'] }
+    })
+    const entry = Object.values(gc.$groupClarify.get())[0]
+
+    const submitted = await gc.submitGroupApprovalChoice(entry, member, choice, { current: false }, () => undefined)
+
+    assert.equal(submitted, true)
+    assert.deepEqual(gc.approvalResponds, [
+      { session_id: 'rt-research-1', request_id: 'req-approval-1', choice }
+    ])
+  }
+})
+
+test('approval submission locks before the RPC so duplicate clicks send exactly once', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+  let release
+  const response = new Promise(resolve => {
+    release = resolve
+  })
+
+  gc.host.request = async (method, params) => {
+    if (method === 'approval.respond') {
+      gc.approvalResponds.push({ ...params })
+      return response
+    }
+    return {}
+  }
+  gc.syncGroupClarify('Core', member, { session_id: 'rt-research-1', pending_approval: APPROVAL_PAYLOAD })
+  const entry = Object.values(gc.$groupClarify.get())[0]
+  const pending = { current: false }
+  const sending = []
+
+  const first = gc.submitGroupApprovalChoice(entry, member, 'once', pending, value => sending.push(value))
+  const duplicate = await gc.submitGroupApprovalChoice(entry, member, 'once', pending, value => sending.push(value))
+
+  assert.equal(duplicate, false)
+  assert.equal(gc.approvalResponds.length, 1)
+  assert.equal(pending.current, true)
+  release({ resolved: true })
+  assert.equal(await first, true)
+  assert.equal(pending.current, false)
+  assert.deepEqual(sending, [true, false])
+})
+
+test('failed approval submission unlocks and keeps the card retryable', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', title: '' }
+  let attempts = 0
+
+  gc.host.request = async (method, params) => {
+    if (method !== 'approval.respond') {
+      return {}
+    }
+    attempts += 1
+    gc.approvalResponds.push({ ...params })
+    if (attempts === 1) {
+      throw new Error('request expired')
+    }
+    return { resolved: true }
+  }
+  gc.syncGroupClarify('Core', member, { session_id: 'rt-research-1', pending_approval: APPROVAL_PAYLOAD })
+  const entry = Object.values(gc.$groupClarify.get())[0]
+  const pending = { current: false }
+
+  await assert.rejects(
+    gc.submitGroupApprovalChoice(entry, member, 'deny', pending, () => undefined),
+    /request expired/
+  )
+  assert.equal(pending.current, false)
+  assert.equal(Object.keys(gc.$groupClarify.get()).length, 1, 'failed response leaves the pending card intact')
+
+  assert.equal(await gc.submitGroupApprovalChoice(entry, member, 'deny', pending, () => undefined), true)
+  assert.equal(attempts, 2)
+  assert.equal(Object.keys(gc.$groupClarify.get()).length, 0)
+})
+
+test('remote member approval submits through that member source', async () => {
+  const gc = load(() => '(pass)')
+  const member = { name: 'research', remoteSource: true, connectionId: 'gw-remote' }
+  const remoteRequests = []
+
+  gc.host.requestProfile = async (route, method, params) => {
+    remoteRequests.push({ route, method, params })
+    return { resolved: true }
+  }
+  gc.syncGroupClarify('Core', member, { session_id: 'rt-remote-1', pending_approval: APPROVAL_PAYLOAD })
+  const entry = Object.values(gc.$groupClarify.get())[0]
+
+  assert.equal(
+    await gc.submitGroupApprovalChoice(entry, member, 'session', { current: false }, () => undefined),
+    true
+  )
+  assert.equal(remoteRequests.length, 1)
+  assert.equal(remoteRequests[0].route.connectionId, 'gw-remote')
+  assert.equal(remoteRequests[0].route.profile, 'research')
+  assert.equal(remoteRequests[0].method, 'approval.respond')
+  assert.equal(
+    JSON.stringify(remoteRequests[0].params),
+    JSON.stringify({
+      session_id: 'rt-remote-1',
+      request_id: 'req-approval-1',
+      choice: 'session'
+    })
+  )
 })
 
 test('clarify outranks approval when a snapshot carries both', () => {


### PR DESCRIPTION
## What does this PR do?

Bot Mode group command approvals now submit as soon as the user clicks an approval choice. Without this fix, the card only staged the choice for a footer action that could be outside the visible room, leaving the hidden member session blocked until timeout.

### Symptom

A group approval card highlights `once`, `session`, `always`, or `deny`, but does not send `approval.respond` until a separate Respond button is clicked. At narrow room heights that footer may not be reachable, so the member turn remains blocked.

### Impact

Users cannot reliably approve or deny commands requested by Bot Mode group members. The blocked hidden member session can hold the serialized group workflow until the approval expires.

### Bug Cause

**Trigger:** `apps/desktop/src/plugins/hermes-bots/plugin.js:10157` / `GroupClarifyCard` approval choice click handler

**Causal chain:**
1. A hidden group member exposes a pending command approval in the room.
2. Clicking an approval choice only updates local `picked` state; `approval.respond` remains owned by a separate footer `submit()` action.
3. If that footer is not visible, no RPC is sent and the member session stays blocked.

**Why it is wrong:** Command approvals are a closed, single-choice action set. Unlike free-text or multi-select clarify prompts, they do not require a second confirmation step.

**Working sibling / contrast:** Clarify prompts still stage free text, batches, and multi-select answers before submission because those inputs can require composition. Standard command approval choices are terminal actions and submit directly.

**Ruled out:** RPC routing was not the missing step. `answerGroupClarify` already sends the hidden runtime session ID, request ID, and choice through `requestForBot`; tests confirm the same path selects the remote member's own connection.

### Fix

Approval choice buttons now call a dedicated immediate-submit path and no longer render a footer action. A ref-backed in-flight lock is acquired before the RPC starts, choices are disabled while sending, and duplicate clicks cannot emit a second request. Failed requests release the lock while preserving the pending card, so the existing error notification is followed by a safe retry path. Clarify submission behavior is unchanged.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` - submit approval choices immediately, lock duplicate clicks, remove the approval-only footer, and preserve retry behavior.
- `apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs` - cover every approval choice, exactly-once submission, failure retry, and remote-source routing.

## How to Test

1. Open a Bot Mode group chat and trigger a member command approval.
2. Click each approval choice and verify the card submits immediately without a Respond button.
3. Verify the member resumes after approval or receives denial, and a failed request leaves the card retryable.
4. Run the plugin test suite:

```bash
cd apps/desktop
npm run check:test:plugins
```

Result: 383 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant repository test entry and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A; behavior is self-explanatory and no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` - N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` - N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility); the renderer logic is platform-independent
- [x] I've updated tool descriptions/schemas - N/A; no model tool behavior changed

## Screenshots / Logs

Automated coverage verifies all server choices, exactly-one RPC behavior, retry after rejection, and routing through a remote member's source.
