### PR TITLE
feat: add progress-aware worker lifecycle watchdog

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1935,11 +1935,17 @@ DEFAULT_CONFIG = {
         # budget still applies.
         "max_summary_chars": 24000,
 
-        "child_timeout_seconds": 0,  # optional wall-clock cap per child agent. 0 (default)
-                                     # = no timeout: children fail only from real errors
-                                     # (API, tools, iteration budget), never a delegation
-                                     # stopwatch. Set a positive number of seconds
-                                     # (floor 30s) to enforce a hard cap.
+        "child_timeout_seconds": 0,  # compatibility emergency cap only; 0 disables it
+                                     # and does not impose a normal child lifetime.
+        # Detached-child watchdog. These are local runtime checks, not model
+        # polling. A progressing child may run beyond any wall-clock boundary;
+        # only a frozen progress signal reaches the cancellation path.
+        "watchdog_interval_seconds": 30,
+        "watchdog_inactivity_seconds": 450,
+        "cancellation_grace_seconds": 120,
+        # 0 disables the emergency absolute ceiling. If enabled, this is a
+        # last-resort runaway guard and is reported separately from inactivity.
+        "emergency_safety_ceiling_seconds": 0,
         "reasoning_effort": "",  # subagent effort: "ultra", "max", "xhigh", "high",
                                  # "medium", "low", "minimal", "none" (empty = inherit)
         "max_concurrent_children": 10,  # unified concurrency cap: max parallel children per batch

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7936,6 +7936,92 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchone()
         return dict(row) if row else None
 
+    def aggregate_session_usage(self, session_id: str) -> Dict[str, Any]:
+        """Aggregate direct parent and immediate delegated-child usage.
+
+        This is a read-only reporting view. It preserves raw sessions and
+        session_model_usage rows and separates parent consumption from child
+        consumption so a caller can compute dispatch, consumption, and
+        accepted-work metrics without treating API calls as useful work.
+        """
+        if not session_id:
+            return {"parent": {}, "children": [], "totals": {}}
+        self.flush_token_counts()
+        fields = (
+            "api_calls", "input_tokens", "output_tokens", "cache_read_tokens",
+            "cache_write_tokens", "reasoning_tokens", "estimated_cost_usd",
+        )
+        def zero() -> Dict[str, Any]:
+            return {field: 0 for field in fields}
+        def add(target: Dict[str, Any], values: Dict[str, Any]) -> None:
+            for field in fields:
+                target[field] += values.get(field, 0)
+
+        parent = zero()
+        parent_by_model: Dict[str, Dict[str, Any]] = {}
+        with self._read_ctx() as conn:
+            if conn is None:
+                return {"parent": parent, "children": [], "totals": dict(parent)}
+            rows = conn.execute(
+                """SELECT s.id, s.api_call_count,
+                          s.input_tokens, s.output_tokens, s.cache_read_tokens,
+                          s.cache_write_tokens, s.reasoning_tokens,
+                          s.estimated_cost_usd, u.model AS usage_model,
+                          u.billing_provider AS usage_provider,
+                          u.api_call_count AS u_api_calls,
+                          u.input_tokens AS u_input_tokens,
+                          u.output_tokens AS u_output_tokens,
+                          u.cache_read_tokens AS u_cache_read_tokens,
+                          u.cache_write_tokens AS u_cache_write_tokens,
+                          u.reasoning_tokens AS u_reasoning_tokens,
+                          u.estimated_cost_usd AS u_estimated_cost_usd
+                     FROM sessions s
+                LEFT JOIN session_model_usage u ON u.session_id = s.id
+                    WHERE s.id = ? OR s.parent_session_id = ?
+                 ORDER BY s.id""",
+                (session_id, session_id),
+            ).fetchall()
+        children: Dict[str, Dict[str, Any]] = {}
+        for row in rows:
+            is_parent = row["id"] == session_id
+            bucket = parent_by_model if is_parent else children.setdefault(
+                row["id"], {"session_id": row["id"], "usage": zero(), "by_model": {}}
+            )["by_model"]
+            target = parent if is_parent else children[row["id"]]["usage"]
+            if row["usage_model"] is None:
+                if any(target.values()):
+                    continue
+                values = {
+                    "api_calls": row["api_call_count"] or 0,
+                    "input_tokens": row["input_tokens"] or 0,
+                    "output_tokens": row["output_tokens"] or 0,
+                    "cache_read_tokens": row["cache_read_tokens"] or 0,
+                    "cache_write_tokens": row["cache_write_tokens"] or 0,
+                    "reasoning_tokens": row["reasoning_tokens"] or 0,
+                    "estimated_cost_usd": row["estimated_cost_usd"] or 0.0,
+                }
+                model_key = "session_summary"
+            else:
+                values = {
+                    "api_calls": row["u_api_calls"] or 0,
+                    "input_tokens": row["u_input_tokens"] or 0,
+                    "output_tokens": row["u_output_tokens"] or 0,
+                    "cache_read_tokens": row["u_cache_read_tokens"] or 0,
+                    "cache_write_tokens": row["u_cache_write_tokens"] or 0,
+                    "reasoning_tokens": row["u_reasoning_tokens"] or 0,
+                    "estimated_cost_usd": row["u_estimated_cost_usd"] or 0.0,
+                }
+                model_key = f"{row['usage_model']}@{row['usage_provider'] or ''}"
+            model_target = bucket.setdefault(model_key, zero())
+            add(model_target, values)
+            add(target, values)
+        parent["by_model"] = parent_by_model
+        child_list = list(children.values())
+        totals = zero()
+        for source in [parent] + [child["usage"] for child in child_list]:
+            add(totals, source)
+        return {"parent": parent, "children": child_list, "totals": totals}
+
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
 

--- a/tests/state/test_session_model_usage_aggregation.py
+++ b/tests/state/test_session_model_usage_aggregation.py
@@ -1,0 +1,36 @@
+"""Read-only parent/child usage aggregation regression tests."""
+from pathlib import Path
+
+from hermes_state import SessionDB
+
+
+def _db(tmp_path: Path) -> SessionDB:
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("parent", source="cli", model="luna")
+    db.create_session("child", source="subagent", model="deepseek", parent_session_id="parent")
+    return db
+
+
+def test_aggregate_separates_parent_and_child_usage(tmp_path):
+    db = _db(tmp_path)
+    db.update_token_counts("parent", input_tokens=10, output_tokens=2, api_call_count=1, model="luna", billing_provider="custom")
+    db.update_token_counts("child", input_tokens=30, output_tokens=7, reasoning_tokens=4, api_call_count=2, model="deepseek", billing_provider="custom")
+    report = db.aggregate_session_usage("parent")
+    assert report["parent"]["api_calls"] == 1
+    assert report["parent"]["input_tokens"] == 10
+    assert report["children"][0]["usage"]["api_calls"] == 2
+    assert report["children"][0]["usage"]["reasoning_tokens"] == 4
+    assert report["totals"]["api_calls"] == 3
+    assert report["totals"]["input_tokens"] == 40
+
+
+def test_aggregation_does_not_mutate_raw_rows(tmp_path):
+    db = _db(tmp_path)
+    db.update_token_counts("child", input_tokens=12, output_tokens=3, api_call_count=1, model="deepseek", billing_provider="custom")
+    before = db.get_session("child")
+    report = db.aggregate_session_usage("parent")
+    after = db.get_session("child")
+    assert report["children"]
+    assert before is not None and after is not None
+    assert after["input_tokens"] == before["input_tokens"]
+    assert after["api_call_count"] == before["api_call_count"]

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -298,6 +298,8 @@ def test_stalled_runner_is_interrupted_then_finalized(monkeypatch):
         assert evt["delegation_id"] == res["delegation_id"]
         assert evt["api_calls"] == 0
         assert "stalled" in evt["error"]
+        assert evt["worker_state"] == "cancellation_confirmed"
+        assert evt["cancellation_state"] == "confirmed"
         # Interrupt was requested BEFORE force-finalization (grace window).
         assert interrupted["count"] >= 1
         assert ad.active_count() == 0
@@ -471,6 +473,15 @@ def test_list_async_delegations_exposes_live_activity(monkeypatch):
         assert not any(k.startswith("_") for k in item)
     finally:
         gate.set()
+
+
+def test_tool_start_does_not_advance_structured_progress_token():
+    """Changing only the current tool is not meaningful worker progress."""
+    assert ad._canonical_progress_token(
+        ((0, None, None, False),)
+    ) == ad._canonical_progress_token(
+        ((0, "terminal", None, False),)
+    )
 
 
 def test_in_tool_stall_uses_higher_threshold(monkeypatch):

--- a/tests/tools/test_cancellation_fence_safety.py
+++ b/tests/tools/test_cancellation_fence_safety.py
@@ -1,0 +1,65 @@
+"""Regression tests for uncertain cancellation and mutating retry fences."""
+import threading
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import _run_single_child
+from tools.worker_lifecycle import WorkerLifecycle, WorkerState
+
+
+def test_fence_is_not_termination_confirmation():
+    lifecycle = WorkerLifecycle(logical_task_id="fenced", now=1.0)
+    lifecycle.transition(WorkerState.STALLED, now=2.0)
+    lifecycle.request_cancellation(now=2.0)
+    lifecycle.mark_cancellation_pending()
+    lifecycle.fence(now=3.0)
+    assert lifecycle.termination_confirmed() is False
+    assert lifecycle.retry_decision(replacement_generation=2) == "cancellation_pending"
+
+
+def test_sync_stall_does_not_claim_provider_termination():
+    release = threading.Event()
+    child = MagicMock()
+    child.get_activity_summary.return_value = {
+        "api_call_count": 0,
+        "current_tool": None,
+        "last_activity_ts": 1.0,
+        "last_activity_desc": "",
+    }
+    child.run_conversation.side_effect = lambda **_kwargs: (
+        release.wait(1.0), {"final_response": "late", "completed": True}
+    )[1]
+    child._delegate_saved_tool_names = []
+    child._delegate_output_schema = None
+    child._subagent_id = None
+    child.model = "test-model"
+    child.session_prompt_tokens = 0
+    child.session_completion_tokens = 0
+    child.session_reasoning_tokens = 0
+    child.session_estimated_cost_usd = 0.0
+    child.session_cost_status = "unknown"
+    parent = MagicMock()
+    parent._current_task_id = None
+    parent._touch_activity = lambda _desc: None
+    try:
+        with patch(
+            "tools.delegate_tool._get_sync_watchdog_settings",
+            return_value=(0.01, 0.02, 0.02, 0.01, 0.0),
+        ), patch("tools.delegate_tool.request_hard_interrupt"):
+            result = _run_single_child(0, "uncertain cancellation", child, parent)
+        assert result["status"] == "stalled"
+        assert result["cancellation_state"] == "pending"
+        assert result["cancellation_confirmed_at"] is None
+    finally:
+        release.set()
+
+
+def test_mutating_tool_boundary_sets_fail_closed_retry_flag():
+    lifecycle = WorkerLifecycle(logical_task_id="mutation", now=1.0)
+    assert lifecycle.note_tool_event("tool.started", "write_file", mutating=True, now=2.0) is False
+    assert lifecycle.snapshot(now=2.0)["mutation_possible"] is True
+    lifecycle.transition(WorkerState.STALLED, now=3.0)
+    lifecycle.request_cancellation(now=3.0)
+    lifecycle.mark_cancellation_pending()
+    lifecycle.fence(now=4.0)
+    lifecycle.confirm_termination(now=5.0)
+    assert lifecycle.retry_decision(replacement_generation=2) == "reconcile_mutation"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1299,9 +1299,12 @@ class TestDelegateHeartbeat(unittest.TestCase):
                 parent_agent=parent,
             )
 
-        self.assertGreater(
+        # Provider wait heartbeats are not meaningful model/tool progress;
+        # the local watchdog must eventually stop refreshing the parent and
+        # classify this synthetic blocked request as stalled.
+        self.assertLessEqual(
             len(touch_calls), 2,
-            f"Heartbeat stopped too early while child was waiting on the model; "
+            f"Provider wait heartbeat incorrectly kept a blocked child alive; "
             f"got {len(touch_calls)} touches",
         )
 

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -225,6 +225,23 @@ class TestRunSingleChildSchemaValidation:
         # exactly ONE retry — bounded
         assert len(child.calls) == 2
 
+    def test_mutating_child_does_not_take_schema_retry_without_reconciliation(self):
+        class MutatingStub(_StubChild):
+            def run_conversation(self, user_message, task_id=None, **kwargs):
+                if not self.calls:
+                    callback = getattr(self, "tool_progress_callback", None)
+                    if callback:
+                        callback("tool.started", "write_file")
+                        callback("tool.completed", "write_file")
+                return super().run_conversation(user_message, task_id=task_id, **kwargs)
+
+        child = MutatingStub(["not json at all", '{"city": "should-not-run"}'])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        entry = _run(child)
+        assert entry["schema_valid"] is False
+        assert entry["schema_retries"] == 0
+        assert len(child.calls) == 1
+
     def test_retry_exception_degrades_to_invalid(self):
         child = _StubChild(["nope"])
         child._delegate_output_schema = ADDRESS_SCHEMA

--- a/tests/tools/test_delegate_progress_watchdog.py
+++ b/tests/tools/test_delegate_progress_watchdog.py
@@ -1,0 +1,137 @@
+"""Focused synchronous progress-watchdog integration tests."""
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import _run_single_child
+
+
+def _child(summary_fn, run_fn):
+    child = MagicMock()
+    child.get_activity_summary.side_effect = summary_fn
+    child.run_conversation.side_effect = run_fn
+    child._delegate_saved_tool_names = []
+    child._delegate_output_schema = None
+    child._subagent_id = None
+    child.model = "test-model"
+    child.session_prompt_tokens = 0
+    child.session_completion_tokens = 0
+    child.session_reasoning_tokens = 0
+    child.session_estimated_cost_usd = 0.0
+    child.session_cost_status = "unknown"
+    return child
+
+
+def _parent():
+    parent = MagicMock()
+    parent._current_task_id = None
+    parent._touch_activity = lambda _desc: None
+    return parent
+
+
+def test_sync_worker_can_cross_old_120_second_boundary_with_progress():
+    counter = {"calls": 0}
+    done = threading.Event()
+
+    def summary():
+        counter["calls"] += 1
+        return {
+            "api_call_count": counter["calls"],
+            "current_tool": None,
+            "last_activity_ts": float(counter["calls"]),
+            "last_activity_desc": "api call completed",
+            "max_iterations": 40,
+        }
+
+    def run(**_kwargs):
+        time.sleep(0.08)
+        done.set()
+        return {"final_response": "long useful result", "completed": True, "api_calls": 3}
+
+    child = _child(summary, run)
+    with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.01), \
+         patch("tools.delegate_tool._HEARTBEAT_STALE_CYCLES_IDLE", 500):
+        result = _run_single_child(0, "safe synthetic long task", child, _parent())
+
+    assert done.is_set()
+    assert result["status"] == "completed"
+    assert result["worker_state"] == "success"
+
+
+def test_sync_worker_stall_requests_cancellation_and_does_not_retry():
+    release = threading.Event()
+    interrupt = MagicMock()
+
+    def summary():
+        return {
+            "api_call_count": 0,
+            "current_tool": None,
+            "last_activity_ts": 1.0,
+            "last_activity_desc": "",
+        }
+
+    def run(**_kwargs):
+        release.wait(1.0)
+        return {"final_response": "late", "completed": True, "api_calls": 0}
+
+    child = _child(summary, run)
+    with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.01), \
+         patch("tools.delegate_tool._HEARTBEAT_STALE_CYCLES_IDLE", 2), \
+         patch("tools.delegate_tool._get_sync_watchdog_settings", return_value=(0.01, 0.02, 0.02, 0.05, 0.0)), \
+         patch("tools.delegate_tool.request_hard_interrupt", side_effect=lambda c: interrupt()):
+        result = _run_single_child(0, "safe synthetic stalled task", child, _parent())
+
+    try:
+        assert result["status"] == "stalled"
+        assert result["worker_state"] == "cancellation_pending"
+        assert result["cancellation_pending"] is True
+        interrupt.assert_called()
+    finally:
+        release.set()
+
+
+def test_sync_stall_result_does_not_report_normal_timeout():
+    release = threading.Event()
+
+    def summary():
+        return {"api_call_count": 1, "current_tool": None, "last_activity_ts": 1.0}
+
+    child = _child(summary, lambda **_kwargs: (release.wait(1), {})[1])
+    with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.01), \
+         patch("tools.delegate_tool._HEARTBEAT_STALE_CYCLES_IDLE", 2), \
+         patch("tools.delegate_tool._get_sync_watchdog_settings", return_value=(0.01, 0.02, 0.02, 0.05, 0.0)), \
+         patch("tools.delegate_tool.request_hard_interrupt"):
+        result = _run_single_child(0, "stall classification", child, _parent())
+    release.set()
+    assert result["status"] == "stalled"
+    assert result["timeout_seconds"] is None
+    assert result["stall_reason"] == "inactivity"
+
+
+def test_sync_watchdog_is_local_and_does_not_invoke_llm():
+    calls = []
+
+    def summary():
+        return {"api_call_count": 1, "current_tool": None, "last_activity_ts": 1.0}
+
+    child = _child(summary, lambda **_kwargs: {"final_response": "ok", "completed": True})
+    parent = _parent()
+    parent._touch_activity = lambda desc: calls.append(desc)
+    with patch("tools.delegate_tool._HEARTBEAT_INTERVAL", 0.01):
+        result = _run_single_child(0, "local watchdog", child, parent)
+    assert result["status"] == "completed"
+    assert calls
+    assert all("llm" not in str(value).lower() for value in calls)
+
+
+def test_mutating_uncertain_stall_is_not_automatically_retried():
+    """The lifecycle primitive fails closed when a side effect may have happened."""
+    from tools.worker_lifecycle import WorkerLifecycle
+    lifecycle = WorkerLifecycle(logical_task_id="mutation", now=1.0)
+    lifecycle.mark_mutation_possible()
+    lifecycle.request_cancellation(now=2.0)
+    lifecycle.mark_cancellation_pending()
+    lifecycle.confirm_termination(now=3.0)
+    assert lifecycle.can_retry(termination_confirmed=True, replacement_generation=2) is False
+    lifecycle.reconcile_mutation()
+    assert lifecycle.can_retry(termination_confirmed=True, replacement_generation=2) is True

--- a/tests/tools/test_provider_waiting_watchdog.py
+++ b/tests/tools/test_provider_waiting_watchdog.py
@@ -1,0 +1,107 @@
+"""Provider waiting must not masquerade as forward progress."""
+import threading
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import _run_single_child
+
+
+def test_sync_provider_wait_heartbeats_do_not_reset_watchdog():
+    release = threading.Event()
+    child = MagicMock()
+    ticks = {"n": 0}
+
+    def summary():
+        ticks["n"] += 1
+        return {
+            "api_call_count": 1,
+            "current_tool": None,
+            # Simulates the provider wait heartbeat advancing while no
+            # response chunk, tool completion, or API completion arrives.
+            "last_activity_ts": float(ticks["n"]),
+            "last_activity_desc": "waiting for non-streaming API response",
+        }
+
+    child.get_activity_summary.side_effect = summary
+    child.run_conversation.side_effect = lambda **_kwargs: (
+        release.wait(1.0), {"final_response": "late", "completed": True}
+    )[1]
+    child._delegate_saved_tool_names = []
+    child._delegate_output_schema = None
+    child._subagent_id = None
+    child.model = "test-model"
+    child.session_prompt_tokens = 0
+    child.session_completion_tokens = 0
+    child.session_reasoning_tokens = 0
+    child.session_estimated_cost_usd = 0.0
+    child.session_cost_status = "unknown"
+
+    parent = MagicMock()
+    parent._current_task_id = None
+    parent._touch_activity = lambda _desc: None
+    with patch(
+        "tools.delegate_tool._get_sync_watchdog_settings",
+        return_value=(0.01, 0.02, 0.02, 0.01, 0.0),
+    ), patch("tools.delegate_tool.request_hard_interrupt"):
+        result = _run_single_child(0, "blocked provider", child, parent)
+
+    try:
+        assert result["status"] == "stalled"
+        assert result["stall_reason"] == "inactivity"
+    finally:
+        release.set()
+        child._interrupt_requested = True
+
+
+def test_stream_response_activity_is_meaningful_progress():
+    from tools.worker_lifecycle import WorkerLifecycle
+
+    lifecycle = WorkerLifecycle(logical_task_id="stream", now=1.0)
+    assert lifecycle.observe_activity(
+        {
+            "api_call_count": 1,
+            "last_activity_ts": 2.0,
+            "last_activity_desc": "receiving stream response",
+        },
+        now=2.0,
+    ) is True
+    assert lifecycle.snapshot(now=2.0)["last_progress_kind"] == "api_call_completed"
+
+
+def test_provider_wait_activity_is_not_meaningful_progress():
+    from tools.worker_lifecycle import WorkerLifecycle
+
+    lifecycle = WorkerLifecycle(logical_task_id="provider", now=1.0)
+    lifecycle.observe_activity(
+        {
+            "api_call_count": 1,
+            "last_activity_ts": 2.0,
+            "last_activity_desc": "waiting for non-streaming API response",
+        },
+        now=2.0,
+    )
+    lifecycle.observe_activity(
+        {
+            "api_call_count": 1,
+            "last_activity_ts": 3.0,
+            "last_activity_desc": "waiting for non-streaming API response",
+        },
+        now=3.0,
+    )
+    assert lifecycle.snapshot(now=3.0)["seconds_since_progress"] == 2.0
+    assert lifecycle.snapshot(now=3.0)["last_progress_kind"] == "started"
+    assert lifecycle.snapshot(now=3.0)["worker_state"] == "running"
+
+
+def test_tool_completion_activity_is_meaningful_progress():
+    from tools.worker_lifecycle import WorkerLifecycle
+
+    lifecycle = WorkerLifecycle(logical_task_id="tool", now=1.0)
+    assert lifecycle.observe_activity(
+        {
+            "api_call_count": 1,
+            "last_activity_ts": 2.0,
+            "last_activity_desc": "tool results posted, continuing iteration #1",
+        },
+        now=2.0,
+    ) is True
+    assert lifecycle.snapshot(now=2.0)["last_progress_kind"] == "api_call_completed"

--- a/tests/tools/test_worker_lifecycle.py
+++ b/tests/tools/test_worker_lifecycle.py
@@ -1,0 +1,165 @@
+"""Regression tests for deterministic delegated-worker lifecycle primitives."""
+from tools.worker_lifecycle import LifecycleWatchdog, WorkerLifecycle, WorkerState
+
+
+def test_progressing_worker_is_not_stalled_by_elapsed_wall_clock():
+    lifecycle = WorkerLifecycle(logical_task_id="task-a", now=100.0)
+    lifecycle.record_progress("api_call_completed", operation="model", now=221.0)
+    watchdog = LifecycleWatchdog(lifecycle, inactivity_threshold=30.0, clock=lambda: 240.0)
+    assert watchdog.should_stall() is False
+    assert lifecycle.snapshot(now=240.0)["worker_state"] == WorkerState.PROGRESSING.value
+
+
+def test_inactivity_enters_stall_candidate_without_wall_clock_deadline():
+    lifecycle = WorkerLifecycle(logical_task_id="task-b", now=100.0)
+    lifecycle.mark_model_wait()
+    watchdog = LifecycleWatchdog(lifecycle, inactivity_threshold=30.0, clock=lambda: 131.0)
+    assert watchdog.should_stall() is True
+    assert lifecycle.snapshot(now=131.0)["worker_state"] == WorkerState.WAITING_ON_MODEL.value
+
+
+def test_tool_start_does_not_reset_progress_timestamp():
+    lifecycle = WorkerLifecycle(logical_task_id="task-c", now=100.0)
+    lifecycle.mark_tool_wait("terminal")
+    assert lifecycle.snapshot(now=160.0)["seconds_since_progress"] == 60.0
+    lifecycle.observe_activity({"api_call_count": 0, "current_tool": "terminal", "last_activity_ts": 100.0}, now=161.0)
+    assert lifecycle.snapshot(now=161.0)["seconds_since_progress"] == 61.0
+
+
+def test_retry_requires_confirmed_termination_and_mutation_reconciliation():
+    lifecycle = WorkerLifecycle(logical_task_id="task-d", now=100.0)
+    lifecycle.mark_mutation_possible()
+    assert lifecycle.can_retry(termination_confirmed=True, replacement_generation=2) is False
+    lifecycle.reconcile_mutation()
+    lifecycle.transition(WorkerState.STALLED, now=101.0)
+    assert lifecycle.can_retry(termination_confirmed=False, replacement_generation=2) is False
+    assert lifecycle.can_retry(termination_confirmed=True, replacement_generation=2) is True
+
+
+def test_late_and_superseded_results_are_fenced():
+    late = WorkerLifecycle(logical_task_id="task-e", now=100.0)
+    late.transition(WorkerState.STALLED, now=101.0)
+    assert late.accept_result(generation=1) == WorkerState.LATE_SUCCESS
+
+    old = WorkerLifecycle(logical_task_id="task-f", execution_generation=1, now=100.0)
+    assert old.accept_result(generation=1, authoritative_generation=2) == WorkerState.SUPERSEDED
+
+
+def test_metadata_is_secret_safe_and_has_required_fields():
+    lifecycle = WorkerLifecycle(logical_task_id="task-g", now=100.0)
+    snapshot = lifecycle.snapshot(now=101.0)
+    required = {
+        "child_started_at", "last_progress_at", "last_progress_kind",
+        "current_operation", "current_operation_started_at", "worker_state",
+        "cancellation_state", "logical_task_id", "execution_generation",
+    }
+    assert required <= snapshot.keys()
+    assert "prompt" not in snapshot
+    assert "secret" not in snapshot
+
+
+def test_cancellation_is_pending_until_worker_returns():
+    lifecycle = WorkerLifecycle(logical_task_id="task-h", now=100.0)
+    lifecycle.request_cancellation(now=110.0)
+    lifecycle.mark_cancellation_pending()
+    assert lifecycle.snapshot()["worker_state"] == WorkerState.CANCELLATION_PENDING.value
+    assert lifecycle.can_retry(termination_confirmed=False, replacement_generation=2) is False
+    lifecycle.confirm_termination(now=111.0)
+    assert lifecycle.snapshot()["worker_state"] == WorkerState.CANCELLATION_CONFIRMED.value
+    assert lifecycle.can_retry(termination_confirmed=True, replacement_generation=2) is True
+
+
+def test_late_result_after_fence_is_accepted_as_late_success():
+    lifecycle = WorkerLifecycle(logical_task_id="task-i", now=100.0)
+    lifecycle.request_cancellation(now=110.0)
+    lifecycle.mark_cancellation_pending()
+    lifecycle.fence(now=111.0)
+    assert lifecycle.accept_result(generation=1) == WorkerState.LATE_SUCCESS
+
+
+def test_watchdog_is_local_and_does_not_call_an_llm():
+    calls = []
+    lifecycle = WorkerLifecycle(logical_task_id="task-j", now=100.0)
+    watchdog = LifecycleWatchdog(lifecycle, inactivity_threshold=30.0, clock=lambda: 100.0)
+    assert watchdog.should_stall() is False
+    assert calls == []
+
+
+def test_attempt_identity_is_stable_and_bounded():
+    lifecycle = WorkerLifecycle(logical_task_id="task-k", execution_generation=3, attempt_number=2, now=100.0)
+    snapshot = lifecycle.snapshot()
+    assert snapshot["logical_task_id"] == "task-k"
+    assert snapshot["execution_generation"] == 3
+    assert snapshot["attempt_number"] == 2
+    assert len(snapshot["logical_task_id"]) < 128
+
+
+def test_accounting_flags_do_not_claim_useful_work_from_api_calls():
+    lifecycle = WorkerLifecycle(logical_task_id="task-l", now=100.0)
+    snapshot = lifecycle.snapshot()
+    assert "useful_work_units" not in snapshot
+    assert "api_calls" not in snapshot
+    lifecycle.transition(WorkerState.STALLED, now=110.0)
+    assert lifecycle.snapshot()["stall_detected"] is True
+
+
+def test_terminal_transitions_are_idempotent():
+    lifecycle = WorkerLifecycle(logical_task_id="task-m", now=100.0)
+    assert lifecycle.transition(WorkerState.SUCCESS, now=101.0) is True
+    assert lifecycle.transition(WorkerState.FAILED, now=102.0) is False
+    assert lifecycle.accept_result(generation=1) == WorkerState.SUCCESS
+
+
+def test_mutation_requires_reconciliation_even_after_fence():
+    lifecycle = WorkerLifecycle(logical_task_id="task-n", now=100.0)
+    lifecycle.mark_mutation_possible()
+    lifecycle.request_cancellation(now=110.0)
+    lifecycle.mark_cancellation_pending()
+    lifecycle.fence(now=111.0)
+    lifecycle.confirm_termination(now=112.0)
+    assert lifecycle.can_retry(termination_confirmed=True, replacement_generation=2) is False
+    lifecycle.reconcile_mutation()
+    assert lifecycle.can_retry(termination_confirmed=True, replacement_generation=2) is True
+
+
+def test_provider_wait_is_not_progress_by_itself():
+    lifecycle = WorkerLifecycle(logical_task_id="task-o", now=100.0)
+    lifecycle.mark_model_wait("provider.socket")
+    assert lifecycle.snapshot(now=130.0)["seconds_since_progress"] == 30.0
+    lifecycle.observe_activity({"api_call_count": 0, "current_tool": None}, now=130.0)
+    assert lifecycle.snapshot(now=130.0)["seconds_since_progress"] == 30.0
+
+
+def test_tool_completion_is_progress_when_activity_advances():
+    lifecycle = WorkerLifecycle(logical_task_id="task-p", now=100.0)
+    lifecycle.mark_tool_wait("terminal")
+    lifecycle.observe_activity({"api_call_count": 1, "current_tool": None, "last_activity_ts": 120.0}, now=121.0)
+    snapshot = lifecycle.snapshot(now=121.0)
+    assert snapshot["last_progress_kind"] == "api_call_completed"
+    assert snapshot["seconds_since_progress"] == 0.0
+
+
+def test_fence_does_not_accept_a_new_generation_as_old_result():
+    lifecycle = WorkerLifecycle(logical_task_id="task-q", execution_generation=1, now=100.0)
+    lifecycle.fence(now=101.0)
+    assert lifecycle.accept_result(generation=1, authoritative_generation=2) == WorkerState.SUPERSEDED
+
+
+def test_snapshot_contains_no_operation_content():
+    lifecycle = WorkerLifecycle(logical_task_id="task-r", now=100.0)
+    lifecycle.record_progress("tool_completed", operation="private/path", now=101.0)
+    snapshot = lifecycle.snapshot()
+    assert snapshot["current_operation"] == "operation"
+    assert "credentials" not in snapshot
+    assert "api_key" not in snapshot
+    assert "prompt" not in snapshot
+
+
+def test_tool_start_is_not_progress_but_completion_is():
+    lifecycle = WorkerLifecycle(logical_task_id="task-s", now=1.0)
+    assert lifecycle.observe_tool_call("file.write", mutating=True, now=2.0) is False
+    assert lifecycle.snapshot(now=100.0)["seconds_since_progress"] == 99.0
+    assert lifecycle.observe_tool_call("file.write", mutating=True, completed=True, now=101.0) is True
+    snapshot = lifecycle.snapshot(now=101.0)
+    assert snapshot["last_progress_kind"] == "tool_completed"
+    assert snapshot["mutation_possible"] is True

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -38,11 +38,19 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
 import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+
+from tools.worker_lifecycle import (
+    LifecycleWatchdog,
+    WorkerLifecycle,
+    WorkerState,
+    meaningful_activity_token,
+)
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
@@ -111,10 +119,58 @@ _DB_LOCK = threading.Lock()
 # delegate_tool: idle (not inside a tool) stays tight so a wedged first API
 # call is caught quickly; in-tool is much higher so legitimately slow tools
 # (long terminal commands, big fetches) get time to finish.
-_STALE_CHECK_INTERVAL = 30.0  # seconds between monitor sweeps
-_STALE_IDLE_SECONDS = 450.0  # no progress, no current tool → stalled
-_STALE_IN_TOOL_SECONDS = 1200.0  # no progress while inside a tool → stalled
-_STALL_GRACE_SECONDS = 120.0  # after interrupt, time for the runner to return
+_STALE_CHECK_INTERVAL = 30.0  # local watchdog sweep interval
+_STALE_IDLE_SECONDS = 450.0  # no meaningful progress while idle
+_STALE_IN_TOOL_SECONDS = 1200.0  # no meaningful progress in a tool
+_STALL_GRACE_SECONDS = 120.0  # bounded cooperative-cancellation grace
+
+
+def _watchdog_settings() -> tuple[float, float, float, float, float]:
+    """Read watchdog settings without invoking a model or touching secrets."""
+    cfg: Dict[str, Any] = {}
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = (load_config_readonly().get("delegation") or {})
+    except Exception:
+        pass
+
+    def number(key: str, default: float, minimum: float = 0.01) -> float:
+        value = cfg.get(key, os.environ.get("HERMES_" + key.upper()))
+        try:
+            return max(minimum, float(value)) if value is not None else default
+        except (TypeError, ValueError):
+            return default
+
+    def configured(key: str, stock: float, runtime_value: float) -> float:
+        # load_config_readonly() supplies merged defaults. Treat a merged stock
+        # value as non-explicit so tests/embedders can tune the runtime constants;
+        # a real non-stock config value remains authoritative.
+        raw = cfg.get(key, os.environ.get("HERMES_" + key.upper()))
+        try:
+            value = float(raw) if raw is not None else stock
+        except (TypeError, ValueError):
+            value = stock
+        if value == stock and runtime_value != stock:
+            value = runtime_value
+        return max(0.01, value)
+
+    interval = configured("watchdog_interval_seconds", 30.0, _STALE_CHECK_INTERVAL)
+    idle = configured("watchdog_inactivity_seconds", 450.0, _STALE_IDLE_SECONDS)
+    grace = configured("cancellation_grace_seconds", 120.0, _STALL_GRACE_SECONDS)
+    tool_idle = configured("watchdog_tool_inactivity_seconds", 1200.0, _STALE_IN_TOOL_SECONDS)
+    raw_ceiling = cfg.get("emergency_safety_ceiling_seconds", os.environ.get("HERMES_EMERGENCY_SAFETY_CEILING_SECONDS"))
+    try:
+        ceiling = max(0.0, float(raw_ceiling)) if raw_ceiling is not None else 0.0
+    except (TypeError, ValueError):
+        ceiling = 0.0
+    return interval, idle, grace, ceiling, tool_idle
+
+
+def _lifecycle_metadata(record: Dict[str, Any], *, now: Optional[float] = None) -> Dict[str, Any]:
+    lifecycle = record.get("lifecycle")
+    if not isinstance(lifecycle, WorkerLifecycle):
+        return {}
+    return lifecycle.snapshot(now=now)
 
 _monitor_lock = threading.Lock()
 _monitor_thread: Optional[threading.Thread] = None
@@ -163,7 +219,15 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             task_json TEXT,
             delivery_claim TEXT,
             delivery_claimed_at REAL,
-            origin_session_id TEXT NOT NULL DEFAULT ''
+            origin_session_id TEXT NOT NULL DEFAULT '',
+            logical_task_id TEXT,
+            execution_generation INTEGER NOT NULL DEFAULT 1,
+            attempt_number INTEGER NOT NULL DEFAULT 1,
+            worker_state TEXT,
+            last_progress_at REAL,
+            last_progress_kind TEXT,
+            cancellation_state TEXT,
+            stall_reason TEXT
         )"""
     )
     columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
@@ -178,6 +242,14 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         # completions recovered after a process restart are unroutable on
         # api_server (the in-memory record that carried it is gone).
         ("origin_session_id", "TEXT"),
+        ("logical_task_id", "TEXT"),
+        ("execution_generation", "INTEGER NOT NULL DEFAULT 1"),
+        ("attempt_number", "INTEGER NOT NULL DEFAULT 1"),
+        ("worker_state", "TEXT"),
+        ("last_progress_at", "REAL"),
+        ("last_progress_kind", "TEXT"),
+        ("cancellation_state", "TEXT"),
+        ("stall_reason", "TEXT"),
     ):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
@@ -257,13 +329,20 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
                (delegation_id, origin_session, origin_ui_session_id,
                 parent_session_id, state, dispatched_at, updated_at,
                 delivery_state, delivery_attempts, owner_pid,
-                owner_started_at, task_json, origin_session_id)
-               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+                owner_started_at, task_json, origin_session_id,
+                logical_task_id, execution_generation, attempt_number,
+                worker_state, last_progress_at, last_progress_kind,
+                cancellation_state, stall_reason)
+               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (record["delegation_id"], record.get("session_key", ""),
              record.get("origin_ui_session_id", ""), record.get("parent_session_id"),
              record["dispatched_at"], now, __import__("os").getpid(),
              owner_started_at, json.dumps(task_payload),
-             record.get("origin_session_id", "")),
+             record.get("origin_session_id", ""), record.get("logical_task_id"),
+             record.get("execution_generation", 1), record.get("attempt_number", 1),
+             record.get("worker_state"), record.get("last_progress_at"),
+             record.get("last_progress_kind"), record.get("cancellation_state"),
+             record.get("stall_reason")),
         )
     _prune_durable_records()
 
@@ -317,10 +396,15 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
     with _DB_LOCK, _transaction() as conn:
         conn.execute(
             """UPDATE async_delegations SET state=?, completed_at=?, updated_at=?,
-               event_json=?, result_json=?, delivery_state='pending'
+               event_json=?, result_json=?, delivery_state='pending',
+               worker_state=?, last_progress_at=?, last_progress_kind=?,
+               cancellation_state=?, stall_reason=?
                WHERE delegation_id=?""",
             (event.get("status", "completed"), event.get("completed_at", now), now,
-             json.dumps(event), json.dumps(result), event["delegation_id"]),
+             json.dumps(event), json.dumps(result), event.get("worker_state"),
+             event.get("last_progress_at"), event.get("last_progress_kind"),
+             event.get("cancellation_state"), event.get("stall_reason"),
+             event["delegation_id"]),
         )
 
 
@@ -810,6 +894,7 @@ def dispatch_async_delegation(
     """
     delegation_id = _new_delegation_id()
     dispatched_at = time.time()
+    lifecycle = WorkerLifecycle(logical_task_id=delegation_id)
     record: Dict[str, Any] = {
         "delegation_id": delegation_id,
         "goal": goal,
@@ -831,6 +916,10 @@ def dispatch_async_delegation(
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "logical_task_id": delegation_id,
+        "execution_generation": 1,
+        "attempt_number": 1,
+        "lifecycle": lifecycle,
     }
     # Capacity check and record insert under ONE lock hold — checking
     # active_count() separately would let two concurrent dispatches (e.g.
@@ -904,6 +993,22 @@ def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
         return
     event_record, _interrupt_fn = claimed
 
+    lifecycle = event_record.get("lifecycle")
+    if isinstance(lifecycle, WorkerLifecycle):
+        generation = int(event_record.get("execution_generation", 1) or 1)
+        accepted = lifecycle.accept_result(
+            generation=generation,
+            authoritative_generation=generation,
+            success=status in {"completed", "success"},
+        )
+        if accepted == WorkerState.LATE_SUCCESS:
+            status = "late_success"
+        elif accepted == WorkerState.SUPERSEDED:
+            status = "superseded"
+        elif accepted == WorkerState.FAILED and status in {"completed", "success"}:
+            status = "failed"
+        result = dict(result)
+        result.update(lifecycle.snapshot(now=event_record.get("completed_at") or time.time()))
     _push_completion_event(event_record, result, status)
     _finish_finalization(delegation_id, status)
 
@@ -985,6 +1090,18 @@ def _push_completion_event(
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
     }
+    lifecycle = record.get("lifecycle")
+    if isinstance(lifecycle, WorkerLifecycle):
+        # A returned child is a confirmed termination boundary. Do this before
+        # publication so a watchdog race cannot classify one attempt twice.
+        lifecycle.confirm_termination(now=completed_at)
+        result = dict(result)
+        result.update(lifecycle.snapshot(now=completed_at))
+    # Metadata may be present in the result but must not be allowed to replace
+    # the authoritative execution identity held by the registry record.
+    for key in ("logical_task_id", "execution_generation", "attempt_number"):
+        if key in record:
+            result[key] = record[key]
     # Routing origin captured at dispatch (see _capture_routing_origin):
     # additive, lets the gateway reconstruct a full SessionSource (incl.
     # scope_id for relay tenant egress) when its own caches are cold.
@@ -998,6 +1115,14 @@ def _push_completion_event(
         "stall_threshold_seconds",
         "stall_phase",
         "stall_grace_seconds",
+        "logical_task_id",
+        "execution_generation",
+        "attempt_number",
+        "worker_state",
+        "cancellation_state",
+        "last_progress_at",
+        "last_progress_kind",
+        "stall_reason",
     ):
         if _k in result:
             evt[_k] = result[_k]
@@ -1052,6 +1177,7 @@ def dispatch_async_delegation_batch(
     delegation_id = delegation_id or _new_delegation_id()
     dispatched_at = time.time()
     n = len(goals)
+    lifecycle = WorkerLifecycle(logical_task_id=delegation_id)
     # A combined goal label for status listings / the completion header.
     combined_goal = (
         goals[0] if n == 1 else f"{n} parallel subagents: " + "; ".join(g[:40] for g in goals)
@@ -1078,6 +1204,10 @@ def dispatch_async_delegation_batch(
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "logical_task_id": delegation_id,
+        "execution_generation": 1,
+        "attempt_number": 1,
+        "lifecycle": lifecycle,
     }
     with _records_lock:
         running = sum(
@@ -1154,6 +1284,22 @@ def _finalize_batch(
         return
     event_record, _interrupt_fn = claimed
 
+    lifecycle = event_record.get("lifecycle")
+    if isinstance(lifecycle, WorkerLifecycle):
+        generation = int(event_record.get("execution_generation", 1) or 1)
+        accepted = lifecycle.accept_result(
+            generation=generation,
+            authoritative_generation=generation,
+            success=status in {"completed", "success"},
+        )
+        if accepted == WorkerState.LATE_SUCCESS:
+            status = "late_success"
+        elif accepted == WorkerState.SUPERSEDED:
+            status = "superseded"
+        elif accepted == WorkerState.FAILED and status in {"completed", "success"}:
+            status = "failed"
+        combined = dict(combined)
+        combined.update(lifecycle.snapshot(now=event_record.get("completed_at") or time.time()))
     _push_batch_completion_event(event_record, combined, status)
     _finish_finalization(delegation_id, status)
 
@@ -1212,6 +1358,14 @@ def _push_batch_completion_event(
         "stall_threshold_seconds",
         "stall_phase",
         "stall_grace_seconds",
+        "logical_task_id",
+        "execution_generation",
+        "attempt_number",
+        "worker_state",
+        "cancellation_state",
+        "last_progress_at",
+        "last_progress_kind",
+        "stall_reason",
     ):
         if _k in combined:
             evt[_k] = combined[_k]
@@ -1246,6 +1400,27 @@ def _ensure_stale_monitor() -> None:
         _monitor_thread.start()
 
 
+def _canonical_progress_token(token: Any) -> Any:
+    """Remove non-progress fields before comparing monitor samples.
+
+    ``_batch_progress`` includes the current tool and an in-tool marker so the
+    monitor can choose its threshold. A tool start may change those fields
+    without producing meaningful work, so they must not refresh the progress
+    clock. The threshold signal remains returned separately by ``progress_fn``.
+    """
+    try:
+        parts = list(token)
+    except TypeError:
+        return token
+    canonical = []
+    for part in parts:
+        if isinstance(part, (tuple, list)) and len(part) >= 3:
+            canonical.append((part[0], part[2]))
+        else:
+            canonical.append(part)
+    return tuple(canonical)
+
+
 def _stale_monitor_loop() -> None:
     """Sweep running delegations for stalled progress.
 
@@ -1263,7 +1438,8 @@ def _stale_monitor_loop() -> None:
       the owning session hears an outcome and the async slot frees. A late
       runner return after that is ignored by ``_begin_finalization``.
     """
-    while not _monitor_stop.wait(_STALE_CHECK_INTERVAL):
+    interval, idle_threshold, grace_seconds, emergency_ceiling, tool_idle_threshold = _watchdog_settings()
+    while not _monitor_stop.wait(interval):
         now = time.time()
         stalled: List[tuple] = []  # (delegation_id, is_batch, quiet_for, in_tool)
         expired: List[str] = []  # stalling past grace → force-finalize
@@ -1274,7 +1450,10 @@ def _stale_monitor_loop() -> None:
                 if status == "stalling":
                     any_monitorable = True
                     interrupted_at = record.get("_interrupted_at") or now
-                    if now - interrupted_at >= _STALL_GRACE_SECONDS:
+                    lifecycle = record.get("lifecycle")
+                    if isinstance(lifecycle, WorkerLifecycle):
+                        lifecycle.mark_cancellation_pending()
+                    if now - interrupted_at >= grace_seconds:
                         expired.append(record["delegation_id"])
                     continue
                 if status != "running":
@@ -1284,28 +1463,67 @@ def _stale_monitor_loop() -> None:
                     continue
                 any_monitorable = True
                 try:
-                    token, in_tool = progress_fn()
+                    raw_token, in_tool = progress_fn()
+                    if isinstance(raw_token, tuple) and raw_token and isinstance(raw_token[0], (tuple, list)):
+                        token = raw_token
+                    else:
+                        token = meaningful_activity_token({
+                            "api_call_count": raw_token[0] if isinstance(raw_token, tuple) and raw_token else 0,
+                            "last_activity_ts": (
+                                raw_token[2] if isinstance(raw_token, tuple) and len(raw_token) >= 3 else None
+                            ),
+                            "last_activity_desc": "receiving stream response" if isinstance(raw_token, tuple) and len(raw_token) >= 3 else "",
+                            "current_tool": raw_token[1] if isinstance(raw_token, tuple) and len(raw_token) >= 2 else None,
+                        })
                 except Exception:
                     # An unreadable child must not look permanently healthy —
                     # keep the last timestamp running instead of refreshing it.
                     token, in_tool = record.get("_progress_token"), False
-                if token != record.get("_progress_token"):
-                    record["_progress_token"] = token
+                # A first observation establishes the baseline; it is not
+                # proof that the child made progress. Provider-wait samples
+                # remain frozen until a completion/chunk boundary appears.
+                canonical_token = _canonical_progress_token(token)
+                previous_token = record.get("_progress_token")
+                if previous_token is None:
+                    record["_progress_token"] = canonical_token
+                    continue
+                if canonical_token != previous_token and canonical_token != (0, None):
+                    record["_progress_token"] = canonical_token
                     record["_progress_ts"] = now
+                    lifecycle = record.get("lifecycle")
+                    if isinstance(lifecycle, WorkerLifecycle):
+                        lifecycle.record_progress("activity_sample", now=now)
                     continue
                 quiet_for = now - (record.get("_progress_ts") or now)
-                limit = (
-                    _STALE_IN_TOOL_SECONDS if in_tool else _STALE_IDLE_SECONDS
+                lifecycle = record.get("lifecycle")
+                limit = idle_threshold
+                if in_tool:
+                    # The explicit configured inactivity threshold is the
+                    # watchdog contract for every operation; the historical
+                    # in-tool constant is only a safe fallback when the
+                    # operator left the configured default untouched.
+                    limit = tool_idle_threshold
+                emergency_hit = bool(
+                    emergency_ceiling
+                    and now - (record.get("dispatched_at") or now) >= emergency_ceiling
                 )
+                if emergency_hit:
+                    limit = 0.0
                 if quiet_for >= limit:
                     record["status"] = "stalling"
                     record["_interrupted_at"] = now
+                    if isinstance(lifecycle, WorkerLifecycle):
+                        lifecycle.transition(WorkerState.STALLED, now=now)
+                        lifecycle.request_cancellation(now=now)
                     # Structured stall context for the terminal event and
                     # status listings (#51690): how long progress was frozen,
                     # which threshold applied, and whether the child was
                     # inside a tool when it went quiet.
                     record["_stall_quiet_seconds"] = round(quiet_for, 2)
                     record["_stall_threshold_seconds"] = limit
+                    record["_stall_reason"] = (
+                        "emergency_safety_ceiling" if emergency_hit else "inactivity"
+                    )
                     record["_stall_in_tool"] = bool(in_tool)
                     stalled.append(
                         (
@@ -1344,8 +1562,15 @@ def _finalize_stalled(delegation_id: str) -> None:
     if claimed is None:
         return
     event_record, _interrupt_fn = claimed
+    lifecycle = event_record.get("lifecycle")
 
     completed_at = event_record.get("completed_at") or time.time()
+    if isinstance(lifecycle, WorkerLifecycle):
+        # This is an observability fence only. The detached runner may still be
+        # inside provider/tool I/O; do not call it termination confirmation and
+        # do not permit a replacement attempt from this record.
+        lifecycle.fence(now=completed_at)
+        lifecycle.mark_cancellation_pending()
     duration = round(
         completed_at - (event_record.get("dispatched_at") or completed_at),
         2,
@@ -1378,8 +1603,14 @@ def _finalize_stalled(delegation_id: str) -> None:
             else "idle" if stall_in_tool is not None
             else None
         ),
-        "stall_grace_seconds": _STALL_GRACE_SECONDS,
+        "stall_grace_seconds": _watchdog_settings()[2],
+        "stall_reason": event_record.get("_stall_reason", "inactivity"),
+        "logical_task_id": event_record.get("logical_task_id"),
+        "execution_generation": event_record.get("execution_generation", 1),
+        "attempt_number": event_record.get("attempt_number", 1),
     }
+    if isinstance(lifecycle, WorkerLifecycle):
+        stall_meta.update(lifecycle.snapshot(now=completed_at))
     if event_record.get("is_batch"):
         _push_batch_completion_event(
             event_record,
@@ -1463,6 +1694,9 @@ def list_async_delegations() -> List[Dict[str, Any]]:
                 if k not in {"interrupt_fn", "progress_fn"}
                 and not k.startswith("_")
             }
+            lifecycle = r.get("lifecycle")
+            if isinstance(lifecycle, WorkerLifecycle):
+                item.update(lifecycle.snapshot(now=now))
             status = r.get("status")
             if status in ("running", "stalling"):
                 ts = r.get("_progress_ts")
@@ -1489,10 +1723,10 @@ def list_async_delegations() -> List[Dict[str, Any]]:
         if fn is None:
             continue
         try:
-            token, in_tool = fn()
+            raw_token, in_tool = fn()
         except Exception:
             continue
-        activity = _children_activity_from_token(token, now)
+        activity = _children_activity_from_token(raw_token, now)
         if activity is not None:
             item["children_activity"] = activity
         item["in_tool"] = bool(in_tool)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -36,6 +36,13 @@ from urllib.parse import urlsplit, urlunsplit
 
 from toolsets import TOOLSETS
 from agent.interrupt_compat import request_hard_interrupt
+from tools.worker_lifecycle import (
+    WorkerLifecycle,
+    WorkerState,
+    activity_signature,
+    meaningful_activity_token,
+    meaningful_activity_advanced,
+)
 
 # Sentinel value used by the runtime provider system for providers that are
 # not natively known (named custom providers, third-party aggregators, etc.).
@@ -1126,6 +1133,54 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 _HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
 _HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+
+
+def _get_sync_watchdog_settings() -> tuple[float, float, float, float, float]:
+    """Return local watchdog settings for the synchronous child path.
+
+    The watchdog is deliberately independent from ``child_timeout_seconds``.
+    The latter is a compatibility emergency cap; these values decide whether
+    an otherwise unbounded child is actually inactive.
+    """
+    cfg = _load_config().get("delegation", {})
+    if not isinstance(cfg, dict):
+        cfg = {}
+
+    def configured(key: str, stock: float, runtime_value: float) -> float:
+        raw = cfg.get(key, os.environ.get("HERMES_" + key.upper()))
+        try:
+            value = float(raw) if raw is not None else stock
+        except (TypeError, ValueError):
+            value = stock
+        if value == stock and runtime_value != stock:
+            value = runtime_value
+        return max(0.01, value)
+
+    interval = configured("watchdog_interval_seconds", 30.0, float(_HEARTBEAT_INTERVAL))
+    idle = configured(
+        "watchdog_inactivity_seconds",
+        float(_HEARTBEAT_STALE_CYCLES_IDLE * 30),
+        float(_HEARTBEAT_STALE_CYCLES_IDLE * _HEARTBEAT_INTERVAL),
+    )
+    tool_idle = configured(
+        "watchdog_tool_inactivity_seconds",
+        float(_HEARTBEAT_STALE_CYCLES_IN_TOOL * 30),
+        float(_HEARTBEAT_STALE_CYCLES_IN_TOOL * _HEARTBEAT_INTERVAL),
+    )
+    grace = configured("cancellation_grace_seconds", 120.0, 120.0)
+    raw_ceiling = cfg.get(
+        "emergency_safety_ceiling_seconds",
+        os.environ.get("HERMES_EMERGENCY_SAFETY_CEILING_SECONDS"),
+    )
+    try:
+        ceiling = max(0.0, float(raw_ceiling)) if raw_ceiling is not None else 0.0
+    except (TypeError, ValueError):
+        ceiling = 0.0
+    return interval, idle, tool_idle, grace, ceiling
+
+
+class _WorkerStalled(RuntimeError):
+    """Internal marker: cancellation was requested but termination unproven."""
 
 
 # ---------------------------------------------------------------------------
@@ -2439,6 +2494,41 @@ def _run_single_child(
     Returns a structured result dict.
     """
     child_start = time.monotonic()
+    _logical_task_id = str(
+        getattr(child, "_delegation_id", None)
+        or getattr(child, "_subagent_id", None)
+        or f"child-{task_index}-{id(child)}"
+    )
+    _lifecycle = WorkerLifecycle(logical_task_id=_logical_task_id)
+    _lifecycle.mark_model_wait("child.run_conversation")
+    _mutation_tools = {
+        "write_file", "patch", "terminal", "git", "github", "browser_file_upload",
+        "deploy", "restart_service", "database_mutation",
+    }
+
+    def _observe_child_tool_event(event_type: Any, tool_name: Any = None, *args, **kwargs) -> None:
+        """Feed host tool boundaries into the attempt fence without content."""
+        text = str(event_type or "")
+        name = str(tool_name or "")
+        started = text in {"tool.started", "delegate.tool_started"}
+        completed = text in {"tool.completed", "delegate.tool_completed"}
+        if not (started or completed):
+            return
+        _lifecycle.note_tool_event(
+            text,
+            name,
+            completed=completed,
+            mutating=name in _mutation_tools,
+        )
+
+    _original_progress_callback = getattr(child, "tool_progress_callback", None)
+    if callable(_original_progress_callback):
+        def _lifecycle_progress_callback(event_type: Any, tool_name: Any = None, *args, **kwargs):
+            _observe_child_tool_event(event_type, tool_name, *args, **kwargs)
+            return _original_progress_callback(event_type, tool_name, *args, **kwargs)
+        child.tool_progress_callback = _lifecycle_progress_callback
+    else:
+        child.tool_progress_callback = _observe_child_tool_event
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, "tool_progress_callback", None)
@@ -2473,18 +2563,20 @@ def _run_single_child(
     # Different thresholds for idle vs in-tool (see _HEARTBEAT_STALE_CYCLES_*).
     # last_activity_ts is the same liveness signal the async stall monitor
     # already uses (streamed chunks + direct_api_call mid-wait heartbeats).
+    _last_seen_signature: List[Any] = [None]
     _last_seen_iter = [0]
     _last_seen_tool = [None]  # type: list
     _last_seen_activity_ts = [None]  # type: list
     _stale_count = [0]
+    _watchdog_stall = threading.Event()
+    _watchdog_reason = [None]
 
     def _heartbeat_loop():
-        while not _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
-            if parent_agent is None:
-                continue
-            touch = getattr(parent_agent, "_touch_activity", None)
-            if not touch:
-                continue
+        watchdog_interval, idle_threshold, tool_idle_threshold, _grace, emergency_ceiling = (
+            _get_sync_watchdog_settings()
+        )
+        while not _heartbeat_stop.wait(watchdog_interval):
+            touch = getattr(parent_agent, "_touch_activity", None) if parent_agent is not None else None
             # Pull detail from the child's own activity tracker
             desc = f"delegate_task: subagent {task_index} working"
             try:
@@ -2493,6 +2585,7 @@ def _run_single_child(
                 child_iter = child_summary.get("api_call_count", 0)
                 child_max = child_summary.get("max_iterations", 0)
                 child_activity_ts = child_summary.get("last_activity_ts")
+                _lifecycle.observe_activity(child_summary, now=time.time())
 
                 # Stale detection: count cycles where iteration, current_tool,
                 # AND last_activity_ts are all frozen. A child running a
@@ -2500,20 +2593,18 @@ def _run_single_child(
                 # child waiting on a slow model refreshes last_activity_ts
                 # via direct_api_call's activity heartbeat — neither should
                 # look stale at the idle threshold.
-                iter_advanced = child_iter > _last_seen_iter[0]
-                tool_changed = child_tool != _last_seen_tool[0]
-                activity_advanced = (
-                    child_activity_ts is not None
-                    and (
-                        _last_seen_activity_ts[0] is None
-                        or child_activity_ts > _last_seen_activity_ts[0]
-                    )
+                signature = activity_signature(child_summary)
+                previous_signature = _last_seen_signature[0]
+                # Tool starts and provider wait heartbeats do not refresh the
+                # watchdog. A meaningful stream/completion boundary does.
+                meaningful = previous_signature is None or meaningful_activity_advanced(
+                    child_summary, previous_signature
                 )
-                if iter_advanced or tool_changed or activity_advanced:
-                    _last_seen_iter[0] = child_iter
+                if meaningful:
+                    _last_seen_signature[0] = signature
+                    _last_seen_iter[0] = signature[0]
                     _last_seen_tool[0] = child_tool
-                    if child_activity_ts is not None:
-                        _last_seen_activity_ts[0] = child_activity_ts
+                    _last_seen_activity_ts[0] = signature[1]
                     _stale_count[0] = 0
                 else:
                     _stale_count[0] += 1
@@ -2523,20 +2614,37 @@ def _run_single_child(
                 # cover legitimately slow tools; idle threshold stays
                 # tight so the gateway timeout can fire on a truly wedged
                 # child.
-                stale_limit = (
-                    _HEARTBEAT_STALE_CYCLES_IN_TOOL
-                    if child_tool
-                    else _HEARTBEAT_STALE_CYCLES_IDLE
+                configured_limit = tool_idle_threshold if child_tool else idle_threshold
+                stale_limit = max(
+                    1,
+                    int(configured_limit / max(watchdog_interval, 0.01) + 0.999),
                 )
-                if _stale_count[0] >= stale_limit:
+                emergency_hit = bool(
+                    emergency_ceiling
+                    and time.time() - child_start >= emergency_ceiling
+                )
+                if _stale_count[0] >= stale_limit or emergency_hit:
+                    _watchdog_reason[0] = (
+                        "emergency_safety_ceiling" if emergency_hit else "inactivity"
+                    )
+                    _lifecycle.transition(WorkerState.STALLED)
+                    _lifecycle.request_cancellation()
+                    _watchdog_stall.set()
+                    try:
+                        request_hard_interrupt(child)
+                    except Exception:
+                        try:
+                            child._interrupt_requested = True
+                        except Exception:
+                            pass
                     logger.warning(
-                        "Subagent %d appears stale (no progress for %d "
+                        "Subagent %d appears stalled (no progress for %d "
                         "heartbeat cycles, tool=%s) — stopping heartbeat",
                         task_index,
                         _stale_count[0],
                         child_tool or "<none>",
                     )
-                    break  # stop touching parent, let gateway timeout fire
+                    break
 
                 if child_tool:
                     desc = (
@@ -2552,10 +2660,11 @@ def _run_single_child(
                         )
             except Exception:
                 pass
-            try:
-                touch(desc)
-            except Exception:
-                pass
+            if touch:
+                try:
+                    touch(desc)
+                except Exception:
+                    pass
 
     _heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
 
@@ -2751,10 +2860,15 @@ def _run_single_child(
             list(file_state.known_reads(parent_task_id)) if parent_task_id else []
         )
 
-        # Run child with an optional hard timeout (off by default —
-        # result(timeout=None) blocks until the child finishes). Stuck-child
-        # protection comes from the heartbeat staleness monitor instead.
+        # Run child with an optional emergency/legacy hard ceiling. The normal
+        # lifecycle decision is always the local progress watchdog; a non-zero
+        # value here is an explicit failsafe, never an ordinary task deadline.
         child_timeout = _get_child_timeout()
+        if child_timeout is not None:
+            logger.warning(
+                "Using configured emergency child ceiling %.1fs; this is not an inactivity timeout",
+                child_timeout,
+            )
         # Daemon worker (tools.daemon_pool): a timed-out child is abandoned
         # below; a stdlib non-daemon worker would then block interpreter
         # exit at atexit-join time if the child never unwinds.
@@ -2800,7 +2914,34 @@ def _run_single_child(
             _run_with_thread_capture,
         )
         try:
-            result = _child_future.result(timeout=child_timeout)
+            _lifecycle.mark_model_wait("child.run_conversation")
+            if child_timeout is None:
+                # There is no ordinary wall-clock deadline. Poll the local
+                # Future only to observe completion or the deterministic
+                # watchdog event; no provider/LLM probe is sent.
+                watchdog_interval, _idle, _tool_idle, cancellation_grace, _ceiling = (
+                    _get_sync_watchdog_settings()
+                )
+                while True:
+                    try:
+                        result = _child_future.result(timeout=watchdog_interval)
+                        break
+                    except FuturesTimeoutError:
+                        if not _watchdog_stall.is_set():
+                            continue
+                        # Give cooperative cancellation a bounded chance to
+                        # unwind. If it does not, return CANCELLATION_PENDING;
+                        # the caller must not launch a replacement attempt.
+                        try:
+                            result = _child_future.result(timeout=cancellation_grace)
+                            break
+                        except FuturesTimeoutError as _stalled_exc:
+                            raise _WorkerStalled(
+                                "worker cancellation remains pending after "
+                                f"{cancellation_grace}s grace"
+                            ) from _stalled_exc
+            else:
+                result = _child_future.result(timeout=child_timeout)
         except Exception as _timeout_exc:
             # No consumer boundary remains once this owner stops waiting for
             # the child. Close acceptance before any completion callback and
@@ -2808,7 +2949,10 @@ def _run_single_child(
             _late_pending_steer = (
                 _close_subagent_steering(_subagent_id, child) if _subagent_id else None
             )
-            # Signal the child to stop so its thread can exit cleanly.
+            # Signal the child to stop so its thread can exit cleanly. This
+            # request is cooperative; the result remains fenced until the
+            # worker actually returns or the owning lifecycle records a safe
+            # terminal boundary.
             try:
                 interrupted = child is not None and request_hard_interrupt(child)
                 if not interrupted and child is not None and hasattr(child, "_interrupt_requested"):
@@ -2816,7 +2960,19 @@ def _run_single_child(
             except Exception:
                 pass
 
-            is_timeout = isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
+            is_stall = isinstance(_timeout_exc, _WorkerStalled)
+            is_timeout = (
+                isinstance(_timeout_exc, (FuturesTimeoutError, TimeoutError))
+                and not is_stall
+            )
+            if is_timeout:
+                _lifecycle.transition(WorkerState.STALLED)
+                _lifecycle.request_cancellation()
+                _lifecycle.mark_cancellation_pending()
+            elif is_stall:
+                _lifecycle.transition(WorkerState.STALLED)
+                _lifecycle.request_cancellation()
+                _lifecycle.mark_cancellation_pending()
             duration = round(time.monotonic() - child_start, 2)
             logger.warning(
                 "Subagent %d %s after %.1fs",
@@ -2893,10 +3049,10 @@ def _run_single_child(
 
             _error_entry = {
                 "task_index": task_index,
-                "status": "timeout" if is_timeout else "error",
+                "status": "stalled" if is_stall else "timeout" if is_timeout else "error",
                 "summary": None,
                 "error": _err,
-                "exit_reason": "timeout" if is_timeout else "error",
+                "exit_reason": "stalled" if is_stall else "timeout" if is_timeout else "error",
                 "api_calls": child_api_calls,
                 "duration_seconds": duration,
                 "timeout_seconds": child_timeout if is_timeout else None,
@@ -2908,7 +3064,10 @@ def _run_single_child(
                 ),
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
+                "stall_reason": _watchdog_reason[0] if is_stall else None,
+                "cancellation_pending": is_stall,
             }
+            _error_entry.update(_lifecycle.snapshot())
             if _late_pending_steer:
                 _error_entry["missed_steer"] = _late_pending_steer
                 _error_entry["error"] += (
@@ -2942,15 +3101,27 @@ def _run_single_child(
             _schema_valid, _schema_errors = validate_output(
                 _first_text, _output_schema
             )
+            _mutation_possible = bool(_lifecycle.snapshot().get("mutation_possible"))
             if (
                 not _schema_valid
                 and _first_text.strip()
                 and not result.get("interrupted", False)
+                and not _mutation_possible
             ):
                 # Exactly one retry turn, carrying the validation errors
                 # verbatim (no schema re-paste — the child already holds
-                # the contract in its context).
+                # the contract in its context). A child that may have crossed
+                # a mutating tool boundary is fail-closed: schema correction
+                # is not an authorization to repeat side effects.
                 _schema_retries = 1
+            elif not _schema_valid and _mutation_possible:
+                _schema_errors = list(_schema_errors) + [
+                    "schema retry suppressed: mutation reconciliation required"
+                ]
+                _schema_retries = 0
+            if _schema_retries:
+                # Exactly one retry turn, carrying the validation errors.
+                # The child already holds the output contract in context.
                 _retry_result = None
                 try:
                     _retry_result = child.run_conversation(
@@ -3027,6 +3198,19 @@ def _run_single_child(
             # tells the parent *how* the task ended.
             status = "completed"
         else:
+            status = "failed"
+
+        # Linearize result acceptance with the watchdog. A child that returns
+        # during cancellation grace is useful late work, not an ordinary
+        # success; it is accepted only for this generation and cannot overwrite
+        # a later authoritative attempt.
+        _accepted_state = _lifecycle.accept_result(
+            generation=_lifecycle.snapshot()["execution_generation"],
+            success=status == "completed",
+        )
+        if _accepted_state == WorkerState.LATE_SUCCESS:
+            status = "late_success"
+        elif _accepted_state in {WorkerState.SUPERSEDED, WorkerState.FAILED}:
             status = "failed"
 
         # Build tool trace from conversation messages (already in memory).
@@ -3127,6 +3311,8 @@ def _run_single_child(
         # Mirrors _child_cost_usd (which is stripped pre-serialization and
         # only feeds the parent session rollup).
         # Inspired by: Perplexity Agent API result shape (idea-level).
+        _lifecycle.confirm_termination()
+        entry.update(_lifecycle.snapshot())
         entry["cost_usd"] = round(entry["_child_cost_usd"], 6)
         _cost_status = getattr(child, "session_cost_status", None)
         entry["cost_status"] = (
@@ -3140,8 +3326,7 @@ def _run_single_child(
         # requested, so legacy (schema-less) payloads keep their exact shape.
         if isinstance(_output_schema, dict):
             entry["schema_valid"] = bool(_schema_valid)
-            if _schema_retries:
-                entry["schema_retries"] = _schema_retries
+            entry["schema_retries"] = _schema_retries
             if not _schema_valid and _schema_errors:
                 entry["schema_errors"] = _schema_errors
 
@@ -3283,6 +3468,9 @@ def _run_single_child(
             "duration_seconds": duration,
             "_child_role": getattr(child, "_delegate_role", None),
         }
+        _lifecycle.transition(WorkerState.FAILED)
+        _lifecycle.confirm_termination()
+        _error_entry.update(_lifecycle.snapshot())
         if _late_pending_steer:
             _error_entry["missed_steer"] = _late_pending_steer
             _error_entry["error"] += (
@@ -4228,11 +4416,13 @@ def delegate_task(
                 try:
                     _summary = _c.get_activity_summary()
                     _tool = _summary.get("current_tool")
+                    _progress = meaningful_activity_token(_summary)
                     parts.append(
                         (
-                            _summary.get("api_call_count", 0),
+                            _progress[0],
                             _tool,
-                            _summary.get("last_activity_ts"),
+                            _progress[1],
+                            _progress[1] is not None,
                         )
                     )
                     in_tool = in_tool or bool(_tool)

--- a/tools/worker_lifecycle.py
+++ b/tools/worker_lifecycle.py
@@ -1,0 +1,493 @@
+"""Deterministic progress-aware lifecycle primitives for delegated workers."""
+from __future__ import annotations
+
+import enum
+import re
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+_SAFE_LABEL = re.compile(r"^[A-Za-z0-9_.:-]{1,80}$")
+
+
+def _safe_label(value: Any, fallback: str = "operation") -> str:
+    text = str(value or "").strip()
+    return text if _SAFE_LABEL.fullmatch(text) else fallback
+
+
+def _activity_class(summary: Any) -> str:
+    if not isinstance(summary, dict):
+        return "unknown"
+    desc = str(summary.get("last_activity_desc", "") or "").lower()
+    if any(word in desc for word in ("waiting for", "starting api", "requesting", "starting", "executing")):
+        return "waiting"
+    if any(word in desc for word in ("receiving", "stream", "chunk")):
+        return "stream"
+    if any(word in desc for word in ("completed", "result", "posted", "finished")):
+        return "completed"
+    return "activity"
+
+
+def activity_signature(summary: Any) -> tuple[Any, Any, str, bool]:
+    """Return a secret-free observation used to compare adjacent samples."""
+    if not isinstance(summary, dict):
+        return (0, None, "unknown", False)
+    try:
+        api_calls = int(summary.get("api_call_count", 0) or 0)
+    except (TypeError, ValueError):
+        api_calls = 0
+    return (
+        api_calls,
+        summary.get("last_activity_ts"),
+        _activity_class(summary),
+        bool(summary.get("current_tool")),
+    )
+
+
+def meaningful_activity_token(summary: Any) -> tuple[Any, Any]:
+    """Return a canonical marker for the latest substantive progress."""
+    signature = activity_signature(summary)
+    api_calls, activity_ts, category, has_tool = signature
+    if category == "waiting" or (has_tool and category not in {"stream", "completed"}):
+        # API-call counters advance at request start in the agent loop. They
+        # are therefore not progress while the provider/tool is still waiting.
+        return 0, None
+    return api_calls, activity_ts
+
+
+def meaningful_activity_advanced(summary: Any, previous: Any) -> bool:
+    """Whether *summary* crossed a meaningful progress boundary.
+
+    ``previous`` is normally an ``activity_signature``. Provider wait/start
+    heartbeats are intentionally never progress, even when their timestamp
+    changes or an API call has merely started.
+    """
+    current = activity_signature(summary)
+    before = previous if isinstance(previous, tuple) and len(previous) == 4 else activity_signature(previous)
+    if current[2] == "waiting":
+        return False
+    # API-call counts can advance at request start, so only count them once
+    # the observation is explicitly a completion/result boundary.
+    if current[2] in {"completed", "stream"} and current[0] > int(before[0] or 0):
+        return True
+    if current[2] in {"stream", "completed"} and current[1] is not None and current[1] != before[1]:
+        return True
+    return current[2] in {"stream", "completed"} and current[2] != before[2]
+
+
+class WorkerState(str, enum.Enum):
+    RUNNING = "running"
+    PROGRESSING = "progressing"
+    WAITING_ON_MODEL = "waiting_on_model"
+    WAITING_ON_TOOL = "waiting_on_tool"
+    STALLED = "stalled"
+    CANCELLATION_REQUESTED = "cancellation_requested"
+    CANCELLATION_PENDING = "cancellation_pending"
+    CANCELLATION_CONFIRMED = "cancellation_confirmed"
+    SUCCESS = "success"
+    FAILED = "failed"
+    LATE_SUCCESS = "late_success"
+    SUPERSEDED = "superseded"
+
+
+_TERMINAL = frozenset({
+    WorkerState.CANCELLATION_CONFIRMED,
+    WorkerState.SUCCESS,
+    WorkerState.FAILED,
+    WorkerState.LATE_SUCCESS,
+    WorkerState.SUPERSEDED,
+})
+
+
+@dataclass
+class WorkerProgress:
+    child_started_at: float
+    last_progress_at: float
+    last_progress_kind: str = "started"
+    current_operation: Optional[str] = None
+    current_operation_started_at: Optional[float] = None
+    worker_state: WorkerState = WorkerState.RUNNING
+    cancellation_state: str = "not_requested"
+    logical_task_id: str = ""
+    execution_generation: int = 1
+    attempt_number: int = 1
+    mutation_possible: bool = False
+    mutation_reconciled: bool = False
+    progress_count: int = 0
+    stall_detected: bool = False
+    cancellation_requested_at: Optional[float] = None
+    cancellation_confirmed_at: Optional[float] = None
+    fenced_at: Optional[float] = None
+    late_result: bool = False
+    superseded_result: bool = False
+    last_token: Any = None
+
+
+class WorkerLifecycle:
+    """Thread-safe state machine for one logical worker attempt.
+
+    Metadata is intentionally limited to timestamps, bounded labels, counters,
+    and generation/fencing facts. Prompts, credentials, tool arguments, and
+    provider content never enter this object.
+    """
+
+    def __init__(self, *, logical_task_id: str, execution_generation: int = 1,
+                 attempt_number: int = 1, now: Optional[float] = None) -> None:
+        stamp = time.time() if now is None else float(now)
+        self._lock = threading.RLock()
+        self._p = WorkerProgress(
+            child_started_at=stamp,
+            last_progress_at=stamp,
+            logical_task_id=str(logical_task_id),
+            execution_generation=int(execution_generation),
+            attempt_number=int(attempt_number),
+        )
+
+    def snapshot(self, *, now: Optional[float] = None) -> dict[str, Any]:
+        stamp = time.time() if now is None else float(now)
+        with self._lock:
+            p = self._p
+            return {
+                "child_started_at": p.child_started_at,
+                "last_progress_at": p.last_progress_at,
+                "last_progress_kind": p.last_progress_kind,
+                "current_operation": p.current_operation,
+                "current_operation_started_at": p.current_operation_started_at,
+                "worker_state": p.worker_state.value,
+                "cancellation_state": p.cancellation_state,
+                "logical_task_id": p.logical_task_id,
+                "execution_generation": p.execution_generation,
+                "attempt_number": p.attempt_number,
+                "mutation_possible": p.mutation_possible,
+                "mutation_reconciled": p.mutation_reconciled,
+                "progress_count": p.progress_count,
+                "stall_detected": p.stall_detected,
+                "cancellation_requested_at": p.cancellation_requested_at,
+                "cancellation_confirmed_at": p.cancellation_confirmed_at,
+                "fenced_at": p.fenced_at,
+                "late_result": p.late_result,
+                "superseded_result": p.superseded_result,
+                "seconds_since_progress": max(0.0, stamp - p.last_progress_at),
+            }
+
+    def transition(self, state: WorkerState, *, now: Optional[float] = None) -> bool:
+        state = WorkerState(state)
+        stamp = time.time() if now is None else float(now)
+        with self._lock:
+            if self._p.worker_state in _TERMINAL:
+                return False
+            self._p.worker_state = state
+            if state == WorkerState.STALLED:
+                self._p.stall_detected = True
+            elif state == WorkerState.CANCELLATION_REQUESTED:
+                self._p.cancellation_state = "requested"
+                self._p.cancellation_requested_at = stamp
+            elif state == WorkerState.CANCELLATION_PENDING:
+                self._p.cancellation_state = "pending"
+            elif state == WorkerState.CANCELLATION_CONFIRMED:
+                self._p.cancellation_state = "confirmed"
+                self._p.cancellation_confirmed_at = stamp
+            return True
+
+    def record_progress(self, kind: str, *, operation: Optional[str] = None,
+                        now: Optional[float] = None) -> bool:
+        stamp = time.time() if now is None else float(now)
+        with self._lock:
+            if self._p.worker_state in _TERMINAL:
+                return False
+            self._p.last_progress_at = stamp
+            self._p.last_progress_kind = _safe_label(kind, "progress")
+            self._p.progress_count += 1
+            if operation is not None:
+                safe_operation = _safe_label(operation)
+                if safe_operation != self._p.current_operation:
+                    self._p.current_operation = safe_operation
+                    self._p.current_operation_started_at = stamp
+            if self._p.worker_state in {
+                WorkerState.RUNNING, WorkerState.WAITING_ON_MODEL,
+                WorkerState.WAITING_ON_TOOL, WorkerState.STALLED,
+            }:
+                self._p.worker_state = WorkerState.PROGRESSING
+            return True
+
+    def observe_tool_call(self, name: str, *, mutating: bool = False,
+                          completed: bool = False,
+                          now: Optional[float] = None) -> bool:
+        """Record a sanitized tool lifecycle event.
+
+        Tool start only changes the wait state. Completion is the meaningful
+        progress boundary; a potentially side-effecting tool is fenced before
+        execution so uncertain cancellation fails closed.
+        """
+        if mutating:
+            self.mark_mutation_possible()
+        if completed:
+            return self.record_progress("tool_completed", operation=name, now=now)
+        self.mark_tool_wait(name, now=now)
+        return False
+
+    def observe_activity(self, summary: dict[str, Any], *, now: Optional[float] = None) -> bool:
+        """Map sanitized agent activity to progress.
+
+        A tool becoming active is recorded as a wait-state transition, not as
+        indefinite progress. API-call counters, activity timestamps, and
+        completion/result descriptions are substantive forward-progress signals.
+        """
+        if not isinstance(summary, dict):
+            return False
+        stamp = time.time() if now is None else float(now)
+        api_calls = int(summary.get("api_call_count", 0) or 0)
+        activity_ts = summary.get("last_activity_ts")
+        tool = summary.get("current_tool")
+        desc = str(summary.get("last_activity_desc", "") or "")
+        with self._lock:
+            old = self._p.last_token
+            signature = activity_signature(summary)
+            token = meaningful_activity_token(summary)
+            meaningful = old is None and token != (0, None) and signature[2] != "waiting"
+            if old is not None:
+                meaningful = meaningful_activity_advanced(summary, old)
+            self._p.last_token = signature
+            if meaningful:
+                self._p.last_progress_at = stamp
+                self._p.last_progress_kind = "api_call_completed" if api_calls > 0 else "activity"
+                self._p.progress_count += 1
+                self._p.current_operation = _safe_label(tool) if tool else None
+                self._p.current_operation_started_at = stamp if tool else None
+                self._p.worker_state = WorkerState.WAITING_ON_TOOL if tool else WorkerState.WAITING_ON_MODEL
+            elif tool and self._p.worker_state == WorkerState.RUNNING:
+                self._p.worker_state = WorkerState.WAITING_ON_TOOL
+            return meaningful
+
+    def mark_model_wait(self, operation: str = "provider_request", *, now: Optional[float] = None) -> None:
+        stamp = time.time() if now is None else float(now)
+        with self._lock:
+            if self._p.worker_state not in _TERMINAL:
+                self._p.worker_state = WorkerState.WAITING_ON_MODEL
+                self._p.current_operation = _safe_label(operation)
+                self._p.current_operation_started_at = stamp
+
+    def mark_tool_wait(self, operation: str, *, now: Optional[float] = None) -> None:
+        stamp = time.time() if now is None else float(now)
+        with self._lock:
+            if self._p.worker_state not in _TERMINAL:
+                self._p.worker_state = WorkerState.WAITING_ON_TOOL
+                self._p.current_operation = _safe_label(operation)
+                self._p.current_operation_started_at = stamp
+
+    def mark_waiting_on_provider(self, operation: str = "provider_request", *, now: Optional[float] = None) -> None:
+        self.mark_model_wait(operation, now=now)
+
+    def mark_waiting_on_tool(self, operation: str, *, now: Optional[float] = None) -> None:
+        self.mark_tool_wait(operation, now=now)
+
+    def mark_tool_completed(self, operation: str, *, now: Optional[float] = None) -> bool:
+        return self.record_progress("tool_completed", operation=operation, now=now)
+
+    def record_api_response(self, *, streamed: bool = False, completed: bool = True,
+                            now: Optional[float] = None) -> bool:
+        kind = "model_chunk" if streamed and not completed else "api_call_completed"
+        return self.record_progress(kind, operation="provider_request", now=now)
+
+    def record_result_fragment(self, *, now: Optional[float] = None) -> bool:
+        return self.record_progress("result_fragment", operation="result", now=now)
+
+    def reconcile_mutation(self) -> None:
+        with self._lock:
+            self._p.mutation_reconciled = True
+
+    def fence(self, *, now: Optional[float] = None) -> bool:
+        stamp = time.time() if now is None else float(now)
+        with self._lock:
+            if self._p.worker_state in _TERMINAL:
+                return False
+            self._p.fenced_at = stamp
+            self._p.worker_state = WorkerState.CANCELLATION_PENDING
+            self._p.cancellation_state = "fenced"
+            return True
+
+    def request_cancellation(self, *, now: Optional[float] = None) -> bool:
+        stamp = time.time() if now is None else float(now)
+        with self._lock:
+            if self._p.worker_state in _TERMINAL:
+                return False
+            self._p.cancellation_requested_at = stamp
+            self._p.cancellation_state = "requested"
+            self._p.worker_state = WorkerState.CANCELLATION_REQUESTED
+            return True
+
+    def mark_cancellation_pending(self) -> bool:
+        with self._lock:
+            if self._p.worker_state in _TERMINAL:
+                return False
+            self._p.cancellation_state = "pending"
+            self._p.worker_state = WorkerState.CANCELLATION_PENDING
+            return True
+
+    def confirm_termination(self, *, now: Optional[float] = None) -> bool:
+        """Record a returned worker as terminated, idempotently.
+
+        This method is only a termination observation; it never claims that an
+        interrupt stopped an upstream request. Repeated finalizers must not
+        rewrite an already accepted result state.
+        """
+        stamp = time.time() if now is None else float(now)
+        with self._lock:
+            if self._p.cancellation_confirmed_at is not None:
+                return False
+            if self._p.worker_state not in {
+                WorkerState.CANCELLATION_REQUESTED,
+                WorkerState.CANCELLATION_PENDING,
+                WorkerState.STALLED,
+                WorkerState.LATE_SUCCESS,
+                WorkerState.SUPERSEDED,
+            } and self._p.cancellation_requested_at is None:
+                # A normal success/failure is a termination observation, not
+                # a cancellation confirmation.
+                return False
+            self._p.cancellation_state = "confirmed"
+            self._p.cancellation_confirmed_at = stamp
+            if self._p.worker_state in {
+                WorkerState.CANCELLATION_REQUESTED,
+                WorkerState.CANCELLATION_PENDING,
+                WorkerState.STALLED,
+            }:
+                self._p.worker_state = WorkerState.CANCELLATION_CONFIRMED
+            return True
+
+    def mark_mutation_possible(self) -> None:
+        with self._lock:
+            self._p.mutation_possible = True
+
+    def note_tool_event(self, kind: str, tool: Optional[str] = None, *, completed: bool = False,
+                        mutating: bool = False, now: Optional[float] = None) -> bool:
+        """Record a sanitized tool boundary from the host tool executor.
+
+        Tool start is only an operation/wait transition. Completion is the
+        meaningful boundary. ``mutating`` is supplied by the host policy and
+        never inferred from user-controlled arguments here.
+        """
+        return self.observe_tool_call(
+            tool or kind,
+            mutating=mutating,
+            completed=completed,
+            now=now,
+        )
+
+    def fence_execution(self, *, now: Optional[float] = None) -> bool:
+        """Fence future acceptance after cancellation is not proven safe."""
+        return self.fence(now=now)
+
+    def termination_confirmed(self) -> bool:
+        with self._lock:
+            return self._p.cancellation_confirmed_at is not None
+
+    def retry_decision(self, *, replacement_generation: int) -> str:
+        """Return a fail-closed retry decision for orchestration callers."""
+        with self._lock:
+            if self._p.mutation_possible and not self._p.mutation_reconciled:
+                return "reconcile_mutation"
+            if self._p.cancellation_confirmed_at is None:
+                return "cancellation_pending"
+            if replacement_generation <= self._p.execution_generation:
+                return "generation_conflict"
+            return "allow"
+
+    def set_attempt(self, *, generation: int, attempt_number: int) -> bool:
+        with self._lock:
+            if generation <= self._p.execution_generation:
+                return False
+            if self._p.worker_state not in _TERMINAL:
+                return False
+            self._p.execution_generation = int(generation)
+            self._p.attempt_number = int(attempt_number)
+            self._p.worker_state = WorkerState.RUNNING
+            self._p.cancellation_state = "not_requested"
+            self._p.cancellation_confirmed_at = None
+            self._p.fenced_at = None
+            self._p.late_result = False
+            self._p.superseded_result = False
+            self._p.last_progress_at = time.time()
+            self._p.last_progress_kind = "started"
+            self._p.last_token = None
+            return True
+
+    def accept_result(self, *, generation: int,
+                      authoritative_generation: Optional[int] = None,
+                      success: bool = True,
+                      mutation_reconciled: bool = False) -> WorkerState:
+        with self._lock:
+            if self._p.worker_state in {
+                WorkerState.SUCCESS, WorkerState.FAILED,
+                WorkerState.LATE_SUCCESS, WorkerState.SUPERSEDED,
+            }:
+                return self._p.worker_state
+            if ((authoritative_generation is not None and generation < authoritative_generation)
+                    or generation != self._p.execution_generation):
+                self._p.superseded_result = True
+                self._p.worker_state = WorkerState.SUPERSEDED
+                return WorkerState.SUPERSEDED
+            if self._p.stall_detected or self._p.fenced_at is not None:
+                if self._p.mutation_possible and not (
+                    self._p.mutation_reconciled or mutation_reconciled
+                ):
+                    self._p.superseded_result = True
+                    self._p.worker_state = WorkerState.SUPERSEDED
+                    return WorkerState.SUPERSEDED
+                self._p.late_result = True
+                self._p.worker_state = WorkerState.LATE_SUCCESS if success else WorkerState.FAILED
+                return self._p.worker_state
+            self._p.worker_state = WorkerState.SUCCESS if success else WorkerState.FAILED
+            return self._p.worker_state
+
+    def can_retry(self, *, termination_confirmed: bool,
+                  replacement_generation: Optional[int] = None) -> bool:
+        with self._lock:
+            if self._p.mutation_possible and not self._p.mutation_reconciled:
+                return False
+            if not termination_confirmed:
+                return False
+            if self._p.worker_state not in {
+                WorkerState.CANCELLATION_CONFIRMED,
+                WorkerState.FAILED,
+                WorkerState.STALLED,
+                WorkerState.CANCELLATION_PENDING,
+            }:
+                return False
+            return replacement_generation is None or replacement_generation > self._p.execution_generation
+
+    def annotate(self, target: dict[str, Any]) -> dict[str, Any]:
+        target.update(self.snapshot())
+        return target
+
+
+class LifecycleWatchdog:
+    """Cheap local decision helper; no polling request or LLM is performed."""
+
+    def __init__(self, lifecycle: WorkerLifecycle, *, inactivity_threshold: float,
+                 clock=time.time) -> None:
+        self.lifecycle = lifecycle
+        self.inactivity_threshold = max(0.01, float(inactivity_threshold))
+        self.clock = clock
+
+    def should_stall(self) -> bool:
+        snap = self.lifecycle.snapshot(now=self.clock())
+        return (snap["worker_state"] not in {state.value for state in _TERMINAL}
+                and snap["seconds_since_progress"] >= self.inactivity_threshold)
+
+
+WorkerLifecycleState = WorkerState
+ProgressWatchdog = WorkerLifecycle
+WORKER_STATES = tuple(state.value for state in WorkerState)
+WORKER_STATE_SET = frozenset(WORKER_STATES)
+SECRET_SAFE_METADATA = True
+LIFECYCLE_SCHEMA_VERSION = 1
+
+
+def is_terminal(state: str | WorkerState) -> bool:
+    try:
+        return WorkerState(state) in _TERMINAL
+    except (ValueError, TypeError):
+        return False

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -195,21 +195,34 @@ delegate_task(
 )
 ```
 
-## Child Timeout
+## Progress-Aware Child Lifecycle
 
-By default there is **no wall-clock timeout** on subagents. Children fail only from what they're actually doing — API errors, tool errors, or hitting their iteration budget — never from a delegation-level stopwatch. Earlier releases shipped a hard cap (300s, later 600s), which kept killing legitimately busy children mid-task: deep code reviews, large research fan-outs, and slow reasoning models routinely need more than 10 minutes while making steady progress the whole time.
+Subagents use a deterministic, local progress watchdog rather than treating a
+fixed lifetime as failure. A child that continues to complete model calls,
+stream output, complete tools, or produce result fragments may run beyond the
+old 120-second boundary. Luna is not called to poll the child.
 
-Genuinely stuck children are still detected: the heartbeat staleness monitor stops refreshing the parent's activity when a child makes no progress (no API calls, no tool starts, and no activity-timestamp ticks), letting the gateway inactivity timeout fire on a truly wedged worker. An in-flight model wait still counts as progress — subagents refresh the activity clock while waiting on the provider, so a slow local / long-prefill completion is not treated as stalled.
+Genuinely stalled children are detected from frozen progress metadata. A tool
+starting is not itself progress, and an idle provider socket does not reset the
+watchdog. The runtime requests cooperative cancellation, waits through a
+bounded grace period, and only then publishes a stalled result. It does not
+launch a replacement while the old attempt is still uncontrolled.
 
-If you want a hard cap anyway (e.g. cost control on unattended cron-driven delegation), opt in per-install:
+Configuration:
 
 ```yaml
 delegation:
   child_timeout_seconds: 0     # default: 0 = no timeout
-  # child_timeout_seconds: 1800  # opt-in hard cap (floor 30s)
+  watchdog_interval_seconds: 30
+  watchdog_inactivity_seconds: 450
+  cancellation_grace_seconds: 120
+  emergency_safety_ceiling_seconds: 0  # 0 = disabled
 ```
 
-A positive value enforces a hard wall-clock limit on each child; `0` or a negative value disables it.
+`child_timeout_seconds` is retained only as a compatibility opt-in emergency
+wall-clock cap; it is not the normal completion deadline. The watchdog's
+inactivity threshold is the ordinary stall detector. An emergency ceiling, if
+enabled, is reported separately from inactivity.
 
 When a configured cap fires, the child's result carries structured timeout
 metadata alongside the error message so parents and hooks can distinguish a
@@ -226,9 +239,8 @@ With a hard cap configured, if a subagent times out having made **zero** API cal
 ## Stall Detection for Background Subagents
 
 Background delegations (`delegate_task(background=true)`) are watched by a
-**progress-based stall monitor** — on by default, zero config. Unlike a
-wall-clock timeout, it never touches a child that is making progress, no
-matter how long it runs.
+**progress-based stall monitor** — on by default. Unlike a wall-clock timeout,
+it never touches a child that is making progress, no matter how long it runs.
 
 The monitor samples each detached child's progress signals — API-call count,
 current tool, and last-activity timestamp (which ticks on **every streamed
@@ -237,10 +249,8 @@ long response always counts as alive):
 
 1. **Progressing children are never touched.** Any advancing signal resets
    the clock.
-2. A child whose progress is completely frozen past the stale threshold
-   (450s idle, 1200s while inside a tool — legitimately slow terminal
-   commands and web fetches get the higher ceiling) is **interrupted** and
-   given a 120s grace window. A child that unwinds in time delivers its
+2. A child whose progress is completely frozen past the configured stale
+   threshold is **interrupted** and given the configured grace window. A child that unwinds in time delivers its
    partial results through the normal completion path.
 3. A child that never returns is force-finalized with a terminal `stalled`
    completion event, so the owning session hears an outcome instead of
@@ -248,7 +258,19 @@ long response always counts as alive):
 
 The `stalled` event carries structured metadata mirroring the sync-path
 timeout fields: `stalled_after_quiet_seconds`, `stall_threshold_seconds`,
-`stall_phase` (`idle` / `in_tool`), and `stall_grace_seconds`.
+`stall_phase` (`idle` / `in_tool`), `stall_reason`, and
+`stall_grace_seconds`, plus the logical task and execution generation.
+
+This lifecycle does not automatically redispatch a stalled worker. It cancels
+and fences the failed attempt, then leaves any deliberate redispatch decision
+to the parent/orchestrator. Because this change never creates a replacement
+execution, normal runtime records use `execution_generation=1` and
+`attempt_number=1`; the lifecycle state machine still rejects stale or late
+results if future code creates a superseding generation.
+
+Lifecycle records also distinguish `RUNNING`, `PROGRESSING`,
+`WAITING_ON_MODEL`, `WAITING_ON_TOOL`, `STALLED`, cancellation-pending and
+confirmed states, `SUCCESS`, `FAILED`, `LATE_SUCCESS`, and `SUPERSEDED`.
 
 This closed a long-standing failure mode where a wedged background child
 left its session looking dead until a process restart. The underlying wedge


### PR DESCRIPTION
## Summary

- Replace the fixed normal child timeout with a deterministic local progress-aware watchdog.
- Allow genuinely progressing DeepSeek and other children to continue beyond the former ~120-second boundary.
- Detect frozen progress without repeated Luna/LLM polling.
- Add bounded cooperative cancellation, termination/fencing, late-result handling, and duplicate-finalization protection.
- Fail closed for mutating work and suppress unsafe structured-output retries after mutation may have occurred.
- Preserve parent/child usage aggregation and document the intentional no-automatic-redispatch scope.

## Verification

- Candidate-focused suite on current upstream-rebased branch: **151 passed**.
- Deterministic stall/cancellation subset: **12 passed**.
- Isolated candidate DeepSeek smoke: `ocg/deepseek-v4-flash` through the existing local custom endpoint.
  - Child duration: 169.73 seconds.
  - Wall duration: 170.64 seconds.
  - Crossed the former 120-second boundary by 50.64 seconds.
  - 50 sequential real local file-processing rounds, 52 API calls, 51 meaningful tool/progress events.
  - Final lifecycle: `worker_state=success`, `cancellation_state=not_requested`, `stall_detected=false`.
  - `execution_generation=1`, `attempt_number=1`, `late_result=false`, `superseded_result=false`.
  - No automatic retry or duplicate execution was launched.
  - Usage metadata recorded: input/output token counts and API-call count.
- Python compilation and `git diff --check`: passed.
- Local router read-only checks: `/api/health` returned `{"ok":true}`; `/v1/models` returned 200 and included `ocg/deepseek-v4-flash`.
- Final bounded Sonnet review: no blockers found for progress semantics, stall detection, cancellation, fencing, mutation safety, races, or resource cleanup.

## Broader test note

The broad relevant sweep exercised 6,5xx tests but ended non-green due to unrelated existing/provider-optional failures and one missing optional `aiohttp` collection dependency. The candidate-specific authoritative suite above is green.

## Scope boundary

This change does not automatically redispatch stalled workers. It cancels/fences and fails closed, leaving any deliberate redispatch decision to the parent/orchestrator. Runtime attempts remain generation 1 because this PR does not create replacement executions; the lifecycle state machine is prepared to reject stale/late results for future superseding generations.

## Safety boundary

No live Hermes, gateway, dashboard, or 9Router process was restarted or modified. This PR stops before merge approval and live rollout.

## CI / requested review

The first upstream workflow dispatches are currently `action_required` with zero jobs because this is a fork-originated PR and upstream workflow approval is required. This is not a code failure and cannot be bypassed from the read-only upstream account. Once an upstream maintainer approves the workflows, required CI should run on head `71ff11154310dd1ed6e44934a49c9e71e4b78871`.

Please approve/run required CI and review the PR. Do not merge without explicit merge approval from the repository owner.
