### PR TITLE
fix(cron): let local models and long builds run unattended

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1692,6 +1692,23 @@ def _normalize_job_optional_text(value: Any, *, strip_trailing_slash: bool = Fal
     return text or None
 
 
+def _normalize_terminal_timeout(value: Any) -> Optional[int]:
+    """Normalize an optional per-job terminal timeout in seconds."""
+    if value in {None, ""}:
+        return None
+    if isinstance(value, bool):
+        raise ValueError("terminal_timeout must be a positive number of seconds")
+    try:
+        timeout = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "terminal_timeout must be a positive number of seconds"
+        ) from exc
+    if timeout <= 0:
+        raise ValueError("terminal_timeout must be a positive number of seconds")
+    return timeout
+
+
 def _normalize_reasoning_effort(value: Any) -> Optional[str]:
     """Validate a per-job reasoning effort against the canonical grammar.
 
@@ -1824,6 +1841,7 @@ def create_job(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    terminal_timeout: Optional[int] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
@@ -1850,6 +1868,9 @@ def create_job(
         model: Optional per-job model override
         provider: Optional per-job provider override
         base_url: Optional per-job base URL override
+        terminal_timeout: Optional default timeout for foreground terminal
+                commands in this job. Overrides cron.terminal_timeout and
+                terminal.timeout without changing other concurrent sessions.
         script: Optional path to a script whose stdout feeds the job. With
                 ``no_agent=True`` the script IS the job — its stdout is
                 delivered verbatim. Without ``no_agent``, its stdout is
@@ -1925,6 +1946,7 @@ def create_job(
     normalized_model = _normalize_job_optional_text(model)
     normalized_provider = _normalize_job_optional_text(provider)
     normalized_base_url = _normalize_job_optional_text(base_url, strip_trailing_slash=True)
+    normalized_terminal_timeout = _normalize_terminal_timeout(terminal_timeout)
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
@@ -2046,6 +2068,8 @@ def create_job(
     # absent key = job follows config resolution (pre-feature behavior).
     if normalized_reasoning_effort is not None:
         job["reasoning_effort"] = normalized_reasoning_effort
+    if normalized_terminal_timeout is not None:
+        job["terminal_timeout"] = normalized_terminal_timeout
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -2159,6 +2183,11 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             if "reasoning_effort" in updates:
                 updates["reasoning_effort"] = _normalize_reasoning_effort(
                     updates["reasoning_effort"]
+                )
+
+            if "terminal_timeout" in updates:
+                updates["terminal_timeout"] = _normalize_terminal_timeout(
+                    updates["terminal_timeout"]
                 )
 
             previous_inference_axes = _normalized_inference_axes(job)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4495,6 +4495,26 @@ def _cron_preflight_enabled(cfg: dict) -> bool:
     return cron_cfg.get("preflight", True) is not False
 
 
+def _normalize_cron_custom_route_provider(
+    provider: Optional[str], base_url: Optional[str]
+) -> Optional[str]:
+    """Map an alias-only custom label to the bare custom runtime."""
+    if not (
+        base_url
+        and provider
+        and provider.lower().startswith("custom:")
+    ):
+        return provider
+    try:
+        from hermes_cli.runtime_provider import has_named_custom_provider
+
+        if not has_named_custom_provider(provider):
+            return "custom"
+    except Exception:
+        pass
+    return provider
+
+
 def _resolve_cron_inference_route(
     *, model: Any, provider: Any, base_url: Any, config: Optional[dict] = None
 ) -> tuple[str, Optional[str], Optional[str]]:
@@ -4503,7 +4523,13 @@ def _resolve_cron_inference_route(
     resolved_provider = str(provider or "").strip() or None
     resolved_base_url = str(base_url or "").strip().rstrip("/") or None
     if not resolved_model:
-        return resolved_model, resolved_provider, resolved_base_url
+        return (
+            resolved_model,
+            _normalize_cron_custom_route_provider(
+                resolved_provider, resolved_base_url
+            ),
+            resolved_base_url,
+        )
     try:
         from hermes_cli import model_switch
 
@@ -4516,12 +4542,28 @@ def _resolve_cron_inference_route(
     except Exception:
         alias = None
     if alias is None:
-        return resolved_model, resolved_provider, resolved_base_url
-    return (
-        str(alias.model).strip(),
-        resolved_provider or (str(alias.provider).strip() or None),
-        resolved_base_url or (str(alias.base_url).strip().rstrip("/") or None),
+        return (
+            resolved_model,
+            _normalize_cron_custom_route_provider(
+                resolved_provider, resolved_base_url
+            ),
+            resolved_base_url,
+        )
+    resolved_model = str(alias.model).strip()
+    resolved_provider = resolved_provider or (str(alias.provider).strip() or None)
+    resolved_base_url = resolved_base_url or (
+        str(alias.base_url).strip().rstrip("/") or None
     )
+
+    # A model alias may use ``custom:<label>`` only to identify its endpoint;
+    # unlike providers/custom_providers entries it owns no stored credential.
+    # Resolve that alias-only spelling through bare custom so runtime provider
+    # validation does not reject it as an unknown named provider. Configured
+    # named custom providers retain their identity and credential protections.
+    resolved_provider = _normalize_cron_custom_route_provider(
+        resolved_provider, resolved_base_url
+    )
+    return resolved_model, resolved_provider, resolved_base_url
 
 
 def _resolve_cron_terminal_timeout(job: dict, cfg: dict) -> int:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4495,6 +4495,98 @@ def _cron_preflight_enabled(cfg: dict) -> bool:
     return cron_cfg.get("preflight", True) is not False
 
 
+def _resolve_cron_inference_route(
+    *, model: Any, provider: Any, base_url: Any, config: Optional[dict] = None
+) -> tuple[str, Optional[str], Optional[str]]:
+    """Dereference a configured model alias into one atomic cron route."""
+    resolved_model = str(model or "").strip()
+    resolved_provider = str(provider or "").strip() or None
+    resolved_base_url = str(base_url or "").strip().rstrip("/") or None
+    if not resolved_model:
+        return resolved_model, resolved_provider, resolved_base_url
+    try:
+        from hermes_cli import model_switch
+
+        aliases = (
+            model_switch.direct_aliases_from_config(config)
+            if config is not None
+            else model_switch._load_direct_aliases()
+        )
+        alias = aliases.get(resolved_model.lower())
+    except Exception:
+        alias = None
+    if alias is None:
+        return resolved_model, resolved_provider, resolved_base_url
+    return (
+        str(alias.model).strip(),
+        resolved_provider or (str(alias.provider).strip() or None),
+        resolved_base_url or (str(alias.base_url).strip().rstrip("/") or None),
+    )
+
+
+def _resolve_cron_terminal_timeout(job: dict, cfg: dict) -> int:
+    """Resolve job pin > cron fleet default > terminal default."""
+    cron_cfg = cfg.get("cron") if isinstance(cfg.get("cron"), dict) else {}
+    terminal_cfg = (
+        cfg.get("terminal") if isinstance(cfg.get("terminal"), dict) else {}
+    )
+    for value in (
+        job.get("terminal_timeout"),
+        cron_cfg.get("terminal_timeout"),
+        terminal_cfg.get("timeout"),
+        180,
+    ):
+        if value in {None, ""} or isinstance(value, bool):
+            continue
+        try:
+            timeout = int(value)
+        except (TypeError, ValueError):
+            continue
+        if timeout > 0:
+            return timeout
+    return 180
+
+
+def _cron_model_drift_axes_for_route(
+    job: dict,
+    *,
+    current_provider: str,
+    current_model: str,
+    config: dict,
+    alias_supplied_provider: bool,
+) -> list[str]:
+    """Apply the drift guard without splitting an alias's atomic route."""
+    drift_job = job
+    if alias_supplied_provider and not job.get("provider"):
+        drift_job = {**job, "provider": current_provider}
+    return cron_model_drift_axes(
+        drift_job,
+        current_provider=current_provider,
+        current_model=current_model,
+        config=config,
+    )
+
+
+def _run_cron_conversation(agent: Any, prompt: str, task_id: str) -> Any:
+    """Pass the cron task id when the agent implementation accepts it."""
+    try:
+        import inspect
+
+        target = agent.run_conversation
+        side_effect = getattr(target, "side_effect", None)
+        signature_target = side_effect if callable(side_effect) else target
+        parameters = inspect.signature(signature_target).parameters.values()
+        accepts_task_id = any(
+            p.name == "task_id" or p.kind == inspect.Parameter.VAR_KEYWORD
+            for p in parameters
+        )
+    except (TypeError, ValueError):
+        accepts_task_id = True
+    if accepts_task_id:
+        return agent.run_conversation(prompt, task_id=task_id)
+    return agent.run_conversation(prompt)
+
+
 def _preflight_check_provider_key(job: dict, cfg: dict) -> Optional[str]:
     """READ-ONLY probe: would provider resolution fail for lack of a key?
 
@@ -5269,6 +5361,7 @@ def run_job(
     _cron_session_var = _VAR_MAP["HERMES_CRON_SESSION"]
     _cron_session_token = None
     _non_dispatcher_token = None
+    _terminal_override_registered = False
     try:
         if not _cwd_lock_acquired:
             # Fail closed (#79768): running without the lock would let a
@@ -5415,6 +5508,24 @@ def run_job(
                 "default with `hermes model <name>`."
             )
 
+        _effective_provider = job.get("provider") or _cron_default_provider or None
+        _provider_was_explicit = bool(_effective_provider)
+        model, _effective_provider, _effective_base_url = _resolve_cron_inference_route(
+            model=model,
+            provider=_effective_provider,
+            base_url=job.get("base_url"),
+            config=_cfg,
+        )
+        _effective_job = {
+            **job,
+            "model": model,
+            "provider": _effective_provider,
+            "base_url": _effective_base_url,
+        }
+        _alias_supplied_provider = (
+            not _provider_was_explicit and bool(_effective_provider)
+        )
+
         # Apply IPv4 preference if configured.
         try:
             from hermes_constants import apply_ipv4_preference
@@ -5477,7 +5588,7 @@ def run_job(
         # job persisted before that guard — or written directly to the jobs store
         # — reaches this sink unchecked. Fail closed before resolution so no
         # off-host call is ever made with a stored key.
-        _guard_job_credential_exfil(job)
+        _guard_job_credential_exfil(_effective_job)
 
         # ---------------------------------------------------------------
         # Pre-dispatch configuration validation (T1-26).
@@ -5497,7 +5608,7 @@ def run_job(
         _pf_reason = None
         try:
             if _cron_preflight_enabled(_cfg):
-                _pf_reason = _preflight_job_config(job, _cfg)
+                _pf_reason = _preflight_job_config(_effective_job, _cfg)
                 if not _pf_reason and job.get("preflight_alerted"):
                     # Configuration validates again — clear the alert-once
                     # marker so a FUTURE config break re-alerts.
@@ -5569,15 +5680,15 @@ def run_job(
                 # Per-job user pin wins; otherwise the cron-fleet default
                 # provider (cron.model_provider); otherwise resolve from
                 # persisted global config.
-                "requested": job.get("provider") or _cron_default_provider or None,
+                "requested": _effective_provider,
                 # Derive provider-specific api_mode from the model this job
                 # will actually run (per-job pin > env > config default), not
                 # the stale persisted default — mirrors the fallback path
                 # below, which already passes its fb_model.
                 "target_model": model,
             }
-            if job.get("base_url"):
-                runtime_kwargs["explicit_base_url"] = job.get("base_url")
+            if _effective_base_url:
+                runtime_kwargs["explicit_base_url"] = _effective_base_url
             runtime = resolve_runtime_provider(**runtime_kwargs)
             primary_provider_for_drift = (
                 str(runtime.get("provider") or "").strip().lower()
@@ -5678,11 +5789,12 @@ def run_job(
                 primary_provider_for_drift or runtime.get("provider") or ""
             ).strip().lower()
             _current_model = str(primary_model_for_drift or "").strip().lower()
-            for _axis in cron_model_drift_axes(
+            for _axis in _cron_model_drift_axes_for_route(
                 job,
                 current_provider=_current_provider,
                 current_model=_current_model,
                 config=_cfg,
+                alias_supplied_provider=_alias_supplied_provider,
             ):
                 _snapshot = str(job.get(f"{_axis}_snapshot") or "").strip().lower()
                 _current = _current_provider if _axis == "provider" else _current_model
@@ -5822,6 +5934,17 @@ def run_job(
             session_id=_cron_session_id,
             session_db=_session_db,
         )
+
+        from tools.terminal_tool import register_task_env_overrides
+
+        register_task_env_overrides(
+            _cron_session_id,
+            {
+                "timeout": _resolve_cron_terminal_timeout(job, _cfg),
+                **({"cwd": _job_workdir} if _job_workdir else {}),
+            },
+        )
+        _terminal_override_registered = True
         
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
@@ -5883,7 +6006,13 @@ def run_job(
         # Tag this fire and time the run_conversation call for the usage_audit.jsonl entry.
         _audit_fire_id = uuid.uuid4().hex
         _audit_t_start = time.monotonic()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+        _cron_future = _cron_pool.submit(
+            _cron_context.run,
+            _run_cron_conversation,
+            agent,
+            prompt,
+            _cron_session_id,
+        )
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:
@@ -6122,6 +6251,16 @@ def run_job(
         return False, output, "", error_msg
 
     finally:
+        if _terminal_override_registered:
+            try:
+                from tools.terminal_tool import clear_task_env_overrides
+
+                clear_task_env_overrides(_cron_session_id)
+            except Exception:
+                logger.debug(
+                    "Job '%s': failed to clear terminal overrides", job_id,
+                    exc_info=True,
+                )
         # Restore TERMINAL_CWD to whatever it was before this job ran.  We
         # only ever mutate it when the job has a workdir AND actually held
         # the write lock — a fail-closed timeout raised before the env-set,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2511,6 +2511,9 @@ DEFAULT_CONFIG = {
         # Inference provider paired with cron.model (NOT the scheduler
         # provider below). Empty string = resolve from global config.
         "model_provider": "",
+        # Default foreground terminal-command timeout for cron agents. null
+        # follows terminal.timeout. A per-job terminal_timeout pin wins.
+        "terminal_timeout": None,
         # Active cron SCHEDULER provider (Axis B — the trigger that decides
         # WHEN a due job fires). Empty string = the built-in in-process 60s
         # ticker (default). Name an installed provider (plugins/cron_providers/<name>/ or

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -96,6 +96,22 @@ def _warn_if_gateway_not_running() -> None:
     print(color("     Check status:  hermes cron status", Colors.DIM))
 
 
+def _current_cron_inference_defaults():
+    """Return config plus the provider/model used by drift diagnostics."""
+    try:
+        from cron.scheduler import _resolve_cron_inference_route
+        from hermes_cli.config import load_config, resolve_cron_model_drift_defaults
+
+        cfg = load_config() or {}
+        provider, model = resolve_cron_model_drift_defaults(cfg)
+        _, resolved_provider, _ = _resolve_cron_inference_route(
+            model=model, provider=provider, base_url=None, config=cfg
+        )
+        return cfg, resolved_provider or provider, model
+    except Exception:
+        return {}, "", ""
+
+
 def cron_list(show_all: bool = False):
     """List all scheduled jobs."""
     from cron.jobs import list_jobs
@@ -114,6 +130,12 @@ def cron_list(show_all: bool = False):
     print()
 
     from cron.jobs import effective_job_state
+    from cron.scheduler import (
+        _cron_model_drift_axes_for_route,
+        _resolve_cron_inference_route,
+    )
+
+    drift_cfg, current_provider, current_model = _current_cron_inference_defaults()
 
     for job in jobs:
         job_id = job.get("id", "?")
@@ -142,10 +164,31 @@ def cron_list(show_all: bool = False):
         deliver_str = ", ".join(deliver)
 
         skills = job.get("skills") or ([job["skill"]] if job.get("skill") else [])
+        cron_cfg = drift_cfg.get("cron") if isinstance(drift_cfg.get("cron"), dict) else {}
+        route_provider = job.get("provider") or cron_cfg.get("model_provider") or None
+        route_model = job.get("model") or cron_cfg.get("model") or current_model
+        provider_was_explicit = bool(route_provider)
+        _, route_provider, _ = _resolve_cron_inference_route(
+            model=route_model,
+            provider=route_provider,
+            base_url=job.get("base_url"),
+            config=drift_cfg,
+        )
+        drifted_axes = _cron_model_drift_axes_for_route(
+            job,
+            current_provider=route_provider or current_provider,
+            current_model=current_model,
+            config=drift_cfg,
+            alias_supplied_provider=(
+                not provider_was_explicit and bool(route_provider)
+            ),
+        )
         if state == "paused":
             status = color("[paused]", Colors.YELLOW)
         elif state == "completed":
             status = color("[completed]", Colors.BLUE)
+        elif drifted_axes:
+            status = color("[drift-blocked]", Colors.RED)
         elif job.get("enabled", True):
             status = color("[active]", Colors.GREEN)
         else:
@@ -173,6 +216,15 @@ def cron_list(show_all: bool = False):
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
+        if drifted_axes:
+            print(
+                f"    {color('⚠ Inference drift:', Colors.RED)} "
+                f"{', '.join(drifted_axes)}"
+            )
+            print(
+                "      Pin the intended route with: hermes cron edit "
+                f"{job_id} --provider <provider> --model <model>"
+            )
 
         # Execution history
         last_status = job.get("last_status")
@@ -392,6 +444,8 @@ def cron_create(args):
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
+        base_url=getattr(args, "base_url", None),
+        terminal_timeout=getattr(args, "terminal_timeout", None),
         no_agent=getattr(args, "no_agent", False) or None,
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
@@ -467,6 +521,8 @@ def cron_edit(args):
         workdir=getattr(args, "workdir", None),
         model=getattr(args, "model", None),
         provider=getattr(args, "model_provider", None),
+        base_url=getattr(args, "base_url", None),
+        terminal_timeout=getattr(args, "terminal_timeout", None),
         no_agent=getattr(args, "no_agent", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
@@ -497,6 +553,8 @@ def cron_edit(args):
         print("  Continuity: on (each run sees the previous run's output)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if updated.get("terminal_timeout"):
+        print(f"  Terminal timeout: {updated['terminal_timeout']}s")
     return 0
 
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -526,6 +526,50 @@ _BUILTIN_DIRECT_ALIASES: dict[str, DirectAlias] = {}
 DIRECT_ALIASES: dict[str, DirectAlias] = {}
 
 
+def direct_aliases_from_config(cfg: dict[str, Any]) -> dict[str, DirectAlias]:
+    """Build direct aliases from an already-loaded config mapping."""
+    merged = dict(_BUILTIN_DIRECT_ALIASES)
+
+    # --- model_aliases (dict-based format) ---
+    user_aliases = cfg.get("model_aliases")
+    if isinstance(user_aliases, dict):
+        for name, entry in user_aliases.items():
+            if not isinstance(entry, dict):
+                continue
+            model = entry.get("model", "")
+            provider = entry.get("provider", "custom")
+            base_url = entry.get("base_url", "")
+            if model:
+                merged[name.strip().lower()] = DirectAlias(
+                    model=model, provider=provider, base_url=base_url,
+                )
+
+    # --- model.aliases (string-based format, from config set) ---
+    model_section = cfg.get("model", {})
+    if isinstance(model_section, dict):
+        simple_aliases = model_section.get("aliases")
+        if isinstance(simple_aliases, dict):
+            current_provider = model_section.get("provider", "")
+            for name, value in simple_aliases.items():
+                if not isinstance(value, str) or not value.strip():
+                    continue
+                key = name.strip().lower()
+                if key in merged:
+                    continue
+                val = value.strip()
+                if "/" in val:
+                    provider, model = val.split("/", 1)
+                else:
+                    provider = current_provider
+                    model = val
+                merged[key] = DirectAlias(
+                    model=model.strip(),
+                    provider=provider.strip() or current_provider,
+                    base_url="",
+                )
+    return merged
+
+
 def _load_direct_aliases() -> dict[str, DirectAlias]:
     """Load direct aliases from config.yaml ``model_aliases:`` section.
 
@@ -546,51 +590,12 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
     into DirectAlias objects.  The provider is parsed from the ``provider/``
     prefix in the value; if no slash, the current provider is used.
     """
-    merged = dict(_BUILTIN_DIRECT_ALIASES)
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
-
-        # --- model_aliases (dict-based format) ---
-        user_aliases = cfg.get("model_aliases")
-        if isinstance(user_aliases, dict):
-            for name, entry in user_aliases.items():
-                if not isinstance(entry, dict):
-                    continue
-                model = entry.get("model", "")
-                provider = entry.get("provider", "custom")
-                base_url = entry.get("base_url", "")
-                if model:
-                    merged[name.strip().lower()] = DirectAlias(
-                        model=model, provider=provider, base_url=base_url,
-                    )
-
-        # --- model.aliases (string-based format, from config set) ---
-        model_section = cfg.get("model", {})
-        if isinstance(model_section, dict):
-            simple_aliases = model_section.get("aliases")
-            if isinstance(simple_aliases, dict):
-                current_provider = model_section.get("provider", "")
-                for name, value in simple_aliases.items():
-                    if not isinstance(value, str) or not value.strip():
-                        continue
-                    key = name.strip().lower()
-                    if key in merged:
-                        continue  # don't override explicit model_aliases entries
-                    val = value.strip()
-                    if "/" in val:
-                        provider, model = val.split("/", 1)
-                    else:
-                        provider = current_provider
-                        model = val
-                    merged[key] = DirectAlias(
-                        model=model.strip(),
-                        provider=provider.strip() or current_provider,
-                        base_url="",
-                    )
+        return direct_aliases_from_config(cfg)
     except Exception:
-        pass
-    return merged
+        return dict(_BUILTIN_DIRECT_ALIASES)
 
 
 def _ensure_direct_aliases() -> None:

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -106,6 +106,23 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         help="Inference provider paired with --model (e.g. 'openrouter', 'nous').",
     )
     cron_create.add_argument(
+        "--base-url",
+        dest="base_url",
+        help=(
+            "Base URL paired with --provider for a custom/local endpoint. "
+            "Named providers may only use their configured endpoint host."
+        ),
+    )
+    cron_create.add_argument(
+        "--terminal-timeout",
+        dest="terminal_timeout",
+        type=int,
+        help=(
+            "Default foreground terminal timeout for this job in seconds. "
+            "Overrides cron.terminal_timeout and terminal.timeout."
+        ),
+    )
+    cron_create.add_argument(
         "--reasoning-effort",
         dest="reasoning_effort",
         help=(
@@ -240,6 +257,20 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--provider",
         dest="model_provider",
         help="Inference provider paired with --model. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--base-url",
+        dest="base_url",
+        help="Custom/local inference base URL. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--terminal-timeout",
+        dest="terminal_timeout",
+        type=int,
+        help=(
+            "Default foreground terminal timeout for this job in seconds. "
+            "Omit to preserve the current value."
+        ),
     )
     cron_edit.add_argument(
         "--reasoning-effort",

--- a/tests/cron/test_cron_custom_routing.py
+++ b/tests/cron/test_cron_custom_routing.py
@@ -1,0 +1,136 @@
+"""Regression coverage for cron custom routing and long-running commands."""
+
+import pytest
+
+from cron import scheduler
+from cron.jobs import create_job, get_job, update_job
+from hermes_cli.model_switch import DirectAlias
+from tools import terminal_tool
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def test_cron_route_dereferences_direct_model_alias(monkeypatch):
+    from hermes_cli import model_switch
+
+    direct_aliases = {
+        "ornith": DirectAlias(
+            model="Ornith-1.5-35B-Q6_K.gguf",
+            provider="custom:ornith",
+            base_url="http://127.0.0.1:8085/v1",
+        )
+    }
+    monkeypatch.setattr(model_switch, "_load_direct_aliases", lambda: direct_aliases)
+
+    assert scheduler._resolve_cron_inference_route(
+        model="ornith", provider=None, base_url=None
+    ) == (
+        "Ornith-1.5-35B-Q6_K.gguf",
+        "custom:ornith",
+        "http://127.0.0.1:8085/v1",
+    )
+
+
+def test_cron_route_keeps_explicit_provider_and_base_url(monkeypatch):
+    from hermes_cli import model_switch
+
+    direct_aliases = {
+        "ornith": DirectAlias(
+            model="aliased-model",
+            provider="custom:alias",
+            base_url="http://alias.invalid/v1",
+        )
+    }
+    monkeypatch.setattr(model_switch, "_load_direct_aliases", lambda: direct_aliases)
+
+    assert scheduler._resolve_cron_inference_route(
+        model="ornith",
+        provider="custom:explicit",
+        base_url="http://127.0.0.1:9999/v1/",
+    ) == (
+        "aliased-model",
+        "custom:explicit",
+        "http://127.0.0.1:9999/v1",
+    )
+
+
+def test_cron_route_reloads_aliases_for_each_fire(monkeypatch):
+    from hermes_cli import model_switch
+
+    aliases = iter(
+        [
+            {"ornith": DirectAlias("model-v1", "custom", "http://one/v1")},
+            {"ornith": DirectAlias("model-v2", "custom", "http://two/v1")},
+        ]
+    )
+    monkeypatch.setattr(model_switch, "_load_direct_aliases", lambda: next(aliases))
+
+    first = scheduler._resolve_cron_inference_route(
+        model="ornith", provider=None, base_url=None
+    )
+    second = scheduler._resolve_cron_inference_route(
+        model="ornith", provider=None, base_url=None
+    )
+
+    assert first == ("model-v1", "custom", "http://one/v1")
+    assert second == ("model-v2", "custom", "http://two/v1")
+
+
+def test_alias_owned_provider_does_not_trigger_drift_guard():
+    job = {
+        "model": "ornith",
+        "provider": None,
+        "provider_snapshot": "openrouter",
+        "model_snapshot": None,
+    }
+
+    assert scheduler._cron_model_drift_axes_for_route(
+        job,
+        current_provider="custom",
+        current_model="Ornith-1.5-35B-Q6_K.gguf",
+        config={},
+        alias_supplied_provider=True,
+    ) == []
+
+
+def test_job_terminal_timeout_round_trips_and_validates(tmp_cron_dir):
+    job = create_job(
+        prompt="Build project",
+        schedule="every 1h",
+        terminal_timeout=900,
+    )
+    assert get_job(job["id"])["terminal_timeout"] == 900
+
+    updated = update_job(job["id"], {"terminal_timeout": 1200})
+    assert updated["terminal_timeout"] == 1200
+
+    with pytest.raises(ValueError, match="positive"):
+        update_job(job["id"], {"terminal_timeout": 0})
+
+
+def test_cron_terminal_timeout_prefers_job_then_fleet_then_terminal_default():
+    assert scheduler._resolve_cron_terminal_timeout(
+        {"terminal_timeout": 900},
+        {"cron": {"terminal_timeout": 600}, "terminal": {"timeout": 180}},
+    ) == 900
+    assert scheduler._resolve_cron_terminal_timeout(
+        {}, {"cron": {"terminal_timeout": 600}, "terminal": {"timeout": 180}}
+    ) == 600
+    assert scheduler._resolve_cron_terminal_timeout(
+        {}, {"terminal": {"timeout": 180}}
+    ) == 180
+
+
+def test_terminal_task_override_controls_default_timeout():
+    assert terminal_tool._resolve_command_timeout(
+        {"timeout": 30}, {"timeout": 900}
+    ) == 900
+    assert terminal_tool._resolve_command_timeout(
+        {"timeout": 30}, {}
+    ) == 30

--- a/tests/cron/test_cron_custom_routing.py
+++ b/tests/cron/test_cron_custom_routing.py
@@ -18,6 +18,7 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 def test_cron_route_dereferences_direct_model_alias(monkeypatch):
     from hermes_cli import model_switch
+    from hermes_cli import runtime_provider
 
     direct_aliases = {
         "ornith": DirectAlias(
@@ -27,18 +28,62 @@ def test_cron_route_dereferences_direct_model_alias(monkeypatch):
         )
     }
     monkeypatch.setattr(model_switch, "_load_direct_aliases", lambda: direct_aliases)
+    monkeypatch.setattr(runtime_provider, "has_named_custom_provider", lambda _: False)
 
     assert scheduler._resolve_cron_inference_route(
         model="ornith", provider=None, base_url=None
     ) == (
         "Ornith-1.5-35B-Q6_K.gguf",
-        "custom:ornith",
+        "custom",
         "http://127.0.0.1:8085/v1",
     )
 
 
-def test_cron_route_keeps_explicit_provider_and_base_url(monkeypatch):
+def test_cron_route_keeps_configured_named_custom_provider(monkeypatch):
     from hermes_cli import model_switch
+    from hermes_cli import runtime_provider
+
+    direct_aliases = {
+        "ornith": DirectAlias(
+            model="aliased-model",
+            provider="custom:ornith",
+            base_url="https://ornith.example/v1",
+        )
+    }
+    monkeypatch.setattr(model_switch, "_load_direct_aliases", lambda: direct_aliases)
+    monkeypatch.setattr(runtime_provider, "has_named_custom_provider", lambda _: True)
+
+    assert scheduler._resolve_cron_inference_route(
+        model="ornith", provider=None, base_url=None
+    ) == (
+        "aliased-model",
+        "custom:ornith",
+        "https://ornith.example/v1",
+    )
+
+
+def test_cron_route_normalizes_unconfigured_custom_provider_without_model_alias(
+    monkeypatch,
+):
+    from hermes_cli import runtime_provider
+
+    monkeypatch.setattr(runtime_provider, "has_named_custom_provider", lambda _: False)
+
+    assert scheduler._resolve_cron_inference_route(
+        model="canonical-model",
+        provider="custom:ornith",
+        base_url="http://127.0.0.1:8085/v1",
+        config={},
+    ) == (
+        "canonical-model",
+        "custom",
+        "http://127.0.0.1:8085/v1",
+    )
+
+
+def test_cron_route_keeps_explicit_base_url_for_alias_only_custom_provider(monkeypatch):
+    from hermes_cli import model_switch
+    from hermes_cli import runtime_provider
 
     direct_aliases = {
         "ornith": DirectAlias(
@@ -48,6 +93,7 @@ def test_cron_route_keeps_explicit_provider_and_base_url(monkeypatch):
         )
     }
     monkeypatch.setattr(model_switch, "_load_direct_aliases", lambda: direct_aliases)
+    monkeypatch.setattr(runtime_provider, "has_named_custom_provider", lambda _: False)
 
     assert scheduler._resolve_cron_inference_route(
         model="ornith",
@@ -55,7 +101,7 @@ def test_cron_route_keeps_explicit_provider_and_base_url(monkeypatch):
         base_url="http://127.0.0.1:9999/v1/",
     ) == (
         "aliased-model",
-        "custom:explicit",
+        "custom",
         "http://127.0.0.1:9999/v1",
     )
 

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -36,15 +36,23 @@ class TestCronCommandLifecycle:
                 "--model",
                 "new-model",
                 "--provider",
-                "nous",
+                "custom",
+                "--base-url",
+                "https://inference.example/v1/",
+                "--terminal-timeout",
+                "900",
             ]
         )
         cron_command(args)
 
         updated = get_job(job["id"])
         assert updated["model"] == "new-model"
-        assert updated["provider"] == "nous"
-        assert "Updated job" in capsys.readouterr().out
+        assert updated["provider"] == "custom"
+        assert updated["base_url"] == "https://inference.example/v1"
+        assert updated["terminal_timeout"] == 900
+        out = capsys.readouterr().out
+        assert "Updated job" in out
+        assert "Terminal timeout: 900s" in out
 
     def test_edit_can_replace_and_clear_skills(self, tmp_cron_dir, capsys):
         job = create_job(
@@ -228,6 +236,40 @@ def test_cron_list_warns_when_gateway_not_running(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Gateway is not running" in out
     assert "Nightly docs" in out
+
+
+def test_cron_list_surfaces_drift_before_first_missed_run(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "cron.jobs.list_jobs",
+        lambda include_disabled=False: [
+            {
+                "id": "job-drift",
+                "name": "Pinned expectation",
+                "schedule_display": "every hour",
+                "state": "scheduled",
+                "enabled": True,
+                "next_run_at": "2026-06-01T00:00:00Z",
+                "deliver": ["local"],
+                "provider": None,
+                "model": None,
+                "provider_snapshot": "openrouter",
+                "model_snapshot": "old/model",
+                "last_status": None,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        cron_cli,
+        "_current_cron_inference_defaults",
+        lambda: ({}, "nous", "new/model"),
+    )
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [123])
+
+    cron_cli.cron_list()
+
+    out = capsys.readouterr().out.lower()
+    assert "drift-blocked" in out
+    assert "--provider <provider> --model <model>" in out
 
 
 def test_cron_tick_invokes_scheduler_tick_with_verbose(monkeypatch):

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -387,6 +387,32 @@ class TestUnifiedCronjobTool:
         stored = get_job(created["job_id"])
         assert stored["deliver"] == "telegram"
 
+    def test_update_persists_unconfigured_custom_alias_route(self, monkeypatch):
+        import hermes_cli.runtime_provider as rp
+        from cron.jobs import get_job
+
+        monkeypatch.setattr(rp, "has_named_custom_provider", lambda n: False)
+        created = json.loads(
+            cronjob(action="create", prompt="x", schedule="every 1h")
+        )
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                model="ornith-review",
+                provider="custom:ornith",
+                base_url="http://127.0.0.1:8085/v1",
+                terminal_timeout=5,
+            )
+        )
+
+        assert updated["success"] is True
+        stored = get_job(created["job_id"])
+        assert stored["model"] == "ornith-review"
+        assert stored["provider"] == "custom:ornith"
+        assert stored["base_url"] == "http://127.0.0.1:8085/v1"
+        assert stored["terminal_timeout"] == 5
+
 
 # =========================================================================
 # Agent-facing surface: per-job model pins are user-owned
@@ -523,6 +549,12 @@ class TestValidateCronBaseUrl:
     def test_named_custom_lookalike_host_blocked(self, monkeypatch):
         self._patch_named_legit(monkeypatch)
         assert self._v("custom:legit", "https://legit.example.attacker.test/v1") is not None
+
+    def test_unconfigured_custom_alias_with_explicit_endpoint_allowed(self, monkeypatch):
+        import hermes_cli.runtime_provider as rp
+
+        monkeypatch.setattr(rp, "has_named_custom_provider", lambda n: False)
+        assert self._v("custom:ornith", "http://127.0.0.1:8085/v1") is None
 
 
     def test_named_registry_offhost_blocked(self):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -641,6 +641,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "model": job.get("model"),
         "provider": job.get("provider"),
         "base_url": job.get("base_url"),
+        "terminal_timeout": job.get("terminal_timeout"),
         "schedule": job.get("schedule_display") or "?",
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
@@ -1203,6 +1204,7 @@ def cronjob(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
+    terminal_timeout: Optional[int] = None,
     reason: Optional[str] = None,
     script: Optional[str] = None,
     context_from: Optional[Union[str, List[str]]] = None,
@@ -1306,6 +1308,7 @@ def cronjob(
                     model=_normalize_optional_job_value(model),
                     provider=_normalize_optional_job_value(provider),
                     base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                    terminal_timeout=terminal_timeout,
                     script=_normalize_optional_job_value(script),
                     context_from=context_from,
                     enabled_toolsets=enabled_toolsets or None,
@@ -1502,6 +1505,8 @@ def cronjob(
                 updates["provider"] = _normalize_optional_job_value(provider)
             if base_url is not None:
                 updates["base_url"] = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+            if terminal_timeout is not None:
+                updates["terminal_timeout"] = terminal_timeout
             if reasoning_effort is not None:
                 # CLI-only lane (see create above): update_job validates
                 # against the canonical grammar; empty string clears the pin.

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -569,6 +569,11 @@ def _validate_cron_base_url(
             f"custom provider's stored credential may only be sent to its own "
             f"configured endpoint ({cfg_host or 'unknown'})."
         )
+    if prov.lower().startswith("custom:"):
+        # Alias-only custom labels carry no configured credential. The
+        # scheduler normalizes them to bare custom before runtime resolution,
+        # so they have the same BYOK trust boundary as provider="custom".
+        return None
     try:
         resolved = resolve_requested_provider(prov)
     except Exception:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2601,6 +2601,16 @@ def _resolve_command_cwd(
     return recorded or default_cwd
 
 
+def _resolve_command_timeout(config: Dict[str, Any], overrides: Dict[str, Any]) -> int:
+    """Return the session-scoped default command timeout."""
+    value = overrides.get("timeout", config["timeout"])
+    try:
+        timeout = int(value)
+    except (TypeError, ValueError):
+        return int(config["timeout"])
+    return timeout if timeout > 0 else int(config["timeout"])
+
+
 def terminal_tool(
     command: str,
     background: bool = False,
@@ -2714,7 +2724,7 @@ def terminal_tool(
                     cwd, env_type, remapped,
                 )
             cwd = remapped
-        default_timeout = config["timeout"]
+        default_timeout = _resolve_command_timeout(config, overrides)
 
         # Validate an explicit timeout before it flows into deadline math.
         # ``timeout or default`` silently turns 0 into the default (0 can't mean

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -24,8 +24,9 @@ All of this is available to Hermes itself through the `cronjob` tool, so you can
 :::tip
 **Which model does a cron job run on?** Resolution at fire time is: per-job pin → `cron.model` in `config.yaml` → the global default from `hermes model`.
 
-- **Per-job pin** — set by *you* via the dashboard, `hermes cron create/edit --model … --provider …`, or by editing `~/.hermes/cron/jobs.json`. Once set, it sticks until you change it. The agent's `cronjob` tool cannot set or change per-job models — inference pins are user-owned.
+- **Per-job pin** — set by *you* via the dashboard or `hermes cron create/edit --model … --provider … [--base-url …]`. Once set, it sticks until you change it. The agent's `cronjob` tool cannot set or change per-job models — inference pins are user-owned. For local OpenAI-compatible servers, use `--provider custom --base-url http://127.0.0.1:8085/v1`; named `custom:<name>` providers resolve through the same configured-provider catalog as interactive sessions.
 - **`cron.model` / `cron.model_provider`** — a cron-fleet default: every unpinned job runs on this model, independent of your chat model. Set it once (`hermes config set cron.model <name>`) and switching your chat model with `hermes model` or `/model` never touches your cron fleet.
+- **Model aliases** — aliases from `model_aliases` or `model.aliases` are dereferenced at fire time as an atomic model/provider/base-URL route. Explicit per-job `--provider` or `--base-url` values still win over the alias fields.
 - **Global default** — only when neither of the above is set does a job follow `hermes model`. In this case Hermes **snapshots** the provider and model at creation, and if the global default later changes the job **fails closed**: it skips the run, makes no inference call, and alerts you **once** — the job stays skipped (and silent) on subsequent ticks until you act or the config is restored (#44585). For recurring or otherwise repeatable jobs, pin the provider/model explicitly (`hermes cron edit <job_id> --provider <provider> --model <model>`) to proceed. A consumed finite one-shot cannot be updated; create a new future one-shot with an explicit provider and model instead. This prevents an unattended job from silently inheriting a switch to a paid provider/model. Setting `cron.model` (or a per-job pin) is the deliberate way to route cron spend, and the drift guard does not engage for an axis covered by it. Operators who instead want unpinned jobs to track the changing global default can [disable the drift guard](#letting-unpinned-jobs-track-global-defaults).
 
 `hermes setup --portal` is the lowest-friction option for unattended runs since OAuth refresh is automatic. See [Nous Portal](/integrations/nous-portal).
@@ -189,6 +190,26 @@ When `workdir` is set:
 Jobs with a `workdir` run sequentially on the scheduler tick, not in the parallel pool. This is deliberate: the cron worker applies the job workdir through process-global terminal state, so two workdir jobs running at the same time would corrupt each other's cwd. Workdir-less jobs still run in parallel as before.
 :::
 
+### Long-running terminal commands
+
+Cron agents normally inherit `terminal.timeout`. For builds, migrations, and
+other foreground commands that need longer, pin a timeout on one job:
+
+```bash
+hermes cron edit <job_id> --terminal-timeout 900
+```
+
+Or set a fleet-wide cron default while leaving interactive sessions unchanged:
+
+```bash
+hermes config set cron.terminal_timeout 900
+```
+
+Resolution is per-job `terminal_timeout` → `cron.terminal_timeout` →
+`terminal.timeout`. The override is session-scoped, so concurrent chat and cron
+agents do not inherit each other's timeout. Commands longer than the foreground
+window should still use the terminal tool's managed background mode.
+
 ## Editing jobs
 
 You do not need to delete and recreate jobs just to change them.
@@ -212,6 +233,9 @@ The `<job_id>` placeholder below (and in [Lifecycle actions](#lifecycle-actions)
 ```bash
 hermes cron edit <job_id> --schedule "every 4h"
 hermes cron edit <job_id> --prompt "Use the revised task"
+hermes cron edit <job_id> --provider custom --model Ornith.gguf \
+  --base-url http://127.0.0.1:8085/v1
+hermes cron edit <job_id> --terminal-timeout 900
 hermes cron edit <job_id> --skill blogwatcher --skill maps
 hermes cron edit <job_id> --add-skill maps
 hermes cron edit <job_id> --remove-skill blogwatcher


### PR DESCRIPTION
## What does this PR do?

Cron jobs can now use configured model aliases and local/custom inference endpoints without hand-editing jobs.json, while long-running build commands can use a cron-scoped terminal timeout. The CLI also surfaces drift-blocked jobs before their first missed run so operators get an actionable recovery command instead of an unexplained "no runs" state.

### Symptom

`hermes cron create/edit` could pin a model and provider but not the base URL required by a local OpenAI-compatible server. Cron also forwarded model aliases literally, rejected or misrouted custom provider routes during preflight, inherited a short global terminal timeout for long builds, and showed model drift only after a failed fire.

### Impact

Users running local models or multi-minute build commands could not configure a working unattended cron job through supported CLI paths. They had to edit jobs.json manually, and drift-blocked jobs could look like they had never run.

### Bug Cause

**Trigger:** `hermes_cli/cron.py::cron_create`, `cron/scheduler.py::run_job`, and `tools/terminal_tool.py::terminal_tool`

**Causal chain:**
1. The cron CLI omitted `base_url`, and the scheduler passed the stored model string directly to provider resolution.
2. Alias model/provider/base URL fields were not resolved as one route, while preflight and runtime resolution inspected different effective values.
3. Terminal defaults came only from process-level terminal config, so a cron job could not safely raise its own command timeout.
4. The CLI list rendered persisted run state but did not evaluate the existing drift guard before the first skipped fire.

**Why it is wrong:** Cron exposed supported custom-provider and alias configuration but dropped required routing fields before the transport boundary. Its process-global timeout path also could not safely vary across concurrent sessions.

**Working sibling / contrast:** Interactive one-shot model selection already dereferences direct aliases into model, provider, and base URL fields. Per-task terminal overrides already isolate sandbox and cwd settings by task ID.

**Ruled out:** This is not a missing local-server credential alone. The same configured route works once base_url is manually persisted, and focused tests reproduce the missing CLI field, literal alias routing, and timeout precedence without a network dependency.

### Fix

- Add user-owned `--base-url` and `--terminal-timeout` options to cron create/edit.
- Resolve `model_aliases` and `model.aliases` from fresh cron config into one effective model/provider/base URL route used by security validation, preflight, and runtime provider resolution.
- Treat an alias-supplied provider as part of the explicit route so the drift guard does not split and reject an atomic alias.
- Apply per-job or fleet-wide cron terminal defaults through task-scoped terminal overrides and clear them after each run.
- Render proactive `[drift-blocked]` state and an exact pinning command in `hermes cron list`.
- Document local endpoints, aliases, long-running commands, and timeout precedence.

## Related Issue

Closes #91726

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py` - persist and validate optional per-job terminal timeouts.
- `cron/scheduler.py` - resolve atomic alias routes, share them across preflight/runtime, preserve drift semantics, and install task-scoped terminal defaults.
- `hermes_cli/cron.py` and `hermes_cli/subcommands/cron.py` - expose base URL and timeout flags plus proactive drift status.
- `hermes_cli/model_switch.py` - build aliases from an already-loaded config so cron can reload them without an extra config/provider scan.
- `tools/terminal_tool.py` - honor task-scoped default command timeouts.
- `website/docs/user-guide/features/cron.md` - document supported routes and long-running command configuration.
- `tests/cron/test_cron_custom_routing.py` and `tests/hermes_cli/test_cron.py` - cover routing, precedence, validation, reload, and list UX.

## How to Test

1. Configure a `model_aliases` entry for a local OpenAI-compatible endpoint.
2. Create or edit a cron job with the alias, or pass `--provider custom --model <model> --base-url <url>`.
3. Set `--terminal-timeout 900`, list the job, and run the focused regression suite:

```bash
scripts/run_tests.sh tests/cron/test_cron_custom_routing.py tests/cron/test_cron_provider_pin.py tests/cron/test_preflight_config.py tests/cron/test_scheduler_cron_session_isolation.py tests/cron/test_codex_execution_paths.py tests/cron/test_cleanup_timeout.py tests/hermes_cli/test_cron.py tests/hermes_cli/test_ollama_cloud_auth.py tests/tools/test_terminal_tool.py -q
```

Result: 84 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant repository test entry and all 84 focused tests pass
- [x] I've added tests for my changes
- [x] I've tested the focused suite on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because defaults are generated from `DEFAULT_CONFIG`
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no contributor workflow changed
- [x] I've considered cross-platform impact; timeout storage and routing are platform-neutral, and task scoping avoids process-global leakage
- [x] Tool descriptions/schemas are N/A because inference pins remain intentionally user-owned CLI settings

## Screenshots / Logs

N/A - behavior is covered by CLI and scheduler regression tests.
