### PR TITLE
fix(curator): cap queue-execute review iterations at 150

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1941,10 +1941,13 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             enabled_toolsets=["skills", "terminal"],
             # Umbrella-building over a large skill collection is worth a
             # high iteration ceiling — the pass typically takes 50-100
-            # API calls against hundreds of candidate skills. The
-            # single-session review path caps itself at a much smaller
-            # number because it's not doing a curation sweep.
-            max_iterations=9999,
+            # API calls against hundreds of candidate skills — but 9999
+            # let a stuck pass burn the full iteration wall (~17M input /
+            # ~135M cache-read tokens per occurrence) before anyone
+            # noticed. Cap at 150: measured pass headroom over the
+            # 50-100 typical, still bounded (#91841; plan S4 in
+            # docs/plans/2026-08-21-cost-integrity-systemics.md).
+            max_iterations=150,
             quiet_mode=True,
             platform="curator",
             skip_context_files=True,

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -830,6 +830,7 @@ def test_review_fork_restricts_toolsets_to_skills_and_terminal(curator_env, monk
     class _StubAgent:
         def __init__(self, *args, **kwargs):
             captured["enabled_toolsets"] = kwargs.get("enabled_toolsets", "UNSET")
+            captured["max_iterations"] = kwargs.get("max_iterations", "UNSET")
             self._memory_write_origin = "assistant_tool"
             self._memory_nudge_interval = 0
             self._skill_nudge_interval = 0
@@ -852,6 +853,12 @@ def test_review_fork_restricts_toolsets_to_skills_and_terminal(curator_env, monk
         "'terminal'] to AIAgent; the full default tool catalog (plus lcm_* "
         "context_engine tools) would be advertised; got "
         f"{captured.get('enabled_toolsets')!r}"
+    )
+    assert captured.get("max_iterations") == 150, (
+        "curator review fork must cap max_iterations at 150 — the old 9999 "
+        "let a stuck pass burn the full iteration wall (~17M input / ~135M "
+        "cache-read tokens per occurrence) before anyone noticed (#91841); "
+        f"got {captured.get('max_iterations')!r}"
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Caps the curator queue-execute review fork's `max_iterations` at 150, down from 9999 (#91841). The old ceiling let a stuck curation pass burn the full iteration wall — measured at ~17M input / ~135M cache-read tokens per occurrence (3 occurrences in one week per the issue's worktracker bead) — before anything bounded it. 150 keeps comfortable headroom over the measured 50–100 iterations a typical umbrella-building pass needs over hundreds of candidate skills, per the cost-integrity plan's S4 (`docs/plans/2026-08-21-cost-integrity-systemics.md`) that recommends exactly this cap.

The cap is a plain constant for now; the issue's alternative (a governor-configurable field) is a config-surface decision left to maintainers — one number change is trivial to retune later either way.

## Related Issue

Fixes #91841

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/curator.py` — `_run_llm_review`'s `AIAgent(...)` construction: `max_iterations=9999` → `max_iterations=150`; the comment now records why (the stuck-pass token burn) and where the figure comes from.
- `tests/agent/test_curator.py` — the existing constructor-capture test (`test_review_fork_restricts_toolsets_to_skills_and_terminal`) now also captures and pins `max_iterations == 150`, so a future edit re-raising the ceiling fails a named assertion spelling out the cost.

## How to Test

1. Automated: `.venv/bin/python -m pytest tests/agent/test_curator.py -q` — should pass (observed result: 27 passed on macOS arm64; the one failure, `test_curator_slot_is_canonical_aux_task`, fails identically on a clean `upstream/main` stash — pre-existing, unrelated to this change).
2. Manual: run a queue-execute curation pass over a large skill collection and confirm it still completes well under 150 iterations (typical passes take 50–100).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted curator suite: 27 passed, 1 pre-existing env failure verified against clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment cites the plan section)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (constant, not a config key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (platform-neutral constant)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
