### PR TITLE
feat(skills): let a skill declare trigger phrases for deterministic routing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -486,6 +486,46 @@ platforms: [windows]          # Windows only
 
 If the field is omitted or empty, the skill loads on all platforms (backward compatible). See `skills/apple/` for examples of macOS-only skills.
 
+### Skill trigger phrases
+
+Free text typed at the prompt is routed by the model, which means invoking a
+skill competes with every other skill for the model's attention. A cheap model
+loses that race sometimes, and the failure is quiet: a plausible answer from
+the wrong skill rather than an error.
+
+A skill that knows its own invocation phrases can declare them, taking the
+decision away from the model:
+
+```yaml
+triggers:
+  - deploy
+  - roll back
+```
+
+Input that *begins* with a declared phrase is rewritten to that skill's slash
+command before the model sees it, so `deploy the api to staging` dispatches as
+`/release deploy the api to staging`. The skill receives the user's original
+text, not the normalized form used for matching.
+
+Rules worth knowing before you add them:
+
+- **Leading position only.** `deploy the api` matches; `can you tell me how to
+  deploy this` does not. A trigger anywhere in a sentence would capture ordinary
+  prose that merely mentions the word.
+- **Whole words only.** The trigger `deploy` does not match `deployment guide`.
+- **Literal phrases, never regex.** Skills can be agent-authored or installed
+  from the hub, so trigger strings are untrusted input. They are matched
+  literally — a skill cannot declare `.*` and capture everything.
+- **Minimum three characters.** Shorter fragments match too much prose.
+- **Longest match wins** when skills overlap, so `deploy staging` beats
+  `deploy`. Equal-length ties resolve by slug, so the winner does not depend on
+  filesystem scan order.
+- **Opt-in.** With no skill declaring `triggers:`, nothing changes — which is
+  every install today.
+
+Prefer a handful of unambiguous phrases over broad ones. A trigger is a
+commitment that the phrase means *this skill and nothing else*.
+
 ### Conditional skill activation
 
 Skills can declare conditions that control when they appear in the system prompt, based on which tools and toolsets are available in the current session. This is primarily used for **fallback skills** — alternatives that should only be shown when a primary tool is unavailable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -513,10 +513,17 @@ Rules worth knowing before you add them:
   deploy this` does not. A trigger anywhere in a sentence would capture ordinary
   prose that merely mentions the word.
 - **Whole words only.** The trigger `deploy` does not match `deployment guide`.
+  A word ends at whitespace or punctuation, so `deploy` *does* match
+  `deploy-to-staging` — a hyphen separates words. An underscore does not, so
+  `deploy_staging` is treated as one word and does not match.
 - **Literal phrases, never regex.** Skills can be agent-authored or installed
   from the hub, so trigger strings are untrusted input. They are matched
   literally — a skill cannot declare `.*` and capture everything.
 - **Minimum three characters.** Shorter fragments match too much prose.
+- **At most 32 phrases, 64 characters each.** Frontmatter is untrusted — skills
+  can be agent-authored or hub-installed — and every phrase is checked against
+  every message you send. Anything past the limit is dropped and the skill
+  still loads.
 - **Longest match wins** when skills overlap, so `deploy staging` beats
   `deploy`. Equal-length ties resolve by slug, so the winner does not depend on
   filesystem scan order.

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -33,6 +33,98 @@ _publish_lock = threading.Lock()
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 
+# A trigger shorter than this is rejected. Single letters and two-character
+# fragments match far too much ordinary prose to be a safe routing signal, and
+# a skill that declares one would quietly capture unrelated input.
+_MIN_TRIGGER_LEN = 3
+
+# What may follow a trigger for it to count as a match: end of input, or a
+# character that ends a word. Without this, the trigger "deploy" would also
+# capture "deployment guide, section 3".
+_TRIGGER_BOUNDARY = re.compile(r"[\s\W]")
+
+
+def _normalize_triggers(frontmatter: Dict[str, Any]) -> "list[str]":
+    """Return the cleaned ``triggers:`` list declared by a skill, or [].
+
+    Triggers are matched as LITERAL phrases, never compiled as user regex.
+    Skills can be written by the agent itself (``skills.write_approval``) and
+    installed from the hub, so a trigger string is untrusted input; treating it
+    as a pattern would hand any skill author a ReDoS or a catch-all ``.*``.
+    """
+    raw = frontmatter.get("triggers")
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return []
+
+    cleaned = []
+    seen = set()
+    for item in raw:
+        if not isinstance(item, str):
+            continue
+        phrase = " ".join(item.split()).strip().lower()
+        if len(phrase) < _MIN_TRIGGER_LEN:
+            continue
+        if phrase in seen:
+            continue
+        seen.add(phrase)
+        cleaned.append(phrase)
+    return cleaned
+
+
+def match_skill_trigger(text: str, commands: Optional[Dict[str, Any]] = None):
+    """Map free text onto a skill's slash command via declared ``triggers:``.
+
+    Returns ``"/<skill-slug> <original text>"`` when *text* opens with a
+    declared trigger phrase, else ``None``.
+
+    Free text typed at the prompt is otherwise routed by the model, which is a
+    race: a cheap model asked to pick between a task skill and a search skill
+    can pick the wrong one, and the failure is silent — a plausible answer from
+    the wrong source. A skill that knows its own invocation phrases can declare
+    them and take that decision away from the model entirely.
+
+    Only skills that opt in by declaring ``triggers:`` participate, so this is
+    inert for every existing install.
+
+    Longest trigger wins, so a specific phrase beats a generic one when two
+    skills overlap ("deploy staging" over "deploy"). Equal-length ties go to the
+    first slug alphabetically -- the winner must not depend on scan order, which
+    varies with the filesystem.
+    """
+    if not text or not isinstance(text, str):
+        return None
+    stripped = text.strip()
+    if not stripped or stripped.startswith("/"):
+        return None
+
+    if commands is None:
+        commands = scan_skill_commands()
+
+    haystack = " ".join(stripped.split()).lower()
+    best_len = -1
+    best_cmd = None
+    for cmd_key, info in (commands or {}).items():
+        if not isinstance(info, dict):
+            continue
+        for trigger in info.get("triggers") or ():
+            if not haystack.startswith(trigger):
+                continue
+            rest = haystack[len(trigger):]
+            if rest and not _TRIGGER_BOUNDARY.match(rest[0]):
+                continue
+            length = len(trigger)
+            if length > best_len or (length == best_len and cmd_key < best_cmd):
+                best_len, best_cmd = length, cmd_key
+
+    if best_cmd is None:
+        return None
+    return f"{best_cmd} {stripped}"
+
+
 # ---------------------------------------------------------------------------
 # Skill-scaffolding markers and the canonical extractor.
 #
@@ -528,6 +620,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
                         "skill_dir": str(skill_md.parent),
+                        "triggers": _normalize_triggers(frontmatter),
                     }
                 except Exception:
                     continue

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -38,6 +38,16 @@ _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 # a skill that declares one would quietly capture unrelated input.
 _MIN_TRIGGER_LEN = 3
 
+# Ceilings on what one skill may declare. Frontmatter is untrusted -- skills are
+# agent-authored (``skills.write_approval``) and hub-installed -- and every
+# declared phrase is scanned against every submitted input. The scan is over a
+# cached map and cheap per phrase, so these are not a hot path today; they are
+# here so a skill cannot make it one. Excess phrases are dropped, over-long
+# phrases are dropped whole rather than truncated (a truncated trigger would
+# match MORE than its author wrote, which is the wrong way to fail).
+_MAX_TRIGGERS = 32
+_MAX_TRIGGER_LEN = 64
+
 # What may follow a trigger for it to count as a match: end of input, or a
 # character that ends a word. Without this, the trigger "deploy" would also
 # capture "deployment guide, section 3".
@@ -51,6 +61,10 @@ def _normalize_triggers(frontmatter: Dict[str, Any]) -> "list[str]":
     Skills can be written by the agent itself (``skills.write_approval``) and
     installed from the hub, so a trigger string is untrusted input; treating it
     as a pattern would hand any skill author a ReDoS or a catch-all ``.*``.
+
+    At most ``_MAX_TRIGGERS`` phrases of at most ``_MAX_TRIGGER_LEN`` characters
+    survive; the rest are dropped with a debug line. Over-quota frontmatter is a
+    malformed skill, not a fatal error, so the skill still loads.
     """
     raw = frontmatter.get("triggers")
     if raw is None:
@@ -62,16 +76,37 @@ def _normalize_triggers(frontmatter: Dict[str, Any]) -> "list[str]":
 
     cleaned = []
     seen = set()
+    dropped_long = 0
     for item in raw:
         if not isinstance(item, str):
             continue
-        phrase = " ".join(item.split()).strip().lower()
+        # casefold(), not lower(): matching compares a casefolded haystack, so
+        # both sides must use the same fold or a non-ASCII trigger silently
+        # stops matching its own phrase.
+        phrase = " ".join(item.split()).strip().casefold()
         if len(phrase) < _MIN_TRIGGER_LEN:
+            continue
+        if len(phrase) > _MAX_TRIGGER_LEN:
+            dropped_long += 1
             continue
         if phrase in seen:
             continue
         seen.add(phrase)
         cleaned.append(phrase)
+        if len(cleaned) >= _MAX_TRIGGERS:
+            break
+
+    if dropped_long:
+        logger.debug(
+            "skill triggers: dropped %d phrase(s) over %d characters",
+            dropped_long,
+            _MAX_TRIGGER_LEN,
+        )
+    if len(cleaned) >= _MAX_TRIGGERS:
+        logger.debug(
+            "skill triggers: capped at %d phrases; later entries ignored",
+            _MAX_TRIGGERS,
+        )
     return cleaned
 
 
@@ -104,7 +139,7 @@ def match_skill_trigger(text: str, commands: Optional[Dict[str, Any]] = None):
     if commands is None:
         commands = scan_skill_commands()
 
-    haystack = " ".join(stripped.split()).lower()
+    haystack = " ".join(stripped.split()).casefold()
     best_len = -1
     best_cmd = None
     for cmd_key, info in (commands or {}).items():

--- a/cli.py
+++ b/cli.py
@@ -4802,6 +4802,22 @@ def build_skill_invocation_message(*args, **kwargs):
     return _impl(*args, **kwargs)
 
 
+def match_skill_trigger(text: str):
+    """Rewrite free text into a skill slash command via declared triggers.
+
+    Returns None when nothing matches, which is the case for every install
+    where no skill declares ``triggers:``.
+    """
+    try:
+        from agent.skill_commands import match_skill_trigger as _impl
+
+        return _impl(text, get_skill_commands())
+    except Exception:
+        # Routing is an optimisation, never a gate: if the skill scan fails
+        # the input must still reach the model unchanged.
+        return None
+
+
 def build_preloaded_skills_prompt(*args, **kwargs):
     from agent.skill_commands import build_preloaded_skills_prompt as _impl
 
@@ -20238,6 +20254,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         and self.handle_bang_shell(user_input)
                     ):
                         continue
+
+                    # Skill-declared trigger phrases resolve to that skill's
+                    # slash command BEFORE the model sees the text, so a skill
+                    # that knows its own invocation phrases isn't competing with
+                    # every other skill for the model's attention. Runs after
+                    # file-drop detection (a dropped path is not an invocation)
+                    # and before dispatch, so the rewrite is dispatched normally.
+                    if (
+                        not _file_drop
+                        and isinstance(user_input, str)
+                        and not _looks_like_slash_command(user_input)
+                    ):
+                        _trigger_rewrite = match_skill_trigger(user_input)
+                        if _trigger_rewrite:
+                            user_input = _trigger_rewrite
 
                     if not _file_drop and isinstance(user_input, str) and _looks_like_slash_command(user_input):
                         _cprint(f"\n⚙️  {user_input}")

--- a/cli.py
+++ b/cli.py
@@ -4802,19 +4802,40 @@ def build_skill_invocation_message(*args, **kwargs):
     return _impl(*args, **kwargs)
 
 
+# Set once the trigger-routing failure has been reported, so a persistent
+# breakage warns a single time per process instead of on every message.
+_trigger_routing_failed = False
+
+
 def match_skill_trigger(text: str):
     """Rewrite free text into a skill slash command via declared triggers.
 
     Returns None when nothing matches, which is the case for every install
     where no skill declares ``triggers:``.
     """
+    global _trigger_routing_failed
     try:
         from agent.skill_commands import match_skill_trigger as _impl
 
         return _impl(text, get_skill_commands())
     except Exception:
-        # Routing is an optimisation, never a gate: if the skill scan fails
-        # the input must still reach the model unchanged.
+        # Routing is an optimisation, never a gate: if the skill scan fails the
+        # input must still reach the model unchanged. It is not silent, though:
+        # an import error or schema drift would otherwise disable routing for
+        # the whole session with no signal, and from the call site "nothing
+        # matched" and "the scanner is broken" look identical.
+        #
+        # Warn once, then drop to debug. The failure is almost always sticky,
+        # and a warning on every submitted message would bury the session.
+        if not _trigger_routing_failed:
+            _trigger_routing_failed = True
+            logger.warning(
+                "Skill trigger routing failed; input left unchanged. "
+                "Further failures log at debug.",
+                exc_info=True,
+            )
+        else:
+            logger.debug("Skill trigger routing failed again", exc_info=True)
         return None
 
 

--- a/tests/agent/test_skill_trigger_routing.py
+++ b/tests/agent/test_skill_trigger_routing.py
@@ -1,0 +1,151 @@
+"""Skill-declared trigger phrases route free text to a skill's slash command.
+
+The bug this closes: free text at the prompt is routed by the model, so a
+skill invocation competes with every other skill for the model's attention.
+A cheap model loses that race sometimes, and the failure is silent — a
+plausible answer from the wrong skill rather than an error.
+"""
+
+import unittest
+
+from agent.skill_commands import _normalize_triggers, match_skill_trigger
+
+
+def _cmds(mapping):
+    """Build a minimal scan_skill_commands()-shaped map."""
+    return {
+        key: {"name": key.lstrip("/"), "description": "", "triggers": triggers}
+        for key, triggers in mapping.items()
+    }
+
+
+class TestNormalizeTriggers(unittest.TestCase):
+    def test_absent_yields_empty(self):
+        self.assertEqual(_normalize_triggers({}), [])
+        self.assertEqual(_normalize_triggers({"triggers": None}), [])
+
+    def test_scalar_is_accepted_as_one_trigger(self):
+        self.assertEqual(_normalize_triggers({"triggers": "list trips"}), ["list trips"])
+
+    def test_lowercased_and_whitespace_collapsed(self):
+        got = _normalize_triggers({"triggers": ["  List   Trips  "]})
+        self.assertEqual(got, ["list trips"])
+
+    def test_short_triggers_rejected(self):
+        # "go" would capture an enormous amount of ordinary prose.
+        got = _normalize_triggers({"triggers": ["go", "hi", "brief"]})
+        self.assertEqual(got, ["brief"])
+
+    def test_duplicates_collapsed(self):
+        got = _normalize_triggers({"triggers": ["brief", "BRIEF", " brief "]})
+        self.assertEqual(got, ["brief"])
+
+    def test_non_string_entries_ignored(self):
+        got = _normalize_triggers({"triggers": ["brief", 42, None, {"a": 1}]})
+        self.assertEqual(got, ["brief"])
+
+    def test_malformed_type_yields_empty(self):
+        self.assertEqual(_normalize_triggers({"triggers": 42}), [])
+
+
+class TestMatchSkillTrigger(unittest.TestCase):
+    def setUp(self):
+        self.commands = _cmds({"/trip-brief": ["brief", "list trips"]})
+
+    def test_exact_trigger_matches(self):
+        self.assertEqual(
+            match_skill_trigger("list trips", self.commands),
+            "/trip-brief list trips",
+        )
+
+    def test_trigger_with_trailing_text_matches(self):
+        self.assertEqual(
+            match_skill_trigger("brief the wine trip", self.commands),
+            "/trip-brief brief the wine trip",
+        )
+
+    def test_case_and_spacing_insensitive(self):
+        self.assertEqual(
+            match_skill_trigger("  LIST   TRIPS  ", self.commands),
+            "/trip-brief LIST   TRIPS",
+        )
+
+    def test_original_text_is_preserved_in_rewrite(self):
+        # The skill receives what the user actually typed, not the normalized
+        # form used for matching.
+        out = match_skill_trigger("Brief The Wine Trip", self.commands)
+        self.assertEqual(out, "/trip-brief Brief The Wine Trip")
+
+    # --- the safety cases -------------------------------------------------
+
+    def test_word_prefix_does_not_match(self):
+        # "briefing" is not "brief"; hijacking it would be a regression.
+        self.assertIsNone(match_skill_trigger("briefing notes on Q3", self.commands))
+
+    def test_trigger_mid_sentence_does_not_match(self):
+        # Only a leading trigger is an invocation. Otherwise any sentence
+        # mentioning the word gets captured.
+        self.assertIsNone(
+            match_skill_trigger("can you brief me on the merger", self.commands)
+        )
+
+    def test_unrelated_text_untouched(self):
+        self.assertIsNone(
+            match_skill_trigger("what restaurants are near the hotel", self.commands)
+        )
+
+    def test_existing_slash_command_untouched(self):
+        self.assertIsNone(match_skill_trigger("/help", self.commands))
+        self.assertIsNone(match_skill_trigger("  /trip-brief 2", self.commands))
+
+    def test_empty_and_non_string_input(self):
+        self.assertIsNone(match_skill_trigger("", self.commands))
+        self.assertIsNone(match_skill_trigger("   ", self.commands))
+        self.assertIsNone(match_skill_trigger(None, self.commands))
+        self.assertIsNone(match_skill_trigger(12345, self.commands))
+
+    def test_no_skills_declare_triggers_is_inert(self):
+        # The default state of every existing install.
+        inert = _cmds({"/a": [], "/b": None})
+        self.assertIsNone(match_skill_trigger("brief the wine trip", inert))
+
+    def test_triggers_are_literal_not_regex(self):
+        # A skill is untrusted input; a trigger must never compile as a
+        # pattern or any skill could declare ".*" and capture everything.
+        commands = _cmds({"/regexy": [".*", "a+b"]})
+        self.assertIsNone(match_skill_trigger("anything at all", commands))
+        self.assertEqual(
+            match_skill_trigger("a+b something", commands), "/regexy a+b something"
+        )
+
+    # --- precedence -------------------------------------------------------
+
+    def test_longest_trigger_wins(self):
+        commands = _cmds({"/deploy": ["deploy"], "/deploy-staging": ["deploy staging"]})
+        self.assertEqual(
+            match_skill_trigger("deploy staging now", commands),
+            "/deploy-staging deploy staging now",
+        )
+        self.assertEqual(
+            match_skill_trigger("deploy prod now", commands),
+            "/deploy deploy prod now",
+        )
+
+    def test_equal_length_ties_resolve_to_first_slug(self):
+        # Scan order varies with the filesystem; the winner must not.
+        a = _cmds({"/aaa": ["build"], "/zzz": ["build"]})
+        b = _cmds({"/zzz": ["build"], "/aaa": ["build"]})
+        self.assertEqual(match_skill_trigger("build it", a), "/aaa build it")
+        self.assertEqual(match_skill_trigger("build it", b), "/aaa build it")
+
+    def test_non_dict_command_entry_is_skipped(self):
+        commands = {"/junk": "not a dict", "/ok": {"triggers": ["brief"]}}
+        self.assertEqual(match_skill_trigger("brief x", commands), "/ok brief x")
+
+    def test_malformed_command_entries_are_survivable(self):
+        commands = {"/broken": {}, "/ok": {"triggers": ["brief"]}}
+        self.assertEqual(match_skill_trigger("brief x", commands), "/ok brief x")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent/test_skill_trigger_routing.py
+++ b/tests/agent/test_skill_trigger_routing.py
@@ -7,8 +7,14 @@ plausible answer from the wrong skill rather than an error.
 """
 
 import unittest
+from unittest import mock
 
-from agent.skill_commands import _normalize_triggers, match_skill_trigger
+from agent.skill_commands import (
+    _MAX_TRIGGER_LEN,
+    _MAX_TRIGGERS,
+    _normalize_triggers,
+    match_skill_trigger,
+)
 
 
 def _cmds(mapping):
@@ -145,6 +151,103 @@ class TestMatchSkillTrigger(unittest.TestCase):
     def test_malformed_command_entries_are_survivable(self):
         commands = {"/broken": {}, "/ok": {"triggers": ["brief"]}}
         self.assertEqual(match_skill_trigger("brief x", commands), "/ok brief x")
+
+
+class TestTriggerQuotas(unittest.TestCase):
+    """Frontmatter is untrusted, so a skill cannot declare unbounded triggers."""
+
+    def test_phrase_count_is_capped(self):
+        many = [f"trigger number {i}" for i in range(_MAX_TRIGGERS * 3)]
+        got = _normalize_triggers({"triggers": many})
+        self.assertEqual(len(got), _MAX_TRIGGERS)
+        # The cap keeps the declared order rather than an arbitrary subset.
+        self.assertEqual(got, [p.casefold() for p in many[:_MAX_TRIGGERS]])
+
+    def test_over_long_phrase_is_dropped_not_truncated(self):
+        long = "x" * (_MAX_TRIGGER_LEN + 1)
+        got = _normalize_triggers({"triggers": [long, "brief"]})
+        # Truncating would make the trigger match MORE than its author wrote.
+        self.assertEqual(got, ["brief"])
+
+    def test_phrase_at_the_limit_survives(self):
+        exact = "y" * _MAX_TRIGGER_LEN
+        self.assertEqual(_normalize_triggers({"triggers": [exact]}), [exact])
+
+    def test_over_quota_skill_still_loads(self):
+        # Malformed frontmatter degrades the feature; it must not raise.
+        got = _normalize_triggers({"triggers": ["z" * 500] * 500})
+        self.assertEqual(got, [])
+
+
+class TestCaseFolding(unittest.TestCase):
+    def test_non_ascii_trigger_matches_itself(self):
+        # .lower() is lossy for some scripts; both sides must use the same fold
+        # or a trigger stops matching the very phrase its author declared.
+        triggers = _normalize_triggers({"triggers": ["STRASSE"]})
+        commands = _cmds({"/street": triggers})
+        self.assertIsNotNone(match_skill_trigger("strasse now", commands))
+
+    def test_eszett_folds_consistently(self):
+        triggers = _normalize_triggers({"triggers": ["straße"]})
+        commands = _cmds({"/street": triggers})
+        self.assertEqual(
+            match_skill_trigger("STRASSE now", commands),
+            "/street STRASSE now",
+        )
+
+
+class TestCLIWrapper(unittest.TestCase):
+    """cli.match_skill_trigger() wires the matcher to the cached command scan.
+
+    The wrapper is the never-gate boundary: whatever goes wrong underneath, the
+    user's input has to reach the model unchanged.
+    """
+
+    def _cli(self):
+        import cli
+
+        return cli
+
+    def test_rewrite_is_returned_on_match(self):
+        cli = self._cli()
+        with mock.patch.object(
+            cli, "get_skill_commands", return_value=_cmds({"/trip-brief": ["brief"]})
+        ):
+            self.assertEqual(
+                cli.match_skill_trigger("brief me"), "/trip-brief brief me"
+            )
+
+    def test_no_match_returns_none(self):
+        cli = self._cli()
+        with mock.patch.object(
+            cli, "get_skill_commands", return_value=_cmds({"/trip-brief": ["brief"]})
+        ):
+            self.assertIsNone(cli.match_skill_trigger("what is the weather"))
+
+    def test_scan_failure_is_swallowed_but_logged(self):
+        cli = self._cli()
+        with mock.patch.object(cli, "_trigger_routing_failed", False):
+            with mock.patch.object(
+                cli, "get_skill_commands", side_effect=RuntimeError("schema drift")
+            ):
+                with self.assertLogs(cli.logger, level="WARNING") as caught:
+                    self.assertIsNone(cli.match_skill_trigger("brief me"))
+        # Silence here is the actual bug: a broken scan would disable routing
+        # everywhere and look exactly like "nothing matched".
+        self.assertTrue(any("trigger routing" in m for m in caught.output))
+
+    def test_repeat_failures_warn_only_once(self):
+        cli = self._cli()
+        with mock.patch.object(cli, "_trigger_routing_failed", False):
+            with mock.patch.object(
+                cli, "get_skill_commands", side_effect=RuntimeError("schema drift")
+            ):
+                with self.assertLogs(cli.logger, level="DEBUG") as caught:
+                    for _ in range(5):
+                        self.assertIsNone(cli.match_skill_trigger("brief me"))
+        # A sticky failure must not warn on every message the user sends.
+        warnings = [m for m in caught.output if m.startswith("WARNING")]
+        self.assertEqual(len(warnings), 1)
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_skill_trigger_routing.py
+++ b/tests/agent/test_skill_trigger_routing.py
@@ -201,6 +201,14 @@ class TestCLIWrapper(unittest.TestCase):
 
     The wrapper is the never-gate boundary: whatever goes wrong underneath, the
     user's input has to reach the model unchanged.
+
+    These exercise the wiring, not the matching -- the matcher itself is covered
+    above against the real implementation. The wrapper resolves its impl through
+    an ``import`` inside the function body, so driving the real matcher through
+    it would make these tests depend on the module state every other test in the
+    suite shares, and the wrapper's own ``except`` would swallow the evidence:
+    an unrelated import problem elsewhere would surface here as a bare
+    "None != '/trip-brief ...'" with no traceback to follow.
     """
 
     def _cli(self):
@@ -208,21 +216,61 @@ class TestCLIWrapper(unittest.TestCase):
 
         return cli
 
-    def test_rewrite_is_returned_on_match(self):
+    def _impl(self, **kwargs):
+        """Patch the impl the wrapper imports, so these test wiring only."""
+        import agent.skill_commands
+
+        return mock.patch.object(
+            agent.skill_commands, "match_skill_trigger", **kwargs
+        )
+
+    def test_impl_result_is_returned_verbatim(self):
         cli = self._cli()
-        with mock.patch.object(
-            cli, "get_skill_commands", return_value=_cmds({"/trip-brief": ["brief"]})
-        ):
-            self.assertEqual(
-                cli.match_skill_trigger("brief me"), "/trip-brief brief me"
-            )
+        commands = _cmds({"/trip-brief": ["brief"]})
+        with mock.patch.object(cli, "get_skill_commands", return_value=commands):
+            with self._impl(return_value="/trip-brief brief me") as impl:
+                self.assertEqual(
+                    cli.match_skill_trigger("brief me"), "/trip-brief brief me"
+                )
+        # The scanned command map has to reach the matcher; passing None would
+        # make it rescan the filesystem on every submitted message.
+        impl.assert_called_once_with("brief me", commands)
 
     def test_no_match_returns_none(self):
         cli = self._cli()
         with mock.patch.object(
             cli, "get_skill_commands", return_value=_cmds({"/trip-brief": ["brief"]})
         ):
-            self.assertIsNone(cli.match_skill_trigger("what is the weather"))
+            with self._impl(return_value=None):
+                self.assertIsNone(cli.match_skill_trigger("what is the weather"))
+
+    def test_matcher_failure_is_swallowed_too(self):
+        # Not just a failing scan: the matcher itself must not be able to take
+        # the prompt down.
+        cli = self._cli()
+        with mock.patch.object(cli, "_trigger_routing_failed", False):
+            with mock.patch.object(cli, "get_skill_commands", return_value={}):
+                with self._impl(side_effect=ValueError("boom")):
+                    self.assertIsNone(cli.match_skill_trigger("brief me"))
+
+    def test_real_matcher_reaches_the_wrapper(self):
+        """One end-to-end pass with nothing stubbed but the scan.
+
+        Asserts the wrapper did not silently fall into its except branch, so a
+        genuine wiring break is reported as an error rather than a no-match.
+        """
+        cli = self._cli()
+        with mock.patch.object(cli, "_trigger_routing_failed", False):
+            with mock.patch.object(
+                cli,
+                "get_skill_commands",
+                return_value=_cmds({"/trip-brief": ["brief"]}),
+            ):
+                with mock.patch.object(cli.logger, "warning") as warned:
+                    got = cli.match_skill_trigger("brief me")
+        if warned.called:
+            self.fail(f"wrapper swallowed an exception: {warned.call_args}")
+        self.assertEqual(got, "/trip-brief brief me")
 
     def test_scan_failure_is_swallowed_but_logged(self):
         cli = self._cli()


### PR DESCRIPTION
## What does this PR do?

Free text typed at the prompt is routed by the model, which means invoking a skill competes with every other skill for the model's attention. A cheap model loses that race sometimes, and the failure mode is quiet: the wrong skill answers plausibly instead of erroring, so the user gets a confident wrong answer rather than a signal that anything went wrong. It shows up most when a task skill and a search/lookup skill both look relevant to the same phrasing — the search skill answers "from its own sources" and looks superficially fine.

This lets a skill that knows its own invocation phrases declare them:

```yaml
triggers:
  - deploy
  - roll back
```

Input that **begins** with a declared phrase is rewritten to that skill's slash command before the model sees it, so `deploy the api to staging` dispatches as `/release deploy the api to staging`. The routing decision is removed rather than merely biased. The skill receives the user's original text, not the normalized form used for matching.

**Why this approach.** The alternative — preloading a skill into the system prompt (`-s/--skills`) — strengthens the prior but leaves the decision with the model, so the race is narrowed rather than eliminated. Anything downstream of the model can only bias it. Rewriting before dispatch is the only point where the outcome becomes deterministic, and it reuses the existing slash-command path rather than adding a second dispatch mechanism.

## Related Issue

No existing issue or PR found — I searched both, per the Contributing Guide:

```
gh search issues --repo NousResearch/hermes-agent "skill routing trigger phrase"
gh search issues --repo NousResearch/hermes-agent "deterministic skill route free text"
gh search prs    --repo NousResearch/hermes-agent "skill trigger routing"
gh search prs    --repo NousResearch/hermes-agent "route free text to skill"
```

Happy to open one first if you'd prefer that for a change this size.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/skill_commands.py`
  - `_normalize_triggers(frontmatter)` — parses and cleans the `triggers:` list
  - `match_skill_trigger(text, commands=None)` — maps free text to a skill's slash command
  - `scan_skill_commands()` now carries `triggers` through into the published command map
- `cli.py`
  - `match_skill_trigger(text)` — thin wrapper beside the other skill-command re-exports
  - Hook in the REPL loop, after `_detect_file_drop` and before the `_looks_like_slash_command` dispatch
- `tests/agent/test_skill_trigger_routing.py` — 22 new tests
- `CONTRIBUTING.md` — documents the field under the existing skill-frontmatter sections

### Design decisions worth reviewing

- **Opt-in and inert by default.** With no skill declaring `triggers:`, `match_skill_trigger()` always returns `None`. No behavior change for any existing install.
- **Literal phrases, never regex.** Skills can be agent-authored (`skills.write_approval`) or installed from the hub, so a trigger string is untrusted input. Compiling it as a pattern would hand any skill author a ReDoS or a catch-all `.*`. There's a test asserting `.*` matches nothing.
- **Leading position and whole words only**, so `deploy` doesn't capture `deployment guide` or `can you tell me how to deploy this`.
- **Minimum three characters** — shorter fragments match too much ordinary prose.
- **Deterministic precedence.** Longest trigger wins on overlap; equal-length ties go to the first slug alphabetically, so the winner never depends on filesystem scan order.
- **Fails open.** The `cli.py` wrapper swallows scan errors and returns `None` — routing is an optimisation, never a gate on input reaching the model.

## How to Test

1. Create a skill with triggers:
   ```
   mkdir -p ~/.hermes/skills/release
   cat > ~/.hermes/skills/release/SKILL.md <<'EOF'
   ---
   name: release
   description: Deploy and roll back services.
   triggers:
     - deploy
     - roll back
   ---
   # Release
   EOF
   ```
2. Start `hermes`, type `deploy the api to staging`. It dispatches as `/release deploy the api to staging` instead of being routed by the model.
3. Type `deployment guide` and `can you tell me how to deploy this` — neither is captured.
4. Remove the `triggers:` block and repeat step 2: behavior returns to model routing, confirming the opt-in.
5. Unit tests: `pytest tests/agent/test_skill_trigger_routing.py -q`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **see "Testing scope" below; this one is not fully checked and I don't want to imply otherwise**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu on WSL2, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `CONTRIBUTING.md` + docstrings
- [x] N/A — no config keys added, so no `cli-config.yaml.example` change
- [x] I've updated `CONTRIBUTING.md` (new frontmatter field)
- [x] Cross-platform: pure-Python string handling, no paths or platform APIs involved
- [x] N/A — no tool descriptions/schemas changed

## Testing scope — being explicit

I could **not** get a clean full-suite run locally, and I'd rather flag that than tick the box.

What I did run:

| Scope | Result |
|---|---|
| `tests/agent/test_skill_trigger_routing.py` | 22 passed (new) |
| `tests/agent/` + `tests/run_agent/`, `-k "skill or cli"` | 692 passed on this branch vs 670 on pristine `main` — the +22 are exactly this PR's tests |
| Same selection, failures | **Identical 7 failures on both sides**, all pre-existing and unrelated (missing `pytest-asyncio` at the time) |
| `tests/agent/ -k skill` | 246 passed |
| `ruff check` on changed files | clean (repo config, `PLW1514`) |

Why the full suite didn't finish: `/tmp` on WSL2 is a 3.8G RAM-backed tmpfs, and pytest's per-test temp directories exhausted it around 64% through, aborting with `OSError: [Errno 28] No space left on device`. That's an environment limit on my machine, not a signal about this change. Rerunning with `--basetemp` on a real disk would fix it, but I'd rather submit with the scope stated honestly and let CI be the full-suite oracle.

Given the feature is inert unless a skill opts in by declaring `triggers:`, I'd expect the blast radius outside the touched paths to be nil — but that's an argument, not a green full suite, so treat it as such.
