### PR TITLE
fix(codex): apply cross-issuer reasoning guard to auxiliary Responses calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1493,7 +1493,10 @@ class _CodexCompletionsAdapter:
         # assistant tool calls as `function_call` items and tool results as
         # `function_call_output` items with a valid call_id, so every
         # Responses path normalizes tool history identically and cannot drift.
-        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+        from agent.codex_responses_adapter import (
+            _chat_messages_to_responses_input,
+            _classify_responses_issuer,
+        )
         from utils import base_url_host_matches
 
         instructions = "You are a helpful assistant."
@@ -1515,6 +1518,31 @@ class _CodexCompletionsAdapter:
         # build_kwargs, so they need the same guard applied independently.
         _host_for_input = str(getattr(self._client, "base_url", "") or "")
         _is_github_for_input = base_url_host_matches(_host_for_input, "githubcopilot.com")
+        _is_xai_for_input = base_url_host_matches(_host_for_input, "x.ai") or base_url_host_matches(
+            _host_for_input, "api.x.ai"
+        )
+        _is_codex_backend_for_input = (
+            base_url_host_matches(_host_for_input, "chatgpt.com")
+            and "/backend-api/codex" in _host_for_input.lower()
+        )
+        # Cross-issuer guard: this adapter replays real conversation history
+        # (including reasoning items minted by whatever Responses endpoint
+        # served the main turn) into an auxiliary endpoint that may be a
+        # *different* provider (e.g. main turn on ChatGPT Codex OAuth,
+        # auxiliary.<task> pointed at xAI or GitHub Copilot). Without
+        # classifying this endpoint's issuer here, the guard in
+        # _chat_messages_to_responses_input defaults to inert
+        # (current_issuer_kind=None) and every foreign encrypted_content
+        # blob is replayed verbatim, which the endpoint cannot decrypt and
+        # rejects with HTTP 400 invalid_encrypted_content — breaking context
+        # compression / flush_memories / MoA aggregation calls that happen
+        # to run right after a mid-session provider switch.
+        _issuer_for_input = _classify_responses_issuer(
+            is_xai_responses=_is_xai_for_input,
+            is_github_responses=_is_github_for_input,
+            is_codex_backend=_is_codex_backend_for_input,
+            base_url=_host_for_input,
+        )
         # Auxiliary calls never send ``context_management`` (native
         # compaction is a main-turn feature), so they must never replay a
         # compaction checkpoint from the replayed history nor let one
@@ -1523,6 +1551,7 @@ class _CodexCompletionsAdapter:
         input_items = _chat_messages_to_responses_input(
             replay_messages,
             is_github_responses=_is_github_for_input,
+            current_issuer_kind=_issuer_for_input,
             native_compaction_eligible=False,
         )
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3076,6 +3076,108 @@ class TestCodexAdapterGithubResponsesMessageIdDrop:
         assert message_item["id"] == "msg_short_but_connection_scoped"
 
 
+class TestAuxiliaryCrossIssuerReasoningGuard:
+    """_CodexCompletionsAdapter must drop reasoning items minted by a
+    *different* Responses issuer than this auxiliary endpoint, mirroring the
+    guard already applied on the main-turn transport
+    (agent/transports/codex.py::convert_messages/build_kwargs).
+
+    Auxiliary calls (context compression, flush_memories, MoA aggregation)
+    replay real conversation history through this adapter instead of the
+    main transport. If the main turn ran on one Responses issuer (e.g.
+    ChatGPT Codex OAuth) and ``auxiliary.<task>`` is configured to a
+    *different* issuer (e.g. xAI or GitHub Copilot Responses), replaying the
+    foreign-issued ``encrypted_content`` blob gets HTTP 400
+    ``invalid_encrypted_content`` and breaks the auxiliary call — unless
+    this adapter classifies its own endpoint and passes it as
+    ``current_issuer_kind`` into the shared converter.
+    """
+
+    @staticmethod
+    def _build_adapter(base_url):
+        from types import SimpleNamespace
+
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        message_item = SimpleNamespace(
+            type="message", role="assistant", status="completed",
+            content=[SimpleNamespace(type="output_text", text="hi")],
+        )
+        events = [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    status="completed", id="resp_test",
+                    usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+                ),
+            ),
+        ]
+
+        class _FakeCreateStream:
+            def __iter__(self): return iter(events)
+            def close(self): pass
+
+        captured_kwargs = {}
+
+        def _create(**kwargs):
+            captured_kwargs.update(kwargs)
+            return _FakeCreateStream()
+
+        real_client = MagicMock()
+        real_client.base_url = base_url
+        real_client.responses.create = _create
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.5")
+        return adapter, captured_kwargs
+
+    @staticmethod
+    def _replay_messages_with_foreign_reasoning(issuer_kind: str):
+        return [
+            {"role": "user", "content": "oi"},
+            {
+                "role": "assistant",
+                "content": "resposta",
+                "codex_reasoning_items": [
+                    {
+                        "type": "reasoning",
+                        "encrypted_content": "BLOB_FROM_OTHER_ISSUER",
+                        "_issuer_kind": issuer_kind,
+                    }
+                ],
+            },
+            {"role": "user", "content": "segunda pergunta"},
+        ]
+
+    def test_drops_reasoning_minted_by_a_different_issuer(self):
+        # Main turn ran on ChatGPT Codex OAuth; this auxiliary call targets
+        # xAI's Responses endpoint — a different issuer that cannot decrypt
+        # a Codex-minted blob.
+        adapter, captured = self._build_adapter(base_url="https://api.x.ai")
+        adapter.create(
+            messages=self._replay_messages_with_foreign_reasoning("codex_backend")
+        )
+        reasoning_items = [
+            item for item in captured["input"] if item.get("type") == "reasoning"
+        ]
+        assert reasoning_items == []
+
+    def test_keeps_reasoning_minted_by_the_same_issuer(self):
+        # Same-issuer replay (both legs on ChatGPT Codex OAuth) must still
+        # work — the guard only drops *foreign* items.
+        adapter, captured = self._build_adapter(
+            base_url="https://chatgpt.com/backend-api/codex"
+        )
+        adapter.create(
+            messages=self._replay_messages_with_foreign_reasoning("codex_backend")
+        )
+        reasoning_items = [
+            item for item in captured["input"] if item.get("type") == "reasoning"
+        ]
+        assert len(reasoning_items) == 1
+        assert reasoning_items[0]["encrypted_content"] == "BLOB_FROM_OTHER_ISSUER"
+
+
 class TestVisionAutoSkipsKimiCoding:
     """_resolve_auto vision branch skips providers that have no vision on
     their main endpoint (e.g. Kimi Coding Plan /coding) and falls through


### PR DESCRIPTION
## Summary

- Closes #91886 — the cross-issuer `encrypted_content` guard in `_chat_messages_to_responses_input()` only ran on the main-turn transport (`agent/transports/codex.py`); the auxiliary call path (`agent/auxiliary_client.py::_CodexCompletionsAdapter`, used by context compression, `flush_memories`, and MoA aggregation) never classified its own endpoint, so `current_issuer_kind` stayed `None` and the guard was inert there.
- A session whose main turn runs on one Responses issuer (e.g. ChatGPT Codex OAuth) while `auxiliary.<task>` targets a different issuer (xAI, GitHub Copilot Responses, another Codex account) would replay a foreign-issued `encrypted_content` reasoning blob on the next auxiliary call and get a non-retryable `HTTP 400 invalid_encrypted_content`, breaking that background call.
- Fix: classify the auxiliary client's own endpoint the same way the main transport does (`_classify_responses_issuer`) and pass it through as `current_issuer_kind`. No change to the shared converter or the main transport; purely additive on the auxiliary path, no behavior change for same-issuer sessions.

## Diagram

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 Session history] -->|codex_reasoning_items encrypted_content| B{Which call path?}
    B -->|⚡ Main turn| C[agent/transports/codex.py]
    B -->|⚡ Auxiliary call| D[agent/auxiliary_client.py]
    C -->|classifies own issuer| E[_classify_responses_issuer]
    D -.->|BEFORE: no classification| F[current_issuer_kind = None]
    D -->|AFTER: classifies own issuer too| E
    E --> G[_chat_messages_to_responses_input guard]
    F -->|guard inert| H[🩸 foreign blob replayed]
    G -->|foreign issuer dropped| I[🚀 same-issuer blob replayed OK]
    H --> J[❌ HTTP 400 invalid_encrypted_content]
    I --> K[✅ auxiliary call succeeds]
```

## Test plan

- [x] New regression tests: `TestAuxiliaryCrossIssuerReasoningGuard::test_drops_reasoning_minted_by_a_different_issuer`, `::test_keeps_reasoning_minted_by_the_same_issuer`
- [x] `pytest tests/agent/test_auxiliary_client.py` — 184 passed
- [x] `pytest tests/agent/test_codex_responses_adapter.py` — 16 passed
- [x] Manual PoC reproducing the leak pre-fix (0 foreign items sent post-fix vs 1 before)


## Infographic : 

<img width="1376" height="768" alt="infographic_cross_issuer_reasoning_91887_art" src="https://github.com/user-attachments/assets/7209eb28-574f-4227-8b46-19151ab08245" />
