### PR TITLE
feat(hooks): on_session_start carries effective reasoning effort + first-observed UTC time

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -988,13 +988,27 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # Plugin hook: on_session_start — fired once when a brand-new
     # session is created (not on continuation).  Plugins can use this
     # to initialise session-scoped state (e.g. warm a memory cache).
+    # The payload is a minimal observation record for external
+    # observers: session identity, model, the effective reasoning
+    # effort (or the literal "unknown" when no effective setting was
+    # exposed), and the UTC time the session-start boundary was first
+    # observed.  It deliberately never carries system/base-prompt
+    # content.  Additive and backward compatible: new kwargs only.
     try:
+        from datetime import datetime, timezone
+
+        from agent.reasoning_effort import effective_reasoning_effort
         from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+
         _invoke_hook(
             "on_session_start",
             session_id=agent.session_id,
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
+            reasoning_effort=effective_reasoning_effort(
+                getattr(agent, "reasoning_config", None)
+            ),
+            observed_at=datetime.now(timezone.utc).isoformat(),
         )
     except Exception as exc:
         logger.warning("on_session_start hook failed: %s", exc)

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -225,3 +225,36 @@ def requested_effort(reasoning_config: Optional[dict]) -> Optional[str]:
         return None
     effort = str(reasoning_config.get("effort") or "").strip().lower()
     return effort or None
+
+
+#: Literal label emitted when Hermes exposes no effective reasoning-effort
+#: setting at an observed boundary (e.g. the server default applies).  It is
+#: an explicit "unknown" — never an inference about a provider default.
+UNKNOWN_REASONING_EFFORT = "unknown"
+
+
+def effective_reasoning_effort(reasoning_config: Optional[dict]) -> str:
+    """Return the effective reasoning-effort label for an observer.
+
+    Maps a Hermes reasoning config to the effort that was actually in force
+    when the config was applied — the label an external observer should
+    record:
+
+    * ``{"enabled": False}``                    → ``"none"``
+    * ``{"enabled": True, "effort": "high"}``   → ``"high"``
+    * ``None`` / empty / malformed              → ``"unknown"``
+
+    ``"unknown"`` means Hermes did not expose an effective setting at the
+    boundary; it is never an inference about a provider default.  Unlike
+    :func:`requested_effort`, an explicit disable is reported as ``"none"``
+    rather than folded into ``None``, so observers can tell "turned off"
+    from "not configured".
+    """
+    if not isinstance(reasoning_config, dict):
+        return UNKNOWN_REASONING_EFFORT
+    effort = str(reasoning_config.get("effort") or "").strip().lower()
+    if effort:
+        return effort
+    if reasoning_config.get("enabled") is False:
+        return "none"
+    return UNKNOWN_REASONING_EFFORT

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -111,6 +111,11 @@ emitted by each built-in hook site.
 
     model           – model name (e.g. "claude-sonnet-4-20250514")
     platform        – platform identifier (e.g. "cli", "whatsapp")
+    reasoning_effort – effective reasoning effort ("none", "minimal", "low",
+                      "medium", "high", "xhigh", "max", "ultra"), or the
+                      literal "unknown" when no effective setting was exposed
+    observed_at     – UTC ISO-8601 timestamp of when Hermes first observed
+                      the session-start boundary (not session creation time)
 
 ``on_session_end`` (emitted from ``agent/turn_finalizer.py``)::
 

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -166,7 +166,13 @@ _DEFAULT_PAYLOADS = {
         "final_response": "All done — the change is applied.",
         "changed_paths": ["src/app.tsx"],
     },
-    "on_session_start": {"session_id": "test-session"},
+    "on_session_start": {
+        "session_id": "test-session",
+        "model": "gpt-4",
+        "platform": "cli",
+        "reasoning_effort": "unknown",
+        "observed_at": "2026-08-21T12:00:00+00:00",
+    },
     "on_session_end": {
         "session_id": "test-session",
         "task_id": "test-task",

--- a/tests/agent/test_reasoning_effort_module.py
+++ b/tests/agent/test_reasoning_effort_module.py
@@ -25,6 +25,7 @@ from agent.reasoning_effort import (
     KIMI_K3_OVERRIDES,
     OPENAI_COMPAT_WIRE_EFFORTS,
     clamp_effort,
+    effective_reasoning_effort,
     kimi_supported_efforts,
     requested_effort,
 )
@@ -171,3 +172,37 @@ class TestRequestedEffort:
         assert requested_effort({"enabled": False, "effort": "high"}) is None
         assert requested_effort("not-a-dict") is None
         assert requested_effort({"effort": ""}) is None
+
+
+class TestEffectiveReasoningEffort:
+    """Observer-facing label — distinguishes "turned off" from "unset".
+
+    ``effective_reasoning_effort`` is what lifecycle observers (e.g. the
+    ``on_session_start`` payload) record: the effort that was actually in
+    force when the config was applied.  The literal ``"unknown"`` means
+    Hermes exposed no effective setting (the provider default applies) —
+    it is never an inference about a default.
+    """
+
+    def test_explicit_effort_passes_through_normalized(self):
+        assert effective_reasoning_effort({"enabled": True, "effort": "High"}) == "high"
+        assert effective_reasoning_effort({"enabled": True, "effort": "medium"}) == "medium"
+        assert effective_reasoning_effort({"effort": "ultra"}) == "ultra"
+
+    def test_disabled_is_none_not_unknown(self):
+        """An explicit disable is an effective setting ("none"), not
+        "unknown" — observers can tell turned-off from not-configured."""
+        assert effective_reasoning_effort({"enabled": False}) == "none"
+        assert effective_reasoning_effort({"enabled": False, "effort": ""}) == "none"
+
+    def test_unset_or_malformed_is_unknown(self):
+        assert effective_reasoning_effort(None) == "unknown"
+        assert effective_reasoning_effort({}) == "unknown"
+        assert effective_reasoning_effort({"enabled": True}) == "unknown"
+        assert effective_reasoning_effort("not-a-dict") == "unknown"
+
+    def test_unknown_constant_is_the_literal_string(self):
+        from agent.reasoning_effort import UNKNOWN_REASONING_EFFORT
+
+        assert UNKNOWN_REASONING_EFFORT == "unknown"
+        assert effective_reasoning_effort(None) is UNKNOWN_REASONING_EFFORT

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -379,5 +379,77 @@ class TestReconstructStaticPrefixMemoization:
         assert getattr(agent, "_static_rebuild_failed_for", None) is None
 
 
+class TestSessionStartObservationPayload:
+    """The on_session_start hook carries a minimal observation record.
+
+    External observers (e.g. Bifrost) record an observed material fact:
+    native session id, model, the effective reasoning effort (or the
+    literal ``"unknown"``), and the UTC time Hermes first observed the
+    session-start boundary.  No system/base-prompt content is included.
+    """
+
+    def _patch_hook(self, monkeypatch):
+        import hermes_cli.lifecycle as lifecycle
+
+        calls = []
+        monkeypatch.setattr(
+            lifecycle,
+            "invoke_hook",
+            lambda *a, **kw: calls.append((a, kw)) or [],
+        )
+        return calls
+
+    def test_fresh_build_fires_with_full_observation_payload(self, monkeypatch):
+        from datetime import datetime, timedelta, timezone
+
+        calls = self._patch_hook(monkeypatch)
+        before = datetime.now(timezone.utc)
+        agent = _make_agent(session_db=None)
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+
+        _restore_or_build_system_prompt(agent, None, [])
+
+        assert len(calls) == 1
+        _, kwargs = calls[0]
+        assert kwargs["session_id"] == "test-session-id"
+        assert kwargs["model"] == "test-model"
+        assert kwargs["platform"] == "cli"
+        assert kwargs["reasoning_effort"] == "high"
+        observed = datetime.fromisoformat(kwargs["observed_at"])
+        assert observed.tzinfo is not None
+        assert observed.utcoffset() == timedelta(0), "observed_at must be UTC"
+        assert before <= observed <= datetime.now(timezone.utc)
+
+    def test_unset_reasoning_config_reports_unknown(self, monkeypatch):
+        calls = self._patch_hook(monkeypatch)
+        agent = _make_agent(session_db=None)
+        agent.reasoning_config = None
+
+        _restore_or_build_system_prompt(agent, None, [])
+
+        assert calls[0][1]["reasoning_effort"] == "unknown"
+
+    def test_disabled_reasoning_reports_none(self, monkeypatch):
+        calls = self._patch_hook(monkeypatch)
+        agent = _make_agent(session_db=None)
+        agent.reasoning_config = {"enabled": False}
+
+        _restore_or_build_system_prompt(agent, None, [])
+
+        assert calls[0][1]["reasoning_effort"] == "none"
+
+    def test_restore_does_not_fire_on_session_start(self, monkeypatch):
+        """Continuation sessions reuse the stored prompt — the hook is
+        deliberately not re-fired (it is a new-session boundary only)."""
+        calls = self._patch_hook(monkeypatch)
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": "Stored prompt"}
+        agent = _make_agent(session_db=db)
+
+        _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        assert calls == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -454,7 +454,7 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `on_stream_end` | Observer | Dispatched when a streaming response finishes or errors, after the stream closes; return ignored. | `final_text`, `finished`, `error`, `turn_id`, `iteration`, `session_id`, `model`, `provider`, `surface` | Full assembled response text; error text may include provider data. |
 | `on_interim_message` | Observer | Dispatched when a mid-loop assistant message is surfaced before the final answer (streaming or non-streaming); return ignored. | `text`, `already_streamed`, `turn_id`, `iteration`, `session_id`, `model`, `provider`, `surface` | Full interim assistant text. |
 | `transform_api_error_classification` | Transform | On each failed provider attempt, at the top of the built-in classifier; all callbacks run, then the first dict with a valid `reason` wins (run-all-then-pick-first), and skipped valid results log a runtime warning. Python plugins only. | `provider`, `model`, `status_code`, `error_type`, `error_code`, `error_message`, `error_body`, `error`, `approx_tokens`, `context_length`, `num_messages` | `error_message` and `error_body` may contain raw provider/user data. |
-| `on_session_start` | Observer | First turn of a new session; return ignored. | `session_id`, `model`, `platform` | Identifiers and routing metadata only. |
+| `on_session_start` | Observer | First turn of a new session; return ignored. | `session_id`, `model`, `platform`, `reasoning_effort` (`"unknown"` when unset), `observed_at` (UTC first-observed session-start time) | Identifiers, routing metadata, and effective reasoning effort — no prompt content. |
 | `on_session_end` | Observer | Canonically at each turn finalization; CLI/TUI exits have additional reduced legacy shapes. Return ignored. | Canonical: `session_id`, `task_id`, `turn_id`, `completed`, `failed`, `interrupted`, `turn_exit_reason`, `model`, `platform`; exit paths may add `reason`/`api_request_id` and omit fields. | IDs, model/platform, and outcome; canonical payload has no message body. |
 | `on_session_finalize` | Observer | CLI/TUI/gateway teardown through `finalize_session`; gateway shutdown or expiry may finalize without a reset. Return ignored. | Surface-dependent `session_id`, `platform`, optionally `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
 | `on_session_reset` | Observer | CLI/TUI session boundary and gateway after the replacement session exists; return ignored. | CLI: `session_id`, `platform`, `reason`; TUI: `session_id`, `platform`; gateway: those plus `reason`, `old_session_id`, `new_session_id` | Session and routing identifiers. |
@@ -887,7 +887,7 @@ Fires **once** when a brand-new session is created. Does **not** fire on session
 **Callback signature:**
 
 ```python
-def my_callback(session_id: str, model: str, platform: str, **kwargs):
+def my_callback(session_id: str, model: str, platform: str, reasoning_effort: str, observed_at: str, **kwargs):
 ```
 
 | Parameter | Type | Description |
@@ -895,25 +895,26 @@ def my_callback(session_id: str, model: str, platform: str, **kwargs):
 | `session_id` | `str` | Unique identifier for the new session |
 | `model` | `str` | The model identifier |
 | `platform` | `str` | Where the session is running |
+| `reasoning_effort` | `str` | The effective reasoning effort (`"none"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"`, `"ultra"`), or the literal `"unknown"` when Hermes exposed no effective setting (e.g. the provider default applies). `"unknown"` is not an inferred default. |
+| `observed_at` | `str` | UTC ISO-8601 timestamp of when Hermes **first observed** the session-start boundary — not session creation time. |
 
-**Fires:** In `run_agent.py`, inside `run_conversation()`, during the first turn of a new session — specifically after the system prompt is built but before the tool loop starts. The check is `if not conversation_history` (no prior messages = new session).
+**Fires:** In `agent/conversation_loop.py`, inside `_restore_or_build_system_prompt()`, during the first turn of a new session — specifically after the system prompt is built but before the tool loop starts. The payload never carries system/base-prompt content; it is a minimal observation record (identity, model, effective reasoning effort, first-observed time).
 
 **Return value:** Ignored.
 
 **Use cases:** Initializing session-scoped state, warming caches, registering the session with an external service, logging session starts.
 
-**Example — initialize a session cache:**
+**Example — register a session with an external observer:**
 
 ```python
-_session_caches = {}
-
-def init_session(session_id, model, platform, **kwargs):
-    _session_caches[session_id] = {
+def init_session(session_id, model, platform, reasoning_effort, observed_at, **kwargs):
+    observer_client.record_session_start({
+        "session_id": session_id,
         "model": model,
         "platform": platform,
-        "tool_calls": 0,
-        "started": __import__("datetime").datetime.now().isoformat(),
-    }
+        "reasoning_effort": reasoning_effort,
+        "observed_at": observed_at,
+    })
 
 def register(ctx):
     ctx.register_hook("on_session_start", init_session)


### PR DESCRIPTION
## What does this PR do?

Enriches the `on_session_start` lifecycle hook into a complete **minimal session-start observation** for external observers (e.g. Bifrost's work chronology). The payload is additive and backward compatible — two new kwargs, nothing removed, no base/system-prompt content.

New kwargs:

- **`reasoning_effort`** — the effective reasoning effort in force at session start (`none` | `minimal` | `low` | `medium` | `high` | `xhigh` | `max` | `ultra`), or the literal string `"unknown"` when Hermes exposed no effective setting (provider default applies). `"unknown"` is an explicit marker, **never** an inferred provider default.
- **`observed_at`** — UTC ISO-8601 timestamp of when Hermes **first observed** the session-start boundary (the hook firing), not session creation time.

An Event records an observed material fact, not correctness: the timestamp means when the boundary was first observed, and `unknown` effort means Hermes did not expose a setting.

## Related Issue

No existing issue — feature request from the Bifrost session-observation workstream.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/conversation_loop.py` — `on_session_start` firing site now passes `reasoning_effort` + `observed_at` alongside the existing `session_id`/`model`/`platform`
- `agent/reasoning_effort.py` — new `effective_reasoning_effort()` helper + `UNKNOWN_REASONING_EFFORT` constant (observer-facing label; distinguishes "turned off" (`none`) from "not configured" (`unknown`))
- `agent/shell_hooks.py` — wire-protocol docstring documents the new `extra` keys
- `hermes_cli/hooks.py` — `hermes hooks test` synthetic `on_session_start` payload aligned with the real call site
- `tests/agent/test_system_prompt_restore.py` — 4 new tests: fresh-build fires with full payload, `unknown` when unset, `none` when disabled, no re-fire on continuation restore
- `tests/agent/test_reasoning_effort_module.py` — 4 new tests for `effective_reasoning_effort`
- `website/docs/user-guide/features/hooks.md` — catalog row + `on_session_start` section updated (incl. correcting the stale "Fires in run_agent.py" location to the real `agent/conversation_loop.py::_restore_or_build_system_prompt`)

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_system_prompt_restore.py tests/agent/test_reasoning_effort_module.py tests/agent/test_shell_hooks.py tests/hermes_cli/test_hooks_cli.py
```

All pass: 3 files / 90 tests baseline → 98 tests with the 8 new ones, plus 46 regression tests across hooks/observability/prompt-restore files.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this feature
- [x] I've run the relevant pytest files and all pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform: Ubuntu 24.04 (WSL)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings, `website/docs/`)
- [x] N/A — no config keys changed (`cli-config.yaml.example` untouched)
- [x] N/A — no architecture/workflow change requiring CONTRIBUTING/AGENTS.md updates
- [x] N/A — cross-platform: pure-Python change, stdlib `datetime` only
- [x] N/A — no tool behavior change