### PR TITLE
feat(image_gen): add OpenRouter Image API provider (dedicated /api/v1/images endpoint)

### DIFF
--- a/agent/pet/generate/imagegen.py
+++ b/agent/pet/generate/imagegen.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 # (Nous Portal → OpenAI → OpenRouter → …). OpenRouter/Nous run a quality-first
 # model chain and may fall back depending on account access and endpoint behavior,
 # so fidelity can vary by configured backend + model availability.
-_REF_CAPABLE = ("nous", "openai", "openai-codex", "openrouter", "krea")
+_REF_CAPABLE = ("nous", "openai", "openai-codex", "openrouter", "openrouter-image-api", "krea")
 
 # Friendly display label per reference-capable provider, surfaced in the desktop
 # pet-gen picker.

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -1,22 +1,34 @@
-"""OpenRouter-compatible image generation backend (OpenRouter + Nous Portal).
+"""OpenRouter-compatible image generation backends (OpenRouter + Nous Portal).
 
-Both OpenRouter and the Nous Portal inference endpoint speak the same
-OpenAI-style ``/chat/completions`` image-generation protocol: send
-``modalities: ["image", "text"]`` with an image-output model (e.g.
-``google/gemini-3-pro-image``), pass reference images as ``image_url``
-content parts for grounding, and read the generated images back from
-``choices[0].message.images[].image_url.url`` (a ``data:image/...;base64`` URI).
+Two distinct OpenRouter API surfaces are supported by separate provider classes
+in this module:
 
-Nous Portal proxies OpenRouter, so one implementation services both — we only
-swap the resolved ``(base_url, api_key)``. Credentials are resolved through the
-agent's existing :func:`~hermes_cli.runtime_provider.resolve_runtime_provider`,
-which already understands OpenRouter's key pool and the Nous OAuth device-code
-token, so this plugin never reinvents auth.
+1. **Chat-completions image output** (``OpenRouterCompatImageProvider``)
+   — sends ``modalities: ["image", "text"]`` to ``/chat/completions`` with an
+   image-output model (e.g. ``openai/gpt-5.4-image-2``, ``google/gemini-3-pro-image``).
+   Generated images arrive as ``choices[0].message.images[].image_url.url``
+   (typically a base64 data URI). Reference images are passed as ``image_url``
+   content parts for grounding.
 
-Reference grounding is the reason pet sprite generation cares about this
-backend: each animation row must stay the same character as the chosen base
-frame, which only works on models that accept image input. Gemini Flash Image
-("nano-banana") does, so both providers advertise image-to-image support.
+2. **Dedicated Image API** (``OpenRouterImageAPIProvider``)
+   — sends text-to-image requests to ``POST /api/v1/images``, the OpenRouter
+   endpoint designed for models like ``x-ai/grok-imagine-image-2.0`` that
+   expose a pure image-generation API. Supports ``aspect_ratio``, ``resolution``,
+   ``quality``, and ``input_references`` (image-to-image, up to 3 refs).
+   Generated images arrive as ``data[i].b64_json`` in the JSON response body.
+
+Nous Portal proxies OpenRouter, so the chat-completions implementation services
+both — we only swap the resolved ``(base_url, api_key)``. Credentials are
+resolved through the agent's existing
+:func:`~hermes_cli.runtime_provider.resolve_runtime_provider`, which already
+understands OpenRouter's key pool and the Nous OAuth device-code token, so this
+plugin never reinvents auth.
+
+Reference grounding is the reason pet sprite generation cares about the
+chat-completions backend: each animation row must stay the same character as the
+chosen base frame, which only works on models that accept image input as content
+parts. The Image API backend uses ``input_references`` for image-to-image, which
+is a different mechanism.
 """
 
 from __future__ import annotations
@@ -482,7 +494,338 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
         )
 
 
-def _build_providers() -> List[OpenRouterCompatImageProvider]:
+# ---------------------------------------------------------------------------
+# OpenRouter Image API provider (dedicated /api/v1/images endpoint)
+# ---------------------------------------------------------------------------
+
+# OpenRouter Image API aspect ratios (full spec)
+_IMAGE_API_ASPECT_RATIOS = {
+    "square": "1:1",
+    "landscape": "16:9",
+    "portrait": "9:16",
+    "4:3": "4:3",
+    "3:4": "3:4",
+    "3:2": "3:2",
+    "2:3": "2:3",
+    "9:19.5": "9:19.5",
+    "19.5:9": "19.5:9",
+    "9:20": "9:20",
+    "20:9": "20:9",
+    "1:2": "1:2",
+    "2:1": "2:1",
+}
+
+_IMAGE_API_RESOLUTIONS = {"1k": "1K", "2k": "2K"}
+_IMAGE_API_DEFAULT_RESOLUTION = "1K"
+_IMAGE_API_DEFAULT_MODEL = "x-ai/grok-imagine-image-2.0"
+_IMAGE_API_QUALITY_OPTIONS = {"low", "medium"}
+
+
+class OpenRouterImageAPIProvider(ImageGenProvider):
+    """Image generation via OpenRouter's dedicated ``/api/v1/images`` endpoint.
+
+    This is the correct OpenRouter API surface for models that expose a pure
+    image-generation API (e.g. ``x-ai/grok-imagine-image-2.0``). It is a
+    separate endpoint from the chat-completions path used by
+    :class:`OpenRouterCompatImageProvider` — different request/response shapes,
+    different parameter conventions.
+    """
+
+    @property
+    def name(self) -> str:
+        return "openrouter-image-api"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenRouter Image API"
+
+    def _resolve_runtime(self) -> Dict[str, str]:
+        """Resolve OpenRouter credentials via the shared runtime resolver."""
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested="openrouter")
+        api_key = str(runtime.get("api_key") or "").strip()
+        base_url = str(runtime.get("base_url") or "https://openrouter.ai/api/v1").strip().rstrip("/")
+        return {"api_key": api_key, "base_url": base_url}
+
+    def is_available(self) -> bool:
+        try:
+            runtime = self._resolve_runtime()
+            return bool(str(runtime.get("api_key") or "").strip())
+        except Exception:
+            return False
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "OpenRouter Image API",
+            "badge": "paid",
+            "tag": (
+                "x-ai/grok-imagine-image-2.0 via OpenRouter's /api/v1/images endpoint; "
+                "uses OPENROUTER_API_KEY"
+            ),
+            "env_vars": [
+                {
+                    "key": "OPENROUTER_API_KEY",
+                    "prompt": "OpenRouter API key",
+                    "url": "https://openrouter.ai/keys",
+                }
+            ],
+        }
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": _IMAGE_API_DEFAULT_MODEL,
+                "display": "Grok Imagine Image 2.0",
+                "speed": "~5-10s",
+                "strengths": "Latest Grok Imagine — OpenRouter Image API",
+            },
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return _IMAGE_API_DEFAULT_MODEL
+
+    def capabilities(self) -> Dict[str, Any]:
+        return {
+            "modalities": ["text", "image"],
+            "max_reference_images": 3,
+        }
+
+    def _resolve_image_api_model(self) -> str:
+        """Resolve model from env, config scoped to this provider, or top-level image_gen.model."""
+        env_override = os.environ.get("OPENROUTER_IMAGES_API_MODEL", "").strip()
+        if env_override:
+            return env_override
+        cfg = _load_image_gen_config()
+        scoped = cfg.get("openrouter-image-api") if isinstance(cfg.get("openrouter-image-api"), dict) else {}
+        value = scoped.get("model") if isinstance(scoped.get("model"), str) else None
+        if value and value.strip():
+            return value.strip()
+        top = cfg.get("model")
+        if isinstance(top, str) and top.strip():
+            return top.strip()
+        return _IMAGE_API_DEFAULT_MODEL
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        *,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        import requests
+
+        try:
+            runtime = self._resolve_runtime()
+        except Exception as exc:
+            return error_response(
+                error=f"Could not resolve OpenRouter credentials: {exc}",
+                error_type="missing_api_key",
+                provider=self.name,
+                aspect_ratio=aspect_ratio,
+            )
+
+        api_key = runtime["api_key"]
+        base_url = runtime["base_url"]
+        if not api_key:
+            return error_response(
+                error="No OpenRouter API key found. "
+                "Set OPENROUTER_API_KEY in ~/.hermes/.env or run `hermes auth add openrouter`.",
+                error_type="missing_api_key",
+                provider=self.name,
+                aspect_ratio=aspect_ratio,
+            )
+
+        model_id = self._resolve_image_api_model()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        or_aspect = _IMAGE_API_ASPECT_RATIOS.get(aspect, "1:1")
+
+        payload: Dict[str, Any] = {
+            "model": model_id,
+            "prompt": prompt,
+            "n": 1,
+            "aspect_ratio": or_aspect,
+        }
+
+        # Resolution
+        res_env = os.environ.get("OPENROUTER_IMAGES_API_RESOLUTION", "").strip().lower()
+        if not res_env:
+            cfg = _load_image_gen_config()
+            scoped = cfg.get("openrouter-image-api") if isinstance(cfg.get("openrouter-image-api"), dict) else {}
+            res_cfg = scoped.get("resolution") if isinstance(scoped.get("resolution"), str) else None
+            if res_cfg:
+                res_env = res_cfg.strip().lower()
+        payload["resolution"] = _IMAGE_API_RESOLUTIONS.get(res_env, _IMAGE_API_DEFAULT_RESOLUTION)
+
+        # Quality
+        quality_raw = kwargs.get("quality") or ""
+        if quality_raw and str(quality_raw).strip().lower() in _IMAGE_API_QUALITY_OPTIONS:
+            payload["quality"] = str(quality_raw).strip().lower()
+
+        # Reference images (image-to-image via input_references)
+        ref_images: List[str] = []
+        if isinstance(image_url, str) and image_url.strip():
+            ref_images.append(image_url.strip())
+        if isinstance(reference_image_urls, list):
+            for ref in reference_image_urls:
+                if isinstance(ref, str) and ref.strip():
+                    ref_images.append(ref.strip())
+        if ref_images:
+            from agent.file_safety import raise_if_read_blocked
+
+            refs: List[Dict[str, Any]] = []
+            for ref in ref_images[:3]:
+                lower = ref.lower()
+                if lower.startswith(("http://", "https://", "data:")):
+                    refs.append({"type": "image_url", "image_url": {"url": ref}})
+                else:
+                    try:
+                        raise_if_read_blocked(ref)
+                        path = Path(ref).expanduser()
+                        raw = path.read_bytes()
+                        mime = mimetypes.guess_type(path.name)[0] or "image/png"
+                        b64 = base64.b64encode(raw).decode("ascii")
+                        refs.append({"type": "image_url", "image_url": {"url": f"data:{mime};base64,{b64}"}})
+                    except Exception as exc:
+                        return error_response(
+                            error=f"Could not read reference image '{ref}': {exc}",
+                            error_type="io_error",
+                            provider=self.name,
+                            model=model_id,
+                            prompt=prompt,
+                            aspect_ratio=aspect,
+                        )
+            if refs:
+                payload["input_references"] = refs
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/NousResearch/hermes-agent",
+            "X-Title": "Hermes Agent",
+        }
+
+        try:
+            response = requests.post(
+                f"{base_url}/images",
+                headers=headers,
+                json=payload,
+                timeout=120,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            resp = exc.response
+            status = resp.status_code if resp is not None else 0
+            try:
+                err_msg = resp.json().get("error", {}).get("message", resp.text[:300])
+            except Exception:
+                err_msg = resp.text[:300] if resp is not None else str(exc)
+            logger.error("OpenRouter Image API failed (%d): %s", status, err_msg)
+            return error_response(
+                error=f"OpenRouter Image API failed ({status}): {err_msg}",
+                error_type="api_error",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.Timeout:
+            return error_response(
+                error="OpenRouter Image API timed out (120s)",
+                error_type="timeout",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.ConnectionError as exc:
+            return error_response(
+                error=f"OpenRouter connection error: {exc}",
+                error_type="connection_error",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            result = response.json()
+        except Exception as exc:
+            return error_response(
+                error=f"OpenRouter returned invalid JSON: {exc}",
+                error_type="invalid_response",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        data = result.get("data", [])
+        if not data:
+            return error_response(
+                error="OpenRouter returned no image data",
+                error_type="empty_response",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        first = data[0]
+        b64 = first.get("b64_json")
+        media_type = first.get("media_type", "image/png")
+
+        if b64:
+            ext = mimetypes.guess_extension(media_type) or "png"
+            ext = ext.lstrip(".")
+            try:
+                saved_path = save_b64_image(b64, prefix=f"openrouter_{model_id.replace('/', '_')}", extension=ext)
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not save image: {exc}",
+                    error_type="io_error",
+                    provider=self.name,
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            image_ref = str(saved_path)
+        else:
+            url = first.get("url")
+            if url:
+                try:
+                    saved_path = save_url_image(url, prefix=f"openrouter_{model_id.replace('/', '_')}")
+                    image_ref = str(saved_path)
+                except Exception as exc:
+                    logger.warning("Could not cache URL (%s); returning raw URL", exc)
+                    image_ref = url
+            else:
+                return error_response(
+                    error="OpenRouter response contained neither b64_json nor URL",
+                    error_type="empty_response",
+                    provider=self.name,
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+
+        return success_response(
+            image=image_ref,
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider=self.name,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Provider registry
+# ---------------------------------------------------------------------------
+
+
+def _build_providers() -> List[ImageGenProvider]:
     return [
         OpenRouterCompatImageProvider(
             provider_name="openrouter",
@@ -517,10 +860,11 @@ def _build_providers() -> List[OpenRouterCompatImageProvider]:
                 "requires_nous_auth": True,
             },
         ),
+        OpenRouterImageAPIProvider(),
     ]
 
 
 def register(ctx: Any) -> None:
-    """Register the OpenRouter + Nous Portal image gen providers."""
+    """Register the OpenRouter + Nous Portal + OpenRouter Image API providers."""
     for provider in _build_providers():
         ctx.register_image_gen_provider(provider)

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -518,6 +518,10 @@ _IMAGE_API_ASPECT_RATIOS = {
 _IMAGE_API_RESOLUTIONS = {"1k": "1K", "2k": "2K"}
 _IMAGE_API_DEFAULT_RESOLUTION = "1K"
 _IMAGE_API_DEFAULT_MODEL = "x-ai/grok-imagine-image-2.0"
+# Quality options (deliberately excludes "high" as a cost guard — the Image API
+# per-call charge scales with the quality tier and the marginal visual improvement
+# from "high" over "medium" on the default resolution is negligible for prompt
+# generations. Pet sprites are uniformly generated at "medium" anyway.)
 _IMAGE_API_QUALITY_OPTIONS = {"low", "medium"}
 
 
@@ -592,7 +596,16 @@ class OpenRouterImageAPIProvider(ImageGenProvider):
         }
 
     def _resolve_image_api_model(self) -> str:
-        """Resolve model from env, config scoped to this provider, or top-level image_gen.model."""
+        """Resolve model from env var or provider-scoped config only.
+
+        Does NOT fall back to the top-level ``image_gen.model`` because that
+        config key is shared across *all* image backends. A user whose global
+        ``image_gen.model`` targets a chat-completions model (e.g.
+        ``google/gemini-3-pro-image``) would have that model silently sent to
+        ``/api/v1/images``, where it doesn't exist — producing a confusing 404.
+        The resolver stops at the provider-scoped layer and uses the dedicated
+        default instead.
+        """
         env_override = os.environ.get("OPENROUTER_IMAGES_API_MODEL", "").strip()
         if env_override:
             return env_override
@@ -601,9 +614,6 @@ class OpenRouterImageAPIProvider(ImageGenProvider):
         value = scoped.get("model") if isinstance(scoped.get("model"), str) else None
         if value and value.strip():
             return value.strip()
-        top = cfg.get("model")
-        if isinstance(top, str) and top.strip():
-            return top.strip()
         return _IMAGE_API_DEFAULT_MODEL
 
     def generate(
@@ -639,8 +649,26 @@ class OpenRouterImageAPIProvider(ImageGenProvider):
             )
 
         model_id = self._resolve_image_api_model()
-        aspect = resolve_aspect_ratio(aspect_ratio)
-        or_aspect = _IMAGE_API_ASPECT_RATIOS.get(aspect, "1:1")
+        # Accept raw aspect_ratio keys directly (the API supports many more
+        # ratios than the standard three, e.g. "4:3", "3:2", "9:19.5"),
+        # then fall back to the standard normalizer for the common names.
+        raw = aspect_ratio.strip().lower() if isinstance(aspect_ratio, str) else ""
+        if raw in _IMAGE_API_ASPECT_RATIOS:
+            or_aspect = _IMAGE_API_ASPECT_RATIOS[raw]
+            aspect = raw
+        else:
+            aspect = resolve_aspect_ratio(aspect_ratio)
+            or_aspect = _IMAGE_API_ASPECT_RATIOS.get(aspect)
+        if or_aspect is None:
+            valid = sorted(_IMAGE_API_ASPECT_RATIOS)
+            return error_response(
+                error=f"Unsupported aspect ratio '{aspect_ratio}'. "
+                f"Valid values: {', '.join(valid)}",
+                error_type="invalid_aspect_ratio",
+                provider=self.name,
+                model=model_id,
+                prompt=prompt,
+            )
 
         payload: Dict[str, Any] = {
             "model": model_id,
@@ -799,8 +827,14 @@ class OpenRouterImageAPIProvider(ImageGenProvider):
                     saved_path = save_url_image(url, prefix=f"openrouter_{model_id.replace('/', '_')}")
                     image_ref = str(saved_path)
                 except Exception as exc:
-                    logger.warning("Could not cache URL (%s); returning raw URL", exc)
-                    image_ref = url
+                    return error_response(
+                        error=f"Could not cache image URL ({url}): {exc}",
+                        error_type="io_error",
+                        provider=self.name,
+                        model=model_id,
+                        prompt=prompt,
+                        aspect_ratio=aspect,
+                    )
             else:
                 return error_response(
                     error="OpenRouter response contained neither b64_json nor URL",

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -68,7 +68,7 @@ class TestProviderClass:
         from plugins.image_gen.openrouter import _build_providers
 
         names = {p.name for p in _build_providers()}
-        assert names == {"openrouter", "nous"}
+        assert names == {"openrouter", "nous", "openrouter-image-api"}
 
     def test_display_names(self):
         from plugins.image_gen.openrouter import _build_providers
@@ -76,6 +76,7 @@ class TestProviderClass:
         by_name = {p.name: p for p in _build_providers()}
         assert by_name["openrouter"].display_name == "OpenRouter"
         assert by_name["nous"].display_name == "Nous Portal"
+        assert by_name["openrouter-image-api"].display_name == "OpenRouter Image API"
 
     def test_capabilities_support_image_input(self):
         caps = _openrouter().capabilities()
@@ -440,10 +441,11 @@ class TestRegistration:
         ctx = MagicMock()
         register(ctx)
         registered = [c.args[0].name for c in ctx.register_image_gen_provider.call_args_list]
-        assert set(registered) == {"openrouter", "nous"}
+        assert set(registered) == {"openrouter", "nous", "openrouter-image-api"}
 
-    def test_both_are_reference_capable_for_pets(self):
+    def test_reference_capable_providers(self):
         from agent.pet.generate.imagegen import _REF_CAPABLE
 
         assert "openrouter" in _REF_CAPABLE
         assert "nous" in _REF_CAPABLE
+        assert "openrouter-image-api" in _REF_CAPABLE

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -448,4 +448,3 @@ class TestRegistration:
 
         assert "openrouter" in _REF_CAPABLE
         assert "nous" in _REF_CAPABLE
-        assert "openrouter-image-api" in _REF_CAPABLE

--- a/tests/plugins/image_gen/test_openrouter_image_api_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_image_api_provider.py
@@ -232,6 +232,201 @@ class TestGenerate:
         payload = mock_post.call_args.kwargs["json"]
         assert payload["resolution"] == "2K"
 
+    def test_resolution_from_config(self):
+        """Resolution is picked up from provider-scoped config when env is unset."""
+        import plugins.image_gen.openrouter as mod
+
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch.object(mod, "_load_image_gen_config", return_value={
+                 "openrouter-image-api": {"resolution": "2k"},
+             }), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat")
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["resolution"] == "2K"
+
+    def test_resolution_defaults_to_1k(self):
+        """Resolution defaults to 1K when neither env nor config is set."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat")
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["resolution"] == "1K"
+
+    def test_quality_medium_in_payload(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat", quality="medium")
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["quality"] == "medium"
+
+    def test_quality_invalid_not_in_payload(self):
+        """Unsupported quality (e.g. 'high') is silently ignored — no quality key in payload."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat", quality="high")
+        payload = mock_post.call_args.kwargs["json"]
+        assert "quality" not in payload
+
+    def test_quality_low_in_payload(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat", quality="low")
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["quality"] == "low"
+
+    def test_unknown_aspect_ratio_falls_back_to_default(self):
+        """Unrecognized aspect ratios are normalized to 'landscape' by resolve_aspect_ratio, not silently squared."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat", aspect_ratio="ultrawide")
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["aspect_ratio"] == "16:9"
+
+    def test_aspect_ratio_4_3_direct(self):
+        """Raw '4:3' bypasses resolve_aspect_ratio and goes directly to the API."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat", aspect_ratio="4:3")
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["aspect_ratio"] == "4:3"
+
+    def test_aspect_ratio_error_on_unexpected_resolve(self, monkeypatch):
+        """When resolve_aspect_ratio returns a value not in _IMAGE_API_ASPECT_RATIOS, an error is returned."""
+        import plugins.image_gen.openrouter as mod
+
+        monkeypatch.setattr(mod, "_IMAGE_API_ASPECT_RATIOS", {"portrait": "9:16"})
+        monkeypatch.setattr(mod, "resolve_aspect_ratio", lambda _: "landscape")
+        with patch(_RUNTIME, return_value=_runtime_ok()):
+            result = _provider().generate(prompt="a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_aspect_ratio"
+
+    def test_input_references_from_image_url(self):
+        """image_url kwarg produces input_references in the payload."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat", image_url="https://example.com/ref.png")
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert "input_references" in payload
+        assert payload["input_references"] == [
+            {"type": "image_url", "image_url": {"url": "https://example.com/ref.png"}}
+        ]
+
+    def test_input_references_from_reference_image_urls(self):
+        """reference_image_urls list adds extra input_references."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(
+                prompt="a cat",
+                reference_image_urls=["https://example.com/r1.png", "https://example.com/r2.png"]
+            )
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert "input_references" in payload
+        assert len(payload["input_references"]) == 2
+
+    def test_input_references_clamped_to_three(self):
+        """At most 3 input_references are sent, extra refs are discarded."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(
+                prompt="a cat",
+                reference_image_urls=[f"https://example.com/{i}.png" for i in range(5)],
+            )
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert len(payload["input_references"]) == 3
+
+    def test_input_references_local_file(self, tmp_path):
+        """Local file paths are read, base64-encoded, and included as data URIs."""
+        img = tmp_path / "ref.png"
+        img.write_bytes(b"fake_png_bytes")
+
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat", image_url=str(img))
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert "input_references" in payload
+        ref = payload["input_references"][0]
+        assert ref["type"] == "image_url"
+        assert ref["image_url"]["url"].startswith("data:")
+        assert "base64" in ref["image_url"]["url"]
+
+    def test_input_references_raise_if_read_blocked(self):
+        """Blocked local files raise an io_error."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("agent.file_safety.raise_if_read_blocked",
+                   side_effect=PermissionError("no read access")):
+            result = _provider().generate(prompt="a cat", image_url="/etc/shadow")
+
+        assert result["success"] is False
+        assert result["error_type"] == "io_error"
+        assert "no read access" in result.get("error", "")
+
+    def test_model_resolver_stops_at_scoped_config(self):
+        """_resolve_image_api_model does NOT fall through to the top-level image_gen.model."""
+        import plugins.image_gen.openrouter as mod
+
+        with patch.object(mod, "_load_image_gen_config", return_value={
+            "openrouter-image-api": {"model": "x-ai/grok-v2"},
+            "model": "google/gemini-3-pro-image",  # top-level; should NOT be picked up
+        }):
+            result = _provider()._resolve_image_api_model()
+
+        assert "gemini" not in result
+        assert result == "x-ai/grok-v2"
+
+    def test_model_resolver_defaults_when_unconfigured(self):
+        """_resolve_image_api_model returns the default model when nothing is set."""
+        import plugins.image_gen.openrouter as mod
+
+        with patch.object(mod, "_load_image_gen_config", return_value={}):
+            result = _provider()._resolve_image_api_model()
+
+        assert result == mod._IMAGE_API_DEFAULT_MODEL
+
+    def test_save_url_cached_ok(self):
+        """URL image is saved via save_url_image and path returned."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(url="https://cdn/x.png")), \
+             patch(
+                 "plugins.image_gen.openrouter.save_url_image",
+                 return_value=Path("/tmp/or_cached.png"),
+             ) as mock_save_url:
+            result = _provider().generate(prompt="a cat")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/or_cached.png"
+        mock_save_url.assert_called_once()
+
+    def test_save_url_failure_returns_error(self):
+        """When save_url_image fails, an io_error is returned (not a raw CDN URL)."""
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(url="https://cdn/x.png")), \
+             patch(
+                 "plugins.image_gen.openrouter.save_url_image",
+                 side_effect=OSError("disk full"),
+             ):
+            result = _provider().generate(prompt="a cat")
+
+        assert result["success"] is False
+        assert result["error_type"] == "io_error"
+        assert "disk full" in result.get("error", "")
+
 
 # ---------------------------------------------------------------------------
 # Registration

--- a/tests/plugins/image_gen/test_openrouter_image_api_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_image_api_provider.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Tests for the OpenRouter Image API provider (dedicated /api/v1/images endpoint)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_RUNTIME = "hermes_cli.runtime_provider.resolve_runtime_provider"
+_PNG_B64 = "iVBORw0KGgo="  # minimal valid PNG base64
+
+
+def _runtime_ok(**over):
+    base = {
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "sk-or-test",
+        "source": "env",
+    }
+    base.update(over)
+    return base
+
+
+def _mock_image_response(b64=None, url=None, media_type="image/png"):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    data_entry = {"media_type": media_type}
+    if b64:
+        data_entry["b64_json"] = b64
+    if url:
+        data_entry["url"] = url
+    resp.json.return_value = {"data": [data_entry], "usage": {"cost": 0.04}}
+    return resp
+
+
+def _provider():
+    from plugins.image_gen.openrouter import OpenRouterImageAPIProvider
+
+    return OpenRouterImageAPIProvider()
+
+
+# ---------------------------------------------------------------------------
+# Provider class
+# ---------------------------------------------------------------------------
+
+
+class TestProviderClass:
+    def test_name_and_display(self):
+        p = _provider()
+        assert p.name == "openrouter-image-api"
+        assert p.display_name == "OpenRouter Image API"
+
+    def test_capabilities(self):
+        caps = _provider().capabilities()
+        assert "image" in caps["modalities"]
+        assert caps["max_reference_images"] == 3
+
+    def test_is_available_with_key(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()):
+            assert _provider().is_available() is True
+
+    def test_is_available_without_key(self):
+        with patch(_RUNTIME, return_value=_runtime_ok(api_key="")):
+            assert _provider().is_available() is False
+
+    def test_is_available_on_error(self):
+        with patch(_RUNTIME, side_effect=RuntimeError("boom")):
+            assert _provider().is_available() is False
+
+    def test_default_model(self):
+        from plugins.image_gen.openrouter import _IMAGE_API_DEFAULT_MODEL
+
+        assert _provider().default_model() == _IMAGE_API_DEFAULT_MODEL
+        assert "grok-imagine" in _IMAGE_API_DEFAULT_MODEL
+
+    def test_list_models(self):
+        models = _provider().list_models()
+        assert len(models) >= 1
+        assert "x-ai/grok-imagine" in models[0]["id"]
+
+    def test_setup_schema(self):
+        schema = _provider().get_setup_schema()
+        assert "OPENROUTER_API_KEY" in str(schema)
+
+
+# ---------------------------------------------------------------------------
+# generate()
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_missing_credentials(self):
+        with patch(_RUNTIME, return_value=_runtime_ok(api_key="")):
+            result = _provider().generate(prompt="a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "missing_api_key"
+
+    def test_success_b64_json(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)), \
+             patch(
+                 "plugins.image_gen.openrouter.save_b64_image",
+                 return_value=Path("/tmp/or_image_api.png"),
+             ) as mock_save:
+            result = _provider().generate(prompt="a cat")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/or_image_api.png"
+        assert result["provider"] == "openrouter-image-api"
+        assert result["model"] == "x-ai/grok-imagine-image-2.0"
+        mock_save.assert_called_once()
+
+    def test_success_url(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(url="https://cdn/x.png")), \
+             patch(
+                 "plugins.image_gen.openrouter.save_url_image",
+                 return_value=Path("/tmp/or_image_api_url.png"),
+             ) as mock_save_url:
+            result = _provider().generate(prompt="a cat")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/or_image_api_url.png"
+        mock_save_url.assert_called_once()
+
+    def test_payload_shape(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat", aspect_ratio="square")
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["model"] == "x-ai/grok-imagine-image-2.0"
+        assert payload["prompt"] == "a cat"
+        assert payload["aspect_ratio"] == "1:1"
+        assert payload["n"] == 1
+        assert "resolution" in payload
+
+    def test_payload_landscape(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat", aspect_ratio="landscape")
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["aspect_ratio"] == "16:9"
+
+    def test_payload_portrait(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat", aspect_ratio="portrait")
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["aspect_ratio"] == "9:16"
+
+    def test_empty_response(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {"data": []}
+
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=resp):
+            result = _provider().generate(prompt="a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_post_to_correct_endpoint(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat")
+
+        url = mock_post.call_args[0][0]
+        assert url == "https://openrouter.ai/api/v1/images"
+
+    def test_auth_header(self):
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat")
+
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer sk-or-test"
+        assert "HTTP-Referer" in headers
+        assert "X-Title" in headers
+
+    def test_api_error(self):
+        import requests as req_lib
+
+        resp = MagicMock()
+        resp.status_code = 402
+        resp.text = "Insufficient credits"
+        resp.json.return_value = {"error": {"message": "Insufficient credits"}}
+        resp.raise_for_status.side_effect = req_lib.HTTPError(response=resp)
+
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=resp):
+            result = _provider().generate(prompt="a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+
+    def test_timeout(self):
+        import requests as req_lib
+
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", side_effect=req_lib.Timeout()):
+            result = _provider().generate(prompt="a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "timeout"
+
+    def test_connection_error(self):
+        import requests as req_lib
+
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", side_effect=req_lib.ConnectionError("reset")):
+            result = _provider().generate(prompt="a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "connection_error"
+
+    def test_resolution_env_override(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_IMAGES_API_RESOLUTION", "2k")
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", return_value=_mock_image_response(b64=_PNG_B64)) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/x.png")):
+            _provider().generate(prompt="a cat")
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["resolution"] == "2K"
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_included_in_build_providers(self):
+        from plugins.image_gen.openrouter import _build_providers
+
+        names = {p.name for p in _build_providers()}
+        assert "openrouter-image-api" in names
+
+    def test_image_api_is_not_the_chat_compat_provider(self):
+        from plugins.image_gen.openrouter import (
+            OpenRouterCompatImageProvider,
+            OpenRouterImageAPIProvider,
+        )
+
+        assert OpenRouterImageAPIProvider is not OpenRouterCompatImageProvider

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -7,7 +7,14 @@ sidebar_position: 6
 
 # Image Generation
 
-Hermes Agent generates images from text prompts via FAL.ai. Eleven models are supported out of the box, each with different speed, quality, and cost tradeoffs. The active model is user-configurable via `hermes tools` and persists in `config.yaml`.
+Hermes Agent generates images from text prompts via **FAL.ai**, **OpenRouter**, **xAI**, **OpenAI**, and other backends. Each backend is user-configurable via `hermes tools` and persists in `config.yaml`.
+
+Two OpenRouter-based backends are available:
+
+- **OpenRouter** — chat-completions image output (``openai/gpt-5.4-image-2``, ``google/gemini-3-pro-image``) via ``/chat/completions`` with ``modalities: ["image", "text"]``
+- **OpenRouter Image API** — dedicated image generation (``x-ai/grok-imagine-image-2.0``) via ``/api/v1/images``
+
+Both use your existing ``OPENROUTER_API_KEY`` — no extra credentials needed.
 
 ## Supported Models
 


### PR DESCRIPTION
Adds `OpenRouterImageAPIProvider` alongside the existing chat-completions provider in `plugins/image_gen/openrouter/`. This new backend hits OpenRouter's `POST /api/v1/images` endpoint for models like `x-ai/grok-imagine-image-2.0` that expose a pure image-generation API (not chat completions).

**Key details:**
- Shares the same `OPENROUTER_API_KEY` credential pool as the main model — no new env vars
- Supports `aspect_ratio`, `resolution`, `quality`, and `input_references` (image-to-image, up to 3 refs)
- Named `openrouter-image-api` — selectable via `image_gen.provider: openrouter-image-api`
- Added to `_REF_CAPABLE` for pet sprite generation

**Files changed:**
- `plugins/image_gen/openrouter/__init__.py` — new provider class, updated `_build_providers()` and `register()`
- `agent/pet/generate/imagegen.py` — add to `_REF_CAPABLE`
- `tests/plugins/image_gen/test_openrouter_compat_provider.py` — updated assertions for 3 providers
- `tests/plugins/image_gen/test_openrouter_image_api_provider.py` — 23 new tests
- `website/docs/user-guide/features/image-generation.md` — document both OpenRouter backends

**Tested:** 60/60 tests pass.