### PR TITLE
chore(skills): complete follow-up cleanups from #33460

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1477,7 +1477,11 @@ def do_repair_official(name: str, restore: bool = False,
     c = console or _console
     if restore and not skip_confirm:
         c.print(f"\n[bold]Restore official optional skill '{name}' from repo source?[/]")
-        c.print("[dim]Existing matching active copies will be moved to a restore backup before copying the official source.[/]")
+        c.print(
+            "[dim]Any existing copies at the canonical path or elsewhere that "
+            "do not match the official source will be moved to a backup under "
+            f"{display_hermes_home()}/skills/.restore-backups/.[/]"
+        )
         try:
             answer = input("Confirm [y/N]: ").strip().lower()
         except (EOFError, KeyboardInterrupt):
@@ -1505,8 +1509,10 @@ def do_repair_official(name: str, restore: bool = False,
         try:
             from agent.prompt_builder import clear_skills_system_prompt_cache
             clear_skills_system_prompt_cache(clear_snapshot=True)
-        except Exception:
-            pass
+        except Exception as exc:
+            logging.getLogger(__name__).debug(
+                "Skills prompt cache clear failed: %s", exc
+            )
 
 
 def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> None:

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,14 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import (
+    do_check,
+    do_install,
+    do_list,
+    do_repair_official,
+    do_update,
+    handle_skills_slash,
+)
 
 
 class _DummyLockFile:
@@ -489,3 +496,54 @@ def test_do_update_unmodified_skill_updates_normally(monkeypatch, tmp_path):
 
     assert installs == ["someone/hub-skill"]
     assert "Updated 1 skill(s)" in sink.getvalue()
+
+
+def test_repair_official_confirmation_describes_every_backup_location(monkeypatch):
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+
+    do_repair_official("demo", restore=True, console=console)
+
+    output = sink.getvalue().lower()
+    assert "canonical path or elsewhere" in output
+    assert ".restore-backups" in output
+
+
+def test_repair_official_logs_prompt_cache_clear_failure(monkeypatch, caplog):
+    import agent.prompt_builder as prompt_builder
+    import tools.skills_sync as skills_sync
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    monkeypatch.setattr(
+        skills_sync,
+        "restore_official_optional_skill",
+        lambda _name, restore=False: {
+            "ok": True,
+            "changed": True,
+            "message": "Official optional skill repair complete.",
+            "restored": ["demo"],
+            "backfilled": [],
+            "backed_up": [],
+        },
+    )
+
+    def fail_cache_clear(*, clear_snapshot):
+        raise RuntimeError("cache unavailable")
+
+    monkeypatch.setattr(
+        prompt_builder,
+        "clear_skills_system_prompt_cache",
+        fail_cache_clear,
+    )
+    caplog.set_level("DEBUG", logger="hermes_cli.skills_hub")
+
+    do_repair_official(
+        "demo",
+        restore=True,
+        console=console,
+        skip_confirm=True,
+    )
+
+    assert "Skills prompt cache clear failed: cache unavailable" in caplog.text

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -502,6 +502,43 @@ class TestHubLockFile:
         names = {e["name"] for e in installed}
         assert names == {"s1", "s2"}
 
+    def test_failed_save_preserves_existing_lock_and_cleans_temp_file(
+        self, tmp_path, monkeypatch
+    ):
+        lock_file = tmp_path / "lock.json"
+        original = '{"version": 1, "installed": {"keep": {}}}\n'
+        lock_file.write_text(original, encoding="utf-8")
+
+        def fail_replace(_tmp_path, _target):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr("utils.atomic_replace", fail_replace)
+
+        with pytest.raises(OSError, match="simulated replace failure"):
+            HubLockFile(path=lock_file).save(
+                {"version": 1, "installed": {"replacement": {}}}
+            )
+
+        assert lock_file.read_text(encoding="utf-8") == original
+        assert list(tmp_path.glob(".lock_*.tmp")) == []
+
+    @pytest.mark.linux_only
+    def test_save_preserves_existing_lock_permissions(self, tmp_path):
+        import os
+        import stat
+
+        lock_file = tmp_path / "lock.json"
+        lock_file.write_text(
+            '{"version": 1, "installed": {}}\n', encoding="utf-8"
+        )
+        os.chmod(lock_file, 0o640)
+
+        HubLockFile(path=lock_file).save(
+            {"version": 1, "installed": {"replacement": {}}}
+        )
+
+        assert stat.S_IMODE(lock_file.stat().st_mode) == 0o640
+
 
 # ---------------------------------------------------------------------------
 # TapsManager
@@ -1199,6 +1236,75 @@ class TestInstallPathSafety:
                     install_path=bad_install_path,
                     files=["SKILL.md"],
                 )
+
+    def test_record_install_rejects_deep_non_official_path(self, tmp_path):
+        lock = HubLockFile(path=tmp_path / "lock.json")
+
+        with pytest.raises(ValueError, match="non-official"):
+            lock.record_install(
+                name="deep-skill",
+                source="github",
+                identifier="owner/repo/deep-skill",
+                trust_level="trusted",
+                scan_verdict="pass",
+                skill_hash="h1",
+                install_path="a/b/deep-skill",
+                files=["SKILL.md"],
+            )
+
+        assert not lock.path.exists()
+
+    def test_record_install_allows_deep_official_path(self, tmp_path):
+        lock = HubLockFile(path=tmp_path / "lock.json")
+
+        lock.record_install(
+            name="deep-skill",
+            source="official",
+            identifier="official/a/b/deep-skill",
+            trust_level="builtin",
+            scan_verdict="pass",
+            skill_hash="h1",
+            install_path="a/b/deep-skill",
+            files=["SKILL.md"],
+        )
+
+        assert lock.get_installed("deep-skill")["install_path"] == "a/b/deep-skill"
+
+    def test_uninstall_allows_legacy_deep_non_official_path(
+        self, tmp_path, isolated_skills_dir, patch_lock_file
+    ):
+        from tools.skills_hub import uninstall_skill
+
+        installed = isolated_skills_dir / "a" / "b" / "legacy-skill"
+        installed.mkdir(parents=True)
+        (installed / "SKILL.md").write_text("legacy", encoding="utf-8")
+        lock_path = tmp_path / "lock.json"
+        lock_path.write_text(
+            json.dumps({
+                "version": 1,
+                "installed": {
+                    "legacy-skill": {
+                        "source": "github",
+                        "identifier": "owner/repo/legacy-skill",
+                        "trust_level": "trusted",
+                        "scan_verdict": "pass",
+                        "content_hash": "h",
+                        "install_path": "a/b/legacy-skill",
+                        "files": ["SKILL.md"],
+                        "metadata": {},
+                        "installed_at": "now",
+                        "updated_at": "now",
+                    }
+                }
+            }),
+            encoding="utf-8",
+        )
+        patch_lock_file(lock_path)
+
+        ok, _message = uninstall_skill("legacy-skill")
+
+        assert ok is True
+        assert not installed.exists()
 
 
     def test_uninstall_rejects_poisoned_absolute_path(self, tmp_path, isolated_skills_dir, patch_lock_file):

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -16,10 +16,87 @@ from tools.skills_sync import (
     _discover_bundled_skills,
     _compute_relative_dest,
     _dir_hash,
+    _optional_skill_index,
+    _backfill_optional_provenance,
     sync_skills,
     reset_bundled_skill,
     restore_official_optional_skill,
 )
+
+
+class TestOptionalProvenance:
+    @staticmethod
+    def _write_skill(root: Path, rel_path: str, frontmatter_name: str) -> Path:
+        skill_dir = root / Path(*rel_path.split("/"))
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {frontmatter_name}\ndescription: test\n---\nBody\n",
+            encoding="utf-8",
+        )
+        return skill_dir
+
+    def test_optional_index_rejects_ambiguous_alias_but_keeps_exact_paths(
+        self, tmp_path, caplog
+    ):
+        optional_dir = tmp_path / "optional-skills"
+        self._write_skill(optional_dir, "alpha/shared", "alpha-skill")
+        self._write_skill(optional_dir, "beta/shared", "beta-skill")
+
+        with patch("tools.skills_sync._get_optional_dir", return_value=optional_dir):
+            index = _optional_skill_index()
+
+        assert "shared" not in index
+        assert index["alpha/shared"][1] == "alpha/shared"
+        assert index["beta/shared"][1] == "beta/shared"
+        assert index["alpha-skill"][1] == "alpha/shared"
+        assert index["beta-skill"][1] == "beta/shared"
+        assert "Ambiguous official optional skill alias 'shared'" in caplog.text
+
+    def test_backfill_skips_colliding_folder_names_with_warning(
+        self, tmp_path, caplog
+    ):
+        optional_dir = tmp_path / "optional-skills"
+        skills_dir = tmp_path / "skills"
+        for rel_path, frontmatter_name in (
+            ("alpha/shared", "alpha-skill"),
+            ("beta/shared", "beta-skill"),
+        ):
+            source = self._write_skill(optional_dir, rel_path, frontmatter_name)
+            destination = skills_dir / Path(*rel_path.split("/"))
+            shutil.copytree(source, destination)
+
+        with patch("tools.skills_sync._get_optional_dir", return_value=optional_dir), \
+             patch("tools.skills_sync.SKILLS_DIR", skills_dir):
+            backfilled = _backfill_optional_provenance(quiet=True)
+
+        assert backfilled == []
+        assert not (skills_dir / ".hub" / "lock.json").exists()
+        assert "Skipping ambiguous official optional skill folder 'shared'" in caplog.text
+
+    def test_backfill_atomic_failure_preserves_existing_lock(
+        self, tmp_path, monkeypatch
+    ):
+        optional_dir = tmp_path / "optional-skills"
+        skills_dir = tmp_path / "skills"
+        source = self._write_skill(optional_dir, "category/demo", "demo")
+        shutil.copytree(source, skills_dir / "category" / "demo")
+        lock_path = skills_dir / ".hub" / "lock.json"
+        lock_path.parent.mkdir(parents=True)
+        original = '{"version": 1, "installed": {"keep": {}}}\n'
+        lock_path.write_text(original, encoding="utf-8")
+
+        def fail_replace(_tmp_path, _target):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr("utils.atomic_replace", fail_replace)
+
+        with patch("tools.skills_sync._get_optional_dir", return_value=optional_dir), \
+             patch("tools.skills_sync.SKILLS_DIR", skills_dir), \
+             pytest.raises(OSError, match="simulated replace failure"):
+            _backfill_optional_provenance(quiet=True)
+
+        assert lock_path.read_text(encoding="utf-8") == original
+        assert list(lock_path.parent.glob(".lock_*.tmp")) == []
 
 
 class TestReadWriteManifest:

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -4,9 +4,11 @@ import shutil
 import json
 import os
 import stat
-import pytest
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from tools.skills_sync import (
     _get_bundled_dir,
@@ -97,6 +99,72 @@ class TestOptionalProvenance:
 
         assert lock_path.read_text(encoding="utf-8") == original
         assert list(lock_path.parent.glob(".lock_*.tmp")) == []
+
+    def test_restore_backup_roots_include_microseconds(self, tmp_path):
+        optional_dir = tmp_path / "optional-skills"
+        skills_dir = tmp_path / "skills"
+        self._write_skill(optional_dir, "category/demo", "demo")
+        destination = skills_dir / "category" / "demo"
+        destination.mkdir(parents=True)
+        (destination / "SKILL.md").write_text("first local edit", encoding="utf-8")
+        moments = [
+            datetime(2026, 8, 22, 12, 30, 45, 111111, tzinfo=timezone.utc),
+            datetime(2026, 8, 22, 12, 30, 45, 222222, tzinfo=timezone.utc),
+        ]
+
+        with patch("tools.skills_sync._get_optional_dir", return_value=optional_dir), \
+             patch("tools.skills_sync.SKILLS_DIR", skills_dir), \
+             patch("tools.skills_sync.datetime") as mock_datetime:
+            mock_datetime.now.side_effect = moments
+            first = restore_official_optional_skill("demo", restore=True)
+            (destination / "SKILL.md").write_text(
+                "second local edit", encoding="utf-8"
+            )
+            second = restore_official_optional_skill("demo", restore=True)
+
+        assert first["backup_dir"] != second["backup_dir"]
+        assert "111111" in first["backup_dir"]
+        assert "222222" in second["backup_dir"]
+
+    def test_restore_reports_no_change_when_canonical_and_recorded(self, tmp_path):
+        from tools.skills_hub import HubLockFile
+
+        optional_dir = tmp_path / "optional-skills"
+        skills_dir = tmp_path / "skills"
+        source = self._write_skill(optional_dir, "category/demo", "demo")
+        shutil.copytree(source, skills_dir / "category" / "demo")
+        HubLockFile(path=skills_dir / ".hub" / "lock.json").record_install(
+            name="demo",
+            source="official",
+            identifier="official/category/demo",
+            trust_level="builtin",
+            scan_verdict="pass",
+            skill_hash="hash",
+            install_path="category/demo",
+            files=["SKILL.md"],
+        )
+
+        with patch("tools.skills_sync._get_optional_dir", return_value=optional_dir), \
+             patch("tools.skills_sync.SKILLS_DIR", skills_dir):
+            result = restore_official_optional_skill("demo")
+
+        assert result["ok"] is True
+        assert result["changed"] is False
+        assert result["restored"] == []
+        assert result["backfilled"] == []
+        assert result["backed_up"] == []
+        assert "No repair needed" in result["message"]
+
+    def test_restore_rejects_undocumented_star_alias(self, tmp_path):
+        optional_dir = tmp_path / "optional-skills"
+        self._write_skill(optional_dir, "category/demo", "demo")
+
+        with patch("tools.skills_sync._get_optional_dir", return_value=optional_dir):
+            result = restore_official_optional_skill("*")
+
+        assert result["ok"] is False
+        assert result["changed"] is False
+        assert "not found" in result["message"]
 
 
 class TestReadWriteManifest:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -39,6 +39,7 @@ from tools.skills_guard import (
 )
 from tools.url_safety import is_safe_url
 from tools.website_policy import check_website_access
+from utils import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -231,7 +232,12 @@ def _validate_install_parent_path(category: str) -> str:
     return _normalize_bundle_path(category, field_name="install parent path", allow_nested=True)
 
 
-def _normalize_lock_install_path(install_path: str, skill_name: str) -> str:
+def _normalize_lock_install_path(
+    install_path: str,
+    skill_name: str,
+    *,
+    source: Optional[str] = None,
+) -> str:
     """Validate a skill install path before it touches the lock file or disk.
 
     Lock-file ``install_path`` entries are the source-of-truth for where
@@ -244,7 +250,10 @@ def _normalize_lock_install_path(install_path: str, skill_name: str) -> str:
     Enforce that ``install_path`` ends with ``<skill_name>``. Nested
     official optional skills may legitimately install below paths such as
     ``mlops/training/<skill_name>``; traversal, absolute paths, empty paths,
-    and mismatched final components are still rejected.
+    and mismatched final components are still rejected. When ``source`` is
+    supplied for a new write, non-official installs are limited to one
+    optional category plus the skill name. Omitting ``source`` preserves
+    read/uninstall compatibility with older, already-recorded lock entries.
     """
     safe_skill_name = _validate_skill_name(skill_name)
     normalized = _normalize_bundle_path(
@@ -255,6 +264,11 @@ def _normalize_lock_install_path(install_path: str, skill_name: str) -> str:
     parts = normalized.split("/")
     if not parts or parts[-1] != safe_skill_name:
         raise ValueError(f"Unsafe install path: {install_path}")
+    if source is not None and source != "official" and len(parts) > 2:
+        raise ValueError(
+            f"Unsafe non-official install path: {install_path} "
+            "(at most category/skill is allowed)"
+        )
     return normalized
 
 
@@ -268,7 +282,12 @@ def _is_path_redirect(path: Path) -> bool:
     return path.is_symlink() or (hasattr(path, "is_junction") and path.is_junction())
 
 
-def _resolve_lock_install_path(install_path: str, skill_name: str) -> Path:
+def _resolve_lock_install_path(
+    install_path: str,
+    skill_name: str,
+    *,
+    source: Optional[str] = None,
+) -> Path:
     """Resolve a lock-file install path without allowing escapes from ``SKILLS_DIR``.
 
     Two layers of defence on top of the existing ``is_relative_to`` check
@@ -281,7 +300,11 @@ def _resolve_lock_install_path(install_path: str, skill_name: str) -> Path:
        — an empty/``"."``/``""`` install_path resolves to the skills root itself,
        and ``rmtree(SKILLS_DIR)`` would wipe every installed skill.
     """
-    normalized = _normalize_lock_install_path(install_path, skill_name)
+    normalized = _normalize_lock_install_path(
+        install_path,
+        skill_name,
+        source=source,
+    )
     skills_dir = _skills_dir()
     skills_root = skills_dir.resolve()
 
@@ -3744,8 +3767,12 @@ class HubLockFile:
             return {"version": 1, "installed": {}}
 
     def save(self, data: dict) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        atomic_write_text(
+            self.path,
+            json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+            tmp_prefix=".lock_",
+            preserve_mode=True,
+        )
 
     def record_install(
         self,
@@ -3765,7 +3792,11 @@ class HubLockFile:
         # for the uninstall_skill rmtree-escape; reject malformed input at
         # write time so the file never carries the bad state.
         safe_name = _validate_skill_name(name)
-        safe_install_path = _normalize_lock_install_path(install_path, safe_name)
+        safe_install_path = _normalize_lock_install_path(
+            install_path,
+            safe_name,
+            source=source,
+        )
         data = self.load()
         data["installed"][safe_name] = {
             "source": source,
@@ -3961,7 +3992,11 @@ def install_from_quarantine(
     # Resolve via the same lock-path validator the uninstaller uses. Catches
     # symlink-in-skills-tree redirects at install time so the lock entry's
     # path can never refer to a redirected target.
-    install_dir = _resolve_lock_install_path(install_rel_path, safe_skill_name)
+    install_dir = _resolve_lock_install_path(
+        install_rel_path,
+        safe_skill_name,
+        source=bundle.source,
+    )
 
     # Refuse to nest a skill inside an existing skill directory. Installing
     # with ``--category <name-of-an-existing-skill>`` would create a hybrid

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -48,7 +48,7 @@ for _stream in (sys.stdout, sys.stderr):
 from hermes_constants import get_bundled_skills_dir, get_hermes_home, get_optional_skills_dir
 from agent.skill_utils import is_excluded_skill_path
 from typing import Dict, List, Optional, Set, Tuple
-from utils import atomic_replace, atomic_write_text
+from utils import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -325,16 +325,18 @@ def _content_hash(directory: Path) -> str:
 
 
 def _optional_skill_index() -> Dict[str, Tuple[str, str, Path]]:
-    """Return official optional skills keyed by folder name and frontmatter name.
+    """Return official optional skills keyed by exact path and unambiguous aliases.
 
     Values are ``(folder_name, install_path, source_dir)``. Multiple keys may
-    point to the same skill so callers can accept either the folder slug used
-    by the hub lock or the user-facing frontmatter name.
+    point to the same skill so callers can accept the exact install path, the
+    folder slug used by the hub lock, or the user-facing frontmatter name.
+    Ambiguous aliases are omitted rather than silently selecting one skill.
     """
     optional_dir = _get_optional_dir()
-    index: Dict[str, Tuple[str, str, Path]] = {}
     if not optional_dir.exists():
-        return index
+        return {}
+
+    entries: List[Tuple[Tuple[str, str, Path], str]] = []
     for skill_md in sorted(optional_dir.rglob("SKILL.md")):
         if is_excluded_skill_path(
             skill_md.relative_to(optional_dir), root=optional_dir
@@ -348,8 +350,29 @@ def _optional_skill_index() -> Dict[str, Tuple[str, str, Path]]:
         folder_name = src.name
         frontmatter_name = _read_skill_name(skill_md, folder_name)
         value = (folder_name, install_path, src)
-        index[folder_name] = value
-        index[frontmatter_name] = value
+        entries.append((value, frontmatter_name))
+
+    index: Dict[str, Tuple[str, str, Path]] = {
+        value[1]: value for value, _frontmatter_name in entries
+    }
+    exact_paths = set(index)
+    aliases: Dict[str, Dict[str, Tuple[str, str, Path]]] = {}
+    for value, frontmatter_name in entries:
+        for alias in {value[0], frontmatter_name}:
+            aliases.setdefault(alias, {})[value[1]] = value
+
+    for alias, targets_by_path in aliases.items():
+        if len(targets_by_path) > 1:
+            logger.warning(
+                "Ambiguous official optional skill alias %r matches install paths: %s; "
+                "use the full install path",
+                alias,
+                ", ".join(sorted(targets_by_path)),
+            )
+            if alias not in exact_paths:
+                index.pop(alias, None)
+            continue
+        index.setdefault(alias, next(iter(targets_by_path.values())))
     return index
 
 
@@ -492,21 +515,8 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
     if not optional_dir.exists():
         return []
 
-    lock_path = _skills_dir() / ".hub" / "lock.json"
-    try:
-        data = json.loads(lock_path.read_text(encoding="utf-8")) if lock_path.exists() else {"version": 1, "installed": {}}
-    except (json.JSONDecodeError, OSError):
-        data = {"version": 1, "installed": {}}
-    installed = data.setdefault("installed", {})
-    existing_paths = {
-        entry.get("install_path")
-        for entry in installed.values()
-        if isinstance(entry, dict)
-    }
-
-    backfilled: List[str] = []
-    changed = False
-    installed_dir_index: Optional[Dict[str, List[Path]]] = None
+    candidates: List[Tuple[Path, str, str]] = []
+    folder_paths: Dict[str, List[str]] = {}
     for skill_md in sorted(optional_dir.rglob("SKILL.md")):
         if is_excluded_skill_path(skill_md):
             continue
@@ -517,6 +527,37 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
             logger.debug("Skipping optional skill with unsafe path %s: %s", src, e)
             continue
         lock_name = src.name
+        candidates.append((src, install_path, lock_name))
+        folder_paths.setdefault(lock_name, []).append(install_path)
+
+    colliding_names = {
+        name for name, paths in folder_paths.items() if len(set(paths)) > 1
+    }
+    for name in sorted(colliding_names):
+        logger.warning(
+            "Skipping ambiguous official optional skill folder %r during provenance "
+            "backfill; install paths: %s",
+            name,
+            ", ".join(sorted(set(folder_paths[name]))),
+        )
+
+    from tools.skills_hub import HubLockFile
+
+    lock_path = _skills_dir() / ".hub" / "lock.json"
+    lock = HubLockFile(path=lock_path)
+    data = lock.load()
+    installed = data.setdefault("installed", {})
+    existing_paths = {
+        entry.get("install_path")
+        for entry in installed.values()
+        if isinstance(entry, dict)
+    }
+
+    backfilled: List[str] = []
+    installed_dir_index: Optional[Dict[str, List[Path]]] = None
+    for src, install_path, lock_name in candidates:
+        if lock_name in colliding_names:
+            continue
         if lock_name in installed or install_path in existing_paths:
             continue
         dest = _skills_dir() / Path(*install_path.split("/"))
@@ -544,50 +585,22 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
         if _dir_hash(dest) != _dir_hash(src):
             continue
 
-        timestamp = datetime.now(timezone.utc).isoformat()
-        installed[lock_name] = {
-            "source": "official",
-            "identifier": f"official/{install_path}",
-            "trust_level": "builtin",
-            "scan_verdict": "backfilled",
-            "content_hash": _content_hash(dest),
-            "install_path": install_path,
-            "files": _skill_file_list(dest),
-            "metadata": {"backfilled_from": "optional-skills"},
-            "installed_at": timestamp,
-            "updated_at": timestamp,
-        }
+        lock.record_install(
+            name=lock_name,
+            source="official",
+            identifier=f"official/{install_path}",
+            trust_level="builtin",
+            scan_verdict="backfilled",
+            skill_hash=_content_hash(dest),
+            install_path=install_path,
+            files=_skill_file_list(dest),
+            metadata={"backfilled_from": "optional-skills"},
+        )
+        installed[lock_name] = {"install_path": install_path}
         existing_paths.add(install_path)
         backfilled.append(lock_name)
-        changed = True
         if not quiet:
             print(f"  = {lock_name} (official optional provenance backfilled)")
-
-    if changed:
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        # Atomic write so a crash mid-write can't silently wipe all provenance
-        # via the JSONDecodeError fallback above (which resets `installed` to
-        # an empty dict).
-        import tempfile
-
-        payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
-        fd, tmp_path = tempfile.mkstemp(
-            dir=str(lock_path.parent),
-            prefix=".lock_",
-            suffix=".tmp",
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(payload)
-                f.flush()
-                os.fsync(f.fileno())
-            atomic_replace(tmp_path, lock_path)
-        except BaseException:
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
     return backfilled
 
 

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -399,18 +399,36 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
     """
     index = _optional_skill_index()
     if not index:
-        return {"ok": False, "message": "No official optional skills directory found.", "restored": [], "backfilled": [], "backed_up": []}
+        return {
+            "ok": False,
+            "changed": False,
+            "message": "No official optional skills directory found.",
+            "restored": [],
+            "backfilled": [],
+            "backed_up": [],
+        }
 
-    targets = sorted(set(index.values()), key=lambda item: item[1]) if name in {"all", "*"} else []
+    targets = (
+        sorted(set(index.values()), key=lambda item: item[1])
+        if name == "all"
+        else []
+    )
     if not targets:
         target = index.get(name)
         if target is None:
-            return {"ok": False, "message": f"Official optional skill not found: {name}", "restored": [], "backfilled": [], "backed_up": []}
+            return {
+                "ok": False,
+                "changed": False,
+                "message": f"Official optional skill not found: {name}",
+                "restored": [],
+                "backfilled": [],
+                "backed_up": [],
+            }
         targets = [target]
 
     restored: List[str] = []
     backed_up: List[str] = []
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
     backup_root = _skills_dir() / ".restore-backups" / f"official-optional-{timestamp}"
 
     for folder_name, install_path, src in targets:
@@ -451,9 +469,18 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
             continue
 
     backfilled = _backfill_optional_provenance(quiet=True)
+    changed = bool(restored or backfilled or backed_up)
     return {
         "ok": True,
-        "message": "Official optional skill repair complete.",
+        "changed": changed,
+        "message": (
+            "Official optional skill repair complete."
+            if changed
+            else (
+                "No repair needed; official optional skill is already canonical "
+                "and provenance is current."
+            )
+        ),
         "restored": restored,
         "backfilled": backfilled,
         "backed_up": backed_up,


### PR DESCRIPTION
## Summary

- cap new non-official skill installs at `category/skill` while preserving official deep paths and legacy uninstall compatibility
- route hub lock and optional-skill backfill writes through the shared atomic writer, preserving existing files on failure and file permissions
- keep exact official install paths, reject ambiguous aliases, and skip colliding backfill candidates with warnings
- clarify official repair outcomes, backup behavior, supported `all` selector, and cache-clear diagnostics

## Testing

- `scripts/run_tests.sh tests/tools/test_skills_hub.py tests/tools/test_skills_sync.py tests/hermes_cli/test_skills_hub.py -k "not test_bundle_content_hash_matches_installed_content_hash and not test_fetch_preserves_binary_assets and not test_preserves_category_structure"` — 119 passed, 3 skipped
- full requested command — 119 passed, 3 pre-existing Windows path-separator failures, 3 skipped
- `python -m ruff check tools/skills_hub.py tools/skills_sync.py hermes_cli/skills_hub.py tests/tools/test_skills_hub.py tests/tools/test_skills_sync.py tests/hermes_cli/test_skills_hub.py`
- `scripts/check-windows-footguns.py --diff origin/main` — reports 89 pre-existing findings in touched test files; no added line matches

Closes #33463