### PR TITLE
fix(desktop): stop missing plugin entries from flooding IPC logs

### DIFF
--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -21,6 +21,7 @@ const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
 const readFileText = vi.fn<(path: string) => Promise<{ text: string }>>()
 const watchDirectory = vi.fn<(path: string) => Promise<{ id: string }>>()
 const watchPreviewFile = vi.fn<(path: string) => Promise<{ id: string }>>()
+const stopPreviewFileWatch = vi.fn<(id: string) => Promise<boolean>>()
 const onPreviewFileChanged = vi.fn()
 
 beforeEach(() => {
@@ -30,6 +31,8 @@ beforeEach(() => {
   readFileText.mockReset()
   watchDirectory.mockReset()
   watchPreviewFile.mockReset()
+  stopPreviewFileWatch.mockReset()
+  stopPreviewFileWatch.mockResolvedValue(true)
   onPreviewFileChanged.mockReset()
   getStatus.mockClear()
   ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
@@ -38,6 +41,7 @@ beforeEach(() => {
     onPreviewFileChanged,
     readDir,
     readFileText,
+    stopPreviewFileWatch,
     watchDirectory,
     watchPreviewFile
   }
@@ -72,22 +76,28 @@ describe('scanDiskPlugins (#66899)', () => {
     expect(readDir).not.toHaveBeenCalled()
   })
 
-  it('probes desktop/plugin.js inside agent-plugin packages (unified packaging)', async () => {
+  it('treats a package without a Desktop half as metadata, not a throwing file read', async () => {
     desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
     agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
-    readDir.mockImplementation(async dir =>
-      dir === '/local/.hermes/plugins'
-        ? { entries: [{ isDirectory: true, name: 'my-feature', path: '/local/.hermes/plugins/my-feature' }] }
-        : { entries: [] }
-    )
-    // No desktop half in this package — probe must target desktop/plugin.js.
-    readFileText.mockRejectedValue(new Error('ENOENT'))
+    readDir.mockImplementation(async dir => {
+      if (dir === '/local/.hermes/plugins') {
+        return { entries: [{ isDirectory: true, name: 'my-feature', path: '/local/.hermes/plugins/my-feature' }] }
+      }
+
+      if (dir === '/local/.hermes/plugins/my-feature') {
+        return {
+          entries: [{ isDirectory: false, name: 'plugin.yaml', path: '/local/.hermes/plugins/my-feature/plugin.yaml' }]
+        }
+      }
+
+      return { entries: [] }
+    })
 
     await discoverRuntimePlugins()
 
-    expect(readFileText).toHaveBeenCalledWith('/local/.hermes/plugins/my-feature/desktop/plugin.js')
-    // The Python half's files must never be probed as a desktop entry.
-    expect(readFileText).not.toHaveBeenCalledWith('/local/.hermes/plugins/my-feature/plugin.js')
+    expect(readDir).toHaveBeenCalledWith('/local/.hermes/plugins/my-feature')
+    expect(readDir).not.toHaveBeenCalledWith('/local/.hermes/plugins/my-feature/desktop')
+    expect(readFileText).not.toHaveBeenCalled()
   })
 
   it('still scans the standalone root when agentPluginsRoot is absent (older shell)', async () => {
@@ -104,11 +114,35 @@ describe('scanDiskPlugins (#66899)', () => {
   it('loads a unified desktop half OPT-IN: inventoried but not activated by default', async () => {
     desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
     agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
-    readDir.mockImplementation(async dir =>
-      dir === '/local/.hermes/plugins'
-        ? { entries: [{ isDirectory: true, name: 'uni', path: '/local/.hermes/plugins/uni' }] }
-        : { entries: [] }
-    )
+    let desktopEntryPresent = true
+
+    readDir.mockImplementation(async dir => {
+      if (dir === '/local/.hermes/plugins') {
+        return { entries: [{ isDirectory: true, name: 'uni', path: '/local/.hermes/plugins/uni' }] }
+      }
+
+      if (dir === '/local/.hermes/plugins/uni') {
+        return {
+          entries: [{ isDirectory: true, name: 'desktop', path: '/local/.hermes/plugins/uni/desktop' }]
+        }
+      }
+
+      if (dir === '/local/.hermes/plugins/uni/desktop') {
+        return {
+          entries: desktopEntryPresent
+            ? [
+                {
+                  isDirectory: false,
+                  name: 'plugin.js',
+                  path: '/local/.hermes/plugins/uni/desktop/plugin.js'
+                }
+              ]
+            : []
+        }
+      }
+
+      return { entries: [] }
+    })
 
     const register = vi.fn()
 
@@ -152,6 +186,14 @@ describe('scanDiskPlugins (#66899)', () => {
       await setPluginEnabled('uni', true)
       expect(register).toHaveBeenCalledTimes(1)
       expect($pluginRecords.get().uni.status).toBe('loaded')
+
+      // Removing only desktop/plugin.js (while the Python package folder
+      // remains) unloads the previous Desktop registration instead of leaving
+      // a live ghost behind.
+      desktopEntryPresent = false
+      await discoverRuntimePlugins()
+      expect($pluginRecords.get().uni).toBeUndefined()
+      expect(stopPreviewFileWatch).toHaveBeenCalledWith('w-uni')
     } finally {
       createObjectURL.mockRestore()
       revokeObjectURL.mockRestore()

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -233,8 +233,10 @@ interface DiskRoot {
   /** Root-level enable posture, forwarded to the loader (see LoadOptions). */
   defaultEnabled?: boolean
   dir: string
-  /** Resolve a scanned folder to its candidate plugin entry file. */
-  entry: (folderPath: string) => string
+  /** Path segments below each scanned package folder. Discovery walks
+   *  directory metadata to this file instead of throwing a content read for
+   *  every ordinary package that has no Desktop half. */
+  entrySegments: readonly string[]
 }
 
 /** Both scan roots, resolved fresh each pass (Electron-local, never the
@@ -251,7 +253,7 @@ async function diskRoots(): Promise<DiskRoot[]> {
   const standalone = await desktop.desktopPluginsRoot?.()
 
   if (standalone) {
-    roots.push({ dir: standalone, entry: folder => `${folder}/plugin.js` })
+    roots.push({ dir: standalone, entrySegments: ['plugin.js'] })
   }
 
   const unified = await desktop.agentPluginsRoot?.()
@@ -261,7 +263,7 @@ async function diskRoots(): Promise<DiskRoot[]> {
     // user allowlists the Python half (plugins.enabled), so the desktop half
     // matches that posture — inventoried in Settings → Plugins, off until
     // toggled. The standalone desktop-plugins door keeps its default-on trust.
-    roots.push({ defaultEnabled: false, dir: unified, entry: folder => `${folder}/desktop/plugin.js` })
+    roots.push({ defaultEnabled: false, dir: unified, entrySegments: ['desktop', 'plugin.js'] })
   }
 
   return roots
@@ -297,7 +299,7 @@ function dropOriginRecord(origin: string, except: DiskPlugin): void {
   dropPlugin(origin)
 }
 
-async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
+async function loadDiskPlugin(entry: DiskPlugin): Promise<boolean> {
   const desktop = window.hermesDesktop!
   const prevId = entry.id
 
@@ -324,9 +326,44 @@ async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
     if (id && id !== entry.origin) {
       dropOriginRecord(entry.origin, entry)
     }
+
+    return true
   } catch {
-    // File vanished mid-read — the next scan reconciles.
+    // File vanished mid-read. The caller uses false to reconcile/unload the
+    // registration instead of retaining a live ghost for a missing entry.
+    return false
   }
+}
+
+async function resolveDiskPluginEntry(
+  desktop: Window['hermesDesktop'],
+  folderPath: string,
+  segments: readonly string[]
+): Promise<string | null> {
+  let currentDir = folderPath
+
+  for (let index = 0; index < segments.length; index += 1) {
+    const { entries } = await desktop.readDir(currentDir)
+    const entry = entries.find(candidate => candidate.name === segments[index])
+
+    if (!entry) {
+      return null
+    }
+
+    const last = index === segments.length - 1
+
+    if (last) {
+      return entry.isDirectory ? null : entry.path
+    }
+
+    if (!entry.isDirectory) {
+      return null
+    }
+
+    currentDir = entry.path
+  }
+
+  return null
 }
 
 async function scanDiskPlugins(): Promise<void> {
@@ -359,17 +396,22 @@ async function scanDiskPlugins(): Promise<void> {
       }
 
       for (const dir of entries.filter(e => e.isDirectory)) {
-        const file = root.entry(dir.path)
+        let file: string | null
+
+        try {
+          file = await resolveDiskPluginEntry(desktop, dir.path, root.entrySegments)
+        } catch {
+          continue // Folder changed during the metadata walk; the next tick reconciles.
+        }
+
+        if (!file) {
+          continue // Ordinary agent package with no Desktop half — not an error.
+        }
+
         seen.add(file)
 
         if (disk.has(file)) {
           continue
-        }
-
-        try {
-          await desktop.readFileText(file)
-        } catch {
-          continue // No entry file (yet) — not a plugin folder for this root.
         }
 
         const record: DiskPlugin = {
@@ -381,7 +423,11 @@ async function scanDiskPlugins(): Promise<void> {
         }
 
         disk.set(file, record)
-        await loadDiskPlugin(record)
+
+        if (!(await loadDiskPlugin(record))) {
+          disk.delete(file)
+          continue
+        }
 
         try {
           record.watchId = (await desktop.watchPreviewFile(file)).id
@@ -445,7 +491,11 @@ export function watchRuntimePlugins(): void {
 
     for (const record of disk.values()) {
       if (record.watchId === id) {
-        void loadDiskPlugin(record)
+        void loadDiskPlugin(record).then(readable => {
+          if (!readable) {
+            void scanDiskPlugins()
+          }
+        })
 
         return
       }


### PR DESCRIPTION
## Summary

Closes a deterministic Desktop error loop reproduced on a real Windows packaged app: the runtime-plugin scanner used `readFileText()` as an existence probe for every package under `~/.hermes/plugins`, even though most agent plugins legitimately have no `desktop/plugin.js`. Electron logs every rejected IPC handler before the renderer's catch runs, so the five-second scan produced repeating bursts of `Text preview failed: file does not exist` and buried real errors.

Discovery now walks directory metadata to the declared entry segments (`plugin.js` or `desktop/plugin.js`) and reads content only after a real file is present. Missing Desktop halves are ordinary inventory state, not exceptions.

The same model also closes the other side of the class: if an entry file disappears while its package directory remains, the next reconciliation no longer marks the absent candidate as seen. The prior Desktop registration is unloaded, its inventory row is removed, and its file watch is retired instead of leaving a live ghost plugin.

## Field evidence

A real Windows Desktop log showed `hermes:readFileText` ENOENT handler failures repeating continuously after launch. The bursts correspond to the scanner's five-second pass across agent-plugin directories without Desktop halves.

## Exact head

[`57251a2cca490b982a92b5da7e8e408b77dc0506`](https://github.com/andrexibiza/hermes-agent/commit/57251a2cca490b982a92b5da7e8e408b77dc0506)

Built directly on upstream `main` at `76f6ba37064614a703ce2d19ade6bb5fbbf4fcf8`. Before publication the exact two-file change passed:

- focused `runtime-loader.test.ts` UI suite;
- ESLint on both changed files;
- all Desktop TypeScript projects through `npm run typecheck`;
- `git diff --check` and exact path-set validation.

## Negative contracts

- no new permissive filesystem IPC was added;
- missing roots/packages remain non-fatal;
- content reads still fail closed for a file that disappears after metadata discovery;
- runtime plugin evaluation, integrity checks, enable posture, and local-root authority are unchanged.
