### PR TITLE
fix(file_safety): return denial reason string instead of bool in _classify_write_denial

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -165,10 +165,10 @@ def _classify_write_denial(path: str) -> Optional[str]:
         # falsify conversation history and invalidate resume/compression state.
         try:
             if resolved == os.path.realpath(os.path.join(base_real, "state.db")):
-                return True
+                return "session_state"
             sessions_real = os.path.realpath(os.path.join(base_real, "sessions"))
             if resolved == sessions_real or resolved.startswith(sessions_real + os.sep):
-                return True
+                return "session_state"
         except Exception:
             pass
         try:
@@ -744,3 +744,4 @@ def get_container_mirror_warning(
         f"(Defense-in-depth — not a security boundary; the terminal tool "
         f"can still bypass.)"
     )
+


### PR DESCRIPTION
## Summary

`_classify_write_denial()` is annotated `-> Optional[str]` and documented as returning `'credential'`, `'safe_root'`, or `None`. However, it returns `True` (a `bool`) for two security-critical cases: writes to `state.db` and the `sessions/` directory.

## The Bug

```python
# agent/file_safety.py, lines ~167-171
try:
    if resolved == os.path.realpath(os.path.join(base_real, "state.db")):
        return True  # BUG: should return "session_state" (str)
    sessions_real = os.path.realpath(os.path.join(base_real, "sessions"))
    if resolved == sessions_real or resolved.startswith(sessions_real + os.sep):
        return True  # BUG: should return "session_state" (str)
except Exception:
    pass
```

## Impact

1. **Type contract violation** — Function signature says `Optional[str]`, callers expect a denial reason string, but get `True`
2. **Current callers survive by accident** — `is_write_denied()` checks `is not None` (works), but `get_write_denied_error()` checks `denial == "safe_root"` (falls through to generic message)
3. **Future breakage guaranteed** — Any developer adding `elif denial == "session_state":` for a specific error message will silently mishandle the `True` value
4. **Security-adjacent** — This is in the file safety module that protects `state.db` and `sessions/` directories from being overwritten

## Fix

Change both `return True` to `return "session_state"` to match the function's type contract and the pattern used by other denial reasons (`"credential"`, `"safe_root"`).
