### PR TITLE
feat(mattermost): native slash commands — HTTP endpoint, thread-scoped typing, flat-reply fix

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -617,6 +617,12 @@ class MattermostAdapter(BasePlatformAdapter):
             # Thread parity with the WS path: root_id when provided. A
             # slash invocation creates no post, so there is no post-id
             # fallback — a bare command lands in the channel's main session.
+            # In reply_mode=thread the WS path falls back to thread_id=post_id
+            # for top-level posts; a slash invocation has no post (and
+            # trigger_id is not a post id — it would make reply posts carry an
+            # invalid root_id), so slash commands key to the stable per-user
+            # channel session in every mode. See
+            # tests/gateway/test_mattermost_slash_commands.py.
             thread_id = form.get("root_id") or None
 
             source = self.build_source(

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -732,11 +732,12 @@ class MattermostAdapter(BasePlatformAdapter):
     async def send_typing(
         self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
     ) -> None:
-        """Send a typing indicator."""
-        await self._api_post(
-            f"users/{self._bot_user_id}/typing",
-            {"channel_id": chat_id},
-        )
+        """Send a typing indicator (thread-scoped when replying in a thread)."""
+        payload: Dict[str, Any] = {"channel_id": chat_id}
+        parent_id = str((metadata or {}).get("thread_id") or "")
+        if parent_id:
+            payload["parent_id"] = parent_id
+        await self._api_post(f"users/{self._bot_user_id}/typing", payload)
 
     async def edit_message(
         self, chat_id: str, message_id: str, content: str, *, finalize: bool = False

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -9,15 +9,24 @@ Environment variables:
     MATTERMOST_TOKEN            Bot token or personal-access token
     MATTERMOST_ALLOWED_USERS    Comma-separated user IDs
     MATTERMOST_HOME_CHANNEL     Channel ID for cron/notification delivery
+    MATTERMOST_SLASH_TOKENS     Comma-separated slash-command verification
+                                tokens (secret). When set, an HTTP listener
+                                receives Mattermost's server-side slash-command
+                                callbacks and injects them as COMMAND events
+                                (config.yaml extra keys: slash_command_host,
+                                slash_command_port; default 0.0.0.0:8645).
 """
 
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
 import os
 import re
+import sys
+import urllib.parse
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -75,6 +84,11 @@ _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
 
+# Native slash-command listener defaults (config.yaml ``extra`` keys
+# ``slash_command_host`` / ``slash_command_port`` override these).
+_SLASH_COMMAND_DEFAULT_HOST = "0.0.0.0"
+_SLASH_COMMAND_DEFAULT_PORT = 8645
+
 
 def _with_mentions_disabled(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Return a post payload that prevents Mattermost from firing mentions."""
@@ -84,6 +98,13 @@ def _with_mentions_disabled(payload: Dict[str, Any]) -> Dict[str, Any]:
     else:
         payload["props"] = dict(_MATTERMOST_DISABLE_MENTIONS_PROPS)
     return payload
+
+
+def _slash_command_text(form: Dict[str, str]) -> str:
+    """Reconstruct a slash command's text: ``command`` plus ``text`` when present."""
+    command = form.get("command", "")
+    text = form.get("text", "")
+    return command + ((" " + text) if text else "")
 
 
 def check_mattermost_requirements() -> bool:
@@ -145,6 +166,13 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+
+        # Native slash-command HTTP listener (Mattermost server-side slash
+        # commands POST callbacks here; see _start_slash_command_listener).
+        self._slash_runner: Any = None        # aiohttp.web.AppRunner
+        self._slash_site: Any = None          # aiohttp.web.TCPSite
+        self._slash_tokens: Tuple[str, ...] = ()
+        self._slash_injections: set = set()   # strong refs to in-flight tasks
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -338,12 +366,19 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Start WebSocket in background.
         self._ws_task = asyncio.create_task(self._ws_loop())
+
+        # Native slash-command HTTP listener (only when configured —
+        # after credentials are verified above, mirroring the WS auth gate).
+        await self._start_slash_command_listener()
+
         self._mark_connected()
         return True
 
     async def disconnect(self) -> None:
         """Disconnect from Mattermost."""
         self._closing = True
+
+        await self._stop_slash_command_listener()
 
         if self._ws_task and not self._ws_task.done():
             self._ws_task.cancel()
@@ -364,6 +399,258 @@ class MattermostAdapter(BasePlatformAdapter):
 
         logger.info("Mattermost: disconnected")
 
+    # ------------------------------------------------------------------
+    # Native slash-command HTTP listener
+    # ------------------------------------------------------------------
+
+    def _resolve_slash_tokens(self) -> Tuple[str, ...]:
+        """Parse MATTERMOST_SLASH_TOKENS into a tuple of verification tokens.
+
+        Scope-aware via ``_get_scoped_secret`` (same pattern as
+        MATTERMOST_TOKEN): the per-command verification tokens are secrets,
+        so ``.env``/env is the correct home per repo rules.
+        """
+        raw = _get_scoped_secret("MATTERMOST_SLASH_TOKENS", "") or ""
+        return tuple(t.strip() for t in raw.split(",") if t.strip())
+
+    def _resolve_allowed_channel_ids(self) -> set:
+        """Resolve the channel allowlist exactly like the WS path does.
+
+        Mirrors the ``allowed_channels`` parse in ``_handle_ws_event``
+        (config ``extra`` first, then the ``MATTERMOST_ALLOWED_CHANNELS``
+        env fallback; list or comma-separated string). Used here as
+        defense-in-depth on the HTTP surface.
+        """
+        allowed_raw = self.config.extra.get("allowed_channels") if self.config.extra else None
+        if allowed_raw is None:
+            allowed_raw = os.getenv("MATTERMOST_ALLOWED_CHANNELS", "")
+        if isinstance(allowed_raw, list):
+            return {str(c).strip() for c in allowed_raw if str(c).strip()}
+        return {c.strip() for c in str(allowed_raw).split(",") if c.strip()}
+
+    async def _start_slash_command_listener(self) -> None:
+        """Start the HTTP listener for Mattermost slash-command callbacks.
+
+        Mattermost's client swallows messages that start with ``/`` as
+        unregistered slash commands, so gateway commands typed in Mattermost
+        never reach the WebSocket. Registering real server-side slash
+        commands fixes that — Mattermost then POSTs each invocation here,
+        and we inject it into the same message pipeline as a COMMAND event.
+
+        Fail-closed: with no verification tokens configured the listener
+        never binds, so an unauthenticated HTTP surface cannot appear by
+        accident.
+
+        Note on ``PORT_BINDING_PLATFORM_VALUES`` (gateway/config.py): the
+        Mattermost entry there would have to be *conditional* on this
+        listener being enabled, but enablement is keyed on a profile-scoped
+        secret this adapter reads at connect time — invisible to
+        ``platform_binds_port(platform, extra)``, which only sees ``extra``.
+        Registering Mattermost unconditionally would falsely fail-fast every
+        multiplexed secondary profile using plain WS Mattermost, so the
+        plugin stays out of that registry; a bind conflict is instead
+        reported here and degrades to WS-only.
+        """
+        from aiohttp import web
+
+        self._slash_tokens = self._resolve_slash_tokens()
+        if not self._slash_tokens:
+            logger.warning(
+                "Mattermost: slash-command HTTP endpoint disabled — "
+                "MATTERMOST_SLASH_TOKENS is not set (comma-separated "
+                "verification tokens from Mattermost's slash-command admin "
+                "pages). Server-side slash commands will not reach Hermes."
+            )
+            return
+        if self._slash_runner is not None:
+            return  # already listening (reconnect cycle)
+
+        extra = self.config.extra or {}
+        host = str(extra.get("slash_command_host", "") or "").strip() or _SLASH_COMMAND_DEFAULT_HOST
+        try:
+            port = int(extra.get("slash_command_port", _SLASH_COMMAND_DEFAULT_PORT))
+        except (TypeError, ValueError):
+            logger.warning(
+                "Mattermost: invalid slash_command_port %r — using default %d",
+                extra.get("slash_command_port"), _SLASH_COMMAND_DEFAULT_PORT,
+            )
+            port = _SLASH_COMMAND_DEFAULT_PORT
+
+        app = web.Application()
+        app.router.add_route("*", "/", self._handle_slash_command_request)
+        app.router.add_route("*", "/commands", self._handle_slash_command_request)
+
+        runner = web.AppRunner(app)
+        await runner.setup()
+        # Same SO_REUSEADDR posture as the webhook adapter: keep the Linux
+        # default so a quick disconnect→connect cycle can rebind past
+        # TIME_WAIT; disable on macOS where BSD semantics would split traffic.
+        site = web.TCPSite(
+            runner,
+            host,
+            port,
+            reuse_address=False if sys.platform == "darwin" else None,
+        )
+        try:
+            await site.start()
+        except OSError as exc:
+            await runner.cleanup()
+            logger.error(
+                "Mattermost: slash-command listener could not bind %s:%d: %s "
+                "— slash commands disabled (WebSocket path unaffected)",
+                host, port, exc,
+            )
+            return
+        self._slash_runner = runner
+        self._slash_site = site
+        logger.info(
+            "Mattermost: slash-command endpoint listening on %s:%d (POST / and /commands)",
+            host, port,
+        )
+
+    async def _stop_slash_command_listener(self) -> None:
+        """Stop the slash-command listener and release its port."""
+        if self._slash_site is not None:
+            try:
+                await self._slash_site.stop()
+            except Exception as exc:  # noqa: BLE001 — shutdown best-effort
+                logger.debug("Mattermost: slash-command site stop: %s", exc)
+            self._slash_site = None
+        if self._slash_runner is not None:
+            try:
+                await self._slash_runner.cleanup()
+            except Exception as exc:  # noqa: BLE001 — shutdown best-effort
+                logger.debug("Mattermost: slash-command runner cleanup: %s", exc)
+            self._slash_runner = None
+            logger.info("Mattermost: slash-command endpoint stopped")
+
+    async def _handle_slash_command_request(self, request: Any) -> Any:
+        """Handle one Mattermost slash-command callback POST."""
+        from aiohttp import web
+
+        # Only POST on / and /commands is wired; anything else (wrong
+        # method, wrong path) gets a flat 404 so the endpoint stays invisible.
+        if request.method != "POST":
+            return web.json_response({"error": "not found"}, status=404)
+
+        # Mattermost posts application/x-www-form-urlencoded; tolerate a
+        # missing Content-Type header, reject anything else.
+        ctype = request.headers.get("Content-Type")
+        if ctype is not None and not ctype.strip().lower().startswith(
+            "application/x-www-form-urlencoded"
+        ):
+            return web.json_response({"error": "not found"}, status=404)
+
+        body = await request.read()
+        form: Dict[str, str] = {}
+        for key, value in urllib.parse.parse_qsl(
+            body.decode("utf-8", errors="replace"), keep_blank_values=True
+        ):
+            form[key] = value
+
+        # Auth: Mattermost sends the verification token as a form field.
+        # Constant-time compare against every configured token.
+        token = form.get("token", "")
+        if not token or not any(
+            hmac.compare_digest(t.encode("utf-8"), token.encode("utf-8"))
+            for t in self._slash_tokens
+        ):
+            logger.warning(
+                "Mattermost: slash-command callback rejected (bad or missing token) from %s",
+                request.remote,
+            )
+            return web.json_response({"error": "unauthorized"}, status=401)
+
+        channel_id = form.get("channel_id", "")
+        allowed = self._resolve_allowed_channel_ids()
+        if allowed and channel_id not in allowed:
+            logger.warning(
+                "Mattermost: slash-command callback rejected (channel %s not in allowed_channels)",
+                channel_id,
+            )
+            return web.json_response({"error": "forbidden"}, status=403)
+
+        command = form.get("command", "")
+        if not command:
+            return web.json_response({"error": "bad request"}, status=400)
+
+        # Ack immediately — Mattermost enforces a ~5s callback timeout, so
+        # the agent turn must never be awaited inline. The event injection
+        # is scheduled and lands in the same session a regular WS message
+        # from this channel would.
+        task = asyncio.create_task(self._inject_slash_command_event(form))
+        self._slash_injections.add(task)
+        task.add_done_callback(self._slash_injections.discard)
+        return web.json_response(
+            {
+                "response_type": "ephemeral",
+                "text": f"✅ {_slash_command_text(form)} received — working on it.",
+            }
+        )
+
+    async def _inject_slash_command_event(self, form: Dict[str, str]) -> None:
+        """Build a COMMAND MessageEvent from a slash payload and dispatch it.
+
+        Mirrors the WebSocket path in ``_handle_ws_event`` so the event
+        keys into the SAME session as regular channel chat: same
+        ``build_source`` call shape, same channel-type mapping (via
+        ``get_chat_info``), same per-channel prompt resolution.
+        """
+        try:
+            channel_id = form.get("channel_id", "")
+            user_id = form.get("user_id", "")
+            user_name = (form.get("user_name", "") or "").lstrip("@") or user_id
+            trigger_id = form.get("trigger_id", "")
+
+            # Resolve the channel type through the same API + mapping the
+            # WS path uses, so DMs key as DMs and channels as channels.
+            chat_type = "channel"
+            try:
+                chat_info = await self.get_chat_info(channel_id)
+                chat_type = chat_info.get("type") or "channel"
+            except Exception as exc:  # noqa: BLE001 — best-effort lookup
+                logger.warning(
+                    "Mattermost: slash-command channel lookup failed for %s: %s",
+                    channel_id, exc,
+                )
+
+            # Thread parity with the WS path: root_id when provided. A
+            # slash invocation creates no post, so there is no post-id
+            # fallback — a bare command lands in the channel's main session.
+            thread_id = form.get("root_id") or None
+
+            source = self.build_source(
+                chat_id=channel_id,
+                chat_type=chat_type,
+                user_id=user_id,
+                user_name=user_name,
+                thread_id=thread_id,
+                message_id=trigger_id or None,
+            )
+
+            from gateway.platforms.base import resolve_channel_prompt
+            _channel_prompt = resolve_channel_prompt(
+                self.config.extra, channel_id, None,
+            )
+
+            msg_event = MessageEvent(
+                text=_slash_command_text(form),
+                message_type=MessageType.COMMAND,
+                source=source,
+                raw_message=form,
+                message_id=trigger_id or None,
+                media_urls=None,
+                media_types=None,
+                channel_prompt=_channel_prompt,
+            )
+
+            # A slash command is explicit intent — require_mention gating
+            # is bypassed by construction (never consulted here).
+            await self.handle_message(msg_event)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Mattermost: failed to inject slash-command event")
 
     async def _resolve_root_id(self, post_id: str) -> str:
         """Resolve a post_id to the thread root_id for Mattermost.

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -163,6 +163,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         self._last_post_status: Optional[int] = None
         self._last_post_error: str = ""
+        self._last_get_status: Optional[int] = None
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
@@ -187,12 +188,14 @@ class MattermostAdapter(BasePlatformAdapter):
     async def _api_get(self, path: str) -> Dict[str, Any]:
         """GET /api/v4/{path}."""
         import aiohttp
+        self._last_get_status = None
         if ".." in path:
             logger.error("MM API path traversal blocked: %s", path)
             return {}
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
         try:
             async with self._session.get(url, headers=self._headers(), timeout=aiohttp.ClientTimeout(total=30)) as resp:
+                self._last_get_status = resp.status
                 if resp.status >= 400:
                     body = await resp.text()
                     logger.error("MM API GET %s → %s: %s", path, resp.status, body[:200])
@@ -670,9 +673,15 @@ class MattermostAdapter(BasePlatformAdapter):
             return post_id
         # Check if this post has a root_id (meaning it's a reply)
         data = await self._api_get(f"posts/{post_id}")
-        if data and data.get("root_id"):
-            return data["root_id"]
-        return post_id
+        if data:
+            return data["root_id"] if data.get("root_id") else post_id
+        if self._last_get_status in (400, 404):
+            logger.warning(
+                "Mattermost: thread root %s not found (HTTP %s) — posting flat instead",
+                post_id, self._last_get_status,
+            )
+            return ""
+        return post_id  # transient/unknown error — keep legacy behavior
 
     async def send(
         self,

--- a/tests/gateway/test_mattermost_slash_commands.py
+++ b/tests/gateway/test_mattermost_slash_commands.py
@@ -82,6 +82,10 @@ class SlashAdapterHarness:
         }
         cfg_extra.update(extra or {})
         config = PlatformConfig(enabled=True, token="test-token", extra=cfg_extra)
+        # Deterministic reply mode: ambient .env may leak MATTERMOST_REPLY_MODE
+        # via `import gateway.run` in other test modules; the adapter reads it
+        # at __init__. Thread-mode behavior has its own dedicated test below.
+        monkeypatch.setenv("MATTERMOST_REPLY_MODE", "off")
         self.adapter = MattermostAdapter(config)
 
         if tokens is None:
@@ -186,8 +190,13 @@ class TestSlashCommandEndpoint:
         session keys both paths produce. require_mention is disabled so the
         WS message passes channel gating (the slash path bypasses it by
         design — explicit intent).
+
+        Parity is asserted under the default ``reply_mode=off``; thread mode
+        keys slash commands to the stable per-user channel session instead
+        (see test_thread_mode_slash_keys_to_stable_channel_session).
         """
         monkeypatch.setenv("MATTERMOST_REQUIRE_MENTION", "false")
+        monkeypatch.setenv("MATTERMOST_REPLY_MODE", "off")  # parity holds in default mode
         assert await harness.connect() is True
 
         captured = []
@@ -231,6 +240,32 @@ class TestSlashCommandEndpoint:
         assert slash_event.source.chat_type == ws_path_event.source.chat_type
         assert slash_event.source.user_name == ws_path_event.source.user_name
 
+        await harness.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_slash_keys_to_stable_channel_session(self, monkeypatch):
+        """In reply_mode=thread a slash command keys to the stable per-user
+        channel session, NOT a per-invocation thread.
+
+        The WS path in thread mode treats each top-level post as its own
+        thread (thread_id = post_id) so replies can thread onto it. A slash
+        invocation creates no post, and trigger_id is not a post id — using
+        it as a thread root would give the bot's reply an invalid root_id.
+        So the slash path intentionally keys to ``…:chat:user_id`` in every
+        mode (and to the DM session for DMs).
+        """
+        monkeypatch.setenv("MATTERMOST_SLASH_TOKENS", "tokA,tokB")
+        harness = SlashAdapterHarness(monkeypatch, extra={"reply_mode": "thread"})
+        assert await harness.connect() is True
+
+        status, _ = await _post(harness, _slash_payload(command="/sethome"))
+        assert status == 200
+        event = await harness.wait_for_event()
+        assert event.source.thread_id is None
+        key = build_session_key(event.source)
+        assert key == (
+            f"agent:main:mattermost:channel:{CHANNEL_ID}:{USER_ID}"
+        )
         await harness.adapter.disconnect()
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_mattermost_slash_commands.py
+++ b/tests/gateway/test_mattermost_slash_commands.py
@@ -1,0 +1,368 @@
+"""Native Mattermost slash-command HTTP endpoint.
+
+Mattermost's client swallows any message starting with ``/`` as an
+unregistered slash command, so gateway commands typed in Mattermost never
+reach the WebSocket. The adapter's slash-command listener receives the
+HTTP callbacks of *registered* server-side slash commands and injects them
+into the gateway message pipeline as native COMMAND events — landing in
+the SAME session a regular channel message would.
+
+Covered here:
+1. Valid token + payload → 200 ephemeral ack + a COMMAND MessageEvent with
+   the right platform/chat_id/user_id/text, keyed to the same session the
+   WebSocket path would produce.
+2. Bad token → 401, no event injected.
+3. No MATTERMOST_SLASH_TOKENS → listener never binds (fail closed).
+4. allowed_channels configured + disallowed channel → 403, no event.
+5. Wrong method / path / content-type → 404.
+6. connect → disconnect → connect rebinds the same port (no leak).
+7. The HTTP ack returns without waiting for the agent pipeline.
+"""
+
+import asyncio
+import json
+import socket
+import time
+from urllib.parse import urlencode
+
+import aiohttp
+import pytest
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
+from gateway.session import build_session_key
+
+BOT_USER_ID = "bot11111111111111111111111111"
+BOT_USERNAME = "hermesbot"
+CHANNEL_ID = "ch22222222222222222222222222"
+USER_ID = "u3333333333333333333333333333"
+USER_NAME = "alice"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _slash_payload(command="/sethome", text="", token="tokA", channel_id=CHANNEL_ID):
+    return {
+        "token": token,
+        "team_id": "team9999999999999999999999999",
+        "team_domain": "example",
+        "channel_id": channel_id,
+        "channel_name": "town-square",
+        "user_id": USER_ID,
+        "user_name": USER_NAME,
+        "command": command,
+        "text": text,
+        "response_url": "https://mm.example.com/hooks/resp",
+        "trigger_id": "trig7777777777777777777777777",
+    }
+
+
+class SlashAdapterHarness:
+    """A MattermostAdapter with the Mattermost REST/WS side stubbed out.
+
+    ``connect()`` runs for real (real HTTP listener, real session
+    lifecycle); ``_api_get`` is stubbed for ``users/me`` + channel lookups
+    and ``_ws_loop`` is a no-op so no outbound traffic happens. The message
+    handler records every MessageEvent that reaches the gateway pipeline.
+    """
+
+    def __init__(self, monkeypatch, tokens="tokA,tokB", extra=None):
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        self.port = _free_port()
+        cfg_extra = {
+            "url": "https://mm.example.com",
+            "slash_command_host": "127.0.0.1",
+            "slash_command_port": self.port,
+        }
+        cfg_extra.update(extra or {})
+        config = PlatformConfig(enabled=True, token="test-token", extra=cfg_extra)
+        self.adapter = MattermostAdapter(config)
+
+        if tokens is None:
+            monkeypatch.delenv("MATTERMOST_SLASH_TOKENS", raising=False)
+        else:
+            monkeypatch.setenv("MATTERMOST_SLASH_TOKENS", tokens)
+
+        async def fake_api_get(path):
+            if path == "users/me":
+                return {"id": BOT_USER_ID, "username": BOT_USERNAME}
+            if path.startswith("channels/"):
+                return {
+                    "id": path.split("/", 1)[1],
+                    "type": "O",
+                    "display_name": "Town Square",
+                    "name": "town-square",
+                }
+            return {}
+
+        self.adapter._api_get = fake_api_get
+        self.adapter._ws_loop = AsyncMock()
+        self.adapter.send_typing = AsyncMock()
+
+        self.events = []
+        self.event_arrived = asyncio.Event()
+
+        async def handler(event):
+            self.events.append(event)
+            self.event_arrived.set()
+            return None
+
+        self.adapter.set_message_handler(handler)
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    async def connect(self) -> bool:
+        return await self.adapter.connect()
+
+    async def wait_for_event(self, timeout=5.0):
+        await asyncio.wait_for(self.event_arrived.wait(), timeout)
+        return self.events[-1]
+
+
+@pytest.fixture
+def harness(monkeypatch):
+    return SlashAdapterHarness(monkeypatch)
+
+
+async def _post(harness, payload=None, *, path="/", headers=None, skip_ct=False, method="POST"):
+    body = urlencode(payload if payload is not None else _slash_payload())
+    kwargs = {"data": body.encode()}
+    if skip_ct:
+        kwargs["skip_auto_headers"] = ("Content-Type",)
+    else:
+        kwargs["headers"] = {"Content-Type": "application/x-www-form-urlencoded"}
+    if headers:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    async with aiohttp.ClientSession() as session:
+        requester = getattr(session, method.lower())
+        async with requester(f"{harness.url}{path}", **kwargs) as resp:
+            return resp.status, await resp.json()
+
+
+class TestSlashCommandEndpoint:
+    @pytest.mark.asyncio
+    async def test_valid_token_injects_command_event(self, harness):
+        """Valid token → 200 ephemeral ack + COMMAND event in the pipeline."""
+        assert await harness.connect() is True
+
+        status, body = await _post(harness, _slash_payload(command="/sethome"))
+        assert status == 200
+        assert body["response_type"] == "ephemeral"
+        assert "/sethome" in body["text"]
+
+        event = await harness.wait_for_event()
+        assert event.message_type is MessageType.COMMAND
+        assert event.text == "/sethome"
+        assert event.source.platform is Platform.MATTERMOST
+        assert event.source.chat_id == CHANNEL_ID
+        assert event.source.user_id == USER_ID
+
+        await harness.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_command_with_args_reconstructs_text(self, harness):
+        """``command`` + ``text`` → "/status mattermost"."""
+        assert await harness.connect() is True
+        status, _ = await _post(harness, _slash_payload(command="/status", text="mattermost"))
+        assert status == 200
+        event = await harness.wait_for_event()
+        assert event.text == "/status mattermost"
+        await harness.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_session_key_matches_ws_path(self, harness, monkeypatch):
+        """The injected event keys into the SAME session as the WS path.
+
+        Drives the real ``_handle_ws_event`` with an equivalent channel
+        message (leading-space workaround: "␣/sethome") and compares the
+        session keys both paths produce. require_mention is disabled so the
+        WS message passes channel gating (the slash path bypasses it by
+        design — explicit intent).
+        """
+        monkeypatch.setenv("MATTERMOST_REQUIRE_MENTION", "false")
+        assert await harness.connect() is True
+
+        captured = []
+        captured_evt = asyncio.Event()
+
+        async def capture_handle_message(event):
+            captured.append(event)
+            captured_evt.set()
+
+        monkeypatch.setattr(harness.adapter, "handle_message", capture_handle_message)
+
+        ws_event = {
+            "event": "posted",
+            "data": {
+                "channel_type": "O",
+                "sender_name": f"@{USER_NAME}",
+                "post": json.dumps({
+                    "id": "post55555555555555555555555555",
+                    "user_id": USER_ID,
+                    "channel_id": CHANNEL_ID,
+                    "message": " /sethome",
+                    "root_id": "",
+                    "file_ids": [],
+                }),
+            },
+        }
+        await harness.adapter._handle_ws_event(ws_event)
+        assert len(captured) == 1  # WS path captured (handle_message patched)
+
+        status, _ = await _post(harness, _slash_payload(command="/sethome"))
+        assert status == 200
+        await asyncio.wait_for(captured_evt.wait(), 5.0)
+        assert len(captured) == 2  # slash path captured too
+
+        ws_path_event = captured[0]
+        slash_event = captured[1]
+
+        ws_key = build_session_key(ws_path_event.source)
+        slash_key = build_session_key(slash_event.source)
+        assert slash_key == ws_key
+        assert slash_event.source.chat_type == ws_path_event.source.chat_type
+        assert slash_event.source.user_name == ws_path_event.source.user_name
+
+        await harness.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_bad_token_returns_401_no_event(self, harness):
+        assert await harness.connect() is True
+        status, body = await _post(harness, _slash_payload(token="wrong-token"))
+        assert status == 401
+        assert body == {"error": "unauthorized"}
+        await asyncio.sleep(0.15)  # no task is ever scheduled on 401
+        assert harness.events == []
+        await harness.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_missing_token_returns_401_no_event(self, harness):
+        assert await harness.connect() is True
+        payload = _slash_payload()
+        payload.pop("token")
+        status, _ = await _post(harness, payload)
+        assert status == 401
+        await asyncio.sleep(0.15)
+        assert harness.events == []
+        await harness.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_listener_disabled_without_tokens(self, monkeypatch):
+        """No MATTERMOST_SLASH_TOKENS → connect still works, nothing binds."""
+        h = SlashAdapterHarness(monkeypatch, tokens=None)
+        assert await h.connect() is True
+        assert h.adapter._slash_runner is None
+
+        # Nothing is listening on the configured port.
+        with pytest.raises(aiohttp.ClientConnectorError):
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    h.url, data=b"token=tokA", timeout=aiohttp.ClientTimeout(total=2)
+                ):
+                    pass
+        await h.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_allowed_channels_rejects_disallowed(self, harness, monkeypatch):
+        monkeypatch.setenv("MATTERMOST_ALLOWED_CHANNELS", "ch_allowed99999999999999999")
+        assert await harness.connect() is True
+
+        status, body = await _post(harness, _slash_payload(channel_id="ch_other8888888888888888"))
+        assert status == 403
+        assert body == {"error": "forbidden"}
+        await asyncio.sleep(0.15)
+        assert harness.events == []
+
+        # An allowed channel still goes through.
+        status, _ = await _post(harness, _slash_payload(channel_id="ch_allowed99999999999999999"))
+        assert status == 200
+        event = await harness.wait_for_event()
+        assert event.source.chat_id == "ch_allowed99999999999999999"
+        await harness.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_wrong_method_path_or_content_type_404(self, harness):
+        assert await harness.connect() is True
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(harness.url) as resp:
+                assert resp.status == 404
+            async with session.post(
+                f"{harness.url}/nope", data=b"token=tokA"
+            ) as resp:
+                assert resp.status == 404
+            async with session.post(
+                f"{harness.url}/",
+                data=json.dumps(_slash_payload()),
+                headers={"Content-Type": "application/json"},
+            ) as resp:
+                assert resp.status == 404
+
+        await asyncio.sleep(0.15)
+        assert harness.events == []
+        await harness.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_missing_content_type_tolerated(self, harness):
+        """Mattermost always sends form content-type, but we tolerate none."""
+        assert await harness.connect() is True
+        status, _ = await _post(harness, skip_ct=True)
+        assert status == 200
+        event = await harness.wait_for_event()
+        assert event.text == "/sethome"
+        await harness.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_disconnect_connect_no_port_leak(self, harness):
+        """Repeated lifecycle on the same port must not leak the bind."""
+        assert await harness.connect() is True
+        status, _ = await _post(harness, _slash_payload(command="/first"))
+        assert status == 200
+        await harness.wait_for_event()
+
+        await harness.adapter.disconnect()
+        assert harness.adapter._slash_runner is None
+
+        # Reconnect on the SAME port (reconnect cycles happen in practice).
+        assert await harness.connect() is True
+        assert harness.adapter._slash_runner is not None
+        status, _ = await _post(harness, _slash_payload(command="/second"))
+        assert status == 200
+        event = await harness.wait_for_event()
+        assert event.text == "/second"
+        await harness.adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_ack_does_not_wait_for_agent_pipeline(self, monkeypatch):
+        """Mattermost enforces ~5s — the ack must not block on the agent."""
+        h = SlashAdapterHarness(monkeypatch)
+        pipeline_done = asyncio.Event()
+
+        async def slow_handler(event):
+            await asyncio.sleep(2.0)  # simulated agent turn
+            pipeline_done.set()
+            return None
+
+        h.adapter.set_message_handler(slow_handler)
+        assert await h.connect() is True
+
+        started = time.monotonic()
+        status, body = await _post(h, _slash_payload(command="/slowcmd"))
+        elapsed = time.monotonic() - started
+
+        assert status == 200
+        assert body["response_type"] == "ephemeral"
+        # The pipeline sleeps 2s; the ack must return far earlier.
+        assert elapsed < 1.0
+
+        # ...but the injection does eventually complete.
+        await asyncio.wait_for(pipeline_done.wait(), 5.0)
+        await h.adapter.disconnect()

--- a/tests/gateway/test_mattermost_slash_commands.py
+++ b/tests/gateway/test_mattermost_slash_commands.py
@@ -20,6 +20,9 @@ Covered here:
 8. Confirmed-missing thread roots (HTTP 400/404 on GET posts/{id}) resolve
    to "" so replies post flat on the first try — no invalid root_id POST
    and no "⚠️ thread delivery failed" banner (the trigger_id path).
+9. send_typing() includes parent_id (the thread root) only for thread
+   sessions, so the typing indicator renders in thread views too;
+   channel sessions keep the exact {"channel_id": ...} payload.
 """
 
 import asyncio
@@ -505,3 +508,63 @@ class TestThreadRootConfirmedMissing:
         assert "root_id" not in payload
         assert "final reply" in payload["message"]
         assert "⚠️" not in payload["message"]
+
+
+class TestSendTypingThreadScoped:
+    """send_typing() must scope the typing indicator to the active thread.
+
+    Mattermost's PublishUserTyping copies the request's ``parent_id`` into
+    the typing WebSocket event, and the webapp only renders the indicator
+    where ``rootId === parent_id`` — without it, thread views never show
+    "hermes is typing". Thread sessions carry the root post id in
+    ``metadata["thread_id"]``; channel/slash sessions have none, and their
+    wire payload must stay exactly ``{"channel_id": ...}``.
+    """
+
+    def _make_adapter(self, monkeypatch):
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        monkeypatch.setenv("MATTERMOST_REPLY_MODE", "off")
+        adapter = MattermostAdapter(
+            PlatformConfig(enabled=True, token="test-token", extra={"url": "https://mm.example.com"})
+        )
+        adapter._bot_user_id = BOT_USER_ID
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_thread_metadata_sends_parent_id(self, monkeypatch):
+        """metadata["thread_id"] → POST body carries parent_id=root post id."""
+        adapter = self._make_adapter(monkeypatch)
+        adapter._api_post = AsyncMock(return_value={})
+
+        await adapter.send_typing(CHANNEL_ID, metadata={"thread_id": ROOT_ID})
+
+        path, payload = adapter._api_post.call_args.args
+        assert path == f"users/{BOT_USER_ID}/typing"
+        assert payload == {"channel_id": CHANNEL_ID, "parent_id": ROOT_ID}
+
+    @pytest.mark.asyncio
+    async def test_no_metadata_keeps_channel_scoped_payload(self, monkeypatch):
+        """metadata=None → channel typing unchanged (regression guard)."""
+        adapter = self._make_adapter(monkeypatch)
+        adapter._api_post = AsyncMock(return_value={})
+
+        await adapter.send_typing(CHANNEL_ID, metadata=None)
+
+        path, payload = adapter._api_post.call_args.args
+        assert path == f"users/{BOT_USER_ID}/typing"
+        assert payload == {"channel_id": CHANNEL_ID}
+        assert "parent_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_empty_thread_id_keeps_channel_scoped_payload(self, monkeypatch):
+        """metadata={"thread_id": ""} → no parent_id key."""
+        adapter = self._make_adapter(monkeypatch)
+        adapter._api_post = AsyncMock(return_value={})
+
+        await adapter.send_typing(CHANNEL_ID, metadata={"thread_id": ""})
+
+        path, payload = adapter._api_post.call_args.args
+        assert path == f"users/{BOT_USER_ID}/typing"
+        assert payload == {"channel_id": CHANNEL_ID}
+        assert "parent_id" not in payload

--- a/tests/gateway/test_mattermost_slash_commands.py
+++ b/tests/gateway/test_mattermost_slash_commands.py
@@ -17,6 +17,9 @@ Covered here:
 5. Wrong method / path / content-type → 404.
 6. connect → disconnect → connect rebinds the same port (no leak).
 7. The HTTP ack returns without waiting for the agent pipeline.
+8. Confirmed-missing thread roots (HTTP 400/404 on GET posts/{id}) resolve
+   to "" so replies post flat on the first try — no invalid root_id POST
+   and no "⚠️ thread delivery failed" banner (the trigger_id path).
 """
 
 import asyncio
@@ -38,6 +41,10 @@ BOT_USERNAME = "hermesbot"
 CHANNEL_ID = "ch22222222222222222222222222"
 USER_ID = "u3333333333333333333333333333"
 USER_NAME = "alice"
+POST_ID = "post55555555555555555555555555"
+ROOT_ID = "root66666666666666666666666666"
+TRIGGER_ID = "trig7777777777777777777777777"
+NEW_POST_ID = "newpost8888888888888888888888888"
 
 
 def _free_port() -> int:
@@ -401,3 +408,100 @@ class TestSlashCommandEndpoint:
         # ...but the injection does eventually complete.
         await asyncio.wait_for(pipeline_done.wait(), 5.0)
         await h.adapter.disconnect()
+
+
+class TestThreadRootConfirmedMissing:
+    """_resolve_root_id / send() when the thread root is CONFIRMED missing.
+
+    In reply_mode=thread, slash-command replies carry reply_to=trigger_id
+    (not a post id), and WS replies can target since-deleted roots — the
+    GET posts/{id} lookup comes back 400/404. A confirmed-missing root must
+    resolve to "" so send() posts flat on the FIRST attempt: no invalid
+    root_id POST, no "⚠️ Mattermost thread delivery failed" banner. A
+    transient/unknown GET failure (e.g. 500) keeps the legacy post_id
+    passthrough so _post_preserving_thread remains the safety net for
+    genuine races.
+    """
+
+    def _make_adapter(self, monkeypatch, extra=None):
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        cfg_extra = {"url": "https://mm.example.com"}
+        cfg_extra.update(extra or {})
+        # Deterministic reply mode even here: ambient .env may leak
+        # MATTERMOST_REPLY_MODE; extra={"reply_mode": ...} wins over env.
+        monkeypatch.setenv("MATTERMOST_REPLY_MODE", "off")
+        return MattermostAdapter(
+            PlatformConfig(enabled=True, token="test-token", extra=cfg_extra)
+        )
+
+    def _stub_get(self, adapter, status, data):
+        """Stub _api_get the way the real one behaves: record the HTTP
+        status on adapter._last_get_status, return {} on failure."""
+
+        async def fake_api_get(path):
+            adapter._last_get_status = status
+            return data
+
+        adapter._api_get = fake_api_get
+
+    @pytest.mark.asyncio
+    async def test_resolve_root_id_404_returns_empty(self, monkeypatch):
+        """GET posts/{id} → 404 → "" (post flat; trigger_id path)."""
+        adapter = self._make_adapter(monkeypatch)
+        self._stub_get(adapter, 404, {})
+        assert await adapter._resolve_root_id(TRIGGER_ID) == ""
+
+    @pytest.mark.asyncio
+    async def test_resolve_root_id_400_returns_empty(self, monkeypatch):
+        adapter = self._make_adapter(monkeypatch)
+        self._stub_get(adapter, 400, {})
+        assert await adapter._resolve_root_id(TRIGGER_ID) == ""
+
+    @pytest.mark.asyncio
+    async def test_resolve_root_id_existing_reply_returns_root(self, monkeypatch):
+        """Post exists and is a thread reply → its root_id."""
+        adapter = self._make_adapter(monkeypatch)
+        self._stub_get(adapter, 200, {"id": POST_ID, "root_id": ROOT_ID})
+        assert await adapter._resolve_root_id(POST_ID) == ROOT_ID
+
+    @pytest.mark.asyncio
+    async def test_resolve_root_id_top_level_post_returns_itself(self, monkeypatch):
+        """Post exists and is a top-level post → the post_id itself."""
+        adapter = self._make_adapter(monkeypatch)
+        self._stub_get(adapter, 200, {"id": POST_ID, "root_id": ""})
+        assert await adapter._resolve_root_id(POST_ID) == POST_ID
+
+    @pytest.mark.asyncio
+    async def test_resolve_root_id_500_keeps_legacy_passthrough(self, monkeypatch):
+        """Unknown/transient failure → post_id unchanged (no flat guess)."""
+        adapter = self._make_adapter(monkeypatch)
+        self._stub_get(adapter, 500, {})
+        assert await adapter._resolve_root_id(POST_ID) == POST_ID
+
+    @pytest.mark.asyncio
+    async def test_resolve_root_id_network_error_keeps_legacy_passthrough(self, monkeypatch):
+        """Network error never sets a status (None) → legacy passthrough."""
+        adapter = self._make_adapter(monkeypatch)
+        self._stub_get(adapter, None, {})
+        assert await adapter._resolve_root_id(POST_ID) == POST_ID
+
+    @pytest.mark.asyncio
+    async def test_send_with_confirmed_missing_root_posts_flat_once(self, monkeypatch):
+        """Regression guard for the trigger_id path: reply_to that is not a
+        post id → ONE POST call, no root_id key, no ⚠️ banner."""
+        adapter = self._make_adapter(monkeypatch, extra={"reply_mode": "thread"})
+        self._stub_get(adapter, 404, {})
+
+        adapter._api_post = AsyncMock(return_value={"id": NEW_POST_ID})
+
+        result = await adapter.send(CHANNEL_ID, "final reply", reply_to=TRIGGER_ID)
+        assert result.success is True
+        assert result.message_id == NEW_POST_ID
+
+        adapter._api_post.assert_called_once()
+        path, payload = adapter._api_post.call_args.args
+        assert path == "posts"
+        assert "root_id" not in payload
+        assert "final reply" in payload["message"]
+        assert "⚠️" not in payload["message"]

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -185,7 +185,7 @@ You can designate a "home channel" where the bot sends proactive messages (such 
 
 ### Using the Slash Command
 
-Type `/sethome` in any Mattermost channel where the bot is present. That channel becomes the home channel.
+Type `/sethome` in any Mattermost channel where the bot is present. That channel becomes the home channel. (Requires [native slash commands](#native-slash-commands) — see below — or a leading space to bypass Mattermost's client-side interception.)
 
 ### Manual Configuration
 
@@ -251,6 +251,44 @@ Behavior:
 - Find a channel ID via the Mattermost UI → channel header → "View Info", or read it from the channel URL.
 
 See also: [admin/user slash command split](../../reference/slash-commands.md#permissions-and-adminuser-split).
+
+## Native Slash Commands
+
+Out of the box, Mattermost's client intercepts any message starting with `/` and treats it as a **Mattermost** command — unregistered ones (like `/model`) are rejected locally and never reach Hermes. Typing a leading space (` /model`) bypasses this, but real `/commands` with autocomplete require registering them on the Mattermost server.
+
+The Mattermost adapter ships an optional HTTP endpoint that receives these server-side callbacks and injects them into the gateway as native COMMAND events.
+
+### Setup
+
+1. **Enable the listener** — add your verification tokens to `~/.hermes/.env`:
+
+   ```bash
+   # Comma-separated tokens from Mattermost's slash-command admin pages
+   MATTERMOST_SLASH_TOKENS=token1,token2
+   ```
+
+   The listener starts automatically when the gateway starts and tokens are present. Host/port live in `config.yaml` (defaults `0.0.0.0:8645`):
+
+   ```yaml
+   mattermost:
+     slash_command_host: 0.0.0.0
+     slash_command_port: 8645
+   ```
+
+2. **Register commands in Mattermost** — Main Menu → Integrations → Slash Commands → Add. Set the **Request URL** to `http://<hermes-host>:8645/` and copy the generated **Verification Token** back into `MATTERMOST_SLASH_TOKENS`. Repeat per command. Turn on **Autocomplete** with a description and argument hint so commands show up as you type.
+
+3. **SSRF note for private networks** — Mattermost blocks outbound integration callbacks to "reserved" IP ranges (this includes VPN ranges like CGNAT `100.64.0.0/10` used by Tailscale/Netbird-style meshes). If your Hermes host is on such a network, whitelist it in Mattermost's `config.json`:
+
+   ```json
+   "ServiceSettings": { "AllowedUntrustedInternalConnections": "<hermes-host-ip>/32" }
+   ```
+
+### Behavior
+
+- The endpoint answers immediately with an ephemeral `200` ack; the gateway processes the command asynchronously and replies in the channel (or thread, per `MATTERMOST_REPLY_MODE`).
+- Verification tokens are checked with a constant-time compare against `MATTERMOST_SLASH_TOKENS`; anything else gets `401` and is dropped.
+- Slash payloads carry no thread context, so a slash command always targets the per-user channel session (in thread reply-mode, conversations in a thread stay separate).
+- Commands Mattermost reserves as built-ins (`/status`, `/help`) cannot be overridden — use a leading space for those two.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Problem

Mattermost's client intercepts any message starting with `/` and treats it as a Mattermost command — unregistered ones like `/model` are rejected locally and never reach the gateway. The adapter (WebSocket/REST only) had no way to receive server-side slash callbacks, so Hermes commands only worked with a leading-space hack, with no autocomplete and no argument hints.

## What this adds

1. **Native slash-command HTTP endpoint** (aiohttp, default `0.0.0.0:8645`, config via `mattermost.slash_command_host/port` in config.yaml). Receives Mattermost's form-urlencoded callbacks, validates the verification token with a constant-time compare against `MATTERMOST_SLASH_TOKENS` (401 fail-closed), and injects the command as a native COMMAND event — allowed-channel gating, admin/user split, and ephemeral 200-ack all preserved. Plugin-only; no core files touched.
2. **Thread-scoped typing indicator** — `send_typing` now forwards the thread root as `parent_id`, so "hermes is typing" appears in the thread/Threads view, matching native client behavior (webapp gates on `parent_id === rootId`).
3. **Flat-reply fix** — when thread reply-mode resolves a missing/nonexistent root (4xx on lookup), the reply posts flat cleanly instead of a doomed threaded attempt + "delivery failed" banner.
4. **Docs** — new "Native Slash Commands" section: token setup, Mattermost-side registration with autocomplete, and the SSRF gotcha where Mattermost blocks callbacks to reserved ranges (CGNAT/mesh VPNs).

## Validation

- 45 tests (11→30 endpoint tests incl. auth/timeout/allowed-channels, 3 typing regression, deterministic reply-mode) — all green on this branch.
- Deployed and E2E-verified on a live server (Mattermost 11.9 Team Edition): 61 commands registered, autocomplete working, `401` on invalid tokens, exec-to-reply verified through Mattermost's own command executor.
