### PR TITLE
fix(profiles): exclude lost+found and portal-recovery from clone-all

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -97,12 +97,17 @@ _CLONE_ALL_STRIP: list[str] = [
 # exclusion list (export also drops logs / caches because the archive is a
 # portable snapshot; clone-all keeps those because the cloned profile is
 # meant to keep working immediately).
+#
+#   lost+found — filesystem-created recovery directory, root-owned 0700 on
+#   every ext filesystem; copying it aborts the whole clone with
+#   PermissionError (#91850) and it is never useful in a profile.
 _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "hermes-agent",
     ".worktrees",
     "profiles",
     "bin",
     "node_modules",
+    "lost+found",
 })
 
 # Per-profile history artifacts excluded from --clone-all regardless of the
@@ -119,6 +124,10 @@ _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
 #   backups             — `hermes backup` archives
 #   state-snapshots     — quick-backup snapshot trees
 #   checkpoints         — session checkpoint data
+#   portal-recovery     — platform-managed recovery snapshots, written by a
+#                         root-owned recovery process (root:root 0640 files
+#                         abort the clone with PermissionError, #91850); a
+#                         profile never restores from the host's snapshots
 _CLONE_ALL_HISTORY_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "state.db",
     "state.db-wal",
@@ -127,6 +136,7 @@ _CLONE_ALL_HISTORY_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "backups",
     "state-snapshots",
     "checkpoints",
+    "portal-recovery",
 })
 
 # Marker file written by `hermes profile create --no-skills`.  When present in

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -110,10 +110,11 @@ _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "lost+found",
 })
 
-# Per-profile history artifacts excluded from --clone-all regardless of the
-# source profile.  A new profile is a fresh workspace — inheriting the source
-# profile's session history, backup archives, or quick-backup snapshots is
-# never useful (restoring one inside the clone would resurrect the SOURCE
+# Per-profile artifacts excluded from --clone-all regardless of the source
+# profile — mostly session/backup history, plus platform-managed recovery
+# trees (portal-recovery) that ride the same per-name mechanism.  A new
+# profile is a fresh workspace — inheriting the source profile's session
+# history, backup archives, or quick-backup snapshots is never useful (restoring one inside the clone would resurrect the SOURCE
 # profile's state) and can balloon the copy by tens of GB.  Unlike
 # ``_CLONE_ALL_DEFAULT_EXCLUDE_ROOT`` this set is NOT gated on the default
 # profile: named profiles accumulate the same artifacts.

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1029,6 +1029,44 @@ class TestEdgeCases:
         assert cloned_config["model"] == "cloned"
         assert (target_dir / ".env").read_text().strip() == "SECRET=yes"
 
+    def test_clone_skips_root_owned_recovery_paths(self, profile_env):
+        """#91850: root-owned paths in the source home must not abort the clone.
+
+        `lost+found` (filesystem-created, root:root 0700 on ext*) and
+        `portal-recovery` (root-owned recovery snapshots) previously hit
+        PermissionError inside copytree and killed the whole profile
+        creation, leaving a partial directory behind. Both are excluded by
+        name: neither is ever useful in a cloned profile. The dirs are
+        created 0700 without chown to simulate the unreadable shape.
+        """
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        (default_home / "config.yaml").write_text("model: test")
+        # Simulate root-only shapes: contents written first, then the parent
+        # dir goes 0o000 so copytree could never read inside (#91850).
+        lost = default_home / "lost+found"
+        lost.mkdir()
+        (lost / "inside").write_text("unreachable")
+        recovery = default_home / "portal-recovery" / "snapshots" / "last-ready"
+        recovery.mkdir(parents=True)
+        (recovery / "config.yaml").write_text("root:root 0640 in reality")
+        lost.chmod(0o000)
+        (default_home / "portal-recovery" / "snapshots").chmod(0o000)
+
+        try:
+            profile_dir = create_profile("luna", clone_config=True, no_alias=True)
+        finally:
+            # Restore modes so tmp_path cleanup can delete the tree.
+            lost.chmod(0o700)
+            (default_home / "portal-recovery" / "snapshots").chmod(0o700)
+
+        # The clone succeeded and carried the readable config…
+        cloned_config = yaml.safe_load((profile_dir / "config.yaml").read_text())
+        assert cloned_config["model"] == "test"
+        # …and neither root-owned path was copied.
+        assert not (profile_dir / "lost+found").exists()
+        assert not (profile_dir / "portal-recovery").exists()
+
 
 
 class TestProfilesToServe:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1050,15 +1050,20 @@ class TestEdgeCases:
         recovery = default_home / "portal-recovery" / "snapshots" / "last-ready"
         recovery.mkdir(parents=True)
         (recovery / "config.yaml").write_text("root:root 0640 in reality")
-        lost.chmod(0o000)
-        (default_home / "portal-recovery" / "snapshots").chmod(0o000)
+        # Mode-tightening only simulates the unreadable shape on POSIX; on
+        # Windows chmod(0o000) does not block reads, so there this test
+        # exercises the name-exclusion logic only.
+        if os.name == "posix":
+            lost.chmod(0o000)
+            (default_home / "portal-recovery" / "snapshots").chmod(0o000)
 
         try:
             profile_dir = create_profile("luna", clone_config=True, no_alias=True)
         finally:
             # Restore modes so tmp_path cleanup can delete the tree.
-            lost.chmod(0o700)
-            (default_home / "portal-recovery" / "snapshots").chmod(0o700)
+            if os.name == "posix":
+                lost.chmod(0o700)
+                (default_home / "portal-recovery" / "snapshots").chmod(0o700)
 
         # The clone succeeded and carried the readable config…
         cloned_config = yaml.safe_load((profile_dir / "config.yaml").read_text())


### PR DESCRIPTION
## What does this PR do?

Fixes profile creation aborting when the source home contains root-owned paths (#91850): `create_profile`'s `shutil.copytree` hits `PermissionError` on the first unreadable entry — on Linux hosts that's always `lost+found` (filesystem-created, `root:root 0700` on ext*) and, on managed deployments, `portal-recovery/` snapshots written by a root-owned recovery process (`root:root 0640` files). The whole `POST /api/profiles` / `hermes profile create` call dies with `shutil.Error` and leaves a partially-created profile directory behind.

The fix follows the issue's preferred option: add both names to `_clone_all_copytree_ignore`'s exclusion sets — `lost+found` joins `_CLONE_ALL_DEFAULT_EXCLUDE_ROOT` (default-home-only infrastructure, same tier as `hermes-agent`/`node_modules`) and `portal-recovery` joins `_CLONE_ALL_HISTORY_EXCLUDE_ROOT` (excluded for every source profile — a profile never restores from the host's platform-managed snapshots). Neither path is ever useful in a cloned profile, so excluding by name is strictly better than the alternative try/except-continue, which would silently swallow future unexpected permission failures instead of surfacing them.

## Related Issue

Fixes #91850

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — `_CLONE_ALL_DEFAULT_EXCLUDE_ROOT`: added `lost+found` with rationale comment; `_CLONE_ALL_HISTORY_EXCLUDE_ROOT`: added `portal-recovery` with rationale comment.
- `tests/hermes_cli/test_profiles.py` — `test_clone_skips_root_owned_recovery_paths`: source home carries a `0o000` `lost+found` (with content inside, unreadable shape) and a `0o000` `portal-recovery/snapshots` subtree; the clone must succeed, carry the readable config, and contain neither excluded path. (Parent modes restored in `finally` so tmp cleanup works.)

## How to Test

1. Automated: `.venv/bin/python -m pytest tests/hermes_cli/test_profiles.py -q` — should pass (observed result: 55 passed, 2 skipped on macOS arm64; clean-main baseline was 54+2, so only the new test was added, zero regressions).
2. Manual (Linux host with an ext filesystem): `hermes profile create luna` from a default home containing `lost+found` — creation now succeeds instead of failing with `shutil.Error`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted profiles suite: 55 passed, 0 failures)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64) — permission-denied shape reproduced via 0o000 modes

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (per-item rationale comments in the exclude sets)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (issue is Linux-specific; exclusion by name is platform-neutral — absent paths are simply never matched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
