### PR TITLE
fix: race between close() and run_turn's self._client reads crashes turns

### DIFF
--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -568,6 +568,23 @@ class CodexAppServerSession:
         last_tool_completion_at: Optional[float] = None
 
         while time.monotonic() < deadline and not turn_complete:
+            # Snapshot self._client once per iteration and use only this
+            # local reference below. close() can run on another thread
+            # (e.g. a session-expiry watchdog) concurrently with this loop
+            # and sets self._client = None; re-reading the attribute
+            # across multiple statements in the same iteration raced that
+            # write and could see it become None between an is_alive()
+            # check and the very next attribute access, crashing the turn
+            # with AttributeError: 'NoneType' object has no attribute
+            # 'is_alive'/'stderr_tail'/etc. A single snapshot makes every
+            # use in this iteration consistent (either the live client or
+            # None), closing that race.
+            client = self._client
+            if client is None:
+                result.error = "codex app-server session was closed during turn execution"
+                result.should_retire = True
+                break
+
             if self._interrupt_event.is_set():
                 self._issue_interrupt(result.turn_id)
                 result.interrupted = True
@@ -577,8 +594,8 @@ class CodexAppServerSession:
             # (e.g. crashed, segfaulted, or its auth refresh thread killed
             # the process), we won't get any more notifications — bail out
             # rather than waiting for the full turn deadline.
-            if not self._client.is_alive():
-                stderr_blob = "\n".join(self._client.stderr_tail(60))
+            if not client.is_alive():
+                stderr_blob = "\n".join(client.stderr_tail(60))
                 hint = _classify_oauth_failure(stderr_blob)
                 if hint is not None:
                     result.error = hint
@@ -610,14 +627,14 @@ class CodexAppServerSession:
 
             # Drain any server-initiated requests (approvals) before
             # reading notifications, so the codex side isn't blocked.
-            sreq = self._client.take_server_request(timeout=0)
+            sreq = client.take_server_request(timeout=0)
             if sreq is not None:
                 # Drain any pending notifications first so per-turn state
                 # (e.g. _pending_file_changes for fileChange approvals) is
                 # up to date when we make the approval decision. Bounded
                 # to avoid starving the server-request response.
                 for _ in range(8):
-                    pending = self._client.take_notification(timeout=0)
+                    pending = client.take_notification(timeout=0)
                     if pending is None:
                         break
                     if not _notification_belongs_to_turn(
@@ -669,7 +686,7 @@ class CodexAppServerSession:
                 last_tool_completion_at = None
                 continue
 
-            note = self._client.take_notification(
+            note = client.take_notification(
                 timeout=notification_poll_timeout
             )
             if note is None:
@@ -746,7 +763,7 @@ class CodexAppServerSession:
                         # rewrite the error into a re-auth hint AND mark
                         # the session for retirement.
                         stderr_blob = "\n".join(
-                            self._client.stderr_tail(40)
+                            client.stderr_tail(40)
                         )
                         hint = _classify_oauth_failure(err_msg, stderr_blob)
                         if hint is not None:

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -385,8 +385,34 @@ class TestRunTurn:
             "expectedTurnId": "turn-live-123",
         }
 
+    def test_close_mid_iteration_does_not_crash_run_turn(self):
+        """close() firing between the is_alive() check and the next
+        self._client use (e.g. a session-expiry watchdog on another thread)
+        must not crash the turn with AttributeError.
 
+        Simulated here by having is_alive() itself trigger close() as a
+        side effect — same race window, deterministic without real threads.
+        run_turn must snapshot self._client once per iteration so the rest
+        of that iteration keeps using the live object even after close()
+        clears self._client.
+        """
+        client = FakeClient()
+        s = make_session(client)
 
+        def is_alive_then_close():
+            # close() runs exactly inside the is_alive() call, the same
+            # window that raced self._client in the unpatched code, then
+            # reports the subprocess as dead so the caller goes on to read
+            # client.stderr_tail(60) right after.
+            s.close()  # simulates a concurrent close() from another thread
+            return False
+
+        client.is_alive = is_alive_then_close
+
+        r = s.run_turn("hi", turn_timeout=2.0)
+
+        assert r.error is not None
+        assert r.should_retire is True
 
 
 


### PR DESCRIPTION
Fixes #91763

## Summary

- `close()` sets `self._client = None`, but `run_turn`'s polling loop reads `self._client` multiple times per iteration with no synchronization against that write
- `close()` can run on a different thread than `run_turn` (e.g. a session-expiry watchdog closing an idle session mid-turn) — if it lands between two reads in the same loop iteration, the second read raises `AttributeError: 'NoneType' object has no attribute '...'`, crashing the turn
- Fix snapshots `self._client` into a local `client` once per iteration and reuses only that local reference; if the snapshot is `None`, the turn ends cleanly with `should_retire=True` instead of crashing

## Root cause

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 run_turn Loop - Thread A] -->|"read #1: self._client.is_alive()"| B[🔥 Client Alive Check]
    C[⚔️ Watchdog - Thread B] -->|"close() concurrently"| D[💀 self._client = None]
    D -.->|races| B
    B -->|"read #2: self._client.stderr_tail()"| E[☠️ AttributeError: NoneType]
    B -.->|Fix: snapshot once| F[🕯️ local client = self._client]
    F -->|reused for both reads| G[✅ Consistent: either live or None, never torn]
```

## Test plan

- [x] New regression test `test_close_mid_iteration_does_not_crash_run_turn` has `is_alive()` trigger `close()` as a side effect (same race window) and asserts the turn ends with `should_retire=True` instead of raising
- [x] Verified the new test raises `AttributeError: 'NoneType' object has no attribute 'stderr_tail'` on unpatched code (confirms it reproduces the exact race), passes after the fix
- [x] Full `tests/agent/transports/` suite passes (306/306)