### PR TITLE
refactor(desktop): derive the tab hover close button from the close verb

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -164,7 +164,6 @@ registry.registerMany([
       collapsible: true,
       dock: { pane: 'workspace', pos: 'left' },
       revealAliases: ['chat-sidebar'],
-      showCloseButton: false,
       // Standing chrome: no close gestures at all — the tab is shown/hidden
       // (zone menu Show/Hide rows + the auto-registered ⌘K toggle below).
       hideOnly: true,

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tab-close-affordance.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tab-close-affordance.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { allPaneIds, group, split } from '../model'
+import { $layoutTree } from '../store'
+
+import { TreeGroup } from './tree-group'
+
+// The hover ✕ and middle-click are ONE affordance in two shapes: whichever tabs
+// the pointer gesture can close must advertise it. A tab that closes on
+// middle-click but hides its ✕ is a close verb the user cannot discover, and a
+// tab that shows a ✕ it will not honor is a dead control. This asserts the
+// equivalence over every tab kind the app registers, so the ✕ can never be
+// wired (or un-wired) on its own again.
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  // jsdom lacks CSS.escape, which tab-strip-scroll uses in a layout effect.
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+const disposers: (() => void)[] = []
+
+/** Every tab kind that shares a strip, paired with what its chrome declares. */
+const PANES: readonly (readonly [string, Record<string, unknown>])[] = [
+  // Standing chrome: no close gesture of any kind.
+  ['sessions', { hideOnly: true, placement: 'left' }],
+  // A plain side pane: closes, so it must say so.
+  ['files', { placement: 'right' }],
+  // The one surface that cannot leave the tree.
+  ['workspace', { placement: 'main', uncloseable: true }],
+  // A mirrored session tile — `placement: 'main'` but closeable.
+  ['session-tile:abc', { placement: 'main' }]
+]
+
+beforeEach(async () => {
+  window.localStorage.clear()
+
+  const { $dismissedPanes, $hiddenTreePanes } = await import('../store')
+  $dismissedPanes.set(new Set())
+  $hiddenTreePanes.set(new Set())
+
+  for (const [id, data] of PANES) {
+    disposers.push(registry.register({ area: 'panes', data, id, render: () => null, title: id }))
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+})
+
+/** All four panes in ONE zone, so every tab renders in the same strip. */
+function renderOneStrip() {
+  $layoutTree.set(
+    split('row', [
+      group(
+        PANES.map(([id]) => id),
+        { active: 'workspace', id: 'grp-all' }
+      ),
+      group(['spacer'], { id: 'grp-spacer' })
+    ])
+  )
+
+  const node = $layoutTree.get()!
+  const zone = (node.type === 'split' ? node.children[0] : node) as never
+
+  render(<TreeGroup node={zone} parentAxis="row" />)
+}
+
+const tabEl = (paneId: string) => document.querySelector<HTMLElement>(`[data-tree-tab="${paneId}"]`)
+
+/** Does this tab advertise a ✕? */
+const hasCloseButton = (paneId: string) => Boolean(tabEl(paneId)?.querySelector('button[aria-label]'))
+
+/** Does the middle-click gesture actually close this tab? Observed through the
+ *  tree, not through a spy — a pane that is gone stopped being a tab. */
+function middleClickCloses(paneId: string): boolean {
+  const tab = tabEl(paneId)!
+  fireEvent.pointerDown(tab, { button: 1 })
+  fireEvent.pointerUp(tab, { button: 1 })
+
+  return !allPaneIds($layoutTree.get()!).includes(paneId)
+}
+
+describe('a tab advertises exactly the close gesture it honors', () => {
+  for (const [paneId] of PANES) {
+    it(`${paneId}: ✕ presence matches middle-click`, () => {
+      renderOneStrip()
+
+      expect(tabEl(paneId)).toBeTruthy()
+
+      const advertised = hasCloseButton(paneId)
+
+      expect(advertised).toBe(middleClickCloses(paneId))
+    })
+  }
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -64,12 +64,12 @@ interface PaneChrome extends PaneSizing {
   /** No Close in the tab menu — the one surface the app can't lose (the
    *  main workspace). Session tiles share `placement: 'main'` but close. */
   uncloseable?: boolean
-  /** Hide the hover ✕ while retaining explicit close behavior for this pane. */
-  showCloseButton?: boolean
-  /** Standing chrome tab (sessions / Bots) whose tab shows NO ✕ and no Close
-   *  verbs — it is shown/hidden instead (the zone menu's Show/Hide rows and a
-   *  ⌘K toggle, via `setStripTabHidden`). Close was too destructive for these:
-   *  an accidental ✕ removed Bot Mode until the next launch. */
+  /** Standing chrome tab (sessions / Bots) with NO close verb at all: no ✕,
+   *  no middle / ⌘-click, no Close menu rows. It is shown/hidden instead (the
+   *  zone menu's Show/Hide rows and a ⌘K toggle, via `setStripTabHidden`).
+   *  Close was too destructive for these: an accidental ✕ removed Bot Mode
+   *  until the next launch. The ✕ follows the verb (see `PaneTab.onClose`),
+   *  so dropping the verb here is what takes the chip off the tab. */
   hideOnly?: boolean
   /** Wrap this pane's TAB (e.g. in a domain context menu — a session tile's
    *  pin/branch/rename/archive/delete). The wrapper must render `tab` as its

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -556,7 +556,6 @@ export function TreeGroup({
                   }}
                   role="tab"
                   selected={isSelected}
-                  showCloseButton={chrome.showCloseButton !== false}
                   style={{ cursor: 'grab' }}
                 >
                   {chrome.tabLead ? (

--- a/apps/desktop/src/components/ui/pane-tab.test.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.test.tsx
@@ -124,15 +124,16 @@ describe('PaneTab hover close button', () => {
     expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
   })
 
-  it('can hide the hover ✕ while retaining the close handler', () => {
+  it('a closeable horizontal tab always shows its ✕ — the chip and the pointer gestures are one affordance', () => {
     const onClose = vi.fn()
     render(
-      <PaneTab onClose={onClose} showCloseButton={false}>
+      <PaneTab onClose={onClose}>
         <PaneTabLabel>tab</PaneTabLabel>
       </PaneTab>
     )
 
-    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Close' })).toBeTruthy()
+
     const tab = screen.getByText('tab')
     fireEvent.pointerDown(tab, { button: 1 })
     fireEvent.pointerUp(tab, { button: 1 })

--- a/apps/desktop/src/components/ui/pane-tab.tsx
+++ b/apps/desktop/src/components/ui/pane-tab.tsx
@@ -53,13 +53,14 @@ interface PaneTabProps extends React.ComponentProps<'div'> {
   dirty?: boolean
   /** Close verb. Horizontal tabs reveal a hover ✕ on the right (a `--tab-face`
    *  gradient fades it over the label); middle-click and ⌘-click always work,
-   *  and stay the only gestures on vertical rails (no room for a chip ✕). */
+   *  and stay the only gestures on vertical rails (no room for a chip ✕).
+   *  There is no way to take the ✕ off a tab that HAS this verb: the chip and
+   *  the pointer gestures are one affordance, so a closeable tab always says
+   *  so. Omit `onClose` to make a tab uncloseable. */
   onClose?: () => void
   /** Part of a multi-tab selection (⌥/Ctrl-click, Shift-click) — an accent
    *  wash marks every tab that a drag would carry, Chrome-style. */
   selected?: boolean
-  /** Whether a closeable horizontal tab reveals the hover ✕. */
-  showCloseButton?: boolean
   /** Vertical rail form (collapsed sidebar zones). */
   vertical?: boolean
   /** Content-facing edge of a vertical rail — the strip line the active tab cuts. */
@@ -83,7 +84,6 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
     onPointerUp,
     onClickCapture,
     selected = false,
-    showCloseButton = true,
     vertical = false,
     side = 'left',
     children,
@@ -162,7 +162,7 @@ export const PaneTab = React.forwardRef<HTMLDivElement, PaneTabProps>(function P
           <span className="size-2 rounded-full bg-amber-500 shadow-[0_0_0_2px_var(--tab-bg),0_1px_2px_rgba(0,0,0,0.45)] dark:bg-amber-400" />
         </span>
       )}
-      {onClose && showCloseButton && !vertical && (
+      {onClose && !vertical && (
         // Hover ✕, painted OVER the label's right edge as an overlay (no
         // layout shift, tab width never jumps on hover). The runway is a tiny
         // transparent→`--tab-face` gradient, so the button melts into the

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -11840,7 +11840,7 @@ export default {
       // sessions pane collapses alone without this flag. The zone then keeps
       // a stranded BOTS tab on screen. The narrow edge overlay mirrors the
       // zone's tab strip, so the pane stays reachable while collapsed.
-      data: { placement: 'left', width: '260px', collapsible: true, showCloseButton: false, hideOnly: true, dock: { pane: 'sessions', pos: 'center', enforce: true } },
+      data: { placement: 'left', width: '260px', collapsible: true, hideOnly: true, dock: { pane: 'sessions', pos: 'center', enforce: true } },
       render: () => jsx(BotsPane, {})
     })
 


### PR DESCRIPTION
## What does this PR do?

The hover close button on a pane tab was wired separately from the close
gestures that do the same job. `PaneTab` gated the button on two independent
inputs — the `onClose` verb, and a `showCloseButton` prop that `TreeGroup` fed
from a `showCloseButton` flag on the pane contribution — while middle-click and
⌘-click read only `onClose`. A tab could therefore close on a pointer gesture
and show no control for it.

The flag had no user that `hideOnly` did not already cover. Both setters also
set `hideOnly: true`, which removes every close gesture:

- the `sessions` pane (`apps/desktop/src/app/contrib/controller.tsx`),
- the Bots pane (`apps/desktop/src/plugins/hermes-bots/plugin.js`).

The history explains why. #89551 added `showCloseButton` as an ✕-suppression
fix. #89572 cherry-picked that commit as its base, then built `hideOnly` on top
and superseded it. The flag stayed behind as a vestigial rung, not as live
design, so this PR deletes it instead of teaching it to track the gestures.

`onClose` alone now decides both shapes. A tab that closes shows the button. A
tab without the verb shows nothing. To make a tab uncloseable, give it no close
verb. `hideOnly` and `uncloseable` keep their meaning: they gate the verb, and
both shapes follow the verb together.

## Related Issue

No issue. This is follow-up cleanup on #89572, which introduced `hideOnly` and
left the superseded flag in the tree.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/ui/pane-tab.tsx`: delete the `showCloseButton`
  prop. The render condition becomes `{onClose && !vertical && …}`. The
  `onClose` doc comment states that the chip and the pointer gestures are one
  affordance.
- `apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts`: delete
  `showCloseButton` from `PaneChrome`. The `hideOnly` comment now says that it
  removes the close verb, and that the ✕ follows the verb.
- `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx`: delete
  the `showCloseButton={chrome.showCloseButton !== false}` callsite.
- `apps/desktop/src/app/contrib/controller.tsx`: drop the flag from the
  `sessions` pane data. Its `hideOnly: true` already removes every gesture.
- `apps/desktop/src/plugins/hermes-bots/plugin.js`: the same for the Bots pane.
- `apps/desktop/src/components/pane-shell/tree/renderer/tab-close-affordance.test.tsx`:
  new contract test (see below). The `DialogContent` / `SheetContent` prop of
  the same name is untouched: it is a different prop, it has no close verb to
  derive from, and `updates-overlay.tsx` changes it while the dialog is open.
- `apps/desktop/src/components/ui/pane-tab.test.tsx`: move the "can hide the
  hover ✕" case off the deleted prop. It now asserts that a closeable tab shows
  the button and honors middle-click.

## How to Test

Behavior is identical before and after, so the proof is the mutation test:

1. `cd apps/desktop && npx vitest run src/components/pane-shell src/components/ui/pane-tab.test.tsx`
   — 154 tests pass.
2. Break the derivation by hand: change the `PaneTab` render condition to
   `{false && onClose && !vertical && (`, which hides the button on tabs that
   still close on middle-click.
3. `npx vitest run src/components/pane-shell/tree/renderer/tab-close-affordance.test.tsx`
   — the `files` and `session-tile:abc` cases fail. The test detects a button
   that stops tracking the verb.
4. Revert step 2. All four cases pass again.

In the app: hover the SESSIONS and BOTS tabs. Neither shows an ✕, and neither
closes on middle-click or ⌘-click, the same as before this PR. Hover a `files`
or session tile tab. Each shows an ✕ and closes on middle-click, the same as
before this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for the Python suite (no Python file changes). The JS suite is the gate here: the full `apps/desktop` vitest run gives 6954 pass, 2 fail. The 2 failures are `electron/remote-lifecycle.test.ts` and `electron/update-handoff-marker.test.ts`. They fail the same way on a clean tree on this machine (nix sandbox spawn paths), and they do not touch the pane shell.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS (Linux 7.1.8)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the
      `PaneTab.onClose` and `PaneChrome.hideOnly` doc comments now carry the
      rule. No user-facing doc mentions the flag.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only change with no platform-conditional code. ⌘-click and middle-click already route through `lib/middle-click.ts` for every host.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Tests

`tab-close-affordance.test.tsx` renders the real `TreeGroup` and asserts one
contract over every tab kind that shares a strip:

```ts
expect(hasCloseButton(paneId)).toBe(middleClickCloses(paneId))
```

It reads closure from the layout tree (the pane is gone), not from a spy, so a
wired-up mock cannot pass it. Cases: `hideOnly` chrome, a plain side pane, the
`uncloseable` workspace, and a mirrored session tile.

The test carries no fixture for the deleted prop, because the compiler already
rejects it: passing `showCloseButton` to `PaneTab` now fails with `TS2322:
Property 'showCloseButton' does not exist`. A test tombstone would only restate
that, under a name the codebase still uses for the unrelated `DialogContent`
prop. The remaining cases still catch the regression they exist for: hiding the
button on a closeable tab fails the `files` and `session-tile` cases.

## Screenshots / Logs

```
$ npx vitest run src/components/pane-shell src/components/ui/pane-tab.test.tsx
 Test Files  29 passed (29)
      Tests  154 passed (154)

$ npm run typecheck
tsc -p . --noEmit && tsc -p tsconfig.electron.json --noEmit && tsc -p tsconfig.e2e.json --noEmit
(clean)

$ npm run lint
✖ 116 problems (0 errors, 116 warnings)
```

The single warning on the new file is `no-restricted-globals` for `document`.
Every sibling DOM probe in that directory carries the same warning.

