### PR TITLE
fix(tools): files_only search keeps paths containing spaces (#91698)

### DIFF
--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -60,6 +60,16 @@ def partial_error_tree(tmp_path):
     os.chmod(locked, 0o755)  # let pytest clean up tmp_path
 
 
+@pytest.fixture
+def spaced_name_tree(tmp_path):
+    """A tree whose match lives only under space-containing names (#91698)."""
+    spaced_dir = tmp_path / "Obsidian Vault"
+    spaced_dir.mkdir()
+    (spaced_dir / "file with space.md").write_text("needle\n")
+    (tmp_path / "plain.md").write_text("needle\n")
+    return tmp_path
+
+
 # Run every test once per available backend method.
 _METHODS = ["_search_with_grep"]
 if shutil.which("rg"):
@@ -94,6 +104,17 @@ class TestSearchErrorGuard:
                       partial_error_tree, output_mode="count")
         assert res.error is None
         assert res.total_count >= 4
+
+    def test_files_only_lists_spaced_paths(self, method, spaced_name_tree):
+        # #91698: rg -l/grep -l emit one bare path per line and POSIX paths
+        # may contain spaces. The splitter must keep them all in the payload —
+        # dropping every spaced path made a fully-spaced result set read as
+        # "no matches" with no error.
+        res = _search(_ops(spaced_name_tree), method, "needle",
+                      spaced_name_tree, output_mode="files_only")
+        assert res.error is None
+        assert res.total_count == 2
+        assert any(" " in f for f in res.files), f"spaced path dropped: {res.files}"
 
 
 class TestSearchContentNewlineWarning:
@@ -130,3 +151,39 @@ class TestSplitToolDiagnostics:
         assert diagnostics == ""
         assert "--" in payload
         assert "a.py-6-after" in payload
+
+
+class TestSplitToolDiagnosticsFilesOnly:
+    """Unit coverage for the mode-aware splitter rule (#91698)."""
+
+    def test_files_only_keeps_paths_with_spaces(self):
+        out = "/tmp/sf_repro/file with space.md\n/tmp/sf_repro/plain.md\n"
+        diagnostics, payload = _split_tool_diagnostics(out, output_mode="files_only")
+        assert diagnostics == ""
+        assert "file with space.md" in payload
+        assert "plain.md" in payload
+
+    def test_files_only_still_folds_error_blocks_into_diagnostics(self):
+        out = (
+            "rg: regex parse error:\n"
+            "    (?:[\n"
+            "       ^\n"
+            "error: unclosed character class\n"
+        )
+        diagnostics, payload = _split_tool_diagnostics(out, output_mode="files_only")
+        assert payload.strip() == ""
+        assert "regex parse error" in diagnostics
+
+    def test_content_mode_still_rejects_prose_lines_with_spaces(self):
+        # The default (content) classification is unchanged: a whitespace-
+        # bearing line that is not a match/context shape stays a diagnostic.
+        out = "some random prose line\na.py:5:hit\n"
+        diagnostics, payload = _split_tool_diagnostics(out)
+        assert "prose line" in diagnostics
+        assert "a.py:5:hit" in payload
+
+    def test_default_output_mode_keeps_call_sites_compatible(self):
+        out = "/tmp/plain.md\n"
+        diagnostics, payload = _split_tool_diagnostics(out)
+        assert diagnostics == ""
+        assert payload == "/tmp/plain.md"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -364,7 +364,7 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
     return result.stdout, None
 
 
-def _split_tool_diagnostics(output: str) -> tuple[str, str]:
+def _split_tool_diagnostics(output: str, output_mode: str = "content") -> tuple[str, str]:
     """Separate rg/grep diagnostic lines from real match output.
 
     ``_exec`` runs commands with ``stderr=subprocess.STDOUT``, so error and
@@ -383,6 +383,13 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
     error) from a partial failure (some files matched, one was unreadable →
     keep the matches). It also means error text can never be mis-parsed as a
     match, a latent bug that predates the exit-code fix.
+
+    Files-only output needs its own rule: ``rg -l``/``grep -l`` emit one bare
+    path per line, and POSIX paths may contain spaces. The whitespace-forbidding
+    shape regex below would reclassify every spaced path as a diagnostic,
+    silently dropping real results (#91698), so in that mode a line counts as
+    a diagnostic only when it has the shape of tool output (tool prefix,
+    indented error block, bare ``error: ...`` line).
     """
     diagnostics: list[str] = []
     payload: list[str] = []
@@ -398,6 +405,13 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
         stripped = line.lstrip()
         if stripped.startswith("rg: ") or stripped.startswith("grep: "):
             diagnostics.append(line)
+            continue
+        if output_mode == "files_only":
+            # See docstring: bare paths welcome, including spaces.
+            if line[:1].isspace() or stripped.startswith("error: "):
+                diagnostics.append(line)
+            else:
+                payload.append(line)
             continue
         # Otherwise classify by output shape. rg's regex-parse-error block
         # also emits an indented caret line and a trailing "error: ..." line
@@ -3182,7 +3196,7 @@ class ShellFileOperations(FileOperations):
         # diagnostic lines ("rg: <file>: <error>", "rg: regex parse error:")
         # are interleaved with match output. Split them out: diagnostics must
         # not be parsed as matches, and on a hard error they ARE the message.
-        diagnostics, payload = _split_tool_diagnostics(stdout)
+        diagnostics, payload = _split_tool_diagnostics(stdout, output_mode)
 
         # rg exit codes: 0=matches found, 1=no matches, 2=error. rg returns 2
         # even on partial errors (e.g. one unreadable file in a tree that
@@ -3330,7 +3344,7 @@ class ShellFileOperations(FileOperations):
         # ("grep: <file>: <error>") are interleaved with matches. Split them
         # out so they're never parsed as matches and so a hard error has a
         # clean message.
-        diagnostics, payload = _split_tool_diagnostics(stdout)
+        diagnostics, payload = _split_tool_diagnostics(stdout, output_mode)
 
         # grep exit codes: 0=matches found, 1=no matches, 2=error. grep
         # returns 2 on partial errors (e.g. an unreadable file) even when


### PR DESCRIPTION
Fixes #91698.

## Root cause

`_split_tool_diagnostics()` classifies merged rg/grep output by shape. Its second alternative (`^[^\s:][^\s]*$`) handles files-only lines — bare paths from `rg -l` / `grep -l` — but forbids whitespace anywhere in the line. A path like `Obsidian Vault/file with space.md` therefore failed the regex, was folded into *diagnostics*, and vanished. With all matches under spaced names the tool returned `total_count: 0` with no error: indistinguishable from a genuine empty search.

## Fix

The splitter is now mode-aware (`output_mode` parameter, default `"content"` so existing call sites and tests are unchanged):

- **files_only**: payload is one bare path per line, so a line is diagnostic only when it has tool-output shape — a tool prefix (checked first, as before), an indented regex-parse-error block, or a bare `error: ...` line. Everything else is a path, spaces welcome.
- **content / count**: unchanged shape classification.

Both `_search_with_rg` and `_search_with_grep` pass their `output_mode` through; the exit-2 hard-error guard keeps working because pure-failure output still lands in diagnostics.

## Tests

- `TestSplitToolDiagnosticsFilesOnly`: spaced paths kept, error blocks still surfaced, content-mode prose rejection unchanged, default-parameter compatibility.
- `TestSearchErrorGuard.test_files_only_lists_spaced_paths`: end-to-end through the real backends on a tree with `Obsidian Vault/file with space.md`.

Local run: `test_search_error_guard.py` 12/12 green (rg not installed on this Windows box, so backend-parametrized tests exercised grep; the rg path shares the same splitter). The six failures in `test_search_zero_match_and_multipath.py` / `test_search_auto_multiline.py` reproduce identically on stashed main here and look environmental (no ripgrep); happy to re-run in CI.