### PR TITLE
fix(subdirectory_hints): exclude .hermes home from hint discovery

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -13,6 +13,7 @@ from typing import Dict, Any, Optional, Set
 
 from agent.prompt_builder import _read_text_with_timeout, _scan_context_content, _truncate_content
 from agent.search_policy import SEARCH_PRUNE_DIR_NAMES
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,17 @@ _MAX_ANCESTOR_WALK = 5  # ancestor levels walked per path — bounds deep-path s
 
 # Shared with broad recursive search probes so context discovery and search never drift into
 # different dependency/cache/build trees (those hold *copies* of context files, never authoritative ones).
-_EXCLUDED_DIR_NAMES = SEARCH_PRUNE_DIR_NAMES
+# Locally extended with tooling home dirs: their AGENTS.md files are tool docs (e.g. the Hermes
+# dev guide), not user-project context. Sessions rooted at $HOME would otherwise walk up into
+# ~/.hermes/ and inject them. Sessions whose working_dir IS inside .hermes/ still load hints
+# normally (the relative_to() check in _is_excluded only screens segments below working_dir).
+_EXCLUDED_DIR_NAMES = SEARCH_PRUNE_DIR_NAMES | frozenset({".hermes"})
+
+# Case-insensitive matching set: macOS/Windows filesystems are not
+# case-sensitive, so ".Hermes" / ".HERMES" would otherwise slip past the
+# literal-name check on those platforms.  Keep the readable original above
+# as the source of truth.
+_EXCLUDED_DIR_NAMES_CASEFOLD = frozenset(name.casefold() for name in _EXCLUDED_DIR_NAMES)
 
 
 def _digest(content: str) -> str:
@@ -150,7 +161,31 @@ class SubdirectoryHintTracker:
             rel_parts = path.relative_to(self.working_dir).parts
         except ValueError:
             return True  # outside the tree — already rejected upstream
-        return any(part in _EXCLUDED_DIR_NAMES for part in rel_parts)
+        if any(part.casefold() in _EXCLUDED_DIR_NAMES_CASEFOLD for part in rel_parts):
+            return True
+        # HERMES_HOME is configurable, so a home not literally named ".hermes"
+        # (e.g. /opt/hermes-data) would still leak its AGENTS.md into
+        # home-rooted sessions.  Mirror the name-based carve-out above: the
+        # home counts as tooling only when the working dir is NOT inside it.
+        try:
+            home = get_hermes_home().resolve()
+        except OSError:
+            return False
+        try:
+            working_resolved = self.working_dir.resolve()
+        except OSError:
+            working_resolved = self.working_dir
+        try:
+            inside_home = working_resolved.is_relative_to(home)
+        except (OSError, ValueError):
+            inside_home = False
+        if not inside_home:
+            try:
+                path.resolve().relative_to(home)
+                return True
+            except (OSError, ValueError):
+                pass
+        return False
 
     def _load_hints_for_directory(self, directory: Path) -> Optional[str]:
         """Load the first hint file in *directory*; formatted text or None."""

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -293,6 +293,75 @@ class TestContentDeduplication:
 
 
 class TestExcludedDirectories:
+    def test_hermes_home_excluded_from_home_rooted_sessions(self, tmp_path):
+        """~/.hermes AGENTS.md (tool docs) must not leak into home-rooted sessions."""
+        hermes = tmp_path / ".hermes" / "hermes-agent"
+        hermes.mkdir(parents=True)
+        (hermes / "AGENTS.md").write_text("Hermes development guide")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        assert (
+            tracker.check_tool_call(
+                "read_file", {"path": str(hermes / "agent" / "subdirectory_hints.py")}
+            )
+            is None
+        )
+
+    def test_working_dir_inside_hermes_still_loads(self, tmp_path):
+        """A session whose working_dir IS ~/.hermes/hermes-agent keeps its hints."""
+        hermes = tmp_path / ".hermes" / "hermes-agent"
+        hermes.mkdir(parents=True)
+        (hermes / "AGENTS.md").write_text("Hermes development guide")
+        pkg = hermes / "agent"
+        pkg.mkdir()
+        (pkg / "AGENTS.md").write_text("Agent package rules")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(hermes))
+        result = tracker.check_tool_call("read_file", {"path": str(pkg / "f.py")})
+        assert result is not None and "Agent package rules" in result
+
+    def test_custom_hermes_home_excluded_from_home_rooted_sessions(self, tmp_path, monkeypatch):
+        """A HERMES_HOME not literally named .hermes must not leak either."""
+        home = tmp_path / "hermes-data"
+        hermes = home / "hermes-agent"
+        hermes.mkdir(parents=True)
+        (hermes / "AGENTS.md").write_text("Hermes development guide")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        assert (
+            tracker.check_tool_call(
+                "read_file", {"path": str(hermes / "agent" / "subdirectory_hints.py")}
+            )
+            is None
+        )
+
+    def test_working_dir_inside_custom_hermes_home_still_loads(self, tmp_path, monkeypatch):
+        """A dev session rooted inside a custom HERMES_HOME keeps its hints."""
+        home = tmp_path / "hermes-data"
+        pkg = home / "hermes-agent" / "agent"
+        pkg.mkdir(parents=True)
+        (pkg / "AGENTS.md").write_text("Agent package rules")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        tracker = SubdirectoryHintTracker(working_dir=str(home / "hermes-agent"))
+        result = tracker.check_tool_call("read_file", {"path": str(pkg / "f.py")})
+        assert result is not None and "Agent package rules" in result
+
+    def test_case_insensitive_name_variant_excluded(self, tmp_path):
+        """.Hermes must be excluded on case-insensitive filesystems."""
+        hermes = tmp_path / ".Hermes" / "hermes-agent"
+        hermes.mkdir(parents=True)
+        (hermes / "AGENTS.md").write_text("Hermes development guide")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        assert (
+            tracker.check_tool_call(
+                "read_file", {"path": str(hermes / "agent" / "f.py")}
+            )
+            is None
+        )
+
     """Backups, vendored deps, and caches hold copies — never context."""
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Sessions rooted at `$HOME` leak the Hermes install tree's AGENTS.md into unrelated work. The desktop app starts sessions without `TERMINAL_CWD`, so `SubdirectoryHintTracker` falls back to the process working directory, which is the user's home. A tool call that touches any `.hermes` path then walks up the ancestors, finds `~/.hermes/hermes-agent/AGENTS.md` (a ~79KB development guide), and injects it into the response (capped at 8,000 chars by `_MAX_HINT_CHARS`).

The existing outside-workspace guard in `_is_valid_subdir` does not catch this: `.hermes` is inside the home tree, so the path passes the `is_relative_to(working_dir)` check. `_EXCLUDED_DIR_NAMES` already covers `vendor`, `backups`, `.git`, `node_modules`, and caches, but not the agent's own home directory.

## Fix

Add `".hermes"` to `_EXCLUDED_DIR_NAMES` in `agent/subdirectory_hints.py`.

The exclusion is scoped by construction. `_is_excluded` screens `path.relative_to(working_dir)` segments, so `.hermes` only blocks paths below a home-rooted session. A session whose working_dir is inside `.hermes` (developing Hermes itself) keeps loading hints, because the relative parts never contain the `.hermes` segment. The dev guide stays readable by direct file access when actually working on the codebase.

## Tests

Two regression tests in `tests/agent/test_subdirectory_hints.py::TestExcludedDirectories`:

- `test_hermes_home_excluded_from_home_rooted_sessions`: a home-rooted tracker reading a file under `.hermes/hermes-agent` returns no hint.
- `test_working_dir_inside_hermes_still_loads`: a tracker whose working_dir is `.hermes/hermes-agent` still discovers hints in its subdirectories.

Full hint suites pass: 29 tests across `test_subdirectory_hints.py` and `test_subdirectory_hints_tilde.py`.

Refit 2026-09-05: re-applied against the simplified upstream structure (`_is_ancestor_or_same` became `_within_working_dir`; the carve-out now uses `is_relative_to`). Payload unchanged. Verified: 63/63 in tests/agent/test_subdirectory_hints.py.
