### PR TITLE
fix(deps): close standalone Nano ID gap and Linux ARM64 package layout

### DIFF
--- a/apps/desktop/scripts/packaged-app-layout.mjs
+++ b/apps/desktop/scripts/packaged-app-layout.mjs
@@ -1,0 +1,3 @@
+export function resolveLinuxUnpackedDirName(arch) {
+  return arch === 'x64' ? 'linux-unpacked' : `linux-${arch}-unpacked`
+}

--- a/apps/desktop/scripts/packaged-app-layout.test.mjs
+++ b/apps/desktop/scripts/packaged-app-layout.test.mjs
@@ -1,0 +1,11 @@
+import { expect, test } from 'vitest'
+
+import { resolveLinuxUnpackedDirName } from './packaged-app-layout.mjs'
+
+test('uses electron-builder default directory on Linux x64', () => {
+  expect(resolveLinuxUnpackedDirName('x64')).toBe('linux-unpacked')
+})
+
+test('includes architecture in electron-builder Linux ARM64 directory', () => {
+  expect(resolveLinuxUnpackedDirName('arm64')).toBe('linux-arm64-unpacked')
+})

--- a/apps/desktop/scripts/test-desktop.mjs
+++ b/apps/desktop/scripts/test-desktop.mjs
@@ -5,6 +5,7 @@ import { spawn, spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import { listPackage } from '@electron/asar'
 
+import { resolveLinuxUnpackedDirName } from './packaged-app-layout.mjs'
 import PACKAGE_JSON from '../package.json' with { type: 'json' }
 
 const MODE = process.argv[2] || 'help'
@@ -38,8 +39,8 @@ const APP = (() => {
       unpackedDistIndex: path.join(unpacked, 'resources', 'app.asar.unpacked', 'dist', 'index.html')
     }
   }
-  // linux unpacked layout matches windows but with different binary name
-  const unpacked = path.join(RELEASE_ROOT, 'linux-unpacked')
+  // electron-builder includes the architecture suffix for non-x64 Linux output.
+  const unpacked = path.join(RELEASE_ROOT, resolveLinuxUnpackedDirName(ARCH))
   return {
     appPath: unpacked,
     binary: path.join(unpacked, 'Hermes'),

--- a/website/.npmrc
+++ b/website/.npmrc
@@ -9,7 +9,7 @@ min-release-age-exclude[]=fast-uri
 # js-yaml 4.3.1 includes fixes for GHSA-5p4m-2wfm-xmqj. remove when > 2wks old (rel 2026-07-31)
 min-release-age-exclude[]=js-yaml
 
-# nanoid 3.3.17 includes fixes for GHSA-2v37-7h3g-55p8. remove when > 2wks old (rel 2026-08-03)
+# nanoid 3.3.18 fixes GHSA-2v37-7h3g-55p8. remove when > 2wks old (rel 2026-08-07)
 min-release-age-exclude[]=nanoid
 
 # mermaid 11.16.1 includes fixes for 5 GHSAs. remove when > 2wks old (rel 2026-08-04)

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14086,6 +14086,24 @@
         "multicast-dns": "cli.js"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
@@ -16213,24 +16231,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
-      }
-    },
-    "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/pretty-error": {

--- a/website/package.json
+++ b/website/package.json
@@ -39,7 +39,7 @@
     "serialize-javascript": "7.0.7",
     "uuid": "14.0.1",
     "minimatch": "10.2.6",
-    "nanoid": "3.3.17",
+    "nanoid": "3.3.18",
     "js-yaml": "4.3.1",
     "dompurify": "3.4.13",
     "mermaid": "11.16.1",


### PR DESCRIPTION
## Current source of truth — 2026-08-27 21:51 CDT

**P0 dependency-security consolidation.** This is a remediation-priority statement, not a claim of active exploitation.

### Exact submitted object

- **head:** `67b2b3eb23c3cb0e073ccf6e041733c18606f3f0`
- **construction parent:** `10b388300a63d83857fac3ca4f8b05b64e01bc50`
- **current main read-back:** `5cc47c994beb243407bb4c8ba47d2ab421cda9cf`
- **topology:** one submitted commit, six changed paths; main has advanced since construction
- **execution state:** exact-head CI, Docker, and Nix completed successfully with real job graphs
- **excluded surfaces:** zero `.github`, publisher, materializer, staging, Electron-version, root-lockfile, or Python-lockfile paths

The prior head `5a508a53ab4c8d31fb29ffc9facfbb5f0a71a105` is historical and no longer the submitted object. Its CI startup failure created zero jobs and remains non-evidence.

## Ownership settlement

One dependency owner now exists per transition:

- **Root Nano ID 3.3.18:** shipped by #95875. #91906 no longer modifies root `.npmrc`, `package.json`, or `package-lock.json` for that transition.
- **Python `h2==4.4.1`:** shipped by #81901. #91906 no longer modifies `uv.lock`.
- **Electron 41.10.3:** remains solely owned by #82137. #91906 no longer modifies `apps/desktop/package.json`, root `allowScripts`, or the Electron lockfile graph.
- **Standalone website Nano ID 3.3.18:** current main still carries `website/package.json` override `nanoid: 3.3.17`; that unique transition remains retained here.
- **Linux ARM64 packaged layout:** the submitted object retains architecture-aware `linux-arm64-unpacked` resolution and its regression coverage.

This is subtraction and consolidation, not a blind restack of the historical eleven-path tree.

## Final changed paths

- `apps/desktop/scripts/packaged-app-layout.mjs`
- `apps/desktop/scripts/packaged-app-layout.test.mjs`
- `apps/desktop/scripts/test-desktop.mjs`
- `website/.npmrc`
- `website/package.json`
- `website/package-lock.json`

## Retained behavior

1. The standalone website graph moves Nano ID `3.3.17` to `3.3.18` and carries the corresponding lockfile realization.
2. Desktop packaged-app verification resolves Electron Builder's Linux output as `linux-unpacked` on x64 and `linux-arm64-unpacked` on ARM64.
3. The packaged-layout regression uses Vitest's `test` and `expect`, so repository test discovery executes it rather than accepting an undiscovered `node:test` file.

## Exact-object execution receipts

All receipts below are for `67b2b3eb23c3cb0e073ccf6e041733c18606f3f0`:

- **CI:** run `33121751884` — **success**; 19 real jobs instantiated, including JS/TS workspace checks, website build, OSV review, and semantic lockfile validation.
- **Docker Build, Test, and Publish:** run `33121751226` — **success**; amd64 and arm64 build jobs instantiated and completed.
- **Nix flake check:** run `33121751234` — **success**; real `flake-check` job instantiated and completed.

Focused-test execution chain:

- exact-head `apps/desktop/package.json` runs `vitest run --config vitest.config.ts` from the workspace `check` script;
- exact-head `apps/desktop/vitest.config.ts` includes `scripts/**/*.test.mjs` in the Electron project;
- CI's successful **JS & TS checks** job executed `npm run --ws check` on this SHA.

The semantic lockfile review observed only `website/package-lock.json` movement for Nano ID `3.3.17 → 3.3.18` and completed successfully. OSV review also completed successfully; unrelated pre-existing findings on untouched root/Python lockfiles are not introduced or owned by this six-path object.

## Landing-edge reconciliation — 2026-08-27 21:51 CDT

The original ready-for-review read was pinned to direct parent `10b388300…`; that zero-behind statement is now historical and is not reused as current proof.

A fresh live reconciliation against `main@5cc47c994beb243407bb4c8ba47d2ab421cda9cf` establishes:

- GitHub reports this PR **mergeable** at current read-back.
- The mainline delta from `10b388300…` to `5cc47c994…` does **not** modify any of this PR's six submitted paths.
- Current `website/package.json` still contains `nanoid: 3.3.17`, so the retained standalone website transition has not been independently superseded.
- No shipped root Nano ID, shipped Python `h2`, or Electron ownership has re-entered the submitted diff.
- Exact-object workflow receipts remain attached only to `67b2b3eb…`; they are not being transferred to current main or any future restack.

This refreshes the semantic landing-edge read without manufacturing a trigger commit or another carrier. Any change to this PR head invalidates these exact-head receipts and requires a fresh complete matrix.

## Provenance

- #85916 by `hdy2001` — Nano ID advisory floor and standalone website gap.
- #89335 by `SovereignSignal` — complete root + website Nano ID implementation.
- #89479 by `schmitzi8` — Electron/internal extractor/Linux ARM64 packaged layout.
- #90486 by `orcaspainting-dev` — scoped root PostCSS → Nano ID repair preserving Nano ID 6.
- #92543 and #92573 by `mrxmoex` — stronger candidate and split lineage.
- #91042 — historical combined `h2` and closure evidence.
- #95875 — current-main root Nano ID owner.
- #81901 — current-main `h2==4.4.1` owner.
- #82137 — sole active Electron 41.10.3 owner.

## Disposition

The destructive topology is reduced to one owner per dependency transition; the historical zero-job object has been replaced by a one-commit executable exact-head object; current main has not collided with the six-path submission; and the retained website Nano ID gap still exists on current main. **Ready for independent review.**