### PR TITLE
feat(doctor): add Command Installation check and auto-fix for Windows native launchers

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2003,9 +2003,10 @@ def run_doctor(args):
             if _norm_bin in _path_dirs:
                 check_ok("Launcher directory is on PATH")
             else:
+                _ps_hint = f"[Environment]::SetEnvironmentVariable('Path', $env:Path + ';{_bin_dir}', 'User')"
                 check_warn(
                     f"Launcher directory not on PATH: {_bin_dir}",
-                    "(run in PowerShell: [Environment]::SetEnvironmentVariable('Path', $env:Path + ';" + str(_bin_dir).replace('\\', '\\\\') + "', 'User'))"
+                    f"(run in PowerShell: {_ps_hint})"
                 )
                 manual_issues.append(f"Add {_bin_dir} to your User PATH")
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1954,6 +1954,60 @@ def run_doctor(args):
                         manual_issues.append(f"Add {_cmd_link_display} to your PATH")
                 else:
                     issues.append(f"Missing {_cmd_link_display}/hermes symlink — run 'hermes doctor --fix'")
+    else:
+        _section("Command Installation")
+        # On Windows native, verify venv Scripts entry points and bin\\ launcher copy
+        _venv_exe = None
+        for _venv_name in ("venv", ".venv"):
+            _candidate = PROJECT_ROOT / _venv_name / "Scripts" / "hermes.exe"
+            if _candidate.exists():
+                _venv_exe = _candidate
+                break
+
+        _bin_dir = PROJECT_ROOT / "bin"
+        _bin_exe = _bin_dir / "hermes.exe"
+
+        if _venv_exe is None:
+            check_warn(
+                "Venv entry point not found",
+                "(hermes.exe not in venv\\Scripts\\ or .venv\\Scripts\\ — reinstall with pip install -e '.[all]')"
+            )
+            manual_issues.append(
+                f"Reinstall entry point: cd {PROJECT_ROOT}; .\\venv\\Scripts\\Activate.ps1; pip install -e '.[all]'"
+            )
+        else:
+            check_ok(f"Venv entry point exists ({_venv_exe.relative_to(PROJECT_ROOT)})")
+
+            if _bin_exe.exists():
+                check_ok(f"Launcher binary exists ({_bin_exe.relative_to(PROJECT_ROOT)})")
+            else:
+                check_warn(
+                    f"Launcher binary not found ({_bin_exe.relative_to(PROJECT_ROOT)})",
+                    "(hermes command may not be available on global PATH)"
+                )
+                if should_fix:
+                    try:
+                        import shutil
+                        _bin_dir.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(_venv_exe, _bin_exe)
+                        check_ok(f"Created launcher copy: {_bin_exe.relative_to(PROJECT_ROOT)}")
+                        fixed_count += 1
+                    except Exception as e:
+                        check_warn(f"Failed to copy launcher binary: {e}")
+                else:
+                    issues.append(f"Missing {_bin_exe.relative_to(PROJECT_ROOT)} — run 'hermes doctor --fix'")
+
+            # Check if bin dir is on PATH
+            _path_dirs = [os.path.normcase(os.path.normpath(p)) for p in os.environ.get("PATH", "").split(os.pathsep) if p]
+            _norm_bin = os.path.normcase(os.path.normpath(str(_bin_dir)))
+            if _norm_bin in _path_dirs:
+                check_ok("Launcher directory is on PATH")
+            else:
+                check_warn(
+                    f"Launcher directory not on PATH: {_bin_dir}",
+                    "(run in PowerShell: [Environment]::SetEnvironmentVariable('Path', $env:Path + ';" + str(_bin_dir).replace('\\', '\\\\') + "', 'User'))"
+                )
+                manual_issues.append(f"Add {_bin_dir} to your User PATH")
 
     _section("External Tools")
     # Git

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -149,7 +149,7 @@ class TestDoctorCommandInstallation:
         assert "Command Installation" in out
         assert "$PREFIX/bin" in out
 
-    @pytest.mark.skipif(sys.platform != "win32", reason="Windows command install tests")
+    @pytest.mark.windows_only
     def test_windows_command_install_fix_and_verify(self, monkeypatch, tmp_path):
         home = tmp_path / ".hermes"
         home.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -149,3 +149,46 @@ class TestDoctorCommandInstallation:
         assert "Command Installation" in out
         assert "$PREFIX/bin" in out
 
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows command install tests")
+    def test_windows_command_install_fix_and_verify(self, monkeypatch, tmp_path):
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+
+        venv_scripts = project / "venv" / "Scripts"
+        venv_scripts.mkdir(parents=True, exist_ok=True)
+        hermes_exe = venv_scripts / "hermes.exe"
+        hermes_exe.write_text("MZ_DUMMY_EXE", encoding="utf-8")
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        # First run: bin/hermes.exe missing -> check_warn
+        out = _run_doctor(fix=False)
+        assert "Command Installation" in out
+        assert "Launcher binary not found" in out
+
+        # Second run: with fix=True -> creates launcher copy
+        out_fix = _run_doctor(fix=True)
+        assert "Created launcher copy" in out_fix
+        bin_exe = project / "bin" / "hermes.exe"
+        assert bin_exe.exists()
+        assert bin_exe.read_text(encoding="utf-8") == "MZ_DUMMY_EXE"
+
+


### PR DESCRIPTION
## What does this PR do?

Brings parity to `hermes doctor` on Windows native by adding the **Command Installation** verification section, which was previously gated to `if sys.platform != "win32":`.

On Windows:
- Checks if `venv\Scripts\hermes.exe` (or `.venv\Scripts\hermes.exe`) exists.
- Verifies the global launcher copy in `bin\hermes.exe` exists.
- Verifies whether `PROJECT_ROOT/bin` is present in the active `PATH` environment variable (case-insensitive & path-normalized).
- Supports auto-repair with `hermes doctor --fix`: copies `hermes.exe` to `bin\hermes.exe` if missing.
- Adds comprehensive unit tests for the Windows branch in `tests/hermes_cli/test_doctor_command_install.py`.

## Type of Change

- [x] New feature / cross-platform improvement (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/doctor.py`: Added Windows native `Command Installation` diagnostics and auto-repair branch under `_section("Command Installation")`.
- `tests/hermes_cli/test_doctor_command_install.py`: Added `test_windows_command_install_fix_and_verify` test case.

## How to Test

1. Run unit test suite:
   ```bash
   pytest tests/hermes_cli/test_doctor_command_install.py -v
   ```
   Result: `1 passed, 3 skipped` (on Windows).
2. Run `hermes doctor` on native Windows:
   ```bash
   hermes doctor
   ```
   Verifies `◆ Command Installation` section is displayed and correctly evaluates launcher binary status.

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits (`feat(doctor):`)
- [x] Verified no duplicate open PRs for Windows doctor command installation
- [x] PR contains only changes related to this feature
- [x] Unit test added and passing
