### PR TITLE
fix(telegram): preserve MarkdownV2 formatting on chunked long messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8523,9 +8523,17 @@ class TelegramAdapter(BasePlatformAdapter):
                     # Already escaped
                     if s > 0 and _seg[s - 1] == '\\':
                         return ch
-                    # ( that opens a MarkdownV2 link [text](url)
+                    # ( that opens a MarkdownV2 link [text](url) — only when
+                    # the link is actually closed on the same line. A link
+                    # truncated by chunk splitting has no closing ')' and its
+                    # bare '(' makes Telegram reject the whole chunk
+                    # ("character '(' is reserved"), forcing the plain-text
+                    # fallback and losing all bold formatting.
                     if ch == '(' and s > 0 and _seg[s - 1] == ']':
-                        return ch
+                        _rest = _seg[s + 1:]
+                        _close = _rest.find(')')
+                        if _close != -1 and '\n' not in _rest[:_close]:
+                            return ch
                     # ) that closes a link URL
                     if ch == ')':
                         before = _seg[:s]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1455,6 +1455,16 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             text_chunks = BasePlatformAdapter.truncate_message(
                 formatted, 4096, len_fn=utf16_len
             )
+            if send_parse_mode == ParseMode.MARKDOWN_V2:
+                # truncate_message appends a chunk indicator "(N/M)" at the
+                # end of every chunk, unescaped. Its bare '(' makes Telegram
+                # reject the chunk ("character '(' is reserved"), forcing the
+                # plain-text fallback and losing all bold formatting. Escape
+                # the indicator so the rest of the chunk renders normally.
+                text_chunks = [
+                    re.sub(r"\((\d+/\d+)\)$", r"\\(\1\\)", c)
+                    for c in text_chunks
+                ]
             for chunk in text_chunks:
                 try:
                     last_msg = await _send_telegram_message_with_retry(


### PR DESCRIPTION
## Problem

Long messages sent to Telegram with **MarkdownV2** parse mode were losing all bold/italic formatting and falling back to plain text.

`truncate_message()` splits at 4096 UTF-16 units. Two failure paths:

1. **Split inside a link** — when a chunk boundary lands inside `[text](url)`, the bare `(` left open makes Telegram reject the whole chunk (`character '(' is reserved`), forcing the plain-text fallback and losing all formatting.
2. **Unescaped chunk indicator** — `truncate_message()` appends `(N/M)` at the end of every chunk. In MarkdownV2 the bare `(` is a reserved character, so the indicator alone rejects the chunk for the same reason.

## Fix

- `plugins/platforms/telegram/adapter.py`: only treat `(` as opening a MarkdownV2 link when the link is actually closed on the same line. A `(` from a truncated link (no closing `)` before the chunk end) is escaped instead, so the chunk renders with formatting intact.
- `tools/send_message_tool.py`: escape the trailing `(N/M)` chunk indicator when the send parse mode is MarkdownV2.

## Verification

- `python3 -m py_compile` on both files.
- Chunks containing truncated links and `(N/M)` indicators now send with MarkdownV2 accepted by Telegram (previously rejected → plain-text fallback).

The patch has been running locally on a fork since 2026-08-08.