### PR TITLE
fix(dashboard): name the anthropic OAuth row for what its button does

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10568,7 +10568,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
     # usage credits on top of a Claude Max plan — see disclaimer in name).
     {
         "id": "anthropic",
-        "name": "Anthropic API Key",
+        # The name must match what the button does: this row's Login opens
+        # Hermes' claude.ai OAuth (PKCE), NOT an API-key entry form. Calling
+        # it "Anthropic API Key" made users who never selected a Claude
+        # model think the API-key path lived here and got an unexpected
+        # Claude sign-in page (#91822 — #24058's dispatch fix made pkce
+        # route correctly; this closes its label side). The actual API-key
+        # path is the row's cli_command (hermes auth add anthropic).
+        "name": "Anthropic OAuth (Claude Sign-in)",
         "flow": "pkce",
         "cli_command": "hermes auth add anthropic",
         "docs_url": "https://docs.claude.com/en/api/getting-started",
@@ -10708,14 +10715,18 @@ def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str
 
 def _oauth_provider_disconnect_hint(provider: Dict[str, Any], status: Dict[str, Any]) -> Optional[str]:
     """Return the manual disconnect path when the API cannot clear this provider."""
+    # env_var first: a key sourced from the environment lives in Settings →
+    # Keys regardless of the entry's flow — including an "external"-flow
+    # row whose credential Hermes itself stores (#91822 made the Anthropic
+    # API-key row external, and its env-sourced key still needs this hint).
+    if status.get("source") == "env_var":
+        return "Remove the API key from Settings → Keys instead."
     if provider.get("flow") == "external":
         if _oauth_provider_disconnect_command(provider):
             # The GUI offers a one-click "run in terminal" path; this hint is the
             # fallback wording for surfaces that only show text.
             return "Managed outside Hermes — run the disconnect command to remove it."
         return "Managed by that provider's CLI; remove it there."
-    if status.get("source") == "env_var":
-        return "Remove the API key from Settings → Keys instead."
     return None
 
 

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -490,6 +490,25 @@ def test_xai_oauth_listed_as_device_code_flow():
     assert "grok" in providers["xai-oauth"]["name"].lower()
 
 
+def test_anthropic_row_name_matches_its_oauth_behavior():
+    """The anthropic row must not call itself an "API Key" path (#91822).
+
+    Its Login button opens Hermes' claude.ai OAuth (pkce) — no key field.
+    A name claiming "API Key" sent users hunting for the key path into a
+    Claude subscription sign-in (label-side sibling of #24058's dispatch
+    fix). The real key path is the row's cli_command.
+    """
+    resp = client.get("/api/providers/oauth", headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    providers = {p["id"]: p for p in resp.json()["providers"]}
+    entry = providers["anthropic"]
+    assert "API Key" not in entry["name"]
+    assert "OAuth" in entry["name"]
+    # The flow stays pkce (existing PKCE users' status/disconnect paths
+    # depend on it); the fix is naming honesty, not flow surgery.
+    assert entry["flow"] == "pkce"
+
+
 def test_accounts_offers_every_oauth_provider_from_catalog():
     """PARITY CONTRACT: every accounts-tab provider in the unified catalog (the
     `hermes model` universe) must be offered by /api/providers/oauth. This keeps


### PR DESCRIPTION
## What does this PR do?

Fixes the dashboard's "Anthropic API Key" row launching a Claude subscription OAuth sign-in (#91822): the row's Login button opens Hermes' claude.ai OAuth (pkce) with no key field in sight, so users who never selected a Claude model got an unexpected Claude sign-in page from a row labeled as the API-key path.

Root cause is the catalog entry's NAME, not its flow: `_OAUTH_PROVIDER_CATALOG`'s `anthropic` entry is named "Anthropic API Key" while `"flow": "pkce"` — and that flow is load-bearing (existing PKCE users' status reporting and the disconnect path that clears `~/.hermes/.anthropic_oauth.json` both key off it; switching the row to `flow: "external"` to hide the button would strand those users). This is the label-side sibling of #24058's dispatch fix: the dispatcher routes pkce correctly now, but the label still promised the wrong thing.

The fix renames the entry to "Anthropic OAuth (Claude Sign-in)" so the button's name matches its behavior; the API-key path remains the row's documented `cli_command` (`hermes auth add anthropic`). It also fixes an independent hint-ordering bug surfaced on the way: `_oauth_provider_disconnect_hint` now checks `source == "env_var"` before the `flow == "external"` early return, so an env-sourced key always gets the "Remove the API key from Settings → Keys instead." hint regardless of the row's flow.

## Related Issue

Fixes #91822

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — `_OAUTH_PROVIDER_CATALOG`: renamed the `anthropic` entry from "Anthropic API Key" to "Anthropic OAuth (Claude Sign-in)" with a comment explaining why the name must match the pkce button and where the real key path lives; `_oauth_provider_disconnect_hint`: moved the `env_var` check ahead of the `external` early return (an env-sourced key's removal hint is flow-independent).
- `tests/hermes_cli/test_web_oauth_dispatch.py` — `test_anthropic_row_name_matches_its_oauth_behavior`: pins that the row's name contains no "API Key" claim and names OAuth, and that the flow stays pkce (existing users' paths depend on it).

## How to Test

1. Automated: `.venv/bin/python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py tests/hermes_cli/test_anthropic_oauth_flow.py tests/hermes_cli/test_dashboard_oauth_endpoints_server_gate.py -q` — should pass (observed result: 20 passed on macOS arm64).
2. Manual: open the dashboard's Keys/Accounts card — the Anthropic row now reads "Anthropic OAuth (Claude Sign-in)"; its Login behavior is unchanged (Claude sign-in), and the API-key instructions still point at `hermes auth add anthropic`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted OAuth/dashboard suites: 20 passed, 0 failures)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (catalog comment documents the naming rationale)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (issue reported on macOS; pure label/hint change, platform-neutral)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
