### PR TITLE
feat(delegation): persistent delegate sessions with Pi and OpenCode backends

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import threading
 import time
 from datetime import datetime
@@ -2741,7 +2742,14 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             or os.getenv("HERMES_PI_BIN", "").strip()
             or "pi"
         ).strip()
-        if Path(_pi_cmd).name in ("pi", "pi-acp") or not _pi_cmd:
+        if _pi_cmd and (
+            Path(_pi_cmd).name in ("pi", "pi-acp")
+            or shutil.which(_pi_cmd) is not None
+            or Path(_pi_cmd).exists()
+        ):
+            # Basename fast-path accepts pi / pi-acp; anything else must
+            # actually resolve on disk so versioned installs and wrapper
+            # scripts pointed at via HERMES_PI_BIN still work.
             client_kwargs.pop("base_url", None)
             client_kwargs.pop("acp_command", None)
             client_kwargs.pop("command", None)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import os
 import re
 import threading
 import time
@@ -2726,7 +2727,60 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)
     _validate_proxy_env_urls()
     _validate_base_url(client_kwargs.get("base_url"))
+    if agent.provider == "pi-rpc" or str(client_kwargs.get("base_url", "")).startswith("pi://"):
+        # First-class pi delegation: drive pi's native JSONL RPC directly.
+        # Unlike ACP, the native protocol exposes extension_ui_request, so
+        # delegated pi agents can ask the parent questions and receive real
+        # free-text answers.
+        from agent.copilot_acp_client import _resolve_command
+        from agent.pi_rpc_client import PI_RPC_MARKER_BASE_URL, PiRPCClient
+
+        _pi_cmd = str(
+            client_kwargs.get("acp_command")
+            or client_kwargs.get("command")
+            or os.getenv("HERMES_PI_BIN", "").strip()
+            or "pi"
+        ).strip()
+        if Path(_pi_cmd).name in ("pi", "pi-acp") or not _pi_cmd:
+            client_kwargs.pop("base_url", None)
+            client_kwargs.pop("acp_command", None)
+            client_kwargs.pop("command", None)
+            client = PiRPCClient(**client_kwargs, base_url=PI_RPC_MARKER_BASE_URL)
+            _ra().logger.info(
+                "Pi RPC client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                agent._client_log_context(),
+            )
+            return client
+        raise RuntimeError(
+            f"pi-rpc provider requires the pi binary (got command '{_pi_cmd}'). "
+            "Install pi or set HERMES_PI_BIN."
+        )
     if agent.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+        # When the ACP transport is actually pi (directly or via the pi-acp
+        # bridge), drive pi's native JSONL RPC instead. Unlike ACP, the
+        # native protocol exposes extension_ui_request, so delegated pi
+        # agents can ask the parent questions and receive real answers.
+        from agent.copilot_acp_client import _resolve_command
+
+        _acp_cmd = str(
+            client_kwargs.get("acp_command")
+            or client_kwargs.get("command")
+            or _resolve_command()
+        ).strip()
+        if Path(_acp_cmd).name in ("pi", "pi-acp"):
+            from agent.pi_rpc_client import PI_RPC_MARKER_BASE_URL, PiRPCClient
+
+            client_kwargs.pop("base_url", None)
+            client = PiRPCClient(**client_kwargs, base_url=PI_RPC_MARKER_BASE_URL)
+            _ra().logger.info(
+                "Pi RPC client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                agent._client_log_context(),
+            )
+            return client
         from agent.copilot_acp_client import CopilotACPClient
 
         client = CopilotACPClient(**client_kwargs)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3688,6 +3688,21 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     elif function_name == "delegate_task":
         def _execute(next_args: dict) -> Any:
             return _finish_agent_tool(agent._dispatch_delegate_task(next_args), next_args)
+    elif function_name == "delegate_session":
+        def _execute(next_args: dict) -> Any:
+            from tools.delegate_session_tool import delegate_session as _delegate_session
+            return _finish_agent_tool(
+                _delegate_session(
+                    action=next_args.get("action") or "start",
+                    session_id=next_args.get("session_id"),
+                    goal=next_args.get("goal"),
+                    context=next_args.get("context"),
+                    message=next_args.get("message"),
+                    timeout=next_args.get("timeout"),
+                    parent_agent=agent,
+                ),
+                next_args,
+            )
     else:
         def _execute(next_args: dict) -> Any:
             dispatch_kwargs = dict(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7198,6 +7198,18 @@ def resolve_provider_client(
             or _read_main_model_for_aux(),
             provider,
         )
+        if provider == "pi-rpc":
+            from agent.pi_rpc_client import PI_RPC_MARKER_BASE_URL, PiRPCClient
+
+            client = PiRPCClient(
+                api_key=str(creds.get("api_key", "")).strip() or "pi-rpc",
+                base_url=PI_RPC_MARKER_BASE_URL,
+                command=str(creds.get("command", "")).strip() or None,
+                args=list(creds.get("args") or []),
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
         if provider == "copilot-acp":
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -57,8 +57,29 @@ def _is_gh_copilot_deprecation_message(stderr_text: str) -> bool:
 
 
 def _resolve_command() -> str:
+    # Re-read .env at call time so changing HERMES_COPILOT_ACP_COMMAND
+    # applies to the next delegation without a gateway restart.
+    env_val = os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+    if not env_val:
+        for candidate in (
+            Path(os.path.expanduser("~/.hermes/.env")),
+            Path(os.path.expanduser("~/.hermes/hermes-agent/.env")),
+        ):
+            try:
+                if not candidate.is_file():
+                    continue
+                for line in candidate.read_text().splitlines():
+                    line = line.strip()
+                    if line.startswith("HERMES_COPILOT_ACP_COMMAND="):
+                        env_val = line.split("=", 1)[1].strip().strip("'\"")
+                        if env_val:
+                            break
+                if env_val:
+                    break
+            except OSError:
+                continue
     return (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+        env_val
         or os.getenv("COPILOT_CLI_PATH", "").strip()
         or "copilot"
     )

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -56,28 +56,41 @@ def _is_gh_copilot_deprecation_message(stderr_text: str) -> bool:
     return any(marker in lower for marker in _DEPRECATION_MARKERS)
 
 
+def _read_env_var(name: str) -> str | None:
+    """Look up ``name`` from the process env first, then the .env files in
+    their documented load order. Tolerates ``export`` prefixes, surrounding
+    spaces, and single/double quoting. Returns ``None`` when unset."""
+    env_val = os.getenv(name, "").strip()
+    if env_val:
+        return env_val
+    for candidate in (
+        Path(os.path.expanduser("~/.hermes/.env")),
+        Path(os.path.expanduser("~/.hermes/hermes-agent/.env")),
+    ):
+        try:
+            if not candidate.is_file():
+                continue
+            for line in candidate.read_text().splitlines():
+                line = line.strip()
+                if line.startswith("export "):
+                    line = line[len("export "):].strip()
+                if not line.startswith(f"{name} ") and not line.startswith(f"{name}="):
+                    continue
+                key, sep, value = line.partition("=")
+                if not sep or key.strip() != name:
+                    continue
+                value = value.strip().strip("'\"")
+                if value:
+                    return value
+        except OSError:
+            continue
+    return None
+
+
 def _resolve_command() -> str:
     # Re-read .env at call time so changing HERMES_COPILOT_ACP_COMMAND
     # applies to the next delegation without a gateway restart.
-    env_val = os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-    if not env_val:
-        for candidate in (
-            Path(os.path.expanduser("~/.hermes/.env")),
-            Path(os.path.expanduser("~/.hermes/hermes-agent/.env")),
-        ):
-            try:
-                if not candidate.is_file():
-                    continue
-                for line in candidate.read_text().splitlines():
-                    line = line.strip()
-                    if line.startswith("HERMES_COPILOT_ACP_COMMAND="):
-                        env_val = line.split("=", 1)[1].strip().strip("'\"")
-                        if env_val:
-                            break
-                if env_val:
-                    break
-            except OSError:
-                continue
+    env_val = _read_env_var("HERMES_COPILOT_ACP_COMMAND")
     return (
         env_val
         or os.getenv("COPILOT_CLI_PATH", "").strip()

--- a/agent/extensions/hermes_ask_user.ts
+++ b/agent/extensions/hermes_ask_user.ts
@@ -1,0 +1,63 @@
+/**
+ * hermes_ask_user — first-party pi extension for Hermes pi-rpc delegation.
+ *
+ * Exposes an `hermes_ask_user` tool to the pi agent. When called, it raises a
+ * blocking UI dialog over the RPC channel (extension_ui_request). Hermes'
+ * PiRPCClient holds the question open, surfaces it to the user as
+ * [pi-question], and the user's steering reply is delivered back as the
+ * answer.
+ *
+ * Uses the documented ExtensionUIContext API: ctx.ui.input() / ctx.ui.select(),
+ * both of which resolve to string | undefined (undefined = cancelled/timeout).
+ */
+export default function (pi: any) {
+  pi.registerTool({
+    name: "hermes_ask_user",
+    label: "Ask User (Hermes)",
+    description:
+      "Ask the supervising human a question and block until they answer. " +
+      "Use when you genuinely need information or a decision before proceeding.",
+    executionMode: "sequential",
+    parameters: {
+      type: "object",
+      properties: {
+        question: { type: "string", description: "The question, self-contained." },
+        options: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional choices; the human may also answer freely.",
+        },
+      },
+      required: ["question"],
+    },
+    async execute(toolCallId: string, args: { question: string; options?: string[] }, signal: any, onUpdate: any, ctx: any) {
+      const question = (args?.question ?? "").trim() || "(no question)";
+      const options = (args?.options ?? []).map((o) => String(o).trim()).filter(Boolean);
+      const ui = ctx && ctx.ui ? ctx.ui : (pi as any).ui;
+      if (!ui || typeof ui.input !== "function") {
+        return {
+          content: [{ type: "text", text: "(no answer provided — proceed with a safe default and note it)" }],
+        };
+      }
+
+      let answer: string | undefined;
+      if (options.length > 0 && typeof ui.select === "function") {
+        // Prepend an explicit freeform escape so the human is never locked in.
+        answer = await ui.select(question, [...options, "Other (type a custom answer)"]);
+        if (answer === "Other (type a custom answer)") {
+          answer = await ui.input(question, "Type your answer...");
+        }
+      } else {
+        answer = await ui.input(question, "Type your answer...");
+      }
+
+      const text = (answer ?? "").trim();
+      if (!text) {
+        return {
+          content: [{ type: "text", text: "(no answer provided — proceed with a safe default and note it)" }],
+        };
+      }
+      return { content: [{ type: "text", text: `User answered: ${text}` }] };
+    },
+  });
+}

--- a/agent/opencode_client.py
+++ b/agent/opencode_client.py
@@ -1,0 +1,457 @@
+"""OpenCode delegate-session client (server API, no TUI scraping).
+
+Hermes drives a headless ``opencode serve`` process over its HTTP JSON API:
+create a session, run prompts asynchronously (``prompt_async`` returns HTTP
+204), poll messages until the assistant reply lands, and supervise native
+interactive questions (``GET /question`` -> auto-answer -> ``POST
+/question/{id}/reply`` with ``{answers:[[label], ...]}``).
+
+The HTTP transport is injectable for hermetic tests; by default a small
+``urllib`` transport talks to a lazily-spawned, reference-counted shared server
+process (one per Hermes process, any cwd — the per-session directory is a query
+parameter on each call).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Callable, Dict, List, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Answerer contract shared with the Pi backend: (method, question, options) -> str | None
+QuestionAnswerer = Callable[[str, str, List[str]], Optional[str]]
+
+_DEFAULT_READY_TIMEOUT = 30.0
+_DEFAULT_POLL_INTERVAL = 0.5
+
+
+class _Transport(Protocol):
+    def request(self, method: str, path: str, body: Optional[dict] = None) -> tuple[int, str]:
+        ...
+
+
+class _UrllibTransport:
+    def __init__(self, base_url: str, timeout: float = 60.0):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def request(self, method: str, path: str, body: Optional[dict] = None) -> tuple[int, str]:
+        url = f"{self.base_url}{path}"
+        data = json.dumps(body).encode("utf-8") if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        if data is not None:
+            req.add_header("content-type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                return resp.status, resp.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            return exc.code, exc.read().decode("utf-8", errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# Shared server lifecycle (one opencode serve per Hermes process)
+# ---------------------------------------------------------------------------
+
+_server_lock = threading.Lock()
+_server_handle: Optional["_ServerHandle"] = None
+
+
+class _ServerHandle:
+    def __init__(self, base_url: str, proc: Optional[subprocess.Popen]):
+        self.base_url = base_url
+        self.proc = proc
+        self.refcount = 0
+
+
+def _server_state() -> Optional[_ServerHandle]:
+    return _server_handle
+
+
+def _reset_server_singleton() -> None:
+    """Test hook: forget the singleton without killing anything."""
+    global _server_handle
+    with _server_lock:
+        _server_handle = None
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _opencode_command() -> List[str]:
+    raw = os.environ.get("HERMES_OPENCODE_BIN", "").strip()
+    if raw:
+        return raw.split()
+    binary = shutil.which("opencode") or str(os.path.join(Path_home(), ".local", "bin", "opencode"))
+    return [binary]
+
+
+def Path_home() -> str:
+    return os.path.expanduser("~")
+
+
+def _wait_ready(base_url: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: Optional[Exception] = None
+    while time.monotonic() < deadline:
+        try:
+            transport = _UrllibTransport(base_url, timeout=5.0)
+            status, _text = transport.request("GET", "/session")
+            if status == 200:
+                return
+        except Exception as exc:  # noqa: BLE001 - readiness polling
+            last_error = exc
+        time.sleep(0.25)
+    raise RuntimeError(f"opencode server not ready at {base_url}: {last_error or 'no response'}")
+
+
+def acquire_opencode_server(ready_timeout: float = _DEFAULT_READY_TIMEOUT) -> _ServerHandle:
+    """Return the shared server handle, spawning ``opencode serve`` if needed."""
+    global _server_handle
+    with _server_lock:
+        if _server_handle is not None:
+            proc = _server_handle.proc
+            if proc is None or proc.poll() is None:
+                _server_handle.refcount += 1
+                return _server_handle
+            _server_handle = None  # dead process: respawn below
+
+        external = os.environ.get("HERMES_OPENCODE_SERVER_URL", "").strip()
+        if external:
+            # Externally managed server: never spawned, never terminated here.
+            handle = _ServerHandle(external.rstrip("/"), None)
+        else:
+            port = _free_port()
+            # ``--pure``: delegate sessions are headless workers; user TUI
+            # plugins are not loaded (they have hung the model stream on real
+            # installs, e.g. oh-my-opencode variants, and add no value here).
+            cmd = _opencode_command() + [
+                "serve", "--pure", "--port", str(port), "--hostname", "127.0.0.1",
+            ]
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            handle = _ServerHandle(f"http://127.0.0.1:{port}", proc)
+        # Readiness-gate only servers we spawned; an externally managed URL
+        # (HERMES_OPENCODE_SERVER_URL) is trusted as-is so a temporarily
+        # unreachable remote does not break startup — real calls surface
+        # connection errors themselves.
+        try:
+            if handle.proc is not None:
+                _wait_ready(handle.base_url, ready_timeout)
+        except Exception:
+            if handle.proc is not None:
+                handle.proc.terminate()
+            raise
+        handle.refcount = 1
+        _server_handle = handle
+        return handle
+
+
+def release_opencode_server(handle: _ServerHandle) -> None:
+    global _server_handle
+    with _server_lock:
+        handle.refcount -= 1
+        if handle.refcount > 0:
+            return
+        if _server_handle is handle:
+            _server_handle = None
+    proc = handle.proc
+    if proc is not None and proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+class OpenCodeClient:
+    """Persistent OpenCode delegate-session client with question supervision."""
+
+    def __init__(
+        self,
+        *,
+        persistent_session: bool = True,
+        session_id: str = "",
+        session_name: str = "",
+        acp_cwd: str = ".",
+        question_answerer: Optional[QuestionAnswerer] = None,
+        transport_factory: Optional[Callable[[str], _Transport]] = None,
+    ):
+        self.persistent_session = persistent_session
+        self.session_id = session_id
+        self.session_name = session_name or f"Hermes {session_id[:8]}"
+        self.cwd = os.path.abspath(acp_cwd)
+        self.question_answerer = question_answerer
+        self._transport_factory = transport_factory
+        self._transport: Optional[_Transport] = None
+        self._server_handle: Optional[_ServerHandle] = None
+        self.native_session_id: Optional[str] = None
+        self.is_closed = False
+
+    # -- internals ---------------------------------------------------------
+
+    def _qdir(self) -> str:
+        return "?" + urllib.parse.urlencode({"directory": self.cwd})
+
+    def _http(self) -> _Transport:
+        if self._transport is not None:
+            return self._transport
+        if self._transport_factory is not None:
+            self._transport = self._transport_factory(self.cwd)
+            return self._transport
+        if self._server_handle is None:
+            self._server_handle = acquire_opencode_server()
+        self._transport = _UrllibTransport(self._server_handle.base_url)
+        return self._transport
+
+    def _request(self, method: str, path: str, body: Optional[dict] = None) -> tuple[int, Any]:
+        status, text = self._http().request(method, path, body)
+        if status >= 400:
+            raise RuntimeError(f"opencode server {method} {path} failed: HTTP {status}: {text[:500]}")
+        if not text:
+            return status, None
+        try:
+            return status, json.loads(text)
+        except ValueError:
+            return status, text
+
+    # -- backend surface ---------------------------------------------------
+
+    def start(self, timeout: float = 30.0) -> Dict[str, Any]:
+        if self.native_session_id:
+            # Reopen a persisted session: verify it is still addressable.
+            try:
+                self._request("GET", f"/session/{self.native_session_id}")
+                return {"sessionId": self.native_session_id}
+            except RuntimeError:
+                logger.info("Stored opencode session %s missing; creating a new one", self.native_session_id)
+        _status, payload = self._request("POST", f"/session{self._qdir()}", {"title": self.session_name})
+        if not isinstance(payload, dict) or not payload.get("id"):
+            raise RuntimeError(f"opencode session create returned no id: {payload!r}"[:500])
+        self.native_session_id = str(payload["id"])
+        return {"sessionId": self.native_session_id}
+
+    def _message_sort_key(self, message: dict) -> tuple:
+        info = message.get("info") or {}
+        created = (info.get("time") or {}).get("created") or 0
+        return (created, info.get("id") or "")
+
+    def _assistant_text(self, message: dict) -> str:
+        parts = message.get("parts") or []
+        return "\n".join(str(p.get("text") or "") for p in parts if p.get("type") == "text").strip()
+
+    def _baseline_messages(self) -> List[dict]:
+        path = f"/session/{self.native_session_id}/message{self._qdir()}"
+        _status, data = self._request("GET", path)
+        messages = data if isinstance(data, list) else (data or {}).get("data") or []
+        return sorted(messages, key=self._message_sort_key)
+
+    def _pending_questions(self) -> List[dict]:
+        # NOTE: /question requires the ?directory= scope; without it OpenCode
+        # silently returns [] even when a question is pending for the session.
+        _status, data = self._request("GET", f"/question{self._qdir()}")
+        rows = data if isinstance(data, list) else (data or {}).get("data") or []
+        return [row for row in rows if row.get("sessionID") == self.native_session_id]
+
+    def _answer_pending_questions(self) -> None:
+        for request in self._pending_questions():
+            request_id = str(request.get("id") or "")
+            if not request_id:
+                continue
+            questions = request.get("questions") or []
+            answers: List[List[str]] = []
+            reject = False
+            for question in questions:
+                options = [str(opt.get("label")) for opt in (question.get("options") or []) if opt.get("label")]
+                method = "select" if options else "ask"
+                answer = None
+                if self.question_answerer is not None:
+                    answer = self.question_answerer(method, str(question.get("question") or ""), options)
+                if answer is None:
+                    reject = True
+                    break
+                if options:
+                    answer = self._match_label(answer, options)
+                    if answer is None:
+                        reject = True
+                        break
+                answers.append([answer])
+            if reject:
+                self._request("POST", f"/question/{request_id}/reject{self._qdir()}", {})
+                logger.info("Rejected unanswerable opencode question %s", request_id)
+            else:
+                self._request("POST", f"/question/{request_id}/reply{self._qdir()}", {"answers": answers})
+                logger.info("Replied to opencode question %s: %s", request_id, answers)
+
+    @staticmethod
+    def _match_label(answer: str, options: List[str]) -> Optional[str]:
+        low = answer.strip().strip(" \"'`.,!\t\n").casefold()
+        for option in options:
+            if option.strip().casefold() == low:
+                return option
+        if low.isdigit():
+            index = int(low)
+            if 1 <= index <= len(options):
+                return options[index - 1]
+        return None
+
+    def run_session_prompt(
+        self,
+        message: str,
+        timeout_seconds: float = 900.0,
+        poll_interval: float = _DEFAULT_POLL_INTERVAL,
+    ) -> Dict[str, Any]:
+        started = time.monotonic()
+        if not self.native_session_id:
+            self.start(timeout=min(30.0, timeout_seconds))
+        baseline_ids = {m.get("info", {}).get("id") for m in self._baseline_messages()}
+        path = f"/session/{self.native_session_id}/prompt_async{self._qdir()}"
+        self._request("POST", path, {"parts": [{"type": "text", "text": message}]})
+        deadline = time.monotonic() + timeout_seconds
+        last_snapshot: Optional[tuple] = None
+        stable_since: Optional[float] = None
+        # OpenCode's /question registration and message-part updates lag behind
+        # the live turn by several seconds; completion therefore requires the
+        # transcript to be unchanged for this long (not merely two polls).
+        stable_window = min(max(5.0, poll_interval * 4), max(1.0, timeout_seconds / 3.0))
+        while time.monotonic() < deadline:
+            self._answer_pending_questions()
+            _status, data = self._request("GET", f"/session/{self.native_session_id}/message{self._qdir()}")
+            messages = data if isinstance(data, list) else (data or {}).get("data") or []
+            messages = sorted(messages, key=self._message_sort_key)
+            fresh = [m for m in messages if m.get("info", {}).get("id") not in baseline_ids]
+            # Snapshot must cover message IDs AND part payloads: OpenCode
+            # streams parts into an existing message, so an ID-only snapshot
+            # goes "stable" while the turn is still mid-flight.
+            snapshot = tuple(
+                (
+                    (m.get("info") or {}).get("id"),
+                    tuple(sorted(str(p) for p in (m.get("parts") or []))),
+                )
+                for m in messages
+            )
+            if snapshot == last_snapshot:
+                if stable_since is None:
+                    stable_since = time.monotonic()
+            else:
+                stable_since = None
+                last_snapshot = snapshot
+            # A multi-step turn emits intermediate assistant text before tool
+            # calls, so completion is "transcript unchanged for the stable
+            # window, nothing pending, and no tool part still running" rather
+            # than "first text part".  (A question tool can be 'running'
+            # briefly before its entry appears in /question.)
+            tools_running = any(
+                (part or {}).get("type") == "tool"
+                and (part.get("state") or {}).get("status") == "running"
+                for m in fresh
+                for part in (m.get("parts") or [])
+            )
+            if (
+                stable_since is not None
+                and time.monotonic() - stable_since >= stable_window
+                and fresh
+                and not tools_running
+                and not self._pending_questions()
+            ):
+                text = "\n".join(
+                    part
+                    for m in fresh
+                    if (m.get("info") or {}).get("role") == "assistant"
+                    for part in [self._assistant_text(m)]
+                    if part
+                ).strip()
+                if text:
+                    return {
+                        "text": text,
+                        "state": {"sessionId": self.native_session_id},
+                        "duration_s": time.monotonic() - started,
+                    }
+                raise RuntimeError(
+                    "OpenCode turn ended without an assistant text reply "
+                    "(a pending question may have been rejected)"
+                )
+            time.sleep(poll_interval)
+        # Timed out: best-effort abort, then surface the timeout.
+        try:
+            self.abort(timeout=10.0)
+        except Exception:
+            logger.debug("opencode abort after timeout failed", exc_info=True)
+        raise TimeoutError(f"OpenCode turn timed out after {timeout_seconds:.0f}s")
+
+    def steer(self, message: str, timeout_seconds: float = 30.0) -> Dict[str, Any]:
+        # OpenCode prompt_async has no native live-steer injection; the tool
+        # layer degrades steer to a queued follow-up turn when no turn is
+        # running.  Reaching this method means the caller chose to send anyway.
+        return {"text": "", "note": "opencode has no live steer; message queued", "queued": True}
+
+    def abort(self, timeout: float = 10.0) -> None:
+        if not self.native_session_id:
+            return
+        self._request("POST", f"/session/{self.native_session_id}/abort{self._qdir()}")
+
+    def get_messages(self, timeout: float = 30.0) -> List[dict]:
+        _status, data = self._request("GET", f"/session/{self.native_session_id}/message{self._qdir()}")
+        messages = data if isinstance(data, list) else (data or {}).get("data") or []
+        return sorted(messages, key=self._message_sort_key)
+
+    def _pending_payload_for(self, session_id: str) -> Optional[Dict[str, Any]]:
+        _status, data = self._request("GET", f"/question{self._qdir()}")
+        rows = data if isinstance(data, list) else (data or {}).get("data") or []
+        for row in rows:
+            if row.get("sessionID") != session_id:
+                continue
+            first = (row.get("questions") or [{}])[0]
+            options = [str(opt.get("label")) for opt in (first.get("options") or []) if opt.get("label")]
+            return {
+                "method": "select" if options else "ask",
+                "question": str(first.get("question") or ""),
+                "options": options[:50],
+                "created_at": time.time(),
+            }
+        return None
+
+    def pending_question_payload(self) -> Optional[Dict[str, Any]]:
+        if not self.native_session_id:
+            return None
+        return self._pending_payload_for(self.native_session_id)
+
+    def is_dead(self) -> bool:
+        handle = self._server_handle
+        if handle is None or handle.proc is None:
+            return False
+        return handle.proc.poll() is not None
+
+    def close(self) -> None:
+        if self.is_closed:
+            return
+        self.is_closed = True
+        handle = self._server_handle
+        self._transport = None
+        self._server_handle = None
+        if handle is not None:
+            try:
+                release_opencode_server(handle)
+            except Exception:
+                logger.debug("opencode server release failed", exc_info=True)

--- a/agent/opencode_client.py
+++ b/agent/opencode_client.py
@@ -7,13 +7,15 @@ interactive questions (``GET /question`` -> auto-answer -> ``POST
 /question/{id}/reply`` with ``{answers:[[label], ...]}``).
 
 The HTTP transport is injectable for hermetic tests; by default a small
-``urllib`` transport talks to a lazily-spawned, reference-counted shared server
-process (one per Hermes process, any cwd — the per-session directory is a query
-parameter on each call).
+``urllib`` transport talks to a single lazily-spawned, process-wide shared
+server that stays running for the life of the Hermes process — every delegate
+session creates a new session inside that one server, scoped per-request via
+the ``?directory=`` query parameter.
 """
 
 from __future__ import annotations
 
+import atexit
 import json
 import logging
 import os
@@ -60,15 +62,19 @@ class _UrllibTransport:
 
 
 # ---------------------------------------------------------------------------
-# Shared server lifecycle (one opencode serve per Hermes process)
+# Shared server lifecycle (ONE opencode serve per Hermes process)
 # ---------------------------------------------------------------------------
 
 _server_lock = threading.Lock()
-# One shared server per working directory: OpenCode pins sessions (and,
-# critically, native question registration over ``GET /question``) to the
-# server's *instance* directory — its startup cwd — so a server spawned in an
-# unrelated cwd would silently hide every interactive question.
+# A single shared server hosts every delegate session: sessions (and their
+# pending native questions, via ``GET /question``) are addressable in any
+# existing directory through the ``?directory=`` query scope, so per-session
+# working directories do NOT need their own server process. The server is
+# spawned once, kept running for the life of the Hermes process, and each
+# delegate_session client creates its own session inside it.
 _servers: Dict[str, "_ServerHandle"] = {}
+
+_SINGLETON_KEY = "__opencode_singleton__"
 
 
 class _ServerHandle:
@@ -125,16 +131,20 @@ def acquire_opencode_server(
     working_directory: str = "",
     ready_timeout: float = _DEFAULT_READY_TIMEOUT,
 ) -> _ServerHandle:
-    """Return the shared server handle for ``working_directory``, spawning one if needed."""
-    key = os.path.abspath(working_directory or os.getcwd())
+    """Return the ONE shared server handle, spawning it on first use.
+
+    ``working_directory`` is accepted for API compatibility but ignored: every
+    call is scoped per-request via the ``?directory=`` query parameter, so a
+    single long-lived server hosts delegate sessions in any directory.
+    """
     with _server_lock:
-        handle = _servers.get(key)
+        handle = _servers.get(_SINGLETON_KEY)
         if handle is not None:
             proc = handle.proc
             if proc is None or proc.poll() is None:
                 handle.refcount += 1
                 return handle
-            _servers.pop(key, None)  # dead process: respawn below
+            _servers.pop(_SINGLETON_KEY, None)  # dead process: respawn below
 
         external = os.environ.get("HERMES_OPENCODE_SERVER_URL", "").strip()
         if external:
@@ -145,13 +155,13 @@ def acquire_opencode_server(
             cmd = _opencode_command() + [
                 "serve", "--port", str(port), "--hostname", "127.0.0.1",
             ]
-            # Spawn with cwd = the session's working directory: OpenCode's
-            # instance directory (startup cwd) controls which sessions (and
-            # their pending native questions) are addressable, and user
-            # plugins load normally.
+            # Spawn from a stable home directory: the per-session directory is
+            # a query parameter on each call, so the startup cwd only needs to
+            # exist for the process lifetime; user plugins load normally.
+            spawn_cwd = Path_home()
             proc = subprocess.Popen(
                 cmd,
-                cwd=key if os.path.isdir(key) else None,
+                cwd=spawn_cwd if os.path.isdir(spawn_cwd) else None,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
@@ -169,25 +179,49 @@ def acquire_opencode_server(
                 handle.proc.terminate()
             raise
         handle.refcount = 1
-        _servers[key] = handle
+        _servers[_SINGLETON_KEY] = handle
+        _ensure_shutdown_hook()
         return handle
 
 
 def release_opencode_server(handle: _ServerHandle) -> None:
+    """Release a client's reference.
+
+    The shared server deliberately STAYS RUNNING: other delegate sessions (or
+    future ones) reuse it, and a warm server avoids the multi-second plugin
+    load on every delegation. It is terminated only by
+    ``shutdown_opencode_server`` (process exit).
+    """
     with _server_lock:
         handle.refcount -= 1
-        if handle.refcount > 0:
-            return
-        for key, current in list(_servers.items()):
-            if current is handle:
-                del _servers[key]
-    proc = handle.proc
-    if proc is not None and proc.poll() is None:
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+        if handle.refcount < 0:
+            handle.refcount = 0
+
+
+def shutdown_opencode_server() -> None:
+    """Terminate the shared server (called at Hermes process exit)."""
+    global _shutdown_registered
+    with _server_lock:
+        handles = list(_servers.values())
+        _servers.clear()
+    for handle in handles:
+        proc = handle.proc
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+_shutdown_registered = False
+
+
+def _ensure_shutdown_hook() -> None:
+    global _shutdown_registered
+    if not _shutdown_registered:
+        atexit.register(shutdown_opencode_server)
+        _shutdown_registered = True
 
 
 # ---------------------------------------------------------------------------

--- a/agent/opencode_client.py
+++ b/agent/opencode_client.py
@@ -64,7 +64,11 @@ class _UrllibTransport:
 # ---------------------------------------------------------------------------
 
 _server_lock = threading.Lock()
-_server_handle: Optional["_ServerHandle"] = None
+# One shared server per working directory: OpenCode pins sessions (and,
+# critically, native question registration over ``GET /question``) to the
+# server's *instance* directory — its startup cwd — so a server spawned in an
+# unrelated cwd would silently hide every interactive question.
+_servers: Dict[str, "_ServerHandle"] = {}
 
 
 class _ServerHandle:
@@ -74,15 +78,14 @@ class _ServerHandle:
         self.refcount = 0
 
 
-def _server_state() -> Optional[_ServerHandle]:
-    return _server_handle
+def _server_state() -> Dict[str, "_ServerHandle"]:
+    return dict(_servers)
 
 
 def _reset_server_singleton() -> None:
-    """Test hook: forget the singleton without killing anything."""
-    global _server_handle
+    """Test hook: forget all servers without killing anything."""
     with _server_lock:
-        _server_handle = None
+        _servers.clear()
 
 
 def _free_port() -> int:
@@ -118,16 +121,20 @@ def _wait_ready(base_url: str, timeout: float) -> None:
     raise RuntimeError(f"opencode server not ready at {base_url}: {last_error or 'no response'}")
 
 
-def acquire_opencode_server(ready_timeout: float = _DEFAULT_READY_TIMEOUT) -> _ServerHandle:
-    """Return the shared server handle, spawning ``opencode serve`` if needed."""
-    global _server_handle
+def acquire_opencode_server(
+    working_directory: str = "",
+    ready_timeout: float = _DEFAULT_READY_TIMEOUT,
+) -> _ServerHandle:
+    """Return the shared server handle for ``working_directory``, spawning one if needed."""
+    key = os.path.abspath(working_directory or os.getcwd())
     with _server_lock:
-        if _server_handle is not None:
-            proc = _server_handle.proc
+        handle = _servers.get(key)
+        if handle is not None:
+            proc = handle.proc
             if proc is None or proc.poll() is None:
-                _server_handle.refcount += 1
-                return _server_handle
-            _server_handle = None  # dead process: respawn below
+                handle.refcount += 1
+                return handle
+            _servers.pop(key, None)  # dead process: respawn below
 
         external = os.environ.get("HERMES_OPENCODE_SERVER_URL", "").strip()
         if external:
@@ -135,14 +142,16 @@ def acquire_opencode_server(ready_timeout: float = _DEFAULT_READY_TIMEOUT) -> _S
             handle = _ServerHandle(external.rstrip("/"), None)
         else:
             port = _free_port()
-            # ``--pure``: delegate sessions are headless workers; user TUI
-            # plugins are not loaded (they have hung the model stream on real
-            # installs, e.g. oh-my-opencode variants, and add no value here).
             cmd = _opencode_command() + [
-                "serve", "--pure", "--port", str(port), "--hostname", "127.0.0.1",
+                "serve", "--port", str(port), "--hostname", "127.0.0.1",
             ]
+            # Spawn with cwd = the session's working directory: OpenCode's
+            # instance directory (startup cwd) controls which sessions (and
+            # their pending native questions) are addressable, and user
+            # plugins load normally.
             proc = subprocess.Popen(
                 cmd,
+                cwd=key if os.path.isdir(key) else None,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
@@ -160,18 +169,18 @@ def acquire_opencode_server(ready_timeout: float = _DEFAULT_READY_TIMEOUT) -> _S
                 handle.proc.terminate()
             raise
         handle.refcount = 1
-        _server_handle = handle
+        _servers[key] = handle
         return handle
 
 
 def release_opencode_server(handle: _ServerHandle) -> None:
-    global _server_handle
     with _server_lock:
         handle.refcount -= 1
         if handle.refcount > 0:
             return
-        if _server_handle is handle:
-            _server_handle = None
+        for key, current in list(_servers.items()):
+            if current is handle:
+                del _servers[key]
     proc = handle.proc
     if proc is not None and proc.poll() is None:
         proc.terminate()
@@ -207,6 +216,8 @@ class OpenCodeClient:
         self._transport: Optional[_Transport] = None
         self._server_handle: Optional[_ServerHandle] = None
         self.native_session_id: Optional[str] = None
+        # Question ids already replied/rejected (SSE watcher + poll loop race).
+        self._answered_questions: set = set()
         self.is_closed = False
 
     # -- internals ---------------------------------------------------------
@@ -221,7 +232,7 @@ class OpenCodeClient:
             self._transport = self._transport_factory(self.cwd)
             return self._transport
         if self._server_handle is None:
-            self._server_handle = acquire_opencode_server()
+            self._server_handle = acquire_opencode_server(working_directory=self.cwd)
         self._transport = _UrllibTransport(self._server_handle.base_url)
         return self._transport
 
@@ -277,7 +288,7 @@ class OpenCodeClient:
     def _answer_pending_questions(self) -> None:
         for request in self._pending_questions():
             request_id = str(request.get("id") or "")
-            if not request_id:
+            if not request_id or request_id in self._answered_questions:
                 continue
             questions = request.get("questions") or []
             answers: List[List[str]] = []
@@ -297,12 +308,20 @@ class OpenCodeClient:
                         reject = True
                         break
                 answers.append([answer])
-            if reject:
-                self._request("POST", f"/question/{request_id}/reject{self._qdir()}", {})
-                logger.info("Rejected unanswerable opencode question %s", request_id)
-            else:
-                self._request("POST", f"/question/{request_id}/reply{self._qdir()}", {"answers": answers})
-                logger.info("Replied to opencode question %s: %s", request_id, answers)
+            try:
+                if reject:
+                    self._request("POST", f"/question/{request_id}/reject{self._qdir()}", {})
+                    logger.info("Rejected unanswerable opencode question %s", request_id)
+                else:
+                    self._request("POST", f"/question/{request_id}/reply{self._qdir()}", {"answers": answers})
+                    logger.info("Replied to opencode question %s: %s", request_id, answers)
+            except RuntimeError as exc:
+                # The SSE watcher and the poll loop can race on the same
+                # question; whoever loses gets QuestionNotFoundError (404).
+                if "QuestionNotFound" not in str(exc):
+                    raise
+                logger.debug("opencode question %s already answered elsewhere", request_id)
+            self._answered_questions.add(request_id)
 
     @staticmethod
     def _match_label(answer: str, options: List[str]) -> Optional[str]:
@@ -315,6 +334,60 @@ class OpenCodeClient:
             if 1 <= index <= len(options):
                 return options[index - 1]
         return None
+
+    def _event_stream_idle(self, timeout: float, idle_flag: "threading.Event") -> None:
+        """Watch the SSE ``/event`` stream; set ``idle_flag`` on ``session.idle``.
+
+        Also answers questions immediately when a ``question.asked`` event for
+        this session arrives (the REST ``/question`` listing lags by several
+        seconds — often past the question's own expiry). Best-effort: transport
+        errors simply stop the watcher (the polling fallback in
+        ``run_session_prompt`` decides completion).
+        """
+        try:
+            transport = self._http()
+            url = f"{transport.base_url}/event{self._qdir()}"  # type: ignore[attr-defined]
+            req = urllib.request.Request(url, headers={"accept": "text/event-stream"})
+            with urllib.request.urlopen(req, timeout=max(5.0, timeout)) as resp:
+                deadline = time.monotonic() + timeout
+                while time.monotonic() < deadline and not idle_flag.is_set():
+                    raw = resp.readline()
+                    if not raw:
+                        break
+                    line = raw.decode("utf-8", errors="replace").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    try:
+                        event = json.loads(line[5:].strip())
+                    except ValueError:
+                        continue
+                    etype = event.get("type")
+                    props = event.get("properties") or {}
+                    if etype == "session.idle" and str(props.get("sessionID") or "") == self.native_session_id:
+                        idle_flag.set()
+                        return
+                    if etype in ("question.asked", "question.v2.asked") and str(
+                        props.get("sessionID") or ""
+                    ) == self.native_session_id:
+                        try:
+                            self._answer_pending_questions()
+                        except Exception:
+                            logger.debug("SSE question auto-answer failed", exc_info=True)
+        except Exception:
+            logger.debug("opencode event stream failed; polling decides completion", exc_info=True)
+
+    def _final_reply_text(self, baseline_ids: set) -> str:
+        """Fetch the transcript and join fresh assistant text parts."""
+        _status, data = self._request("GET", f"/session/{self.native_session_id}/message{self._qdir()}")
+        messages = data if isinstance(data, list) else (data or {}).get("data") or []
+        messages = sorted(messages, key=self._message_sort_key)
+        fresh = [m for m in messages if m.get("info", {}).get("id") not in baseline_ids]
+        return "\n".join(
+            self._assistant_text(m)
+            for m in fresh
+            if (m.get("info") or {}).get("role") == "assistant"
+            and self._assistant_text(m)
+        ).strip()
 
     def run_session_prompt(
         self,
@@ -331,68 +404,96 @@ class OpenCodeClient:
         deadline = time.monotonic() + timeout_seconds
         last_snapshot: Optional[tuple] = None
         stable_since: Optional[float] = None
-        # OpenCode's /question registration and message-part updates lag behind
-        # the live turn by several seconds; completion therefore requires the
-        # transcript to be unchanged for this long (not merely two polls).
+        # Completion signal, in order of reliability:
+        #   1. SSE ``session.idle`` for this session (authoritative; watched on
+        #      a background thread so question answering keeps running).
+        #   2. Fallback heuristic: transcript (IDs + part payloads) unchanged
+        #      for the stable window with a fresh assistant message, no tool
+        #      part running, and no pending question. Snapshot polling alone is
+        #      unreliable because /question registration lags the live turn by
+        #      many seconds and empty assistant shells appear immediately.
         stable_window = min(max(5.0, poll_interval * 4), max(1.0, timeout_seconds / 3.0))
-        while time.monotonic() < deadline:
-            self._answer_pending_questions()
-            _status, data = self._request("GET", f"/session/{self.native_session_id}/message{self._qdir()}")
-            messages = data if isinstance(data, list) else (data or {}).get("data") or []
-            messages = sorted(messages, key=self._message_sort_key)
-            fresh = [m for m in messages if m.get("info", {}).get("id") not in baseline_ids]
-            # Snapshot must cover message IDs AND part payloads: OpenCode
-            # streams parts into an existing message, so an ID-only snapshot
-            # goes "stable" while the turn is still mid-flight.
-            snapshot = tuple(
-                (
-                    (m.get("info") or {}).get("id"),
-                    tuple(sorted(str(p) for p in (m.get("parts") or []))),
+        idle_flag = threading.Event()
+        watcher = threading.Thread(
+            target=self._event_stream_idle,
+            args=(timeout_seconds, idle_flag),
+            daemon=True,
+        )
+        watcher.start()
+        try:
+            while time.monotonic() < deadline:
+                self._answer_pending_questions()
+                _status, data = self._request("GET", f"/session/{self.native_session_id}/message{self._qdir()}")
+                messages = data if isinstance(data, list) else (data or {}).get("data") or []
+                messages = sorted(messages, key=self._message_sort_key)
+                fresh = [m for m in messages if m.get("info", {}).get("id") not in baseline_ids]
+                snapshot = tuple(
+                    (
+                        (m.get("info") or {}).get("id"),
+                        tuple(sorted(str(p) for p in (m.get("parts") or []))),
+                    )
+                    for m in messages
                 )
-                for m in messages
-            )
-            if snapshot == last_snapshot:
-                if stable_since is None:
-                    stable_since = time.monotonic()
-            else:
-                stable_since = None
-                last_snapshot = snapshot
-            # A multi-step turn emits intermediate assistant text before tool
-            # calls, so completion is "transcript unchanged for the stable
-            # window, nothing pending, and no tool part still running" rather
-            # than "first text part".  (A question tool can be 'running'
-            # briefly before its entry appears in /question.)
-            tools_running = any(
-                (part or {}).get("type") == "tool"
-                and (part.get("state") or {}).get("status") == "running"
-                for m in fresh
-                for part in (m.get("parts") or [])
-            )
-            if (
-                stable_since is not None
-                and time.monotonic() - stable_since >= stable_window
-                and fresh
-                and not tools_running
-                and not self._pending_questions()
-            ):
-                text = "\n".join(
-                    part
+                if snapshot == last_snapshot:
+                    if stable_since is None:
+                        stable_since = time.monotonic()
+                else:
+                    stable_since = None
+                    last_snapshot = snapshot
+                tools_running = any(
+                    (part or {}).get("type") == "tool"
+                    and (part.get("state") or {}).get("status") == "running"
                     for m in fresh
-                    if (m.get("info") or {}).get("role") == "assistant"
-                    for part in [self._assistant_text(m)]
-                    if part
-                ).strip()
-                if text:
-                    return {
-                        "text": text,
-                        "state": {"sessionId": self.native_session_id},
-                        "duration_s": time.monotonic() - started,
-                    }
-                raise RuntimeError(
-                    "OpenCode turn ended without an assistant text reply "
-                    "(a pending question may have been rejected)"
+                    for part in (m.get("parts") or [])
                 )
-            time.sleep(poll_interval)
+                has_assistant = any(
+                    (m.get("info") or {}).get("role") == "assistant" and (m.get("parts") or [])
+                    for m in fresh
+                )
+                # Idle events can be observed before the transcript fetch
+                # below reflects them; give the message endpoint a short
+                # grace period after the flag trips so the final text lands.
+                completed = idle_flag.is_set() and (
+                    not tools_running or time.monotonic() - started > timeout_seconds
+                )
+                if completed or (
+                    stable_since is not None
+                    and time.monotonic() - stable_since >= stable_window
+                    and fresh
+                    and has_assistant
+                    and not tools_running
+                    and not self._pending_questions()
+                ):
+                    if idle_flag.is_set() and tools_running:
+                        # Idle raced a still-running tool part: keep waiting.
+                        idle_flag.clear()
+                        continue
+                    text = self._final_reply_text(baseline_ids)
+                    if text:
+                        return {
+                            "text": text,
+                            "state": {"sessionId": self.native_session_id},
+                            "duration_s": time.monotonic() - started,
+                        }
+                    if idle_flag.is_set():
+                        # Authoritative idle but no assistant text yet: one
+                        # short re-check before declaring the turn empty.
+                        time.sleep(min(2.0, poll_interval * 2))
+                        text = self._final_reply_text(baseline_ids)
+                        if text:
+                            return {
+                                "text": text,
+                                "state": {"sessionId": self.native_session_id},
+                                "duration_s": time.monotonic() - started,
+                            }
+                    raise RuntimeError(
+                        "OpenCode turn ended without an assistant text reply "
+                        "(a pending question may have been rejected)"
+                    )
+                time.sleep(poll_interval)
+        finally:
+            idle_flag.set()  # stop the SSE watcher
+            watcher.join(timeout=5)
         # Timed out: best-effort abort, then surface the timeout.
         try:
             self.abort(timeout=10.0)

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -60,11 +60,12 @@ pending_questions: dict[str, "PendingQuestion"] = {}
 class PendingQuestion:
     """One unanswered extension_ui_request from a pi child."""
 
-    def __init__(self, method: str, title: str, options: list[str] | None):
+    def __init__(self, method: str, title: str, options: list[str] | None, owner: "PiRPCClient | None" = None):
         self.id = f"q_{int(time.time() * 1000)}_{id(self):x}"
         self.method = method
         self.title = title
         self.options = list(options or [])
+        self.owner = owner  # owning client; questions die with their client
         self.answered = threading.Event()
         self.answer: dict[str, Any] | None = None
         self.created_at = time.time()
@@ -111,11 +112,17 @@ class PendingQuestion:
 def answer_oldest_pending_question(text: str) -> bool:
     """Route free text to the oldest pending pi question, if any.
 
+    Questions whose owning client has closed are skipped (their run is
+    gone; answering them would steal the text from a live question).
     Returns True when the text was consumed as a question answer.
     """
     with _registry_lock:
         oldest = None
-        for question in pending_questions.values():
+        for question in list(pending_questions.values()):
+            if question.owner is not None and question.owner.is_closed:
+                pending_questions.pop(question.id, None)
+                question.answered.set()  # unblock the dead waiter if any
+                continue
             if oldest is None or question.created_at < oldest.created_at:
                 oldest = question
         if oldest is None:
@@ -266,6 +273,18 @@ class PiRPCClient:
         tools = os.getenv("HERMES_PI_TOOLS", "").strip()
         if tools:
             argv += ["--tools", tools]
+        # Auto-load pi-ask-user (interactive questions) if installed; users can
+        # force extra extensions with HERMES_PI_EXTENSIONS (colon-separated).
+        ask_user = os.path.join(
+            os.path.expanduser("~"), ".pi", "agent", "npm", "node_modules",
+            "pi-ask-user", "index.ts",
+        )
+        exts = []
+        if os.path.isfile(ask_user):
+            exts.append(ask_user)
+        exts += [p for p in os.getenv("HERMES_PI_EXTENSIONS", "").split(":") if p]
+        for ext in exts:
+            argv += ["-e", ext]
         try:
             proc = subprocess.Popen(
                 argv,
@@ -414,7 +433,7 @@ class PiRPCClient:
             except Exception:
                 pass
             return
-        question = PendingQuestion(method, title, options)
+        question = PendingQuestion(method, title, options, owner=self)
         with _registry_lock:
             pending_questions[question.id] = question
 

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -1,0 +1,537 @@
+"""Native Pi JSONL RPC client for delegated agents (no ACP bridge).
+
+Option C replacement for the pi-acp bridge: Hermes speaks pi's own
+``--mode rpc`` protocol directly, which exposes ``extension_ui_request``
+(confirm / select / input / editor). Unlike ACP — which has no free-text
+question channel — this lets a delegated pi agent ask the parent a
+question and receive a real answer.
+
+Contract parity with the pi-acp bridge is preserved:
+- tool activity inside the child is surfaced as ``[pi-tool ...]`` /
+  ``[pi-tool:ok|FAILED] ...`` markers in the reasoning stream (parsed by
+  ``copilot_acp_client.parse_pi_tool_markers``), and
+- every run appends a fenced ``pi-delegation-result`` JSON footer to the
+  final message (parsed by ``parse_pi_result_footer``).
+
+Interactive questions:
+- An incoming ``extension_ui_request`` is registered in a module-level
+  registry (``pending_questions``) and surfaced as a ``[pi-question]``
+  marker in the reasoning stream plus the question text in the message
+  stream, so the live delegation transcript shows it.
+- The run then blocks (up to ``question_timeout_seconds``, default 600)
+  waiting for an answer. ``tools.delegate_tool.steer_subagent`` checks
+  the registry and routes a steer message to the oldest pending question
+  as free text (``{"text": ...}`` for input/editor, option matching for
+  select, yes/no parsing for confirm).
+- On timeout the old auto-answer policy applies (confirm=true,
+  select=first, input/editor=cancelled) so a delegation never hangs
+  forever.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+import time
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agent.copilot_acp_client import (
+    _completion_to_stream_chunks,
+    _extract_tool_calls_from_text,
+    _format_messages_as_prompt,
+)
+from tools.environments.local import hermes_subprocess_env
+
+PI_RPC_MARKER_BASE_URL = "pi://rpc"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+_DEFAULT_QUESTION_TIMEOUT = float(os.getenv("HERMES_PI_QUESTION_TIMEOUT", "600"))
+
+# Module-level registry of live questions from all running pi children.
+# Key: unique question id. Value: PendingQuestion.
+_registry_lock = threading.Lock()
+pending_questions: dict[str, "PendingQuestion"] = {}
+
+
+class PendingQuestion:
+    """One unanswered extension_ui_request from a pi child."""
+
+    def __init__(self, method: str, title: str, options: list[str] | None):
+        self.id = f"q_{int(time.time() * 1000)}_{id(self):x}"
+        self.method = method
+        self.title = title
+        self.options = list(options or [])
+        self.answered = threading.Event()
+        self.answer: dict[str, Any] | None = None
+        self.created_at = time.time()
+
+    def answer_with(self, text: str) -> dict[str, Any]:
+        """Map free text to the response payload pi expects."""
+        cleaned = (text or "").strip()
+        low = cleaned.lower()
+        if self.method == "confirm":
+            if low in ("y", "yes", "true", "ok", "confirm"):
+                payload = {"confirmed": True}
+            elif low in ("n", "no", "false", "cancel"):
+                payload = {"confirmed": False}
+            else:
+                # Non-boolean answer to a confirm: treat non-empty as yes.
+                payload = {"confirmed": bool(cleaned)}
+        elif self.method == "select":
+            match = None
+            for option in self.options:
+                if option and option.lower() == low:
+                    match = option
+                    break
+            if match is None and low.isdigit():
+                idx = int(low)
+                if 1 <= idx <= len(self.options):
+                    match = self.options[idx - 1]
+            if match is None and self.options:
+                match = self.options[0]
+            payload = {"value": match} if match is not None else {"cancelled": True}
+        else:  # input, editor — free text is exactly what these want
+            payload = {"text": cleaned} if cleaned else {"cancelled": True}
+        self.answer = payload
+        self.answered.set()
+        return payload
+
+    def auto_answer(self) -> dict[str, Any]:
+        if self.method == "confirm":
+            return {"confirmed": True}
+        if self.method == "select":
+            return {"value": self.options[0]} if self.options else {"cancelled": True}
+        return {"cancelled": True}
+
+
+def answer_oldest_pending_question(text: str) -> bool:
+    """Route free text to the oldest pending pi question, if any.
+
+    Returns True when the text was consumed as a question answer.
+    """
+    with _registry_lock:
+        oldest = None
+        for question in pending_questions.values():
+            if oldest is None or question.created_at < oldest.created_at:
+                oldest = question
+        if oldest is None:
+            return False
+        pending_questions.pop(oldest.id, None)
+    oldest.answer_with(text)
+    return True
+
+
+def _resolve_pi_bin() -> str:
+    return (
+        os.getenv("HERMES_PI_BIN", "").strip()
+        or os.getenv("PI_BIN", "").strip()
+        or "pi"
+    )
+
+
+def _resolve_acp_command(kwargs_command: str | None) -> str:
+    # When wired through the copilot-acp plumbing, the command may be
+    # ``pi`` or ``pi-acp``; either way we drive pi natively.
+    return _resolve_pi_bin()
+
+
+class _PiChatCompletions:
+    def __init__(self, client: "PiRPCClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _PiChatNamespace:
+    def __init__(self, client: "PiRPCClient"):
+        self.completions = _PiChatCompletions(client)
+
+
+class PiRPCClient:
+    """Minimal OpenAI-client-compatible facade over `pi --mode rpc`."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        **_: Any,
+    ) -> None:
+        self.api_key = api_key or "pi-rpc"
+        self.base_url = base_url or PI_RPC_MARKER_BASE_URL
+        self._pi_bin = _resolve_acp_command(command or acp_command)
+        self._cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _PiChatNamespace(self)
+        self.is_closed = False
+        self._proc: subprocess.Popen[str] | None = None
+        self._stdin_lock = threading.Lock()
+        self._pending: dict[int, list] = {}
+        self._pending_lock = threading.Lock()
+        self._next_id = 0
+        self._stderr_tail: deque[str] = deque(maxlen=40)
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def close(self) -> None:
+        self.is_closed = True
+        proc = self._proc
+        self._proc = None
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    # -- shim entrypoint ---------------------------------------------------
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        stream: bool = False,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            messages or [], model=model, tools=tools, tool_choice=tool_choice
+        )
+        if timeout is None:
+            effective_timeout = _DEFAULT_TIMEOUT_SECONDS
+        elif isinstance(timeout, (int, float)):
+            effective_timeout = float(timeout)
+        else:
+            candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+            effective_timeout = max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+        response_text, reasoning_text = self._run_prompt(
+            prompt_text, timeout_seconds=effective_timeout
+        )
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        completion = SimpleNamespace(
+            choices=[choice], usage=usage, model=model or "pi-rpc"
+        )
+        if stream:
+            return _completion_to_stream_chunks(completion)
+        return completion
+
+    # -- pi protocol -------------------------------------------------------
+
+    def _spawn(self) -> subprocess.Popen[str]:
+        argv = [self._pi_bin, "--mode", "rpc", "--no-session"]
+        model = os.getenv("HERMES_PI_MODEL", "").strip()
+        if model:
+            argv += ["--model", model]
+        tools = os.getenv("HERMES_PI_TOOLS", "").strip()
+        if tools:
+            argv += ["--tools", tools]
+        try:
+            proc = subprocess.Popen(
+                argv,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+                cwd=self._cwd,
+                env=hermes_subprocess_env(),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start pi binary '{self._pi_bin}'. Install pi or set HERMES_PI_BIN."
+            ) from exc
+        if proc.stdin is None or proc.stdout is None:
+            proc.kill()
+            raise RuntimeError("pi rpc process did not expose stdin/stdout pipes.")
+        self._proc = proc
+        threading.Thread(target=self._reader, daemon=True).start()
+        threading.Thread(target=self._stderr_reader, daemon=True).start()
+        return proc
+
+    def _reader(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            return
+        try:
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except ValueError:
+                    continue
+                self._dispatch(msg)
+        except Exception:
+            pass
+
+    def _stderr_reader(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stderr is None:
+            return
+        for line in proc.stderr:
+            self._stderr_tail.append(line.rstrip("\n"))
+
+    def _send_pi(self, command: dict) -> None:
+        proc = self._proc
+        if proc is None or proc.stdin is None:
+            raise RuntimeError("pi rpc child is not running")
+        with self._stdin_lock:
+            proc.stdin.write(json.dumps(command) + "\n")
+            proc.stdin.flush()
+
+    def _request_pi(self, command: dict, timeout: float = 60.0) -> dict:
+        with self._pending_lock:
+            self._next_id += 1
+            request_id = self._next_id
+            waiter = threading.Event()
+            slot: list = [None]
+            self._pending[request_id] = [waiter, slot]
+        self._send_pi(dict(command, id=request_id))
+        if not waiter.wait(timeout):
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+            raise TimeoutError(f"pi did not answer command {command.get('type')!r}")
+        return slot[0] or {}
+
+    def _dispatch(self, msg: dict) -> None:
+        msg_type = msg.get("type")
+
+        if msg_type == "response":
+            request_id = msg.get("id")
+            with self._pending_lock:
+                entry = (
+                    self._pending.pop(request_id, None)
+                    if isinstance(request_id, int)
+                    else None
+                )
+            if entry is not None:
+                entry[1][0] = msg
+                entry[0].set()
+            return
+
+        if msg_type == "extension_ui_request":
+            self._handle_ui_request(msg)
+            return
+
+        if msg_type in ("tool_execution_start", "tool_execution_end"):
+            name = str(msg.get("toolName") or "tool")
+            if msg_type == "tool_execution_start":
+                args = msg.get("args")
+                args_txt = (
+                    args
+                    if isinstance(args, str)
+                    else json.dumps(args, ensure_ascii=False, default=str)
+                )
+                line = f"[pi-tool] {name} {args_txt}".strip()
+            else:
+                result = msg.get("result")
+                details = result.get("details") if isinstance(result, dict) else None
+                ok = details.get("success") if isinstance(details, dict) else None
+                mark = "ok" if ok is not False else "FAILED"
+                size = (
+                    len(result)
+                    if isinstance(result, str)
+                    else len(json.dumps(result, default=str))
+                )
+                line = f"[pi-tool:{mark}] {name} -> result {size} bytes"
+            self._reasoning_parts.append(line[:400] + "\n")
+            return
+
+        if msg_type == "message_update":
+            event = msg.get("assistantMessageEvent") or {}
+            kind = event.get("type")
+            delta = event.get("delta")
+            if not isinstance(delta, str) or not delta:
+                return
+            if kind == "text_delta":
+                self.text_streamed = True
+                self._text_parts.append(delta)
+            elif kind == "thinking_delta":
+                self._reasoning_parts.append(delta)
+            return
+
+        if msg_type == "agent_settled":
+            self._settled.set()
+            return
+
+    # -- interactive questions ----------------------------------------------
+
+    def _handle_ui_request(self, msg: dict) -> None:
+        method = str(msg.get("method") or "input")
+        request_id = msg.get("id")
+        title = str(msg.get("title") or "")
+        options = msg.get("options") or []
+        if method not in ("input", "select", "confirm", "editor"):
+            # setStatus / notify / setWidget and similar are fire-and-forget
+            # UI notifications from extensions, not questions. Acknowledge
+            # immediately so the child never blocks on them.
+            try:
+                self._send_pi({"type": "extension_ui_response", "id": request_id, "ok": True})
+            except Exception:
+                pass
+            return
+        question = PendingQuestion(method, title, options)
+        with _registry_lock:
+            pending_questions[question.id] = question
+
+        self._reasoning_parts.append(
+            f"[pi-question] {method}: {title}"
+            + (f" options={options}" if options else "")
+            + "\n"
+        )
+        self._text_parts.append(
+            f"\n[Question from pi delegate — steer this delegation with your answer"
+            f" (timeout {int(_DEFAULT_QUESTION_TIMEOUT)}s)]: {title}\n"
+        )
+
+        try:
+            answered = question.answered.wait(_DEFAULT_QUESTION_TIMEOUT)
+        finally:
+            with _registry_lock:
+                pending_questions.pop(question.id, None)
+
+        payload = question.answer if answered else question.auto_answer()
+
+        if not answered:
+            self._reasoning_parts.append(
+                f"[pi-question] timed out; auto-answered {method} -> {payload}\n"
+            )
+        else:
+            self._reasoning_parts.append(
+                f"[pi-question] answered with user text -> {payload}\n"
+            )
+        try:
+            self._send_pi(
+                {"type": "extension_ui_response", "id": request_id, **payload}
+            )
+        except Exception:
+            pass
+
+    # -- run ------------------------------------------------------------------
+
+    def _git_status_snapshot(self) -> dict[str, str] | None:
+        try:
+            proc = subprocess.run(
+                ["git", "-C", self._cwd, "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except Exception:
+            return None
+        if proc.returncode != 0:
+            return None
+        return {
+            line[3:]: line for line in proc.stdout.splitlines() if len(line) > 3
+        }
+
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        self._spawn()
+        self._text_parts: list[str] = []
+        self._reasoning_parts: list[str] = []
+        self._settled = threading.Event()
+        self.text_streamed = False
+
+        before_status = self._git_status_snapshot()
+        started = time.monotonic()
+
+        policy = (
+            "[Delegation policy] You are a delegated implementer. Make the "
+            "requested changes in the working tree, but do NOT run git "
+            "commit or git push — leave all changes uncommitted for the "
+            "reviewing agent to review and land."
+        )
+
+        status = "end_turn"
+        try:
+            response = self._request_pi(
+                {"type": "prompt", "message": policy + "\n\n" + prompt_text},
+                timeout=timeout_seconds,
+            )
+            if not response.get("success"):
+                error = response.get("error") or "prompt rejected"
+                self._text_parts.append(f"\n[pi-rpc error] prompt rejected: {error}\n")
+                status = "error"
+            else:
+                self._settled.wait(timeout_seconds)
+                if not self._settled.is_set():
+                    try:
+                        self._send_pi({"type": "abort"})
+                    except Exception:
+                        pass
+                    self._settled.wait(10)
+                    self._text_parts.append(
+                        f"\n[pi-rpc error] timed out after {timeout_seconds:.0f}s\n"
+                    )
+                    status = "error"
+        except TimeoutError as exc:
+            self._text_parts.append(f"\n[pi-rpc error] {exc}\n")
+            status = "error"
+
+        if status == "end_turn" and not self.text_streamed:
+            try:
+                last = self._request_pi({"type": "get_last_assistant_text"})
+                text = (last.get("data") or {}).get("text")
+                if isinstance(text, str) and text:
+                    self._text_parts.append(text)
+            except Exception:
+                pass
+
+        after_status = self._git_status_snapshot()
+        touched = sorted(
+            line
+            for path, line in (after_status or {}).items()
+            if (before_status or {}).get(path) != line
+        ) if before_status is not None and after_status is not None else []
+        footer = {
+            "status": status,
+            "duration_s": round(time.monotonic() - started, 1),
+            "git_repo": after_status is not None,
+            "touched_files": touched,
+        }
+        self._text_parts.append(
+            "\n```pi-delegation-result\n"
+            + json.dumps(footer, ensure_ascii=False)
+            + "\n```\n"
+        )
+        return "".join(self._text_parts), "".join(self._reasoning_parts)

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -134,8 +134,12 @@ def _resolve_pi_bin() -> str:
 
 
 def _resolve_acp_command(kwargs_command: str | None) -> str:
-    # When wired through the copilot-acp plumbing, the command may be
-    # ``pi`` or ``pi-acp``; either way we drive pi natively.
+    # An explicitly passed command that exists on disk wins (lets callers
+    # and tests pin the exact binary). Bare names (``pi`` / ``pi-acp`` from
+    # the copilot-acp plumbing) resolve through env so HERMES_PI_BIN still
+    # overrides; we drive pi natively either way.
+    if kwargs_command and Path(kwargs_command).exists():
+        return kwargs_command
     return _resolve_pi_bin()
 
 

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -71,15 +71,22 @@ class PendingQuestion:
         self.created_at = time.time()
 
     def answer_with(self, text: str) -> dict[str, Any]:
-        """Map free text to the pi-ask-user response shape (AskResponse)."""
+        """Map free text onto pi's extension_ui_response dialog shapes.
+
+        Pi's RPC dialogs resolve via:
+          input/select -> ``r.cancelled ? undefined : r.value``
+          confirm      -> ``r.cancelled ? false : r.confirmed``
+        So the wire payload is ``{value}`` / ``{confirmed}`` / ``{cancelled}``
+        — NOT the third-party pi-ask-user ``{kind: ...}`` shape.
+        """
         cleaned = (text or "").strip()
         low = cleaned.lower()
         if self.method == "confirm":
-            # yes/no/true/false → selection with "yes" or "no".
             is_yes = low in ("y", "yes", "true", "ok", "confirm", "t", "1", "yeah", "yep")
-            payload = {"kind": "selection", "selections": ["yes"] if is_yes else ["no"]}
+            payload = {"confirmed": is_yes}
         elif self.method == "select":
-            # Match by option text first, then by 1‑based index.
+            # Match by option text first, then by 1‑based index, else pass the
+            # raw text through as a freeform selection.
             match = None
             for option in self.options:
                 if option and option.lower() == low:
@@ -89,12 +96,9 @@ class PendingQuestion:
                 idx = int(low)
                 if 1 <= idx <= len(self.options):
                     match = self.options[idx - 1]
-            if match is None and self.options:
-                match = self.options[0]
-            selections = [match] if match is not None else (self.options[:1] if self.options else [cleaned])
-            payload = {"kind": "selection", "selections": selections}
+            payload = {"value": match if match is not None else cleaned} if (match is not None or cleaned) else {"cancelled": True}
         else:  # input, editor — free text.
-            payload = {"kind": "freeform", "text": cleaned} if cleaned else {"cancelled": True}
+            payload = {"value": cleaned} if cleaned else {"cancelled": True}
         self.answer = payload
         self.answered.set()
         return payload
@@ -102,9 +106,9 @@ class PendingQuestion:
     def auto_answer(self) -> dict[str, Any]:
         """Default answer for fallback policy."""
         if self.method == "confirm":
-            return {"kind": "selection", "selections": ["yes"]}
+            return {"confirmed": True}
         if self.method == "select":
-            return {"kind": "selection", "selections": self.options[:1]} if self.options else {"cancelled": True}
+            return {"value": self.options[0]} if self.options else {"cancelled": True}
         return {"cancelled": True}
 
 
@@ -272,13 +276,19 @@ class PiRPCClient:
         tools = os.getenv("HERMES_PI_TOOLS", "").strip()
         if tools:
             argv += ["--tools", tools]
-        # Auto-load pi-ask-user (interactive questions) if installed; users can
-        # force extra extensions with HERMES_PI_EXTENSIONS (colon-separated).
+        # Auto-load the first-party hermes_ask_user extension (ships with this
+        # repo) and optionally pi-ask-user; users can force extra extensions
+        # with HERMES_PI_EXTENSIONS (colon-separated).
+        exts = []
+        first_party = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "extensions", "hermes_ask_user.ts"
+        )
+        if os.path.isfile(first_party):
+            exts.append(first_party)
         ask_user = os.path.join(
             os.path.expanduser("~"), ".pi", "agent", "npm", "node_modules",
             "pi-ask-user", "index.ts",
         )
-        exts = []
         if os.path.isfile(ask_user):
             exts.append(ask_user)
         exts += [p for p in os.getenv("HERMES_PI_EXTENSIONS", "").split(":") if p]

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -71,18 +71,15 @@ class PendingQuestion:
         self.created_at = time.time()
 
     def answer_with(self, text: str) -> dict[str, Any]:
-        """Map free text to the response payload pi expects."""
+        """Map free text to the pi-ask-user response shape (AskResponse)."""
         cleaned = (text or "").strip()
         low = cleaned.lower()
         if self.method == "confirm":
-            if low in ("y", "yes", "true", "ok", "confirm"):
-                payload = {"confirmed": True}
-            elif low in ("n", "no", "false", "cancel"):
-                payload = {"confirmed": False}
-            else:
-                # Non-boolean answer to a confirm: treat non-empty as yes.
-                payload = {"confirmed": bool(cleaned)}
+            # yes/no/true/false → selection with "yes" or "no".
+            is_yes = low in ("y", "yes", "true", "ok", "confirm", "t", "1", "yeah", "yep")
+            payload = {"kind": "selection", "selections": ["yes"] if is_yes else ["no"]}
         elif self.method == "select":
+            # Match by option text first, then by 1‑based index.
             match = None
             for option in self.options:
                 if option and option.lower() == low:
@@ -94,18 +91,20 @@ class PendingQuestion:
                     match = self.options[idx - 1]
             if match is None and self.options:
                 match = self.options[0]
-            payload = {"value": match} if match is not None else {"cancelled": True}
-        else:  # input, editor — free text is exactly what these want
-            payload = {"text": cleaned} if cleaned else {"cancelled": True}
+            selections = [match] if match is not None else (self.options[:1] if self.options else [cleaned])
+            payload = {"kind": "selection", "selections": selections}
+        else:  # input, editor — free text.
+            payload = {"kind": "freeform", "text": cleaned} if cleaned else {"cancelled": True}
         self.answer = payload
         self.answered.set()
         return payload
 
     def auto_answer(self) -> dict[str, Any]:
+        """Default answer for fallback policy."""
         if self.method == "confirm":
-            return {"confirmed": True}
+            return {"kind": "selection", "selections": ["yes"]}
         if self.method == "select":
-            return {"value": self.options[0]} if self.options else {"cancelled": True}
+            return {"kind": "selection", "selections": self.options[:1]} if self.options else {"cancelled": True}
         return {"cancelled": True}
 
 

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -100,9 +100,23 @@ class PendingQuestion:
         return payload
 
     def auto_answer(self) -> dict[str, Any]:
-        """Default answer for fallback policy."""
+        """Legacy fallback used by non-session Pi compatibility callers."""
         if self.method == "confirm":
             return {"confirmed": True}
+        if self.method == "select":
+            return {"value": self.options[0]} if self.options else {"cancelled": True}
+        return {"cancelled": True}
+
+    def supervised_fallback(self) -> dict[str, Any]:
+        """Conservative unattended fallback for persistent delegate sessions.
+
+        A failed Hermes auto-answer must never silently approve a confirmation.
+        Select questions choose the first offered option only because Pi's select
+        contract requires a concrete option to continue; free-text/editor
+        questions cancel rather than inventing user intent.
+        """
+        if self.method == "confirm":
+            return {"confirmed": False}
         if self.method == "select":
             return {"value": self.options[0]} if self.options else {"cancelled": True}
         return {"cancelled": True}
@@ -519,7 +533,8 @@ class PiRPCClient:
         method = str(msg.get("method") or "input")
         request_id = msg.get("id")
         title = str(msg.get("title") or "")
-        options = msg.get("options") or []
+        raw_options = msg.get("options")
+        options = [str(item) for item in raw_options] if isinstance(raw_options, (list, tuple)) else []
         if method not in ("input", "select", "confirm", "editor"):
             # setStatus / notify / setWidget and similar are fire-and-forget
             # UI notifications from extensions, not questions. Acknowledge
@@ -555,11 +570,11 @@ class PiRPCClient:
                     f"[pi-question:auto] Hermes answered {method} -> {payload}\n"
                 )
             else:
-                payload = question.auto_answer()
+                payload = question.supervised_fallback()
                 question.answer = payload
                 question.answered.set()
                 self._reasoning_parts.append(
-                    f"[pi-question:auto] Hermes had no answer; safe fallback -> {payload}\n"
+                    f"[pi-question:auto] Hermes had no answer; conservative fallback -> {payload}\n"
                 )
             try:
                 self._send_pi(

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -135,6 +135,33 @@ def answer_oldest_pending_question(text: str) -> bool:
     return True
 
 
+def pending_question_for_owner(owner: "PiRPCClient") -> PendingQuestion | None:
+    """Return the oldest live question owned by one persistent Pi client."""
+    with _registry_lock:
+        matches = [
+            question
+            for question in pending_questions.values()
+            if question.owner is owner and not owner.is_closed
+        ]
+    return min(matches, key=lambda question: question.created_at) if matches else None
+
+
+def answer_pending_question_for_owner(owner: "PiRPCClient", text: str) -> bool:
+    """Answer only a question belonging to *owner*; never steal another session's input."""
+    with _registry_lock:
+        matches = [
+            question
+            for question in pending_questions.values()
+            if question.owner is owner and not owner.is_closed
+        ]
+        if not matches:
+            return False
+        question = min(matches, key=lambda item: item.created_at)
+        pending_questions.pop(question.id, None)
+    question.answer_with(text)
+    return True
+
+
 def _resolve_pi_bin() -> str:
     return (
         os.getenv("HERMES_PI_BIN", "").strip()
@@ -180,20 +207,31 @@ class PiRPCClient:
         acp_cwd: str | None = None,
         command: str | None = None,
         args: list[str] | None = None,
+        persistent_session: bool = False,
+        session_id: str | None = None,
+        session_name: str | None = None,
         **_: Any,
     ) -> None:
         self.api_key = api_key or "pi-rpc"
         self.base_url = base_url or PI_RPC_MARKER_BASE_URL
         self._pi_bin = _resolve_acp_command(command or acp_command)
         self._cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self._persistent_session = bool(persistent_session)
+        self._session_id = (session_id or "").strip() or None
+        self._session_name = (session_name or "").strip() or None
         self.chat = _PiChatNamespace(self)
         self.is_closed = False
         self._proc: subprocess.Popen[str] | None = None
         self._stdin_lock = threading.Lock()
+        self._prompt_lock = threading.Lock()
         self._pending: dict[int, list] = {}
         self._pending_lock = threading.Lock()
         self._next_id = 0
         self._stderr_tail: deque[str] = deque(maxlen=40)
+        self._text_parts: list[str] = []
+        self._reasoning_parts: list[str] = []
+        self._settled = threading.Event()
+        self.text_streamed = False
 
     # -- lifecycle ---------------------------------------------------------
 
@@ -269,7 +307,18 @@ class PiRPCClient:
     # -- pi protocol -------------------------------------------------------
 
     def _spawn(self) -> subprocess.Popen[str]:
-        argv = [self._pi_bin, "--mode", "rpc", "--no-session"]
+        if self._proc is not None and self._proc.poll() is None:
+            return self._proc
+        if self.is_closed:
+            raise RuntimeError("pi rpc client is closed")
+        argv = [self._pi_bin, "--mode", "rpc"]
+        if self._persistent_session:
+            if self._session_id:
+                argv += ["--session-id", self._session_id]
+            if self._session_name:
+                argv += ["--name", self._session_name]
+        else:
+            argv.append("--no-session")
         model = os.getenv("HERMES_PI_MODEL", "").strip()
         if model:
             argv += ["--model", model]
@@ -478,6 +527,97 @@ class PiRPCClient:
             )
         except Exception:
             pass
+
+    # -- persistent-session control -------------------------------------------
+
+    def start(self, *, timeout: float = 30.0) -> dict[str, Any]:
+        """Start the Pi RPC process and return native session state."""
+        self._spawn()
+        response = self._request_pi({"type": "get_state"}, timeout=timeout)
+        if response.get("success") is False:
+            raise RuntimeError(response.get("error") or "pi get_state failed")
+        data = response.get("data")
+        return data if isinstance(data, dict) else {}
+
+    def get_state(self, *, timeout: float = 30.0) -> dict[str, Any]:
+        self._spawn()
+        response = self._request_pi({"type": "get_state"}, timeout=timeout)
+        if response.get("success") is False:
+            raise RuntimeError(response.get("error") or "pi get_state failed")
+        data = response.get("data")
+        return data if isinstance(data, dict) else {}
+
+    def get_messages(self, *, timeout: float = 30.0) -> list[Any]:
+        self._spawn()
+        response = self._request_pi({"type": "get_messages"}, timeout=timeout)
+        if response.get("success") is False:
+            raise RuntimeError(response.get("error") or "pi get_messages failed")
+        data = response.get("data")
+        if isinstance(data, dict) and isinstance(data.get("messages"), list):
+            return data["messages"]
+        return data if isinstance(data, list) else []
+
+    def answer_pending_question(self, text: str) -> bool:
+        return answer_pending_question_for_owner(self, text)
+
+    def steer(self, message: str, *, timeout: float = 30.0) -> dict[str, Any]:
+        """Steer a running Pi turn, or answer its pending extension question."""
+        if self.answer_pending_question(message):
+            return {"success": True, "command": "answer_question"}
+        self._spawn()
+        return self._request_pi({"type": "steer", "message": message}, timeout=timeout)
+
+    def abort(self, *, timeout: float = 30.0) -> dict[str, Any]:
+        self._spawn()
+        return self._request_pi({"type": "abort"}, timeout=timeout)
+
+    def run_session_prompt(
+        self,
+        message: str,
+        *,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        """Run one turn against the same persistent Pi process/session.
+
+        Unlike the OpenAI compatibility path, this method does not reconstruct
+        prior conversation into the prompt: Pi owns the conversation state.
+        """
+        with self._prompt_lock:
+            self._spawn()
+            self._text_parts = []
+            self._reasoning_parts = []
+            self._settled = threading.Event()
+            self.text_streamed = False
+            started = time.monotonic()
+            response = self._request_pi(
+                {"type": "prompt", "message": message}, timeout=timeout_seconds
+            )
+            if not response.get("success"):
+                raise RuntimeError(response.get("error") or "pi prompt rejected")
+            self._settled.wait(timeout_seconds)
+            if not self._settled.is_set():
+                try:
+                    self._send_pi({"type": "abort"})
+                except Exception:
+                    pass
+                self._settled.wait(10)
+                raise TimeoutError(f"pi session turn timed out after {timeout_seconds:.0f}s")
+            if not self.text_streamed:
+                try:
+                    last = self._request_pi({"type": "get_last_assistant_text"})
+                    text = (last.get("data") or {}).get("text")
+                    if isinstance(text, str) and text:
+                        self._text_parts.append(text)
+                except Exception:
+                    pass
+            state = self.get_state(timeout=min(30.0, timeout_seconds))
+            return {
+                "success": True,
+                "text": "".join(self._text_parts),
+                "reasoning": "".join(self._reasoning_parts),
+                "duration_s": round(time.monotonic() - started, 1),
+                "state": state,
+            }
 
     # -- run ------------------------------------------------------------------
 

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -14,18 +14,14 @@ Contract parity with the pi-acp bridge is preserved:
   final message (parsed by ``parse_pi_result_footer``).
 
 Interactive questions:
-- An incoming ``extension_ui_request`` is registered in a module-level
-  registry (``pending_questions``) and surfaced as a ``[pi-question]``
-  marker in the reasoning stream plus the question text in the message
-  stream, so the live delegation transcript shows it.
-- The run then blocks (up to ``question_timeout_seconds``, default 600)
-  waiting for an answer. ``tools.delegate_tool.steer_subagent`` checks
-  the registry and routes a steer message to the oldest pending question
-  as free text (``{"text": ...}`` for input/editor, option matching for
-  select, yes/no parsing for confirm).
-- On timeout the old auto-answer policy applies (confirm=true,
-  select=first, input/editor=cancelled) so a delegation never hangs
-  forever.
+- Persistent ``delegate_session`` clients install a Hermes-side answer callback.
+  Pi questions are answered immediately by the supervising Hermes model using
+  its current conversation/project context; they are not forwarded to the user.
+- Legacy/non-session callers retain the module-level ``pending_questions``
+  registry and manual steer path for compatibility.
+- If Hermes cannot produce an automatic answer, a safe deterministic fallback
+  applies (confirm=true, select=first, input/editor=cancelled) so a delegation
+  never hangs forever.
 """
 
 from __future__ import annotations
@@ -38,7 +34,7 @@ import time
 from collections import deque
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Callable
 
 from agent.copilot_acp_client import (
     _completion_to_stream_chunks,
@@ -210,6 +206,7 @@ class PiRPCClient:
         persistent_session: bool = False,
         session_id: str | None = None,
         session_name: str | None = None,
+        question_answerer: Callable[[str, str, list[str]], str | None] | None = None,
         **_: Any,
     ) -> None:
         self.api_key = api_key or "pi-rpc"
@@ -219,6 +216,7 @@ class PiRPCClient:
         self._persistent_session = bool(persistent_session)
         self._session_id = (session_id or "").strip() or None
         self._session_name = (session_name or "").strip() or None
+        self._question_answerer = question_answerer
         self.chat = _PiChatNamespace(self)
         self.is_closed = False
         self._proc: subprocess.Popen[str] | None = None
@@ -237,6 +235,34 @@ class PiRPCClient:
 
     def close(self) -> None:
         self.is_closed = True
+
+        # Wake extension-question waiters owned by this client. Otherwise the
+        # question handler can linger until HERMES_PI_QUESTION_TIMEOUT even
+        # though the RPC process is already gone.
+        with _registry_lock:
+            own_questions = [
+                question for question in pending_questions.values()
+                if question.owner is self
+            ]
+            for question in own_questions:
+                pending_questions.pop(question.id, None)
+        for question in own_questions:
+            question.answer = {"cancelled": True}
+            question.answered.set()
+
+        # Likewise fail any synchronous RPC requests immediately on close
+        # rather than making callers wait for their command timeout.
+        with self._pending_lock:
+            pending = list(self._pending.values())
+            self._pending.clear()
+        for waiter, slot in pending:
+            slot[0] = {
+                "type": "response",
+                "success": False,
+                "error": "pi rpc client closed",
+            }
+            waiter.set()
+
         proc = self._proc
         self._proc = None
         if proc is None:
@@ -431,7 +457,19 @@ class PiRPCClient:
             return
 
         if msg_type == "extension_ui_request":
-            self._handle_ui_request(msg)
+            # Interactive dialogs can wait for user/Hermes input for minutes.
+            # Never block the sole stdout reader on that wait: Pi must remain
+            # responsive to get_state/get_messages/abort and other RPCs while a
+            # question is pending. Fire-and-forget UI notifications stay inline.
+            if str(msg.get("method") or "input") in {"input", "select", "confirm", "editor"}:
+                threading.Thread(
+                    target=self._handle_ui_request,
+                    args=(msg,),
+                    name=f"pi-ui-{msg.get('id', 'request')}",
+                    daemon=True,
+                ).start()
+            else:
+                self._handle_ui_request(msg)
             return
 
         if msg_type in ("tool_execution_start", "tool_execution_end"):
@@ -492,14 +530,48 @@ class PiRPCClient:
                 pass
             return
         question = PendingQuestion(method, title, options, owner=self)
-        with _registry_lock:
-            pending_questions[question.id] = question
-
         self._reasoning_parts.append(
             f"[pi-question] {method}: {title}"
             + (f" options={options}" if options else "")
             + "\n"
         )
+
+        # Persistent delegate_session clients install a Hermes-side answerer.
+        # Resolve those questions immediately with the supervising Hermes model
+        # instead of surfacing them to the human or waiting for steer().
+        if self._question_answerer is not None:
+            answer_text = ""
+            try:
+                answer_text = str(
+                    self._question_answerer(method, title, list(options)) or ""
+                ).strip()
+            except Exception as exc:
+                self._reasoning_parts.append(
+                    f"[pi-question:auto] Hermes answerer failed: {exc.__class__.__name__}\n"
+                )
+            if answer_text:
+                payload = question.answer_with(answer_text)
+                self._reasoning_parts.append(
+                    f"[pi-question:auto] Hermes answered {method} -> {payload}\n"
+                )
+            else:
+                payload = question.auto_answer()
+                question.answer = payload
+                question.answered.set()
+                self._reasoning_parts.append(
+                    f"[pi-question:auto] Hermes had no answer; safe fallback -> {payload}\n"
+                )
+            try:
+                self._send_pi(
+                    {"type": "extension_ui_response", "id": request_id, **payload}
+                )
+            except Exception:
+                pass
+            return
+
+        # Legacy/non-session callers keep the interactive steer path.
+        with _registry_lock:
+            pending_questions[question.id] = question
         self._text_parts.append(
             f"\n[Question from pi delegate — steer this delegation with your answer"
             f" (timeout {int(_DEFAULT_QUESTION_TIMEOUT)}s)]: {title}\n"

--- a/agent/pi_rpc_client.py
+++ b/agent/pi_rpc_client.py
@@ -31,6 +31,7 @@ import os
 import subprocess
 import threading
 import time
+import warnings
 from collections import deque
 from pathlib import Path
 from types import SimpleNamespace
@@ -45,7 +46,23 @@ from tools.environments.local import hermes_subprocess_env
 
 PI_RPC_MARKER_BASE_URL = "pi://rpc"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
-_DEFAULT_QUESTION_TIMEOUT = float(os.getenv("HERMES_PI_QUESTION_TIMEOUT", "600"))
+def _env_float(name: str, default: float) -> float:
+    """Parse a float env var defensively so one bad value can't crash import."""
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        warnings.warn(
+            f"Ignoring malformed {name}={raw!r}; using default {default}",
+            stacklevel=2,
+        )
+        return default
+    return value if value > 0 else default
+
+
+_DEFAULT_QUESTION_TIMEOUT = _env_float("HERMES_PI_QUESTION_TIMEOUT", 600.0)
 
 # Module-level registry of live questions from all running pi children.
 # Key: unique question id. Value: PendingQuestion.
@@ -226,6 +243,7 @@ class PiRPCClient:
         self.api_key = api_key or "pi-rpc"
         self.base_url = base_url or PI_RPC_MARKER_BASE_URL
         self._pi_bin = _resolve_acp_command(command or acp_command)
+        self._extra_args = [a for a in (args or acp_args or []) if isinstance(a, str)]
         self._cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self._persistent_session = bool(persistent_session)
         self._session_id = (session_id or "").strip() or None
@@ -239,6 +257,8 @@ class PiRPCClient:
         self._pending: dict[int, list] = {}
         self._pending_lock = threading.Lock()
         self._next_id = 0
+        self._prompt_tokens = 0
+        self._completion_tokens = 0
         self._stderr_tail: deque[str] = deque(maxlen=40)
         self._text_parts: list[str] = []
         self._reasoning_parts: list[str] = []
@@ -322,10 +342,11 @@ class PiRPCClient:
             prompt_text, timeout_seconds=effective_timeout
         )
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+        pt, ct = self._prompt_tokens, self._completion_tokens
         usage = SimpleNamespace(
-            prompt_tokens=0,
-            completion_tokens=0,
-            total_tokens=0,
+            prompt_tokens=pt,
+            completion_tokens=ct,
+            total_tokens=pt + ct,
             prompt_tokens_details=SimpleNamespace(cached_tokens=0),
         )
         assistant_message = SimpleNamespace(
@@ -351,7 +372,13 @@ class PiRPCClient:
             return self._proc
         if self.is_closed:
             raise RuntimeError("pi rpc client is closed")
-        argv = [self._pi_bin, "--mode", "rpc"]
+        argv = [self._pi_bin]
+        # Honor explicit caller-provided args (e.g. from credential
+        # resolution), but always derive the mode/session flags from client
+        # state so they can't contradict persistent_session=True.
+        if self._extra_args:
+            argv += [a for a in self._extra_args if a not in ("--mode", "rpc", "--no-session")]
+        argv += ["--mode", "rpc"]
         if self._persistent_session:
             if self._session_id:
                 argv += ["--session-id", self._session_id]
@@ -514,13 +541,29 @@ class PiRPCClient:
             event = msg.get("assistantMessageEvent") or {}
             kind = event.get("type")
             delta = event.get("delta")
-            if not isinstance(delta, str) or not delta:
-                return
-            if kind == "text_delta":
-                self.text_streamed = True
-                self._text_parts.append(delta)
-            elif kind == "thinking_delta":
-                self._reasoning_parts.append(delta)
+            if isinstance(delta, str) and delta:
+                if kind == "text_delta":
+                    self.text_streamed = True
+                    self._text_parts.append(delta)
+                elif kind == "thinking_delta":
+                    self._reasoning_parts.append(delta)
+            # Best-effort token accounting: pi surfaces usage on some
+            # message_update / settled events under varying key shapes
+            # depending on version. Capture anything we recognize; when pi
+            # reports nothing we stay at zero — which means pi delegations are
+            # INVISIBLE to any parent-side usage/cost guard keyed on these
+            # numbers. Do not build budget enforcement on pi usage.
+            for src in (event, msg):
+                usage_src = src.get("usage") if isinstance(src, dict) else None
+                for cand in (usage_src, src if isinstance(src, dict) else None):
+                    if not isinstance(cand, dict):
+                        continue
+                    pt = cand.get("prompt_tokens") or cand.get("inputTokens") or cand.get("input_tokens")
+                    ct = cand.get("completion_tokens") or cand.get("outputTokens") or cand.get("output_tokens")
+                    if isinstance(pt, (int, float)) or isinstance(ct, (int, float)):
+                        self._prompt_tokens = max(self._prompt_tokens, int(pt or 0))
+                        self._completion_tokens = max(self._completion_tokens, int(ct or 0))
+                        break
             return
 
         if msg_type == "agent_settled":
@@ -728,6 +771,8 @@ class PiRPCClient:
         self._spawn()
         self._text_parts: list[str] = []
         self._reasoning_parts: list[str] = []
+        self._prompt_tokens = 0
+        self._completion_tokens = 0
         self._settled = threading.Event()
         self.text_streamed = False
 

--- a/docs/plans/2026-08-24-delegate-session-opencode-backend.md
+++ b/docs/plans/2026-08-24-delegate-session-opencode-backend.md
@@ -1,0 +1,165 @@
+# Plan: Configurable delegate_session Backends (Pi + OpenCode)
+
+- artifact_contract: ce-unified-plan/v1
+- artifact_readiness: implementation-ready
+- execution: code
+- plan_depth: standard
+- risk: medium
+- date: 2026-08-24
+- branch: feat/delegate-session-opencode (on top of merged Pi work, head 9940f829df)
+
+## Goal
+
+Make `delegate_session` backend-configurable. Pi remains the default; OpenCode is
+added as a second backend driven by the OpenCode HTTP server API (never TUI
+scraping). Hermes supervises backend-native interactive questions and answers
+OpenCode `question.asked` requests itself via the existing `run_oneshot`
+auto-answer path, with zero user involvement.
+
+## Settled decisions (from user instruction)
+
+1. **Pi stays the default backend** — user-directed; rejected alternative:
+   OpenCode-first or no default. Reason: preserves existing behavior.
+2. **OpenCode backend uses the server/session HTTP API** (`opencode serve`) —
+   user-directed ("server/session APIs rather than TUI scraping"); rejected:
+   pty/TUI scraping. Reason: machine-readable, robust.
+3. **API semantics preserved** — start/resume/send/steer/status/messages/list/stop
+   unchanged; a `backend` parameter is additive. Rejected: a new tool name.
+   Reason: no regression for Pi callers.
+4. **Durable resume metadata is backend-aware** — metadata gains a `backend`
+   field; resume reopens the correct backend. Rejected: separate stores.
+5. **Hermes autonomously answers OpenCode questions** — rejected: surfacing to
+   the user. Reason: user explicitly required no user intervention.
+6. **Live e2e validation with installed opencode 1.18.18 is part of done** —
+   rejected: hermetic-only validation. Reason: user requirement.
+
+## Grounded API facts (probed against local opencode 1.18.18, OpenAPI /doc)
+
+- `opencode serve --port N --hostname 127.0.0.1` → HTTP JSON API.
+- `POST /session?directory=<cwd>` body `{title}` → `{id: "ses_...", ...}`.
+- `POST /session/{id}/prompt_async` body `{parts:[{type:"text",text}]}` → HTTP 204,
+  runs asynchronously. (There is no native "steer" for prompt_async.)
+- `GET /question` → array of pending `QuestionRequest`:
+  `{id:"que_..", sessionID, questions:[{question, header, options:[{label,description}], multiple, custom}], tool}`.
+- `POST /question/{requestID}/reply` body `{answers:[[label,...], ...]}`
+  (one answer-array per question, values are option labels) — `custom:true`
+  allows a free-text label. `POST /question/{requestID}/reject` also exists.
+- `POST /session/{id}/abort` (empty body), `GET /session/{id}/message`
+  → array of `{info:{id,role,time,...}, parts:[{type:"text",text},...]}`.
+- `GET /session/status` → `{}` on this build (unreliable); busy/idle must be
+  tracked from message polling / active turn bookkeeping, not this endpoint.
+- Agent/model come from user opencode config (cliproxyapi provider present).
+- OpenCode permissions (`permission.asked`) are a separate mechanism; this work
+  targets `question.*` (delegate sessions should run with a permission ruleset
+  that does not block, or permission events surface as errors — documented
+  limitation, not auto-approved in v1).
+
+## Design
+
+### Backend protocol (structural refactor of tools/delegate_session_tool.py)
+
+Introduce `DelegateBackend` protocol with methods mapped from the existing
+Pi-coupled call sites:
+
+- `start(cwd, session_name) -> native_id` — begin/attach native session
+- `run_prompt(text, timeout) -> {"text": str, "native_session_id": str, "duration_s": float}`
+- `steer(text, timeout) -> response` — live course correction
+- `abort(timeout)` — cancel active turn
+- `get_messages(timeout) -> list` — recent transcript
+- `close()` — release backend resources
+- `is_dead()` — backend process/connection liveness (replaces `client._proc.poll()`)
+- `pending_question()` — `None | {"method","question","options","created_at"}`
+
+Pi backend: thin adapter over the existing `PiRPCClient` (behavior preserved
+byte-for-byte at the tool layer; existing tests must pass unchanged).
+
+OpenCode backend (`agent/opencode_client.py`, new):
+
+- **Server lifecycle**: one lazily-spawned shared `opencode serve` per Hermes
+  process (module-level singleton). Spawn with a free 127.0.0.1 port, env
+  `HERMES_OPENCODE_BIN` override (default `opencode`), readiness = HTTP 200 on
+  `/session` (poll ≤30s). Reference-counted close; refcount 0 terminates server.
+- **start**: `POST /session?directory=<cwd>` with `title`.
+- **send**: dispatch thread → `POST prompt_async`, then poll `GET
+  /session/{id}/message` until a new assistant message with text parts appears
+  after the user message (timeout = tool timeout; abort via `POST abort` on
+  timeout or stop).
+- **steer**: no native steer for prompt_async. Mirror the existing Pi semantics:
+  if a turn is running, do NOT inject concurrently — degrade steer to a queued
+  send for v1 and return `degraded_to_send` + note (same contract Pi already
+  exposes when a turn ended). Documented limitation.
+- **questions**: poll `GET /question` (same cadence as message polling, plus a
+  dedicated lightweight poller while a turn runs). Filter by `sessionID`. For
+  each pending request: call the shared Hermes auto-answer callback
+  (`(method, question, options) -> str|None`), then `POST /question/{id}/reply`
+  with `answers=[[answer]]` per question (free text allowed when `custom`;
+  otherwise best label-match; `None` answer → `reject` — conservative fallback).
+- **resume**: server is stateless across restarts but OpenCode persists sessions
+  on disk; reopening = ensure server up + reuse stored `native_session_id`
+  (messages endpoint works for persisted sessions; a missing session is a
+  bounded error).
+- **status**: derived from in-memory record + turn thread + `is_dead()`.
+
+### Tool layer changes (tools/delegate_session_tool.py)
+
+- New `backend` argument: `"pi"` (default) | `"opencode"`, resolved as
+  `arg → HERMES_DELEGATE_SESSION_BACKEND env → "pi"`.
+- Backend selection applies at start/resume; other actions look up the stored
+  backend from the record/metadata (a mismatched explicit `backend` on control
+  actions is a bounded tool_error).
+- Registry/store: record gains `backend`; `_SESSIONS` keyed by session_id as
+  today (IDs are UUIDs, collision-free across backends).
+- Metadata v2: `{version:2, backend, session_id, native_session_id (renamed
+  from pi_session_id; pi_session_id kept as read-alias), owner, cwd, created_at,
+  updated_at}`. v1 files load with backend="pi".
+- `list` includes `backend`; `_summary` renames `pi_session_id` →
+  `native_session_id` (keep `pi_session_id` as duplicate field for one release
+  for model-callers; tests assert both).
+- Auto-answer: factor `_auto_answer_pi_question` into backend-neutral
+  `_auto_answer_delegate_question(parent_agent, backend_name, method, question,
+  options)`; wording generalized ("your coding delegate"), logic unchanged.
+- `check_delegate_session_requirements`: true when pi OR opencode is available.
+- Schema: add `backend` enum param; description generalized.
+
+## Implementation units
+
+- **U1** `agent/opencode_client.py` — `OpenCodeClient` implementing the backend
+  surface (server singleton lifecycle, session create, prompt_async+poll,
+  question poll/reply/reject, abort, messages, close, is_dead). Pure stdlib
+  (`urllib.request`/`http.client`), no new deps. HTTP layer injectable for
+  hermetic tests.
+- **U2** `tools/delegate_session_tool.py` refactor — `DelegateBackend` protocol,
+  Pi adapter wrapping `PiRPCClient`, backend resolution, store/metadata v2,
+  generalized auto-answer, generalized schema/description.
+- **U3** Tests:
+  - `tests/tools/test_delegate_session_tool.py` — extend: Pi default regression
+    (backend omitted → Pi path), backend=opencode routing with a fake backend,
+    metadata v2 round-trip + v1 migration, list includes backend, mismatched
+    backend error.
+  - `tests/agent/test_opencode_client.py` — hermetic: fake HTTP transport
+    (create/prompt 204/message growth/timeout abort), question reply payload
+    shape (`answers=[[label]]`), reject fallback, server spawn/readiness with
+    stub binary, refcounted close.
+  - Pi compatibility: existing `tests/agent/test_pi_rpc_client.py` and
+    `tests/tools/test_delegate_session_tool.py` pass unchanged (except additive
+    assertions).
+- **U4** Live e2e validation (manual script `scripts/validate_delegate_opencode.py`,
+  not shipped as a pytest): real `opencode serve`, delegate goal that forces the
+  OpenCode ask tool ("Use the ask tool to ask which color, then report the
+  answer"), parent agent stub feeding auto-answer via `run_oneshot`; assert a
+  `question.asked` was replied with a Hermes-generated answer and the session
+  transcript contains it — no user interaction.
+
+## Non-goals
+
+- Auto-approving OpenCode `permission.asked` (separate mechanism; v1 surfaces
+  permission-blocked turns as session errors).
+- Native concurrent steer injection (OpenCode has none for prompt_async).
+- Changing delegate_task semantics.
+
+## Risks
+
+- `/session/status` unreliable (`{}`) → busy tracking must be client-side. Mitigated by design.
+- Question free-text requires `custom:true`; non-custom selects need exact label
+  match → answerer prompt already enforces exact-option output; mismatch → reject fallback.
+- Server singleton vs multi-cwd sessions: fine — sessions are per-directory query params.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -305,6 +305,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "pi-rpc": ProviderConfig(
+        id="pi-rpc",
+        name="Pi (native JSONL RPC)",
+        auth_type="external_process",
+        inference_base_url="pi://rpc",
+        base_url_env_var="",  # fixed internal marker; not configurable
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",
@@ -7513,6 +7520,28 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             provider=provider_id,
             code="invalid_provider",
         )
+
+    if provider_id == "pi-rpc":
+        # Pi speaks its native JSONL RPC protocol directly — no ACP bridge,
+        # no Copilot CLI env vars. The client builds its own argv
+        # (``pi --mode rpc --no-session``); command/args are resolved for
+        # liveness only.
+        command = os.getenv("HERMES_PI_BIN", "").strip() or "pi"
+        resolved_command = shutil.which(command)
+        if not resolved_command:
+            raise AuthError(
+                f"Could not find the pi binary '{command}'. Install pi or set HERMES_PI_BIN.",
+                provider=provider_id,
+                code="missing_pi_binary",
+            )
+        return {
+            "provider": provider_id,
+            "api_key": "pi-rpc",
+            "base_url": "pi://rpc",
+            "command": resolved_command,
+            "args": ["--mode", "rpc", "--no-session"],
+            "source": "process",
+        }
 
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -2236,6 +2236,19 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    if provider == "pi-rpc":
+        creds = resolve_external_process_provider_credentials(provider)
+        return {
+            "provider": "pi-rpc",
+            "api_mode": "chat_completions",
+            "base_url": creds.get("base_url", "").rstrip("/"),
+            "api_key": creds.get("api_key", ""),
+            "command": creds.get("command", ""),
+            "args": list(creds.get("args") or []),
+            "source": creds.get("source", "process"),
+            "requested_provider": requested_provider,
+        }
+
     # Anthropic (native Messages API)
     if provider == "anthropic":
         # Allow base URL override from config.yaml model.base_url, but only

--- a/plugins/model-providers/pi-rpc/__init__.py
+++ b/plugins/model-providers/pi-rpc/__init__.py
@@ -1,0 +1,40 @@
+"""Pi RPC provider profile.
+
+pi-rpc drives the local ``pi`` coding agent over its native JSONL RPC
+protocol (``pi --mode rpc``) — no ACP bridge. The native protocol exposes
+``extension_ui_request``, so delegated pi agents can ask the parent
+questions and receive real free-text answers.
+
+The profile captures auth + endpoint metadata for registry migration;
+client construction is handled in run_agent.py / auxiliary_client.py,
+which build ``PiRPCClient`` for ``provider == "pi-rpc"``.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class PiRPCProfile(ProviderProfile):
+    """Pi coding agent — external JSONL RPC process, no REST endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is owned by the pi subprocess config."""
+        return None
+
+
+pi_rpc = PiRPCProfile(
+    name="pi-rpc",
+    aliases=("pi", "pi-agent"),
+    api_mode="chat_completions",  # JSONL RPC is routed via chat_completions plumbing
+    env_vars=(),  # Managed by the pi subprocess
+    base_url="pi://rpc",  # internal marker scheme
+    auth_type="external_process",
+)
+
+register_provider(pi_rpc)

--- a/plugins/model-providers/pi-rpc/plugin.yaml
+++ b/plugins/model-providers/pi-rpc/plugin.yaml
@@ -1,0 +1,5 @@
+name: pi-rpc-provider
+kind: model-provider
+version: 1.0.0
+description: Pi coding agent via native JSONL RPC
+author: local

--- a/scripts/validate_delegate_opencode.py
+++ b/scripts/validate_delegate_opencode.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+"""Live e2e validation of the OpenCode delegate_session backend (plan U4).
+
+Proves, against a real local ``opencode serve`` (no mocks):
+
+1. ``delegate_session(action='start', backend='opencode')`` opens a session.
+2. A delegate goal that forces the OpenCode ``ask`` tool produces a
+   ``question.asked`` request.
+3. Hermes answers it autonomously via ``_auto_answer_delegate_question`` /
+   ``run_oneshot`` (a parent-agent stub pins the expected answer in its
+   context) — zero user interaction.
+4. The OpenCode session transcript contains the Hermes-generated reply and
+   the delegate's final report.
+
+Usage: python scripts/validate_delegate_opencode.py [workdir]
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+
+def log(step: str, detail: str = "") -> None:
+    print(f"[validate] {step}{': ' + detail if detail else ''}", flush=True)
+
+
+class ParentStub:
+    """Minimal parent-agent stand-in: carries context run_oneshot reads."""
+
+    def __init__(self, secret: str):
+        self.session_id = "validate-opencode-e2e"
+        self.model = ""
+        self.provider = ""
+        self.base_url = ""
+        self.api_key = ""
+        self.api_mode = ""
+        self.auth_mode = ""
+        self._session_messages = [
+            {
+                "role": "user",
+                "content": (
+                    "Project decision already made: the password for this task is "
+                    f"exactly '{secret}'. Any delegate that asks for the password "
+                    "must be told this value verbatim."
+                ),
+            },
+            {"role": "assistant", "content": f"Understood; the password is {secret}."},
+        ]
+
+
+def main() -> int:
+    secret = "sunset-ferret-42"
+    workdir = sys.argv[1] if len(sys.argv) > 1 else tempfile.mkdtemp(prefix="oc-e2e-")
+    workdir = str(Path(workdir).resolve())
+    Path(workdir).mkdir(parents=True, exist_ok=True)
+    log("workdir", workdir)
+
+    answer_path = Path(workdir) / "answer.txt"
+
+    os.environ.setdefault("HERMES_DELEGATE_SESSION_BACKEND", "pi")  # default untouched
+
+    import tools.delegate_session_tool as ds
+
+    if not ds.check_delegate_session_requirements():
+        log("FAIL", "neither pi nor opencode available")
+        return 1
+
+    parent = ParentStub(secret)
+    goal = (
+        "You must use the built-in ask tool to ask the supervisor one question: "
+        "'What is the project password?' The question must offer these exact "
+        "options: 'sunset-ferret-42' and 'blue-otter-17'. After receiving the "
+        f"answer via the ask tool, write the received answer to the exact file "
+        f"path {answer_path} (contents: exactly the answer you received, single "
+        "line), then reply with DONE and the answer. Do the file write yourself "
+        "with the write tool; do not delegate it to a subagent."
+    )
+
+    log("starting opencode delegate session")
+    raw = ds.delegate_session(
+        action="start", goal=goal, backend="opencode",
+        timeout=600, parent_agent=parent,
+    )
+    start_payload = json.loads(raw)
+    if not start_payload.get("success"):
+        log("FAIL", f"start failed: {raw[:1000]}")
+        return 1
+    sid = start_payload["session_id"]
+    log("session started", f"id={sid} backend={start_payload.get('backend')} native={start_payload.get('native_session_id')}")
+
+    # Watch the turn; record any question that was answered.
+    answered: list[dict] = []
+    original = ds._auto_answer_delegate_question
+
+    def spy(parent_agent, backend_name, method, question, options):
+        answer = original(parent_agent, backend_name, method, question, options)
+        answered.append({"method": method, "question": question, "answer": answer})
+        log("question auto-answered", f"{method}: {question!r} -> {answer!r}")
+        return answer
+
+    ds._auto_answer_delegate_question = spy
+    try:
+        deadline = time.time() + 600
+        final_text = None
+        while time.time() < deadline:
+            status = json.loads(ds.delegate_session(action="status", session_id=sid, parent_agent=parent))
+            if status.get("error"):
+                log("FAIL", f"session error: {status['error']}")
+                return 1
+            last = (status.get("last_result") or {}).get("text")
+            if status.get("status") == "idle" and last:
+                final_text = last
+                break
+            time.sleep(3)
+    finally:
+        ds._auto_answer_delegate_question = original
+
+    if final_text is None:
+        log("FAIL", "turn never produced a result")
+        return 1
+    log("turn finished", f"result: {final_text[:300]}")
+
+    ok = True
+    if not answered:
+        log("FAIL", "no question.asked was observed/replied")
+        ok = False
+    else:
+        q = answered[0]
+        if secret not in str(q.get("answer")):
+            log("FAIL", f"auto-answer did not contain the secret: {q.get('answer')!r}")
+            ok = False
+
+    answer_file = Path(workdir) / "answer.txt"
+    if not answer_file.is_file():
+        log("FAIL", "delegate did not write answer.txt")
+        ok = False
+    else:
+        contents = answer_file.read_text().strip()
+        log("answer.txt", contents)
+        if secret not in contents:
+            log("FAIL", "answer.txt does not contain the Hermes-provided answer")
+            ok = False
+
+    # Transcript check: the reply payload we sent shows up in the session messages.
+    raw_msgs = ds.delegate_session(action="messages", session_id=sid, parent_agent=parent)
+    msgs_payload = json.loads(raw_msgs)
+    transcript = msgs_payload.get("messages_json", "")
+    if secret not in transcript:
+        log("FAIL", "session transcript does not contain the auto-answered secret")
+        ok = False
+    else:
+        log("transcript contains Hermes-generated answer")
+
+    try:
+        ds.delegate_session(action="stop", session_id=sid, parent_agent=parent)
+        log("session stopped")
+    finally:
+        if workdir.startswith(tempfile.gettempdir()):
+            shutil.rmtree(workdir, ignore_errors=True)
+
+    log("RESULT", "PASS — OpenCode question answered autonomously by Hermes" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_opencode_client.py
+++ b/tests/agent/test_opencode_client.py
@@ -263,10 +263,11 @@ def test_server_singleton_spawn_readiness_and_release(tmp_path, monkeypatch):
     monkeypatch.delenv("HERMES_OPENCODE_SERVER_URL", raising=False)
     oc._reset_server_singleton()
     try:
-        handle = oc.acquire_opencode_server()
+        handle = oc.acquire_opencode_server(working_directory=str(tmp_path))
         assert handle.base_url.startswith("http://127.0.0.1:")
-        # Second acquire reuses the same process.
-        again = oc.acquire_opencode_server()
+        key = str(tmp_path)
+        # Second acquire for the same directory reuses the same process.
+        again = oc.acquire_opencode_server(working_directory=str(tmp_path))
         assert again is handle
         import urllib.request
 
@@ -278,7 +279,7 @@ def test_server_singleton_spawn_readiness_and_release(tmp_path, monkeypatch):
         while handle.proc.poll() is None and time.time() < deadline:
             time.sleep(0.05)
         assert handle.proc.poll() is not None
-        assert oc._server_state() is None
+        assert key not in oc._server_state()
     finally:
         oc._reset_server_singleton()
 

--- a/tests/agent/test_opencode_client.py
+++ b/tests/agent/test_opencode_client.py
@@ -265,21 +265,28 @@ def test_server_singleton_spawn_readiness_and_release(tmp_path, monkeypatch):
     try:
         handle = oc.acquire_opencode_server(working_directory=str(tmp_path))
         assert handle.base_url.startswith("http://127.0.0.1:")
-        key = str(tmp_path)
-        # Second acquire for the same directory reuses the same process.
-        again = oc.acquire_opencode_server(working_directory=str(tmp_path))
+        # Acquires for DIFFERENT directories reuse the same single server.
+        other = tmp_path / "other"
+        other.mkdir()
+        again = oc.acquire_opencode_server(working_directory=str(other))
         assert again is handle
         import urllib.request
 
         with urllib.request.urlopen(f"{handle.base_url}/session", timeout=5) as resp:
             assert resp.status == 200
+        # Release does NOT terminate the shared server — it stays warm.
         oc.release_opencode_server(handle)
         oc.release_opencode_server(handle)
+        time.sleep(0.3)
+        assert handle.proc.poll() is None
+        assert oc._server_state()
+        # Explicit shutdown terminates it.
+        oc.shutdown_opencode_server()
         deadline = time.time() + 10
         while handle.proc.poll() is None and time.time() < deadline:
             time.sleep(0.05)
         assert handle.proc.poll() is not None
-        assert key not in oc._server_state()
+        assert not oc._server_state()
     finally:
         oc._reset_server_singleton()
 

--- a/tests/agent/test_opencode_client.py
+++ b/tests/agent/test_opencode_client.py
@@ -1,0 +1,312 @@
+"""Hermetic coverage for the OpenCode delegate backend client.
+
+No network, no real ``opencode`` binary: the HTTP transport and the server
+process are injected fakes.  Payload shapes mirror the opencode 1.18.x server
+OpenAPI surface (probed live 2026-08-24): ``prompt_async`` returns HTTP 204,
+messages are ``{info:{id,role,...}, parts:[{type:"text",text},...]}``, and
+question replies are ``{answers:[[label], ...]}`` with one entry per question.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.parse
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import agent.opencode_client as oc
+from agent.opencode_client import OpenCodeClient
+
+
+class FakeTransport:
+    """Scriptable HTTP transport recording requests in order."""
+
+    def __init__(self, responses, default=None):
+        # responses: list of (status, obj_or_text) or callables
+        # default: repeatable (status, obj_or_text) served once scripted
+        # responses run out — lets polling loops run without exhaustively
+        # scripting every tick.
+        self.responses = list(responses)
+        self.default = default
+        self.requests: list[tuple[str, str, dict | None]] = []
+
+    def request(self, method, path, body=None):
+        self.requests.append((method, path, body))
+        if self.responses:
+            nxt = self.responses.pop(0)
+        elif self.default is not None:
+            nxt = self.default
+        else:
+            raise AssertionError(f"unexpected request after scripted responses: {method} {path}")
+        if callable(nxt):
+            nxt = nxt(method, path, body)
+        status, payload = nxt
+        text = payload if isinstance(payload, str) else json.dumps(payload)
+        return status, text
+
+
+def _msg(mid, role, text, created=1):
+    return {
+        "info": {"id": mid, "sessionID": "ses_x", "role": role, "time": {"created": created}},
+        "parts": [{"id": f"prt_{mid}", "type": "text", "text": text}],
+    }
+
+
+def make_client(transport, answerer=None, preset_session=True):
+    client = OpenCodeClient(
+        persistent_session=True,
+        session_id="hermes-test",
+        session_name="Hermes test",
+        acp_cwd="/tmp",
+        question_answerer=answerer,
+        transport_factory=lambda cwd: transport,
+    )
+    if preset_session:
+        # Mirror the delegate-tool flow: the tool layer opens the native
+        # session (start) before dispatching turns, so scripted responses
+        # below begin at prompt_async.  The start test itself disables this.
+        client.native_session_id = "ses_x"
+    return client
+
+
+def test_start_creates_session_and_returns_native_id():
+    transport = FakeTransport([(200, {"id": "ses_abc", "title": "Hermes test"})])
+    client = make_client(transport, preset_session=False)
+    state = client.start(timeout=5.0)
+    assert state["sessionId"] == "ses_abc"
+    method, path, body = transport.requests[0]
+    assert method == "POST" and path.startswith("/session")
+    assert "directory" in path
+    assert body == {"title": "Hermes test"}
+
+
+def test_run_prompt_waits_for_new_assistant_text():
+    final = [_msg("m1", "user", "hi", 1), _msg("m2", "assistant", "hello!", 2)]
+    transport = FakeTransport(
+        [
+            (204, ""),  # prompt_async accepted
+            (200, [_msg("m1", "user", "hi", 1)]),  # baseline snapshot
+            (200, [_msg("m1", "user", "hi", 1)]),  # poll 1: nothing new
+        ],
+        default=lambda _m, _p, _b: (200, final if _p.startswith("/session") else []),
+    )
+    client = make_client(transport)
+    result = client.run_session_prompt("hi", timeout_seconds=5.0)
+    assert result["text"] == "hello!"
+    assert result["state"]["sessionId"] == "ses_x"
+    assert result["duration_s"] >= 0.0
+
+
+def test_run_prompt_timeout_aborts_and_raises():
+    transport = FakeTransport([(204, "")], default=(200, []))
+    client = make_client(transport)
+    with pytest.raises(TimeoutError):
+        client.run_session_prompt("hi", timeout_seconds=0.2, poll_interval=0.05)
+    methods = [r[0] for r in transport.requests]
+    assert "POST" in methods and any("abort" in r[1] for r in transport.requests)
+
+
+def _question_script(question, assistant_text="done", mid="m2"):
+    """Scripted transport flow: prompt, pending question, then a reply-triggered
+    assistant reply.  The assistant message only appears after the question
+    reply/reject was actually POSTed, proving the answer path unblocked the turn."""
+    state: dict = {"replied": False}
+    empty_msgs = (200, [_msg("m1", "user", "hi", 1)])
+    final_msgs = (200, [_msg("m1", "user", "hi", 1), _msg(mid, "assistant", assistant_text, 2)])
+    qdir = "?" + urllib.parse.urlencode({"directory": "/tmp"})
+
+    def questions(_m, path, _b):
+        # Only answer the scoped listing; the completion check polls it too.
+        return (200, [question]) if (not state["replied"] and path == f"/question{qdir}") else (200, [])
+
+    def messages(_m, _p, _b):
+        return final_msgs if state["replied"] else empty_msgs
+
+    def capture(method, path, body):
+        if method == "POST" and "/question/" in path and (f"/reply{qdir}" in path or f"/reject{qdir}" in path):
+            state["replied"] = True
+            return (204, "")
+        raise AssertionError(f"unexpected POST in question script: {path}")
+
+    def route(method, path, body):
+        # Repeatable router served once the scripted list runs out: any number
+        # of extra question/message polls is fine, shape follows state.
+        if path.startswith("/question"):
+            return questions(method, path, body)
+        if path.startswith("/session"):
+            return messages(method, path, body)
+        raise AssertionError(f"unexpected request in question script: {method} {path}")
+
+    return [
+        (204, ""),  # prompt_async
+        empty_msgs,  # baseline snapshot (taken before the poll loop)
+        questions,  # tick 1: pending question found
+        capture,  # reply/reject POST unblocks the turn
+    ], route
+
+
+def test_question_answered_with_reply_payload():
+    question = {
+        "id": "que_1",
+        "sessionID": "ses_x",
+        "questions": [
+            {
+                "question": "Which color?",
+                "header": "Color",
+                "options": [{"label": "red", "description": "r"}, {"label": "blue", "description": "b"}],
+                "multiple": False,
+                "custom": False,
+            }
+        ],
+    }
+    seen: dict = {}
+
+    def answerer(method, question_text, options):
+        seen["args"] = (method, question_text, list(options))
+        return "blue"
+
+    transport = scripted, router = _question_script(question)
+    transport = FakeTransport(scripted, default=router)
+    client = make_client(transport, answerer=answerer)
+    result = client.run_session_prompt("hi", timeout_seconds=5.0, poll_interval=0.05)
+    assert result["text"] == "done"
+    assert seen["args"][0] == "select"
+    assert seen["args"][1] == "Which color?"
+    assert seen["args"][2] == ["red", "blue"]
+    qdir = client._qdir()
+    reply = [r for r in transport.requests if r[1] == f"/question/que_1/reply{qdir}"]
+    assert reply and reply[0][2] == {"answers": [["blue"]]}
+
+
+def test_question_unanswerable_rejected():
+    question = {
+        "id": "que_2",
+        "sessionID": "ses_x",
+        "questions": [{"question": "Q?", "header": "H", "options": [], "multiple": False, "custom": False}],
+    }
+    transport = scripted, router = _question_script(question, assistant_text="ok")
+    transport = FakeTransport(scripted, default=router)
+    client = make_client(transport, answerer=lambda *a: None)
+    result = client.run_session_prompt("hi", timeout_seconds=5.0, poll_interval=0.05)
+    assert result["text"] == "ok"
+    qdir = client._qdir()
+    assert any(r[1] == f"/question/que_2/reject{qdir}" for r in transport.requests)
+
+
+def test_question_for_other_session_ignored():
+    question = {"id": "que_3", "sessionID": "ses_OTHER", "questions": [{"question": "?", "header": "H", "options": []}]}
+    final = [_msg("m1", "user", "hi", 1), _msg("m2", "assistant", "ok", 2)]
+
+    def route(method, path, body):
+        # Repeatable default: questions stay foreign, messages settle on the
+        # final transcript so the completion convergence can trigger.
+        if path.startswith("/question"):
+            return (200, [question])
+        return (200, final)
+
+    transport = FakeTransport(
+        [
+            (204, ""),  # prompt_async
+            (200, [_msg("m1", "user", "hi", 1)]),  # baseline snapshot
+        ],
+        default=route,
+    )
+    client = make_client(transport, answerer=lambda *a: pytest.fail("must not answer other sessions"))
+    assert client.run_session_prompt("hi", timeout_seconds=5.0, poll_interval=0.05)["text"] == "ok"
+    assert not any("/question/que_3/reply" in r[1] for r in transport.requests)
+
+
+def test_abort_and_messages_and_close():
+    transport = FakeTransport(
+        [
+            (204, ""),  # abort
+            (200, [_msg("m1", "user", "hi", 1), _msg("m2", "assistant", "ok", 2)]),
+        ],
+        default=(200, []),
+    )
+    client = make_client(transport)
+    client.abort(timeout=5.0)
+    assert any("abort" in r[1] for r in transport.requests)
+    messages = client.get_messages(timeout=5.0)
+    assert messages[-1]["info"]["role"] == "assistant"
+    client.close()  # no server ref -> no crash
+
+
+def test_get_messages_missing_session_is_error():
+    transport = FakeTransport([(404, json.dumps({"name": "NotFoundError", "data": {"message": "SessionNotFound"}}))])
+    client = make_client(transport)
+    with pytest.raises(RuntimeError):
+        client.get_messages(timeout=5.0)
+
+
+def test_server_singleton_spawn_readiness_and_release(tmp_path, monkeypatch):
+    stub = tmp_path / "opencode-stub.py"
+    stub.write_text(
+        "import sys\n"
+        "from http.server import BaseHTTPRequestHandler, HTTPServer\n"
+        "port = int(sys.argv[sys.argv.index('--port') + 1])\n"
+        "class H(BaseHTTPRequestHandler):\n"
+        "    def do_GET(self):\n"
+        "        if self.path.startswith('/session'):\n"
+        "            self.send_response(200); self.end_headers(); self.wfile.write(b'[]')\n"
+        "        else:\n"
+        "            self.send_response(200); self.end_headers(); self.wfile.write(b'{}')\n"
+        "    def log_message(self, *a): pass\n"
+        "HTTPServer(('127.0.0.1', port), H).serve_forever()\n"
+    )
+    monkeypatch.setenv("HERMES_OPENCODE_BIN", f"{sys.executable} {stub}")
+    monkeypatch.delenv("HERMES_OPENCODE_SERVER_URL", raising=False)
+    oc._reset_server_singleton()
+    try:
+        handle = oc.acquire_opencode_server()
+        assert handle.base_url.startswith("http://127.0.0.1:")
+        # Second acquire reuses the same process.
+        again = oc.acquire_opencode_server()
+        assert again is handle
+        import urllib.request
+
+        with urllib.request.urlopen(f"{handle.base_url}/session", timeout=5) as resp:
+            assert resp.status == 200
+        oc.release_opencode_server(handle)
+        oc.release_opencode_server(handle)
+        deadline = time.time() + 10
+        while handle.proc.poll() is None and time.time() < deadline:
+            time.sleep(0.05)
+        assert handle.proc.poll() is not None
+        assert oc._server_state() is None
+    finally:
+        oc._reset_server_singleton()
+
+
+def test_external_server_url_env_short_circuits_spawn(monkeypatch):
+    monkeypatch.setenv("HERMES_OPENCODE_SERVER_URL", "http://127.0.0.1:9999")
+    oc._reset_server_singleton()
+    try:
+        handle = oc.acquire_opencode_server()
+        assert handle.base_url == "http://127.0.0.1:9999"
+        assert handle.proc is None  # externally managed, never terminated by us
+        oc.release_opencode_server(handle)
+    finally:
+        oc._reset_server_singleton()
+
+
+def test_is_dead_tracks_server_process(monkeypatch):
+    monkeypatch.delenv("HERMES_OPENCODE_SERVER_URL", raising=False)
+
+    class DeadProc:
+        returncode = 3
+
+        def poll(self):
+            return 3
+
+    transport = FakeTransport([(200, {"id": "ses_x"})])
+    client = make_client(transport)
+    client._server_handle = type("H", (), {"proc": DeadProc(), "refcount": 1})()
+    assert client.is_dead()
+    client._server_handle = None
+    assert not client.is_dead()

--- a/tests/agent/test_pi_rpc_client.py
+++ b/tests/agent/test_pi_rpc_client.py
@@ -84,8 +84,8 @@ def clean_registry():
     pending_questions.clear()
 
 
-def make_client(fake_pi):
-    return PiRPCClient(acp_command=fake_pi, base_url="pi://rpc-test")
+def make_client(fake_pi, **kwargs):
+    return PiRPCClient(acp_command=fake_pi, base_url="pi://rpc-test", **kwargs)
 
 
 def create(client, content, timeout=120):
@@ -154,6 +154,51 @@ def test_answer_oldest_empty_registry(clean_registry):
     assert answer_oldest_pending_question("x") is False
 
 
+def test_extension_question_dispatch_does_not_block_rpc_reader(fake_pi):
+    client = make_client(fake_pi)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_handler(_msg):
+        entered.set()
+        release.wait(timeout=2)
+
+    client._handle_ui_request = blocking_handler
+    started = time.monotonic()
+    client._dispatch({"type": "extension_ui_request", "id": 7, "method": "input", "title": "q"})
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.2
+    assert entered.wait(timeout=1)
+    release.set()
+    client.close()
+
+
+def test_close_wakes_owned_pending_questions(fake_pi, clean_registry):
+    client = make_client(fake_pi)
+    q = PendingQuestion("input", "still there?", None, owner=client)
+    pending_questions[q.id] = q
+
+    client.close()
+
+    assert q.answered.wait(timeout=0.2)
+    assert q.answer == {"cancelled": True}
+    assert q.id not in pending_questions
+
+
+def test_close_fails_pending_rpc_waiters_immediately(fake_pi):
+    client = make_client(fake_pi)
+    waiter = threading.Event()
+    slot = [None]
+    with client._pending_lock:
+        client._pending[123] = [waiter, slot]
+
+    client.close()
+
+    assert waiter.is_set()
+    assert slot[0]["success"] is False
+    assert "closed" in slot[0]["error"]
+
+
 # ------------------------------------------------------- e2e over fake pi
 
 def test_round_trip_markers_question_footer(fake_pi, clean_registry):
@@ -180,6 +225,25 @@ def test_round_trip_markers_question_footer(fake_pi, clean_registry):
     assert "pi-delegation-result" in msg.content
     # tool markers ride the reasoning field for shared parsing
     assert "[pi-tool:ok] bash" in (msg.reasoning or "")
+    client.close()
+
+
+def test_persistent_question_answerer_resolves_without_user_steer(fake_pi, clean_registry):
+    calls = []
+
+    def answerer(method, title, options):
+        calls.append((method, title, options))
+        return "6543"
+
+    client = make_client(fake_pi, persistent_session=True, question_answerer=answerer)
+    completion = create(client, "go", timeout=180)
+    msg = completion.choices[0].message
+
+    assert "answered with: 6543" in msg.content
+    assert calls == [("input", "Which DB port?", [])]
+    assert pending_questions == {}
+    assert "Question from pi delegate" not in msg.content
+    assert "[pi-question:auto] Hermes answered" in (msg.reasoning or "")
     client.close()
 
 

--- a/tests/agent/test_pi_rpc_client.py
+++ b/tests/agent/test_pi_rpc_client.py
@@ -13,7 +13,6 @@ the real binary or network. Pins the behaviors the parent relies on:
 
 import stat
 import sys
-import textwrap
 import threading
 import time
 
@@ -29,41 +28,45 @@ from agent.pi_rpc_client import (
 
 # ---------------------------------------------------------------- fake pi
 
-FAKE_PI = textwrap.dedent(
-    """
-    import json, sys
-    def send(o): sys.stdout.write(json.dumps(o) + "\\n"); sys.stdout.flush()
-    send({"type": "ready"})
-    prompt_id = None
-    while True:
-        line = sys.stdin.readline()
-        if not line:
-            break
-        line = line.strip()
-        if not line:
-            continue
-        msg = json.loads(line)
-        if msg.get("type") == "prompt":
-            prompt_id = msg["id"]
-            # 1) tool-call markers (reasoning), 2) a question, 3) block
-            # here (NOT in the for-loop) until answered, 4) final answer
-            # echoing the response payload + footer.
-            send({"type": "assistant", "thought":
-                  '[pi-tool] bash {"cmd": "ls"}\n'
-                  "[pi-tool:ok] bash -> result 12 bytes"})
-            send({"type": "extension_ui_request", "id": 9001,
-                  "method": "input", "title": "Which DB port?"})
-            while True:
-                r = json.loads(sys.stdin.readline())
-                if r.get("type") == "extension_ui_response":
-                    ans = r.get("text")
-                    break
-            footer = "{\"status\": \"end_turn\", \"duration_s\": 1.5, \"touched_files\": []}"
-            send({"type": "assistant",
-                  "text": "answered with: %s\n```pi-delegation-result\n%s\n```" % (ans, footer)})
-            send({"type": "prompt_done", "id": prompt_id})
-    """
-)
+# The fake pi script. Built as a plain string (not a triple-quoted blob)
+# so indentation is explicit and a stray margin can never break dedent.
+FAKE_PI = "\n".join([
+    "import json, sys",
+    "last_text = ''",
+    "def send(o): sys.stdout.write(json.dumps(o) + chr(10)); sys.stdout.flush()",
+    'send({"type": "ready"})',
+    "while True:",
+    "    line = sys.stdin.readline()",
+    "    if not line: break",
+    "    line = line.strip()",
+    "    if not line: continue",
+    "    msg = json.loads(line)",
+    '    if msg.get("type") == "get_last_assistant_text":',
+    '        send({"type": "response", "id": msg["id"], "success": True,',
+    '              "data": {"text": last_text}})',
+    '        continue',
+    '    if msg.get("type") != "prompt": continue',
+    '    # acknowledge the request, then run the scripted exchange:',
+    '    # 1) tool-call markers (reasoning), 2) a question, 3) block',
+    '    # until answered, 4) final answer echoing the answer + footer.',
+    '    send({"type": "response", "id": msg["id"], "success": True})',
+    '    send({"type": "assistant", "thought":',
+    '          \'[pi-tool] bash {"cmd": "ls"}\\n[pi-tool:ok] bash -> result 12 bytes\'})',
+    '    send({"type": "message_update", "assistantMessageEvent":',
+    '          {"type": "thinking_delta", "delta":',
+    '           \'[pi-tool] bash {"cmd": "ls"}\\n[pi-tool:ok] bash -> result 12 bytes\\n\'}})',
+    '    send({"type": "extension_ui_request", "id": 9001,',
+    '          "method": "input", "title": "Which DB port?"})',
+    "    while True:",
+    "        r = json.loads(sys.stdin.readline())",
+    '        if r.get("type") == "extension_ui_response":',
+    '            ans = r.get("text"); break',
+    '    footer = \'{"status": "end_turn", "duration_s": 1.5, "touched_files": []}\'',
+    '    send({"type": "assistant", "text": "answered with: %s\\n```pi-delegation-result\\n%s\\n```" % (ans, footer)})',
+    '    last_text = "answered with: %s" % ans',
+    '    send({"type": "prompt_done", "id": msg["id"]})',
+    '    send({"type": "agent_settled"})',
+])
 
 
 @pytest.fixture
@@ -85,9 +88,11 @@ def make_client(fake_pi):
     return PiRPCClient(acp_command=fake_pi, base_url="pi://rpc-test")
 
 
-def create(client, content):
+def create(client, content, timeout=120):
     return client.chat.completions.create(
-        model="test-model", messages=[{"role": "user", "content": content}]
+        model="test-model",
+        messages=[{"role": "user", "content": content}],
+        timeout=timeout,
     )
 
 
@@ -156,14 +161,17 @@ def test_round_trip_markers_question_footer(fake_pi, clean_registry):
     # Background answerer stands in for steer_subagent's routing: as soon
     # as the child's question registers, answer it with free text.
     def answerer():
-        for _ in range(200):
+        # Poll far longer than the 600s file-level budget: under heavy
+        # parallel load the fake-pi spawn can take a while, and if this
+        # thread gives up the question waits on the full default timeout.
+        for _ in range(2000):
             if pending_questions:
                 answer_oldest_pending_question("5432")
                 return
-            time.sleep(0.05)
+            time.sleep(0.1)
     t = threading.Thread(target=answerer, daemon=True)
     t.start()
-    completion = create(client, "delegate this")
+    completion = create(client, "delegate this", timeout=180)
     t.join(timeout=5)
     msg = completion.choices[0].message
     # free-text answer reached the child and is echoed in its final text
@@ -179,7 +187,7 @@ def test_question_timeout_auto_answers(fake_pi, clean_registry, monkeypatch):
     monkeypatch.setattr("agent.pi_rpc_client._DEFAULT_QUESTION_TIMEOUT", 1.0)
     client = make_client(fake_pi)
     start = time.time()
-    completion = create(client, "go")
+    completion = create(client, "go", timeout=180)
     elapsed = time.time() - start
     # No steer ever arrives: after ~1s the input question is auto-answered
     # (cancelled policy), the run still completes with a footer.

--- a/tests/agent/test_pi_rpc_client.py
+++ b/tests/agent/test_pi_rpc_client.py
@@ -1,0 +1,199 @@
+"""PiRPCClient — native pi --mode rpc delegate contract.
+
+Hermetic: exercises the JSONL protocol against a fake pi subprocess, never
+the real binary or network. Pins the behaviors the parent relies on:
+(1) tool markers + result footer surface on the shim message exactly like
+    the pi-acp bridge's, so existing parsing in conversation_loop /
+    delegate_tool is shared unchanged;
+(2) extension_ui_request questions register as pending and free-text
+    answers map per method (input/editor -> text, select -> option match
+    or index, confirm -> yes/no), with safe auto-answer fallback;
+(3) the pi-rpc provider resolves without any ACP env vars set.
+"""
+
+import stat
+import sys
+import textwrap
+import threading
+import time
+
+import pytest
+
+from agent.pi_rpc_client import (
+    PiRPCClient,
+    PendingQuestion,
+    answer_oldest_pending_question,
+    pending_questions,
+)
+
+
+# ---------------------------------------------------------------- fake pi
+
+FAKE_PI = textwrap.dedent(
+    """
+    import json, sys
+    def send(o): sys.stdout.write(json.dumps(o) + "\\n"); sys.stdout.flush()
+    send({"type": "ready"})
+    prompt_id = None
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            break
+        line = line.strip()
+        if not line:
+            continue
+        msg = json.loads(line)
+        if msg.get("type") == "prompt":
+            prompt_id = msg["id"]
+            # 1) tool-call markers (reasoning), 2) a question, 3) block
+            # here (NOT in the for-loop) until answered, 4) final answer
+            # echoing the response payload + footer.
+            send({"type": "assistant", "thought":
+                  '[pi-tool] bash {"cmd": "ls"}\n'
+                  "[pi-tool:ok] bash -> result 12 bytes"})
+            send({"type": "extension_ui_request", "id": 9001,
+                  "method": "input", "title": "Which DB port?"})
+            while True:
+                r = json.loads(sys.stdin.readline())
+                if r.get("type") == "extension_ui_response":
+                    ans = r.get("text")
+                    break
+            footer = "{\"status\": \"end_turn\", \"duration_s\": 1.5, \"touched_files\": []}"
+            send({"type": "assistant",
+                  "text": "answered with: %s\n```pi-delegation-result\n%s\n```" % (ans, footer)})
+            send({"type": "prompt_done", "id": prompt_id})
+    """
+)
+
+
+@pytest.fixture
+def fake_pi(tmp_path):
+    p = tmp_path / "fake-pi"
+    p.write_text("#!%s\n%s" % (sys.executable, FAKE_PI))
+    p.chmod(p.stat().st_mode | stat.S_IEXEC)
+    return str(p)
+
+
+@pytest.fixture
+def clean_registry():
+    pending_questions.clear()
+    yield
+    pending_questions.clear()
+
+
+def make_client(fake_pi):
+    return PiRPCClient(acp_command=fake_pi, base_url="pi://rpc-test")
+
+
+def create(client, content):
+    return client.chat.completions.create(
+        model="test-model", messages=[{"role": "user", "content": content}]
+    )
+
+
+# ------------------------------------------------- answer text mapping
+
+@pytest.mark.parametrize(
+    "method,steer,expected",
+    [
+        ("input", "PostgreSQL on 5432", {"text": "PostgreSQL on 5432"}),
+        ("editor", "line1\nline2", {"text": "line1\nline2"}),
+        ("input", "  trimmed  ", {"text": "trimmed"}),
+        ("select", "2", {"value": "Use REST"}),
+        ("select", "use grpc", {"value": "Use gRPC"}),
+        ("confirm", "yes", {"confirmed": True}),
+        ("confirm", "no", {"confirmed": False}),
+        ("confirm", "cancel", {"confirmed": False}),
+    ],
+)
+def test_answer_with_maps_per_method(method, steer, expected):
+    q = PendingQuestion(method, "q", ["Use gRPC", "Use REST"])
+    assert q.answer_with(steer) == expected
+
+
+def test_select_fallbacks_never_crash():
+    # non-matching, non-numeric text -> first option; empty options -> cancel
+    q = PendingQuestion("select", "t", ["a", "b"])
+    assert q.answer_with("whatever") == {"value": "a"}
+    q2 = PendingQuestion("select", "t", [])
+    assert q2.answer_with("anything") == {"cancelled": True}
+
+
+def test_empty_input_is_cancelled_not_empty_text():
+    q = PendingQuestion("input", "t", None)
+    assert q.answer_with("   ") == {"cancelled": True}
+
+
+def test_auto_answer_policy():
+    assert PendingQuestion("confirm", "t", None).auto_answer() == {"confirmed": True}
+    assert PendingQuestion("select", "t", ["a"]).auto_answer() == {"value": "a"}
+    assert PendingQuestion("input", "t", None).auto_answer() == {"cancelled": True}
+
+
+# ---------------------------------------------------------------- registry
+
+def test_answer_oldest_routes_to_oldest(clean_registry):
+    old = PendingQuestion("input", "old", None)
+    old.created_at -= 10
+    new = PendingQuestion("input", "new", None)
+    pending_questions[old.id] = old
+    pending_questions[new.id] = new
+    assert answer_oldest_pending_question("the answer") is True
+    assert old.id not in pending_questions
+    assert new.id in pending_questions
+    assert old.answer == {"text": "the answer"}
+    assert old.answered.is_set()
+
+
+def test_answer_oldest_empty_registry(clean_registry):
+    assert answer_oldest_pending_question("x") is False
+
+
+# ------------------------------------------------------- e2e over fake pi
+
+def test_round_trip_markers_question_footer(fake_pi, clean_registry):
+    client = make_client(fake_pi)
+    # Background answerer stands in for steer_subagent's routing: as soon
+    # as the child's question registers, answer it with free text.
+    def answerer():
+        for _ in range(200):
+            if pending_questions:
+                answer_oldest_pending_question("5432")
+                return
+            time.sleep(0.05)
+    t = threading.Thread(target=answerer, daemon=True)
+    t.start()
+    completion = create(client, "delegate this")
+    t.join(timeout=5)
+    msg = completion.choices[0].message
+    # free-text answer reached the child and is echoed in its final text
+    assert "answered with: 5432" in msg.content
+    # footer contract intact on the final message
+    assert "pi-delegation-result" in msg.content
+    # tool markers ride the reasoning field for shared parsing
+    assert "[pi-tool:ok] bash" in (msg.reasoning or "")
+    client.close()
+
+
+def test_question_timeout_auto_answers(fake_pi, clean_registry, monkeypatch):
+    monkeypatch.setattr("agent.pi_rpc_client._DEFAULT_QUESTION_TIMEOUT", 1.0)
+    client = make_client(fake_pi)
+    start = time.time()
+    completion = create(client, "go")
+    elapsed = time.time() - start
+    # No steer ever arrives: after ~1s the input question is auto-answered
+    # (cancelled policy), the run still completes with a footer.
+    assert elapsed < 30
+    assert "pi-delegation-result" in completion.choices[0].message.content
+    assert pending_questions == {}
+    client.close()
+
+
+# ---------------------------------------------------------------- provider
+
+def test_pi_rpc_provider_resolves_without_acp_env(monkeypatch):
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+    monkeypatch.delenv("HERMES_COPILOT_ACP_COMMAND", raising=False)
+    monkeypatch.delenv("HERMES_COPILOT_ACP_ARGS", raising=False)
+    r = resolve_runtime_provider(requested="pi-rpc")
+    assert r is not None

--- a/tests/agent/test_pi_rpc_client.py
+++ b/tests/agent/test_pi_rpc_client.py
@@ -135,6 +135,83 @@ def test_auto_answer_policy():
     assert PendingQuestion("input", "t", None).auto_answer() == {"cancelled": True}
 
 
+def test_supervised_fallback_never_silently_approves():
+    assert PendingQuestion("confirm", "t", None).supervised_fallback() == {"confirmed": False}
+    assert PendingQuestion("select", "t", ["a", "b"]).supervised_fallback() == {"value": "a"}
+    assert PendingQuestion("select", "t", []).supervised_fallback() == {"cancelled": True}
+    assert PendingQuestion("input", "t", None).supervised_fallback() == {"cancelled": True}
+    assert PendingQuestion("editor", "t", None).supervised_fallback() == {"cancelled": True}
+
+
+@pytest.mark.parametrize(
+    "method,options,answer,expected",
+    [
+        ("input", [], "5432", {"value": "5432"}),
+        ("editor", [], "line1\nline2", {"value": "line1\nline2"}),
+        ("select", ["Use REST", "Use gRPC"], "Use gRPC", {"value": "Use gRPC"}),
+        ("confirm", [], "yes", {"confirmed": True}),
+    ],
+)
+def test_persistent_auto_answer_handles_every_dialog_type(fake_pi, clean_registry, method, options, answer, expected):
+    sent = []
+    client = make_client(
+        fake_pi,
+        persistent_session=True,
+        question_answerer=lambda _method, _title, _options: answer,
+    )
+    client._send_pi = lambda payload: sent.append(payload)
+
+    client._handle_ui_request({"type": "extension_ui_request", "id": 77, "method": method, "title": "Question", "options": options})
+
+    assert sent == [{"type": "extension_ui_response", "id": 77, **expected}]
+    assert pending_questions == {}
+    client.close()
+
+
+@pytest.mark.parametrize(
+    "method,options,expected",
+    [
+        ("confirm", [], {"confirmed": False}),
+        ("select", ["safe", "risky"], {"value": "safe"}),
+        ("input", [], {"cancelled": True}),
+        ("editor", [], {"cancelled": True}),
+    ],
+)
+def test_persistent_answerer_failure_uses_conservative_fallback(fake_pi, clean_registry, method, options, expected):
+    sent = []
+
+    def failing_answerer(_method, _title, _options):
+        raise RuntimeError("answer model unavailable")
+
+    client = make_client(fake_pi, persistent_session=True, question_answerer=failing_answerer)
+    client._send_pi = lambda payload: sent.append(payload)
+
+    client._handle_ui_request({"type": "extension_ui_request", "id": 88, "method": method, "title": "Question", "options": options})
+
+    assert sent == [{"type": "extension_ui_response", "id": 88, **expected}]
+    assert pending_questions == {}
+    assert "conservative fallback" in "".join(client._reasoning_parts)
+    client.close()
+
+
+def test_concurrent_persistent_sessions_do_not_cross_answer(fake_pi, clean_registry):
+    sent_a = []
+    sent_b = []
+    client_a = make_client(fake_pi, persistent_session=True, question_answerer=lambda *_args: "alpha")
+    client_b = make_client(fake_pi, persistent_session=True, question_answerer=lambda *_args: "beta")
+    client_a._send_pi = lambda payload: sent_a.append(payload)
+    client_b._send_pi = lambda payload: sent_b.append(payload)
+
+    ta = threading.Thread(target=client_a._handle_ui_request, args=({"type": "extension_ui_request", "id": 101, "method": "input", "title": "A"},))
+    tb = threading.Thread(target=client_b._handle_ui_request, args=({"type": "extension_ui_request", "id": 202, "method": "input", "title": "B"},))
+    ta.start(); tb.start(); ta.join(timeout=2); tb.join(timeout=2)
+
+    assert sent_a == [{"type": "extension_ui_response", "id": 101, "value": "alpha"}]
+    assert sent_b == [{"type": "extension_ui_response", "id": 202, "value": "beta"}]
+    assert pending_questions == {}
+    client_a.close(); client_b.close()
+
+
 # ---------------------------------------------------------------- registry
 
 def test_answer_oldest_routes_to_oldest(clean_registry):

--- a/tests/agent/test_pi_rpc_client.py
+++ b/tests/agent/test_pi_rpc_client.py
@@ -60,7 +60,7 @@ FAKE_PI = "\n".join([
     "    while True:",
     "        r = json.loads(sys.stdin.readline())",
     '        if r.get("type") == "extension_ui_response":',
-    '            ans = r.get("text"); break',
+    '            ans = r.get("value"); break',
     '    footer = \'{"status": "end_turn", "duration_s": 1.5, "touched_files": []}\'',
     '    send({"type": "assistant", "text": "answered with: %s\\n```pi-delegation-result\\n%s\\n```" % (ans, footer)})',
     '    last_text = "answered with: %s" % ans',
@@ -101,9 +101,9 @@ def create(client, content, timeout=120):
 @pytest.mark.parametrize(
     "method,steer,expected",
     [
-        ("input", "PostgreSQL on 5432", {"text": "PostgreSQL on 5432"}),
-        ("editor", "line1\nline2", {"text": "line1\nline2"}),
-        ("input", "  trimmed  ", {"text": "trimmed"}),
+        ("input", "PostgreSQL on 5432", {"value": "PostgreSQL on 5432"}),
+        ("editor", "line1\nline2", {"value": "line1\nline2"}),
+        ("input", "  trimmed  ", {"value": "trimmed"}),
         ("select", "2", {"value": "Use REST"}),
         ("select", "use grpc", {"value": "Use gRPC"}),
         ("confirm", "yes", {"confirmed": True}),
@@ -117,11 +117,11 @@ def test_answer_with_maps_per_method(method, steer, expected):
 
 
 def test_select_fallbacks_never_crash():
-    # non-matching, non-numeric text -> first option; empty options -> cancel
+    # non-matching, non-numeric text passes through as freeform value; empty text -> cancel
     q = PendingQuestion("select", "t", ["a", "b"])
-    assert q.answer_with("whatever") == {"value": "a"}
+    assert q.answer_with("whatever") == {"value": "whatever"}
     q2 = PendingQuestion("select", "t", [])
-    assert q2.answer_with("anything") == {"cancelled": True}
+    assert q2.answer_with("  ") == {"cancelled": True}
 
 
 def test_empty_input_is_cancelled_not_empty_text():
@@ -146,7 +146,7 @@ def test_answer_oldest_routes_to_oldest(clean_registry):
     assert answer_oldest_pending_question("the answer") is True
     assert old.id not in pending_questions
     assert new.id in pending_questions
-    assert old.answer == {"text": "the answer"}
+    assert old.answer == {"value": "the answer"}
     assert old.answered.is_set()
 
 

--- a/tests/agent/test_pi_rpc_client.py
+++ b/tests/agent/test_pi_rpc_client.py
@@ -346,3 +346,86 @@ def test_pi_rpc_provider_resolves_without_acp_env(monkeypatch):
     monkeypatch.delenv("HERMES_COPILOT_ACP_ARGS", raising=False)
     r = resolve_runtime_provider(requested="pi-rpc")
     assert r is not None
+
+
+# ------------------------------------------------- review follow-up coverage
+
+
+def test_malformed_question_timeout_env_does_not_crash_import(monkeypatch):
+    import importlib
+
+    import agent.pi_rpc_client as mod
+
+    monkeypatch.setenv("HERMES_PI_QUESTION_TIMEOUT", "not-a-number")
+    with pytest.warns(UserWarning):
+        reloaded = importlib.reload(mod)
+    assert reloaded._DEFAULT_QUESTION_TIMEOUT == 600.0
+    monkeypatch.setenv("HERMES_PI_QUESTION_TIMEOUT", "120")
+    reloaded = importlib.reload(mod)
+    assert reloaded._DEFAULT_QUESTION_TIMEOUT == 120.0
+    monkeypatch.delenv("HERMES_PI_QUESTION_TIMEOUT", raising=False)
+    importlib.reload(mod)
+
+
+def test_explicit_args_are_honored_without_contradicting_session_flags(fake_pi):
+    # Explicit args (e.g. from credential resolution) must be passed through,
+    # but the internal mode/session flags derive from client state.
+    client = make_client(
+        fake_pi,
+        persistent_session=True,
+        session_id="sess-42",
+        args=["--mode", "acp", "--no-session", "--verbose"],
+    )
+    client._spawn()
+    argv = client._proc.args
+    assert "--verbose" in argv
+    assert argv.count("--mode") == 1
+    assert argv[argv.index("--mode") + 1] == "rpc"
+    assert "--no-session" not in argv
+    assert argv[argv.index("--session-id") + 1] == "sess-42"
+    client.close()
+
+
+def test_usage_tokens_captured_from_message_update(fake_pi):
+    # message_update events carrying usage (any of several key shapes pi has
+    # used) must land in the completion's token counts.
+    client = make_client(fake_pi)
+    client._dispatch({
+        "type": "message_update",
+        "assistantMessageEvent": {
+            "type": "usage",
+            "usage": {"prompt_tokens": 11, "completion_tokens": 7},
+        },
+    })
+    assert (client._prompt_tokens, client._completion_tokens) == (11, 7)
+    # camelCase shape on the event itself
+    client._dispatch({
+        "type": "message_update",
+        "assistantMessageEvent": {"type": "usage", "inputTokens": 20, "outputTokens": 9},
+    })
+    assert (client._prompt_tokens, client._completion_tokens) == (20, 9)
+    # usage-free events must not disturb counters
+    client._dispatch({
+        "type": "message_update",
+        "assistantMessageEvent": {"type": "text_delta", "delta": "hi"},
+    })
+    assert (client._prompt_tokens, client._completion_tokens) == (20, 9)
+
+
+def test_read_env_var_tolerates_export_and_quotes(tmp_path, monkeypatch):
+    from agent.copilot_acp_client import _read_env_var
+
+    monkeypatch.delenv("HERMES_X_TEST", raising=False)
+    env_file = tmp_path / "hermes-home" / ".hermes" / ".env"
+    env_file.parent.mkdir(parents=True)
+    env_file.write_text(
+        "export  HERMES_X_TEST = 'hello world'\n"
+        "OTHER=1\n"
+    )
+    monkeypatch.setenv("HOME", str(tmp_path / "hermes-home"))
+    assert _read_env_var("HERMES_X_TEST") == "hello world"
+    monkeypatch.setenv("HERMES_X_TEST", "from-process-env")
+    assert _read_env_var("HERMES_X_TEST") == "from-process-env"
+    monkeypatch.delenv("HERMES_X_TEST", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "nonexistent-home"))
+    assert _read_env_var("HERMES_X_TEST") is None

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -218,6 +218,15 @@ class TestToolsetConsistency:
         # silently let a platform diverge so far that nothing is shared).
         assert len(core) > 20, f"Suspiciously small shared core: {len(core)} tools"
 
+    def test_top_level_delegation_surfaces_include_persistent_sessions(self):
+        """Any top-level surface exposing Hermes child delegation must also expose Pi sessions."""
+        for name, toolset in TOOLSETS.items():
+            tools = set(toolset.get("tools", ()))
+            if "delegate_task" in tools:
+                assert "delegate_session" in tools, (
+                    f"{name} exposes delegate_task but hides delegate_session"
+                )
+
 
 class TestPluginToolsets:
     def test_get_all_toolsets_includes_plugin_toolset(self, monkeypatch):

--- a/tests/tools/test_delegate_session_tool.py
+++ b/tests/tools/test_delegate_session_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import threading
 import time
 
@@ -178,13 +179,20 @@ def test_auto_answer_uses_supervising_context_and_main_runtime(monkeypatch):
 
 def test_auto_answer_normalizes_confirm_and_select(monkeypatch):
     parent = Parent()
-    answers = iter(["Proceed, yes.", "use grpc"])
+    answers = iter(["Proceed, yes.", "use grpc", "2", "not one of the options", "maybe"])
     monkeypatch.setattr("agent.oneshot.run_oneshot", lambda **_kwargs: next(answers))
 
     assert ds._auto_answer_pi_question(parent, "confirm", "Continue?", []) == "yes"
     assert ds._auto_answer_pi_question(
         parent, "select", "Transport?", ["Use REST", "Use gRPC"]
     ) == "Use gRPC"
+    assert ds._auto_answer_pi_question(
+        parent, "select", "Transport?", ["Use REST", "Use gRPC"]
+    ) == "Use gRPC"
+    assert ds._auto_answer_pi_question(
+        parent, "select", "Transport?", ["Use REST", "Use gRPC"]
+    ) is None
+    assert ds._auto_answer_pi_question(parent, "confirm", "Continue?", []) is None
 
 
 def test_send_reuses_same_client_and_preserves_followup_history():
@@ -275,6 +283,7 @@ def test_stop_then_resume_reopens_in_same_gateway_process():
     assert resumed["status"] == "idle"
     assert FakePiClient.instances[-1] is not first_client
     assert FakePiClient.instances[-1].is_closed is False
+    assert callable(FakePiClient.instances[-1].question_answerer)
 
 
 def test_resume_after_registry_loss_uses_durable_original_workspace(monkeypatch, tmp_path):
@@ -311,6 +320,28 @@ def test_list_includes_offline_durable_sessions_after_registry_loss():
     row = next(row for row in listed["sessions"] if row["session_id"] == sid)
     assert row["status"] == "offline"
     assert row["cwd"] == started["cwd"]
+
+
+def test_durable_metadata_cache_prunes_oldest_files(monkeypatch, tmp_path):
+    root = ds._session_store_root()
+    root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(ds, "_MAX_DURABLE_SESSIONS", 3)
+    created = []
+    for index in range(5):
+        path = root / f"session-{index}.json"
+        path.write_text(json.dumps({"session_id": str(index)}))
+        os.utime(path, (100 + index, 100 + index))
+        created.append(path)
+
+    ds._prune_durable_metadata(root)
+
+    assert [path.name for path in ds._metadata_files_newest(root)] == [
+        "session-4.json",
+        "session-3.json",
+        "session-2.json",
+    ]
+    assert not created[0].exists()
+    assert not created[1].exists()
 
 
 def test_durable_resume_metadata_enforces_conversation_owner():

--- a/tests/tools/test_delegate_session_tool.py
+++ b/tests/tools/test_delegate_session_tool.py
@@ -1,0 +1,200 @@
+"""Regression coverage for persistent Pi delegate_session semantics."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import pytest
+
+import tools.delegate_session_tool as ds
+
+
+class Parent:
+    def __init__(self, session_id: str = "parent-session") -> None:
+        self.session_id = session_id
+
+
+class FakePiClient:
+    instances = []
+
+    def __init__(self, *, persistent_session=False, session_id=None, session_name=None, acp_cwd=None, **_kwargs):
+        self.persistent_session = persistent_session
+        self.session_id = session_id
+        self.session_name = session_name
+        self.cwd = acp_cwd
+        self.is_closed = False
+        self.messages = []
+        self.steers = []
+        self.started_turn = threading.Event()
+        self.release_turn = threading.Event()
+        self.block_turns = False
+        self._proc = None
+        self.__class__.instances.append(self)
+
+    def start(self, *, timeout=30.0):
+        return {
+            "sessionId": self.session_id,
+            "sessionFile": f"/tmp/{self.session_id}.jsonl",
+            "messageCount": len(self.messages),
+            "isStreaming": False,
+        }
+
+    def run_session_prompt(self, message, *, timeout_seconds=900.0):
+        self.messages.append(message)
+        self.started_turn.set()
+        if self.block_turns:
+            assert self.release_turn.wait(timeout=5)
+        return {
+            "success": True,
+            "text": f"done:{message}",
+            "reasoning": "",
+            "duration_s": 0.01,
+            "state": {
+                "sessionId": self.session_id,
+                "messageCount": len(self.messages),
+                "isStreaming": False,
+            },
+        }
+
+    def get_messages(self, *, timeout=30.0):
+        return [{"role": "user", "content": m} for m in self.messages]
+
+    def steer(self, message, *, timeout=30.0):
+        self.steers.append(message)
+        return {"success": True, "command": "steer"}
+
+    def abort(self, *, timeout=30.0):
+        self.release_turn.set()
+        return {"success": True, "command": "abort"}
+
+    def close(self):
+        self.is_closed = True
+        self.release_turn.set()
+
+
+@pytest.fixture(autouse=True)
+def clean_sessions(monkeypatch, tmp_path):
+    with ds._SESSION_LOCK:
+        for record in ds._SESSIONS.values():
+            try:
+                record["client"].close()
+            except Exception:
+                pass
+        ds._SESSIONS.clear()
+    FakePiClient.instances.clear()
+    monkeypatch.setattr(ds, "PiRPCClient", FakePiClient)
+    monkeypatch.setattr(ds, "resolve_agent_cwd", lambda: tmp_path)
+    monkeypatch.setattr(ds, "pending_question_for_owner", lambda _client: None)
+    yield
+    with ds._SESSION_LOCK:
+        for record in ds._SESSIONS.values():
+            try:
+                record["client"].close()
+            except Exception:
+                pass
+        ds._SESSIONS.clear()
+
+
+def payload(raw: str) -> dict:
+    return json.loads(raw)
+
+
+def wait_for_status(parent: Parent, sid: str, wanted: str, timeout: float = 2.0) -> dict:
+    deadline = time.time() + timeout
+    latest = {}
+    while time.time() < deadline:
+        latest = payload(ds.delegate_session(action="status", session_id=sid, parent_agent=parent))
+        if latest.get("status") == wanted:
+            return latest
+        time.sleep(0.01)
+    raise AssertionError(f"session {sid} never reached {wanted}: {latest}")
+
+
+def test_start_creates_native_persistent_pi_session():
+    parent = Parent()
+    result = payload(ds.delegate_session(action="start", parent_agent=parent))
+
+    assert result["success"] is True
+    assert result["created"] is True
+    assert result["status"] == "idle"
+    assert result["session_id"] == result["pi_session_id"]
+    client = FakePiClient.instances[-1]
+    assert client.persistent_session is True
+    assert client.session_id == result["session_id"]
+    assert client.cwd == result["cwd"]
+
+
+def test_send_reuses_same_client_and_preserves_followup_history():
+    parent = Parent()
+    started = payload(ds.delegate_session(action="start", parent_agent=parent))
+    sid = started["session_id"]
+    client = FakePiClient.instances[-1]
+
+    first = payload(ds.delegate_session(action="send", session_id=sid, message="first", parent_agent=parent))
+    assert first["accepted"] is True
+    wait_for_status(parent, sid, "idle")
+
+    second = payload(ds.delegate_session(action="send", session_id=sid, message="second", parent_agent=parent))
+    assert second["accepted"] is True
+    final = wait_for_status(parent, sid, "idle")
+
+    assert FakePiClient.instances == [client]
+    assert client.messages == ["first", "second"]
+    assert final["last_result"]["text"] == "done:second"
+
+
+def test_steer_targets_live_session_instead_of_spawning_child_agent():
+    parent = Parent()
+    started = payload(ds.delegate_session(action="start", parent_agent=parent))
+    sid = started["session_id"]
+    client = FakePiClient.instances[-1]
+    client.block_turns = True
+
+    payload(ds.delegate_session(action="send", session_id=sid, message="long task", parent_agent=parent))
+    assert client.started_turn.wait(timeout=1)
+
+    steered = payload(ds.delegate_session(action="steer", session_id=sid, message="focus on tests", parent_agent=parent))
+    assert steered["success"] is True
+    assert client.steers == ["focus on tests"]
+
+    client.release_turn.set()
+    wait_for_status(parent, sid, "idle")
+
+
+def test_sessions_are_scoped_to_owning_hermes_conversation():
+    owner = Parent("owner")
+    stranger = Parent("stranger")
+    started = payload(ds.delegate_session(action="start", parent_agent=owner))
+    sid = started["session_id"]
+
+    denied = ds.delegate_session(action="status", session_id=sid, parent_agent=stranger)
+    assert "not found for this conversation" in denied.lower()
+
+    owner_list = payload(ds.delegate_session(action="list", parent_agent=owner))
+    stranger_list = payload(ds.delegate_session(action="list", parent_agent=stranger))
+    assert [row["session_id"] for row in owner_list["sessions"]] == [sid]
+    assert stranger_list["sessions"] == []
+
+
+def test_stop_closes_client_but_native_id_can_be_resumed():
+    parent = Parent()
+    started = payload(ds.delegate_session(action="start", parent_agent=parent))
+    sid = started["session_id"]
+    first_client = FakePiClient.instances[-1]
+
+    stopped = payload(ds.delegate_session(action="stop", session_id=sid, parent_agent=parent))
+    assert stopped["closed"] is True
+    assert first_client.is_closed is True
+
+    # Simulate a gateway restart/process-local registry loss while Pi's native
+    # session remains durable on disk, then reopen the same native session id.
+    with ds._SESSION_LOCK:
+        ds._SESSIONS.pop(sid, None)
+    resumed = payload(ds.delegate_session(action="resume", session_id=sid, parent_agent=parent))
+    assert resumed["created"] is True
+    assert resumed["session_id"] == sid
+    assert resumed["pi_session_id"] == sid
+    assert FakePiClient.instances[-1] is not first_client
+    assert FakePiClient.instances[-1].session_id == sid

--- a/tests/tools/test_delegate_session_tool.py
+++ b/tests/tools/test_delegate_session_tool.py
@@ -19,11 +19,12 @@ class Parent:
 class FakePiClient:
     instances = []
 
-    def __init__(self, *, persistent_session=False, session_id=None, session_name=None, acp_cwd=None, **_kwargs):
+    def __init__(self, *, persistent_session=False, session_id=None, session_name=None, acp_cwd=None, question_answerer=None, **_kwargs):
         self.persistent_session = persistent_session
         self.session_id = session_id
         self.session_name = session_name
         self.cwd = acp_cwd
+        self.question_answerer = question_answerer
         self.is_closed = False
         self.messages = []
         self.steers = []
@@ -86,6 +87,7 @@ def clean_sessions(monkeypatch, tmp_path):
     FakePiClient.instances.clear()
     monkeypatch.setattr(ds, "PiRPCClient", FakePiClient)
     monkeypatch.setattr(ds, "resolve_agent_cwd", lambda: tmp_path)
+    monkeypatch.setattr(ds, "_session_store_root", lambda: tmp_path / "delegate-session-store")
     monkeypatch.setattr(ds, "pending_question_for_owner", lambda _client: None)
     yield
     with ds._SESSION_LOCK:
@@ -124,6 +126,65 @@ def test_start_creates_native_persistent_pi_session():
     assert client.persistent_session is True
     assert client.session_id == result["session_id"]
     assert client.cwd == result["cwd"]
+
+
+def test_start_installs_hermes_auto_question_answerer(monkeypatch):
+    parent = Parent()
+    seen = []
+
+    def fake_answerer(parent_arg, method, title, options):
+        seen.append((parent_arg, method, title, options))
+        return "Hermes chose this"
+
+    monkeypatch.setattr(ds, "_auto_answer_pi_question", fake_answerer)
+    result = payload(ds.delegate_session(action="start", parent_agent=parent))
+    client = FakePiClient.instances[-1]
+
+    assert result["success"] is True
+    assert callable(client.question_answerer)
+    assert client.question_answerer("input", "Which path?", ["A", "B"]) == "Hermes chose this"
+    assert seen == [(parent, "input", "Which path?", ["A", "B"])]
+
+
+def test_auto_answer_uses_supervising_context_and_main_runtime(monkeypatch):
+    parent = Parent()
+    parent._session_messages = [
+        {"role": "user", "content": "Use PostgreSQL for this project."},
+        {"role": "assistant", "content": "I will keep the existing database choice."},
+        {"role": "tool", "content": "Detected database port 5432."},
+    ]
+    parent._current_main_runtime = lambda: {
+        "provider": "test-provider",
+        "model": "test-model",
+        "base_url": "https://example.invalid/v1",
+        "api_key": "secret-not-logged",
+    }
+    captured = {}
+
+    def fake_oneshot(**kwargs):
+        captured.update(kwargs)
+        return "5432"
+
+    monkeypatch.setattr("agent.oneshot.run_oneshot", fake_oneshot)
+    answer = ds._auto_answer_pi_question(parent, "input", "Which DB port?", [])
+
+    assert answer == "5432"
+    assert "Use PostgreSQL for this project" in captured["user_input"]
+    assert "Detected database port 5432" in captured["user_input"]
+    assert "Never ask the user" in captured["instructions"]
+    assert captured["task"] == "delegate_session_question"
+    assert captured["main_runtime"]["model"] == "test-model"
+
+
+def test_auto_answer_normalizes_confirm_and_select(monkeypatch):
+    parent = Parent()
+    answers = iter(["Proceed, yes.", "use grpc"])
+    monkeypatch.setattr("agent.oneshot.run_oneshot", lambda **_kwargs: next(answers))
+
+    assert ds._auto_answer_pi_question(parent, "confirm", "Continue?", []) == "yes"
+    assert ds._auto_answer_pi_question(
+        parent, "select", "Transport?", ["Use REST", "Use gRPC"]
+    ) == "Use gRPC"
 
 
 def test_send_reuses_same_client_and_preserves_followup_history():
@@ -198,3 +259,68 @@ def test_stop_closes_client_but_native_id_can_be_resumed():
     assert resumed["pi_session_id"] == sid
     assert FakePiClient.instances[-1] is not first_client
     assert FakePiClient.instances[-1].session_id == sid
+
+
+def test_stop_then_resume_reopens_in_same_gateway_process():
+    parent = Parent()
+    started = payload(ds.delegate_session(action="start", parent_agent=parent))
+    sid = started["session_id"]
+    first_client = FakePiClient.instances[-1]
+
+    payload(ds.delegate_session(action="stop", session_id=sid, parent_agent=parent))
+    resumed = payload(ds.delegate_session(action="resume", session_id=sid, parent_agent=parent))
+
+    assert resumed["success"] is True
+    assert resumed["created"] is True
+    assert resumed["status"] == "idle"
+    assert FakePiClient.instances[-1] is not first_client
+    assert FakePiClient.instances[-1].is_closed is False
+
+
+def test_resume_after_registry_loss_uses_durable_original_workspace(monkeypatch, tmp_path):
+    parent = Parent()
+    original = tmp_path / "original"
+    elsewhere = tmp_path / "elsewhere"
+    original.mkdir()
+    elsewhere.mkdir()
+    monkeypatch.setattr(ds, "resolve_agent_cwd", lambda: original)
+
+    started = payload(ds.delegate_session(action="start", parent_agent=parent))
+    sid = started["session_id"]
+    assert FakePiClient.instances[-1].cwd == str(original.resolve())
+
+    with ds._SESSION_LOCK:
+        stale = ds._SESSIONS.pop(sid)
+    stale["client"].close()
+    monkeypatch.setattr(ds, "resolve_agent_cwd", lambda: elsewhere)
+
+    resumed = payload(ds.delegate_session(action="resume", session_id=sid, parent_agent=parent))
+    assert resumed["cwd"] == str(original.resolve())
+    assert FakePiClient.instances[-1].cwd == str(original.resolve())
+
+
+def test_list_includes_offline_durable_sessions_after_registry_loss():
+    parent = Parent()
+    started = payload(ds.delegate_session(action="start", parent_agent=parent))
+    sid = started["session_id"]
+    with ds._SESSION_LOCK:
+        stale = ds._SESSIONS.pop(sid)
+    stale["client"].close()
+
+    listed = payload(ds.delegate_session(action="list", parent_agent=parent))
+    row = next(row for row in listed["sessions"] if row["session_id"] == sid)
+    assert row["status"] == "offline"
+    assert row["cwd"] == started["cwd"]
+
+
+def test_durable_resume_metadata_enforces_conversation_owner():
+    owner = Parent("owner")
+    stranger = Parent("stranger")
+    started = payload(ds.delegate_session(action="start", parent_agent=owner))
+    sid = started["session_id"]
+    with ds._SESSION_LOCK:
+        stale = ds._SESSIONS.pop(sid)
+    stale["client"].close()
+
+    denied = ds.delegate_session(action="resume", session_id=sid, parent_agent=stranger)
+    assert "belongs to another conversation" in denied.lower()

--- a/tests/tools/test_delegate_session_tool.py
+++ b/tests/tools/test_delegate_session_tool.py
@@ -441,3 +441,173 @@ def test_registry_dispatch_resolves_bound_parent(monkeypatch):
     # Without a bound parent the explicit error is preserved.
     err = entry.handler({"action": "list"})
     assert "requires a parent agent context" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Backend-configurable sessions (Pi default + OpenCode)
+# ---------------------------------------------------------------------------
+
+class FakeOpenCodeClient(FakePiClient):
+    """Fake OpenCode backend client mirroring agent.opencode_client surface."""
+
+    instances = []
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.native_session_id = None
+
+    def pending_question_payload(self):
+        return None
+
+    def is_dead(self):
+        return False
+
+
+def test_default_backend_is_pi():
+    parent = Parent()
+    result = payload(ds.delegate_session(action="start", parent_agent=parent))
+    assert result["backend"] == "pi"
+    assert result["pi_session_id"] == result["native_session_id"] == result["session_id"]
+    assert isinstance(FakePiClient.instances[-1], FakePiClient)
+
+
+def test_backend_env_var_selects_opencode(monkeypatch):
+    monkeypatch.setattr(ds, "OpenCodeClient", FakeOpenCodeClient)
+    monkeypatch.setenv("HERMES_DELEGATE_SESSION_BACKEND", "opencode")
+    parent = Parent()
+    result = payload(ds.delegate_session(action="start", parent_agent=parent))
+    assert result["backend"] == "opencode"
+    assert result["native_session_id"]
+    assert result["pi_session_id"] == result["native_session_id"]  # compatibility alias
+
+
+def test_backend_arg_routes_to_opencode_client(monkeypatch):
+    monkeypatch.setattr(ds, "OpenCodeClient", FakeOpenCodeClient)
+    parent = Parent()
+    result = payload(ds.delegate_session(action="start", backend="opencode", parent_agent=parent))
+    assert result["backend"] == "opencode"
+    client = FakeOpenCodeClient.instances[-1]
+    assert client.cwd  # opened in resolved cwd
+    # follow-up send reaches the same client
+    sid = result["session_id"]
+    accepted = payload(ds.delegate_session(action="send", session_id=sid, message="go", parent_agent=parent))
+    assert accepted["accepted"] is True
+    done = wait_for_status(parent, sid, "idle")
+    assert done["last_result"]["text"].startswith("done:")
+
+
+def test_unknown_backend_is_bounded_error():
+    parent = Parent()
+    err = ds.delegate_session(action="start", backend="claude", parent_agent=parent)
+    assert "unknown backend" in err.lower()
+
+
+def test_control_action_with_mismatched_backend_errors(monkeypatch):
+    monkeypatch.setattr(ds, "OpenCodeClient", FakeOpenCodeClient)
+    parent = Parent()
+    started = payload(ds.delegate_session(action="start", backend="opencode", parent_agent=parent))
+    sid = started["session_id"]
+    err = ds.delegate_session(action="send", session_id=sid, message="x", backend="pi", parent_agent=parent)
+    assert "is a opencode delegate session" in err.lower()
+
+
+def test_resume_of_live_session_with_other_backend_errors(monkeypatch):
+    monkeypatch.setattr(ds, "OpenCodeClient", FakeOpenCodeClient)
+    parent = Parent()
+    started = payload(ds.delegate_session(action="start", parent_agent=parent))  # pi
+    sid = started["session_id"]
+    err = ds.delegate_session(action="resume", session_id=sid, backend="opencode", parent_agent=parent)
+    assert "cannot be reopened as a opencode session" in err.lower()
+
+
+def test_metadata_v2_roundtrip_reopens_correct_backend(monkeypatch, tmp_path):
+    monkeypatch.setattr(ds, "OpenCodeClient", FakeOpenCodeClient)
+    parent = Parent()
+    started = payload(ds.delegate_session(action="start", backend="opencode", parent_agent=parent))
+    sid = started["session_id"]
+    native = started["native_session_id"]
+    with ds._SESSION_LOCK:
+        stale = ds._SESSIONS.pop(sid)
+    stale["client"].close()
+
+    meta = ds._load_metadata(sid)
+    assert meta["version"] == 2
+    assert meta["backend"] == "opencode"
+    assert meta["native_session_id"] == native
+
+    # metadata snapshot keeps the pi_session_id alias for one release
+    assert meta["pi_session_id"] == native
+
+    # resume without an explicit backend reopens the stored backend
+    resumed = payload(ds.delegate_session(action="resume", session_id=sid, parent_agent=parent))
+    assert resumed["backend"] == "opencode"
+    client = FakeOpenCodeClient.instances[-1]
+    assert client.native_session_id == native
+
+
+def test_v1_metadata_loads_as_pi(monkeypatch, tmp_path):
+    parent = Parent()
+    sid = "legacy-v1-session"
+    root = ds._session_store_root()
+    root.mkdir(parents=True, exist_ok=True)
+    legacy = {
+        "version": 1,
+        "session_id": sid,
+        "pi_session_id": "pi_native_123",
+        "owner": "parent-session",
+        "cwd": str(tmp_path),
+        "created_at": 1.0,
+        "updated_at": 1.0,
+    }
+    ds._metadata_path(sid).write_text(json.dumps(legacy))
+
+    resumed = payload(ds.delegate_session(action="resume", session_id=sid, parent_agent=parent))
+    assert resumed["backend"] == "pi"
+    # pi session id is reused as the native session on resume
+    assert resumed["native_session_id"] == "pi_native_123"
+    # re-persisted as v2
+    assert ds._load_metadata(sid)["version"] == 2
+
+
+def test_list_includes_backend_field(monkeypatch):
+    monkeypatch.setattr(ds, "OpenCodeClient", FakeOpenCodeClient)
+    parent = Parent()
+    pi_row = payload(ds.delegate_session(action="start", parent_agent=parent))
+    oc_row = payload(ds.delegate_session(action="start", backend="opencode", parent_agent=parent))
+
+    listed = payload(ds.delegate_session(action="list", parent_agent=parent))
+    by_id = {row["session_id"]: row for row in listed["sessions"]}
+    assert by_id[pi_row["session_id"]]["backend"] == "pi"
+    assert by_id[oc_row["session_id"]]["backend"] == "opencode"
+    assert "native_session_id" in by_id[pi_row["session_id"]]
+    assert "pi_session_id" in by_id[oc_row["session_id"]]
+
+    # offline durable rows also carry the backend
+    for sid in (pi_row["session_id"], oc_row["session_id"]):
+        with ds._SESSION_LOCK:
+            stale = ds._SESSIONS.pop(sid)
+        stale["client"].close()
+    listed2 = payload(ds.delegate_session(action="list", parent_agent=parent))
+    by_id2 = {row["session_id"]: row for row in listed2["sessions"]}
+    assert by_id2[pi_row["session_id"]]["backend"] == "pi"
+    assert by_id2[oc_row["session_id"]]["backend"] == "opencode"
+
+
+def test_registry_handler_forwards_backend(monkeypatch):
+    from tools import registry as reg
+
+    entry = reg.registry.get_entry("delegate_session")
+    from agent.subagent_lifecycle import bind_subagent_parent
+
+    owner = Parent("backend-forward")
+    with bind_subagent_parent(owner):
+        err = entry.handler({"action": "start", "backend": "bogus"})
+    assert "unknown backend" in err.lower()
+
+
+def test_check_requirements_accepts_opencode_only(monkeypatch, tmp_path):
+    monkeypatch.setattr(ds.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(ds.Path, "home", lambda: tmp_path)  # no ~/.local/bin binaries
+    assert ds.check_delegate_session_requirements() is False
+    monkeypatch.setenv("HERMES_OPENCODE_SERVER_URL", "http://127.0.0.1:1")
+    assert ds.check_delegate_session_requirements() is True

--- a/tests/tools/test_delegate_session_tool.py
+++ b/tests/tools/test_delegate_session_tool.py
@@ -214,6 +214,38 @@ def test_send_reuses_same_client_and_preserves_followup_history():
     assert final["last_result"]["text"] == "done:second"
 
 
+def test_steer_on_idle_session_degrades_to_send_instead_of_erroring():
+    parent = Parent()
+    started = payload(ds.delegate_session(action="start", parent_agent=parent))
+    sid = started["session_id"]
+    client = FakePiClient.instances[-1]
+
+    payload(ds.delegate_session(action="send", session_id=sid, message="first", parent_agent=parent))
+    wait_for_status(parent, sid, "idle")
+
+    # Race window: turn already ended, but the caller tries to steer.
+    steered = payload(ds.delegate_session(action="steer", session_id=sid, message="focus on tests", parent_agent=parent))
+    assert steered["success"] is True
+    assert steered["degraded_to_send"] is True
+    assert "follow-up" in steered["note"]
+    # No steer was attempted (session was idle); message became a new turn instead.
+    assert client.steers == []
+    final = wait_for_status(parent, sid, "idle")
+    assert client.messages == ["first", "focus on tests"]
+    assert final["last_result"]["text"] == "done:focus on tests"
+
+
+def test_steer_on_closed_session_still_errors_with_resume_hint():
+    parent = Parent()
+    started = payload(ds.delegate_session(action="start", parent_agent=parent))
+    sid = started["session_id"]
+
+    payload(ds.delegate_session(action="stop", session_id=sid, parent_agent=parent))
+
+    result = payload(ds.delegate_session(action="steer", session_id=sid, message="hello", parent_agent=parent))
+    assert result.get("error") or result.get("success") is not True
+
+
 def test_steer_targets_live_session_instead_of_spawning_child_agent():
     parent = Parent()
     started = payload(ds.delegate_session(action="start", parent_agent=parent))

--- a/tests/tools/test_delegate_session_tool.py
+++ b/tests/tools/test_delegate_session_tool.py
@@ -355,3 +355,38 @@ def test_durable_resume_metadata_enforces_conversation_owner():
 
     denied = ds.delegate_session(action="resume", session_id=sid, parent_agent=stranger)
     assert "belongs to another conversation" in denied.lower()
+
+
+def test_runtime_dispatch_passes_parent_agent(monkeypatch):
+    """invoke_tool must pass parent_agent to delegate_session (regression).
+
+    The generic dispatch path never forwards parent_agent, so delegate_session
+    used to fail with "requires a parent agent context" on every live call.
+    """
+    from agent.agent_runtime_helpers import invoke_tool
+
+    calls = {}
+
+    def fake_delegate_session(**kwargs):
+        calls.update(kwargs)
+        return '{"ok": true}'
+
+    monkeypatch.setattr(
+        "tools.delegate_session_tool.delegate_session", fake_delegate_session
+    )
+
+    agent = Parent("dispatch-agent")
+    # Attributes the dispatch chain touches before reaching the tool.
+    setattr(agent, "_memory_manager", None)
+    setattr(agent, "_subagent_lifecycle", None)
+
+    raw = invoke_tool(
+        agent,
+        "delegate_session",
+        {"action": "list"},
+        effective_task_id="task-1",
+    )
+
+    assert calls.get("parent_agent") is agent
+    assert calls.get("action") == "list"
+    assert raw == '{"ok": true}'

--- a/tests/tools/test_delegate_session_tool.py
+++ b/tests/tools/test_delegate_session_tool.py
@@ -390,3 +390,22 @@ def test_runtime_dispatch_passes_parent_agent(monkeypatch):
     assert calls.get("parent_agent") is agent
     assert calls.get("action") == "list"
     assert raw == '{"ok": true}'
+
+
+def test_registry_dispatch_resolves_bound_parent(monkeypatch):
+    """Registry dispatch (no explicit parent_agent) must fall back to the
+    turn-bound active parent instead of failing with 'requires a parent
+    agent context'."""
+    from agent.subagent_lifecycle import bind_subagent_parent
+    from tools import registry as reg
+
+    entry = reg.registry.get_entry("delegate_session")
+    owner = Parent("registry-owner")
+    with bind_subagent_parent(owner):
+        result = entry.handler({"action": "list"})
+    payload_result = json.loads(result)
+    assert payload_result.get("success") is True, payload_result
+
+    # Without a bound parent the explicit error is preserved.
+    err = entry.handler({"action": "list"})
+    assert "requires a parent agent context" in err.lower()

--- a/tools/delegate_session_tool.py
+++ b/tools/delegate_session_tool.py
@@ -61,6 +61,31 @@ def _metadata_snapshot(record: Dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _metadata_files_newest(root: Path) -> list[Path]:
+    """Return readable metadata files newest-first, tolerating concurrent churn."""
+    ranked: list[tuple[float, Path]] = []
+    try:
+        candidates = list(root.glob("*.json"))
+    except OSError:
+        return []
+    for candidate in candidates:
+        try:
+            ranked.append((candidate.stat().st_mtime, candidate))
+        except OSError:
+            continue
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    return [path for _mtime, path in ranked]
+
+
+def _prune_durable_metadata(root: Path) -> None:
+    """Bound Hermes' delegate-session metadata cache without touching Pi history."""
+    for stale in _metadata_files_newest(root)[_MAX_DURABLE_SESSIONS:]:
+        try:
+            stale.unlink()
+        except OSError:
+            logger.debug("Could not prune stale delegate-session metadata %s", stale, exc_info=True)
+
+
 def _persist_metadata(record: Dict[str, Any]) -> None:
     """Persist enough metadata to reopen the native Pi session after restart."""
     session_id = str(record.get("session_id") or "").strip()
@@ -80,6 +105,7 @@ def _persist_metadata(record: Dict[str, Any]) -> None:
         except OSError:
             pass
         tmp.replace(path)
+        _prune_durable_metadata(path.parent)
     except OSError:
         logger.debug("Could not persist delegate-session metadata for %s", session_id, exc_info=True)
 
@@ -99,11 +125,7 @@ def _durable_rows_for_owner(owner: str) -> list[dict[str, Any]]:
     if not root.is_dir():
         return []
     rows: list[dict[str, Any]] = []
-    try:
-        paths = sorted(root.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
-    except OSError:
-        return []
-    for path in paths[:_MAX_DURABLE_SESSIONS]:
+    for path in _metadata_files_newest(root)[:_MAX_DURABLE_SESSIONS]:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
@@ -235,16 +257,25 @@ def _auto_answer_pi_question(
     if not answer:
         return None
     if method == "select" and options:
-        low = answer.casefold()
+        low = answer.casefold().strip(" \"'`.,!\t\n")
         for option in options:
-            if option.casefold() == low:
+            if option.casefold().strip(" \"'`.,!\t\n") == low:
                 return option
+        if low.isdigit():
+            index = int(low)
+            if 1 <= index <= len(options):
+                return options[index - 1]
+        # A select response must be one of Pi's offered values. Returning None
+        # deliberately activates the conservative supervised fallback instead
+        # of sending an invalid free-form selection over the RPC protocol.
+        return None
     if method == "confirm":
         low = answer.casefold().strip(" .!\t\n")
         if low.startswith(("yes", "true", "approve", "confirm", "proceed")):
             return "yes"
         if low.startswith(("no", "false", "deny", "reject", "stop")):
             return "no"
+        return None
     return _bounded(answer, 2000)
 
 

--- a/tools/delegate_session_tool.py
+++ b/tools/delegate_session_tool.py
@@ -1,0 +1,352 @@
+"""Persistent external-agent delegation sessions.
+
+`delegate_task` is intentionally a Hermes->Hermes child-agent primitive.  This
+module provides the complementary session primitive for external agents whose
+native protocol already owns conversation state.  Pi is the first backend:
+Hermes keeps one `pi --mode rpc` process/session alive and can send follow-up
+turns, steer an active turn, answer Pi extension questions, inspect messages,
+and stop/resume the native Pi session without wrapping it in a child AIAgent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from agent.pi_rpc_client import PiRPCClient, pending_question_for_owner
+from agent.runtime_cwd import resolve_agent_cwd
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_SESSION_LOCK = threading.RLock()
+_SESSIONS: Dict[str, Dict[str, Any]] = {}
+_MAX_TEXT = 12_000
+
+
+def check_delegate_session_requirements() -> bool:
+    return bool(shutil.which("pi") or Path.home().joinpath(".local", "bin", "pi").is_file())
+
+
+def _owner_key(parent_agent: Any) -> str:
+    durable = str(getattr(parent_agent, "session_id", "") or "").strip()
+    return durable or f"agent:{id(parent_agent)}"
+
+
+def _bounded(value: Any, maximum: int = _MAX_TEXT) -> str:
+    text = str(value or "")
+    return text if len(text) <= maximum else text[: maximum - 3] + "..."
+
+
+def _pending_payload(client: PiRPCClient) -> dict[str, Any] | None:
+    question = pending_question_for_owner(client)
+    if question is None:
+        return None
+    return {
+        "method": question.method,
+        "question": _bounded(question.title, 2000),
+        "options": list(question.options)[:50],
+        "created_at": question.created_at,
+    }
+
+
+def _summary(record: Dict[str, Any], *, include_result: bool = True) -> dict[str, Any]:
+    client: PiRPCClient = record["client"]
+    out = {
+        "session_id": record["session_id"],
+        "pi_session_id": record.get("pi_session_id") or record["session_id"],
+        "status": record.get("status", "unknown"),
+        "cwd": record.get("cwd"),
+        "created_at": record.get("created_at"),
+        "updated_at": record.get("updated_at"),
+        "pending_question": _pending_payload(client),
+        "error": record.get("error") or None,
+    }
+    if include_result and record.get("last_result"):
+        result = record["last_result"]
+        out["last_result"] = {
+            "text": _bounded(result.get("text")),
+            "duration_s": result.get("duration_s"),
+        }
+    return out
+
+
+def _lookup(session_id: str, parent_agent: Any) -> Dict[str, Any] | None:
+    owner = _owner_key(parent_agent)
+    with _SESSION_LOCK:
+        record = _SESSIONS.get(session_id)
+        if record is None or record.get("owner") != owner:
+            return None
+        return record
+
+
+def _run_turn(record: Dict[str, Any], message: str, timeout: float) -> None:
+    client: PiRPCClient = record["client"]
+    with _SESSION_LOCK:
+        if record.get("status") == "closed":
+            return
+        record["status"] = "running"
+        record["error"] = ""
+        record["updated_at"] = time.time()
+    try:
+        result = client.run_session_prompt(message, timeout_seconds=timeout)
+        state = result.get("state") if isinstance(result, dict) else {}
+        with _SESSION_LOCK:
+            record["last_result"] = result
+            record["pi_session_id"] = (
+                state.get("sessionId") if isinstance(state, dict) else None
+            ) or record.get("pi_session_id") or record["session_id"]
+            if record.get("status") != "closed":
+                record["status"] = "idle"
+            record["updated_at"] = time.time()
+    except Exception as exc:  # noqa: BLE001 - surfaced as bounded session state
+        logger.exception("Pi delegate session %s turn failed", record.get("session_id"))
+        with _SESSION_LOCK:
+            if record.get("status") != "closed":
+                record["status"] = "error"
+            record["error"] = _bounded(exc, 2000)
+            record["updated_at"] = time.time()
+
+
+def _dispatch_turn(record: Dict[str, Any], message: str, timeout: float) -> None:
+    thread = threading.Thread(
+        target=_run_turn,
+        args=(record, message, timeout),
+        name=f"pi-delegate-{record['session_id'][:8]}",
+        daemon=True,
+    )
+    with _SESSION_LOCK:
+        record["thread"] = thread
+        record["status"] = "running"
+        record["updated_at"] = time.time()
+    thread.start()
+
+
+def _initial_prompt(goal: str, context: str | None) -> str:
+    policy = (
+        "[Delegation policy] You are a coding delegate operating in a persistent "
+        "session owned by Hermes. Work directly in the current working tree. Do "
+        "not commit or push unless Hermes explicitly asks you to. Ask questions "
+        "when a decision is genuinely required; Hermes can answer through the "
+        "same delegate session."
+    )
+    parts = [policy]
+    if context and context.strip():
+        parts.append("Context from Hermes:\n" + context.strip())
+    if goal and goal.strip():
+        parts.append("Task:\n" + goal.strip())
+    return "\n\n".join(parts)
+
+
+def delegate_session(
+    *,
+    action: str = "start",
+    session_id: Optional[str] = None,
+    goal: Optional[str] = None,
+    context: Optional[str] = None,
+    message: Optional[str] = None,
+    timeout: Optional[int] = None,
+    parent_agent: Any = None,
+) -> str:
+    """Create/control a persistent Pi delegation session."""
+    if parent_agent is None:
+        return tool_error("delegate_session requires a parent agent context.")
+
+    normalized = (action or "start").strip().lower()
+    if normalized not in {"start", "resume", "send", "steer", "status", "messages", "list", "stop"}:
+        return tool_error(
+            "Unknown action. Use start, resume, send, steer, status, messages, list, or stop."
+        )
+    effective_timeout = float(max(10, min(int(timeout or 900), 3600)))
+    owner = _owner_key(parent_agent)
+
+    if normalized == "list":
+        with _SESSION_LOCK:
+            rows = [
+                _summary(record, include_result=False)
+                for record in _SESSIONS.values()
+                if record.get("owner") == owner
+            ]
+        return json.dumps({"success": True, "sessions": rows}, ensure_ascii=False)
+
+    if normalized in {"start", "resume"}:
+        requested_id = (session_id or "").strip()
+        if normalized == "resume" and not requested_id:
+            return tool_error("action='resume' requires session_id.")
+        handle = requested_id or str(uuid.uuid4())
+        with _SESSION_LOCK:
+            existing = _SESSIONS.get(handle)
+            if existing is not None:
+                if existing.get("owner") != owner:
+                    return tool_error("That delegate session belongs to another conversation.")
+                return json.dumps({"success": True, "reused": True, **_summary(existing)}, ensure_ascii=False)
+
+        cwd = str(resolve_agent_cwd().resolve())
+        client = PiRPCClient(
+            persistent_session=True,
+            session_id=handle,
+            session_name=f"Hermes {handle[:8]}",
+            acp_cwd=cwd,
+        )
+        try:
+            state = client.start(timeout=min(30.0, effective_timeout))
+        except Exception as exc:  # noqa: BLE001
+            client.close()
+            return tool_error(f"Could not start Pi delegate session: {_bounded(exc, 1000)}")
+        native_id = str(state.get("sessionId") or handle)
+        now = time.time()
+        record: Dict[str, Any] = {
+            "session_id": handle,
+            "pi_session_id": native_id,
+            "owner": owner,
+            "cwd": cwd,
+            "client": client,
+            "status": "idle",
+            "created_at": now,
+            "updated_at": now,
+            "last_result": None,
+            "error": "",
+            "thread": None,
+        }
+        with _SESSION_LOCK:
+            _SESSIONS[handle] = record
+        if goal and goal.strip():
+            _dispatch_turn(record, _initial_prompt(goal, context), effective_timeout)
+        return json.dumps({"success": True, "created": True, **_summary(record)}, ensure_ascii=False)
+
+    if not session_id or not session_id.strip():
+        return tool_error(f"action='{normalized}' requires session_id.")
+    record = _lookup(session_id.strip(), parent_agent)
+    if record is None:
+        return tool_error("Delegate session not found for this conversation. Use action='resume' to reopen a native Pi session.")
+    client: PiRPCClient = record["client"]
+
+    if normalized == "status":
+        proc = getattr(client, "_proc", None)
+        if record.get("status") not in {"closed", "error"} and proc is not None and proc.poll() is not None:
+            with _SESSION_LOCK:
+                record["status"] = "error"
+                record["error"] = f"Pi RPC process exited with code {proc.returncode}"
+                record["updated_at"] = time.time()
+        return json.dumps({"success": True, **_summary(record)}, ensure_ascii=False)
+
+    if normalized == "messages":
+        try:
+            messages = client.get_messages(timeout=min(30.0, effective_timeout))
+        except Exception as exc:  # noqa: BLE001
+            return tool_error(f"Could not read Pi session messages: {_bounded(exc, 1000)}")
+        # Keep the tool result bounded while preserving the newest conversational state.
+        safe = messages[-40:]
+        encoded = json.dumps(safe, ensure_ascii=False, default=str)
+        if len(encoded) > 40_000:
+            encoded = encoded[-40_000:]
+        return json.dumps({"success": True, "session_id": record["session_id"], "messages_json": encoded}, ensure_ascii=False)
+
+    if normalized == "send":
+        text = (message or goal or "").strip()
+        if not text:
+            return tool_error("action='send' requires message.")
+        with _SESSION_LOCK:
+            if record.get("status") == "running":
+                return tool_error("Pi session is currently running. Use action='steer' to redirect it, or wait for idle.")
+            if record.get("status") == "closed":
+                return tool_error("Pi session is closed. Use action='resume' to reopen it.")
+        _dispatch_turn(record, text, effective_timeout)
+        return json.dumps({"success": True, "accepted": True, **_summary(record, include_result=False)}, ensure_ascii=False)
+
+    if normalized == "steer":
+        text = (message or "").strip()
+        if not text:
+            return tool_error("action='steer' requires message.")
+        with _SESSION_LOCK:
+            if record.get("status") != "running":
+                return tool_error("Pi session is not running. Use action='send' for a new follow-up turn.")
+        try:
+            response = client.steer(text, timeout=min(30.0, effective_timeout))
+        except Exception as exc:  # noqa: BLE001
+            return tool_error(f"Could not steer Pi session: {_bounded(exc, 1000)}")
+        return json.dumps({"success": True, "response": response, **_summary(record, include_result=False)}, ensure_ascii=False, default=str)
+
+    if normalized == "stop":
+        try:
+            if record.get("status") == "running":
+                client.abort(timeout=min(10.0, effective_timeout))
+        except Exception:
+            logger.debug("Pi delegate abort failed before close", exc_info=True)
+        client.close()
+        with _SESSION_LOCK:
+            record["status"] = "closed"
+            record["updated_at"] = time.time()
+        return json.dumps({"success": True, "closed": True, **_summary(record)}, ensure_ascii=False)
+
+    return tool_error("Unhandled delegate_session action.")
+
+
+DELEGATE_SESSION_SCHEMA = {
+    "name": "delegate_session",
+    "description": (
+        "Delegate coding work to Pi through a persistent native RPC session. "
+        "Use this instead of delegate_task when the worker should be Pi. The Pi "
+        "conversation survives across turns: start a session, send follow-ups, "
+        "steer a running turn (including answering Pi questions), inspect status "
+        "or messages, and stop/resume the same native Pi session. delegate_task "
+        "remains the Hermes child-agent primitive."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["start", "resume", "send", "steer", "status", "messages", "list", "stop"],
+                "description": "Session lifecycle/control action. Omit for start.",
+            },
+            "session_id": {
+                "type": "string",
+                "description": "Persistent Pi delegation/session id returned by start. Required for all actions except start/list.",
+            },
+            "goal": {
+                "type": "string",
+                "description": "Initial coding objective for action='start'. The turn runs asynchronously in the persistent Pi session.",
+            },
+            "context": {
+                "type": "string",
+                "description": "Initial background/context passed with goal when starting the Pi session.",
+            },
+            "message": {
+                "type": "string",
+                "description": "Follow-up for send, or live course correction/question answer for steer.",
+            },
+            "timeout": {
+                "type": "integer",
+                "minimum": 10,
+                "maximum": 3600,
+                "description": "Maximum seconds allowed for each Pi turn (default 900).",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+registry.register(
+    name="delegate_session",
+    toolset="delegation",
+    schema=DELEGATE_SESSION_SCHEMA,
+    handler=lambda args, **kw: delegate_session(
+        action=args.get("action") or "start",
+        session_id=args.get("session_id"),
+        goal=args.get("goal"),
+        context=args.get("context"),
+        message=args.get("message"),
+        timeout=args.get("timeout"),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_delegate_session_requirements,
+    emoji="🔁",
+)

--- a/tools/delegate_session_tool.py
+++ b/tools/delegate_session_tool.py
@@ -10,8 +10,10 @@ and stop/resume the native Pi session without wrapping it in a child AIAgent.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import os
 import shutil
 import threading
 import time
@@ -28,6 +30,88 @@ logger = logging.getLogger(__name__)
 _SESSION_LOCK = threading.RLock()
 _SESSIONS: Dict[str, Dict[str, Any]] = {}
 _MAX_TEXT = 12_000
+_MAX_DURABLE_SESSIONS = 500
+
+
+def _session_store_root() -> Path:
+    """Profile-scoped durable metadata store (IDs/cwd only; never prompt text)."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        root = Path(get_hermes_home())
+    except Exception:
+        root = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    return root / "cache" / "delegate-sessions"
+
+
+def _metadata_path(session_id: str) -> Path:
+    digest = hashlib.sha256(session_id.encode("utf-8", errors="replace")).hexdigest()
+    return _session_store_root() / f"{digest}.json"
+
+
+def _metadata_snapshot(record: Dict[str, Any]) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "session_id": record.get("session_id"),
+        "pi_session_id": record.get("pi_session_id") or record.get("session_id"),
+        "owner": record.get("owner"),
+        "cwd": record.get("cwd"),
+        "created_at": record.get("created_at"),
+        "updated_at": record.get("updated_at"),
+    }
+
+
+def _persist_metadata(record: Dict[str, Any]) -> None:
+    """Persist enough metadata to reopen the native Pi session after restart."""
+    session_id = str(record.get("session_id") or "").strip()
+    if not session_id:
+        return
+    path = _metadata_path(session_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            path.parent.chmod(0o700)
+        except OSError:
+            pass
+        tmp = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+        tmp.write_text(json.dumps(_metadata_snapshot(record), ensure_ascii=False, indent=2), encoding="utf-8")
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            pass
+        tmp.replace(path)
+    except OSError:
+        logger.debug("Could not persist delegate-session metadata for %s", session_id, exc_info=True)
+
+
+def _load_metadata(session_id: str) -> dict[str, Any] | None:
+    try:
+        data = json.loads(_metadata_path(session_id).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or data.get("session_id") != session_id:
+        return None
+    return data
+
+
+def _durable_rows_for_owner(owner: str) -> list[dict[str, Any]]:
+    root = _session_store_root()
+    if not root.is_dir():
+        return []
+    rows: list[dict[str, Any]] = []
+    try:
+        paths = sorted(root.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+    except OSError:
+        return []
+    for path in paths[:_MAX_DURABLE_SESSIONS]:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict) or data.get("owner") != owner or not data.get("session_id"):
+            continue
+        rows.append(data)
+    return rows
 
 
 def check_delegate_session_requirements() -> bool:
@@ -42,6 +126,126 @@ def _owner_key(parent_agent: Any) -> str:
 def _bounded(value: Any, maximum: int = _MAX_TEXT) -> str:
     text = str(value or "")
     return text if len(text) <= maximum else text[: maximum - 3] + "..."
+
+
+def _message_text(value: Any) -> str:
+    """Best-effort text extraction for recent supervising-agent context."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts = [_message_text(item) for item in value]
+        return "\n".join(part for part in parts if part)
+    if isinstance(value, dict):
+        for key in ("text", "content", "output", "result"):
+            if key in value:
+                text = _message_text(value.get(key))
+                if text:
+                    return text
+    return ""
+
+
+def _parent_context_excerpt(parent_agent: Any, maximum: int = 24_000) -> str:
+    """Return bounded recent conversation/tool context for Hermes auto-answers."""
+    history = getattr(parent_agent, "_session_messages", None)
+    if not isinstance(history, list):
+        return ""
+    chunks: list[str] = []
+    used = 0
+    for message in reversed(history[-60:]):
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "context").strip().lower()
+        if role == "system":
+            continue
+        text = _message_text(message.get("content"))
+        if not text and role == "tool":
+            text = _message_text(message)
+        text = text.strip()
+        if not text:
+            continue
+        chunk = f"{role.upper()}: {_bounded(text, 6000)}"
+        if used + len(chunk) + 2 > maximum:
+            remaining = maximum - used
+            if remaining > 200:
+                chunks.append(chunk[:remaining])
+            break
+        chunks.append(chunk)
+        used += len(chunk) + 2
+    return "\n\n".join(reversed(chunks))
+
+
+def _parent_main_runtime(parent_agent: Any) -> dict[str, Any] | None:
+    getter = getattr(parent_agent, "_current_main_runtime", None)
+    if callable(getter):
+        try:
+            runtime = getter()
+            if isinstance(runtime, dict):
+                return runtime
+        except Exception:
+            logger.debug("Could not read parent runtime for Pi question answer", exc_info=True)
+    runtime = {
+        key: getattr(parent_agent, key, "") or ""
+        for key in ("model", "provider", "base_url", "api_key", "api_mode", "auth_mode")
+    }
+    return runtime if any(runtime.values()) else None
+
+
+def _auto_answer_pi_question(
+    parent_agent: Any,
+    method: str,
+    question: str,
+    options: list[str],
+) -> str | None:
+    """Have supervising Hermes answer a Pi question without involving the user."""
+    from agent.oneshot import run_oneshot
+
+    context = _parent_context_excerpt(parent_agent)
+    option_block = "\n".join(f"- {item}" for item in options[:50]) or "(none)"
+    if method == "confirm":
+        format_rule = "Answer exactly yes or no."
+    elif method == "select" and options:
+        format_rule = "Answer with exactly one of the listed options, with no explanation."
+    else:
+        format_rule = "Answer directly and concisely. Return only the answer Pi should receive."
+
+    instructions = (
+        "You are Hermes supervising a persistent Pi coding delegate. Pi has asked "
+        "a question during delegated work. Answer it yourself from the available "
+        "conversation/project context. Never ask the user, never request clarification, "
+        "and never defer the decision back to the user. If context is incomplete, make "
+        "the safest reasonable reversible choice that best advances the user's stated "
+        "goal. Do not mention that you are an auxiliary model. " + format_rule
+    )
+    user_input = (
+        f"Pi question type: {method}\n"
+        f"Pi question: {question}\n"
+        f"Options:\n{option_block}\n\n"
+        "Recent supervising Hermes context:\n"
+        f"{context or '(no additional context available)'}"
+    )
+    answer = run_oneshot(
+        instructions=instructions,
+        user_input=user_input,
+        task="delegate_session_question",
+        max_tokens=256,
+        temperature=0.0,
+        timeout=60.0,
+        main_runtime=_parent_main_runtime(parent_agent),
+    ).strip()
+    if not answer:
+        return None
+    if method == "select" and options:
+        low = answer.casefold()
+        for option in options:
+            if option.casefold() == low:
+                return option
+    if method == "confirm":
+        low = answer.casefold().strip(" .!\t\n")
+        if low.startswith(("yes", "true", "approve", "confirm", "proceed")):
+            return "yes"
+        if low.startswith(("no", "false", "deny", "reject", "stop")):
+            return "no"
+    return _bounded(answer, 2000)
 
 
 def _pending_payload(client: PiRPCClient) -> dict[str, Any] | None:
@@ -105,6 +309,7 @@ def _run_turn(record: Dict[str, Any], message: str, timeout: float) -> None:
             if record.get("status") != "closed":
                 record["status"] = "idle"
             record["updated_at"] = time.time()
+        _persist_metadata(record)
     except Exception as exc:  # noqa: BLE001 - surfaced as bounded session state
         logger.exception("Pi delegate session %s turn failed", record.get("session_id"))
         with _SESSION_LOCK:
@@ -112,6 +317,7 @@ def _run_turn(record: Dict[str, Any], message: str, timeout: float) -> None:
                 record["status"] = "error"
             record["error"] = _bounded(exc, 2000)
             record["updated_at"] = time.time()
+        _persist_metadata(record)
 
 
 def _dispatch_turn(record: Dict[str, Any], message: str, timeout: float) -> None:
@@ -133,8 +339,8 @@ def _initial_prompt(goal: str, context: str | None) -> str:
         "[Delegation policy] You are a coding delegate operating in a persistent "
         "session owned by Hermes. Work directly in the current working tree. Do "
         "not commit or push unless Hermes explicitly asks you to. Ask questions "
-        "when a decision is genuinely required; Hermes can answer through the "
-        "same delegate session."
+        "when a decision is genuinely required; the supervising Hermes agent will "
+        "answer them automatically through the same delegate session."
     )
     parts = [policy]
     if context and context.strip():
@@ -168,31 +374,73 @@ def delegate_session(
 
     if normalized == "list":
         with _SESSION_LOCK:
-            rows = [
-                _summary(record, include_result=False)
-                for record in _SESSIONS.values()
-                if record.get("owner") == owner
-            ]
+            live_records = [record for record in _SESSIONS.values() if record.get("owner") == owner]
+            live_ids = {str(record.get("session_id") or "") for record in live_records}
+            rows = [_summary(record, include_result=False) for record in live_records]
+        for meta in _durable_rows_for_owner(owner):
+            sid = str(meta.get("session_id") or "")
+            if not sid or sid in live_ids:
+                continue
+            rows.append({
+                "session_id": sid,
+                "pi_session_id": meta.get("pi_session_id") or sid,
+                "status": "offline",
+                "cwd": meta.get("cwd"),
+                "created_at": meta.get("created_at"),
+                "updated_at": meta.get("updated_at"),
+                "pending_question": None,
+                "error": None,
+            })
+        rows.sort(key=lambda row: float(row.get("updated_at") or 0), reverse=True)
         return json.dumps({"success": True, "sessions": rows}, ensure_ascii=False)
 
     if normalized in {"start", "resume"}:
         requested_id = (session_id or "").strip()
         if normalized == "resume" and not requested_id:
-            return tool_error("action='resume' requires session_id.")
+            return tool_error("action=resume requires session_id.")
         handle = requested_id or str(uuid.uuid4())
+        saved = _load_metadata(handle) if requested_id else None
+        if saved is not None and saved.get("owner") not in {None, owner}:
+            return tool_error("That delegate session belongs to another conversation.")
+
+        existing = None
         with _SESSION_LOCK:
             existing = _SESSIONS.get(handle)
             if existing is not None:
                 if existing.get("owner") != owner:
                     return tool_error("That delegate session belongs to another conversation.")
-                return json.dumps({"success": True, "reused": True, **_summary(existing)}, ensure_ascii=False)
+                client_obj = existing.get("client")
+                proc = getattr(client_obj, "_proc", None)
+                process_dead = proc is not None and proc.poll() is not None
+                reopen = normalized == "resume" and (
+                    existing.get("status") in {"closed", "error"}
+                    or getattr(client_obj, "is_closed", False)
+                    or process_dead
+                )
+                if not reopen:
+                    return json.dumps({"success": True, "reused": True, **_summary(existing)}, ensure_ascii=False)
+                _SESSIONS.pop(handle, None)
+        if existing is not None:
+            try:
+                existing["client"].close()
+            except Exception:
+                logger.debug("Could not close stale Pi delegate client before resume", exc_info=True)
 
-        cwd = str(resolve_agent_cwd().resolve())
+        saved_cwd = str((saved or {}).get("cwd") or "").strip()
+        cwd_path = Path(saved_cwd).expanduser() if saved_cwd else resolve_agent_cwd()
+        if not cwd_path.is_dir():
+            return tool_error(
+                f"Cannot resume Pi delegate session because its workspace no longer exists: {_bounded(cwd_path, 1000)}"
+            )
+        cwd = str(cwd_path.resolve())
         client = PiRPCClient(
             persistent_session=True,
             session_id=handle,
             session_name=f"Hermes {handle[:8]}",
             acp_cwd=cwd,
+            question_answerer=lambda method, title, options: _auto_answer_pi_question(
+                parent_agent, method, title, options
+            ),
         )
         try:
             state = client.start(timeout=min(30.0, effective_timeout))
@@ -208,7 +456,7 @@ def delegate_session(
             "cwd": cwd,
             "client": client,
             "status": "idle",
-            "created_at": now,
+            "created_at": (saved or {}).get("created_at") or now,
             "updated_at": now,
             "last_result": None,
             "error": "",
@@ -216,6 +464,7 @@ def delegate_session(
         }
         with _SESSION_LOCK:
             _SESSIONS[handle] = record
+        _persist_metadata(record)
         if goal and goal.strip():
             _dispatch_turn(record, _initial_prompt(goal, context), effective_timeout)
         return json.dumps({"success": True, "created": True, **_summary(record)}, ensure_ascii=False)
@@ -234,6 +483,7 @@ def delegate_session(
                 record["status"] = "error"
                 record["error"] = f"Pi RPC process exited with code {proc.returncode}"
                 record["updated_at"] = time.time()
+            _persist_metadata(record)
         return json.dumps({"success": True, **_summary(record)}, ensure_ascii=False)
 
     if normalized == "messages":
@@ -283,6 +533,7 @@ def delegate_session(
         with _SESSION_LOCK:
             record["status"] = "closed"
             record["updated_at"] = time.time()
+        _persist_metadata(record)
         return json.dumps({"success": True, "closed": True, **_summary(record)}, ensure_ascii=False)
 
     return tool_error("Unhandled delegate_session action.")
@@ -294,8 +545,9 @@ DELEGATE_SESSION_SCHEMA = {
         "Delegate coding work to Pi through a persistent native RPC session. "
         "Use this instead of delegate_task when the worker should be Pi. The Pi "
         "conversation survives across turns: start a session, send follow-ups, "
-        "steer a running turn (including answering Pi questions), inspect status "
-        "or messages, and stop/resume the same native Pi session. delegate_task "
+        "steer a running turn, inspect status or messages, and stop/resume the "
+        "same native Pi session. Pi questions are answered automatically by the "
+        "supervising Hermes agent rather than forwarded to the user. delegate_task "
         "remains the Hermes child-agent primitive."
     ),
     "parameters": {
@@ -320,7 +572,7 @@ DELEGATE_SESSION_SCHEMA = {
             },
             "message": {
                 "type": "string",
-                "description": "Follow-up for send, or live course correction/question answer for steer.",
+                "description": "Follow-up for send, or live course correction for steer. Pi questions are answered automatically by Hermes.",
             },
             "timeout": {
                 "type": "integer",
@@ -336,7 +588,7 @@ DELEGATE_SESSION_SCHEMA = {
 
 registry.register(
     name="delegate_session",
-    toolset="delegation",
+    toolset="delegation_session",
     schema=DELEGATE_SESSION_SCHEMA,
     handler=lambda args, **kw: delegate_session(
         action=args.get("action") or "start",

--- a/tools/delegate_session_tool.py
+++ b/tools/delegate_session_tool.py
@@ -2,10 +2,12 @@
 
 `delegate_task` is intentionally a Hermes->Hermes child-agent primitive.  This
 module provides the complementary session primitive for external agents whose
-native protocol already owns conversation state.  Pi is the first backend:
-Hermes keeps one `pi --mode rpc` process/session alive and can send follow-up
-turns, steer an active turn, answer Pi extension questions, inspect messages,
-and stop/resume the native Pi session without wrapping it in a child AIAgent.
+native protocol already owns conversation state.  Backends are configurable
+via the ``backend`` argument (``"pi"`` default | ``"opencode"``) or the
+``HERMES_DELEGATE_SESSION_BACKEND`` environment variable: Hermes keeps one
+native process/session alive per record and can send follow-up turns, steer an
+active turn, answer backend questions autonomously, inspect messages, and
+stop/resume the native session without wrapping it in a child AIAgent.
 """
 
 from __future__ import annotations
@@ -21,6 +23,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from agent.opencode_client import OpenCodeClient
 from agent.pi_rpc_client import PiRPCClient, pending_question_for_owner
 from agent.runtime_cwd import resolve_agent_cwd
 from tools.registry import registry, tool_error
@@ -31,6 +34,31 @@ _SESSION_LOCK = threading.RLock()
 _SESSIONS: Dict[str, Dict[str, Any]] = {}
 _MAX_TEXT = 12_000
 _MAX_DURABLE_SESSIONS = 500
+
+_KNOWN_BACKENDS = ("pi", "opencode")
+
+
+def _default_backend() -> str:
+    raw = os.environ.get("HERMES_DELEGATE_SESSION_BACKEND", "").strip().lower()
+    return raw if raw in _KNOWN_BACKENDS else "pi"
+
+
+def _resolve_backend(requested: Any, saved: Any = None) -> Optional[str]:
+    """Resolve the effective backend; explicit argument wins over metadata."""
+    raw = str(requested or "").strip().lower()
+    if raw:
+        if raw not in _KNOWN_BACKENDS:
+            return None
+        return raw
+    if isinstance(saved, str) and saved.strip().lower() in _KNOWN_BACKENDS:
+        return saved.strip().lower()
+    return _default_backend()
+
+
+def _backend_client_class(backend: str):
+    if backend == "opencode":
+        return OpenCodeClient
+    return PiRPCClient
 
 
 def _session_store_root() -> Path:
@@ -51,9 +79,11 @@ def _metadata_path(session_id: str) -> Path:
 
 def _metadata_snapshot(record: Dict[str, Any]) -> dict[str, Any]:
     return {
-        "version": 1,
+        "version": 2,
+        "backend": record.get("backend") or "pi",
         "session_id": record.get("session_id"),
-        "pi_session_id": record.get("pi_session_id") or record.get("session_id"),
+        "native_session_id": record.get("native_session_id") or record.get("session_id"),
+        "pi_session_id": record.get("native_session_id") or record.get("session_id"),  # v1 read-alias
         "owner": record.get("owner"),
         "cwd": record.get("cwd"),
         "created_at": record.get("created_at"),
@@ -137,7 +167,13 @@ def _durable_rows_for_owner(owner: str) -> list[dict[str, Any]]:
 
 
 def check_delegate_session_requirements() -> bool:
-    return bool(shutil.which("pi") or Path.home().joinpath(".local", "bin", "pi").is_file())
+    pi_available = bool(shutil.which("pi") or Path.home().joinpath(".local", "bin", "pi").is_file())
+    opencode_available = bool(
+        os.environ.get("HERMES_OPENCODE_SERVER_URL", "").strip()
+        or shutil.which("opencode")
+        or Path.home().joinpath(".local", "bin", "opencode").is_file()
+    )
+    return pi_available or opencode_available
 
 
 def _owner_key(parent_agent: Any) -> str:
@@ -218,7 +254,17 @@ def _auto_answer_pi_question(
     question: str,
     options: list[str],
 ) -> str | None:
-    """Have supervising Hermes answer a Pi question without involving the user."""
+    return _auto_answer_delegate_question(parent_agent, "pi", method, question, options)
+
+
+def _auto_answer_delegate_question(
+    parent_agent: Any,
+    backend_name: str,
+    method: str,
+    question: str,
+    options: list[str],
+) -> str | None:
+    """Have supervising Hermes answer a delegate question without involving the user."""
     from agent.oneshot import run_oneshot
 
     context = _parent_context_excerpt(parent_agent)
@@ -228,10 +274,10 @@ def _auto_answer_pi_question(
     elif method == "select" and options:
         format_rule = "Answer with exactly one of the listed options, with no explanation."
     else:
-        format_rule = "Answer directly and concisely. Return only the answer Pi should receive."
+        format_rule = "Answer directly and concisely. Return only the answer the delegate should receive."
 
     instructions = (
-        "You are Hermes supervising a persistent Pi coding delegate. Pi has asked "
+        f"You are Hermes supervising a persistent {backend_name} coding delegate. The delegate has asked "
         "a question during delegated work. Answer it yourself from the available "
         "conversation/project context. Never ask the user, never request clarification, "
         "and never defer the decision back to the user. If context is incomplete, make "
@@ -239,8 +285,8 @@ def _auto_answer_pi_question(
         "goal. Do not mention that you are an auxiliary model. " + format_rule
     )
     user_input = (
-        f"Pi question type: {method}\n"
-        f"Pi question: {question}\n"
+        f"Delegate question type: {method}\n"
+        f"Delegate question: {question}\n"
         f"Options:\n{option_block}\n\n"
         "Recent supervising Hermes context:\n"
         f"{context or '(no additional context available)'}"
@@ -265,9 +311,9 @@ def _auto_answer_pi_question(
             index = int(low)
             if 1 <= index <= len(options):
                 return options[index - 1]
-        # A select response must be one of Pi's offered values. Returning None
+        # A select response must be one of the offered values. Returning None
         # deliberately activates the conservative supervised fallback instead
-        # of sending an invalid free-form selection over the RPC protocol.
+        # of sending an invalid free-form selection over the native protocol.
         return None
     if method == "confirm":
         low = answer.casefold().strip(" .!\t\n")
@@ -279,7 +325,22 @@ def _auto_answer_pi_question(
     return _bounded(answer, 2000)
 
 
-def _pending_payload(client: PiRPCClient) -> dict[str, Any] | None:
+def _pending_payload(record: Dict[str, Any]) -> dict[str, Any] | None:
+    client = record["client"]
+    backend = record.get("backend") or "pi"
+    if backend == "opencode":
+        payload: Any = None
+        getter = getattr(client, "pending_question_payload", None)
+        if callable(getter):
+            payload = getter()
+        if not isinstance(payload, dict):
+            return None
+        return {
+            "method": payload.get("method"),
+            "question": _bounded(payload.get("question"), 2000),
+            "options": list(payload.get("options") or [])[:50],
+            "created_at": payload.get("created_at"),
+        }
     question = pending_question_for_owner(client)
     if question is None:
         return None
@@ -292,15 +353,16 @@ def _pending_payload(client: PiRPCClient) -> dict[str, Any] | None:
 
 
 def _summary(record: Dict[str, Any], *, include_result: bool = True) -> dict[str, Any]:
-    client: PiRPCClient = record["client"]
     out = {
         "session_id": record["session_id"],
-        "pi_session_id": record.get("pi_session_id") or record["session_id"],
+        "backend": record.get("backend") or "pi",
+        "native_session_id": record.get("native_session_id") or record["session_id"],
+        "pi_session_id": record.get("native_session_id") or record["session_id"],  # kept for model-callers
         "status": record.get("status", "unknown"),
         "cwd": record.get("cwd"),
         "created_at": record.get("created_at"),
         "updated_at": record.get("updated_at"),
-        "pending_question": _pending_payload(client),
+        "pending_question": _pending_payload(record),
         "error": record.get("error") or None,
     }
     if include_result and record.get("last_result"):
@@ -322,7 +384,7 @@ def _lookup(session_id: str, parent_agent: Any) -> Dict[str, Any] | None:
 
 
 def _run_turn(record: Dict[str, Any], message: str, timeout: float) -> None:
-    client: PiRPCClient = record["client"]
+    client = record["client"]
     with _SESSION_LOCK:
         if record.get("status") == "closed":
             return
@@ -334,15 +396,15 @@ def _run_turn(record: Dict[str, Any], message: str, timeout: float) -> None:
         state = result.get("state") if isinstance(result, dict) else {}
         with _SESSION_LOCK:
             record["last_result"] = result
-            record["pi_session_id"] = (
+            record["native_session_id"] = (
                 state.get("sessionId") if isinstance(state, dict) else None
-            ) or record.get("pi_session_id") or record["session_id"]
+            ) or record.get("native_session_id") or record["session_id"]
             if record.get("status") != "closed":
                 record["status"] = "idle"
             record["updated_at"] = time.time()
         _persist_metadata(record)
     except Exception as exc:  # noqa: BLE001 - surfaced as bounded session state
-        logger.exception("Pi delegate session %s turn failed", record.get("session_id"))
+        logger.exception("Delegate session %s turn failed", record.get("session_id"))
         with _SESSION_LOCK:
             if record.get("status") != "closed":
                 record["status"] = "error"
@@ -355,7 +417,7 @@ def _dispatch_turn(record: Dict[str, Any], message: str, timeout: float) -> None
     thread = threading.Thread(
         target=_run_turn,
         args=(record, message, timeout),
-        name=f"pi-delegate-{record['session_id'][:8]}",
+        name=f"delegate-{record['session_id'][:8]}",
         daemon=True,
     )
     with _SESSION_LOCK:
@@ -389,9 +451,10 @@ def delegate_session(
     context: Optional[str] = None,
     message: Optional[str] = None,
     timeout: Optional[int] = None,
+    backend: Optional[str] = None,
     parent_agent: Any = None,
 ) -> str:
-    """Create/control a persistent Pi delegation session."""
+    """Create/control a persistent native delegation session (Pi or OpenCode)."""
     if parent_agent is None:
         return tool_error("delegate_session requires a parent agent context.")
 
@@ -400,6 +463,8 @@ def delegate_session(
         return tool_error(
             "Unknown action. Use start, resume, send, steer, status, messages, list, or stop."
         )
+    if backend is not None and str(backend).strip().lower() not in _KNOWN_BACKENDS:
+        return tool_error(f"Unknown backend {backend!r}. Use 'pi' or 'opencode'.")
     effective_timeout = float(max(10, min(int(timeout or 900), 3600)))
     owner = _owner_key(parent_agent)
 
@@ -414,7 +479,9 @@ def delegate_session(
                 continue
             rows.append({
                 "session_id": sid,
-                "pi_session_id": meta.get("pi_session_id") or sid,
+                "backend": meta.get("backend") or "pi",
+                "native_session_id": meta.get("native_session_id") or meta.get("pi_session_id") or sid,
+                "pi_session_id": meta.get("pi_session_id") or meta.get("native_session_id") or sid,
                 "status": "offline",
                 "cwd": meta.get("cwd"),
                 "created_at": meta.get("created_at"),
@@ -434,15 +501,27 @@ def delegate_session(
         if saved is not None and saved.get("owner") not in {None, owner}:
             return tool_error("That delegate session belongs to another conversation.")
 
+        backend_name = _resolve_backend(backend, (saved or {}).get("backend"))
+        if backend_name is None:
+            return tool_error(f"Unknown backend {backend!r}. Use 'pi' or 'opencode'.")
+
         existing = None
         with _SESSION_LOCK:
             existing = _SESSIONS.get(handle)
             if existing is not None:
                 if existing.get("owner") != owner:
                     return tool_error("That delegate session belongs to another conversation.")
+                if backend is not None and (existing.get("backend") or "pi") != backend_name:
+                    return tool_error(
+                        f"Session {handle} is a {existing.get('backend') or 'pi'} delegate session; "
+                        f"it cannot be reopened as a {backend_name} session."
+                    )
                 client_obj = existing.get("client")
                 proc = getattr(client_obj, "_proc", None)
                 process_dead = proc is not None and proc.poll() is not None
+                is_dead = getattr(client_obj, "is_dead", None)
+                if callable(is_dead) and is_dead():
+                    process_dead = True
                 reopen = normalized == "resume" and (
                     existing.get("status") in {"closed", "error"}
                     or getattr(client_obj, "is_closed", False)
@@ -455,34 +534,49 @@ def delegate_session(
             try:
                 existing["client"].close()
             except Exception:
-                logger.debug("Could not close stale Pi delegate client before resume", exc_info=True)
+                logger.debug("Could not close stale delegate client before resume", exc_info=True)
 
         saved_cwd = str((saved or {}).get("cwd") or "").strip()
         cwd_path = Path(saved_cwd).expanduser() if saved_cwd else resolve_agent_cwd()
         if not cwd_path.is_dir():
             return tool_error(
-                f"Cannot resume Pi delegate session because its workspace no longer exists: {_bounded(cwd_path, 1000)}"
+                f"Cannot resume delegate session because its workspace no longer exists: {_bounded(cwd_path, 1000)}"
             )
         cwd = str(cwd_path.resolve())
-        client = PiRPCClient(
+        native_hint = str((saved or {}).get("native_session_id") or (saved or {}).get("pi_session_id") or "").strip()
+        client_class = _backend_client_class(backend_name)
+        answer_backend = backend_name
+        if answer_backend == "pi":
+            def _answer(method: str, title: str, options: list[str]) -> Optional[str]:
+                # Late-bound so tests can patch ds._auto_answer_pi_question.
+                return _auto_answer_pi_question(parent_agent, method, title, options)
+        else:
+            def _answer(method: str, title: str, options: list[str]) -> Optional[str]:
+                return _auto_answer_delegate_question(parent_agent, answer_backend, method, title, options)
+
+        client = client_class(
             persistent_session=True,
-            session_id=handle,
+            session_id=native_hint or handle,
             session_name=f"Hermes {handle[:8]}",
             acp_cwd=cwd,
-            question_answerer=lambda method, title, options: _auto_answer_pi_question(
-                parent_agent, method, title, options
-            ),
+            question_answerer=_answer,
         )
+        if native_hint and hasattr(client, "native_session_id"):
+            client.native_session_id = native_hint
         try:
             state = client.start(timeout=min(30.0, effective_timeout))
         except Exception as exc:  # noqa: BLE001
-            client.close()
-            return tool_error(f"Could not start Pi delegate session: {_bounded(exc, 1000)}")
+            try:
+                client.close()
+            except Exception:
+                logger.debug("Could not close failed %s delegate client", backend_name, exc_info=True)
+            return tool_error(f"Could not start {backend_name} delegate session: {_bounded(exc, 1000)}")
         native_id = str(state.get("sessionId") or handle)
         now = time.time()
         record: Dict[str, Any] = {
             "session_id": handle,
-            "pi_session_id": native_id,
+            "backend": backend_name,
+            "native_session_id": native_id,
             "owner": owner,
             "cwd": cwd,
             "client": client,
@@ -504,15 +598,25 @@ def delegate_session(
         return tool_error(f"action='{normalized}' requires session_id.")
     record = _lookup(session_id.strip(), parent_agent)
     if record is None:
-        return tool_error("Delegate session not found for this conversation. Use action='resume' to reopen a native Pi session.")
-    client: PiRPCClient = record["client"]
+        return tool_error("Delegate session not found for this conversation. Use action='resume' to reopen a native session.")
+    session_backend = record.get("backend") or "pi"
+    if backend is not None and str(backend).strip().lower() != session_backend:
+        return tool_error(
+            f"Session {record['session_id']} is a {session_backend} delegate session; pass backend='{session_backend}' or omit it."
+        )
+    client = record["client"]
 
     if normalized == "status":
         proc = getattr(client, "_proc", None)
-        if record.get("status") not in {"closed", "error"} and proc is not None and proc.poll() is not None:
+        dead = proc is not None and proc.poll() is not None
+        is_dead = getattr(client, "is_dead", None)
+        if callable(is_dead) and is_dead():
+            dead = True
+        if record.get("status") not in {"closed", "error"} and dead:
+            exit_code = getattr(proc, "returncode", None) if proc is not None else None
             with _SESSION_LOCK:
                 record["status"] = "error"
-                record["error"] = f"Pi RPC process exited with code {proc.returncode}"
+                record["error"] = f"{session_backend} delegate process exited with code {exit_code}"
                 record["updated_at"] = time.time()
             _persist_metadata(record)
         return json.dumps({"success": True, **_summary(record)}, ensure_ascii=False)
@@ -521,7 +625,7 @@ def delegate_session(
         try:
             messages = client.get_messages(timeout=min(30.0, effective_timeout))
         except Exception as exc:  # noqa: BLE001
-            return tool_error(f"Could not read Pi session messages: {_bounded(exc, 1000)}")
+            return tool_error(f"Could not read {session_backend} session messages: {_bounded(exc, 1000)}")
         # Keep the tool result bounded while preserving the newest conversational state.
         safe = messages[-40:]
         encoded = json.dumps(safe, ensure_ascii=False, default=str)
@@ -535,9 +639,9 @@ def delegate_session(
             return tool_error("action='send' requires message.")
         with _SESSION_LOCK:
             if record.get("status") == "running":
-                return tool_error("Pi session is currently running. Use action='steer' to redirect it, or wait for idle.")
+                return tool_error("Delegate session is currently running. Use action='steer' to redirect it, or wait for idle.")
             if record.get("status") == "closed":
-                return tool_error("Pi session is closed. Use action='resume' to reopen it.")
+                return tool_error("Delegate session is closed. Use action='resume' to reopen it.")
         _dispatch_turn(record, text, effective_timeout)
         return json.dumps({"success": True, "accepted": True, **_summary(record, include_result=False)}, ensure_ascii=False)
 
@@ -548,17 +652,17 @@ def delegate_session(
         with _SESSION_LOCK:
             status = record.get("status")
             if status == "closed":
-                return tool_error("Pi session is closed. Use action='resume' to reopen it.")
+                return tool_error("Delegate session is closed. Use action='resume' to reopen it.")
             if status != "running":
-                # Auto-degrade: the turn already ended, so a live steer is
-                # impossible. Route the message through the send path so the
-                # course-correction is not lost to a race window.
+                # Auto-degrade: the turn already ended (or the backend has no
+                # live steer), so route the message through the send path so
+                # the course-correction is not lost to a race window.
                 _dispatch_turn(record, text, effective_timeout)
                 return json.dumps(
                     {
                         "success": True,
                         "degraded_to_send": True,
-                        "note": "Pi turn had already ended; message was delivered as a new follow-up turn.",
+                        "note": f"{session_backend} turn had already ended; message was delivered as a new follow-up turn.",
                         **_summary(record, include_result=False),
                     },
                     ensure_ascii=False,
@@ -566,7 +670,7 @@ def delegate_session(
         try:
             response = client.steer(text, timeout=min(30.0, effective_timeout))
         except Exception as exc:  # noqa: BLE001
-            return tool_error(f"Could not steer Pi session: {_bounded(exc, 1000)}")
+            return tool_error(f"Could not steer {session_backend} session: {_bounded(exc, 1000)}")
         return json.dumps({"success": True, "response": response, **_summary(record, include_result=False)}, ensure_ascii=False, default=str)
 
     if normalized == "stop":
@@ -574,7 +678,7 @@ def delegate_session(
             if record.get("status") == "running":
                 client.abort(timeout=min(10.0, effective_timeout))
         except Exception:
-            logger.debug("Pi delegate abort failed before close", exc_info=True)
+            logger.debug("Delegate abort failed before close", exc_info=True)
         client.close()
         with _SESSION_LOCK:
             record["status"] = "closed"
@@ -588,13 +692,15 @@ def delegate_session(
 DELEGATE_SESSION_SCHEMA = {
     "name": "delegate_session",
     "description": (
-        "Delegate coding work to Pi through a persistent native RPC session. "
-        "Use this instead of delegate_task when the worker should be Pi. The Pi "
-        "conversation survives across turns: start a session, send follow-ups, "
-        "steer a running turn, inspect status or messages, and stop/resume the "
-        "same native Pi session. Pi questions are answered automatically by the "
-        "supervising Hermes agent rather than forwarded to the user. delegate_task "
-        "remains the Hermes child-agent primitive."
+        "Delegate coding work to Pi or OpenCode through a persistent native "
+        "session. Use this instead of delegate_task when the worker should be "
+        "an external coding agent. The native conversation survives across "
+        "turns: start a session, send follow-ups, steer a running turn, "
+        "inspect status or messages, and stop/resume the same native session. "
+        "Backend questions are answered automatically by the supervising "
+        "Hermes agent rather than forwarded to the user. Pi is the default "
+        "backend; pass backend='opencode' to delegate to OpenCode via its "
+        "server API. delegate_task remains the Hermes child-agent primitive."
     ),
     "parameters": {
         "type": "object",
@@ -606,25 +712,34 @@ DELEGATE_SESSION_SCHEMA = {
             },
             "session_id": {
                 "type": "string",
-                "description": "Persistent Pi delegation/session id returned by start. Required for all actions except start/list.",
+                "description": "Persistent delegation/session id returned by start. Required for all actions except start/list.",
             },
             "goal": {
                 "type": "string",
-                "description": "Initial coding objective for action='start'. The turn runs asynchronously in the persistent Pi session.",
+                "description": "Initial coding objective for action='start'. The turn runs asynchronously in the persistent native session.",
             },
             "context": {
                 "type": "string",
-                "description": "Initial background/context passed with goal when starting the Pi session.",
+                "description": "Initial background/context passed with goal when starting the session.",
             },
             "message": {
                 "type": "string",
-                "description": "Follow-up for send, or live course correction for steer. Pi questions are answered automatically by Hermes.",
+                "description": "Follow-up for send, or live course correction for steer. Delegate questions are answered automatically by Hermes.",
             },
             "timeout": {
                 "type": "integer",
                 "minimum": 10,
                 "maximum": 3600,
-                "description": "Maximum seconds allowed for each Pi turn (default 900).",
+                "description": "Maximum seconds allowed for each delegate turn (default 900).",
+            },
+            "backend": {
+                "type": "string",
+                "enum": ["pi", "opencode"],
+                "description": (
+                    "External agent backend for the session: 'pi' (default) or "
+                    "'opencode'. Applies at start/resume; control actions use the "
+                    "stored backend."
+                ),
             },
         },
         "required": [],
@@ -662,6 +777,7 @@ registry.register(
         context=args.get("context"),
         message=args.get("message"),
         timeout=args.get("timeout"),
+        backend=args.get("backend"),
         parent_agent=_resolve_parent_agent(kw.get("parent_agent")),
     ),
     check_fn=check_delegate_session_requirements,

--- a/tools/delegate_session_tool.py
+++ b/tools/delegate_session_tool.py
@@ -617,6 +617,25 @@ DELEGATE_SESSION_SCHEMA = {
 }
 
 
+def _resolve_parent_agent(parent_agent: Any) -> Any:
+    """Fall back to the turn-bound active parent when not explicitly forwarded.
+
+    The generic registry dispatch path (handle_function_call -> registry.dispatch)
+    cannot forward the agent object, so a delegate_session call routed through it
+    would otherwise always fail with "requires a parent agent context". The
+    conversation loop binds the parent for the duration of each turn, which is
+    exactly the context a live tool call executes in.
+    """
+    if parent_agent is not None:
+        return parent_agent
+    try:
+        from agent.subagent_lifecycle import get_active_subagent_parent
+
+        return get_active_subagent_parent()
+    except Exception:
+        return None
+
+
 registry.register(
     name="delegate_session",
     toolset="delegation_session",
@@ -628,7 +647,7 @@ registry.register(
         context=args.get("context"),
         message=args.get("message"),
         timeout=args.get("timeout"),
-        parent_agent=kw.get("parent_agent"),
+        parent_agent=_resolve_parent_agent(kw.get("parent_agent")),
     ),
     check_fn=check_delegate_session_requirements,
     emoji="🔁",

--- a/tools/delegate_session_tool.py
+++ b/tools/delegate_session_tool.py
@@ -546,8 +546,23 @@ def delegate_session(
         if not text:
             return tool_error("action='steer' requires message.")
         with _SESSION_LOCK:
-            if record.get("status") != "running":
-                return tool_error("Pi session is not running. Use action='send' for a new follow-up turn.")
+            status = record.get("status")
+            if status == "closed":
+                return tool_error("Pi session is closed. Use action='resume' to reopen it.")
+            if status != "running":
+                # Auto-degrade: the turn already ended, so a live steer is
+                # impossible. Route the message through the send path so the
+                # course-correction is not lost to a race window.
+                _dispatch_turn(record, text, effective_timeout)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "degraded_to_send": True,
+                        "note": "Pi turn had already ended; message was delivered as a new follow-up turn.",
+                        **_summary(record, include_result=False),
+                    },
+                    ensure_ascii=False,
+                )
         try:
             response = client.steer(text, timeout=min(30.0, effective_timeout))
         except Exception as exc:  # noqa: BLE001

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -328,6 +328,18 @@ def steer_subagent(
         agent = record.get("agent")
         if agent is None:
             return False
+        # A delegated pi (native RPC) child may be blocked on an
+        # extension_ui_request. Route the steer text to the oldest pending
+        # question first — that IS the answer — before falling back to the
+        # normal next-request injection.
+        try:
+            from agent.pi_rpc_client import answer_oldest_pending_question
+
+            if answer_oldest_pending_question(text):
+                logger.debug("steer routed to pending pi question for %s", subagent_id)
+                return True
+        except Exception as exc:
+            logger.debug("pi question routing unavailable: %s", exc)
         try:
             return bool(agent.steer(text))
         except Exception as exc:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -333,8 +333,21 @@ def steer_subagent(
         # question first — that IS the answer — before falling back to the
         # normal next-request injection.
         try:
-            from agent.pi_rpc_client import answer_oldest_pending_question
+            from agent.pi_rpc_client import answer_oldest_pending_question, pending_questions, _registry_lock
+            import time
 
+            # If no question is registered yet, wait up to 2 seconds for one
+            # to appear — the child may have just sent the request but the
+            # parent hasn't registered it yet. This avoids the race where a
+            # steer sent immediately after the question marker is seen bypasses
+            # into the child instead of answering the question.
+            if not pending_questions:
+                deadline = time.time() + 2.0
+                while time.time() < deadline:
+                    time.sleep(0.05)
+                    with _registry_lock:
+                        if pending_questions:
+                            break
             if answer_oldest_pending_question(text):
                 logger.debug("steer routed to pending pi question for %s", subagent_id)
                 return True

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -49,7 +49,8 @@ from utils import base_url_hostname, is_truthy_value
 # Tools that children must never have access to
 DELEGATE_BLOCKED_TOOLS = frozenset(
     [
-        "delegate_task",  # no recursive delegation
+        "delegate_task",  # no recursive Hermes-child delegation
+        "delegate_session",  # no external-agent delegation from leaf children
         "clarify",  # no user interaction
         "memory",  # no writes to shared MEMORY.md
         "send_message",  # no cross-platform side effects
@@ -4845,6 +4846,7 @@ def _build_top_level_description() -> str:
         "USE FOR: reasoning-heavy subtasks, work that would flood your context "
         "with intermediate data, or independent parallel workstreams.\n"
         "DO NOT USE FOR (use these instead):\n"
+        "- Persistent Pi coding delegation -> delegate_session (native Pi RPC session)\n"
         "- Mechanical multi-step work with no reasoning needed -> execute_code\n"
         "- A single tool call -> call the tool directly\n"
         "- Tasks needing user interaction -> subagents cannot ask questions\n"

--- a/toolsets.py
+++ b/toolsets.py
@@ -274,8 +274,8 @@ TOOLSETS = {
     },
     
     "delegation": {
-        "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "description": "Delegate work to isolated Hermes subagents or persistent external-agent sessions",
+        "tools": ["delegate_task", "delegate_session"],
         "includes": []
     },
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -67,7 +67,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "delegate_session",
     # Cronjob management
     "cronjob",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
@@ -279,6 +279,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "delegation_session": {
+        "description": "Persistent external-agent delegation sessions (internal scoping surface)",
+        "tools": ["delegate_session"],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 
@@ -397,7 +403,7 @@ TOOLSETS = {
             "browser_exec",
             "todo", "memory",
             "session_search", "clarify",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_session",
         ],
         "includes": [],
         # Posture toolset: selected per-session by agent/coding_context.py,
@@ -430,7 +436,7 @@ TOOLSETS = {
             "browser_exec",
             "todo", "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_session",
         ],
         "includes": []
     },
@@ -459,7 +465,7 @@ TOOLSETS = {
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code", "delegate_task", "delegate_session",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)

--- a/website/docs/guides/delegation-patterns.md
+++ b/website/docs/guides/delegation-patterns.md
@@ -1,14 +1,14 @@
 ---
 sidebar_position: 13
 title: "Delegation & Parallel Work"
-description: "When and how to use subagent delegation — patterns for parallel research, code review, and multi-file work"
+description: "When to use isolated Hermes subagents versus persistent Pi delegate sessions"
 ---
 
 # Delegation & Parallel Work
 
-Hermes can spawn isolated child agents to work on tasks in parallel. Each subagent gets its own conversation, terminal session, and toolset. Only the final summary comes back — intermediate tool calls never enter your context window.
+Hermes supports both isolated child-agent tasks and persistent external coding sessions. Use `delegate_task` for fresh-context Hermes subagents and parallel work; use `delegate_session` when coding work should stay in one native Pi conversation across follow-ups.
 
-For the full feature reference, see [Subagent Delegation](/user-guide/features/delegation).
+For the full feature reference, see [Delegation](/user-guide/features/delegation).
 
 ---
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -1,14 +1,44 @@
 ---
 sidebar_position: 7
-title: "Subagent Delegation"
-description: "Spawn isolated child agents for parallel workstreams with delegate_task"
+title: "Delegation"
+description: "Use isolated Hermes subagents with delegate_task or persistent Pi coding sessions with delegate_session"
 ---
 
-# Subagent Delegation
+# Delegation
 
-The `delegate_task` tool spawns child AIAgent instances with isolated context, inherited tool access, and their own terminal sessions. Each child gets a fresh conversation and works independently — only its final summary enters the parent's context.
+Hermes has two distinct delegation primitives:
 
-Top-level model calls run in the background automatically. Hermes returns a handle immediately so the conversation can continue, then posts the result back as a new message. An orchestrator subagent waits for its own workers so it can synthesize their results before returning.
+| Tool | Worker | Lifecycle | Best for |
+| --- | --- | --- | --- |
+| `delegate_task` | Hermes child `AIAgent` | Fresh isolated task; final summary returns to the parent | Parallel reasoning, research, reviews, bounded subtasks |
+| `delegate_session` | Pi over native `--mode rpc` | Persistent native session; follow-ups reuse the same Pi conversation | Interactive coding work that benefits from continuity |
+
+`delegate_task` spawns child AIAgent instances with isolated context, inherited tool access, and their own terminal sessions. Each child gets a fresh conversation and works independently — only its final summary enters the parent's context. Top-level model calls run in the background automatically. Hermes returns a handle immediately so the conversation can continue, then posts the result back as a new message. An orchestrator subagent waits for its own workers so it can synthesize their results before returning.
+
+`delegate_session` does **not** wrap Pi in a child AIAgent. Hermes launches a native persistent Pi RPC session and keeps the same Pi conversation across follow-up turns. Pi questions are answered automatically by the supervising Hermes model from recent conversation/project context; they are not forwarded to the human. If that internal answer fails, persistent sessions use conservative fail-closed behavior for confirmations rather than silently approving them.
+
+## Persistent Pi Session
+
+```python
+delegate_session(
+    action="start",
+    goal="Implement the API change and validate it",
+    context="Project root: /home/user/project. Preserve backward compatibility."
+)
+```
+
+The returned `session_id` is used for later control calls:
+
+```python
+delegate_session(action="status", session_id="...")
+delegate_session(action="send", session_id="...", message="Now add regression tests")
+delegate_session(action="steer", session_id="...", message="Focus on the parser, not the transport")
+delegate_session(action="messages", session_id="...")
+delegate_session(action="stop", session_id="...")
+delegate_session(action="resume", session_id="...")
+```
+
+`resume` reopens the same native Pi session, including after Hermes loses its process-local registry, and restores the session's recorded workspace. Session metadata contains IDs/timestamps/workspace only; prompt text remains in Pi's native session history.
 
 ## Single Task
 

--- a/website/docs/user-guide/features/tools.md
+++ b/website/docs/user-guide/features/tools.md
@@ -25,7 +25,7 @@ High-level categories:
 | **Terminal & Files** | `terminal`, `process`, `read_file`, `patch` | Execute commands and manipulate files. |
 | **Browser** | `browser_navigate`, `browser_snapshot`, `browser_vision` | Interactive browser automation with text and vision support. |
 | **Media** | `vision_analyze`, `image_generate`, `text_to_speech` | Multimodal analysis and generation. |
-| **Agent orchestration** | `todo`, `clarify`, `execute_code`, `delegate_task` | Planning, clarification, code execution, and subagent delegation. |
+| **Agent orchestration** | `todo`, `clarify`, `execute_code`, `delegate_task`, `delegate_session` | Planning, clarification, code execution, isolated Hermes subagents, and persistent Pi coding sessions. |
 | **Memory & recall** | `memory`, `session_search` | Persistent memory and session search. |
 | **Automation** | `cronjob` | Scheduled tasks with create/list/update/pause/resume/run/remove actions. Outbound delivery is handled by cron's own delivery, the `hermes send` CLI, and the gateway notifier — not by an agent-callable tool. |
 | **Integrations** | `ha_*`, MCP server tools | Home Assistant, MCP, and other integrations. |


### PR DESCRIPTION
## Summary

Adds persistent native external-agent delegation sessions to Hermes with a backend-neutral `delegate_session` interface. Pi remains the default backend; OpenCode is now supported through its headless server/session APIs.

### What this adds
- `delegate_session` actions: start, resume, send, steer, status, messages, list, stop
- configurable backend selection (`pi` default, `opencode` supported)
- durable backend-aware session metadata and resume support
- automatic Hermes supervision of backend questions without returning control to the user
- Pi RPC question supervision with conservative select/confirm handling
- OpenCode integration over `opencode serve` HTTP APIs instead of TUI scraping
- one shared persistent OpenCode server per Hermes process with native per-delegation sessions
- OpenCode native question handling and reply routing
- message/status/abort/resume lifecycle integration and regression coverage

### Validation
- committed feature branch is clean
- broader delegation regression suite: **246 passed**
- focused final verification: **99 passed**
- Python compile checks passed for the new/changed runtime files
- live OpenCode 1.18.18 acceptance test passed end-to-end: OpenCode emitted a native question, supervising Hermes supplied the expected test answer autonomously, OpenCode continued without user intervention, the delegated task completed, the output artifact and transcript contained the answer, and the validator exited **0** with `RESULT: PASS — OpenCode question answered autonomously by Hermes`

### Compatibility
- Pi remains the behavior when `backend` is omitted.
- Existing Pi metadata is interpreted as `backend=pi`.
- OpenCode support is additive.

### Scope

This PR remains self-contained to persistent external-agent delegation and Pi/OpenCode backend support. Machine-specific environment configuration and unrelated local changes are excluded.
