### PR TITLE
fix(telegram,tools): retry inbound get_file + unwrap visible tool_call

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1160,6 +1160,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         try:
             from tools import tool_search as _ts
             if function_name == _ts.TOOL_CALL_NAME:
+                # visible_names not passed: model-facing current_defs are not
+                # available here without another get_tool_definitions rebuild.
+                # Default None preserves prior reject-non-deferrable behavior;
+                # handle_function_call still unwraps visible non-deferrable tools.
                 _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
                 if not _err and _underlying:
                     if _underlying in _tool_search_scoped_names(agent):
@@ -2009,6 +2013,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         try:
             from tools import tool_search as _ts
             if function_name == _ts.TOOL_CALL_NAME:
+                # visible_names not passed: model-facing current_defs are not
+                # available here without another get_tool_definitions rebuild.
+                # Default None preserves prior reject-non-deferrable behavior;
+                # handle_function_call still unwraps visible non-deferrable tools.
                 _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
                 if not _err and _underlying:
                     if _underlying in _tool_search_scoped_names(agent):

--- a/model_tools.py
+++ b/model_tools.py
@@ -1301,25 +1301,31 @@ def handle_function_call(
                 )
             )
         if function_name == _ts_mod.TOOL_CALL_NAME:
-            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(function_args or {})
+            _visible_names = {
+                t["function"]["name"]
+                for t in current_defs
+                if isinstance(t, dict) and t.get("function", {}).get("name")
+            }
+            underlying_name, underlying_args, err = _ts_mod.resolve_underlying_call(
+                function_args or {},
+                visible_names=_visible_names,
+            )
             if err or not underlying_name:
                 return _return_bridge_result(
                     tool_error(err or "tool_call could not be resolved")
                 )
-            # Defense in depth: the underlying tool MUST be in the session's
-            # scoped deferrable catalog. resolve_underlying_call() only checks
-            # that the name is deferrable in the global registry; this gate
-            # additionally rejects any tool the session was not granted, so a
-            # restricted session can never invoke an out-of-scope tool through
-            # the bridge even if the catalog scoping above regressed.
-            _scoped_deferrable = _ts_mod.scoped_deferrable_names(current_defs)
-            if underlying_name not in _scoped_deferrable:
-                return _return_bridge_result(
-                    tool_error(
-                        f"'{underlying_name}' is not available in this session. "
-                        "Use tool_search to find tools you can call."
+            # Already-visible tools (eager in current_defs) skip the deferrable
+            # catalog gate — the model wrapped a tool it already had. True
+            # deferred tools still must be in the scoped deferrable catalog.
+            if underlying_name not in _visible_names:
+                _scoped_deferrable = _ts_mod.scoped_deferrable_names(current_defs)
+                if underlying_name not in _scoped_deferrable:
+                    return _return_bridge_result(
+                        tool_error(
+                            f"'{underlying_name}' is not available in this session. "
+                            "Use tool_search to find tools you can call."
+                        )
                     )
-                )
             # Probe-validate against the deferred tool's schema (ironclaw#5149):
             # a blind call missing required arguments returns the parameter
             # schema instead of dispatching into an opaque downstream failure.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -55,6 +55,20 @@ def _scoped_gate_env(name: str, default: str = "") -> str:
         return (os.getenv(name) or default).strip()
 
 
+async def telegram_get_file_with_retry(source, *, attempts: int = 3, delay: float = 0.5):
+    from telegram.error import NetworkError, TimedOut
+    last = None
+    for i in range(attempts):
+        try:
+            return await source.get_file()
+        except (TimedOut, NetworkError) as exc:
+            last = exc
+            if i + 1 >= attempts:
+                break
+            await asyncio.sleep(delay * (2 ** i))
+    raise last
+
+
 def _consume_abandoned_task(task: asyncio.Task) -> None:
     """Observe a detached task's terminal exception to avoid noisy loop logs."""
     try:
@@ -9853,7 +9867,7 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 # msg.photo is a list of PhotoSize sorted by size; take the largest
                 photo = msg.photo[-1]
-                file_obj = await photo.get_file()
+                file_obj = await telegram_get_file_with_retry(photo)
                 # Download the image bytes directly into memory
                 image_bytes = await file_obj.download_as_bytearray()
                 # Determine extension from the file path if available
@@ -9889,7 +9903,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.info("[Telegram] Skipped oversized user voice (size=%s)", getattr(msg.voice, "file_size", None))
                     await self.handle_message(event)
                     return
-                file_obj = await msg.voice.get_file()
+                file_obj = await telegram_get_file_with_retry(msg.voice)
                 audio_bytes = await file_obj.download_as_bytearray()
                 cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".ogg")
                 event.media_urls = [cached_path]
@@ -9906,7 +9920,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.info("[Telegram] Skipped oversized user audio (size=%s)", getattr(msg.audio, "file_size", None))
                     await self.handle_message(event)
                     return
-                file_obj = await msg.audio.get_file()
+                file_obj = await telegram_get_file_with_retry(msg.audio)
                 audio_bytes = await file_obj.download_as_bytearray()
                 cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".mp3")
                 event.media_urls = [cached_path]
@@ -9924,7 +9938,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.info("[Telegram] Skipped oversized user video (size=%s)", getattr(msg.video, "file_size", None))
                     await self.handle_message(event)
                     return
-                file_obj = await msg.video.get_file()
+                file_obj = await telegram_get_file_with_retry(msg.video)
                 video_bytes = await file_obj.download_as_bytearray()
                 ext = ".mp4"
                 if getattr(file_obj, "file_path", None):
@@ -9978,7 +9992,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # payload is actually an image, route it through the image cache
                 # and batching path instead of rejecting it as a document.
                 if ext in _TELEGRAM_IMAGE_EXTENSIONS or doc_mime.startswith("image/"):
-                    file_obj = await doc.get_file()
+                    file_obj = await telegram_get_file_with_retry(doc)
                     image_bytes = await file_obj.download_as_bytearray()
                     image_ext = ext if ext in _TELEGRAM_IMAGE_EXTENSIONS else _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, ".jpg")
                     try:
@@ -10018,7 +10032,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     ext = image_mime_to_ext.get(doc.mime_type, "")
 
                 if ext in SUPPORTED_VIDEO_TYPES:
-                    file_obj = await doc.get_file()
+                    file_obj = await telegram_get_file_with_retry(doc)
                     video_bytes = await file_obj.download_as_bytearray()
                     cached_path = cache_video_from_bytes(bytes(video_bytes), ext=ext)
                     event.media_urls = [cached_path]
@@ -10038,7 +10052,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # to message the agent is the gate, not the file extension.
                 # Known types keep their precise MIME; unknown types are tagged
                 # application/octet-stream so the agent reaches for terminal tools.
-                file_obj = await doc.get_file()
+                file_obj = await telegram_get_file_with_retry(doc)
                 doc_bytes = await file_obj.download_as_bytearray()
                 raw_bytes = bytes(doc_bytes)
                 from gateway.platforms.base import cache_media_bytes

--- a/tests/gateway/test_telegram_inbound_media_retry.py
+++ b/tests/gateway/test_telegram_inbound_media_retry.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+try:
+    from telegram.error import TimedOut
+except ImportError:  # pragma: no cover - fallback if python-telegram-bot is absent
+    class TimedOut(Exception):
+        pass
+
+
+class FakeSource:
+    def __init__(self):
+        self.calls = 0
+
+    async def get_file(self):
+        self.calls += 1
+        if self.calls < 3:
+            raise TimedOut("timed out")
+        return SimpleNamespace(file_path="x.ogg")
+
+
+def test_get_file_retries_on_timedout_then_succeeds():
+    import asyncio
+
+    from plugins.platforms.telegram.adapter import telegram_get_file_with_retry
+
+    src = FakeSource()
+    file_obj = asyncio.run(telegram_get_file_with_retry(src, attempts=3, delay=0))
+    assert src.calls == 3
+    assert file_obj.file_path == "x.ogg"
+
+
+class AlwaysTimeoutSource:
+    def __init__(self):
+        self.calls = 0
+
+    async def get_file(self):
+        self.calls += 1
+        raise TimedOut("timed out")
+
+
+def test_get_file_raises_after_attempts_exhausted():
+    import asyncio
+
+    import pytest
+
+    from plugins.platforms.telegram.adapter import telegram_get_file_with_retry
+
+    src = AlwaysTimeoutSource()
+    with pytest.raises(TimedOut):
+        asyncio.run(telegram_get_file_with_retry(src, attempts=3, delay=0))
+    assert src.calls == 3

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -677,3 +677,14 @@ class TestDeferredCallSchemaProbe:
         ))
         assert result.get("ok") is True
         assert result.get("doc") == "abc"
+
+
+def test_resolve_underlying_call_passes_through_visible_non_deferrable():
+    from tools.tool_search import resolve_underlying_call
+    name, args, err = resolve_underlying_call(
+        {"name": "mcp__composio__OUTLOOK_QUERY_EMAILS", "arguments": {"query": "from:x"}},
+        visible_names={"mcp__composio__OUTLOOK_QUERY_EMAILS"},
+    )
+    assert err is None
+    assert name == "mcp__composio__OUTLOOK_QUERY_EMAILS"
+    assert args["query"] == "from:x"

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -1029,7 +1029,10 @@ def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str
         return None
 
 
-def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
+def resolve_underlying_call(
+    args: Dict[str, Any],
+    visible_names: Optional[set[str]] = None,
+) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
     """Parse a ``tool_call`` invocation into (underlying_name, args, error_msg).
 
     Used by:
@@ -1038,6 +1041,10 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     * the trajectory recorder.
 
     On parse error, returns ``(None, {}, error_message)``.
+
+    ``visible_names``: optional set of names already in the model-facing tools
+    list. A non-deferrable tool in that set (and not a bridge tool) is
+    unwrapped so a wrapped call still dispatches instead of erroring.
     """
     name = str(args.get("name") or "").strip()
     if not name:
@@ -1055,6 +1062,8 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name):
+        if visible_names and name in visible_names and name not in BRIDGE_TOOL_NAMES:
+            return name, raw_args, None
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."


### PR DESCRIPTION
## Summary
- Retry Telegram inbound `get_file` on `TimedOut`/`NetworkError` (voice/photo/audio/video/document). Existing `_surface_media_cache_failure` still runs after retries exhaust. Sticker/send-path unchanged.
- Unwrap `tool_call` for tools already in the model-facing list (Composio Gmail/Outlook on cron). `resolve_underlying_call(..., visible_names=)` + `handle_function_call` skips the scoped-deferrable gate when the name is already visible. Bridge tools still rejected.

## Test plan
- [x] `pytest tests/gateway/test_telegram_inbound_media_retry.py tests/tools/test_tool_search.py` — 36 passed
- [x] Success after 2 timeouts (`delay=0`); 3 timeouts re-raise
- [x] Visible non-deferrable `mcp__composio__OUTLOOK_QUERY_EMAILS` unwraps; core tools still rejected

## Notes
Atomic vs current `main` (`f7a5c9e`). 6 files, +121/−22.