### PR TITLE
fix(acp): align session lifecycle with wire contract

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -16,6 +16,7 @@ from typing import Any, Deque, Optional
 from urllib.parse import unquote, urlparse
 
 import acp
+from acp.exceptions import RequestError
 from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
@@ -25,6 +26,7 @@ from acp.schema import (
     AvailableCommandsUpdate,
     BlobResourceContents,
     ClientCapabilities,
+    CloseSessionResponse,
     EmbeddedResourceContentBlock,
     ForkSessionResponse,
     ImageContentBlock,
@@ -33,6 +35,7 @@ from acp.schema import (
     InitializeResponse,
     ListSessionsResponse,
     LoadSessionResponse,
+    McpCapabilities,
     McpServerHttp,
     McpServerSse,
     McpServerStdio,
@@ -46,6 +49,7 @@ from acp.schema import (
     SetSessionModeResponse,
     ResourceContentBlock,
     SessionCapabilities,
+    SessionCloseCapabilities,
     SessionForkCapabilities,
     SessionInfoUpdate,
     SessionListCapabilities,
@@ -241,6 +245,7 @@ _LIST_SESSIONS_PAGE_SIZE = 50
 # the total; aggregator providers stay intentionally uncapped inside the shared
 # inventory, and the current model is always kept via the fallback insert below.
 ACP_MAX_MODELS_PER_PROVIDER = 200
+_CLOSE_SESSION_TIMEOUT_SECONDS = 30.0
 _MAX_ACP_RESOURCE_BYTES = 512 * 1024
 _TEXT_RESOURCE_MIME_PREFIXES = ("text/",)
 _TEXT_RESOURCE_MIME_TYPES = {
@@ -253,6 +258,11 @@ _TEXT_RESOURCE_MIME_TYPES = {
     "application/toml",
     "application/sql",
 }
+
+
+def _session_not_found(session_id: str) -> RequestError:
+    """Return a wire-visible JSON-RPC error for an unknown ACP session."""
+    return RequestError(-32002, "Resource not found", {"sessionId": session_id})
 
 
 def _resource_display_name(uri: str, name: str | None = None, title: str | None = None) -> str:
@@ -670,6 +680,10 @@ class HermesACPAgent(acp.Agent):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
         self._conn: Optional[acp.Client] = None
+        self._mcp_ownership_lock = asyncio.Lock()
+        self._session_mcp_servers: dict[str, set[str]] = {}
+        self._mcp_server_refcounts: dict[str, int] = defaultdict(int)
+        self._external_mcp_servers: set[str] = set()
 
     # ---- Connection lifecycle -----------------------------------------------
 
@@ -1129,32 +1143,163 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list[McpServerStdio | McpServerHttp | McpServerSse] | None,
     ) -> None:
         """Register ACP-provided MCP servers and refresh the agent tool surface."""
-        if not mcp_servers:
+        if mcp_servers is None:
             return
 
+        config_map: dict[str, dict] = {}
+        for server in mcp_servers:
+            name = server.name
+            if isinstance(server, McpServerStdio):
+                config = {
+                    "command": server.command,
+                    "args": list(server.args),
+                    "env": {item.name: item.value for item in server.env},
+                }
+            else:
+                config = {
+                    "url": server.url,
+                    "headers": {item.name: item.value for item in server.headers},
+                }
+                if isinstance(server, McpServerSse):
+                    config["transport"] = "sse"
+            config_map[name] = config
+
+        requested_names = set(config_map)
+        persistent_names: set[str] = set()
+        if os.environ.get("HERMES_ACP_SKIP_CONFIGURED_MCP") != "1":
+            try:
+                from hermes_cli.config import load_config
+
+                persistent_names = {
+                    str(name)
+                    for name, config in (load_config().get("mcp_servers") or {}).items()
+                    if not isinstance(config, dict) or config.get("enabled", True) is not False
+                }
+            except Exception:
+                logger.debug("Could not inspect configured MCP ownership", exc_info=True)
+        release_names: set[str] = set()
+        old_names: set[str] = set()
+        added: set[str] = set()
+        removed: set[str] = set()
+        preexisting: set[str] = set()
+        newly_registered: set[str] = set()
+        ownership_updated = False
         try:
-            from tools.mcp_tool import register_mcp_servers
+            from tools.mcp_tool import (
+                get_registered_mcp_server_names,
+                register_mcp_servers,
+                release_mcp_servers,
+            )
 
-            config_map: dict[str, dict] = {}
-            for server in mcp_servers:
-                name = server.name
-                if isinstance(server, McpServerStdio):
-                    config = {
-                        "command": server.command,
-                        "args": list(server.args),
-                        "env": {item.name: item.value for item in server.env},
-                    }
+            # Registration and ownership publication are one serialized unit:
+            # otherwise two concurrent sessions can mistake the first session's
+            # just-connected server for a pre-existing external owner.
+            async with self._mcp_ownership_lock:
+                with state.runtime_lock:
+                    if state.closing:
+                        raise _session_not_found(state.session_id)
+                preexisting = (
+                    await asyncio.to_thread(get_registered_mcp_server_names)
+                ) | persistent_names
+                if config_map:
+                    await asyncio.to_thread(register_mcp_servers, config_map)
+                old_names = self._session_mcp_servers.get(state.session_id, set())
+                added = requested_names - old_names
+                removed = old_names - requested_names
+                newly_registered = added - preexisting
+                for name in added:
+                    if name in preexisting and self._mcp_server_refcounts.get(name, 0) == 0:
+                        self._external_mcp_servers.add(name)
+                    self._mcp_server_refcounts[name] += 1
+                for name in removed:
+                    remaining = self._mcp_server_refcounts.get(name, 0) - 1
+                    if remaining > 0:
+                        self._mcp_server_refcounts[name] = remaining
+                    else:
+                        self._mcp_server_refcounts.pop(name, None)
+                        if name not in self._external_mcp_servers:
+                            release_names.add(name)
+                if requested_names:
+                    self._session_mcp_servers[state.session_id] = requested_names
                 else:
-                    config = {
-                        "url": server.url,
-                        "headers": {item.name: item.value for item in server.headers},
-                    }
-                config_map[name] = config
-
-            await asyncio.to_thread(register_mcp_servers, config_map)
+                    self._session_mcp_servers.pop(state.session_id, None)
+                ownership_updated = True
+                if release_names:
+                    try:
+                        await asyncio.to_thread(
+                            release_mcp_servers, sorted(release_names)
+                        )
+                    except Exception:
+                        cleanup_failed: set[str] = set()
+                        if newly_registered:
+                            try:
+                                await asyncio.to_thread(
+                                    release_mcp_servers,
+                                    sorted(newly_registered),
+                                )
+                            except Exception:
+                                cleanup_failed = set(newly_registered)
+                                logger.warning(
+                                    "Session %s: failed to roll back newly registered ACP MCP servers: %s",
+                                    state.session_id,
+                                    ", ".join(sorted(cleanup_failed)),
+                                    exc_info=True,
+                                )
+                        for name in added - cleanup_failed:
+                            remaining = self._mcp_server_refcounts.get(name, 0) - 1
+                            if remaining > 0:
+                                self._mcp_server_refcounts[name] = remaining
+                            else:
+                                self._mcp_server_refcounts.pop(name, None)
+                        for name in removed:
+                            self._mcp_server_refcounts[name] += 1
+                        restored_names = set(old_names) | cleanup_failed
+                        if restored_names:
+                            self._session_mcp_servers[state.session_id] = restored_names
+                        else:
+                            self._session_mcp_servers.pop(state.session_id, None)
+                        logger.warning(
+                            "Session %s: failed to replace ACP MCP servers; restored prior ownership",
+                            state.session_id,
+                            exc_info=True,
+                        )
+                        return
+        except RequestError:
+            raise
         except Exception:
+            cleanup_failed: set[str] = set()
+            if ownership_updated:
+                async with self._mcp_ownership_lock:
+                    if newly_registered:
+                        try:
+                            await asyncio.to_thread(
+                                release_mcp_servers, sorted(newly_registered)
+                            )
+                        except Exception:
+                            # Keep any connection whose compensating release
+                            # failed owned so a later close can retry cleanup.
+                            cleanup_failed = set(newly_registered)
+                            logger.warning(
+                                "Session %s: failed to roll back newly registered ACP MCP servers: %s",
+                                state.session_id,
+                                ", ".join(sorted(cleanup_failed)),
+                                exc_info=True,
+                            )
+                    for name in added - cleanup_failed:
+                        remaining = self._mcp_server_refcounts.get(name, 0) - 1
+                        if remaining > 0:
+                            self._mcp_server_refcounts[name] = remaining
+                        else:
+                            self._mcp_server_refcounts.pop(name, None)
+                    for name in removed:
+                        self._mcp_server_refcounts[name] += 1
+                    restored_names = set(old_names) | cleanup_failed
+                    if restored_names:
+                        self._session_mcp_servers[state.session_id] = restored_names
+                    else:
+                        self._session_mcp_servers.pop(state.session_id, None)
             logger.warning(
-                "Session %s: failed to register ACP MCP servers",
+                "Session %s: failed to register or release ACP MCP servers",
                 state.session_id,
                 exc_info=True,
             )
@@ -1164,9 +1309,15 @@ class HermesACPAgent(acp.Agent):
             from model_tools import get_tool_definitions
             from agent.memory_manager import inject_memory_provider_tools
 
+            prior_explicit_toolsets = {f"mcp-{name}" for name in old_names}
+            base_toolsets = [
+                name
+                for name in (getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"])
+                if name not in prior_explicit_toolsets
+            ]
             enabled_toolsets = _expand_acp_enabled_toolsets(
-                getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
-                mcp_server_names=[server.name for server in mcp_servers],
+                base_toolsets,
+                mcp_server_names=sorted(requested_names),
             )
             state.agent.enabled_toolsets = enabled_toolsets
             disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
@@ -1193,6 +1344,32 @@ class HermesACPAgent(acp.Agent):
                 state.session_id,
                 exc_info=True,
             )
+
+    async def _release_session_mcp_servers(self, session_id: str) -> None:
+        """Drop one session's MCP ownership and release last-owned servers."""
+        from tools.mcp_tool import release_mcp_servers
+
+        release_names: set[str] = set()
+        async with self._mcp_ownership_lock:
+            owned = self._session_mcp_servers.pop(session_id, set())
+            for name in owned:
+                remaining = self._mcp_server_refcounts.get(name, 0) - 1
+                if remaining > 0:
+                    self._mcp_server_refcounts[name] = remaining
+                else:
+                    self._mcp_server_refcounts.pop(name, None)
+                    if name not in self._external_mcp_servers:
+                        release_names.add(name)
+            if release_names:
+                try:
+                    await asyncio.to_thread(release_mcp_servers, sorted(release_names))
+                except Exception:
+                    # Keep ownership retryable when transport cleanup fails. The
+                    # session remains live and a later session/close can try again.
+                    self._session_mcp_servers[session_id] = set(owned)
+                    for name in owned:
+                        self._mcp_server_refcounts[name] += 1
+                    raise
 
     def _schedule_mcp_late_refresh(self, state: SessionState) -> None:
         """Refresh the agent's tool snapshot when background MCP discovery lands late.
@@ -1316,8 +1493,10 @@ class HermesACPAgent(acp.Agent):
             agent_info=Implementation(name="hermes-agent", version=HERMES_VERSION),
             agent_capabilities=AgentCapabilities(
                 load_session=True,
-                prompt_capabilities=PromptCapabilities(image=True),
+                mcp_capabilities=McpCapabilities(http=True, sse=True),
+                prompt_capabilities=PromptCapabilities(image=True, embedded_context=True),
                 session_capabilities=SessionCapabilities(
+                    close=SessionCloseCapabilities(),
                     fork=SessionForkCapabilities(),
                     list=SessionListCapabilities(),
                     resume=SessionResumeCapabilities(),
@@ -1334,7 +1513,7 @@ class HermesACPAgent(acp.Agent):
         # Hermes' threat model (ACP is stdio-only, local-trust), but poor
         # API hygiene and confusing if ACP ever grows multi-method auth.
         if not isinstance(method_id, str):
-            return None
+            raise RequestError.invalid_params({"methodId": method_id})
         normalized_method = method_id.strip().lower()
         provider = detect_provider()
 
@@ -1342,10 +1521,14 @@ class HermesACPAgent(acp.Agent):
             # Terminal auth launches Hermes setup/model selection out-of-band.
             # Only report success once that flow has produced usable runtime
             # credentials for the normal ACP session.
-            return AuthenticateResponse() if provider else None
+            if not provider:
+                raise RequestError.auth_required()
+            return AuthenticateResponse()
 
-        if not provider or normalized_method != provider:
-            return None
+        if not provider:
+            raise RequestError.auth_required()
+        if normalized_method != provider:
+            raise RequestError.invalid_params({"methodId": method_id})
         return AuthenticateResponse()
 
     # ---- Session management -------------------------------------------------
@@ -1619,7 +1802,7 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.update_cwd(session_id, cwd)
         if state is None:
             logger.warning("load_session: session %s not found", session_id)
-            return None
+            raise _session_not_found(session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("Loaded session %s", session_id)
@@ -1666,23 +1849,14 @@ class HermesACPAgent(acp.Agent):
     ) -> ResumeSessionResponse:
         state = self.session_manager.update_cwd(session_id, cwd)
         if state is None:
-            logger.warning("resume_session: session %s not found, creating new", session_id)
-            state = self.session_manager.create_session(cwd=cwd)
+            logger.warning("resume_session: session %s not found", session_id)
+            raise _session_not_found(session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("Resumed session %s", state.session_id)
-        # See `load_session` above for the spec rationale — replay must
-        # complete before the response so clients receive the full transcript
-        # within the request's lifetime.
-        try:
-            await self._replay_session_history(state)
-        except Exception:
-            logger.warning(
-                "ACP history replay raised during session/resume for %s — "
-                "resume will still succeed, partial transcript may be missing",
-                state.session_id,
-                exc_info=True,
-            )
+        # ACP session/resume reconnects without replaying prior messages.
+        # Clients that need the transcript use session/load, which replays it
+        # synchronously before returning.
         self._schedule_available_commands_update(state.session_id)
         self._schedule_usage_update(state)
         return ResumeSessionResponse(
@@ -1692,6 +1866,60 @@ class HermesACPAgent(acp.Agent):
                 state.session_id, getattr(state.agent, "session_id", state.session_id)
             ),
         )
+
+    async def close_session(
+        self, session_id: str, **kwargs: Any
+    ) -> CloseSessionResponse:
+        """Cancel active work and unload the session without deleting history."""
+        state = self.session_manager.get_session(session_id)
+        if state is None:
+            logger.warning("close_session: session %s not found", session_id)
+            raise _session_not_found(session_id)
+        with state.runtime_lock:
+            if state.close_in_progress:
+                raise RequestError.internal_error(
+                    {"sessionId": session_id, "reason": "close already in progress"}
+                )
+            first_attempt = not state.closing
+            state.closing = True
+            state.close_in_progress = True
+            state.queued_prompts.clear()
+        try:
+            if first_attempt:
+                from tools.approval import clear_session as clear_approval_session
+
+                clear_approval_session(session_id)
+            await self.cancel(session_id)
+            with state.runtime_lock:
+                running = state.is_running
+            if running:
+                try:
+                    await asyncio.wait_for(
+                        asyncio.to_thread(state.idle_event.wait),
+                        timeout=_CLOSE_SESSION_TIMEOUT_SECONDS,
+                    )
+                except TimeoutError as exc:
+                    raise RequestError.internal_error(
+                        {"sessionId": session_id, "reason": "turn did not stop before close timeout"}
+                    ) from exc
+            try:
+                await self._release_session_mcp_servers(session_id)
+            except Exception as exc:
+                logger.warning(
+                    "Session %s: failed to release ACP MCP servers",
+                    session_id,
+                    exc_info=True,
+                )
+                raise RequestError.internal_error(
+                    {"sessionId": session_id, "reason": "MCP resource release failed"}
+                ) from exc
+            if self.session_manager.unload_session(session_id) is None:
+                raise _session_not_found(session_id)
+            logger.info("Closed session %s", session_id)
+            return CloseSessionResponse()
+        finally:
+            with state.runtime_lock:
+                state.close_in_progress = False
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
         state = self.session_manager.get_session(session_id)
@@ -1722,16 +1950,17 @@ class HermesACPAgent(acp.Agent):
         **kwargs: Any,
     ) -> ForkSessionResponse:
         state = self.session_manager.fork_session(session_id, cwd=cwd)
-        new_id = state.session_id if state else ""
-        if state is not None:
-            await self._register_session_mcp_servers(state, mcp_servers)
+        if state is None:
+            logger.warning("fork_session: session %s not found", session_id)
+            raise _session_not_found(session_id)
+        new_id = state.session_id
+        await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Forked session %s -> %s", session_id, new_id)
-        if new_id:
-            self._schedule_available_commands_update(new_id)
+        self._schedule_available_commands_update(new_id)
         return ForkSessionResponse(
             session_id=new_id,
-            models=self._build_model_state(state) if state is not None else None,
-            modes=self._session_modes(state) if state is not None else None,
+            models=self._build_model_state(state),
+            modes=self._session_modes(state),
         )
 
     async def list_sessions(
@@ -1798,6 +2027,9 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.error("prompt: session %s not found", session_id)
             return PromptResponse(stop_reason="refusal")
+        with state.runtime_lock:
+            if state.closing:
+                raise _session_not_found(session_id)
 
         user_text = _extract_text(prompt).strip()
         user_content = _content_blocks_to_openai_user_content(prompt)
@@ -1880,6 +2112,8 @@ class HermesACPAgent(acp.Agent):
         redirected = False
         queued_depth: int | None = None
         with state.runtime_lock:
+            if state.closing:
+                raise _session_not_found(session_id)
             if state.is_running:
                 if (
                     text_only_prompt
@@ -1906,6 +2140,7 @@ class HermesACPAgent(acp.Agent):
                     queued_depth = len(state.queued_prompts)
             else:
                 state.is_running = True
+                state.idle_event.clear()
                 state.current_prompt_text = user_text or "[Image attachment]"
 
         if redirected:
@@ -2127,6 +2362,7 @@ class HermesACPAgent(acp.Agent):
             with state.runtime_lock:
                 state.is_running = False
                 state.current_prompt_text = ""
+                state.idle_event.set()
             return PromptResponse(stop_reason="end_turn")
 
         if result.get("messages"):
@@ -2187,6 +2423,7 @@ class HermesACPAgent(acp.Agent):
         with state.runtime_lock:
             state.is_running = False
             state.current_prompt_text = ""
+            state.idle_event.set()
 
         while True:
             with state.runtime_lock:
@@ -2599,7 +2836,7 @@ class HermesACPAgent(acp.Agent):
             )
             return SetSessionModelResponse()
         logger.warning("Session %s: model switch requested for missing session", session_id)
-        return None
+        raise _session_not_found(session_id)
 
     async def set_session_mode(
         self, mode_id: str, session_id: str, **kwargs: Any
@@ -2608,7 +2845,7 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.get_session(session_id)
         if state is None:
             logger.warning("Session %s: mode switch requested for missing session", session_id)
-            return None
+            raise _session_not_found(session_id)
         normalized_mode = str(mode_id or "").strip()
         if normalized_mode not in self._MODE_TO_EDIT_APPROVAL_POLICY:
             normalized_mode = self._MODE_DEFAULT
@@ -2624,7 +2861,7 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.get_session(session_id)
         if state is None:
             logger.warning("Session %s: config update requested for missing session", session_id)
-            return None
+            raise _session_not_found(session_id)
 
         if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
             mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -20,7 +20,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from dataclasses import dataclass, field
-from threading import Lock
+from threading import Event, Lock
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -181,6 +181,15 @@ class SessionState:
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
+    mode: str = "default"
+    config_options: Dict[str, Any] = field(default_factory=dict)
+    idle_event: Any = field(default_factory=Event)
+    closing: bool = False
+    close_in_progress: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.is_running:
+            self.idle_event.set()
 
 
 class SessionManager:
@@ -241,6 +250,20 @@ class SessionManager:
         # Attempt to restore from database.
         return self._restore(session_id)
 
+    def unload_session(self, session_id: str) -> Optional[SessionState]:
+        """Unload one active session while preserving its persisted history."""
+        with self._lock:
+            state = self._sessions.get(session_id)
+        if state is None:
+            return None
+        self._persist(state)
+        with self._lock:
+            if self._sessions.get(session_id) is not state:
+                return None
+            self._sessions.pop(session_id, None)
+        _clear_task_cwd(session_id)
+        return state
+
     def remove_session(self, session_id: str) -> bool:
         """Remove a session from memory and database. Returns True if it existed."""
         with self._lock:
@@ -272,6 +295,8 @@ class SessionManager:
             model=getattr(agent, "model", original.model) or original.model,
             history=copy.deepcopy(original.history),
             cancel_event=threading.Event(),
+            mode=original.mode,
+            config_options=copy.deepcopy(original.config_options),
         )
         with self._lock:
             self._sessions[new_id] = state
@@ -432,7 +457,7 @@ class SessionManager:
 
         # Ensure model is a plain string (not a MagicMock or other proxy).
         model_str = str(state.model) if state.model else None
-        session_meta = {"cwd": state.cwd}
+        session_meta: Dict[str, Any] = {"cwd": state.cwd}
         provider = getattr(state.agent, "provider", None)
         base_url = getattr(state.agent, "base_url", None)
         api_mode = getattr(state.agent, "api_mode", None)
@@ -442,6 +467,9 @@ class SessionManager:
             session_meta["base_url"] = base_url.strip()
         if isinstance(api_mode, str) and api_mode.strip():
             session_meta["api_mode"] = api_mode.strip()
+        session_meta["mode"] = state.mode
+        if state.config_options:
+            session_meta["config_options"] = state.config_options
         cwd_json = json.dumps(session_meta)
 
         try:
@@ -452,7 +480,7 @@ class SessionManager:
                     session_id=state.session_id,
                     source="acp",
                     model=model_str,
-                    model_config={"cwd": state.cwd},
+                    model_config=session_meta,
                 )
             else:
                 # Update model_config (contains cwd) if changed.
@@ -532,6 +560,8 @@ class SessionManager:
         requested_provider = row.get("billing_provider")
         restored_base_url = row.get("billing_base_url")
         restored_api_mode = None
+        restored_mode = "default"
+        restored_config_options: Dict[str, Any] = {}
         mc = row.get("model_config")
         if mc:
             try:
@@ -541,6 +571,12 @@ class SessionManager:
                     requested_provider = meta.get("provider") or requested_provider
                     restored_base_url = meta.get("base_url") or restored_base_url
                     restored_api_mode = meta.get("api_mode") or restored_api_mode
+                    raw_mode = meta.get("mode")
+                    if isinstance(raw_mode, str) and raw_mode:
+                        restored_mode = raw_mode
+                    raw_options = meta.get("config_options")
+                    if isinstance(raw_options, dict):
+                        restored_config_options = dict(raw_options)
             except (json.JSONDecodeError, TypeError):
                 pass
 
@@ -579,6 +615,8 @@ class SessionManager:
             model=model or getattr(agent, "model", "") or "",
             history=history,
             cancel_event=threading.Event(),
+            mode=restored_mode,
+            config_options=restored_config_options,
         )
         with self._lock:
             self._sessions[session_id] = state

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -7,15 +7,18 @@ Exercises the full flow through the ACP server layer:
     session_update events arrive at the mock client
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 import acp
+from acp.exceptions import RequestError
 from acp.schema import (
     EnvVariable,
     HttpHeader,
     McpServerHttp,
+    McpServerSse,
     McpServerStdio,
     NewSessionResponse,
     PromptResponse,
@@ -106,6 +109,26 @@ class TestMcpRegistrationE2E:
         assert state.agent.tools == fake_tools
         assert state.agent.valid_tool_names == {
             "mcp_test_fs_read", "mcp_test_fs_write", "mcp_test_api_search", "terminal"
+        }
+
+    @pytest.mark.asyncio
+    async def test_sse_server_preserves_sse_transport(self, acp_agent):
+        server = McpServerSse(
+            name="events",
+            url="https://example.test/sse",
+            headers=[HttpHeader(name="X-Test", value="1")],
+        )
+        registered = {}
+
+        with patch("tools.mcp_tool.get_registered_mcp_server_names", return_value=set()), \
+             patch("tools.mcp_tool.register_mcp_servers", side_effect=lambda cfg: registered.update(cfg) or []), \
+             patch("model_tools.get_tool_definitions", return_value=[]):
+            await acp_agent.new_session(cwd="/tmp", mcp_servers=[server])
+
+        assert registered["events"] == {
+            "url": "https://example.test/sse",
+            "headers": {"X-Test": "1"},
+            "transport": "sse",
         }
 
     @pytest.mark.asyncio
@@ -311,3 +334,132 @@ class TestSessionLifecycleMcpE2E:
 
         assert fork_resp.session_id != ""
         assert "api" in registered
+
+    @pytest.mark.asyncio
+    async def test_close_releases_session_mcp_after_last_owner(self, acp_agent):
+        server = McpServerStdio(name="owned", command="/bin/test", args=[], env=[])
+        released = []
+
+        with patch("tools.mcp_tool.get_registered_mcp_server_names", return_value=set()), \
+             patch("tools.mcp_tool.register_mcp_servers", return_value=[]), \
+             patch("tools.mcp_tool.release_mcp_servers", side_effect=lambda names: released.extend(names)), \
+             patch("model_tools.get_tool_definitions", return_value=[]):
+            first = await acp_agent.new_session(cwd="/tmp", mcp_servers=[server])
+            second = await acp_agent.new_session(cwd="/tmp", mcp_servers=[server])
+            await acp_agent.close_session(first.session_id)
+            assert released == []
+            await acp_agent.close_session(second.session_id)
+
+        assert released == ["owned"]
+
+    @pytest.mark.asyncio
+    async def test_close_mcp_release_failure_keeps_ownership_retryable(self, acp_agent):
+        server = McpServerStdio(name="retry", command="/bin/test", args=[], env=[])
+        attempts = []
+
+        def release(names):
+            attempts.append(list(names))
+            if len(attempts) == 1:
+                raise RuntimeError("release failed")
+
+        with patch("tools.mcp_tool.get_registered_mcp_server_names", return_value=set()), \
+             patch("tools.mcp_tool.register_mcp_servers", return_value=[]), \
+             patch("tools.mcp_tool.release_mcp_servers", side_effect=release), \
+             patch("model_tools.get_tool_definitions", return_value=[]):
+            resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=[server])
+            with pytest.raises(RequestError) as exc_info:
+                await acp_agent.close_session(resp.session_id)
+            assert exc_info.value.code == -32603
+            assert resp.session_id in acp_agent.session_manager._sessions
+            assert acp_agent._session_mcp_servers[resp.session_id] == {"retry"}
+            await acp_agent.close_session(resp.session_id)
+
+        assert attempts == [["retry"], ["retry"]]
+
+    @pytest.mark.asyncio
+    async def test_mcp_replacement_release_failure_rolls_back_ownership(self, acp_agent):
+        old_server = McpServerStdio(name="old", command="/bin/old", args=[], env=[])
+        new_server = McpServerStdio(name="new", command="/bin/new", args=[], env=[])
+        release_attempts = []
+
+        def release(names):
+            release_attempts.append(list(names))
+            if list(names) == ["old"]:
+                raise RuntimeError("release failed")
+
+        with patch("tools.mcp_tool.get_registered_mcp_server_names", return_value=set()), \
+             patch("tools.mcp_tool.register_mcp_servers", return_value=[]), \
+             patch("tools.mcp_tool.release_mcp_servers", side_effect=release), \
+             patch("model_tools.get_tool_definitions", return_value=[]):
+            created = await acp_agent.new_session(cwd="/tmp", mcp_servers=[old_server])
+            await acp_agent.load_session(
+                "/tmp", created.session_id, [new_server]
+            )
+
+        assert acp_agent._session_mcp_servers[created.session_id] == {"old"}
+        assert acp_agent._mcp_server_refcounts == {"old": 1}
+        assert release_attempts == [["old"], ["new"]]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["load", "resume"])
+    async def test_closing_session_rejects_mcp_reregistration(self, acp_agent, method):
+        created = await acp_agent.new_session(cwd="/tmp")
+        state = acp_agent.session_manager.get_session(created.session_id)
+        server = McpServerStdio(name="new", command="/bin/test", args=[], env=[])
+
+        with patch("tools.mcp_tool.get_registered_mcp_server_names", return_value=set()), \
+             patch("tools.mcp_tool.register_mcp_servers", return_value=[]), \
+             patch("tools.mcp_tool.release_mcp_servers", return_value=[]), \
+             patch("model_tools.get_tool_definitions", return_value=[]):
+            await acp_agent._mcp_ownership_lock.acquire()
+            try:
+                if method == "load":
+                    task = asyncio.create_task(
+                        acp_agent.load_session("/tmp", created.session_id, [server])
+                    )
+                else:
+                    task = asyncio.create_task(
+                        acp_agent.resume_session("/tmp", created.session_id, [server])
+                    )
+                await asyncio.sleep(0)
+                with state.runtime_lock:
+                    state.closing = True
+            finally:
+                acp_agent._mcp_ownership_lock.release()
+
+            with pytest.raises(RequestError) as exc_info:
+                await task
+
+        assert exc_info.value.code == -32002
+        assert created.session_id not in acp_agent._session_mcp_servers
+        assert acp_agent._mcp_server_refcounts == {}
+
+    @pytest.mark.asyncio
+    async def test_close_preserves_preexisting_mcp_server(self, acp_agent):
+        server = McpServerStdio(name="shared", command="/bin/test", args=[], env=[])
+        released = []
+
+        with patch("tools.mcp_tool.get_registered_mcp_server_names", return_value={"shared"}), \
+             patch("tools.mcp_tool.register_mcp_servers", return_value=[]), \
+             patch("tools.mcp_tool.release_mcp_servers", side_effect=lambda names: released.extend(names)), \
+             patch("model_tools.get_tool_definitions", return_value=[]):
+            resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=[server])
+            await acp_agent.close_session(resp.session_id)
+
+        assert released == []
+
+    @pytest.mark.asyncio
+    async def test_close_preserves_globally_configured_mcp_server(self, acp_agent, monkeypatch):
+        server = McpServerStdio(name="configured", command="/bin/test", args=[], env=[])
+        released = []
+        monkeypatch.delenv("HERMES_ACP_SKIP_CONFIGURED_MCP", raising=False)
+
+        with patch("tools.mcp_tool.get_registered_mcp_server_names", return_value=set()), \
+             patch("tools.mcp_tool.register_mcp_servers", return_value=[]), \
+             patch("tools.mcp_tool.release_mcp_servers", side_effect=lambda names: released.extend(names)), \
+             patch("hermes_cli.config.load_config", return_value={"mcp_servers": {"configured": {}}}), \
+             patch("model_tools.get_tool_definitions", return_value=[]):
+            resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=[server])
+            await acp_agent.close_session(resp.session_id)
+
+        assert released == []

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, AsyncMock, patch
 import pytest
 
 import acp
+from acp.exceptions import RequestError
 from acp.agent.router import build_agent_router
 from acp.schema import (
     AgentCapabilities,
@@ -16,9 +17,11 @@ from acp.schema import (
     AgentThoughtChunk,
     AuthenticateResponse,
     AvailableCommandsUpdate,
+    CloseSessionResponse,
     Implementation,
     InitializeResponse,
     LoadSessionResponse,
+    McpCapabilities,
     NewSessionResponse,
     PromptResponse,
     ResumeSessionResponse,
@@ -98,6 +101,17 @@ class TestInitialize:
         assert isinstance(resp, InitializeResponse)
         assert resp.protocol_version == acp.PROTOCOL_VERSION
 
+    @pytest.mark.asyncio
+    async def test_initialize_advertises_implemented_capabilities(self, agent):
+        resp = await agent.initialize(protocol_version=1)
+
+        caps = resp.agent_capabilities
+        assert caps.prompt_capabilities.embedded_context is True
+        assert isinstance(caps.mcp_capabilities, McpCapabilities)
+        assert caps.mcp_capabilities.http is True
+        assert caps.mcp_capabilities.sse is True
+        assert caps.session_capabilities.close is not None
+
 
 
 
@@ -147,17 +161,22 @@ class TestAuthenticate:
             "acp_adapter.server.detect_provider",
             lambda: "openrouter",
         )
-        resp = await agent.authenticate(method_id="totally-invalid-method")
-        assert resp is None
+        with pytest.raises(RequestError) as exc_info:
+            await agent.authenticate(method_id="totally-invalid-method")
+
+        assert exc_info.value.code == -32602
+        assert exc_info.value.data == {"methodId": "totally-invalid-method"}
 
     @pytest.mark.asyncio
-    async def test_authenticate_without_provider(self, agent, monkeypatch):
+    async def test_authenticate_without_provider_requires_auth(self, agent, monkeypatch):
         monkeypatch.setattr(
             "acp_adapter.server.detect_provider",
             lambda: None,
         )
-        resp = await agent.authenticate(method_id="openrouter")
-        assert resp is None
+        with pytest.raises(RequestError) as exc_info:
+            await agent.authenticate(method_id="openrouter")
+
+        assert exc_info.value.code == -32000
 
     @pytest.mark.asyncio
     async def test_authenticate_accepts_terminal_setup_after_provider_configured(self, agent, monkeypatch):
@@ -282,9 +301,20 @@ class TestSessionOps:
 
 
     @pytest.mark.asyncio
-    async def test_load_session_not_found_returns_none(self, agent):
-        resp = await agent.load_session(cwd="/tmp", session_id="bogus")
-        assert resp is None
+    async def test_load_session_not_found_raises_resource_error(self, agent):
+        with pytest.raises(RequestError) as exc_info:
+            await agent.load_session(cwd="/tmp", session_id="bogus")
+
+        assert exc_info.value.code == -32002
+        assert exc_info.value.data == {"sessionId": "bogus"}
+
+    @pytest.mark.asyncio
+    async def test_resume_session_not_found_raises_resource_error(self, agent):
+        with pytest.raises(RequestError) as exc_info:
+            await agent.resume_session(cwd="/tmp", session_id="bogus")
+
+        assert exc_info.value.code == -32002
+        assert exc_info.value.data == {"sessionId": "bogus"}
 
 
 
@@ -292,7 +322,8 @@ class TestSessionOps:
 
 
     @pytest.mark.asyncio
-    async def test_resume_session_replays_persisted_history_to_client(self, agent):
+    async def test_resume_session_does_not_replay_persisted_history(self, agent):
+        """ACP resume reconnects without replay; only session/load replays."""
         mock_conn = MagicMock(spec=acp.Client)
         mock_conn.session_update = AsyncMock()
         agent._conn = mock_conn
@@ -308,11 +339,95 @@ class TestSessionOps:
 
         assert isinstance(resp, ResumeSessionResponse)
         updates = [call.kwargs["update"] for call in mock_conn.session_update.await_args_list]
-        assert any(
-            isinstance(update, UserMessageChunk)
-            and update.content.text == "So tell me the current state"
-            for update in updates
+        assert not any(isinstance(update, UserMessageChunk) for update in updates)
+
+    @pytest.mark.asyncio
+    async def test_close_session_cancels_and_unloads_but_keeps_history(self, agent):
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [{"role": "user", "content": "keep me"}]
+        state.is_running = True
+        state.current_prompt_text = "keep me"
+        state.idle_event.clear()
+        state.agent.interrupt.side_effect = lambda: (
+            setattr(state, "is_running", False),
+            state.idle_event.set(),
         )
+        agent.session_manager.save_session(state.session_id)
+
+        resp = await agent.close_session(state.session_id)
+
+        assert isinstance(resp, CloseSessionResponse)
+        assert state.cancel_event.is_set()
+        state.agent.interrupt.assert_called_once()
+        assert state.session_id not in agent.session_manager._sessions
+        assert agent.session_manager._get_db().get_session(state.session_id) is not None
+
+        from tools.approval import approve_session, is_approved
+
+        approve_session(state.session_id, "dangerous_pattern")
+        assert is_approved(state.session_id, "dangerous_pattern")
+        restored = agent.session_manager.get_session(state.session_id)
+        await agent.close_session(restored.session_id)
+        assert not is_approved(state.session_id, "dangerous_pattern")
+
+    @pytest.mark.asyncio
+    async def test_close_session_waits_for_running_turn_to_finish(self, agent):
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.is_running = True
+        state.idle_event.clear()
+
+        close_task = asyncio.create_task(agent.close_session(state.session_id))
+        await asyncio.sleep(0.01)
+
+        assert not close_task.done()
+        try:
+            with pytest.raises(RequestError) as exc_info:
+                await agent.prompt(
+                    prompt=[TextContentBlock(type="text", text="race the close")],
+                    session_id=state.session_id,
+                )
+            assert exc_info.value.code == -32002
+        finally:
+            state.is_running = False
+            state.idle_event.set()
+
+        assert isinstance(await close_task, CloseSessionResponse)
+
+    @pytest.mark.asyncio
+    async def test_close_session_not_found_raises_resource_error(self, agent):
+        with pytest.raises(RequestError) as exc_info:
+            await agent.close_session("bogus")
+
+        assert exc_info.value.code == -32002
+        assert exc_info.value.data == {"sessionId": "bogus"}
+
+    @pytest.mark.asyncio
+    async def test_close_timeout_remains_retryable_and_blocks_prompts(self, agent):
+        new_resp = await agent.new_session(cwd="/tmp")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.is_running = True
+        state.idle_event.clear()
+
+        with patch("acp_adapter.server._CLOSE_SESSION_TIMEOUT_SECONDS", 0.01):
+            with pytest.raises(RequestError) as exc_info:
+                await agent.close_session(state.session_id)
+        assert exc_info.value.code == -32603
+        try:
+            assert state.closing is True
+            assert state.close_in_progress is False
+            assert state.session_id in agent.session_manager._sessions
+            with pytest.raises(RequestError):
+                await agent.prompt(
+                    prompt=[TextContentBlock(type="text", text="must stay blocked")],
+                    session_id=state.session_id,
+                )
+        finally:
+            state.is_running = False
+            state.idle_event.set()
+
+        assert isinstance(await agent.close_session(state.session_id), CloseSessionResponse)
 
 
 
@@ -336,6 +451,14 @@ class TestListAndFork:
         fork_resp = await agent.fork_session(cwd="/forked", session_id=new_resp.session_id)
         assert fork_resp.session_id
         assert fork_resp.session_id != new_resp.session_id
+
+    @pytest.mark.asyncio
+    async def test_fork_session_not_found_raises_resource_error(self, agent):
+        with pytest.raises(RequestError) as exc_info:
+            await agent.fork_session(cwd="/forked", session_id="bogus")
+
+        assert exc_info.value.code == -32002
+        assert exc_info.value.data == {"sessionId": "bogus"}
 
     @pytest.mark.asyncio
     async def test_list_sessions_includes_title_and_updated_at(self, agent):
@@ -391,6 +514,20 @@ class TestSessionConfiguration:
 
         assert mode_result == {}
         assert config_result["configOptions"] == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("method", ["model", "mode", "config"])
+    async def test_session_configuration_not_found_raises_resource_error(self, agent, method):
+        with pytest.raises(RequestError) as exc_info:
+            if method == "model":
+                await agent.set_session_model("openrouter:test", "bogus")
+            elif method == "mode":
+                await agent.set_session_mode("default", "bogus")
+            else:
+                await agent.set_config_option("approval_mode", "bogus", "auto")
+
+        assert exc_info.value.code == -32002
+        assert exc_info.value.data == {"sessionId": "bogus"}
 
 
 

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -259,6 +259,44 @@ class TestListAndCleanup:
         # Removing again returns False
         assert manager.remove_session(state.session_id) is False
 
+    def test_unload_session_keeps_persisted_history(self, manager):
+        state = manager.create_session()
+        state.history = [{"role": "user", "content": "keep me"}]
+        manager.save_session(state.session_id)
+
+        unloaded = manager.unload_session(state.session_id)
+
+        assert unloaded is state
+        assert state.session_id not in manager._sessions
+        assert manager._get_db().get_session(state.session_id) is not None
+        restored = manager.get_session(state.session_id)
+        assert restored is not None
+        assert restored.history[0]["content"] == "keep me"
+
+    def test_session_ui_state_survives_restore(self, manager):
+        state = manager.create_session()
+        state.mode = "accept_edits"
+        state.config_options = {"custom": "value"}
+        manager.save_session(state.session_id)
+        manager.unload_session(state.session_id)
+
+        restored = manager.get_session(state.session_id)
+
+        assert restored is not None
+        assert restored.mode == "accept_edits"
+        assert restored.config_options == {"custom": "value"}
+
+    def test_fork_copies_session_ui_state(self, manager):
+        state = manager.create_session()
+        state.mode = "dont_ask"
+        state.config_options = {"custom": True}
+
+        forked = manager.fork_session(state.session_id, cwd="/tmp/fork")
+
+        assert forked is not None
+        assert forked.mode == "dont_ask"
+        assert forked.config_options == {"custom": True}
+
 
 # ---------------------------------------------------------------------------
 # persistence — sessions survive process restarts (via SessionDB)

--- a/tests/tools/test_mcp_selective_release.py
+++ b/tests/tools/test_mcp_selective_release.py
@@ -1,0 +1,96 @@
+"""Selective MCP release used by ACP session/close."""
+
+import asyncio
+
+from tools import mcp_tool
+from tools.registry import registry
+
+
+def test_release_mcp_servers_shuts_down_only_selected_live_server(monkeypatch):
+    calls = []
+
+    class FakeServer:
+        def __init__(self, name):
+            self.name = name
+
+        async def shutdown(self):
+            calls.append(self.name)
+
+        def _deregister_tools(self):
+            calls.append(f"deregister:{self.name}")
+
+    selected = FakeServer("selected")
+    preserved = FakeServer("preserved")
+    monkeypatch.setitem(mcp_tool._servers, "selected", selected)
+    monkeypatch.setitem(mcp_tool._servers, "preserved", preserved)
+    monkeypatch.setattr(
+        mcp_tool,
+        "_run_on_mcp_loop",
+        lambda factory, timeout=30: asyncio.run(factory()),
+    )
+
+    released = mcp_tool.release_mcp_servers(["selected"])
+
+    assert released == ["selected"]
+    assert calls == ["selected"]
+    assert "selected" not in mcp_tool._servers
+    assert mcp_tool._servers["preserved"] is preserved
+
+
+def test_release_failure_keeps_live_server_tracked(monkeypatch):
+    class FailingServer:
+        name = "failing"
+
+        async def shutdown(self):
+            raise RuntimeError("shutdown failed")
+
+    server = FailingServer()
+    monkeypatch.setitem(mcp_tool._servers, "failing", server)
+    monkeypatch.setattr(
+        mcp_tool,
+        "_run_on_mcp_loop",
+        lambda factory, timeout=30: asyncio.run(factory()),
+    )
+
+    try:
+        import pytest
+
+        with pytest.raises(RuntimeError, match="shutdown failed"):
+            mcp_tool.release_mcp_servers(["failing"])
+        assert mcp_tool._servers["failing"] is server
+        assert "failing" not in mcp_tool._server_releasing
+    finally:
+        mcp_tool._servers.pop("failing", None)
+        mcp_tool._server_releasing.discard("failing")
+
+
+def test_release_mcp_servers_deregisters_lazy_tools(monkeypatch):
+    server_name = "acp-release-lazy"
+    tool_name = "mcp_acp_release_lazy_demo"
+    schema = {
+        "name": tool_name,
+        "description": "test",
+        "parameters": {"type": "object", "properties": {}},
+    }
+    registry.register(
+        name=tool_name,
+        toolset=f"mcp-{server_name}",
+        schema=schema,
+        handler=lambda _args: "{}",
+    )
+    monkeypatch.setitem(mcp_tool._lazy_server_configs, server_name, {"lazy": True})
+    monkeypatch.setitem(mcp_tool._lazy_server_tool_names, server_name, [tool_name])
+    mcp_tool._track_mcp_tool_server(tool_name, server_name)
+
+    try:
+        released = mcp_tool.release_mcp_servers([server_name])
+
+        assert released == [server_name]
+        assert registry.get_toolset_for_tool(tool_name) is None
+        assert tool_name not in mcp_tool._mcp_tool_server_names
+        assert server_name not in mcp_tool._lazy_server_configs
+    finally:
+        registry.deregister(tool_name)
+        mcp_tool._forget_mcp_tool_server(tool_name)
+        mcp_tool._lazy_server_configs.pop(server_name, None)
+        mcp_tool._lazy_server_tool_names.pop(server_name, None)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -113,7 +113,7 @@ import time
 from types import SimpleNamespace
 from typing import Callable
 from datetime import datetime
-from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple
+from typing import Any, Coroutine, Dict, Iterable, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 from tools.registry import tool_error
@@ -4214,6 +4214,7 @@ class MCPServerTask:
 
 _servers: Dict[str, MCPServerTask] = {}
 _server_connecting: set[str] = set()
+_server_releasing: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
 # Lazy MCP startup (#56832): servers whose tools were registered from the
 # on-disk schema cache without spawning/connecting. Keyed by server name;
@@ -5722,6 +5723,8 @@ def _get_connected_server_for_call(server_name: str) -> Optional[MCPServerTask]:
     handlers all trigger the deferred spawn (#56832).
     """
     with _lock:
+        if server_name in _server_releasing:
+            return None
         server = _servers.get(server_name)
         is_lazy = server_name in _lazy_server_configs
     if is_lazy and (server is None or server.session is None):
@@ -7220,6 +7223,91 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+
+def get_registered_mcp_server_names() -> set[str]:
+    """Return a thread-safe snapshot of live, lazy, and connecting servers."""
+    with _lock:
+        return set(_servers) | set(_lazy_server_configs) | set(_server_connecting)
+
+
+def release_mcp_servers(server_names: Iterable[str]) -> List[str]:
+    """Release selected MCP servers without disturbing unrelated connections.
+
+    Callers are responsible for ownership/refcount decisions. Live servers stay
+    registered until transport shutdown succeeds, and calls are blocked through
+    ``_server_releasing`` during that interval. This makes a scheduling failure
+    or timeout retryable without losing the only tracked server handle.
+    """
+    names = {str(name).strip() for name in server_names if str(name).strip()}
+    if not names:
+        return []
+
+    with _lock:
+        live_servers = {
+            name: _servers[name]
+            for name in names
+            if name in _servers
+        }
+        lazy_tools = {
+            name: list(_lazy_server_tool_names.get(name, []))
+            for name in names
+            if name in _lazy_server_configs or name in _lazy_server_tool_names
+        }
+        selected = set(live_servers) | set(lazy_tools)
+        _server_releasing.update(selected)
+
+    try:
+        if live_servers:
+            async def _shutdown_selected() -> None:
+                results = await asyncio.gather(
+                    *(server.shutdown() for server in live_servers.values()),
+                    return_exceptions=True,
+                )
+                failures = [
+                    (name, result)
+                    for name, result in zip(live_servers, results)
+                    if isinstance(result, BaseException)
+                ]
+                if failures:
+                    details = "; ".join(f"{name}: {result}" for name, result in failures)
+                    raise RuntimeError(f"MCP selective shutdown failed: {details}")
+
+            _run_on_mcp_loop(_shutdown_selected, timeout=15)
+    except BaseException:
+        with _lock:
+            _server_releasing.difference_update(selected)
+        raise
+
+    with _lock:
+        for name, server in live_servers.items():
+            if _servers.get(name) is server:
+                _servers.pop(name, None)
+        for name in selected:
+            _lazy_server_configs.pop(name, None)
+            _lazy_server_fingerprints.pop(name, None)
+            _lazy_server_tool_names.pop(name, None)
+            _server_connecting.discard(name)
+            _server_connect_errors.pop(name, None)
+            _server_connect_retry_after.pop(name, None)
+            _server_connect_failures.pop(name, None)
+            _server_error_counts.pop(name, None)
+            _server_breaker_opened_at.pop(name, None)
+            _server_trust_levels.pop(name, None)
+            _tool_read_only_hints.pop(name, None)
+            _parallel_safe_servers.discard(name)
+        _server_releasing.difference_update(selected)
+
+    if lazy_tools:
+        from tools.registry import registry
+
+        for tool_names in lazy_tools.values():
+            for tool_name in tool_names:
+                registry.deregister(tool_name)
+                _forget_mcp_tool_server(tool_name)
+
+    return sorted(selected)
+
 
 def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     """Connect to explicit MCP servers and register their tools.

--- a/website/docs/developer-guide/acp-internals.md
+++ b/website/docs/developer-guide/acp-internals.md
@@ -41,7 +41,7 @@ Stdout is reserved for ACP JSON-RPC transport. Human-readable logs go to stderr.
 Responsibilities:
 
 - initialize / authenticate
-- new/load/resume/fork/list/cancel session methods
+- new/load/resume/fork/list/cancel/close session methods
 - prompt execution
 - session model switching
 - wiring sync AIAgent callbacks into ACP async notifications
@@ -58,12 +58,15 @@ Each session stores:
 - `model`
 - `history`
 - `cancel_event`
+- runtime queue/lock/interrupted-prompt state
+- `mode` and `config_options`
 
 The manager is thread-safe and supports:
 
 - create
 - get
 - remove
+- unload (preserving persisted history)
 - fork
 - list
 - cleanup
@@ -76,7 +79,8 @@ The manager is thread-safe and supports:
 Bridged callbacks:
 
 - `tool_progress_callback`
-- `thinking_callback` (currently set to `None` in the ACP bridge — reasoning is forwarded through `step_callback` instead)
+- `reasoning_callback` (provider/model reasoning; `thinking_callback` is set to
+  `None` so local waiting-status text does not become an ACP thought)
 - `step_callback`
 
 Because `AIAgent` runs in a worker thread while ACP I/O lives on the main event loop, the bridge uses:
@@ -92,6 +96,7 @@ asyncio.run_coroutine_threadsafe(...)
 Mapping:
 
 - `allow_once` -> Hermes `once`
+- `allow_session` -> Hermes `session`
 - `allow_always` -> Hermes `always`
 - reject options -> Hermes `deny`
 
@@ -117,7 +122,7 @@ new_session(cwd)
   -> bind task_id/session_id to cwd override
 
 prompt(..., session_id)
-  -> extract text from ACP content blocks
+  -> convert text/image/resource blocks into model content
   -> reset cancel event
   -> install callbacks + approval bridge
   -> run AIAgent in ThreadPoolExecutor
@@ -130,8 +135,18 @@ prompt(..., session_id)
 `cancel(session_id)`:
 
 - sets the session cancel event
-- calls `agent.interrupt()` when available
+- requests a hard agent interrupt
 - causes the prompt response to return `stop_reason="cancelled"`
+
+### Load, resume, and close
+
+- `load_session()` restores persisted state and replays history before its
+  response.
+- `resume_session()` restores state without replaying history.
+- `close_session()` cancels active work, clears session approvals, and unloads
+  the live session while preserving its `state.db` transcript for a later load.
+  ACP-provided MCP servers are reference-counted and selectively released after
+  their last owning session closes.
 
 ### Forking
 
@@ -169,9 +184,12 @@ ACP temporarily installs an approval callback on the terminal tool during prompt
 
 ## Current limitations
 
-- ACP sessions are persisted to the shared `~/.hermes/state.db` (SessionDB) and transparently restored across process restarts; they appear in `session_search`
-- non-text prompt blocks are currently ignored for request text extraction
-- editor-specific UX varies by ACP client implementation
+- Audio prompt blocks are not converted into model input.
+- Linked resources must be local files to be read directly; embedded and local
+  resources are bounded to 512 KiB when inlined.
+- History replay reconstructs text, reasoning, and tool activity but does not
+  reconstruct prior image/audio attachments.
+- Editor-specific UX varies by ACP client implementation.
 
 ## Related files
 

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -243,11 +243,12 @@ older installs. As a manual fallback, configure Buzz's agent command as
 
 #### Model picker
 
-Buzz Desktop (v0.5.1+) renders Hermes' full model menu in the agent's runtime
-settings. The list comes from Hermes itself over ACP: it shows every model
-from providers you have authenticated in Hermes (the same inventory behind
-`hermes model` and the `/model` command), so a model missing from the menu
-means its provider has no credentials configured on the Hermes side.
+Buzz Desktop (v0.5.1+) renders Hermes' ACP model menu in the agent's runtime
+settings. The list comes from the same configured-provider inventory used by
+`hermes model` and `/model`, with named custom endpoints appended. To keep the
+editor selector bounded, Hermes exposes at most 200 models per provider; a
+missing model can therefore mean either that its provider is not configured or
+that it falls beyond that provider's ACP selector cap.
 
 Entry IDs take the form `provider:model` (e.g. `openrouter:z-ai/glm-5.1`), or
 `custom:<name>:<model>` for custom OpenAI-compatible endpoints defined in
@@ -297,13 +298,14 @@ do not set them by hand in `.env` or `config.yaml`.
 
 | Variable | Value | Effect |
 |----------|-------|--------|
-| `HERMES_ACP_SKIP_CONFIGURED_MCP` | `1` | Skip starting the **globally configured** MCP servers from `config.yaml` before the ACP JSON-RPC loop begins. |
+| `HERMES_ACP_SKIP_CONFIGURED_MCP` | `1` | Skip background discovery of the **globally configured** MCP servers from `config.yaml`. |
 
-Hermes normally starts every MCP server configured in `config.yaml` before it
-enters the ACP JSON-RPC loop. A host that owns MCP itself — passing the
-session's servers explicitly through `session/new` — does not need that global
-startup, and an unrelated slow or interactive MCP server would otherwise delay
-`initialize`. Setting the marker to exactly `1` lets such a host skip it.
+Hermes normally starts configured MCP discovery in a background thread so a
+slow or interactive server cannot block `initialize`. Session construction
+waits briefly for fast servers and performs a pre-first-turn late refresh for
+servers that finish afterward. A host that owns MCP itself — passing the
+session's servers explicitly through `session/new` — can set the marker to
+exactly `1` to skip global discovery entirely.
 
 Only the global `config.yaml` discovery is skipped. **MCP servers supplied by
 the ACP session through `session/new` are still registered**, so a host loses
@@ -313,7 +315,9 @@ disable MCP.
 
 ## Session behavior
 
-ACP sessions are tracked by the ACP adapter's in-memory session manager while the server is running.
+ACP sessions are tracked in memory while active and persisted in the shared
+`~/.hermes/state.db`. They survive ACP process restarts, appear in
+`session_search`, and can be returned by `session/list`.
 
 Each session stores:
 
@@ -322,8 +326,16 @@ Each session stores:
 - selected model
 - current conversation history
 - cancel event
+- selected edit-approval mode and ACP config-option state
 
-The underlying `AIAgent` still uses Hermes' normal persistence/logging paths, but ACP `list/load/resume/fork` are scoped to the currently running ACP server process.
+`session/load` restores a persisted session and replays its transcript before
+the RPC response. `session/resume` reconnects without transcript replay, as
+required by ACP v1. `session/fork` copies backend history under a new session
+ID. `session/close` cancels active work, revokes session-scoped command
+approvals, and unloads runtime resources without deleting persisted history.
+ACP-supplied MCP connections are reference-counted: a connection is released
+when its last ACP session closes, while globally configured or otherwise
+pre-existing MCP servers remain available.
 
 ## Working directory behavior
 
@@ -331,11 +343,15 @@ ACP sessions bind the editor's cwd to the Hermes task ID so file and terminal to
 
 ## Approvals
 
-Dangerous terminal commands can be routed back to the editor as approval prompts. ACP approval options are simpler than the CLI flow:
+Dangerous terminal commands can be routed back to the editor as approval
+prompts. Hermes can expose these option IDs:
 
 - allow once
+- allow for session
 - allow always
 - deny
+- deny always (when supported by the ACP client SDK; currently treated as a
+  one-call denial by Hermes)
 
 Whether you actually see a prompt is up to the host. A host is free to answer the
 request programmatically instead of showing it to you, in which case these
@@ -344,9 +360,9 @@ treat that path as unattended execution regardless of your `approvals` setting.
 
 On timeout or error, the approval bridge denies the request.
 
-### Session-scoped edit auto-approval
+### Session-scoped approval and edit modes
 
-ACP exposes a third tier between *allow once* and *allow always*: **Allow for session**. Picking it from the editor's permission prompt records the approval inside the current ACP session only — every subsequent matching command in that session goes through without prompting, but a new ACP session (or restarting the editor) resets the slate and re-prompts the first time.
+ACP exposes a third tier between *allow once* and *allow always*: **Allow for session**. Picking it from a permission prompt records the matching dangerous-command approval inside the current ACP session only. The selected editor mode (`Default`, `Accept Edits`, or `Don't Ask`) is a separate file-edit policy: it controls `write_file` and `patch`, never dangerous terminal commands. Modes and ACP config selections persist with the session; command-pattern approvals remain process-local.
 
 | Option | Editor label | Scope | Persisted across restarts |
 |---|---|---|---|


### PR DESCRIPTION
## Summary

- align ACP v1 session lifecycle behavior: `load` replays, `resume` does not, and missing sessions return wire-visible JSON-RPC errors
- implement and advertise `session/close`, including hard cancellation, prompt-race exclusion, approval revocation, retryable timeouts, and persistence-preserving unload
- advertise implemented embedded-context and MCP transports, preserving the SSE transport discriminator
- persist ACP mode/config state across restore and fork
- reference-count ACP-provided MCP servers and release only last-owned connections, preserving globally configured/pre-existing servers with rollback-safe selective shutdown
- correct ACP user/developer documentation that contradicted the implementation

## Test plan

- `scripts/run_tests.sh tests/acp tests/acp_adapter/test_acp_commands.py tests/acp_adapter/test_acp_images.py tests/acp_adapter/test_acp_mcp_discovery.py tests/acp_adapter/test_detect_provider_entra.py tests/acp_adapter/test_acp_logging_redaction.py tests/tools/test_mcp_selective_release.py`
- `.venv/bin/ruff check acp_adapter/server.py acp_adapter/session.py tools/mcp_tool.py tests/acp/test_server.py tests/acp/test_session.py tests/acp/test_mcp_e2e.py tests/tools/test_mcp_selective_release.py`
- `git diff --check`

Latest full run: 174 passed, 0 failed. Latest focused lifecycle/MCP run: 58 passed, 0 failed.
