### PR TITLE
fix(cron): deliver profile-store jobs with the owning profile's bot under multiplex

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6405,6 +6405,31 @@ def run_one_job(
     fire_owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
     execution_token = object()
     profile_home = _get_hermes_home().resolve()
+
+    # Run the job under the profile's secret scope. get_secret() fails
+    # closed outside a scope once profile isolation is in play (multiple
+    # gateway profiles / room→profile multiplexing), and cron fires from
+    # the ticker thread where no per-turn scope is installed — so
+    # resolve_runtime_provider() raised UnscopedSecretError before model
+    # selection, breaking every cron job. Mirrors the per-turn pattern in
+    # gateway/run.py (_profile_runtime_scope).
+    #
+    # The scope must ALSO stay installed through _deliver_result (both the
+    # live-adapter send and the standalone fallback resolve credentials via
+    # get_secret / load_gateway_config at delivery time), so it is reset in
+    # this wrapper's finally — AFTER the body's save/deliver/mark sequence,
+    # including the failure-path delivery in the body's outer except (#83182).
+    # Resetting it in a finally around run_job alone (as before) left
+    # delivery reading another profile's — or no — credentials.
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+
+    _scope_token = set_secret_scope(
+        build_profile_secret_scope(profile_home)
+    )
     with _running_lock:
         _running_fire_owners.setdefault(job["id"], {})[execution_token] = (
             fire_owner or None,
@@ -6428,6 +6453,7 @@ def run_one_job(
             ),
         )
     finally:
+        reset_secret_scope(_scope_token)
         with _running_lock:
             executions = _running_fire_owners.get(job["id"])
             if executions is not None:
@@ -6505,22 +6531,11 @@ def _run_one_job_body(
         # becomes running only immediately before the actual run.
         mark_execution_running(execution_id)
 
-        # Run the job under the profile's secret scope. get_secret() fails
-        # closed outside a scope once profile isolation is in play (multiple
-        # gateway profiles / room→profile multiplexing), and cron fires from
-        # the ticker thread where no per-turn scope is installed — so
-        # resolve_runtime_provider() raised UnscopedSecretError before model
-        # selection, breaking every cron job. Mirrors the per-turn pattern in
-        # gateway/run.py (_profile_runtime_scope).
-        from agent.secret_scope import (
-            build_profile_secret_scope,
-            reset_secret_scope,
-            set_secret_scope,
-        )
-
-        _scope_token = set_secret_scope(
-            build_profile_secret_scope(_get_hermes_home())
-        )
+        # NOTE: the profile secret scope is installed by the run_one_job
+        # wrapper and stays active through this body's ENTIRE sequence —
+        # run_job, save, delivery (live-adapter and standalone), and mark —
+        # so delivery resolves THIS profile's credentials (#83182). It is
+        # torn down in the wrapper's finally, after this body returns.
         # Defer the cron agent's async-resource teardown until AFTER delivery.
         # run_job normally closes the agent (and reaps stale async clients) in
         # its finally block; doing that before _deliver_result runs means the
@@ -6552,8 +6567,6 @@ def _run_one_job_body(
             for _deferred_agent in _deferred_agents:
                 _teardown_cron_agent(_deferred_agent, job["id"])
             raise
-        finally:
-            reset_secret_scope(_scope_token)
 
         if _fire_claim_ownership_lost():
             for _deferred_agent in _deferred_agents:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2820,6 +2820,23 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             pconfig = config.platforms.get(platform)
             runtime_adapter = None
 
+        # Multiplex profile-credential fix (#83182): load_gateway_config() reads
+        # the Telegram/Discord/Slack bot token from os.environ, but under
+        # multiplex the process-wide os.environ holds the DEFAULT profile's
+        # token. The ticking profile's token lives in the secret scope (installed
+        # by run_one_job's scope wrapper), not os.environ. Patch pconfig.token
+        # from the secret scope so the standalone lane sends with the correct
+        # profile's bot identity.
+        if pconfig is not None and transport is None:
+            from gateway.config import PLATFORM_TOKEN_ENV_NAMES
+            from agent.secret_scope import get_secret
+            from dataclasses import replace as _dc_replace
+            _env_name = PLATFORM_TOKEN_ENV_NAMES.get(platform)
+            if _env_name:
+                _scoped_token = get_secret(_env_name, None)
+                if _scoped_token and _scoped_token != pconfig.token:
+                    pconfig = _dc_replace(pconfig, token=_scoped_token)
+
         if transport is not None and transport.is_relay:
             # A relay transport carries the RELAY adapter's config, and
             # resolve_delivery_transport already applied relay's enablement

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import inspect
 import threading
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Optional
 
 # Cap for the exponential tick backoff applied while consecutive ticks fail
 # with fd exhaustion (EMFILE/ENFILE, #87644).  Base is the tick interval
@@ -488,6 +488,28 @@ def scheduler_for_profile_mode(
     return InProcessCronScheduler()
 
 
+def _profile_tick_adapters(
+    profile_name: Optional[str],
+    adapters: Any = None,
+    profile_adapters: Any = None,
+):
+    """Resolve the live-adapter map a multiplex tick should deliver through.
+
+    Under multiplexing (#83182), a profile's cron tick must deliver through
+    THAT profile's adapters — each secondary profile's bot sends with its own
+    credential — not the shared default-profile map. Falls back to the shared
+    map for the default profile, for profiles with no secondary adapters
+    (e.g. platform served only by the primary), or when the caller did not
+    supply ``profile_adapters`` (older gateway / tests).
+    """
+    if not profile_name or profile_name == "default":
+        return adapters
+    pmap = (profile_adapters or {}).get(profile_name)
+    if pmap:
+        return pmap
+    return adapters
+
+
 class InProcessCronScheduler(CronScheduler):
     """Default provider: the historical in-process 60s ticker.
 
@@ -511,6 +533,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -538,6 +561,7 @@ class InProcessCronScheduler(CronScheduler):
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                profile_adapters=profile_adapters,
             )
             return
 
@@ -609,6 +633,7 @@ class InProcessCronScheduler(CronScheduler):
         loop=None,
         interval=60,
         can_dispatch=None,
+        profile_adapters=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -661,13 +686,18 @@ class InProcessCronScheduler(CronScheduler):
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
                     for entry in profile_homes:
+                        profile_name = (
+                            entry[0] if isinstance(entry, tuple) else None
+                        )
                         home = entry[1] if isinstance(entry, tuple) else entry
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=_profile_tick_adapters(
+                                        profile_name, adapters, profile_adapters
+                                    ),
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30788,6 +30788,15 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
                 cron_start_kwargs["profile_homes"] = profile_homes
+                # Per-profile live adapters (#83182): a secondary profile's
+                # cron delivery must send through that profile's own bot
+                # (its own credential), not the default profile's adapter.
+                # The ticker picks each profile's map by name when ticking
+                # its store; profiles without secondary adapters fall back
+                # to the shared map below.
+                _profile_adapters = getattr(runner, "_profile_adapters", None)
+                if _profile_adapters:
+                    cron_start_kwargs["profile_adapters"] = _profile_adapters
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",
                     len(profile_homes),

--- a/tests/cron/test_cron_multiplex_delivery_identity.py
+++ b/tests/cron/test_cron_multiplex_delivery_identity.py
@@ -1,0 +1,212 @@
+"""Regression tests for #83182 — cron delivery identity under multiplex.
+
+Two contracts under multiplex_profiles:
+
+1. **Scope held through delivery.** ``run_one_job`` installs the job-owning
+   profile's secret scope and keeps it installed through the ENTIRE
+   body — run_job, save, ``_deliver_result`` (live-adapter and standalone),
+   and mark — resetting it only in the wrapper's finally. Before #83182 the
+   scope was reset in a finally around ``run_job`` alone, so delivery read
+   credentials from ``os.environ`` (another profile's bot token, or none).
+
+2. **Per-profile adapter map.** The multiplex ticker ticks each profile with
+   THAT profile's live adapters (``_profile_adapters[<name>]``), falling back
+   to the shared map for the default profile or when no per-profile map is
+   supplied. Before #83182 every profile tick delivered through the shared
+   default-profile dict — wrong bot identity for every secondary profile.
+
+The tests assert the behavior contracts (how the pieces relate), not
+snapshots — they stub the pipeline and assert which credential/adapters each
+stage observed.
+"""
+import threading
+
+import pytest
+
+import cron.scheduler as s
+import cron.scheduler_provider as sp
+
+
+def _patch_pipeline(monkeypatch, *, deliver_capture):
+    """Patch the job pipeline; deliver_capture records what delivery sees."""
+
+    def fake_run_job(job, *, defer_agent_teardown=None, **kw):
+        return (True, "out", "final response", None)
+
+    def fake_save(jid, out):
+        return f"/tmp/{jid}.txt"
+
+    def fake_deliver(job, content, adapters=None, loop=None):
+        # Capture the adapters delivery is offered AND the secret scope that
+        # is active at delivery time — the two things #83182 is about.
+        from agent.secret_scope import current_secret_scope
+
+        deliver_capture.append(
+            {
+                "adapters": adapters,
+                "scope": dict(current_secret_scope() or {}),
+            }
+        )
+        return None
+
+    def fake_mark(jid, ok, err=None, delivery_error=None, **_kw):
+        return True
+
+    monkeypatch.setattr(s, "run_job", fake_run_job)
+    monkeypatch.setattr(s, "save_job_output", fake_save)
+    monkeypatch.setattr(s, "_deliver_result", fake_deliver)
+    monkeypatch.setattr(s, "mark_job_run", fake_mark)
+
+
+class TestScopeHeldThroughDelivery:
+    """Contract 1: the profile secret scope is live at delivery time."""
+
+    def test_scope_active_during_delivery(self, tmp_path, monkeypatch):
+        from agent import secret_scope as ss
+
+        # Build a profile home with a .env so the scope has content.
+        profile_home = tmp_path / "profiles" / "alpha"
+        profile_home.mkdir(parents=True)
+        (profile_home / ".env").write_text("TELEGRAM_BOT_TOKEN=alpha-token\n")
+
+        monkeypatch.setattr(
+            "cron.scheduler._get_hermes_home", lambda: profile_home
+        )
+        # Neutralize store side effects that write into the real home.
+        monkeypatch.setattr(s, "create_execution", lambda jid, **kw: {"id": "e1"})
+        monkeypatch.setattr(s, "mark_execution_running", lambda eid: None)
+        monkeypatch.setattr(s, "claim_dispatch", lambda jid: True)
+        monkeypatch.setattr(s, "finish_execution", lambda eid, **kw: None)
+        monkeypatch.setattr(s, "advance_next_runs", lambda ids: None)
+        monkeypatch.setattr(
+            s, "_consume_interrupted_flag", lambda jid, tok: False
+        )
+
+        capture = []
+        _patch_pipeline(monkeypatch, deliver_capture=capture)
+
+        job = {"id": "j-scope", "name": "scope-test", "deliver": "telegram:1"}
+        tok = ss.set_secret_scope(None) if False else None
+        prev = ss.current_secret_scope()
+        assert prev is None  # hermetic: no scope leaking from the test env
+
+        s.run_one_job(job)
+
+        assert capture, "delivery must have run"
+        assert capture[0]["scope"].get("TELEGRAM_BOT_TOKEN") == "alpha-token"
+
+    def test_scope_reset_after_job_completes(self, tmp_path, monkeypatch):
+        from agent import secret_scope as ss
+
+        profile_home = tmp_path / "profiles" / "beta"
+        profile_home.mkdir(parents=True)
+        (profile_home / ".env").write_text("TELEGRAM_BOT_TOKEN=beta-token\n")
+
+        monkeypatch.setattr(
+            "cron.scheduler._get_hermes_home", lambda: profile_home
+        )
+        monkeypatch.setattr(s, "create_execution", lambda jid, **kw: {"id": "e1"})
+        monkeypatch.setattr(s, "mark_execution_running", lambda eid: None)
+        monkeypatch.setattr(s, "claim_dispatch", lambda jid: True)
+        monkeypatch.setattr(s, "finish_execution", lambda eid, **kw: None)
+        monkeypatch.setattr(s, "advance_next_runs", lambda ids: None)
+        monkeypatch.setattr(
+            s, "_consume_interrupted_flag", lambda jid, tok: False
+        )
+
+        capture = []
+        _patch_pipeline(monkeypatch, deliver_capture=capture)
+
+        job = {"id": "j-reset", "name": "reset-test", "deliver": "telegram:1"}
+        assert ss.current_secret_scope() is None
+        s.run_one_job(job)
+        # After the wrapper returns, the scope is torn down again.
+        assert ss.current_secret_scope() is None
+
+
+class TestProfileTickAdapters:
+    """Contract 2: the multiplex tick offers each profile its own adapters."""
+
+    def test_secondary_profile_uses_own_adapters(self):
+        shared = {"shared": object()}
+        trader_map = {"trader-map": object()}
+        profile_adapters = {"trader": trader_map}
+
+        resolved = sp._profile_tick_adapters(
+            "trader", shared, profile_adapters
+        )
+        assert resolved is trader_map
+
+    def test_default_profile_uses_shared_adapters(self):
+        shared = {"shared": object()}
+        profile_adapters = {"trader": {"trader-map": object()}}
+
+        resolved = sp._profile_tick_adapters(
+            "default", shared, profile_adapters
+        )
+        bare = sp._profile_tick_adapters(None, shared, profile_adapters)
+        assert resolved is shared
+        assert bare is shared
+
+    def test_unknown_profile_falls_back_to_shared(self):
+        shared = {"shared": object()}
+        profile_adapters = {"trader": {"trader-map": object()}}
+
+        resolved = sp._profile_tick_adapters(
+            "cric", shared, profile_adapters
+        )
+        assert resolved is shared
+
+    def test_no_profile_adapters_supplied(self):
+        shared = {"shared": object()}
+
+        assert (
+            sp._profile_tick_adapters("trader", shared, None) is shared
+        )
+        assert sp._profile_tick_adapters("trader", shared, {}) is shared
+
+
+class TestMultiplexTickUsesProfileAdapters:
+    """The ticker's per-profile loop passes the profile's own map to tick."""
+
+    def test_tick_receives_profile_map(self, monkeypatch, tmp_path):
+        calls = []
+        stop = threading.Event()
+
+        def fake_cron_tick(*, adapters=None, **kw):
+            calls.append(adapters)
+            # Stop after the first per-profile tick so the blocking loop exits.
+            stop.set()
+
+        # scheduler_provider reads cron.scheduler.tick lazily inside
+        # _start_multiplex — patch at the source module.
+        monkeypatch.setattr(
+            "cron.scheduler.tick", fake_cron_tick, raising=True
+        )
+
+        # Neutralize recovery/heartbeat store side effects.
+        monkeypatch.setattr(
+            sp.InProcessCronScheduler, "recover_interrupted", lambda self: 0
+        )
+        monkeypatch.setattr(
+            "cron.jobs.record_ticker_heartbeat", lambda **kw: None
+        )
+        monkeypatch.setattr("cron.jobs.clear_ticker_error", lambda: None)
+
+        provider = sp.InProcessCronScheduler()
+        shared = {"shared": object()}
+        trader_map = {"trader-map": object()}
+
+        homes = [("trader", tmp_path / "profiles" / "trader")]
+        (tmp_path / "profiles" / "trader").mkdir(parents=True)
+        provider._start_multiplex(
+            stop,
+            profile_homes=homes,
+            adapters=shared,
+            loop=None,
+            interval=60,
+            can_dispatch=None,
+            profile_adapters={"trader": trader_map},
+        )
+
+        assert trader_map in calls


### PR DESCRIPTION
## What does this PR do?

Fixes cron delivery identity for secondary profiles under a multiplexed gateway (`multiplex_profiles: true`): a job owned by profile X now **delivers through profile X's own bot** instead of the default profile's bot.

Implements the expected behavior from #83182 end-to-end:

1. **Secret scope held through delivery** (`cron/scheduler.py`) — the job-owning profile's secret scope was previously reset in a `finally` around `run_job` *alone*, before `_deliver_result` ran. Delivery then resolved `TELEGRAM_BOT_TOKEN` with no scope active — falling back to `os.environ` (empty or another profile's value in a multiplex unit). The scope is now installed by the `run_one_job` wrapper and reset in the wrapper's `finally`, after the full execute → save → **deliver** → mark sequence (including the failure-path delivery in the body's outer `except`).

2. **Per-profile adapter map for the tick** (`cron/scheduler_provider.py`) — the multiplex ticker passed the *shared* default-profile adapter map to every profile's `cron_tick`. It now resolves each profile's own map via the new `profile_adapters` kwarg (`_profile_tick_adapters` helper): secondary profiles get `_profile_adapters[<name>]`; the default profile — and profiles with no secondary adapters — keep the shared map, so single-profile gateways are unchanged.

3. **Gateway wiring** (`gateway/run.py`) — `start_gateway` now passes `runner._profile_adapters` to the cron provider alongside the shared map (additive kwarg; external providers ignore it).

## Related Issue

Fixes #83182

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `cron/scheduler.py` — move the profile secret-scope install/reset from `_run_one_job_body` (around `run_job` alone) to the `run_one_job` wrapper, so the scope spans the entire body including both `_deliver_result` call sites
- `cron/scheduler_provider.py` — new `profile_adapters` kwarg on `InProcessCronScheduler.start` / `_start_multiplex`; `_profile_tick_adapters(profile, shared, profile_adapters)` resolves each tick's adapter map; the per-profile loop uses it
- `gateway/run.py` — pass `runner._profile_adapters` (when populated) as `profile_adapters` in `cron_start_kwargs` under multiplex
- `tests/cron/test_cron_multiplex_delivery_identity.py` — 7 regression tests: scope active at delivery time, scope torn down after completion, per-profile adapter resolution (own / default / unknown / unsupplied), and the multiplex tick passing the profile's own map to `cron_tick`

## How to Test

**Unit/regression (repo venv, verified):**

```bash
pytest tests/cron/test_cron_multiplex_delivery_identity.py -q   # 7 passed
pytest tests/cron/ -q                                           # 0 new failures vs origin/main baseline
pytest tests/gateway/ -q -k "multiplex or profile"              # 253 passed, 2 skipped
```

**E2E reproduction (how the bug was originally observed):** on a multiplex gateway with a secondary profile `trader` that owns a Telegram bot token and a `telegram:<chat>`-delivered cron job in its store, fire the job on the scheduler — before the fix the message arrives from the default profile's bot (visible in the gateway log as a delivery flush keyed `agent:main:...`); with this PR it arrives from the trader bot's identity, and the log shows the tick's delivery routing through the profile-owned credential. Verified live on a 7-profile multiplex gateway (all scheduled briefings now deliver from their own bots).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cron):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no open PR addresses #83182; issue explicitly notes it is distinct from #51853/#54675/PR #59315)
- [x] My PR contains **only** changes related to this fix (3 files + 1 test file, single commit)
- [x] I've run `pytest tests/ -q` and all tests pass (full cron + gateway multiplex suites: **0 new failures vs origin/main baseline**; 10 pre-existing environment-dependent failures occur identically on clean origin/main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
