### PR TITLE
fix(agent): attribute routed OpenRouter requests to Hermes Agent

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -261,6 +261,10 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
         # Availability probe: credentials/base_url resolved — that is the
         # answer. Skip the openai import + httpx/SSL construction entirely.
         return _AuxProbeClientStub(api_key=api_key, base_url=base_url)
+    if base_url_host_matches(base_url, "openrouter.ai"):
+        headers = build_or_headers()
+        headers.update(kwargs.get("default_headers") or {})
+        kwargs["default_headers"] = headers
     kwargs = {**_openai_http_client_kwargs(base_url), **kwargs}
     # OpenCode Zen free tier: the keyless placeholder must never reach the
     # wire — the Zen relay serves free models anonymously but 401s any
@@ -6560,9 +6564,7 @@ def resolve_provider_client(
             _clean_base, _dq = _extract_url_query_params(custom_base)
             if _dq:
                 extra["default_query"] = _dq
-            if base_url_host_matches(custom_base, "openrouter.ai"):
-                extra["default_headers"] = build_or_headers()
-            elif base_url_host_matches(custom_base, "api.kimi.com"):
+            if base_url_host_matches(custom_base, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
             elif base_url_host_matches(custom_base, "githubcopilot.com"):
                 from hermes_cli.copilot_auth import copilot_request_headers
@@ -6857,9 +6859,7 @@ def resolve_provider_client(
 
         # Provider-specific headers
         headers = {}
-        if base_url_host_matches(base_url, "openrouter.ai"):
-            headers.update(build_or_headers())
-        elif base_url_host_matches(base_url, "api.kimi.com"):
+        if base_url_host_matches(base_url, "api.kimi.com"):
             headers["User-Agent"] = "claude-code/0.1.0"
         elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.copilot_auth import copilot_request_headers

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6560,7 +6560,9 @@ def resolve_provider_client(
             _clean_base, _dq = _extract_url_query_params(custom_base)
             if _dq:
                 extra["default_query"] = _dq
-            if base_url_host_matches(custom_base, "api.kimi.com"):
+            if base_url_host_matches(custom_base, "openrouter.ai"):
+                extra["default_headers"] = build_or_headers()
+            elif base_url_host_matches(custom_base, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
             elif base_url_host_matches(custom_base, "githubcopilot.com"):
                 from hermes_cli.copilot_auth import copilot_request_headers
@@ -6855,7 +6857,9 @@ def resolve_provider_client(
 
         # Provider-specific headers
         headers = {}
-        if base_url_host_matches(base_url, "api.kimi.com"):
+        if base_url_host_matches(base_url, "openrouter.ai"):
+            headers.update(build_or_headers())
+        elif base_url_host_matches(base_url, "api.kimi.com"):
             headers["User-Agent"] = "claude-code/0.1.0"
         elif base_url_host_matches(base_url, "githubcopilot.com"):
             from hermes_cli.copilot_auth import copilot_request_headers

--- a/tests/agent/test_auxiliary_openrouter_attribution_headers.py
+++ b/tests/agent/test_auxiliary_openrouter_attribution_headers.py
@@ -16,6 +16,7 @@ def _isolated_config(tmp_path, monkeypatch):
         encoding="utf-8",
     )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
 
 
 def _resolved_headers(**kwargs):
@@ -50,3 +51,43 @@ def test_api_key_provider_routed_to_openrouter_gets_attribution_headers():
 
     assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
     assert headers["X-Title"] == "Hermes Agent"
+
+
+def test_named_custom_openrouter_provider_gets_attribution_headers(_isolated_config):
+    (_isolated_config / "config.yaml").write_text(
+        "model:\n  default: test-model\n"
+        "custom_providers:\n"
+        "  - name: named-openrouter\n"
+        "    base_url: https://openrouter.ai/api/v1\n"
+        "    api_key: test-key\n",
+        encoding="utf-8",
+    )
+
+    headers = _resolved_headers(
+        provider="named-openrouter",
+        model="openai/gpt-4o-mini",
+    )
+
+    assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
+    assert headers["X-Title"] == "Hermes Agent"
+
+
+def test_openrouter_user_headers_override_attribution_defaults(_isolated_config):
+    (_isolated_config / "config.yaml").write_text(
+        "model:\n"
+        "  default: test-model\n"
+        "  default_headers:\n"
+        "    HTTP-Referer: https://example.test/custom\n"
+        "    X-Title: Custom App\n",
+        encoding="utf-8",
+    )
+
+    headers = _resolved_headers(
+        provider="custom",
+        model="openai/gpt-4o-mini",
+        explicit_api_key="test-key",
+        explicit_base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert headers["HTTP-Referer"] == "https://example.test/custom"
+    assert headers["X-Title"] == "Custom App"

--- a/tests/agent/test_auxiliary_openrouter_attribution_headers.py
+++ b/tests/agent/test_auxiliary_openrouter_attribution_headers.py
@@ -1,0 +1,52 @@
+"""Regression tests for OpenRouter attribution in auxiliary provider resolution."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.auxiliary_client import resolve_provider_client
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "model:\n  default: test-model\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+
+def _resolved_headers(**kwargs):
+    mock_openai = MagicMock()
+    mock_openai.return_value = MagicMock(name="openrouter-client")
+    with patch("agent.auxiliary_client.OpenAI", mock_openai):
+        client, _ = resolve_provider_client(**kwargs)
+
+    assert client is not None
+    return mock_openai.call_args.kwargs.get("default_headers", {})
+
+
+def test_custom_openrouter_endpoint_gets_attribution_headers():
+    headers = _resolved_headers(
+        provider="custom",
+        model="openai/gpt-4o-mini",
+        explicit_api_key="test-key",
+        explicit_base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
+    assert headers["X-Title"] == "Hermes Agent"
+
+
+def test_api_key_provider_routed_to_openrouter_gets_attribution_headers():
+    headers = _resolved_headers(
+        provider="alibaba",
+        model="qwen/qwen3-coder",
+        explicit_api_key="test-key",
+        explicit_base_url="https://openrouter.ai/api/v1",
+    )
+
+    assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
+    assert headers["X-Title"] == "Hermes Agent"


### PR DESCRIPTION
## What does this PR do?

Requests resolved through OpenAI-compatible provider paths now retain Hermes Agent attribution when their effective endpoint is OpenRouter. Without this fix, OpenRouter records these requests as `App: Unknown`, even though direct OpenRouter and async auxiliary paths are attributed correctly.

### Symptom

A built-in API-key provider or custom endpoint configured with `https://openrouter.ai/api/v1` sends auxiliary requests without `HTTP-Referer` and `X-Title`, so OpenRouter cannot associate the traffic with Hermes Agent.

### Impact

Operators routing compatible providers through OpenRouter receive incomplete application attribution in the OpenRouter Generations dashboard. The affected share depends on which provider-resolution paths their profiles use.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py:resolve_provider_client()` when either the `custom` branch or generic `auth_type == "api_key"` branch resolves an `openrouter.ai` base URL.

**Causal chain:**
1. A profile resolves credentials through a custom or built-in API-key provider while targeting OpenRouter.
2. Provider-specific header dispatch handles several endpoint hosts but omits `openrouter.ai`.
3. The OpenAI client is constructed without OpenRouter attribution headers, and OpenRouter reports the request as `App: Unknown`.

**Why it is wrong:** Attribution is determined by the effective endpoint, not the configured provider label. These branches must apply the same OpenRouter headers as the direct and async auxiliary construction paths.

**Working sibling / contrast:** Direct `provider="openrouter"` resolution and `_to_async_client()` already call `build_or_headers()` for OpenRouter endpoints.

**Ruled out:** Model switching is not required to trigger this bug; regression tests reproduce both omissions directly in fresh `resolve_provider_client()` calls.

### Fix

Detect `openrouter.ai` in both synchronous provider-resolution branches and apply `build_or_headers()` before merging user-configured header overrides. Added focused regression coverage for the custom and generic API-key routes.

## Related Issue

Closes #91858

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - apply OpenRouter attribution headers based on the resolved endpoint in custom and API-key provider branches.
- `tests/agent/test_auxiliary_openrouter_attribution_headers.py` - verify both affected resolution paths pass `HTTP-Referer` and `X-Title` to the OpenAI client.

## How to Test

1. Configure a custom endpoint or API-key provider with `https://openrouter.ai/api/v1`.
2. Resolve an auxiliary client and inspect the OpenAI client constructor headers.
3. Run the focused and neighboring auxiliary-client tests:

```bash
scripts/run_tests.sh tests/agent/test_auxiliary_openrouter_attribution_headers.py tests/agent/test_auxiliary_user_default_headers.py -q
scripts/run_tests.sh tests/agent/test_auxiliary_client.py -q
```

Verified locally: 189 tests passed across these commands.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is unchanged - N/A
- [x] No config keys changed - N/A
- [x] Architecture and workflows are unchanged - N/A
- [x] Cross-platform impact considered; the change is endpoint-host dispatch - N/A
- [x] Tool descriptions and schemas are unchanged - N/A

## Screenshots / Logs

N/A - the regression is verified through OpenAI client-construction tests.
