### PR TITLE
fix(bedrock): honour ephemeral output cap on Converse requests

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1822,6 +1822,14 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+def _take_ephemeral_output_cap(agent) -> int | None:
+    """Return and clear the one-shot output-cap override for the next request."""
+    ephemeral_cap = getattr(agent, "_ephemeral_max_output_tokens", None)
+    if ephemeral_cap is not None:
+        agent._ephemeral_max_output_tokens = None
+    return ephemeral_cap
+
+
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     if tools_for_api is None:
@@ -1832,9 +1840,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         anthropic_messages = agent._prepare_anthropic_messages_for_api(api_messages)
         ctx_len = getattr(agent, "context_compressor", None)
         ctx_len = ctx_len.context_length if ctx_len else None
-        ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
-        if ephemeral_out is not None:
-            agent._ephemeral_max_output_tokens = None  # consume immediately
+        ephemeral_out = _take_ephemeral_output_cap(agent)
         anthropic_kwargs = _transport.build_kwargs(
             model=agent.model,
             messages=anthropic_messages,
@@ -1865,14 +1871,12 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         # set (length continuation boost, truncated tool-call boost, output-cap
         # clamp). Without consuming it here, Converse traffic always requested
         # the static cap and every retry re-truncated identically.
-        _bedrock_ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
-        if _bedrock_ephemeral_out is not None:
-            agent._ephemeral_max_output_tokens = None  # consume immediately
+        ephemeral_cap = _take_ephemeral_output_cap(agent)
         return _bt.build_kwargs(
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
-            max_tokens=_bedrock_ephemeral_out or agent.max_tokens or 4096,
+            max_tokens=ephemeral_cap if ephemeral_cap is not None else (agent.max_tokens or 4096),
             region=region,
             guardrail_config=guardrail,
         )
@@ -2037,9 +2041,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         _profile = None
 
     if _profile:
-        _ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
-        if _ephemeral_out is not None:
-            agent._ephemeral_max_output_tokens = None
+        _ephemeral_out = _take_ephemeral_output_cap(agent)
 
         # Strip image parts for non-vision models that have provider profiles
         # (e.g. DeepSeek, Kimi). The legacy path below already does this, but
@@ -2072,9 +2074,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     # ── Legacy flag path ────────────────────────────────────────────
     # Reached only when get_provider_profile() returns None — i.e. a
     # completely unknown provider not in providers/ registry.
-    _ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
-    if _ephemeral_out is not None:
-        agent._ephemeral_max_output_tokens = None
+    _ephemeral_out = _take_ephemeral_output_cap(agent)
 
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1861,11 +1861,18 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         _bt = agent._get_transport()
         region = getattr(agent, "_bedrock_region", None) or "us-east-1"
         guardrail = getattr(agent, "_bedrock_guardrail_config", None)
+        # Honour the one-shot output-cap override the truncation recovery paths
+        # set (length continuation boost, truncated tool-call boost, output-cap
+        # clamp). Without consuming it here, Converse traffic always requested
+        # the static cap and every retry re-truncated identically.
+        _bedrock_ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
+        if _bedrock_ephemeral_out is not None:
+            agent._ephemeral_max_output_tokens = None  # consume immediately
         return _bt.build_kwargs(
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
-            max_tokens=agent.max_tokens or 4096,
+            max_tokens=_bedrock_ephemeral_out or agent.max_tokens or 4096,
             region=region,
             guardrail_config=guardrail,
         )

--- a/tests/agent/test_bedrock_ephemeral_output_cap.py
+++ b/tests/agent/test_bedrock_ephemeral_output_cap.py
@@ -1,0 +1,82 @@
+"""Bedrock Converse must honour the one-shot output-cap override.
+
+The truncation recovery paths in ``agent/conversation_loop.py`` (length
+continuation boost, truncated tool-call boost, and the output-cap clamp) all
+signal the next request's cap by setting ``_ephemeral_max_output_tokens`` on the
+agent.  Every other transport branch in ``build_api_kwargs`` consumes it; the
+``bedrock_converse`` branch used to ignore it, so retries re-requested the same
+static cap and re-truncated identically — the agentic loop broke with
+"Response truncated due to output length limit".
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.chat_completion_helpers import build_api_kwargs
+
+
+class _RecordingTransport:
+    """Captures the max_tokens the caller asked for."""
+
+    def __init__(self):
+        self.seen_max_tokens = None
+
+    def build_kwargs(self, model, messages, tools=None, **params):
+        self.seen_max_tokens = params.get("max_tokens")
+        return {"modelId": model, "messages": messages}
+
+
+@pytest.fixture
+def bedrock_agent():
+    transport = _RecordingTransport()
+    agent = SimpleNamespace(
+        api_mode="bedrock_converse",
+        model="us.anthropic.claude-opus-5",
+        tools=[],
+        max_tokens=8192,
+        _bedrock_region="us-west-2",
+        _bedrock_guardrail_config=None,
+        _get_transport=lambda: transport,
+    )
+    return agent, transport
+
+
+def test_ephemeral_cap_overrides_static_max_tokens(bedrock_agent):
+    agent, transport = bedrock_agent
+    agent._ephemeral_max_output_tokens = 32768
+
+    build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    assert transport.seen_max_tokens == 32768
+
+
+def test_ephemeral_cap_is_consumed_after_one_request(bedrock_agent):
+    """The override is one-shot: the following request falls back to the static cap."""
+    agent, transport = bedrock_agent
+    agent._ephemeral_max_output_tokens = 32768
+
+    build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+    assert agent._ephemeral_max_output_tokens is None
+
+    build_api_kwargs(agent, [{"role": "user", "content": "again"}])
+    assert transport.seen_max_tokens == 8192
+
+
+def test_static_cap_used_when_no_override_present(bedrock_agent):
+    agent, transport = bedrock_agent
+    agent._ephemeral_max_output_tokens = None
+
+    build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    assert transport.seen_max_tokens == 8192
+
+
+def test_falls_back_to_default_when_nothing_configured(bedrock_agent):
+    agent, transport = bedrock_agent
+    agent._ephemeral_max_output_tokens = None
+    agent.max_tokens = None
+
+    build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    assert transport.seen_max_tokens == 4096

--- a/tests/agent/test_bedrock_ephemeral_output_cap.py
+++ b/tests/agent/test_bedrock_ephemeral_output_cap.py
@@ -72,6 +72,16 @@ def test_static_cap_used_when_no_override_present(bedrock_agent):
     assert transport.seen_max_tokens == 8192
 
 
+def test_ephemeral_cap_is_selected_by_presence_not_truthiness(bedrock_agent):
+    agent, transport = bedrock_agent
+    agent._ephemeral_max_output_tokens = 0
+
+    build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    assert transport.seen_max_tokens == 0
+    assert agent._ephemeral_max_output_tokens is None
+
+
 def test_falls_back_to_default_when_nothing_configured(bedrock_agent):
     agent, transport = bedrock_agent
     agent._ephemeral_max_output_tokens = None


### PR DESCRIPTION
## Summary

On `bedrock_converse`, the truncation-recovery machinery is dead code: retries re-request the same output cap, re-truncate at the same point, and the turn ends with `Response truncated due to output length limit`, breaking the agentic loop.

The recovery paths in `agent/conversation_loop.py` all signal the next request's output budget by setting `_ephemeral_max_output_tokens` on the agent:

| Path | Location |
|---|---|
| Length continuation boost (2x/4x/8x/16x, capped 32768) | `conversation_loop.py:6606-6621` |
| Truncated tool-call retry boost | `conversation_loop.py:3930-3961` |
| Output-cap-too-large clamp | `conversation_loop.py:5677` |

Every transport branch in `build_api_kwargs` consumes that override and clears it:

- `anthropic_messages` — `chat_completion_helpers.py:1835`
- provider-profile path — `:2033`
- legacy flag path — `:2068`

`bedrock_converse` (`:1868`) did not. It passed `agent.max_tokens or 4096` unconditionally and left the override set, so every boost was computed and then silently discarded. The clamp path was affected identically, meaning an output-cap error was also unrecoverable on Converse.

## Fix

Consume the override in the Converse branch, matching the one-shot semantics of the other transports.

## Note on the 4096 fallback

An unset `model.max_tokens` makes Converse requests fall back to 4096 output tokens — far below what current Claude models on Bedrock support (Opus 4.6/4.7/4.8 and Sonnet 5 are 128k per `_ANTHROPIC_OUTPUT_LIMITS`). That is what makes this truncation path routine rather than rare on Bedrock. Left as-is here since changing the default is a behavioural change beyond this bug, but it may be worth revisiting separately.

## Test plan

New `tests/agent/test_bedrock_ephemeral_output_cap.py`, 4 cases: override honoured, override consumed after one request (one-shot), static cap used when absent, 4096 fallback when nothing configured.

- With the fix: **4 passed**
- With `agent/chat_completion_helpers.py` reverted via `git stash`: **2 failed** — confirms the tests fail for the intended reason rather than passing tautologically
- Continuation/truncation suites (`test_partial_stream_finish_reason.py`, `test_continuation_ceiling_wedge.py`, `test_continuation_repetition_guard.py`) + new file: **33 passed**
- `tests/agent/` filtered on `bedrock or output_cap or truncat or length`: **235 passed, 1 skipped**

`tests/run_agent/test_run_agent.py` reports 4 failures (`TestBuildApiKwargs::test_provider_preferences_injected`, `test_reasoning_config_default_openrouter`, `test_qwen_portal_formats_messages_and_metadata`, `TestAnthropicInterruptHandler::test_interruptible_anthropic_interrupt_never_closes_shared_client`). These are **identical with this patch stashed** — pre-existing on `main` at `fd3a783a3`, in OpenRouter/Qwen/Anthropic paths untouched here.

Found while debugging a recurring loop break on a Bedrock Converse provider with Claude Opus 5.
