### PR TITLE
feat: stealth/ox-alpha free model in the Nous Portal catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -306,6 +306,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nvidia/nemotron-3-super-120b-a12b",
         # Sakana
         "sakana/fugu-ultra",
+        # Stealth — "Ox Alpha" reasoning model, free ($0/$0 on the portal),
+        # 1M ctx / 131K max output. Same model as OpenCode Zen's
+        # x-preview-f-free; metadata entries live under the bare "ox-alpha"
+        # slug (model_metadata.py / reasoning_timeouts.py).
+        "stealth/ox-alpha",
     ],
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-21T11:29:05Z",
+  "updated_at": "2026-08-21T19:47:17Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -286,6 +286,9 @@
         },
         {
           "id": "sakana/fugu-ultra"
+        },
+        {
+          "id": "stealth/ox-alpha"
         }
       ]
     }


### PR DESCRIPTION
## Summary
`stealth/ox-alpha` ("Ox Alpha") now appears in the Nous Portal curated model list — the third catalog surface for the stealth model, after the OpenCode Zen rollout (#91250) and the OpenRouter listing (#91284).

## Changes
- `hermes_cli/models.py`: `stealth/ox-alpha` added to `_PROVIDER_MODELS["nous"]` (Stealth block at list bottom, per newest-first-within-family + vendor grouping convention)
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` (nous: 32 models)

## Metadata (verified skips)
- Pricing snapshot: **skipped** — nous route bills via `official_models_api` (confirmed `resolve_billing_route("stealth/ox-alpha", provider="nous")`), and the model is free ($0/$0 on the live portal)
- Context length: **already resolves** — bare `ox-alpha` entry (1,048,576) in `DEFAULT_CONTEXT_LENGTHS` from #91284 matches the prefixed slug too
- Reasoning timeout: **already present** — `("ox-alpha", 300)` floor from #91284

## Validation
| Check | Result |
|---|---|
| Live portal `GET /v1/models` | `stealth/ox-alpha` served: free, 1M ctx, 131K max output, mandatory reasoning |
| `tests/hermes_cli/test_models.py` + `test_model_catalog.py` | 98 passed |
| E2E picker fallback (temp HERMES_HOME, keys stripped) | curated list path carries the model; note the offline picker path prefers the docs-hosted manifest, which this PR's regen updates |

## Infographic

![Ox Alpha lands in the Nous Portal catalog](https://v3b.fal.media/files/b/0aa74468/cCAzRBMIwhGTx6pHHc51F_iZYNK0O6.png)
