### PR TITLE
fix(desktop): let users stop in-flight bot group requests

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -260,6 +260,10 @@ function groupActivityLabel(event) {
   const kind = event?.kind
   const base = GROUP_ACTIVITY_LABELS[kind] || kind || 'did something'
 
+  if (kind === 'cancelled' && event?.reason === 'user') {
+    return 'turn stopped by you'
+  }
+
   if (kind === 'cancelled' || kind === 'settled') {
     return base
   }
@@ -5425,6 +5429,66 @@ async function ensureGroupChatSession(group, member) {
   return { runtime: created?.session_id || null, stored }
 }
 
+let groupTurnSequence = 0
+
+function clearGroupActiveTurn(group, memberKey, token) {
+  updateGroupChat(group, room => {
+    if (room.activeTurns?.[memberKey]?.token !== token) {
+      return room
+    }
+
+    const activeTurns = { ...room.activeTurns }
+    delete activeTurns[memberKey]
+    room.activeTurns = activeTurns
+
+    return room
+  })
+}
+
+/** Stop the current room drive and cooperatively interrupt every member RPC
+ * that is already in flight. The epoch bump retires the orchestration loop
+ * immediately; session.interrupt stops the actual backend turns instead of
+ * merely hiding their progress in the room. */
+async function cancelGroupChatRun(group, members) {
+  const room = $groupChats.get()[group]
+
+  if (!room?.running) {
+    return false
+  }
+
+  const activeTurns = Object.values(room.activeTurns || {})
+  const byKey = new Map((members || []).map(member => [groupMemberKey(member), member]))
+
+  updateGroupChat(group, current => {
+    current.epoch = (current.epoch || 0) + 1
+    current.running = false
+    current.turn = null
+    current.activeTurns = {}
+    return current
+  })
+  clearGroupClarify(group)
+  recordGroupActivity(group, { kind: 'cancelled', member: null, reason: 'user' })
+
+  const results = await Promise.allSettled(
+    activeTurns.map(active => {
+      const member = active.member || byKey.get(active.memberKey)
+
+      if (!member || !active.runtime) {
+        return Promise.resolve()
+      }
+
+      return requestForBot(member, 'session.interrupt', { session_id: active.runtime })
+    })
+  )
+  const failure = results.find(result => result.status === 'rejected')
+
+  if (failure) {
+    throw failure.reason
+  }
+
+  return true
+}
+
 const GROUP_TURN_TIMEOUT_MS = 180000
 const GROUP_TURN_POLL_MS = 2000
 // A member turn that is VISIBLY still working (session reports
@@ -5580,10 +5644,11 @@ async function answerGroupClarify(entry, member, answers) {
  *  so slow models aren't cut off mid-run. A turn that still times out
  *  records a stranded marker so the finished reply can be harvested into
  *  the room at the member's next turn instead of being lost. */
-async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
+async function runGroupChatMemberTurn(group, member, prompt, thread, images, epoch) {
+  const isCurrent = () => (($groupChats.get()[group] || {}).epoch || 0) === epoch
   const { runtime, stored } = await ensureGroupChatSession(group, member)
 
-  if (!runtime) {
+  if (!runtime || !isCurrent()) {
     return null
   }
 
@@ -5651,13 +5716,37 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
     ? `${prompt}\n\nAttached files staged in your session workspace:\n${fileRefs.join('\n')}`
     : prompt
 
-  await requestForBot(member, 'prompt.submit', { session_id: runtime, text: turnText })
+  if (!isCurrent()) {
+    return null
+  }
+
+  const memberKey = groupMemberKey(member)
+  const token = ++groupTurnSequence
+  updateGroupChat(group, room => {
+    room.activeTurns = {
+      ...(room.activeTurns || {}),
+      [memberKey]: { member, memberKey, runtime, token }
+    }
+    return room
+  })
+
+  try {
+    await requestForBot(member, 'prompt.submit', { session_id: runtime, text: turnText })
+  } catch (error) {
+    clearGroupActiveTurn(group, memberKey, token)
+    throw error
+  }
 
   const started = Date.now()
   let deadline = started + GROUP_TURN_TIMEOUT_MS
 
   while (Date.now() < deadline) {
     await new Promise(resolve => setTimeout(resolve, GROUP_TURN_POLL_MS))
+
+    if (!isCurrent()) {
+      clearGroupActiveTurn(group, memberKey, token)
+      return null
+    }
 
     let state = null
 
@@ -5696,11 +5785,14 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
             thread
           })
 
+          clearGroupActiveTurn(group, memberKey, token)
+
           return replyText
         }
       }
 
       recordGroupActivity(group, { kind: 'passed', member: member.name, thread })
+      clearGroupActiveTurn(group, memberKey, token)
 
       return null
     }
@@ -5723,6 +5815,7 @@ async function runGroupChatMemberTurn(group, member, prompt, thread, images) {
     r.stranded = { ...(r.stranded || {}), [groupMemberKey(member)]: { before, thread } }
     return r
   })
+  clearGroupActiveTurn(group, memberKey, token)
 
   return null
 }
@@ -5808,6 +5901,16 @@ async function harvestStrandedGroupReply(group, member) {
   }
 }
 
+function recordGroupRunSuperseded(group, thread) {
+  const userStopped = currentGroupActivity(group).some(
+    event => event.kind === 'cancelled' && event.reason === 'user'
+  )
+
+  if (!userStopped) {
+    recordGroupActivity(group, { kind: 'cancelled', member: null, thread })
+  }
+}
+
 /** Drive one bounded round-robin turn for ONE THREAD. Serial — one member at
  *  a time. A newer user send bumps the room epoch; this loop notices at the
  *  next member boundary, bails, and the newest send's own loop takes over.
@@ -5825,7 +5928,7 @@ async function runGroupChatRounds(group, members, thread) {
       // late, never lost.
       for (const member of members) {
         if (!isCurrent()) {
-          recordGroupActivity(group, { kind: 'cancelled', member: null, thread })
+          recordGroupRunSuperseded(group, thread)
           return
         }
 
@@ -5853,7 +5956,7 @@ async function runGroupChatRounds(group, members, thread) {
       for (const member of responders) {
         if (!isCurrent() || posted >= GROUP_CHAT_MAX_MESSAGES) {
           if (!isCurrent()) {
-            recordGroupActivity(group, { kind: 'cancelled', member: null, thread })
+            recordGroupRunSuperseded(group, thread)
           }
           return
         }
@@ -5894,10 +5997,15 @@ async function runGroupChatRounds(group, members, thread) {
         let reply = null
 
         try {
-          reply = await runGroupChatMemberTurn(group, member, prompt, thread, deltaImages)
+          reply = await runGroupChatMemberTurn(group, member, prompt, thread, deltaImages, startEpoch)
         } catch {
           recordGroupActivity(group, { kind: 'failed', member: member.name, thread })
           reply = null // a failed turn is a pass, never a room error
+        }
+
+        if (!isCurrent()) {
+          recordGroupRunSuperseded(group, thread)
+          return
         }
 
         // The member has now seen everything up to the pre-reply log length.
@@ -10923,13 +11031,29 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
               jsx(GroupClarifyCard, { entry, members }, `clarify:${entry.memberKey}:${entry.requestId}`)
             ),
             room.running
-              ? jsx('div', {
-                  className: 'px-2 py-1 text-[0.7rem] italic text-(--ui-text-quaternary)',
-                  children: roomClarifies.length
-                    ? 'Waiting for your answer…'
-                    : room.turn
-                      ? `${groupSpeakerLabel(room.turn)} is thinking…`
-                      : 'The room is working…'
+              ? jsxs('div', {
+                  className: 'flex items-center gap-2 px-2 py-1',
+                  children: [
+                    jsx('span', {
+                      className: 'min-w-0 flex-1 truncate text-[0.7rem] italic text-(--ui-text-quaternary)',
+                      children: roomClarifies.length
+                        ? 'Waiting for your answer…'
+                        : room.turn
+                          ? `${groupSpeakerLabel(room.turn)} is thinking…`
+                          : 'The room is working…'
+                    }),
+                    jsx(Button, {
+                      type: 'button',
+                      variant: 'ghost',
+                      size: 'sm',
+                      className: 'shrink-0 text-destructive hover:text-destructive',
+                      title: 'Stop every running agent turn in this room',
+                      onClick: () => void cancelGroupChatRun(group, memberDescriptors()).catch(error => {
+                        host.notifyError?.(error, 'Could not stop the group turn')
+                      }),
+                      children: 'Stop'
+                    })
+                  ]
                 }, 'working')
               : null,
             // Scroll anchor (#89835): rooms opened at scroll position 0, mid-

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
@@ -21,6 +21,7 @@ function load(turnScript = () => '(pass)') {
     return slot
   }
   const calls = []
+  const interrupts = []
   const sessions = new Map()
   const runtimeToStored = new Map()
   const titleToStored = new Map()
@@ -42,6 +43,10 @@ function load(turnScript = () => '(pass)') {
     document: { getElementById: () => null, createElement: () => ({}), head: { appendChild: () => undefined } },
     host: {
       request: async (method, params) => {
+        if (method === 'session.interrupt') {
+          interrupts.push({ ...params })
+          return { ok: true }
+        }
         if (method === 'session.create') {
           sessionSequence += 1
           const stored = `sid-${params.profile}-${sessionSequence}`
@@ -98,7 +103,7 @@ function load(turnScript = () => '(pass)') {
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__ga = { sendToGroupChat, recordGroupActivity, currentGroupActivity, groupActivityLabel, updateGroupChat, $groupChats, $groupActivity, GROUP_ACTIVITY_LIMIT };\n'
+      '\nglobalThis.__ga = { sendToGroupChat, cancelGroupChatRun, recordGroupActivity, currentGroupActivity, groupActivityLabel, updateGroupChat, $groupChats, $groupActivity, GROUP_ACTIVITY_LIMIT };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -106,7 +111,7 @@ function load(turnScript = () => '(pass)') {
     storage: { get: () => null, set: (key, value) => storageWrites.set(key, value) },
     register: () => undefined
   })
-  return { ...context.__ga, calls, sessions, storageWrites }
+  return { ...context.__ga, calls, interrupts, sessions, storageWrites }
 }
 
 const MEMBERS = [{ name: 'research', title: '' }, { name: 'builder', title: '' }, { name: 'ops', title: 'The Ops' }]
@@ -156,6 +161,27 @@ test('a failed member turn records failed instead of a phantom reply', async () 
 
   const events = feed(gc, 'Flaky')
   assert.equal(events.some(e => e.kind === 'failed' && e.member === 'builder'), true)
+})
+
+test('stop interrupts the live member session and retires the room run immediately', async () => {
+  const neverFinishes = new Promise(() => {})
+  const gc = load(() => neverFinishes)
+  const members = [{ name: 'research', title: '' }]
+
+  gc.sendToGroupChat('Busy', members, 'long running request')
+  for (let i = 0; i < 50 && gc.calls.length < 1; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+
+  assert.equal(gc.calls.length, 1, 'the member turn is in flight')
+  assert.equal(gc.$groupChats.get().Busy.running, true)
+
+  await gc.cancelGroupChatRun('Busy', members)
+
+  assert.deepEqual(gc.interrupts, [{ session_id: gc.calls[0].runtime }])
+  assert.equal(gc.$groupChats.get().Busy.running, false)
+  assert.equal(gc.$groupChats.get().Busy.turn, null)
+  assert.equal(gc.currentGroupActivity('Busy').at(-1).kind, 'cancelled')
 })
 
 test('a newer send interrupts the previous run and records cancelled in the CURRENT epoch', async () => {
@@ -247,6 +273,7 @@ test('labels read like a person wrote them, with settled/cancelled as room-level
   assert.equal(gc.groupActivityLabel({ kind: 'replied', member: 'research' }), 'research replied')
   assert.equal(gc.groupActivityLabel({ kind: 'timed-out', member: 'ops' }), 'ops took too long')
   assert.equal(gc.groupActivityLabel({ kind: 'cancelled', member: null }), 'turn interrupted by a newer message')
+  assert.equal(gc.groupActivityLabel({ kind: 'cancelled', member: null, reason: 'user' }), 'turn stopped by you')
   assert.equal(gc.groupActivityLabel({ kind: 'settled', member: null }), 'turn settled')
 })
 


### PR DESCRIPTION
## What does this PR do?

Bot group chats now show a Stop action while a room turn is running. Stopping retires the room drive immediately and sends `session.interrupt` to each active member session, so users no longer have to wait for a mistaken or long-running group request to finish.

### Symptom

A bot group room only displayed that a member was thinking. It exposed no Stop button, Escape gesture, or group-specific command while the member session was in flight.

### Impact

Desktop Bot Mode users could not cancel a group request that was slow, mistaken, or heading in the wrong direction. The hidden member session continued running until it completed or timed out.

### Bug Cause

**Trigger:** `apps/desktop/src/plugins/hermes-bots/plugin.js` / `runGroupChatMemberTurn` and `GroupChatWorkspace`

**Causal chain:**
1. A group send creates or resumes a hidden per-member session and submits the room delta.
2. The member runtime session id remained local to the turn worker, while the room UI only received `running` and `turn` presentation state.
3. The workspace therefore had no target for `session.interrupt` and rendered status text without a cancellation action, leaving the backend turn running.

**Why it is wrong:** The room could supersede orchestration with an epoch bump, but that only stopped the client loop at a later boundary. It did not interrupt the agent turn already running in the gateway.

**Working sibling / contrast:** The standalone Desktop chat already routes its Stop action through `session.interrupt`. Bot group turns use the same gateway sessions but did not preserve the active runtime id or expose the action.

**Ruled out:** The gateway protocol is not missing cancellation support. `session.interrupt` already performs the cooperative hard interrupt and pending-prompt cleanup; the gap was in Bot Mode orchestration and UI wiring.

### Fix

- Track active member runtime sessions as runtime-only room state, including their connection route.
- Add a visible Stop action beside the running-room status.
- On Stop, bump the room epoch, clear pending room prompts, retire the UI state, and interrupt every active member session on its own gateway connection.
- Fence stale loops so an interrupted or superseded member cannot append a late reply, and report user stops distinctly in the room activity feed.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/plugin.js` - retain active group member session targets, interrupt them from a visible Stop action, and fence stale room loops.
- `apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs` - reproduce an in-flight group turn and verify Stop sends the interrupt and retires the room state.

## How to Test

1. Open a Desktop Bot Mode group chat and send a request that keeps one member running.
2. Click Stop beside the room's running status.
3. Confirm the room leaves its running state and the member turn is interrupted without appending a late response.
4. Automated checks run locally:

```bash
node --check src/plugins/hermes-bots/plugin.js
node --test src/plugins/hermes-bots/tests/*.test.mjs
```

Result: 392 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant plugin test suite and all 392 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the automated path on Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, the UI text and inline behavior documentation are colocated with the implementation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the change uses existing renderer and gateway RPC surfaces
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Automated regression coverage verifies the running member receives `session.interrupt`, the room leaves `running`, the active speaker clears, and the activity feed records the user stop.
