### PR TITLE
feat(update): enforce generation-fenced deployment transaction authority

### DIFF
--- a/hermes_cli/deployment_plan.py
+++ b/hermes_cli/deployment_plan.py
@@ -1,0 +1,537 @@
+"""Authoritative deployment-plan model for install/update/bootstrap admission.
+
+This module is deliberately import-light and side-effect-free. It answers what
+may exist or mutate on the current machine; callers own the actual mutation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping, MutableMapping
+
+SCHEMA_VERSION = 1
+DEFAULT_PLAN_FILE = "deployment-plan.json"
+
+
+class DeploymentPlanError(RuntimeError):
+    """Base error for invalid or unenforceable deployment plans."""
+
+    code = "DEPLOYMENT_PLAN_ERROR"
+
+    def __init__(self, message: str, *, remediation: str | None = None) -> None:
+        super().__init__(message)
+        self.remediation = remediation
+
+
+class DeploymentPlanInvalid(DeploymentPlanError):
+    """A persisted or explicit plan is malformed or internally inconsistent."""
+
+    code = "DEPLOYMENT_PLAN_INVALID"
+
+
+class DeploymentMutationDenied(DeploymentPlanError):
+    """The requested mutation is outside the authoritative deployment plan."""
+
+    code = "DEPLOYMENT_MUTATION_DENIED"
+
+
+class DeploymentMode(str, Enum):
+    CLI_ONLY = "cli-only"
+    LOCAL_DESKTOP = "local-desktop"
+    REMOTE_ONLY = "remote-only"
+    HYBRID = "hybrid"
+
+
+class DeploymentKind(str, Enum):
+    GIT_VENV = "git-venv"
+    LAUNCHD = "launchd-supervised"
+    SYSTEMD = "systemd-supervised"
+    DESKTOP_MANAGED = "desktop-managed"
+    EXTERNALLY_MANAGED = "externally-managed"
+    IMAGE_MANAGED = "image-managed"
+
+
+_MODE_COMPONENT_CEILINGS: Mapping[DeploymentMode, frozenset[str]] = MappingProxyType(
+    {
+        DeploymentMode.CLI_ONLY: frozenset({"source", "python-runtime", "cli"}),
+        DeploymentMode.LOCAL_DESKTOP: frozenset(
+            {
+                "source",
+                "python-runtime",
+                "node-runtime",
+                "cli",
+                "desktop",
+                "gateway",
+            }
+        ),
+        DeploymentMode.REMOTE_ONLY: frozenset({"desktop-client", "remote-routes"}),
+        DeploymentMode.HYBRID: frozenset(
+            {
+                "source",
+                "python-runtime",
+                "node-runtime",
+                "cli",
+                "desktop",
+                "gateway",
+                "desktop-client",
+                "remote-routes",
+            }
+        ),
+    }
+)
+
+_MODE_RUNTIME_ORIGINS: Mapping[DeploymentMode, frozenset[str]] = MappingProxyType(
+    {
+        DeploymentMode.CLI_ONLY: frozenset({"managed", "external"}),
+        DeploymentMode.LOCAL_DESKTOP: frozenset({"managed", "external"}),
+        DeploymentMode.REMOTE_ONLY: frozenset({"remote"}),
+        DeploymentMode.HYBRID: frozenset({"managed", "external", "remote"}),
+    }
+)
+
+_MUTABLE_KINDS = frozenset(
+    {
+        DeploymentKind.GIT_VENV,
+        DeploymentKind.LAUNCHD,
+        DeploymentKind.SYSTEMD,
+        DeploymentKind.DESKTOP_MANAGED,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DeploymentPlan:
+    """Immutable authority describing the deployment that may exist."""
+
+    schema_version: int
+    mode: DeploymentMode
+    kind: DeploymentKind
+    hermes_home: Path
+    canonical_checkout: Path | None
+    allowed_components: frozenset[str]
+    allowed_runtime_origins: frozenset[str]
+    automatic_local_provisioning: bool
+    required_postconditions: tuple[str, ...]
+    source: str
+    target_generation: str | None = None
+
+    @property
+    def in_place_mutation_allowed(self) -> bool:
+        return self.kind in _MUTABLE_KINDS and self.mode is not DeploymentMode.REMOTE_ONLY
+
+    @property
+    def digest(self) -> str:
+        payload = self.to_dict(include_source=False)
+        encoded = json.dumps(
+            payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def to_dict(self, *, include_source: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "mode": self.mode.value,
+            "kind": self.kind.value,
+            "hermes_home": str(self.hermes_home),
+            "canonical_checkout": (
+                str(self.canonical_checkout)
+                if self.canonical_checkout is not None
+                else None
+            ),
+            "allowed_components": sorted(self.allowed_components),
+            "allowed_runtime_origins": sorted(self.allowed_runtime_origins),
+            "automatic_local_provisioning": self.automatic_local_provisioning,
+            "required_postconditions": list(self.required_postconditions),
+            "target_generation": self.target_generation,
+        }
+        if include_source:
+            payload["source"] = self.source
+            payload["digest"] = self.digest
+        return payload
+
+    def assert_component_allowed(self, component: str) -> None:
+        if component not in self.allowed_components:
+            raise DeploymentMutationDenied(
+                f"deployment mode {self.mode.value!r} forbids component {component!r}",
+                remediation=(
+                    "change the persisted deployment plan explicitly before "
+                    "adding or activating this component"
+                ),
+            )
+
+    def assert_runtime_origin_allowed(self, origin: str) -> None:
+        if origin not in self.allowed_runtime_origins:
+            raise DeploymentMutationDenied(
+                f"deployment mode {self.mode.value!r} forbids runtime origin {origin!r}",
+                remediation="select a runtime origin authorized by the deployment plan",
+            )
+
+
+def _resolved_path(value: str | os.PathLike[str]) -> Path:
+    return Path(value).expanduser().resolve(strict=False)
+
+
+def _env_flag(env: Mapping[str, str], name: str) -> bool:
+    return env.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def default_hermes_home(env: Mapping[str, str] | None = None) -> Path:
+    env = os.environ if env is None else env
+    configured = env.get("HERMES_HOME")
+    if configured:
+        return _resolved_path(configured)
+    return _resolved_path(Path.home() / ".hermes")
+
+
+def default_project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def deployment_plan_path(
+    *,
+    hermes_home: Path,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    env = os.environ if env is None else env
+    explicit = env.get("HERMES_DEPLOYMENT_PLAN")
+    if explicit:
+        return _resolved_path(explicit)
+    return hermes_home / DEFAULT_PLAN_FILE
+
+
+def _enum_value(enum_type, raw: Any, field: str):
+    try:
+        return enum_type(str(raw))
+    except (TypeError, ValueError) as exc:
+        choices = ", ".join(member.value for member in enum_type)
+        raise DeploymentPlanInvalid(
+            f"invalid deployment-plan {field}: {raw!r}; expected one of {choices}"
+        ) from exc
+
+
+def _string_set(raw: Any, field: str) -> frozenset[str]:
+    if not isinstance(raw, list) or any(
+        not isinstance(item, str) or not item.strip() for item in raw
+    ):
+        raise DeploymentPlanInvalid(
+            f"deployment-plan {field} must be a list of non-empty strings"
+        )
+    return frozenset(item.strip() for item in raw)
+
+
+def _string_tuple(raw: Any, field: str) -> tuple[str, ...]:
+    if not isinstance(raw, list) or any(
+        not isinstance(item, str) or not item.strip() for item in raw
+    ):
+        raise DeploymentPlanInvalid(
+            f"deployment-plan {field} must be a list of non-empty strings"
+        )
+    return tuple(item.strip() for item in raw)
+
+
+def _default_postconditions(mode: DeploymentMode) -> tuple[str, ...]:
+    common = ("source-generation", "python-generation")
+    if mode is DeploymentMode.CLI_ONLY:
+        return common + ("cli-entrypoint",)
+    if mode is DeploymentMode.LOCAL_DESKTOP:
+        return common + (
+            "node-generation",
+            "desktop-generation",
+            "managed-process-generation",
+        )
+    if mode is DeploymentMode.REMOTE_ONLY:
+        return ("no-local-runtime", "desktop-client-generation")
+    return common + (
+        "node-generation",
+        "desktop-generation",
+        "managed-process-generation",
+        "remote-route-continuity",
+    )
+
+
+def _validate_plan(
+    *,
+    mode: DeploymentMode,
+    kind: DeploymentKind,
+    allowed_components: frozenset[str],
+    allowed_runtime_origins: frozenset[str],
+    automatic_local_provisioning: bool,
+    canonical_checkout: Path | None,
+) -> None:
+    component_ceiling = _MODE_COMPONENT_CEILINGS[mode]
+    excess = allowed_components - component_ceiling
+    if excess:
+        raise DeploymentPlanInvalid(
+            f"deployment mode {mode.value!r} cannot authorize components: "
+            + ", ".join(sorted(excess))
+        )
+
+    origin_ceiling = _MODE_RUNTIME_ORIGINS[mode]
+    excess_origins = allowed_runtime_origins - origin_ceiling
+    if excess_origins:
+        raise DeploymentPlanInvalid(
+            f"deployment mode {mode.value!r} cannot authorize runtime origins: "
+            + ", ".join(sorted(excess_origins))
+        )
+
+    if mode is DeploymentMode.REMOTE_ONLY and automatic_local_provisioning:
+        raise DeploymentPlanInvalid(
+            "remote-only deployments cannot authorize automatic local provisioning"
+        )
+    if kind in {DeploymentKind.IMAGE_MANAGED, DeploymentKind.EXTERNALLY_MANAGED}:
+        if automatic_local_provisioning:
+            raise DeploymentPlanInvalid(
+                f"{kind.value} deployments cannot authorize local provisioning"
+            )
+    if kind in _MUTABLE_KINDS and canonical_checkout is None:
+        raise DeploymentPlanInvalid(
+            f"{kind.value} deployments require a canonical_checkout"
+        )
+
+
+def plan_from_mapping(
+    raw: Mapping[str, Any],
+    *,
+    hermes_home: Path,
+    source: str,
+    project_root: Path | None = None,
+) -> DeploymentPlan:
+    if raw.get("schema_version") != SCHEMA_VERSION:
+        raise DeploymentPlanInvalid(
+            f"unsupported deployment-plan schema_version: "
+            f"{raw.get('schema_version')!r}; expected {SCHEMA_VERSION}"
+        )
+
+    mode = _enum_value(DeploymentMode, raw.get("mode"), "mode")
+    kind = _enum_value(DeploymentKind, raw.get("kind"), "kind")
+    project_root = default_project_root() if project_root is None else project_root
+
+    if "allowed_components" in raw:
+        allowed_components = _string_set(raw["allowed_components"], "allowed_components")
+    else:
+        allowed_components = _MODE_COMPONENT_CEILINGS[mode]
+
+    if "allowed_runtime_origins" in raw:
+        allowed_runtime_origins = _string_set(
+            raw["allowed_runtime_origins"], "allowed_runtime_origins"
+        )
+    else:
+        allowed_runtime_origins = _MODE_RUNTIME_ORIGINS[mode]
+
+    automatic_local_provisioning = raw.get(
+        "automatic_local_provisioning",
+        mode
+        in {
+            DeploymentMode.CLI_ONLY,
+            DeploymentMode.LOCAL_DESKTOP,
+            DeploymentMode.HYBRID,
+        }
+        and kind in _MUTABLE_KINDS,
+    )
+    if not isinstance(automatic_local_provisioning, bool):
+        raise DeploymentPlanInvalid(
+            "deployment-plan automatic_local_provisioning must be boolean"
+        )
+
+    checkout_raw = raw.get("canonical_checkout")
+    if checkout_raw is None:
+        canonical_checkout = None
+    elif isinstance(checkout_raw, str) and checkout_raw.strip():
+        canonical_checkout = _resolved_path(checkout_raw)
+    else:
+        raise DeploymentPlanInvalid(
+            "deployment-plan canonical_checkout must be a non-empty path or null"
+        )
+
+    if "required_postconditions" in raw:
+        required_postconditions = _string_tuple(
+            raw["required_postconditions"], "required_postconditions"
+        )
+    else:
+        required_postconditions = _default_postconditions(mode)
+
+    target_generation = raw.get("target_generation")
+    if target_generation is not None and (
+        not isinstance(target_generation, str) or not target_generation.strip()
+    ):
+        raise DeploymentPlanInvalid(
+            "deployment-plan target_generation must be a non-empty string or null"
+        )
+    if isinstance(target_generation, str):
+        target_generation = target_generation.strip()
+
+    _validate_plan(
+        mode=mode,
+        kind=kind,
+        allowed_components=allowed_components,
+        allowed_runtime_origins=allowed_runtime_origins,
+        automatic_local_provisioning=automatic_local_provisioning,
+        canonical_checkout=canonical_checkout,
+    )
+
+    return DeploymentPlan(
+        schema_version=SCHEMA_VERSION,
+        mode=mode,
+        kind=kind,
+        hermes_home=hermes_home,
+        canonical_checkout=canonical_checkout,
+        allowed_components=allowed_components,
+        allowed_runtime_origins=allowed_runtime_origins,
+        automatic_local_provisioning=automatic_local_provisioning,
+        required_postconditions=required_postconditions,
+        source=source,
+        target_generation=target_generation,
+    )
+
+
+def infer_compatibility_plan(
+    *,
+    hermes_home: Path,
+    project_root: Path,
+    env: Mapping[str, str],
+) -> DeploymentPlan:
+    explicit_kind = env.get("HERMES_DEPLOYMENT_KIND")
+    if explicit_kind:
+        kind = _enum_value(DeploymentKind, explicit_kind.strip(), "kind")
+    elif _env_flag(env, "HERMES_IMAGE_MANAGED"):
+        kind = DeploymentKind.IMAGE_MANAGED
+    elif _env_flag(env, "HERMES_DESKTOP"):
+        kind = DeploymentKind.DESKTOP_MANAGED
+    else:
+        kind = DeploymentKind.GIT_VENV
+
+    explicit_mode = env.get("HERMES_DEPLOYMENT_MODE")
+    if explicit_mode:
+        mode = _enum_value(DeploymentMode, explicit_mode.strip(), "mode")
+    elif _env_flag(env, "HERMES_REMOTE_ONLY"):
+        mode = DeploymentMode.REMOTE_ONLY
+    elif kind is DeploymentKind.DESKTOP_MANAGED:
+        mode = DeploymentMode.LOCAL_DESKTOP
+    else:
+        mode = DeploymentMode.CLI_ONLY
+
+    canonical_checkout = (
+        None
+        if kind in {DeploymentKind.IMAGE_MANAGED, DeploymentKind.EXTERNALLY_MANAGED}
+        else project_root
+    )
+    auto_provision = mode is not DeploymentMode.REMOTE_ONLY and kind in _MUTABLE_KINDS
+    return plan_from_mapping(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "mode": mode.value,
+            "kind": kind.value,
+            "canonical_checkout": (
+                str(canonical_checkout) if canonical_checkout is not None else None
+            ),
+            "automatic_local_provisioning": auto_provision,
+        },
+        hermes_home=hermes_home,
+        source="compatibility-inference",
+        project_root=project_root,
+    )
+
+
+def load_deployment_plan(
+    *,
+    env: Mapping[str, str] | None = None,
+    project_root: Path | None = None,
+    hermes_home: Path | None = None,
+) -> DeploymentPlan:
+    env = os.environ if env is None else env
+    project_root = (
+        default_project_root() if project_root is None else _resolved_path(project_root)
+    )
+    hermes_home = (
+        default_hermes_home(env)
+        if hermes_home is None
+        else _resolved_path(hermes_home)
+    )
+    path = deployment_plan_path(hermes_home=hermes_home, env=env)
+    if not path.exists():
+        return infer_compatibility_plan(
+            hermes_home=hermes_home,
+            project_root=project_root,
+            env=env,
+        )
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise DeploymentPlanInvalid(
+            f"cannot read deployment plan {path}: {exc}",
+            remediation=(
+                f"repair or remove {path}; Hermes will not guess through an "
+                "explicit but unreadable deployment authority"
+            ),
+        ) from exc
+    if not isinstance(raw, dict):
+        raise DeploymentPlanInvalid(
+            f"deployment plan {path} must contain a JSON object"
+        )
+    return plan_from_mapping(
+        raw,
+        hermes_home=hermes_home,
+        source=str(path),
+        project_root=project_root,
+    )
+
+
+def _mutation_remediation(plan: DeploymentPlan) -> str:
+    if plan.kind is DeploymentKind.IMAGE_MANAGED:
+        return "pull the target Hermes image and recreate the container"
+    if plan.kind is DeploymentKind.EXTERNALLY_MANAGED:
+        return "use the external package or deployment manager that owns this install"
+    if plan.mode is DeploymentMode.REMOTE_ONLY:
+        return "update the remote backend or packaged client through its declared owner"
+    return "change the persisted deployment plan explicitly before mutating this install"
+
+
+def admit_update(
+    args: Any,
+    *,
+    env: MutableMapping[str, str] | None = None,
+    project_root: Path | None = None,
+) -> DeploymentPlan:
+    """Admit one update command and attach its immutable plan to ``args``.
+
+    ``--check`` is observation and remains side-effect-free for every deployment
+    kind. Mutation requires an in-place-mutable kind, a non-remote-only mode,
+    and execution from the canonical checkout.
+    """
+
+    env = os.environ if env is None else env
+    project_root = (
+        default_project_root() if project_root is None else _resolved_path(project_root)
+    )
+    plan = load_deployment_plan(env=env, project_root=project_root)
+    setattr(args, "_deployment_plan", plan)
+
+    if bool(getattr(args, "check", False)):
+        return plan
+
+    if not plan.in_place_mutation_allowed:
+        raise DeploymentMutationDenied(
+            f"{plan.kind.value}/{plan.mode.value} is not updatable in place",
+            remediation=_mutation_remediation(plan),
+        )
+
+    if plan.canonical_checkout is None:
+        raise DeploymentMutationDenied(
+            "deployment plan has no canonical checkout for in-place update",
+            remediation=_mutation_remediation(plan),
+        )
+    if _resolved_path(plan.canonical_checkout) != project_root:
+        raise DeploymentMutationDenied(
+            "this process is not running from the deployment plan's canonical "
+            f"checkout ({plan.canonical_checkout})",
+            remediation=f"run `hermes update` from {plan.canonical_checkout}",
+        )
+
+    env["HERMES_DEPLOYMENT_PLAN_DIGEST"] = plan.digest
+    return plan

--- a/hermes_cli/deployment_transaction.py
+++ b/hermes_cli/deployment_transaction.py
@@ -1,0 +1,351 @@
+"""Generation-fenced mutation authority for one Hermes deployment update.
+
+This module is intentionally deployment-specific.  It does not try to wrap every
+mutation in Hermes.  It binds the Phase-2 updater mutation boundary to the exact
+DeploymentPlan, canonical checkout, pre-mutation source generation, and one
+durable operation owner.  Callers may only report source mutation success after
+the same authority observes the committed generation.
+
+Architecture interlocks: #88683, #90049, #90144, #90145, #90150, #90866,
+#91277.  The admission model lives in ``deployment_plan.py``; this module is the
+physical ownership/fencing layer immediately below it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.deployment_plan import (
+    DeploymentMutationDenied,
+    DeploymentPlan,
+    DeploymentPlanError,
+)
+
+TRANSACTION_SCHEMA_VERSION = 1
+TRANSACTION_LOCK_NAME = "deployment-update.lock"
+TRANSACTION_RECEIPT_NAME = "deployment-update-receipt.json"
+
+
+class DeploymentTransactionError(DeploymentPlanError):
+    """Base error for deployment mutation ownership/proof failures."""
+
+    code = "DEPLOYMENT_TRANSACTION_ERROR"
+
+
+class DeploymentTransactionBusy(DeploymentTransactionError):
+    """Another live or unreconciled update transaction owns this deployment."""
+
+    code = "DEPLOYMENT_TRANSACTION_BUSY"
+
+
+class DeploymentTransactionStale(DeploymentTransactionError):
+    """The transaction's durable ownership token no longer matches this caller."""
+
+    code = "DEPLOYMENT_TRANSACTION_STALE"
+
+
+class DeploymentGenerationMismatch(DeploymentTransactionError):
+    """The committed source generation is not the generation this plan allowed."""
+
+    code = "DEPLOYMENT_GENERATION_MISMATCH"
+
+
+def _resolved(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _git_generation(checkout: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=checkout,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except OSError as exc:
+        raise DeploymentTransactionError(
+            f"cannot inspect deployment generation at {checkout}: {exc}",
+            remediation="repair the canonical checkout before retrying the update",
+        ) from exc
+    generation = result.stdout.strip()
+    if result.returncode != 0 or len(generation) != 40:
+        detail = (result.stderr or result.stdout).strip()
+        raise DeploymentTransactionError(
+            f"cannot resolve deployment generation at {checkout}: {detail or 'git rev-parse failed'}",
+            remediation="repair the canonical checkout before retrying the update",
+        )
+    return generation
+
+
+def _write_durable_json(path: Path, payload: dict[str, Any], *, exclusive: bool = False) -> None:
+    """Write JSON and fsync both the file and containing directory when possible."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    flags = os.O_WRONLY | os.O_CREAT
+    flags |= os.O_EXCL if exclusive else os.O_TRUNC
+    fd = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "wb", closefd=False) as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+    finally:
+        os.close(fd)
+    try:
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+    except (AttributeError, OSError):
+        return
+    try:
+        os.fsync(directory_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(directory_fd)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise DeploymentTransactionStale(
+            f"deployment transaction authority at {path} is unreadable",
+            remediation=(
+                "do not continue mutation; reconcile the existing update transaction "
+                "and its deployment-update.lock first"
+            ),
+        ) from exc
+    if not isinstance(raw, dict):
+        raise DeploymentTransactionStale(
+            f"deployment transaction authority at {path} is not an object"
+        )
+    return raw
+
+
+@dataclass(frozen=True, slots=True)
+class DeploymentMutationPermit:
+    """Exact immutable authority carried from admission to commit verification."""
+
+    operation_id: str
+    plan_digest: str
+    canonical_checkout: str
+    admitted_generation: str
+    target_generation: str | None
+    issued_at_ns: int
+
+    @property
+    def digest(self) -> str:
+        payload = {
+            "operation_id": self.operation_id,
+            "plan_digest": self.plan_digest,
+            "canonical_checkout": self.canonical_checkout,
+            "admitted_generation": self.admitted_generation,
+            "target_generation": self.target_generation,
+            "issued_at_ns": self.issued_at_ns,
+        }
+        return hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": TRANSACTION_SCHEMA_VERSION,
+            "operation_id": self.operation_id,
+            "plan_digest": self.plan_digest,
+            "canonical_checkout": self.canonical_checkout,
+            "admitted_generation": self.admitted_generation,
+            "target_generation": self.target_generation,
+            "issued_at_ns": self.issued_at_ns,
+            "permit_digest": self.digest,
+        }
+
+
+class DeploymentUpdateTransaction:
+    """Exclusive generation-fenced authority for one in-place deployment update.
+
+    Acquisition is fail-closed and durable: the lock is created with O_EXCL and
+    contains the exact permit.  Every later transition rereads that token before
+    trusting ownership, so replacing the lock after admission cannot self-certify
+    a stale transaction.  The lock is only removed by the authority that created
+    it, after either a verified commit or a recorded abort.
+    """
+
+    def __init__(self, plan: DeploymentPlan) -> None:
+        if not plan.in_place_mutation_allowed:
+            raise DeploymentMutationDenied(
+                f"deployment kind {plan.kind.value!r} does not permit in-place mutation"
+            )
+        if plan.canonical_checkout is None:
+            raise DeploymentMutationDenied(
+                "deployment plan does not identify a canonical checkout"
+            )
+        checkout = _resolved(plan.canonical_checkout)
+        if checkout != _resolved(Path.cwd()) and checkout != _resolved(plan.canonical_checkout):
+            # Defensive shape guard; admission remains the owner of cwd policy.
+            raise DeploymentMutationDenied("canonical checkout identity changed during admission")
+
+        self.plan = plan
+        self.checkout = checkout
+        self.lock_path = _resolved(plan.hermes_home) / TRANSACTION_LOCK_NAME
+        self.receipt_path = _resolved(plan.hermes_home) / TRANSACTION_RECEIPT_NAME
+        self.permit = DeploymentMutationPermit(
+            operation_id=uuid.uuid4().hex,
+            plan_digest=plan.digest,
+            canonical_checkout=str(checkout),
+            admitted_generation=_git_generation(checkout),
+            target_generation=plan.target_generation,
+            issued_at_ns=time.time_ns(),
+        )
+        self._acquired = False
+        self._settled = False
+
+    def acquire(self) -> "DeploymentUpdateTransaction":
+        if self._acquired:
+            return self
+        try:
+            _write_durable_json(self.lock_path, self.permit.to_dict(), exclusive=True)
+        except FileExistsError as exc:
+            existing = None
+            try:
+                existing = _read_json(self.lock_path)
+            except DeploymentTransactionStale:
+                pass
+            owner = existing.get("operation_id") if existing else "unknown"
+            raise DeploymentTransactionBusy(
+                f"deployment update authority is already held by operation {owner}",
+                remediation=(
+                    f"reconcile {self.lock_path}; Hermes will not overlap deployment mutations"
+                ),
+            ) from exc
+        self._acquired = True
+        return self
+
+    def assert_current(self) -> None:
+        if not self._acquired or self._settled:
+            raise DeploymentTransactionStale("deployment transaction is not active")
+        durable = _read_json(self.lock_path)
+        expected = self.permit.to_dict()
+        for key in (
+            "schema_version",
+            "operation_id",
+            "plan_digest",
+            "canonical_checkout",
+            "admitted_generation",
+            "target_generation",
+            "issued_at_ns",
+            "permit_digest",
+        ):
+            if durable.get(key) != expected.get(key):
+                raise DeploymentTransactionStale(
+                    f"deployment transaction authority changed after admission ({key})",
+                    remediation="stop mutation and reconcile the durable transaction owner",
+                )
+        if _resolved(Path(str(durable["canonical_checkout"]))) != self.checkout:
+            raise DeploymentTransactionStale("canonical checkout identity changed after admission")
+        if self.plan.digest != self.permit.plan_digest:
+            raise DeploymentTransactionStale("deployment-plan authority changed after admission")
+
+    def verify_committed_generation(self) -> str:
+        """Bind update completion to the generation now present at the admitted root."""
+
+        self.assert_current()
+        observed = _git_generation(self.checkout)
+        target = self.permit.target_generation
+        if target is not None and observed != target:
+            raise DeploymentGenerationMismatch(
+                f"deployment committed generation {observed} but authority required {target}",
+                remediation="do not report update success; restore or advance to the authorized generation",
+            )
+        return observed
+
+    def settle_verified(self, committed_generation: str) -> None:
+        self.assert_current()
+        receipt = {
+            **self.permit.to_dict(),
+            "status": "verified",
+            "committed_generation": committed_generation,
+            "verified_at_ns": time.time_ns(),
+        }
+        _write_durable_json(self.receipt_path, receipt)
+        self._release_owned_lock()
+        self._settled = True
+
+    def abort(self, reason: str) -> None:
+        if self._settled:
+            return
+        if self._acquired:
+            self.assert_current()
+            receipt = {
+                **self.permit.to_dict(),
+                "status": "aborted",
+                "reason": reason,
+                "observed_generation": _git_generation(self.checkout),
+                "aborted_at_ns": time.time_ns(),
+            }
+            _write_durable_json(self.receipt_path, receipt)
+            self._release_owned_lock()
+        self._settled = True
+
+    def _release_owned_lock(self) -> None:
+        # Re-read immediately before unlink: authority cannot replace itself and
+        # then use an old in-memory permit to delete the successor's lock.
+        self.assert_current()
+        try:
+            self.lock_path.unlink()
+        except OSError as exc:
+            raise DeploymentTransactionError(
+                f"cannot release deployment update authority at {self.lock_path}: {exc}",
+                remediation="reconcile the durable lock before starting another update",
+            ) from exc
+        try:
+            directory_fd = os.open(self.lock_path.parent, os.O_RDONLY)
+        except (AttributeError, OSError):
+            return
+        try:
+            os.fsync(directory_fd)
+        except OSError:
+            pass
+        finally:
+            os.close(directory_fd)
+
+    def __enter__(self) -> "DeploymentUpdateTransaction":
+        return self.acquire()
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        if self._settled:
+            return False
+        if exc is None:
+            # A caller that exits without proving/settling the committed
+            # generation has not completed the transaction.
+            self.abort("mutation scope exited without verified settlement")
+        else:
+            self.abort(f"{exc_type.__name__ if exc_type else 'error'}: {exc}")
+        return False
+
+
+def run_under_deployment_authority(plan: DeploymentPlan, mutation) -> Any:
+    """Execute one legacy update under exact deployment authority.
+
+    This is deliberately the only compatibility wrapper: it fences the existing
+    monolithic updater without claiming stage-level proof it does not possess.
+    Stage-aware mutation can consume ``DeploymentMutationPermit`` directly as
+    #91277 Phase 2 replaces the legacy path.
+    """
+
+    tx = DeploymentUpdateTransaction(plan)
+    with tx:
+        result = mutation()
+        committed = tx.verify_committed_generation()
+        tx.settle_verified(committed)
+        return result

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -12,7 +12,7 @@ from typing import Callable
 
 
 def _plan_bound_update_handler(cmd_update: Callable) -> Callable:
-    """Bind update admission to the authoritative deployment plan."""
+    """Bind update admission and mutation to one deployment authority object."""
 
     @wraps(cmd_update)
     def _handler(args):
@@ -31,23 +31,32 @@ def _plan_bound_update_handler(cmd_update: Callable) -> Callable:
             is_check = bool(getattr(args, "check", False))
             is_plan = bool(getattr(args, "plan", False))
             if is_plan:
-                # Existing --plan is an observation-only inventory path. Keep it
-                # outside mutation admission just like --check; it must work for
-                # image/external/remote deployments precisely so it can explain
-                # why mutation is unavailable.
+                # Existing --plan is observation-only. It must remain usable on
+                # image/external/remote deployments so it can explain why a
+                # physical update is unavailable.
                 plan = load_deployment_plan()
                 setattr(args, "_deployment_plan", plan)
             else:
                 plan = admit_update(args)
-            # Test doubles may return None; production paths always attach a plan.
-            if plan is not None and not (is_check or is_plan):
-                enforce_legacy_update_envelope(plan)
+
+            # Test doubles may return None; production paths attach a plan.
+            if plan is None or is_check or is_plan:
+                return cmd_update(args)
+
+            enforce_legacy_update_envelope(plan)
+
+            # The legacy updater is still monolithic. Fence the whole physical
+            # mutation under one exact deployment permit instead of pretending
+            # we have stage-level proof. Phase-2 stage consumers can later carry
+            # the same permit directly without changing the authority contract.
+            from hermes_cli.deployment_transaction import run_under_deployment_authority
+
+            return run_under_deployment_authority(plan, lambda: cmd_update(args))
         except DeploymentPlanError as exc:
             print(f"✗ {exc}", file=sys.stderr)
             if exc.remediation:
                 print(f"  {exc.remediation}", file=sys.stderr)
             raise SystemExit(2) from exc
-        return cmd_update(args)
 
     return _handler
 

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -6,7 +6,50 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import sys
+from functools import wraps
 from typing import Callable
+
+
+def _plan_bound_update_handler(cmd_update: Callable) -> Callable:
+    """Bind update admission to the authoritative deployment plan."""
+
+    @wraps(cmd_update)
+    def _handler(args):
+        from hermes_cli.deployment_plan import (
+            DeploymentPlanError,
+            admit_update,
+            load_deployment_plan,
+        )
+        from hermes_cli.update_deployment_guard import (
+            enforce_legacy_update_envelope,
+            validate_update_plan_source,
+        )
+
+        try:
+            validate_update_plan_source()
+            is_check = bool(getattr(args, "check", False))
+            is_plan = bool(getattr(args, "plan", False))
+            if is_plan:
+                # Existing --plan is an observation-only inventory path. Keep it
+                # outside mutation admission just like --check; it must work for
+                # image/external/remote deployments precisely so it can explain
+                # why mutation is unavailable.
+                plan = load_deployment_plan()
+                setattr(args, "_deployment_plan", plan)
+            else:
+                plan = admit_update(args)
+            # Test doubles may return None; production paths always attach a plan.
+            if plan is not None and not (is_check or is_plan):
+                enforce_legacy_update_envelope(plan)
+        except DeploymentPlanError as exc:
+            print(f"✗ {exc}", file=sys.stderr)
+            if exc.remediation:
+                print(f"  {exc.remediation}", file=sys.stderr)
+            raise SystemExit(2) from exc
+        return cmd_update(args)
+
+    return _handler
 
 
 def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
@@ -111,4 +154,4 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
     )
-    update_parser.set_defaults(func=cmd_update)
+    update_parser.set_defaults(func=_plan_bound_update_handler(cmd_update))

--- a/hermes_cli/update_deployment_guard.py
+++ b/hermes_cli/update_deployment_guard.py
@@ -1,0 +1,137 @@
+"""Fail-closed guard for the legacy updater's deployment-plan boundary.
+
+The current updater still performs a monolithic source/runtime mutation. Until its
+individual stages consume deployment-plan authority directly, narrowed plans must
+be refused rather than admitted and then silently widened by legacy behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Mapping
+
+from hermes_cli.deployment_plan import (
+    SCHEMA_VERSION,
+    DeploymentMutationDenied,
+    DeploymentPlan,
+    DeploymentPlanInvalid,
+    default_hermes_home,
+    deployment_plan_path,
+    plan_from_mapping,
+)
+
+_PLAN_KEYS = frozenset(
+    {
+        "schema_version",
+        "mode",
+        "kind",
+        "canonical_checkout",
+        "allowed_components",
+        "allowed_runtime_origins",
+        "automatic_local_provisioning",
+        "required_postconditions",
+        "target_generation",
+    }
+)
+
+
+def _resolved_plan_path(env: Mapping[str, str]) -> tuple[Path, bool]:
+    hermes_home = default_hermes_home(env)
+    explicit = bool(env.get("HERMES_DEPLOYMENT_PLAN", "").strip())
+    return deployment_plan_path(hermes_home=hermes_home, env=env), explicit
+
+
+def validate_update_plan_source(env: Mapping[str, str] | None = None) -> None:
+    """Reject missing explicit authorities and unknown persisted plan keys.
+
+    The canonical deployment-plan loader retains compatibility inference when no
+    plan is configured. That fallback is not valid when an operator explicitly
+    names a plan path, and safety-bearing key typos must not be ignored.
+    """
+
+    env = os.environ if env is None else env
+    path, explicit = _resolved_plan_path(env)
+    if explicit and not path.exists():
+        raise DeploymentPlanInvalid(
+            f"explicit deployment plan does not exist: {path}",
+            remediation=(
+                "repair HERMES_DEPLOYMENT_PLAN or remove the explicit setting; "
+                "Hermes will not infer mutation authority through a missing file"
+            ),
+        )
+    if not path.exists():
+        return
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        # load_deployment_plan() owns the canonical parse/read diagnostic.
+        return
+    if not isinstance(raw, dict):
+        return
+
+    unknown = sorted(set(raw) - _PLAN_KEYS)
+    if unknown:
+        raise DeploymentPlanInvalid(
+            "unknown deployment-plan keys: " + ", ".join(unknown),
+            remediation=(
+                "remove or correct unknown keys; Hermes will not ignore fields "
+                "that may have been intended to narrow deployment authority"
+            ),
+        )
+
+
+def _full_legacy_envelope(plan: DeploymentPlan) -> DeploymentPlan:
+    """Build the mode/kind envelope the monolithic updater can enforce today."""
+
+    if plan.canonical_checkout is None:
+        raise DeploymentMutationDenied(
+            "deployment plan has no canonical checkout for legacy update admission"
+        )
+    return plan_from_mapping(
+        {
+            "schema_version": SCHEMA_VERSION,
+            "mode": plan.mode.value,
+            "kind": plan.kind.value,
+            "canonical_checkout": str(plan.canonical_checkout),
+            "automatic_local_provisioning": True,
+        },
+        hermes_home=plan.hermes_home,
+        source="legacy-update-envelope",
+        project_root=plan.canonical_checkout,
+    )
+
+
+def enforce_legacy_update_envelope(plan: DeploymentPlan) -> None:
+    """Refuse authority narrowing that the current updater cannot stage-gate."""
+
+    if not plan.in_place_mutation_allowed:
+        return
+
+    full = _full_legacy_envelope(plan)
+    if plan.allowed_components != full.allowed_components:
+        raise DeploymentMutationDenied(
+            "legacy updater cannot enforce narrowed allowed_components",
+            remediation=(
+                "use a stage-aware updater or restore the full component envelope "
+                "for this deployment mode"
+            ),
+        )
+    if plan.allowed_runtime_origins != full.allowed_runtime_origins:
+        raise DeploymentMutationDenied(
+            "legacy updater cannot enforce narrowed allowed_runtime_origins",
+            remediation=(
+                "use a stage-aware updater or restore the full runtime-origin "
+                "envelope for this deployment mode"
+            ),
+        )
+    if not plan.automatic_local_provisioning:
+        raise DeploymentMutationDenied(
+            "legacy updater may provision local runtimes but this plan forbids automatic local provisioning",
+            remediation=(
+                "use a stage-aware updater or explicitly authorize automatic local "
+                "provisioning for this legacy mutation path"
+            ),
+        )

--- a/tests/hermes_cli/test_deployment_plan.py
+++ b/tests/hermes_cli/test_deployment_plan.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.deployment_plan import (
+    DeploymentKind,
+    DeploymentMode,
+    DeploymentMutationDenied,
+    DeploymentPlanInvalid,
+    admit_update,
+    load_deployment_plan,
+)
+
+
+def _write_plan(home: Path, **overrides) -> Path:
+    payload = {
+        "schema_version": 1,
+        "mode": "cli-only",
+        "kind": "git-venv",
+        "canonical_checkout": str(home / "repo"),
+    }
+    payload.update(overrides)
+    path = home / "deployment-plan.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_missing_plan_uses_compatible_cli_only_authority(tmp_path):
+    repo = tmp_path / "repo"
+    plan = load_deployment_plan(
+        env={"HERMES_HOME": str(tmp_path / "home")},
+        project_root=repo,
+    )
+    assert plan.mode is DeploymentMode.CLI_ONLY
+    assert plan.kind is DeploymentKind.GIT_VENV
+    assert plan.canonical_checkout == repo.resolve()
+    assert "desktop" not in plan.allowed_components
+
+
+def test_explicit_but_corrupt_plan_fails_closed(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "deployment-plan.json").write_text("{", encoding="utf-8")
+    with pytest.raises(DeploymentPlanInvalid, match="cannot read deployment plan"):
+        load_deployment_plan(
+            env={"HERMES_HOME": str(home)},
+            project_root=tmp_path / "repo",
+        )
+
+
+def test_remote_only_cannot_smuggle_local_components(tmp_path):
+    home = tmp_path / "home"
+    _write_plan(
+        home,
+        mode="remote-only",
+        kind="externally-managed",
+        canonical_checkout=None,
+        allowed_components=["desktop-client", "python-runtime"],
+    )
+    with pytest.raises(DeploymentPlanInvalid, match="cannot authorize components"):
+        load_deployment_plan(
+            env={"HERMES_HOME": str(home)},
+            project_root=tmp_path / "repo",
+        )
+
+
+@pytest.mark.parametrize(
+    ("mode", "kind", "message"),
+    [
+        ("remote-only", "externally-managed", "not updatable in place"),
+        ("cli-only", "image-managed", "not updatable in place"),
+    ],
+)
+def test_non_owned_deployments_refuse_in_place_update(tmp_path, mode, kind, message):
+    home = tmp_path / "home"
+    _write_plan(
+        home,
+        mode=mode,
+        kind=kind,
+        canonical_checkout=None,
+        automatic_local_provisioning=False,
+    )
+    args = argparse.Namespace(check=False)
+    with pytest.raises(DeploymentMutationDenied, match=message):
+        admit_update(
+            args,
+            env={"HERMES_HOME": str(home)},
+            project_root=tmp_path / "repo",
+        )
+
+
+def test_update_check_is_observation_for_image_managed_install(tmp_path):
+    home = tmp_path / "home"
+    _write_plan(
+        home,
+        kind="image-managed",
+        canonical_checkout=None,
+        automatic_local_provisioning=False,
+    )
+    args = argparse.Namespace(check=True)
+    plan = admit_update(
+        args,
+        env={"HERMES_HOME": str(home)},
+        project_root=tmp_path / "repo",
+    )
+    assert plan.kind is DeploymentKind.IMAGE_MANAGED
+    assert args._deployment_plan is plan
+
+
+def test_mutation_requires_the_canonical_checkout(tmp_path):
+    home = tmp_path / "home"
+    _write_plan(home)
+    with pytest.raises(DeploymentMutationDenied, match="canonical checkout"):
+        admit_update(
+            argparse.Namespace(check=False),
+            env={"HERMES_HOME": str(home)},
+            project_root=tmp_path / "other",
+        )
+
+
+def test_admitted_update_carries_plan_and_digest(tmp_path):
+    home = tmp_path / "home"
+    repo = home / "repo"
+    _write_plan(home)
+    env = {"HERMES_HOME": str(home)}
+    args = argparse.Namespace(check=False)
+    plan = admit_update(args, env=env, project_root=repo)
+    assert args._deployment_plan is plan
+    assert env["HERMES_DEPLOYMENT_PLAN_DIGEST"] == plan.digest
+    assert len(plan.digest) == 64
+
+
+def test_remote_only_never_authorizes_local_provisioning(tmp_path):
+    home = tmp_path / "home"
+    _write_plan(
+        home,
+        mode="remote-only",
+        kind="externally-managed",
+        canonical_checkout=None,
+        automatic_local_provisioning=True,
+    )
+    with pytest.raises(DeploymentPlanInvalid, match="remote-only"):
+        load_deployment_plan(
+            env={"HERMES_HOME": str(home)},
+            project_root=tmp_path / "repo",
+        )

--- a/tests/hermes_cli/test_deployment_transaction.py
+++ b/tests/hermes_cli/test_deployment_transaction.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import deployment_plan
+from hermes_cli import deployment_transaction as txmod
+
+
+OLD_SHA = "1" * 40
+NEW_SHA = "2" * 40
+OTHER_SHA = "3" * 40
+
+
+def _plan(tmp_path: Path, *, target_generation: str | None = None):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return deployment_plan.plan_from_mapping(
+        {
+            "schema_version": 1,
+            "mode": "cli-only",
+            "kind": "git-venv",
+            "canonical_checkout": str(repo),
+            "automatic_local_provisioning": True,
+            "target_generation": target_generation,
+        },
+        hermes_home=tmp_path / "home",
+        source="test",
+        project_root=repo,
+    )
+
+
+def test_second_transaction_cannot_overlap_same_deployment(monkeypatch, tmp_path):
+    plan = _plan(tmp_path)
+    monkeypatch.setattr(txmod, "_git_generation", lambda checkout: OLD_SHA)
+
+    first = txmod.DeploymentUpdateTransaction(plan).acquire()
+    second = txmod.DeploymentUpdateTransaction(plan)
+    with pytest.raises(txmod.DeploymentTransactionBusy, match="already held"):
+        second.acquire()
+
+    first.abort("test cleanup")
+
+
+def test_authority_replacement_after_admission_fails_closed(monkeypatch, tmp_path):
+    plan = _plan(tmp_path)
+    monkeypatch.setattr(txmod, "_git_generation", lambda checkout: OLD_SHA)
+    tx = txmod.DeploymentUpdateTransaction(plan).acquire()
+
+    durable = json.loads(tx.lock_path.read_text(encoding="utf-8"))
+    durable["operation_id"] = "replacement-owner"
+    tx.lock_path.write_text(json.dumps(durable), encoding="utf-8")
+
+    with pytest.raises(txmod.DeploymentTransactionStale, match="changed after admission"):
+        tx.assert_current()
+
+    # A stale owner must not delete the replacement authority.
+    assert tx.lock_path.exists()
+
+
+def test_required_target_generation_is_verified_before_success(monkeypatch, tmp_path):
+    plan = _plan(tmp_path, target_generation=NEW_SHA)
+    generations = iter((OLD_SHA, OTHER_SHA, OTHER_SHA))
+    monkeypatch.setattr(txmod, "_git_generation", lambda checkout: next(generations))
+    tx = txmod.DeploymentUpdateTransaction(plan).acquire()
+
+    with pytest.raises(txmod.DeploymentGenerationMismatch, match="authority required"):
+        tx.verify_committed_generation()
+
+    tx.abort("generation mismatch")
+    receipt = json.loads(tx.receipt_path.read_text(encoding="utf-8"))
+    assert receipt["status"] == "aborted"
+    assert receipt["target_generation"] == NEW_SHA
+
+
+def test_verified_settlement_persists_exact_permit_and_generation(monkeypatch, tmp_path):
+    plan = _plan(tmp_path, target_generation=NEW_SHA)
+    generations = iter((OLD_SHA, NEW_SHA))
+    monkeypatch.setattr(txmod, "_git_generation", lambda checkout: next(generations))
+    tx = txmod.DeploymentUpdateTransaction(plan).acquire()
+
+    committed = tx.verify_committed_generation()
+    tx.settle_verified(committed)
+
+    receipt = json.loads(tx.receipt_path.read_text(encoding="utf-8"))
+    assert receipt["status"] == "verified"
+    assert receipt["operation_id"] == tx.permit.operation_id
+    assert receipt["plan_digest"] == plan.digest
+    assert receipt["permit_digest"] == tx.permit.digest
+    assert receipt["admitted_generation"] == OLD_SHA
+    assert receipt["committed_generation"] == NEW_SHA
+    assert not tx.lock_path.exists()
+
+
+def test_unsettled_scope_records_abort_instead_of_false_success(monkeypatch, tmp_path):
+    plan = _plan(tmp_path)
+    monkeypatch.setattr(txmod, "_git_generation", lambda checkout: OLD_SHA)
+
+    with txmod.DeploymentUpdateTransaction(plan):
+        pass
+
+    receipt = json.loads(
+        (plan.hermes_home / txmod.TRANSACTION_RECEIPT_NAME).read_text(encoding="utf-8")
+    )
+    assert receipt["status"] == "aborted"
+    assert "without verified settlement" in receipt["reason"]
+
+
+def test_run_wrapper_carries_one_authority_across_mutation(monkeypatch, tmp_path):
+    plan = _plan(tmp_path, target_generation=NEW_SHA)
+    generations = iter((OLD_SHA, NEW_SHA))
+    monkeypatch.setattr(txmod, "_git_generation", lambda checkout: next(generations))
+    observed = []
+
+    def mutation():
+        lock = plan.hermes_home / txmod.TRANSACTION_LOCK_NAME
+        payload = json.loads(lock.read_text(encoding="utf-8"))
+        observed.append((payload["plan_digest"], payload["admitted_generation"]))
+        return 37
+
+    assert txmod.run_under_deployment_authority(plan, mutation) == 37
+    assert observed == [(plan.digest, OLD_SHA)]

--- a/tests/hermes_cli/test_update_deployment_plan.py
+++ b/tests/hermes_cli/test_update_deployment_plan.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import deployment_plan
+from hermes_cli.subcommands.update import build_update_parser
+from hermes_cli.update_deployment_guard import (
+    enforce_legacy_update_envelope,
+    validate_update_plan_source,
+)
+
+
+def _parser(cmd_update):
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+    build_update_parser(subparsers, cmd_update=cmd_update)
+    return parser
+
+
+def _mutable_plan(tmp_path: Path, **overrides):
+    repo = tmp_path / "repo"
+    payload = {
+        "schema_version": 1,
+        "mode": "cli-only",
+        "kind": "git-venv",
+        "canonical_checkout": str(repo),
+        "automatic_local_provisioning": True,
+    }
+    payload.update(overrides)
+    return deployment_plan.plan_from_mapping(
+        payload,
+        hermes_home=tmp_path / "home",
+        source="test",
+        project_root=repo,
+    )
+
+
+def test_update_handler_admits_before_calling_implementation(monkeypatch):
+    calls = []
+
+    def fake_admit(args):
+        calls.append(("plan", args.check))
+
+    def fake_update(args):
+        calls.append(("update", args.check))
+        return 17
+
+    monkeypatch.delenv("HERMES_DEPLOYMENT_PLAN", raising=False)
+    monkeypatch.setattr(deployment_plan, "admit_update", fake_admit)
+    args = _parser(fake_update).parse_args(["update", "--check"])
+    assert args.func(args) == 17
+    assert calls == [("plan", True), ("update", True)]
+
+
+def test_plan_refusal_prevents_update_implementation(monkeypatch, capsys):
+    called = False
+
+    def fake_update(args):
+        nonlocal called
+        called = True
+
+    def deny(args):
+        raise deployment_plan.DeploymentMutationDenied(
+            "image-managed is not updatable in place",
+            remediation="pull and recreate",
+        )
+
+    monkeypatch.delenv("HERMES_DEPLOYMENT_PLAN", raising=False)
+    monkeypatch.setattr(deployment_plan, "admit_update", deny)
+    args = _parser(fake_update).parse_args(["update"])
+    with pytest.raises(SystemExit) as exc:
+        args.func(args)
+    assert exc.value.code == 2
+    assert called is False
+    err = capsys.readouterr().err
+    assert "not updatable in place" in err
+    assert "pull and recreate" in err
+
+
+def test_explicit_missing_plan_path_fails_closed(tmp_path):
+    missing = tmp_path / "missing-plan.json"
+    with pytest.raises(
+        deployment_plan.DeploymentPlanInvalid,
+        match="explicit deployment plan does not exist",
+    ):
+        validate_update_plan_source(
+            {
+                "HERMES_HOME": str(tmp_path / "home"),
+                "HERMES_DEPLOYMENT_PLAN": str(missing),
+            }
+        )
+
+
+def test_unknown_safety_bearing_plan_key_fails_closed(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    plan_path = home / "deployment-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "mode": "cli-only",
+                "kind": "git-venv",
+                "canonical_checkout": str(tmp_path / "repo"),
+                "allowed_component": ["source"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        deployment_plan.DeploymentPlanInvalid,
+        match="unknown deployment-plan keys: allowed_component",
+    ):
+        validate_update_plan_source({"HERMES_HOME": str(home)})
+
+
+def test_legacy_update_refuses_narrowed_component_authority(tmp_path):
+    plan = _mutable_plan(
+        tmp_path,
+        allowed_components=["source", "cli"],
+    )
+    with pytest.raises(
+        deployment_plan.DeploymentMutationDenied,
+        match="narrowed allowed_components",
+    ):
+        enforce_legacy_update_envelope(plan)
+
+
+def test_legacy_update_refuses_narrowed_runtime_origin_authority(tmp_path):
+    plan = _mutable_plan(
+        tmp_path,
+        allowed_runtime_origins=["external"],
+    )
+    with pytest.raises(
+        deployment_plan.DeploymentMutationDenied,
+        match="narrowed allowed_runtime_origins",
+    ):
+        enforce_legacy_update_envelope(plan)
+
+
+def test_legacy_update_refuses_disabled_local_provisioning(tmp_path):
+    plan = _mutable_plan(
+        tmp_path,
+        automatic_local_provisioning=False,
+    )
+    with pytest.raises(
+        deployment_plan.DeploymentMutationDenied,
+        match="forbids automatic local provisioning",
+    ):
+        enforce_legacy_update_envelope(plan)
+
+
+def test_update_check_does_not_require_full_legacy_mutation_envelope(
+    monkeypatch, tmp_path
+):
+    calls = []
+    narrowed = _mutable_plan(
+        tmp_path,
+        allowed_components=["source", "cli"],
+        automatic_local_provisioning=False,
+    )
+
+    def fake_admit(args):
+        calls.append(("plan", args.check))
+        return narrowed
+
+    def fake_update(args):
+        calls.append(("update", args.check))
+        return 23
+
+    monkeypatch.delenv("HERMES_DEPLOYMENT_PLAN", raising=False)
+    monkeypatch.setattr(deployment_plan, "admit_update", fake_admit)
+    args = _parser(fake_update).parse_args(["update", "--check"])
+    assert args.func(args) == 23
+    assert calls == [("plan", True), ("update", True)]
+
+
+def test_update_plan_remains_observation_only(monkeypatch, tmp_path):
+    calls = []
+    narrowed = _mutable_plan(
+        tmp_path,
+        allowed_components=["source", "cli"],
+        automatic_local_provisioning=False,
+    )
+
+    def fake_load():
+        calls.append("plan")
+        return narrowed
+
+    def fake_update(args):
+        calls.append(("update", args.plan))
+        return 29
+
+    monkeypatch.delenv("HERMES_DEPLOYMENT_PLAN", raising=False)
+    monkeypatch.setattr(deployment_plan, "load_deployment_plan", fake_load)
+    args = _parser(fake_update).parse_args(["update", "--plan"])
+    assert args.func(args) == 29
+    assert calls == ["plan", ("update", True)]


### PR DESCRIPTION
## Scope

Implements the next physical-enforcement layer below #91316's deployment-plan admission. This is deliberately **deployment-specific**, not a repository-wide mutation wrapper: one `hermes update` mutation receives one durable authority object bound to the exact admitted plan, canonical checkout, pre-mutation generation, optional target generation, and operation ID.

## Invariant

> A deployment mutation may settle its source boundary only if the authority admitted before mutation is still the durable owner at settlement and the committed source generation is observed at the exact admitted deployment root.

That closes the compatibility-layer gap between "the plan allowed this update" and "the object actually mutated under that authority." It does **not** claim stage-level, process-level, or fleet-wide completion proof that the legacy monolithic updater cannot yet provide.

## Implementation

- Adds `DeploymentMutationPermit` carrying plan digest, canonical checkout, admitted generation, optional target generation, operation ID, issue time, and deterministic permit digest.
- Acquires one durable per-deployment update owner with `O_CREAT|O_EXCL`; overlapping updater mutations fail closed.
- Re-reads the durable token before generation observation and immediately before release, so an in-memory caller cannot self-certify after its ownership object has been replaced.
- Persists scoped settled/aborted source-boundary evidence and fsyncs file + containing directory where supported.
- Requires an explicitly authorized `target_generation` to equal the generation actually present at settlement.
- Wraps the existing monolithic updater under this authority without pretending it has stage-level proof.
- Preserves both observation-only `--check` and `--plan`, plus #91803's `--switch-branch` contract inherited through the reconciled #91316 parent.
- Adds focused regressions for overlapping ownership, post-admission authority replacement, target-generation mismatch, settlement evidence, false-success prevention, and permit continuity across the mutation.

## Topology / interlocks

Primary implementation lane:
- #88683 — transactional install/update/bootstrap architecture
- #91277 — Phase-2 deployment-plan tracker
- #91316 — prerequisite admission/substrate; this PR is stacked on exact head `99abee7d0365f4426294be0fd1045263b206d03d`

Architecture laws consumed, not duplicated:
- #90144 — proof scope must equal mutation scope
- #90145 — teardown/recovery fenced by durable generation identity
- #90049 — typed completion proof / false-success class
- #90150 — delivered artifact/process realization belongs in proof
- #90866 — qualified identity + generation + proof scope + typed completion survive to the side effect

Adjacent concrete implementations:
- #91803 — parked-branch target ownership
- #91079 — Desktop rollback/candidate transaction
- #91559 — PID-incarnation-safe runtime observation

## Boundary

This PR establishes the **source/deployment mutation authority** for the legacy updater. It intentionally does not declare the full #91277 Phase-2 fleet transaction complete: process replacement, per-stage component permits, exact physical-root incarnation, and post-relaunch generation handshakes still need to consume/extend this authority before the deployment can carry a full typed completion proof.

## Exact object

- Head: [`6b5e0fa3319f9ce7570484cca9f60dc5181ad8d4`](https://github.com/andrexibiza/hermes-agent/commit/6b5e0fa3319f9ce7570484cca9f60dc5181ad8d4)
- Parent/prerequisite: #91316 head [`99abee7d0365f4426294be0fd1045263b206d03d`](https://github.com/andrexibiza/hermes-agent/commit/99abee7d0365f4426294be0fd1045263b206d03d)
- #91316 is itself rebuilt directly on observed upstream `main` `b6bcb3e791c673e63974029bbab40cc9326803ff`
- Active implementation delta over #91316: **one commit, three files**
- Superseded construction heads are outside active ancestry; no checks are inherited from them.

## Verification

Fresh exact-head CI/Docker/Nix for `6b5e0fa3...` is required. No prior green status is presented as evidence for this exact object.

Part of #88683.
Part of #91277.
Depends on #91316.