### PR TITLE
fix(bot): add per-profile reasoning effort controls

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -66,6 +66,13 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { jsx, jsxs } from 'react/jsx-runtime'
 
 const { McpTab, ToolsetConfigPanel } = sdk
+const FALLBACK_REASONING_EFFORTS = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']
+const BOT_REASONING_EFFORTS =
+  typeof sdk === 'undefined' ? FALLBACK_REASONING_EFFORTS : sdk.REASONING_EFFORT_VALUES || FALLBACK_REASONING_EFFORTS
+const botReasoningEffortLabel =
+  typeof sdk === 'undefined' || typeof sdk.reasoningEffortLabel !== 'function'
+    ? effort => effort
+    : sdk.reasoningEffortLabel
 // Keep optional exports feature-detected; test harnesses may strip the SDK namespace.
 const SkillsView = typeof sdk === 'undefined' ? undefined : sdk.SkillsView
 // TRUE only on builds whose SkillsView routes `fixedConnection` to the pinned
@@ -6881,6 +6888,7 @@ function AdvancedProfileConfig({ bot, state, setState }) {
           ...prev,
           provider: res.model?.provider || '',
           model: res.model?.default || '',
+          reasoningEffort: res.reasoning_effort || '',
           soul: res.soul || '',
           skills: res.skills || [],
           toolsets: res.toolsets || [],
@@ -6961,6 +6969,10 @@ function AdvancedProfileConfig({ bot, state, setState }) {
           value: { provider: state.provider, model: state.model },
           onChange: patch => setState(prev => ({ ...prev, dirtyModel: true, ...patch }))
         }),
+        jsx(ReasoningEffortPicker, {
+          value: state.reasoningEffort,
+          onChange: reasoningEffort => setState(prev => ({ ...prev, dirtyReasoning: true, reasoningEffort }))
+        }),
         labeled(
           'Capabilities (applies immediately — skills, tools, MCP)',
           jsx('div', {
@@ -6987,6 +6999,10 @@ function AdvancedProfileConfig({ bot, state, setState }) {
       jsx(ModelPicker, {
         value: { provider: state.provider, model: state.model },
         onChange: patch => setState(prev => ({ ...prev, dirtyModel: true, ...patch }))
+      }),
+      jsx(ReasoningEffortPicker, {
+        value: state.reasoningEffort,
+        onChange: reasoningEffort => setState(prev => ({ ...prev, dirtyReasoning: true, reasoningEffort }))
       }),
       labeled(
         `Skills (${enabledSkills}/${state.skills.length} enabled)`,
@@ -7410,11 +7426,13 @@ function emptyAdvancedState() {
     loaded: false,
     provider: '',
     model: '',
+    reasoningEffort: '',
     soul: '',
     skills: [],
     toolsets: [],
     mcp: [],
     dirtyModel: false,
+    dirtyReasoning: false,
     dirtySoul: false,
     dirtySkills: false,
     dirtyToolsets: false,
@@ -7450,6 +7468,10 @@ async function applyAdvancedConfig(bot, state) {
     } else {
       applied.model = false
     }
+  }
+
+  if (state.dirtyReasoning) {
+    payload.reasoning_effort = state.reasoningEffort.trim()
   }
 
   if (state.dirtySkills) {
@@ -7490,6 +7512,37 @@ function labeled(label, control) {
       control
     ]
   })
+}
+
+function ReasoningEffortPicker({ value, onChange }) {
+  return labeled(
+    'Reasoning effort',
+    jsxs(Select, {
+      value: value || '__inherit__',
+      onValueChange: next => onChange(next === '__inherit__' ? '' : next),
+      children: [
+        jsx(SelectTrigger, {
+          className: 'h-8 rounded-md',
+          children: jsx(SelectValue, { placeholder: 'Use profile default' })
+        }),
+        jsxs(SelectContent, {
+          children: [
+            jsx(SelectItem, { value: '__inherit__', children: 'Use inherited/default' }),
+            ...BOT_REASONING_EFFORTS.map(effort =>
+              jsx(
+                SelectItem,
+                {
+                  value: effort,
+                  children: botReasoningEffortLabel(effort)
+                },
+                effort
+              )
+            )
+          ]
+        })
+      ]
+    })
+  )
 }
 
 function EditProfileDialog({ bot, open, onClose }) {
@@ -7565,7 +7618,10 @@ function EditProfileDialog({ bot, open, onClose }) {
       }
     }
 
-    if (adv.loaded && (adv.dirtyModel || adv.dirtySoul || adv.dirtySkills || adv.dirtyToolsets || adv.dirtyMcp)) {
+    if (
+      adv.loaded &&
+      (adv.dirtyModel || adv.dirtyReasoning || adv.dirtySoul || adv.dirtySkills || adv.dirtyToolsets || adv.dirtyMcp)
+    ) {
       try {
         const res = await applyAdvancedConfig(bot.name, adv)
         const failed = Object.entries(res?.applied || {}).filter(([, ok]) => !ok)
@@ -7643,7 +7699,7 @@ function EditProfileDialog({ bot, open, onClose }) {
               onClick: () => setAdvanced(v => !v),
               children: [
                 jsx(Codicon, { name: advanced ? 'chevron-down' : 'chevron-right', className: 'text-[0.8rem]' }),
-                'Advanced — model, skills, toolsets, SOUL.md'
+                'Advanced — model, reasoning, skills, toolsets, SOUL.md'
               ]
             }),
             advanced
@@ -7689,6 +7745,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
   const [cloneFrom, setCloneFrom] = useState('default')
   const [model, setModel] = useState('')
   const [provider, setProvider] = useState('')
+  const [reasoningEffort, setReasoningEffort] = useState('')
   const [soul, setSoul] = useState('')
   const [noSkills, setNoSkills] = useState(false)
   const [shareAuth, setShareAuth] = useState(true)
@@ -7792,6 +7849,7 @@ function CreateAgentDialog({ open, onClose, roster }) {
     setCloneFrom('default')
     setModel('')
     setProvider('')
+    setReasoningEffort('')
     setSoul('')
     setNoSkills(false)
     setShareAuth(true)
@@ -7896,7 +7954,8 @@ function CreateAgentDialog({ open, onClose, roster }) {
         // ignore the param and copy — still functional, just forked.
         share_auth: shareAuth,
         soul: composeSoul({ name: slug, title, description, roster, customSoul: soul }),
-        ...(model.trim() && provider.trim() ? { model: model.trim(), provider: provider.trim() } : {})
+        ...(model.trim() && provider.trim() ? { model: model.trim(), provider: provider.trim() } : {}),
+        ...(reasoningEffort.trim() ? { reasoning_effort: reasoningEffort.trim() } : {})
       })
 
       createdRef.current = slug
@@ -8256,6 +8315,10 @@ function CreateAgentDialog({ open, onClose, roster }) {
                                 }
                               },
                               placeholderModel: 'inherited from launch profile'
+                            }),
+                            jsx(ReasoningEffortPicker, {
+                              value: reasoningEffort,
+                              onChange: setReasoningEffort
                             }),
                             labeled(
                               'SOUL.md (optional — replaces the generated persona)',

--- a/tests/tui_gateway/test_profile_reasoning_effort.py
+++ b/tests/tui_gateway/test_profile_reasoning_effort.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+import tui_gateway.server as server
+
+
+def _profile_env(tmp_path: Path, monkeypatch, *, reasoning_effort: object = "") -> Path:
+    home = tmp_path / ".hermes"
+    profile = home / "profiles" / "bot"
+    profile.mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    config = {"model": {"provider": "openrouter", "default": "test/model"}}
+    if reasoning_effort != "":
+        config["agent"] = {"reasoning_effort": reasoning_effort}
+    (profile / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    return profile
+
+
+def _result(method: str, params: dict) -> dict:
+    envelope = server._methods[method]("test", params)
+    assert "error" not in envelope, envelope
+    return envelope["result"]
+
+
+def test_profiles_describe_reports_reasoning_effort(tmp_path, monkeypatch):
+    _profile_env(tmp_path, monkeypatch, reasoning_effort="high")
+
+    result = _result("profiles.describe", {"name": "bot"})
+
+    assert result["reasoning_effort"] == "high"
+
+
+def test_profiles_describe_normalizes_disabled_reasoning(tmp_path, monkeypatch):
+    _profile_env(tmp_path, monkeypatch, reasoning_effort=False)
+
+    result = _result("profiles.describe", {"name": "bot"})
+
+    assert result["reasoning_effort"] == "none"
+
+
+def test_profiles_configure_persists_reasoning_effort(tmp_path, monkeypatch):
+    profile = _profile_env(tmp_path, monkeypatch)
+
+    result = _result(
+        "profiles.configure",
+        {"name": "bot", "reasoning_effort": "xhigh"},
+    )
+
+    assert result["ok"] is True
+    assert result["applied"]["reasoning_effort"] is True
+    raw = yaml.safe_load((profile / "config.yaml").read_text(encoding="utf-8"))
+    assert raw["agent"]["reasoning_effort"] == "xhigh"
+
+
+def test_profiles_configure_rejects_invalid_reasoning_effort(tmp_path, monkeypatch):
+    profile = _profile_env(tmp_path, monkeypatch, reasoning_effort="low")
+
+    result = _result(
+        "profiles.configure",
+        {"name": "bot", "reasoning_effort": "impossible"},
+    )
+
+    assert result["ok"] is False
+    assert result["applied"]["reasoning_effort"] is False
+    raw = yaml.safe_load((profile / "config.yaml").read_text(encoding="utf-8"))
+    assert raw["agent"]["reasoning_effort"] == "low"
+
+
+def test_profiles_configure_clears_reasoning_effort(tmp_path, monkeypatch):
+    profile = _profile_env(tmp_path, monkeypatch, reasoning_effort="high")
+
+    result = _result(
+        "profiles.configure",
+        {"name": "bot", "reasoning_effort": ""},
+    )
+
+    assert result["ok"] is True
+    raw = yaml.safe_load((profile / "config.yaml").read_text(encoding="utf-8"))
+    assert "reasoning_effort" not in raw.get("agent", {})
+
+
+def test_profiles_create_persists_reasoning_effort(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = _result(
+        "profiles.create",
+        {
+            "name": "deep-bot",
+            "reasoning_effort": "ultra",
+            "mirror_credentials": False,
+            "no_skills": True,
+        },
+    )
+
+    assert result["ok"] is True
+    profile = home / "profiles" / "deep-bot"
+    raw = yaml.safe_load((profile / "config.yaml").read_text(encoding="utf-8"))
+    assert raw["agent"]["reasoning_effort"] == "ultra"

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -291,7 +291,8 @@ def _(rid, params: dict) -> dict:
     Params: ``name`` (required, lowercase slug), ``description``,
     ``clone_from`` (source profile; omitted = fresh profile with bundled
     skills), ``clone_all``, ``no_skills``, ``soul`` (SOUL.md content),
-    ``model`` + ``provider`` (optional model pin, best-effort), and
+    ``model`` + ``provider`` (optional model pin, best-effort),
+    ``reasoning_effort`` (optional per-profile reasoning level), and
     ``mirror_credentials`` (default true) — copy the launch profile's
     ``.env`` and ``auth.json`` into the new profile, and inherit its
     model.provider/model.default when no explicit pin is given.
@@ -321,6 +322,18 @@ def _(rid, params: dict) -> dict:
     name = str(params.get("name") or "").strip()
     if not name:
         return _err(rid, 4061, "name required")
+
+    reasoning_effort = None
+    if "reasoning_effort" in params:
+        candidate = str(params.get("reasoning_effort") or "").strip().lower()
+        try:
+            from hermes_constants import parse_reasoning_effort
+
+            if candidate and parse_reasoning_effort(candidate) is None:
+                return _err(rid, 4065, f"invalid reasoning_effort '{candidate}'")
+            reasoning_effort = candidate
+        except Exception:
+            return _err(rid, 4065, f"invalid reasoning_effort '{candidate}'")
     try:
         from hermes_cli import profiles as profiles_mod
 
@@ -358,6 +371,23 @@ def _(rid, params: dict) -> dict:
         try:
             (path / "SOUL.md").write_text(soul, encoding="utf-8")
             soul_written = True
+        except Exception:
+            pass
+
+    if reasoning_effort:
+        try:
+            from hermes_cli.config import read_user_config_raw, save_config
+            from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+            token = set_hermes_home_override(str(path))
+            try:
+                cfg = read_user_config_raw() or {}
+                agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+                agent_cfg["reasoning_effort"] = reasoning_effort
+                cfg["agent"] = agent_cfg
+                save_config(cfg)
+            finally:
+                reset_hermes_home_override(token)
         except Exception:
             pass
 
@@ -663,6 +693,13 @@ def _(rid, params: dict) -> dict:
                 pass
 
             model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+            agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+            raw_reasoning_effort = agent_cfg.get("reasoning_effort", "")
+            reasoning_effort = (
+                "none"
+                if raw_reasoning_effort is False
+                else str(raw_reasoning_effort or "").strip().lower()
+            )
 
             description = ""
             try:
@@ -682,6 +719,7 @@ def _(rid, params: dict) -> dict:
                         "provider": str(model_cfg.get("provider") or ""),
                         "default": str(model_cfg.get("default") or ""),
                     },
+                    "reasoning_effort": reasoning_effort,
                     "skills": installed,
                     "toolsets": toolsets_out,
                     "toolsets_pinned": pinned_set is not None,
@@ -701,6 +739,7 @@ def _(rid, params: dict) -> dict:
     Params: ``name`` (required) plus any of:
     ``description`` (str), ``soul`` (str, full SOUL.md replacement),
     ``model`` + ``provider`` (both required together),
+    ``reasoning_effort`` (str; empty clears the profile override),
     ``disabled_skills`` (list[str], replace semantics),
     ``enabled_toolsets`` (list[str], replace semantics; empty list clears
     the pin so every toolset is enabled again), and
@@ -845,6 +884,7 @@ def _(rid, params: dict) -> dict:
             isinstance(params.get("disabled_skills"), list)
             or isinstance(params.get("enabled_toolsets"), list)
             or isinstance(params.get("enabled_mcp_servers"), list)
+            or "reasoning_effort" in params
         )
         if needs_cfg:
             # Launch profile's MCP catalog, read BEFORE the home override
@@ -865,6 +905,35 @@ def _(rid, params: dict) -> dict:
                 from hermes_cli.config import load_config, save_config
 
                 cfg = load_config() or {}
+
+                if "reasoning_effort" in params:
+                    try:
+                        from hermes_cli.config import read_user_config_raw
+                        from hermes_constants import parse_reasoning_effort
+
+                        effort = str(params.get("reasoning_effort") or "").strip().lower()
+                        if effort and parse_reasoning_effort(effort) is None:
+                            applied["reasoning_effort"] = False
+                        else:
+                            raw_cfg = read_user_config_raw() or {}
+                            agent_cfg = (
+                                raw_cfg.get("agent")
+                                if isinstance(raw_cfg.get("agent"), dict)
+                                else {}
+                            )
+                            if effort:
+                                agent_cfg["reasoning_effort"] = effort
+                            else:
+                                agent_cfg.pop("reasoning_effort", None)
+                            if agent_cfg:
+                                raw_cfg["agent"] = agent_cfg
+                            else:
+                                raw_cfg.pop("agent", None)
+                            save_config(raw_cfg)
+                            applied["reasoning_effort"] = True
+                            cfg = load_config() or {}
+                    except Exception:
+                        applied["reasoning_effort"] = False
 
                 if isinstance(params.get("disabled_skills"), list):
                     try:


### PR DESCRIPTION
## Summary

- add a reasoning-effort selector to Bot Mode's create and edit profile flows
- round-trip `agent.reasoning_effort` through the profile JSON-RPC API
- validate profile-level reasoning values and support clearing an existing override

## Root cause

Bot Mode only exposed and persisted the profile's model/provider pair. The profile RPC contract omitted `agent.reasoning_effort`, so the desktop had neither a value to render while editing nor a field it could persist while creating or updating a bot.

## Testing

- `scripts/run_tests.sh tests/tui_gateway/test_profiles_list_preferred_session.py tests/tui_gateway/test_profile_reasoning_effort.py -q`
- `node --test src/plugins/hermes-bots/tests/*.test.mjs`
- `node --check src/plugins/hermes-bots/plugin.js`

## Related Issue

N/A
