### PR TITLE
fix(gateway): multiplex refusal must exit EX_CONFIG (78), not 1

### DIFF
--- a/contributors/emails/samtcam@gmail.com
+++ b/contributors/emails/samtcam@gmail.com
@@ -1,0 +1,1 @@
+samclams

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5619,7 +5619,18 @@ def _guard_named_profile_under_multiplexer(force: bool = False) -> None:
     print()
     print("  Pass --force to start a separate profile gateway anyway (not")
     print("  recommended while the multiplexer is running).")
-    sys.exit(1)
+    # EX_CONFIG, not a generic failure. This refusal is decided entirely by
+    # configuration (multiplex_profiles plus the allowlist), so it is permanent:
+    # no number of retries can change the answer. Exiting 1 made it look
+    # transient to a service manager -- and the systemd unit this module
+    # generates pairs Restart=always/RestartSec=5 with StartLimitIntervalSec=0,
+    # deliberately trading systemd's generic start-rate limiter for the specific
+    # RestartPreventExitStatus=GATEWAY_FATAL_CONFIG_EXIT_CODE backstop declared
+    # beside it. Returning 1 left that backstop unarmed with the limiter already
+    # off, so a correct refusal became an unbounded restart loop. 78 also reaches
+    # the s6 finish script's 125 "permanent failure" translation (see #51228),
+    # the same path the other fatal-config exits take.
+    sys.exit(GATEWAY_FATAL_CONFIG_EXIT_CODE)
 
 
 def _guard_supervised_gateway_conflict(force: bool = False) -> None:

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -2,6 +2,7 @@
 import pytest
 
 from gateway.config import GatewayConfig
+from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
 
 
 class TestServedProfilesStatus:
@@ -82,8 +83,9 @@ class TestNamedProfileMultiplexerGuard:
 
         from hermes_cli import gateway as gw
 
-        with pytest.raises(SystemExit, match="1"):
+        with pytest.raises(SystemExit) as excinfo:
             gw._guard_named_profile_under_multiplexer(force=False)
+        assert excinfo.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
     def test_served_profile_is_still_guarded(self, monkeypatch, tmp_path):
         self._fake_running_default_gateway(monkeypatch, tmp_path)
@@ -97,8 +99,9 @@ class TestNamedProfileMultiplexerGuard:
 
         from hermes_cli import gateway as gw
 
-        with pytest.raises(SystemExit, match="1"):
+        with pytest.raises(SystemExit) as excinfo:
             gw._guard_named_profile_under_multiplexer(force=False)
+        assert excinfo.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
     @pytest.mark.parametrize(
         "allowlist_yaml",


### PR DESCRIPTION
## Summary

The multiplex-profile refusal guard exits `GATEWAY_FATAL_CONFIG_EXIT_CODE` (78/EX_CONFIG) instead of `1`, so systemd's `RestartPreventExitStatus=78` backstop actually fires and stops the unit instead of restarting every 5s forever.

## Changes

- `hermes_cli/gateway.py` — `_guard_named_profile_under_multiplexer()`: `sys.exit(1)` → `sys.exit(GATEWAY_FATAL_CONFIG_EXIT_CODE)` with a WHY comment explaining the systemd contract.
- `tests/gateway/test_multiplex_lifecycle.py` — both guard assertions: `pytest.raises(SystemExit, match="1")` (regex, matched 1/21/100/111) → `excinfo.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE` (exact integer).
- `contributors/emails/samtcam@gmail.com` — AUTHOR_MAP entry for contributor attribution.

## Validation

| | Before | After |
|---|---|---|
| Exit code | `1` (looks transient) | `78` (EX_CONFIG, permanent) |
| Test assertion | `match="1"` (regex, pins nothing) | `== GATEWAY_FATAL_CONFIG_EXIT_CODE` (exact) |
| Mutation check | N/A | Reverting to `sys.exit(1)` → 2 tests FAIL; restoring → 9/9 pass |
| ruff | clean | clean |

Salvage of #91806 by @samclams — cherry-picked with authorship preserved. Closes #91806.
