### PR TITLE
fix(gateway): multiplex refusal must exit EX_CONFIG (78), not 1

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5619,7 +5619,18 @@ def _guard_named_profile_under_multiplexer(force: bool = False) -> None:
     print()
     print("  Pass --force to start a separate profile gateway anyway (not")
     print("  recommended while the multiplexer is running).")
-    sys.exit(1)
+    # EX_CONFIG, not a generic failure. This refusal is decided entirely by
+    # configuration (multiplex_profiles plus the allowlist), so it is permanent:
+    # no number of retries can change the answer. Exiting 1 made it look
+    # transient to a service manager -- and the systemd unit this module
+    # generates pairs Restart=always/RestartSec=5 with StartLimitIntervalSec=0,
+    # deliberately trading systemd's generic start-rate limiter for the specific
+    # RestartPreventExitStatus=GATEWAY_FATAL_CONFIG_EXIT_CODE backstop declared
+    # beside it. Returning 1 left that backstop unarmed with the limiter already
+    # off, so a correct refusal became an unbounded restart loop. 78 also reaches
+    # the s6 finish script's 125 "permanent failure" translation (see #51228),
+    # the same path the other fatal-config exits take.
+    sys.exit(GATEWAY_FATAL_CONFIG_EXIT_CODE)
 
 
 def _guard_supervised_gateway_conflict(force: bool = False) -> None:

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -2,6 +2,7 @@
 import pytest
 
 from gateway.config import GatewayConfig
+from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
 
 
 class TestServedProfilesStatus:
@@ -82,8 +83,9 @@ class TestNamedProfileMultiplexerGuard:
 
         from hermes_cli import gateway as gw
 
-        with pytest.raises(SystemExit, match="1"):
+        with pytest.raises(SystemExit) as excinfo:
             gw._guard_named_profile_under_multiplexer(force=False)
+        assert excinfo.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
     def test_served_profile_is_still_guarded(self, monkeypatch, tmp_path):
         self._fake_running_default_gateway(monkeypatch, tmp_path)
@@ -97,8 +99,9 @@ class TestNamedProfileMultiplexerGuard:
 
         from hermes_cli import gateway as gw
 
-        with pytest.raises(SystemExit, match="1"):
+        with pytest.raises(SystemExit) as excinfo:
             gw._guard_named_profile_under_multiplexer(force=False)
+        assert excinfo.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
     @pytest.mark.parametrize(
         "allowlist_yaml",


### PR DESCRIPTION
## What does this PR do?

`hermes gateway start --profile <name>` correctly **refuses** to start when the default gateway
is already running as a profile multiplexer — but it refuses with `sys.exit(1)`.

That refusal is decided entirely by configuration (`multiplex_profiles` plus the allowlist), so it
is **permanent**: no number of retries can change the answer. Exit `1` makes it look transient to a
service manager, and the systemd unit *this same module generates* is built on the assumption that
permanent failures exit `78`:

```
Restart=always
RestartSec=5
RestartForceExitStatus=75          # EX_TEMPFAIL  -> restart
RestartPreventExitStatus=78        # EX_CONFIG    -> stop
StartLimitIntervalSec=0            # generic start-rate limiter deliberately OFF
```

`StartLimitIntervalSec=0` trades systemd's generic rate limiter for that one specific backstop.
Returning `1` left the backstop unarmed **with the limiter already off**, so a correct refusal
became an unbounded restart loop — one refusal every 5 seconds, forever, with no `start-limit-hit`
to stop it.

The unit template does not hardcode `78` — it interpolates the constant itself
(`RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}`, L3535/L3573). So the generated unit was
already waiting for the exact value the guard declined to return.

Both halves of that contract live in `hermes_cli/gateway.py`: the unit template around L3518/L3561
and the guard around L5510, ~2000 lines apart. This PR makes them agree.

The guard's *behaviour* is unchanged and is not weakened — a second gateway would double-bind
platforms, and `--force` remains the only way past it. Only the exit code changes.

`GATEWAY_FATAL_CONFIG_EXIT_CODE = 78` already exists in `gateway/restart.py` and is already imported
by `gateway.py`; this is adopting an existing convention, not introducing one. It also reaches the
s6 finish script's `125` "permanent failure" translation, the same path the other fatal-config
exits take.

## Related Issue

No existing issue — the report is inline above. I searched open PRs (`multiplex`, `EX_CONFIG`,
`RestartPreventExitStatus`, `restart loop`) and open issues before filing; nothing covers this.

**Related but NOT fixed by this PR:** #79519 is a gateway restart loop with a different cause
(a `hermes-restart-oneshot` launchctl job that re-triggers itself, plus string-repr `mcp_servers.args`).
Same symptom class, unrelated mechanism — flagging it so triage doesn't fold the two together.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py` — `_guard_named_profile_under_multiplexer()` now exits
  `GATEWAY_FATAL_CONFIG_EXIT_CODE` (78) instead of `1`, with a comment explaining why this
  particular refusal is permanent and how it pairs with the generated unit.
- `tests/gateway/test_multiplex_lifecycle.py` — both refusal assertions now check the exit code
  directly:

  ```python
  -   with pytest.raises(SystemExit, match="1"):
  -       gw._guard_named_profile_under_multiplexer(force=False)
  +   with pytest.raises(SystemExit) as excinfo:
  +       gw._guard_named_profile_under_multiplexer(force=False)
  +   assert excinfo.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
  ```

  Worth calling out: `pytest.raises(match=...)` is a **regex search** over `str(exc)`, so the old
  `match="1"` was satisfied by `1`, `21`, `100` and `111` alike. It read like an exit-code
  assertion but pinned nothing — which is why the mismatch survived.

## How to Test

1. `pytest tests/gateway/test_multiplex_lifecycle.py -q` → 9 passed.
2. **Controlled pair** (the assertion has to be able to fail): revert only the source line back to
   `sys.exit(1)`, leaving the tests as-is → the 2 refusal tests **fail**. Restore → they pass.
   Ran both arms; green arm 2 passed, red arm 2 failed.
3. Live reproduction, on the box where this was found: with `multiplex_profiles` on and the default
   gateway running, `hermes gateway start --profile trading` under a unit generated from the template
   above. **Before:** restart every 5s indefinitely. **After:** `status=78/CONFIG`, `NRestarts=0`,
   exactly one refusal, unit settles into `failed` and stays there.

**Scope note, stated plainly:** I did **not** run the full `pytest tests/ -q`. This was found on a
live money-facing gateway box, and installing the dev extras into that venv to run the whole suite
was a risk I wasn't willing to take on someone else's behalf. I ran the affected test file in a
clean `git worktree` off `upstream/main` (not the deployed tree), with an import-aim check
confirming the interpreter loaded the worktree's `hermes_cli.gateway` and not the installed one.
CI will cover the rest — if it turns up anything, I'll fix it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **see scope note above.** Ran
      `tests/gateway/test_multiplex_lifecycle.py` (9 passed) plus a controlled pair; not the full suite.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (trixie), Python 3.11, systemd user units

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(N/A — no user-facing
      doc states the refusal's exit code; the change is a comment plus the code)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no config keys)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

      The systemd path is Linux-only, but the change is not: `78` is `EX_CONFIG` from `sysexits.h`,
      already used elsewhere in this codebase, and is a plain process exit code on every platform.
      launchd's `KeepAlive`/`SuccessfulExit` and s6's finish-script translation both key off the
      exit status the same way. Nothing here reads a Linux-only API.

- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A)*

## Screenshots / Logs

Before (systemd, generated unit, `multiplex_profiles` on):

```
hermes-gateway-trading.service: Scheduled restart job, restart counter is at 41.
hermes-gateway-trading.service: Main process exited, code=exited, status=1/FAILURE
  ✗ The default gateway is running as a profile multiplexer and already serves ...
```

After:

```
Main process exited, code=exited, status=78/CONFIG
hermes-gateway-trading.service: Failed with result 'exit-code'.
# NRestarts=0 — RestartPreventExitStatus=78 now matches, and the loop is gone.
```
