### PR TITLE
fix: max_spawn_depth=0 no longer silently coerced to 1

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -263,6 +263,17 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("depth limit", result["error"].lower())
 
+    @patch("tools.delegate_tool._load_config",
+           return_value={"max_spawn_depth": 0})
+    def test_max_spawn_depth_zero_blocks_first_delegation(self, mock_cfg):
+        """An operator setting delegation.max_spawn_depth: 0 must actually
+        disable delegation for the top-level agent (depth 0), not just have
+        the config value silently coerced back to the default of 1."""
+        parent = _make_mock_parent(depth=0)
+        result = json.loads(delegate_task(goal="test", parent_agent=parent))
+        self.assertIn("error", result)
+        self.assertIn("depth limit", result["error"].lower())
+
 
     def test_child_inherits_runtime_credentials(self):
         parent = _make_mock_parent(depth=0)
@@ -1505,13 +1516,23 @@ class TestMaxSpawnDepth(unittest.TestCase):
 
     @patch("tools.delegate_tool._load_config",
            return_value={"max_spawn_depth": 0})
-    def test_max_spawn_depth_clamped_below_one(self, mock_cfg):
+    def test_max_spawn_depth_zero_disables_delegation(self, mock_cfg):
+        """max_spawn_depth=0 is the documented way to disable delegation
+        entirely (parent depth 0 >= max_spawn_depth 0 blocks the first
+        delegate_task call) — it must be honored, not silently clamped
+        back up to 1."""
+        from tools.delegate_tool import _get_max_spawn_depth
+        self.assertEqual(_get_max_spawn_depth(), 0)
+
+    @patch("tools.delegate_tool._load_config",
+           return_value={"max_spawn_depth": -3})
+    def test_max_spawn_depth_clamped_below_zero(self, mock_cfg):
         import logging
         from tools.delegate_tool import _get_max_spawn_depth
         with self.assertLogs("tools.delegate_tool", level=logging.WARNING) as cm:
             result = _get_max_spawn_depth()
-        self.assertEqual(result, 1)
-        self.assertTrue(any("below floor 1" in m for m in cm.output))
+        self.assertEqual(result, 0)
+        self.assertTrue(any("below floor 0" in m for m in cm.output))
 
 # =========================================================================
 # role param plumbing

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -129,10 +129,14 @@ _HIGH_CONCURRENCY_WARNED = False
 MAX_DEPTH = 1  # flat by default: parent (0) -> child (1); grandchild rejected unless max_spawn_depth raised.
 # Configurable depth cap consulted by _get_max_spawn_depth; MAX_DEPTH
 # stays as the default fallback and is still the symbol tests import.
-_MIN_SPAWN_DEPTH = 1
+_MIN_SPAWN_DEPTH = 0
 # No upper ceiling on spawn depth — like max_concurrent_children, depth has a
-# floor of 1 and no ceiling. Deeper trees multiply API cost, so the default
-# stays flat (MAX_DEPTH = 1); raising the config knob is an explicit opt-in.
+# floor of 0 and no ceiling. 0 is a valid, explicit "disable delegation
+# entirely" value (the parent's own depth is 0, so depth >= max_spawn_depth
+# blocks the very first delegate_task call) — only negative values are
+# nonsensical and get clamped up to the floor. Deeper trees multiply API
+# cost, so the default stays flat (MAX_DEPTH = 1); raising the config knob
+# is an explicit opt-in.
 
 
 # ---------------------------------------------------------------------------
@@ -971,13 +975,19 @@ def _get_child_timeout() -> Optional[float]:
 
 
 def _get_max_spawn_depth() -> int:
-    """Read delegation.max_spawn_depth from config, floored at 1 (no ceiling).
+    """Read delegation.max_spawn_depth from config, floored at 0 (no ceiling).
 
     depth 0 = parent agent.  max_spawn_depth = N means agents at depths
     0..N-1 can spawn; depth N is the leaf floor.  Default 1 is flat:
     parent spawns children (depth 1), depth-1 children cannot spawn
     (blocked by this guard AND, for leaf children, by the delegation
     toolset strip in _strip_blocked_tools).
+
+    max_spawn_depth=0 disables delegation entirely: the parent's own
+    depth (0) is already >= 0, so the depth check in delegate_task
+    blocks the very first call. This is the documented way an operator
+    opts out of subagent spawning — it must be honored exactly, not
+    silently coerced back up to 1.
 
     Raise to 2+ to unlock nested orchestration. role="orchestrator"
     removes the toolset strip for spawning children when


### PR DESCRIPTION
Fixes #91765

## Summary

- `_get_max_spawn_depth()` floored `delegation.max_spawn_depth` at 1, so `max_spawn_depth: 0` (the documented way to disable subagent spawning) was silently overridden back to 1
- The top-level agent's own depth is 0, and the gate is `depth >= max_spawn_depth` — so `0` is the *only* value that actually blocks delegation for the top-level agent; flooring at 1 always permits at least one level
- Fix lowers the floor to 0, so 0 passes through unclamped and only negative values get clamped up

## Root cause

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 Operator sets max_spawn_depth: 0] -->|Intent: disable delegation| B{_get_max_spawn_depth}
    B -->|"floored = max(_MIN_SPAWN_DEPTH=1, 0)"| C[⚡ Coerced to 1]
    C --> D[🚀 delegate_task gate: depth 0 >= max_spawn 1?]
    D -->|False: NOT blocked| E[💀 Subagent spawns anyway]
    B -.->|"Fix: _MIN_SPAWN_DEPTH = 0"| F[✅ floored = 0]
    F --> G[🚀 delegate_task gate: depth 0 >= max_spawn 0?]
    G -->|True: blocked| H[✅ Delegation disabled as intended]
```

## Test plan

- [x] Updated `test_max_spawn_depth_clamped_below_one` (which pinned the old buggy behavior) into `test_max_spawn_depth_zero_disables_delegation` + `test_max_spawn_depth_clamped_below_zero`
- [x] New end-to-end test `test_max_spawn_depth_zero_blocks_first_delegation` asserts `delegate_task` itself returns a depth-limit error when `max_spawn_depth=0`, not just the getter
- [x] `tests/tools/test_delegate.py` — same 8 pre-existing failures as on unmodified `main` (unrelated environment flakiness, confirmed via diff against baseline), zero new failures

## Infographic :

<img width="1376" height="768" alt="infographic_max_spawn_depth_91772_art" src="https://github.com/user-attachments/assets/5427ea5b-c2b1-4af6-8c7c-d564b7ce5ec0" />
