### PR TITLE
fix(desktop): thread the active connection's profile to the readDir IPC path

### DIFF
--- a/apps/desktop/electron/fs-ipc.ts
+++ b/apps/desktop/electron/fs-ipc.ts
@@ -28,7 +28,7 @@ export function registerFsIpc({
   directoryExists,
   resolveGitBinary
 }: FsIpcDeps) {
-  ipcMain.handle('hermes:fs:readDir', async (_event, dirPath) => readDirForIpc(dirPath))
+  ipcMain.handle('hermes:fs:readDir', async (_event, dirPath, profile) => readDirForIpc(dirPath, { profile }))
 
   ipcMain.handle('hermes:fs:gitRoot', async (_event, startPath) => gitRootForIpc(startPath))
 

--- a/apps/desktop/electron/fs-read-dir.test.ts
+++ b/apps/desktop/electron/fs-read-dir.test.ts
@@ -4,9 +4,10 @@ import os from 'node:os'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-import { test } from 'vitest'
+import { afterEach, test, vi } from 'vitest'
 
 import { readDirForIpc } from './fs-read-dir'
+import * as wslPathBridge from './wsl-path-bridge'
 
 function mkTmpDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-fs-read-dir-'))
@@ -372,4 +373,44 @@ test('readDirForIpc bounds concurrent stats while preserving complete sorted out
   )
   assert.equal(result.entries.find(entry => entry.name === failedName)?.isDirectory, false)
   assert.equal(result.entries.filter(entry => entry.isDirectory).length, successfulDirectoryNames.size)
+})
+
+// ── profile threading (fs-ipc.ts's IPC handler forwards options.profile) ──
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('readDirForIpc forwards options.profile to resolveLocalReadPath, not just the default fallback', async () => {
+  // Without this, resolveLocalReadPath's own profile argument falls back to
+  // a process-global "active" profile pinned to the primary window — a
+  // secondary/pool profile's directory read would resolve WSL bridge
+  // eligibility against the WRONG profile. This proves the IPC-facing entry
+  // point actually reaches through with the caller's profile, not that
+  // resolveLocalReadPath itself works (that's covered in
+  // wsl-path-bridge-profile.test.ts).
+  const root = mkTmpDir()
+  const spy = vi.spyOn(wslPathBridge, 'resolveLocalReadPath')
+
+  try {
+    await readDirForIpc(root, { profile: 'team-pool' })
+    assert.equal(spy.mock.calls.length, 1)
+    assert.equal(spy.mock.calls[0][0], root)
+    assert.equal(spy.mock.calls[0][2], 'team-pool')
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('readDirForIpc passes undefined profile through when the caller omits it', async () => {
+  const root = mkTmpDir()
+  const spy = vi.spyOn(wslPathBridge, 'resolveLocalReadPath')
+
+  try {
+    await readDirForIpc(root)
+    assert.equal(spy.mock.calls.length, 1)
+    assert.equal(spy.mock.calls[0][2], undefined)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
 })

--- a/apps/desktop/electron/fs-read-dir.ts
+++ b/apps/desktop/electron/fs-read-dir.ts
@@ -84,7 +84,14 @@ async function readDirForIpc(dirPath, options: any = {}) {
 
   // On a Windows host with a WSL backend, a WSL/POSIX cwd (`/home/...`,
   // `/mnt/c/...`) isn't readable as-is; bridge it to a UNC/drive form first.
-  const readPath = resolveLocalReadPath(String(dirPath ?? ''))
+  // `options.profile` is the profile of the connection whose directory is
+  // being read — WITHOUT it, resolveLocalReadPath falls back to a
+  // process-global "active" profile that only tracks the PRIMARY window's
+  // backend, so browsing a secondary/pool profile with a different bridge
+  // eligibility than the primary silently used the wrong one (#66447-adjacent
+  // gap: the picker's defaultPath was fixed to thread a profile, this read
+  // path never was).
+  const readPath = resolveLocalReadPath(String(dirPath ?? ''), undefined, options.profile)
 
   try {
     ;({ resolvedPath: resolved } = await resolveDirectoryForIpc(readPath, {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -264,7 +264,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   // Fire-and-forget: persists a renderer error-boundary catch (with component
   // stack) to desktop.log so crashes survive the window (#79428).
   reportRendererError: report => ipcRenderer.send('hermes:logs:renderer-error', report),
-  readDir: dirPath => ipcRenderer.invoke('hermes:fs:readDir', dirPath),
+  readDir: (dirPath, profile) => ipcRenderer.invoke('hermes:fs:readDir', dirPath, profile),
   gitRoot: startPath => ipcRenderer.invoke('hermes:fs:gitRoot', startPath),
   revealPath: targetPath => ipcRenderer.invoke('hermes:fs:reveal', targetPath),
   openDir: dirPath => ipcRenderer.invoke('hermes:fs:openDir', dirPath),

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -287,7 +287,7 @@ declare global {
         message: string
         componentStack: string
       }) => void
-      readDir: (path: string) => Promise<HermesReadDirResult>
+      readDir: (path: string, profile?: string) => Promise<HermesReadDirResult>
       gitRoot?: (path: string) => Promise<string | null>
       // Reveal a path in the OS file manager (Finder / Explorer).
       revealPath?: (path: string) => Promise<boolean>

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -86,7 +86,11 @@ describe('desktop filesystem facade', () => {
     await expect(desktopGitRoot('/work')).resolves.toBe('/local')
     await expect(selectDesktopPaths({ directories: true })).resolves.toEqual(['/local'])
 
-    expect(readDir).toHaveBeenCalledWith('/work')
+    // readDir threads the active connection's profile (like selectPaths
+    // already does below) — WITHOUT it, the WSL bridge resolves eligibility
+    // against the primary window's profile even when browsing a secondary
+    // profile's directory (#66447-adjacent gap).
+    expect(readDir).toHaveBeenCalledWith('/work', 'team-local')
     expect(readFileText).toHaveBeenCalledWith('/work/file.txt')
     expect(readFileDataUrl).toHaveBeenCalledWith('/work/file.txt')
     expect(gitRoot).toHaveBeenCalledWith('/work')
@@ -142,6 +146,27 @@ describe('desktop filesystem facade', () => {
 
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/list?path=%2Fsrv%2Fproject', profile: 'remote-docker' })
     expect(api).toHaveBeenCalledWith({ path: '/api/fs/default-cwd', profile: 'remote-docker' })
+  })
+
+  it('threads the CURRENTLY active local profile to readDir on every switch, not a pinned primary', async () => {
+    // Both profiles are local (mode: 'local') — isDesktopFsRemoteMode() takes
+    // the Electron IPC branch for both, so this proves readDir doesn't just
+    // forward SOME profile, but the one the renderer is actually looking at
+    // right now, even when it changes mid-session (secondary/pool profile
+    // browsed after the primary, and back again). Without threading it,
+    // wsl-path-bridge.ts's resolveLocalReadPath falls back to a
+    // process-global "active" profile pinned to the PRIMARY window only.
+    $connection.set({ mode: 'local', profile: 'primary' } as never)
+    await readDesktopDir('/home/alex/primary-project')
+    expect(readDir).toHaveBeenLastCalledWith('/home/alex/primary-project', 'primary')
+
+    $connection.set({ mode: 'local', profile: 'team-pool' } as never)
+    await readDesktopDir('/home/alex/pool-project')
+    expect(readDir).toHaveBeenLastCalledWith('/home/alex/pool-project', 'team-pool')
+
+    $connection.set({ mode: 'local', profile: 'primary' } as never)
+    await readDesktopDir('/home/alex/primary-again')
+    expect(readDir).toHaveBeenLastCalledWith('/home/alex/primary-again', 'primary')
   })
 
   it('keys SSH filesystem caches by stable host identity instead of the forwarded port', () => {

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -65,7 +65,11 @@ function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T
 
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {
   if (!isDesktopFsRemoteMode()) {
-    return bridge().readDir(path)
+    // The active $connection's profile — WITHOUT it, the Electron IPC path
+    // resolves WSL bridge eligibility against the primary window's own
+    // profile, not whichever (possibly secondary/pool) profile's directory
+    // is actually being browsed. Mirrors selectDesktopPaths's profile thread.
+    return bridge().readDir(path, desktopFsProfile())
   }
 
   return remoteFsApi<HermesReadDirResult>(fsPath('list', path))


### PR DESCRIPTION
## Summary

`wsl-path-bridge.ts::resolveLocalReadPath(dirPath, distro?, profile?)` already accepts a `profile` argument and resolves WSL bridge eligibility per-profile (`deec043276`, "scope WSL bridge state by profile") — but without an explicit profile it falls back to a process-global `activeWslBridgeProfile` that is pinned **only at boot/primary-switch** to `primaryProfileKey()` (`main.ts:10592`/`15060` — `setActiveGatewayProfile` is never called with any other profile, confirmed by grep). The native folder-picker's `defaultPath` resolution (`resolvePickerDefaultPath`) was already fixed to thread a profile through; the fs directory-read path never was.

I traced the actual call chain end-to-end (not just the function's own signature) before writing this fix:

```
readDesktopDir(path)                                  [desktop-fs.ts, local mode]
  -> bridge().readDir(path)                            [no profile]
  -> preload.ts: ipcRenderer.invoke('hermes:fs:readDir', dirPath)   [no profile]
  -> fs-ipc.ts: readDirForIpc(dirPath)                  [no options]
  -> fs-read-dir.ts: resolveLocalReadPath(dirPath)      [no profile -> stale fallback]
```

**Concrete failure:** primary profile is a remote backend (bridge inactive, correctly cached as `false`). A secondary/pool profile is a locally-spawned WSL-hosted backend (bridge active, correctly cached as `true` under its own key — `ensureBackend`'s `setWslBridgeProfileState` calls are genuinely per-profile, verified). The user switches `$connection` to the secondary profile and browses its file tree. `isDesktopFsRemoteMode()` sees `'local'` (correct — the secondary *is* local) and takes the Electron-IPC branch, which resolves eligibility against `activeWslBridgeProfile` (still `'primary'`, from boot) instead of the secondary profile actually being browsed — the primary's stale "inactive" state applies, the WSL→UNC bridge is skipped, and the secondary's genuine `/home/...` POSIX cwd is handed straight to `fs.readdir()` on Windows, where it doesn't exist.

## A wrong first instinct I caught before writing the fix

`fs-ipc.ts` already has a `readActiveDesktopProfile` dependency in scope (used by `localPluginsRoot()` a few lines below the `readDir` handler) — reusing it looked like the obvious fix. I checked its definition (`main.ts:8653`) before doing that: it's the disk-persisted **primary window's own** profile preference — literally `primaryProfileKey()`'s source. Using it here would have kept resolving to the wrong (primary) profile in exactly the scenario this bug describes; it would not have fixed anything. The correct source is the renderer's live `$connection` state (`desktopFsProfile()`, already used by `remoteFsApi`/`selectDesktopPaths` for this exact purpose) — threaded through as a plain optional positional argument, matching `resolveLocalReadPath`'s own existing shape, rather than introducing an options-object convention this bridge method didn't have.

## Fix

`readDir(path, profile?)` threaded through every layer: `preload.ts`, the `hermes:fs:readDir` IPC handler (`fs-ipc.ts`), `readDirForIpc`'s `options.profile` (`fs-read-dir.ts`), and `readDesktopDir`'s `desktopFsProfile()` call (`desktop-fs.ts`). `global.d.ts`'s bridge type updated to match.

## Test plan

- [x] `desktop-fs.test.ts`: updated the pre-existing local-mode assertion — it asserted `readDir` was called *without* a profile, which was asserting the bug. Added a dedicated multi-profile-switch regression test (primary → pool → primary, each `readDir` call checked against the *currently* active profile, not a pinned one).
- [x] `fs-read-dir.test.ts`: two new tests proving `readDirForIpc` forwards `options.profile` to `resolveLocalReadPath` (and correctly passes `undefined` when the caller omits it).
- [x] Mutation-verified in two separate passes: stashed `desktop-fs.ts` alone (both its tests failed with the exact pre-fix `vi.fn() called with no profile` output), then stashed `fs-read-dir.ts` alone (the profile-forwarding test failed showing `undefined` instead of `'team-pool'`; the negative-control "omitted" test correctly still passed either way).
- [x] Full `apps/desktop/electron/` suite: 1518 passed, 3 skipped, 1 pre-existing failure (`remote-lifecycle.test.ts`'s installer-wrapper PID probe) — confirmed unrelated by re-running it in total isolation with none of this PR's files present; it's a subprocess-exit-timing race (`ps -ww -o command= -p <pid>` against an already-exited PID).
- [x] `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.electron.json`.
- `eslint` could not run in this sandbox — `eslint.config.mjs` needs the `globals` package, which lives at the workspace root and isn't present in a `npm ci --workspace=apps/desktop`-scoped install. Pre-existing, documented environment limitation, unrelated to this change.

## Competing PRs

Checked `gh pr list --search` with several keyword combinations right before opening this PR. **#66203** ("bridge WSL paths for the remaining file-read handlers on Windows") touches `main.ts`'s `hermes:readFileText`/`hermes:readFileDataUrl` handlers and a new `local-read-path.ts` module — confirmed via `gh pr diff` hunk headers, zero overlap with `fs-ipc.ts`'s `hermes:fs:readDir` handler or `fs-read-dir.ts` (it's the complementary gap on file-*text* reads, which never bridged at all regardless of profile — a different, orthogonal issue). No other hits.