### PR TITLE
docs(windows): align PowerShell installer URL with canonical domain in windows-native guide

### DIFF
--- a/website/docs/user-guide/windows-native.md
+++ b/website/docs/user-guide/windows-native.md
@@ -20,7 +20,7 @@ If you prefer a real POSIX environment (for the dashboard's embedded terminal, `
 Open **PowerShell** (or Windows Terminal) and run:
 
 ```powershell
-iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
+iex (irm https://hermes-agent.nousresearch.com/install.ps1)
 ```
 
 No admin rights required. The installer goes to `%LOCALAPPDATA%\hermes\` and adds `hermes` to your **User PATH** — open a new terminal after it finishes.
@@ -28,7 +28,7 @@ No admin rights required. The installer goes to `%LOCALAPPDATA%\hermes\` and add
 **Installer options** (requires the scriptblock form to pass parameters):
 
 ```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1))) -NoVenv -SkipSetup -Branch main
+& ([scriptblock]::Create((irm https://hermes-agent.nousresearch.com/install.ps1))) -NoVenv -SkipSetup -Branch main
 ```
 
 | Parameter | Default | Purpose |


### PR DESCRIPTION
## What does this PR do?

Aligns the PowerShell installer URLs in `website/docs/user-guide/windows-native.md` with the canonical domain URL (`https://hermes-agent.nousresearch.com/install.ps1`) used across the rest of the documentation site (`getting-started/installation.md`, `getting-started/quickstart.md`, `index.mdx`, and `guides/run-nemotron-3-ultra-free.md`).

Previously, `windows-native.md` used legacy `raw.githubusercontent.com` URLs for both the basic `iex (irm ...)` and parameterized `& ([scriptblock]::Create((irm ...)))` forms.

## Type of Change

- [x] Documentation improvement (non-breaking change)

## Changes Made

- `website/docs/user-guide/windows-native.md`: Updated 2 installer invocations from `https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1` to `https://hermes-agent.nousresearch.com/install.ps1`.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits (`docs(windows):`)
- [x] Verified no duplicate open PRs for windows-native installer URL alignment
- [x] PR contains only changes related to this fix
