### PR TITLE
fix(security): only warn about SSH password auth when a daemon is listening

### DIFF
--- a/hermes_cli/security_audit_startup.py
+++ b/hermes_cli/security_audit_startup.py
@@ -84,15 +84,68 @@ def _iter_sshd_config_lines() -> list[str]:
     return lines
 
 
+def _sshd_is_listening() -> Optional[bool]:
+    """Is an SSH daemon actually accepting connections?
+
+    Returns True/False only when positively determined, and None when the
+    answer is unknowable from here. Callers must treat None as "assume it is
+    running" so a detection gap can never silence a real finding.
+
+    Config presence is not evidence of a running daemon: macOS ships
+    /etc/ssh/sshd_config whether or not Remote Login is enabled.
+    """
+    import socket
+
+    port = 22
+    listen_addrs: list[str] = []
+    for line in _iter_sshd_config_lines():
+        m = re.match(r"(?i)^Port\s+(\d+)", line)
+        if m:
+            port = int(m.group(1))
+        m = re.match(r"(?i)^ListenAddress\s+(\S+)", line)
+        if m:
+            listen_addrs.append(m.group(1).lower())
+
+    # An explicit bind to a non-loopback address cannot be probed from here.
+    for a in listen_addrs:
+        if not (
+            a.startswith("0.0.0.0")
+            or a.startswith("::")
+            or a.startswith("127.")
+            or a in ("*", "localhost")
+        ):
+            return None
+
+    refused = 0
+    for host, family in (("127.0.0.1", socket.AF_INET), ("::1", socket.AF_INET6)):
+        sock = socket.socket(family, socket.SOCK_STREAM)
+        sock.settimeout(0.35)
+        try:
+            sock.connect((host, port))
+            return True
+        except ConnectionRefusedError:
+            refused += 1
+        except OSError:
+            pass  # unreachable family or timeout — inconclusive for this host
+        finally:
+            sock.close()
+    return False if refused else None
+
+
 def _ssh_password_auth_enabled() -> Optional[str]:
     """Warn when an SSH daemon has password authentication enabled.
 
     Password auth on a public SSH daemon is the classic brute-force surface
     and pairs badly with a root-capable agent box. POSIX-only; returns None
-    when there's no sshd config to read (e.g. Windows, or SSH not installed).
+    when there's no sshd config to read (e.g. Windows, or SSH not installed)
+    or when no daemon is actually listening.
     """
     lines = _iter_sshd_config_lines()
     if not lines:
+        return None
+    # No daemon accepting connections means no brute-force surface. Only skip
+    # on a positive "not listening"; None (inconclusive) still warns.
+    if _sshd_is_listening() is False:
         return None
     # Last directive wins in sshd_config. Default (no directive) is "yes".
     verdict = "yes"

--- a/tests/hermes_cli/test_security_audit_startup.py
+++ b/tests/hermes_cli/test_security_audit_startup.py
@@ -25,6 +25,66 @@ def _reset_audit_sentinel():
 # ── SSH password-auth check ─────────────────────────────────────────────────
 
 
+def test_ssh_check_silent_when_no_daemon_listening(monkeypatch):
+    """Config alone is not exposure — macOS ships sshd_config with Remote Login off."""
+    monkeypatch.setattr(audit, "_iter_sshd_config_lines", lambda: ["UsePAM yes"])
+    monkeypatch.setattr(audit, "_sshd_is_listening", lambda: False)
+    assert audit._ssh_password_auth_enabled() is None
+
+
+def test_ssh_check_warns_when_daemon_listening(monkeypatch):
+    monkeypatch.setattr(audit, "_iter_sshd_config_lines", lambda: ["UsePAM yes"])
+    monkeypatch.setattr(audit, "_sshd_is_listening", lambda: True)
+    msg = audit._ssh_password_auth_enabled()
+    assert msg is not None
+    assert "default — no explicit directive" in msg
+
+
+def test_ssh_check_warns_when_detection_inconclusive(monkeypatch):
+    """None must never suppress: a detection gap cannot hide a real finding."""
+    monkeypatch.setattr(audit, "_iter_sshd_config_lines", lambda: ["UsePAM yes"])
+    monkeypatch.setattr(audit, "_sshd_is_listening", lambda: None)
+    assert audit._ssh_password_auth_enabled() is not None
+
+
+def test_ssh_check_explicit_no_still_short_circuits(monkeypatch):
+    monkeypatch.setattr(audit, "_iter_sshd_config_lines", lambda: ["PasswordAuthentication no"])
+    monkeypatch.setattr(audit, "_sshd_is_listening", lambda: True)
+    assert audit._ssh_password_auth_enabled() is None
+
+
+def test_sshd_is_listening_false_on_closed_port(monkeypatch):
+    """A closed loopback port is a positive 'no daemon'."""
+    # Port 1 is reserved and never bound in CI sandboxes.
+    monkeypatch.setattr(audit, "_iter_sshd_config_lines", lambda: ["Port 1"])
+    assert audit._sshd_is_listening() is False
+
+
+def test_sshd_is_listening_true_on_open_port(monkeypatch):
+    """A bound loopback port is a positive 'daemon present'."""
+    import socket
+
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    try:
+        monkeypatch.setattr(
+            audit, "_iter_sshd_config_lines", lambda: [f"Port {srv.getsockname()[1]}"]
+        )
+        assert audit._sshd_is_listening() is True
+    finally:
+        srv.close()
+
+
+def test_sshd_is_listening_inconclusive_for_external_bind(monkeypatch):
+    """An explicit non-loopback ListenAddress cannot be probed from here."""
+    monkeypatch.setattr(
+        audit, "_iter_sshd_config_lines", lambda: ["ListenAddress 203.0.113.7", "Port 22"]
+    )
+    assert audit._sshd_is_listening() is None
+
+
+
 # ── container / volume-mount check ──────────────────────────────────────────
 
 
@@ -43,6 +103,7 @@ def _reset_audit_sentinel():
 def test_run_security_audit_aggregates(monkeypatch, tmp_path):
     monkeypatch.setattr(audit, "_is_root", lambda: True)
     monkeypatch.setattr(audit, "_iter_sshd_config_lines", lambda: ["PasswordAuthentication yes"])
+    monkeypatch.setattr(audit, "_sshd_is_listening", lambda: True)
     monkeypatch.setattr(audit, "_in_container", lambda: False)
     findings = audit.run_security_audit(hermes_home=tmp_path, config={})
     assert len(findings) == 2  # root + ssh


### PR DESCRIPTION
Fixes #91819.

## What & why

`_ssh_password_auth_enabled()` inferred that an SSH daemon was exposed from the **presence of `/etc/ssh/sshd_config`**, never checking whether `sshd` was actually running.

macOS ships that file unconditionally, whether or not Remote Login is enabled, and its stock `PasswordAuthentication` line is a comment. So the check found no explicit directive, fell back to its assumed default of `yes`, and warned — on **every stock macOS install with Remote Login off**, which is the default state. It fires on every gateway start.

The check was right that the config *would* permit password auth. The unsound step was going from "config would permit it" to "a box is exposed": the daemon is what creates the surface, and there isn't one.

Beyond log noise this was unactionable without weakening something — either edit a system security file to satisfy a check about a daemon that isn't running, or start ignoring startup security warnings, which erodes the audit for findings that are real.

## How

`_sshd_is_listening()` probes the configured `Port` on loopback and is deliberately **tri-state**:

| result | meaning | effect |
| --- | --- | --- |
| `False` | connection refused — positively no daemon | finding suppressed |
| `True` | socket accepted — daemon present | **warns** |
| `None` | unknowable (external `ListenAddress`, timeout) | **warns** |

Only a positive `False` suppresses. A detection gap can never hide a real finding — that seemed like the important invariant for a security check, so it's asserted directly in `test_ssh_check_warns_when_detection_inconclusive`.

`psutil.net_connections()` raises `AccessDenied` for non-root on macOS, so a plain loopback `connect()` is used instead. `socket` is stdlib and cross-platform; the enclosing function still returns early on Windows, where there's no sshd config to read.

## Test changes

One existing test needed updating: `test_run_security_audit_aggregates` monkeypatched `_iter_sshd_config_lines` and asserted 2 findings. The function it exercises now has a live-socket dependency, so the test would probe whatever host CI runs on — and fail there, since CI has no sshd. It now pins `_sshd_is_listening` explicitly. Flagging it since it's a change to an existing assertion rather than a pure addition.

Seven new tests fill the previously empty `── SSH password-auth check ──` section, covering all three tri-states, the explicit-`no` short-circuit, and `_sshd_is_listening()` itself against a closed port, a really-bound socket, and an unprobeable external bind.

## How to test

Reproduce on any macOS box with Remote Login off (the default):

```bash
netstat -an -p tcp | grep LISTEN | awk '{print $4}' | grep -E '\.22$'   # no output
python -c "from hermes_cli import security_audit_startup as S; print(S.run_security_audit())"
```

Before: an SSH finding. After: no SSH finding, while a machine with `sshd` actually listening still gets one.

```bash
pytest tests/hermes_cli/test_security_audit_startup.py -q     # 10 passed
```

I also confirmed the new tests aren't vacuous — reverting just the source change (keeping the tests) fails 8 of them, including the updated existing one.

## Platforms tested

macOS 26.6.2 (arm64), Python 3.12 and 3.14 — `tests/hermes_cli/test_security_audit_startup.py` and `test_security_audit.py`, 24 passed.

I could not run the full `tests/hermes_cli/` directory locally: unrelated modules in it need `fastapi`/`uvicorn`, which my throwaway environment didn't have. Worth a CI run over the rest. Linux/WSL2 behaviour should be unchanged where an sshd is genuinely listening, but I haven't exercised it on those platforms — the case worth a second pair of eyes is a container that has an sshd config and no running daemon, which this now correctly stops warning about.
