### PR TITLE
fix(desktop): select translucency defaults by platform family, not glass support

### DIFF
--- a/apps/desktop/src/store/translucency.ts
+++ b/apps/desktop/src/store/translucency.ts
@@ -116,7 +116,12 @@ export function setAppearance(appearance: Appearance): void {
 
 /** The resolved state for the painted appearance — the shape every consumer reads. */
 export const $translucency = computed([$translucencyBook, $appearance], (book, appearance) =>
-  resolveTranslucency(book, appearance, GLASS_IS_WINDOWS)
+  // The third argument selects the DEFAULTS table (windows vs mac), so it must
+  // be the platform family, not GLASS_IS_WINDOWS: on Windows 10 glass is
+  // unsupported and that flag is false, which dealt Win10 the macOS defaults
+  // (light intensity 66) — with the mode forced to 'clear' there, that reads
+  // as a ~70%-opaque window.
+  resolveTranslucency(book, appearance, isWindowsPlatform())
 )
 
 /** Write an edit against the appearance being painted. */


### PR DESCRIPTION
## Symptom

On Windows 10 the chat window paints at roughly 70% opacity out of the box (light appearance) — the shipped Windows translucency defaults never reach the window.

## Root cause

`$translucency` in `apps/desktop/src/store/translucency.ts` called:

```ts
resolveTranslucency(book, appearance, GLASS_IS_WINDOWS)
```

The third parameter of `resolveTranslucency` selects the `DEFAULT_VALUES` table (`mac` vs `windows`) in `apps/shared/src/translucency.ts`. But `GLASS_IS_WINDOWS = GLASS_SUPPORTED && !isMacPlatform()` is a **glass-capability** flag: on Windows 10 glass is unsupported, so the flag is `false` and Win10 fell back to the **macOS defaults** — light intensity 66 instead of 20, dark 22 instead of 5, and the macOS-only `header`/`titlebar` materials instead of `under-window`. With glass unsupported the mode is forced to `clear`, and intensity 66 in clear mode reads as a ~70%-opaque window.

## Fix

Pass the platform family — `isWindowsPlatform()`, already imported and used elsewhere in the same module — instead of the glass-capability flag.

`resolveTranslucency` has a single call site; verified there are no sibling paths deriving the defaults table from `GLASS_IS_WINDOWS` (its only other consumer is the material-picker ladder in `appearance-settings.tsx`, which governs which glass materials are *offered*, not the defaults table).

## Testing

`npx vitest run src/store/translucency.test.ts` — 35/35 pass. The jsdom suite pins `navigator.platform = 'MacIntel'`, so both flags are `false` under test and behaviour there is unchanged; the Win10 path is not reachable from jsdom.