### PR TITLE
feat: 'ox alpha' now finds x-preview-f-free in every model picker

### DIFF
--- a/apps/desktop/src/lib/model-search-text.ts
+++ b/apps/desktop/src/lib/model-search-text.ts
@@ -9,7 +9,10 @@
  * web/src/lib/model-search-text.ts, and hermes_cli/model_search.py.
  */
 const MODEL_SEARCH_ALIASES: Record<string, readonly string[]> = {
-  k3: ['kimi-k3', 'kimi']
+  k3: ['kimi-k3', 'kimi'],
+  // OpenCode Zen serves the "Ox Alpha" stealth model under an opaque
+  // preview slug; let users find it by its public codename.
+  'x-preview-f-free': ['ox-alpha', 'ox']
 }
 
 /** Haystack for fuzzy/substring model search; never changes the wire id. */

--- a/hermes_cli/model_search.py
+++ b/hermes_cli/model_search.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 # Lowercased wire id → extra tokens appended to the search haystack only.
 _MODEL_SEARCH_ALIASES: dict[str, tuple[str, ...]] = {
     "k3": ("kimi-k3", "kimi"),
+    # OpenCode Zen serves the "Ox Alpha" stealth model under an opaque
+    # preview slug; let users find it by its public codename.
+    "x-preview-f-free": ("ox-alpha", "ox"),
 }
 
 # Lowercased wire id → canonical public slug it aliases. Used by picker

--- a/tests/hermes_cli/test_model_search.py
+++ b/tests/hermes_cli/test_model_search.py
@@ -16,3 +16,17 @@ def test_filter_indices_surfaces_k3_for_kimi_query():
     assert "k3" in ranked
 
 
+def test_model_search_text_adds_ox_alpha_aliases():
+    assert model_search_text("x-preview-f-free") == "x-preview-f-free ox-alpha ox"
+    assert model_search_text("X-Preview-F-Free") == "X-Preview-F-Free ox-alpha ox"
+
+
+def test_filter_indices_surfaces_ox_alpha_preview_slug():
+    models = ["x-preview-f-free", "gpt-5.6-sol", "kimi-k3"]
+    haystacks = [model_search_text(m) for m in models]
+    for query in ("ox", "ox-alpha"):
+        ranked = [models[i] for i in _filter_indices(haystacks, query)]
+        assert "x-preview-f-free" in ranked, query
+
+
+

--- a/ui-tui/src/lib/model-search-text.test.ts
+++ b/ui-tui/src/lib/model-search-text.test.ts
@@ -13,6 +13,11 @@ describe('modelSearchText', () => {
     expect(modelSearchText('k3')).toBe('k3 kimi-k3 kimi')
     expect(modelSearchText('K3')).toBe('K3 kimi-k3 kimi')
   })
+
+  it('adds ox-alpha aliases for the Ox Alpha preview wire id', () => {
+    expect(modelSearchText('x-preview-f-free')).toBe('x-preview-f-free ox-alpha ox')
+    expect(modelSearchText('X-Preview-F-Free')).toBe('X-Preview-F-Free ox-alpha ox')
+  })
 })
 
 describe('model picker search with aliases', () => {
@@ -31,5 +36,13 @@ describe('model picker search with aliases', () => {
   it('does not invent k3 for unrelated queries', () => {
     const ranked = fuzzyRank(models, 'glm', modelSearchText).map(r => r.item)
     expect(ranked).toEqual([])
+  })
+
+  it('surfaces the Ox Alpha preview slug when the user searches ox', () => {
+    const zenModels = ['x-preview-f-free', 'gpt-5.6-sol', 'kimi-k3']
+    const ranked = fuzzyRank(zenModels, 'ox', modelSearchText).map(r => r.item)
+    expect(ranked).toContain('x-preview-f-free')
+    const rankedFull = fuzzyRank(zenModels, 'ox-alpha', modelSearchText).map(r => r.item)
+    expect(rankedFull).toContain('x-preview-f-free')
   })
 })

--- a/ui-tui/src/lib/model-search-text.ts
+++ b/ui-tui/src/lib/model-search-text.ts
@@ -9,7 +9,10 @@
  * hermes_cli/model_search.py.
  */
 const MODEL_SEARCH_ALIASES: Record<string, readonly string[]> = {
-  k3: ['kimi-k3', 'kimi']
+  k3: ['kimi-k3', 'kimi'],
+  // OpenCode Zen serves the "Ox Alpha" stealth model under an opaque
+  // preview slug; let users find it by its public codename.
+  'x-preview-f-free': ['ox-alpha', 'ox']
 }
 
 /** Haystack for fuzzy/substring model search; never changes the wire id. */

--- a/web/src/lib/model-search-text.ts
+++ b/web/src/lib/model-search-text.ts
@@ -10,6 +10,9 @@
  */
 const MODEL_SEARCH_ALIASES: Record<string, readonly string[]> = {
   k3: ["kimi-k3", "kimi"],
+  // OpenCode Zen serves the "Ox Alpha" stealth model under an opaque
+  // preview slug; let users find it by its public codename.
+  "x-preview-f-free": ["ox-alpha", "ox"],
 };
 
 /** Haystack for fuzzy/substring model search; never changes the wire id. */


### PR DESCRIPTION
## Summary
Searching "ox" or "ox-alpha" in any model picker now surfaces the Ox Alpha stealth model, whose OpenCode Zen wire slug is the opaque `x-preview-f-free`.

## Changes
- `hermes_cli/model_search.py`: `x-preview-f-free → ("ox-alpha", "ox")` search alias (same mechanism as the `k3 → kimi-k3` precedent)
- `apps/desktop/src/lib/model-search-text.ts`, `web/src/lib/model-search-text.ts`, `ui-tui/src/lib/model-search-text.ts`: same entry in all sync-locked alias tables
- Tests: `tests/hermes_cli/test_model_search.py` (+2), `ui-tui/src/lib/model-search-text.test.ts` (+2)

Wire id is unchanged — it still renders as-is and is what gets sent to the provider; the alias only extends the search haystack. Canonical-dedup checked: no collision with opencode-go's keyed `ox-alpha-free` slug or the nous `stealth/ox-alpha` id.

## Validation
| Check | Result |
|---|---|
| `test_model_search.py` + `test_model_search_alias_dedup.py` | 6 passed |
| `ui-tui` vitest `model-search-text.test.ts` | 7 passed |
| `model_alias_canonical` collision probe (`ox-alpha-free`, `stealth/ox-alpha`) | identity preserved, no collisions |

## Infographic

![Search ox — find the stealth model](https://v3b.fal.media/files/b/0aa7451e/JmQeH7HltcVtIyzeIRb82_CvozeOc8.png)
