### PR TITLE
fix: write_file_tool has no bypass for the read_file-echo content guard

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -80,6 +80,42 @@ class TestWriteFileHandler:
         assert "line-number" in result["error"].lower()
         mock_get.assert_not_called()
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_rejects_legitimate_pipe_delimited_csv_without_force(self, mock_get):
+        """A real CSV export with sequential row IDs matches the same
+        shape heuristic as a read_file echo and is blocked by default —
+        this pins that current (over-broad but intentional) behavior."""
+        from tools.file_tools import write_file_tool
+
+        csv_content = "1|apple|0.50\n2|banana|0.30\n3|orange|0.75\n4|grape|1.20\n"
+        result = json.loads(write_file_tool("/tmp/prices.csv", csv_content))
+
+        assert "error" in result
+        assert "line-number" in result["error"].lower()
+        mock_get.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_force_true_bypasses_line_numbered_content_guard(self, mock_get):
+        """force=True is the escape hatch for legitimate pipe-delimited
+        content that the heuristic in the test above false-positives on —
+        without it there was no way to ever write such content."""
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"status": "ok", "path": "/tmp/prices.csv"}
+        mock_ops.write_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import write_file_tool
+
+        csv_content = "1|apple|0.50\n2|banana|0.30\n3|orange|0.75\n4|grape|1.20\n"
+        result = json.loads(
+            write_file_tool("/tmp/prices.csv", csv_content, force=True)
+        )
+
+        assert result["status"] == "ok"
+        mock_ops.write_file.assert_called_once()
+        written_content = mock_ops.write_file.call_args[0][1]
+        assert written_content == csv_content
 
     @patch("tools.file_tools._get_file_ops")
     def test_unexpected_exception_still_logs_error(self, mock_get, caplog):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -348,9 +348,9 @@ _TOOL_STUBS = {
     ),
     "write_file": (
         "write_file",
-        "path: str, content: str, cross_profile: bool = False",
-        '"""Write content to a file (always overwrites). Returns dict with status. cross_profile=True opts out of the cross-Hermes-profile soft guard."""',
-        '{"path": path, "content": content, "cross_profile": cross_profile}',
+        "path: str, content: str, cross_profile: bool = False, force: bool = False",
+        '"""Write content to a file (always overwrites). Returns dict with status. cross_profile=True opts out of the cross-Hermes-profile soft guard. force=True opts out of the read_file-echo content guard."""',
+        '{"path": path, "content": content, "cross_profile": cross_profile, "force": force}',
     ),
     "search_files": (
         "search_files",

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2221,6 +2221,7 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
 
 def write_file_tool(path: str, content: str, task_id: str = "default",
                     cross_profile: bool = False,
+                    force: bool = False,
                     session_id: str | None = None) -> str:
     """Write content to a file.
 
@@ -2229,6 +2230,14 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     skills/plugins/cron/memories directory; everything else is unaffected.
     Pass ``True`` after explicit user direction — same shape as ``force``
     on the terminal tool.
+
+    ``force`` opts out of the read_file-display-text heuristic below.
+    That heuristic is a similarity check on shape (mostly-consecutive
+    ``N|line`` prefixes), not a guarantee — legitimate pipe-delimited data
+    with sequential row numbers (CSV exports, numbered logs, queue dumps)
+    can match it and would otherwise be permanently unwritable with no
+    escape hatch. Pass ``True`` after explicit user direction, same shape
+    as ``cross_profile``.
     """
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
@@ -2246,11 +2255,12 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         cross_warning = _check_cross_profile_path(path, task_id)
         if cross_warning:
             return tool_error(cross_warning)
-    if _is_internal_file_tool_content(content):
+    if not force and _is_internal_file_tool_content(content):
         return tool_error(
             "Refusing to write internal read_file display text as file content. "
             "Strip read_file line-number prefixes or reconstruct the intended "
-            "file contents before writing."
+            "file contents before writing. If this content is genuinely "
+            "pipe-delimited data (not a read_file echo), retry with force=true."
         )
     try:
         # Resolve once for the registry lock + stale check.  Failures here
@@ -2676,6 +2686,11 @@ WRITE_FILE_SCHEMA = {
                 "description": "Opt out of the cross-profile soft guard. Defaults to false. Set true ONLY after explicit user direction to edit another Hermes profile's skills/plugins/cron/memories — by default these writes are blocked with a warning because they affect a different profile than the one this session is running under.",
                 "default": False,
             },
+            "force": {
+                "type": "boolean",
+                "description": "Opt out of the read_file-display-text guard. Defaults to false. Set true ONLY when the write was blocked with 'Refusing to write internal read_file display text as file content' and the content is genuinely pipe-delimited data (e.g. a CSV export with sequential row numbers like '1|apple\\n2|banana'), not an accidental read_file echo.",
+                "default": False,
+            },
         },
         "required": ["path", "content"]
     }
@@ -2780,6 +2795,7 @@ def _handle_write_file(args, **kw):
     return write_file_tool(
         path=args["path"], content=args["content"], task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
+        force=bool(args.get("force", False)),
         session_id=kw.get("session_id"),
     )
 


### PR DESCRIPTION
Fixes #91766

## Summary

- `_is_internal_file_tool_content()`'s shape heuristic (mostly-consecutive `N|line` prefixes) has no escape hatch in `write_file_tool`, unlike the adjacent `cross_profile` guard which already has an explicit opt-out one check above it
- Legitimate pipe-delimited data with sequential row numbers (CSV exports, numbered logs, queue dumps) matches the same shape and was permanently unwritable through this tool, with no override even after explicit user direction
- Fix adds a `force: bool = False` parameter, mirroring the existing `force` parameter on the `terminal()` tool and the `cross_profile` bypass pattern already used one guard above in the same function

## Root cause

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 write_file_tool content] -->|"cross_profile guard"| B{cross_profile=True?}
    B -->|Yes: bypass available| C[✅ Guard skipped]
    A --> D{"_is_internal_file_tool_content"}
    D -->|"Legit CSV: '1|apple' '2|banana'..."| E[🔥 Matches read_file echo shape]
    E --> F[☠️ Refused — NO bypass exists]
    D -.->|"Fix: force=True"| G[⚔️ Guard skipped, write proceeds]
```

## Test plan

- [x] New test `test_rejects_legitimate_pipe_delimited_csv_without_force` pins the current default-blocked behavior
- [x] New test `test_force_true_bypasses_line_numbered_content_guard` asserts `force=True` writes the content successfully
- [x] `tests/tools/test_file_tools.py` — same 6 pre-existing failures as on unmodified `main` (Windows path-resolution environment differences, confirmed via diff against baseline), zero new failures

## Infographic :

<img width="1376" height="768" alt="infographic_write_file_echo_guard_91773_art" src="https://github.com/user-attachments/assets/9a10a3e5-4de1-4c06-b954-7b8f3b29e689" />
