### PR TITLE
fix(cli): guard empty message text in _display_resumed_history

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -901,20 +901,20 @@ class CLIAgentSetupMixin:
             elif role == "user":
                 lines.append("  ● You: ", style=f"dim bold {_session_label_c}")
                 # Show first line inline, indent rest
-                msg_lines = text.splitlines()
+                msg_lines = text.splitlines() or [""]
                 lines.append(msg_lines[0] + "\n", style="dim")
                 for ml in msg_lines[1:]:
                     lines.append(f"         {ml}\n", style="dim")
             elif role == "assistant_last":
                 # Last assistant response shown in full, non-dim
                 lines.append("  ◆ Hermes: ", style=f"bold {_assistant_label_c}")
-                msg_lines = text.splitlines()
+                msg_lines = text.splitlines() or [""]
                 lines.append(msg_lines[0] + "\n", style="")
                 for ml in msg_lines[1:]:
                     lines.append(f"            {ml}\n", style="")
             else:
                 lines.append("  ◆ Hermes: ", style=f"dim bold {_assistant_label_c}")
-                msg_lines = text.splitlines()
+                msg_lines = text.splitlines() or [""]
                 lines.append(msg_lines[0] + "\n", style="dim")
                 for ml in msg_lines[1:]:
                     lines.append(f"            {ml}\n", style="dim")

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -173,6 +173,37 @@ class TestDisplayResumedHistory:
 
 
 
+    def test_empty_message_content_does_not_crash(self):
+        """Regression: _display_resumed_history IndexError when a message has empty text.
+
+        An assistant turn that produced no text (or a blank user message)
+        makes ``text.splitlines()`` return ``[]``, crashing on ``msg_lines[0]``.
+        The fix guards with ``or [""]`` so the message renders as a blank line.
+        """
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": ""},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "Follow-up question"},
+            {"role": "assistant", "content": "Real answer"},
+        ]
+        # Must not raise IndexError
+        output = self._capture_display(cli)
+
+        assert "Follow-up question" in output
+        assert "Real answer" in output
+
+    def test_whitespace_only_message_does_not_crash(self):
+        """Whitespace-only messages should also not crash the resume display."""
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "   "},
+            {"role": "assistant", "content": "\n\n"},
+        ]
+        output = self._capture_display(cli)
+        # Should render without error
+        assert "You:" in output
+
     def test_minimal_config_suppresses_display(self):
         cli = _make_cli(config_overrides={"display": {"resume_display": "minimal"}})
         # resume_display is captured as an instance variable during __init__


### PR DESCRIPTION
## Summary

`hermes chat --resume <id>` (and `--continue`) crashes with `IndexError: list index out of range` when a resumed session contains a message whose text is empty or whitespace-only (e.g. reasoning-only turns, tool-only assistant messages, blank user messages).

## Root cause

`_display_resumed_history` calls `text.splitlines()` on each entry, then accesses `msg_lines[0]` without guarding for empty results. `str.splitlines()` returns `[]` for empty strings, so `msg_lines[0]` raises `IndexError`.

This affects all three display branches: `user`, `assistant_last`, and regular `assistant`.

## Fix

Guard with `or [""]` so an empty message renders as a blank line instead of crashing:

```python
msg_lines = text.splitlines() or [""]
```

Applied identically in all three branches (lines 904, 911, 917).

## Verification

- 17 tests pass in `tests/cli/test_resume_display.py` (including 2 new regression tests)
- Mutation check: reverting the fix causes `test_empty_message_content_does_not_crash` to fail with the exact `IndexError` from the traceback — tests have teeth
- `ruff check` clean

## Salvage note

Salvage of #59276 by @AlexFucuson9 — rebased onto current `origin/main` (the original branch was 9887 commits behind). Authorship preserved via cherry-pick. Original PR to be closed with credit.

Fixes #59265