### PR TITLE
fix(agent): stop disk exhaustion from triggering provider retries

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6024,27 +6024,22 @@ def run_conversation(
                     # exists; otherwise "trying fallback..." is a lie and the
                     # session looks like it's recovering when it's about to
                     # abort silently (#35314, #17446).
-                    if (
-                        classified.reason != FailoverReason.disk_space
-                        and agent._has_pending_fallback()
-                    ):
-                        if classified.reason == FailoverReason.content_policy_blocked:
-                            agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
-                        elif classified.reason == FailoverReason.ssl_cert_verification:
-                            agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
-                        else:
-                            agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if (
-                        classified.reason != FailoverReason.disk_space
-                        and agent._try_activate_fallback()
-                    ):
-                        active_system_prompt = _sync_failover_system_message(
-                            agent, api_messages, active_system_prompt)
-                        retry_count = 0
-                        compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
-                        _retry.restart_with_rebuilt_messages = True
-                        break
+                    if classified.reason != FailoverReason.disk_space:
+                        if agent._has_pending_fallback():
+                            if classified.reason == FailoverReason.content_policy_blocked:
+                                agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
+                            elif classified.reason == FailoverReason.ssl_cert_verification:
+                                agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
+                            else:
+                                agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                        if agent._try_activate_fallback():
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt)
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            _retry.restart_with_rebuilt_messages = True
+                            break
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
                             api_kwargs, reason="non_retryable_client_error", error=api_error,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6024,14 +6024,20 @@ def run_conversation(
                     # exists; otherwise "trying fallback..." is a lie and the
                     # session looks like it's recovering when it's about to
                     # abort silently (#35314, #17446).
-                    if agent._has_pending_fallback():
+                    if (
+                        classified.reason != FailoverReason.disk_space
+                        and agent._has_pending_fallback()
+                    ):
                         if classified.reason == FailoverReason.content_policy_blocked:
                             agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
                         elif classified.reason == FailoverReason.ssl_cert_verification:
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if (
+                        classified.reason != FailoverReason.disk_space
+                        and agent._try_activate_fallback()
+                    ):
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -6053,7 +6059,12 @@ def run_conversation(
                     # it verbatim (e.g. a cron failure notification dumped a
                     # ~60KB Cloudflare challenge page as 31 Discord messages).
                     _nonretryable_summary = agent._summarize_api_error(api_error)
-                    if classified.reason == FailoverReason.content_policy_blocked:
+                    if classified.reason == FailoverReason.disk_space:
+                        agent._emit_status(
+                            f"❌ Local storage is full or its disk quota is exhausted: "
+                            f"{_nonretryable_summary}"
+                        )
+                    elif classified.reason == FailoverReason.content_policy_blocked:
                         agent._emit_status(
                             f"❌ Provider safety filter blocked this request: "
                             f"{_nonretryable_summary}"
@@ -6113,8 +6124,13 @@ def run_conversation(
                             agent._vprint(f"{agent.log_prefix}      • Does your account have access to {_model}?", force=True)
                             if base_url_host_matches(str(_base), "openrouter.ai"):
                                 agent._vprint(f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
-                    else:
+                    elif classified.reason != FailoverReason.disk_space:
                         agent._vprint(f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
+                    if classified.reason == FailoverReason.disk_space:
+                        agent._vprint(
+                            f"{agent.log_prefix}   💡 Free disk space or increase the disk quota on the filesystem used by Hermes, then retry.",
+                            force=True,
+                        )
                     # Content-policy blocks deserve their own actionable
                     # guidance — neither "fix your API key" nor "retry won't
                     # help" tells the user what to actually do. The provider
@@ -6180,7 +6196,11 @@ def run_conversation(
                     # Persisting the failed user message would make the
                     # session even larger, causing the same failure on the
                     # next attempt. (#1630)
-                    if status_code == 400 and (approx_tokens > 50000 or len(api_messages) > 80):
+                    if classified.reason == FailoverReason.disk_space:
+                        # Persistence is another local write and will reproduce
+                        # the same failure until storage is available again.
+                        pass
+                    elif status_code == 400 and (approx_tokens > 50000 or len(api_messages) > 80):
                         agent._vprint(
                             f"{agent.log_prefix}⚠️  Skipping session persistence "
                             f"for large failed session to prevent growth loop.",
@@ -6215,6 +6235,21 @@ def run_conversation(
                             base_url=_base,
                             model=_model,
                         )
+                    if classified.reason == FailoverReason.disk_space:
+                        _disk_space_response = (
+                            "Local storage is full or its disk quota is exhausted. "
+                            "Free disk space or increase the disk quota on the "
+                            "filesystem used by Hermes, then retry."
+                        )
+                        return {
+                            "final_response": _disk_space_response,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "error": _nonretryable_summary,
+                            "failure_reason": FailoverReason.disk_space.value,
+                        }
                     return {
                         "final_response": _nonretryable_summary,
                         "messages": messages,

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -712,9 +712,7 @@ def _is_disk_space_error(error: Exception) -> bool:
             current_msg = str(current).lower()
             if any(pattern in current_msg for pattern in _DISK_SPACE_PATTERNS):
                 return True
-        current = getattr(current, "__cause__", None) or getattr(
-            current, "__context__", None
-        )
+        current = getattr(current, "__cause__", None)
     return False
 
 # Server disconnect patterns (no status code, but transport-level).

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -700,21 +700,22 @@ _DISK_SPACE_PATTERNS = (
 )
 
 
-def _is_disk_space_error(error: Exception, error_msg: str) -> bool:
+def _is_disk_space_error(error: Exception) -> bool:
     """Detect local filesystem exhaustion before generic message matching."""
     current: Optional[BaseException] = error
     seen = set()
     while current is not None and id(current) not in seen:
         seen.add(id(current))
-        if (
-            isinstance(current, OSError)
-            and getattr(current, "errno", None) in _DISK_SPACE_ERRNOS
-        ):
-            return True
+        if isinstance(current, OSError):
+            if getattr(current, "errno", None) in _DISK_SPACE_ERRNOS:
+                return True
+            current_msg = str(current).lower()
+            if any(pattern in current_msg for pattern in _DISK_SPACE_PATTERNS):
+                return True
         current = getattr(current, "__cause__", None) or getattr(
             current, "__context__", None
         )
-    return any(pattern in error_msg for pattern in _DISK_SPACE_PATTERNS)
+    return False
 
 # Server disconnect patterns (no status code, but transport-level).
 # These are the "ambiguous" patterns — a plain connection close could be
@@ -927,7 +928,7 @@ def classify_api_error(
     # storage. It must beat billing's generic "quota" patterns and OSError's
     # generic transport classification: credential rotation, provider
     # fallback, compression, and retry all repeat the same failed local write.
-    if _is_disk_space_error(error, error_msg):
+    if _is_disk_space_error(error):
         return _result(FailoverReason.disk_space, retryable=False)
 
     # ── 1. Provider-specific patterns (highest priority) ────────────

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -12,6 +12,7 @@ that the main retry loop in run_agent.py consults for every API failure.
 from __future__ import annotations
 
 import enum
+import errno
 import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
@@ -47,6 +48,7 @@ class FailoverReason(enum.Enum):
 
     # Transport
     timeout = "timeout"                  # Connection/read timeout — rebuild client + retry
+    disk_space = "disk_space"            # Local filesystem/quota exhausted — abort
     # TLS certificate verification failure — deterministic for the host
     # (TLS-inspecting proxy, missing/expired CA bundle, self-signed cert).
     # Retrying reproduces the identical handshake failure, so fail fast
@@ -686,6 +688,34 @@ _TRANSPORT_ERROR_TYPES = frozenset({
     "APITimeoutError",
 })
 
+_DISK_SPACE_ERRNOS = frozenset({
+    errno.ENOSPC,
+    getattr(errno, "EDQUOT", None),
+}) - {None}
+
+_DISK_SPACE_PATTERNS = (
+    "no space left on device",
+    "disk quota exceeded",
+    "not enough space on the disk",
+)
+
+
+def _is_disk_space_error(error: Exception, error_msg: str) -> bool:
+    """Detect local filesystem exhaustion before generic message matching."""
+    current: Optional[BaseException] = error
+    seen = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if (
+            isinstance(current, OSError)
+            and getattr(current, "errno", None) in _DISK_SPACE_ERRNOS
+        ):
+            return True
+        current = getattr(current, "__cause__", None) or getattr(
+            current, "__context__", None
+        )
+    return any(pattern in error_msg for pattern in _DISK_SPACE_PATTERNS)
+
 # Server disconnect patterns (no status code, but transport-level).
 # These are the "ambiguous" patterns — a plain connection close could be
 # transient transport hiccup OR server-side context overflow rejection
@@ -892,6 +922,13 @@ def classify_api_error(
             reason.value, provider, status_code,
         )
         return _result(reason, **plugin_classification)
+
+    # Local disk/quota exhaustion is deterministic until the operator frees
+    # storage. It must beat billing's generic "quota" patterns and OSError's
+    # generic transport classification: credential rotation, provider
+    # fallback, compression, and retry all repeat the same failed local write.
+    if _is_disk_space_error(error, error_msg):
+        return _result(FailoverReason.disk_space, retryable=False)
 
     # ── 1. Provider-specific patterns (highest priority) ────────────
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -640,11 +640,23 @@ class TestClassifyApiError:
         assert result.should_fallback is False
         assert result.should_compress is False
 
-    def test_disk_quota_message_beats_billing_patterns(self):
-        result = classify_api_error(Exception("Disk quota exceeded"))
+    def test_disk_quota_oserror_message_beats_billing_patterns(self):
+        result = classify_api_error(OSError("Disk quota exceeded"))
 
         assert result.reason == FailoverReason.disk_space
         assert result.should_rotate_credential is False
+
+    def test_remote_disk_quota_message_remains_provider_error(self):
+        error = MockAPIError(
+            "Disk quota exceeded",
+            status_code=507,
+            body={"error": {"message": "Disk quota exceeded"}},
+        )
+
+        result = classify_api_error(error)
+
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
 
     def test_wrapped_disk_exhaustion_preserves_errno_classification(self):
         inner = OSError(errno.ENOSPC, "No space left on device")

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1,5 +1,7 @@
 """Tests for agent.error_classifier — structured API error classification."""
 
+import errno
+
 import pytest
 from agent.error_classifier import (
     ClassifiedError,
@@ -55,7 +57,7 @@ class TestFailoverReason:
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
             "upstream_rate_limit",
-            "overloaded", "server_error", "timeout",
+            "overloaded", "server_error", "timeout", "disk_space",
             "ssl_cert_verification",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
@@ -621,6 +623,38 @@ class TestClassifyApiError:
 
 
     # ── Transport errors ──
+
+    @pytest.mark.parametrize(
+        "error_errno,message",
+        [
+            (errno.ENOSPC, "No space left on device"),
+            (getattr(errno, "EDQUOT", 122), "Disk quota exceeded"),
+        ],
+    )
+    def test_disk_exhaustion_is_non_retryable(self, error_errno, message):
+        result = classify_api_error(OSError(error_errno, message))
+
+        assert result.reason == FailoverReason.disk_space
+        assert result.retryable is False
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is False
+        assert result.should_compress is False
+
+    def test_disk_quota_message_beats_billing_patterns(self):
+        result = classify_api_error(Exception("Disk quota exceeded"))
+
+        assert result.reason == FailoverReason.disk_space
+        assert result.should_rotate_credential is False
+
+    def test_wrapped_disk_exhaustion_preserves_errno_classification(self):
+        inner = OSError(errno.ENOSPC, "No space left on device")
+        outer = RuntimeError("provider request failed")
+        outer.__cause__ = inner
+
+        result = classify_api_error(outer)
+
+        assert result.reason == FailoverReason.disk_space
+        assert result.retryable is False
 
     def test_read_timeout(self):
         e = ReadTimeout("Read timed out")

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -668,6 +668,22 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.disk_space
         assert result.retryable is False
 
+    def test_implicit_disk_context_does_not_override_provider_error(self):
+        inner = OSError(errno.ENOSPC, "No space left on device")
+        outer = MockAPIError("Internal server error", status_code=500)
+        outer.__context__ = inner
+
+        result = classify_api_error(outer)
+
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
+    def test_plain_runtime_disk_message_is_not_treated_as_local_storage(self):
+        result = classify_api_error(RuntimeError("No space left on device"))
+
+        assert result.reason == FailoverReason.unknown
+        assert result.retryable is True
+
     def test_read_timeout(self):
         e = ReadTimeout("Read timed out")
         result = classify_api_error(e)

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -6,6 +6,8 @@ Verifies that:
 - Preflight compression proactively compresses oversized sessions before API calls
 """
 
+import errno
+
 import pytest
 #pytestmark = pytest.mark.skip(reason="Hangs in non-interactive environments")
 
@@ -141,6 +143,27 @@ def test_current_user_turn_is_persisted_before_provider_call(agent):
         == "new message that must survive a crash"
     )
     assert isinstance(persisted_messages[-1]["timestamp"], float)
+
+
+def test_disk_full_aborts_without_retry_or_provider_fallback(agent):
+    agent.client.chat.completions.create.side_effect = OSError(
+        errno.ENOSPC, "No space left on device"
+    )
+    agent._fallback_chain = [{"provider": "anthropic", "model": "claude"}]
+
+    with (
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent, "_try_activate_fallback") as activate_fallback,
+    ):
+        result = agent.run_conversation("hello", conversation_history=[])
+
+    assert agent.client.chat.completions.create.call_count == 1
+    activate_fallback.assert_not_called()
+    assert result["failure_reason"] == "disk_space"
+    assert "local storage" in result["final_response"].lower()
+    assert "free disk space" in result["final_response"].lower()
 
 
 class TestHTTP413Compression:


### PR DESCRIPTION
## What does this PR do?

Disk-full and disk-quota `OSError` failures now abort immediately as local storage problems instead of being reported as provider timeouts or billing failures. This prevents repeated writes, credential rotation, and provider fallback when only freeing local storage can recover.

### Symptom

When the filesystem used by Hermes returns `ENOSPC` or `EDQUOT`, the agent retries the same operation. A quota-bearing message can also be classified as billing and rotate credentials.

### Impact

Operators receive misleading provider or credential diagnostics while Hermes repeats a deterministic local write failure. The affected scope is any provider call path that surfaces local filesystem exhaustion to the shared classifier.

### Bug Cause

**Trigger:** `agent/error_classifier.py:classify_api_error` receives an `OSError` caused by `ENOSPC` or `EDQUOT`.

**Causal chain:**
1. A Hermes write fails because the local filesystem is full or its user quota is exhausted.
2. Generic message matching can interpret `quota` as billing, while the catch-all `OSError` transport branch otherwise classifies the failure as a timeout.
3. The conversation loop rotates credentials, retries, or activates a fallback provider even though every route uses the same exhausted local filesystem.

**Why it is wrong:** Provider recovery cannot free local disk space, so each recovery action repeats the same deterministic failure and hides the actionable cause.

**Working sibling / contrast:** Real network `OSError` subclasses and timeout exceptions remain in the retryable transport bucket; only filesystem exhaustion errno values and their canonical messages take the terminal path.

**Ruled out:** This is not provider quota exhaustion. Errno-based reproduction returns `ENOSPC` or `EDQUOT` before any provider-specific status or billing response exists.

### Fix

Detect filesystem exhaustion from errno across wrapped exception chains, with narrow message fallbacks when wrappers lose errno. Classify it as a non-retryable `disk_space` reason before billing and transport patterns, skip provider fallback and session persistence, and return actionable local-storage guidance.

## Related Issue

Closes #91815

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` - add errno-first disk exhaustion classification with wrapped-error and message fallback handling.
- `agent/conversation_loop.py` - abort without provider fallback or another persistence write and surface local-storage recovery guidance.
- `tests/agent/test_error_classifier.py` - cover `ENOSPC`, `EDQUOT`, wrapped errors, and quota-pattern precedence.
- `tests/run_agent/test_413_compression.py` - verify one API attempt, no fallback activation, and the terminal result contract.

## How to Test

1. Raise `OSError(errno.ENOSPC, "No space left on device")` from the provider call path.
2. Verify the agent performs one API attempt, does not activate fallback, and returns `failure_reason: disk_space` with free-space guidance.
3. Run the automated regression suites:

```bash
scripts/run_tests.sh tests/agent/test_error_classifier.py -q
scripts/run_tests.sh tests/run_agent/test_413_compression.py -q
```

Locally verified: 111 classifier tests and 27 conversation-loop tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant test files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing configuration or API changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: errno detection covers POSIX, and the canonical Windows disk-full message fallback is included
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed

## Screenshots / Logs

N/A - automated tests exercise the classifier and terminal conversation result.
