### PR TITLE
feat(api): expose authenticated bot profile roster

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3287,9 +3287,19 @@ class APIServerAdapter(BasePlatformAdapter):
                 "gateway_path": "" if is_default else f"/p/{name}",
             })
 
+        # Config alone is not proof that this checkout can inject the official
+        # canonical Bot Chat protocol. Older Hermes builds accept the setting
+        # but do not ship bot_mode_probe; expose the actual runtime capability.
+        try:
+            from tools.bot_mode_probe import get_bot_mode_protocol_section  # noqa: F401
+            bot_mode_protocol = True
+        except (ImportError, ModuleNotFoundError):
+            bot_mode_protocol = False
+
         return web.json_response({
             "object": "hermes.profile.list",
             "canonical_chat_title": "Bot Chat",
+            "bot_mode_protocol": bot_mode_protocol,
             "data": data,
         })
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2186,6 +2186,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/health/detailed", self._handle_health_detailed),
             ("GET", "/v1/health", self._handle_health),
             ("GET", "/v1/models", self._handle_models),
+            ("GET", "/api/profiles", self._handle_profiles),
             ("GET", "/api/model/options", self._handle_model_options),
             ("GET", "/v1/capabilities", self._handle_capabilities),
             # Authenticated browser-control surface: POST registration
@@ -3236,6 +3237,61 @@ class APIServerAdapter(BasePlatformAdapter):
             })
 
         return web.json_response({"object": "list", "data": models})
+
+    async def _handle_profiles(self, request: "web.Request") -> "web.Response":
+        """GET /api/profiles — authenticated, read-only Bot Mode roster.
+
+        The response intentionally omits filesystem paths, credential presence,
+        and every secret-bearing field. Named entries are addressable through
+        the existing multiplex ``/p/<profile>`` route; selecting one does not
+        require a client to switch machines or mutate its project context.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            from hermes_cli import profiles as profiles_mod
+
+            profiles = await asyncio.to_thread(profiles_mod.list_profiles)
+        except Exception:
+            logger.exception("[%s] GET /api/profiles failed", self.name)
+            return web.json_response(
+                _openai_error(
+                    "Failed to list Hermes profiles.",
+                    code="profiles_list_failed",
+                ),
+                status=500,
+            )
+
+        data = []
+        for info in profiles:
+            name = str(getattr(info, "name", "") or "").strip()
+            if not name:
+                continue
+            is_default = bool(getattr(info, "is_default", False))
+            title = (
+                "Hermes"
+                if is_default
+                else " ".join(part.capitalize() for part in re.split(r"[-_]", name) if part)
+            )
+            data.append({
+                "id": name,
+                "name": name,
+                "title": title or name,
+                "description": str(getattr(info, "description", "") or ""),
+                "model": getattr(info, "model", None),
+                "provider": getattr(info, "provider", None),
+                "skill_count": int(getattr(info, "skill_count", 0) or 0),
+                "is_default": is_default,
+                "gateway_path": "" if is_default else f"/p/{name}",
+            })
+
+        return web.json_response({
+            "object": "hermes.profile.list",
+            "canonical_chat_title": "Bot Chat",
+            "data": data,
+        })
 
     async def _handle_model_options(self, request: "web.Request") -> "web.Response":
         """GET /api/model/options — return Hermes provider/model inventory.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6602,11 +6602,10 @@ class APIServerAdapter(BasePlatformAdapter):
             include_disabled = request.query.get("include_disabled", "").lower() in {"true", "1"}
             jobs = _cron_list(include_disabled=include_disabled)
             owner = self._bot_owner_for_request()
-            owned_jobs = [
-                {**job, "bot_owner": owner} if isinstance(job, dict) else job
-                for job in jobs
-            ]
-            return web.json_response({"jobs": owned_jobs, "scoped": owner})
+            # Preserve the established jobs payload exactly; clients may compare
+            # or cache those objects. Ownership is authoritative for the whole
+            # profile-scoped response, so report it once at the envelope level.
+            return web.json_response({"jobs": jobs, "scoped": owner, "bot_owner": owner})
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6577,6 +6577,19 @@ class APIServerAdapter(BasePlatformAdapter):
             )
         return job_id, None
 
+    @staticmethod
+    def _bot_owner_for_request() -> str:
+        """Return the profile whose cron store the current request can see."""
+        routed = (_api_request_profile.get() or "").strip()
+        if routed:
+            return routed
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            return (get_active_profile_name() or "default").strip() or "default"
+        except Exception:
+            return "default"
+
     async def _handle_list_jobs(self, request: "web.Request") -> "web.Response":
         """GET /api/jobs — list all cron jobs."""
         auth_err = self._check_auth(request)
@@ -6588,7 +6601,12 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             include_disabled = request.query.get("include_disabled", "").lower() in {"true", "1"}
             jobs = _cron_list(include_disabled=include_disabled)
-            return web.json_response({"jobs": jobs})
+            owner = self._bot_owner_for_request()
+            owned_jobs = [
+                {**job, "bot_owner": owner} if isinstance(job, dict) else job
+                for job in jobs
+            ]
+            return web.json_response({"jobs": owned_jobs, "scoped": owner})
         except Exception as e:
             return web.json_response({"error": _redact_api_error_text(e)}, status=500)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -883,9 +883,16 @@ class TestProfilesEndpoint:
                 has_env=True,
             ),
         ]
+        unsupported_probe = types.ModuleType("tools.bot_mode_probe")
         app = _create_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch("hermes_cli.profiles.list_profiles", return_value=profiles):
+            with (
+                patch("hermes_cli.profiles.list_profiles", return_value=profiles),
+                patch.dict(
+                    sys.modules,
+                    {"tools.bot_mode_probe": unsupported_probe},
+                ),
+            ):
                 resp = await cli.get(
                     "/api/profiles",
                     headers={"Authorization": "Bearer sk-secret"},

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -33,6 +33,7 @@ from gateway.platforms.api_server import (
     _IdempotencyCache,
     _derive_chat_session_id,
     _hermes_version,
+    _api_request_profile,
     _redact_api_error_text,
     _request_agent_overrides,
     check_api_server_requirements,
@@ -949,6 +950,41 @@ class TestProfilesEndpoint:
                 body = await resp.json()
 
         assert body["bot_mode_protocol"] is True
+
+
+class TestCronJobsBotOwnership:
+    @pytest.mark.asyncio
+    async def test_list_jobs_reports_profile_scope_without_mutating_store(self, auth_adapter):
+        stored_job = {
+            "id": "abc123def456",
+            "name": "[bot:researcher] Daily brief",
+            "schedule": "0 9 * * *",
+        }
+        app = _create_app(auth_adapter)
+        app.router.add_get("/api/jobs", auth_adapter._handle_list_jobs)
+        token = _api_request_profile.set("researcher")
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                with (
+                    patch.object(auth_adapter, "_check_auth", return_value=None),
+                    patch("gateway.platforms.api_server._CRON_AVAILABLE", True),
+                    patch(
+                        "gateway.platforms.api_server._cron_list",
+                        return_value=[stored_job],
+                    ),
+                ):
+                    resp = await cli.get(
+                        "/api/jobs?include_disabled=true",
+                        headers={"Authorization": "Bearer sk-secret"},
+                    )
+                    assert resp.status == 200
+                    body = await resp.json()
+        finally:
+            _api_request_profile.reset(token)
+
+        assert body["scoped"] == "researcher"
+        assert body["jobs"][0]["bot_owner"] == "researcher"
+        assert "bot_owner" not in stored_job
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -924,6 +924,25 @@ class TestProfilesEndpoint:
         assert "/secret/" not in serialized
         assert "has_env" not in serialized
 
+    @pytest.mark.asyncio
+    async def test_profiles_reports_bot_protocol_when_runtime_injector_exists(self, auth_adapter):
+        probe = types.ModuleType("tools.bot_mode_probe")
+        probe.get_bot_mode_protocol_section = lambda: ""
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("hermes_cli.profiles.list_profiles", return_value=[]),
+                patch.dict(sys.modules, {"tools.bot_mode_probe": probe}),
+            ):
+                resp = await cli.get(
+                    "/api/profiles",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+                body = await resp.json()
+
+        assert body["bot_mode_protocol"] is True
+
 
 # ---------------------------------------------------------------------------
 # /v1/capabilities endpoint

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -983,7 +983,8 @@ class TestCronJobsBotOwnership:
             _api_request_profile.reset(token)
 
         assert body["scoped"] == "researcher"
-        assert body["jobs"][0]["bot_owner"] == "researcher"
+        assert body["bot_owner"] == "researcher"
+        assert body["jobs"] == [stored_job]
         assert "bot_owner" not in stored_job
 
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -308,6 +308,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)
     app.router.add_get("/v1/models", adapter._handle_models)
+    app.router.add_get("/api/profiles", adapter._handle_profiles)
     app.router.add_get("/api/model/options", adapter._handle_model_options)
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
     app.router.add_get("/v1/skills", adapter._handle_skills)
@@ -843,6 +844,84 @@ class TestModelsEndpoint:
             "include_unconfigured": True,
             "refresh": True,
         }
+
+
+# ---------------------------------------------------------------------------
+# /api/profiles endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestProfilesEndpoint:
+    @pytest.mark.asyncio
+    async def test_profiles_requires_bearer_auth(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/profiles")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_profiles_returns_safe_bot_roster(self, auth_adapter):
+        profiles = [
+            types.SimpleNamespace(
+                name="default",
+                is_default=True,
+                model="kimi-code-k3",
+                provider="openrouter",
+                description="General operator",
+                skill_count=12,
+                path="/secret/default",
+                has_env=True,
+            ),
+            types.SimpleNamespace(
+                name="realestate",
+                is_default=False,
+                model="gpt-5.6-sol",
+                provider="openai",
+                description="Real-estate acquisition specialist",
+                skill_count=7,
+                path="/secret/profiles/realestate",
+                has_env=True,
+            ),
+        ]
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("hermes_cli.profiles.list_profiles", return_value=profiles):
+                resp = await cli.get(
+                    "/api/profiles",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert resp.status == 200
+                body = await resp.json()
+
+        assert body["object"] == "hermes.profile.list"
+        assert body["canonical_chat_title"] == "Bot Chat"
+        assert body["data"] == [
+            {
+                "id": "default",
+                "name": "default",
+                "title": "Hermes",
+                "description": "General operator",
+                "model": "kimi-code-k3",
+                "provider": "openrouter",
+                "skill_count": 12,
+                "is_default": True,
+                "gateway_path": "",
+            },
+            {
+                "id": "realestate",
+                "name": "realestate",
+                "title": "Realestate",
+                "description": "Real-estate acquisition specialist",
+                "model": "gpt-5.6-sol",
+                "provider": "openai",
+                "skill_count": 7,
+                "is_default": False,
+                "gateway_path": "/p/realestate",
+            },
+        ]
+        serialized = json.dumps(body)
+        assert "/secret/" not in serialized
+        assert "has_env" not in serialized
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -895,6 +895,7 @@ class TestProfilesEndpoint:
 
         assert body["object"] == "hermes.profile.list"
         assert body["canonical_chat_title"] == "Bot Chat"
+        assert body["bot_mode_protocol"] is False
         assert body["data"] == [
             {
                 "id": "default",

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -68,12 +68,14 @@ class TestApiServerRouteTable:
         adapter = _make_adapter(multiplex=True)
         paths = {path for _method, path, _handler in adapter._http_route_table()}
         assert "/v1/models" in paths
+        assert "/api/profiles" in paths
         assert "/api/model/options" in paths
         assert "/v1/chat/completions" in paths
         assert "/api/sessions/{session_id}/model" in paths
         # connect() mirrors every native path under /p/{profile}/…
         mirrored = {f"/p/{{profile}}{path}" for path in paths}
         assert "/p/{profile}/v1/models" in mirrored
+        assert "/p/{profile}/api/profiles" in mirrored
         assert "/p/{profile}/api/model/options" in mirrored
         assert "/p/{profile}/v1/chat/completions" in mirrored
         assert "/p/{profile}/api/sessions/{session_id}/model" in mirrored


### PR DESCRIPTION
## Summary

- Add an authenticated `GET /api/profiles` endpoint for gateway clients.
- Return only privacy-safe profile metadata, canonical Bot Chat fields, and effective runtime Bot protocol capability.
- Mirror the endpoint through multiplexed `/p/<profile>` routes without weakening per-profile credential isolation.
- Report authoritative profile ownership once on the `/api/jobs` response envelope as `bot_owner` while preserving the established `jobs` objects exactly.

## Why

Mobile and other remote Bot Mode clients need a truthful roster and profile-owned routine reads. They cannot safely inspect local profile files, infer ownership from display names, or trust configured intent when the installed runtime lacks the Bot Chat protocol injector.

The response-envelope ownership field is backward compatible: existing consumers receive unchanged cron job objects, while Bot Mode clients can fail closed if the authenticated profile scope is wrong or absent.

## Verification on commit `e92637788eb080b533f712169b47387cebf7744a`

```text
.venv/bin/python -m pytest -q \
  tests/gateway/test_api_server.py \
  tests/gateway/test_api_server_jobs.py \
  tests/gateway/test_multiplex_api_server_routing.py \
  tests/gateway/test_multiplex_credential_isolation.py

138 passed, 0 failed
```

The compatibility test asserts both `body["jobs"] == [stored_job]` and that the stored job is not mutated.
