### PR TITLE
feat(security): detect persistent instruction-file poisoning

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -59,6 +59,11 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Bitwarden Secrets Manager encrypted disk cache.
             str(hermes_home / "cache" / "bws_cache.enc.json"),
             str(hermes_root / "cache" / "bws_cache.enc.json"),
+            # Operator-accepted tirith config-scan baseline. Generic agent file
+            # tools must not rewrite this application-owned security state to
+            # hide a newly poisoned instruction file; update it only through
+            # the explicit ``hermes security scan --update-baseline`` command.
+            str(hermes_home / "security" / "tirith-scan-baseline.json"),
             os.path.join(home, ".netrc"),
             os.path.join(home, ".pgpass"),
             os.path.join(home, ".npmrc"),

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -476,6 +476,7 @@ terminal:
 #   tirith_enabled: true        # Enable/disable tirith scanning
 #   tirith_path: "tirith"       # Path to tirith binary (supports ~ expansion)
 #   tirith_timeout: 5           # Scan timeout in seconds
+#   tirith_scan_timeout: 120     # On-demand file scan timeout in seconds
 #   tirith_fail_open: true      # Allow commands if tirith unavailable
 #   approval:
 #     transport: builtin        # Or an explicitly enabled plugin transport name

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3784,6 +3784,7 @@ _SECURITY_COMMENT = """
 #   tirith_enabled: true
 #   tirith_path: "tirith"
 #   tirith_timeout: 5
+#   tirith_scan_timeout: 120
 #   tirith_fail_open: true
 """
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2456,6 +2456,7 @@ DEFAULT_CONFIG = {
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,
+        "tirith_scan_timeout": 120,
         "tirith_fail_open": True,
         "website_blocklist": {
             "enabled": False,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5637,6 +5637,10 @@ def cmd_verify(args):
 def cmd_security(args):
     """Dispatch `hermes security <subcmd>`."""
     sub = getattr(args, "security_command", None)
+    if sub == "scan":
+        from hermes_cli.security_config_scan import cmd_security_scan
+
+        sys.exit(int(cmd_security_scan(args) or 0))
     if sub in ("audit", None):
         from hermes_cli.security_audit import cmd_security_audit
 

--- a/hermes_cli/security_config_scan.py
+++ b/hermes_cli/security_config_scan.py
@@ -209,10 +209,7 @@ def _render_human(
     incomplete_reasons: list[str],
 ) -> str:
     lines = [f"Scanned {scanned_count} file(s); tirith reported {len(findings)} finding(s)."]
-    if incomplete_reasons:
-        lines.append(f"Scan incomplete: {'; '.join(incomplete_reasons)}.")
-        lines.append("The baseline was not updated; resolve the incomplete analysis and retry.")
-    elif updated:
+    if updated:
         lines.append(f"Baseline updated with {len(findings)} finding(s): {baseline_path}")
     elif not new_findings:
         lines.append("No new findings since the accepted baseline.")
@@ -223,6 +220,9 @@ def _render_human(
             lines.append(f"  [{finding.severity}] {finding.path}: {finding.rule_id} — {finding.title}")
         if not baseline_exists:
             lines.append("Review the findings, then rerun with --update-baseline to accept them.")
+    if incomplete_reasons:
+        lines.append(f"Scan incomplete: {'; '.join(incomplete_reasons)}.")
+        lines.append("The baseline was not updated; resolve the incomplete analysis and retry.")
     return "\n".join(lines)
 
 

--- a/hermes_cli/security_config_scan.py
+++ b/hermes_cli/security_config_scan.py
@@ -57,6 +57,7 @@ class ConfigFinding:
 class ScanSummary:
     scanned_count: int
     findings: list[ConfigFinding]
+    incomplete_reasons: tuple[str, ...] = ()
 
 
 def _finding_fingerprint(path: str, raw: dict[str, Any]) -> str:
@@ -99,7 +100,23 @@ def _parse_tirith_output(payload: dict[str, Any]) -> ScanSummary:
 
     findings.sort(key=lambda item: (-SEVERITY_ORDER.get(item.severity, -1), item.path, item.rule_id))
     scanned_count = payload.get("scanned_count", 1 if "path" in payload else 0)
-    return ScanSummary(scanned_count=int(scanned_count or 0), findings=findings)
+    incomplete_reasons: list[str] = []
+    panic_count = payload.get("panic_count", 0)
+    if isinstance(panic_count, int) and not isinstance(panic_count, bool) and panic_count > 0:
+        incomplete_reasons.append(f"tirith reported {panic_count} rule panic(s)")
+    if payload.get("truncated") is True:
+        incomplete_reasons.append("tirith truncated the scan")
+    if payload.get("analysis_incomplete") is True:
+        reason = "tirith reported incomplete analysis"
+        coverage_gaps = payload.get("coverage_gaps")
+        if isinstance(coverage_gaps, list) and coverage_gaps:
+            reason += f" ({len(coverage_gaps)} coverage gap(s))"
+        incomplete_reasons.append(reason)
+    return ScanSummary(
+        scanned_count=int(scanned_count or 0),
+        findings=findings,
+        incomplete_reasons=tuple(incomplete_reasons),
+    )
 
 
 def _scan_path(
@@ -189,9 +206,13 @@ def _write_baseline(path: Path, findings: list[ConfigFinding]) -> None:
 def _render_human(
     *, scanned_count: int, findings: list[ConfigFinding], new_findings: list[ConfigFinding],
     baseline_path: Path, baseline_exists: bool, updated: bool,
+    incomplete_reasons: list[str],
 ) -> str:
     lines = [f"Scanned {scanned_count} file(s); tirith reported {len(findings)} finding(s)."]
-    if updated:
+    if incomplete_reasons:
+        lines.append(f"Scan incomplete: {'; '.join(incomplete_reasons)}.")
+        lines.append("The baseline was not updated; resolve the incomplete analysis and retry.")
+    elif updated:
         lines.append(f"Baseline updated with {len(findings)} finding(s): {baseline_path}")
     elif not new_findings:
         lines.append("No new findings since the accepted baseline.")
@@ -221,7 +242,8 @@ def cmd_security_scan(args: argparse.Namespace) -> int:
     if not tirith:
         print("tirith is disabled or unavailable; configure security.tirith_path", file=sys.stderr)
         return 2
-    timeout = getattr(args, "timeout", None) or cfg.get("tirith_scan_timeout", 120)
+    requested_timeout = getattr(args, "timeout", None)
+    timeout = cfg.get("tirith_scan_timeout", 120) if requested_timeout is None else requested_timeout
     if not isinstance(timeout, int) or timeout <= 0:
         print("scan timeout must be a positive integer", file=sys.stderr)
         return 2
@@ -234,8 +256,11 @@ def cmd_security_scan(args: argparse.Namespace) -> int:
         summaries = [_scan_path(tirith, path, timeout, include_patterns) for path in paths]
         findings = [finding for summary in summaries for finding in summary.findings]
         scanned_count = sum(summary.scanned_count for summary in summaries)
+        incomplete_reasons = [
+            reason for summary in summaries for reason in summary.incomplete_reasons
+        ]
         new_findings = [finding for finding in findings if finding.fingerprint not in baseline]
-        updated = bool(getattr(args, "update_baseline", False))
+        updated = bool(getattr(args, "update_baseline", False)) and not incomplete_reasons
         if updated:
             _write_baseline(baseline_path, findings)
     except (OSError, RuntimeError) as exc:
@@ -248,6 +273,8 @@ def cmd_security_scan(args: argparse.Namespace) -> int:
         "new_finding_count": len(new_findings),
         "baseline": str(baseline_path),
         "baseline_updated": updated,
+        "analysis_incomplete": bool(incomplete_reasons),
+        "incomplete_reasons": incomplete_reasons,
         "new_findings": [finding.as_dict() for finding in new_findings],
     }
     if getattr(args, "json", False):
@@ -261,9 +288,12 @@ def cmd_security_scan(args: argparse.Namespace) -> int:
                 baseline_path=baseline_path,
                 baseline_exists=baseline_exists,
                 updated=updated,
+                incomplete_reasons=incomplete_reasons,
             )
         )
 
+    if incomplete_reasons:
+        return 2
     if updated:
         return 0
     threshold = SEVERITY_ORDER[str(getattr(args, "fail_on", "high")).upper()]

--- a/hermes_cli/security_config_scan.py
+++ b/hermes_cli/security_config_scan.py
@@ -1,0 +1,270 @@
+"""On-demand tirith scan for persistent Hermes instruction poisoning."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+BASELINE_SCHEMA_VERSION = 1
+SEVERITY_ORDER = {"INFO": 0, "LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+DEFAULT_INSTRUCTION_PATTERNS = (
+    "SOUL.md",
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".cursorrules",
+    "config.yaml",
+    "mcp.json",
+    ".mcp.json",
+    "skills/*",
+    "memories/*",
+    "workspace/*",
+    ".claude/*",
+    ".cursor/*",
+    ".hermes/*",
+    ".github/copilot-instructions.md",
+)
+
+
+@dataclass(frozen=True)
+class ConfigFinding:
+    path: str
+    rule_id: str
+    severity: str
+    title: str
+    fingerprint: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "path": self.path,
+            "rule_id": self.rule_id,
+            "severity": self.severity,
+            "title": self.title,
+            "fingerprint": self.fingerprint,
+        }
+
+
+@dataclass(frozen=True)
+class ScanSummary:
+    scanned_count: int
+    findings: list[ConfigFinding]
+
+
+def _finding_fingerprint(path: str, raw: dict[str, Any]) -> str:
+    """Hash the complete finding without persisting evidence or file content."""
+    canonical = json.dumps(
+        {"path": path, "finding": raw},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _parse_tirith_output(payload: dict[str, Any]) -> ScanSummary:
+    """Normalize tirith directory- and single-file JSON schemas."""
+    files = payload.get("files")
+    if not isinstance(files, list):
+        files = [payload] if "path" in payload else []
+
+    findings: list[ConfigFinding] = []
+    for file_result in files:
+        if not isinstance(file_result, dict):
+            continue
+        path = str(file_result.get("path") or "<unknown>")
+        raw_findings = file_result.get("findings") or []
+        if not isinstance(raw_findings, list):
+            continue
+        for raw in raw_findings:
+            if not isinstance(raw, dict):
+                continue
+            findings.append(
+                ConfigFinding(
+                    path=path,
+                    rule_id=str(raw.get("rule_id") or "unknown"),
+                    severity=str(raw.get("severity") or "unknown").upper(),
+                    title=str(raw.get("title") or raw.get("description") or ""),
+                    fingerprint=_finding_fingerprint(path, raw),
+                )
+            )
+
+    findings.sort(key=lambda item: (-SEVERITY_ORDER.get(item.severity, -1), item.path, item.rule_id))
+    scanned_count = payload.get("scanned_count", 1 if "path" in payload else 0)
+    return ScanSummary(scanned_count=int(scanned_count or 0), findings=findings)
+
+
+def _scan_path(
+    tirith: str,
+    path: Path,
+    timeout: int,
+    include_patterns: tuple[str, ...] = (),
+) -> ScanSummary:
+    command = [
+        tirith,
+        "scan",
+        str(path),
+        "--profile",
+        "ai-agent-repo",
+        "--fail-on",
+        "high",
+        "--json",
+    ]
+    for pattern in include_patterns:
+        command.extend(("--include", pattern))
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"tirith scan failed for {path}: {exc}") from exc
+
+    if result.returncode not in {0, 1, 2}:
+        detail = result.stderr.strip() or f"exit code {result.returncode}"
+        raise RuntimeError(f"tirith scan failed for {path}: {detail}")
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise RuntimeError(f"tirith returned invalid JSON for {path}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"tirith returned an invalid result for {path}")
+    return _parse_tirith_output(payload)
+
+
+def _load_baseline(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"could not read baseline {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"invalid baseline document in {path}")
+    if payload.get("schema_version") != BASELINE_SCHEMA_VERSION:
+        raise RuntimeError(f"unsupported baseline schema in {path}")
+    fingerprints = payload.get("fingerprints")
+    if not isinstance(fingerprints, list) or not all(isinstance(item, str) for item in fingerprints):
+        raise RuntimeError(f"invalid baseline fingerprints in {path}")
+    return set(fingerprints)
+
+
+def _write_baseline(path: Path, findings: list[ConfigFinding]) -> None:
+    if path.is_symlink():
+        raise RuntimeError(f"refusing to replace symlinked baseline {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": BASELINE_SCHEMA_VERSION,
+        "fingerprints": sorted({finding.fingerprint for finding in findings}),
+    }
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _render_human(
+    *, scanned_count: int, findings: list[ConfigFinding], new_findings: list[ConfigFinding],
+    baseline_path: Path, baseline_exists: bool, updated: bool,
+) -> str:
+    lines = [f"Scanned {scanned_count} file(s); tirith reported {len(findings)} finding(s)."]
+    if updated:
+        lines.append(f"Baseline updated with {len(findings)} finding(s): {baseline_path}")
+    elif not new_findings:
+        lines.append("No new findings since the accepted baseline.")
+    else:
+        scope = "No baseline exists; treating all findings as new." if not baseline_exists else f"{len(new_findings)} new finding(s):"
+        lines.append(scope)
+        for finding in new_findings:
+            lines.append(f"  [{finding.severity}] {finding.path}: {finding.rule_id} — {finding.title}")
+        if not baseline_exists:
+            lines.append("Review the findings, then rerun with --update-baseline to accept them.")
+    return "\n".join(lines)
+
+
+def cmd_security_scan(args: argparse.Namespace) -> int:
+    """Implementation of ``hermes security scan``."""
+    home = Path(get_hermes_home())
+    explicit_paths = bool(getattr(args, "paths", None))
+    paths = [Path(item).expanduser() for item in (getattr(args, "paths", None) or [home])]
+    missing = [str(path) for path in paths if not path.exists()]
+    if missing:
+        print(f"scan path does not exist: {missing[0]}", file=sys.stderr)
+        return 2
+
+    from tools.tirith_security import resolve_tirith_for_scan
+
+    tirith, cfg = resolve_tirith_for_scan()
+    if not tirith:
+        print("tirith is disabled or unavailable; configure security.tirith_path", file=sys.stderr)
+        return 2
+    timeout = getattr(args, "timeout", None) or cfg.get("tirith_scan_timeout", 120)
+    if not isinstance(timeout, int) or timeout <= 0:
+        print("scan timeout must be a positive integer", file=sys.stderr)
+        return 2
+
+    baseline_path = Path(getattr(args, "baseline", None) or home / "security" / "tirith-scan-baseline.json")
+    baseline_exists = baseline_path.exists()
+    try:
+        baseline = _load_baseline(baseline_path)
+        include_patterns = () if explicit_paths else DEFAULT_INSTRUCTION_PATTERNS
+        summaries = [_scan_path(tirith, path, timeout, include_patterns) for path in paths]
+        findings = [finding for summary in summaries for finding in summary.findings]
+        scanned_count = sum(summary.scanned_count for summary in summaries)
+        new_findings = [finding for finding in findings if finding.fingerprint not in baseline]
+        updated = bool(getattr(args, "update_baseline", False))
+        if updated:
+            _write_baseline(baseline_path, findings)
+    except (OSError, RuntimeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    output = {
+        "scanned_count": scanned_count,
+        "finding_count": len(findings),
+        "new_finding_count": len(new_findings),
+        "baseline": str(baseline_path),
+        "baseline_updated": updated,
+        "new_findings": [finding.as_dict() for finding in new_findings],
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(output, indent=2))
+    else:
+        print(
+            _render_human(
+                scanned_count=scanned_count,
+                findings=findings,
+                new_findings=new_findings,
+                baseline_path=baseline_path,
+                baseline_exists=baseline_exists,
+                updated=updated,
+            )
+        )
+
+    if updated:
+        return 0
+    threshold = SEVERITY_ORDER[str(getattr(args, "fail_on", "high")).upper()]
+    return int(any(SEVERITY_ORDER.get(finding.severity, -1) >= threshold for finding in new_findings))

--- a/hermes_cli/subcommands/security.py
+++ b/hermes_cli/subcommands/security.py
@@ -59,4 +59,46 @@ def build_security_parser(subparsers, *, cmd_security: Callable) -> None:
         help="Skip scanning pinned MCP servers in config.yaml",
     )
     audit_parser.set_defaults(func=cmd_security)
+
+    scan_parser = security_subparsers.add_parser(
+        "scan",
+        help="Scan instruction files for persistent config poisoning",
+        description=(
+            "Run tirith's AI-config scanner against HERMES_HOME (or explicit paths) "
+            "and report only findings not present in the accepted baseline."
+        ),
+    )
+    scan_parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Files or directories to scan (default: the active HERMES_HOME)",
+    )
+    scan_parser.add_argument(
+        "--baseline",
+        default=None,
+        help="Baseline file (default: HERMES_HOME/security/tirith-scan-baseline.json)",
+    )
+    scan_parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="Accept the current findings as the new baseline after review",
+    )
+    scan_parser.add_argument(
+        "--fail-on",
+        default="high",
+        choices=["low", "medium", "high", "critical"],
+        help="Exit non-zero for a new finding at this severity (default: high)",
+    )
+    scan_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help="Per-path tirith timeout in seconds (default: security.tirith_scan_timeout)",
+    )
+    scan_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    scan_parser.set_defaults(func=cmd_security)
     security_parser.set_defaults(func=cmd_security)

--- a/tests/hermes_cli/test_security_config_scan.py
+++ b/tests/hermes_cli/test_security_config_scan.py
@@ -297,6 +297,28 @@ class TestSecurityScanCommand:
         assert "Scan incomplete: tirith truncated the scan." in output
         assert "baseline was not updated" in output
 
+    def test_incomplete_human_output_preserves_detected_findings(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        baseline = tmp_path / "baseline.json"
+        monkeypatch.setattr(scan, "get_hermes_home", lambda: home)
+        payload = _tirith_payload(title="Hidden instruction")
+        payload["panic_count"] = 1
+        _install_fake_tirith(monkeypatch, payload)
+
+        code = scan.cmd_security_scan(
+            _args(home, baseline, update_baseline=True, json=False)
+        )
+        output = capsys.readouterr().out
+
+        assert code == 2
+        assert "[HIGH] SOUL.md: agent_instruction_hidden — Hidden instruction" in output
+        assert "Scan incomplete: tirith reported 1 rule panic(s)." in output
+        assert "baseline was not updated" in output
+        assert not baseline.exists()
+
     def test_default_baseline_is_application_owned_security_state(
         self, tmp_path, monkeypatch
     ):

--- a/tests/hermes_cli/test_security_config_scan.py
+++ b/tests/hermes_cli/test_security_config_scan.py
@@ -202,6 +202,19 @@ class TestSecurityScanCommand:
         assert code == 2
         assert "does not exist" in capsys.readouterr().err
 
+    def test_default_baseline_is_application_owned_security_state(
+        self, tmp_path, monkeypatch
+    ):
+        from agent.file_safety import is_write_denied
+
+        home = tmp_path / ".hermes" / "profiles" / "work"
+        home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        baseline = home / "security" / "tirith-scan-baseline.json"
+
+        assert is_write_denied(str(baseline)) is True
+
 
 class TestSecurityScanParser:
     def test_scan_options_are_wired_to_security_handler(self):

--- a/tests/hermes_cli/test_security_config_scan.py
+++ b/tests/hermes_cli/test_security_config_scan.py
@@ -1,0 +1,221 @@
+"""Behavior tests for ``hermes security scan``."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from types import SimpleNamespace
+
+from hermes_cli import security_config_scan as scan
+from hermes_cli.subcommands.security import build_security_parser
+
+
+def _tirith_payload(*, title: str = "Hidden instruction", severity: str = "high") -> dict:
+    return {
+        "schema_version": 4,
+        "scanned_count": 2,
+        "total_findings": 1,
+        "files": [
+            {
+                "path": "SOUL.md",
+                "is_config_file": True,
+                "findings": [
+                    {
+                        "rule_id": "agent_instruction_hidden",
+                        "severity": severity,
+                        "title": title,
+                        "description": "hidden prompt text",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _args(path, baseline, **overrides):
+    values = {
+        "paths": [str(path)],
+        "baseline": str(baseline),
+        "update_baseline": False,
+        "fail_on": "high",
+        "timeout": None,
+        "json": True,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _install_fake_tirith(monkeypatch, payload: dict) -> None:
+    monkeypatch.setattr(
+        "tools.tirith_security.resolve_tirith_for_scan",
+        lambda: ("tirith", {"tirith_scan_timeout": 17}),
+    )
+    monkeypatch.setattr(
+        scan,
+        "_scan_path",
+        lambda tirith, path, timeout, include_patterns=(): scan._parse_tirith_output(payload),
+    )
+
+
+class TestTirithOutputParsing:
+    def test_directory_output_is_flattened_and_sorted(self):
+        result = scan._parse_tirith_output(_tirith_payload())
+
+        assert result.scanned_count == 2
+        assert len(result.findings) == 1
+        finding = result.findings[0]
+        assert finding.path == "SOUL.md"
+        assert finding.rule_id == "agent_instruction_hidden"
+        assert finding.severity == "HIGH"
+        assert len(finding.fingerprint) == 64
+
+    def test_single_file_schema_is_supported(self):
+        payload = {
+            "schema_version": 3,
+            "path": "AGENTS.md",
+            "findings": [{"rule_id": "html_comment", "severity": "critical"}],
+        }
+
+        result = scan._parse_tirith_output(payload)
+
+        assert result.scanned_count == 1
+        assert result.findings[0].path == "AGENTS.md"
+        assert result.findings[0].severity == "CRITICAL"
+
+    def test_fingerprint_changes_when_same_rule_has_new_evidence(self):
+        before = scan._parse_tirith_output(_tirith_payload(title="Old content"))
+        after = scan._parse_tirith_output(_tirith_payload(title="New content"))
+
+        assert before.findings[0].fingerprint != after.findings[0].fingerprint
+
+
+class TestTirithSubprocessContract:
+    def test_finding_exit_code_is_valid_and_json_is_parsed(self, tmp_path, monkeypatch):
+        completed = SimpleNamespace(
+            returncode=1,
+            stdout=json.dumps(_tirith_payload()),
+            stderr="",
+        )
+        calls = []
+
+        def fake_run(command, **kwargs):
+            calls.append((command, kwargs))
+            return completed
+
+        monkeypatch.setattr(scan.subprocess, "run", fake_run)
+        result = scan._scan_path("/bin/tirith", tmp_path, 23)
+
+        assert result.scanned_count == 2
+        command, kwargs = calls[0]
+        assert command[:3] == ["/bin/tirith", "scan", str(tmp_path)]
+        assert command[-1] == "--json"
+        assert kwargs["timeout"] == 23
+
+    def test_default_instruction_filter_is_forwarded_to_tirith(self, tmp_path, monkeypatch):
+        completed = SimpleNamespace(returncode=0, stdout=json.dumps({"scanned_count": 0, "files": []}), stderr="")
+        calls = []
+        monkeypatch.setattr(
+            scan.subprocess,
+            "run",
+            lambda command, **kwargs: calls.append(command) or completed,
+        )
+
+        scan._scan_path("tirith", tmp_path, 5, ("SOUL.md", "skills/*"))
+
+        command = calls[0]
+        assert command.count("--include") == 2
+        assert command[-4:] == ["--include", "SOUL.md", "--include", "skills/*"]
+
+    def test_invalid_json_is_an_operational_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            scan.subprocess,
+            "run",
+            lambda *a, **kw: SimpleNamespace(returncode=0, stdout="not-json", stderr=""),
+        )
+
+        try:
+            scan._scan_path("tirith", tmp_path, 1)
+        except RuntimeError as exc:
+            assert "invalid JSON" in str(exc)
+        else:
+            raise AssertionError("invalid JSON must fail closed")
+
+
+class TestSecurityScanCommand:
+    def test_new_high_finding_fails_gate(self, tmp_path, monkeypatch, capsys):
+        home = tmp_path / "home"
+        home.mkdir()
+        baseline = tmp_path / "baseline.json"
+        monkeypatch.setattr(scan, "get_hermes_home", lambda: home)
+        _install_fake_tirith(monkeypatch, _tirith_payload())
+
+        code = scan.cmd_security_scan(_args(home, baseline))
+        output = json.loads(capsys.readouterr().out)
+
+        assert code == 1
+        assert output["new_finding_count"] == 1
+        assert output["new_findings"][0]["severity"] == "HIGH"
+
+    def test_explicit_baseline_update_suppresses_unchanged_finding(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        baseline = tmp_path / "baseline.json"
+        monkeypatch.setattr(scan, "get_hermes_home", lambda: home)
+        _install_fake_tirith(monkeypatch, _tirith_payload())
+
+        update_code = scan.cmd_security_scan(
+            _args(home, baseline, update_baseline=True)
+        )
+        capsys.readouterr()
+        second_code = scan.cmd_security_scan(_args(home, baseline))
+        output = json.loads(capsys.readouterr().out)
+
+        assert update_code == 0
+        assert second_code == 0
+        assert output["new_finding_count"] == 0
+        stored = json.loads(baseline.read_text(encoding="utf-8"))
+        assert stored["schema_version"] == scan.BASELINE_SCHEMA_VERSION
+        assert len(stored["fingerprints"]) == 1
+
+    def test_medium_finding_respects_default_high_gate(self, tmp_path, monkeypatch, capsys):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(scan, "get_hermes_home", lambda: home)
+        _install_fake_tirith(monkeypatch, _tirith_payload(severity="medium"))
+
+        code = scan.cmd_security_scan(_args(home, tmp_path / "missing-baseline.json"))
+        capsys.readouterr()
+
+        assert code == 0
+
+    def test_missing_scan_path_returns_usage_error(self, tmp_path, monkeypatch, capsys):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(scan, "get_hermes_home", lambda: home)
+
+        code = scan.cmd_security_scan(
+            _args(tmp_path / "does-not-exist", tmp_path / "baseline.json")
+        )
+
+        assert code == 2
+        assert "does not exist" in capsys.readouterr().err
+
+
+class TestSecurityScanParser:
+    def test_scan_options_are_wired_to_security_handler(self):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        handler = lambda args: args
+        build_security_parser(subparsers, cmd_security=handler)
+
+        args = parser.parse_args(
+            ["security", "scan", "./workspace", "--fail-on", "critical", "--json"]
+        )
+
+        assert args.func is handler
+        assert args.security_command == "scan"
+        assert args.paths == ["./workspace"]
+        assert args.fail_on == "critical"
+        assert args.json is True

--- a/tests/hermes_cli/test_security_config_scan.py
+++ b/tests/hermes_cli/test_security_config_scan.py
@@ -88,6 +88,34 @@ class TestTirithOutputParsing:
 
         assert before.findings[0].fingerprint != after.findings[0].fingerprint
 
+    def test_v033_rule_panic_marks_scan_incomplete(self):
+        result = scan._parse_tirith_output(
+            {
+                "schema_version": 3,
+                "scanned_count": 0,
+                "panic_count": 1,
+                "panic_files": ["SOUL.md"],
+                "files": [],
+            }
+        )
+
+        assert result.incomplete_reasons == ("tirith reported 1 rule panic(s)",)
+
+    def test_current_incomplete_analysis_preserves_coverage_gap_count(self):
+        result = scan._parse_tirith_output(
+            {
+                "schema_version": 4,
+                "scanned_count": 1,
+                "analysis_incomplete": True,
+                "coverage_gaps": ["unsupported encoding", "read failure"],
+                "files": [],
+            }
+        )
+
+        assert result.incomplete_reasons == (
+            "tirith reported incomplete analysis (2 coverage gap(s))",
+        )
+
 
 class TestTirithSubprocessContract:
     def test_finding_exit_code_is_valid_and_json_is_parsed(self, tmp_path, monkeypatch):
@@ -201,6 +229,73 @@ class TestSecurityScanCommand:
 
         assert code == 2
         assert "does not exist" in capsys.readouterr().err
+
+    def test_incomplete_scan_is_operational_failure_and_does_not_update_baseline(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        baseline = tmp_path / "baseline.json"
+        monkeypatch.setattr(scan, "get_hermes_home", lambda: home)
+        payload = {
+            "schema_version": 3,
+            "scanned_count": 0,
+            "panic_count": 1,
+            "files": [],
+        }
+        _install_fake_tirith(monkeypatch, payload)
+
+        code = scan.cmd_security_scan(
+            _args(home, baseline, update_baseline=True)
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert code == 2
+        assert output["analysis_incomplete"] is True
+        assert output["incomplete_reasons"] == ["tirith reported 1 rule panic(s)"]
+        assert output["baseline_updated"] is False
+        assert not baseline.exists()
+
+    def test_explicit_zero_timeout_is_rejected_before_scan(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(scan, "get_hermes_home", lambda: home)
+        monkeypatch.setattr(
+            "tools.tirith_security.resolve_tirith_for_scan",
+            lambda: ("tirith", {"tirith_scan_timeout": 17}),
+        )
+        calls = []
+        monkeypatch.setattr(scan, "_scan_path", lambda *args, **kwargs: calls.append(args))
+
+        code = scan.cmd_security_scan(
+            _args(home, tmp_path / "baseline.json", timeout=0)
+        )
+
+        assert code == 2
+        assert calls == []
+        assert "positive integer" in capsys.readouterr().err
+
+    def test_incomplete_scan_is_reported_in_human_output(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(scan, "get_hermes_home", lambda: home)
+        _install_fake_tirith(
+            monkeypatch,
+            {"scanned_count": 1, "truncated": True, "files": []},
+        )
+
+        code = scan.cmd_security_scan(
+            _args(home, tmp_path / "baseline.json", json=False)
+        )
+        output = capsys.readouterr().out
+
+        assert code == 2
+        assert "Scan incomplete: tirith truncated the scan." in output
+        assert "baseline was not updated" in output
 
     def test_default_baseline_is_application_owned_security_state(
         self, tmp_path, monkeypatch

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -71,6 +71,7 @@ def _load_security_config() -> dict:
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,
+        "tirith_scan_timeout": 120,
         "tirith_fail_open": True,
     }
     try:
@@ -83,6 +84,7 @@ def _load_security_config() -> dict:
         "tirith_enabled": _env_bool("TIRITH_ENABLED", cfg.get("tirith_enabled", defaults["tirith_enabled"])),
         "tirith_path": os.getenv("TIRITH_BIN", cfg.get("tirith_path", defaults["tirith_path"])),
         "tirith_timeout": _env_int("TIRITH_TIMEOUT", cfg.get("tirith_timeout", defaults["tirith_timeout"])),
+        "tirith_scan_timeout": cfg.get("tirith_scan_timeout", defaults["tirith_scan_timeout"]),
         "tirith_fail_open": _env_bool("TIRITH_FAIL_OPEN", cfg.get("tirith_fail_open", defaults["tirith_fail_open"])),
     }
 
@@ -718,6 +720,25 @@ def ensure_installed(*, log_failures: bool = True):
         _install_thread.start()
 
     return None  # Not available yet; commands will fail-open until ready
+
+
+def resolve_tirith_for_scan() -> tuple[str | None, dict]:
+    """Resolve tirith synchronously for an explicit on-demand file scan.
+
+    Interactive startup uses :func:`ensure_installed` so downloads never delay
+    chat. ``hermes security scan`` is already an explicit blocking operation,
+    so it may use the synchronous resolver and either return an executable path
+    or report that scanning is unavailable.
+    """
+    cfg = _load_security_config()
+    if not cfg["tirith_enabled"]:
+        return None, cfg
+
+    path = _resolve_tirith_path(cfg["tirith_path"])
+    if os.path.isfile(path) and os.access(path, os.X_OK):
+        return path, cfg
+    found = shutil.which(path)
+    return found, cfg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds `hermes security scan`, an on-demand entry point for tirith's file scanner so operators can detect persistent poisoning in Hermes instruction and configuration files. The command scans the active profile's instruction surface by default, supports explicit paths and JSON output, and gates only findings that are new relative to an operator-accepted baseline.

### Motivation

Hermes already installs and invokes tirith for pre-execution command checks, but it did not expose tirith's file scanner. Poisoned `SOUL.md`, `AGENTS.md`, skills, memories, or profile configuration can therefore persist across sessions without an operator-facing detection path.

### Behavior

- `hermes security scan` scans the active `HERMES_HOME` instruction surface with tirith's `ai-agent-repo` profile.
- Explicit paths scan their full file or directory contents.
- New HIGH or CRITICAL findings fail by default; `--fail-on` adjusts the threshold.
- `--update-baseline` explicitly accepts the current fingerprint set. Baselines store hashes only, not finding evidence or file content.
- The default baseline is application-owned security state and cannot be rewritten by generic agent file tools.
- `--json` emits a stable machine-readable summary.

Automatic startup scans, scheduled scans, and SARIF re-wrapping are intentionally out of scope.

### Implementation

The existing tirith resolver now has a synchronous path for explicit scans while chat startup remains non-blocking. Scan output from tirith's directory and single-file JSON schemas is normalized, fingerprinted, compared with an atomic profile-scoped baseline, and rendered by the existing `hermes security` command group.

## Related Issue

Closes #91873

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Security fix

## Changes Made

- `hermes_cli/security_config_scan.py` - runs tirith file scans, normalizes findings, and manages baseline diffs.
- `hermes_cli/subcommands/security.py` and `hermes_cli/main.py` - expose and dispatch `hermes security scan`.
- `tools/tirith_security.py` - resolve tirith synchronously for explicit on-demand scans.
- `agent/file_safety.py` - prevent generic file tools from rewriting the accepted baseline.
- `hermes_cli/config_defaults.py`, `hermes_cli/config.py`, and `cli-config.yaml.example` - add and document the profile-aware scan timeout setting.
- `tests/hermes_cli/test_security_config_scan.py` - cover parser, subprocess, JSON schema, baseline, severity, and file-safety behavior.

## How to Test

1. Run `hermes security scan --json` against a profile containing a planted hidden instruction.
2. Review the output and run `hermes security scan --update-baseline`.
3. Add or alter a finding and confirm the next scan reports it as new and exits non-zero at the configured threshold.
4. Automated validation (29 passed):

```bash
scripts/run_tests.sh tests/hermes_cli/test_security_config_scan.py tests/agent/test_file_safety_session_state.py tests/hermes_cli/test_security_audit.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant repository tests and all tests pass
- [x] I've added tests for my changes
- [x] I've considered cross-platform behavior; unsupported tirith platforms fail with an actionable error while explicit binaries remain supported

### Documentation & Housekeeping

- [x] I've updated relevant command help and docstrings
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] Architecture/workflow documentation changes are N/A
- [x] Tool schema changes are N/A
