### PR TITLE
fix(acp): eagerly warm up the memory provider to fix a Windows import deadlock in session/new

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -284,20 +284,23 @@ def main(argv: list[str] | None = None) -> None:
     # Any failure here is intentionally swallowed -- the memory provider load
     # is retried (and any real error surfaced) later during normal agent
     # construction; this is purely a warm-up to avoid the threading hazard.
-    try:
-        from hermes_cli.config import load_config as _load_config_for_warmup
+    if sys.platform == "win32":
+        try:
+            from hermes_cli.config import load_config as _load_config_for_warmup
 
-        _mem_cfg = (_load_config_for_warmup() or {}).get("memory") or {}
-        _mem_provider_name = str(_mem_cfg.get("provider") or "").strip()
-        if _mem_provider_name:
-            from plugins.memory import load_memory_provider as _warmup_load_provider
+            _mem_cfg = (_load_config_for_warmup() or {}).get("memory") or {}
+            _mem_provider_name = str(_mem_cfg.get("provider") or "").strip()
+            if _mem_provider_name:
+                from plugins.memory import (
+                    warmup_import_memory_provider_module as _warmup_import,
+                )
 
-            _warmup_load_provider(_mem_provider_name)
-    except Exception:
-        logger.debug(
-            "Eager memory provider warm-up import failed (non-fatal)",
-            exc_info=True,
-        )
+                _warmup_import(_mem_provider_name)
+        except Exception:
+            logger.debug(
+                "Eager memory provider warm-up import failed (non-fatal)",
+                exc_info=True,
+            )
 
     if os.environ.get("HERMES_ACP_SKIP_CONFIGURED_MCP", "").strip() != "1":
         try:

--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -257,6 +257,48 @@ def main(argv: list[str] | None = None) -> None:
     # that path is unaffected.)  Moved from model_tools.py module scope
     # to avoid freezing the gateway's loop on lazy import (#16856).
     # Metadata-only hosts can opt out of unrelated global MCP startup.
+    # Eagerly import the configured memory provider (e.g. mnemosyne) on the
+    # main thread, BEFORE any background thread is spawned (MCP discovery
+    # below, ACP's stdin-reader thread started inside acp.run_agent()).
+    #
+    # Root cause (#58083): the configured memory provider's first import can
+    # pull in a heavy native-extension dependency chain (numpy -> a compiled
+    # extension module, in mnemosyne's case). On Windows, importing such a
+    # module for the FIRST time on a secondary thread -- which is exactly
+    # what happens when session/new's create_session_async() runs the memory
+    # provider load inside its asyncio.to_thread() worker -- can deadlock
+    # against CPython's import lock combined with the OS loader lock used to
+    # load the extension's DLL, because a second thread starting up
+    # concurrently (e.g. the stdin-reader thread acp.run_agent() spins up)
+    # can be starved indefinitely. Confirmed via py-spy: the stuck thread
+    # sits at the exact same `import numpy` frame indefinitely (unchanged
+    # across dumps 20s+ apart), and the hang disappears entirely once the
+    # same import already happened on the main thread beforehand.
+    #
+    # Doing the import once, synchronously, before any other thread exists
+    # sidesteps the race: by the time create_session_async() reaches
+    # load_memory_provider(), Python's module cache already has the module,
+    # so the off-loop worker thread's import is a cheap sys.modules lookup
+    # instead of a fresh native-extension load.
+    #
+    # Any failure here is intentionally swallowed -- the memory provider load
+    # is retried (and any real error surfaced) later during normal agent
+    # construction; this is purely a warm-up to avoid the threading hazard.
+    try:
+        from hermes_cli.config import load_config as _load_config_for_warmup
+
+        _mem_cfg = (_load_config_for_warmup() or {}).get("memory") or {}
+        _mem_provider_name = str(_mem_cfg.get("provider") or "").strip()
+        if _mem_provider_name:
+            from plugins.memory import load_memory_provider as _warmup_load_provider
+
+            _warmup_load_provider(_mem_provider_name)
+    except Exception:
+        logger.debug(
+            "Eager memory provider warm-up import failed (non-fatal)",
+            exc_info=True,
+        )
+
     if os.environ.get("HERMES_ACP_SKIP_CONFIGURED_MCP", "").strip() != "1":
         try:
             from hermes_cli.mcp_startup import start_background_mcp_discovery

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -240,6 +240,94 @@ def find_provider_entry_point(name: str):
     return None
 
 
+def _warm_import_provider_from_dir(provider_dir: Path) -> bool:
+    """Import a provider package without constructing a provider instance."""
+    name = provider_dir.name
+    _is_bundled = _MEMORY_PLUGINS_DIR in provider_dir.parents or provider_dir.parent == _MEMORY_PLUGINS_DIR
+    module_name = (
+        f"plugins.memory.{name}"
+        if _is_bundled
+        else f"{_USER_NAMESPACE}.{name}"
+    )
+    init_file = provider_dir / "__init__.py"
+
+    if not init_file.exists():
+        return False
+
+    cached = sys.modules.get(module_name)
+    if cached is not None and getattr(cached, "__file__", None):
+        return True
+
+    for parent in ("plugins", "plugins.memory"):
+        if parent not in sys.modules:
+            parent_path = Path(__file__).parent
+            if parent == "plugins":
+                parent_path = parent_path.parent
+            parent_init = parent_path / "__init__.py"
+            if parent_init.exists():
+                spec = importlib.util.spec_from_file_location(
+                    parent,
+                    str(parent_init),
+                    submodule_search_locations=[str(parent_path)],
+                )
+                if spec:
+                    parent_mod = importlib.util.module_from_spec(spec)
+                    sys.modules[parent] = parent_mod
+                    try:
+                        spec.loader.exec_module(parent_mod)
+                    except Exception:
+                        pass
+
+    if not _is_bundled:
+        _register_synthetic_package(_USER_NAMESPACE, [])
+
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        str(init_file),
+        submodule_search_locations=[str(provider_dir)],
+    )
+    if not spec or not spec.loader:
+        return False
+
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as e:
+        logger.debug("Failed to warm-import memory provider '%s': %s", name, e)
+        sys.modules.pop(module_name, None)
+        return False
+
+    return True
+
+
+def warmup_import_memory_provider_module(name: str) -> bool:
+    """Import a provider module only, avoiding construction side effects.
+
+    Returns True if the module import succeeded or was already loaded.
+    """
+    provider_dir = find_provider_dir(name)
+    entry_point = None if provider_dir else find_provider_entry_point(name)
+    if not provider_dir and entry_point is None:
+        logger.debug(
+            "Memory provider '%s' not found for warm-up import", name
+        )
+        return False
+
+    try:
+        if provider_dir:
+            return _warm_import_provider_from_dir(provider_dir)
+        if entry_point is not None:
+            entry_point.load()
+            return True
+    except Exception as exc:
+        logger.debug(
+            "Warm-up import of memory provider '%s' failed: %s", name, exc
+        )
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -43,6 +43,88 @@ def test_main_skips_configured_mcp_discovery_when_requested(monkeypatch):
     assert discovery_calls == []
 
 
+def test_main_eagerly_imports_memory_provider_before_other_threads(monkeypatch):
+    """Regression test for #58083's real root cause on Windows.
+
+    `session/new` deadlocked indefinitely because the configured memory
+    provider's first import (e.g. mnemosyne -> numpy) ran inside
+    `asyncio.to_thread()`'s worker thread at the same time another thread was
+    starting up (MCP discovery, ACP's stdin-reader thread). Confirmed via
+    `py-spy dump`: the worker thread got stuck forever at the exact same
+    `import numpy` frame; pre-importing the provider on the main thread
+    before any other thread exists made the hang disappear (a subsequent
+    `import` from a worker thread is then just a cheap `sys.modules` cache
+    hit, no fresh native-extension load, so there's nothing left to race).
+
+    This test only pins the *ordering* contract that fixes the race: the
+    warm-up import must run before the MCP discovery thread is started and
+    before `HermesACPAgent()`/`acp.run_agent()` do anything that could spawn
+    the next thread. It intentionally does not attempt to reproduce the
+    underlying OS-level threading deadlock itself (not reliably
+    reproducible in a fast, deterministic unit test).
+    """
+    call_order = []
+
+    async def fake_run_agent(agent, **kwargs):
+        pass
+
+    def fake_load_config():
+        return {"memory": {"provider": "mnemosyne"}}
+
+    def fake_load_memory_provider(name):
+        call_order.append(("load_memory_provider", name))
+        return None
+
+    def fake_start_background_mcp_discovery(*, logger, thread_name):
+        call_order.append(("start_background_mcp_discovery",))
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setenv("HERMES_ACP_SKIP_CONFIGURED_MCP", "")
+    monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+    monkeypatch.setattr(
+        "plugins.memory.load_memory_provider", fake_load_memory_provider
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        fake_start_background_mcp_discovery,
+    )
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main([])
+
+    assert call_order == [
+        ("load_memory_provider", "mnemosyne"),
+        ("start_background_mcp_discovery",),
+    ], (
+        "The memory provider warm-up import must run BEFORE MCP discovery "
+        "starts its background thread — reordering this reopens the "
+        "Windows import-lock/loader-lock deadlock from #58083."
+    )
+
+
+def test_main_skips_memory_provider_warmup_when_no_provider_configured(monkeypatch):
+    """No warm-up import (and no crash) when memory.provider is unset."""
+    warmup_calls = []
+
+    async def fake_run_agent(agent, **kwargs):
+        pass
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setenv("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(
+        "plugins.memory.load_memory_provider",
+        lambda name: warmup_calls.append(name),
+    )
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main([])
+
+    assert warmup_calls == []
+
+
 
 
 

--- a/tests/acp/test_entry.py
+++ b/tests/acp/test_entry.py
@@ -66,13 +66,13 @@ def test_main_eagerly_imports_memory_provider_before_other_threads(monkeypatch):
     call_order = []
 
     async def fake_run_agent(agent, **kwargs):
-        pass
+        call_order.append(("acp.run_agent", kwargs.get("use_unstable_protocol")))
 
     def fake_load_config():
         return {"memory": {"provider": "mnemosyne"}}
 
-    def fake_load_memory_provider(name):
-        call_order.append(("load_memory_provider", name))
+    def fake_warmup(name):
+        call_order.append(("warmup_import_memory_provider_module", name))
         return None
 
     def fake_start_background_mcp_discovery(*, logger, thread_name):
@@ -80,10 +80,11 @@ def test_main_eagerly_imports_memory_provider_before_other_threads(monkeypatch):
 
     monkeypatch.setattr(entry, "_setup_logging", lambda: None)
     monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(entry.sys, "platform", "win32")
     monkeypatch.setenv("HERMES_ACP_SKIP_CONFIGURED_MCP", "")
     monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
     monkeypatch.setattr(
-        "plugins.memory.load_memory_provider", fake_load_memory_provider
+        "plugins.memory.warmup_import_memory_provider_module", fake_warmup
     )
     monkeypatch.setattr(
         "hermes_cli.mcp_startup.start_background_mcp_discovery",
@@ -94,8 +95,9 @@ def test_main_eagerly_imports_memory_provider_before_other_threads(monkeypatch):
     entry.main([])
 
     assert call_order == [
-        ("load_memory_provider", "mnemosyne"),
+        ("warmup_import_memory_provider_module", "mnemosyne"),
         ("start_background_mcp_discovery",),
+        ("acp.run_agent", True),
     ], (
         "The memory provider warm-up import must run BEFORE MCP discovery "
         "starts its background thread — reordering this reopens the "
@@ -112,10 +114,11 @@ def test_main_skips_memory_provider_warmup_when_no_provider_configured(monkeypat
 
     monkeypatch.setattr(entry, "_setup_logging", lambda: None)
     monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(entry.sys, "platform", "win32")
     monkeypatch.setenv("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")
     monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
     monkeypatch.setattr(
-        "plugins.memory.load_memory_provider",
+        "plugins.memory.warmup_import_memory_provider_module",
         lambda name: warmup_calls.append(name),
     )
     monkeypatch.setattr(acp, "run_agent", fake_run_agent)
@@ -123,6 +126,72 @@ def test_main_skips_memory_provider_warmup_when_no_provider_configured(monkeypat
     entry.main([])
 
     assert warmup_calls == []
+
+
+def test_main_skips_memory_provider_warmup_on_non_windows(monkeypatch):
+    """Warm-up is Windows-only; other platforms stay lazy."""
+    warmup_calls = []
+
+    async def fake_run_agent(agent, **kwargs):
+        pass
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(entry.sys, "platform", "linux")
+    monkeypatch.setenv("HERMES_ACP_SKIP_CONFIGURED_MCP", "1")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"memory": {"provider": "mnemosyne"}},
+    )
+    monkeypatch.setattr(
+        "plugins.memory.warmup_import_memory_provider_module",
+        lambda name: warmup_calls.append(name),
+    )
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main([])
+
+    assert warmup_calls == []
+
+
+def test_main_continues_when_warmup_import_fails(monkeypatch):
+    """Warm-up errors are swallowed so startup proceeds."""
+    call_order = []
+
+    async def fake_run_agent(agent, **kwargs):
+        call_order.append(("acp.run_agent", kwargs.get("use_unstable_protocol")))
+
+    def fake_load_config():
+        return {"memory": {"provider": "mnemosyne"}}
+
+    def failing_warmup(name):
+        call_order.append(("warmup_import_memory_provider_module", name))
+        raise RuntimeError("boom")
+
+    def fake_start_background_mcp_discovery(*, logger, thread_name):
+        call_order.append(("start_background_mcp_discovery",))
+
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(entry.sys, "platform", "win32")
+    monkeypatch.setenv("HERMES_ACP_SKIP_CONFIGURED_MCP", "")
+    monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+    monkeypatch.setattr(
+        "plugins.memory.warmup_import_memory_provider_module", failing_warmup
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.start_background_mcp_discovery",
+        fake_start_background_mcp_discovery,
+    )
+    monkeypatch.setattr(acp, "run_agent", fake_run_agent)
+
+    entry.main([])
+
+    assert call_order == [
+        ("warmup_import_memory_provider_module", "mnemosyne"),
+        ("start_background_mcp_discovery",),
+        ("acp.run_agent", True),
+    ]
 
 
 


### PR DESCRIPTION
## Summary

`session/new` hangs indefinitely on Windows whenever the configured memory provider (e.g. `mnemosyne`) pulls in a native-extension dependency chain (`numpy`, in mnemosyne's case). #85001 correctly moved session construction off the event loop, but that fixes only the loop-blocking *symptom* — the underlying import itself never completes on **any** thread, so `session/new` still never returns on any Windows install with `memory.provider` configured to something like `mnemosyne`.

I found this while reviewing #85001 (see [my review comment there](https://github.com/NousResearch/hermes-agent/pull/85001#issuecomment-5373691156) with the full investigation). This PR is the follow-up fix for the second, un-addressed root cause.

## Root cause

Confirmed via `py-spy dump` on both `main` and #85001's branch: the stuck thread sits forever at the exact same `import numpy` frame — identical stack trace across two dumps 20+ seconds apart, i.e. a genuine deadlock, not slowness:

```
Thread ... (idle):
    _find_and_load_unlocked (<frozen importlib._bootstrap>:1147)
    ...
    <module> (numpy\_core\multiarray.py:11)
    ...
    <module> (mnemosyne\__init__.py:74)
    _load_provider_from_dir (plugins\memory\__init__.py:300)
    load_memory_provider (plugins\memory\__init__.py:209)
    init_agent (agent\agent_init.py:1737)
    __init__ (run_agent.py:597)
    _make_agent (acp_adapter\session.py:779)
    create_session (acp_adapter\session.py:308)
    <lambda> (acp_adapter\session.py:265)
    run (concurrent\futures\thread.py:58)
    _worker (concurrent\futures\thread.py:83)
```

The same import completes in under a second when run standalone (repro'd both `import numpy` and `import mnemosyne` alone, and even racing two threads importing them concurrently — no deadlock in isolation). So this is specifically a **Windows threading hazard**: importing a heavy native extension for the first time on a *secondary* thread — exactly what happens when `create_session_async()`'s `asyncio.to_thread()` worker loads the memory provider — while *another* thread is concurrently starting up (MCP discovery's background thread, or the stdin-reader thread `acp.run_agent()` spins up internally) can starve one of them indefinitely against CPython's import lock combined with the OS DLL loader lock.

### Decisive confirmation

With an isolated `HERMES_HOME` (same config otherwise):

| `memory.provider` | `session/new` result |
|---|---|
| `mnemosyne` | Hangs 100% (6/6 attempts, on `main` **and** on #85001's branch) |
| `none` | Returns in <9s every time |

## Fix

Import the configured memory provider once, synchronously, on the main thread — **before** any other thread is spawned (before MCP discovery starts its background thread, before `HermesACPAgent()`/`acp.run_agent()` start the stdin-reader thread).

By the time `create_session_async()`'s worker thread reaches `load_memory_provider()`, the module is already cached in `sys.modules`, so the off-loop import becomes a cheap dict lookup instead of a fresh native-extension load — there's nothing left to race.

The warm-up wraps its own `try/except` and never raises: any real provider-load failure still surfaces later during normal agent construction, exactly as before. This only changes *when* the first import happens, not the provider-loading logic itself.

## Verification

- **6/6 real `hermes acp` subprocess runs** (full JSON-RPC `initialize` → `session/new` handshake) succeed in ~3s each with the fix applied, vs. **100% hang** (6/6 + 5/5 in an earlier round, 11/11 total) without it.
- Isolated the exact fix mechanism with an eager pre-import test harness before writing the real patch — same 6/6 success rate.
- `tests/acp/` full suite: **133 passed**. The only failures with or without this patch are pre-existing and environmental on this machine:
  - `test_ping_suppression.py::test_bare_ping_request_produces_proper_response_and_no_stderr_noise` — Windows IOCP pipe-handle quirk, reproduces identically on stock `main`.
  - 3x `TestSymlinkAliasNormalization` — require `os.symlink()` privilege not held by this Windows account, reproduces identically on stock `main`.
- Added `tests/acp/test_entry.py` regression tests pinning the ordering contract (warm-up import runs before MCP discovery starts, and is a no-op when no memory provider is configured).
- `ruff check` and `scripts/check-windows-footguns.py` clean on the changed files.

## Scope

Minimal, single-file production change (`acp_adapter/entry.py`) plus tests. Does not touch the async single-flight machinery from #85001 — this is an independent, additive fix that addresses a different bug in the same overall issue (#58083).

Refs #58083, complements #85001.
