### PR TITLE
ci: add coverage gate job (HA-D10)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -253,3 +253,54 @@ jobs:
           OPENROUTER_API_KEY: ""
           OPENAI_API_KEY: ""
           NOUS_API_KEY: ""
+
+  # Coverage gate: runs the full suite once with coverage enabled and
+  # fails the build if overall line coverage drops below the threshold
+  # set in pyproject.toml [tool.coverage.report] fail_under (70%).
+  # This is the enforced counterpart to HA-D10-001 — previously CI ran
+  # 3215 tests with no coverage gate, so large untested regressions
+  # could merge silently.
+  coverage:
+    name: Coverage gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          version: "0.9.28"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.11
+        uses: ./.github/actions/retry
+        with:
+          command: uv python install 3.11
+
+      - name: Install dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: uv sync --locked --python 3.11 --extra all --extra dev --extra anthropic --extra mistral --extra fal --extra modal --extra daytona --extra hindsight --extra parallel-web
+
+      - name: Run tests with coverage
+        run: |
+          source .venv/bin/activate
+          python -m pytest tests/ -m 'not integration' \
+            --cov --cov-report=term-missing --cov-report=xml
+        env:
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+
+      - name: Upload coverage report
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report
+          path: coverage.xml
+          retention-days: 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
+dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0", "pytest-cov==7.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.1", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
@@ -472,6 +472,19 @@ markers = [
 ]
 # integration tests take way too long to run in the normal CI environments
 addopts = "-m 'not integration'"
+
+# Coverage gate: enforced by the dedicated `coverage` job in tests.yml.
+# `fail_under` is intentionally conservative (70%) so the gate catches
+# large untested regressions without blocking routine PRs on thin edges.
+[tool.coverage.run]
+source = ["agent", "tools", "gateway", "hermes_cli", "plugins", "acp_adapter"]
+omit = ["tests/*", "scripts/*", "**/migrations/*"]
+parallel = true
+
+[tool.coverage.report]
+fail_under = 70
+show_missing = true
+
 
 [tool.ty.environment]
 python-version = "3.13"


### PR DESCRIPTION
## Summary
Resolves HA-D10-001: the 3215-test suite ran with no coverage enforcement, so large untested regressions could land silently.

## What changed
- `.github/workflows/tests.yml`: new `coverage` job runs the full suite once with `pytest-cov` and fails the build if overall line coverage drops below `fail_under` (70%) set in `pyproject.toml [tool.coverage.report]`.
- `pyproject.toml`: added `pytest-cov==7.0.0` to the `dev` extra so CI's `uv sync --extra dev` installs it.

## Why a separate job
Coverage is collected on a single slice to avoid `.coverage` merge complexity across 12 OS×Python×slice matrix entries. The existing `test` matrix is untouched.

## Test plan
- [ ] `coverage` job runs green on this PR
- [ ] Lowering `fail_under` locally demonstrates the gate fails as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)