### PR TITLE
chore(state): tidy post-salvage residue in state.db durability test

### DIFF
--- a/tests/test_state_db_write_durability.py
+++ b/tests/test_state_db_write_durability.py
@@ -34,8 +34,6 @@ import sqlite3
 import sys
 from pathlib import Path
 
-import pytest
-
 import hermes_state
 from hermes_state import (
     _connect_repair_durable,
@@ -55,7 +53,7 @@ def _make_db(tmp_path: Path) -> Path:
     return db
 
 
-# ── Defect 1: repair-path write durability ──────────────────────────────
+# ── Repair-path write durability ────────────────────────────────────────
 
 
 def test_connect_repair_durable_sets_macos_barriers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Test-only cleanup of two leftovers from the #91852 salvage descope. No behavior change.

When #91852 dropped the deferred `verify_state_db_integrity()` tests, two pieces of their scaffolding stayed behind in `tests/test_state_db_write_durability.py`:

## Changes

- Drop the now-unused `import pytest` — it was only used by the removed integrity tests; no markers/raises/fixtures remain in this file (the sibling guard test keeps its `import pytest` for `@pytest.mark.requires_wal`).
- Rename the `# ── Defect 1: repair-path write durability ──` section label to `# ── Repair-path write durability ──`. The sibling "Defect 2" integrity-gate section was descoped out, so the "Defect 1" numbering was left dangling.

## Validation

`tests/test_state_db_write_durability.py`: 4 passed. `ruff --select F401` clean.
