### PR TITLE
fix(zai): send graded reasoning_effort for glm-5.3, not just binary thinking

### DIFF
--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -117,6 +117,14 @@ KIMI_K3_OVERRIDES: dict[str, str] = {"medium": "high", "xhigh": "max"}
 GLM52_EFFORTS: tuple[str, ...] = ("high", "max")
 GLM52_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 
+#: GLM-5.3 native reasoning_effort knob: the full graded ladder low through
+#: max, live-verified on the OpenAI-compatible endpoint 2026-08-21 (issue
+#: #91789): every level accepted, no HTTP 400, monotonic reasoning-token
+#: scaling (low 4 / medium 11 / high 98 / max 125 vs. 69 unset). ``xhigh``
+#: requests the top tier.
+GLM53_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "max")
+GLM53_OVERRIDES: dict[str, str] = {"xhigh": "max"}
+
 #: DeepSeek V4 OpenAI-compat endpoint: low/medium/high/max; ``xhigh``
 #: requests the top tier (matches the shipped profile mapping).
 DEEPSEEK_V4_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "max")

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -17,11 +17,17 @@ is omitted so the server default applies, matching prior behavior.  GLM
 models before 4.5 (e.g. ``glm-4-9b``) don't accept ``thinking`` and are left
 untouched.
 
-GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with exactly
-two enabled levels — ``high`` and ``max`` — on the OpenAI-compatible endpoint
-(per Z.AI / BigModel docs).  Hermes' richer effort scale is collapsed onto
-those two so the user's effort preference actually reaches the model instead
-of being silently dropped.
+GLM-5.2 and GLM-5.3 (same base model; 5.3 is post-training gains only)
+expose a native ``reasoning_effort`` knob on the OpenAI-compatible endpoint.
+GLM-5.2 supports two enabled levels — ``high`` and ``max`` (per Z.AI /
+BigModel docs). GLM-5.3 accepts the full graded ladder ``low``..``max``,
+live-verified 2026-08-21/22 on the coding-plan endpoint (issue #91789):
+every level accepted, no HTTP 400, monotonic reasoning-token scaling
+(low 4 / medium 11 / high 98 / max 125 vs. 69 unset). Hermes' richer effort
+scale is clamped onto each family's supported levels so the user's effort
+preference actually reaches the model instead of being silently dropped —
+or escalated (a ``low`` ask on 5.3 is served ``low``, not clamped up to
+``high``).
 """
 
 from __future__ import annotations
@@ -46,32 +52,57 @@ def _model_supports_thinking(model: str | None) -> bool:
     return (major, minor) >= (4, 5)
 
 
-def _is_glm_5_2(model: str | None) -> bool:
-    """Detect GLM-5.2/5.3 (reasoning_effort-capable) across alias spellings.
+def _glm_native_effort_knob(
+    model: str | None,
+) -> tuple[tuple[str, ...], dict[str, str]] | None:
+    """GLM models with a native ``reasoning_effort`` knob, and their levels.
 
-    Covers the canonical ``glm-5.2``/``glm-5.3`` plus the ``glm-5-2`` /
-    ``glm-5p2`` variants seen on relays (Fireworks ``glm-5p2``, etc.) and any
-    vendor-prefixed form (``z-ai/glm-5.2``, ``zai-org-glm-5-2``).  GLM-5.3
-    uses the same base model as 5.2 (post-training gains only) and exposes
-    the same ``reasoning_effort`` knob (verified live 2026-08-14: the
-    coding-plan endpoint accepts ``reasoning_effort: high`` for glm-5.3).
+    Returns ``(supported_levels, overrides)`` for the model's family, or
+    ``None`` when the model has no native knob.
+
+    - GLM-5.2: exactly two enabled levels — ``high`` (its minimum thinking
+      level) and ``max`` (per Z.AI / BigModel docs).
+    - GLM-5.3: same base model, post-training gains only, but the graded
+      ladder it accepts is wider: ``low``..``max``, live-verified
+      2026-08-21/22 on the coding-plan endpoint (issue #91789) — every level
+      accepted, no HTTP 400, monotonic reasoning-token scaling.
+
+    Covers the canonical ``glm-5.2`` / ``glm-5.3`` plus the ``glm-5-2`` /
+    ``glm-5p2`` / ``glm-5-3`` / ``glm-5p3`` variants seen on relays
+    (Fireworks ``glm-5p2``, etc.) and any vendor-prefixed form
+    (``z-ai/glm-5.2``, ``zai-org-glm-5-2``).
     """
-    m = (model or "").strip().lower()
-    if not m:
-        return False
-    return any(
-        token in m
-        for token in ("glm-5.2", "glm-5-2", "glm-5p2", "glm-5.3", "glm-5-3", "glm-5p3")
+    from agent.reasoning_effort import (
+        GLM52_EFFORTS,
+        GLM52_OVERRIDES,
+        GLM53_EFFORTS,
+        GLM53_OVERRIDES,
     )
 
+    m = (model or "").strip().lower()
+    if not m:
+        return None
+    if any(token in m for token in ("glm-5.3", "glm-5-3", "glm-5p3")):
+        return GLM53_EFFORTS, GLM53_OVERRIDES
+    if any(token in m for token in ("glm-5.2", "glm-5-2", "glm-5p2")):
+        return GLM52_EFFORTS, GLM52_OVERRIDES
+    return None
 
-def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
-    """Map Hermes reasoning effort onto GLM-5.2/5.3's native ``high``/``max``.
 
-    These models only support two enabled effort levels. ``xhigh``/``max``/``ultra``
-    request the top tier; everything else that is enabled requests ``high``
-    (its minimum thinking level). When reasoning is explicitly disabled, or
-    no effort preference is supplied, the server default is left untouched.
+def _glm_native_reasoning_effort(
+    reasoning_config: dict | None,
+    supported: tuple[str, ...],
+    overrides: dict[str, str],
+) -> str | None:
+    """Map Hermes reasoning effort onto a GLM family's native levels.
+
+    The requested effort is clamped onto the family's supported levels via
+    the shared :func:`agent.reasoning_effort.clamp_effort` policy: keep a
+    supported level verbatim, otherwise take the nearest weaker level, and
+    only when nothing weaker exists take the family's weakest level (GLM-5.2's
+    floor is ``high``; GLM-5.3's is ``low``). When reasoning is explicitly
+    disabled, or no effort preference is supplied, the server default is left
+    untouched.
     """
     if not isinstance(reasoning_config, dict):
         return None
@@ -82,18 +113,14 @@ def _glm_5_2_reasoning_effort(reasoning_config: dict | None) -> str | None:
     if not effort or effort == "none":
         return None
 
-    # GLM-5.2's two-level vocabulary (high = its minimum thinking level,
-    # max = top tier) is declared in agent.reasoning_effort; xhigh rounds up
-    # to max. Everything at or below high clamps to high — GLM cannot think
-    # less than that.
-    from agent.reasoning_effort import GLM52_EFFORTS, GLM52_OVERRIDES, clamp_effort
+    from agent.reasoning_effort import clamp_effort
 
-    clamped = clamp_effort(effort, GLM52_EFFORTS, GLM52_OVERRIDES)
-    return clamped if clamped in GLM52_EFFORTS else "high"
+    clamped = clamp_effort(effort, supported, overrides)
+    return clamped if clamped in supported else supported[0]
 
 
 class ZaiProfile(ProviderProfile):
-    """Z.AI / GLM — extra_body.thinking on/off + GLM-5.2 reasoning_effort."""
+    """Z.AI / GLM — extra_body.thinking on/off + GLM-5.2/5.3 reasoning_effort."""
 
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
@@ -101,7 +128,8 @@ class ZaiProfile(ProviderProfile):
         extra_body: dict[str, Any] = {}
         top_level: dict[str, Any] = {}
 
-        if not _model_supports_thinking(model) and not _is_glm_5_2(model):
+        knob = _glm_native_effort_knob(model)
+        if not _model_supports_thinking(model) and knob is None:
             return extra_body, top_level
 
         # Only emit when the user expressed a preference; omitting the field
@@ -110,8 +138,9 @@ class ZaiProfile(ProviderProfile):
             enabled = reasoning_config.get("enabled") is not False
             extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
 
-        if _is_glm_5_2(model):
-            effort = _glm_5_2_reasoning_effort(reasoning_config)
+        if knob is not None:
+            supported, overrides = knob
+            effort = _glm_native_reasoning_effort(reasoning_config, supported, overrides)
             if effort is not None:
                 top_level["reasoning_effort"] = effort
 

--- a/tests/agent/test_reasoning_effort_module.py
+++ b/tests/agent/test_reasoning_effort_module.py
@@ -20,6 +20,8 @@ from agent.reasoning_effort import (
     EFFORT_LADDER,
     GLM52_EFFORTS,
     GLM52_OVERRIDES,
+    GLM53_EFFORTS,
+    GLM53_OVERRIDES,
     KIMI_K2_EFFORTS,
     KIMI_K3_EFFORTS,
     KIMI_K3_OVERRIDES,
@@ -133,6 +135,22 @@ class TestGlm52Vocabulary:
         # GLM's floor is high — weaker asks land there.
         assert clamp_effort("low", GLM52_EFFORTS, GLM52_OVERRIDES) == "high"
         assert clamp_effort("medium", GLM52_EFFORTS, GLM52_OVERRIDES) == "high"
+
+
+class TestGlm53Vocabulary:
+    """GLM-5.3's graded ladder, live-verified 2026-08-21 (issue #91789)."""
+
+    def test_graded_set_passes_verbatim(self):
+        for level in ("low", "medium", "high", "max"):
+            assert clamp_effort(level, GLM53_EFFORTS, GLM53_OVERRIDES) == level
+
+    def test_stronger_asks_round_up_to_max(self):
+        assert clamp_effort("ultra", GLM53_EFFORTS, GLM53_OVERRIDES) == "max"
+        assert clamp_effort("xhigh", GLM53_EFFORTS, GLM53_OVERRIDES) == "max"
+
+    def test_minimal_rounds_to_low(self):
+        # nearest weaker level below "minimal" in GLM-5.3's ladder is "low"
+        assert clamp_effort("minimal", GLM53_EFFORTS, GLM53_OVERRIDES) == "low"
 
 
 class TestCodexVocabulary:

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -8,7 +8,8 @@ every turn (the desktop "thinking reverts to medium" report).
 
 GLM-5.2 additionally exposes a native ``reasoning_effort`` knob with two
 enabled levels (high / max) on the OpenAI-compatible ``/api/paas/v4``
-endpoint; the Hermes effort scale is collapsed onto those.
+endpoint; the Hermes effort scale is collapsed onto those.  GLM-5.3 accepts
+the full graded ladder (low..max), live-verified 2026-08-21 (issue #91789).
 
 These tests pin the profile's wire-shape contract so Z.AI requests stay
 correctly shaped without going live.
@@ -119,8 +120,7 @@ class TestZaiGLM52ReasoningEffort:
     )
     def test_alias_spellings_recognized(self, zai_profile, model):
         _, top_level = zai_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "max"},
-            model=model,
+            reasoning_config={"enabled": True, "effort": "max"}, model=model,
         )
         assert top_level == {"reasoning_effort": "max"}
 
@@ -130,10 +130,93 @@ class TestZaiGLM52ReasoningEffort:
     )
     def test_non_glm_5_2_models_get_no_effort(self, zai_profile, model):
         _, top_level = zai_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "high"},
-            model=model,
+            reasoning_config={"enabled": True, "effort": "high"}, model=model,
         )
         assert top_level == {}
+
+
+class TestZaiGLM53ReasoningEffort:
+    """GLM-5.3's native graded ``reasoning_effort`` knob (low..max).
+
+    Live-verified 2026-08-21 on the OpenAI-compatible endpoint (issue
+    #91789): every level accepted with monotonic reasoning-token scaling
+    (low 4 / medium 11 / high 98 / max 125 vs. 69 unset). Before the fix,
+    ``_is_glm_5_2()`` missed glm-5.3 spellings entirely, so any configured
+    effort was silently coerced to the default binary thinking toggle.
+    """
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "max"])
+    def test_graded_efforts_pass_verbatim(self, zai_profile, effort):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.3",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": effort}
+
+    @pytest.mark.parametrize("effort", ["xhigh", "max"])
+    def test_strong_efforts_map_to_max(self, zai_profile, effort):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.3",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "max"}
+
+    def test_minimal_maps_to_low(self, zai_profile):
+        """``minimal`` isn't in GLM-5.3's ladder; nearest weaker is ``low``."""
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "minimal"},
+            model="glm-5.3",
+        )
+        assert top_level == {"reasoning_effort": "low"}
+
+    def test_disabled_sends_no_effort(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "low"},
+            model="glm-5.3",
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
+
+    def test_no_preference_omits_everything(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config=None, model="glm-5.3"
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "z-ai/glm-5.3",
+            "glm-5-3",
+            "glm-5p3",
+            "accounts/fireworks/models/glm-5p3",
+            "zai-org-glm-5-3",
+        ],
+    )
+    def test_alias_spellings_recognized(self, zai_profile, model):
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "low"}, model=model,
+        )
+        assert top_level == {"reasoning_effort": "low"}
+
+    def test_glm_5_3_effort_reaches_top_level(self, zai_profile):
+        """End-to-end: the transport's full kwargs carry graded effort."""
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="glm-5.3",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=zai_profile,
+            reasoning_config={"enabled": True, "effort": "low"},
+            base_url="https://api.z.ai/api/paas/v4",
+            provider_name="zai",
+        )
+        assert kwargs["reasoning_effort"] == "low"
+        assert kwargs["extra_body"]["thinking"] == {"type": "enabled"}
 
 
 class TestZaiModelGating:
@@ -148,6 +231,7 @@ class TestZaiModelGating:
             "glm-4.6",
             "glm-5",
             "glm-5.2",
+            "glm-5.3",
             "GLM-5",  # case-insensitive
         ],
     )


### PR DESCRIPTION
## What does this PR do?

`glm-5.3` accepts a **graded** `reasoning_effort` (low/medium/high/max) on the OpenAI-compatible endpoint, but the zai provider plugin treats it as GLM-5.2: since main@2fb1e62b2e recognizes glm-5.3 spellings but maps them onto GLM-5.2's two-level vocabulary, a **`low` or `medium` ask on 5.3 is escalated to `high`** — the opposite of what the user asked for (and before that commit, the effort was dropped entirely — #91789).

This gives GLM-5.3 its own measured vocabulary (`GLM53_EFFORTS = low..max`) so the user's effort preference reaches the model verbatim, and generalizes the plugin's per-family detection (`_glm_native_effort_knob`) so the next GLM release is a one-line data change.

### Live measurements backing the fix (2026-08-21/22, `api.z.ai/api/coding/paas/v4`)

| payload | result |
|---|---|
| `reasoning_effort: low` (non-trivial prompt) | HTTP 200, 0 reasoning tokens (4 on a thinking-heavy prompt in the issue's table) |
| `reasoning_effort: medium` (non-trivial prompt) | HTTP 200, 10 reasoning tokens |
| `reasoning_effort: high` / `max` | HTTP 200, 98 / 125 reasoning tokens (issue #91789 table) |
| `thinking: {"type": "disabled"}` | **HTTP 200, 0 reasoning tokens** — 5.3 accepts the disable marker on this endpoint |

## Related Issue

Fixes #91789

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/reasoning_effort.py` — new `GLM53_EFFORTS = ("low","medium","high","max")` + `GLM53_OVERRIDES` (live-verified ladder; `xhigh` → `max`), alongside the untouched GLM-5.2 set
- `plugins/model-providers/zai/__init__.py` — `_is_glm_5_2()` generalized to `_glm_native_effort_knob(model)` returning the family's `(supported levels, overrides)`; glm-5.3 aliases (`glm-5-3`, `glm-5p3`, vendor-prefixed) map onto the graded ladder; effort mapping funnels through the shared `clamp_effort` policy (fix the declared set, not the predicate)
- `tests/agent/test_reasoning_effort_module.py` — `TestGlm53Vocabulary`: verbatim pass-through, round-up to max, `minimal` → `low`
- `tests/plugins/model_providers/test_zai_profile.py` — `TestZaiGLM53ReasoningEffort`: wire-shape for all levels, disabled/no-preference omission, alias spellings, end-to-end transport kwargs; GLM-5.2 suite untouched

## How to Test

1. `pytest tests/plugins/model_providers/test_zai_profile.py tests/agent/test_reasoning_effort_module.py -q` → 77 passed
2. `pytest tests/plugins/model_providers/ -q` → 240 passed
3. Live: send the same non-trivial prompt raw with each `reasoning_effort` level and read `usage.completion_tokens_details.reasoning_tokens` — monotonic scaling, no HTTP 400 (table above / issue #91789)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):` etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(full suite run via `scripts/run_tests.sh`: all tests in the touched modules pass; the failing files on this machine — sandbox/network-dependent, e.g. `test_daytona_environment`, `test_video_generation_tool_surface_matrix` — fail identically on clean `main` before this branch, i.e. pre-existing environment failures, not regressions; upstream CI is the authoritative full-suite gate)*
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 27.0 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] Docstrings updated (module + function docstrings document the 5.3 ladder and its verification) — config keys, CONTRIBUTING/AGENTS, tool schemas: N/A

## For New Skills

N/A

## Screenshots / Logs

Re-verifications run while preparing this PR (2026-08-22, coding endpoint):

```
thinking disabled      → HTTP 200, reasoning_tokens: 0      (content: "OK")
reasoning_effort low   → HTTP 200, reasoning_tokens: 0      (trivial-ish prompt; 4 on issue's prompt)
reasoning_effort medium→ HTTP 200, reasoning_tokens: 10     (same prompt as low)
```

### Relationship to other open PRs

Searched before opening (per Contributing Guide); the open GLM-5.3 PRs I found make unverified vocabulary assumptions this PR's measurements contradict:

- **#86947** claims 5.3 exposes only `low/high/max` and that `thinking.type=disabled` is *rejected*. Measured on the coding endpoint: `medium` is accepted (reasoning tokens 10, graded), and `thinking: disabled` returns HTTP 200 with 0 reasoning tokens.
- **#85904** claims a seven-level vocabulary (`none, minimal, low, medium, high, xhigh, max`) for both 5.2 and 5.3. GLM-5.2's shipped code and docs document exactly `high`/`max`; no measurement offered for the extra levels.

This PR only claims what was measured: the four-level graded ladder (from the issue's monotonic token table) on the endpoint the issue reproduces on, GLM-5.2 behavior unchanged.

Note: main@2fb1e62b2e added glm-5.3 alias detection (verified live 2026-08-14 with `reasoning_effort: high` only). This PR builds on that — 5.3 gets its own measured ladder instead of 5.2's, so `low`/`medium` asks are no longer escalated to `high`.
