### PR TITLE
fix(webhook): a port conflict stops retrying and says so on runtime status

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -33,6 +33,7 @@ Security:
 import asyncio
 import base64
 import binascii
+import errno
 import hashlib
 import hmac
 import json
@@ -323,14 +324,48 @@ class WebhookAdapter(BasePlatformAdapter):
         except OSError as exc:
             await self._runner.cleanup()
             self._runner = None
+            where = self._host or "all IPv4+IPv6 interfaces"
             logger.error(
                 "[webhook] Could not bind %s:%d: %s. "
                 "Set a different host or port in config.yaml under "
                 "platforms.webhook.extra.",
-                self._host or "all IPv4+IPv6 interfaces",
+                where,
                 self._port,
                 exc,
             )
+            # A bare ``return False`` left the runtime entry as
+            # ``{state: "disconnected", error_code: null}``, indistinguishable
+            # from a webhook the owner had simply turned off, so fleet
+            # monitoring read the agent as healthy while it collided forever.
+            if getattr(exc, "errno", None) == errno.EADDRINUSE:
+                # Same call, same reasoning, same remedy as the api_server
+                # guard above this in the tree (#52132: 1568+ retries over 5
+                # days across multi-profile setups all defaulting to one port).
+                # A port conflict is configuration, not a transient blip: the
+                # holder keeps it for its lifetime, so a retryable failure just
+                # loops at the backoff cap filling errors.log. Observed again
+                # on five prod instances where the default profile's webhook
+                # collided with a named profile's
+                # (hermes-cloud:prod:gateway-stale-lock:2026-08-19).
+                # Non-retryable drops it from the reconnect queue instead.
+                self._set_fatal_error(
+                    "webhook_port_in_use",
+                    f"Port {self._port} on {where} is already in use, most "
+                    f"likely by another gateway profile. Set "
+                    f"platforms.webhook.extra.port in config.yaml to a "
+                    f"different value, then `/platform resume webhook`.",
+                    retryable=False,
+                )
+            else:
+                # Anything else (a denied port, an interface not up yet) can
+                # genuinely clear on its own, so keep it in the reconnect queue
+                # while still naming the failure on runtime status.
+                self._set_fatal_error(
+                    "webhook_bind_failed",
+                    f"Could not bind the webhook listener to {where}:"
+                    f"{self._port}: {exc}",
+                    retryable=True,
+                )
             return False
         self._mark_connected()
 

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -16,6 +16,7 @@ Covers:
 
 import asyncio
 import base64
+import errno
 import hashlib
 import hmac
 import json
@@ -1024,3 +1025,70 @@ def test_route_profile_validation_fails_closed():
         assert WebhookAdapter._route_allows_profile(
             {"profile": malformed}, "worker"
         ) is False
+
+
+# Regression coverage for the prod stale-lock/duplicate-runtime log flood
+# (OOF hermes-cloud:prod:gateway-stale-lock:2026-08-19).
+class TestBindFailureStampsRuntimeStatus:
+    """A webhook that cannot bind must say so on runtime status.
+
+    Observed on five prod instances: the default profile's webhook adapter
+    collided with a named profile that already held the port, so it retried at
+    the 300s reconnect cap forever. connect() logged and returned a bare False
+    without calling ``_set_fatal_error``, leaving the runtime entry as
+    ``{state: "disconnected", error_code: null}`` — indistinguishable from a
+    webhook the owner had simply turned off. ``gateway_running`` stayed true,
+    so fleet monitoring read those agents as healthy while they collided every
+    five minutes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_port_conflict_is_stamped_and_not_retryable(self):
+        """Real bind conflict: the second adapter reports why it failed."""
+        holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        holder.bind(("127.0.0.1", 0))
+        holder.listen(1)
+        taken_port = holder.getsockname()[1]
+        try:
+            adapter = _make_adapter(
+                routes={"r1": {"secret": "real-secret-abc123", "prompt": "x"}},
+                host="127.0.0.1",
+                port=taken_port,
+            )
+            with patch.object(adapter, "_reload_dynamic_routes"):
+                result = await adapter.connect()
+
+            assert result is False
+            assert adapter._runner is None
+            assert adapter._fatal_error_code == "webhook_port_in_use"
+            # NOT retryable, matching the api_server port guard (#52132): the
+            # holder keeps the port for its lifetime, so staying in the
+            # reconnect queue just loops at the backoff cap forever. This is
+            # what actually stops the log flood.
+            assert adapter._fatal_error_retryable is False
+            assert str(taken_port) in adapter._fatal_error_message
+            assert "already in use" in adapter._fatal_error_message
+            assert "/platform resume webhook" in adapter._fatal_error_message
+        finally:
+            holder.close()
+
+    @pytest.mark.asyncio
+    async def test_non_addrinuse_oserror_is_still_stamped(self):
+        """A non-conflict bind failure stamps too, but stays retryable."""
+        adapter = _make_adapter(
+            routes={"r1": {"secret": "real-secret-abc123", "prompt": "x"}},
+            host="127.0.0.1",
+        )
+        site = MagicMock()
+        site.start = AsyncMock(
+            side_effect=OSError(errno.EACCES, "permission denied")
+        )
+        with patch.object(adapter, "_reload_dynamic_routes"), patch(
+            "gateway.platforms.webhook.web.TCPSite", return_value=site
+        ):
+            result = await adapter.connect()
+
+        assert result is False
+        assert adapter._fatal_error_code == "webhook_bind_failed"
+        assert adapter._fatal_error_retryable is True
+        assert "permission denied" in adapter._fatal_error_message


### PR DESCRIPTION
## What does this PR do?

The webhook adapter was the only one of 23 platform adapters that never called `_set_fatal_error`. On a bind failure it logged and returned a bare `False`, so two things went wrong at once:

1. The reconnect watcher treated it as retryable and looped at the 300s backoff cap forever, filling `errors.log`.
2. The runtime entry stayed `{state: "disconnected", error_code: null}`, indistinguishable from a webhook the owner had simply turned off. Since `gateway_running` stays `true`, fleet monitoring read the agent as healthy while it collided every five minutes.

Observed on five prod instances in the 2026-08-19 Hermes Cloud health briefing (366 to 854 log lines each in 24h, OOF `hermes-cloud:prod:gateway-stale-lock:2026-08-19`). In every case the default profile's webhook collided with a named profile in the same container that already held the port; the loser retried at exactly the 300s cap. Verified live by polling `/api/status` twice 100s apart and watching `updated_at` advance 301s and 302s on two of them.

This is the approach because `api_server` already solved the identical problem and this mirrors it rather than inventing anything. Its guard (#52132: "1568+ retries over 5 days across multi-profile setups all defaulting to the same port") makes `EADDRINUSE` **non-retryable**, on the reasoning that a port conflict is configuration, not a transient blip: the holder keeps the port for its lifetime, so staying in the reconnect queue can only loop. Same call, same code-name shape, same recovery instruction.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`gateway/platforms/webhook.py`, in the `except OSError` around `site.start()`:

- `EADDRINUSE` now stamps `_set_fatal_error("webhook_port_in_use", ..., retryable=False)`. The message names the port, says another gateway profile is the likely holder, and gives the recovery: set `platforms.webhook.extra.port`, then `/platform resume webhook`. Non-retryable drops it from the reconnect queue, which is what actually stops the flood.
- Any other `OSError` (a denied port, an interface not up yet) stamps `_set_fatal_error("webhook_bind_failed", ..., retryable=True)`. These can genuinely clear on their own, so it stays queued while still naming the failure on runtime status. This is one step better than `api_server`, which stamps nothing in that branch.
- Added the `errno` import.

`tests/gateway/test_webhook_adapter.py`: new `TestBindFailureStampsRuntimeStatus`.

Note the log line and the `return False` are unchanged, so nothing that reads the log or the connect result behaves differently.

## How to Test

```
pytest tests/gateway/test_webhook_adapter.py -q          # 38 passed
pytest tests/gateway/test_api_server_bind_guard.py \
       tests/gateway/test_webhook_integration.py \
       tests/gateway/test_webhook_dynamic_routes.py \
       tests/gateway/test_webhook_deliver_only.py -q     # 61 passed with the above
```

The port-conflict test does a **real bind** (holds a socket on an OS-assigned port) rather than mocking, so it exercises the actual `EADDRINUSE` path. Both new tests fail against unmodified `origin/main`, so they are not vacuous.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
      <!-- NOT the full suite. Ran the webhook + api_server bind suites listed
           above (61 passed) in a minimal venv; leaving the full run to CI. -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.5.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
      <!-- N/A: no public interface changed; the reasoning lives in inline comments. -->
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
      <!-- N/A: no new config keys. `platforms.webhook.extra.port` already exists. -->
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
      <!-- errno.EADDRINUSE is portable, and the branch is guarded with
           getattr(exc, "errno", None) so a platform that omits errno takes the
           retryable path rather than raising. The pre-existing darwin
           reuse_address special case is untouched. -->
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
