### PR TITLE
fix(slack): honor native agent stop control

### DIFF
--- a/plugins/platforms/slack/__init__.py
+++ b/plugins/platforms/slack/__init__.py
@@ -1,3 +1,3 @@
-from .adapter import register
+from .native_stop import register
 
 __all__ = ["register"]

--- a/plugins/platforms/slack/native_stop.py
+++ b/plugins/platforms/slack/native_stop.py
@@ -1,0 +1,238 @@
+"""Slack Agent native stop-event bridge.
+
+Slack's Agents & AI Apps surface emits ``agent_session_stopped`` when a user
+clicks the native Stop control. The bridge turns that platform lifecycle event
+into Hermes' existing ``/stop`` command instead of introducing a second
+cancellation primitive.
+
+The runtime adapter subclass is kept separate from ``adapter.py`` so the event
+bridge remains small and independently testable while reusing the canonical
+Slack adapter for message/session routing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from gateway.platforms.base import MessageEvent, MessageType
+
+from . import adapter as _adapter
+
+logger = logging.getLogger(__name__)
+
+_NATIVE_STOP_REGISTRATION_ATTR = "_hermes_agent_session_stopped_registration"
+
+
+class SlackAgentStopAdapter(_adapter.SlackAdapter):
+    """Slack adapter with native Agent-session stop control wired to ``/stop``."""
+
+    def _start_socket_mode_handler(self) -> None:
+        # Register before the Socket Mode reader starts so there is no window
+        # where Slack can deliver a stop event only to the catch-all listener.
+        self._register_agent_session_stopped_listener()
+        super()._start_socket_mode_handler()
+
+    def _register_agent_session_stopped_listener(self) -> None:
+        app = self._app
+        if app is None:
+            return
+
+        # AsyncApp can outlive a concrete adapter across profile reloads and
+        # error-path reinitialization. Registration authority therefore belongs
+        # to the app, not the adapter instance. Keep one listener per app and
+        # retarget its mutable owner to the newest adapter instead of stacking
+        # callbacks or leaving a callback bound to a stale adapter.
+        registration = getattr(app, _NATIVE_STOP_REGISTRATION_ATTR, None)
+        if registration is not None:
+            if not isinstance(registration, dict) or "adapter" not in registration:
+                raise RuntimeError(
+                    "Slack native-stop listener registration marker is invalid"
+                )
+            registration["adapter"] = self
+            return
+
+        registration = {"adapter": self}
+
+        @app.event("agent_session_stopped")
+        async def handle_agent_session_stopped(event, body):
+            owner = registration.get("adapter")
+            if owner is None:
+                return
+            await owner._handle_agent_session_stopped(event, body)
+
+        setattr(app, _NATIVE_STOP_REGISTRATION_ATTR, registration)
+
+    async def _handle_agent_session_stopped(
+        self,
+        event: dict,
+        body: Optional[dict] = None,
+    ) -> None:
+        """Route Slack's native Stop button through the canonical ``/stop`` lane."""
+        channel_id = str(event.get("channel") or "")
+        thread_ts = str(event.get("thread_ts") or "")
+        user_id = str(event.get("user") or "")
+        team_id = str(
+            event.get("team_id")
+            or self._event_team_id(event, body)
+            or ""
+        )
+        message_ts = str(event.get("message_ts") or "")
+
+        # Stop is a destructive control-plane action. If Slack did not provide
+        # enough identity to bind it to one exact Hermes lane, fail closed.
+        if not channel_id or not thread_ts or not user_id:
+            logger.warning(
+                "[Slack] Ignoring malformed agent_session_stopped event "
+                "(channel=%r thread_ts=%r user=%r)",
+                channel_id,
+                thread_ts,
+                user_id,
+            )
+            return
+
+        if team_id:
+            self._remember_channel_team(channel_id, team_id)
+
+        channel_type = str(event.get("channel_type") or "")
+        if not channel_type and channel_id.startswith("D"):
+            channel_type = "im"
+        is_dm = channel_type in {"im", "mpim"}
+
+        user_name = await self._resolve_user_name(
+            user_id,
+            chat_id=channel_id,
+            team_id=team_id,
+        )
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_name=self._channel_name_cache.get(
+                (team_id, channel_id),
+                channel_id,
+            ),
+            chat_type="dm" if is_dm else "group",
+            user_id=user_id,
+            user_name=user_name,
+            thread_id=thread_ts,
+            scope_id=team_id or None,
+        )
+
+        stop_event = MessageEvent(
+            text="/stop",
+            message_type=MessageType.COMMAND,
+            source=source,
+            raw_message=event,
+            message_id=str(
+                event.get("event_ts")
+                or message_ts
+                or f"agent_session_stopped:{thread_ts}"
+            ),
+            metadata={
+                "slack_team_id": team_id,
+                "slack_channel_id": channel_id,
+                "thread_id": thread_ts,
+                "thread_ts": thread_ts,
+                "user_id": user_id,
+                "native_agent_session_stop": True,
+            },
+        )
+
+        # This is the only cancellation action. BasePlatformAdapter.handle_message
+        # reaches the same gateway /stop path as a typed Slack command, preserving
+        # authorization, session guards, agent interruption, cleanup, and the
+        # normal user-visible "stopped" acknowledgement.
+        await self.handle_message(stop_event)
+
+        # UI cleanup is deliberately separate from cancellation authority. It
+        # only settles Slack-native presentation state after the canonical stop
+        # has been dispatched, and it is bound to Slack's exact channel/thread/
+        # workspace/message identities.
+        await self._settle_agent_session_stopped_ui(
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            team_id=team_id,
+            message_ts=message_ts,
+        )
+
+    async def _settle_agent_session_stopped_ui(
+        self,
+        *,
+        channel_id: str,
+        thread_ts: str,
+        team_id: str,
+        message_ts: str,
+    ) -> None:
+        """Best-effort clear of Slack-native stream/status presentation."""
+        metadata = {
+            "thread_id": thread_ts,
+            "thread_ts": thread_ts,
+            "slack_team_id": team_id,
+        }
+
+        try:
+            await self.stop_typing(channel_id, metadata=metadata)
+        except Exception:
+            logger.debug(
+                "[Slack] Failed to clear Assistant status after native stop",
+                exc_info=True,
+            )
+
+        # ``message_ts`` identifies the concrete native streamed message Slack
+        # put the Stop control on. Stop that exact stream even if Hermes lost
+        # its in-memory stream bookkeeping across a restart. Never infer a
+        # stream from channel alone: concurrent Slack threads share channel IDs.
+        if not self._app or not message_ts:
+            return
+
+        try:
+            await self._get_client(
+                channel_id,
+                team_id=team_id or None,
+            ).chat_stopStream(
+                channel=channel_id,
+                ts=message_ts,
+            )
+        except Exception as exc:
+            logger.debug(
+                "[Slack] chat.stopStream failed after native stop for %s/%s: %s",
+                channel_id,
+                message_ts,
+                exc,
+            )
+            return
+
+        active_stream = self._active_streams.get(channel_id)
+        if (
+            active_stream is not None
+            and str(active_stream.get("ts") or "") == message_ts
+        ):
+            self._active_streams.pop(channel_id, None)
+
+
+def _build_adapter(config):
+    return SlackAgentStopAdapter(config)
+
+
+class _PlatformRegistrationProxy:
+    """Preserve Slack registration metadata while replacing only its factory."""
+
+    def __init__(self, ctx: Any):
+        self._ctx = ctx
+
+    def register_platform(self, *args, **kwargs):
+        base_factory = kwargs.get("adapter_factory")
+        if base_factory is not _adapter._build_adapter:
+            raise RuntimeError(
+                "Slack native-stop registration expected the canonical "
+                "Slack adapter factory"
+            )
+        kwargs["adapter_factory"] = _build_adapter
+        return self._ctx.register_platform(*args, **kwargs)
+
+    def __getattr__(self, name: str):
+        return getattr(self._ctx, name)
+
+
+def register(ctx) -> None:
+    """Plugin entry point with the native-stop-capable runtime adapter."""
+    _adapter.register(_PlatformRegistrationProxy(ctx))

--- a/tests/gateway/test_slack_native_stop.py
+++ b/tests/gateway/test_slack_native_stop.py
@@ -1,0 +1,230 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.base import MessageType
+from plugins.platforms.slack import native_stop
+from plugins.platforms.slack.native_stop import SlackAgentStopAdapter
+
+
+class _FakeApp:
+    def __init__(self):
+        self.registrations = []
+
+    def event(self, event_name):
+        def decorator(callback):
+            self.registrations.append((event_name, callback))
+            return callback
+
+        return decorator
+
+
+def _bare_adapter():
+    adapter = SlackAgentStopAdapter.__new__(SlackAgentStopAdapter)
+    adapter._app = object()
+    adapter._channel_team = {}
+    adapter._channel_teams = {}
+    adapter._CHANNEL_TEAM_MAX = 10000
+    adapter._channel_name_cache = {}
+    adapter._active_streams = {}
+    adapter._event_team_id = MagicMock(return_value="")
+    adapter._resolve_user_name = AsyncMock(return_value="Ada")
+    adapter.build_source = MagicMock(return_value=SimpleNamespace())
+    adapter.handle_message = AsyncMock()
+    adapter.stop_typing = AsyncMock()
+    client = SimpleNamespace(chat_stopStream=AsyncMock())
+    adapter._get_client = MagicMock(return_value=client)
+    return adapter, client
+
+
+@pytest.mark.asyncio
+async def test_agent_session_stopped_routes_through_canonical_stop_and_clears_ui():
+    adapter, client = _bare_adapter()
+    adapter._active_streams["C123ABC456"] = {
+        "ts": "1782234987.693923",
+        "draft_id": 7,
+        "sent": "working",
+    }
+    event = {
+        "type": "agent_session_stopped",
+        "channel": "C123ABC456",
+        "thread_ts": "1782234671.392669",
+        "message_ts": "1782234987.693923",
+        "user": "U123ABC456",
+        "team_id": "T0123ABC456",
+        "event_ts": "1783536983.783769",
+    }
+
+    await adapter._handle_agent_session_stopped(event, {})
+
+    assert adapter._channel_team == {"C123ABC456": "T0123ABC456"}
+    assert adapter._channel_teams == {"C123ABC456": {"T0123ABC456"}}
+    adapter._resolve_user_name.assert_awaited_once_with(
+        "U123ABC456",
+        chat_id="C123ABC456",
+        team_id="T0123ABC456",
+    )
+    adapter.build_source.assert_called_once_with(
+        chat_id="C123ABC456",
+        chat_name="C123ABC456",
+        chat_type="group",
+        user_id="U123ABC456",
+        user_name="Ada",
+        thread_id="1782234671.392669",
+        scope_id="T0123ABC456",
+    )
+
+    stop_event = adapter.handle_message.await_args.args[0]
+    assert stop_event.text == "/stop"
+    assert stop_event.message_type is MessageType.COMMAND
+    assert stop_event.raw_message is event
+    assert stop_event.message_id == "1783536983.783769"
+    assert stop_event.metadata["native_agent_session_stop"] is True
+    assert stop_event.metadata["slack_team_id"] == "T0123ABC456"
+    assert stop_event.metadata["thread_id"] == "1782234671.392669"
+
+    adapter.stop_typing.assert_awaited_once_with(
+        "C123ABC456",
+        metadata={
+            "thread_id": "1782234671.392669",
+            "thread_ts": "1782234671.392669",
+            "slack_team_id": "T0123ABC456",
+        },
+    )
+    adapter._get_client.assert_called_once_with(
+        "C123ABC456", team_id="T0123ABC456"
+    )
+    client.chat_stopStream.assert_awaited_once_with(
+        channel="C123ABC456",
+        ts="1782234987.693923",
+    )
+    assert "C123ABC456" not in adapter._active_streams
+
+
+@pytest.mark.asyncio
+async def test_agent_session_stopped_fails_closed_without_exact_lane_identity():
+    adapter, client = _bare_adapter()
+    event = {
+        "type": "agent_session_stopped",
+        "channel": "C123ABC456",
+        "user": "U123ABC456",
+        "team_id": "T0123ABC456",
+    }
+
+    await adapter._handle_agent_session_stopped(event, {})
+
+    adapter.handle_message.assert_not_awaited()
+    adapter.stop_typing.assert_not_awaited()
+    client.chat_stopStream.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_session_stopped_does_not_drop_unrelated_channel_stream():
+    adapter, client = _bare_adapter()
+    adapter._active_streams["C123ABC456"] = {
+        "ts": "1782234000.000000",
+        "draft_id": 3,
+        "sent": "other thread",
+    }
+    event = {
+        "type": "agent_session_stopped",
+        "channel": "C123ABC456",
+        "thread_ts": "1782234671.392669",
+        "message_ts": "1782234987.693923",
+        "user": "U123ABC456",
+        "team_id": "T0123ABC456",
+    }
+
+    await adapter._handle_agent_session_stopped(event, {})
+
+    client.chat_stopStream.assert_awaited_once_with(
+        channel="C123ABC456",
+        ts="1782234987.693923",
+    )
+    assert adapter._active_streams["C123ABC456"]["ts"] == "1782234000.000000"
+
+
+@pytest.mark.asyncio
+async def test_ui_stream_stop_still_runs_when_typing_cleanup_fails():
+    adapter, client = _bare_adapter()
+    adapter.stop_typing = AsyncMock(side_effect=RuntimeError("status unavailable"))
+
+    await adapter._settle_agent_session_stopped_ui(
+        channel_id="C123ABC456",
+        thread_ts="1782234671.392669",
+        team_id="T0123ABC456",
+        message_ts="1782234987.693923",
+    )
+
+    client.chat_stopStream.assert_awaited_once_with(
+        channel="C123ABC456",
+        ts="1782234987.693923",
+    )
+
+
+def test_native_stop_listener_is_registered_before_socket_mode_and_only_once():
+    adapter, _ = _bare_adapter()
+    app = _FakeApp()
+    adapter._app = app
+
+    with patch.object(
+        native_stop._adapter.SlackAdapter,
+        "_start_socket_mode_handler",
+    ) as parent_start:
+        adapter._start_socket_mode_handler()
+        adapter._start_socket_mode_handler()
+
+    assert [name for name, _ in app.registrations] == ["agent_session_stopped"]
+    assert parent_start.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_native_stop_listener_rebinds_shared_app_to_replacement_adapter():
+    first_adapter, _ = _bare_adapter()
+    replacement_adapter, _ = _bare_adapter()
+    first_adapter._handle_agent_session_stopped = AsyncMock()
+    replacement_adapter._handle_agent_session_stopped = AsyncMock()
+    app = _FakeApp()
+    first_adapter._app = app
+    replacement_adapter._app = app
+
+    first_adapter._register_agent_session_stopped_listener()
+    replacement_adapter._register_agent_session_stopped_listener()
+
+    assert [name for name, _ in app.registrations] == ["agent_session_stopped"]
+    callback = app.registrations[0][1]
+    event = {"type": "agent_session_stopped"}
+    body = {"team_id": "T0123ABC456"}
+    await callback(event, body)
+
+    first_adapter._handle_agent_session_stopped.assert_not_awaited()
+    replacement_adapter._handle_agent_session_stopped.assert_awaited_once_with(
+        event,
+        body,
+    )
+
+
+def test_plugin_registration_preserves_metadata_and_replaces_only_factory():
+    captured = {}
+
+    class Context:
+        def register_platform(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    native_stop.register(Context())
+
+    kwargs = captured["kwargs"]
+    assert kwargs["name"] == "slack"
+    assert kwargs["label"] == "Slack"
+    assert kwargs["adapter_factory"] is native_stop._build_adapter
+    assert kwargs["check_fn"] is native_stop._adapter.slack_deps_present
+    assert kwargs["ensure_deps_fn"] is native_stop._adapter.check_slack_requirements
+
+
+def test_registration_proxy_refuses_unknown_base_factory():
+    proxy = native_stop._PlatformRegistrationProxy(SimpleNamespace())
+
+    with pytest.raises(RuntimeError, match="canonical Slack adapter factory"):
+        proxy.register_platform(adapter_factory=lambda config: config)


### PR DESCRIPTION
## Summary

Slack's Agents & AI Apps surface emits `agent_session_stopped` when a user clicks the native Stop control. Hermes previously acknowledged that lifecycle event without routing it into execution cancellation.

This PR binds the native control to Hermes' existing `/stop` authority instead of inventing a second cancellation primitive:

- register `agent_session_stopped` before Socket Mode starts;
- bind the event to the exact Slack workspace / channel / thread / user lane and fail closed when that identity is incomplete;
- synthesize the ordinary `MessageEvent("/stop")` and dispatch through the canonical gateway path, preserving authorization, session guards, execution interruption, cleanup, and acknowledgement;
- settle Slack-native presentation separately by clearing the exact Assistant thread status and stopping the exact `message_ts` stream;
- never evict an unrelated active stream merely because it shares the same Slack channel.

## Listener ownership / review closure

The native listener is owned by the concrete Slack `AsyncApp`, not by an adapter instance. That matters because an `AsyncApp` can survive profile reload or error-path adapter reconstruction.

The app stores one mutable registration owner. A replacement adapter rebinds that owner without registering another callback, so a native Stop cannot fan out into duplicate `/stop` dispatches and the surviving callback cannot remain bound to a stale adapter. A malformed pre-existing registration marker fails closed instead of silently stacking another listener.

The registration proxy also refuses an unexpected base `adapter_factory` rather than silently overriding future Slack registration drift.

This closes the blocking review finding from [#issuecomment-5374495474](https://github.com/NousResearch/hermes-agent/pull/91725#issuecomment-5374495474).

## Regression proof

Focused coverage pins:

- canonical `/stop` routing with exact workspace/thread identity;
- malformed lifecycle events fail closed before cancellation or UI mutation;
- exact `message_ts` stream cleanup without disturbing an unrelated same-channel stream;
- real `SlackAdapter` channel/workspace bookkeeping (`_channel_team` + ambiguity map), rather than a mocked ownership seam;
- listener registration before Socket Mode and exactly once per `AsyncApp`;
- replacement-adapter / same-app rebinding: one callback remains and it dispatches only to the newest adapter;
- `chat.stopStream` still runs when status cleanup fails;
- preservation of Slack plugin registration metadata;
- fail-closed rejection if the base Slack registration factory contract drifts.

## Exact landing object

The branch was rebuilt after the review fix directly on current upstream `main`, so superseded development objects are not ancestors of the active PR.

- Base: [`76f6ba37064614a703ce2d19ade6bb5fbbf4fcf8`](https://github.com/NousResearch/hermes-agent/commit/76f6ba37064614a703ce2d19ade6bb5fbbf4fcf8)
- Head: [`b8630fc06e780272b790547ac470087e329d0bd2`](https://github.com/andrexibiza/hermes-agent/commit/b8630fc06e780272b790547ac470087e329d0bd2)
- GitHub merge candidate: [`0affef576989a11f8745e4b7e51d8fdb69b182db`](https://github.com/NousResearch/hermes-agent/commit/0affef576989a11f8745e4b7e51d8fdb69b182db)
- Topology: one commit, three intended files, 1 ahead / 0 behind, open, non-draft, mergeable
- [CI 32528152901](https://github.com/NousResearch/hermes-agent/actions/runs/32528152901) — **success**
- [Docker 32528152228](https://github.com/NousResearch/hermes-agent/actions/runs/32528152228) — **success**
- [Nix 32528152283](https://github.com/NousResearch/hermes-agent/actions/runs/32528152283) — **success**

All acceptance evidence above is attached directly to `b8630fc06e780272b790547ac470087e329d0bd2`; no green state is inherited from superseded commits.

Fixes #90978