### PR TITLE
feat: free models show the sale star + '-100%' in the picker discount column

### DIFF
--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -263,13 +263,25 @@ function ModelPrice({ price, isCurrent }: { price?: ModelPricing; isCurrent: boo
 
   if (price.free) {
     return (
-      <span
-        className={cn(
-          'shrink-0 rounded-sm px-1 py-0.5 text-[0.62rem] font-semibold uppercase tracking-wide',
-          isCurrent ? 'bg-primary-foreground/20' : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
-        )}
-      >
-        {copy.free}
+      <span className="shrink-0 inline-flex items-center gap-1.5">
+        {typeof price.discount_percent === 'number' ? (
+          <span
+            className={cn(
+              'rounded-sm px-1 py-0.5 text-[0.62rem] font-semibold',
+              isCurrent ? 'bg-primary-foreground/20' : 'bg-amber-500/15 text-amber-700 dark:text-amber-400'
+            )}
+          >
+            -{price.discount_percent}%
+          </span>
+        ) : null}
+        <span
+          className={cn(
+            'shrink-0 rounded-sm px-1 py-0.5 text-[0.62rem] font-semibold uppercase tracking-wide',
+            isCurrent ? 'bg-primary-foreground/20' : 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
+          )}
+        >
+          {copy.free}
+        </span>
       </span>
     )
   }

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7693,16 +7693,22 @@ def _prompt_model_selection(
                     if sale is not None:
                         any_on_sale = True
                         pct, was_prompt_raw, was_out_raw = sale
-                        was_inp = (
-                            _format_price_per_mtok(was_prompt_raw)
-                            if was_prompt_raw != ""
-                            else "?"
-                        )
-                        was_out = (
-                            _format_price_per_mtok(was_out_raw)
-                            if was_out_raw != ""
-                            else "?"
-                        )
+                        # Natively-free models (no gateway original) carry
+                        # empty was_* raws — leave them empty so the row
+                        # shows bare "-100%" with no "was ?/?" suffix.
+                        if was_prompt_raw == "" and was_out_raw == "":
+                            was_inp = was_out = ""
+                        else:
+                            was_inp = (
+                                _format_price_per_mtok(was_prompt_raw)
+                                if was_prompt_raw != ""
+                                else "?"
+                            )
+                            was_out = (
+                                _format_price_per_mtok(was_out_raw)
+                                if was_out_raw != ""
+                                else "?"
+                            )
             else:
                 inp, out, cache = "", "", ""
             _price_cache[mid] = (inp, out, cache, pct, was_inp, was_out)
@@ -7739,7 +7745,8 @@ def _prompt_model_selection(
         segs = [*name_segs, (price_part, None)]
         if on_sale:
             segs.append((f"  -{pct}%", "yellow"))
-            segs.append((f"  was {was_inp}/{was_out}", "dim"))
+            if was_inp or was_out:
+                segs.append((f"  was {was_inp}/{was_out}", "dim"))
         if mid == current_model:
             segs.append(("  ← currently in use", None))
         return segs

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -882,8 +882,9 @@ def _apply_pricing(
             # Sale chrome is Nous Portal-only. Other providers (OpenRouter,
             # Novita, …) never get discount_percent / was_* even if a nested
             # pricing.original somehow appeared in their catalog. Free / $0
-            # models never get sale chrome either — even if original leaked.
-            if slug == "nous" and not is_free:
+            # models get flat -100% chrome (was_* only when the gateway
+            # served an original).
+            if slug == "nous":
                 sale = compute_sale_discount(
                     inp_raw, out_raw, p.get("original")
                 )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2303,15 +2303,13 @@ def compute_sale_discount(
     that rounds below 1% is treated as no sale (never render "-0%"). Returns
     ``None`` when there is no sale (missing/equal/invalid original), so UIs
     show normal prices.
+
+    Free / $0 models are a special case: they are always "-100%" sale chrome
+    (Teknium, Aug 2026 — the picker's discount column should say 100% off
+    rather than sit blank on free rows). The ``was_*`` raws come from
+    ``original`` when the gateway serves one and are empty strings otherwise;
+    callers must skip the "was" segment when both are empty.
     """
-    if not isinstance(original, dict):
-        return None
-
-    was_prompt = original.get("prompt")
-    was_completion = original.get("completion")
-    if was_prompt in (None, "") and was_completion in (None, ""):
-        return None
-
     def _finite(raw: Any) -> float | None:
         try:
             n = float(raw)
@@ -2326,11 +2324,26 @@ def compute_sale_discount(
             return None
         return n if n >= 0 and n == n else None
 
-    # Free / $0 models never show sale chrome, even if a leftover list price
-    # is higher (e.g. a :free sibling that inherited pricing.original).
+    orig_dict = original if isinstance(original, dict) else {}
+    was_prompt = orig_dict.get("prompt")
+    was_completion = orig_dict.get("completion")
+
+    # Free / $0 models: flat 100% off, with "was" prices only when the
+    # gateway actually served an original (e.g. a :free sibling); a
+    # natively-free model (stealth/ox-alpha) gets bare "-100%" chrome.
     cur_prompt_any = _nonneg(prompt) if prompt not in (None, "") else None
     cur_comp_any = _nonneg(completion) if completion not in (None, "") else None
-    if cur_prompt_any == 0 and cur_comp_any == 0:
+    if cur_prompt_any == 0 and cur_comp_any in (0, None):
+        return (
+            100,
+            str(was_prompt) if was_prompt not in (None, "") else "",
+            str(was_completion) if was_completion not in (None, "") else "",
+        )
+
+    if not isinstance(original, dict):
+        return None
+
+    if was_prompt in (None, "") and was_completion in (None, ""):
         return None
 
     cur_prompt = _finite(prompt) if prompt not in (None, "") else None

--- a/tests/hermes_cli/test_inventory_pricing.py
+++ b/tests/hermes_cli/test_inventory_pricing.py
@@ -42,8 +42,8 @@ def test_apply_pricing_formats_per_model_prices(monkeypatch):
     assert pricing["b/free"]["input"] == "free"
 
 
-def test_apply_pricing_omits_sale_for_free_models_even_with_original(monkeypatch):
-    """Free models must not get was_*/discount_percent even if original leaked."""
+def test_apply_pricing_free_models_get_flat_100_percent_sale(monkeypatch):
+    """Free models show -100% chrome; was_* only when original was served."""
     _patch_pricing(
         monkeypatch,
         free_tier=False,
@@ -57,16 +57,26 @@ def test_apply_pricing_omits_sale_for_free_models_even_with_original(monkeypatch
                         "completion": "0.00001",
                     },
                 },
+                "b/natively-free": {
+                    "prompt": "0",
+                    "completion": "0",
+                },
             }
         },
     )
-    rows = [{"slug": "nous", "models": ["a/free"]}]
+    rows = [{"slug": "nous", "models": ["a/free", "b/natively-free"]}]
     inv._apply_pricing(rows)
     free = rows[0]["pricing"]["a/free"]
     assert free["free"] is True
-    assert "discount_percent" not in free
-    assert "was_input" not in free
-    assert "was_output" not in free
+    assert free["discount_percent"] == 100
+    assert free["was_input"] == "$2.00"
+    assert free["was_output"] == "$10.00"
+    native = rows[0]["pricing"]["b/natively-free"]
+    assert native["free"] is True
+    assert native["discount_percent"] == 100
+    # No gateway original → no fabricated was prices.
+    assert "was_input" not in native
+    assert "was_output" not in native
 
 
 def test_apply_pricing_omits_sale_when_original_not_cheaper(monkeypatch):

--- a/tests/hermes_cli/test_sale_pricing.py
+++ b/tests/hermes_cli/test_sale_pricing.py
@@ -12,6 +12,20 @@ from hermes_cli.models import (
 )
 
 
+def test_free_model_gets_flat_100_percent_discount():
+    """$0/$0 models always show -100%; was_* pass through when present."""
+    assert compute_sale_discount("0", "0", None) == (100, "", "")
+    assert compute_sale_discount(
+        "0", "0", {"prompt": "0.000002", "completion": "0.00001"}
+    ) == (100, "0.000002", "0.00001")
+    # "0.0000000000" strings (Nous portal shape) count as free too.
+    assert compute_sale_discount("0.0000000000", "0.0000000000", None) == (100, "", "")
+
+
+def test_paid_model_without_original_shows_no_sale():
+    assert compute_sale_discount("0.000002", "0.00001", None) is None
+
+
 
 
 


### PR DESCRIPTION
## Summary
Free ($0/$0) Nous Portal models now show the sale star and a "-100%" discount badge in the model pickers — previously rows like `stealth/ox-alpha` and `upstage/solar-pro4:free` sat with a blank discount column and no ★ next to the -20% sale rows, reading as missing data.

## Changes
- `hermes_cli/models.py`: `compute_sale_discount` returns a flat `100` for free models; `was_*` raws pass through only when the gateway served a `pricing.original` (`:free` siblings), empty otherwise — natively-free models never fabricate "was" prices
- `hermes_cli/auth.py`: CLI picker skips the `was ?/?` segment when both raws are empty; the ★ already follows on-sale state so free rows get it automatically
- `hermes_cli/inventory.py`: desktop pricing feed no longer excludes free models from sale chrome (`discount_percent: 100` flows through)
- `apps/desktop/src/components/model-picker.tsx`: FREE badge row renders the amber `-100%` pill beside it when `discount_percent` is present
- Tests: flipped the free-models-never-get-sale pinning tests to the new contract; added `compute_sale_discount` free-model unit tests (incl. the portal's `"0.0000000000"` string shape)

Sale chrome remains Nous Portal-only — OpenRouter and other providers are untouched.

## Validation
| Check | Result |
|---|---|
| `test_sale_pricing.py` + `test_inventory_pricing.py` | 10 passed |
| Live E2E against `inference-api.nousresearch.com` catalog | `stealth/ox-alpha` + `solar-pro4:free` → `★ … free free -100%` (no "was"); paid sale rows unchanged (`-20% was $…/$…`) |

## Infographic

![Free models: 100% off](https://v3b.fal.media/files/b/0aa745d9/ZfxWfr690yfELsdlZtHFr_lCqSdgFN.png)
