### PR TITLE
fix(desktop): bind contribution visibility to live authority

### DIFF
--- a/apps/desktop/src/contrib/registry.test.ts
+++ b/apps/desktop/src/contrib/registry.test.ts
@@ -1,0 +1,66 @@
+import { atom } from 'nanostores'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ContributionRegistry } from './registry'
+
+describe('ContributionRegistry visibility authority', () => {
+  it('invalidates the owning area when a live condition changes', () => {
+    const registry = new ContributionRegistry()
+    const visible = atom(true)
+    const onAreaChange = vi.fn()
+
+    registry.register({ area: 'statusBar.right', id: 'live', when: visible })
+    registry.subscribeArea('statusBar.right', onAreaChange)
+
+    const first = registry.getArea('statusBar.right')
+    expect(first.map(item => item.id)).toEqual(['live'])
+    expect(registry.getArea('statusBar.right')).toBe(first)
+
+    visible.set(false)
+
+    expect(onAreaChange).toHaveBeenCalledTimes(1)
+    expect(registry.getArea('statusBar.right')).toEqual([])
+
+    visible.set(true)
+
+    expect(onAreaChange).toHaveBeenCalledTimes(2)
+    expect(registry.getArea('statusBar.right').map(item => item.id)).toEqual(['live'])
+  })
+
+  it('detaches a replaced contribution from its previous authority', () => {
+    const registry = new ContributionRegistry()
+    const stale = atom(true)
+    const current = atom(true)
+    const onAreaChange = vi.fn()
+
+    registry.register({ area: 'panes', id: 'same', when: stale })
+    registry.register({ area: 'panes', id: 'same', when: current })
+    registry.subscribeArea('panes', onAreaChange)
+
+    stale.set(false)
+
+    expect(onAreaChange).not.toHaveBeenCalled()
+    expect(registry.getArea('panes').map(item => item.id)).toEqual(['same'])
+
+    current.set(false)
+
+    expect(onAreaChange).toHaveBeenCalledTimes(1)
+    expect(registry.getArea('panes')).toEqual([])
+  })
+
+  it('detaches visibility authority when a contribution is removed', () => {
+    const registry = new ContributionRegistry()
+    const visible = atom(true)
+    const onAreaChange = vi.fn()
+
+    const dispose = registry.register({ area: 'titleBar.right', id: 'temporary', when: visible })
+    registry.subscribeArea('titleBar.right', onAreaChange)
+
+    dispose()
+    onAreaChange.mockClear()
+    visible.set(false)
+
+    expect(onAreaChange).not.toHaveBeenCalled()
+    expect(registry.getArea('titleBar.right')).toEqual([])
+  })
+})

--- a/apps/desktop/src/contrib/registry.ts
+++ b/apps/desktop/src/contrib/registry.ts
@@ -16,26 +16,24 @@ const EMPTY: readonly Contribution[] = Object.freeze([])
  * same primitive resolves at any depth of the recursive Area scene graph
  * (`statusBar.right`, `rightColumn.panel`, `capabilities.detail.actions`, ...).
  *
- * Snapshots are cached per area and only invalidated on mutation so the value
- * is referentially stable for `useSyncExternalStore` (no render loops).
+ * Snapshots are cached per area and invalidated by either registry mutation or
+ * a registered contribution's live visibility authority. The registry owns
+ * those authority subscriptions, so replacing/removing a contribution detaches
+ * the old source before it can keep invalidating a projection it no longer owns.
  *
  * Invalidation is AREA-SCOPED: mutating one area only clears that area's
  * snapshot and only notifies subscribers of that area, so registering a
  * statusbar item can never re-render a titlebar slot (or any other unrelated
  * area). `registerMany`/`removeMany` collapse a batch into one notification
  * per touched area. A global listener channel (`subscribe`) still fires on
- * every mutation for engines that react to any change (pane adoption).
- *
- * Note: cache invalidation is mutation-driven, so a purely dynamic `when()`
- * that flips without a register/remove won't re-resolve on its own -- fine for
- * the current surfaces (no dynamic `when` is in use); revisit if we need
- * reactive `when`.
+ * every invalidation for engines that react to any change (pane adoption).
  */
-class ContributionRegistry {
+export class ContributionRegistry {
   private byArea = new Map<string, Contribution[]>()
   private snapshot = new Map<string, readonly Contribution[]>()
   private areaListeners = new Map<string, Set<Listener>>()
   private globalListeners = new Set<Listener>()
+  private conditionListeners = new Map<string, () => void>()
 
   /** Register one contribution. Returns a disposer that removes it. */
   register = (c: Contribution): (() => void) => this.registerMany([c])
@@ -49,7 +47,8 @@ class ContributionRegistry {
     return () => this.removeMany(cs.map(c => ({ area: c.area, id: c.id })))
   }
 
-  /** Resolved, sorted, filtered entries for an area. Stable ref until mutated. */
+  /** Resolved, sorted, filtered entries for an area. Stable ref until its
+   *  registry contents or one of its visibility authorities changes. */
   getArea = (area: string): readonly Contribution[] => {
     const cached = this.snapshot.get(area)
 
@@ -63,7 +62,7 @@ class ContributionRegistry {
       !raw || raw.length === 0
         ? EMPTY
         : raw
-            .filter(c => c.enabled !== false && (c.when ? c.when() : true))
+            .filter(c => c.enabled !== false && (c.when ? c.when.get() : true))
             .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
 
     this.snapshot.set(area, resolved)
@@ -71,8 +70,8 @@ class ContributionRegistry {
     return resolved
   }
 
-  /** Subscribe to ANY registry mutation (engines that react to every change,
-   *  e.g. pane adoption). React trees should prefer `subscribeArea`. */
+  /** Subscribe to ANY registry invalidation (engines that react to every
+   *  change, e.g. pane adoption). React trees should prefer `subscribeArea`. */
   subscribe = (fn: Listener): (() => void) => {
     this.globalListeners.add(fn)
 
@@ -81,8 +80,8 @@ class ContributionRegistry {
     }
   }
 
-  /** Subscribe to mutations of ONE area only — the leaf-level channel behind
-   *  `useContributions`, so a slot re-renders solely for its own area. */
+  /** Subscribe to invalidations of ONE area only — the leaf-level channel
+   *  behind `useContributions`, so a slot re-renders solely for its own area. */
   subscribeArea = (area: string, fn: Listener): (() => void) => {
     const set = this.areaListeners.get(area) ?? new Set<Listener>()
     set.add(fn)
@@ -111,10 +110,26 @@ class ContributionRegistry {
     }
   }
 
+  private conditionKey(area: string, id: string): string {
+    return `${area}\u0000${id}`
+  }
+
   /** Insert/replace an entry without notifying (batchable). */
   private put(c: Contribution) {
+    const key = this.conditionKey(c.area, c.id)
+
+    // Replacement transfers authority to the new contribution. The previous
+    // source must be detached before the new one can become observable or a
+    // stale source could continue invalidating an area it no longer owns.
+    this.conditionListeners.get(key)?.()
+    this.conditionListeners.delete(key)
+
     const list = this.byArea.get(c.area) ?? []
     this.byArea.set(c.area, [...list.filter(e => e.id !== c.id), c])
+
+    if (c.when) {
+      this.conditionListeners.set(key, c.when.listen(() => this.invalidate([c.area])))
+    }
   }
 
   /** Remove an entry without notifying (batchable). Returns whether it existed. */
@@ -130,6 +145,10 @@ class ContributionRegistry {
     if (next.length === list.length) {
       return false
     }
+
+    const key = this.conditionKey(area, id)
+    this.conditionListeners.get(key)?.()
+    this.conditionListeners.delete(key)
 
     if (next.length) {
       this.byArea.set(area, next)
@@ -153,7 +172,8 @@ class ContributionRegistry {
       }
     }
 
-    // Global listeners fire once per batch, regardless of how many areas moved.
+    // Global listeners fire once per batch/authority change, regardless of how
+    // many areas moved in a registry mutation.
     this.globalListeners.forEach(l => l())
     $registryVersion.set($registryVersion.get() + 1)
   }

--- a/apps/desktop/src/contrib/types.ts
+++ b/apps/desktop/src/contrib/types.ts
@@ -10,6 +10,20 @@ import type { ReactNode } from 'react'
 export type ContributionSource = 'core' | (string & {})
 
 /**
+ * Live boolean authority for contribution visibility. This is intentionally a
+ * structural contract rather than a Nano Stores import: core and plugin state
+ * can supply any readonly source with the same `get` + `listen` semantics.
+ *
+ * The registry owns the listener lifetime. A visibility source therefore
+ * invalidates its projected area when it changes, and is detached when the
+ * contribution is replaced or removed.
+ */
+export interface ContributionCondition {
+  get(): boolean
+  listen(listener: (value: boolean) => void): () => void
+}
+
+/**
  * The single, uniform primitive every surface consumes. A bar renders these as
  * inline items via `<Slot>`; a dock renders them as stacked/tabbed panes via
  * `<PaneHost>`. Same shape either way -- the host decides how to present them.
@@ -25,12 +39,9 @@ export interface Contribution {
   title?: string
   /** Ascending sort key within the area; ties keep insertion order. */
   order?: number
-  /** Dynamic visibility predicate. Omit for always-on.
-   *  NOTE: evaluated when the area's snapshot is (re)built — i.e. on a
-   *  register/remove in that area, NOT reactively. A `when()` that flips on
-   *  external state won't re-resolve on its own; trigger a registry mutation
-   *  (or don't rely on it flipping without one). */
-  when?: () => boolean
+  /** Live visibility authority. Omit for always-on. The registry subscribes to
+   *  this source and invalidates exactly this contribution's area on change. */
+  when?: ContributionCondition
   /** Soft disable without unregistering. `false` hides it. */
   enabled?: boolean
   /** Renders the contribution's content (UI contributions). */

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -180,20 +180,33 @@ interface PluginContext {
 }
 ```
 
-A **contribution** is the one primitive every surface shares:
+A **contribution** is the one primitive every surface shares. Visibility is a
+live readonly authority rather than a pull-only callback: the registry owns the
+subscription and invalidates exactly the contribution's area when the authority
+changes.
 
 ```ts
+interface ContributionCondition {
+  get(): boolean
+  listen(listener: (value: boolean) => void): () => void
+}
+
 interface Contribution {
   id: string          // you write the local id; the host namespaces it
   area: string        // WHERE it goes (a contribution-area constant)
   title?: string
   order?: number      // sort within the area (lower = earlier)
-  when?: () => boolean // dynamic visibility; re-evaluated by the area
+  when?: ContributionCondition // live visibility; e.g. atom()/computed()/host.state.*
   enabled?: boolean
   render?: () => ReactNode  // the component to mount
   data?: unknown      // area-specific payload (see the cookbook)
 }
 ```
+
+`when` may be any readonly source with `get()` + `listen()` semantics. Nano Stores
+`atom()` / `computed()` values and readonly `host.state.*` values satisfy this
+shape. Replacement and disposal detach the old subscription, so a stale source
+cannot continue invalidating an area it no longer owns.
 
 You provide `render`, `data`, or both, depending on the area.
 
@@ -218,7 +231,6 @@ Import the area constants from the SDK; each area has its own `data` payload.
 A pane is a tile in the layout tree. `placement` is the semantic role — the pane
 stacks (as tabs) with existing panes of that role; the user can drag it anywhere
 afterward.
-
 ```javascript
 ctx.register({
   id: 'pane',
@@ -658,7 +670,6 @@ ctx.socket('/events', () => {
   queryClient.invalidateQueries({ queryKey: ['my-plugin', 'items'] })
 })
 ```
-
 ## The UI kit and theming
 
 Import the app's real components directly so your UI is native by default:


### PR DESCRIPTION
## Summary

Closes #91894.

Desktop's contribution registry exposed `when?: () => boolean` as dynamic visibility, but cached each area's filtered projection until a register/remove mutation. A visibility predicate could change while the UI remained stale indefinitely; the public SDK contract promised live re-evaluation that the registry had no authority edge to perform.

This moves the fix to the projection boundary instead of adding another caller-side refresh:

- `Contribution.when` is now a structural readonly boolean authority (`get()` + `listen()`), compatible with Nano Stores without coupling the contribution contract to a concrete store implementation.
- `ContributionRegistry` owns one visibility subscription per `(area, id)` and invalidates exactly that area when the authority changes.
- replacement detaches the previous authority before the new contribution takes ownership;
- removal/disposal detaches the authority so a stale source cannot continue invalidating registry state;
- cached snapshots stay referentially stable between actual registry/authority changes;
- public Desktop Plugin SDK prose now documents the live observable-source contract and `host.state` / `atom()` / `computed()` usage.

The contract now matches the state model already exposed to plugins: `host.state.*`, `atom()`, and `computed()` are observable sources rather than pull-only callbacks.

## Root cause / invariant

A projection must never outlive, contradict, or invent its authoritative source.

The defect was not "the registry forgot to refresh." It accepted a pull-only predicate while caching the result, so there was no subscription edge from source state to projection invalidation. The registry is already the shared projection seam for core and plugin UI; that is where the authority lifecycle now lives.

This is the same architecture direction as #91714 (one tab-strip resolver), #91777 (close affordance derives from `onClose`), #91695 (live privilege revocation), #91493 (typed failure provenance), and #91828 (absence/reconciliation), without overlapping their implementation scopes.

## Tests

`registry.test.ts` binds the three load-bearing contracts:

1. a visible contribution disappears/reappears immediately when its Nano Store authority flips, with no unrelated registry mutation;
2. replacing the same `(area, id)` detaches the old authority;
3. disposing a contribution detaches its authority, so later source changes cannot invalidate the area.

The first test also asserts the cached snapshot is referentially stable before the authority actually changes.

## Exact object evidence

Current submitted head: `9d88ef6263c80be59be680bfa65ebe2441218715`.

Exact-head GitHub Actions are green:

- CI `32548443956` — success
- Docker `32548443574` — success
- Nix `32548443570` — success

There are zero unresolved inline review threads on the submitted object.

## Scope

Four files only:

- `apps/desktop/src/contrib/types.ts`
- `apps/desktop/src/contrib/registry.ts`
- `apps/desktop/src/contrib/registry.test.ts`
- `website/docs/developer-guide/desktop-plugin-sdk.md`

No runtime compatibility shim is added for an API that the registry could never make truthful.