### PR TITLE
fix(auth): resolve base_url from the token in `hermes auth add` for Z.AI Coding Plan keys

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -102,6 +102,43 @@ def _provider_base_url(provider: str) -> str:
     return pconfig.inference_base_url if pconfig else ""
 
 
+def _resolve_base_url_for_token(provider: str, token: str) -> str:
+    """Resolve a manually added key's base URL from the token itself.
+
+    Mirrors the env-seed path in ``agent/credential_pool`` so that
+    ``hermes auth add`` lands the same endpoint an env-seeded entry would,
+    instead of blindly stamping the registry default. For providers whose
+    correct endpoint depends on the key — Z.AI GLM Coding Plan keys
+    authenticate only on ``/api/coding/paas/v4`` and 429/1113 on the metered
+    ``/api/paas/v4``; Kimi Code ``sk-kimi-`` keys route to the coding
+    endpoint — dispatch through the provider's resolver (which honours a
+    ``*_BASE_URL`` env override, reuses the cached ``detected_endpoint``, and
+    otherwise probes). Every other provider keeps the registry default.
+    """
+    default = _provider_base_url(provider)
+    if provider not in ("zai", "kimi-coding"):
+        return default
+    pconfig = PROVIDER_REGISTRY.get(provider)
+    if not pconfig:
+        return default
+    env_url = ""
+    if pconfig.base_url_env_var:
+        try:
+            from agent.credential_pool import get_env_prefer_dotenv
+
+            env_url = get_env_prefer_dotenv(pconfig.base_url_env_var).rstrip("/")
+        except Exception:
+            env_url = ""
+    try:
+        if provider == "kimi-coding":
+            resolved = auth_mod._resolve_kimi_base_url(token, pconfig.inference_base_url, env_url)
+        else:
+            resolved = auth_mod._resolve_zai_base_url(token, pconfig.inference_base_url, env_url)
+    except Exception:
+        return default
+    return resolved or default
+
+
 def _oauth_default_label(provider: str, count: int) -> str:
     return f"{provider}-oauth-{count}"
 
@@ -216,7 +253,7 @@ def auth_add_command(args) -> None:
             priority=0,
             source=SOURCE_MANUAL,
             access_token=token,
-            base_url=_provider_base_url(provider),
+            base_url=_resolve_base_url_for_token(provider, token),
         )
         pool.add_entry(entry)
         print(f'Added {provider} credential #{len(pool.entries())}: "{label}"')

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -94,6 +94,84 @@ def test_auth_add_api_key_persists_manual_entry(tmp_path, monkeypatch):
     assert entry["access_token"] == "sk-or-manual"
 
 
+def test_auth_add_zai_resolves_coding_base_url_from_env_override(tmp_path, monkeypatch):
+    """`hermes auth add zai` must resolve base_url from the token like the
+
+    env-seed path, not stamp the metered registry default. Regression for
+    #91846: GLM Coding Plan keys authenticate only on /api/coding/paas/v4,
+    so a manual-add entry left on /api/paas/v4 429/1113s and is marked
+    exhausted. Here GLM_BASE_URL pins the coding endpoint (deterministic,
+    no network probe), and the manual entry must adopt it.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for key in ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("GLM_BASE_URL", "https://api.z.ai/api/coding/paas/v4")
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "zai"
+        auth_type = "api-key"
+        api_key = "id123.codingplansecret"
+        label = "cli-test"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = next(
+        item for item in payload["credential_pool"]["zai"] if item["source"] == "manual"
+    )
+    assert entry["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+
+
+def test_auth_add_zai_reuses_cached_detected_endpoint(tmp_path, monkeypatch):
+    """The manual-add path must reuse the same cached `detected_endpoint` the
+
+    env-seed path writes (keyed on the API-key hash), giving manual-pool
+    parity with env-seeded entries without re-probing. Regression for #91846.
+    """
+    import hashlib
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for key in ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY", "GLM_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
+
+    token = "id123.codingplansecret"
+    key_hash = hashlib.sha256(token.encode()).hexdigest()[:16]
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "zai": {
+                    "detected_endpoint": {
+                        "base_url": "https://api.z.ai/api/coding/paas/v4",
+                        "key_hash": key_hash,
+                    }
+                }
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "zai"
+        auth_type = "api-key"
+        api_key = token
+        label = "cli-test"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = next(
+        item for item in payload["credential_pool"]["zai"] if item["source"] == "manual"
+    )
+    assert entry["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+
+
 def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})


### PR DESCRIPTION
## What does this PR do?

`hermes auth add zai --api-key <key>` created the pool entry with the registry-default **metered** endpoint (`https://api.z.ai/api/paas/v4`) hardcoded into `base_url`, ignoring the token entirely. For GLM **Coding Plan** keys — which authenticate only on `https://api.z.ai/api/coding/paas/v4` and return `429 / 1113 "Insufficient balance"` on the metered endpoint — the first request failed and the credential was immediately marked `exhausted`, even though the key is valid and paid.

The env-seeded path already resolves the correct endpoint from the token via `_resolve_zai_base_url` (`agent/credential_pool.py`), so an env-provided key worked while the same key added through `hermes auth add` did not. This resolves the base URL from the token at creation time, giving the manual-add path parity with the env-seed path: the token is routed through the provider's resolver, which honors a `*_BASE_URL` override, reuses the cached `detected_endpoint`, and otherwise probes — landing Coding Plan keys on the coding endpoint and caching the result.

A shared `_resolve_base_url_for_token(provider, token)` helper also covers the sibling `kimi-coding` case (`sk-kimi-` keys → coding endpoint); every other provider keeps the registry default unchanged.

## Related Issue

Fixes #91846

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth_commands.py`: add `_resolve_base_url_for_token(provider, token)`, mirroring the env-seed dispatch (`zai` → `_resolve_zai_base_url`, `kimi-coding` → `_resolve_kimi_base_url`); the API-key branch of `auth_add_command` now sets `base_url=_resolve_base_url_for_token(provider, token)` instead of `_provider_base_url(provider)`.
- `tests/hermes_cli/test_auth_commands.py`: add two regression tests — the manual entry adopts the coding endpoint via a `GLM_BASE_URL` override, and reuses a cached `detected_endpoint` keyed on the API-key hash.

## How to Test

1. With the fix reverted, `hermes auth add zai --api-key <coding-plan-key> --label test` — the new pool entry's `base_url` is `https://api.z.ai/api/paas/v4` (metered), regardless of the key.
2. With the fix applied, the same command resolves the token through `_resolve_zai_base_url` and stores `base_url = https://api.z.ai/api/coding/paas/v4`.
3. Endpoint check with a real Coding Plan key confirms the split the fix relies on:
   - `POST https://api.z.ai/api/paas/v4/chat/completions` → `429 {"code":"1113","message":"Insufficient balance ..."}`
   - `POST https://api.z.ai/api/coding/paas/v4/chat/completions` → `200` (valid completion)
4. `pytest tests/hermes_cli/test_auth_commands.py -q` → all pass; both new tests fail when the fix is reverted (negative control).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
