### PR TITLE
fix(cron): preserve interval phase across ticker and claim jitter

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1123,8 +1123,34 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
     return None
 
 
-# --- Ticker heartbeat (liveness signal for `hermes cron status`) ---
+def _advance_recurring_run(job: Dict[str, Any], now: datetime) -> Optional[str]:
+    """Return the crash-safe next slot without adding scheduler observation drift.
 
+    Interval schedules keep their persisted ``next_run_at`` phase. If that slot
+    is due, advance by whole intervals to the first future slot; if an earlier
+    dispatch step already reserved a future slot, keep it unchanged. Cron
+    schedules retain their existing claim-time calculation.
+    """
+    schedule = job.get("schedule", {})
+    if schedule.get("kind") != "interval":
+        return compute_next_run(schedule, now.isoformat())
+
+    try:
+        interval = timedelta(minutes=float(schedule["minutes"]))
+        if interval.total_seconds() <= 0:
+            return None
+        scheduled = _ensure_aware(datetime.fromisoformat(job["next_run_at"]))
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return compute_next_run(schedule, now.isoformat())
+
+    if scheduled > now:
+        return scheduled.isoformat()
+    elapsed = now - scheduled
+    periods = elapsed // interval + 1
+    return (scheduled + periods * interval).isoformat()
+
+
+# --- Ticker heartbeat (liveness signal for `hermes cron status`) ---
 def _write_marker(name: str, text: str, tmp_prefix: str) -> None:
     """Atomic (never torn) best-effort marker write; failures swallowed so markers never break the
     tick."""
@@ -2264,7 +2290,23 @@ def _advance_after_run(job: Dict[str, Any], now: str) -> None:
             _complete_job_record(job)
             return
 
-    job["next_run_at"] = compute_next_run(job["schedule"], now)
+    # Interval jobs normally keep the future slot reserved before dispatch. This
+    # preserves their wall-clock phase instead of adding sub-second completion
+    # drift that a 60s ticker can turn into a full extra minute. A long run
+    # whose reserved slot has already passed still re-anchors from completion,
+    # preserving the no-immediate-catch-up completion contract.
+    reserved_next = job.get("next_run_at")
+    keep_reserved_interval = False
+    if kind == "interval" and reserved_next:
+        try:
+            keep_reserved_interval = (
+                _ensure_aware(datetime.fromisoformat(reserved_next))
+                > _ensure_aware(datetime.fromisoformat(now))
+            )
+        except (TypeError, ValueError):
+            pass
+    if not keep_reserved_interval:
+        job["next_run_at"] = compute_next_run(job["schedule"], now)
     if job["next_run_at"] is not None:
         if job.get("state") != "paused":
             job["state"] = "scheduled"
@@ -2498,7 +2540,7 @@ def advance_next_runs(job_ids) -> int:
         return 0
     with _jobs_lock():
         jobs = load_jobs()
-        now = _hermes_now().isoformat()
+        now = _hermes_now()
         advanced = 0
         for job in jobs:
             if (
@@ -2507,7 +2549,7 @@ def advance_next_runs(job_ids) -> int:
                 or job.get("schedule", {}).get("kind") not in {"cron", "interval"}
             ):
                 continue
-            new_next = compute_next_run(job["schedule"], now)
+            new_next = _advance_recurring_run(job, now)
             if new_next and new_next != job.get("next_run_at"):
                 job["next_run_at"] = new_next
                 advanced += 1
@@ -2541,6 +2583,7 @@ def _machine_id() -> str:
 def claim_job_for_fire(
     job_id: str, *, claim_ttl_seconds: int = FIRE_CLAIM_TTL_SECONDS, force: bool = False,
     manual: bool = False, return_job: bool = False,
+    advance_schedule: bool = True,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for one external 'fire' (multi-machine at-most-once); True iff THIS
     caller won (``CronScheduler.fire_due``: exactly one of N replicas runs a job). Under the
@@ -2580,8 +2623,8 @@ def claim_job_for_fire(
         # Per-acquisition token: a process may legitimately reclaim its own stale lease, and the
         # previous runner must not heartbeat the new claim merely because hostname + PID match.
         job["fire_claim"] = {"at": now.isoformat(), "by": f"{_machine_id()}:{uuid.uuid4().hex}"}
-        if job.get("schedule", {}).get("kind") in {"cron", "interval"}:
-            nxt = compute_next_run(job["schedule"], now.isoformat())
+        if advance_schedule and job.get("schedule", {}).get("kind") in {"cron", "interval"}:
+            nxt = _advance_recurring_run(job, now)
             if nxt:
                 job["next_run_at"] = nxt
         save_jobs(jobs)
@@ -2597,7 +2640,6 @@ def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
     return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
-
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by
 # _sweep_completed_oneshots once they age out.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3541,7 +3541,9 @@ def _sweep_mcp_orphans() -> None:
 def _process_due_job(job: dict, adapters, loop, verbose: bool) -> bool:
     """Run one due job via the shared ``run_one_job`` body."""
     # Claim only when the worker actually starts, so a queued lease can't expire first.
-    claimed = claim_job_for_fire(job["id"], return_job=True)
+    # The ticker reserved the next recurring slot before dispatch, so the claim
+    # must not advance it a second time.
+    claimed = claim_job_for_fire(job["id"], return_job=True, advance_schedule=False)
     if not claimed:
         finish_execution(
             job["execution_id"], success=False, error="Fire claim lost; execution was not started.")

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -7,6 +7,7 @@ claim for a given fire. Single-machine deployments always win (unaffected).
 These exercise the real store against a temp HERMES_HOME (no mocks) per the
 E2E-over-mocks discipline for file-touching code.
 """
+from datetime import datetime, timedelta, timezone
 import threading
 import time
 
@@ -24,15 +25,44 @@ def temp_home(tmp_path, monkeypatch):
 def test_claim_succeeds_once_then_blocks(temp_home):
     """First claim for a fire wins; a second claim for the same fire loses, and
     next_run_at is advanced (a re-delivery for the old time can't re-fire)."""
-    from cron.jobs import create_job, claim_job_for_fire, get_job
+    from cron import jobs
 
-    job = create_job(prompt="x", schedule="every 5m", name="t")
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="t")
     jid = job["id"]
-    before = get_job(jid)["next_run_at"]
+    stored = jobs.load_jobs()
+    stored[0]["next_run_at"] = (
+        datetime.now(timezone.utc) - timedelta(seconds=1)
+    ).isoformat()
+    jobs.save_jobs(stored)
+    before_job = jobs.get_job(jid)
+    assert before_job is not None
+    before = before_job["next_run_at"]
 
-    assert claim_job_for_fire(jid) is True
-    assert claim_job_for_fire(jid) is False
-    assert get_job(jid)["next_run_at"] != before
+    assert jobs.claim_job_for_fire(jid) is True
+    assert jobs.claim_job_for_fire(jid) is False
+    claimed_job = jobs.get_job(jid)
+    assert claimed_job is not None
+    assert claimed_job["next_run_at"] != before
+
+
+def test_external_interval_claim_advances_from_due_slot(temp_home, monkeypatch):
+    """External scheduler jitter must not shift an interval's persisted phase."""
+    from cron import jobs
+
+    due = datetime(2026, 8, 30, 12, 5, tzinfo=timezone.utc)
+    now = due + timedelta(milliseconds=250)
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="phase-locked")
+    stored = jobs.load_jobs()
+    stored[0]["next_run_at"] = due.isoformat()
+    jobs.save_jobs(stored)
+
+    claimed = jobs.claim_job_for_fire(job["id"], return_job=True)
+
+    assert isinstance(claimed, dict)
+    assert datetime.fromisoformat(claimed["next_run_at"]) == due + timedelta(
+        minutes=5
+    )
 
 
 def test_claim_oneshot_cannot_be_double_claimed(temp_home):

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -818,6 +818,76 @@ class TestMarkJobRun:
 class TestAdvanceNextRun:
     """Tests for advance_next_run() — crash-safety for recurring jobs."""
 
+    def test_interval_keeps_due_time_phase_through_claim_and_completion(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """Sub-tick runtime must not turn ``every 2m`` into a three-tick job."""
+        clock = {"now": datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)}
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: clock["now"])
+        job = create_job(prompt="phase locked", schedule="every 2m")
+        first_due = datetime.fromisoformat(job["next_run_at"])
+
+        # The 60-second ticker notices the fire fractionally after its exact due
+        # time. Advancing from that observation time would permanently add the
+        # fraction and make the tick at 12:04:00 miss the next run.
+        clock["now"] = first_due + timedelta(milliseconds=250)
+        assert advance_next_run(job["id"]) is True
+        expected_next = first_due + timedelta(minutes=2)
+        advanced = get_job(job["id"])
+        assert isinstance(advanced, dict)
+        assert datetime.fromisoformat(advanced["next_run_at"]) == expected_next
+
+        # The durable claim and a quick completion happen slightly later still;
+        # neither may re-anchor the already-advanced interval slot.
+        clock["now"] += timedelta(milliseconds=50)
+        claimed = claim_job_for_fire(
+            job["id"], return_job=True, advance_schedule=False
+        )
+        assert isinstance(claimed, dict)
+        assert datetime.fromisoformat(claimed["next_run_at"]) == expected_next
+
+        clock["now"] += timedelta(milliseconds=200)
+        assert mark_job_run(
+            job["id"],
+            success=True,
+            expected_fire_owner=claimed["fire_claim"]["by"],
+        )
+        completed = get_job(job["id"])
+        assert isinstance(completed, dict)
+        assert datetime.fromisoformat(completed["next_run_at"]) == expected_next
+
+        clock["now"] = expected_next
+        assert job["id"] in {due["id"] for due in get_due_jobs()}
+
+    def test_long_interval_run_reanchors_from_completion(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """A run that outlives its reserved slot must still wait a full interval."""
+        clock = {"now": datetime(2026, 8, 21, 12, 0, tzinfo=timezone.utc)}
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: clock["now"])
+        job = create_job(prompt="slow", schedule="every 2m")
+        first_due = datetime.fromisoformat(job["next_run_at"])
+
+        clock["now"] = first_due
+        assert advance_next_run(job["id"])
+        claimed = claim_job_for_fire(
+            job["id"], return_job=True, advance_schedule=False
+        )
+        assert isinstance(claimed, dict)
+
+        completion = first_due + timedelta(minutes=3, seconds=30)
+        clock["now"] = completion
+        assert mark_job_run(
+            job["id"],
+            success=True,
+            expected_fire_owner=claimed["fire_claim"]["by"],
+        )
+        completed = get_job(job["id"])
+        assert isinstance(completed, dict)
+        assert datetime.fromisoformat(completed["next_run_at"]) == (
+            completion + timedelta(minutes=2)
+        )
+
     def test_advances_interval_job(self, tmp_cron_dir):
         """Interval jobs should have next_run_at bumped to the next future occurrence."""
         job = create_job(prompt="Recurring check", schedule="every 1h")

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -131,7 +131,12 @@ class TestRunningJobGuard:
         result = callback()
         future.set_result(result)
 
-        assert claim_calls == [("queued-job", {"return_job": True})]
+        assert claim_calls == [
+            (
+                "queued-job",
+                {"return_job": True, "advance_schedule": False},
+            )
+        ]
         assert "queued-job" not in sched._running_job_ids
 
 

--- a/tests/cron/test_terminal_job_rearm.py
+++ b/tests/cron/test_terminal_job_rearm.py
@@ -160,9 +160,17 @@ class TestRecurringJobStuckInErrorStateIsRecoverable:
 
     @staticmethod
     def _force_error_state(job_id):
-        """Reproduce the exact state _mark_job_run_locked produces when
-        compute_next_run() fails for a recurring job (e.g. croniter
-        missing): state=error, enabled stays True, next_run_at=None."""
+        """Reproduce the state produced when next-run computation fails.
+
+        Expire the interval's crash-safe reserved slot so completion must
+        compute another one; a future reservation is intentionally preserved.
+        """
+        record = get_job(job_id)
+        assert isinstance(record, dict)
+        record["next_run_at"] = (
+            datetime.now(timezone.utc) - timedelta(seconds=1)
+        ).isoformat()
+        save_jobs([record])
         with mock.patch("cron.jobs.compute_next_run", return_value=None):
             mark_job_run(job_id, success=True)
 

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -371,8 +371,8 @@ def test_profile_call_cannot_retarget_ticker_store_mid_write(
     monkeypatch.setattr(cron_jobs, "OUTPUT_DIR", default_cron / "output")
     monkeypatch.setattr(
         cron_jobs,
-        "compute_next_run",
-        lambda _schedule, _last_run_at=None: "2026-07-10T00:00:00+00:00",
+        "_advance_recurring_run",
+        lambda _job, _now: "2026-07-10T00:00:00+00:00",
     )
 
     ticker_loaded = threading.Event()


### PR DESCRIPTION
## Summary

Prevent recurring interval schedules from drifting under ticker, dispatch, completion, and external-scheduler latency.

- advance intervals by whole periods from their persisted due slot
- let native ticker claims retain the crash-safe slot reserved before dispatch
- preserve future reservations after quick completion
- re-anchor jobs that outlive their reserved slot to avoid catch-up bursts
- apply the same persisted-slot advancement to direct/external claims
- leave cron-expression scheduling unchanged

## Consolidation

This incorporates the compatible direct-claim insight from #46741. Attribution is retained in commit `5e2147c405615a8b5c5f8c6e9f0a33e87a1dd8c2`. The terminal-job recovery fixture now expires the reservation before simulating next-run computation failure, matching the real error state instead of contradicting the intended reservation behavior.

## Verification

- claim/jobs/parallel-pool tests — 136 passed
- dashboard profile tests — 31 passed
- scheduler/provider tests — 135 passed
- terminal-job rearm tests — 15 passed
- combined post-CI-fix regression set — 152 passed
- Ruff and `git diff --check` — passed