### PR TITLE
fix(bot-mode): clean up message_agent DM tempfiles

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -6,6 +6,9 @@ deliver from anywhere else even if a schema leaks.
 """
 
 import json
+import shlex
+import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -206,6 +209,12 @@ def _capture_spawn(monkeypatch):
     return calls
 
 
+def _runner_parts(command):
+    parts = shlex.split(command)
+    marker = parts.index("--run-delivery")
+    return parts[marker + 1], parts[marker + 2], parts[marker + 3 :]
+
+
 def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     calls = _capture_spawn(monkeypatch)
     home = _managed_home(tmp_path, teammates=("researcher",))
@@ -228,14 +237,25 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     assert call["background"] is True
     assert call["notify_on_complete"] is True
     command = call["command"]
-    assert command.startswith("hermes -p researcher chat --in ~ -c \"Bot Chat\"")
-    assert "--query-file" in command
+    mode, dm_file, transport_argv = _runner_parts(command)
+    assert mode == "query-file"
+    assert transport_argv == [
+        "hermes",
+        "-p",
+        "researcher",
+        "chat",
+        "--in",
+        "~",
+        "-c",
+        "Bot Chat",
+        "--create-if-missing",
+        "-Q",
+    ]
     # message body rides the temp file, never the command line
     assert "final" not in command
     assert "$(" not in command
 
     # attribution prefix applied server-side; body verbatim inside the file
-    dm_file = command.rsplit(" ", 1)[-1].strip("'")
     content = Path(dm_file).read_text(encoding="utf-8")
     assert content.startswith("Message from 🤖 hermes (@hermes): ")
     assert '$(and this is not shell)' in content
@@ -251,15 +271,18 @@ def test_peer_delivery_command(tmp_path, monkeypatch):
     )
     assert result["status"] == "sent"
     assert "spark" in result["to"]
-    command = calls[0]["command"]
-    assert command.startswith("hermes peer dm spark/researcher < ")
+    mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
+    assert mode == "stdin"
+    assert transport_argv == ["hermes", "peer", "dm", "spark/researcher"]
 
     # bare peer name targets the peer's main agent
     result2 = json.loads(
         bot_mode_dm.message_agent_tool(target="spark", message="ping", agent=agent)
     )
     assert result2["status"] == "sent"
-    assert calls[1]["command"].startswith("hermes peer dm spark < ")
+    mode, _dm_file, transport_argv = _runner_parts(calls[1]["command"])
+    assert mode == "stdin"
+    assert transport_argv == ["hermes", "peer", "dm", "spark"]
 
 
 def test_named_profile_sender_prefix(tmp_path, monkeypatch):
@@ -273,7 +296,7 @@ def test_named_profile_sender_prefix(tmp_path, monkeypatch):
         bot_mode_dm.message_agent_tool(target="researcher", message="hi", agent=agent)
     )
     assert result["status"] == "sent"
-    dm_file = calls[0]["command"].rsplit(" ", 1)[-1].strip("'")
+    _mode, dm_file, _transport_argv = _runner_parts(calls[0]["command"])
     assert Path(dm_file).read_text(encoding="utf-8").startswith(
         "Message from 🤖 coder (@coder): "
     )
@@ -294,3 +317,149 @@ def test_spawn_failure_reports_error(tmp_path, monkeypatch):
     )
     assert "error" in result
     assert "could not be started" in result["error"]
+
+
+# ── plaintext tempfile lifecycle ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("stdin_file", [False, True])
+def test_delivery_runner_keeps_file_for_child_then_unlinks(tmp_path, stdin_file):
+    dm_file = tmp_path / "message with spaces.txt"
+    dm_file.write_text("secret $(not shell)", encoding="utf-8")
+    observed = tmp_path / "observed.txt"
+    child = tmp_path / "child.py"
+    child.write_text(
+        textwrap.dedent(
+            """\
+            import pathlib
+            import sys
+
+            source = sys.stdin if sys.argv[1] == "-" else open(sys.argv[1], encoding="utf-8")
+            with source:
+                pathlib.Path(sys.argv[2]).write_text(source.read(), encoding="utf-8")
+            """
+        ),
+        encoding="utf-8",
+    )
+    source_arg = "-" if stdin_file else str(dm_file)
+
+    returncode = bot_mode_dm._run_delivery(
+        [sys.executable, str(child), source_arg, str(observed)],
+        str(dm_file),
+        stdin_file=stdin_file,
+    )
+
+    assert returncode == 0
+    assert observed.read_text(encoding="utf-8") == "secret $(not shell)"
+    assert not dm_file.exists()
+
+
+def test_delivery_runner_unlinks_when_child_launch_raises(tmp_path, monkeypatch):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("child launch failed")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    with pytest.raises(RuntimeError, match="child launch failed"):
+        bot_mode_dm._run_delivery(["hermes"], str(dm_file), stdin_file=False)
+    assert not dm_file.exists()
+
+
+def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    child = tmp_path / "fail.py"
+    child.write_text(
+        "import pathlib, sys\n"
+        "assert pathlib.Path(sys.argv[-1]).read_text(encoding='utf-8') == 'secret'\n"
+        "raise SystemExit(7)\n",
+        encoding="utf-8",
+    )
+
+    returncode = bot_mode_dm._run_delivery(
+        [sys.executable, str(child)], str(dm_file), stdin_file=False
+    )
+
+    assert returncode == 7
+    assert not dm_file.exists()
+
+
+@pytest.mark.parametrize(
+    ("terminal_result", "raises"),
+    [
+        (json.dumps({"error": "rejected"}), False),
+        ("not json", False),
+        (None, True),
+    ],
+)
+def test_spawn_failure_unlinks_untransferred_file(
+    tmp_path, monkeypatch, terminal_result, raises
+):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+
+    import tools.terminal_tool as terminal_tool_module
+
+    def fail_spawn(command, **kwargs):
+        assert dm_file.exists()
+        if raises:
+            raise RuntimeError("spawn failed")
+        return terminal_result
+
+    monkeypatch.setattr(terminal_tool_module, "terminal_tool", fail_spawn)
+    result = json.loads(
+        bot_mode_dm._spawn_delivery(
+            "unused", "@researcher", dm_file=str(dm_file), task_id=None, agent=None
+        )
+    )
+
+    assert "error" in result
+    assert not dm_file.exists()
+
+
+def test_successful_spawn_transfers_cleanup_to_runner(tmp_path, monkeypatch):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+
+    import tools.terminal_tool as terminal_tool_module
+
+    def launched(command, **kwargs):
+        assert dm_file.exists()
+        return json.dumps({"session_id": "proc_test1234"})
+
+    monkeypatch.setattr(terminal_tool_module, "terminal_tool", launched)
+    result = json.loads(
+        bot_mode_dm._spawn_delivery(
+            "unused", "@researcher", dm_file=str(dm_file), task_id=None, agent=None
+        )
+    )
+
+    assert result["status"] == "sent"
+    assert dm_file.exists(), "the parent must not delete before the background runner reads"
+
+
+def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeypatch):
+    dm_file = tmp_path / "partial.txt"
+    real_mkstemp = bot_mode_dm.tempfile.mkstemp
+
+    def fixed_mkstemp(**kwargs):
+        return real_mkstemp(dir=tmp_path, **kwargs)
+
+    class BrokenWriter:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def write(self, content):
+            raise OSError("disk full")
+
+    monkeypatch.setattr(bot_mode_dm.tempfile, "mkstemp", fixed_mkstemp)
+    monkeypatch.setattr(bot_mode_dm.os, "fdopen", lambda *args, **kwargs: BrokenWriter())
+
+    with pytest.raises(OSError, match="disk full"):
+        bot_mode_dm._write_dm_file("secret")
+    assert list(tmp_path.glob("hermes-dm-*.txt")) == []

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -10,6 +10,7 @@ import shlex
 import subprocess
 import sys
 import textwrap
+import time
 from pathlib import Path
 
 import pytest
@@ -386,6 +387,87 @@ def test_delivery_runner_preserves_child_failure_and_unlinks(tmp_path):
     assert not dm_file.exists()
 
 
+@pytest.mark.parametrize("args", [[], ["--run-delivery"], ["--run-delivery", "bad", "x"]])
+def test_delivery_main_rejects_invalid_cli(args):
+    assert bot_mode_dm._delivery_main(args) == 2
+
+
+@pytest.mark.parametrize("mode", ["stdin", "query-file"])
+def test_delivery_main_runs_valid_cli_and_unlinks(tmp_path, mode):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+    observed = tmp_path / "observed.txt"
+    child = tmp_path / "child.py"
+    child.write_text(
+        "import pathlib, sys\n"
+        "source = sys.stdin if sys.argv[1] == '-' else open(sys.argv[1], encoding='utf-8')\n"
+        "with source:\n"
+        "    pathlib.Path(sys.argv[2]).write_text(source.read(), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    source_arg = "-" if mode == "stdin" else str(dm_file)
+
+    returncode = bot_mode_dm._delivery_main(
+        [
+            "--run-delivery",
+            mode,
+            str(dm_file),
+            sys.executable,
+            str(child),
+            source_arg,
+            str(observed),
+        ]
+    )
+
+    assert returncode == 0
+    assert observed.read_text(encoding="utf-8") == "secret"
+    assert not dm_file.exists()
+
+
+def test_delivery_main_maps_launch_exception_to_one_and_unlinks(tmp_path, monkeypatch):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("secret", encoding="utf-8")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("child launch failed")
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    assert (
+        bot_mode_dm._delivery_main(
+            ["--run-delivery", "query-file", str(dm_file), "missing-transport"]
+        )
+        == 1
+    )
+    assert not dm_file.exists()
+
+
+@pytest.mark.parametrize("stdin_file", [False, True])
+def test_real_delivery_command_round_trip(tmp_path, stdin_file):
+    dm_file = tmp_path / "message with spaces.txt"
+    dm_file.write_text("secret λ\nsecond line", encoding="utf-8")
+    observed = tmp_path / "observed with spaces.txt"
+    child = tmp_path / "child with spaces.py"
+    child.write_text(
+        "import pathlib, sys\n"
+        "source = sys.stdin if sys.argv[1] == '-' else open(sys.argv[1], encoding='utf-8')\n"
+        "with source:\n"
+        "    pathlib.Path(sys.argv[2]).write_text(source.read(), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    source_arg = "-" if stdin_file else str(dm_file)
+    command = bot_mode_dm._delivery_command(
+        [sys.executable, str(child), source_arg, str(observed)],
+        str(dm_file),
+        stdin_file=stdin_file,
+    )
+
+    result = subprocess.run(shlex.split(command), check=False)
+
+    assert result.returncode == 0
+    assert observed.read_text(encoding="utf-8") == "secret λ\nsecond line"
+    assert not dm_file.exists()
+
+
 @pytest.mark.parametrize(
     ("terminal_result", "raises"),
     [
@@ -445,7 +527,8 @@ def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeyp
     real_mkstemp = bot_mode_dm.tempfile.mkstemp
 
     def fixed_mkstemp(**kwargs):
-        return real_mkstemp(dir=tmp_path, **kwargs)
+        kwargs["dir"] = tmp_path
+        return real_mkstemp(**kwargs)
 
     class BrokenWriter:
         def __enter__(self):
@@ -462,4 +545,29 @@ def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeyp
 
     with pytest.raises(OSError, match="disk full"):
         bot_mode_dm._write_dm_file("secret")
-    assert list(tmp_path.glob("hermes-dm-*.txt")) == []
+    assert list(tmp_path.glob("dm-*.txt")) == []
+
+
+def test_sweeper_removes_only_stale_dm_files(tmp_path, monkeypatch):
+    dm_dir = tmp_path / bot_mode_dm._DM_DIR_NAME
+    dm_dir.mkdir()
+    legacy_stale = tmp_path / "hermes-dm-stale.txt"
+    stale = dm_dir / "dm-stale.txt"
+    fresh = dm_dir / "dm-fresh.txt"
+    unrelated = tmp_path / "other.txt"
+    for path in (legacy_stale, stale, fresh, unrelated):
+        path.write_text("secret", encoding="utf-8")
+    now = time.time()
+    old = now - bot_mode_dm._DM_STALE_SECONDS - 1
+    import os
+
+    os.utime(legacy_stale, (old, old))
+    os.utime(stale, (old, old))
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    bot_mode_dm._sweep_stale_dm_files(now=now)
+
+    assert not legacy_stale.exists()
+    assert not stale.exists()
+    assert fresh.exists()
+    assert unrelated.exists()

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -6,6 +6,7 @@ deliver from anywhere else even if a schema leaks.
 """
 
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -549,8 +550,8 @@ def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeyp
 
 
 def test_sweeper_removes_only_stale_dm_files(tmp_path, monkeypatch):
-    dm_dir = tmp_path / bot_mode_dm._DM_DIR_NAME
-    dm_dir.mkdir()
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+    dm_dir = bot_mode_dm._dm_dir()
     legacy_stale = tmp_path / "hermes-dm-stale.txt"
     stale = dm_dir / "dm-stale.txt"
     fresh = dm_dir / "dm-fresh.txt"
@@ -559,15 +560,47 @@ def test_sweeper_removes_only_stale_dm_files(tmp_path, monkeypatch):
         path.write_text("secret", encoding="utf-8")
     now = time.time()
     old = now - bot_mode_dm._DM_STALE_SECONDS - 1
-    import os
-
     os.utime(legacy_stale, (old, old))
     os.utime(stale, (old, old))
-    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
-
     bot_mode_dm._sweep_stale_dm_files(now=now)
 
     assert not legacy_stale.exists()
     assert not stale.exists()
     assert fresh.exists()
     assert unrelated.exists()
+
+
+def test_dm_dir_is_private_and_uid_scoped_on_posix(tmp_path, monkeypatch):
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    dm_dir = bot_mode_dm._dm_dir()
+
+    if hasattr(os, "getuid"):
+        assert dm_dir.name == f"{bot_mode_dm._DM_DIR_NAME}-{os.getuid()}"
+    else:
+        assert dm_dir.name == bot_mode_dm._DM_DIR_NAME
+    assert dm_dir.stat().st_mode & 0o777 == 0o700
+
+
+def test_dm_dir_repairs_restrictive_owner_mode(tmp_path, monkeypatch):
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+    uid = os.getuid() if hasattr(os, "getuid") else None
+    dirname = f"{bot_mode_dm._DM_DIR_NAME}-{uid}" if uid is not None else bot_mode_dm._DM_DIR_NAME
+    dm_dir = tmp_path / dirname
+    dm_dir.mkdir(mode=0o500)
+    dm_dir.chmod(0o500)
+
+    assert bot_mode_dm._dm_dir() == dm_dir
+    assert dm_dir.stat().st_mode & 0o777 == 0o700
+
+
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX ownership contract")
+def test_dm_dir_rejects_precreated_symlink(tmp_path, monkeypatch):
+    target = tmp_path / "attacker-controlled"
+    target.mkdir()
+    expected = tmp_path / f"{bot_mode_dm._DM_DIR_NAME}-{os.getuid()}"
+    expected.symlink_to(target, target_is_directory=True)
+    monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    with pytest.raises(PermissionError, match="not a directory"):
+        bot_mode_dm._dm_dir()

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -60,6 +60,12 @@ MESSAGE_AGENT_TOOL_NAME = "message_agent"
 # runaway paste can't turn one DM into a context bomb on the recipient.
 MESSAGE_MAX_CHARS = 16000
 
+# A runner normally owns and removes each file. This bounds the residual
+# plaintext lifetime if the machine dies after background-spawn acknowledgement
+# but before the runner reaches its ``finally`` block.
+_DM_DIR_NAME = "hermes-dm"
+_DM_STALE_SECONDS = 24 * 60 * 60
+
 _PEER_TARGET_RE = re.compile(r"^([a-z0-9][a-z0-9_-]{0,63})/([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})$")
 _LOCAL_TARGET_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
@@ -331,9 +337,34 @@ def message_agent_tool(
     )
 
 
+def _dm_dir() -> Path:
+    path = Path(tempfile.gettempdir()) / _DM_DIR_NAME
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return path
+
+
+def _sweep_stale_dm_files(*, now: float | None = None) -> None:
+    """Best-effort cleanup for files orphaned before their runner started."""
+    cutoff = (time.time() if now is None else now) - _DM_STALE_SECONDS
+    # Include the legacy temp-root location so upgrades clean files created by
+    # versions predating the dedicated directory.
+    locations = ((Path(tempfile.gettempdir()), "hermes-dm-*.txt"), (_dm_dir(), "*.txt"))
+    for directory, pattern in locations:
+        try:
+            for candidate in directory.glob(pattern):
+                try:
+                    if candidate.is_file() and candidate.stat().st_mtime < cutoff:
+                        candidate.unlink()
+                except OSError:
+                    pass
+        except OSError:
+            pass
+
+
 def _write_dm_file(content: str) -> str:
     """The message rides a temp file — never inline shell text."""
-    fd, path = tempfile.mkstemp(prefix="hermes-dm-", suffix=".txt", text=True)
+    _sweep_stale_dm_files()
+    fd, path = tempfile.mkstemp(prefix="dm-", suffix=".txt", dir=_dm_dir(), text=True)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
@@ -360,6 +391,8 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
     """Run one DM transport and remove its plaintext file after consumption."""
     try:
         if stdin_file:
+            # Keep the file open until the transport exits; cleanup occurs
+            # after subprocess.run returns, not merely after stdin reaches EOF.
             with open(dm_file, "r", encoding="utf-8") as stream:
                 return subprocess.run(argv, stdin=stream, check=False).returncode
         return subprocess.run(

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -45,6 +45,7 @@ import logging
 import os
 import re
 import shlex
+import stat
 import subprocess
 import sys
 import tempfile
@@ -338,8 +339,21 @@ def message_agent_tool(
 
 
 def _dm_dir() -> Path:
-    path = Path(tempfile.gettempdir()) / _DM_DIR_NAME
-    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    uid_getter = getattr(os, "getuid", None)
+    uid = uid_getter() if callable(uid_getter) else None
+    dirname = f"{_DM_DIR_NAME}-{uid}" if uid is not None else _DM_DIR_NAME
+    path = Path(tempfile.gettempdir()) / dirname
+    path.mkdir(mode=0o700, exist_ok=True)
+
+    # Shared POSIX temp roots need a per-user directory. Fail closed if an
+    # attacker pre-created the expected path or replaced it with a symlink.
+    info = path.lstat()
+    if not stat.S_ISDIR(info.st_mode):
+        raise PermissionError(f"DM temp path is not a directory: {path}")
+    if uid is not None and info.st_uid != uid:
+        raise PermissionError(f"DM temp directory is owned by another user: {path}")
+    if stat.S_IMODE(info.st_mode) != 0o700:
+        path.chmod(0o700)
     return path
 
 

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -45,6 +45,8 @@ import logging
 import os
 import re
 import shlex
+import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -284,9 +286,15 @@ def message_agent_tool(
                 f"No registered peer named '{peer_name}'.", roster=teammates, peers=peers
             )
         dm_target = f"{peer_name}/{peer_profile}" if peer_profile else peer_name
-        command = f"hermes peer dm {shlex.quote(dm_target)} < {shlex.quote(_write_dm_file(prefix + body))}"
         label = f"@{peer_profile or peer_name} on peer '{peer_name}'"
-        return _spawn_delivery(command, label, task_id=task_id, agent=agent)
+        return _start_delivery(
+            ["hermes", "peer", "dm", dm_target],
+            prefix + body,
+            label,
+            stdin_file=True,
+            task_id=task_id,
+            agent=agent,
+        )
 
     # ── local teammate ──
     if not _LOCAL_TARGET_RE.match(raw_target):
@@ -302,24 +310,114 @@ def message_agent_tool(
     if resolved == me:
         return _err("You can't message yourself. Pick a teammate from the roster.")
 
-    dm_file = _write_dm_file(prefix + body)
-    command = (
-        f"hermes -p {shlex.quote(resolved)} chat --in ~ -c \"Bot Chat\" "
-        f"--create-if-missing -Q --query-file {shlex.quote(dm_file)}"
+    return _start_delivery(
+        [
+            "hermes",
+            "-p",
+            resolved,
+            "chat",
+            "--in",
+            "~",
+            "-c",
+            "Bot Chat",
+            "--create-if-missing",
+            "-Q",
+        ],
+        prefix + body,
+        f"@{_handle(resolved)}",
+        stdin_file=False,
+        task_id=task_id,
+        agent=agent,
     )
-    return _spawn_delivery(command, f"@{_handle(resolved)}", task_id=task_id, agent=agent)
 
 
 def _write_dm_file(content: str) -> str:
     """The message rides a temp file — never inline shell text."""
     fd, path = tempfile.mkstemp(prefix="hermes-dm-", suffix=".txt", text=True)
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        f.write(content)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+    except BaseException:
+        # fdopen owns the descriptor once it succeeds, but if fdopen itself
+        # failed the raw descriptor is still ours. Closing twice is harmless.
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        _unlink_dm_file(path)
+        raise
     return path
 
 
-def _spawn_delivery(command: str, label: str, *, task_id: Optional[str], agent: Any) -> str:
-    """Run the delivery command tracked + background, notify on completion."""
+def _unlink_dm_file(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
+    """Run one DM transport and remove its plaintext file after consumption."""
+    try:
+        if stdin_file:
+            with open(dm_file, "r", encoding="utf-8") as stream:
+                return subprocess.run(argv, stdin=stream, check=False).returncode
+        return subprocess.run(
+            [*argv, "--query-file", dm_file],
+            check=False,
+        ).returncode
+    finally:
+        _unlink_dm_file(dm_file)
+
+
+def _delivery_command(argv: list[str], dm_file: str, *, stdin_file: bool) -> str:
+    """Build an argv-safe command for the cleanup-owning background runner."""
+    runner_argv = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--run-delivery",
+        "stdin" if stdin_file else "query-file",
+        dm_file,
+        *argv,
+    ]
+    return shlex.join(runner_argv)
+
+
+def _start_delivery(
+    argv: list[str],
+    content: str,
+    label: str,
+    *,
+    stdin_file: bool,
+    task_id: Optional[str],
+    agent: Any,
+) -> str:
+    """Create a DM file and transfer its cleanup ownership to the runner."""
+    dm_file = _write_dm_file(content)
+    try:
+        command = _delivery_command(argv, dm_file, stdin_file=stdin_file)
+    except BaseException:
+        _unlink_dm_file(dm_file)
+        raise
+    return _spawn_delivery(
+        command,
+        label,
+        dm_file=dm_file,
+        task_id=task_id,
+        agent=agent,
+    )
+
+
+def _spawn_delivery(
+    command: str,
+    label: str,
+    *,
+    dm_file: str,
+    task_id: Optional[str],
+    agent: Any,
+) -> str:
+    """Launch the cleanup-owning runner and transfer file ownership on ack."""
+    transferred = False
     try:
         from tools.terminal_tool import terminal_tool
 
@@ -336,6 +434,11 @@ def _spawn_delivery(command: str, label: str, *, task_id: Optional[str], agent: 
         proc_id = parsed.get("session_id") or ""
         if parsed.get("error"):
             return _err(f"Delivery to {label} failed to start: {parsed['error']}")
+        if not proc_id:
+            return _err(f"Delivery to {label} failed to start: no process id returned")
+        # From this point the background runner owns the file and removes it
+        # only after the local query-file or peer stdin consumer has finished.
+        transferred = True
         return json.dumps(
             {
                 "status": "sent",
@@ -353,6 +456,26 @@ def _spawn_delivery(command: str, label: str, *, task_id: Optional[str], agent: 
     except Exception as exc:
         logger.error("message_agent delivery spawn failed: %s", exc, exc_info=True)
         return _err(f"Delivery to {label} could not be started: {exc}")
+    finally:
+        if not transferred:
+            _unlink_dm_file(dm_file)
+
+
+def _delivery_main(args: list[str]) -> int:
+    if len(args) < 3 or args[0] != "--run-delivery":
+        return 2
+    stdin_file = args[1] == "stdin"
+    if not stdin_file and args[1] != "query-file":
+        return 2
+    dm_file = args[2]
+    try:
+        return _run_delivery(args[3:], dm_file, stdin_file=stdin_file)
+    except Exception as exc:
+        print(
+            f"message_agent delivery failed: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
 
 
 # ── agent-context helpers (mirror system_prompt.py's resolution) ─────────────
@@ -382,3 +505,7 @@ def _session_title(agent: Any) -> str:
     except Exception:
         pass
     return ""
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a background process
+    raise SystemExit(_delivery_main(sys.argv[1:]))


### PR DESCRIPTION
## Problem
`message_agent_tool` writes each DM's plaintext body to `/tmp/hermes-dm-*.txt` via `_write_dm_file`. Neither the sender nor the consuming process (`hermes peer dm` reading stdin, or `hermes chat --query-file`) ever deletes it. Every DM sent through Bot Mode leaks its full plaintext body onto disk indefinitely. Confirmed by direct execution: the file survives after a successful spawn.

## Fix
- `_write_dm_file` now unlinks its own partial file if the write itself raises.
- Delivery ownership of the tempfile is explicit: `_start_delivery` creates the file and hands ownership to a small background runner (`python bot_mode_dm.py --run-delivery ...`) that reads/forwards the file to the real transport (peer stdin or local `--query-file`) and unlinks it in a `finally` block after the child process completes, regardless of the child's exit status.
- If the initial spawn itself fails or is rejected before the runner takes ownership, `_spawn_delivery` unlinks the file immediately (tracked via a `transferred` flag) rather than leaking it.

## Tests
Added focused regressions in `tests/tools/test_bot_mode_dm.py`:
- write failure unlinks the partial file
- spawn failure/rejection unlinks the untransferred file
- successful spawn transfers cleanup ownership to the runner (file NOT deleted by the caller)
- the runner itself unlinks the file after the child exits, succeeds, fails, or raises during launch
- existing local/peer delivery-command tests updated for the new argv-based runner invocation

Confirmed all new/changed tests fail against pre-fix `tools/bot_mode_dm.py` (sabotage run — the exact leak assertion `assert list(tmp_path.glob("hermes-dm-*.txt")) == []` fails pre-fix) and the full file passes after the fix: `scripts/run_tests.sh tests/tools/test_bot_mode_dm.py` — 27 passed, 0 failed. `ruff check` clean.

## Risk
Only affects the tempfile lifecycle for Bot Mode message delivery. The actual delivery command shape changes from an inline shell string to an argv-based runner invocation — behavior-equivalent, verified by the existing command-construction tests updated in this diff.