### PR TITLE
fix(update): Windows venv-holder guard names holders correctly and can see the gateway it must pause (#90778, #87594 — proven live on windows-latest)

### DIFF
--- a/.github/workflows/windows-venv-e2e.yml
+++ b/.github/workflows/windows-venv-e2e.yml
@@ -58,4 +58,4 @@ jobs:
           set -uo pipefail
           uv run --no-sync python -m pytest \
             tests/hermes_cli/test_venv_holder_windows_live.py \
-            -o addopts= -v --timeout=300 -p no:cacheprovider
+            -o addopts= -v -p no:cacheprovider

--- a/.github/workflows/windows-venv-e2e.yml
+++ b/.github/workflows/windows-venv-e2e.yml
@@ -1,0 +1,61 @@
+name: Windows venv-holder live E2E
+
+# ON-DEMAND ONLY (fleet-update #91277, venv-holder consolidation work).
+#
+# Runs the live venv-holder E2E suite on a real windows-latest runner:
+# spawns actual processes with realistic Hermes argv shapes and drives the
+# REAL detection/classification/exemption code against the live process
+# table — the coverage that cannot exist on the Linux lanes and that the
+# maintainer cannot exercise locally before the work reaches main.
+#
+# Deliberately NOT wired to pull_request/main: it fires only on pushes to
+# wine2e/** working branches, so it costs nothing on normal PRs. Delete or
+# keep dormant after the venv-holder work lands.
+
+on:
+  push:
+    branches:
+      - "wine2e/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-venv-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  venv-holder-e2e:
+    name: venv-holder live E2E (windows-latest)
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          version: "0.9.28"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.11
+        uses: ./.github/actions/retry
+        with:
+          command: uv python install 3.11
+
+      - name: Install dependencies
+        uses: ./.github/actions/retry
+        with:
+          command: uv sync --locked --python 3.11 --extra dev
+
+      - name: Run venv-holder live E2E
+        shell: bash
+        run: |
+          set -uo pipefail
+          uv run --no-sync python -m pytest \
+            tests/hermes_cli/test_venv_holder_windows_live.py \
+            -o addopts= -v --timeout=300 -p no:cacheprovider

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3935,6 +3935,49 @@ def _defer_update_for_self_lock(loaded: list[str]) -> None:
     _m()._write_update_incomplete_marker()
 
 
+_HOLDER_VALUE_FLAGS_FALLBACK = frozenset(
+    {
+        "--profile", "-p", "--config",
+        "--model", "-m", "--provider", "--reasoning",
+        "--toolsets", "-t", "--skills", "-s",
+        "--continue", "-c", "--resume", "-r",
+        "--oneshot", "-z", "--in", "--usage-file",
+    }
+)
+_holder_value_flags_cache: frozenset | None = None
+
+
+def _holder_value_flags() -> frozenset:
+    """Top-level CLI flags that consume a value — derived from the REAL parser.
+
+    Introspects ``build_top_level_parser()`` (every option with nargs != 0)
+    so the holder classifier can never drift from the argparse surface
+    (#91869 review: a handwritten subset misparsed ``--reasoning high
+    serve`` as subcommand ``high`` and ``-m dashboard serve`` as
+    ``dashboard`` — recreating the wrong-hint class). The pre-argparse
+    profile selectors (``--profile``/``-p``, ``--config``) are added
+    explicitly since they are stripped before argparse sees argv. Falls
+    back to a static snapshot when the parser cannot be imported (the
+    updater must classify holders even mid-upgrade on a broken tree).
+    Cached per process.
+    """
+    global _holder_value_flags_cache
+    if _holder_value_flags_cache is not None:
+        return _holder_value_flags_cache
+    flags: set[str] = {"--profile", "-p", "--config"}
+    try:
+        from hermes_cli._parser import build_top_level_parser
+
+        parser = build_top_level_parser()[0]
+        for action in parser._actions:
+            if action.option_strings and action.nargs != 0:
+                flags.update(action.option_strings)
+        _holder_value_flags_cache = frozenset(flags)
+    except Exception:
+        _holder_value_flags_cache = _HOLDER_VALUE_FLAGS_FALLBACK
+    return _holder_value_flags_cache
+
+
 def _hermes_holder_subcommand(cmdline: str) -> str | None:
     """The actual Hermes SUBCOMMAND a venv-holder argv runs, or None.
 
@@ -3966,12 +4009,13 @@ def _hermes_holder_subcommand(cmdline: str) -> str | None:
     if entry_idx is None:
         return None
 
-    value_flags = {"--profile", "-p", "--config", "--model", "--provider"}
+    value_flags = _holder_value_flags()
     i = entry_idx + 1
     while i < len(tokens):
         token = tokens[i]
-        if token in value_flags:
-            i += 2
+        if token in value_flags or token.split("=", 1)[0] in value_flags:
+            # --flag value consumes two tokens; --flag=value consumes one.
+            i += 1 if "=" in token else 2
             continue
         if token.startswith("-"):
             i += 1

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3684,7 +3684,27 @@ def _detect_venv_python_processes(
     skip: set[int] = set(exclude_pids or set())
     skip.add(os.getpid())
     try:
+        from gateway.status import looks_like_gateway_command_line as _is_gw
+    except Exception:
+        _is_gw = None
+    try:
         for anc in psutil.Process().parents():
+            # #87594: do NOT blanket-exclude ancestors. When `/update` runs
+            # from a messaging platform the updater is a CHILD of the gateway
+            # — excluding all ancestors hides the gateway from the scan, so
+            # the pause machinery downstream never sees the one process it
+            # exists to stop, and the update dead-ends on `venv-blocked`.
+            # A GATEWAY ancestor stays visible (the pause path stops it
+            # gracefully; a detached child updater survives its parent's
+            # stop on Windows). Every other ancestor (shells, terminals,
+            # this CLI's own venv python chain) stays excluded — an updater
+            # must never nominate its own interactive ancestry as blockers.
+            try:
+                anc_cmdline = " ".join(anc.cmdline() or [])
+            except Exception:
+                anc_cmdline = ""
+            if _is_gw is not None and anc_cmdline and _is_gw(anc_cmdline):
+                continue
             skip.add(int(anc.pid))
     except Exception:
         pass
@@ -3915,18 +3935,71 @@ def _defer_update_for_self_lock(loaded: list[str]) -> None:
     _m()._write_update_incomplete_marker()
 
 
+def _hermes_holder_subcommand(cmdline: str) -> str | None:
+    """The actual Hermes SUBCOMMAND a venv-holder argv runs, or None.
+
+    Token-based, never substring (#90778: ``kanban --preserve-cache``
+    contained \"serve\" and got labeled as the Desktop backend). Finds the
+    ``hermes_cli.main`` / ``hermes(.exe)`` entry token, then returns the
+    first following token that is not a flag or a flag's value. Profile
+    selectors (``--profile X``, ``-p X``) are skipped like the canonical
+    gateway matcher does. Returns None when no subcommand can be
+    determined — callers must NOT guess a label in that case.
+    """
+    try:
+        import shlex
+
+        tokens = shlex.split(cmdline, posix=False)
+    except Exception:
+        tokens = cmdline.split()
+
+    entry_idx: int | None = None
+    for i, token in enumerate(tokens):
+        low = token.lower().strip('"')
+        if low.endswith("hermes_cli.main") and i > 0 and tokens[i - 1] == "-m":
+            entry_idx = i
+            break
+        base = low.rsplit("\\", 1)[-1].rsplit("/", 1)[-1]
+        if base in ("hermes", "hermes.exe"):
+            entry_idx = i
+            break
+    if entry_idx is None:
+        return None
+
+    value_flags = {"--profile", "-p", "--config", "--model", "--provider"}
+    i = entry_idx + 1
+    while i < len(tokens):
+        token = tokens[i]
+        if token in value_flags:
+            i += 2
+            continue
+        if token.startswith("-"):
+            i += 1
+            continue
+        return token.lower()
+    return None
+
+
 def _format_venv_python_holders_message(matches: list[tuple[int, str, str]]) -> str:
-    """Explain which venv processes block the update and how to clear them."""
+    """Explain which venv processes block the update and how to clear them.
+
+    Holder labels come from the parsed SUBCOMMAND, never substring matching
+    (#90778): a standalone ``hermes dashboard`` must not be labeled as the
+    Desktop backend (advice to close an app that isn't running), and flags
+    like ``--preserve-cache`` must not match \"serve\". Unknown argv gets no
+    hint rather than a wrong one.
+    """
     lines = [
         "✗ Other Hermes processes are running from this install's venv:",
     ]
+    hint_by_subcommand = {
+        "serve": "  ← Hermes backend (if the Desktop app is open, close it)",
+        "dashboard": "  ← hermes dashboard (stop it: hermes dashboard stop, or close that terminal)",
+        "gateway": "  ← gateway",
+    }
     for pid, name, cmdline in matches[:6]:
-        hint = ""
-        low = cmdline.lower()
-        if "serve" in low or "dashboard" in low:
-            hint = "  ← Hermes Desktop backend (close the desktop app)"
-        elif "gateway" in low:
-            hint = "  ← gateway"
+        sub = _hermes_holder_subcommand(cmdline)
+        hint = hint_by_subcommand.get(sub or "", "")
         lines.append(f"  PID {pid}  {name}  {cmdline[:120]}{hint}")
     if len(matches) > 6:
         lines.append(f"  ... and {len(matches) - 6} more")
@@ -3983,9 +4056,23 @@ def _venv_launcher_ancestors(pids: list[int]) -> list[int]:
 
     # Never return ourselves or our own ancestry: a CLI ``hermes update``
     # runs from the venv python and would otherwise nominate itself.
+    # Same #87594 carve-out as _detect_venv_python_processes: a GATEWAY
+    # ancestor is not "our own ancestry" in the interactive sense — it is
+    # the process the pause machinery must see (the /update-from-gateway
+    # topology makes the updater the gateway's child).
+    try:
+        from gateway.status import looks_like_gateway_command_line as _is_gw
+    except Exception:
+        _is_gw = None
     skip: set[int] = {os.getpid()}
     try:
         for anc in psutil.Process().parents():
+            try:
+                anc_cmdline = " ".join(anc.cmdline() or [])
+            except Exception:
+                anc_cmdline = ""
+            if _is_gw is not None and anc_cmdline and _is_gw(anc_cmdline):
+                continue
             skip.add(int(anc.pid))
     except Exception:
         pass

--- a/tests/gateway/test_goal_resume_restart.py
+++ b/tests/gateway/test_goal_resume_restart.py
@@ -34,8 +34,23 @@ def hermes_home(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HERMES_HOME", str(home))
+    # get_hermes_home() prefers the context-local override over the env
+    # var, so a set_hermes_home_override() leaked by ANY earlier test in
+    # this xdist worker would silently point the goals DB at a dead tmp
+    # dir and make resume enqueue nothing (CI-only flake). Pin the
+    # override to THIS home so the fixture is immune to leaks.
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    token = set_hermes_home_override(str(home))
     goals._DB_CACHE.clear()
     yield home
+    try:
+        reset_hermes_home_override(token)
+    except Exception:
+        pass
     goals._DB_CACHE.clear()
 
 

--- a/tests/hermes_cli/test_venv_holder_classifier.py
+++ b/tests/hermes_cli/test_venv_holder_classifier.py
@@ -1,0 +1,61 @@
+"""Cross-platform unit tests for the venv-holder message classifier (#90778)."""
+
+import pytest
+
+from hermes_cli.update_cmd import (
+    _format_venv_python_holders_message,
+    _hermes_holder_subcommand,
+)
+
+
+class TestHolderSubcommand:
+    @pytest.mark.parametrize(
+        ("cmdline", "expected"),
+        [
+            (r"C:\x\venv\Scripts\python.exe -m hermes_cli.main serve --host 127.0.0.1", "serve"),
+            (r"C:\x\venv\Scripts\python.exe -m hermes_cli.main dashboard", "dashboard"),
+            (r"python.exe -m hermes_cli.main gateway run", "gateway"),
+            # profile selector skipped; its VALUE must not become the subcommand
+            (r"python -m hermes_cli.main --profile serve gateway run", "gateway"),
+            (r"python -m hermes_cli.main -p work serve", "serve"),
+            # 90778: flags containing subcommand words are not subcommands
+            (r"python -m hermes_cli.main kanban --preserve-cache", "kanban"),
+            (r"C:\bin\hermes.exe dashboard", "dashboard"),
+            (r"/usr/local/bin/hermes serve", "serve"),
+            # no hermes entry at all
+            (r"python -c import time; time.sleep(3)", None),
+            # entry but no subcommand
+            (r"python -m hermes_cli.main", None),
+        ],
+    )
+    def test_parses_subcommand(self, cmdline, expected):
+        assert _hermes_holder_subcommand(cmdline) == expected
+
+
+class TestHolderMessage:
+    def _msg(self, cmdline):
+        return _format_venv_python_holders_message([(4242, "python.exe", cmdline)])
+
+    def test_dashboard_not_labeled_desktop_backend(self):
+        message = self._msg(r"C:\v\Scripts\python.exe -m hermes_cli.main dashboard")
+        assert "close the desktop app" not in message.lower()
+        assert "hermes dashboard" in message
+
+    def test_preserve_cache_not_labeled_serve(self):
+        message = self._msg(r"python -m hermes_cli.main kanban --preserve-cache")
+        holder_line = next(l for l in message.splitlines() if "PID 4242" in l)
+        # the holder LINE gets no serve/desktop hint (generic footer text
+        # legitimately mentions the desktop app)
+        assert "←" not in holder_line
+
+    def test_serve_gets_backend_hint(self):
+        message = self._msg(r"python -m hermes_cli.main serve --host 127.0.0.1 --port 0")
+        assert "Hermes backend" in message
+
+    def test_gateway_hint(self):
+        message = self._msg(r"python -m hermes_cli.main gateway run")
+        assert "← gateway" in message
+
+    def test_unknown_argv_gets_no_hint(self):
+        message = self._msg(r"python -c import this")
+        assert "←" not in message

--- a/tests/hermes_cli/test_venv_holder_classifier.py
+++ b/tests/hermes_cli/test_venv_holder_classifier.py
@@ -20,6 +20,15 @@ class TestHolderSubcommand:
             (r"python -m hermes_cli.main -p work serve", "serve"),
             # 90778: flags containing subcommand words are not subcommands
             (r"python -m hermes_cli.main kanban --preserve-cache", "kanban"),
+            # 91869 review: EVERY top-level value flag must be skipped —
+            # a flag VALUE equal to a subcommand must not become the label
+            (r"python -m hermes_cli.main --reasoning high serve", "serve"),
+            (r"python -m hermes_cli.main -m dashboard serve", "serve"),
+            (r"python -m hermes_cli.main -t browser,files gateway run", "gateway"),
+            (r"python -m hermes_cli.main --model=dashboard serve", "serve"),
+            # -c consumes ONE value token; later bare tokens are (harmless,
+            # unhinted) subcommand candidates — pin that shape honestly
+            (r"python -m hermes_cli.main -c mysession serve", "serve"),
             (r"C:\bin\hermes.exe dashboard", "dashboard"),
             (r"/usr/local/bin/hermes serve", "serve"),
             # no hermes entry at all

--- a/tests/hermes_cli/test_venv_holder_windows_live.py
+++ b/tests/hermes_cli/test_venv_holder_windows_live.py
@@ -199,9 +199,16 @@ class TestAncestorExclusion:
             "import json, os, sys\n"
             f"sys.path.insert(0, {str(PROJECT_ROOT)!r})\n"
             "from hermes_cli.update_cmd import _detect_venv_python_processes\n"
+            "import psutil\n"
+            "from gateway.status import looks_like_gateway_command_line\n"
+            "parent = psutil.Process(os.getppid())\n"
+            "parent_cmdline = ' '.join(parent.cmdline() or [])\n"
             "matches = _detect_venv_python_processes()\n"
             "print(json.dumps({'ppid': os.getppid(),"
-            " 'pids': [p for p, _, _ in matches]}))\n",
+            " 'pids': [p for p, _, _ in matches],"
+            " 'parent_cmdline': parent_cmdline,"
+            " 'parent_exe': parent.exe() or '',"
+            " 'matcher_says_gateway': looks_like_gateway_command_line(parent_cmdline)}))\n",
             encoding="utf-8",
         )
         parent_oneliner = (

--- a/tests/hermes_cli/test_venv_holder_windows_live.py
+++ b/tests/hermes_cli/test_venv_holder_windows_live.py
@@ -188,23 +188,28 @@ class TestAncestorExclusion:
     ancestor-exclusion must not hide the gateway from the scan entirely:
     the gateway must still be visible to the pause machinery."""
 
-    def test_gateway_parent_visible_to_child_scan(self):
-        # Simulate the /update topology: parent (fake gateway) spawns a
-        # child python that runs the REAL detection and reports whether it
-        # can see its gateway parent.
-        child_code = (
-            "import json, sys\n"
+    def test_gateway_parent_visible_to_child_scan(self, tmp_path):
+        # Simulate the /update topology: parent (gateway-argv process) spawns
+        # a child python that runs the REAL detection and reports whether it
+        # can see its gateway parent. The child's code lives in a FILE so the
+        # parent's cmdline stays realistic (a real gateway's argv is clean
+        # `... -m hermes_cli.main gateway run`, not a multi-line -c blob).
+        child_file = tmp_path / "child_scan.py"
+        child_file.write_text(
+            "import json, os, sys\n"
             f"sys.path.insert(0, {str(PROJECT_ROOT)!r})\n"
             "from hermes_cli.update_cmd import _detect_venv_python_processes\n"
-            "import os\n"
             "matches = _detect_venv_python_processes()\n"
-            "print(json.dumps({'ppid': os.getppid(), 'pids': [p for p, _, _ in matches]}))\n"
+            "print(json.dumps({'ppid': os.getppid(),"
+            " 'pids': [p for p, _, _ in matches]}))\n",
+            encoding="utf-8",
         )
-        parent_code = (
-            "import subprocess, sys\n"
-            f"out = subprocess.run([sys.executable, '-c', {child_code!r}],"
-            " capture_output=True, text=True, cwd=" + repr(str(PROJECT_ROOT)) + ")\n"
-            "print(out.stdout.strip())\n"
+        parent_oneliner = (
+            "import subprocess, sys;"
+            f" r = subprocess.run([sys.executable, {str(child_file)!r}],"
+            f" capture_output=True, text=True, cwd={str(PROJECT_ROOT)!r});"
+            " print(r.stdout.strip());"
+            " sys.stderr.write(r.stderr[-500:])"
         )
         # The parent's argv carries `gateway run` so it IS a gateway to any
         # cmdline classifier; it runs the child synchronously.
@@ -212,7 +217,7 @@ class TestAncestorExclusion:
             [
                 sys.executable,
                 "-c",
-                parent_code,
+                parent_oneliner,
                 "-m",
                 "hermes_cli.main",
                 "gateway",

--- a/tests/hermes_cli/test_venv_holder_windows_live.py
+++ b/tests/hermes_cli/test_venv_holder_windows_live.py
@@ -201,14 +201,14 @@ class TestAncestorExclusion:
             "from hermes_cli.update_cmd import _detect_venv_python_processes\n"
             "import psutil\n"
             "from gateway.status import looks_like_gateway_command_line\n"
-            "parent = psutil.Process(os.getppid())\n"
-            "parent_cmdline = ' '.join(parent.cmdline() or [])\n"
+            "# The venv shim makes every spawn a launcher/worker CHAIN, so the\n"
+            "# gateway is an ANCESTOR, not necessarily the direct parent —\n"
+            "# find it the same way the pause machinery would: by argv.\n"
+            "gw = [int(a.pid) for a in psutil.Process().parents()\n"
+            "      if looks_like_gateway_command_line(' '.join(a.cmdline() or []))]\n"
             "matches = _detect_venv_python_processes()\n"
-            "print(json.dumps({'ppid': os.getppid(),"
-            " 'pids': [p for p, _, _ in matches],"
-            " 'parent_cmdline': parent_cmdline,"
-            " 'parent_exe': parent.exe() or '',"
-            " 'matcher_says_gateway': looks_like_gateway_command_line(parent_cmdline)}))\n",
+            "print(json.dumps({'gateway_ancestors': gw,"
+            " 'pids': [p for p, _, _ in matches]}))\n",
             encoding="utf-8",
         )
         parent_oneliner = (
@@ -240,9 +240,13 @@ class TestAncestorExclusion:
         line = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else "{}"
         payload = json.loads(line)
         assert payload, f"child scan produced no output: {result.stderr[-500:]}"
-        # The gateway parent must be visible to the scan so the pause
-        # machinery can stop it (#87594). Plain ancestor-exclusion hides it.
-        assert payload["ppid"] in payload["pids"], (
+        assert payload["gateway_ancestors"], (
+            f"harness broke: no gateway-argv ancestor found: {payload}"
+        )
+        # The gateway ancestor must be visible to the scan so the pause
+        # machinery can stop it (#87594). Blanket ancestor-exclusion hid it.
+        visible = set(payload["gateway_ancestors"]) & set(payload["pids"])
+        assert visible, (
             "gateway ancestor invisible to venv scan — /update from the "
             f"gateway can never pause it (#87594): {payload}"
         )

--- a/tests/hermes_cli/test_venv_holder_windows_live.py
+++ b/tests/hermes_cli/test_venv_holder_windows_live.py
@@ -1,0 +1,236 @@
+"""LIVE Windows E2E for the venv-holder preflight (fleet-update #91277).
+
+Runs ONLY on a real Windows host (the on-demand ``windows-venv-e2e.yml``
+lane). Spawns REAL processes with realistic Hermes argv shapes and drives
+the actual detection / classification / exemption code against the live
+process table — no mocked psutil, no faked cmdlines.
+
+Each test documents which cluster issue it probes. Tests written BEFORE
+the consolidation fix intentionally pin the CORRECT behavior, so on
+unfixed main the buggy ones fail — that failure on the Windows runner is
+the empirical premise-check for each issue:
+
+  #90778 — holder message mislabels `hermes dashboard` as the Desktop
+           backend, and matches subcommands by substring ("--preserve"
+           contains "serve").
+  #78089 — pausable-gateway exemption vs. long managed-runtime
+           interpreter paths (claimed fixed on main; verified here).
+  #87594 — ancestor-exclusion hides the gateway from the scan when the
+           updater is spawned BY the gateway (/update path).
+  #81774 — serve backends have no pause path (documented behavior probe).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="live Windows venv-holder E2E"
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _spawn(args: list[str], cwd: Path | None = None) -> subprocess.Popen:
+    """Spawn a real sleeper process whose argv carries the given tail.
+
+    ``python -c "sleep" <tail...>`` — the tail is inert data to the child
+    but fully visible to psutil cmdline scans, which is what the detection
+    code classifies on.
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(300)", *args],
+        cwd=str(cwd or PROJECT_ROOT),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    time.sleep(0.8)  # let the process table settle
+    assert proc.poll() is None, "sleeper died at spawn"
+    return proc
+
+
+def _detect() -> list[tuple[int, str, str]]:
+    from hermes_cli.update_cmd import _detect_venv_python_processes
+
+    return _detect_venv_python_processes()
+
+
+def _kill(*procs: subprocess.Popen) -> None:
+    for proc in procs:
+        try:
+            proc.kill()
+            proc.wait(timeout=10)
+        except Exception:
+            pass
+
+
+class TestDetection:
+    def test_detects_hermes_argv_process(self):
+        """Baseline: a live process running `-m hermes_cli.main serve` with
+        cwd under the install root is detected as a venv holder."""
+        proc = _spawn(["-m", "hermes_cli.main", "serve"])
+        try:
+            matches = _detect()
+            pids = [pid for pid, _, _ in matches]
+            assert proc.pid in pids, f"holder scan missed live process: {matches}"
+            cmdline = next(c for p, _, c in matches if p == proc.pid)
+            # Full cmdline, not a 120-char prefix (#78089 regression guard).
+            assert "hermes_cli.main" in cmdline
+        finally:
+            _kill(proc)
+
+    def test_foreign_python_not_detected(self):
+        """A python process with no Hermes argv and cwd OUTSIDE the install
+        must not be reported as a holder."""
+        import tempfile
+
+        outside = Path(tempfile.mkdtemp())
+        proc = _spawn(["totally", "unrelated"], cwd=outside)
+        try:
+            pids = [pid for pid, _, _ in _detect()]
+            assert proc.pid not in pids
+        finally:
+            _kill(proc)
+
+    def test_long_runtime_path_gateway_detected_with_full_argv(self):
+        """#78089: a gateway launched via a long managed-runtime interpreter
+        path must surface with its FULL argv so the pausable exemption can
+        see `gateway run` past the 120-char mark."""
+        # Pad the argv front so `gateway run` sits beyond 120 chars.
+        padding = os.path.join("C:\\", "Users", "x" * 90, ".hermes-runtime")
+        proc = _spawn([padding, "-m", "hermes_cli.main", "gateway", "run"])
+        try:
+            matches = _detect()
+            cmdline = next((c for p, _, c in matches if p == proc.pid), None)
+            assert cmdline is not None, "long-path gateway missed by scan"
+            assert "gateway run" in cmdline.lower(), (
+                f"argv truncated before `gateway run`: {cmdline!r}"
+            )
+        finally:
+            _kill(proc)
+
+
+class TestClassification:
+    def test_pausable_exemption_sees_long_path_gateway(self):
+        """#78089 follow-through: `_leftover_pausable_gateway_pids` must
+        classify the long-path gateway as pausable (not None)."""
+        from hermes_cli.update_cmd import _leftover_pausable_gateway_pids
+
+        padding = os.path.join("C:\\", "Users", "y" * 90, ".hermes-runtime")
+        proc = _spawn([padding, "-m", "hermes_cli.main", "gateway", "run"])
+        try:
+            matches = [m for m in _detect() if m[0] == proc.pid]
+            assert matches, "gateway not detected"
+            pids = _leftover_pausable_gateway_pids(matches)
+            assert pids == [proc.pid], (
+                f"pausable exemption failed for long-path gateway: {pids}"
+            )
+        finally:
+            _kill(proc)
+
+    def test_serve_backend_not_classified_pausable(self):
+        """#81774 premise probe: a serve backend is NOT pausable today —
+        pinning current behavior so the consolidation change is visible."""
+        from hermes_cli.update_cmd import _leftover_pausable_gateway_pids
+
+        proc = _spawn(["-m", "hermes_cli.main", "serve"])
+        try:
+            matches = [m for m in _detect() if m[0] == proc.pid]
+            assert matches, "serve backend not detected"
+            assert _leftover_pausable_gateway_pids(matches) is None
+        finally:
+            _kill(proc)
+
+
+class TestHolderMessage:
+    """#90778 — the refusal message must name holders accurately."""
+
+    def test_dashboard_not_labeled_desktop_backend(self):
+        from hermes_cli.update_cmd import _format_venv_python_holders_message
+
+        proc = _spawn(["-m", "hermes_cli.main", "dashboard"])
+        try:
+            matches = [m for m in _detect() if m[0] == proc.pid]
+            assert matches, "dashboard process not detected"
+            message = _format_venv_python_holders_message(matches)
+            assert "close the desktop app" not in message.lower(), (
+                "standalone `hermes dashboard` mislabeled as the Desktop "
+                f"backend (#90778):\n{message}"
+            )
+        finally:
+            _kill(proc)
+
+    def test_substring_subcommand_not_mislabeled(self):
+        """`--preserve-cache` contains 'serve'; the classifier must not
+        label an unrelated subcommand as the Desktop backend (#90778)."""
+        from hermes_cli.update_cmd import _format_venv_python_holders_message
+
+        proc = _spawn(["-m", "hermes_cli.main", "kanban", "--preserve-cache"])
+        try:
+            matches = [m for m in _detect() if m[0] == proc.pid]
+            assert matches, "kanban process not detected"
+            message = _format_venv_python_holders_message(matches)
+            assert "close the desktop app" not in message.lower(), (
+                f"substring match mislabeled `--preserve-cache` (#90778):\n{message}"
+            )
+        finally:
+            _kill(proc)
+
+
+class TestAncestorExclusion:
+    """#87594 — when the updater is a CHILD of the gateway (/update path),
+    ancestor-exclusion must not hide the gateway from the scan entirely:
+    the gateway must still be visible to the pause machinery."""
+
+    def test_gateway_parent_visible_to_child_scan(self):
+        # Simulate the /update topology: parent (fake gateway) spawns a
+        # child python that runs the REAL detection and reports whether it
+        # can see its gateway parent.
+        child_code = (
+            "import json, sys\n"
+            f"sys.path.insert(0, {str(PROJECT_ROOT)!r})\n"
+            "from hermes_cli.update_cmd import _detect_venv_python_processes\n"
+            "import os\n"
+            "matches = _detect_venv_python_processes()\n"
+            "print(json.dumps({'ppid': os.getppid(), 'pids': [p for p, _, _ in matches]}))\n"
+        )
+        parent_code = (
+            "import subprocess, sys\n"
+            f"out = subprocess.run([sys.executable, '-c', {child_code!r}],"
+            " capture_output=True, text=True, cwd=" + repr(str(PROJECT_ROOT)) + ")\n"
+            "print(out.stdout.strip())\n"
+        )
+        # The parent's argv carries `gateway run` so it IS a gateway to any
+        # cmdline classifier; it runs the child synchronously.
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                parent_code,
+                "-m",
+                "hermes_cli.main",
+                "gateway",
+                "run",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            timeout=120,
+        )
+        import json
+
+        line = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else "{}"
+        payload = json.loads(line)
+        assert payload, f"child scan produced no output: {result.stderr[-500:]}"
+        # The gateway parent must be visible to the scan so the pause
+        # machinery can stop it (#87594). Plain ancestor-exclusion hides it.
+        assert payload["ppid"] in payload["pids"], (
+            "gateway ancestor invisible to venv scan — /update from the "
+            f"gateway can never pause it (#87594): {payload}"
+        )


### PR DESCRIPTION
## Summary

The Windows venv-holder guard now names holders correctly and can see the gateway it must pause — with both fixes proven on a real windows-latest runner (8/8 live E2E, spawned processes, real scan) before this PR touched main. Fixes #90778 and #87594; empirically verifies #78089 is already fixed. Part of the #91277 venv-holder consolidation.

## Evidence-driven scope

An on-demand Windows lane (fires ONLY on `wine2e/**` branches — inert on PRs/main) ran the probe suite against unfixed main first: #90778 reproduced live (both the `hermes dashboard` mislabel and `--preserve-cache` matching "serve"), #87594 reproduced live (scan returned `pids: []` under a gateway parent), #78089 passed (already fixed on main — issue can be closed).

## Changes

- `_hermes_holder_subcommand()` (#90778): token-based parse of the actual Hermes subcommand — profile selectors skipped, flags never matched, unknown argv gets NO hint instead of a wrong one. Holder hints keyed on the parsed subcommand; `hermes dashboard` now gets "stop it: hermes dashboard stop", not "close the desktop app".
- Ancestor-exclusion carve-out (#87594), applied at BOTH sites of the class (`_detect_venv_python_processes`, `_venv_launcher_ancestors`): a GATEWAY ancestor (canonical `looks_like_gateway_command_line`) stays visible to the scan so the pause machinery can stop it when `/update` runs as the gateway's child; shells/terminals/own-venv ancestry stay excluded.
- `windows-venv-e2e.yml` (on-demand) + `test_venv_holder_windows_live.py`: live E2E harness — real spawned processes with Hermes argv shapes, real detection/classification/message code, no mocked psutil. The #87594 probe walks ancestors by argv (the runner's launcher/worker chain diagnostics are in the test comments).
- 15 cross-platform classifier unit tests (run on the normal Linux lanes).

## Validation

| Check | Result |
|---|---|
| Live Windows E2E (windows-latest, run 32533912826) | 8/8 pass — was 3 failures on unfixed main |
| Cross-platform unit tests (15) + update-suite siblings (57 total) | pass |
| ruff | clean |

## Infographic

![venv guard fixed](https://v3b.fal.media/files/b/0aa7486c/LMIUhMjDQ-9NPYMqGa2Dw_lEiuIDZ8.png)
