### PR TITLE
fix(cli): re-validate unresolved toolsets after plugin discovery before warning

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5274,6 +5274,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
             invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]
             if invalid:
+                # Plugin toolsets are likewise unknown until discover_plugins()
+                # has populated the registry (_get_platform_tools enables a
+                # newly installed plugin's toolset by default, so it arrives
+                # here before discovery on a cold start). Re-validate after a
+                # one-time discovery pass before declaring anything unknown —
+                # mirror of the TUI gateway's approach (tui_gateway/server.py).
+                try:
+                    from hermes_cli.plugins import discover_plugins
+
+                    discover_plugins()
+                    invalid = [t for t in invalid if not validate_toolset(t)]
+                except Exception:
+                    pass
+            if invalid:
                 self._console_print(f"[bold red]Warning: Unknown toolsets: {', '.join(invalid)}[/]")
         
         # Filesystem checkpoints: CLI flag > config

--- a/cli.py
+++ b/cli.py
@@ -5286,7 +5286,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     discover_plugins()
                     invalid = [t for t in invalid if not validate_toolset(t)]
                 except Exception:
-                    pass
+                    # A plugin that raises during import must not masquerade
+                    # as a config error, but keep the two failure modes
+                    # distinguishable in the logs (same level as the
+                    # background-discovery failure handler in plugins.py).
+                    logger.warning(
+                        "plugin discovery failed while re-validating toolsets",
+                        exc_info=True,
+                    )
             if invalid:
                 self._console_print(f"[bold red]Warning: Unknown toolsets: {', '.join(invalid)}[/]")
         

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -106,6 +106,47 @@ class TestVerboseAndToolProgress:
         assert cli.tool_progress_mode in {"off", "new", "all", "verbose"}
 
 
+class TestToolsetValidationWarning:
+    """Constructor-time validation must not false-positive on plugin toolsets
+    that discover_plugins() would register moments later (#91757).
+
+    ``_make_cli`` reloads ``cli``, so the patches target the underlying
+    modules (``toolsets``, ``hermes_cli.plugins``) whose attributes the CLI's
+    thin wrappers resolve on every call — patching ``cli`` itself would be
+    wiped by the reload.
+    """
+
+    def test_plugin_toolset_false_positive_suppressed(self, capsys):
+        import toolsets as toolsets_mod
+        import hermes_cli.plugins as plugins_mod
+
+        discovered = {"ran": False}
+
+        def _fake_validate(name):
+            if name == "hermes-cli":
+                return True
+            return discovered["ran"]  # plugin toolset known only after discovery
+
+        with patch.object(toolsets_mod, "validate_toolset", side_effect=_fake_validate), \
+             patch.object(plugins_mod, "discover_plugins", side_effect=lambda: discovered.__setitem__("ran", True)):
+            _make_cli(toolsets=["hermes-cli", "cad_compare"])
+
+        assert "Unknown toolsets" not in capsys.readouterr().out
+
+    def test_genuinely_unknown_toolset_still_warns(self, capsys):
+        import toolsets as toolsets_mod
+        import hermes_cli.plugins as plugins_mod
+
+        def _fake_validate(name):
+            return name == "hermes-cli"
+
+        with patch.object(toolsets_mod, "validate_toolset", side_effect=_fake_validate), \
+             patch.object(plugins_mod, "discover_plugins", side_effect=lambda: None):
+            _make_cli(toolsets=["hermes-cli", "ghost_set"])
+
+        assert "Unknown toolsets: ghost_set" in capsys.readouterr().out
+
+
 class TestFallbackChainInit:
     def test_merges_new_and_legacy_fallback_config(self):
         cli = _make_cli(config_overrides={

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -146,6 +146,37 @@ class TestToolsetValidationWarning:
 
         assert "Unknown toolsets: ghost_set" in capsys.readouterr().out
 
+    def test_discovery_crash_does_not_propagate_and_still_warns(self, capsys):
+        """A plugin raising during discovery must not escape the constructor;
+        the toolset warning still prints so the failure stays user-visible."""
+        import toolsets as toolsets_mod
+        import hermes_cli.plugins as plugins_mod
+
+        def _fake_validate(name):
+            return name == "hermes-cli"
+
+        with patch.object(toolsets_mod, "validate_toolset", side_effect=_fake_validate), \
+             patch.object(plugins_mod, "discover_plugins", side_effect=RuntimeError("boom")):
+            _make_cli(toolsets=["hermes-cli", "ghost_set"])  # must not raise
+
+        assert "Unknown toolsets: ghost_set" in capsys.readouterr().out
+
+    def test_multiple_invalid_names_trigger_single_discovery_pass(self, capsys):
+        """Discovery runs once for the whole invalid list, not once per name."""
+        import toolsets as toolsets_mod
+        import hermes_cli.plugins as plugins_mod
+
+        def _fake_validate(name):
+            return name == "hermes-cli"
+
+        with patch.object(toolsets_mod, "validate_toolset", side_effect=_fake_validate), \
+             patch.object(plugins_mod, "discover_plugins", side_effect=lambda: None) as discover:
+            _make_cli(toolsets=["hermes-cli", "ghost_set", "phantom_set"])
+
+        discover.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Unknown toolsets: ghost_set, phantom_set" in out
+
 
 class TestFallbackChainInit:
     def test_merges_new_and_legacy_fallback_config(self):


### PR DESCRIPTION
## What does this PR do?

Fixes the false-positive `Warning: Unknown toolsets: <plugin_toolset>` printed at CLI startup for every freshly installed plugin that registers a custom toolset (#91757).

Root cause: `_get_platform_tools()` enables a newly installed plugin's toolset by default, so it reaches the `HermesCLI` constructor's toolset validation before `discover_plugins()` has ever run. `validate_toolset()` only knows plugin toolsets once discovery has populated the registry, so a toolset that loads perfectly moments later is declared "unknown" on the very first line of output. The validation code already acknowledged this ordering problem for MCP server names (they are exempted via the `mcp_servers` config keys); plugin toolsets just needed the equivalent treatment.

The fix mirrors the pattern the TUI gateway already uses (`tui_gateway/server.py`): when unresolved names remain, run a one-time `discover_plugins()` and re-validate before declaring anything unknown. Discovery only runs when something is actually unresolved (zero cost on the normal path), and a discovery failure degrades to the current behavior (the warning still prints) rather than masking genuinely unknown names.

## Related Issue

Fixes #91757

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — toolset validation in the `HermesCLI` constructor: when the first pass leaves unresolved names, run `discover_plugins()` once and re-validate (mirror of `tui_gateway/server.py`'s approach); only names still unresolved after discovery trigger the warning.
- `tests/cli/test_cli_init.py` — `TestToolsetValidationWarning`: a plugin toolset that resolves after discovery produces no warning (issue reproduction), and a genuinely unknown name still warns after a no-op discovery — the two cases jointly pin the new behavior without weakening the check.

## How to Test

1. Automated: `.venv/bin/python -m pytest tests/cli/test_cli_init.py tests/cli/test_cli_interrupt_drain_regression.py tests/hermes_cli/test_mcp_discovery_timing.py -q` — should pass (observed result: 55 passed, 1 platform-skipped on macOS arm64).
2. Manual (issue reproduction): install a plugin registering a custom toolset (e.g. `toolset="cad_compare"`) without listing it in `known_plugin_toolsets`, then start `hermes` — no `Warning: Unknown toolsets: cad_compare` should print, and the plugin's tools should load as before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted CLI-init and discovery suites: 55 passed, 0 failures)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment documents the mirroring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (issue reported on Windows; fix is platform-neutral)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
