### PR TITLE
fix(honcho): tolerate legacy peer response config

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -56,6 +56,55 @@ def _sanitize_url(url: str | None) -> str | None:
 HOST = "hermes"
 
 
+def _install_peer_response_compat() -> type | None:
+    """Accept legacy peer-level observation data on SDK responses only.
+
+    Honcho uses the same strict ``PeerConfig`` model for requests and
+    responses. Older/self-hosted servers can still return the retired
+    ``configuration.observe_others`` field, causing every peer lookup to fail
+    validation. Keep request validation strict while replacing only the SDK's
+    response model with a narrow compatibility subclass that consumes and
+    excludes that one legacy field.
+    """
+    import sys
+
+    try:
+        from honcho.api_types import PeerConfig, PeerResponse
+    except ModuleNotFoundError as exc:
+        # Unit tests and third-party wrappers may provide a minimal ``honcho``
+        # module with only the public Honcho client. There is no SDK response
+        # model to patch in that shape.
+        if exc.name == "honcho.api_types":
+            return None
+        raise
+    from pydantic import Field
+
+    if getattr(PeerResponse, "__hermes_legacy_observe_others_compat__", False):
+        return PeerResponse
+
+    original_response = PeerResponse
+
+    class _PeerResponseConfig(PeerConfig):
+        observe_others: bool | None = Field(default=None, exclude=True)
+
+    class _PeerResponseCompat(original_response):
+        configuration: _PeerResponseConfig = Field(  # pyright: ignore[reportIncompatibleVariableOverride]
+            default_factory=_PeerResponseConfig
+        )
+
+    setattr(_PeerResponseCompat, "__hermes_legacy_observe_others_compat__", True)
+
+    # The SDK imports PeerResponse into several module globals. Replace only
+    # references to the exact original response class; request models and any
+    # independently changed SDK symbols remain untouched.
+    for module_name, module in tuple(sys.modules.items()):
+        if module_name == "honcho" or module_name.startswith("honcho."):
+            if getattr(module, "PeerResponse", None) is original_response:
+                setattr(module, "PeerResponse", _PeerResponseCompat)
+
+    return _PeerResponseCompat
+
+
 def profile_host_key(profile: str | None) -> str:
     """Return the safe Honcho host key for a Hermes profile."""
     if not profile or profile in {"default", "custom"}:
@@ -1267,6 +1316,7 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
 
         try:
             from honcho import Honcho
+            _install_peer_response_compat()
         except ImportError:
             raise ImportError(
                 "honcho-ai is required for Honcho integration. "

--- a/tests/plugins/memory/test_honcho_response_compat.py
+++ b/tests/plugins/memory/test_honcho_response_compat.py
@@ -1,0 +1,82 @@
+"""Compatibility tests for Honcho peer responses from older servers."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+from pydantic import ValidationError
+
+from plugins.memory.honcho.client import _install_peer_response_compat
+
+
+LEGACY_PEER_RESPONSE = {
+    "id": "runi",
+    "workspace_id": "abel-cell-v1",
+    "created_at": "2026-08-01T00:00:00Z",
+    "metadata": {},
+    "configuration": {"observe_others": False},
+}
+
+
+def test_legacy_observe_others_is_accepted_only_on_peer_responses():
+    import honcho.api_types as api_types
+    import honcho.peer as peer_module
+
+    starting_refs = {
+        module_name: getattr(module, "PeerResponse", None)
+        for module_name, module in tuple(sys.modules.items())
+        if module_name == "honcho" or module_name.startswith("honcho.")
+    }
+    current_response = api_types.PeerResponse
+    original_response = (
+        current_response.__mro__[1]
+        if getattr(current_response, "__hermes_legacy_observe_others_compat__", False)
+        else current_response
+    )
+
+    try:
+        with pytest.raises(ValidationError):
+            original_response.model_validate(LEGACY_PEER_RESPONSE)
+        with pytest.raises(ValidationError):
+            api_types.PeerConfig.model_validate({"observe_others": False})
+
+        compat_response = _install_peer_response_compat()
+        assert compat_response is not None
+
+        parsed = compat_response.model_validate(LEGACY_PEER_RESPONSE)
+        assert parsed.id == "runi"
+        assert "observe_others" not in parsed.configuration.model_dump()
+        assert api_types.PeerResponse is compat_response
+        assert peer_module.PeerResponse is compat_response
+        assert _install_peer_response_compat() is compat_response
+
+        # Request models remain strict: the response shim must not make the
+        # deprecated peer-level setting writable again.
+        with pytest.raises(ValidationError):
+            api_types.PeerConfig.model_validate({"observe_others": False})
+    finally:
+        for module_name, response_class in starting_refs.items():
+            module = sys.modules.get(module_name)
+            if module is not None and response_class is not None:
+                setattr(module, "PeerResponse", response_class)
+
+
+def test_peer_response_compat_noops_for_minimal_fake_honcho_module():
+    saved_modules = {
+        name: module
+        for name, module in tuple(sys.modules.items())
+        if name == "honcho" or name.startswith("honcho.")
+    }
+    for name in saved_modules:
+        sys.modules.pop(name, None)
+    sys.modules["honcho"] = ModuleType("honcho")
+
+    try:
+        assert _install_peer_response_compat() is None
+    finally:
+        for name in tuple(sys.modules):
+            if name == "honcho" or name.startswith("honcho."):
+                sys.modules.pop(name, None)
+        sys.modules.update(saved_modules)


### PR DESCRIPTION
## Summary

Self-hosted/older Honcho servers can still return the retired peer-level `configuration.observe_others` field. Current `honcho-ai` response parsing uses the same strict `PeerConfig` model as request validation, so a successful peer lookup fails with:

```text
PeerResponse.configuration.observe_others
Extra inputs are not permitted
```

This PR installs a narrow response-only compatibility model when constructing the Honcho client:

- accepts only the known legacy response field;
- excludes it from serialization;
- leaves request `PeerConfig` strict;
- replaces only SDK module globals that still reference the exact original `PeerResponse` class;
- is idempotent;
- no-ops when a test/wrapper provides a minimal `honcho` module without `honcho.api_types`.

## Why response-only

`observe_others` is session-peer configuration in current Honcho. Making the request model permissive would silently reintroduce a retired write surface. The compatibility shim exists only to parse a legacy server response.

## Verification

Canonical focused runner:

```text
scripts/run_tests.sh \
  tests/plugins/memory/test_honcho_response_compat.py \
  tests/test_honcho_client_config.py \
  tests/test_honcho_client_concurrency.py \
  tests/test_honcho_startup_fail_open.py \
  tests/test_honcho_session_context.py \
  tests/honcho_plugin/test_client.py
```

Result: **88 passed, 0 failed**.

Live self-hosted verification on a fresh named Hermes profile also loaded the expected peer card/representation and persisted a streaming A2A turn after the shim was active.

## Test plan

- [x] Legacy response parses after compatibility installation.
- [x] Legacy field is absent from `model_dump()`.
- [x] Request `PeerConfig` still rejects peer-level `observe_others`.
- [x] SDK `PeerResponse` module references use the compatibility class.
- [x] Repeated installation returns the same compatibility class.
- [x] Process-global SDK references are restored by the regression test.
- [x] A minimal fake `honcho` module without `honcho.api_types` no-ops.
- [x] Client configuration, concurrency, startup fail-open, session context, and plugin client suites pass.
