### PR TITLE
fix(state): fail closed on damaged state.db before gateway writes

### DIFF
--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -17,6 +17,11 @@ from .session import (
     build_session_context_prompt,
 )
 from .delivery import DeliveryRouter, DeliveryTarget
+from .state_db_authority import install_gateway_state_db_authority
+
+# Installation is passive: no path is resolved and no database is opened until
+# a writable SessionDB is actually constructed by a gateway surface.
+install_gateway_state_db_authority()
 
 __all__ = [
     # Config

--- a/gateway/state_db_authority/__init__.py
+++ b/gateway/state_db_authority/__init__.py
@@ -1,0 +1,45 @@
+"""Proof-bearing writer admission for every gateway ``SessionDB`` path.
+
+Import is passive. The first writable handle for a canonical state.db path runs
+Hermes' full health probe, opens a kernel-identity anchor, and receives a proof
+whose lifetime ends with the last live admitted handle. Replacing the pathname
+while that proof is live is refused as split-brain.
+"""
+
+from ._authority import AUTHORITY, GatewayStateDBAuthority
+from ._install import install_gateway_state_db_authority
+from ._model import (
+    IntegrityVerdict,
+    StateDBAdmissionBusyError,
+    StateDBAdmissionError,
+    StateDBAdmissionProof,
+    StateDBFileIdentity,
+    StateDBGenerationConflictError,
+    StateDBIntegrityError,
+    StateDBIntegrityReport,
+    canonical_state_db_path,
+    sqlite_read_only_uri,
+)
+from ._verify import verify_state_db_integrity
+
+
+def gateway_state_db_authority_snapshot():
+    return AUTHORITY.snapshot()
+
+
+__all__ = [
+    "GatewayStateDBAuthority",
+    "IntegrityVerdict",
+    "StateDBAdmissionBusyError",
+    "StateDBAdmissionError",
+    "StateDBAdmissionProof",
+    "StateDBFileIdentity",
+    "StateDBGenerationConflictError",
+    "StateDBIntegrityError",
+    "StateDBIntegrityReport",
+    "canonical_state_db_path",
+    "gateway_state_db_authority_snapshot",
+    "install_gateway_state_db_authority",
+    "sqlite_read_only_uri",
+    "verify_state_db_integrity",
+]

--- a/gateway/state_db_authority/_authority.py
+++ b/gateway/state_db_authority/_authority.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+import hermes_state
+
+from ._context import EXPECTED_GENERATION, ORIGINAL_SESSION_DB, PENDING_FAILURE
+from ._lock import CrossProcessAdmissionLock
+from ._model import (
+    IntegrityVerdict,
+    StateDBAdmissionBusyError,
+    StateDBAdmissionError,
+    StateDBAdmissionProof,
+    StateDBFileIdentity,
+    StateDBGenerationConflictError,
+    StateDBIntegrityError,
+    StateDBIntegrityReport,
+    anchor_identity,
+    canonical_state_db_path,
+    format_refusal,
+    problem_verdict,
+    same_identity,
+    stat_identity,
+)
+from ._verify import repair_and_reverify, verify_state_db_integrity
+
+
+@dataclass
+class _LiveGeneration:
+    proof: StateDBAdmissionProof
+    anchor_fd: int
+    holders: int = 0
+
+
+class GatewayStateDBAuthority:
+    """Own proof-bearing first admission for every gateway writer handle."""
+
+    def __init__(self) -> None:
+        self._map_lock = threading.Lock()
+        self._path_locks: dict[Path, threading.RLock] = {}
+        self._live: dict[Path, _LiveGeneration] = {}
+
+    def _path_lock(self, path: Path) -> threading.RLock:
+        with self._map_lock:
+            return self._path_locks.setdefault(path, threading.RLock())
+
+    def _bootstrap(
+        self,
+        instance: Any,
+        path: Path,
+        original_init: Callable[..., None],
+    ) -> None:
+        """Materialize required schema bytes, then close the bootstrap writer.
+
+        Bootstrap is not an integrity proof. The file can be replaced after
+        schema creation, so the temporary writer is always closed before the
+        ordinary verify -> identity anchor -> exact-generation open sequence.
+        """
+        try:
+            original_init(instance, db_path=path, read_only=False)
+            conn = getattr(instance, "_conn", None)
+            if conn is None:
+                raise RuntimeError("SessionDB bootstrap returned without a connection")
+            # Prove only that schema materialization reached the required tables.
+            # The canonical full integrity probe runs after this writer closes.
+            conn.execute("SELECT 1 FROM sessions LIMIT 1").fetchone()
+            conn.execute("SELECT 1 FROM messages LIMIT 1").fetchone()
+        except StateDBAdmissionError:
+            self._close_quietly(instance)
+            raise
+        except Exception as exc:
+            self._close_quietly(instance)
+            report = StateDBIntegrityReport(
+                path=path,
+                verdict=problem_verdict(str(exc)),
+                checked="bootstrap_schema",
+                problems=(str(exc),),
+                identity=(stat_identity(path) if path.exists() else None),
+            )
+            raise StateDBIntegrityError(
+                format_refusal(report),
+                path=path,
+                report=report,
+            ) from exc
+
+        try:
+            ORIGINAL_SESSION_DB.close(instance)
+            # Do not leave a closed bootstrap handle looking like the admitted
+            # connection while the exact generation is being verified/opened.
+            instance._conn = None
+        except Exception as exc:
+            report = StateDBIntegrityReport(
+                path=path,
+                verdict=problem_verdict(str(exc)),
+                checked="bootstrap_close",
+                problems=(str(exc),),
+                identity=(stat_identity(path) if path.exists() else None),
+            )
+            raise StateDBIntegrityError(
+                format_refusal(report),
+                path=path,
+                report=report,
+            ) from exc
+
+    @staticmethod
+    def _close_quietly(instance: Any) -> None:
+        try:
+            ORIGINAL_SESSION_DB.close(instance)
+        except Exception:
+            pass
+        try:
+            instance._conn = None
+        except Exception:
+            pass
+
+    @staticmethod
+    def _open_anchor(
+        path: Path,
+        expected: StateDBFileIdentity,
+    ) -> tuple[int, StateDBFileIdentity]:
+        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+        fd = os.open(path, flags)
+        actual = anchor_identity(fd)
+        if same_identity(expected, actual):
+            return fd, actual
+        os.close(fd)
+        raise StateDBGenerationConflictError(
+            f"state.db at {path} changed before its admission anchor opened",
+            path=path,
+        )
+
+    @staticmethod
+    def _assert_anchor_is_current(live: _LiveGeneration) -> None:
+        try:
+            current = stat_identity(live.proof.path)
+            anchored = anchor_identity(live.anchor_fd)
+        except OSError as exc:
+            raise StateDBGenerationConflictError(
+                f"cannot prove the admitted state.db is current: {exc}",
+                path=live.proof.path,
+                report=live.proof.report,
+            ) from exc
+        if not same_identity(current, anchored):
+            raise StateDBGenerationConflictError(
+                f"state.db at {live.proof.path} was replaced while generation "
+                f"{live.proof.proof_id} still has live writers; refusing split-brain",
+                path=live.proof.path,
+                report=live.proof.report,
+            )
+
+    @staticmethod
+    def _open_exact_generation(
+        instance: Any,
+        path: Path,
+        identity: StateDBFileIdentity,
+        original_init: Callable[..., None],
+    ) -> None:
+        token = EXPECTED_GENERATION.set((path, identity))
+        try:
+            original_init(instance, db_path=path, read_only=False)
+        finally:
+            EXPECTED_GENERATION.reset(token)
+
+    @staticmethod
+    def _refuse_unhealthy(report: StateDBIntegrityReport, path: Path) -> None:
+        if report.may_open_writer and report.identity is not None:
+            return
+        error_type = (
+            StateDBAdmissionBusyError
+            if report.verdict is IntegrityVerdict.BUSY
+            else StateDBIntegrityError
+        )
+        raise error_type(
+            format_refusal(report),
+            path=path,
+            report=report,
+        )
+
+    def initialize_writable(
+        self,
+        instance: Any,
+        *,
+        db_path: Path | str | None,
+        original_init: Callable[..., None],
+    ) -> None:
+        path = canonical_state_db_path(db_path)
+        try:
+            with self._path_lock(path), CrossProcessAdmissionLock(path):
+                live = self._live.get(path)
+                if live is not None:
+                    self._assert_anchor_is_current(live)
+                    self._open_exact_generation(
+                        instance,
+                        path,
+                        live.proof.identity,
+                        original_init,
+                    )
+                    live.holders += 1
+                    instance._gateway_state_db_admission = live.proof
+                    return
+
+                report = verify_state_db_integrity(path)
+                needs_schema_materialization = report.verdict in {
+                    IntegrityVerdict.ABSENT,
+                    IntegrityVerdict.EMPTY,
+                    IntegrityVerdict.SCHEMA_INCOMPLETE,
+                }
+                is_zeroed = getattr(
+                    hermes_state,
+                    "is_zeroed_state_db",
+                    lambda _path: False,
+                )
+                if (
+                    report.verdict is IntegrityVerdict.CORRUPT
+                    and path.exists()
+                    and is_zeroed(path)
+                ):
+                    needs_schema_materialization = True
+
+                if needs_schema_materialization:
+                    # Materialize schema only. Never inherit health from the
+                    # temporary bootstrap handle: close it, then verify the
+                    # exact path generation that will actually be admitted.
+                    self._bootstrap(instance, path, original_init)
+                    report = repair_and_reverify(
+                        path,
+                        verify_state_db_integrity(path),
+                    )
+                else:
+                    report = repair_and_reverify(path, report)
+
+                self._refuse_unhealthy(report, path)
+                assert report.identity is not None
+                anchor_fd, identity = self._open_anchor(path, report.identity)
+                try:
+                    # All writers, including schema-materializing writers, are
+                    # admitted only after the same generation has a canonical
+                    # health proof and an anchor. There is no bootstrap
+                    # exception to verify -> anchor -> exact-open.
+                    self._open_exact_generation(
+                        instance,
+                        path,
+                        identity,
+                        original_init,
+                    )
+                    if not same_identity(identity, stat_identity(path)):
+                        raise StateDBGenerationConflictError(
+                            f"state.db at {path} changed while its writer opened",
+                            path=path,
+                            report=report,
+                        )
+                    proof = StateDBAdmissionProof(
+                        proof_id=uuid.uuid4().hex,
+                        path=path,
+                        identity=identity,
+                        report=report,
+                        verified_at=time.time(),
+                    )
+                    self._live[path] = _LiveGeneration(
+                        proof=proof,
+                        anchor_fd=anchor_fd,
+                        holders=1,
+                    )
+                    instance._gateway_state_db_admission = proof
+                except BaseException:
+                    self._close_quietly(instance)
+                    os.close(anchor_fd)
+                    raise
+        except StateDBAdmissionError as exc:
+            PENDING_FAILURE.set(exc)
+            raise
+
+    def release(self, instance: Any) -> None:
+        proof = getattr(instance, "_gateway_state_db_admission", None)
+        if not isinstance(proof, StateDBAdmissionProof):
+            return
+        instance._gateway_state_db_admission = None
+        with self._path_lock(proof.path):
+            live = self._live.get(proof.path)
+            if live is None or live.proof.proof_id != proof.proof_id:
+                return
+            live.holders -= 1
+            if live.holders > 0:
+                return
+            self._live.pop(proof.path, None)
+            try:
+                os.close(live.anchor_fd)
+            except OSError:
+                pass
+
+    def snapshot(self) -> dict[str, dict[str, Any]]:
+        with self._map_lock:
+            paths = list(self._live)
+        result: dict[str, dict[str, Any]] = {}
+        for path in paths:
+            with self._path_lock(path):
+                live = self._live.get(path)
+                if live is None:
+                    continue
+                result[str(path)] = {
+                    "proof_id": live.proof.proof_id,
+                    "holders": live.holders,
+                    "identity": {
+                        "device": live.proof.identity.device,
+                        "inode": live.proof.identity.inode,
+                    },
+                    "report": live.proof.report.as_dict(),
+                }
+        return result
+
+
+AUTHORITY = GatewayStateDBAuthority()

--- a/gateway/state_db_authority/_context.py
+++ b/gateway/state_db_authority/_context.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import contextvars
+from pathlib import Path
+from typing import Optional
+
+import hermes_state
+
+from ._model import StateDBAdmissionError, StateDBFileIdentity
+
+
+EXPECTED_GENERATION: contextvars.ContextVar[
+    Optional[tuple[Path, StateDBFileIdentity]]
+] = contextvars.ContextVar("gateway_state_db_expected_generation", default=None)
+PENDING_FAILURE: contextvars.ContextVar[Optional[StateDBAdmissionError]] = (
+    contextvars.ContextVar("gateway_state_db_pending_failure", default=None)
+)
+
+ORIGINAL_SESSION_DB = getattr(
+    hermes_state.SessionDB,
+    "_gateway_state_db_original_class",
+    hermes_state.SessionDB,
+)
+ORIGINAL_TRACKED_CONNECT = getattr(
+    hermes_state._connect_tracked_db,
+    "__wrapped__",
+    hermes_state._connect_tracked_db,
+)

--- a/gateway/state_db_authority/_install.py
+++ b/gateway/state_db_authority/_install.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import hermes_state
+
+from ._authority import AUTHORITY
+from ._context import (
+    EXPECTED_GENERATION,
+    ORIGINAL_SESSION_DB,
+    ORIGINAL_TRACKED_CONNECT,
+    PENDING_FAILURE,
+)
+from ._model import (
+    StateDBAdmissionError,
+    StateDBGenerationConflictError,
+    canonical_state_db_path,
+    same_identity,
+    stat_identity,
+)
+
+
+def _database_matches_expected(database: Any, expected_path: Path) -> bool:
+    if isinstance(database, Path):
+        candidate = database
+    elif isinstance(database, str):
+        if database == ":memory:" or database.startswith("file:"):
+            return False
+        candidate = Path(database)
+    else:
+        return False
+    return canonical_state_db_path(candidate) == expected_path
+
+
+def guarded_tracked_connect(database: Any, *args: Any, **kwargs: Any):
+    expected = EXPECTED_GENERATION.get()
+    if expected is None or not _database_matches_expected(database, expected[0]):
+        return ORIGINAL_TRACKED_CONNECT(database, *args, **kwargs)
+
+    path, identity = expected
+    try:
+        before = stat_identity(path)
+    except OSError as exc:
+        raise StateDBGenerationConflictError(
+            f"state.db disappeared before writer connect: {exc}",
+            path=path,
+        ) from exc
+    if not same_identity(before, identity):
+        raise StateDBGenerationConflictError(
+            f"state.db at {path} no longer matches the verified generation",
+            path=path,
+        )
+
+    conn = ORIGINAL_TRACKED_CONNECT(database, *args, **kwargs)
+    try:
+        if not same_identity(stat_identity(path), identity):
+            raise StateDBGenerationConflictError(
+                f"state.db at {path} changed generation during writer connect",
+                path=path,
+            )
+        return conn
+    except BaseException:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        raise
+
+
+def _install_connect_guard() -> None:
+    current = hermes_state._connect_tracked_db
+    if getattr(current, "_gateway_state_db_generation_guard", False):
+        return
+    guarded_tracked_connect._gateway_state_db_generation_guard = True
+    guarded_tracked_connect.__wrapped__ = current
+    hermes_state._connect_tracked_db = guarded_tracked_connect
+
+
+def _build_admitted_session_db_class():
+    original = ORIGINAL_SESSION_DB
+
+    class GatewayAdmittedSessionDB(original):
+        _gateway_state_db_authority_wrapped = True
+        _gateway_state_db_original_class = original
+
+        def __init__(self, db_path: Path = None, read_only: bool = False):
+            if read_only:
+                original.__init__(self, db_path=db_path, read_only=True)
+                return
+            token = PENDING_FAILURE.set(None)
+            try:
+                AUTHORITY.initialize_writable(
+                    self,
+                    db_path=db_path,
+                    original_init=original.__init__,
+                )
+            finally:
+                PENDING_FAILURE.reset(token)
+
+        def close(self) -> None:
+            try:
+                original.close(self)
+            finally:
+                AUTHORITY.release(self)
+
+    GatewayAdmittedSessionDB.__name__ = "GatewayAdmittedSessionDB"
+    GatewayAdmittedSessionDB.__qualname__ = "GatewayAdmittedSessionDB"
+    GatewayAdmittedSessionDB.__module__ = __name__
+    return GatewayAdmittedSessionDB
+
+
+def _install_session_store_authority() -> type:
+    """Inject authority at the gateway-owned writer construction seam only.
+
+    ``hermes_state.SessionDB`` is shared by CLI doctor, sessions repair,
+    console recovery, tests, and non-gateway runtimes. Replacing that class
+    process-wide makes importing ``gateway`` seize authority over unrelated
+    callers and changes their native exception/repair contracts. SessionStore
+    is the gateway writer owner, so replace only its per-profile opener while
+    preserving its cache and JSONL-fallback behavior byte-for-byte.
+    """
+    from gateway.session import SessionStore
+
+    current = SessionStore._open_session_db_for_active_scope
+    if getattr(current, "_gateway_state_db_authority", False):
+        return getattr(current, "_gateway_state_db_class")
+
+    native_open = current
+    admitted_session_db = _build_admitted_session_db_class()
+
+    def open_with_gateway_state_db_authority(self):
+        # Preserve the established SessionStore monkeypatch seam exactly. Tests
+        # and embedders replace hermes_state.SessionDB to inject construction
+        # failures; the gateway authority must not turn those into integrity
+        # verdicts or silently bypass their fallback/guard semantics. A normal
+        # production process keeps the native class, so every real writer still
+        # flows through the admitted constructor below.
+        if hermes_state.SessionDB is not ORIGINAL_SESSION_DB:
+            return native_open(self)
+
+        from hermes_state import _default_db_path
+
+        path = Path(_default_db_path())
+        with self._db_handles_lock:
+            if path in self._db_handles:
+                return self._db_handles[path]
+            db = None
+            try:
+                # Bind the authority to the exact path SessionStore resolved
+                # for this profile scope. Passing None here lets a later
+                # context/default resolver choose a different generation than
+                # the cache key, defeating both profile routing and admission.
+                db = admitted_session_db(db_path=path)
+            except StateDBAdmissionError:
+                # Integrity/generation refusal is an authoritative terminal
+                # outcome, not permission to cache None and silently fall back.
+                raise
+            except RuntimeError as exc:
+                if "live-system guard" in str(exc):
+                    raise
+                print(
+                    "[gateway] Warning: SQLite session store unavailable, "
+                    f"falling back to JSONL: {exc}"
+                )
+            except Exception as exc:
+                print(
+                    "[gateway] Warning: SQLite session store unavailable, "
+                    f"falling back to JSONL: {exc}"
+                )
+            self._db_handles[path] = db
+            return db
+
+    open_with_gateway_state_db_authority._gateway_state_db_authority = True
+    open_with_gateway_state_db_authority._gateway_state_db_class = (
+        admitted_session_db
+    )
+    open_with_gateway_state_db_authority.__wrapped__ = current
+    SessionStore._open_session_db_for_active_scope = (
+        open_with_gateway_state_db_authority
+    )
+    return admitted_session_db
+
+
+def install_gateway_state_db_authority() -> type:
+    """Install passive, reload-safe gateway-only writer authority."""
+    _install_connect_guard()
+    return _install_session_store_authority()

--- a/gateway/state_db_authority/_lock.py
+++ b/gateway/state_db_authority/_lock.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ._model import StateDBAdmissionError
+
+
+class CrossProcessAdmissionLock:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self.path = db_path.with_name(db_path.name + ".gateway-admission.lock")
+        self._handle = None
+
+    def __enter__(self) -> "CrossProcessAdmissionLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = open(self.path, "a+b")
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                self._handle.seek(0)
+                msvcrt.locking(self._handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX)
+        except Exception as exc:
+            self._handle.close()
+            self._handle = None
+            raise StateDBAdmissionError(
+                f"state.db admission lock unavailable for {self.path}: {exc}",
+                path=self.db_path,
+            ) from exc
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        handle, self._handle = self._handle, None
+        if handle is None:
+            return
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except Exception:
+            pass
+        finally:
+            handle.close()

--- a/gateway/state_db_authority/_model.py
+++ b/gateway/state_db_authority/_model.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+
+class IntegrityVerdict(str, Enum):
+    ABSENT = "absent"
+    EMPTY = "empty"
+    SCHEMA_INCOMPLETE = "schema_incomplete"
+    VERIFIED = "verified"
+    CORRUPT = "corrupt"
+    BUSY = "busy"
+    ENVIRONMENT_ERROR = "environment_error"
+    UNSUPPORTED_OBJECT = "unsupported_object"
+
+
+@dataclass(frozen=True)
+class StateDBFileIdentity:
+    device: int
+    inode: int
+
+    @classmethod
+    def from_stat(cls, result: os.stat_result) -> "StateDBFileIdentity":
+        return cls(device=int(result.st_dev), inode=int(result.st_ino))
+
+
+@dataclass(frozen=True)
+class StateDBIntegrityReport:
+    path: Path
+    verdict: IntegrityVerdict
+    checked: str
+    problems: tuple[str, ...] = ()
+    identity: Optional[StateDBFileIdentity] = None
+    may_open_writer: bool = False
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "verdict": self.verdict.value,
+            "checked": self.checked,
+            "problems": list(self.problems),
+            "identity": (
+                {
+                    "device": self.identity.device,
+                    "inode": self.identity.inode,
+                }
+                if self.identity is not None
+                else None
+            ),
+            "may_open_writer": self.may_open_writer,
+        }
+
+
+@dataclass(frozen=True)
+class StateDBAdmissionProof:
+    proof_id: str
+    path: Path
+    identity: StateDBFileIdentity
+    report: StateDBIntegrityReport
+    verified_at: float
+
+
+class StateDBAdmissionError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        path: Path,
+        report: Optional[StateDBIntegrityReport] = None,
+    ) -> None:
+        super().__init__(message)
+        self.path = path
+        self.report = report
+
+
+class StateDBIntegrityError(StateDBAdmissionError):
+    pass
+
+
+class StateDBGenerationConflictError(StateDBAdmissionError):
+    pass
+
+
+class StateDBAdmissionBusyError(StateDBAdmissionError):
+    pass
+
+
+def canonical_state_db_path(db_path: Path | str | None = None) -> Path:
+    import hermes_state
+
+    raw = (
+        Path(db_path)
+        if db_path is not None
+        else Path(hermes_state._default_db_path())
+    )
+    return raw.expanduser().resolve(strict=False)
+
+
+def sqlite_read_only_uri(path: Path | str) -> str:
+    """Percent-encode reserved filename characters before adding URI options."""
+    return canonical_state_db_path(path).as_uri() + "?mode=ro"
+
+
+def identity_from_stat(result: os.stat_result) -> StateDBFileIdentity:
+    return StateDBFileIdentity.from_stat(result)
+
+
+def stat_identity(path: Path) -> StateDBFileIdentity:
+    return identity_from_stat(path.stat())
+
+
+def anchor_identity(anchor_fd: int) -> StateDBFileIdentity:
+    return identity_from_stat(os.fstat(anchor_fd))
+
+
+def same_identity(
+    left: StateDBFileIdentity,
+    right: StateDBFileIdentity,
+) -> bool:
+    return left.device == right.device and left.inode == right.inode
+
+
+_MISSING_REQUIRED_SCHEMA_PROBLEMS = frozenset(
+    {
+        "no such table: sessions",
+        "no such table: main.sessions",
+        "no such table: messages",
+        "no such table: main.messages",
+    }
+)
+
+
+def is_schema_incomplete(problem: str) -> bool:
+    """Identify only the native probe's required-table absence contract."""
+    normalized = " ".join(str(problem).strip().lower().split())
+    return normalized in _MISSING_REQUIRED_SCHEMA_PROBLEMS
+
+
+def problem_verdict(problem: str) -> IntegrityVerdict:
+    lowered = problem.lower()
+    if "locked" in lowered or "busy" in lowered:
+        return IntegrityVerdict.BUSY
+    markers = (
+        "malformed",
+        "not a database",
+        "rowid out of order",
+        "2nd reference to page",
+        "never used",
+        "wrong # of entries in index",
+        "fts5 read probe failed",
+        "fts write",
+        "corrupt",
+    )
+    if any(marker in lowered for marker in markers):
+        return IntegrityVerdict.CORRUPT
+    return IntegrityVerdict.ENVIRONMENT_ERROR
+
+
+def is_repairable(report: StateDBIntegrityReport) -> bool:
+    text = " ".join(report.problems).lower()
+    return any(
+        marker in text
+        for marker in (
+            "malformed database schema",
+            "fts5 read probe failed",
+            "fts write",
+            "wrong # of entries in index",
+        )
+    )
+
+
+def format_refusal(report: StateDBIntegrityReport) -> str:
+    detail = "; ".join(report.problems[:3]) or "no diagnostic detail"
+    return (
+        f"state.db writer admission refused for {report.path}: "
+        f"verdict={report.verdict.value}, checked={report.checked}; {detail}. "
+        "No gateway writer was opened. Run `hermes doctor` and use the "
+        "canonical state.db recovery path before retrying."
+    )

--- a/gateway/state_db_authority/_verify.py
+++ b/gateway/state_db_authority/_verify.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import sqlite3
+import stat
+from pathlib import Path
+
+import hermes_state
+
+from ._model import (
+    IntegrityVerdict,
+    StateDBIntegrityReport,
+    canonical_state_db_path,
+    identity_from_stat,
+    is_repairable,
+    is_schema_incomplete,
+    problem_verdict,
+    same_identity,
+    sqlite_read_only_uri,
+    stat_identity,
+)
+
+
+def verify_state_db_integrity(path: Path | str) -> StateDBIntegrityReport:
+    """Run the canonical Hermes health contract against one exact file."""
+    resolved = canonical_state_db_path(path)
+    try:
+        before = resolved.stat()
+    except FileNotFoundError:
+        return StateDBIntegrityReport(
+            path=resolved,
+            verdict=IntegrityVerdict.ABSENT,
+            checked="absent",
+        )
+    except OSError as exc:
+        return StateDBIntegrityReport(
+            path=resolved,
+            verdict=IntegrityVerdict.ENVIRONMENT_ERROR,
+            checked="stat",
+            problems=(f"stat failed: {exc}",),
+        )
+
+    identity = identity_from_stat(before)
+    if not stat.S_ISREG(before.st_mode):
+        return StateDBIntegrityReport(
+            path=resolved,
+            verdict=IntegrityVerdict.UNSUPPORTED_OBJECT,
+            checked="stat",
+            problems=("state.db is not a regular file",),
+            identity=identity,
+        )
+    if before.st_size == 0:
+        return StateDBIntegrityReport(
+            path=resolved,
+            verdict=IntegrityVerdict.EMPTY,
+            checked="empty",
+            identity=identity,
+        )
+
+    try:
+        from hermes_cli.sqlite_safe_read import has_live_connection
+
+        if has_live_connection(resolved):
+            return StateDBIntegrityReport(
+                path=resolved,
+                verdict=IntegrityVerdict.BUSY,
+                checked="live_connection",
+                problems=(
+                    "a state.db connection is already live in this process; "
+                    "an independent probe could cancel its POSIX locks",
+                ),
+                identity=identity,
+            )
+    except ImportError:
+        pass
+    except Exception as exc:
+        return StateDBIntegrityReport(
+            path=resolved,
+            verdict=IntegrityVerdict.ENVIRONMENT_ERROR,
+            checked="live_connection",
+            problems=(f"live-connection probe failed: {exc}",),
+            identity=identity,
+        )
+
+    conn = None
+    try:
+        conn = sqlite3.connect(
+            sqlite_read_only_uri(resolved),
+            uri=True,
+            timeout=5.0,
+            isolation_level=None,
+        )
+        conn.execute("PRAGMA query_only=ON")
+        conn.execute("PRAGMA schema_version").fetchone()
+    except sqlite3.Error as exc:
+        return StateDBIntegrityReport(
+            path=resolved,
+            verdict=problem_verdict(str(exc)),
+            checked="read_only_open",
+            problems=(str(exc),),
+            identity=identity,
+        )
+    except Exception as exc:
+        return StateDBIntegrityReport(
+            path=resolved,
+            verdict=IntegrityVerdict.ENVIRONMENT_ERROR,
+            checked="read_only_open",
+            problems=(str(exc),),
+            identity=identity,
+        )
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    try:
+        problem = hermes_state._db_opens_cleanly(resolved)
+    except Exception as exc:
+        problem = str(exc)
+    if problem:
+        if is_schema_incomplete(problem):
+            return StateDBIntegrityReport(
+                path=resolved,
+                verdict=IntegrityVerdict.SCHEMA_INCOMPLETE,
+                checked="canonical_schema",
+                problems=(str(problem),),
+                identity=identity,
+            )
+        return StateDBIntegrityReport(
+            path=resolved,
+            verdict=problem_verdict(problem),
+            checked="canonical_full",
+            problems=(str(problem),),
+            identity=identity,
+        )
+
+    try:
+        after_identity = stat_identity(resolved)
+    except OSError as exc:
+        return StateDBIntegrityReport(
+            path=resolved,
+            verdict=IntegrityVerdict.ENVIRONMENT_ERROR,
+            checked="post_stat",
+            problems=(f"post-verification stat failed: {exc}",),
+            identity=identity,
+        )
+    if not same_identity(identity, after_identity):
+        return StateDBIntegrityReport(
+            path=resolved,
+            verdict=IntegrityVerdict.BUSY,
+            checked="generation_changed",
+            problems=("state.db was replaced during verification",),
+            identity=after_identity,
+        )
+    return StateDBIntegrityReport(
+        path=resolved,
+        verdict=IntegrityVerdict.VERIFIED,
+        checked="canonical_full",
+        identity=after_identity,
+        may_open_writer=True,
+    )
+
+
+def repair_and_reverify(
+    path: Path,
+    report: StateDBIntegrityReport,
+) -> StateDBIntegrityReport:
+    if report.verdict is not IntegrityVerdict.CORRUPT or not is_repairable(report):
+        return report
+    result = hermes_state.repair_state_db_schema(path)
+    if result.get("repaired"):
+        return verify_state_db_integrity(path)
+    detail = result.get("error") or "canonical repair did not establish health"
+    return StateDBIntegrityReport(
+        path=path,
+        verdict=IntegrityVerdict.CORRUPT,
+        checked="canonical_repair",
+        problems=(*report.problems, str(detail)),
+        identity=(stat_identity(path) if path.exists() else report.identity),
+    )

--- a/tests/gateway/test_session_store_prune.py
+++ b/tests/gateway/test_session_store_prune.py
@@ -34,6 +34,11 @@ def test_session_store_default_db_uses_runtime_hermes_home(tmp_path, monkeypatch
     config = GatewayConfig(default_reset_policy=SessionResetPolicy(mode="none"))
     fake_home = tmp_path / "alt_hermes_home"
     fake_home.mkdir()
+    import hermes_state
+
+    monkeypatch.setattr(
+        hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH
+    )
     monkeypatch.setenv("HERMES_HOME", str(fake_home))
 
     with patch("gateway.session.SessionStore._ensure_loaded"):

--- a/tests/gateway/test_state_db_authority.py
+++ b/tests/gateway/test_state_db_authority.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import importlib
+import os
+import sqlite3
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+import gateway
+import gateway.state_db_authority._install as authority_install
+import hermes_state
+from gateway.config import GatewayConfig
+from gateway.state_db_authority import (
+    IntegrityVerdict,
+    StateDBGenerationConflictError,
+    StateDBIntegrityError,
+    gateway_state_db_authority_snapshot,
+    install_gateway_state_db_authority,
+    sqlite_read_only_uri,
+    verify_state_db_integrity,
+)
+
+
+NATIVE_SESSION_DB = hermes_state.SessionDB
+GATEWAY_SESSION_DB = install_gateway_state_db_authority()
+
+
+@pytest.fixture(autouse=True)
+def _proof_lifetime_is_test_bounded():
+    assert gateway_state_db_authority_snapshot() == {}
+    yield
+    assert gateway_state_db_authority_snapshot() == {}
+
+
+def _healthy_db(path: Path) -> Path:
+    db = GATEWAY_SESSION_DB(db_path=path)
+    db.close()
+    return path
+
+
+def _corrupt_file(path: Path) -> Path:
+    path.write_bytes(b"this is not a sqlite database")
+    return path
+
+
+def test_gateway_import_is_passive_reload_safe_and_gateway_scoped():
+    installed_opener = gateway.SessionStore._open_session_db_for_active_scope
+
+    assert hermes_state.SessionDB is NATIVE_SESSION_DB
+    assert not getattr(
+        hermes_state.SessionDB,
+        "_gateway_state_db_authority_wrapped",
+        False,
+    )
+    assert getattr(installed_opener, "_gateway_state_db_authority", False)
+    assert getattr(installed_opener, "_gateway_state_db_class") is GATEWAY_SESSION_DB
+    assert gateway_state_db_authority_snapshot() == {}
+
+    importlib.reload(gateway)
+
+    assert hermes_state.SessionDB is NATIVE_SESSION_DB
+    assert gateway.SessionStore._open_session_db_for_active_scope is installed_opener
+    assert install_gateway_state_db_authority() is GATEWAY_SESSION_DB
+    assert gateway_state_db_authority_snapshot() == {}
+
+
+def test_non_gateway_session_db_keeps_native_failure_contract(
+    tmp_path, monkeypatch
+):
+    def native_failure(*_args, **_kwargs):
+        raise sqlite3.DatabaseError("native non-gateway failure")
+
+    monkeypatch.setattr(hermes_state, "apply_wal_with_fallback", native_failure)
+
+    with pytest.raises(sqlite3.DatabaseError, match="native non-gateway failure"):
+        NATIVE_SESSION_DB(db_path=tmp_path / "native.db")
+
+    assert gateway_state_db_authority_snapshot() == {}
+
+
+def test_read_only_session_db_never_claims_writer_authority(tmp_path):
+    path = _healthy_db(tmp_path / "state.db")
+
+    db = GATEWAY_SESSION_DB(db_path=path, read_only=True)
+    try:
+        assert gateway_state_db_authority_snapshot() == {}
+    finally:
+        db.close()
+
+
+def test_first_writer_proof_is_shared_only_while_handles_are_live(tmp_path):
+    path = tmp_path / "state.db"
+
+    first = GATEWAY_SESSION_DB(db_path=path)
+    first_snapshot = gateway_state_db_authority_snapshot()[str(path.resolve())]
+    second = GATEWAY_SESSION_DB(db_path=path)
+    second_snapshot = gateway_state_db_authority_snapshot()[str(path.resolve())]
+
+    assert first_snapshot["proof_id"] == second_snapshot["proof_id"]
+    assert second_snapshot["holders"] == 2
+
+    second.close()
+    assert gateway_state_db_authority_snapshot()[str(path.resolve())]["holders"] == 1
+
+    first.close()
+    assert gateway_state_db_authority_snapshot() == {}
+
+
+def test_closed_generation_is_reverified_before_same_path_reopens(tmp_path):
+    path = _healthy_db(tmp_path / "state.db")
+    _corrupt_file(path)
+
+    with pytest.raises(StateDBIntegrityError, match="writer admission refused"):
+        GATEWAY_SESSION_DB(db_path=path)
+
+    assert gateway_state_db_authority_snapshot() == {}
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows prevents replacing an open SQLite file",
+)
+def test_live_generation_replacement_refuses_split_brain(tmp_path):
+    path = tmp_path / "state.db"
+    live = GATEWAY_SESSION_DB(db_path=path)
+    replacement = _healthy_db(tmp_path / "replacement.db")
+    os.replace(replacement, path)
+
+    try:
+        with pytest.raises(StateDBGenerationConflictError, match="split-brain"):
+            GATEWAY_SESSION_DB(db_path=path)
+    finally:
+        live.close()
+
+    reopened = GATEWAY_SESSION_DB(db_path=path)
+    reopened.close()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows prevents replacing the admission anchor target",
+)
+def test_tracked_connect_rejects_replacement_before_schema_initialization(
+    tmp_path, monkeypatch
+):
+    path = _healthy_db(tmp_path / "state.db")
+    replacement = _healthy_db(tmp_path / "replacement.db")
+    replacement_bytes = replacement.read_bytes()
+    real_connect = authority_install.ORIGINAL_TRACKED_CONNECT
+
+    def replace_then_connect(database, *args, **kwargs):
+        os.replace(replacement, path)
+        return real_connect(database, *args, **kwargs)
+
+    monkeypatch.setattr(
+        authority_install,
+        "ORIGINAL_TRACKED_CONNECT",
+        replace_then_connect,
+    )
+
+    with pytest.raises(StateDBGenerationConflictError, match="during writer connect"):
+        GATEWAY_SESSION_DB(db_path=path)
+
+    assert path.read_bytes() == replacement_bytes
+
+
+def test_reserved_uri_characters_never_redirect_probe_to_sibling(tmp_path):
+    path = _corrupt_file(tmp_path / "state?profile#one.db")
+    uri = sqlite_read_only_uri(path)
+
+    assert "%3F" in uri and "%23" in uri
+    report = verify_state_db_integrity(path)
+
+    assert report.verdict is IntegrityVerdict.CORRUPT
+    assert report.may_open_writer is False
+    assert not (tmp_path / "state").exists()
+
+
+def test_torn_btree_is_rejected_by_canonical_full_probe(tmp_path):
+    path = _healthy_db(tmp_path / "state.db")
+    with sqlite3.connect(path) as conn:
+        conn.execute("PRAGMA journal_mode=DELETE")
+        page_size = int(conn.execute("PRAGMA page_size").fetchone()[0])
+        conn.executemany(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            [(f"sid-{index}", "gateway", float(index)) for index in range(1000)],
+        )
+
+    raw = bytearray(path.read_bytes())
+    assert len(raw) > page_size * 5
+    raw[page_size * 4 : page_size * 5] = b"\xff" * page_size
+    path.write_bytes(raw)
+
+    report = verify_state_db_integrity(path)
+
+    assert report.verdict is IntegrityVerdict.CORRUPT
+    assert report.checked == "canonical_full"
+    assert report.problems
+    assert report.may_open_writer is False
+
+
+def test_absence_and_object_type_are_not_healthy_verdicts(tmp_path):
+    absent = verify_state_db_integrity(tmp_path / "absent.db")
+    directory = tmp_path / "directory.db"
+    directory.mkdir()
+    unsupported = verify_state_db_integrity(directory)
+
+    assert absent.verdict is IntegrityVerdict.ABSENT
+    assert absent.may_open_writer is False
+    assert unsupported.verdict is IntegrityVerdict.UNSUPPORTED_OBJECT
+    assert unsupported.may_open_writer is False
+
+
+def test_session_store_propagates_integrity_refusal_and_does_not_cache_it(
+    tmp_path, monkeypatch
+):
+    path = _corrupt_file(tmp_path / "state.db")
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", path)
+
+    store = object.__new__(gateway.SessionStore)
+    store._db_handles = {}
+    store._db_handles_lock = threading.Lock()
+
+    for _ in range(2):
+        with pytest.raises(StateDBIntegrityError):
+            store._open_session_db_for_active_scope()
+        assert path.resolve() not in store._db_handles
+
+
+def test_normal_session_store_gets_an_admitted_handle(tmp_path, monkeypatch):
+    path = tmp_path / "state.db"
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", path)
+
+    store = gateway.SessionStore(tmp_path / "sessions", GatewayConfig())
+    try:
+        proof = getattr(store._db, "_gateway_state_db_admission", None)
+        assert proof is not None
+        assert proof.path == path.resolve()
+    finally:
+        store.close_all_db_handles()

--- a/tests/gateway/test_state_db_authority_bootstrap.py
+++ b/tests/gateway/test_state_db_authority_bootstrap.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+import gateway  # noqa: F401  -- installs the gateway state.db authority
+import gateway.state_db_authority._authority as authority_mod
+from gateway.state_db_authority import (
+    IntegrityVerdict,
+    StateDBIntegrityError,
+    gateway_state_db_authority_snapshot,
+    install_gateway_state_db_authority,
+    verify_state_db_integrity,
+)
+
+
+GATEWAY_SESSION_DB = install_gateway_state_db_authority()
+
+
+def test_existing_sqlite_without_session_schema_is_materialized_and_reverified(
+    tmp_path: Path,
+) -> None:
+    """A healthy shared SQLite generation may predate the session schema."""
+    path = tmp_path / "state.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE shared_metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO shared_metadata (key, value) VALUES (?, ?)",
+            ("owner", "gateway-independent"),
+        )
+
+    before = verify_state_db_integrity(path)
+    assert before.verdict is IntegrityVerdict.SCHEMA_INCOMPLETE
+    assert before.checked == "canonical_schema"
+    assert before.may_open_writer is False
+
+    db = GATEWAY_SESSION_DB(db_path=path)
+    try:
+        proof = db._gateway_state_db_admission
+        assert proof.report.verdict is IntegrityVerdict.VERIFIED
+        assert proof.report.checked == "canonical_full"
+        assert (
+            db._conn.execute(
+                "SELECT value FROM shared_metadata WHERE key = 'owner'"
+            ).fetchone()[0]
+            == "gateway-independent"
+        )
+        tables = {
+            row[0]
+            for row in db._conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type = 'table' AND name IN ('sessions', 'messages')"
+            ).fetchall()
+        }
+        assert tables == {"sessions", "messages"}
+        identity = proof.identity
+    finally:
+        db.close()
+
+    after = verify_state_db_integrity(path)
+    assert after.verdict is IntegrityVerdict.VERIFIED
+    assert after.identity == identity
+    assert gateway_state_db_authority_snapshot() == {}
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows prevents replacing the bootstrap database while handles may exist",
+)
+def test_first_run_replacement_after_bootstrap_must_prove_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A replacement generation cannot inherit bootstrap health."""
+    path = tmp_path / "state.db"
+    replacement = tmp_path / "replacement.db"
+    replacement.write_bytes(b"not a sqlite database")
+
+    real_bootstrap = authority_mod.AUTHORITY._bootstrap
+
+    def bootstrap_then_replace(instance, bootstrap_path, original_init):
+        real_bootstrap(instance, bootstrap_path, original_init)
+        os.replace(replacement, bootstrap_path)
+
+    monkeypatch.setattr(
+        authority_mod.AUTHORITY,
+        "_bootstrap",
+        bootstrap_then_replace,
+    )
+
+    with pytest.raises(StateDBIntegrityError, match="writer admission refused"):
+        GATEWAY_SESSION_DB(db_path=path)
+
+    assert gateway_state_db_authority_snapshot() == {}


### PR DESCRIPTION
## Summary

Add proactive integrity and physical-generation admission for **gateway-owned** `state.db` writers.

This branch is one commit directly on current upstream `main` `706f33d42415d706b8f93dd299f4b317428e4a6b`. Original implementation provenance remains rooted at @dhanesh's `c9c39e5794307b028423cc3dc1a6a18a4bf6155a`; the submitted commit retains `Co-authored-by: Dhanesh B <dhanesh1022@gmail.com>`.

## Contract

Before `SessionStore` receives a writable handle, the authority:

- read-only probes the exact database through Hermes' canonical health check;
- distinguishes a structurally healthy shared SQLite generation that merely predates the `sessions`/`messages` schema;
- uses native `SessionDB` only to materialize required schema, then closes that temporary writer;
- independently re-verifies the resulting path generation;
- binds admission to device/inode plus a live anchor fd;
- opens the writer under an `EXPECTED_GENERATION` guard that checks identity before and after SQLite connect;
- shares a proof only while that exact generation has live gateway holders;
- refuses pathname replacement as split-brain;
- re-verifies after the final holder closes;
- propagates integrity/generation refusal instead of caching a JSONL fallback.

## Ownership correction

The predecessor head replaced `hermes_state.SessionDB` process-wide after `gateway` import. Exact CI showed that this captured unrelated CLI doctor, sessions repair, console recovery, and malformed-schema recovery paths.

Head `4e087e7c9aac7768333f6ad3c3f07bdadb5d976c` installs the admitted constructor only at `SessionStore._open_session_db_for_active_scope`. The shared `hermes_state.SessionDB` class remains native. The tracked-connect guard remains passive unless the gateway authority has installed an explicit expected-generation context.

## Regression evidence

Tests cover:

- healthy pre-schema SQLite with unrelated durable data preserved through materialization;
- corrupt pathname replacement immediately after bootstrap;
- native non-gateway exception semantics after `gateway` import;
- reload-safe gateway-only installation;
- proof sharing/release and post-close re-verification;
- split-brain replacement and connect-time generation swaps;
- canonical corruption, torn B-tree, reserved URI characters, unsupported objects, and SessionStore refusal propagation.

## Exact topology

- parent: `706f33d42415d706b8f93dd299f4b317428e4a6b`
- head: `4e087e7c9aac7768333f6ad3c3f07bdadb5d976c`
- shape: one commit, ten files, one ahead / zero behind
- exact-head runs: CI `32639691260`, Docker `32639690984`, Nix `32639690979`

No predecessor result is inherited.