### PR TITLE
fix(kanban): terminalize goal workers and make admission retry-safe

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -20739,21 +20739,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 # Main Entry Point
 # ============================================================================
 
-def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
+def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> dict:
     """Drive a kanban goal_mode worker through the Ralph-style goal loop.
 
     Called from the quiet single-query path AFTER the worker's first turn,
     only when ``HERMES_KANBAN_GOAL_MODE`` is set (dispatcher-spawned
     goal_mode card). Wires the worker's ``run_conversation`` and the kanban
-    DB into ``goals.run_kanban_goal_loop``. All errors are swallowed by the
-    caller — a broken goal loop must never wedge a worker, the dispatcher's
-    claim TTL / crash detection is the backstop.
+    ``hermes_cli.goals.run_kanban_goal_loop``. Terminalization failures are
+    returned to the caller so a failed DB write cannot become a clean exit.
     """
     import os as _os
 
     task_id = (_os.environ.get("HERMES_KANBAN_TASK") or "").strip()
     if not task_id:
-        return
+        return {"outcome": "stopped", "reason": "no kanban task id"}
     worker_run_id = None
     raw_run_id = (_os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
     if raw_run_id:
@@ -20761,6 +20760,10 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             worker_run_id = int(raw_run_id)
         except ValueError:
             logger.warning("invalid HERMES_KANBAN_RUN_ID=%r", raw_run_id)
+    if worker_run_id is None:
+        # A goal worker without a run identity cannot safely read or mutate
+        # lifecycle state. Never fall back to task-wide terminalization.
+        raise RuntimeError("kanban worker run identity unavailable")
 
     from hermes_cli import kanban_db as _kb
     from hermes_cli.goals import run_kanban_goal_loop as _run_loop, DEFAULT_MAX_TURNS as _DEF_TURNS
@@ -20776,14 +20779,14 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
         except Exception:
             pass
     if task is None:
-        return
+        return {"outcome": "stopped", "reason": "task not found"}
 
     goal_parts = [task.title or ""]
     if task.body:
         goal_parts.append(task.body)
     goal_text = "\n\n".join(p for p in goal_parts if p).strip()
     if not goal_text:
-        return
+        return {"outcome": "stopped", "reason": "empty goal"}
 
     max_turns = task.goal_max_turns or _DEF_TURNS
 
@@ -20813,22 +20816,24 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             except Exception:
                 pass
 
-    def _block(reason: str) -> None:
+    def _block(reason: str) -> bool:
         c = _kb.connect()
         try:
-            _kb.block_task(
+            from agent.redact import redact_sensitive_text
+
+            return bool(_kb.block_task(
                 c,
                 task_id,
-                reason=reason,
+                reason=redact_sensitive_text(str(reason), force=True),
                 expected_run_id=worker_run_id,
-            )
+            ))
         finally:
             try:
                 c.close()
             except Exception:
                 pass
 
-    _run_loop(
+    return _run_loop(
         task_id=task_id,
         goal_text=goal_text,
         run_turn=_run_turn,
@@ -21373,11 +21378,39 @@ def main(
                         # out (→ sticky block). Gated on the env vars the
                         # dispatcher sets in `_default_spawn`; a no-op for every
                         # normal worker and every non-kanban `-q` run.
-                        if os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1":
+                        _goal_loop_error = None
+                        if (
+                            os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1"
+                            and not (
+                                isinstance(result, dict)
+                                and result.get("failed")
+                            )
+                        ):
                             try:
-                                _run_kanban_goal_loop_q(cli, response)
+                                _goal_result = _run_kanban_goal_loop_q(cli, response)
+                                if _goal_result.get("outcome") == "terminalization_failed":
+                                    _goal_loop_error = (
+                                        "kanban goal terminalization failed; "
+                                        "the task state was not durably recorded"
+                                    )
+                                elif (
+                                    _goal_result.get("outcome") == "stopped"
+                                    and str(_goal_result.get("reason", "")).startswith(
+                                        ("status check failed", "run_turn error")
+                                    )
+                                ):
+                                    _goal_loop_error = (
+                                        "kanban goal loop failed before terminalizing "
+                                        "the task"
+                                    )
                             except Exception as _goal_exc:
                                 logger.debug("kanban goal loop failed: %s", _goal_exc)
+                                _goal_loop_error = (
+                                    "kanban goal loop failed before terminalizing "
+                                    "the task"
+                                )
+                        if _goal_loop_error:
+                            print(f"Error: {_goal_loop_error}", file=sys.stderr)
 
                         # Session ID goes to stderr so piped stdout is clean.
                         print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
@@ -21407,6 +21440,8 @@ def main(
                                     _exit_code = _RL_CODE
                                 except Exception:
                                     _exit_code = 1
+                        if _goal_loop_error:
+                            _exit_code = 1
                         sys.exit(_exit_code)
 
                 # Exit with error code if credentials or agent init fails

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -2202,7 +2202,10 @@ def run_kanban_goal_loop(
     Returns a decision dict: ``{"outcome", "turns_used", "reason"}`` where
     outcome is one of ``"completed_by_worker"``, ``"review_requested_by_worker"``,
     ``"changes_requested_by_reviewer"``, ``"blocked_budget"``,
-    ``"blocked_by_worker"``, or ``"stopped"``.
+    ``"blocked_transport"``, ``"blocked_by_worker"``,
+    ``"terminalization_failed"``, or ``"stopped"``. A terminalization failure
+    is distinct from a successful block so callers can fail closed rather than
+    exit cleanly while the task remains running.
     """
 
     def _log(msg: str) -> None:
@@ -2220,6 +2223,22 @@ def run_kanban_goal_loop(
     # The first turn already consumed one unit of budget.
     turns_used = 1
     nudged_to_finalize = False
+    consecutive_transport_failures = 0
+
+    def _block_or_report_failure(reason: str) -> bool:
+        """Require the durable block callback to confirm success."""
+        try:
+            result = block_fn(reason)
+        except Exception as exc:
+            _log(
+                "kanban goal loop: terminal block failed "
+                f"({type(exc).__name__})"
+            )
+            return False
+        if result is not True:
+            _log("kanban goal loop: terminal block was not confirmed")
+            return False
+        return True
 
     while True:
         # Did the worker terminate the task itself this turn?
@@ -2256,20 +2275,45 @@ def run_kanban_goal_loop(
         verdict, reason, _parse_failed, _wait, _transport_failed = judge_goal(goal_text, last_response)
         if verdict == "wait":
             verdict = "continue"
+        if _transport_failed:
+            consecutive_transport_failures += 1
+        else:
+            consecutive_transport_failures = 0
         _log(f"kanban goal loop: turn {turns_used}/{max_turns} verdict={verdict} reason={_truncate(reason, 120)}")
+
+        if consecutive_transport_failures >= DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES:
+            transport_reason = (
+                "Goal-mode worker's judge transport failed "
+                f"{consecutive_transport_failures} times in a row; "
+                "check the auxiliary judge provider and credentials."
+            )
+            if not _block_or_report_failure(transport_reason):
+                return {
+                    "outcome": "terminalization_failed",
+                    "turns_used": turns_used,
+                    "reason": "terminal block was not durably recorded",
+                }
+            return {
+                "outcome": "blocked_transport",
+                "turns_used": turns_used,
+                "reason": transport_reason,
+            }
 
         if verdict == "done":
             if nudged_to_finalize:
                 # Already asked once to call kanban_complete and it still
                 # didn't — block for review rather than spin.
                 _log(f"kanban goal loop: task {task_id} judged done but worker won't finalize; blocking")
-                try:
-                    block_fn(
-                        f"Goal-mode worker's output looked complete but it never "
-                        f"called kanban_complete after a finalize nudge ({reason})."
-                    )
-                except Exception as exc:
-                    _log(f"kanban goal loop: block_fn failed ({exc})")
+                block_reason = (
+                    f"Goal-mode worker's output looked complete but it never "
+                    f"called kanban_complete after a finalize nudge ({reason})."
+                )
+                if not _block_or_report_failure(block_reason):
+                    return {
+                        "outcome": "terminalization_failed",
+                        "turns_used": turns_used,
+                        "reason": "terminal block was not durably recorded",
+                    }
                 return {"outcome": "blocked_budget", "turns_used": turns_used, "reason": "judged done, never finalized"}
             prompt = KANBAN_GOAL_FINALIZE_TEMPLATE.format(reason=_truncate(reason, 400))
             nudged_to_finalize = True
@@ -2279,14 +2323,17 @@ def run_kanban_goal_loop(
         # Budget check BEFORE spending another turn.
         if turns_used >= max_turns:
             _log(f"kanban goal loop: task {task_id} exhausted {turns_used}/{max_turns} turns; blocking")
-            try:
-                block_fn(
-                    f"Goal-mode worker exhausted its turn budget "
-                    f"({turns_used}/{max_turns}) without completing the task. "
-                    f"Last judge verdict: {_truncate(reason, 300)}"
-                )
-            except Exception as exc:
-                _log(f"kanban goal loop: block_fn failed ({exc})")
+            block_reason = (
+                f"Goal-mode worker exhausted its turn budget "
+                f"({turns_used}/{max_turns}) without completing the task. "
+                f"Last judge verdict: {_truncate(reason, 300)}"
+            )
+            if not _block_or_report_failure(block_reason):
+                return {
+                    "outcome": "terminalization_failed",
+                    "turns_used": turns_used,
+                    "reason": "terminal block was not durably recorded",
+                }
             return {"outcome": "blocked_budget", "turns_used": turns_used, "reason": "turn budget exhausted"}
 
         # Run another turn in the same session.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4330,6 +4330,7 @@ def _end_run(
     error: Optional[str] = None,
     metadata: Optional[dict] = None,
     status: Optional[str] = None,
+    expected_run_id: Optional[int] = None,
 ) -> Optional[int]:
     """Close the currently-active run for ``task_id`` and clear the pointer.
 
@@ -4347,7 +4348,9 @@ def _end_run(
     if not row or not row["current_run_id"]:
         return None
     run_id = int(row["current_run_id"])
-    conn.execute(
+    if expected_run_id is not None and run_id != int(expected_run_id):
+        return None
+    cur = conn.execute(
         """
         UPDATE task_runs
            SET status        = ?,
@@ -4360,6 +4363,7 @@ def _end_run(
                claim_expires = NULL,
                worker_pid    = NULL
          WHERE id = ?
+           AND task_id = ?
            AND ended_at IS NULL
         """,
         (
@@ -4370,11 +4374,18 @@ def _end_run(
             json.dumps(metadata, ensure_ascii=False) if metadata else None,
             now,
             run_id,
+            task_id,
         ),
     )
-    conn.execute(
-        "UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,),
+    if cur.rowcount != 1:
+        raise sqlite3.IntegrityError("active run could not be closed exactly once")
+    pointer = conn.execute(
+        "UPDATE tasks SET current_run_id = NULL "
+        "WHERE id = ? AND current_run_id = ?",
+        (task_id, run_id),
     )
+    if pointer.rowcount != 1:
+        raise sqlite3.IntegrityError("active run pointer changed during terminalization")
     return run_id
 
 
@@ -5493,7 +5504,10 @@ def complete_task(
             outcome="completed", status="done",
             summary=summary if summary is not None else result,
             metadata=metadata,
+            expected_run_id=expected_run_id,
         )
+        if expected_run_id is not None and run_id != int(expected_run_id):
+            raise sqlite3.IntegrityError("expected run was not terminalized")
         # If complete_task was called on a never-claimed task (ready or
         # blocked → done with no run in flight), synthesize a
         # zero-duration run so the handoff fields are persisted in
@@ -6328,7 +6342,10 @@ def block_task(
                 conn, task_id,
                 outcome="blocked", status="blocked",
                 summary=reason,
+                expected_run_id=expected_run_id,
             )
+            if expected_run_id is not None and run_id != int(expected_run_id):
+                raise sqlite3.IntegrityError("expected run was not terminalized")
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
                     conn, task_id, outcome="blocked", summary=reason,
@@ -6386,7 +6403,10 @@ def block_task(
                 conn, task_id,
                 outcome="blocked", status="blocked",
                 summary=reason,
+                expected_run_id=expected_run_id,
             )
+            if expected_run_id is not None and run_id != int(expected_run_id):
+                raise sqlite3.IntegrityError("expected run was not terminalized")
             if run_id is None and reason:
                 run_id = _synthesize_ended_run(
                     conn, task_id, outcome="blocked", summary=reason,
@@ -6440,7 +6460,10 @@ def block_task(
                 conn, task_id,
                 outcome="blocked", status="blocked",
                 summary=reason,
+                expected_run_id=expected_run_id,
             )
+            if expected_run_id is not None and run_id != int(expected_run_id):
+                raise sqlite3.IntegrityError("expected run was not terminalized")
             # Synthesize a run when blocking a never-claimed task so the
             # reason is preserved in attempt history.
             if run_id is None and reason:
@@ -6624,7 +6647,10 @@ def request_review(
             status="review",
             summary=summary,
             metadata=metadata,
+            expected_run_id=expected_run_id,
         )
+        if expected_run_id is not None and run_id != int(expected_run_id):
+            raise sqlite3.IntegrityError("expected run was not terminalized")
         if run_id is None and (summary or metadata):
             run_id = _synthesize_ended_run(
                 conn,
@@ -6752,7 +6778,10 @@ def request_changes(
             outcome="changes_requested",
             status=new_status,
             summary=reason,
+            expected_run_id=expected_run_id,
         )
+        if expected_run_id is not None and run_id != int(expected_run_id):
+            raise sqlite3.IntegrityError("expected run was not terminalized")
         _append_event(
             conn,
             task_id,
@@ -7946,7 +7975,10 @@ def schedule_task(
             conn, task_id,
             outcome="scheduled", status="scheduled",
             summary=reason,
+            expected_run_id=expected_run_id,
         )
+        if expected_run_id is not None and run_id != int(expected_run_id):
+            raise sqlite3.IntegrityError("expected run was not terminalized")
         if run_id is None and reason:
             run_id = _synthesize_ended_run(
                 conn, task_id,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -342,6 +342,7 @@ def _fire_dispatch_tick_hook(
             result.auto_assigned_default,
             result.respawn_guarded,
             result.skipped_per_profile_capped,
+            result.skipped_resource_policy,
             result.skipped_unassigned,
             result.skipped_nonspawnable,
         )):
@@ -8045,6 +8046,126 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
 )
 
 
+def _resource_policy_path() -> Optional[Path]:
+    """Resolve an explicitly configured admission policy.
+
+    Admission is opt-in for backward compatibility. Once configured, a
+    missing or invalid file fails closed; installations that never enabled
+    this extension keep the historical dispatcher behaviour.
+    """
+    override = os.environ.get("HERMES_KANBAN_RESOURCE_POLICY", "").strip()
+    if override:
+        return Path(override).expanduser()
+    try:
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly() or {}
+        kanban_cfg = cfg.get("kanban") or {}
+        configured = kanban_cfg.get("resource_policy_file") or kanban_cfg.get("resource_policy")
+        if configured:
+            return Path(str(configured)).expanduser()
+    except Exception:
+        pass
+    return None
+
+
+def _resource_policy_workspace(task: "Task", board: Optional[str]) -> Optional[str]:
+    """Compute a non-mutating prospective workspace for pre-claim admission."""
+    if task.workspace_path:
+        return str(Path(task.workspace_path).expanduser().resolve(strict=False))
+    kind = task.workspace_kind or "scratch"
+    if kind == "scratch":
+        return str((workspaces_root(board=board) / task.id).resolve(strict=False))
+    if kind == "worktree":
+        try:
+            metadata = read_board_metadata(board or get_current_board())
+            default_workdir = str(metadata.get("default_workdir") or "").strip()
+            if default_workdir:
+                repo = _git_toplevel(Path(default_workdir).expanduser())
+                if repo:
+                    return str((repo / ".worktrees" / task.id).resolve(strict=False))
+        except Exception:
+            pass
+    return None
+
+
+def _resource_policy_task_candidate(row: Mapping[str, Any], policy: Mapping[str, Any], board: str) -> dict[str, Any]:
+    from hermes_cli import resource_policy as _rp
+    workspace = row["workspace_path"]
+    return _rp.candidate(
+        task_id=str(row["id"]), assignee=row["assignee"], board=board,
+        status=row["status"], workspace=workspace, git_origin=None, policy=policy,
+    )
+
+
+def _resource_policy_active_candidates(conn: sqlite3.Connection, board: Optional[str], policy: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Read running peers read-only from canonical board paths.
+
+    This deliberately does not call ``kanban_db_path`` for peers: workers pin
+    ``HERMES_KANBAN_DB`` to their own board, so peer discovery must bypass that
+    override and dedupe the current board by canonical resolved path.
+    """
+    current_slug = _normalize_board_slug(board) or get_current_board()
+    try:
+        current_path = str((kanban_home() / "kanban.db" if current_slug == DEFAULT_BOARD else board_dir(current_slug) / "kanban.db").resolve())
+    except Exception:
+        current_path = None
+    rows = conn.execute("SELECT id, assignee, status, workspace_path FROM tasks WHERE status = 'running'").fetchall()
+    active = [_resource_policy_task_candidate(row, policy, current_slug) for row in rows]
+    try:
+        boards = list_boards(include_archived=False)
+    except Exception:
+        boards = []
+    for meta in boards:
+        slug = _normalize_board_slug(meta.get("slug")) or DEFAULT_BOARD
+        path = (kanban_home() / "kanban.db" if slug == DEFAULT_BOARD else board_dir(slug) / "kanban.db")
+        try:
+            resolved = str(path.resolve())
+            if current_path and resolved == current_path or not path.exists():
+                continue
+            peer = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=1)
+            peer.row_factory = sqlite3.Row
+            try:
+                peer_rows = peer.execute("SELECT id, assignee, status, workspace_path FROM tasks WHERE status = 'running'").fetchall()
+                active.extend(_resource_policy_task_candidate(row, policy, slug) for row in peer_rows)
+            finally:
+                peer.close()
+        except Exception as exc:
+            _log.debug("kanban resource policy: peer board %s unavailable: %s", slug, exc)
+    return active
+
+
+def _resource_policy_admission(conn: sqlite3.Connection, task: "Task", board: Optional[str], active: list[dict[str, Any]], policy: Optional[Mapping[str, Any]], policy_error: Optional[str] = None) -> tuple[dict[str, Any], bool, str]:
+    """Evaluate a ready/review task before the claim CAS mutates its row."""
+    from hermes_cli import resource_policy as _rp
+    board_slug = _normalize_board_slug(board) or get_current_board()
+    if policy is None:
+        row = {
+            "task_id": task.id,
+            "status": task.status,
+            "resource_class": "material",
+        }
+        if policy_error:
+            return row, False, policy_error
+        return row, True, "resource policy not configured"
+    workspace = _resource_policy_workspace(task, board)
+    try:
+        row, allowed, reason = _rp.decision(
+            task_id=task.id, assignee=task.assignee, board=board_slug,
+            status=task.status, workspace=workspace, active=active,
+            policy=policy,
+        )
+        _log.info("kanban resource admission task=%s class=%s allowed=%s reason=%s", task.id, row.get("resource_class"), allowed, reason)
+        return row, allowed, reason
+    except Exception as exc:
+        return {"task_id": task.id, "resource_class": "material"}, False, f"resource policy evaluation failed: {str(exc).splitlines()[0][:180]}"
+
+
+def _record_resource_policy_denial(conn: sqlite3.Connection, task_id: str, resource_class: str, reason: str) -> None:
+    """Persist only a sanitized admission reason; never paths or policy data."""
+    with write_txn(conn):
+        _append_event(conn, task_id, "admission_denied", {"resource_class": str(resource_class)[:80], "reason": str(reason)[:240]})
+
+
 @dataclass
 class DispatchResult:
     """Outcome of a single ``dispatch`` pass."""
@@ -8081,6 +8202,8 @@ class DispatchResult:
     subsequent tick when the assignee has capacity. Separate bucket so
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
+    skipped_resource_policy: list[tuple[str, str]] = field(default_factory=list)
+    """Tasks deferred by the machine-readable resource/power admission policy."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -9784,8 +9907,18 @@ def count_running_tasks_other_boards(board: Optional[str] = None) -> int:
     Fails open per board: one broken/corrupt board must not brick dispatch
     on the healthy ones.
     """
+    # Workers inherit HERMES_KANBAN_DB as a defense-in-depth pin.  Resolve
+    # board slugs directly here so peer-board accounting cannot collapse onto
+    # the worker's pinned current DB.
+    current_slug = _normalize_board_slug(board) or get_current_board()
     try:
-        current_path = str(kanban_db_path(board=board).expanduser().resolve())
+        current_path = str(
+            (
+                kanban_home() / "kanban.db"
+                if current_slug == DEFAULT_BOARD
+                else board_dir(current_slug) / "kanban.db"
+            ).expanduser().resolve()
+        )
     except Exception:
         current_path = None
     try:
@@ -9796,13 +9929,19 @@ def count_running_tasks_other_boards(board: Optional[str] = None) -> int:
     for meta in boards:
         slug = meta.get("slug") or DEFAULT_BOARD
         try:
-            path = kanban_db_path(board=slug).expanduser()
+            path = (
+                kanban_home() / "kanban.db"
+                if slug == DEFAULT_BOARD
+                else board_dir(slug) / "kanban.db"
+            ).expanduser()
             resolved = str(path.resolve())
             if current_path is not None and resolved == current_path:
                 continue
             if not path.exists():
                 continue
-            other = connect(board=slug)
+            other = sqlite3.connect(
+                f"file:{path}?mode=ro", uri=True, timeout=1
+            )
             try:
                 total += count_running_tasks(other)
             finally:
@@ -9974,6 +10113,23 @@ def _dispatch_once_locked(
     reap_worker_zombies()
 
     result = DispatchResult()
+    _resource_policy = None
+    _resource_policy_error = None
+    _resource_active: list[dict[str, Any]] = []
+    _policy_path = _resource_policy_path()
+    if _policy_path is not None:
+        try:
+            from hermes_cli import resource_policy as _rp
+            _resource_policy = _rp.load_policy(_policy_path)
+        except Exception as exc:
+            _resource_policy_error = (
+                "resource policy unavailable; fail-closed "
+                f"({str(exc).splitlines()[0][:180]})"
+            )
+            _log.error(
+                "kanban resource policy load failed: %s",
+                _resource_policy_error,
+            )
     result.reclaimed = release_stale_claims(conn)
     if reconcile_orphans:
         # Orphaned-card reconciliation: requeue 'running' cards whose claim
@@ -10002,6 +10158,26 @@ def _dispatch_once_locked(
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+
+    # Lifecycle reconciliation above may turn a stale/crashed RUNNING task
+    # back into READY. Build admission state only afterwards; otherwise the
+    # retry can conflict with its own stale start-of-tick snapshot.
+    if _resource_policy is not None:
+        try:
+            _resource_active = _resource_policy_active_candidates(
+                conn, board, _resource_policy,
+            )
+        except Exception as exc:
+            _resource_policy = None
+            _resource_policy_error = (
+                "resource policy peer snapshot unavailable; fail-closed "
+                f"({str(exc).splitlines()[0][:180]})"
+            )
+            _resource_active = []
+            _log.error(
+                "kanban resource policy snapshot failed: %s",
+                _resource_policy_error,
+            )
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
@@ -10226,6 +10402,17 @@ def _dispatch_once_locked(
                     (row["id"], row_assignee, current)
                 )
                 continue
+        candidate_task = get_task(conn, row["id"])
+        if candidate_task is None:
+            continue
+        policy_row, policy_allowed, policy_reason = _resource_policy_admission(
+            conn, candidate_task, board, _resource_active, _resource_policy, _resource_policy_error,
+        )
+        if not policy_allowed:
+            result.skipped_resource_policy.append((row["id"], policy_reason))
+            if not dry_run:
+                _record_resource_policy_denial(conn, row["id"], policy_row.get("resource_class", "material"), policy_reason)
+            continue
         # Respawn guard: refuse to re-spawn when useful work is already
         # in-flight/recent, or when the last failure is a deterministic
         # blocker (quota / auth). The guard defers the spawn this tick so
@@ -10250,6 +10437,7 @@ def _dispatch_once_locked(
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
             spawned += 1
+            _resource_active.append(policy_row)
             # Increment per-profile counter even in dry_run so the cap
             # check sees the would-be spawn on subsequent iterations.
             # Without this, dry_run reports every task as spawnable and
@@ -10313,6 +10501,7 @@ def _dispatch_once_locked(
             # complete_task).
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
+            _resource_active.append(policy_row)
             # Track the new in-flight count for this profile so later
             # iterations in this same tick respect the per-profile cap
             # (#21582). Subsequent ticks re-query from the DB.
@@ -10368,6 +10557,17 @@ def _dispatch_once_locked(
                     (row["id"], row["assignee"], current)
                 )
                 continue
+        candidate_task = get_task(conn, row["id"])
+        if candidate_task is None:
+            continue
+        policy_row, policy_allowed, policy_reason = _resource_policy_admission(
+            conn, candidate_task, board, _resource_active, _resource_policy, _resource_policy_error,
+        )
+        if not policy_allowed:
+            result.skipped_resource_policy.append((row["id"], policy_reason))
+            if not dry_run:
+                _record_resource_policy_denial(conn, row["id"], policy_row.get("resource_class", "material"), policy_reason)
+            continue
         guard_reason = check_respawn_guard(conn, row["id"], lane="review")
         if guard_reason is not None:
             result.respawn_guarded.append((row["id"], guard_reason))
@@ -10381,6 +10581,7 @@ def _dispatch_once_locked(
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             spawned += 1
+            _resource_active.append(policy_row)
             if _per_profile_cap is not None:
                 _per_profile_running[row["assignee"]] = (
                     _per_profile_running.get(row["assignee"], 0) + 1
@@ -10436,6 +10637,7 @@ def _dispatch_once_locked(
             )
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
+            _resource_active.append(policy_row)
             if _per_profile_cap is not None and claimed.assignee:
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1

--- a/hermes_cli/resource_policy.py
+++ b/hermes_cli/resource_policy.py
@@ -1,0 +1,199 @@
+"""Fail-closed resource/power admission for Kanban dispatcher claims."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+_log = logging.getLogger(__name__)
+SCHEMA_VERSION = 1
+MATERIAL_CLASSES = frozenset({"material", "local_intensive", "dangerous", "production", "integrator", "release", "migration", "schema", "routing", "lockfile", "manifest", "control_plane_exclusive"})
+READONLY_CLASSES = frozenset({"readonly_qa"})
+CLASS_ALIASES = {"normal": "material", "read_only": "readonly_qa", "read-only": "readonly_qa", "control_plane": "control_plane_exclusive"}
+
+class ResourcePolicyError(ValueError):
+    """Policy cannot safely evaluate an admission decision."""
+
+
+def _safe_reason(value: Any) -> str:
+    text = " ".join(str(value).split())
+    return text[:240] or "unspecified policy error"
+
+
+def load_policy(path: str | os.PathLike[str]) -> dict[str, Any]:
+    try:
+        value = json.loads(Path(path).read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ResourcePolicyError(f"resource policy load failed: {_safe_reason(exc)}") from exc
+    if not isinstance(value, dict):
+        raise ResourcePolicyError("resource policy must be an object")
+    schema = value.get("schema_version", value.get("version"))
+    if schema != SCHEMA_VERSION:
+        raise ResourcePolicyError("unsupported resource policy schema")
+    required = ("aggregate_material_lanes", "max_read_only_qa_lanes", "per_profile_material", "power")
+    if any(key not in value for key in required):
+        raise ResourcePolicyError("resource policy missing required fields")
+    for key in required[:3]:
+        if not isinstance(value[key], int) or value[key] < 0:
+            raise ResourcePolicyError(f"resource policy field {key} is invalid")
+    if not isinstance(value["power"], dict):
+        raise ResourcePolicyError("resource policy power section is invalid")
+    classes = value.get("resource_classes")
+    if not isinstance(classes, list) or "material" not in classes or "readonly_qa" not in classes:
+        raise ResourcePolicyError("resource policy resource_classes are invalid")
+    return value
+
+
+def _rule(policy: Mapping[str, Any], task_id: str, assignee: Optional[str], board: str) -> dict[str, Any]:
+    overrides = policy.get("task_overrides") or {}
+    profiles = policy.get("profile_defaults") or {}
+    boards = policy.get("board_defaults") or {}
+    raw = overrides.get(task_id)
+    if raw is None:
+        raw = profiles.get(assignee or "")
+    if raw is None:
+        raw = boards.get(board, boards.get("*"))
+    if raw is None:
+        raw = policy.get("defaults") or {"resource_class": "material"}
+    if isinstance(raw, str):
+        raw = {"resource_class": raw}
+    if not isinstance(raw, dict):
+        raise ResourcePolicyError("resource classification rule is invalid")
+    return dict(raw)
+
+
+def classify(policy: Mapping[str, Any], task_id: str, assignee: Optional[str], board: str) -> tuple[str, dict[str, Any]]:
+    rule = _rule(policy, task_id, assignee, board)
+    cls = CLASS_ALIASES.get(str(rule.get("resource_class", "material")).strip().lower(), str(rule.get("resource_class", "material")).strip().lower())
+    if cls not in MATERIAL_CLASSES | READONLY_CLASSES:
+        raise ResourcePolicyError("resource classification is invalid")
+    rule["resource_class"] = cls
+    rule["components"] = sorted({str(v).strip() for v in (rule.get("components") or []) if str(v).strip()})
+    rule["mutable_paths"] = sorted({str(v).strip() for v in (rule.get("mutable_paths") or []) if str(v).strip()})
+    rule["ports"] = sorted({str(v).strip() for v in (rule.get("ports") or []) if str(v).strip()})
+    rule["external_accounts"] = sorted({str(v).strip() for v in (rule.get("external_accounts") or []) if str(v).strip()})
+    rule["release_authority"] = str(rule.get("release_authority") or "").strip()
+    return cls, rule
+
+
+def normalize_workspace(path: Optional[str]) -> Optional[str]:
+    if not path:
+        return None
+    try:
+        p = Path(str(path)).expanduser()
+        if not p.is_absolute():
+            return None
+        return str(p.resolve(strict=False))
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def git_common_origin(path: Optional[str]) -> Optional[str]:
+    normalized = normalize_workspace(path)
+    if not normalized:
+        return None
+    probe = Path(normalized)
+    if not probe.exists():
+        probe = probe.parent
+    try:
+        result = subprocess.run(["git", "-C", str(probe), "rev-parse", "--path-format=absolute", "--git-common-dir"], capture_output=True, text=True, timeout=3, check=False)
+        if result.returncode != 0:
+            return None
+        common = Path((result.stdout or "").strip())
+        if not common.is_absolute():
+            common = (probe / common)
+        return str(common.resolve(strict=False))
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+
+
+def candidate(*, task_id: str, assignee: Optional[str], board: str, status: str, workspace: Optional[str], git_origin: Optional[str], policy: Mapping[str, Any]) -> dict[str, Any]:
+    cls, rule = classify(policy, task_id, assignee, board)
+    return {"task_id": task_id, "profile": assignee, "board": board, "status": status, "workspace": normalize_workspace(workspace), "git_origin": git_origin or git_common_origin(workspace), "resource_class": cls, "components": rule["components"], "mutable_paths": rule["mutable_paths"], "ports": rule["ports"], "external_accounts": rule["external_accounts"], "release_authority": rule["release_authority"]}
+
+
+def _power_state(policy: Mapping[str, Any], now: Optional[float] = None) -> tuple[str, str]:
+    power = policy["power"]
+    path = Path(str(power.get("state_path", ""))).expanduser()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        state = str(raw.get("state", "")).strip()
+        event = raw.get("last_event") or {}
+        telemetry = event.get("telemetry") or {}
+        timestamp = max(float(raw.get("updated_at", 0) or 0), float(event.get("timestamp", 0) or 0), float(telemetry.get("timestamp", 0) or 0))
+        max_age = float(power.get("max_age_seconds", 300))
+        age = (time.time() if now is None else float(now)) - timestamp
+        if not state or age < 0 or age > max_age:
+            return "STALE", "power telemetry stale or missing"
+        if state in set(power.get("normal_states") or []):
+            return state, "AC_OK"
+        if state in set(power.get("ac_loss_states") or []):
+            return state, "fresh AC-loss state"
+        return "UNKNOWN", "unknown power state"
+    except Exception as exc:
+        return "UNKNOWN", f"power state unavailable: {_safe_reason(exc)}"
+
+
+def _overlap(left: Mapping[str, Any], right: Mapping[str, Any]) -> Optional[str]:
+    for key, label in (("mutable_paths", "mutable path"), ("ports", "port"), ("external_accounts", "external account")):
+        if set(left.get(key) or []).intersection(right.get(key) or []):
+            return f"{label} overlap"
+    if left.get("release_authority") and left.get("release_authority") == right.get("release_authority"):
+        return "release authority overlap"
+    if left.get("workspace") and left.get("workspace") == right.get("workspace"):
+        return "workspace overlap"
+    if left.get("git_origin") and left.get("git_origin") == right.get("git_origin"):
+        if left.get("components") and right.get("components") and set(left["components"]).isdisjoint(right["components"]):
+            return None
+        return "git common origin overlap"
+    if set(left.get("components") or []).intersection(right.get("components") or []):
+        return "declared component overlap"
+    return None
+
+
+def admit(candidate_row: Mapping[str, Any], active: list[Mapping[str, Any]], policy: Mapping[str, Any], *, now: Optional[float] = None) -> tuple[bool, str]:
+    cls = str(candidate_row.get("resource_class", "material"))
+    if candidate_row.get("status") == "triage":
+        return False, "triage is not dispatchable; no portfolio admission effect"
+    if cls in MATERIAL_CLASSES and not candidate_row.get("workspace"):
+        return False, "material workspace unresolved"
+    power_state, power_reason = _power_state(policy, now=now)
+    power = policy["power"]
+    if power_state in set(power.get("ac_loss_states") or []) and cls in set(power.get("ac_loss_denies") or []):
+        return False, "fresh AC-loss denies classified intensive/dangerous work"
+    if power_state in {"UNKNOWN", "STALE"} and cls in {"local_intensive", "dangerous"}:
+        return False, f"{power_reason}; intensive/dangerous admission is fail-closed"
+    # A tick can reconcile a crashed task and immediately retry it. Ignore a
+    # stale row for the same task id defensively so it cannot deny itself.
+    live = [
+        row for row in active
+        if row.get("status") == "running"
+        and row.get("status") != "triage"
+        and row.get("task_id") != candidate_row.get("task_id")
+    ]
+    for row in live:
+        conflict = _overlap(candidate_row, row)
+        if conflict:
+            return False, conflict
+    if cls in set(policy.get("exclusive_resource_classes") or []) or cls == "control_plane_exclusive":
+        if any(str(row.get("resource_class")) in set(policy.get("single_flight_classes") or policy.get("exclusive_resource_classes") or []) or str(row.get("resource_class")) == "control_plane_exclusive" for row in live):
+            return False, "exclusive resource class is single-flight"
+    if cls in MATERIAL_CLASSES:
+        if sum(1 for row in live if row.get("resource_class") in MATERIAL_CLASSES) >= int(policy["aggregate_material_lanes"]):
+            return False, "aggregate material lane cap"
+        if sum(1 for row in live if row.get("resource_class") in MATERIAL_CLASSES and row.get("profile") == candidate_row.get("profile")) >= int(policy["per_profile_material"]):
+            return False, "same profile material cap"
+    else:
+        if sum(1 for row in live if row.get("resource_class") in READONLY_CLASSES) >= int(policy["max_read_only_qa_lanes"]):
+            return False, "read-only/QA lane cap"
+    return True, "admitted"
+
+
+def decision(*, task_id: str, assignee: Optional[str], board: str, status: str, workspace: Optional[str], active: list[Mapping[str, Any]], policy: Mapping[str, Any], git_origin: Optional[str] = None, now: Optional[float] = None) -> tuple[dict[str, Any], bool, str]:
+    row = candidate(task_id=task_id, assignee=assignee, board=board, status=status, workspace=workspace, git_origin=git_origin, policy=policy)
+    allowed, reason = admit(row, active, policy, now=now)
+    return row, allowed, reason

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -434,6 +434,90 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
         conn.close()
 
 
+def test_stale_run_cannot_complete_new_attempt(kanban_home, monkeypatch):
+    """A late completion cannot close a task's successor run."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="retry completion guarded", assignee="worker")
+        kb.claim_task(conn, tid)
+        run1 = kb.latest_run(conn, tid)
+        kb._set_worker_pid(conn, tid, 98766)
+        monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+        assert kb.detect_crashed_workers(conn) == [tid]
+
+        kb.claim_task(conn, tid)
+        run2 = kb.latest_run(conn, tid)
+        assert run2.id != run1.id
+        assert not kb.complete_task(
+            conn, tid, summary="late", expected_run_id=run1.id,
+        )
+        task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        assert task.current_run_id == run2.id
+        assert kb.get_run(conn, run2.id).ended_at is None
+    finally:
+        conn.close()
+
+
+def test_terminalization_is_exactly_once(kanban_home):
+    """A second completion is a no-op and cannot append another terminal run."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="complete once", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert kb.complete_task(
+            conn, tid, summary="finished", expected_run_id=run_id,
+        )
+        assert not kb.complete_task(
+            conn, tid, summary="duplicate", expected_run_id=run_id,
+        )
+        assert len(kb.list_runs(conn, tid)) == 1
+        assert [e for e in kb.list_events(conn, tid) if e.kind == "completed"]
+        assert not [
+            e for e in kb.list_events(conn, tid)
+            if e.kind == "completed"
+            and e.payload
+            and e.payload.get("summary") == "duplicate"
+        ]
+    finally:
+        conn.close()
+
+
+def test_terminalization_db_failure_rolls_back_and_does_not_report_success(kanban_home):
+    """A failed run-row write rolls back the task transition for reaping."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="db failure", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        conn.execute(
+            """
+            CREATE TRIGGER fail_task_run_close
+            BEFORE UPDATE OF status ON task_runs
+            BEGIN
+                SELECT RAISE(ABORT, 'synthetic run close failure');
+            END
+            """
+        )
+        conn.commit()
+        with pytest.raises(Exception, match="synthetic run close failure"):
+            kb.complete_task(
+                conn,
+                tid,
+                summary="must not succeed",
+                expected_run_id=run_id,
+            )
+        task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        assert task.current_run_id == run_id
+        assert kb.get_run(conn, run_id).ended_at is None
+    finally:
+        conn.close()
+
+
 
 
 

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -205,3 +205,50 @@ class TestCLIJudgeGate:
         rc, complete_calls = self._run(monkeypatch, goal_mode=False)
         assert rc == 0
         assert complete_calls == ["t1"]
+
+
+def test_goal_loop_bounds_transport_failures_before_an_extra_turn(monkeypatch):
+    """Repeated judge transport errors stop at the dedicated failure bound."""
+    calls = []
+    blocked = []
+
+    def fake_judge(*_args, **_kwargs):
+        return "continue", "judge unavailable", False, None, True
+
+    monkeypatch.setattr(goals, "judge_goal", fake_judge)
+    res = goals.run_kanban_goal_loop(
+        task_id="t-transport",
+        goal_text="do the thing",
+        run_turn=lambda prompt: calls.append(prompt) or "still working",
+        task_status_fn=lambda: "running",
+        block_fn=lambda reason: blocked.append(reason) or True,
+        max_turns=50,
+        first_response="first turn",
+    )
+
+    assert res["outcome"] == "blocked_transport"
+    assert res["turns_used"] == goals.DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES
+    assert len(calls) == goals.DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES - 1
+    assert len(blocked) == 1
+    assert "transport" in blocked[0].lower()
+
+
+def test_goal_loop_surfaces_block_terminalization_failure(monkeypatch):
+    """A failed block write is not reported as a successful terminal outcome."""
+    monkeypatch.setattr(
+        goals,
+        "judge_goal",
+        lambda *_args, **_kwargs: ("continue", "not done", False, None, False),
+    )
+    res = goals.run_kanban_goal_loop(
+        task_id="t-block-failure",
+        goal_text="do the thing",
+        run_turn=lambda _prompt: "still working",
+        task_status_fn=lambda: "running",
+        block_fn=lambda _reason: False,
+        max_turns=1,
+        first_response="first turn",
+    )
+
+    assert res["outcome"] == "terminalization_failed"
+    assert res["turns_used"] == 1

--- a/tests/hermes_cli/test_kanban_resource_policy.py
+++ b/tests/hermes_cli/test_kanban_resource_policy.py
@@ -1,0 +1,153 @@
+"""Regression coverage for opt-in resource admission and crash retries."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import resource_policy as rp
+
+
+def _write_policy(tmp_path: Path) -> Path:
+    state = tmp_path / "power.json"
+    state.write_text(json.dumps({
+        "state": "AC_OK",
+        "updated_at": time.time(),
+    }))
+    policy = tmp_path / "resource-policy.json"
+    policy.write_text(json.dumps({
+        "schema_version": 1,
+        "aggregate_material_lanes": 3,
+        "max_read_only_qa_lanes": 1,
+        "per_profile_material": 1,
+        "defaults": {"resource_class": "material"},
+        "board_defaults": {"*": {"resource_class": "material"}},
+        "profile_defaults": {
+            "qa-worker": {"resource_class": "readonly_qa"},
+        },
+        "task_overrides": {},
+        "exclusive_resource_classes": ["production", "release"],
+        "single_flight_classes": ["production", "release"],
+        "power": {
+            "state_path": str(state),
+            "max_age_seconds": 300,
+            "normal_states": ["AC_OK"],
+            "ac_loss_states": ["DRAINING", "DATA_AT_REST"],
+            "ac_loss_denies": ["local_intensive", "dangerous"],
+        },
+        "resource_classes": [
+            "material", "readonly_qa", "local_intensive", "dangerous",
+            "production", "release",
+        ],
+    }))
+    return policy
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_resource_policy_ignores_stale_snapshot_of_same_task(
+    tmp_path: Path,
+) -> None:
+    policy = rp.load_policy(_write_policy(tmp_path))
+    workspace = str(tmp_path / "worker-space")
+    candidate = rp.candidate(
+        task_id="t_same",
+        assignee="infra-worker",
+        board="default",
+        status="ready",
+        workspace=workspace,
+        git_origin=None,
+        policy=policy,
+    )
+    stale = dict(candidate, status="running")
+    allowed, reason = rp.admit(candidate, [stale], policy)
+
+    assert allowed is True
+    assert reason == "admitted"
+
+
+def test_dispatch_requeues_dead_worker_without_self_admission_conflict(
+    kanban_home: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    policy_path = _write_policy(tmp_path)
+    monkeypatch.setenv("HERMES_KANBAN_RESOURCE_POLICY", str(policy_path))
+
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+
+    workspace = tmp_path / "isolated-worker"
+    spawns: list[str] = []
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="crash-retry",
+            assignee="infra-worker",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        first = kb.claim_task(conn, task_id)
+        assert first is not None
+        first_run = first.current_run_id
+        kb._set_worker_pid(conn, task_id, 987654)
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace, **_kw: (
+                spawns.append(task.id) or 4242
+            ),
+            max_spawn=1,
+            failure_limit=3,
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "running"
+        assert task.current_run_id != first_run
+        assert task_id in result.crashed
+        assert spawns == [task_id]
+        assert not result.skipped_resource_policy
+
+
+def test_unconfigured_resource_policy_keeps_legacy_dispatch(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.delenv("HERMES_KANBAN_RESOURCE_POLICY", raising=False)
+    monkeypatch.setattr(profiles, "profile_exists", lambda _name: True)
+    spawns: list[str] = []
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="legacy-no-policy",
+            assignee="worker",
+        )
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda task, _workspace, **_kw: (
+                spawns.append(task.id) or 1234
+            ),
+            max_spawn=1,
+        )
+
+    assert spawns == [task_id]
+    assert [row[0] for row in result.spawned] == [task_id]


### PR DESCRIPTION
## Summary
- fail closed goal-worker terminalization with exact run identity
- add opt-in resource/power admission with configured-policy fail-closed behavior
- rebuild admission snapshots after lifecycle reconciliation and ignore stale self rows
- cover crash-to-retry, legacy no-policy behavior, host caps, and terminal lifecycle

## Validation
- 140 relevant tests passed, 1 Windows-only skip
- resource-policy contract: 12/12
- normal imported dispatcher fixture: pass
- py_compile and diff check: pass

## Operational context
This fixes a production sequence where a dead worker was requeued and then denied against its own stale workspace snapshot. No direct-main push or production mutation is included.