### PR TITLE
fix(agent): require reload after skill pruning

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -746,7 +746,7 @@ def _skill_pruned_marker(skill_name: str) -> str:
 # emit helper and this extractor together.
 _SKILL_PRUNED_MARKER_RE = re.compile(
     re.escape(SKILL_PRUNED_MARKER_PREFIX)
-    + r"[^\]]*?reload with skill_view\(name='([^']+)'\)"
+    + r"[^\]]*?reload with skill_view\(name='([^']+)'\)\]"
 )
 
 
@@ -755,7 +755,9 @@ def _extract_pruned_skill_names(text: str) -> list[str]:
     names: list[str] = []
     for match in _SKILL_PRUNED_MARKER_RE.finditer(text or ""):
         name = match.group(1)
-        if name not in names:
+        # Recognition is exact, not merely prefix-shaped: the clear/arm path,
+        # compressor emit sites, and prompt guidance all share this helper.
+        if match.group(0) == _skill_pruned_marker(name) and name not in names:
             names.append(name)
     return names
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -232,10 +232,10 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities.\n"
     "\n"
     "## Skill Safety Rule\n"
-    "1. **UNAVAILABLE** — If a skill placeholder contains `[SKILL_PRUNED]`, the skill content was lost in compression and is inaccessible.\n"
-    "2. **RELOAD** — Before performing any action that depends on a skill, re-check its content with `skill_view(name='...')` if it shows `[SKILL_PRUNED]`.\n"
+    "1. **UNAVAILABLE** — If a skill placeholder contains `[SKILL_PRUNED: content lost in compression; reload with skill_view(name='...')]`, the skill content was lost in compression and is inaccessible.\n"
+    "2. **RELOAD** — Before performing any other action, reload every skill named by that marker with `skill_view(name='...')`.\n"
     "3. **WAIT** — If a skill is loading or was just pruned, wait for the reload confirmation before proceeding.\n"
-    "4. **DEDUP** — After reloading a pruned skill, **ignore any remaining `[SKILL_PRUNED]` markers for that same skill** — they are historical artifacts from previous compactions and do not need further action."
+    "4. **DEDUP** — After reloading a pruned skill, ignore remaining markers for that same skill until its content is pruned again."
 )
 
 KANBAN_GUIDANCE = (

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -23,6 +23,7 @@ from hermes_constants import (
 from typing import List, Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
+from agent.context_compressor import _skill_pruned_marker
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS,
     ORG_ACTIVE_MARKER,
@@ -232,7 +233,7 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities.\n"
     "\n"
     "## Skill Safety Rule\n"
-    "1. **UNAVAILABLE** — If a skill placeholder contains `[SKILL_PRUNED: content lost in compression; reload with skill_view(name='...')]`, the skill content was lost in compression and is inaccessible.\n"
+    f"1. **UNAVAILABLE** — If a skill placeholder contains `{_skill_pruned_marker('x')}`, the skill content was lost in compression and is inaccessible.\n"
     "2. **RELOAD** — Before performing any other action, reload every skill named by that marker with `skill_view(name='...')`.\n"
     "3. **WAIT** — If a skill is loading or was just pruned, wait for the reload confirmation before proceeding.\n"
     "4. **DEDUP** — After reloading a pruned skill, ignore remaining markers for that same skill until its content is pruned again."

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -71,6 +71,22 @@ def _pending_skill_reload_snapshot(agent) -> tuple[str, ...]:
         return tuple(getattr(agent, "_pending_skill_reloads", []))
 
 
+def _is_pending_main_skill_reload(
+    function_name: str,
+    function_args: dict[str, Any],
+    pending_skill_reloads: tuple[str, ...],
+) -> bool:
+    """Return whether this call must deliver a complete main ``SKILL.md``."""
+    skill_name = function_args.get("name")
+    return (
+        function_name == "skill_view"
+        and isinstance(skill_name, str)
+        and bool(skill_name)
+        and not function_args.get("file_path")
+        and skill_name in pending_skill_reloads
+    )
+
+
 def _message_text(message: dict[str, Any]) -> str:
     content = message.get("content", "")
     if isinstance(content, str):
@@ -79,6 +95,17 @@ def _message_text(message: dict[str, Any]) -> str:
         return json.dumps(content, ensure_ascii=False)
     except (TypeError, ValueError):
         return str(content or "")
+
+
+def _successful_tool_payload(text: str) -> dict[str, Any] | None:
+    """Parse a complete leading success payload while allowing appended notices."""
+    try:
+        payload, _ = json.JSONDecoder().raw_decode(text.lstrip())
+    except (TypeError, ValueError):
+        return None
+    if isinstance(payload, dict) and payload.get("success") is True:
+        return payload
+    return None
 
 
 def refresh_pending_skill_reloads(agent, messages: list[dict[str, Any]]) -> list[str]:
@@ -129,7 +156,11 @@ def refresh_pending_skill_reloads(agent, messages: list[dict[str, Any]]) -> list
                     )
                 except (TypeError, ValueError):
                     parsed = None
-                if isinstance(parsed, dict) and isinstance(parsed.get("name"), str):
+                if (
+                    isinstance(parsed, dict)
+                    and isinstance(parsed.get("name"), str)
+                    and not parsed.get("file_path")
+                ):
                     skill_calls[call_id] = parsed["name"]
 
         text = _message_text(message)
@@ -142,11 +173,8 @@ def refresh_pending_skill_reloads(agent, messages: list[dict[str, Any]]) -> list
         skill_name = skill_calls.get(str(message.get("tool_call_id") or ""))
         if not skill_name or skill_name not in pending:
             continue
-        try:
-            payload = json.loads(text)
-        except (TypeError, ValueError):
-            continue
-        if isinstance(payload, dict) and payload.get("success") is True:
+        payload = _successful_tool_payload(text)
+        if payload is not None and isinstance(payload.get("content"), str):
             pending.remove(skill_name)
 
     with _pending_skill_reload_lock(agent):
@@ -179,22 +207,59 @@ def _pending_skill_reload_block(
 def _record_successful_skill_reload(
     agent, function_name: str, function_args: dict[str, Any], result: Any
 ) -> None:
-    """Clear one pending name only after its ``skill_view`` succeeds."""
-    if function_name != "skill_view":
+    """Clear one pending name after its complete main skill reached context."""
+    if function_name != "skill_view" or function_args.get("file_path"):
         return
     skill_name = function_args.get("name")
     if not isinstance(skill_name, str) or not skill_name:
         return
-    try:
-        payload = json.loads(result) if isinstance(result, str) else result
-    except (TypeError, ValueError):
+    if not isinstance(result, str):
         return
-    if not isinstance(payload, dict) or payload.get("success") is not True:
+    payload = _successful_tool_payload(result)
+    if payload is None or not isinstance(payload.get("content"), str):
         return
     with _pending_skill_reload_lock(agent):
         pending = getattr(agent, "_pending_skill_reloads", [])
         if skill_name in pending:
             pending.remove(skill_name)
+
+
+def _finalize_successful_skill_reloads(
+    agent,
+    candidates: list[tuple[str, dict, dict]],
+    effective_task_id: str,
+) -> None:
+    """Clear reloads only after final result-budget processing preserved them."""
+    for function_name, function_args, tool_message in candidates:
+        content = tool_message.get("content", "")
+        _record_successful_skill_reload(
+            agent,
+            function_name,
+            function_args,
+            content,
+        )
+        payload = _successful_tool_payload(content) if isinstance(content, str) else None
+        if payload is not None and payload.get("dedup") is True:
+            # A stale pre-compression repeat-view cache must not strand the
+            # reload boundary. Keep the name pending and make the next model
+            # round's canonical skill_view return the complete SKILL.md.
+            try:
+                from tools.skills_tool import reset_skill_view_dedup
+
+                reset_skill_view_dedup(effective_task_id)
+            except Exception:
+                logger.debug("skill reload dedup reset failed", exc_info=True)
+
+
+def _protected_skill_reload_call_ids(
+    candidates: list[tuple[str, dict, dict]],
+) -> set[str]:
+    """Return call ids whose complete instructional payload must stay inline."""
+    return {
+        str(tool_message.get("tool_call_id") or "")
+        for _, _, tool_message in candidates
+        if tool_message.get("tool_call_id")
+    }
 
 
 def _record_persisted_path_for_stub(agent, tool_call_id: str, function_result) -> None:
@@ -857,11 +922,17 @@ def _run_agent_tool_execution_middleware(
         )
         _hb_thread.start()
         try:
-            result = execute(final_args)
-            _record_successful_skill_reload(
-                agent, function_name, final_args, result
-            )
-            return result
+            if _is_pending_main_skill_reload(
+                function_name,
+                final_args,
+                pending_skill_reloads
+                if pending_skill_reloads is not None
+                else _pending_skill_reload_snapshot(agent),
+            ):
+                from tools.skills_tool import reset_skill_view_dedup
+
+                reset_skill_view_dedup(effective_task_id)
+            return execute(final_args)
         finally:
             _hb_stop.set()
             _hb_thread.join(timeout=2.0)
@@ -1230,6 +1301,7 @@ def execute_tool_calls_concurrent(
     *,
     finalize: bool = True,
     pending_skill_reloads: tuple[str, ...] | None = None,
+    skill_reload_candidates: list[tuple[str, dict, dict]] | None = None,
 ) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
@@ -1244,6 +1316,8 @@ def execute_tool_calls_concurrent(
     num_tools = len(tool_calls)
     if pending_skill_reloads is None:
         pending_skill_reloads = _pending_skill_reload_snapshot(agent)
+    if skill_reload_candidates is None:
+        skill_reload_candidates = []
 
     # Resolve the context-scaled tool-output budget once per turn (cheap, but
     # avoids rebuilding it per result inside the loop below).
@@ -1836,6 +1910,7 @@ def execute_tool_calls_concurrent(
         r = results[i]
         blocked = False
         is_error = True
+        preserve_skill_reload = False
         progress_function_name = name
         # A worker can finish and write results[i] in the window between the
         # deadline snapshot (timed_out_indices, taken from not_done) and this
@@ -1912,6 +1987,13 @@ def execute_tool_calls_concurrent(
             if blocked:
                 effect_disposition = "none"
 
+            preserve_skill_reload = (
+                not blocked
+                and _is_pending_main_skill_reload(
+                    function_name, function_args, pending_skill_reloads
+                )
+            )
+
             if not blocked:
                 function_result = agent._append_guardrail_observation(
                     function_name,
@@ -1919,6 +2001,7 @@ def execute_tool_calls_concurrent(
                     function_result,
                     failed=is_error,
                     tool_call_id=getattr(tc, "id", "") or "",
+                    preserve_full_result=preserve_skill_reload,
                 )
 
             if is_error:
@@ -1952,7 +2035,10 @@ def execute_tool_calls_concurrent(
             tool_use_id=tc.id,
             env=get_active_env(effective_task_id),
             config=_tool_budget,
-        ) if not _is_multimodal_tool_result(function_result) else function_result
+        ) if (
+            not _is_multimodal_tool_result(function_result)
+            and not preserve_skill_reload
+        ) else function_result
         _record_persisted_path_for_stub(agent, tc.id, function_result)
 
         subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
@@ -1980,6 +2066,8 @@ def execute_tool_calls_concurrent(
             effect_disposition=effect_disposition,
         )
         messages.append(tool_message)
+        if preserve_skill_reload:
+            skill_reload_candidates.append((name, args, tool_message))
         risk_metadata = tool_message.get("_tool_output_risk")
         if not _flush_session_db_after_tool_progress(
             agent,
@@ -2049,7 +2137,17 @@ def execute_tool_calls_concurrent(
     num_tools = len(parsed_calls)
     if finalize and num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
-        enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id), config=_tool_budget)
+        enforce_turn_budget(
+            turn_tool_msgs,
+            env=get_active_env(effective_task_id),
+            config=_tool_budget,
+            protected_tool_call_ids=_protected_skill_reload_call_ids(
+                skill_reload_candidates
+            ),
+        )
+        _finalize_successful_skill_reloads(
+            agent, skill_reload_candidates, effective_task_id
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # Append any pending user steer text to the last tool result so the
@@ -2089,6 +2187,7 @@ def execute_tool_calls_sequential(
     *,
     finalize: bool = True,
     pending_skill_reloads: tuple[str, ...] | None = None,
+    skill_reload_candidates: list[tuple[str, dict, dict]] | None = None,
 ) -> None:
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools.
 
@@ -2100,6 +2199,8 @@ def execute_tool_calls_sequential(
     _tool_budget = _budget_for_agent(agent)
     if pending_skill_reloads is None:
         pending_skill_reloads = _pending_skill_reload_snapshot(agent)
+    if skill_reload_candidates is None:
+        skill_reload_candidates = []
 
     # Keep every runtime-tool branch on one bounded execution funnel without
     # duplicating timeout policy across the branch-specific callbacks below.
@@ -2816,6 +2917,12 @@ def execute_tool_calls_sequential(
                 duration_ms=int(tool_duration * 1000),
                 middleware_trace=list(middleware_trace),
             )
+        preserve_skill_reload = (
+            not _execution_blocked
+            and _is_pending_main_skill_reload(
+                function_name, function_args, pending_skill_reloads
+            )
+        )
         if not _execution_blocked:
             function_result = agent._append_guardrail_observation(
                 function_name,
@@ -2823,6 +2930,7 @@ def execute_tool_calls_sequential(
                 function_result,
                 failed=_is_error_result,
                 tool_call_id=getattr(tool_call, "id", "") or "",
+                preserve_full_result=preserve_skill_reload,
             )
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
@@ -2860,7 +2968,10 @@ def execute_tool_calls_sequential(
             tool_use_id=tool_call.id,
             env=get_active_env(effective_task_id),
             config=_tool_budget,
-        ) if not _is_multimodal_tool_result(function_result) else function_result
+        ) if (
+            not _is_multimodal_tool_result(function_result)
+            and not preserve_skill_reload
+        ) else function_result
         _record_persisted_path_for_stub(agent, tool_call.id, function_result)
 
         # Discover subdirectory context files from tool arguments
@@ -2881,6 +2992,10 @@ def execute_tool_calls_sequential(
             effect_disposition="unknown" if _execution_timed_out else None,
         )
         messages.append(tool_message)
+        if preserve_skill_reload:
+            skill_reload_candidates.append(
+                (function_name, function_args, tool_message)
+            )
         risk_metadata = tool_message.get("_tool_output_risk")
         if not _flush_session_db_after_tool_progress(
             agent,
@@ -2967,7 +3082,17 @@ def execute_tool_calls_sequential(
     # be discarded when aggregate budget enforcement replaces a tool result.
     num_tools_seq = len(assistant_message.tool_calls)
     if finalize and num_tools_seq > 0:
-        enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id), config=_tool_budget)
+        enforce_turn_budget(
+            messages[-num_tools_seq:],
+            env=get_active_env(effective_task_id),
+            config=_tool_budget,
+            protected_tool_call_ids=_protected_skill_reload_call_ids(
+                skill_reload_candidates
+            ),
+        )
+        _finalize_successful_skill_reloads(
+            agent, skill_reload_candidates, effective_task_id
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # See _execute_tool_calls_parallel for the rationale. Same hook,
@@ -3016,6 +3141,7 @@ def execute_tool_calls_segmented(
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
     pending_skill_reloads = _pending_skill_reload_snapshot(agent)
+    skill_reload_candidates: list[tuple[str, dict, dict]] = []
 
     for kind, calls in segments:
         if getattr(agent, "_incremental_persistence_failed", False):
@@ -3026,12 +3152,14 @@ def execute_tool_calls_segmented(
                 agent, segment_message, messages, effective_task_id, api_call_count,
                 finalize=False,
                 pending_skill_reloads=pending_skill_reloads,
+                skill_reload_candidates=skill_reload_candidates,
             )
         else:
             execute_tool_calls_sequential(
                 agent, segment_message, messages, effective_task_id, api_call_count,
                 finalize=False,
                 pending_skill_reloads=pending_skill_reloads,
+                skill_reload_candidates=skill_reload_candidates,
             )
 
         if getattr(agent, "_incremental_persistence_failed", False):
@@ -3045,6 +3173,12 @@ def execute_tool_calls_segmented(
             messages[-total_tools:],
             env=get_active_env(effective_task_id),
             config=_tool_budget,
+            protected_tool_call_ids=_protected_skill_reload_call_ids(
+                skill_reload_candidates
+            ),
+        )
+        _finalize_successful_skill_reloads(
+            agent, skill_reload_candidates, effective_task_id
         )
         agent._apply_pending_steer_to_tool_results(messages, total_tools)
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -60,6 +60,17 @@ def _pending_skill_reload_lock(agent) -> threading.RLock:
     return vars(agent).setdefault("_pending_skill_reload_lock", threading.RLock())
 
 
+def _pending_skill_reload_snapshot(agent) -> tuple[str, ...]:
+    """Fix pending names for one model-emitted tool batch.
+
+    A successful ``skill_view`` clears live state immediately, but sibling calls
+    were chosen before the model saw the reloaded instructions. Keeping the
+    batch-start snapshot blocks those calls until the next model round.
+    """
+    with _pending_skill_reload_lock(agent):
+        return tuple(getattr(agent, "_pending_skill_reloads", []))
+
+
 def _message_text(message: dict[str, Any]) -> str:
     content = message.get("content", "")
     if isinstance(content, str):
@@ -143,12 +154,19 @@ def refresh_pending_skill_reloads(agent, messages: list[dict[str, Any]]) -> list
         return list(pending)
 
 
-def _pending_skill_reload_block(agent, function_name: str) -> str | None:
+def _pending_skill_reload_block(
+    agent,
+    function_name: str,
+    pending_skill_reloads: tuple[str, ...] | None = None,
+) -> str | None:
     """Block non-reload tools while canonical prune markers remain pending."""
     if function_name == "skill_view":
         return None
-    with _pending_skill_reload_lock(agent):
-        pending = list(getattr(agent, "_pending_skill_reloads", []))
+    pending = (
+        _pending_skill_reload_snapshot(agent)
+        if pending_skill_reloads is None
+        else pending_skill_reloads
+    )
     if not pending:
         return None
     calls = "; ".join(f"skill_view(name='{name}')" for name in pending)
@@ -696,6 +714,7 @@ def _run_agent_tool_execution_middleware(
     middleware_trace: list[dict[str, Any]] | None = None,
     begin_execution=None,
     authorization_gate: _ConcurrentToolAuthorizationGate | None = None,
+    pending_skill_reloads: tuple[str, ...] | None = None,
 ) -> _ManagedToolResult:
     """Run Relay rewrites before Hermes policy and dispatch exactly once."""
     from agent import relay_tools
@@ -740,7 +759,9 @@ def _run_agent_tool_execution_middleware(
                 return
             begin_execution(callback)
 
-        block_message = _pending_skill_reload_block(agent, function_name)
+        block_message = _pending_skill_reload_block(
+            agent, function_name, pending_skill_reloads
+        )
         block_error_type = "skill_reload_block"
         if block_message is None:
             block_message = scope_block
@@ -938,6 +959,7 @@ def _run_sequential_tool_execution_middleware(
     scope_block: str | None = None,
     display_index: int | None = None,
     middleware_trace: list[dict[str, Any]] | None = None,
+    pending_skill_reloads: tuple[str, ...] | None = None,
 ) -> _ManagedToolResult:
     """Run one sequential call with the concurrent executor's deadline.
 
@@ -956,6 +978,7 @@ def _run_sequential_tool_execution_middleware(
         "scope_block": scope_block,
         "display_index": display_index,
         "middleware_trace": middleware_trace,
+        "pending_skill_reloads": pending_skill_reloads,
     }
     if function_name in _NEVER_PARALLEL_TOOLS:
         return _run_agent_tool_execution_middleware(agent, **kwargs)
@@ -1198,7 +1221,16 @@ def _begin_tool_execution(
             pass
 
 
-def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
+def execute_tool_calls_concurrent(
+    agent,
+    assistant_message,
+    messages: list,
+    effective_task_id: str,
+    api_call_count: int = 0,
+    *,
+    finalize: bool = True,
+    pending_skill_reloads: tuple[str, ...] | None = None,
+) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
     Results are collected in the original tool-call order and appended to
@@ -1210,6 +1242,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     """
     tool_calls = assistant_message.tool_calls
     num_tools = len(tool_calls)
+    if pending_skill_reloads is None:
+        pending_skill_reloads = _pending_skill_reload_snapshot(agent)
 
     # Resolve the context-scaled tool-output budget once per turn (cheap, but
     # avoids rebuilding it per result inside the loop below).
@@ -1494,6 +1528,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     middleware_trace=middleware_trace,
                     begin_execution=_advance_start,
                     authorization_gate=authorization_gate,
+                    pending_skill_reloads=pending_skill_reloads,
                 )
                 result = managed.result
                 function_args = managed.args
@@ -2045,7 +2080,16 @@ def _append_cancelled_tool_results(messages: list, tool_calls, *, reason: str) -
         ))
 
 
-def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
+def execute_tool_calls_sequential(
+    agent,
+    assistant_message,
+    messages: list,
+    effective_task_id: str,
+    api_call_count: int = 0,
+    *,
+    finalize: bool = True,
+    pending_skill_reloads: tuple[str, ...] | None = None,
+) -> None:
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools.
 
     ``finalize=False`` skips the end-of-batch aggregate budget enforcement
@@ -2054,10 +2098,13 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+    if pending_skill_reloads is None:
+        pending_skill_reloads = _pending_skill_reload_snapshot(agent)
 
     # Keep every runtime-tool branch on one bounded execution funnel without
     # duplicating timeout policy across the branch-specific callbacks below.
     def _run_agent_tool_execution_middleware(agent, **kwargs):
+        kwargs["pending_skill_reloads"] = pending_skill_reloads
         return _run_sequential_tool_execution_middleware(agent, **kwargs)
 
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
@@ -2931,7 +2978,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
 
 
-def execute_tool_calls_segmented(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, segments=None) -> None:
+def execute_tool_calls_segmented(
+    agent,
+    assistant_message,
+    messages: list,
+    effective_task_id: str,
+    api_call_count: int = 0,
+    segments=None,
+) -> None:
     """Execute a mixed tool-call batch as ordered parallel/sequential segments.
 
     ``segments`` is the ``(kind, calls)`` plan from
@@ -2961,6 +3015,8 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
         _exec_cwd = Path(_active_env.cwd) if _active_env is not None and _active_env.cwd else None
         segments = _plan_tool_batch_segments(assistant_message.tool_calls, execution_cwd=_exec_cwd)
 
+    pending_skill_reloads = _pending_skill_reload_snapshot(agent)
+
     for kind, calls in segments:
         if getattr(agent, "_incremental_persistence_failed", False):
             return
@@ -2969,11 +3025,13 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
             execute_tool_calls_concurrent(
                 agent, segment_message, messages, effective_task_id, api_call_count,
                 finalize=False,
+                pending_skill_reloads=pending_skill_reloads,
             )
         else:
             execute_tool_calls_sequential(
                 agent, segment_message, messages, effective_task_id, api_call_count,
                 finalize=False,
+                pending_skill_reloads=pending_skill_reloads,
             )
 
         if getattr(agent, "_incremental_persistence_failed", False):

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -60,6 +60,15 @@ def _pending_skill_reload_lock(agent) -> threading.RLock:
     return vars(agent).setdefault("_pending_skill_reload_lock", threading.RLock())
 
 
+@dataclass
+class _PendingSkillReloadScanState:
+    """Append-only transcript watermark plus unresolved reload call ids."""
+
+    message_count: int
+    last_message_id: int | None
+    skill_calls: dict[str, str]
+
+
 def _pending_skill_reload_snapshot(agent) -> tuple[str, ...]:
     """Fix pending names for one model-emitted tool batch.
 
@@ -108,77 +117,111 @@ def _successful_tool_payload(text: str) -> dict[str, Any] | None:
     return None
 
 
-def refresh_pending_skill_reloads(agent, messages: list[dict[str, Any]]) -> list[str]:
-    """Rebuild the bounded pending-reload list from a transcript.
+def refresh_pending_skill_reloads(
+    agent,
+    messages: list[dict[str, Any]],
+    *,
+    force_full: bool = False,
+) -> list[str]:
+    """Refresh pending reloads from only the transcript's appended tail.
 
     Canonical prune markers add a skill. A later successful ``skill_view``
     result clears it, so markers retained by a subsequent compaction remain
     historical rather than re-arming the guard. If that reloaded body is pruned
     later, its new marker occurs after the successful result and adds it again.
+
+    A message-count + last-message identity watermark makes ordinary turn
+    boundaries O(appended tail). Compression/reset callers invalidate the
+    append-only assumption with ``force_full=True`` (or by clearing the scan
+    state); replaced/truncated transcripts are detected and rescanned in full.
     """
     from agent.context_compressor import (
         _MAX_PRUNED_SKILL_MARKERS,
         _extract_pruned_skill_names,
     )
 
-    pending: list[str] = []
-    skill_calls: dict[str, str] = {}
-
-    for message in messages or []:
-        if not isinstance(message, dict):
-            continue
-
-        if message.get("role") == "assistant":
-            for tool_call in message.get("tool_calls") or []:
-                if isinstance(tool_call, dict):
-                    call_id = str(tool_call.get("id") or "")
-                    function = tool_call.get("function") or {}
-                    function_name = (
-                        function.get("name") if isinstance(function, dict) else None
-                    )
-                    arguments = (
-                        function.get("arguments")
-                        if isinstance(function, dict)
-                        else None
-                    )
-                else:
-                    call_id = str(getattr(tool_call, "id", "") or "")
-                    function = getattr(tool_call, "function", None)
-                    function_name = getattr(function, "name", None)
-                    arguments = getattr(function, "arguments", None)
-                if function_name != "skill_view" or not call_id:
-                    continue
-                try:
-                    parsed = (
-                        json.loads(arguments or "{}")
-                        if isinstance(arguments, str)
-                        else arguments
-                    )
-                except (TypeError, ValueError):
-                    parsed = None
-                if (
-                    isinstance(parsed, dict)
-                    and isinstance(parsed.get("name"), str)
-                    and not parsed.get("file_path")
-                ):
-                    skill_calls[call_id] = parsed["name"]
-
-        text = _message_text(message)
-        for name in _extract_pruned_skill_names(text):
-            if name not in pending and len(pending) < _MAX_PRUNED_SKILL_MARKERS:
-                pending.append(name)
-
-        if message.get("role") != "tool":
-            continue
-        skill_name = skill_calls.get(str(message.get("tool_call_id") or ""))
-        if not skill_name or skill_name not in pending:
-            continue
-        payload = _successful_tool_payload(text)
-        if payload is not None and isinstance(payload.get("content"), str):
-            pending.remove(skill_name)
-
+    transcript = messages or []
     with _pending_skill_reload_lock(agent):
+        state = getattr(agent, "_pending_skill_reload_scan_state", None)
+        can_resume = (
+            not force_full
+            and isinstance(state, _PendingSkillReloadScanState)
+            and state.message_count <= len(transcript)
+            and (
+                state.message_count == 0
+                or id(transcript[state.message_count - 1]) == state.last_message_id
+            )
+        )
+        if can_resume:
+            assert isinstance(state, _PendingSkillReloadScanState)
+            start = state.message_count
+            pending = list(getattr(agent, "_pending_skill_reloads", []))
+            skill_calls = dict(state.skill_calls)
+        else:
+            start = 0
+            pending = []
+            skill_calls = {}
+
+        for message in transcript[start:]:
+            if not isinstance(message, dict):
+                continue
+
+            if message.get("role") == "assistant":
+                for tool_call in message.get("tool_calls") or []:
+                    if isinstance(tool_call, dict):
+                        call_id = str(tool_call.get("id") or "")
+                        function = tool_call.get("function") or {}
+                        function_name = (
+                            function.get("name") if isinstance(function, dict) else None
+                        )
+                        arguments = (
+                            function.get("arguments")
+                            if isinstance(function, dict)
+                            else None
+                        )
+                    else:
+                        call_id = str(getattr(tool_call, "id", "") or "")
+                        function = getattr(tool_call, "function", None)
+                        function_name = getattr(function, "name", None)
+                        arguments = getattr(function, "arguments", None)
+                    if function_name != "skill_view" or not call_id:
+                        continue
+                    try:
+                        parsed = (
+                            json.loads(arguments or "{}")
+                            if isinstance(arguments, str)
+                            else arguments
+                        )
+                    except (TypeError, ValueError):
+                        parsed = None
+                    if (
+                        isinstance(parsed, dict)
+                        and isinstance(parsed.get("name"), str)
+                        and not parsed.get("file_path")
+                    ):
+                        skill_calls[call_id] = parsed["name"]
+
+            text = _message_text(message)
+            for name in _extract_pruned_skill_names(text):
+                if name not in pending and len(pending) < _MAX_PRUNED_SKILL_MARKERS:
+                    pending.append(name)
+
+            if message.get("role") != "tool":
+                continue
+            call_id = str(message.get("tool_call_id") or "")
+            skill_name = skill_calls.pop(call_id, None)
+            if not skill_name or skill_name not in pending:
+                continue
+            payload = _successful_tool_payload(text)
+            if payload is not None and isinstance(payload.get("content"), str):
+                pending.remove(skill_name)
+
         agent._pending_skill_reloads = pending
+        agent._pending_skill_reload_scan_state = _PendingSkillReloadScanState(
+            message_count=len(transcript),
+            last_message_id=id(transcript[-1]) if transcript else None,
+            skill_calls=skill_calls,
+        )
         return list(pending)
 
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -55,6 +55,130 @@ from tools.budget_config import BudgetConfig, DEFAULT_BUDGET, budget_for_context
 logger = logging.getLogger(__name__)
 
 
+def _pending_skill_reload_lock(agent) -> threading.RLock:
+    """Return the per-agent lock protecting pending skill reload state."""
+    return vars(agent).setdefault("_pending_skill_reload_lock", threading.RLock())
+
+
+def _message_text(message: dict[str, Any]) -> str:
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return content
+    try:
+        return json.dumps(content, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return str(content or "")
+
+
+def refresh_pending_skill_reloads(agent, messages: list[dict[str, Any]]) -> list[str]:
+    """Rebuild the bounded pending-reload list from a transcript.
+
+    Canonical prune markers add a skill. A later successful ``skill_view``
+    result clears it, so markers retained by a subsequent compaction remain
+    historical rather than re-arming the guard. If that reloaded body is pruned
+    later, its new marker occurs after the successful result and adds it again.
+    """
+    from agent.context_compressor import (
+        _MAX_PRUNED_SKILL_MARKERS,
+        _extract_pruned_skill_names,
+    )
+
+    pending: list[str] = []
+    skill_calls: dict[str, str] = {}
+
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+
+        if message.get("role") == "assistant":
+            for tool_call in message.get("tool_calls") or []:
+                if isinstance(tool_call, dict):
+                    call_id = str(tool_call.get("id") or "")
+                    function = tool_call.get("function") or {}
+                    function_name = (
+                        function.get("name") if isinstance(function, dict) else None
+                    )
+                    arguments = (
+                        function.get("arguments")
+                        if isinstance(function, dict)
+                        else None
+                    )
+                else:
+                    call_id = str(getattr(tool_call, "id", "") or "")
+                    function = getattr(tool_call, "function", None)
+                    function_name = getattr(function, "name", None)
+                    arguments = getattr(function, "arguments", None)
+                if function_name != "skill_view" or not call_id:
+                    continue
+                try:
+                    parsed = (
+                        json.loads(arguments or "{}")
+                        if isinstance(arguments, str)
+                        else arguments
+                    )
+                except (TypeError, ValueError):
+                    parsed = None
+                if isinstance(parsed, dict) and isinstance(parsed.get("name"), str):
+                    skill_calls[call_id] = parsed["name"]
+
+        text = _message_text(message)
+        for name in _extract_pruned_skill_names(text):
+            if name not in pending and len(pending) < _MAX_PRUNED_SKILL_MARKERS:
+                pending.append(name)
+
+        if message.get("role") != "tool":
+            continue
+        skill_name = skill_calls.get(str(message.get("tool_call_id") or ""))
+        if not skill_name or skill_name not in pending:
+            continue
+        try:
+            payload = json.loads(text)
+        except (TypeError, ValueError):
+            continue
+        if isinstance(payload, dict) and payload.get("success") is True:
+            pending.remove(skill_name)
+
+    with _pending_skill_reload_lock(agent):
+        agent._pending_skill_reloads = pending
+        return list(pending)
+
+
+def _pending_skill_reload_block(agent, function_name: str) -> str | None:
+    """Block non-reload tools while canonical prune markers remain pending."""
+    if function_name == "skill_view":
+        return None
+    with _pending_skill_reload_lock(agent):
+        pending = list(getattr(agent, "_pending_skill_reloads", []))
+    if not pending:
+        return None
+    calls = "; ".join(f"skill_view(name='{name}')" for name in pending)
+    return (
+        "Skill instructions were pruned during compression. Reload every pending "
+        f"skill before calling {function_name}: {calls}"
+    )
+
+
+def _record_successful_skill_reload(
+    agent, function_name: str, function_args: dict[str, Any], result: Any
+) -> None:
+    """Clear one pending name only after its ``skill_view`` succeeds."""
+    if function_name != "skill_view":
+        return
+    skill_name = function_args.get("name")
+    if not isinstance(skill_name, str) or not skill_name:
+        return
+    try:
+        payload = json.loads(result) if isinstance(result, str) else result
+    except (TypeError, ValueError):
+        return
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        return
+    with _pending_skill_reload_lock(agent):
+        pending = getattr(agent, "_pending_skill_reloads", [])
+        if skill_name in pending:
+            pending.remove(skill_name)
+
+
 def _record_persisted_path_for_stub(agent, tool_call_id: str, function_result) -> None:
     """Tell the stall guards where a persisted result's full content lives.
 
@@ -616,8 +740,11 @@ def _run_agent_tool_execution_middleware(
                 return
             begin_execution(callback)
 
-        block_message = scope_block
-        block_error_type = "tool_scope_block"
+        block_message = _pending_skill_reload_block(agent, function_name)
+        block_error_type = "skill_reload_block"
+        if block_message is None:
+            block_message = scope_block
+            block_error_type = "tool_scope_block"
         if block_message is None:
             block_error_type = "plugin_block"
 
@@ -709,7 +836,11 @@ def _run_agent_tool_execution_middleware(
         )
         _hb_thread.start()
         try:
-            return execute(final_args)
+            result = execute(final_args)
+            _record_successful_skill_reload(
+                agent, function_name, final_args, result
+            )
+            return result
         finally:
             _hb_stop.set()
             _hb_thread.join(timeout=2.0)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -627,6 +627,11 @@ def build_turn_context(
 
     # Initialize conversation (copy to avoid mutating the caller's list).
     messages = list(conversation_history) if conversation_history else []
+    # Rehydrate the deterministic skill-reload guard on every turn. Historical
+    # markers are cleared by successful later skill_view results during the scan.
+    from agent.tool_executor import refresh_pending_skill_reloads
+
+    refresh_pending_skill_reloads(agent, messages)
 
     # The CLI may already have staged this input outside the history passed to
     # ``run_conversation``. Reuse it only when its clean transcript text matches

--- a/run_agent.py
+++ b/run_agent.py
@@ -794,6 +794,7 @@ class AIAgent:
         # Compression markers are session-scoped; rebuild from persisted history
         # at the next turn boundary.
         self._pending_skill_reloads = []
+        self._pending_skill_reload_scan_state = None
 
         # Copilot x-initiator: True for the first API call of a user turn,
         # False for tool-loop follow-ups (#3040).
@@ -8060,19 +8061,8 @@ class AIAgent:
                 "_active_compression_commit_fence", missing_fence
             )
             self._active_compression_commit_fence = active_fence
+        reload_scan_messages = messages
         try:
-            def _record_pending_reloads(result):
-                try:
-                    from agent.tool_executor import refresh_pending_skill_reloads
-
-                    refresh_pending_skill_reloads(self, result[0])
-                except Exception:
-                    logger.debug(
-                        "post-compression skill reload scan failed",
-                        exc_info=True,
-                    )
-                return result
-
             def _run(fence=None, target_messages=None):
                 return compress_context(
                     self,
@@ -8090,11 +8080,15 @@ class AIAgent:
             # Callers that already own a progress-aware wait (gateway session
             # hygiene) pass commit_fence and must not be double-wrapped.
             if commit_fence is not None:
-                return _record_pending_reloads(_run(active_fence))
+                result = _run(active_fence)
+                reload_scan_messages = result[0]
+                return result
 
             idle_timeout, total_ceiling = resolve_context_compression_timeouts()
             if idle_timeout <= 0:
-                return _record_pending_reloads(_run(active_fence))
+                result = _run(active_fence)
+                reload_scan_messages = result[0]
+                return result
 
             def _snapshot_worker(fence=None):
                 # #76354 review F3: the pooled worker must NEVER share the
@@ -8212,6 +8206,7 @@ class AIAgent:
                 fence=active_fence,
                 telemetry_agent=self,
             )
+            reload_scan_messages = result[0]
             # compress_context ran on a daemon pool worker thread; the session
             # id rotation updated hermes_logging._session_context (a
             # threading.local) on the WORKER thread, not this one. Propagate
@@ -8238,8 +8233,22 @@ class AIAgent:
                     "post-compression session ContextVar rebind failed",
                     exc_info=True,
                 )
-            return _record_pending_reloads(result)
+            return result
         finally:
+            # One exit funnel for direct, timeout/fallback, and exceptional
+            # compression paths. Compression may replace or mutate transcript
+            # rows, so invalidate the append-only scan watermark every time.
+            try:
+                from agent.tool_executor import refresh_pending_skill_reloads
+
+                refresh_pending_skill_reloads(
+                    self, reload_scan_messages, force_full=True
+                )
+            except Exception:
+                logger.debug(
+                    "post-compression skill reload scan failed",
+                    exc_info=True,
+                )
             with fence_registration_lock:
                 if previous_fence is missing_fence:
                     vars(self).pop("_active_compression_commit_fence", None)

--- a/run_agent.py
+++ b/run_agent.py
@@ -8272,6 +8272,7 @@ class AIAgent:
         *,
         failed: bool,
         tool_call_id: str = "",
+        preserve_full_result: bool = False,
     ) -> str:
         decision = self._tool_guardrails.after_call(
             tool_name,
@@ -8287,7 +8288,7 @@ class AIAgent:
         # are append-only; nothing already sent to the provider is mutated).
         stall_notice = None
         result_stub = None
-        if self._stall_guards_enabled():
+        if self._stall_guards_enabled() and not preserve_full_result:
             try:
                 observation = self._tool_guardrails.observe_call(
                     tool_name,

--- a/run_agent.py
+++ b/run_agent.py
@@ -791,6 +791,9 @@ class AIAgent:
         
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
+        # Compression markers are session-scoped; rebuild from persisted history
+        # at the next turn boundary.
+        self._pending_skill_reloads = []
 
         # Copilot x-initiator: True for the first API call of a user turn,
         # False for tool-loop follow-ups (#3040).
@@ -8058,6 +8061,18 @@ class AIAgent:
             )
             self._active_compression_commit_fence = active_fence
         try:
+            def _record_pending_reloads(result):
+                try:
+                    from agent.tool_executor import refresh_pending_skill_reloads
+
+                    refresh_pending_skill_reloads(self, result[0])
+                except Exception:
+                    logger.debug(
+                        "post-compression skill reload scan failed",
+                        exc_info=True,
+                    )
+                return result
+
             def _run(fence=None, target_messages=None):
                 return compress_context(
                     self,
@@ -8075,11 +8090,11 @@ class AIAgent:
             # Callers that already own a progress-aware wait (gateway session
             # hygiene) pass commit_fence and must not be double-wrapped.
             if commit_fence is not None:
-                return _run(active_fence)
+                return _record_pending_reloads(_run(active_fence))
 
             idle_timeout, total_ceiling = resolve_context_compression_timeouts()
             if idle_timeout <= 0:
-                return _run(active_fence)
+                return _record_pending_reloads(_run(active_fence))
 
             def _snapshot_worker(fence=None):
                 # #76354 review F3: the pooled worker must NEVER share the
@@ -8223,7 +8238,7 @@ class AIAgent:
                     "post-compression session ContextVar rebind failed",
                     exc_info=True,
                 )
-            return result
+            return _record_pending_reloads(result)
         finally:
             with fence_registration_lock:
                 if previous_fence is missing_fence:

--- a/tests/agent/test_ghost_skill_pruning.py
+++ b/tests/agent/test_ghost_skill_pruning.py
@@ -288,7 +288,7 @@ class TestSkillsGuidanceSafetyRule:
         from agent.prompt_builder import SKILLS_GUIDANCE
 
         assert "## Skill Safety Rule" in SKILLS_GUIDANCE
-        assert _skill_pruned_marker("...") in SKILLS_GUIDANCE
+        assert _skill_pruned_marker("x") in SKILLS_GUIDANCE
         assert "skill_view(name='...')" in SKILLS_GUIDANCE
         # The rule list must use REAL newlines — the original PR hunk risked
         # literal backslash-n escape text rendering into the system prompt.

--- a/tests/agent/test_ghost_skill_pruning.py
+++ b/tests/agent/test_ghost_skill_pruning.py
@@ -288,7 +288,7 @@ class TestSkillsGuidanceSafetyRule:
         from agent.prompt_builder import SKILLS_GUIDANCE
 
         assert "## Skill Safety Rule" in SKILLS_GUIDANCE
-        assert "[SKILL_PRUNED]" in SKILLS_GUIDANCE
+        assert _skill_pruned_marker("...") in SKILLS_GUIDANCE
         assert "skill_view(name='...')" in SKILLS_GUIDANCE
         # The rule list must use REAL newlines — the original PR hunk risked
         # literal backslash-n escape text rendering into the system prompt.

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -1,6 +1,7 @@
 """Runtime tests for tool-call loop guardrails."""
 
 import json
+import threading
 import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -374,6 +375,114 @@ def test_pruned_skill_blocks_other_tools_before_dispatch():
     dispatch.assert_not_called()
     assert "skill_view(name='pdf')" in messages[0]["content"]
     assert agent._pending_skill_reloads == ["pdf"]
+
+
+def test_reload_success_does_not_release_later_tool_in_same_sequential_batch():
+    agent = _make_agent("skill_view", "web_search")
+    refresh_pending_skill_reloads(
+        agent, [{"role": "user", "content": _skill_pruned_marker("pdf")}]
+    )
+    calls = [
+        _mock_tool_call("skill_view", json.dumps({"name": "pdf"}), "c-reload"),
+        _mock_tool_call(
+            "web_search", json.dumps({"query": "must wait"}), "c-after-reload"
+        ),
+    ]
+    messages = []
+    executed = []
+
+    def dispatch(name, args, task_id, **kwargs):
+        del task_id, kwargs
+        executed.append((name, args))
+        if name == "skill_view":
+            return json.dumps({"success": True, "name": "pdf", "content": "rules"})
+        return json.dumps({"ok": True})
+
+    with patch("run_agent.handle_function_call", side_effect=dispatch):
+        agent._execute_tool_calls_sequential(
+            SimpleNamespace(content="", tool_calls=calls), messages, "task-1"
+        )
+
+    assert executed == [("skill_view", {"name": "pdf"})]
+    assert agent._pending_skill_reloads == []
+    assert "skill_view(name='pdf')" in messages[1]["content"]
+
+
+def test_reload_success_does_not_race_later_tool_in_same_concurrent_batch():
+    agent = _make_agent("skill_view", "web_search")
+    refresh_pending_skill_reloads(
+        agent, [{"role": "user", "content": _skill_pruned_marker("pdf")}]
+    )
+    calls = [
+        _mock_tool_call("skill_view", json.dumps({"name": "pdf"}), "c-reload"),
+        _mock_tool_call(
+            "web_search", json.dumps({"query": "must wait"}), "c-after-reload"
+        ),
+    ]
+    messages = []
+    executed = []
+    reload_finished = threading.Event()
+
+    def relay_execute(name, args, callback, **kwargs):
+        del kwargs
+        if name == "web_search":
+            assert reload_finished.wait(timeout=5)
+        result = callback(dict(args))
+        if name == "skill_view":
+            reload_finished.set()
+        return result, dict(args)
+
+    def dispatch(name, args, task_id, **kwargs):
+        del task_id, kwargs
+        executed.append((name, args))
+        if name == "skill_view":
+            return json.dumps({"success": True, "name": "pdf", "content": "rules"})
+        return json.dumps({"ok": True})
+
+    with (
+        patch("agent.relay_tools.execute", side_effect=relay_execute),
+        patch("run_agent.handle_function_call", side_effect=dispatch),
+    ):
+        agent._execute_tool_calls_concurrent(
+            SimpleNamespace(content="", tool_calls=calls), messages, "task-1"
+        )
+
+    assert executed == [("skill_view", {"name": "pdf"})]
+    assert agent._pending_skill_reloads == []
+    assert "skill_view(name='pdf')" in messages[1]["content"]
+
+
+def test_reload_boundary_survives_mixed_batch_segmentation():
+    agent = _make_agent("skill_view", "write_file")
+    refresh_pending_skill_reloads(
+        agent, [{"role": "user", "content": _skill_pruned_marker("pdf")}]
+    )
+    calls = [
+        _mock_tool_call("skill_view", json.dumps({"name": "pdf"}), "c-reload"),
+        _mock_tool_call(
+            "write_file",
+            json.dumps({"path": "/tmp/must-wait", "content": "blocked"}),
+            "c-after-reload",
+        ),
+    ]
+    messages = []
+    executed = []
+
+    def dispatch(name, args, task_id, **kwargs):
+        del task_id, kwargs
+        executed.append((name, args))
+        if name == "skill_view":
+            return json.dumps({"success": True, "name": "pdf", "content": "rules"})
+        return json.dumps({"success": True})
+
+    with patch("run_agent.handle_function_call", side_effect=dispatch):
+        agent._execute_tool_calls(
+            SimpleNamespace(content="", tool_calls=calls), messages, "task-1"
+        )
+
+    assert executed == [("skill_view", {"name": "pdf"})]
+    assert agent._pending_skill_reloads == []
+    assert "skill_view(name='pdf')" in messages[1]["content"]
 
 
 def test_successful_skill_view_roundtrip_clears_pending_reload_but_failure_does_not():

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -553,6 +553,133 @@ def test_successful_skill_view_roundtrip_clears_pending_reload_but_failure_does_
     assert refresh_pending_skill_reloads(agent, history) == ["skill-0"]
 
 
+def test_pending_reload_refresh_scans_only_appended_tail_and_replaced_history():
+    agent = _make_agent("skill_view")
+    history = [{"role": "user", "content": _skill_pruned_marker("pdf")}]
+
+    with patch("agent.tool_executor._message_text", wraps=lambda msg: msg["content"]) as text:
+        assert refresh_pending_skill_reloads(agent, history) == ["pdf"]
+        assert text.call_count == 1
+
+        text.reset_mock()
+        assert refresh_pending_skill_reloads(agent, history) == ["pdf"]
+        text.assert_not_called()
+
+        history.append({"role": "user", "content": "appended tail"})
+        text.reset_mock()
+        assert refresh_pending_skill_reloads(agent, history) == ["pdf"]
+        assert text.call_count == 1
+
+        replacement = [dict(message) for message in history]
+        replacement[0]["content"] = _skill_pruned_marker("xlsx")
+        text.reset_mock()
+        assert refresh_pending_skill_reloads(agent, replacement) == ["xlsx"]
+        assert text.call_count == len(replacement)
+
+
+def test_pending_reload_refresh_force_full_rescans_after_compression():
+    agent = _make_agent("skill_view")
+    history = [{"role": "user", "content": _skill_pruned_marker("pdf")}]
+    assert refresh_pending_skill_reloads(agent, history) == ["pdf"]
+
+    # Compression may rewrite a retained row in place, preserving both list
+    # length and object identity. Its caller must explicitly invalidate the
+    # append-only watermark so the rewritten marker is observed.
+    history[0]["content"] = _skill_pruned_marker("xlsx")
+    assert refresh_pending_skill_reloads(agent, history) == ["pdf"]
+    assert refresh_pending_skill_reloads(agent, history, force_full=True) == ["xlsx"]
+
+    history[0]["content"] = _skill_pruned_marker("docx")
+    agent.reset_session_state()
+    assert refresh_pending_skill_reloads(agent, history) == ["docx"]
+
+
+def test_pending_reload_tail_scan_matches_skill_call_to_later_result():
+    agent = _make_agent("skill_view")
+    history = [
+        {"role": "user", "content": _skill_pruned_marker("pdf")},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "c-tail-reload",
+                    "type": "function",
+                    "function": {
+                        "name": "skill_view",
+                        "arguments": json.dumps({"name": "pdf"}),
+                    },
+                }
+            ],
+        },
+    ]
+    assert refresh_pending_skill_reloads(agent, history) == ["pdf"]
+
+    history.append(
+        {
+            "role": "tool",
+            "tool_call_id": "c-tail-reload",
+            "content": json.dumps(
+                {"success": True, "name": "pdf", "content": "rules"}
+            ),
+        }
+    )
+    assert refresh_pending_skill_reloads(agent, history) == []
+
+
+def test_compression_exception_refreshes_pending_reloads_from_mutated_transcript():
+    agent = _make_agent("skill_view")
+    messages = [{"role": "user", "content": "before compression"}]
+    assert refresh_pending_skill_reloads(agent, messages) == []
+
+    def fail_after_mutating_transcript(*args, **kwargs):
+        del args, kwargs
+        messages[0]["content"] = _skill_pruned_marker("pdf")
+        raise RuntimeError("synthetic compression failure")
+
+    with (
+        patch(
+            "agent.conversation_compression.compress_context",
+            side_effect=fail_after_mutating_transcript,
+        ),
+        patch(
+            "agent.conversation_compression.resolve_context_compression_timeouts",
+            return_value=(0, 0),
+        ),
+    ):
+        try:
+            agent._compress_context(messages, "system prompt", force=True)
+        except RuntimeError as exc:
+            assert str(exc) == "synthetic compression failure"
+        else:
+            raise AssertionError("compression failure was not propagated")
+
+    assert agent._pending_skill_reloads == ["pdf"]
+
+
+def test_malformed_successful_skill_view_body_keeps_reload_guard_armed():
+    agent = _make_agent("skill_view")
+    refresh_pending_skill_reloads(
+        agent, [{"role": "user", "content": _skill_pruned_marker("pdf")}]
+    )
+    loaded = _mock_tool_call(
+        "skill_view", json.dumps({"name": "pdf"}), "c-malformed-reload"
+    )
+    messages = []
+
+    with patch(
+        "run_agent.handle_function_call",
+        return_value=json.dumps(
+            {"success": True, "name": "pdf", "content": ["not", "a", "string"]}
+        ),
+    ):
+        agent._execute_tool_calls_sequential(
+            SimpleNamespace(content="", tool_calls=[loaded]), messages, "task-1"
+        )
+
+    assert agent._pending_skill_reloads == ["pdf"]
+
+
 def test_support_file_view_does_not_clear_live_or_rehydrated_main_reload(
     tmp_path: Path, monkeypatch
 ):

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -5,6 +5,12 @@ import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from agent.context_compressor import (
+    _MAX_PRUNED_SKILL_MARKERS,
+    _skill_pruned_marker,
+    _summarize_tool_result,
+)
+from agent.tool_executor import refresh_pending_skill_reloads
 from run_agent import AIAgent
 
 
@@ -342,6 +348,97 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     mock_hfc.assert_not_called()
     assert "plugin policy" in messages[0]["content"]
     assert agent._tool_guardrails.before_call("web_search", args).action == "allow"
+
+
+def test_pruned_skill_blocks_other_tools_before_dispatch():
+    agent = _make_agent("skill_view", "web_search")
+    refresh_pending_skill_reloads(
+        agent,
+        [
+            {
+                "role": "tool",
+                "content": _summarize_tool_result(
+                    "skill_view", '{"name":"pdf"}', "x" * 6000
+                ),
+            }
+        ],
+    )
+    tc = _mock_tool_call("web_search", json.dumps({"query": "blocked"}), "c-pruned")
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as dispatch:
+        agent._execute_tool_calls_sequential(
+            SimpleNamespace(content="", tool_calls=[tc]), messages, "task-1"
+        )
+
+    dispatch.assert_not_called()
+    assert "skill_view(name='pdf')" in messages[0]["content"]
+    assert agent._pending_skill_reloads == ["pdf"]
+
+
+def test_successful_skill_view_roundtrip_clears_pending_reload_but_failure_does_not():
+    agent = _make_agent("skill_view", "web_search")
+    markers = [
+        {"role": "user", "content": _skill_pruned_marker(f"skill-{i}")}
+        for i in range(_MAX_PRUNED_SKILL_MARKERS + 3)
+    ]
+    refresh_pending_skill_reloads(agent, markers)
+    assert len(agent._pending_skill_reloads) == _MAX_PRUNED_SKILL_MARKERS
+    assert agent._pending_skill_reloads[0] == "skill-0"
+
+    failed = _mock_tool_call(
+        "skill_view", json.dumps({"name": "skill-0"}), "c-reload-failed"
+    )
+    with patch(
+        "run_agent.handle_function_call",
+        return_value=json.dumps({"success": False, "error": "missing"}),
+    ):
+        agent._execute_tool_calls_sequential(
+            SimpleNamespace(content="", tool_calls=[failed]), [], "task-1"
+        )
+    assert agent._pending_skill_reloads[0] == "skill-0"
+
+    loaded = _mock_tool_call(
+        "skill_view", json.dumps({"name": "skill-0"}), "c-reload-ok"
+    )
+    with patch(
+        "run_agent.handle_function_call",
+        return_value=json.dumps({"success": True, "name": "skill-0", "content": "rules"}),
+    ):
+        agent._execute_tool_calls_sequential(
+            SimpleNamespace(content="", tool_calls=[loaded]), [], "task-1"
+        )
+
+    assert "skill-0" not in agent._pending_skill_reloads
+    assert agent._pending_skill_reloads[0] == "skill-1"
+
+    # Rebuilding state on the next turn treats the retained marker as
+    # historical because the later persisted skill_view result succeeded.
+    history = [
+        {"role": "user", "content": _skill_pruned_marker("skill-0")},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{
+                "id": "c-persisted-reload",
+                "type": "function",
+                "function": {
+                    "name": "skill_view",
+                    "arguments": json.dumps({"name": "skill-0"}),
+                },
+            }],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c-persisted-reload",
+            "content": json.dumps({"success": True, "name": "skill-0"}),
+        },
+    ]
+    assert refresh_pending_skill_reloads(agent, history) == []
+
+    # A later compaction marker for the same skill re-arms the guard.
+    history.append({"role": "user", "content": _skill_pruned_marker("skill-0")})
+    assert refresh_pending_skill_reloads(agent, history) == ["skill-0"]
 
 
 def test_default_run_conversation_warns_without_guardrail_halt():

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -3,6 +3,7 @@
 import json
 import threading
 import uuid
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -540,7 +541,9 @@ def test_successful_skill_view_roundtrip_clears_pending_reload_but_failure_does_
         {
             "role": "tool",
             "tool_call_id": "c-persisted-reload",
-            "content": json.dumps({"success": True, "name": "skill-0"}),
+            "content": json.dumps(
+                {"success": True, "name": "skill-0", "content": "rules"}
+            ),
         },
     ]
     assert refresh_pending_skill_reloads(agent, history) == []
@@ -548,6 +551,117 @@ def test_successful_skill_view_roundtrip_clears_pending_reload_but_failure_does_
     # A later compaction marker for the same skill re-arms the guard.
     history.append({"role": "user", "content": _skill_pruned_marker("skill-0")})
     assert refresh_pending_skill_reloads(agent, history) == ["skill-0"]
+
+
+def test_support_file_view_does_not_clear_live_or_rehydrated_main_reload(
+    tmp_path: Path, monkeypatch
+):
+    skill_name = "reload-support-boundary"
+    hermes_home = tmp_path / "hermes-home"
+    skill_dir = hermes_home / "skills" / skill_name
+    references_dir = skill_dir / "references"
+    references_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "# Main policy\n\nMAIN-POLICY-SENTINEL\n", encoding="utf-8"
+    )
+    (references_dir / "note.md").write_text(
+        "SUPPORT-FILE-SENTINEL\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    agent = _make_agent("skill_view", "web_search")
+    refresh_pending_skill_reloads(
+        agent, [{"role": "user", "content": _skill_pruned_marker(skill_name)}]
+    )
+    support_args = {"name": skill_name, "file_path": "references/note.md"}
+    support_call = _mock_tool_call(
+        "skill_view", json.dumps(support_args), "c-support-only"
+    )
+    messages = []
+
+    agent._execute_tool_calls_sequential(
+        SimpleNamespace(content="", tool_calls=[support_call]),
+        messages,
+        "task-1",
+    )
+
+    assert "SUPPORT-FILE-SENTINEL" in messages[0]["content"]
+    assert "MAIN-POLICY-SENTINEL" not in messages[0]["content"]
+    assert agent._pending_skill_reloads == [skill_name]
+
+    history = [
+        {"role": "user", "content": _skill_pruned_marker(skill_name)},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "c-support-only",
+                    "type": "function",
+                    "function": {
+                        "name": "skill_view",
+                        "arguments": json.dumps(support_args),
+                    },
+                }
+            ],
+        },
+        messages[0],
+    ]
+    assert refresh_pending_skill_reloads(agent, history) == [skill_name]
+
+
+def test_pending_main_reload_stays_complete_through_dedup_and_result_budgets(
+    tmp_path: Path, monkeypatch
+):
+    skill_name = "reload-full-delivery"
+    tail_sentinel = "TAIL-POLICY-SENTINEL"
+    hermes_home = tmp_path / "hermes-home"
+    skill_dir = hermes_home / "skills" / skill_name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "# Full policy\n\n" + ("instruction line\n" * 2_500) + tail_sentinel,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    agent = _make_agent("skill_view", "web_search")
+    call_args = {"name": skill_name}
+
+    # Seed the identical-result tracker with the same successful call. The
+    # recovery call below would otherwise be replaced by a result-reference
+    # stub before the model could receive the restored policy.
+    getattr(agent, "context_compressor").context_length = 200_000
+    first_call = _mock_tool_call(
+        "skill_view", json.dumps(call_args), "c-before-prune"
+    )
+    agent._execute_tool_calls_sequential(
+        SimpleNamespace(content="", tool_calls=[first_call]), [], "task-1"
+    )
+
+    refresh_pending_skill_reloads(
+        agent, [{"role": "user", "content": _skill_pruned_marker(skill_name)}]
+    )
+    # A 16K-token context produces a 9,600-char per-result cap and a
+    # 19,200-char aggregate cap, both below this real skill_view response.
+    getattr(agent, "context_compressor").context_length = 16_000
+    reload_call = _mock_tool_call(
+        "skill_view", json.dumps(call_args), "c-reload-full"
+    )
+    messages = []
+
+    agent._execute_tool_calls_sequential(
+        SimpleNamespace(content="", tool_calls=[reload_call]),
+        messages,
+        "task-1",
+    )
+
+    delivered = messages[0]["content"]
+    payload = json.loads(delivered)
+    assert payload["success"] is True
+    assert tail_sentinel in payload["content"]
+    assert "<persisted-output>" not in delivered
+    assert "result-reference" not in delivered
+    assert agent._pending_skill_reloads == []
 
 
 def test_default_run_conversation_warns_without_guardrail_halt():

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -400,22 +400,29 @@ def enforce_turn_budget(
     tool_messages: list[dict],
     env=None,
     config: BudgetConfig = DEFAULT_BUDGET,
+    protected_tool_call_ids: set[str] | None = None,
 ) -> list[dict]:
     """Layer 3: enforce aggregate budget across all tool results in a turn.
 
     If total chars exceed budget, persist the largest non-persisted results
-    first (via sandbox write) until under budget. Already-persisted results
-    are skipped.
+    first (via sandbox write) until under budget. Already-persisted results and
+    explicitly protected instructional results are skipped. A protected result
+    may intentionally leave the turn above its normal aggregate budget because
+    replacing it would make the recovery protocol impossible to complete.
 
     Mutates the list in-place and returns it.
     """
+    protected_tool_call_ids = protected_tool_call_ids or set()
     candidates = []
     total_size = 0
     for i, msg in enumerate(tool_messages):
         content = msg.get("content", "")
         size = len(content)
         total_size += size
-        if PERSISTED_OUTPUT_TAG not in content:
+        if (
+            PERSISTED_OUTPUT_TAG not in content
+            and str(msg.get("tool_call_id") or "") not in protected_tool_call_ids
+        ):
             candidates.append((i, size))
 
     if total_size <= config.turn_budget:


### PR DESCRIPTION
## Summary

- make `SKILLS_GUIDANCE` emit the same canonical `[SKILL_PRUNED: ...reload with skill_view(...)]` marker as the compressor
- rebuild a bounded per-session pending-reload list from compacted history and clear names only after successful `skill_view(name=...)` results
- block non-`skill_view` tools through the existing pre-tool block path while reloads remain pending
- preserve historical-marker dedup semantics while re-arming when the same skill is pruned again
- snapshot pending names for each model-emitted tool batch so sequential, concurrent, and mixed-segment sibling calls cannot act before the model sees the restored skill instructions

## Non-goals

- no skill auto-patching
- no synthesized `SKILL.md` stubs
- no new model tool or prompt-cache mutation

## Verification

- `scripts/run_tests.sh tests/run_agent/test_tool_call_guardrail_runtime.py tests/agent/test_ghost_skill_pruning.py -q` (28 passed)
- broader focused run across 7 compaction/turn-context files (83 passed)
- `uvx ruff check .`
- `python -m py_compile` on all changed Python files
- ad-hoc `hermes-verify-skill-prune-reload-boundary.py` exercised prompt-marker parity, persisted clear/re-arm, and same-batch sequential/concurrent blocking; temporary script removed afterward
