### PR TITLE
fix(agent): stop reporting transport/router truncation as an output-length limit

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7062,7 +7062,26 @@ def run_conversation(
                         )
                         agent._invalid_json_retries = 0
                         agent._cleanup_task_resources(effective_task_id)
-                        _final_response = "Response truncated due to output length limit"
+                        # Only call it an output-length truncation when the
+                        # model actually reported one. This branch is the
+                        # secondary detector for the case where the length
+                        # handler above was bypassed: an upstream router
+                        # rewrote finish_reason away from "length" (e.g.
+                        # OpenRouter) or a transport/stream break left the tool
+                        # arguments cut off mid-JSON after a timeout+retry. In
+                        # those cases the real cause is transport/router
+                        # corruption, not max_output_tokens — say so instead of
+                        # the misleading "output length limit" (#91717).
+                        if finish_reason == "length":
+                            _final_response = "Response truncated due to output length limit"
+                        else:
+                            _final_response = (
+                                "Tool call arguments were truncated mid-JSON, but the model "
+                                f"did not report an output-length limit (finish_reason="
+                                f"{finish_reason!r}). This usually means a transport/stream "
+                                "interruption or an upstream router rewriting finish_reason "
+                                "(e.g. OpenRouter). The tool was not executed."
+                            )
                         # Same tool-tail close as interrupt / invalid-tool
                         # exhaustion — this path never reaches finalize_turn.
                         close_interrupted_tool_sequence(messages, _final_response)

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -789,3 +789,121 @@ class TestSendTimePadMultimodalSafety:
         assert out[2]["content"] == ""
         # input list untouched (repair is copy-on-write)
         assert api_messages[1]["content"] == ""
+
+
+class TestRouterRewriteTruncationMessageIsHonest:
+    """Regression for #91717: the invalid-JSON truncation detector (the
+    secondary path that fires when the primary finish_reason='length' handler
+    was bypassed) must NOT blame the output-length limit when the model never
+    reported one.
+
+    Scenario: after a transport timeout, OpenRouter's router delivers a retry
+    whose finish_reason is rewritten from 'length' to 'tool_calls', and whose
+    tool-call arguments are cut off mid-JSON. The old code hardcoded
+    'Response truncated due to output length limit', misleading operators into
+    tuning max_tokens / switching models when the real cause is transport /
+    router corruption.
+    """
+
+    def _router_rewrite_response(self):
+        # finish_reason='tool_calls' (NOT 'length') + truncated JSON args
+        # ('{"cmd": "ls' — no closing brace), on a normal generation id (not
+        # the partial-stream stub). This bypasses the length handler and lands
+        # in the invalid-JSON truncation detector.
+        msg = SimpleNamespace(
+            role="assistant",
+            content="",
+            tool_calls=[SimpleNamespace(
+                id="call_1", type="function",
+                function=SimpleNamespace(name="terminal", arguments='{"cmd": "ls'),
+            )],
+            reasoning_content=None,
+        )
+        return SimpleNamespace(
+            id="gen-router-rewrite-xyz",
+            model="deepseek/deepseek-v4-flash",
+            choices=[SimpleNamespace(
+                index=0, message=msg, finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+
+    def test_router_rewrite_truncation_does_not_claim_output_length_limit(
+        self, loop_agent,
+    ):
+        loop_agent.valid_tool_names = {"terminal"}
+        loop_agent.client.chat.completions.create.side_effect = (
+            lambda *a, **kw: self._router_rewrite_response()
+        )
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("list the files")
+
+        final = result["final_response"] or ""
+        error = result["error"] or ""
+
+        # The misleading output-length-limit label must be gone: finish_reason
+        # was 'tool_calls', never 'length'.
+        assert "output length limit" not in final, (
+            "Router-rewrite / transport truncation must not be reported as an "
+            "output-length limit (#91717)."
+        )
+        assert "output length limit" not in error
+        # The honest message names the real suspect and surfaces finish_reason.
+        assert "finish_reason='tool_calls'" in final
+        assert (
+            "transport" in final or "router" in final
+        ), "Honest message must point at transport/router corruption."
+        # Recovery invariants preserved: incomplete tool args never execute.
+        assert result["completed"] is False
+        assert result["partial"] is True
+
+    def _genuine_length_truncated_tool_call(self):
+        # finish_reason='length' (the model truly hit its output cap) with a
+        # tool call whose JSON args are cut off. On a normal generation id, so
+        # it is NOT treated as a partial-stream network stub. After the loop
+        # exhausts its truncated-tool-call retries this lands on the primary
+        # length handler's tool-call path (scenario 1 in the issue's table).
+        msg = SimpleNamespace(
+            role="assistant",
+            content="",
+            tool_calls=[SimpleNamespace(
+                id="call_1", type="function",
+                function=SimpleNamespace(name="terminal", arguments='{"cmd": "ls'),
+            )],
+            reasoning_content=None,
+        )
+        return SimpleNamespace(
+            id="gen-real-length",
+            model="test/model",
+            choices=[SimpleNamespace(index=0, message=msg, finish_reason="length")],
+            usage=None,
+        )
+
+    def test_genuine_length_truncation_keeps_output_limit_wording(self, loop_agent):
+        """The primary length handler (finish_reason='length', real
+        output-cap exhaustion) must keep the accurate 'output length limit'
+        wording — scenario 1 in the issue's table is correct and must not
+        regress from the honest-message fix."""
+        loop_agent.valid_tool_names = {"terminal"}
+        loop_agent.client.chat.completions.create.side_effect = (
+            lambda *a, **kw: self._genuine_length_truncated_tool_call()
+        )
+
+        with (
+            patch.object(loop_agent, "_persist_session"),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("run a long command")
+
+        blob = (result.get("final_response") or "") + (result.get("error") or "")
+        assert "output length limit" in blob, (
+            "A genuine finish_reason='length' truncation must still reference "
+            "the output length limit — the honest-message fix must not blank "
+            "out the accurate case (#91717 scenario 1)."
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes a misleading agent error message. When a tool call comes back with
arguments cut off mid-JSON, the conversation loop's secondary truncation
detector always reported:

```
Response truncated due to output length limit
```

That message is a false positive whenever the truncation is **not** a real
output-cap. The common trigger is a transport-layer timeout followed by a retry
whose response is corrupted mid-payload, often because an upstream router (e.g.
OpenRouter) rewrites `finish_reason` from `length` to `tool_calls`. That rewrite
bypasses the primary `finish_reason == "length"` handler and lands in the
invalid-JSON path, which then blamed `max_output_tokens` even though the model
never reported hitting it. Operators end up tuning `max_tokens` or switching
models when the real cause is provider routing / timeouts.

The fix makes that one message honest. It only claims an output-length limit
when `finish_reason` is actually `"length"`; otherwise it reports that the tool
arguments were truncated mid-JSON with no output-length limit reported —
pointing at a transport/stream interruption or an upstream router rewriting
`finish_reason` — and surfaces the observed `finish_reason`. The recovery
behavior (refuse to execute incomplete tool arguments, close the tool tail,
persist, return partial) is unchanged; only the presentation is corrected. The
genuine output-cap case keeps its accurate wording.

## Related Issue

Fixes #91717

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py`: in the invalid-JSON truncation detector, choose
  the final message based on `finish_reason`. Keep `"Response truncated due to
  output length limit"` only when `finish_reason == "length"`; otherwise report
  that the tool arguments were truncated mid-JSON without an output-length limit
  (likely a transport/stream interruption or upstream router rewriting
  `finish_reason`), including the observed `finish_reason`.
- `tests/run_agent/test_partial_stream_finish_reason.py`: add
  `TestRouterRewriteTruncationMessageIsHonest` with two regression tests —
  (1) a `finish_reason="tool_calls"` response with truncated tool-call arguments
  must not be reported as an output-length limit and must name the
  transport/router cause; (2) a genuine `finish_reason="length"` truncation must
  still reference the output length limit.

## How to Test

1. Drive the conversation loop with an assistant response whose `finish_reason`
   is `"tool_calls"` (as an upstream router rewrite would leave it) and whose
   tool-call `arguments` are incomplete JSON, e.g. `{"cmd": "ls` (no closing
   brace). Before the fix the returned `final_response`/`error` is `"Response
   truncated due to output length limit"`; after the fix it reports the
   arguments were truncated mid-JSON with `finish_reason='tool_calls'` and points
   at a transport/router cause.
2. Verify a real output-cap truncation (`finish_reason="length"`) still reports
   the output length limit.
3. Run the regression tests:
   ```
   scripts/run_tests.sh tests/run_agent/test_partial_stream_finish_reason.py -q
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (misleading) vs after (honest) for a router-rewrite truncation
(`finish_reason='tool_calls'`, tool args `{"cmd": "ls`):

```
before: Response truncated due to output length limit
after:  Tool call arguments were truncated mid-JSON, but the model did not
        report an output-length limit (finish_reason='tool_calls'). This
        usually means a transport/stream interruption or an upstream router
        rewriting finish_reason (e.g. OpenRouter). The tool was not executed.
```

```
scripts/run_tests.sh tests/run_agent/test_partial_stream_finish_reason.py -q
=== Summary: 1 files, 19 tests passed, 0 failed (100% complete) ===
```
