### PR TITLE
fix: repair_message_sequence drops tool results for SDK tool_call objects

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -716,10 +716,16 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         if role == "assistant":
             known_tool_ids = set()
             for tc in (msg.get("tool_calls") or []):
-                if not isinstance(tc, dict):
-                    continue
+                # Mirror ``_get_tool_call_id_static``'s dict-or-object
+                # tolerance: SDK tool_call objects (e.g. an unserialized
+                # ``ChatCompletionMessageToolCall``) reach this pass on
+                # host-fed / pre-serialization histories just as often as
+                # plain dicts. Skipping non-dict entries left
+                # ``known_tool_ids`` empty for such messages, so the
+                # following legitimate ``tool`` result was misclassified
+                # as orphaned and silently dropped.
                 for key in ("id", "call_id"):
-                    tc_id = tc.get(key)
+                    tc_id = tc.get(key) if isinstance(tc, dict) else getattr(tc, key, None)
                     if tc_id:
                         known_tool_ids.add(tc_id)
             filtered.append(msg)

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -503,6 +503,44 @@ def test_repair_drops_stale_empty_tool_calls_on_merged_assistant():
     assert "second" in assistants[0]["content"]
 
 
+def test_repair_keeps_tool_result_when_tool_calls_are_sdk_objects():
+    """repair_message_sequence must not drop a valid tool result just because
+    the assistant's ``tool_calls`` entries are unserialized SDK objects
+    (e.g. ``ChatCompletionMessageToolCall``) instead of plain dicts.
+
+    Host-fed / pre-serialization histories (gateway multi-queue replay,
+    session resume) can carry SDK tool_call objects into this pass. The
+    dict-only ``tc.get(key)`` lookup previously left ``known_tool_ids``
+    empty for such messages, so the id-matching pass below misclassified
+    the legitimate tool result as an orphan and silently deleted it —
+    corrupting the persisted history and leaving the assistant's
+    tool_calls unanswered (itself a strict-provider HTTP 400 trigger)."""
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    class SDKToolCall:
+        def __init__(self, call_id):
+            self.id = call_id
+            self.call_id = None
+            self.function = type("F", (), {"name": "read_file", "arguments": "{}"})()
+
+    messages = [
+        {"role": "user", "content": "read the file"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [SDKToolCall("call_1")],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "file contents"},
+    ]
+    agent = type("Agent", (), {})()
+    repair_message_sequence(agent, messages)
+
+    roles = [m.get("role") for m in messages]
+    assert "tool" in roles, "legitimate tool result was dropped as a false orphan"
+    tool_msg = next(m for m in messages if m.get("role") == "tool")
+    assert tool_msg["content"] == "file contents"
+
+
 
 
 


### PR DESCRIPTION
Fixes #91762

## Summary

- `repair_message_sequence`'s tool_call id-matching pass skipped any non-dict `tool_calls` entry entirely (`if not isinstance(tc, dict): continue`), leaving `known_tool_ids` empty whenever an assistant turn carried unserialized SDK tool_call objects instead of dicts
- That misclassified the following legitimate `tool` result as an orphan and silently deleted it from the persisted conversation history — the exact failure mode this pass exists to prevent, just from the other direction
- Fix extracts `id`/`call_id` via `getattr()` for non-dict entries too, mirroring `AIAgent._get_tool_call_id_static`'s existing dict-or-object tolerance used elsewhere in the same file

## Root cause

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 Assistant Turn w/ tool_calls] -->|SDK Object, not dict| B{isinstance dict?}
    B -->|False: continue, skip| C[⚡ known_tool_ids stays EMPTY]
    B -->|True: dict path| D[✅ known_tool_ids populated]
    C --> E[🚀 Next tool Result Message]
    D --> E
    E -->|tool_call_id not in known_tool_ids| F[💀 Silently Dropped as Orphan]
    E -->|tool_call_id in known_tool_ids| G[✅ Kept: Valid Tool Result]
    F -.->|Fix: getattr fallback| D
```

## Test plan

- [x] New regression test `test_repair_keeps_tool_result_when_tool_calls_are_sdk_objects` reproduces the drop with an `SDKToolCall`-shaped object and asserts the tool result survives
- [x] Full `tests/run_agent/test_message_sequence_repair.py` suite passes (22/22)
- [x] Verified the new test fails with the exact drop behavior on unpatched code before applying the fix


## Infographic : 

 
<img width="1376" height="768" alt="infographic_repair_message_sequence_sdk_91768_art" src="https://github.com/user-attachments/assets/6d7fe176-d9e2-482e-9f2a-f07df66384ae" />

 