### PR TITLE
fix(desktop): pin macOS package to Electron architecture

### DIFF
--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -22,8 +22,20 @@
 import path from 'node:path'
 
 import { stampExeIdentity } from './set-exe-identity.mjs'
+import { archNameFromBuilderValue, assertMachOArchitecture } from './native-binary-arch.mjs'
 
 export default async function afterPack(context) {
+  if (context.electronPlatformName === 'darwin') {
+    const productName = context.packager?.appInfo?.productFilename || 'Hermes'
+    const executable = path.join(context.appOutDir, `${productName}.app`, 'Contents', 'MacOS', productName)
+    const expectedArch = archNameFromBuilderValue(context.arch)
+    if (!expectedArch) {
+      throw new Error(`[after-pack] unknown electron-builder architecture value: ${context.arch}`)
+    }
+    assertMachOArchitecture(executable, expectedArch)
+    return
+  }
+
   if (context.electronPlatformName !== 'win32') {
     return
   }

--- a/apps/desktop/scripts/native-binary-arch.mjs
+++ b/apps/desktop/scripts/native-binary-arch.mjs
@@ -1,0 +1,92 @@
+import { closeSync, openSync, readSync } from 'node:fs'
+
+const CPU_TYPE_X86_64 = 0x01000007
+const CPU_TYPE_ARM64 = 0x0100000c
+const FAT_MAGIC = 0xcafebabe
+const FAT_CIGAM = 0xbebafeca
+const FAT_MAGIC_64 = 0xcafebabf
+const FAT_CIGAM_64 = 0xbfbafeca
+const MH_MAGIC_64 = 0xfeedfacf
+const MH_CIGAM_64 = 0xcffaedfe
+
+function cpuTypeToArch(cpuType) {
+  if (cpuType === CPU_TYPE_X86_64) return 'x64'
+  if (cpuType === CPU_TYPE_ARM64) return 'arm64'
+  return null
+}
+
+export function classifyMachOArchitectures(filePath) {
+  let descriptor
+  let buffer
+  try {
+    descriptor = openSync(filePath, 'r')
+    buffer = Buffer.alloc(4096)
+    const bytesRead = readSync(descriptor, buffer, 0, buffer.length, 0)
+    buffer = buffer.subarray(0, bytesRead)
+  } catch {
+    return null
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor)
+  }
+  if (buffer.length < 8) return null
+
+  const magic = buffer.readUInt32BE(0)
+  if (magic === MH_MAGIC_64 || magic === MH_CIGAM_64) {
+    const littleEndian = magic === MH_CIGAM_64
+    const cpuType = littleEndian ? buffer.readUInt32LE(4) : buffer.readUInt32BE(4)
+    const arch = cpuTypeToArch(cpuType)
+    return arch ? new Set([arch]) : null
+  }
+
+  const fat = magic === FAT_MAGIC || magic === FAT_CIGAM || magic === FAT_MAGIC_64 || magic === FAT_CIGAM_64
+  if (!fat) return null
+
+  const littleEndian = magic === FAT_CIGAM || magic === FAT_CIGAM_64
+  const is64 = magic === FAT_MAGIC_64 || magic === FAT_CIGAM_64
+  const readUInt32 = littleEndian ? buffer.readUInt32LE.bind(buffer) : buffer.readUInt32BE.bind(buffer)
+  const count = readUInt32(4)
+  const entrySize = is64 ? 32 : 20
+  const arches = new Set()
+  for (let index = 0; index < count; index += 1) {
+    const offset = 8 + index * entrySize
+    if (offset + entrySize > buffer.length) return null
+    const arch = cpuTypeToArch(readUInt32(offset))
+    if (arch) arches.add(arch)
+  }
+  return arches.size > 0 ? arches : null
+}
+
+export function electronBuilderArchFlag(architectures) {
+  if (!architectures || architectures.size === 0) return null
+  if (architectures.size === 1) return `--${[...architectures][0]}`
+  if (architectures.has('arm64') && architectures.has('x64') && architectures.size === 2) return '--universal'
+  return null
+}
+
+export function hasExplicitArchFlag(args) {
+  return args.some((arg) =>
+    ['--ia32', '--x64', '--armv7l', '--arm64', '--universal'].includes(arg) ||
+    arg === '--arch' ||
+    arg.startsWith('--arch=')
+  )
+}
+
+export function archNameFromBuilderValue(value) {
+  return ['ia32', 'x64', 'armv7l', 'arm64', 'universal'][value] ?? null
+}
+
+export function assertMachOArchitecture(filePath, expectedArch) {
+  const architectures = classifyMachOArchitectures(filePath)
+  if (!architectures) {
+    throw new Error(`cannot classify packed Electron binary architecture: ${filePath}`)
+  }
+  if (expectedArch === 'universal') {
+    if (!(architectures.has('arm64') && architectures.has('x64'))) {
+      throw new Error(`packed Electron architecture mismatch: expected universal, got ${[...architectures].join('+')}`)
+    }
+    return
+  }
+  if (!architectures.has(expectedArch)) {
+    throw new Error(`packed Electron architecture mismatch: expected ${expectedArch}, got ${[...architectures].join('+')}`)
+  }
+}

--- a/apps/desktop/scripts/native-binary-arch.test.mjs
+++ b/apps/desktop/scripts/native-binary-arch.test.mjs
@@ -33,11 +33,33 @@ function thinMachO(cpuType) {
   return buffer
 }
 
+// Big-endian on-disk thin Mach-O (MH_MAGIC_64 read as-is, cpuType big-endian).
+function thinMachOBigEndian(cpuType) {
+  const buffer = Buffer.alloc(32)
+  buffer.writeUInt32BE(0xfeedfacf, 0)
+  buffer.writeUInt32BE(cpuType, 4)
+  return buffer
+}
+
 function universalMachO(cpuTypes) {
   const buffer = Buffer.alloc(8 + cpuTypes.length * 20)
   buffer.writeUInt32BE(0xcafebabe, 0)
   buffer.writeUInt32BE(cpuTypes.length, 4)
   cpuTypes.forEach((cpuType, index) => buffer.writeUInt32BE(cpuType, 8 + index * 20))
+  return buffer
+}
+
+// Fat Mach-O in an arbitrary encoding, to exercise the byte-swapped and 64-bit
+// header variants that only differ in magic, endianness, and entry stride.
+function fatMachO({ magic, littleEndian, is64, cpuTypes }) {
+  const entrySize = is64 ? 32 : 20
+  const buffer = Buffer.alloc(8 + cpuTypes.length * entrySize)
+  const writeU32 = (value, offset) =>
+    littleEndian ? buffer.writeUInt32LE(value, offset) : buffer.writeUInt32BE(value, offset)
+  // The magic is compared after a fixed big-endian read, so write it big-endian.
+  buffer.writeUInt32BE(magic, 0)
+  writeU32(cpuTypes.length, 4)
+  cpuTypes.forEach((cpuType, index) => writeU32(cpuType, 8 + index * entrySize))
   return buffer
 }
 
@@ -56,6 +78,39 @@ test('classifies thin x64 Mach-O', () => {
 test('classifies universal arm64 and x64 Mach-O', () => {
   withTempBinary(universalMachO([CPU_TYPE_X86_64, CPU_TYPE_ARM64]), (file) => {
     assert.deepEqual([...classifyMachOArchitectures(file)], ['x64', 'arm64'])
+  })
+})
+
+test('classifies a big-endian thin Mach-O', () => {
+  withTempBinary(thinMachOBigEndian(CPU_TYPE_ARM64), (file) => {
+    assert.deepEqual([...classifyMachOArchitectures(file)], ['arm64'])
+  })
+})
+
+test('classifies a byte-swapped fat Mach-O (FAT_CIGAM)', () => {
+  const buffer = fatMachO({ magic: 0xbebafeca, littleEndian: true, is64: false, cpuTypes: [CPU_TYPE_X86_64, CPU_TYPE_ARM64] })
+  withTempBinary(buffer, (file) => {
+    assert.deepEqual([...classifyMachOArchitectures(file)], ['x64', 'arm64'])
+  })
+})
+
+test('classifies a 64-bit fat Mach-O (FAT_MAGIC_64)', () => {
+  const buffer = fatMachO({ magic: 0xcafebabf, littleEndian: false, is64: true, cpuTypes: [CPU_TYPE_ARM64] })
+  withTempBinary(buffer, (file) => {
+    assert.deepEqual([...classifyMachOArchitectures(file)], ['arm64'])
+  })
+})
+
+test('classifies a byte-swapped 64-bit fat Mach-O (FAT_CIGAM_64)', () => {
+  const buffer = fatMachO({ magic: 0xbfbafeca, littleEndian: true, is64: true, cpuTypes: [CPU_TYPE_X86_64] })
+  withTempBinary(buffer, (file) => {
+    assert.deepEqual([...classifyMachOArchitectures(file)], ['x64'])
+  })
+})
+
+test('returns null for a file smaller than the header', () => {
+  withTempBinary(Buffer.alloc(4), (file) => {
+    assert.equal(classifyMachOArchitectures(file), null)
   })
 })
 

--- a/apps/desktop/scripts/native-binary-arch.test.mjs
+++ b/apps/desktop/scripts/native-binary-arch.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+
+import {
+  archNameFromBuilderValue,
+  assertMachOArchitecture,
+  classifyMachOArchitectures,
+  electronBuilderArchFlag,
+  hasExplicitArchFlag
+} from './native-binary-arch.mjs'
+
+const CPU_TYPE_X86_64 = 0x01000007
+const CPU_TYPE_ARM64 = 0x0100000c
+
+function withTempBinary(buffer, callback) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-macho-'))
+  const file = path.join(root, 'Electron')
+  try {
+    fs.writeFileSync(file, buffer)
+    callback(file)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function thinMachO(cpuType) {
+  const buffer = Buffer.alloc(32)
+  buffer.writeUInt32LE(0xfeedfacf, 0)
+  buffer.writeUInt32LE(cpuType, 4)
+  return buffer
+}
+
+function universalMachO(cpuTypes) {
+  const buffer = Buffer.alloc(8 + cpuTypes.length * 20)
+  buffer.writeUInt32BE(0xcafebabe, 0)
+  buffer.writeUInt32BE(cpuTypes.length, 4)
+  cpuTypes.forEach((cpuType, index) => buffer.writeUInt32BE(cpuType, 8 + index * 20))
+  return buffer
+}
+
+test('classifies thin arm64 Mach-O', () => {
+  withTempBinary(thinMachO(CPU_TYPE_ARM64), (file) => {
+    assert.deepEqual([...classifyMachOArchitectures(file)], ['arm64'])
+  })
+})
+
+test('classifies thin x64 Mach-O', () => {
+  withTempBinary(thinMachO(CPU_TYPE_X86_64), (file) => {
+    assert.deepEqual([...classifyMachOArchitectures(file)], ['x64'])
+  })
+})
+
+test('classifies universal arm64 and x64 Mach-O', () => {
+  withTempBinary(universalMachO([CPU_TYPE_X86_64, CPU_TYPE_ARM64]), (file) => {
+    assert.deepEqual([...classifyMachOArchitectures(file)], ['x64', 'arm64'])
+  })
+})
+
+test('maps Electron architecture to builder flag', () => {
+  assert.equal(electronBuilderArchFlag(new Set(['arm64'])), '--arm64')
+  assert.equal(electronBuilderArchFlag(new Set(['x64'])), '--x64')
+  assert.equal(electronBuilderArchFlag(new Set(['x64', 'arm64'])), '--universal')
+})
+
+test('preserves explicit builder architecture', () => {
+  assert.equal(hasExplicitArchFlag(['--mac', '--arm64']), true)
+  assert.equal(hasExplicitArchFlag(['--arch=x64']), true)
+  assert.equal(hasExplicitArchFlag(['--dir']), false)
+})
+
+test('maps electron-builder numeric architecture values', () => {
+  assert.equal(archNameFromBuilderValue(1), 'x64')
+  assert.equal(archNameFromBuilderValue(3), 'arm64')
+  assert.equal(archNameFromBuilderValue(4), 'universal')
+})
+
+test('architecture gate rejects a mismatched packed binary', () => {
+  withTempBinary(thinMachO(CPU_TYPE_ARM64), (file) => {
+    assert.throws(() => assertMachOArchitecture(file, 'x64'), /expected x64, got arm64/)
+    assert.doesNotThrow(() => assertMachOArchitecture(file, 'arm64'))
+  })
+})

--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -8,6 +8,11 @@ import fs from "node:fs"
 import path from "node:path"
 import { spawnSync } from "node:child_process"
 import { createRequire } from "node:module"
+import {
+  classifyMachOArchitectures,
+  electronBuilderArchFlag,
+  hasExplicitArchFlag,
+} from "./native-binary-arch.mjs"
 
 const require = createRequire(import.meta.url)
 
@@ -40,6 +45,20 @@ const dist = electronDistDir()
 const args = []
 if (dist && fs.existsSync(distBinary(dist))) {
   args.push(`-c.electronDist=${dist}`)
+  const requestedArgs = process.argv.slice(2)
+  if (process.platform === "darwin" && !hasExplicitArchFlag(requestedArgs)) {
+    const architectures = classifyMachOArchitectures(distBinary(dist))
+    const archFlag = electronBuilderArchFlag(architectures)
+    if (!archFlag) {
+      console.error("[run-electron-builder] cannot determine the local Electron architecture")
+      process.exit(1)
+    }
+    args.push(archFlag)
+    console.log(
+      `[run-electron-builder] pinning target architecture to ${archFlag.slice(2)} ` +
+        `(local Electron; process.arch=${process.arch})`
+    )
+  }
 } else {
   console.warn(
     "[run-electron-builder] no local electron dist; electron-builder will fetch " +

--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -50,7 +50,10 @@ if (dist && fs.existsSync(distBinary(dist))) {
     const architectures = classifyMachOArchitectures(distBinary(dist))
     const archFlag = electronBuilderArchFlag(architectures)
     if (!archFlag) {
-      console.error("[run-electron-builder] cannot determine the local Electron architecture")
+      console.error(
+        "[run-electron-builder] cannot determine the local Electron architecture; " +
+          "pass an explicit --x64, --arm64 or --universal flag to skip detection"
+      )
       process.exit(1)
     }
     args.push(archFlag)


### PR DESCRIPTION
## Summary

Fixes macOS desktop packages that mix an arm64 Electron binary with x64 native modules when the build runs under Rosetta.

The builder now reads the architecture from the Electron binary being packaged. It pins electron-builder to that target. An afterPack gate rejects a bundle when the target and packed Mach-O binary disagree.

Fixes #90079.

## Tests

`npx vitest run scripts/native-binary-arch.test.mjs scripts/stage-native-deps.test.mjs` passed 37 tests.

`npm run pack` produced `platform=darwin arch=arm64` on Apple Silicon. `file` confirmed both `Hermes` and packaged `pty.node` are arm64. The afterPack gate rejects an x64 target against this bundle and accepts arm64.

AI assistance was used. I reviewed the change and ran these tests on real Apple Silicon hardware.
