### PR TITLE
fix(desktop): wrap code blocks in bot group chat message bodies

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -10709,7 +10709,7 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
                           }),
                           jsx('div', {
                             className:
-                              'text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:overflow-x-auto',
+                              'text-xs text-(--ui-text-secondary) [&_p]:mb-1 [&_p:last-child]:mb-0 [&_ul]:mb-1 [&_ul]:list-disc [&_ul]:pl-4 [&_ol]:mb-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:whitespace-pre-wrap [&_pre]:break-words',
                             // The app shell sets user-select: none globally; message bodies opt
                             // back in so drag-select and ⌘C work in group chat logs.
                             'data-selectable-text': 'true',

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-room-overflow.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-room-overflow.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+// Room message-body overflow (2026-08-21): a bot reply containing a long
+// fenced code block did not wrap and the room offered no horizontal scroll,
+// so the code was clipped on BOTH visible edges — unreadable. The approval
+// card's command block already wraps (whitespace-pre-wrap break-all); the
+// message body was the outlier with a bare `[&_pre]:overflow-x-auto`, and the
+// room's scroll viewport clips x with no scroll affordance.
+//
+// Tracked upstream: #70451 (markdown/code forces horizontal scroll), #91706
+// (approval Respond unreachable — the overflowing pre sat over the footer).
+
+test('bot message body code blocks wrap instead of clipping (#70451)', () => {
+  // Slice ONLY renderEntry — the function owning the message-body container.
+  const start = source.indexOf('const renderEntry = (entry, index) => {')
+  assert.ok(start !== -1, 'renderEntry exists')
+  const end = source.indexOf('\n  // Threads:', start + 1)
+  const component = source.slice(start, end === -1 ? source.length : end)
+
+  // The body must wrap long code (pre-wrap) and break unbreakable tokens
+  // (break-words) so nothing is ever clipped off the room's fixed x extent.
+  assert.match(component, /\[&_pre\]:whitespace-pre-wrap/)
+  assert.match(component, /\[&_pre\]:break-words/)
+  // A bare overflow-x-auto (horizontal scroll with no room affordance) must
+  // not be the only handling — it is what produced the clipped edges.
+  assert.doesNotMatch(component, /\[&_pre\]:overflow-x-auto$/)
+})


### PR DESCRIPTION
## What

Bot Mode group chat message bodies clipped long fenced code blocks on **both visible edges** with no way to read them — the room's scroll-area viewport clips `x` and offers no horizontal scroll affordance, so a bare `[&_pre]:overflow-x-auto` on the message body did nothing useful: the line was just cut off. This also sat the overflowing `pre` over the `GroupClarifyCard` footer, intercepting the Respond button's pointer events so it was only reachable by keyboard (Tab).

## Root cause

`apps/desktop/src/plugins/hermes-bots/plugin.js` — `renderEntry`'s message-body div:

```js
className: 'text-xs text-(--ui-text-secondary) [&_p]:mb-1 … [&_pre]:overflow-x-auto'
```

The approval card's own command block already wraps (`plugin.js:10187`: `whitespace-pre-wrap break-all`); the **message body was the outlier** with a bare `overflow-x-auto`. Because the room clips `x` with no scroll affordance, that `pre`'s intended horizontal scroll never surfaced — content was clipped instead.

## Fix

Change the message-body `pre` handling from `[&_pre]:overflow-x-auto` to `[&_pre]:whitespace-pre-wrap [&_pre]:break-words` (matching the approval card's wrap behavior), so long code wraps inside the fixed-x room instead of clipping.

Fixes the group-room half of #70451 (markdown/code forces horizontal scroll) and clears the #91706 Respond-unreachable pointer-interception path (keyboard-only reachability gone).

## Tests

`apps/desktop/src/plugins/hermes-bots/tests/group-room-overflow.test.mjs` — source-assertion regression test asserting the message body wraps (`[&_pre]:whitespace-pre-wrap` + `[&_pre]:break-words`) and no longer relies on a bare `[&_pre]:overflow-x-auto`. Verified RED against current source, then GREEN with the fix. Full plugin suite: 392/392 pass.

Note: the broader `markdown-text.tsx` path (#70451's main-chat half, scoped to prose/tables) is covered by #70520; this is the **group-room code path**, which that PR does not touch. Scoped deliberately so the two changes land independently.
