### PR TITLE
fix(photon): ignore read receipt events

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1333,6 +1333,12 @@ class PhotonAdapter(BasePlatformAdapter):
                 )
             )
             return
+        # Read receipts are provider control events, not user messages. Photon
+        # Spectrum 12 exposes them through the same stream; dispatching them as
+        # unknown content creates a fake prompt and can feed a read-receipt loop.
+        if ctype in {"read", "read_receipt"}:
+            logger.debug("[photon] ignoring read receipt event")
+            return
         # U+FFFC placeholder — wait for the real attachment instead of
         # dispatching. Detected before _record_last_inbound so the placeholder
         # is not recorded as the reaction target — the real attachment will be.

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -99,6 +99,21 @@ def _voice_event(
 
 
 @pytest.mark.asyncio
+async def test_read_receipt_event_is_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider read receipts never become fake user prompts."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _dm_event("", msg_id="spc-msg-read")
+    event["content"] = {"type": "read", "messageId": "spc-msg-target"}
+    await adapter._dispatch_inbound(event)
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
 async def test_on_inbound_line_dispatches_and_dedups(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Ignore Photon `read` and `read_receipt` control events before inbound dispatch.
- Prevent read receipts from becoming fake user prompts or feeding a receipt-response loop.
- Add a regression test proving no `MessageEvent` is emitted for a read receipt.

## Root cause

Spectrum 12 exposes provider read receipts on the same inbound event stream as user content. Photon treated an unrecognized `content.type` as user-facing text:

```text
[Photon content type not handled: read]
```

That surfaced control-plane events to the agent instead of dropping them at the adapter boundary.

## Verification

- `scripts/run_tests.sh tests/plugins/platforms/photon/test_inbound.py -q` — 8 passed
- `.venv/bin/python -m pytest tests/plugins/platforms/photon -q` — 130 passed
- `git diff --check` — passed

Related: #91215
