### PR TITLE
fix: honor --ignore-rules during subdirectory discovery

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2883,6 +2883,7 @@ def init_agent(
 
     agent._subdirectory_hints = SubdirectoryHintTracker(
         working_dir=os.getenv("TERMINAL_CWD") or None,
+        enabled=not agent.skip_context_files,
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -82,7 +82,8 @@ class SubdirectoryHintTracker:
             tool_result += hints  # append to the tool result string
     """
 
-    def __init__(self, working_dir: Optional[str] = None):
+    def __init__(self, working_dir: Optional[str] = None, enabled: bool = True):
+        self.enabled = enabled
         self.working_dir = Path(working_dir or os.getcwd()).resolve()
         self._loaded_dirs: Set[Path] = set()
         # Content digests already injected — prevents re-sending the same file
@@ -90,7 +91,8 @@ class SubdirectoryHintTracker:
         self._loaded_digests: Set[str] = set()
         # Pre-mark the working dir as loaded (startup context handles it)
         self._loaded_dirs.add(self.working_dir)
-        self._seed_working_dir_digest()
+        if self.enabled:
+            self._seed_working_dir_digest()
 
     def _seed_working_dir_digest(self) -> None:
         """Record the CWD context file's digest so it is never re-injected.
@@ -123,6 +125,9 @@ class SubdirectoryHintTracker:
 
         Returns formatted hint text to append to the tool result, or None.
         """
+        if not self.enabled:
+            return None
+
         dirs = self._extract_directories(tool_name, tool_args)
         if not dirs:
             return None

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -1,10 +1,19 @@
 """Tests for progressive subdirectory hint discovery."""
 
+import sys
+import types
+
 import pytest
 from pathlib import Path
 from unittest.mock import patch
 
 from agent.subdirectory_hints import SubdirectoryHintTracker
+
+
+# Stub optional heavy imports so run_agent imports cleanly in isolation.
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
 
 
 @pytest.fixture
@@ -114,6 +123,50 @@ class TestSubdirectoryHintTracker:
         assert tracker.check_tool_call("read_file", {}) is None
         assert tracker.check_tool_call("terminal", {"command": ""}) is None
 
+
+class TestDisabledTracker:
+    """Disabled trackers must not discover or read context files."""
+
+    def test_disabled_tracker_does_not_read_or_inject_context(self, project):
+        """Disabling discovery prevents startup seeding and progressive reads."""
+        with patch.object(Path, "is_file", autospec=True) as is_file:
+            with patch.object(Path, "read_text", autospec=True) as read_text:
+                tracker = SubdirectoryHintTracker(
+                    working_dir=str(project),
+                    enabled=False,
+                )
+                result = tracker.check_tool_call(
+                    "read_file",
+                    {"path": str(project / "backend" / "src" / "main.py")},
+                )
+
+        assert result is None
+        is_file.assert_not_called()
+        read_text.assert_not_called()
+
+    def test_aiagent_skip_context_files_disables_tracker(
+        self, tmp_path, monkeypatch
+    ):
+        """AIAgent's context-file opt-out also disables progressive hints."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="gpt-5.5",
+            provider="openai-codex",
+            api_key="test-api-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="cli",
+        )
+
+        assert agent._subdirectory_hints.enabled is False
 
 
 class TestPermissionErrorHandling:


### PR DESCRIPTION
## Summary

- disable progressive subdirectory context discovery whenever `skip_context_files` is enabled by CLI `--ignore-rules`
- avoid even the initial context-file digest read while discovery is disabled
- preserve the existing enabled-by-default behavior for every current tracker caller

## Problem

`--ignore-rules` suppressed startup project-context loading, but `SubdirectoryHintTracker` was still constructed and consulted after tool calls. Accessing a nested path could therefore discover and inject an `AGENTS.md` (or equivalent) despite the explicit opt-out.

## Implementation

`SubdirectoryHintTracker` now accepts `enabled=True`. Disabled trackers skip startup digest seeding and return before extracting directories. `AIAgent` wires this to `not skip_context_files`.

## Test plan

- [x] TDD regression observed RED first: 2 failed, 26 passed
- [x] focused tracker suite: 28 passed, 0 failed
- [x] CLI ignore-flag suite: 7 passed, 0 failed
- [x] integration smoke: disabled mode returned no hint for a real nested `AGENTS.md`; normal mode still injected it
- [x] Ruff on all changed files
- [x] independent read-only review: PASS, no blocking findings

The broader `tests/agent/` run completed with 10 failures in 7 unrelated files. The exact same 10 failures reproduced at the untouched base SHA in a detached worktree; they are environment/dependency mismatches (`anthropic` absent and the installed `nemo_relay` API/config version differing from the checkout), not regressions from this change.

## Related work

This closes the remaining progressive-discovery gap left by related isolation work in #88360. It also generalizes the tracker `enabled` direction seen in #9434 to the current `skip_context_files` / `--ignore-rules` path.
