### PR TITLE
fix(opencode): ox-alpha-free on Go never gets its reasoning_effort clamped

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -49,6 +49,22 @@ def _is_glm_5_2_model(model: str | None) -> bool:
     return any(token in m for token in ("glm-5.2", "glm-5-2", "glm-5p2"))
 
 
+# Model slugs that all route to the same underlying "Ox Alpha" stealth model
+# (see hermes_cli/models.py: stealth/ox-alpha on OpenRouter) across the
+# different OpenCode relays that serve it:
+#   - x-preview-f-free — Zen (keyless) and opencode-free (keyless twin)
+#   - ox-alpha-free     — Go (keyed subscription twin, Go relay requires a
+#                         key; added to the opencode-go catalog 2026-08-21)
+# Same model, same wire contract (reasoning_effort: low/high/max only —
+# anything else 400s, because the model always engages in thinking),
+# just reached under a different catalog name per relay.
+_OX_ALPHA_MODEL_SLUGS = frozenset({"x-preview-f-free", "ox-alpha-free"})
+
+
+def _is_ox_alpha_model(model: str | None) -> bool:
+    return _flat_model_name(model) in _OX_ALPHA_MODEL_SLUGS
+
+
 class OpenCodeGoProfile(ProviderProfile):
     """OpenCode Go - model-specific reasoning controls."""
 
@@ -124,6 +140,14 @@ class OpenCodeGoProfile(ProviderProfile):
                 extra_body["thinking"] = {"type": "enabled"}
             return extra_body, top_level
 
+        if _is_ox_alpha_model(model):
+            # ox-alpha-free is the Go-subscription twin of the Zen/Free
+            # keyless "Ox Alpha" stealth model (see hermes_cli/models.py's
+            # opencode-go catalog entry) — same underlying model, same
+            # low/high/max-only wire contract, reached under a different
+            # catalog slug because the Go relay requires a key.
+            return _build_ox_alpha_reasoning_extras(reasoning_config, model)
+
         if not _is_deepseek_thinking_model(model):
             return extra_body, top_level
 
@@ -161,13 +185,15 @@ class OpenCodeGoProfile(ProviderProfile):
 def _build_ox_alpha_reasoning_extras(
     reasoning_config: dict | None, model: str | None
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Shared Ox Alpha (x-preview-f-free) reasoning_effort translation.
+    """Shared Ox Alpha reasoning_effort translation.
 
-    Used by both the opencode-zen profile and the opencode-free keyless
-    profile — the model is reachable through either provider and the wire
-    contract is identical (low/high/max only; anything else 400s).
+    Used by the opencode-zen profile, the keyless opencode-free profile, and
+    the opencode-go profile (its "ox-alpha-free" Go-subscription twin) — see
+    ``_OX_ALPHA_MODEL_SLUGS``. Same underlying model reachable through all
+    three providers under different catalog slugs; the wire contract is
+    identical (low/high/max only; anything else 400s).
     """
-    if _flat_model_name(model) != "x-preview-f-free":
+    if not _is_ox_alpha_model(model):
         return {}, {}
     if not isinstance(reasoning_config, dict):
         return {}, {}

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -196,6 +196,55 @@ class TestOpenCodeGoGLM52Reasoning:
         assert top_level == {"reasoning_effort": "max"}
 
 
+class TestOpenCodeGoOxAlphaReasoning:
+    """ox-alpha-free is the Go-subscription twin of Zen/Free's keyless
+    "Ox Alpha" stealth model — same low/high/max-only wire contract."""
+
+    def test_max_effort_is_emitted(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model="ox-alpha-free",
+        )
+        assert extra_body == {}
+        assert top_level == {"reasoning_effort": "max"}
+
+    def test_unsupported_efforts_clamp_to_wire_vocabulary(self, opencode_go_profile):
+        """medium/xhigh are not on Ox Alpha's wire (400 raw); they must clamp
+        to the nearest supported level, never pass through unclamped."""
+        for requested, expected in (("medium", "low"), ("xhigh", "max")):
+            _, top_level = opencode_go_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": True, "effort": requested},
+                model="ox-alpha-free",
+            )
+            assert top_level == {"reasoning_effort": expected}, requested
+
+    @pytest.mark.parametrize("reasoning_config", [None, {"enabled": False}])
+    def test_unset_or_disabled_preserves_server_default(
+        self, opencode_go_profile, reasoning_config
+    ):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config=reasoning_config,
+            model="ox-alpha-free",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_aggregator_prefix_still_recognized(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model="opencode-go/ox-alpha-free",
+        )
+        assert top_level == {"reasoning_effort": "max"}
+
+    def test_other_go_models_are_untouched(self, opencode_go_profile):
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "max"},
+            model="qwen3.6-plus",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+
 class TestOpenCodeGoModelGating:
     """Other OpenCode Go models must not receive Kimi/DeepSeek/GLM controls."""
 
@@ -237,6 +286,20 @@ class TestOpenCodeGoFullKwargsIntegration:
         )
         assert "extra_body" not in kwargs
         assert kwargs["reasoning_effort"] == "high"
+
+    def test_ox_alpha_free_reasoning_reaches_top_level(self, opencode_go_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="ox-alpha-free",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=opencode_go_profile,
+            reasoning_config={"enabled": True, "effort": "max"},
+            base_url="https://opencode.ai/zen/go/v1",
+        )
+        assert "extra_body" not in kwargs
+        assert kwargs["reasoning_effort"] == "max"
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(
         self, opencode_go_profile


### PR DESCRIPTION
## Summary

- `_build_ox_alpha_reasoning_extras()` translates the "Ox Alpha" stealth model's low/high/max-only `reasoning_effort` vocabulary (raw `medium` 400s: *"This model always engages in thinking... use low, high, or max"*). It was wired into `OpenCodeZenProfile` and the keyless `OpenCodeFreeProfile` by #91377/#91323 (same-day), both of which reach the model under the catalog slug `x-preview-f-free`.
- Four hours later, the same-day catalog-drift-sync commit `624723130b` added `ox-alpha-free` to `opencode-go`'s curated model list, describing it as *"the Go-subscription twin of the Zen keyless Ox Alpha"* — same underlying model, reached under a different slug because the Go relay requires a key.
- `OpenCodeGoProfile.build_api_kwargs_extras()` has three model-specific branches (GLM-5.2, Kimi K2, DeepSeek) and none of them match `ox-alpha-free`, so a request silently falls through to a no-op. Even a direct call to the shared helper from Go's profile would not have helped on its own: the helper's guard checked for the literal slug `x-preview-f-free`, which never matches `ox-alpha-free`.

Empirically verified against the current tree, before this fix:
```python
OpenCodeGoProfile().build_api_kwargs_extras(
    reasoning_config={"enabled": True, "effort": "medium"},
    model="ox-alpha-free",
)  # -> ({}, {})
```
A user on `opencode-go` selecting `ox-alpha-free` with `reasoning_effort=medium` configured (a common default) gets no `reasoning_effort` sent at all — either running at an unintended server default, or (per the model's documented behavior) risking the same raw-400 the original Zen/Free fix was written to prevent.

## Fix

- Widened the shared helper's model-slug recognition from a single literal string to `_OX_ALPHA_MODEL_SLUGS = {"x-preview-f-free", "ox-alpha-free"}` — both route to the same stealth model per the catalog-drift-sync commit's own characterization.
- Added the missing branch to `OpenCodeGoProfile.build_api_kwargs_extras()`, placed ahead of the DeepSeek fallthrough so the existing GLM-5.2 / Kimi-K2 / DeepSeek dispatch order and behavior are unaffected.

**Honesty note on verification depth:** I could not live-verify the Go relay's wire contract in this sandbox (no API key). This fix reuses the catalog-drift-sync commit's own "same underlying model" framing, plus the fact that the "always engages in thinking" 400 is a documented property of the model itself (not of the relay fronting it) — the same reasoning basis the original Zen/Free fix used before its own live verification. If the Go relay's `reasoning_effort` contract for this specific model ever diverges from Zen's, that would need a follow-up.

## Test plan

- [x] New `TestOpenCodeGoOxAlphaReasoning` class: max-effort emission, clamp-to-wire-vocabulary (medium→low, xhigh→max), unset/disabled no-op, aggregator-prefix (`opencode-go/ox-alpha-free`) recognition, other-Go-models-untouched negative control.
- [x] New full-transport integration test (`ChatCompletionsTransport.build_kwargs`) confirming `reasoning_effort` reaches the outgoing request kwargs.
- [x] Mutation-verified: stashed the production fix, ran the new tests — 3/5 fail against pre-fix code with the exact `({}, {})` no-op shown above; the 2 that still pass are negative-control assertions that were already correct pre-fix.
- [x] `tests/plugins/model_providers/test_opencode_go_profile.py` full file: 34/34 passed.
- [x] Broader opencode-family neighbor suite (9 files: custom-family runtime, model-switch anthropic routing, zen model-limit, go flat-namespace, zen free-keyless, go validation-fallback, go in-model-list, opencode-free provider, opencode-free client-headers): 86/86 passed.
- [x] `ruff check` clean on both changed files.

## Competing PRs

Checked `gh pr list --search` with several keyword combinations ("ox-alpha-free reasoning", "opencode-go ox-alpha", "OpenCodeGoProfile ox-alpha", "ox alpha go reasoning_effort") right before opening this PR. The only hit referencing Ox Alpha is #91799 ("'ox alpha' now finds x-preview-f-free in every model picker") — confirmed via `gh pr diff` to touch only `model-search-text.ts`/`model_search.py` (picker search-text aliasing), zero file overlap with this change.