### PR TITLE
fix(credits): suppress stealth preview top-up notices

### DIFF
--- a/agent/credits_tracker.py
+++ b/agent/credits_tracker.py
@@ -221,12 +221,16 @@ class AgentNotice:
 def is_free_tier_model(model: str, base_url: str = "") -> bool:
     """Return True when *model* is a Nous free-tier model, using ONLY local data.
 
-    Two signals, both zero-network:
+    Three signals, all zero-network:
 
     1. The ``:free`` suffix — the canonical Nous free SKU marker (e.g.
        ``nvidia/nemotron-3-ultra:free``). Free by construction on the API side
        (spend is forced to 0 for ``:free`` ids).
-    2. A peek into the in-process pricing cache in ``hermes_cli.models``
+    2. The ``stealth/`` namespace on Nous' canonical inference endpoint. These
+       are free preview SKUs but intentionally omit the public ``:free`` suffix.
+       Restricting this signal to the Nous endpoint avoids trusting a model name
+       controlled by an unrelated OpenAI-compatible provider.
+    3. A peek into the in-process pricing cache in ``hermes_cli.models``
        (populated when the model picker fetched ``/v1/models`` pricing for
        *base_url*). PEEK ONLY — a cache miss never triggers a fetch. This is
        CLI/TUI-session best-effort: gateway sessions never run the picker's
@@ -243,15 +247,17 @@ def is_free_tier_model(model: str, base_url: str = "") -> bool:
         return True
     if not base_url:
         return False
+    key = base_url.rstrip("/")
+    if key.endswith("/v1"):
+        key = key[:-3].rstrip("/")
+    if model.startswith("stealth/") and key == "https://inference-api.nousresearch.com":
+        return True
     try:
         from hermes_cli.models import _is_model_free, _pricing_cache
 
         # Mirror get_pricing_for_provider's key normalization: the agent's
         # Nous base_url is /v1-suffixed (https://inference-api.nousresearch.com/v1)
         # but the picker keys _pricing_cache on the pre-/v1 root.
-        key = base_url.rstrip("/")
-        if key.endswith("/v1"):
-            key = key[:-3].rstrip("/")
         pricing = _pricing_cache.get(key)
         if not pricing:
             return False

--- a/run_agent.py
+++ b/run_agent.py
@@ -4251,7 +4251,7 @@ class AIAgent:
                 latch = self._credits_latch = new_credits_latch()
             # Free-model gate: a depleted account on a free model can still
             # inference, so the depleted error banner is suppressed. Local-data
-            # only (":free" suffix + pricing-cache peek) — never a network call.
+            # only (known free SKU markers + pricing-cache peek) — never a network call.
             model_is_free = is_free_tier_model(
                 getattr(self, "model", "") or "",
                 getattr(self, "base_url", "") or "",

--- a/tests/agent/test_credits_policy.py
+++ b/tests/agent/test_credits_policy.py
@@ -313,6 +313,28 @@ class TestDepletedFreeModelSuppression:
 
 class TestIsFreeTierModel:
 
+    def test_nous_stealth_preview_is_free_without_pricing_cache(self, monkeypatch):
+        from agent.credits_tracker import is_free_tier_model
+        import hermes_cli.models as models_mod
+
+        monkeypatch.setattr(models_mod, "_pricing_cache", {})
+
+        assert is_free_tier_model(
+            "stealth/ox-alpha",
+            "https://inference-api.nousresearch.com/v1",
+        ) is True
+
+    def test_stealth_prefix_is_not_trusted_on_other_endpoints(self, monkeypatch):
+        from agent.credits_tracker import is_free_tier_model
+        import hermes_cli.models as models_mod
+
+        monkeypatch.setattr(models_mod, "_pricing_cache", {})
+
+        assert is_free_tier_model(
+            "stealth/paid-model",
+            "https://inference.example.com/v1",
+        ) is False
+
 
     def test_pricing_cache_peek_zero_priced_model(self, monkeypatch):
         from agent.credits_tracker import is_free_tier_model


### PR DESCRIPTION
## Summary

- recognize Nous `stealth/` preview SKUs as free-tier models even when gateway sessions have no pricing cache
- scope the prefix signal to the canonical Nous inference endpoint so unrelated providers cannot suppress real depletion warnings
- cover the gateway-shaped cache-miss path and the non-Nous safety boundary

## Testing

- `scripts/run_tests.sh tests/agent/test_credits_policy.py tests/run_agent/test_credits_notices_toggle.py tests/agent/test_nous_credits_snapshot.py tests/agent/test_nous_credits_gauge.py tests/agent/test_credits_view.py tests/agent/test_credits_tracker.py tests/agent/test_credits_fixture_snapshot.py tests/agent/test_credits_cold_start.py -q` (106 passed)

## Related Issue

Closes #91843
