### PR TITLE
fix(dashboard): strip compaction scaffolding from session messages

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -22,6 +22,10 @@ from fastapi import APIRouter, HTTPException, Query, Request  # noqa: F401
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 
+from agent.compaction_display import (
+    _COMPACTION_INTERNAL_FIELDS,
+    project_compaction_message_for_display,
+)
 from hermes_cli.web_deps import late
 from hermes_cli.web_models import (
     BulkDeleteSessions,
@@ -48,6 +52,27 @@ _prune_sessions = late("_prune_sessions")
 _read_session_import_body = late("_read_session_import_body")
 _session_latest_descendant = late("_session_latest_descendant")
 _strip_session_list_rows = late("_strip_session_list_rows")
+
+
+def _project_dashboard_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove model-only compaction scaffolding from a dashboard message.
+
+    Mirrors ``gateway/platforms/api_server.py``'s ``_project_client_message``:
+    standalone handoffs have no transcript content and are kept as hidden
+    empty rows (not dropped) so callers paginating this endpoint see stable
+    message identities/counts. Merged handoffs keep only the real prior-tail
+    content that precedes the internal summary delimiter. Tool calls and
+    reasoning are dropped from both shapes — a carrier's inherited state is
+    historical bookkeeping, not something the dashboard should render.
+    """
+    projected = project_compaction_message_for_display(message)
+    if projected is None:
+        projected = message.copy()
+        for internal_key in _COMPACTION_INTERNAL_FIELDS:
+            projected.pop(internal_key, None)
+        projected["content"] = ""
+        projected["display_kind"] = "hidden"
+    return projected
 
 
 @list_router.get("/api/sessions")
@@ -642,6 +667,13 @@ async def get_session_messages(
     if result is None:
         raise HTTPException(status_code=404, detail="Session not found")
     sid, _limit, messages = result
+    # Strip model-only compaction scaffolding (handoff boilerplate, inherited
+    # tool_calls/reasoning carriers) before this reaches the dashboard —
+    # matches the projection every other client-facing history surface
+    # (tui_gateway, gateway/run.py, the OpenAI-compatible api_server) already
+    # applies. Row identities/count are preserved (see
+    # _project_dashboard_message) so pagination math here is unaffected.
+    messages = [_project_dashboard_message(m) for m in messages]
     return {
         "session_id": sid,
         "messages": messages,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2132,6 +2132,176 @@ class TestWebServerEndpoints:
             "msg 499",
         ]
 
+    def test_get_session_messages_strips_compaction_scaffolding(self):
+        """Model-only compaction carriers (handoff boilerplate, inherited
+        tool_calls/reasoning) must not reach the dashboard — matches the
+        projection every other client-facing history surface (tui_gateway,
+        gateway/run.py, the OpenAI-compatible api_server) already applies.
+        """
+        from agent.context_compressor import (
+            HISTORICAL_TASK_HEADING,
+            SUMMARY_PREFIX,
+            _MERGED_PRIOR_CONTEXT_HEADER,
+            _MERGED_SUMMARY_DELIMITER,
+            _SUMMARY_END_MARKER,
+        )
+        from hermes_state import SessionDB
+
+        standalone_summary = (
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        )
+        merged_carrier = (
+            f"{_MERGED_PRIOR_CONTEXT_HEADER}\n"
+            "Refactor complete.\n\n"
+            f"{_MERGED_SUMMARY_DELIMITER}\n\n"
+            f"{standalone_summary}"
+        )
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="dashboard-compaction-leak", source="cli")
+            db.append_messages_batch(
+                "dashboard-compaction-leak",
+                [
+                    {
+                        # assistant role: reasoning_content/codex_reasoning_items
+                        # only persist for assistant rows (verified against
+                        # SessionDB directly) — user-role would make these
+                        # stripping assertions vacuously true either way.
+                        "role": "assistant",
+                        "content": standalone_summary,
+                        "tool_calls": [{"id": "stale"}],
+                        "reasoning_content": "internal compression reasoning",
+                        "codex_reasoning_items": [{"type": "reasoning", "id": "internal"}],
+                    },
+                    {
+                        "role": "assistant",
+                        "content": merged_carrier,
+                        "tool_calls": [{"id": "prior-call"}],
+                        "finish_reason": "tool_calls",
+                    },
+                    {"role": "user", "content": "test the browser controller again"},
+                ],
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/dashboard-compaction-leak/messages")
+        assert resp.status_code == 200
+        messages = resp.json()["messages"]
+        assert len(messages) == 3
+
+        # Standalone handoff: hidden empty row, not the raw ~700-word
+        # "[CONTEXT COMPACTION — REFERENCE ONLY]" boilerplate, and no
+        # inherited carrier fields.
+        assert messages[0]["content"] == ""
+        assert messages[0]["display_kind"] == "hidden"
+        assert "tool_calls" not in messages[0]
+        assert "reasoning_content" not in messages[0]
+        assert "codex_reasoning_items" not in messages[0]
+
+        # Merged carrier: only the real prior-tail content survives.
+        assert messages[1]["content"] == "Refactor complete."
+        assert "tool_calls" not in messages[1]
+        assert "finish_reason" not in messages[1]
+        assert "PRIOR CONTEXT" not in messages[1]["content"]
+        assert "CONTEXT COMPACTION" not in messages[1]["content"]
+
+        # A genuinely live message is untouched.
+        assert messages[2]["content"] == "test the browser controller again"
+
+        rendered = " ".join(str(m.get("content") or "") for m in messages)
+        assert "CONTEXT COMPACTION" not in rendered
+        assert "REFERENCE ONLY" not in rendered
+
+    def test_get_session_messages_hidden_summary_preserves_pagination_count(self):
+        """A hidden standalone-handoff row must still count toward
+        ``pagination.returned`` — the projection hides content, it must not
+        change row identities/counts (callers paginate by row, not by
+        visible content)."""
+        from agent.context_compressor import (
+            HISTORICAL_TASK_HEADING,
+            SUMMARY_PREFIX,
+            _SUMMARY_END_MARKER,
+        )
+        from hermes_state import SessionDB
+
+        standalone_summary = (
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        )
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="dashboard-compaction-count", source="cli")
+            db.append_messages_batch(
+                "dashboard-compaction-count",
+                [
+                    {"role": "user", "content": standalone_summary},
+                    {"role": "user", "content": "live q"},
+                    {"role": "assistant", "content": "live a"},
+                ],
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/dashboard-compaction-count/messages")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["pagination"]["returned"] == 3
+        assert len(payload["messages"]) == 3
+
+    def test_export_session_keeps_full_fidelity_compaction_content(self):
+        """The dashboard's /export endpoint is round-trip-compatible with
+        /api/sessions/import (see import_sessions_endpoint's docstring:
+        "Import one or more sessions exported from the dashboard or CLI").
+        Unlike /messages (a display surface), export must stay full-fidelity
+        — stripping compaction carrier state here would silently corrupt a
+        re-imported session's recovery history. This locks that scope
+        decision in as a regression guard.
+        """
+        from agent.context_compressor import (
+            HISTORICAL_TASK_HEADING,
+            SUMMARY_PREFIX,
+            _SUMMARY_END_MARKER,
+        )
+        from hermes_state import SessionDB
+
+        standalone_summary = (
+            f"{SUMMARY_PREFIX}\n\n"
+            f"{HISTORICAL_TASK_HEADING}\nold work\n\n"
+            f"{_SUMMARY_END_MARKER}"
+        )
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="export-compaction-fidelity", source="cli")
+            db.append_messages_batch(
+                "export-compaction-fidelity",
+                [
+                    {
+                        # assistant role: reasoning_content only persists for
+                        # assistant rows (verified against SessionDB directly).
+                        "role": "assistant",
+                        "content": standalone_summary,
+                        "tool_calls": [{"id": "stale"}],
+                        "reasoning_content": "internal compression reasoning",
+                    },
+                ],
+            )
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/export-compaction-fidelity/export")
+        assert resp.status_code == 200
+        message = resp.json()["messages"][0]
+        assert message["content"] == standalone_summary
+        assert message["tool_calls"] == [{"id": "stale"}]
+        assert message["reasoning_content"] == "internal compression reasoning"
+
     def test_export_session_streams_bounded_message_pages(self, monkeypatch):
         from hermes_state import SessionDB
 


### PR DESCRIPTION
## Summary

`agent/compaction_display.py::project_compaction_message_for_display()` strips model-only compaction carrier state (handoff boilerplate, inherited `tool_calls`/reasoning fields) before conversation history reaches a client. It was wired into `tui_gateway/server.py`, `gateway/run.py`, and `gateway/platforms/api_server.py` by the same-day "hide compaction carriers across surfaces" cluster (#91517) — but `hermes_cli/web_routers/sessions.py`, the dashboard's own FastAPI session-messages endpoint, was never touched. `grep -n "compaction" hermes_cli/web_routers/sessions.py` returned zero hits before this fix, and `#91517`'s own file list (checked via `gh pr view --json files`) doesn't include this file.

`GET /api/sessions/{id}/messages` feeds the dashboard's expanded message view — verified both consumers (`web/src/pages/SessionsPage.tsx`, `apps/desktop/src/api/sessions.ts`) use it purely for on-screen rendering. After a session compacts, a row from this endpoint carries the full `"[CONTEXT COMPACTION — REFERENCE ONLY] ..."` handoff boilerplate (~700 words of internal LLM-steering instructions) plus raw `tool_calls`/`reasoning_content`/`codex_reasoning_items` for merged carriers — exactly the class of leak the same-day cluster set out to close.

## Scope decision: `/export` intentionally NOT touched

I initially assumed both `get_session_messages` and `export_session_endpoint` needed the fix, but checked further before writing it. `import_sessions_endpoint`'s own docstring says: *"Import one or more sessions exported from the dashboard or CLI"* — the dashboard's `/export` is round-trip-compatible with `/api/sessions/import`. Stripping compaction carrier state from export would silently corrupt a re-imported session's recovery history (lost `tool_calls`/`reasoning_content`/etc. on the target machine). This mirrors the CLI's `hermes sessions export` (a full-fidelity backup tool), which the same reasoning already exempts elsewhere in this codebase. I locked this decision in with a regression-guard test (`test_export_session_keeps_full_fidelity_compaction_content`).

## Fix

Small local wrapper `_project_dashboard_message()` mirroring `gateway/platforms/api_server.py`'s existing `_project_client_message()`: standalone handoffs become hidden empty rows (not dropped — pagination row-counts stay stable) rather than raw boilerplate; merged carriers keep only the real prior-tail content. Applied to every message returned by `get_session_messages`.

## Test plan

- [x] `test_get_session_messages_strips_compaction_scaffolding`: standalone handoff → hidden empty row with no inherited carrier fields; merged carrier → only real prior-tail content survives; a genuinely live message is untouched; raw marker text never appears anywhere in the response.
- [x] `test_get_session_messages_hidden_summary_preserves_pagination_count`: a hidden row still counts toward `pagination.returned` (negative control — passes with or without the fix, since it tests row identity, not content).
- [x] `test_export_session_keeps_full_fidelity_compaction_content`: regression guard locking in the export-stays-raw scope decision.
- [x] Mutation-verified: stashed the production fix, the scaffolding-stripping test failed showing the exact raw boilerplate text leaking through; the pagination-count test correctly still passed (legitimate negative control, unaffected by the fix either way).
- [x] Caught while writing the tests: my first draft put `reasoning_content` on a `role="user"` row — verified directly against `SessionDB` that `reasoning_content`/`codex_reasoning_items` only persist for `role="assistant"` rows, which would have made those specific assertions vacuously true regardless of the fix. Moved to `role="assistant"`, matching how these carriers actually arrive.
- [x] Full `tests/hermes_cli/test_web_server.py`: 167 passed, 1 pre-existing skip (unrelated).
- [x] `tests/test_web_server_sessiondb_eventloop.py`: 3/3 passed (neighbor suite touching the same DB-access pattern).
- [x] Full `hermes_cli.web_server.app` still imports cleanly (311 routes) — no circular-import issue from the new top-level `agent.compaction_display` import.
- [x] `ruff check` clean on both changed files.
- Could **not** run the sibling `tests/gateway/test_api_server_compaction_projection.py` (same projection mechanism, `api_server.py`'s surface) in this sandbox: `aiohttp` lives under the optional `[messaging]`/`[slack]`/`[matrix]` extras, not `[dev]`, and isn't installed here — import fails at collection, unrelated to this change.

## Competing PRs

Checked `gh pr list --search` with several keyword combinations right before opening this PR. **#69321** ("paginate compacted session history") touches the same `get_session_messages` function body (textual overlap: `include_compacted`/`from_end`/`total`-count pagination work) — but it's 3 weeks stale relative to current `main` (last updated 2026-07-30, base diff predates the `order`/`Query(...)` validation and `include_compacted` param that already exist on current `main`, `mergeable: UNKNOWN`) and orthogonal in intent (pagination semantics vs. compaction-scaffolding stripping). No semantic conflict. **#59585**/**#60878**/**#85611** were checked and confirmed unrelated (pre-date this projection mechanism or touch different files). **#57741** (PII redaction) has zero file overlap.