### PR TITLE
feat(agent): per-session cumulative token budget (abort or warn on breach)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1981,6 +1981,20 @@ def init_agent(
             _agent_section.get("run_budget_seconds")
         )
 
+    # Cumulative per-session token budget (#91713). null/0/invalid keeps the
+    # guard dormant (unlimited) — zero behavior change in the default path.
+    from agent.session_budget import (
+        normalize_budget_action,
+        normalize_budget_tokens,
+    )
+
+    agent.session_budget_tokens = normalize_budget_tokens(
+        _agent_section.get("session_budget_tokens")
+    )
+    agent.session_budget_action = normalize_budget_action(
+        _agent_section.get("session_budget_action")
+    )
+
     # Empty-response retry guard config (NS-503): additive
     # ``agent.empty_response_guard`` subsection. Resolution is tolerant —
     # a malformed section falls back to the schema defaults (guard on,

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -927,6 +927,18 @@ def _record_review_usage_to_parent(
     Best-effort by contract: accounting must never fail the review.
     """
     try:
+        # Count this fork's tokens toward the parent's per-session token
+        # budget (#91713), independent of DB persistence: the guard is a live
+        # in-memory counter, so aux spend must register even when the parent
+        # runs without a session_db. session_total_tokens deliberately excludes
+        # aux, so the budget reads this side-counter instead.
+        try:
+            parent_agent.session_aux_tokens_for_budget = int(
+                getattr(parent_agent, "session_aux_tokens_for_budget", 0) or 0
+            ) + int(usage.get("input_tokens") or 0) + int(usage.get("output_tokens") or 0)
+        except Exception:
+            pass
+
         session_db = getattr(parent_agent, "_session_db", None)
         session_id = getattr(parent_agent, "session_id", None)
         if session_db is None or not session_id:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -88,6 +88,7 @@ from agent.retry_utils import (
     zai_coding_overload_retry_ceiling,
 )
 from agent.repetition_guard import is_repetition_dominated
+from agent import session_budget as _session_budget
 from agent.trajectory import has_incomplete_scratchpad
 # Bind before the turn starts so a source-tree swap cannot load a skewed
 # finalizer at turn end.
@@ -1973,7 +1974,52 @@ def run_conversation(
             if not agent.quiet_mode:
                 agent._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
             break
-        
+
+        # Per-session cumulative token budget guard (#91713). Checked before
+        # each API call so an exhausted budget refuses the *next* call — this
+        # runs on the first iteration too, so a session already over budget
+        # from a prior turn is refused before spending anything. `abort` ends
+        # the turn (and, because the used>=cap condition persists, every later
+        # turn) until the user raises/clears the cap; `warn` fires once and
+        # continues. No-op when no budget is set.
+        _budget_action = _session_budget.evaluate_breach(agent)
+        if _budget_action == "abort":
+            _turn_exit_reason = "session_budget_exhausted"
+            _budget_msg = _session_budget.budget_exhausted_message(agent)
+            logger.warning(
+                "Session token budget exhausted: %d/%s tokens after %d calls",
+                _session_budget.budget_used_tokens(agent),
+                agent.session_budget_tokens,
+                agent.session_api_calls,
+            )
+            if not agent.quiet_mode:
+                agent._safe_print(f"\n{_budget_msg}")
+            agent._cleanup_task_resources(effective_task_id)
+            agent._persist_session(messages, conversation_history)
+            return {
+                "final_response": final_response or _budget_msg,
+                "messages": messages,
+                "api_calls": api_call_count,
+                "completed": False,
+                "failed": True,
+                "error": f"session_budget_exhausted: {_budget_msg}",
+            }
+        elif _budget_action == "warn":
+            # warn: emit once (evaluate_breach latched it), then keep going.
+            logger.warning(
+                "Session token budget reached (warn): %d/%s tokens after %d calls",
+                _session_budget.budget_used_tokens(agent),
+                agent.session_budget_tokens,
+                agent.session_api_calls,
+            )
+            if not agent.quiet_mode:
+                agent._safe_print(
+                    f"\n⚠️  session token budget reached "
+                    f"({_session_budget.budget_used_tokens(agent):,}/"
+                    f"{agent.session_budget_tokens:,} tokens after "
+                    f"{agent.session_api_calls} calls) — continuing (warn mode)."
+                )
+
         api_call_count += 1
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")

--- a/agent/session_budget.py
+++ b/agent/session_budget.py
@@ -1,0 +1,116 @@
+"""Per-session cumulative token budget guard (issue #91713).
+
+Existing runaway-cost controls are context- or wall-clock-based:
+``compression.threshold_tokens`` caps a *single* request's context, and the
+run-budget/watchdog bounds *elapsed time*. Neither catches a session making
+many rapid small calls that never trip the compression threshold — each call
+is cheap, the aggregate is not.
+
+This module adds a cumulative cap counted across *all* API calls of a session
+(input + output), including auxiliary forks (background review, MoA). It is a
+pure-local guard over counters the agent loop already maintains
+(``session_total_tokens``) plus an aux accumulator
+(``session_aux_tokens_for_budget``) fed at the aux-recording chokepoints.
+
+Default off: ``session_budget_tokens`` of ``None``/``0`` means unlimited, so
+the default path has zero behavior change — mirroring ``run_budget_seconds``.
+"""
+
+from typing import Any, Optional
+
+__all__ = [
+    "normalize_budget_tokens",
+    "normalize_budget_action",
+    "budget_used_tokens",
+    "budget_remaining_tokens",
+    "budget_exceeded",
+    "evaluate_breach",
+    "budget_exhausted_message",
+]
+
+
+def normalize_budget_tokens(value: Any) -> Optional[int]:
+    """Normalize a cumulative token budget to a positive int or None.
+
+    None / absent / non-numeric / zero / negative all resolve to ``None``
+    (feature off = unlimited), so a malformed config value can never activate
+    the guard, only leave it dormant. ``bool`` is rejected because YAML
+    ``true`` would otherwise become a 1-token budget.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        tokens = int(value)
+    except (TypeError, ValueError):
+        return None
+    return tokens if tokens > 0 else None
+
+
+def normalize_budget_action(value: Any) -> str:
+    """Normalize the breach action to ``"abort"`` (default) or ``"warn"``."""
+    if isinstance(value, str) and value.strip().lower() == "warn":
+        return "warn"
+    return "abort"
+
+
+def budget_used_tokens(agent: Any) -> int:
+    """Cumulative tokens counted against the budget for this session.
+
+    Sums the main-loop total (``session_total_tokens`` — already includes the
+    MoA/codex path) and the auxiliary accumulator
+    (``session_aux_tokens_for_budget`` — background-review forks), so aux spend
+    counts toward the cap even though it is not part of ``session_total_tokens``.
+    """
+    return int(getattr(agent, "session_total_tokens", 0) or 0) + int(
+        getattr(agent, "session_aux_tokens_for_budget", 0) or 0
+    )
+
+
+def budget_remaining_tokens(agent: Any) -> Optional[int]:
+    """Tokens left before the cap, or ``None`` when no budget is set."""
+    cap = normalize_budget_tokens(getattr(agent, "session_budget_tokens", None))
+    if cap is None:
+        return None
+    return max(0, cap - budget_used_tokens(agent))
+
+
+def budget_exceeded(agent: Any) -> bool:
+    """True when a budget is set and cumulative usage has reached the cap."""
+    cap = normalize_budget_tokens(getattr(agent, "session_budget_tokens", None))
+    if cap is None:
+        return False
+    return budget_used_tokens(agent) >= cap
+
+
+def evaluate_breach(agent: Any) -> Optional[str]:
+    """Decide the guard action for the current budget state.
+
+    Returns ``"abort"`` on every breach when the action is ``abort``; returns
+    ``"warn"`` on the *first* breach in ``warn`` mode and ``None`` on every
+    later warn-mode breach (so a session over budget warns once and keeps
+    going); returns ``None`` when no budget is set or the cap is not yet
+    reached. The one-shot warn state latches on ``agent._session_budget_warned``
+    (reset with the session counters). Isolating the decision here keeps the
+    abort/warn/warn-once behavior unit-testable without the full turn loop.
+    """
+    if not budget_exceeded(agent):
+        return None
+    if normalize_budget_action(getattr(agent, "session_budget_action", "abort")) == "abort":
+        return "abort"
+    if not getattr(agent, "_session_budget_warned", False):
+        agent._session_budget_warned = True
+        return "warn"
+    return None
+
+
+def budget_exhausted_message(agent: Any) -> str:
+    """User-facing message for an exhausted session token budget."""
+    calls = int(getattr(agent, "session_api_calls", 0) or 0)
+    cap = normalize_budget_tokens(getattr(agent, "session_budget_tokens", None)) or 0
+    used = budget_used_tokens(agent)
+    return (
+        f"⚠️  session token budget exhausted after {calls} calls "
+        f"({used:,}/{cap:,} tokens). Further turns are refused until "
+        f"agent.session_budget_tokens is raised or cleared in config "
+        f"(applies on the next session)."
+    )

--- a/agent/session_budget.py
+++ b/agent/session_budget.py
@@ -39,6 +39,11 @@ def normalize_budget_tokens(value: Any) -> Optional[int]:
     """
     if value is None or isinstance(value, bool):
         return None
+    # Only accept real config shapes (int / float / numeric string). Objects
+    # that merely implement ``__int__`` (unittest.mock.MagicMock → 1, etc.)
+    # must not activate a 1-token budget.
+    if not isinstance(value, (int, float, str)):
+        return None
     try:
         tokens = int(value)
     except (TypeError, ValueError):

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -958,6 +958,17 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Cumulative token budget per session (input + output across ALL API calls,
+  # including auxiliary forks like background review and MoA).
+  # null / 0 = unlimited (default, current behavior). Set a positive integer
+  # to cap a single runaway session — catches the rapid-small-calls loop that
+  # neither compression.threshold_tokens (context size) nor a wall-clock
+  # budget bounds. On breach: `abort` ends the turn and refuses further turns
+  # until the budget is raised/cleared; `warn` warns once and continues.
+  # Remaining budget is shown in /usage when set.
+  # session_budget_tokens: 5000000
+  # session_budget_action: abort   # abort | warn
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/cli.py
+++ b/cli.py
@@ -13577,6 +13577,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         print(f"  Prompt tokens (total):     {prompt:>10,}")
         print(f"  Completion tokens:         {completion:>10,}")
         print(f"  Total tokens:              {total:>10,}")
+        from agent.session_budget import (
+            budget_remaining_tokens as _budget_remaining,
+        )
+        _sb_remaining = _budget_remaining(agent)
+        if _sb_remaining is not None:
+            print(
+                f"  Session budget remaining:  {_sb_remaining:>10,}"
+                f"  / {agent.session_budget_tokens:,} ({agent.session_budget_action})"
+            )
         print(f"  API calls:                 {calls:>10,}")
         print(f"  Session duration:          {elapsed:>10}")
         print(f"  {'─' * 40}")

--- a/cli.py
+++ b/cli.py
@@ -13579,12 +13579,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         print(f"  Total tokens:              {total:>10,}")
         from agent.session_budget import (
             budget_remaining_tokens as _budget_remaining,
+            normalize_budget_tokens as _normalize_budget,
         )
+        _sb_cap = _normalize_budget(getattr(agent, "session_budget_tokens", None))
         _sb_remaining = _budget_remaining(agent)
-        if _sb_remaining is not None:
+        if _sb_cap is not None and _sb_remaining is not None:
+            _sb_action = getattr(agent, "session_budget_action", "abort")
+            if not isinstance(_sb_action, str):
+                _sb_action = "abort"
             print(
                 f"  Session budget remaining:  {_sb_remaining:>10,}"
-                f"  / {agent.session_budget_tokens:,} ({agent.session_budget_action})"
+                f"  / {_sb_cap:,} ({_sb_action})"
             )
         print(f"  API calls:                 {calls:>10,}")
         print(f"  Session duration:          {elapsed:>10}")

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5394,12 +5394,17 @@ class GatewaySlashCommandsMixin:
             lines.append(t("gateway.usage.label_total", count=f"{agent.session_total_tokens:,}"))
             from agent.session_budget import (
                 budget_remaining_tokens as _budget_remaining,
+                normalize_budget_tokens as _normalize_budget,
             )
+            _sb_cap = _normalize_budget(getattr(agent, "session_budget_tokens", None))
             _sb_remaining = _budget_remaining(agent)
-            if _sb_remaining is not None:
+            if _sb_cap is not None and _sb_remaining is not None:
+                _sb_action = getattr(agent, "session_budget_action", "abort")
+                if not isinstance(_sb_action, str):
+                    _sb_action = "abort"
                 lines.append(
                     f"Session budget remaining: {_sb_remaining:,} / "
-                    f"{agent.session_budget_tokens:,} ({agent.session_budget_action})"
+                    f"{_sb_cap:,} ({_sb_action})"
                 )
             lines.append(t("gateway.usage.label_api_calls", count=agent.session_api_calls))
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5392,6 +5392,15 @@ class GatewaySlashCommandsMixin:
             lines.append(t("gateway.usage.label_input_tokens", count=f"{input_tokens:,}"))
             lines.append(t("gateway.usage.label_output_tokens", count=f"{output_tokens:,}"))
             lines.append(t("gateway.usage.label_total", count=f"{agent.session_total_tokens:,}"))
+            from agent.session_budget import (
+                budget_remaining_tokens as _budget_remaining,
+            )
+            _sb_remaining = _budget_remaining(agent)
+            if _sb_remaining is not None:
+                lines.append(
+                    f"Session budget remaining: {_sb_remaining:,} / "
+                    f"{agent.session_budget_tokens:,} ({agent.session_budget_action})"
+                )
             lines.append(t("gateway.usage.label_api_calls", count=agent.session_api_calls))
 
             # Context window and compressions

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -54,6 +54,19 @@ DEFAULT_CONFIG = {
         # implicit provider stale timeouts are capped to the remaining
         # budget. CLI one-shot equivalent: `hermes chat --run-budget N`.
         "run_budget_seconds": None,
+        # Optional cumulative token budget per session (#91713). Counted
+        # across ALL API calls of the session (input + output), including
+        # auxiliary forks (background review, MoA). null/0 = unlimited
+        # (default, current behavior). When set to a positive integer and
+        # breached: `abort` ends the current turn with an explanatory message
+        # and refuses further turns until the budget is raised/cleared;
+        # `warn` emits a one-time warning and keeps going. Remaining budget is
+        # surfaced in the usage/status view when set. Complements the
+        # context-size cap (compression.threshold_tokens) and the wall-clock
+        # run budget above — this is the guard against the rapid-small-calls
+        # runaway that trips neither.
+        "session_budget_tokens": None,
+        "session_budget_action": "abort",  # abort | warn
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/run_agent.py
+++ b/run_agent.py
@@ -785,6 +785,15 @@ class AIAgent:
         self.session_cache_write_tokens = 0
         self.session_reasoning_tokens = 0
         self.session_api_calls = 0
+        # Auxiliary tokens (background-review forks) counted toward the
+        # per-session token budget but NOT part of session_total_tokens
+        # (which the aux path deliberately leaves untouched). See
+        # agent/session_budget.py (#91713).
+        self.session_aux_tokens_for_budget = 0
+        # One-shot latch for the `warn` breach action, so a session over its
+        # token budget warns once rather than every turn. Reset with the
+        # session counters (a new session re-arms the warning).
+        self._session_budget_warned = False
         self.session_estimated_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"

--- a/tests/agent/test_session_budget.py
+++ b/tests/agent/test_session_budget.py
@@ -29,6 +29,7 @@ def _agent(total=0, aux=0, cap=None, action="abort", calls=0, warned=False):
         (True, None),       # bool rejected (YAML `true`)
         (False, None),
         ("nope", None),
+        (object(), None),   # non-numeric objects stay unlimited
         (5_000_000, 5_000_000),
         ("5000000", 5_000_000),
         (100.0, 100),
@@ -36,6 +37,18 @@ def _agent(total=0, aux=0, cap=None, action="abort", calls=0, warned=False):
 )
 def test_normalize_budget_tokens(value, expected):
     assert sb.normalize_budget_tokens(value) == expected
+
+
+def test_normalize_budget_tokens_rejects_int_coercible_objects():
+    """MagicMock and other __int__ objects must not become a 1-token cap."""
+    from unittest.mock import MagicMock
+
+    class Intish:
+        def __int__(self):
+            return 5
+
+    assert sb.normalize_budget_tokens(MagicMock()) is None
+    assert sb.normalize_budget_tokens(Intish()) is None
 
 
 # ── normalize_budget_action ────────────────────────────────────────────────

--- a/tests/agent/test_session_budget.py
+++ b/tests/agent/test_session_budget.py
@@ -1,0 +1,155 @@
+"""Tests for the per-session cumulative token budget guard (#91713)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent import session_budget as sb
+
+
+def _agent(total=0, aux=0, cap=None, action="abort", calls=0, warned=False):
+    return SimpleNamespace(
+        session_total_tokens=total,
+        session_aux_tokens_for_budget=aux,
+        session_budget_tokens=cap,
+        session_budget_action=action,
+        session_api_calls=calls,
+        _session_budget_warned=warned,
+    )
+
+
+# ── normalize_budget_tokens ────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, None),
+        (0, None),          # 0 = unlimited
+        (-5, None),         # negative = unlimited
+        (True, None),       # bool rejected (YAML `true`)
+        (False, None),
+        ("nope", None),
+        (5_000_000, 5_000_000),
+        ("5000000", 5_000_000),
+        (100.0, 100),
+    ],
+)
+def test_normalize_budget_tokens(value, expected):
+    assert sb.normalize_budget_tokens(value) == expected
+
+
+# ── normalize_budget_action ────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, "abort"),
+        ("abort", "abort"),
+        ("warn", "warn"),
+        ("WARN", "warn"),
+        (" warn ", "warn"),
+        ("garbage", "abort"),   # unknown → safe default (abort)
+        (123, "abort"),
+    ],
+)
+def test_normalize_budget_action(value, expected):
+    assert sb.normalize_budget_action(value) == expected
+
+
+# ── used / remaining / exceeded ────────────────────────────────────────────
+
+def test_used_includes_aux_forks():
+    # The whole point of the aux side-counter: aux spend counts toward the cap
+    # even though it is not part of session_total_tokens.
+    assert sb.budget_used_tokens(_agent(total=1000, aux=500)) == 1500
+
+
+def test_remaining_none_when_unlimited():
+    assert sb.budget_remaining_tokens(_agent(total=999, cap=None)) is None
+    assert sb.budget_remaining_tokens(_agent(total=999, cap=0)) is None
+
+
+def test_remaining_counts_down_and_floors_at_zero():
+    assert sb.budget_remaining_tokens(_agent(total=400, aux=100, cap=1000)) == 500
+    # Over budget floors at 0, never negative.
+    assert sb.budget_remaining_tokens(_agent(total=1200, cap=1000)) == 0
+
+
+def test_exceeded_false_when_unlimited():
+    assert sb.budget_exceeded(_agent(total=10**9, cap=None)) is False
+
+
+def test_exceeded_is_inclusive_at_cap():
+    assert sb.budget_exceeded(_agent(total=999, cap=1000)) is False
+    assert sb.budget_exceeded(_agent(total=1000, cap=1000)) is True   # >= cap
+    assert sb.budget_exceeded(_agent(total=900, aux=100, cap=1000)) is True
+
+
+def test_exhausted_message_reports_calls_and_totals():
+    msg = sb.budget_exhausted_message(_agent(total=4000, aux=1000, cap=5000, calls=42))
+    assert "42 calls" in msg
+    assert "5,000" in msg
+    assert "5,000/5,000" in msg  # used == cap here
+    # Recovery guidance must not imply live in-session mutation (config only,
+    # takes effect next session).
+    assert "next session" in msg
+
+
+# ── evaluate_breach: the enforcement decision (abort / warn-once / none) ────
+
+def test_evaluate_breach_none_when_under_or_unlimited():
+    assert sb.evaluate_breach(_agent(total=500, cap=1000)) is None
+    assert sb.evaluate_breach(_agent(total=10**9, cap=None)) is None
+    assert sb.evaluate_breach(_agent(total=10**9, cap=0)) is None
+
+
+def test_evaluate_breach_abort_every_time():
+    ag = _agent(total=1000, cap=1000, action="abort")
+    assert sb.evaluate_breach(ag) == "abort"
+    assert sb.evaluate_breach(ag) == "abort"  # abort is not one-shot
+
+
+def test_evaluate_breach_warn_is_one_shot_and_latches():
+    ag = _agent(total=1000, cap=1000, action="warn")
+    assert ag._session_budget_warned is False
+    assert sb.evaluate_breach(ag) == "warn"      # first breach warns
+    assert ag._session_budget_warned is True      # latch set
+    assert sb.evaluate_breach(ag) is None         # subsequent breaches: continue silently
+
+
+def test_evaluate_breach_counts_aux_toward_cap():
+    # Breach reached only once aux is included.
+    assert sb.evaluate_breach(_agent(total=900, aux=0, cap=1000)) is None
+    assert sb.evaluate_breach(_agent(total=900, aux=100, cap=1000)) == "abort"
+
+
+# ── config defaults wiring ─────────────────────────────────────────────────
+
+def test_config_defaults_present_and_off_by_default():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    agent_cfg = DEFAULT_CONFIG["agent"]
+    assert agent_cfg["session_budget_tokens"] is None  # unlimited by default
+    assert agent_cfg["session_budget_action"] == "abort"
+
+
+# ── aux-fork wiring (background review feeds the budget counter) ────────────
+
+def test_background_review_usage_feeds_budget_counter():
+    from agent.background_review import _record_review_usage_to_parent
+
+    parent = SimpleNamespace(
+        _session_db=None,       # no DB: budget must still register
+        session_id=None,
+        session_aux_tokens_for_budget=0,
+    )
+    _record_review_usage_to_parent(
+        parent, {"input_tokens": 700, "output_tokens": 300}
+    )
+    assert parent.session_aux_tokens_for_budget == 1000
+
+    # Accumulates across forks.
+    _record_review_usage_to_parent(
+        parent, {"input_tokens": 250, "output_tokens": 250}
+    )
+    assert parent.session_aux_tokens_for_budget == 1500

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5526,13 +5526,20 @@ def _get_usage(agent) -> dict:
     # Per-session token budget (#91713): surface remaining budget in the TUI
     # usage payload when a cap is configured, so the TUI status shows headroom
     # alongside the CLI/gateway /usage views. Absent keys when unset (unlimited).
-    from agent.session_budget import budget_remaining_tokens as _budget_remaining
+    from agent.session_budget import (
+        budget_remaining_tokens as _budget_remaining,
+        normalize_budget_tokens as _normalize_budget,
+        normalize_budget_action as _normalize_action,
+    )
 
+    _sb_cap = _normalize_budget(getattr(agent, "session_budget_tokens", None))
     _sb_remaining = _budget_remaining(agent)
-    if _sb_remaining is not None:
+    if _sb_cap is not None and _sb_remaining is not None:
         usage["budget_remaining"] = _sb_remaining
-        usage["budget_total"] = getattr(agent, "session_budget_tokens", None)
-        usage["budget_action"] = getattr(agent, "session_budget_action", "abort")
+        usage["budget_total"] = _sb_cap
+        usage["budget_action"] = _normalize_action(
+            getattr(agent, "session_budget_action", "abort")
+        )
     comp = getattr(agent, "context_compressor", None)
     if comp:
         # context_used is the *current-window* occupancy. Do NOT fall back to

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5523,6 +5523,16 @@ def _get_usage(agent) -> dict:
         "total": g("session_total_tokens"),
         "calls": g("session_api_calls"),
     }
+    # Per-session token budget (#91713): surface remaining budget in the TUI
+    # usage payload when a cap is configured, so the TUI status shows headroom
+    # alongside the CLI/gateway /usage views. Absent keys when unset (unlimited).
+    from agent.session_budget import budget_remaining_tokens as _budget_remaining
+
+    _sb_remaining = _budget_remaining(agent)
+    if _sb_remaining is not None:
+        usage["budget_remaining"] = _sb_remaining
+        usage["budget_total"] = getattr(agent, "session_budget_tokens", None)
+        usage["budget_action"] = getattr(agent, "session_budget_action", "abort")
     comp = getattr(agent, "context_compressor", None)
     if comp:
         # context_used is the *current-window* occupancy. Do NOT fall back to


### PR DESCRIPTION
## What does this PR do?

Adds an optional **per-session cumulative token budget** to the agent runtime.

Existing runaway-cost controls are context- or wall-clock-based: `compression.threshold_tokens` caps a *single* request's context, and `run_budget_seconds` bounds *elapsed time*. Neither catches a session making **many rapid small calls** that never trip the compression threshold — each call is cheap, the aggregate is not.

This guard counts tokens cumulatively across all API calls of a session (input + output), including auxiliary forks (background review; MoA is already folded into the session total), and on breach either **aborts** the turn (refusing further turns until the budget is raised/cleared) or **warns** once and continues. It defaults to unlimited, so the default path is unchanged.

The approach reuses the counter the runtime already maintains (`session_total_tokens`) plus a small side-counter for aux forks, and hooks a single guard at the top of the conversation loop — mirroring the existing iteration-budget exit pattern rather than adding a parallel accounting path.

## Related Issue

Fixes #91713

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/session_budget.py` (new) — guard module: config normalization, `budget_used_tokens` / `budget_remaining_tokens` / `budget_exceeded`, the `evaluate_breach` decision (abort every breach; warn once), and the user-facing exhausted message.
- `hermes_cli/config_defaults.py` — new `agent.session_budget_tokens` (null/0 = unlimited, default) and `agent.session_budget_action` (`abort` | `warn`).
- `cli-config.yaml.example` — documented the two new keys.
- `agent/agent_init.py` — resolve the two config keys onto the agent (dormant when unset).
- `run_agent.py` — initialize `session_aux_tokens_for_budget` and the one-shot warn latch in `reset_session_state`.
- `agent/conversation_loop.py` — guard at the top of the loop, evaluated before each API call: abort returns a terminal turn result before spending; warn emits once and continues.
- `agent/background_review.py` — count background-review fork tokens toward the budget (independent of session-DB persistence).
- `cli.py`, `gateway/slash_commands.py`, `tui_gateway/server.py` — surface remaining budget in the `/usage` / status views when a cap is set.
- `tests/agent/test_session_budget.py` (new) — 28 tests.

## How to Test

1. Set a small cap in `config.yaml`:
   ```yaml
   agent:
     session_budget_tokens: 50000
     session_budget_action: abort   # or: warn
   ```
2. Run a session that spends past the cap. With `abort`, the turn ends with `session token budget exhausted after N calls (used/cap tokens)`, it is logged, and further turns are refused until the cap is raised or cleared in config. With `warn`, a single warning is emitted and the session continues. `/usage` shows `Session budget remaining` while a cap is set.
3. Unit tests:
   ```
   pytest tests/agent/test_session_budget.py -q
   ```
   Output: `28 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_session_budget.py -q
............................                                             [100%]
28 passed
```
