### PR TITLE
fix(email): consistent "Hermes Agent" sender + resilient IMAP polling (Gmail datacenter delays)

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -33,7 +33,7 @@ from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
-from email.utils import formatdate
+from email.utils import formataddr, formatdate
 from email import encoders
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -1165,7 +1165,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        msg["From"] = formataddr(("Hermes Agent", self._address))
         msg["To"] = to_addr
 
         # Thread context for reply
@@ -1280,7 +1280,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        msg["From"] = formataddr(("Hermes Agent", self._address))
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
@@ -1360,7 +1360,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        msg["From"] = formataddr(("Hermes Agent", self._address))
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
@@ -1440,7 +1440,7 @@ async def _standalone_send(
     import smtplib
     import ssl as _ssl
     from email.mime.text import MIMEText
-    from email.utils import formatdate
+    from email.utils import formataddr, formatdate
 
     extra = getattr(pconfig, "extra", {}) or {}
     address = extra.get("address") or _get_secret("EMAIL_ADDRESS", "")
@@ -1456,7 +1456,7 @@ async def _standalone_send(
 
     try:
         msg = MIMEText(message, "plain", "utf-8")
-        msg["From"] = address
+        msg["From"] = formataddr(("Hermes Agent", address))
         msg["To"] = chat_id
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -35,6 +35,10 @@ from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
 from email.utils import formataddr, formatdate
 from email import encoders
+
+# Single source of truth for the sender display name (review #91746 item 3):
+# four send paths previously hardcoded "Hermes Agent" and would drift.
+EMAIL_DISPLAY_NAME = "Hermes Agent"
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -556,7 +560,12 @@ class EmailAdapter(BasePlatformAdapter):
         self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
         self._smtp_host = (_get_secret("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
         self._smtp_port = _esecret_int("EMAIL_SMTP_PORT", 587)
-        self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 60)
+        # Gmail applies 20-55s security delays per IMAP op from datacenter
+        # IPs, so it needs a longer default poll cadence. Everyone else keeps
+        # the historical 15s (review #91746 item 4: don't change global
+        # latency for all deployments). Overridable via EMAIL_POLL_INTERVAL.
+        _gmail_default = 60 if "gmail" in self._imap_host.lower() else 15
+        self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", _gmail_default)
         # Exponential backoff after IMAP fetch failures (Gmail delays every
         # IMAP op from datacenter IPs by 20-55s; a single poll cycle can take
         # ~200s). Instead of dying fatally we back off and keep polling.
@@ -606,6 +615,9 @@ class EmailAdapter(BasePlatformAdapter):
         # "checked, nothing new" from "the check itself failed" (#80016).
         self._last_fetch_failed: bool = False
         self._last_fetch_error: str = ""
+        # Consecutive fetch failures -> degraded-mailbox observability
+        # without fatal teardown (review #91746 item 2).
+        self._consecutive_failures: int = 0
 
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
@@ -680,7 +692,7 @@ class EmailAdapter(BasePlatformAdapter):
         delay of ~25-33s to logins from datacenter IPs. Raises on failure."""
         imap = None
         try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=300)
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=90)
             imap.login(self._address, self._password)
             _send_imap_id(imap)
             imap.select("INBOX")
@@ -826,18 +838,31 @@ class EmailAdapter(BasePlatformAdapter):
         """Poll IMAP for new messages at regular intervals."""
         while self._running:
             try:
-                await self._check_inbox()
-                # Successful check (even with zero new mails) resets backoff
-                if not self._last_fetch_failed:
+                ok = await self._check_inbox()
+                # Only an actually-successful check resets the backoff.
+                # (review #91746 item 1: the failure path must not clear it,
+                # otherwise every failed poll sleeps only _poll_interval and
+                # the Gmail hammering this patch exists to stop returns.)
+                if ok:
                     self._poll_backoff = 0.0
             except asyncio.CancelledError:
                 break
             except Exception as e:
+                # Generic poll errors get the same exponential backoff pacing
+                # as IMAP failures (review nit) to avoid tight-loop hammering.
                 logger.error("[Email] Poll error: %s", e)
+                self._poll_backoff = min(
+                    max(self._poll_backoff * 2, 30.0), self._poll_backoff_max
+                )
             await asyncio.sleep(self._poll_interval + self._poll_backoff)
 
-    async def _check_inbox(self) -> None:
-        """Check INBOX for unseen messages and dispatch them."""
+    async def _check_inbox(self) -> bool:
+        """Check INBOX for unseen messages and dispatch them.
+
+        Returns True when the IMAP check itself succeeded (even with zero
+        new mails), False when the fetch failed. The poll loop resets the
+        backoff only on True.
+        """
         # Run IMAP operations in a thread to avoid blocking the event loop
         loop = asyncio.get_running_loop()
         messages = await loop.run_in_executor(None, self._fetch_new_messages)
@@ -849,15 +874,17 @@ class EmailAdapter(BasePlatformAdapter):
             await self._dispatch_message(msg_data)
         if self._last_fetch_failed:
             # The IMAP check itself failed (connect/login/select/search/fetch),
-            # not just an empty inbox. Do NOT escalate through the fatal-error
-            # hook: a timeout here (Gmail applies 20-55s delays per IMAP op
-            # from datacenter IPs) would tear the adapter down and throw it
-            # into the gateway reconnect queue — which historically stalled
-            # Telegram delivery on this host. Instead: the poll loop's next
-            # iteration re-opens a fresh IMAP connection (each poll builds its
-            # own imaplib session), so we just back off exponentially and keep
-            # going. Telegram stays fully decoupled.
-            self._last_fetch_failed = False
+            # not just an empty inbox. Do NOT tear the adapter down through the
+            # fatal-error hook: a timeout here (Gmail applies 20-55s delays per
+            # IMAP op from datacenter IPs) would throw it into the gateway
+            # reconnect queue — which historically stalled Telegram delivery
+            # on this host. Instead: back off exponentially and keep going;
+            # each poll builds its own imaplib session. Telegram stays fully
+            # decoupled. Observability (review #91746 item 2): after 10
+            # consecutive failures a prominent error is logged — surfaces via
+            # the health watchdogs — so a permanently broken mailbox (expired
+            # app password, disabled IMAP) does not degrade to silence.
+            self._consecutive_failures += 1
             err = self._last_fetch_error or "IMAP fetch failed"
             self._poll_backoff = min(
                 max(self._poll_backoff * 2, 30.0), self._poll_backoff_max
@@ -866,13 +893,24 @@ class EmailAdapter(BasePlatformAdapter):
                 "[Email] IMAP fetch failed (%s); backing off %.0fs before next poll",
                 err, self._poll_backoff,
             )
+            if self._consecutive_failures >= 10 and self._consecutive_failures % 10 == 0:
+                logger.error(
+                    "[Email] DEGRADED: %d consecutive IMAP fetch failures (%s) — "
+                    "check app password / IMAP enablement.",
+                    self._consecutive_failures, err,
+                )
+            return False
+        # Actual success: clear failure state for the next poll.
+        self._consecutive_failures = 0
+        self._last_fetch_failed = False
+        return True
 
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
         imap: Optional[imaplib.IMAP4] = None
         try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=300)
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=90)
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
@@ -942,6 +980,12 @@ class EmailAdapter(BasePlatformAdapter):
             logger.error("[Email] IMAP fetch error: %s", e)
             self._last_fetch_failed = True
             self._last_fetch_error = str(e)
+        else:
+            # Fetch vollständig erfolgreich: Fehlerzustand zurücksetzen, damit
+            # _check_inbox den nächsten Poll als Erfolg werten kann (sonst
+            # bliebe das Flag nach dem ersten Fehlschlag dauerhaft True und
+            # jeder Folge-Poll würde fälschlich als Fehler behandelt).
+            self._last_fetch_failed = False
         # Keep the reconnect snapshot current with every poll so a mid-outage
         # adapter recreation restores an up-to-date baseline: stale snapshots
         # would re-dispatch messages this instance already processed.
@@ -1182,12 +1226,12 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
-        msg["From"] = formataddr(("Hermes Agent", self._address))
+        msg["From"] = formataddr((EMAIL_DISPLAY_NAME, self._address))
         msg["To"] = to_addr
 
         # Thread context for reply
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
+        subject = ctx.get("subject", EMAIL_DISPLAY_NAME)
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
@@ -1297,11 +1341,11 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
-        msg["From"] = formataddr(("Hermes Agent", self._address))
+        msg["From"] = formataddr((EMAIL_DISPLAY_NAME, self._address))
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
+        subject = ctx.get("subject", EMAIL_DISPLAY_NAME)
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
@@ -1377,11 +1421,11 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
-        msg["From"] = formataddr(("Hermes Agent", self._address))
+        msg["From"] = formataddr((EMAIL_DISPLAY_NAME, self._address))
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
+        subject = ctx.get("subject", EMAIL_DISPLAY_NAME)
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
@@ -1473,9 +1517,9 @@ async def _standalone_send(
 
     try:
         msg = MIMEText(message, "plain", "utf-8")
-        msg["From"] = formataddr(("Hermes Agent", address))
+        msg["From"] = formataddr((EMAIL_DISPLAY_NAME, address))
         msg["To"] = chat_id
-        msg["Subject"] = "Hermes Agent"
+        msg["Subject"] = EMAIL_DISPLAY_NAME
         msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -556,7 +556,12 @@ class EmailAdapter(BasePlatformAdapter):
         self._imap_port = _esecret_int("EMAIL_IMAP_PORT", 993)
         self._smtp_host = (_get_secret("EMAIL_SMTP_HOST", "") or extra.get("smtp_host", "")).strip()
         self._smtp_port = _esecret_int("EMAIL_SMTP_PORT", 587)
-        self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 15)
+        self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 60)
+        # Exponential backoff after IMAP fetch failures (Gmail delays every
+        # IMAP op from datacenter IPs by 20-55s; a single poll cycle can take
+        # ~200s). Instead of dying fatally we back off and keep polling.
+        self._poll_backoff: float = 0.0
+        self._poll_backoff_max: float = 300.0
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
@@ -669,6 +674,45 @@ class EmailAdapter(BasePlatformAdapter):
             # Retry with IPv4 only.
             return _connect(ipv4_only=True)
 
+    def _imap_connect_test(self, is_reconnect: bool) -> None:
+        """Synchronous IMAP connect/login/scan test. Runs in an executor
+        thread (never in the event loop) because Gmail applies a security
+        delay of ~25-33s to logins from datacenter IPs. Raises on failure."""
+        imap = None
+        try:
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=300)
+            imap.login(self._address, self._password)
+            _send_imap_id(imap)
+            imap.select("INBOX")
+            snapshot = self._seen_uids_snapshot.get(self._address)
+            if is_reconnect and snapshot is not None:
+                # Reconnect within the same process: restore the previous
+                # adapter's seen-UID baseline instead of re-marking the whole
+                # mailbox. Mail that arrived during the outage stays UNSEEN
+                # relative to the baseline and is dispatched by the next poll
+                # instead of being silently skipped.
+                self._seen_uids = set(snapshot)
+                self._trim_seen_uids()
+                logger.info(
+                    "[Email] IMAP reconnect test passed. Restored %d seen UIDs; "
+                    "messages received during the outage will be processed.",
+                    len(self._seen_uids),
+                )
+            else:
+                # First connect (or no snapshot): mark all existing messages as
+                # seen so we only process new ones.
+                status, data = imap.uid("search", None, "ALL")
+                if status == "OK" and data and data[0]:
+                    for uid in data[0].split():
+                        self._seen_uids.add(uid)
+                # Keep only the most recent UIDs to prevent unbounded growth
+                self._trim_seen_uids()
+                logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
+        finally:
+            if imap is not None:
+                _close_imap(imap)
+        self._seen_uids_snapshot[self._address] = set(self._seen_uids)
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         # Validate up front so a missing host surfaces as an actionable config
@@ -702,47 +746,13 @@ class EmailAdapter(BasePlatformAdapter):
             return False
 
         try:
-            # Test IMAP connection. The handle is closed in ``finally`` —
-            # before this, a failure in login/select/search left the TCP
-            # socket open with no owner, leaking one fd per connect attempt.
-            # Under the gateway's reconnect watcher (fresh adapter instance
-            # per retry) against an unreachable/proxied host this grew
-            # monotonically until fd exhaustion on macOS's 256 soft limit
-            # (#79889).
-            imap = None
-            try:
-                imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-                imap.login(self._address, self._password)
-                _send_imap_id(imap)
-                imap.select("INBOX")
-                snapshot = self._seen_uids_snapshot.get(self._address)
-                if is_reconnect and snapshot is not None:
-                    # Reconnect within the same process: restore the previous
-                    # adapter's seen-UID baseline instead of re-marking the whole
-                    # mailbox. Mail that arrived during the outage stays UNSEEN
-                    # relative to the baseline and is dispatched by the next poll
-                    # instead of being silently skipped.
-                    self._seen_uids = set(snapshot)
-                    self._trim_seen_uids()
-                    logger.info(
-                        "[Email] IMAP reconnect test passed. Restored %d seen UIDs; "
-                        "messages received during the outage will be processed.",
-                        len(self._seen_uids),
-                    )
-                else:
-                    # First connect (or no snapshot): mark all existing messages as
-                    # seen so we only process new ones.
-                    status, data = imap.uid("search", None, "ALL")
-                    if status == "OK" and data and data[0]:
-                        for uid in data[0].split():
-                            self._seen_uids.add(uid)
-                    # Keep only the most recent UIDs to prevent unbounded growth
-                    self._trim_seen_uids()
-                    logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
-            finally:
-                if imap is not None:
-                    _close_imap(imap)
-            self._seen_uids_snapshot[self._address] = set(self._seen_uids)
+            # Test IMAP connection — run in executor thread so the slow
+            # Gmail login (security delay ~25-33s from datacenter IPs) can
+            # never block the gateway event loop (which historically stalled
+            # Telegram delivery on this host). The handle is closed in
+            # ``finally`` inside _imap_connect_test (#79889).
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._imap_connect_test, is_reconnect)
         except Exception as e:
             logger.error("[Email] IMAP connection failed: %s", e)
             # Always set an explicit fatal code (OOF-156): returning False
@@ -817,11 +827,14 @@ class EmailAdapter(BasePlatformAdapter):
         while self._running:
             try:
                 await self._check_inbox()
+                # Successful check (even with zero new mails) resets backoff
+                if not self._last_fetch_failed:
+                    self._poll_backoff = 0.0
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 logger.error("[Email] Poll error: %s", e)
-            await asyncio.sleep(self._poll_interval)
+            await asyncio.sleep(self._poll_interval + self._poll_backoff)
 
     async def _check_inbox(self) -> None:
         """Check INBOX for unseen messages and dispatch them."""
@@ -836,26 +849,30 @@ class EmailAdapter(BasePlatformAdapter):
             await self._dispatch_message(msg_data)
         if self._last_fetch_failed:
             # The IMAP check itself failed (connect/login/select/search/fetch),
-            # not just an empty inbox. Surface it through the fatal-error hook
-            # so the gateway's existing reconnect/backoff/status machinery
-            # re-establishes the mailbox instead of silently treating every
-            # failed check as "nothing new" (#80016). The handler runs in a
-            # detached task (gateway/run.py), so awaiting it from our own poll
-            # task is safe even though teardown cancels this task.
+            # not just an empty inbox. Do NOT escalate through the fatal-error
+            # hook: a timeout here (Gmail applies 20-55s delays per IMAP op
+            # from datacenter IPs) would tear the adapter down and throw it
+            # into the gateway reconnect queue — which historically stalled
+            # Telegram delivery on this host. Instead: the poll loop's next
+            # iteration re-opens a fresh IMAP connection (each poll builds its
+            # own imaplib session), so we just back off exponentially and keep
+            # going. Telegram stays fully decoupled.
             self._last_fetch_failed = False
-            self._set_fatal_error(
-                "email_imap_fetch_failed",
-                self._last_fetch_error or "IMAP fetch failed",
-                retryable=True,
+            err = self._last_fetch_error or "IMAP fetch failed"
+            self._poll_backoff = min(
+                max(self._poll_backoff * 2, 30.0), self._poll_backoff_max
             )
-            await self._notify_fatal_error()
+            logger.warning(
+                "[Email] IMAP fetch failed (%s); backing off %.0fs before next poll",
+                err, self._poll_backoff,
+            )
 
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
         imap: Optional[imaplib.IMAP4] = None
         try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=300)
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)


### PR DESCRIPTION

## Summary
Two fixes for the email platform adapter, split into two commits (independently applicable):

1. **Display name in From header** — all four send paths now set `From: Hermes Agent <address>`
   via `formataddr()` instead of the bare address.
2. **IMAP polling resilience** — the connection test runs in an executor thread, polling uses
   exponential backoff instead of fatal-error escalation, and defaults/timeouts are adjusted
   for Gmail's datacenter-IP delays.

## Motivation

### Commit 1 — display name
Clients that render the display name showed either an empty name or "HERMES AGENT" (derived
from the address local-part), depending on client. The subject default already says
"Hermes Agent"; the From display name should match it for a consistent sender identity.

### Commit 2 — resilience
Gmail applies 20-55s delays to IMAP operations from datacenter/cloud IPs (security
heuristics). Measured on this host (Ubuntu VPS, gateway running from a datacenter IP):
- IMAP login: ~25-33s
- A single poll cycle: up to ~200s

Two problems resulted:
1. The IMAP connection test in `connect()` ran inline on the event loop → the slow Gmail
   login blocked the entire gateway loop, stalling Telegram delivery on this host.
2. Every failed poll escalated through the fatal-error hook → adapter teardown + reconnect
   churn on repeated Gmail timeouts.

## Changes
- `_poll_interval` default 15s → 60s (`EMAIL_POLL_INTERVAL` still overridable).
- New `_imap_connect_test()` (sync, executor-thread): connect/login/scan; keeps the
  fd-leak-safe `_close_imap()` teardown from #79889.
- `connect()` awaits the test via `run_in_executor` — the event loop never blocks on IMAP.
- Exponential poll backoff 30s → 300s on fetch failures, reset on any successful check.
  A failed poll no longer escalates through the fatal-error hook — each poll builds a fresh
  imaplib session, so the next iteration reconnects naturally. IMAP polling stays decoupled
  from the gateway reconnect machinery and from Telegram delivery.
- IMAP socket timeout 30s → 300s so slow-but-valid Gmail responses are not cut off.

## Trade-off / discussion point
The second commit intentionally changes part of the #80016 behavior (fatal-error escalation
on fetch failures). Escalation makes sense for hard failures, but for Gmail's *expected*
delays it caused reconnect churn. If maintainers prefer keeping escalation, a middle ground
would be escalating only after N consecutive failures — happy to adjust.

## Test plan
- Syntax: `python3 -m py_compile plugins/platforms/email/adapter.py`.
- Production soak: combined changes deployed on a live gateway (Gmail IMAP, datacenter IP)
  since 2026-08-14; the previously observed event-loop stall did not recur and Telegram
  delivery stayed responsive during Gmail delay windows.
- Connect/send smoke tests via the gateway.

## References
- #79889 (fd leak, socket teardown)
- #80016 (fatal-error escalation on fetch failure)
- Gmail IMAP delays from datacenter IPs (observed; documented in code comments)

====================================================================
FÜR OLIVER: SO REICHST DU ES EIN
====================================================================

Voraussetzung: GitHub-Account. Dann:

1. gh installieren + einloggen:
     apt install gh && gh auth login   (HTTPS-Token oder Browser)
2. Repo forken (Browser oder: gh repo fork NousResearch/hermes-agent --clone)
3. Branch + Commits:
     cd <fork-clone>
     git checkout -b fix/email-adapter-sender-and-imap-resilience origin/main
     git am /root/.hermes/backups/pr-email-adapter/0001-*.patch
     git am /root/.hermes/backups/pr-email-adapter/0002-*.patch
   WICHTIG: git am übernimmt die Commit-Autoren als "Oliver <oliver@hermes-prep.local>".
   Vor dem Push als GitHub-Identität neu setzen:
     git commit --amend --reset-author -C HEAD   (Commit 2, dann rebase oder einzeln)
     (bzw. git config user.name/user.email auf die GitHub-Adresse stellen und
      git rebase --exec 'git commit --amend --reset-author -C HEAD' fcbd1076)
4. Pushen + PR:
     git push -u origin fix/email-adapter-sender-and-imap-resilience
     gh pr create --title "fix(email): consistent \"Hermes Agent\" sender + resilient IMAP polling" \
        --body "…PR-Beschreibung oben…"
   Oder PR im Browser über den erscheinenden Link.

Alternativen:
- Nur Commit 1 (Absender) einreichen: nur 0001 anwenden — kleiner, schnell reviewbar.
- Der IMAP-Commit ist der größere Eingriff; die Diskussions-Passage (Trade-off) hilft dem
  Maintainer-Team bei der Entscheidung. Bei Rückfragen können wir anpassen.

Review vor Ort:
  cd /tmp/pr-prep && git show 2872f350 && git show 1250d509

Stand 21.08.2026 — solange nicht gemergt, bleibt P1 in der Registry PENDING und der
lokale Patch + Update-Guard bleiben aktiv.
