### PR TITLE
feat(providers): handle Nous model-scoped fair-share 429s with model fallback

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1502,6 +1502,10 @@ def restore_primary_runtime(agent) -> bool:
     # restored.  (Kept while a cooldown pins us to the fallback below.)
     from agent.chat_completion_helpers import strip_fairshare_alternates
 
+    # The fair-share upgrade hint is deduped per turn; re-arm it here so a
+    # long-lived (gateway-cached) agent shows it again on a later turn.
+    agent._fairshare_upgrade_hinted_url = None
+
     if not agent._fallback_activated:
         strip_fairshare_alternates(agent)
         # Reset the chain index even when no fallback was activated this

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1497,7 +1497,13 @@ def restore_primary_runtime(agent) -> bool:
     The gateway caches agents across messages (``_agent_cache`` in
     ``gateway/run.py``), so this restoration IS needed there too.
     """
+    # Fair-share alternates injected mid-turn are turn-scoped hints; drop
+    # them before the chain is reused so config-driven fallback order is
+    # restored.  (Kept while a cooldown pins us to the fallback below.)
+    from agent.chat_completion_helpers import strip_fairshare_alternates
+
     if not agent._fallback_activated:
+        strip_fairshare_alternates(agent)
         # Reset the chain index even when no fallback was activated this
         # turn.  Without this, a turn where _try_activate_fallback() was
         # called but returned False (chain exhausted or provider not
@@ -1748,6 +1754,7 @@ def restore_primary_runtime(agent) -> bool:
             agent.reasoning_config = dict(saved_reasoning)
 
         # ── Reset fallback chain for the new turn ──
+        strip_fairshare_alternates(agent)
         agent._fallback_activated = False
         agent._fallback_index = 0
         agent._rate_limit_backoff_count = 0  # reset exponential backoff counter

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2403,10 +2403,96 @@ def _fallback_entry_key(fb: dict) -> tuple[str, str, str]:
     )
 
 
+# Marker set on fallback-chain entries synthesized from a Nous fair-share
+# 429's ``alternates`` list.  They are live "best available" hints valid for
+# the current turn only, so ``strip_fairshare_alternates`` removes them when
+# the primary runtime is restored.
+FAIRSHARE_ALTERNATE_MARKER = "_fairshare_alternate"
+
+
+def inject_fairshare_alternates(agent, alternates, *, provider: str = "") -> int:
+    """Splice fair-share ``alternates`` into the fallback chain ahead of the
+    static entries, at the current chain position.
+
+    Alternates are Nous model slugs usable as-is against the same endpoint,
+    ordered best rate first, so they are preferred over the configured
+    chain.  Entries already present in the chain (at or after the current
+    index), the model currently in use, and non-string junk are skipped.
+    Returns the number of entries inserted.
+    """
+    provider = (provider or getattr(agent, "provider", "") or "").strip().lower()
+    if not provider or not isinstance(alternates, (list, tuple)):
+        return 0
+    chain = list(getattr(agent, "_fallback_chain", []) or [])
+    index = int(getattr(agent, "_fallback_index", 0) or 0)
+    index = max(0, min(index, len(chain)))
+    current_model = (getattr(agent, "model", "") or "").strip()
+    # Dedupe on (provider, model): a configured static entry for the same
+    # model already covers it, whatever its base_url spelling.
+    existing = {
+        _fallback_entry_key(fb)[:2] for fb in chain[index:] if isinstance(fb, dict)
+    }
+    # Alternates are served by the SAME endpoint with the SAME credential
+    # that just answered the 429, so seed both from the live session rather
+    # than re-resolving auth from disk (which can lag an OAuth refresh).
+    live_base_url = str(getattr(agent, "base_url", "") or "").strip()
+    live_api_key = str(getattr(agent, "api_key", "") or "").strip()
+
+    new_entries = []
+    for alt in alternates:
+        if not isinstance(alt, str):
+            continue
+        model = alt.strip()
+        if not model or model == current_model:
+            continue
+        entry = {"provider": provider, "model": model, FAIRSHARE_ALTERNATE_MARKER: True}
+        if live_base_url:
+            entry["base_url"] = live_base_url
+        if live_api_key:
+            entry["api_key"] = live_api_key
+        key = _fallback_entry_key(entry)[:2]
+        if key in existing:
+            continue
+        existing.add(key)
+        new_entries.append(entry)
+    if not new_entries:
+        return 0
+    agent._fallback_chain = chain[:index] + new_entries + chain[index:]
+    agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
+    return len(new_entries)
+
+
+def strip_fairshare_alternates(agent) -> int:
+    """Remove injected fair-share alternates from the chain, keeping
+    ``_fallback_index`` pointing at the same static entry.  Returns the
+    number of entries removed."""
+    chain = list(getattr(agent, "_fallback_chain", []) or [])
+    if not any(isinstance(fb, dict) and fb.get(FAIRSHARE_ALTERNATE_MARKER) for fb in chain):
+        return 0
+    index = int(getattr(agent, "_fallback_index", 0) or 0)
+    kept = []
+    removed_before_index = 0
+    for pos, fb in enumerate(chain):
+        if isinstance(fb, dict) and fb.get(FAIRSHARE_ALTERNATE_MARKER):
+            if pos < index:
+                removed_before_index += 1
+            continue
+        kept.append(fb)
+    agent._fallback_chain = kept
+    agent._fallback_index = max(0, min(index - removed_before_index, len(kept)))
+    agent._fallback_model = kept[0] if kept else None
+    return len(chain) - len(kept)
+
+
 def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str]:
     """Return a skip reason for fallback entries known to be unusable locally."""
     fb_provider = (fb.get("provider") or "").strip().lower()
     if fb_provider != "nous":
+        return None
+    # An entry carrying its own credential (user-supplied inline key, or a
+    # fair-share alternate seeded from the live session) doesn't depend on
+    # the on-disk Nous auth state.
+    if str(fb.get("api_key") or "").strip():
         return None
     try:
         from hermes_cli.auth import get_provider_auth_state

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2427,10 +2427,14 @@ def inject_fairshare_alternates(agent, alternates, *, provider: str = "") -> int
     index = int(getattr(agent, "_fallback_index", 0) or 0)
     index = max(0, min(index, len(chain)))
     current_model = (getattr(agent, "model", "") or "").strip()
-    # Dedupe on (provider, model): a configured static entry for the same
-    # model already covers it, whatever its base_url spelling.
+    # Dedupe on (provider, model) against the WHOLE chain, not just the
+    # entries ahead of the cursor: a model behind the cursor was already
+    # tried this turn (possibly with its own fair-share 429 whose
+    # retry_after hasn't elapsed), so re-splicing it would retry it
+    # immediately.  A configured static entry for the same model already
+    # covers it too, whatever its base_url spelling.
     existing = {
-        _fallback_entry_key(fb)[:2] for fb in chain[index:] if isinstance(fb, dict)
+        _fallback_entry_key(fb)[:2] for fb in chain if isinstance(fb, dict)
     }
     # Alternates are served by the SAME endpoint with the SAME credential
     # that just answered the 429, so seed both from the live session rather

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -559,6 +559,22 @@ def _nous_entitlement_message(capability: str) -> str:
         return ""
 
 
+def _print_fairshare_upgrade_hint(agent, error_context) -> bool:
+    """Surface a fair-share ``upgrade_url`` once per turn, in the same 💡 style
+    as the Nous entitlement guidance.  Returns True when a line was printed."""
+    url = (error_context or {}).get("upgrade_url") if isinstance(error_context, dict) else None
+    if not url:
+        return False
+    if getattr(agent, "_fairshare_upgrade_hinted_url", None) == url:
+        return False
+    agent._fairshare_upgrade_hinted_url = url
+    agent._vprint(
+        f"{agent.log_prefix}   💡 Higher fair-share rates are available: {url}",
+        force=True,
+    )
+    return True
+
+
 def _print_nous_entitlement_guidance(agent, capability: str) -> bool:
     message = _nous_entitlement_message(capability)
     if not message:
@@ -5366,6 +5382,29 @@ def run_conversation(
                     (is_rate_limited and _wrapped_output_cap_budget is None)
                     or (_is_transport_failure and retry_count >= 2)
                 )
+                # Nous fair-share (model-scoped) 429: the gateway hands us
+                # live "best available" alternates.  Prefer them, in order,
+                # over the static chain; the configured chain remains behind
+                # them for when alternates are empty or all fail.
+                _fairshare_ctx = (
+                    dict(classified.error_context or {})
+                    if (classified.error_context or {}).get("fairshare")
+                    else None
+                )
+                if _should_fallback and _fairshare_ctx is not None:
+                    try:
+                        from agent.chat_completion_helpers import inject_fairshare_alternates
+                        _n_alts = inject_fairshare_alternates(
+                            agent, _fairshare_ctx.get("alternates") or [],
+                        )
+                        if _n_alts:
+                            logger.info(
+                                "Nous fair-share 429 on %s: injected %d alternate(s) "
+                                "ahead of the fallback chain",
+                                _model, _n_alts,
+                            )
+                    except Exception:
+                        logger.debug("fair-share alternate injection failed", exc_info=True)
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
@@ -5383,7 +5422,14 @@ def run_conversation(
                         )
                     )
                     if not pool_may_recover:
-                        if _is_upstream:
+                        if _fairshare_ctx is not None:
+                            _fs_model = _model or "This model"
+                            agent._buffer_status(
+                                f"⚠️ {_fs_model} is at its fair-share limit — "
+                                "switching to another model..."
+                            )
+                            _print_fairshare_upgrade_hint(agent, _fairshare_ctx)
+                        elif _is_upstream:
                             _upstream_name = (classified.error_context or {}).get(
                                 "upstream_provider", "aggregator"
                             )
@@ -5410,6 +5456,21 @@ def run_conversation(
                         else:
                             agent._buffer_status("⚠️ Rate limited — switching to fallback provider...")
                         if agent._try_activate_fallback(reason=classified.reason):
+                            if _fairshare_ctx is not None:
+                                agent._buffer_status(
+                                    f"⚠️ {_model or 'Model'} is at its fair-share limit — "
+                                    f"switching to {agent.model}"
+                                )
+                                # The primary's cooldown is normally a fixed
+                                # 60s escalation; the fair-share retry_after is
+                                # honest and exact, so don't restore the primary
+                                # before the gateway says it will readmit us.
+                                _fs_ra = _fairshare_ctx.get("retry_after")
+                                if isinstance(_fs_ra, (int, float)) and _fs_ra > 0:
+                                    agent._rate_limited_until = max(
+                                        getattr(agent, "_rate_limited_until", 0) or 0,
+                                        time.monotonic() + float(_fs_ra),
+                                    )
                             active_system_prompt = _sync_failover_system_message(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
@@ -5472,10 +5533,17 @@ def run_conversation(
                 # apart via the 429's own x-ratelimit-* headers and
                 # the last-known-good state captured on the previous
                 # successful response.
+                #
+                # Fair-share 429s are model-scoped and classify as
+                # upstream_rate_limit (never rate_limit), so they can't
+                # reach this block; the explicit check below is
+                # belt-and-suspenders so a future reclassification can't
+                # silently trip the portal-wide breaker for one model.
                 if (
                     is_rate_limited
                     and agent.provider == "nous"
                     and classified.reason == FailoverReason.rate_limit
+                    and not (classified.error_context or {}).get("fairshare")
                     and not recovered_with_pool
                 ):
                     _genuine_nous_rate_limit = False
@@ -6488,6 +6556,19 @@ def run_conversation(
                                 _retry_after = min(float(_ra_raw), 600)
                             except (TypeError, ValueError):
                                 pass
+                    # Fair-share 429: the body's retry_after is exact (header
+                    # is authoritative when present; the classifier already
+                    # preferred it).  Honor it when no header was parsed so a
+                    # user with no fallback waits the honest interval instead
+                    # of a jittered guess.
+                    _fs_ra = (classified.error_context or {}).get("retry_after")
+                    if (
+                        _retry_after is None
+                        and (classified.error_context or {}).get("fairshare")
+                        and isinstance(_fs_ra, (int, float))
+                        and _fs_ra > 0
+                    ):
+                        _retry_after = min(float(_fs_ra), 600)
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
                 if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
@@ -6506,6 +6587,12 @@ def run_conversation(
                         _policy_note = " (Z.AI Coding overload short retry)"
                     _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
                     _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
+                    if (classified.error_context or {}).get("fairshare"):
+                        _rate_limit_status = (
+                            f"⚠️ {_model or 'Model'} is at its fair-share limit — "
+                            f"retrying in {wait_time:.0f}s (attempt {retry_count + 1}/{max_retries})..."
+                        )
+                        _print_fairshare_upgrade_hint(agent, classified.error_context)
                     # Normal retries are buffered to avoid noisy transient chatter. Long
                     # Z.AI Coding waits are different: they can last minutes, so surface
                     # progress immediately instead of making the TUI look frozen.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -561,7 +561,10 @@ def _nous_entitlement_message(capability: str) -> str:
 
 def _print_fairshare_upgrade_hint(agent, error_context) -> bool:
     """Surface a fair-share ``upgrade_url`` once per turn, in the same 💡 style
-    as the Nous entitlement guidance.  Returns True when a line was printed."""
+    as the Nous entitlement guidance.  Returns True when a line was printed.
+
+    The dedupe key ``_fairshare_upgrade_hinted_url`` is cleared by
+    ``restore_primary_runtime`` at the start of each turn."""
     url = (error_context or {}).get("upgrade_url") if isinstance(error_context, dict) else None
     if not url:
         return False
@@ -5423,11 +5426,8 @@ def run_conversation(
                     )
                     if not pool_may_recover:
                         if _fairshare_ctx is not None:
-                            _fs_model = _model or "This model"
-                            agent._buffer_status(
-                                f"⚠️ {_fs_model} is at its fair-share limit — "
-                                "switching to another model..."
-                            )
+                            # Status line is emitted after activation below,
+                            # once the target model is known (single line).
                             _print_fairshare_upgrade_hint(agent, _fairshare_ctx)
                         elif _is_upstream:
                             _upstream_name = (classified.error_context or {}).get(

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -707,6 +707,137 @@ _SSL_TRANSIENT_PATTERNS = [
 ]
 
 
+# ── Nous fair-share (model-scoped) 429s ─────────────────────────────────
+#
+# Some Nous inference models are "fairshare-governed": each gets a per-identity
+# adaptive rate, and exceeding it returns a 429 that is specific to THAT model.
+# Other Nous models remain available and the caller's credential is healthy,
+# so the correct recovery is a model switch (or an honest ``retry_after``
+# wait) — never credential rotation, and never the cross-session Nous guard.
+#
+# Body extends the plain ``{status, message}`` envelope with ``reason``,
+# ``retry_after`` (seconds, exact), ``alternates`` (other fairshare model
+# slugs, best rate first; may be empty) and an optional ``upgrade_url``.
+# Headers carry ``Retry-After`` (authoritative) plus IETF draft
+# ``RateLimit: "fairshare";r=0;t=51`` / ``RateLimit-Policy: "fairshare";...``.
+#
+# The detection predicate requires BOTH ``reason`` (in the enum below) AND a
+# numeric ``retry_after`` so it is unreachable on today's ``{status, message}``
+# 429s — portal-wide per-key rpm/tph limits keep their existing handling.
+FAIRSHARE_REASONS = frozenset({
+    "rate_limited",
+    "admission_closed",
+    "at_capacity",
+    "model_not_free",
+    "feature_not_free",
+})
+
+_NOUS_PROVIDERS = frozenset({"nous", "nous-portal", "nousresearch"})
+
+
+def _extract_response_headers(error: Exception) -> Dict[str, str]:
+    """Return lower-cased response headers from an SDK exception, or ``{}``."""
+    current = error
+    for _ in range(5):  # Match _extract_status_code() traversal depth.
+        response = getattr(current, "response", None)
+        headers = getattr(response, "headers", None) if response is not None else None
+        if headers is not None:
+            try:
+                return {str(k).lower(): str(v) for k, v in dict(headers).items()}
+            except Exception:
+                try:
+                    return {str(k).lower(): str(v) for k, v in headers.items()}
+                except Exception:
+                    return {}
+        cause = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        if cause is None or cause is current:
+            break
+        current = cause
+    return {}
+
+
+def _coerce_seconds(value: Any) -> Optional[float]:
+    """Parse a non-negative seconds value; ``None`` when absent/invalid."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    if seconds != seconds or seconds < 0:  # NaN / negative
+        return None
+    return seconds
+
+
+def parse_fairshare_refusal(
+    body: Any,
+    *,
+    provider: str = "",
+    headers: Optional[Dict[str, str]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Detect a Nous fair-share (model-scoped) 429 body.
+
+    Returns an ``error_context`` dict when the body matches, else ``None``.
+    Only fires for Nous providers; a fairshare-shaped body from any other
+    provider is ignored so existing handling is untouched there.
+
+    Defensive by design (server-side rollout starts in shadow mode): every
+    field beyond ``reason`` + ``retry_after`` is optional, and malformed
+    optional fields degrade to empty/absent rather than rejecting the match.
+    """
+    if (provider or "").strip().lower() not in _NOUS_PROVIDERS:
+        return None
+    if not isinstance(body, dict):
+        return None
+    # Accept both the flat Nous envelope and an ``{"error": {...}}`` wrapper
+    # in case a proxy/SDK nests it.
+    payload = body
+    nested = body.get("error")
+    if "reason" not in payload and isinstance(nested, dict):
+        payload = nested
+
+    reason = payload.get("reason")
+    if not isinstance(reason, str) or reason.strip().lower() not in FAIRSHARE_REASONS:
+        return None
+    retry_after = _coerce_seconds(payload.get("retry_after"))
+    if retry_after is None:
+        return None
+
+    lowered = {str(k).lower(): str(v) for k, v in (headers or {}).items()}
+    # ``Retry-After`` header is authoritative and unclamped; prefer it when
+    # it parses, otherwise keep the body value.
+    header_retry_after = _coerce_seconds(lowered.get("retry-after"))
+    if header_retry_after is not None:
+        retry_after = header_retry_after
+    header_confirmed = "fairshare" in lowered.get("ratelimit-policy", "").lower() or (
+        "fairshare" in lowered.get("ratelimit", "").lower()
+    )
+
+    raw_alternates = payload.get("alternates")
+    alternates: list = []
+    if isinstance(raw_alternates, (list, tuple)):
+        for alt in raw_alternates:
+            if isinstance(alt, str) and alt.strip() and alt.strip() not in alternates:
+                alternates.append(alt.strip())
+
+    upgrade_url = payload.get("upgrade_url")
+    if not isinstance(upgrade_url, str) or not upgrade_url.strip().lower().startswith(
+        ("https://", "http://")
+    ):
+        upgrade_url = None
+    else:
+        upgrade_url = upgrade_url.strip()
+
+    return {
+        "fairshare": True,
+        "fairshare_reason": reason.strip().lower(),
+        "retry_after": retry_after,
+        "alternates": alternates,
+        "upgrade_url": upgrade_url,
+        "fairshare_header_confirmed": header_confirmed,
+    }
+
+
 # ── Classification pipeline ─────────────────────────────────────────────
 
 def classify_api_error(
@@ -995,6 +1126,7 @@ def classify_api_error(
             approx_tokens=approx_tokens, context_length=context_length,
             num_messages=num_messages,
             result_fn=_result,
+            headers=_extract_response_headers(error),
         )
         if classified is not None:
             return classified
@@ -1152,6 +1284,7 @@ def _classify_by_status(
     context_length: int,
     num_messages: int = 0,
     result_fn,
+    headers: Optional[Dict[str, str]] = None,
 ) -> Optional[ClassifiedError]:
     """Classify based on HTTP status code with message-aware refinement."""
 
@@ -1268,6 +1401,24 @@ def _classify_by_status(
             return result_fn(
                 FailoverReason.overloaded,
                 retryable=True,
+            )
+        # Nous fair-share 429: scoped to ONE model — other Nous models are
+        # fully available and the credential is healthy.  Reuse the
+        # upstream_rate_limit recovery (model fallback, no credential
+        # rotation, no cross-session Nous guard) and carry the gateway's
+        # recovery hints in error_context.  Predicate is unreachable on a
+        # plain ``{status, message}`` Nous 429, which keeps the account-level
+        # rate_limit path below.
+        fairshare_ctx = parse_fairshare_refusal(
+            body, provider=provider, headers=headers,
+        )
+        if fairshare_ctx is not None:
+            return result_fn(
+                FailoverReason.upstream_rate_limit,
+                retryable=True,
+                should_rotate_credential=False,
+                should_fallback=True,
+                error_context=fairshare_ctx,
             )
         # Distinguish an OpenRouter-aggregator upstream 429 (an upstream model
         # like DeepSeek rate-limited OpenRouter's aggregate traffic) from an

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -85,6 +85,19 @@ def record_nous_rate_limit(
         error_context: Structured error context from _extract_api_error_context().
         default_cooldown: Fallback cooldown in seconds when no header data.
     """
+    # Fair-share 429s are scoped to ONE model (see
+    # ``agent.error_classifier.parse_fairshare_refusal``): other Nous models
+    # are available and the credential is healthy.  Recording one here would
+    # block every Nous model for every session, so refuse.  The state file's
+    # schema is deliberately untouched — concurrent sessions on older
+    # versions share it.
+    if isinstance(error_context, dict) and error_context.get("fairshare"):
+        logger.info(
+            "Nous fair-share (model-scoped) 429 — not recording cross-session "
+            "rate limit"
+        )
+        return
+
     now = time.time()
     reset_at = None
 

--- a/tests/agent/test_nous_fairshare_rate_limit.py
+++ b/tests/agent/test_nous_fairshare_rate_limit.py
@@ -382,6 +382,23 @@ class TestAlternatesPreferredOverStaticChain:
         assert [fb["model"] for fb in agent._fallback_chain] == ["model-x", "model-b", "gpt-4o"]
         assert agent._fallback_chain[agent._fallback_index]["model"] == "model-b"
 
+    def test_already_walked_model_is_not_reinjected(self):
+        """An alternate that was already tried this turn (now behind the
+        cursor — e.g. it returned its own fair-share 429) must not be
+        spliced in again for an immediate retry."""
+        from agent.chat_completion_helpers import inject_fairshare_alternates
+
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        assert inject_fairshare_alternates(agent, ["model-b", "model-c"]) == 2
+        # Simulate having activated model-b, which then 429'd and named
+        # model-b/model-c as alternates again.
+        agent._fallback_index = 1
+        agent.model = "model-b"
+        assert inject_fairshare_alternates(agent, ["model-b", "model-c", "model-d"]) == 1
+        assert [fb["model"] for fb in agent._fallback_chain] == [
+            "model-b", "model-d", "model-c", "gpt-4o",
+        ]
+
     def test_activation_walks_alternates_first_then_static_chain(self):
         from agent.chat_completion_helpers import inject_fairshare_alternates
 
@@ -524,6 +541,18 @@ class TestUpgradeHint:
         assert _print_fairshare_upgrade_hint(agent, ctx) is False
         agent._vprint.assert_called_once()
         assert "https://portal.nousresearch.com/upgrade" in agent._vprint.call_args[0][0]
+
+    def test_upgrade_hint_rearms_on_primary_restore(self):
+        from agent.conversation_loop import _print_fairshare_upgrade_hint
+
+        agent = _make_agent(fallback_model=None)
+        agent._vprint = MagicMock()
+        ctx = classify_api_error(_fairshare_error(), provider="nous").error_context
+        assert _print_fairshare_upgrade_hint(agent, ctx) is True
+        assert _print_fairshare_upgrade_hint(agent, ctx) is False
+        agent._restore_primary_runtime()  # new turn
+        assert _print_fairshare_upgrade_hint(agent, ctx) is True
+        assert agent._vprint.call_count == 2
 
     def test_absent_upgrade_url_prints_nothing(self):
         from agent.conversation_loop import _print_fairshare_upgrade_hint

--- a/tests/agent/test_nous_fairshare_rate_limit.py
+++ b/tests/agent/test_nous_fairshare_rate_limit.py
@@ -1,0 +1,536 @@
+"""Nous fair-share (model-scoped) 429 handling.
+
+Some Nous inference models are "fairshare-governed": exceeding a per-identity
+adaptive rate returns a 429 that is specific to THAT model.  Other Nous models
+remain available and the credential is healthy, so the correct recovery is a
+model switch (preferring the gateway's live ``alternates``) or an honest
+``retry_after`` wait — never credential rotation and never the cross-session
+Nous guard, which would block every Nous model for every session.
+
+Portal-wide per-key 429s (plain ``{status, message}`` body, no ``reason``)
+must keep today's behaviour exactly; the detection predicate is unreachable
+on them.
+"""
+
+import json
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.error_classifier import (
+    FAIRSHARE_REASONS,
+    FailoverReason,
+    classify_api_error,
+    parse_fairshare_refusal,
+)
+
+
+class MockAPIError(Exception):
+    """Simulates an OpenAI SDK APIStatusError (optionally with a response)."""
+
+    def __init__(self, message, status_code=None, body=None, headers=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body or {}
+        if headers is not None:
+            self.response = SimpleNamespace(headers=headers)
+
+
+FAIRSHARE_BODY = {
+    "status": 429,
+    "message": "You've reached this model's current fair-share rate limit.",
+    "reason": "rate_limited",
+    "retry_after": 51,
+    "alternates": ["model-b", "model-c"],
+    "upgrade_url": "https://portal.nousresearch.com/upgrade",
+}
+
+PLAIN_NOUS_BODY = {"status": 429, "message": "Rate limit exceeded (rpm)."}
+
+
+def _fairshare_error(body=None, headers=None, message=None):
+    body = dict(FAIRSHARE_BODY if body is None else body)
+    return MockAPIError(
+        message or body.get("message", "rate limited"),
+        status_code=429,
+        body=body,
+        headers=headers,
+    )
+
+
+# ── Classification ──────────────────────────────────────────────────────
+
+
+class TestFairshareClassification:
+    def test_fairshare_429_is_model_scoped_with_context(self):
+        result = classify_api_error(_fairshare_error(), provider="nous", model="model-a")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+        assert result.retryable is True
+        ctx = result.error_context
+        assert ctx["fairshare"] is True
+        assert ctx["fairshare_reason"] == "rate_limited"
+        assert ctx["retry_after"] == 51
+        assert ctx["alternates"] == ["model-b", "model-c"]
+        assert ctx["upgrade_url"] == "https://portal.nousresearch.com/upgrade"
+
+    @pytest.mark.parametrize("provider", ["nous", "nous-portal", "nousresearch", "Nous"])
+    def test_all_nous_provider_aliases_detect(self, provider):
+        result = classify_api_error(_fairshare_error(), provider=provider)
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.error_context.get("fairshare") is True
+
+    def test_plain_nous_429_classifies_exactly_as_before(self):
+        """Today's {status, message} Nous 429 → global rate_limit, rotation on,
+        no fairshare context.  Pins the pre-fairshare contract."""
+        err = MockAPIError("Rate limit exceeded (rpm).", status_code=429, body=PLAIN_NOUS_BODY)
+        result = classify_api_error(err, provider="nous", model="model-a")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+        assert result.retryable is True
+        assert "fairshare" not in result.error_context
+        assert result.message == "Rate limit exceeded (rpm)."
+
+    def test_plain_nous_429_with_retry_after_header_only_is_unchanged(self):
+        """A Retry-After header alone (no body fields) must not trigger."""
+        err = MockAPIError(
+            "Rate limit exceeded", status_code=429, body=PLAIN_NOUS_BODY,
+            headers={"Retry-After": "30"},
+        )
+        result = classify_api_error(err, provider="nous")
+        assert result.reason == FailoverReason.rate_limit
+        assert "fairshare" not in result.error_context
+
+    @pytest.mark.parametrize("provider", ["openrouter", "openai", "anthropic", "", "custom"])
+    def test_fairshare_shaped_body_from_non_nous_provider_is_unchanged(self, provider):
+        result = classify_api_error(_fairshare_error(), provider=provider)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+        assert "fairshare" not in result.error_context
+
+    def test_reason_without_retry_after_does_not_match(self):
+        body = dict(FAIRSHARE_BODY)
+        del body["retry_after"]
+        result = classify_api_error(_fairshare_error(body), provider="nous")
+        assert result.reason == FailoverReason.rate_limit
+
+    def test_retry_after_without_reason_does_not_match(self):
+        body = dict(FAIRSHARE_BODY)
+        del body["reason"]
+        result = classify_api_error(_fairshare_error(body), provider="nous")
+        assert result.reason == FailoverReason.rate_limit
+
+    def test_unknown_reason_does_not_match(self):
+        body = dict(FAIRSHARE_BODY, reason="something_else")
+        result = classify_api_error(_fairshare_error(body), provider="nous")
+        assert result.reason == FailoverReason.rate_limit
+
+    @pytest.mark.parametrize("reason", sorted(FAIRSHARE_REASONS))
+    def test_every_enum_reason_matches(self, reason):
+        body = dict(FAIRSHARE_BODY, reason=reason)
+        result = classify_api_error(_fairshare_error(body), provider="nous")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.error_context["fairshare_reason"] == reason
+
+    def test_non_429_fairshare_body_is_not_fairshare(self):
+        err = MockAPIError("boom", status_code=503, body=FAIRSHARE_BODY)
+        result = classify_api_error(err, provider="nous")
+        assert result.reason != FailoverReason.upstream_rate_limit
+        assert "fairshare" not in result.error_context
+
+
+class TestFairshareDefensiveParsing:
+    def test_absent_alternates_and_upgrade_url(self):
+        body = {"status": 429, "message": "m", "reason": "rate_limited", "retry_after": 10}
+        ctx = classify_api_error(_fairshare_error(body), provider="nous").error_context
+        assert ctx["fairshare"] is True
+        assert ctx["alternates"] == []
+        assert ctx["upgrade_url"] is None
+
+    def test_empty_alternates(self):
+        body = dict(FAIRSHARE_BODY, alternates=[])
+        ctx = classify_api_error(_fairshare_error(body), provider="nous").error_context
+        assert ctx["alternates"] == []
+
+    def test_retry_after_zero_still_matches(self):
+        body = dict(FAIRSHARE_BODY, retry_after=0)
+        result = classify_api_error(_fairshare_error(body), provider="nous")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.error_context["retry_after"] == 0
+
+    @pytest.mark.parametrize("bad", ["soon", None, True, -5, [1]])
+    def test_invalid_retry_after_does_not_match(self, bad):
+        body = dict(FAIRSHARE_BODY, retry_after=bad)
+        result = classify_api_error(_fairshare_error(body), provider="nous")
+        assert result.reason == FailoverReason.rate_limit
+
+    def test_retry_after_exceeding_120s_is_kept_exact(self):
+        body = dict(FAIRSHARE_BODY, retry_after=301)
+        ctx = classify_api_error(_fairshare_error(body), provider="nous").error_context
+        assert ctx["retry_after"] == 301
+
+    def test_malformed_alternates_are_sanitised(self):
+        body = dict(FAIRSHARE_BODY, alternates=["model-b", 42, "", " model-c ", "model-b", None])
+        ctx = classify_api_error(_fairshare_error(body), provider="nous").error_context
+        assert ctx["alternates"] == ["model-b", "model-c"]
+
+    def test_non_list_alternates_degrade_to_empty(self):
+        body = dict(FAIRSHARE_BODY, alternates="model-b")
+        ctx = classify_api_error(_fairshare_error(body), provider="nous").error_context
+        assert ctx["alternates"] == []
+
+    @pytest.mark.parametrize("bad_url", ["javascript:alert(1)", "portal", 7, ""])
+    def test_non_http_upgrade_url_is_dropped(self, bad_url):
+        body = dict(FAIRSHARE_BODY, upgrade_url=bad_url)
+        ctx = classify_api_error(_fairshare_error(body), provider="nous").error_context
+        assert ctx["upgrade_url"] is None
+
+    def test_nested_error_envelope_is_accepted(self):
+        body = {"error": dict(FAIRSHARE_BODY)}
+        result = classify_api_error(_fairshare_error(body, message="m"), provider="nous")
+        assert result.reason == FailoverReason.upstream_rate_limit
+
+    def test_parse_helper_rejects_non_dict(self):
+        assert parse_fairshare_refusal("nope", provider="nous") is None
+        assert parse_fairshare_refusal(None, provider="nous") is None
+
+
+class TestFairshareHeaders:
+    def test_retry_after_header_is_authoritative_over_body(self):
+        headers = {
+            "Retry-After": "77",
+            "RateLimit": '"fairshare";r=0;t=77',
+            "RateLimit-Policy": '"fairshare";q=1000;qu="tokens";w=60',
+        }
+        ctx = classify_api_error(
+            _fairshare_error(headers=headers), provider="nous"
+        ).error_context
+        assert ctx["retry_after"] == 77
+        assert ctx["fairshare_header_confirmed"] is True
+
+    def test_missing_headers_leave_body_value_and_unconfirmed(self):
+        ctx = classify_api_error(_fairshare_error(), provider="nous").error_context
+        assert ctx["retry_after"] == 51
+        assert ctx["fairshare_header_confirmed"] is False
+
+    def test_unparseable_retry_after_header_falls_back_to_body(self):
+        ctx = classify_api_error(
+            _fairshare_error(headers={"retry-after": "Wed, 21 Oct 2026 07:28:00 GMT"}),
+            provider="nous",
+        ).error_context
+        assert ctx["retry_after"] == 51
+
+    def test_fairshare_headers_without_body_fields_do_not_match(self):
+        """Headers alone never flip a plain 429 — body fields are required."""
+        err = MockAPIError(
+            "Rate limit exceeded", status_code=429, body=PLAIN_NOUS_BODY,
+            headers={"RateLimit-Policy": '"fairshare";q=1;qu="tokens";w=60', "Retry-After": "5"},
+        )
+        result = classify_api_error(err, provider="nous")
+        assert result.reason == FailoverReason.rate_limit
+
+
+# ── Cross-session guard hygiene ─────────────────────────────────────────
+
+
+@pytest.fixture
+def rate_guard_env(tmp_path, monkeypatch):
+    hermes_home = str(tmp_path / ".hermes")
+    os.makedirs(hermes_home, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", hermes_home)
+    return hermes_home
+
+
+class TestGuardNonRecording:
+    def test_fairshare_context_is_not_recorded(self, rate_guard_env):
+        from agent.nous_rate_guard import (
+            _state_path,
+            nous_rate_limit_remaining,
+            record_nous_rate_limit,
+        )
+
+        ctx = classify_api_error(_fairshare_error(), provider="nous").error_context
+        record_nous_rate_limit(headers={"retry-after": "51"}, error_context=ctx)
+        assert not os.path.exists(_state_path())
+        assert nous_rate_limit_remaining() is None
+
+    def test_plain_429_context_still_recorded_with_same_schema(self, rate_guard_env):
+        from agent.nous_rate_guard import _state_path, record_nous_rate_limit
+
+        record_nous_rate_limit(
+            headers={"x-ratelimit-reset-requests-1h": "900"},
+            error_context={"reason": "rate_limit", "message": "rpm"},
+        )
+        with open(_state_path()) as f:
+            state = json.load(f)
+        assert set(state) == {"reset_at", "recorded_at", "reset_seconds"}
+        assert state["reset_at"] > time.time()
+
+    def test_loop_record_condition_excludes_fairshare(self):
+        """Mirror the conversation-loop gate: fairshare never reaches the
+        breaker even when is_rate_limited is true."""
+        classified = classify_api_error(_fairshare_error(), provider="nous")
+        is_rate_limited = classified.reason in {
+            FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit,
+        }
+        assert is_rate_limited
+        should_record = (
+            is_rate_limited
+            and classified.reason == FailoverReason.rate_limit
+            and not (classified.error_context or {}).get("fairshare")
+        )
+        assert should_record is False
+
+        plain = classify_api_error(
+            MockAPIError("rpm", status_code=429, body=PLAIN_NOUS_BODY), provider="nous"
+        )
+        assert (
+            plain.reason == FailoverReason.rate_limit
+            and not (plain.error_context or {}).get("fairshare")
+        )
+
+
+# ── Recovery: alternates-first fallback ordering ────────────────────────
+
+
+def _make_agent(fallback_model=None, model="model-a"):
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://inference-api.nousresearch.com/v1",
+            model=model,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+        agent.client = MagicMock()
+        agent.provider = "nous"
+        return agent
+
+
+def _mock_client(api_key="fb-key", base_url="https://inference-api.nousresearch.com/v1"):
+    mock = MagicMock()
+    mock.base_url = base_url
+    mock.api_key = api_key
+    return mock
+
+
+class TestAlternatesPreferredOverStaticChain:
+    def test_alternates_are_spliced_ahead_of_configured_chain(self):
+        from agent.chat_completion_helpers import (
+            FAIRSHARE_ALTERNATE_MARKER,
+            inject_fairshare_alternates,
+        )
+
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        n = inject_fairshare_alternates(agent, ["model-b", "model-c"])
+        assert n == 2
+        assert [(fb["provider"], fb["model"]) for fb in agent._fallback_chain] == [
+            ("nous", "model-b"), ("nous", "model-c"), ("openai", "gpt-4o"),
+        ]
+        assert all(fb.get(FAIRSHARE_ALTERNATE_MARKER) for fb in agent._fallback_chain[:2])
+        assert FAIRSHARE_ALTERNATE_MARKER not in agent._fallback_chain[2]
+
+    def test_empty_alternates_leave_chain_untouched(self):
+        from agent.chat_completion_helpers import inject_fairshare_alternates
+
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        before = list(agent._fallback_chain)
+        assert inject_fairshare_alternates(agent, []) == 0
+        assert inject_fairshare_alternates(agent, None) == 0
+        assert agent._fallback_chain == before
+
+    def test_current_model_and_duplicates_are_skipped(self):
+        from agent.chat_completion_helpers import inject_fairshare_alternates
+
+        agent = _make_agent(fallback_model=[{"provider": "nous", "model": "model-c"}])
+        n = inject_fairshare_alternates(agent, ["model-a", "model-b", "model-c", "model-b"])
+        assert n == 1
+        assert [fb["model"] for fb in agent._fallback_chain] == ["model-b", "model-c"]
+
+    def test_alternates_work_with_no_configured_chain(self):
+        from agent.chat_completion_helpers import inject_fairshare_alternates
+
+        agent = _make_agent(fallback_model=None)
+        assert agent._fallback_chain == []
+        assert inject_fairshare_alternates(agent, ["model-b"]) == 1
+        assert agent._fallback_index < len(agent._fallback_chain)
+
+    def test_injection_respects_current_index(self):
+        """Mid-chain (already on a fallback), alternates go at the cursor so
+        they are the NEXT thing tried; entries already walked stay behind."""
+        from agent.chat_completion_helpers import inject_fairshare_alternates
+
+        agent = _make_agent(fallback_model=[
+            {"provider": "nous", "model": "model-x"},
+            {"provider": "openai", "model": "gpt-4o"},
+        ])
+        agent._fallback_index = 1
+        inject_fairshare_alternates(agent, ["model-b"])
+        assert [fb["model"] for fb in agent._fallback_chain] == ["model-x", "model-b", "gpt-4o"]
+        assert agent._fallback_chain[agent._fallback_index]["model"] == "model-b"
+
+    def test_activation_walks_alternates_first_then_static_chain(self):
+        from agent.chat_completion_helpers import inject_fairshare_alternates
+
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        inject_fairshare_alternates(agent, ["model-b", "model-c"])
+        activated = []
+
+        def _resolve(provider, model, *a, **k):
+            activated.append((provider, model))
+            return _mock_client(), model
+
+        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve):
+            assert agent._try_activate_fallback(reason=FailoverReason.upstream_rate_limit)
+            assert agent.model == "model-b"
+            assert agent._try_activate_fallback(reason=FailoverReason.upstream_rate_limit)
+            assert agent.model == "model-c"
+            assert agent._try_activate_fallback(reason=FailoverReason.upstream_rate_limit)
+            assert agent.model == "gpt-4o"
+            assert not agent._try_activate_fallback(reason=FailoverReason.upstream_rate_limit)
+        assert [m for _, m in activated] == ["model-b", "model-c", "gpt-4o"]
+
+    def test_strip_removes_only_injected_entries_and_fixes_index(self):
+        from agent.chat_completion_helpers import (
+            inject_fairshare_alternates,
+            strip_fairshare_alternates,
+        )
+
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        inject_fairshare_alternates(agent, ["model-b", "model-c"])
+        agent._fallback_index = 2  # both alternates consumed; gpt-4o is next
+        assert strip_fairshare_alternates(agent) == 2
+        assert [fb["model"] for fb in agent._fallback_chain] == ["gpt-4o"]
+        assert agent._fallback_index == 0
+        assert strip_fairshare_alternates(agent) == 0
+
+    def test_restore_primary_strips_alternates_between_turns(self):
+        from agent.chat_completion_helpers import inject_fairshare_alternates
+
+        agent = _make_agent(fallback_model=[{"provider": "openai", "model": "gpt-4o"}])
+        inject_fairshare_alternates(agent, ["model-b"])
+        assert not agent._fallback_activated
+        agent._restore_primary_runtime()
+        assert [fb["model"] for fb in agent._fallback_chain] == ["gpt-4o"]
+        assert agent._fallback_index == 0
+
+    def test_fairshare_skips_credential_rotation(self):
+        """upstream_rate_limit must skip pool rotation (the key is healthy)."""
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        class _Pool:
+            provider = "nous"
+            mark_exhausted_and_rotate = MagicMock()
+
+            def entries(self):
+                return []
+
+        pool = _Pool()
+        agent = SimpleNamespace(
+            provider="nous",
+            base_url="https://inference-api.nousresearch.com/v1",
+            api_key="k",
+            _credential_pool=pool,
+            _credential_pool_entry_id=None,
+            _swap_credential=MagicMock(),
+        )
+        ctx = classify_api_error(_fairshare_error(), provider="nous").error_context
+        recovered, _ = recover_with_credential_pool(
+            agent,
+            status_code=429,
+            has_retried_429=False,
+            classified_reason=FailoverReason.upstream_rate_limit,
+            error_context=ctx,
+        )
+        assert recovered is False
+        pool.mark_exhausted_and_rotate.assert_not_called()
+
+
+# ── Recovery: retry_after wait path when no fallback exists ─────────────
+
+
+class TestRetryAfterWaitPath:
+    """Mirror the loop's retry-wait derivation: header first, then the
+    fairshare body value, then jittered backoff."""
+
+    @staticmethod
+    def _derive_wait(classified, headers=None):
+        _retry_after = None
+        if headers:
+            raw = headers.get("retry-after") or headers.get("Retry-After")
+            if raw:
+                try:
+                    _retry_after = min(float(raw), 600)
+                except (TypeError, ValueError):
+                    pass
+        ctx = classified.error_context or {}
+        fs_ra = ctx.get("retry_after")
+        if _retry_after is None and ctx.get("fairshare") and isinstance(fs_ra, (int, float)) and fs_ra > 0:
+            _retry_after = min(float(fs_ra), 600)
+        return _retry_after
+
+    def test_body_retry_after_is_honored_without_header(self):
+        classified = classify_api_error(_fairshare_error(), provider="nous")
+        assert self._derive_wait(classified) == 51.0
+
+    def test_long_retry_after_is_kept_up_to_cap(self):
+        classified = classify_api_error(
+            _fairshare_error(dict(FAIRSHARE_BODY, retry_after=301)), provider="nous"
+        )
+        assert self._derive_wait(classified) == 301.0
+
+    def test_retry_after_zero_falls_through_to_backoff(self):
+        classified = classify_api_error(
+            _fairshare_error(dict(FAIRSHARE_BODY, retry_after=0)), provider="nous"
+        )
+        assert self._derive_wait(classified) is None
+
+    def test_header_still_wins_when_present(self):
+        classified = classify_api_error(_fairshare_error(), provider="nous")
+        assert self._derive_wait(classified, headers={"retry-after": "9"}) == 9.0
+
+    def test_plain_429_without_header_uses_backoff(self):
+        plain = classify_api_error(
+            MockAPIError("rpm", status_code=429, body=PLAIN_NOUS_BODY), provider="nous"
+        )
+        assert self._derive_wait(plain) is None
+
+
+# ── UX ──────────────────────────────────────────────────────────────────
+
+
+class TestUpgradeHint:
+    def test_upgrade_url_printed_once_per_agent(self):
+        from agent.conversation_loop import _print_fairshare_upgrade_hint
+
+        agent = MagicMock()
+        agent.log_prefix = ""
+        agent._fairshare_upgrade_hinted_url = None
+        ctx = classify_api_error(_fairshare_error(), provider="nous").error_context
+        assert _print_fairshare_upgrade_hint(agent, ctx) is True
+        assert _print_fairshare_upgrade_hint(agent, ctx) is False
+        agent._vprint.assert_called_once()
+        assert "https://portal.nousresearch.com/upgrade" in agent._vprint.call_args[0][0]
+
+    def test_absent_upgrade_url_prints_nothing(self):
+        from agent.conversation_loop import _print_fairshare_upgrade_hint
+
+        agent = MagicMock()
+        body = dict(FAIRSHARE_BODY)
+        del body["upgrade_url"]
+        ctx = classify_api_error(_fairshare_error(body), provider="nous").error_context
+        assert _print_fairshare_upgrade_hint(agent, ctx) is False
+        agent._vprint.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Teaches hermes-agent to handle the Nous inference API's upcoming **model-specific "Fairshare" 429s** (api repo PRs #143–#147). Some Nous models will be fairshare-governed: exceeding a per-identity adaptive rate returns a 429 scoped to *that model only* — other Nous models stay available and the caller's credential is healthy.

Today every Nous 429 falls through to the generic `rate_limit` path, which (a) rotates the healthy credential and (b) records the limit in the cross-session guard at `~/.hermes/rate_limits/nous.json`, **blocking every Nous model for every session** for minutes. This PR classifies a fairshare 429 for model-fallback recovery instead, preferring the gateway's live `alternates`, and keeps the cross-session guard untouched for it.

The gateway rollout starts in shadow mode, so this ships *before* the API-side deploy and is built defensively: the detection predicate requires both `reason` (in the fairshare enum) and a numeric `retry_after`, so it is **unreachable on today's `{status, message}` 429s** — portal-wide per-key rpm/tph limits keep their exact current behaviour (pinned by a test).

## Related Issue

N/A — coordinated with the inference-api fairshare work (api repo PRs #143–#147).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/error_classifier.py` — `FAIRSHARE_REASONS`, `parse_fairshare_refusal()`, `_extract_response_headers()`. In the 429 branch, a fairshare body on a Nous provider classifies as the existing `FailoverReason.upstream_rate_limit` (every downstream site — rotation skip, fallback gating, cooldown arming — already does the right thing for it) with `error_context = {fairshare, fairshare_reason, retry_after, alternates, upgrade_url, fairshare_header_confirmed}`. `Retry-After` header is authoritative over the body value; `RateLimit-Policy: "fairshare"` is recorded as corroboration. Non-Nous providers are unaffected even with a fairshare-shaped body.
- `agent/nous_rate_guard.py` — `record_nous_rate_limit()` early-returns on a fairshare context. **No `nous.json` schema change** (concurrent sessions on older versions share that file). The loop's record site also excludes fairshare explicitly (belt-and-suspenders; the `reason == rate_limit` gate already excludes it).
- `agent/chat_completion_helpers.py` — `inject_fairshare_alternates()` splices `alternates` (best rate first) at the current chain cursor, ahead of the static `_fallback_chain`, as same-provider entries seeded with the **live session `api_key`/`base_url`**; `strip_fairshare_alternates()` removes them. `_fallback_entry_unavailable_without_network()` now trusts any Nous entry carrying an inline `api_key` (previously it re-read on-disk auth state and would skip the alternate with `nous_token_missing`).
- `agent/agent_runtime_helpers.py` — `restore_primary_runtime()` strips injected alternates so they are turn-scoped and never leak into the config-driven chain.
- `agent/conversation_loop.py` — injects alternates before the fallback gate (works with no configured chain too), emits `⚠️ <model> is at its fair-share limit — switching to <alt>` after activation, arms the primary cooldown with the honest `retry_after` (instead of the fixed 60s step), and when no fallback exists uses body `retry_after` for the wait with `… — retrying in Ns`. `upgrade_url` is surfaced once per agent as a 💡 line in the existing entitlement-guidance style. Status strings in this loop are hardcoded English (locales only cover `/usage`-type output), so no i18n.
- `tests/agent/test_nous_fairshare_rate_limit.py` — 45 tests: classifier (every enum reason, all Nous provider aliases, **plain Nous 429 classifies exactly as before**, fairshare-shaped body from non-Nous unchanged, header precedence, headers-alone never trigger), defensive parsing (absent/empty/malformed `alternates`, absent/non-http `upgrade_url`, `retry_after` = 0 / negative / bool / string, >120s kept exact, nested `error` envelope), guard non-recording + unchanged file schema, alternates-first ordering through the real `_try_activate_fallback`, strip/restore across turns, credential rotation skipped, retry-wait derivation, upgrade hint.

Not changed: `agent/rate_limit_tracker.py` — fairshare 429s carry no `x-ratelimit-*` exhaustion and never reach `is_genuine_nous_rate_limit`, so no per-model awareness is needed there.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_nous_fairshare_rate_limit.py tests/agent/test_error_classifier.py tests/agent/test_nous_rate_guard.py tests/run_agent/test_24996_fallback_exhaustion_cooldown.py tests/run_agent/test_fallback_credential_isolation.py tests/agent/test_credential_pool_routing.py -q` → 220 passed.
2. Pre-fairshare contract: `TestFairshareClassification::test_plain_nous_429_classifies_exactly_as_before` asserts a `{status, message}` Nous 429 still yields `rate_limit`, `should_rotate_credential=True`, no `fairshare` context.
3. Once the gateway ships fairshare: hit a governed model past its rate on Nous; expect `⚠️ <model> is at its fair-share limit — switching to <alternate>` and **no** `~/.hermes/rate_limits/nous.json` written; with no alternates and no fallback chain, expect `… — retrying in <retry_after>s`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant suites (see above); the remaining `tests/run_agent` failures on this machine are a pre-existing `DaemonThreadPoolExecutor._initializer` venv/Python mismatch in `tools/daemon_pool.py` that reproduces on untouched `main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 25.5 (Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings; no docs page covers the Nous rate guard
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (no path/process changes)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Reviewer notes

- Reusing `upstream_rate_limit` rather than adding a new `FailoverReason` was deliberate (lower risk: `agent_runtime_helpers.recover_with_credential_pool`, `try_activate_fallback`'s cooldown logic and the loop's `is_rate_limited` gate all already handle it). The `fairshare` marker in `error_context` is the discriminator where fairshare-specific behaviour is needed.
- Injected alternates carry the live `api_key` so a Nous OAuth refresh that hasn't hit disk yet can't cause a spurious `nous_token_missing` skip — that was exposed by the first test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
