### PR TITLE
fix(google-workspace): extract nested Gmail MIME bodies safely

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -137,21 +137,28 @@ def _headers_dict(msg: dict) -> dict[str, str]:
 
 
 def _extract_message_body(msg: dict) -> str:
-    body = ""
     payload = msg.get("payload", {})
     if payload.get("body", {}).get("data"):
-        body = base64.urlsafe_b64decode(payload["body"]["data"]).decode("utf-8", errors="replace")
-    elif payload.get("parts"):
-        for part in payload["parts"]:
-            if part.get("mimeType") == "text/plain" and part.get("body", {}).get("data"):
+        return base64.urlsafe_b64decode(payload["body"]["data"]).decode("utf-8", errors="replace")
+
+    def find_part(parts: list[dict], mime_type: str) -> str:
+        for part in parts:
+            part_type = part.get("mimeType", "")
+            if part_type == mime_type and part.get("body", {}).get("data"):
                 body = base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8", errors="replace")
-                break
-        if not body:
-            for part in payload["parts"]:
-                if part.get("mimeType") == "text/html" and part.get("body", {}).get("data"):
-                    body = base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8", errors="replace")
-                    break
-    return body
+                if body.strip():
+                    return body
+            # Descend only through MIME containers. Attached message/rfc822
+            # parts can expose their own nested text parts, but those belong to
+            # the attachment rather than the containing message body.
+            if part_type.startswith("multipart/"):
+                body = find_part(part.get("parts", []), mime_type)
+                if body:
+                    return body
+        return ""
+
+    parts = payload.get("parts", [])
+    return find_part(parts, "text/plain") or find_part(parts, "text/html")
 
 
 def _extract_doc_text(doc: dict) -> str:

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -1,5 +1,7 @@
 """Tests for Google Workspace gws bridge and CLI wrapper."""
 
+import base64
+import binascii
 import importlib.util
 import json
 import subprocess
@@ -52,6 +54,111 @@ def api_module(monkeypatch, tmp_path):
     # Bypass authentication check — no real token file in CI.
     module._ensure_authenticated = lambda: None
     return module
+
+
+def _gmail_body(text: str) -> dict[str, str]:
+    return {"data": base64.urlsafe_b64encode(text.encode()).decode()}
+
+
+def test_extract_message_body_finds_text_in_nested_mime_parts(api_module):
+    msg = {
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "parts": [
+                {
+                    "mimeType": "multipart/alternative",
+                    "parts": [
+                        {"mimeType": "text/plain", "body": _gmail_body("Nested body")},
+                    ],
+                },
+            ],
+        },
+    }
+
+    assert api_module._extract_message_body(msg) == "Nested body"
+
+
+def test_extract_message_body_prefers_substantive_plain_text_over_html(api_module):
+    msg = {
+        "payload": {
+            "parts": [
+                {"mimeType": "text/html", "body": _gmail_body("<p>HTML body</p>")},
+                {
+                    "mimeType": "multipart/alternative",
+                    "parts": [
+                        {"mimeType": "text/plain", "body": _gmail_body("Plain body")},
+                    ],
+                },
+            ],
+        },
+    }
+
+    assert api_module._extract_message_body(msg) == "Plain body"
+
+
+def test_extract_message_body_falls_back_to_html_for_whitespace_only_plain(api_module):
+    msg = {
+        "payload": {
+            "parts": [
+                {"mimeType": "text/plain", "body": _gmail_body(" \n\t")},
+                {"mimeType": "text/html", "body": _gmail_body("<p>HTML fallback</p>")},
+            ],
+        },
+    }
+
+    assert api_module._extract_message_body(msg) == "<p>HTML fallback</p>"
+
+
+def test_extract_message_body_preserves_top_level_body_behavior(api_module):
+    msg = {"payload": {"mimeType": "text/plain", "body": _gmail_body("Top-level body")}}
+
+    assert api_module._extract_message_body(msg) == "Top-level body"
+
+
+def test_extract_message_body_ignores_attached_rfc822_text(api_module):
+    msg = {
+        "payload": {
+            "mimeType": "multipart/mixed",
+            "parts": [
+                {"mimeType": "text/html", "body": _gmail_body("<p>Message body</p>")},
+                {
+                    "mimeType": "message/rfc822",
+                    "parts": [
+                        {"mimeType": "text/plain", "body": _gmail_body("Attached body")},
+                    ],
+                },
+            ],
+        },
+    }
+
+    assert api_module._extract_message_body(msg) == "<p>Message body</p>"
+
+
+def test_extract_message_body_returns_empty_when_data_is_missing(api_module):
+    msg = {
+        "payload": {
+            "mimeType": "multipart/alternative",
+            "parts": [
+                {"mimeType": "text/plain", "body": {}},
+                {"mimeType": "text/html"},
+            ],
+        },
+    }
+
+    assert api_module._extract_message_body(msg) == ""
+
+
+def test_extract_message_body_preserves_malformed_base64_error(api_module):
+    msg = {
+        "payload": {
+            "parts": [
+                {"mimeType": "text/plain", "body": {"data": "a"}},
+            ],
+        },
+    }
+
+    with pytest.raises(binascii.Error):
+        api_module._extract_message_body(msg)
 
 
 def _write_token(path: Path, *, token="ya29.test", expiry=None, **extra):


### PR DESCRIPTION
Fix Gmail body extraction for nested multipart payloads while preserving attachment boundaries. Search multipart containers in two passes, preferring substantive text/plain and falling back to substantive text/html, without allowing text inside attached message/rfc822 parts to replace the containing message body. Preserve direct top-level body decoding and malformed-base64 behavior.

This is the preferred consolidation of #43102 and #68828: both establish the need for recursive plain-before-HTML traversal, but their unrestricted MIME-tree walks can select attachment text. The safer compatible behavior and focused regressions remain here.

Verification on current main:
- scripts/run_tests.sh tests/skills/test_google_workspace_api.py — 11 passed
- Ruff — passed
- git diff --check — passed