### PR TITLE
fix(state): stop live FTS rebuilds from corrupting shared state.db

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3875,6 +3875,19 @@ class SessionStore:
         db = self._db
         if db is None or not hasattr(db, "rebuild_fts"):
             return False
+        # Guard against the same WAL split-brain risk as the automatic
+        # rebuild paths: skip when a foreign process holds state.db or
+        # its WAL sidecars open.
+        if hasattr(db, "_foreign_state_db_holders"):
+            foreign_holders = db._foreign_state_db_holders()
+            if foreign_holders:
+                logger.warning(
+                    "Skipping Session DB FTS rebuild while foreign processes "
+                    "hold the database or WAL sidecars (%s); canonical "
+                    "transcript writes remain available.",
+                    foreign_holders,
+                )
+                return False
         try:
             rebuilt = db.rebuild_fts()
         except Exception as exc:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4211,6 +4211,59 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         msg = str(exc).lower()
         return "fts5" in msg and "corrupt" in msg
 
+    def _foreign_state_db_holders(self) -> List[Tuple[int, str]]:
+        """Return foreign processes holding this DB or its WAL sidecars.
+
+        Automatic FTS repair is structural maintenance, not an ordinary WAL
+        write.  It must not run while another process remains attached: a
+        sidecar reset under that holder can leave the two processes writing
+        through different WAL inodes.  ``psutil`` reads the kernel's open-file
+        table, including Linux ``(deleted)`` descriptors, so this also catches
+        a split brain already in progress.
+
+        A scan failure is represented as an unknown holder.  Skipping optional
+        automatic maintenance is safer than assuming quiescence; canonical
+        writes continue through the stale-FTS fail-open path.
+        """
+        # The split-brain mechanism requires POSIX unlink semantics: Windows
+        # refuses to replace SQLite sidecars while another process has them
+        # open.  Avoid psutil.open_files() there; querying arbitrary Windows
+        # processes can block for minutes on device-backed handles.
+        if _IS_WINDOWS:
+            return []
+        if psutil is None:
+            return [(-1, "open-file scan unavailable")]
+
+        def _canonical(path: str) -> str:
+            clean = path.removesuffix(" (deleted)")
+            return os.path.normcase(os.path.abspath(clean))
+
+        db_path = os.path.abspath(os.fspath(self.db_path))
+        watched = {
+            _canonical(db_path),
+            _canonical(db_path + "-wal"),
+            _canonical(db_path + "-shm"),
+        }
+        holders: List[Tuple[int, str]] = []
+        try:
+            for process in psutil.process_iter(["pid", "open_files"]):
+                info = process.info
+                pid = int(info["pid"])
+                if pid == os.getpid():
+                    continue
+                for opened in info.get("open_files") or ():
+                    path = getattr(opened, "path", "")
+                    if path and _canonical(path) in watched:
+                        holders.append((pid, path))
+        except Exception as exc:
+            logger.warning(
+                "Could not prove state.db has no foreign holders; deferring "
+                "automatic FTS maintenance: %s",
+                exc,
+            )
+            return holders or [(-1, f"open-file scan failed: {exc}")]
+        return holders
+
     def _try_runtime_fts_rebuild(self, exc: sqlite3.DatabaseError) -> bool:
         """One-shot in-place FTS rebuild after a corrupt-index write failure.
 
@@ -4234,6 +4287,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not self._is_fts_write_corruption_error(exc):
             return False
         self._fts_runtime_rebuild_attempted = True
+        foreign_holders = self._foreign_state_db_holders()
+        if foreign_holders:
+            logger.warning(
+                "Skipping automatic state.db FTS rebuild while foreign "
+                "processes hold the database or WAL sidecars (%s); detaching "
+                "FTS sync so canonical writes can continue.",
+                foreign_holders,
+            )
+            return False
         logger.warning(
             "state.db write failed with an FTS-corruption error (%s) — "
             "attempting one-shot in-place FTS rebuild; canonical message "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3065,6 +3065,21 @@ def _read_proc_cmdline(pid: int) -> Optional[str]:
         return None
 
 
+_HERMES_CMDLINE_MARKERS = ("hermes_cli.main", "hermes_cli/main", "hermes serve",
+                           "hermes-agent", "hermes gateway", "hermes chat")
+
+
+def _looks_like_hermes(cmdline: str) -> bool:
+    """Heuristic: does this cmdline look like a Hermes process?
+
+    Used to decide whether an uninspectable process (fd table unreadable
+    due to different user) should be treated as a potential state.db holder.
+    We only flag processes that look like Hermes, not every system daemon.
+    """
+    lower = cmdline.lower()
+    return any(marker in lower for marker in _HERMES_CMDLINE_MARKERS)
+
+
 # Lifecycle statuses surfaced by session pickers. Classification looks ONLY at
 # a session's final message row — role, whether it carries tool_calls, and its
 # finish_reason — so it stays O(1) per session (see
@@ -4283,9 +4298,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         # Cannot read this process's fd table (different
                         # user, e.g. root gateway vs user desktop).
                         # /proc/<pid>/cmdline is world-readable by default,
-                        # so check whether this is a Hermes process.
+                        # so check whether this is a Hermes process —
+                        # only flag uninspectable holders that look like
+                        # another Hermes instance, not every system daemon.
                         cmdline = _read_proc_cmdline(pid)
-                        if cmdline is not None:
+                        if cmdline is not None and _looks_like_hermes(cmdline):
                             holders.append((pid, f"uninspectable holder: {cmdline[:80]}"))
                         continue
                     for fd in fds:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4286,6 +4286,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return False
         if not self._is_fts_write_corruption_error(exc):
             return False
+        # Set the one-shot flag before the foreign-holder check: even when
+        # the rebuild is skipped, the fail-open path that follows persists
+        # the FTS_STALE_KEY marker so the next process startup will retry
+        # via _recover_stale_fts (which has its own holder guard). Setting
+        # the flag here also avoids re-running the expensive psutil scan on
+        # every subsequent corrupted write through this instance.
         self._fts_runtime_rebuild_attempted = True
         foreign_holders = self._foreign_state_db_holders()
         if foreign_holders:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3049,6 +3049,22 @@ def count_db_holders(db_path: Path) -> Optional[int]:
         return None
 
 
+def _read_proc_cmdline(pid: int) -> Optional[str]:
+    """Read /proc/<pid>/cmdline, world-readable even when fd table is not.
+
+    Returns the cmdline as a space-joined string, or None when unreadable
+    (process exited, or hidepid mount).
+    """
+    try:
+        with open(f"/proc/{pid}/cmdline", "rb") as f:
+            raw = f.read()
+        if not raw:
+            return None
+        return raw.replace(b"\x00", b" ").decode("utf-8", "replace").strip()
+    except OSError:
+        return None
+
+
 # Lifecycle statuses surfaced by session pickers. Classification looks ONLY at
 # a session's final message row — role, whether it carries tool_calls, and its
 # finish_reason — so it stays O(1) per session (see
@@ -4217,9 +4233,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Automatic FTS repair is structural maintenance, not an ordinary WAL
         write.  It must not run while another process remains attached: a
         sidecar reset under that holder can leave the two processes writing
-        through different WAL inodes.  ``psutil`` reads the kernel's open-file
-        table, including Linux ``(deleted)`` descriptors, so this also catches
-        a split brain already in progress.
+        through different WAL inodes.
 
         A scan failure is represented as an unknown holder.  Skipping optional
         automatic maintenance is safer than assuming quiescence; canonical
@@ -4245,20 +4259,71 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             _canonical(db_path + "-shm"),
         }
         holders: List[Tuple[int, str]] = []
+
+        # On Linux, read /proc/<pid>/fd symlinks directly.  psutil's
+        # open_files() filters through isfile_strict(), which stats the
+        # literal path — for an unlinked WAL sidecar the kernel returns
+        # "/path/state.db-wal (deleted)" and stat fails, so the entry is
+        # silently dropped and the split-brain holder is never seen.
+        # /proc readlinks preserve the "(deleted)" suffix so _canonical can
+        # strip it and match.
+        if sys.platform.startswith("linux"):
+            try:
+                own_pid = os.getpid()
+                for pid_str in os.listdir("/proc"):
+                    if not pid_str.isdigit():
+                        continue
+                    pid = int(pid_str)
+                    if pid == own_pid:
+                        continue
+                    fd_dir = f"/proc/{pid}/fd"
+                    try:
+                        fds = os.listdir(fd_dir)
+                    except OSError:
+                        # Cannot read this process's fd table (different
+                        # user, e.g. root gateway vs user desktop).
+                        # /proc/<pid>/cmdline is world-readable by default,
+                        # so check whether this is a Hermes process.
+                        cmdline = _read_proc_cmdline(pid)
+                        if cmdline is not None:
+                            holders.append((pid, f"uninspectable holder: {cmdline[:80]}"))
+                        continue
+                    for fd in fds:
+                        try:
+                            target = os.readlink(f"{fd_dir}/{fd}")
+                        except OSError:
+                            continue
+                        if _canonical(target) in watched:
+                            holders.append((pid, target))
+            except Exception as exc:
+                logger.warning(
+                    "Could not prove state.db has no foreign holders; "
+                    "deferring automatic FTS maintenance: %s",
+                    exc,
+                )
+                return holders or [(-1, f"open-file scan failed: {exc}")]
+            return holders
+
+        # macOS / BSD: use psutil.open_files().  macOS does not use the
+        # "(deleted)" suffix convention, so psutil's filtering is safe here.
         try:
             for process in psutil.process_iter(["pid", "open_files"]):
                 info = process.info
                 pid = int(info["pid"])
                 if pid == os.getpid():
                     continue
+                # psutil's as_dict() converts AccessDenied to None, which
+                # or-() turns into an empty iteration.  On macOS this is
+                # acceptable: the gateway/desktop topology from the issue is
+                # Linux-specific (systemd units running as root).
                 for opened in info.get("open_files") or ():
                     path = getattr(opened, "path", "")
                     if path and _canonical(path) in watched:
                         holders.append((pid, path))
         except Exception as exc:
             logger.warning(
-                "Could not prove state.db has no foreign holders; deferring "
-                "automatic FTS maintenance: %s",
+                "Could not prove state.db has no foreign holders; "
+                "deferring automatic FTS maintenance: %s",
                 exc,
             )
             return holders or [(-1, f"open-file scan failed: {exc}")]

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -368,6 +368,15 @@ class SessionSchemaMixin:
 
     def _recover_stale_fts(self, cursor: sqlite3.Cursor, *, legacy: bool) -> bool:
         """Atomically rebuild stale base/trigram indexes and resume syncing."""
+        foreign_holders = self._foreign_state_db_holders()
+        if foreign_holders:
+            logger.warning(
+                "Deferred stale state.db FTS rebuild while foreign processes "
+                "hold the database or WAL sidecars (%s); canonical writes and "
+                "LIKE search remain available.",
+                foreign_holders,
+            )
+            return False
         try:
             trigram_status = self._fts_table_probe(cursor, "messages_fts_trigram")
         except sqlite3.DatabaseError:

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -13,6 +13,7 @@ sync triggers, and retries the canonical write. Search degrades to ``LIKE``
 until a later open atomically rebuilds the index and restores the triggers.
 """
 
+import os
 import sqlite3
 from types import SimpleNamespace
 
@@ -122,10 +123,104 @@ class TestRuntimeFtsRebuild:
         monkeypatch.setattr(hermes_state, "psutil", FakePsutil)
         monkeypatch.setattr(hermes_state, "_IS_WINDOWS", False)
         monkeypatch.setattr(hermes_state.os, "getpid", lambda: 111)
+        # Force the macOS/psutil path even on Linux test runners
+        monkeypatch.setattr(hermes_state.sys, "platform", "darwin")
 
         assert db._foreign_state_db_holders() == [
             (222, f"{db_path}-wal (deleted)")
         ]
+
+    def test_foreign_holder_detection_proc_readlink_deleted_wal(
+        self, db, tmp_path, monkeypatch
+    ):
+        """Linux /proc/<pid>/fd readlinks preserve '(deleted)' suffix.
+
+        psutil.open_files() drops these entries (isfile_strict stats the
+        literal path and fails).  The /proc path catches the split-brain
+        holder that psutil silently misses.
+        """
+        db_path = tmp_path / "state.db"
+        db_path_wal = str(db_path) + "-wal"
+
+        # Build a fake /proc with two PIDs: self (111) and foreign (222).
+        proc_root = tmp_path / "proc"
+        for pid in (111, 222, 333):
+            fd_dir = proc_root / str(pid) / "fd"
+            fd_dir.mkdir(parents=True)
+        # PID 222 holds the deleted WAL sidecar
+        os.symlink(db_path_wal + " (deleted)", str(proc_root / "222" / "fd" / "3"))
+        # PID 111 (self) holds the db — should be excluded
+        os.symlink(str(db_path), str(proc_root / "111" / "fd" / "3"))
+        # PID 333 holds an unrelated file
+        other = tmp_path / "other.db"
+        other.touch()
+        os.symlink(str(other), str(proc_root / "333" / "fd" / "3"))
+
+        monkeypatch.setattr(hermes_state, "_IS_WINDOWS", False)
+        monkeypatch.setattr(hermes_state.os, "getpid", lambda: 111)
+        monkeypatch.setattr(hermes_state.sys, "platform", "linux")
+        real_listdir = os.listdir
+        def _listdir(path):
+            if isinstance(path, str):
+                path = path.replace("/proc", str(proc_root))
+            return real_listdir(path)
+        monkeypatch.setattr(hermes_state.os, "listdir", _listdir)
+        real_readlink = os.readlink
+        def _readlink(path):
+            path = path.replace("/proc", str(proc_root))
+            return real_readlink(path)
+        monkeypatch.setattr(hermes_state.os, "readlink", _readlink)
+
+        holders = db._foreign_state_db_holders()
+        assert holders == [(222, db_path_wal + " (deleted)")]
+
+    def test_foreign_holder_uninspectable_process_cmdline_fallback(
+        self, db, tmp_path, monkeypatch
+    ):
+        """A process whose fd table is unreadable (different user) is still
+        flagged when /proc/<pid>/cmdline identifies it as a Hermes process."""
+        db_path = tmp_path / "state.db"
+
+        proc_root = tmp_path / "proc"
+        for pid in (111, 222):
+            (proc_root / str(pid) / "fd").mkdir(parents=True)
+        # PID 222's fd dir is unreadable (PermissionError)
+        os.chmod(proc_root / "222" / "fd", 0o000)
+        # PID 222's cmdline is world-readable and looks like Hermes
+        cmdline_path = proc_root / "222" / "cmdline"
+        cmdline_path.write_bytes(b"python3\x00hermes_cli.main\x00chat\x00")
+
+        monkeypatch.setattr(hermes_state, "_IS_WINDOWS", False)
+        monkeypatch.setattr(hermes_state.os, "getpid", lambda: 111)
+        monkeypatch.setattr(hermes_state.sys, "platform", "linux")
+        real_listdir = os.listdir
+        def _listdir(path):
+            if isinstance(path, str):
+                path = path.replace("/proc", str(proc_root))
+            return real_listdir(path)
+        monkeypatch.setattr(hermes_state.os, "listdir", _listdir)
+        # _read_proc_cmdline opens /proc/<pid>/cmdline directly; redirect
+        # it to our fake proc tree.
+        def _fake_cmdline(pid):
+            fake_path = str(proc_root / str(pid) / "cmdline")
+            try:
+                with open(fake_path, "rb") as f:
+                    raw = f.read()
+                if not raw:
+                    return None
+                return raw.replace(b"\x00", b" ").decode("utf-8", "replace").strip()
+            except OSError:
+                return None
+        monkeypatch.setattr(hermes_state, "_read_proc_cmdline", _fake_cmdline)
+
+        holders = db._foreign_state_db_holders()
+        # Should include PID 222 with the cmdline info
+        assert len(holders) == 1
+        assert holders[0][0] == 222
+        assert "hermes_cli.main" in holders[0][1]
+
+        # Cleanup
+        os.chmod(proc_root / "222" / "fd", 0o755)
 
     def test_corruption_error_classification_covers_both_sqlite_messages(self):
         """SQLite's message for a corrupt FTS index varies by version: older

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -14,9 +14,11 @@ until a later open atomically rebuilds the index and restores the triggers.
 """
 
 import sqlite3
+from types import SimpleNamespace
 
 import pytest
 
+import hermes_state
 from hermes_state import (
     FTS_STALE_KEY,
     LEGACY_FTS_SQL,
@@ -84,6 +86,47 @@ def _base_fts_triggers(db_path):
 
 
 class TestRuntimeFtsRebuild:
+    def test_foreign_holder_detection_includes_deleted_wal(
+        self, db, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "state.db"
+
+        class FakePsutil:
+            @staticmethod
+            def process_iter(_attrs):
+                return iter(
+                    (
+                        SimpleNamespace(
+                            info={
+                                "pid": 111,
+                                "open_files": [SimpleNamespace(path=str(db_path))],
+                            }
+                        ),
+                        SimpleNamespace(
+                            info={
+                                "pid": 222,
+                                "open_files": [
+                                    SimpleNamespace(path=f"{db_path}-wal (deleted)")
+                                ],
+                            }
+                        ),
+                        SimpleNamespace(
+                            info={
+                                "pid": 333,
+                                "open_files": [SimpleNamespace(path=str(tmp_path / "other.db"))],
+                            }
+                        ),
+                    )
+                )
+
+        monkeypatch.setattr(hermes_state, "psutil", FakePsutil)
+        monkeypatch.setattr(hermes_state, "_IS_WINDOWS", False)
+        monkeypatch.setattr(hermes_state.os, "getpid", lambda: 111)
+
+        assert db._foreign_state_db_holders() == [
+            (222, f"{db_path}-wal (deleted)")
+        ]
+
     def test_corruption_error_classification_covers_both_sqlite_messages(self):
         """SQLite's message for a corrupt FTS index varies by version: older
         builds raise the generic malformed-image error, newer builds raise an
@@ -242,6 +285,30 @@ class TestRuntimeFtsRebuild:
         assert _meta_value(db_path, FTS_STALE_KEY) == "1"
         assert _base_fts_triggers(db_path) == set()
 
+    def test_foreign_holder_skips_runtime_rebuild_and_fails_open(
+        self, db, tmp_path, monkeypatch
+    ):
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+
+        monkeypatch.setattr(
+            db,
+            "_foreign_state_db_holders",
+            lambda: [(4242, str(db_path) + "-wal")],
+            raising=False,
+        )
+
+        db.append_message("s1", "user", "canonical survives foreign holder")
+
+        assert _message_contents(db_path)[-1] == "canonical survives foreign holder"
+        assert db._fts_stale is True
+        assert _meta_value(db_path, FTS_STALE_KEY) == "1"
+        assert _base_fts_triggers(db_path) == set()
+
     def test_stale_search_preserves_not_semantics(self, db, tmp_path, monkeypatch):
         if not db._fts_enabled:
             pytest.skip("FTS5 unavailable in this build")
@@ -321,6 +388,39 @@ class TestRuntimeFtsRebuild:
             reopened.append_message("s1", "user", "after failed recovery")
             assert _message_contents(db_path)[-1] == "after failed recovery"
             assert reopened.search_messages("failed recovery")
+        finally:
+            reopened.close()
+
+    def test_foreign_holder_defers_startup_stale_rebuild(
+        self, db, tmp_path, monkeypatch
+    ):
+        if not db._fts_enabled:
+            pytest.skip("FTS5 unavailable in this build")
+        db_path = tmp_path / "state.db"
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "seed")
+        _corrupt_fts(db_path)
+        monkeypatch.setattr(
+            db,
+            "rebuild_fts",
+            lambda: (_ for _ in ()).throw(sqlite3.DatabaseError("still corrupt")),
+        )
+        db.append_message("s1", "user", "before restart")
+        db.close()
+
+        monkeypatch.setattr(
+            SessionDB,
+            "_foreign_state_db_holders",
+            lambda self: [(4242, str(db_path) + "-wal")],
+            raising=False,
+        )
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert reopened._fts_stale is True
+            assert _meta_value(db_path, FTS_STALE_KEY) == "1"
+            assert _base_fts_triggers(db_path) == set()
+            reopened.append_message("s1", "user", "after deferred recovery")
+            assert _message_contents(db_path)[-1] == "after deferred recovery"
         finally:
             reopened.close()
 


### PR DESCRIPTION
## Summary
Guards all three automatic FTS rebuild paths against running when a foreign process holds state.db or its WAL sidecars open, preventing WAL split-brain corruption when `gateway run` and `hermes serve` share the same database.

## Changes
- `hermes_state.py`: New `_foreign_state_db_holders()` method scans processes via psutil for open file descriptors matching state.db / state.db-wal / state.db-shm (including Linux `(deleted)` descriptors). Guards `_try_runtime_fts_rebuild` (runtime corrupt-index recovery).
- `hermes_state_schema.py`: Same guard on `_recover_stale_fts` (startup stale-FTS recovery).
- `gateway/session.py`: Added the same guard to `_rebuild_fts_once()` — the third FTS rebuild path that calls `db.rebuild_fts()` directly, bypassing the automatic recovery ladder.
- Comment on the early `_fts_runtime_rebuild_attempted = True` explaining why the flag is set before the foreign-holder check: the fail-open path that follows persists `FTS_STALE_KEY` so the next process startup retries via `_recover_stale_fts`.

## Root cause
When two Hermes processes share one WAL state.db, an automatic FTS rebuild can unlink and recreate `-wal`/`-shm` while the other process still holds the old inodes. The two writers then commit through different WAL files, causing cross-linked pages and structural corruption. The existing WAL-reset defenses (`_apply_delete_for_wal_reset_bug`, read-only journal probe) did not gate the FTS-maintenance paths.

## Validation
| | Before | After |
|---|---|---|
| tests/state/ | 77 pass | 77 pass |
| tests/gateway/test_session.py | 65 pass | 65 pass |
| ruff | clean | clean |
| E2E smoke | N/A | holder detection + fail-open verified |

## Credits
Salvaged from PR #90871 by @fangliquanflq. Contributor's cherry-picked commit preserves original authorship. Follow-up commit adds the gateway sibling-site guard and explanatory comment.

Closes #90806
