### PR TITLE
fix(gateway): scope session DB recovery paths to profile

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24347,13 +24347,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         cause = classify_persistence_error(error)
         hint = format_session_db_unavailable()
         if cause == "corrupt":
+            hermes_home = get_hermes_home()
+            state_db_path = hermes_home / "state.db"
+            backups_path = hermes_home / "backups"
             message = (
                 "⚠️ Session database corruption detected. Messages may not be "
                 "persisted. Recovery options:\n"
                 "1. Run `hermes doctor --fix`\n"
-                "2. Salvage with: sqlite3 ~/.hermes/state.db \".recover\" "
+                f"2. Salvage with: sqlite3 \"{state_db_path}\" \".recover\" "
                 "(then replace state.db)\n"
-                "3. Restore from a backup in ~/.hermes/backups/\n"
+                f"3. Restore from a backup in {backups_path}/\n"
                 f"Error: {error}"
             )
         else:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3947,6 +3947,9 @@ class AIAgent:
                     "please send it again in a moment."
                 )
             if cause == "corrupt":
+                hermes_home = get_hermes_home()
+                state_db_path = hermes_home / "state.db"
+                backups_path = hermes_home / "backups"
                 return (
                     prefix
                     + "the turn was stopped because the state database "
@@ -3954,9 +3957,9 @@ class AIAgent:
                     "have been lost on restart). Freeing disk space will "
                     "not help. Recovery options:\n"
                     "1. Run `hermes doctor --fix`\n"
-                    "2. Salvage with: sqlite3 ~/.hermes/state.db \".recover\" "
+                    f"2. Salvage with: sqlite3 \"{state_db_path}\" \".recover\" "
                     "(then replace state.db)\n"
-                    "3. Restore from a backup in ~/.hermes/backups/\n"
+                    f"3. Restore from a backup in {backups_path}/\n"
                     "Then send your message again."
                 )
             if cause == "disk":

--- a/tests/run_agent/test_corruption_recovery_guidance.py
+++ b/tests/run_agent/test_corruption_recovery_guidance.py
@@ -15,7 +15,54 @@ The fix adds:
    with the full recovery path (hermes doctor, sqlite3 .recover, backups)
 """
 
-from pytest import fixture
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_corruption_warning_uses_active_profile_home(tmp_path, monkeypatch):
+    """Recovery commands must target the profile whose database failed."""
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    default_home = tmp_path / "default"
+    profile_home = tmp_path / "profiles" / "isolated"
+    default_home.mkdir()
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+
+    send = AsyncMock(return_value=None)
+    adapter = SimpleNamespace(send=send)
+    transport = SimpleNamespace(adapter=adapter, is_relay=False, send=send)
+    home = SimpleNamespace(
+        chat_id="home-chat",
+        thread_id=None,
+        user_id=None,
+        scope_id=None,
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(
+        platforms={Platform.DISCORD: SimpleNamespace(home_channel=home)}
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._session_db_init_error = "database disk image is malformed"
+    runner._thread_metadata_for_target = lambda *args, **kwargs: None
+
+    token = set_hermes_home_override(profile_home)
+    try:
+        with patch("gateway.run.resolve_delivery_transport", return_value=transport):
+            await runner._send_session_db_warning_notifications()
+    finally:
+        reset_hermes_home_override(token)
+
+    message = send.await_args.args[2]
+    assert str(profile_home / "state.db") in message
+    assert str(profile_home / "backups") in message
+    assert str(default_home) not in message
+    assert "~/.hermes" not in message
 
 
 def test_format_turn_completion_corrupt_includes_recovery_options():

--- a/tests/run_agent/test_corruption_recovery_guidance.py
+++ b/tests/run_agent/test_corruption_recovery_guidance.py
@@ -78,6 +78,27 @@ def test_format_turn_completion_corrupt_includes_recovery_options():
     assert "Freeing disk space will not help" in explanation
 
 
+def test_format_turn_completion_corrupt_uses_active_profile_home(tmp_path):
+    """Formatter recovery paths must target the active profile."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from run_agent import AIAgent
+
+    profile_home = tmp_path / "profiles" / "isolated"
+    token = set_hermes_home_override(profile_home)
+    try:
+        explanation = AIAgent._format_turn_completion_explanation(
+            "session_persistence_failed", "corrupt"
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    state_db_path = profile_home / "state.db"
+    backups_path = profile_home / "backups"
+    assert f'sqlite3 "{state_db_path}" ".recover"' in explanation
+    assert f"{backups_path}/" in explanation
+    assert "~/.hermes" not in explanation
+
+
 def test_format_turn_completion_disk_still_advises_space():
     """The 'disk' cause still gives disk-space advice (unchanged)."""
     from run_agent import AIAgent


### PR DESCRIPTION
## What does this PR do?

Makes the gateway's state database corruption warning resolve recovery paths from the active `HERMES_HOME` / profile scope instead of embedding `~/.hermes`.

An isolated or multiplexed profile can otherwise receive a warning that tells its operator to recover or replace the default profile's database. The warning now uses `get_hermes_home()` at notification time, preserving context-local profile overrides as well as process-level `HERMES_HOME`.

## Related Issue

No existing issue found; this was reproduced on current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/run.py`: render the corruption recovery command and backup directory from the active Hermes home.
- `tests/run_agent/test_corruption_recovery_guidance.py`: add an end-to-end warning-delivery regression with a process default home and a different context-scoped profile home.

## How to Test

1. Run `scripts/run_tests.sh tests/run_agent/test_corruption_recovery_guidance.py tests/test_hermes_state_wal_fallback.py -q`.
2. Confirm all 25 focused tests pass.
3. Run `uvx ruff==0.15.10 check gateway/run.py tests/run_agent/test_corruption_recovery_guidance.py`.

The regression was observed RED before the production change: the delivered message still contained `~/.hermes/state.db` and `~/.hermes/backups/` instead of the selected profile paths.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — path rendering uses `pathlib.Path`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused verification: 25 passed. Ruff: all checks passed.

The full canonical suite was attempted and reached 66% before the 10-minute local cap. Unrelated files failed because optional SDKs such as `anthropic` and `hindsight_client_api` are not installed in this checkout; the touched regression file passed during that run.
