### PR TITLE
feat(desktop): add safe generic plugin routing capabilities

### DIFF
--- a/apps/desktop/src/app/chat/composer/attachment-relay.test.ts
+++ b/apps/desktop/src/app/chat/composer/attachment-relay.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ComposerAttachment } from '@/store/composer'
+
+import {
+  captureHostComposerAttachmentAuthority,
+  createComposerAttachmentAttempt,
+  type RelayAttachmentDeps,
+  type RelayAttachmentTarget,
+  relayComposerAttachments as relayAuthorizedViews
+} from './attachment-relay'
+
+const attachment = (id: string, label: string): ComposerAttachment => ({
+  id,
+  occurrenceId: `occ-${id}`,
+  kind: id.includes('image') ? 'image' : 'file',
+  label,
+  path: `C:/private/${label}`
+})
+
+const target: RelayAttachmentTarget = {
+  connectionId: 'connection-remote',
+  profile: 'worker',
+  runtimeSessionId: 'runtime-1',
+  storedSessionId: 'stored-1',
+  lineageRootId: 'root-1'
+}
+
+const testViews = new WeakMap<ComposerAttachment, ComposerAttachment>()
+
+const authorizeTrustedForTest = (
+  attachments: readonly ComposerAttachment[],
+  options: { now?: () => number; ttlMs?: number } = {}
+) => {
+  const authority = captureHostComposerAttachmentAuthority(attachments)
+  const attempt = createComposerAttachmentAttempt(authority, attachments, attachments, options)
+  attachments.forEach((attachment, index) => testViews.set(attachment, attempt.attachments[index]!))
+  return () => {
+    attempt.release()
+    attachments.forEach(attachment => testViews.delete(attachment))
+  }
+}
+
+const relayTrustedForTest = (
+  relayTarget: RelayAttachmentTarget,
+  attachments: readonly ComposerAttachment[],
+  relayDeps: RelayAttachmentDeps
+) => relayAuthorizedViews(relayTarget, attachments.map(attachment => testViews.get(attachment) ?? attachment), relayDeps)
+
+function deps(bytesById: Record<string, Uint8Array>): RelayAttachmentDeps {
+  return {
+    maxBytes: 1024,
+    now: () => 1234,
+    read: vi.fn(async item => ({
+      bytes: bytesById[item.id],
+      mediaType: item.kind === 'image' ? 'image/png' : 'text/plain'
+    })),
+    revalidate: vi.fn(async () => undefined),
+    stage: vi.fn(async (exactTarget, item) => ({
+      attached: true,
+      bytes: item.bytes.byteLength,
+      mediaType: item.mediaType,
+      name: item.name,
+      order: item.order,
+      runtimeSessionId: exactTarget.runtimeSessionId,
+      sha256: item.sha256,
+      storedName: item.name,
+      refText: item.mediaType.startsWith('image/') ? undefined : `@file:${item.name}`
+    }))
+  }
+}
+
+describe('authorized composer attachment relay', () => {
+  it('preserves complete ordered integrity and non-path provenance', async () => {
+    const items = [attachment('file-1', 'notes.txt'), attachment('image-2', 'café.png')]
+    const release = authorizeTrustedForTest(items, { now: () => 1234 })
+    const relayDeps = deps({
+      'file-1': new TextEncoder().encode('alpha'),
+      'image-2': new TextEncoder().encode('β')
+    })
+
+    try {
+      const relayed = await relayTrustedForTest(target, items, relayDeps)
+
+      expect(relayed.map(item => item.order)).toEqual([0, 1])
+      expect(relayed.map(item => item.name)).toEqual(['notes.txt', 'café.png'])
+      expect(relayed.map(item => item.storedName)).toEqual(['notes.txt', 'café.png'])
+      expect(relayed.map(item => item.mediaType)).toEqual(['text/plain', 'image/png'])
+      expect(relayed.map(item => item.size)).toEqual([5, 2])
+      expect(relayed.every(item => /^[0-9a-f]{64}$/.test(item.sha256))).toBe(true)
+      expect(relayed.every(item => item.runtimeSessionId === target.runtimeSessionId)).toBe(true)
+      expect(relayed.map(item => item.provenance)).toEqual([
+        { kind: 'composer', sourceId: 'file-1', occurrenceId: 'occ-file-1', authorizedAt: 1234 },
+        { kind: 'composer', sourceId: 'image-2', occurrenceId: 'occ-image-2', authorizedAt: 1234 }
+      ])
+      expect(JSON.stringify(relayed)).not.toContain('C:/private')
+      expect(relayDeps.revalidate).toHaveBeenCalledTimes(9)
+    } finally {
+      release()
+    }
+  })
+
+  it('rejects fabricated, inherited, revoked, and expired authorization before reads', async () => {
+    const real = attachment('file-real', 'real.txt')
+    const fabricated = Object.assign(Object.create(real), { id: real.id }) as ComposerAttachment
+    const relayDeps = deps({ 'file-real': new Uint8Array([1]) })
+    const release = authorizeTrustedForTest([real], { now: () => 1000, ttlMs: 30 })
+
+    await expect(relayTrustedForTest(target, [fabricated], relayDeps)).rejects.toThrow(/authorized composer attachment/i)
+    release()
+    await expect(relayTrustedForTest(target, [real], relayDeps)).rejects.toThrow(/authorized composer attachment/i)
+    const expired = authorizeTrustedForTest([real], { now: () => 1000, ttlMs: 30 })
+    relayDeps.now = () => 1031
+    await expect(relayTrustedForTest(target, [real], relayDeps)).rejects.toThrow(/authorized composer attachment/i)
+    expired()
+    expect(relayDeps.read).not.toHaveBeenCalled()
+    expect(relayDeps.stage).not.toHaveBeenCalled()
+  })
+
+  it('rechecks authorization after reading and immediately before staging', async () => {
+    const item = attachment('file-race', 'before.txt')
+    const relayDeps = deps({ 'file-race': new Uint8Array([1]) })
+    vi.mocked(relayDeps.read).mockImplementationOnce(async () => {
+      item.path = 'C:/private/changed-after-read.txt'
+      return { bytes: new Uint8Array([1]), mediaType: 'text/plain' }
+    })
+    const release = authorizeTrustedForTest([item])
+
+    try {
+      await expect(relayTrustedForTest(target, [item], relayDeps)).rejects.toThrow(/changed after authorization/i)
+      expect(relayDeps.stage).not.toHaveBeenCalled()
+    } finally {
+      release()
+    }
+  })
+
+  it('rechecks authorization after target validation immediately before reading bytes', async () => {
+    const item = attachment('file-before-read', 'before-read.txt')
+    const relayDeps = deps({ 'file-before-read': new Uint8Array([1]) })
+    const release = authorizeTrustedForTest([item])
+    let probes = 0
+    vi.mocked(relayDeps.revalidate).mockImplementation(async () => {
+      probes += 1
+      if (probes === 2) {
+        release()
+      }
+    })
+
+    await expect(relayTrustedForTest(target, [item], relayDeps)).rejects.toThrow(/authorized composer attachment/i)
+    expect(relayDeps.read).not.toHaveBeenCalled()
+    expect(relayDeps.stage).not.toHaveBeenCalled()
+  })
+
+  it('rechecks authorization after target validation immediately before staging bytes', async () => {
+    const item = attachment('file-before-stage', 'before-stage.txt')
+    const relayDeps = deps({ 'file-before-stage': new Uint8Array([1]) })
+    const release = authorizeTrustedForTest([item])
+    let probes = 0
+    vi.mocked(relayDeps.revalidate).mockImplementation(async () => {
+      probes += 1
+      if (probes === 4) {
+        release()
+      }
+    })
+
+    await expect(relayTrustedForTest(target, [item], relayDeps)).rejects.toThrow(/authorized composer attachment/i)
+    expect(relayDeps.read).toHaveBeenCalledTimes(1)
+    expect(relayDeps.stage).not.toHaveBeenCalled()
+  })
+
+  it('revalidates the exact target at every mutation boundary and stops before a stale second read', async () => {
+    const items = [attachment('file-a', 'a.txt'), attachment('file-b', 'b.txt')]
+    const relayDeps = deps({ 'file-a': new Uint8Array([1]), 'file-b': new Uint8Array([2]) })
+    let probes = 0
+    vi.mocked(relayDeps.revalidate).mockImplementation(async () => {
+      probes += 1
+      if (probes === 5) {
+        throw new Error('stale exact target')
+      }
+    })
+    const release = authorizeTrustedForTest(items)
+
+    try {
+      await expect(relayTrustedForTest(target, items, relayDeps)).rejects.toThrow(/stale exact target/i)
+      expect(relayDeps.read).toHaveBeenCalledTimes(1)
+      expect(relayDeps.stage).toHaveBeenCalledTimes(1)
+    } finally {
+      release()
+    }
+  })
+
+  it.each(['../escape', '..\\escape', 'C:stream', '\\\\server\\share', '/rooted', 'NUL', 'trailing.', 'trailing '])(
+    'rejects unsafe cross-platform name %s',
+    async label => {
+      const item = attachment('file-unsafe', label)
+      const relayDeps = deps({ 'file-unsafe': new Uint8Array([1]) })
+      const release = authorizeTrustedForTest([item])
+      try {
+        await expect(relayTrustedForTest(target, [item], relayDeps)).rejects.toThrow(/attachment name/i)
+        expect(relayDeps.stage).not.toHaveBeenCalled()
+      } finally {
+        release()
+      }
+    }
+  )
+
+  it('rejects unsafe media types, oversized bytes, and invalid byte payloads before staging', async () => {
+    const item = attachment('file-large', 'large.bin')
+    const relayDeps = deps({ 'file-large': new Uint8Array(1025) })
+    const release = authorizeTrustedForTest([item])
+    try {
+      await expect(relayTrustedForTest(target, [item], relayDeps)).rejects.toThrow(/size limit/i)
+      vi.mocked(relayDeps.read).mockResolvedValueOnce({ bytes: new Uint8Array([1]), mediaType: 'text/plain\r\nx-bad: 1' })
+      await expect(relayTrustedForTest(target, [item], relayDeps)).rejects.toThrow(/media type/i)
+      expect(relayDeps.stage).not.toHaveBeenCalled()
+    } finally {
+      release()
+    }
+  })
+
+  it.each([
+    ['name', { name: 'other.txt' }],
+    ['media type', { mediaType: 'application/json' }],
+    ['size', { bytes: 999 }],
+    ['hash', { sha256: '0'.repeat(64) }],
+    ['order', { order: 9 }],
+    ['stored name', { storedName: '../unsafe' }],
+    ['session', { runtimeSessionId: 'runtime-other' }]
+  ])('rejects target-side %s integrity mismatch', async (_field, mismatch) => {
+    const item = attachment('file-integrity', 'notes.txt')
+    const relayDeps = deps({ 'file-integrity': new TextEncoder().encode('hello') })
+    vi.mocked(relayDeps.stage).mockImplementationOnce(async (exactTarget, staged) => ({
+      attached: true,
+      bytes: staged.bytes.byteLength,
+      mediaType: staged.mediaType,
+      name: staged.name,
+      order: staged.order,
+      runtimeSessionId: exactTarget.runtimeSessionId,
+      sha256: staged.sha256,
+      storedName: staged.name,
+      ...mismatch
+    }))
+    const release = authorizeTrustedForTest([item])
+    try {
+      await expect(relayTrustedForTest(target, [item], relayDeps)).rejects.toThrow(/integrity/i)
+    } finally {
+      release()
+    }
+  })
+})

--- a/apps/desktop/src/app/chat/composer/attachment-relay.ts
+++ b/apps/desktop/src/app/chat/composer/attachment-relay.ts
@@ -1,0 +1,431 @@
+import type { ComposerAttachment } from '@/store/composer'
+
+const AUTHORIZATION_TTL_MS = 30_000
+const WINDOWS_RESERVED_NAME = /^(?:aux|con|nul|prn|com[1-9]|lpt[1-9])(?:\.|$)/i
+const SAFE_MEDIA_TYPE = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/i
+
+interface AttachmentGrant {
+  authorizedAt: number
+  changed: () => boolean
+  expiresAt: number
+  source: ComposerAttachment
+  sourceShape: AttachmentShape
+  shape: AttachmentShape
+}
+
+const authorized = new WeakMap<ComposerAttachment, AttachmentGrant>()
+
+interface AttachmentShape {
+  descriptors: Array<[PropertyKey, PropertyDescriptor]>
+  prototype: object | null
+}
+
+export interface HostComposerAttachmentAuthority {}
+
+interface HostComposerAttachmentAuthorityState {
+  shapes: WeakMap<ComposerAttachment, AttachmentShape>
+}
+
+const hostAuthorityStates = new WeakMap<HostComposerAttachmentAuthority, HostComposerAttachmentAuthorityState>()
+
+function captureAttachmentShape(attachment: ComposerAttachment): AttachmentShape | null {
+  if (Object.getPrototypeOf(attachment) !== Object.prototype) {
+    return null
+  }
+
+  return {
+    descriptors: Reflect.ownKeys(attachment).map(key => [key, Object.getOwnPropertyDescriptor(attachment, key)!]),
+    prototype: Object.getPrototypeOf(attachment)
+  }
+}
+
+function attachmentMatchesShape(attachment: ComposerAttachment, shape: AttachmentShape): boolean {
+  if (Object.getPrototypeOf(attachment) !== shape.prototype) {
+    return false
+  }
+
+  const keys = Reflect.ownKeys(attachment)
+  if (keys.length !== shape.descriptors.length || keys.some((key, index) => key !== shape.descriptors[index]?.[0])) {
+    return false
+  }
+
+  return shape.descriptors.every(([key, expected]) => {
+    const actual = Object.getOwnPropertyDescriptor(attachment, key)
+    if (!actual) {
+      return false
+    }
+    if (
+      actual.configurable !== expected.configurable ||
+      actual.enumerable !== expected.enumerable ||
+      ('writable' in actual && actual.writable !== expected.writable)
+    ) {
+      return false
+    }
+    if ('value' in expected) {
+      return 'value' in actual && Object.is(actual.value, expected.value)
+    }
+
+    return actual.get === expected.get && actual.set === expected.set
+  })
+}
+
+export function captureHostComposerAttachmentAuthority(
+  attachments: readonly ComposerAttachment[]
+): HostComposerAttachmentAuthority {
+  const shapes = new WeakMap<ComposerAttachment, AttachmentShape>()
+  for (const attachment of attachments) {
+    const shape = captureAttachmentShape(attachment)
+    if (shape) {
+      shapes.set(attachment, shape)
+    }
+  }
+
+  const authority = Object.freeze(Object.create(null)) as HostComposerAttachmentAuthority
+  hostAuthorityStates.set(authority, { shapes })
+
+  return authority
+}
+
+function assertAuthorized(attachment: ComposerAttachment, now: number): AttachmentGrant {
+  const grant = authorized.get(attachment)
+
+  if (!grant || now > grant.expiresAt) {
+    throw new Error('attachment is not an authorized composer attachment')
+  }
+
+  if (
+    grant.changed() ||
+    !attachmentMatchesShape(attachment, grant.shape) ||
+    !attachmentMatchesShape(grant.source, grant.sourceShape)
+  ) {
+    throw new Error('composer attachment changed after authorization')
+  }
+
+  return grant
+}
+
+function safeAttachmentName(label: string): string {
+  if (
+    !label ||
+    label.length > 255 ||
+    [...label].some(character => {
+      const code = character.charCodeAt(0)
+      return code < 32 || code === 127
+    }) ||
+    /[\\/:]/.test(label) ||
+    label === '.' ||
+    label === '..' ||
+    label.endsWith('.') ||
+    label.endsWith(' ') ||
+    WINDOWS_RESERVED_NAME.test(label)
+  ) {
+    throw new Error('invalid attachment name')
+  }
+
+  return label
+}
+
+function exactBytes(value: unknown): Uint8Array {
+  if (!ArrayBuffer.isView(value) || (value as { BYTES_PER_ELEMENT?: number }).BYTES_PER_ELEMENT !== 1) {
+    throw new Error('attachment reader did not return bytes')
+  }
+
+  const view = value as Uint8Array
+
+  return new Uint8Array(view.buffer, view.byteOffset, view.byteLength)
+}
+
+async function sha256(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new Uint8Array(bytes).buffer)
+
+  return [...new Uint8Array(digest)].map(value => value.toString(16).padStart(2, '0')).join('')
+}
+
+export interface RelayAttachmentTarget {
+  connectionId: string
+  profile: string
+  runtimeSessionId: string
+  storedSessionId: string
+  lineageRootId: string
+}
+
+export interface RelayStageInput {
+  bytes: Uint8Array
+  kind: 'file' | 'image'
+  mediaType: string
+  name: string
+  order: number
+  sha256: string
+}
+
+export interface RelayStageReceipt {
+  attached: boolean
+  bytes: number
+  mediaType: string
+  name: string
+  order: number
+  refText?: string
+  runtimeSessionId: string
+  sha256: string
+  storedName: string
+}
+
+export interface RelayedAttachment {
+  id: string
+  kind: 'file' | 'image'
+  mediaType: string
+  name: string
+  occurrenceId: null | string
+  order: number
+  provenance: {
+    authorizedAt: number
+    kind: 'composer'
+    occurrenceId: null | string
+    sourceId: string
+  }
+  refText?: string
+  runtimeSessionId: string
+  sha256: string
+  size: number
+  storedName: string
+}
+
+export interface RelayAttachmentDeps {
+  maxBytes: number
+  now: () => number
+  read: (attachment: ComposerAttachment) => Promise<{ bytes: Uint8Array; mediaType: string }>
+  revalidate: (target: RelayAttachmentTarget) => Promise<void>
+  stage: (target: RelayAttachmentTarget, input: RelayStageInput) => Promise<RelayStageReceipt>
+}
+
+const ATTACHMENT_KEYS = [
+  'id',
+  'occurrenceId',
+  'kind',
+  'label',
+  'detail',
+  'refText',
+  'previewUrl',
+  'thumbnailUrl',
+  'path',
+  'attachedSessionId',
+  'uploadState'
+] as const
+
+function copyAttachmentData(attachment: ComposerAttachment): ComposerAttachment {
+  const copy: Record<string, unknown> = {}
+  for (const key of ATTACHMENT_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(attachment, key)) {
+      copy[key] = attachment[key]
+    }
+  }
+
+  return copy as unknown as ComposerAttachment
+}
+
+function trackedAttachmentView(attachment: ComposerAttachment): {
+  changed: () => boolean
+  view: ComposerAttachment
+} {
+  let changed = false
+  const target = copyAttachmentData(attachment)
+  const mark = () => {
+    changed = true
+  }
+  let view: ComposerAttachment
+  view = new Proxy(target, {
+    defineProperty(current, key, descriptor) {
+      mark()
+      return Reflect.defineProperty(current, key, descriptor)
+    },
+    deleteProperty(current, key) {
+      mark()
+      return Reflect.deleteProperty(current, key)
+    },
+    preventExtensions(current) {
+      mark()
+      return Reflect.preventExtensions(current)
+    },
+    set(current, key, value, receiver) {
+      if (receiver === view) {
+        mark()
+      }
+      return Reflect.set(current, key, value, receiver)
+    },
+    setPrototypeOf(current, prototype) {
+      mark()
+      return Reflect.setPrototypeOf(current, prototype)
+    }
+  })
+
+  return { changed: () => changed, view }
+}
+
+export interface ComposerAttachmentAttempt {
+  attachments: ComposerAttachment[]
+  originForUnchangedView: (attachment: ComposerAttachment) => ComposerAttachment | null
+  release: () => void
+}
+
+export function createComposerAttachmentAttempt(
+  authority: HostComposerAttachmentAuthority,
+  attachments: readonly ComposerAttachment[],
+  origins: readonly (ComposerAttachment | null)[],
+  options: { now?: () => number; ttlMs?: number } = {}
+): ComposerAttachmentAttempt {
+  const authorityState = hostAuthorityStates.get(authority)
+  if (!authorityState || attachments.length !== origins.length) {
+    throw new Error('invalid host composer attachment authority')
+  }
+  const now = options.now ?? Date.now
+  const authorizedAt = now()
+  const expiresAt = authorizedAt + (options.ttlMs ?? AUTHORIZATION_TTL_MS)
+  const views: ComposerAttachment[] = []
+  const attemptOrigins = new WeakMap<ComposerAttachment, ComposerAttachment>()
+
+  for (const [index, attachment] of attachments.entries()) {
+    const tracked = trackedAttachmentView(attachment)
+    const origin = origins[index]
+    const sourceShape = origin ? authorityState.shapes.get(origin) : undefined
+    const viewShape = captureAttachmentShape(tracked.view)
+    if (origin && sourceShape && viewShape && attachmentMatchesShape(origin, sourceShape)) {
+      authorized.set(tracked.view, {
+        authorizedAt,
+        changed: tracked.changed,
+        expiresAt,
+        shape: viewShape,
+        source: origin,
+        sourceShape
+      })
+      attemptOrigins.set(tracked.view, origin)
+    }
+    views.push(tracked.view)
+  }
+
+  return {
+    attachments: views,
+    originForUnchangedView: attachment => {
+      const origin = attemptOrigins.get(attachment)
+      if (!origin) {
+        return null
+      }
+      try {
+        assertAuthorized(attachment, now())
+        return origin
+      } catch {
+        return null
+      }
+    },
+    release: () => {
+      for (const attachment of views) {
+        authorized.delete(attachment)
+      }
+    }
+  }
+}
+
+export function composerAttachmentsAreAuthorized(
+  attachments: readonly ComposerAttachment[],
+  now = Date.now()
+): boolean {
+  try {
+    for (const attachment of attachments) {
+      assertAuthorized(attachment, now)
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function relayComposerAttachments(
+  target: RelayAttachmentTarget,
+  attachments: readonly ComposerAttachment[],
+  deps: RelayAttachmentDeps
+): Promise<RelayedAttachment[]> {
+  await deps.revalidate(target)
+  const relayed: RelayedAttachment[] = []
+
+  for (const [order, attachment] of attachments.entries()) {
+    const grant = assertAuthorized(attachment, deps.now())
+    const source = grant.source
+
+    if (source.kind !== 'file' && source.kind !== 'image') {
+      throw new Error('unsupported composer attachment kind')
+    }
+
+    const name = safeAttachmentName(source.label)
+    await deps.revalidate(target)
+    assertAuthorized(attachment, deps.now())
+    const read = await deps.read(source)
+    assertAuthorized(attachment, deps.now())
+    await deps.revalidate(target)
+
+    const bytes = exactBytes(read.bytes)
+
+    if (!bytes.byteLength || bytes.byteLength > deps.maxBytes) {
+      throw new Error('attachment exceeds the size limit')
+    }
+    if (!SAFE_MEDIA_TYPE.test(read.mediaType)) {
+      throw new Error('invalid attachment media type')
+    }
+
+    const digest = await sha256(bytes)
+    assertAuthorized(attachment, deps.now())
+    await deps.revalidate(target)
+    assertAuthorized(attachment, deps.now())
+    const staged = await deps.stage(target, {
+      bytes,
+      kind: source.kind,
+      mediaType: read.mediaType,
+      name,
+      order,
+      sha256: digest
+    })
+    assertAuthorized(attachment, deps.now())
+    await deps.revalidate(target)
+
+    let storedName: string
+    try {
+      storedName = safeAttachmentName(staged.storedName)
+    } catch {
+      throw new Error('attachment relay integrity mismatch')
+    }
+
+    if (
+      staged.attached !== true ||
+      staged.bytes !== bytes.byteLength ||
+      staged.mediaType !== read.mediaType ||
+      staged.name !== name ||
+      staged.order !== order ||
+      staged.runtimeSessionId !== target.runtimeSessionId ||
+      staged.sha256 !== digest ||
+      storedName !== staged.storedName ||
+      (staged.refText !== undefined && !staged.refText.includes(storedName))
+    ) {
+      throw new Error('attachment relay integrity mismatch')
+    }
+
+    relayed.push({
+      id: source.id,
+      kind: source.kind,
+      mediaType: read.mediaType,
+      name,
+      occurrenceId: source.occurrenceId ?? null,
+      order,
+      provenance: {
+        authorizedAt: grant.authorizedAt,
+        kind: 'composer',
+        occurrenceId: source.occurrenceId ?? null,
+        sourceId: source.id
+      },
+      ...(staged.refText ? { refText: staged.refText } : {}),
+      runtimeSessionId: target.runtimeSessionId,
+      sha256: digest,
+      size: bytes.byteLength,
+      storedName
+    })
+  }
+
+  return relayed
+}

--- a/apps/desktop/src/app/chat/composer/contrib.test.ts
+++ b/apps/desktop/src/app/chat/composer/contrib.test.ts
@@ -1,8 +1,10 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { registry } from '@/contrib/registry'
+import type { ComposerAttachment } from '@/store/composer'
 
-import { COMPOSER_AREAS, type ComposerMiddleware, runComposerMiddleware } from './contrib'
+import { composerAttachmentsAreAuthorized } from './attachment-relay'
+import { COMPOSER_AREAS, type ComposerDraft, type ComposerMiddleware, runComposerMiddleware } from './contrib'
 
 const disposers: Array<() => void> = []
 
@@ -11,6 +13,14 @@ function addMiddleware(id: string, handler: ComposerMiddleware['handler'], order
     registry.register({ id, area: COMPOSER_AREAS.middleware, order, data: { handler } satisfies ComposerMiddleware })
   )
 }
+
+const hostAttachment = (): ComposerAttachment => ({
+  id: 'host-file',
+  occurrenceId: 'host-occurrence',
+  kind: 'file',
+  label: 'host.txt',
+  path: 'C:/trusted/host.txt'
+})
 
 afterEach(() => {
   disposers.splice(0).forEach(d => d())
@@ -46,9 +56,449 @@ describe('runComposerMiddleware', () => {
     expect(await runComposerMiddleware({ text: 'x' })).toEqual({ text: 'x!' })
   })
 
+  it('never exposes authoritative state and discards irreversible throwing attempts', async () => {
+    const first = hostAttachment()
+    const second: ComposerAttachment = {
+      id: 'host-image',
+      occurrenceId: 'host-image-occurrence',
+      kind: 'image',
+      label: 'host.png',
+      detail: 'image metadata',
+      path: 'C:/trusted/host.png'
+    }
+    const attachments = [first, second]
+    const draft = { text: 'exact text', attachments }
+    let firstAttempt: { attachments: ComposerAttachment[]; draft: object; first: ComposerAttachment } | undefined
+    let observed: unknown
+    const later = vi.fn((next: typeof draft) => {
+      const nextAttachments = next.attachments
+      observed = {
+        authoritativeArrayExposed: nextAttachments === attachments,
+        authoritativeDraftExposed: next === draft,
+        authoritativeFirstExposed: nextAttachments[0] === first,
+        authorized: composerAttachmentsAreAuthorized(nextAttachments),
+        firstAttemptArrayReused: nextAttachments === firstAttempt?.attachments,
+        firstAttemptDraftReused: next === firstAttempt?.draft,
+        firstAttemptObjectReused: nextAttachments[0] === firstAttempt?.first,
+        attachments: nextAttachments.map(item => ({ ...item })),
+        text: next.text
+      }
+      return next
+    })
+
+    addMiddleware('mutate-then-throw', current => {
+      firstAttempt = {
+        attachments: current.attachments!,
+        draft: current,
+        first: current.attachments![0]!
+      }
+      current.text = 'corrupted'
+      current.attachments!.reverse()
+      current.attachments!.push({ ...first, id: 'fabricated' })
+      Object.defineProperty(current.attachments![1]!, 'label', {
+        configurable: false,
+        enumerable: true,
+        value: 'locked-mutation.txt',
+        writable: false
+      })
+      Object.freeze(current.attachments![1]!)
+      Object.setPrototypeOf(current.attachments![0]!, { poisoned: true })
+      Object.preventExtensions(current.attachments![0]!)
+      Object.seal(current.attachments!)
+      ;(current as typeof draft & { injected?: string }).injected = 'bad'
+      Object.setPrototypeOf(current, { poisoned: true })
+      Object.freeze(current)
+      throw new Error('restore this attempt')
+    })
+    addMiddleware('later', later as ComposerMiddleware['handler'])
+
+    const result = await runComposerMiddleware(draft)
+
+    expect(later).toHaveBeenCalledOnce()
+    expect(observed).toEqual({
+      authoritativeArrayExposed: false,
+      authoritativeDraftExposed: false,
+      authoritativeFirstExposed: false,
+      authorized: true,
+      firstAttemptArrayReused: false,
+      firstAttemptDraftReused: false,
+      firstAttemptObjectReused: false,
+      attachments: [hostAttachment(), second],
+      text: 'exact text'
+    })
+    expect(result).toEqual(draft)
+    expect(draft).toEqual({ text: 'exact text', attachments: [first, second] })
+    expect(Object.isExtensible(draft)).toBe(true)
+    expect(Object.isExtensible(attachments)).toBe(true)
+    expect(Object.isExtensible(first)).toBe(true)
+    expect(Object.getPrototypeOf(draft)).toBe(Object.prototype)
+    expect(Object.getPrototypeOf(first)).toBe(Object.prototype)
+  })
+
+  it('adopts valid attempt-local mutation into a fresh later attempt', async () => {
+    const original = hostAttachment()
+    const draft = { text: 'original', attachments: [original] }
+    let firstAttempt: ComposerDraft | undefined
+    let laterObserved: unknown
+
+    addMiddleware('mutate-valid-view', current => {
+      firstAttempt = current
+      current.text = 'adopted'
+      return current
+    })
+    addMiddleware('observe-adopted-copy', current => {
+      laterObserved = {
+        authorized: composerAttachmentsAreAuthorized(current.attachments ?? []),
+        draftReused: current === firstAttempt,
+        originalArrayExposed: current.attachments === draft.attachments,
+        originalObjectExposed: current.attachments?.[0] === original,
+        text: current.text
+      }
+      return current
+    })
+
+    const result = await runComposerMiddleware(draft)
+
+    expect(laterObserved).toEqual({
+      authorized: true,
+      draftReused: false,
+      originalArrayExposed: false,
+      originalObjectExposed: false,
+      text: 'adopted'
+    })
+    expect(result).toEqual({ text: 'adopted', attachments: [original] })
+    expect(draft.text).toBe('original')
+  })
+
   it('supports async handlers', async () => {
     addMiddleware('async', async d => ({ ...d, text: d.text.toUpperCase() }))
 
     expect(await runComposerMiddleware({ text: 'quiet' })).toEqual({ text: 'QUIET' })
+  })
+
+  it('supports additive pass dispositions without changing legacy draft results', async () => {
+    addMiddleware('pass', d => ({ disposition: 'pass', draft: { ...d, text: `${d.text}!` } }))
+    addMiddleware('legacy', d => ({ ...d, text: `${d.text}?` }))
+
+    expect(await runComposerMiddleware({ text: 'hello' })).toEqual({ text: 'hello!?' })
+  })
+
+  it.each([
+    [
+      'text accessor',
+      (_draft: ComposerDraft, reads: () => void) => {
+        const nested = { attachments: [] as ComposerAttachment[] } as Record<string, unknown>
+        Object.defineProperty(nested, 'text', {
+          enumerable: true,
+          get: () => {
+            reads()
+            return 'getter text'
+          }
+        })
+        return nested
+      }
+    ],
+    ['inherited text', () => Object.assign(Object.create({ text: 'inherited' }), { attachments: [] })],
+    ['symbol key', () => ({ text: 'symbol', [Symbol('extra')]: true })],
+    ['extra key', () => ({ text: 'extra', extra: true })],
+    ['missing text', () => ({ attachments: [] })],
+    ['wrong text type', () => ({ text: 42 })],
+    [
+      'attachments accessor',
+      (_draft: ComposerDraft, reads: () => void) => {
+        const nested = { text: 'getter attachments' } as Record<string, unknown>
+        Object.defineProperty(nested, 'attachments', {
+          enumerable: true,
+          get: () => {
+            reads()
+            return []
+          }
+        })
+        return nested
+      }
+    ],
+    ['non-array attachments', () => ({ text: 'object attachments', attachments: {} })],
+    [
+      'sparse attachments',
+      () => {
+        const attachments = new Array<ComposerAttachment>(1)
+        return { text: 'sparse', attachments }
+      }
+    ],
+    [
+      'exotic array prototype',
+      (draft: ComposerDraft) => {
+        const attachments = [...(draft.attachments ?? [])]
+        Object.setPrototypeOf(attachments, { poisoned: true })
+        return { text: 'exotic', attachments }
+      }
+    ],
+    [
+      'array extra key',
+      (draft: ComposerDraft) => {
+        const attachments = [...(draft.attachments ?? [])] as ComposerAttachment[] & { extra?: boolean }
+        attachments.extra = true
+        return { text: 'array extra', attachments }
+      }
+    ],
+    [
+      'hostile attachment getter',
+      (_draft: ComposerDraft, reads: () => void) => {
+        const item = { id: 'hostile', kind: 'file' } as Record<string, unknown>
+        Object.defineProperty(item, 'label', {
+          enumerable: true,
+          get: () => {
+            reads()
+            return 'hostile.txt'
+          }
+        })
+        return { text: 'hostile attachment', attachments: [item] }
+      }
+    ],
+    [
+      'inherited attachment semantics',
+      (draft: ComposerDraft) => ({
+        text: 'inherited attachment',
+        attachments: [Object.create(draft.attachments?.[0] ?? null)]
+      })
+    ],
+    [
+      'attachment symbol key',
+      (draft: ComposerDraft) => ({
+        text: 'attachment symbol',
+        attachments: [{ ...(draft.attachments?.[0] ?? hostAttachment()), [Symbol('extra')]: true }]
+      })
+    ],
+    [
+      'attachment extra key',
+      (draft: ComposerDraft) => ({
+        text: 'attachment extra',
+        attachments: [{ ...(draft.attachments?.[0] ?? hostAttachment()), extra: true }]
+      })
+    ],
+    ['missing attachment id', () => ({ text: 'missing id', attachments: [{ kind: 'file', label: 'x.txt' }] })],
+    ['wrong attachment kind', () => ({ text: 'wrong kind', attachments: [{ id: 'x', kind: 7, label: 'x.txt' }] })],
+    [
+      'copied arbitrary path attachment',
+      (draft: ComposerDraft) => ({ text: 'copied path', attachments: [{ ...draft.attachments?.[0] }] })
+    ],
+    [
+      'changed authoritative view path',
+      (draft: ComposerDraft) => {
+        const item = draft.attachments![0]!
+        item.path = 'C:/arbitrary/replaced.txt'
+        return { text: 'changed path', attachments: [item] }
+      }
+    ]
+  ] as Array<[
+    string,
+    (draft: ComposerDraft, reads: () => void) => unknown
+  ]>)('discards invalid nested pass draft: %s', async (_name, build) => {
+    const reads = vi.fn()
+    const later = vi.fn((draft: ComposerDraft) => ({ ...draft, text: `${draft.text} safe` }))
+    addMiddleware('invalid-pass', draft => ({
+      disposition: 'pass',
+      draft: build(draft, reads) as ComposerDraft
+    }))
+    addMiddleware('later', later)
+
+    const result = await runComposerMiddleware({ text: 'original', attachments: [hostAttachment()] })
+
+    expect(result).toEqual({ text: 'original safe', attachments: [hostAttachment()] })
+    expect(reads).not.toHaveBeenCalled()
+    expect(later).toHaveBeenCalledOnce()
+  })
+
+  it('adopts one closed valid nested pass draft and preserves exact-view relay provenance', async () => {
+    let authorized = false
+    addMiddleware('valid-pass', draft => ({
+      disposition: 'pass',
+      draft: { text: 'valid pass', attachments: [...(draft.attachments ?? [])] }
+    }))
+    addMiddleware('later', draft => {
+      authorized = composerAttachmentsAreAuthorized(draft.attachments ?? [])
+      return draft
+    })
+
+    const result = await runComposerMiddleware({ text: 'original', attachments: [hostAttachment()] })
+
+    expect(result).toEqual({ text: 'valid pass', attachments: [hostAttachment()] })
+    expect(authorized).toBe(true)
+  })
+
+  it('adopts a closed null-prototype pass draft with a safe pathless replacement attachment', async () => {
+    let authorized = true
+    addMiddleware('valid-null-pass', () => {
+      const attachment = Object.assign(Object.create(null), {
+        id: 'url-1',
+        kind: 'url',
+        label: 'Reference',
+        refText: 'https://example.test/reference'
+      }) as ComposerAttachment
+      return {
+        disposition: 'pass',
+        draft: Object.assign(Object.create(null), { text: 'null prototype', attachments: [attachment] })
+      }
+    })
+    addMiddleware('observe-pathless-replacement', draft => {
+      authorized = composerAttachmentsAreAuthorized(draft.attachments ?? [])
+      return draft
+    })
+
+    const result = await runComposerMiddleware({ text: 'original', attachments: [hostAttachment()] })
+
+    expect(result).toEqual({
+      text: 'null prototype',
+      attachments: [{ id: 'url-1', kind: 'url', label: 'Reference', refText: 'https://example.test/reference' }]
+    })
+    expect(authorized).toBe(false)
+  })
+
+  it('authorizes only unchanged attachments originating at the initial host boundary', async () => {
+    const original = hostAttachment()
+    const fabricated = { ...original, path: 'C:/arbitrary/forged.txt' }
+    const inherited = Object.assign(Object.create(original), { id: original.id }) as ComposerAttachment
+    const seen: boolean[][] = []
+
+    addMiddleware('replace-with-fabricated', draft => ({ ...draft, attachments: [fabricated, inherited] }))
+    addMiddleware('observe-forgeries', draft => {
+      seen.push([
+        composerAttachmentsAreAuthorized([original]),
+        composerAttachmentsAreAuthorized([fabricated]),
+        composerAttachmentsAreAuthorized([inherited])
+      ])
+      return { ...draft, attachments: [original] }
+    })
+    addMiddleware('observe-restored-host', draft => {
+      seen.push([composerAttachmentsAreAuthorized(draft.attachments ?? [])])
+      return draft
+    })
+
+    const result = await runComposerMiddleware({ text: 'host', attachments: [original] })
+
+    expect(seen).toEqual([[false, false, false], [true]])
+    expect(result).toMatchObject({ attachments: [original] })
+  })
+
+  it('keeps host provenance private from copied, deserialized, derived, fabricated, and changed views', async () => {
+    const statuses: boolean[][] = []
+    addMiddleware('probe-private-provenance', draft => {
+      const exact = draft.attachments![0]!
+      const copied = { ...exact }
+      const deserialized = JSON.parse(JSON.stringify(exact)) as ComposerAttachment
+      const derived = Object.assign(Object.create(exact), { id: exact.id }) as ComposerAttachment
+      const fabricated = { id: 'fabricated', kind: 'file' as const, label: 'fake.txt', path: 'C:/arbitrary/fake.txt' }
+      statuses.push([
+        composerAttachmentsAreAuthorized([exact]),
+        composerAttachmentsAreAuthorized([copied]),
+        composerAttachmentsAreAuthorized([deserialized]),
+        composerAttachmentsAreAuthorized([derived]),
+        composerAttachmentsAreAuthorized([fabricated])
+      ])
+      exact.label = 'changed.txt'
+      statuses.push([composerAttachmentsAreAuthorized([exact])])
+      throw new Error('discard changed attempt')
+    })
+    addMiddleware('fresh-attempt', draft => {
+      statuses.push([composerAttachmentsAreAuthorized(draft.attachments ?? [])])
+      return draft
+    })
+
+    const result = await runComposerMiddleware({ text: 'original', attachments: [hostAttachment()] })
+
+    expect(statuses).toEqual([[true, false, false, false, false], [false], [true]])
+    expect(result).toEqual({ text: 'original', attachments: [hostAttachment()] })
+  })
+
+  it('allows attachment removal without minting authority for replacement objects', async () => {
+    const original = hostAttachment()
+    const copied = { ...original }
+    const seen: boolean[] = []
+
+    addMiddleware('remove', draft => ({ ...draft, attachments: [] }))
+    addMiddleware('observe-removal', draft => {
+      seen.push(composerAttachmentsAreAuthorized(draft.attachments ?? []))
+      seen.push(composerAttachmentsAreAuthorized([copied]))
+      return { ...draft, attachments: [copied] }
+    })
+    addMiddleware('observe-copy', draft => {
+      seen.push(composerAttachmentsAreAuthorized(draft.attachments ?? []))
+      return draft
+    })
+
+    await runComposerMiddleware({ text: 'host', attachments: [original] })
+
+    expect(seen).toEqual([true, false, true])
+  })
+
+  it('returns a rejected draft and prevents later middleware', async () => {
+    const later = vi.fn((d: { text: string }) => d)
+    addMiddleware('reject', () => ({ disposition: 'reject', reason: 'not accepted' }))
+    addMiddleware('later', later, 99)
+
+    expect(await runComposerMiddleware({ text: 'keep exactly' })).toEqual({
+      disposition: 'reject',
+      draft: { text: 'keep exactly' },
+      reason: 'not accepted'
+    })
+    expect(later).not.toHaveBeenCalled()
+  })
+
+  it('returns consume and prevents later middleware after a successful side-effect', async () => {
+    const later = vi.fn((d: { text: string }) => d)
+    addMiddleware('consume', () => ({ disposition: 'consume', receipt: { state: 'durably_accepted' } }))
+    addMiddleware('later', later, 99)
+
+    expect(await runComposerMiddleware({ text: 'send once' })).toEqual({
+      disposition: 'consume',
+      receipt: { state: 'durably_accepted' }
+    })
+    expect(later).not.toHaveBeenCalled()
+  })
+
+  it('isolates exceptions as pass-through and rejects inherited disposition values', async () => {
+    addMiddleware('boom', () => {
+      throw new Error('plugin failed')
+    })
+    addMiddleware(
+      'poisoned',
+      () => Object.create({ disposition: 'consume' }) as unknown as ReturnType<ComposerMiddleware['handler']>
+    )
+    addMiddleware('after', d => ({ ...d, text: `${d.text} safe` }))
+
+    expect(await runComposerMiddleware({ text: 'still' })).toEqual({ text: 'still safe' })
+  })
+
+  it('recognizes dispositions only from closed own data-property shapes without invoking getters', async () => {
+    let getterCalls = 0
+    const hostileGetter = Object.create(null) as Record<string, unknown>
+    Object.defineProperty(hostileGetter, 'disposition', {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1
+        return 'consume'
+      }
+    })
+    const polluted = Object.assign(Object.create({ polluted: true }), { disposition: 'consume' })
+    const later = vi.fn((draft: { text: string }) => ({ ...draft, text: `${draft.text} safe` }))
+
+    addMiddleware('getter', () => hostileGetter as unknown as ReturnType<ComposerMiddleware['handler']>)
+    addMiddleware('extra', () => ({ disposition: 'consume', extra: true }) as ReturnType<ComposerMiddleware['handler']>)
+    addMiddleware('polluted', () => polluted as ReturnType<ComposerMiddleware['handler']>)
+    addMiddleware('later', later)
+
+    expect(await runComposerMiddleware({ text: 'still' })).toEqual({ text: 'still safe' })
+    expect(getterCalls).toBe(0)
+    expect(later).toHaveBeenCalledOnce()
+  })
+
+  it('preserves a legacy replacement draft with an inherited disposition property', async () => {
+    const replacement = Object.assign(Object.create({ disposition: 'consume' }), { text: 'legacy replacement' })
+    addMiddleware('legacy-inherited', () => replacement)
+
+    const result = await runComposerMiddleware({ text: 'original' })
+
+    expect(result).toEqual({ text: 'legacy replacement' })
+    expect((result as { text: string }).text).toBe('legacy replacement')
   })
 })

--- a/apps/desktop/src/app/chat/composer/contrib.ts
+++ b/apps/desktop/src/app/chat/composer/contrib.ts
@@ -28,6 +28,12 @@ import type { TodoItem } from '@/lib/todos'
 import type { ComposerAttachment } from '@/store/composer'
 import type { ComposerAction } from '@/store/composer-actions'
 
+import {
+  captureHostComposerAttachmentAuthority,
+  type ComposerAttachmentAttempt,
+  createComposerAttachmentAttempt
+} from './attachment-relay'
+
 export const COMPOSER_AREAS = {
   top: 'composer.top',
   bottom: 'composer.bottom',
@@ -45,10 +51,290 @@ export interface ComposerDraft {
   attachments?: ComposerAttachment[]
 }
 
+export interface ComposerPassDisposition {
+  disposition: 'pass'
+  draft?: ComposerDraft
+}
+
+export interface ComposerRejectDisposition {
+  disposition: 'reject'
+  reason?: string
+}
+
+export interface ComposerConsumeDisposition {
+  disposition: 'consume'
+  receipt?: unknown
+}
+
+export type ComposerDisposition = ComposerConsumeDisposition | ComposerPassDisposition | ComposerRejectDisposition
+export type ComposerMiddlewareResult = ComposerDisposition | ComposerDraft | null
+export type ComposerRunResult =
+  | ComposerDraft
+  | null
+  | (ComposerRejectDisposition & { draft: ComposerDraft })
+  | ComposerConsumeDisposition
+
+function closedDataDescriptors(value: unknown): null | Record<PropertyKey, PropertyDescriptor> {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  let prototype: object | null
+  let descriptors: Record<PropertyKey, PropertyDescriptor>
+  try {
+    prototype = Object.getPrototypeOf(value)
+    descriptors = Object.getOwnPropertyDescriptors(value) as Record<PropertyKey, PropertyDescriptor>
+  } catch {
+    return null
+  }
+  if (prototype !== null && prototype !== Object.prototype) {
+    return null
+  }
+  if (Reflect.ownKeys(descriptors).some(key => !('value' in descriptors[key]!))) {
+    return null
+  }
+
+  return descriptors
+}
+
+function closedComposerDisposition(value: unknown): ComposerDisposition | null {
+  const descriptors = closedDataDescriptors(value)
+  const kind = descriptors?.disposition?.value
+  if (!descriptors || (kind !== 'pass' && kind !== 'reject' && kind !== 'consume')) {
+    return null
+  }
+
+  const allowed = kind === 'pass' ? ['disposition', 'draft'] : kind === 'reject' ? ['disposition', 'reason'] : ['disposition', 'receipt']
+  const required = ['disposition']
+  const keys = Reflect.ownKeys(descriptors)
+  if (
+    required.some(key => !Object.prototype.hasOwnProperty.call(descriptors, key)) ||
+    keys.some(key => typeof key !== 'string' || !allowed.includes(key))
+  ) {
+    return null
+  }
+  if (kind === 'pass' && descriptors.draft && (!descriptors.draft.value || typeof descriptors.draft.value !== 'object')) {
+    return null
+  }
+  if (kind === 'reject' && descriptors.reason && typeof descriptors.reason.value !== 'string') {
+    return null
+  }
+
+  return value as ComposerDisposition
+}
+
+export function isComposerTerminalRunResult(
+  value: ComposerRunResult
+): value is ComposerConsumeDisposition | (ComposerRejectDisposition & { draft: ComposerDraft }) {
+  const descriptors = closedDataDescriptors(value)
+  const kind = descriptors?.disposition?.value
+  if (!descriptors || (kind !== 'consume' && kind !== 'reject')) {
+    return false
+  }
+  const allowed = kind === 'consume' ? ['disposition', 'receipt'] : ['disposition', 'draft', 'reason']
+  const keys = Reflect.ownKeys(descriptors)
+  return (
+    keys.every(key => typeof key === 'string' && allowed.includes(key)) &&
+    Object.prototype.hasOwnProperty.call(descriptors, 'disposition') &&
+    (kind !== 'reject' || Object.prototype.hasOwnProperty.call(descriptors, 'draft'))
+  )
+}
+
 /** Payload of a `composer.middleware` data contribution. */
 export interface ComposerMiddleware {
-  /** Rewrite (return a draft), pass through (same draft), or cancel (null). */
-  handler: (draft: ComposerDraft) => ComposerDraft | null | Promise<ComposerDraft | null>
+  /** Legacy draft/null results remain exact; dispositions add pass/reject/consume. */
+  handler: (draft: ComposerDraft) => ComposerMiddlewareResult | Promise<ComposerMiddlewareResult>
+}
+
+interface AuthoritativeComposerAttachment {
+  data: ComposerAttachment
+  origin: ComposerAttachment | null
+}
+
+interface AuthoritativeComposerDraft {
+  attachments?: AuthoritativeComposerAttachment[]
+  text: string
+}
+
+const COMPOSER_ATTACHMENT_KEYS = [
+  'id',
+  'occurrenceId',
+  'kind',
+  'label',
+  'detail',
+  'refText',
+  'previewUrl',
+  'thumbnailUrl',
+  'path',
+  'attachedSessionId',
+  'uploadState'
+] as const
+const COMPOSER_ATTACHMENT_KINDS = new Set(['file', 'folder', 'image', 'review', 'terminal', 'url'])
+const COMPOSER_DRAFT_KEYS = new Set(['text', 'attachments'])
+
+function copyAttachment(attachment: ComposerAttachment): ComposerAttachment {
+  return { ...attachment }
+}
+
+function materializeDraft(draft: AuthoritativeComposerDraft): ComposerDraft {
+  return {
+    text: draft.text,
+    ...(draft.attachments ? { attachments: draft.attachments.map(item => copyAttachment(item.data)) } : {})
+  }
+}
+
+function denseAttachmentArray(value: unknown): unknown[] | null {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) {
+    return null
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(value) as unknown as Record<PropertyKey, PropertyDescriptor>
+  const length = descriptors.length?.value
+  if (!Number.isSafeInteger(length) || length < 0) {
+    return null
+  }
+  const keys = Reflect.ownKeys(descriptors)
+  if (
+    keys.length !== length + 1 ||
+    keys.some(key => key !== 'length' && (typeof key !== 'string' || !/^\d+$/.test(key) || Number(key) >= length))
+  ) {
+    return null
+  }
+  const items: unknown[] = []
+  for (let index = 0; index < length; index += 1) {
+    const descriptor = descriptors[String(index)]
+    if (!descriptor || !('value' in descriptor)) {
+      return null
+    }
+    items.push(descriptor.value)
+  }
+
+  return items
+}
+
+function safeInheritedDispositionPrototype(value: object): boolean {
+  let prototype: object | null
+  try {
+    prototype = Object.getPrototypeOf(value)
+  } catch {
+    return false
+  }
+  if (!prototype) {
+    return false
+  }
+  const parent = Object.getPrototypeOf(prototype)
+  if (parent !== Object.prototype && parent !== null) {
+    return false
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(prototype) as Record<PropertyKey, PropertyDescriptor>
+  const keys = Reflect.ownKeys(descriptors)
+  return keys.length === 1 && keys[0] === 'disposition' && 'value' in descriptors.disposition!
+}
+
+function validatedAttachment(
+  value: unknown,
+  attempt: ComposerAttachmentAttempt
+): AuthoritativeComposerAttachment | null {
+  const descriptors = closedDataDescriptors(value)
+  if (!descriptors) {
+    return null
+  }
+  const keys = Reflect.ownKeys(descriptors)
+  if (
+    keys.some(
+      key =>
+        typeof key !== 'string' ||
+        !COMPOSER_ATTACHMENT_KEYS.includes(key as (typeof COMPOSER_ATTACHMENT_KEYS)[number])
+    ) ||
+    !Object.prototype.hasOwnProperty.call(descriptors, 'id') ||
+    !Object.prototype.hasOwnProperty.call(descriptors, 'kind') ||
+    !Object.prototype.hasOwnProperty.call(descriptors, 'label')
+  ) {
+    return null
+  }
+  if (
+    typeof descriptors.id!.value !== 'string' ||
+    !descriptors.id!.value ||
+    typeof descriptors.label!.value !== 'string' ||
+    !descriptors.label!.value ||
+    typeof descriptors.kind!.value !== 'string' ||
+    !COMPOSER_ATTACHMENT_KINDS.has(descriptors.kind!.value)
+  ) {
+    return null
+  }
+  for (const key of COMPOSER_ATTACHMENT_KEYS) {
+    if (!descriptors[key] || key === 'id' || key === 'kind' || key === 'label') {
+      continue
+    }
+    const field = descriptors[key]!.value
+    if (typeof field !== 'string' || (key === 'uploadState' && field !== 'uploading' && field !== 'error')) {
+      return null
+    }
+  }
+  const origin = attempt.originForUnchangedView(value as ComposerAttachment)
+  if (descriptors.path && !origin) {
+    return null
+  }
+  const data: Record<string, unknown> = {}
+  for (const key of COMPOSER_ATTACHMENT_KEYS) {
+    if (descriptors[key]) {
+      data[key] = descriptors[key]!.value
+    }
+  }
+
+  return { data: data as unknown as ComposerAttachment, origin }
+}
+
+function adoptDraft(
+  value: unknown,
+  attempt: ComposerAttachmentAttempt,
+  options: { allowInheritedDisposition?: boolean } = {}
+): AuthoritativeComposerDraft | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  let prototype: object | null
+  let descriptors: Record<PropertyKey, PropertyDescriptor>
+  try {
+    prototype = Object.getPrototypeOf(value)
+    descriptors = Object.getOwnPropertyDescriptors(value) as Record<PropertyKey, PropertyDescriptor>
+  } catch {
+    return null
+  }
+  if (
+    prototype !== null &&
+    prototype !== Object.prototype &&
+    !(options.allowInheritedDisposition && safeInheritedDispositionPrototype(value))
+  ) {
+    return null
+  }
+  const keys = Reflect.ownKeys(descriptors)
+  if (
+    keys.some(key => typeof key !== 'string' || !COMPOSER_DRAFT_KEYS.has(key)) ||
+    keys.some(key => !('value' in descriptors[key]!)) ||
+    !Object.prototype.hasOwnProperty.call(descriptors, 'text') ||
+    typeof descriptors.text!.value !== 'string'
+  ) {
+    return null
+  }
+  let attachments: AuthoritativeComposerAttachment[] | undefined
+  if (descriptors.attachments) {
+    const items = denseAttachmentArray(descriptors.attachments.value)
+    if (!items) {
+      return null
+    }
+    attachments = []
+    for (const item of items) {
+      const attachment = validatedAttachment(item, attempt)
+      if (!attachment) {
+        return null
+      }
+      attachments.push(attachment)
+    }
+  }
+
+  return {
+    text: descriptors.text.value,
+    ...(attachments ? { attachments } : {})
+  }
 }
 
 /** One row a `composer.atCompletions` source offers for the current query. */
@@ -91,8 +377,16 @@ export interface ComposerAttachmentProvider {
  * and cancels the send. A throwing handler is treated as pass-through so a
  * broken plugin can't eat messages.
  */
-export async function runComposerMiddleware(draft: ComposerDraft): Promise<ComposerDraft | null> {
-  let current = draft
+export async function runComposerMiddleware(draft: ComposerDraft): Promise<ComposerRunResult> {
+  const hostAttachments = draft.attachments ?? []
+  const hostAttachmentAuthority = captureHostComposerAttachmentAuthority(hostAttachments)
+  let current: AuthoritativeComposerDraft = {
+    text: draft.text,
+    ...(draft.attachments
+      ? { attachments: hostAttachments.map(attachment => ({ data: attachment, origin: attachment })) }
+      : {})
+  }
+  let invoked = false
 
   for (const contribution of registry.getArea(COMPOSER_AREAS.middleware)) {
     const middleware = contribution.data as ComposerMiddleware | undefined
@@ -101,20 +395,77 @@ export async function runComposerMiddleware(draft: ComposerDraft): Promise<Compo
       continue
     }
 
+    invoked = true
+    const authoritativeAttachments = current.attachments ?? []
+    const attachmentAttempt = createComposerAttachmentAttempt(
+      hostAttachmentAuthority,
+      authoritativeAttachments.map(item => item.data),
+      authoritativeAttachments.map(item => item.origin)
+    )
+    const attemptDraft: ComposerDraft = {
+      text: current.text,
+      ...(current.attachments ? { attachments: attachmentAttempt.attachments } : {})
+    }
+
     try {
-      const next = await middleware.handler(current)
+      const next = await middleware.handler(attemptDraft)
 
       if (next === null) {
         return null
       }
 
-      current = next
+      if (typeof next !== 'object') {
+        continue
+      }
+
+      const disposition = closedComposerDisposition(next)
+      if (disposition) {
+
+        if (disposition.disposition === 'pass') {
+          const nextDraft = Object.getOwnPropertyDescriptor(disposition, 'draft')?.value as ComposerDraft | undefined
+          if (nextDraft) {
+            const adopted = adoptDraft(nextDraft, attachmentAttempt)
+            if (adopted) {
+              current = adopted
+            }
+          }
+          continue
+        }
+
+        if (disposition.disposition === 'reject') {
+          return {
+            disposition: 'reject',
+            draft: materializeDraft(current),
+            ...(typeof Object.getOwnPropertyDescriptor(disposition, 'reason')?.value === 'string'
+              ? { reason: Object.getOwnPropertyDescriptor(disposition, 'reason')!.value as string }
+              : {})
+          }
+        }
+
+        if (disposition.disposition === 'consume') {
+          return {
+            disposition: 'consume',
+            ...(Object.prototype.hasOwnProperty.call(disposition, 'receipt')
+              ? { receipt: Object.getOwnPropertyDescriptor(disposition, 'receipt')!.value }
+              : {})
+          }
+        }
+
+        continue
+      }
+
+      const adopted = adoptDraft(next, attachmentAttempt, { allowInheritedDisposition: true })
+      if (adopted) {
+        current = adopted
+      }
     } catch {
-      // Pass-through: a faulty middleware must never swallow the message.
+      // Attempt-local objects are discarded; authoritative state was never exposed.
+    } finally {
+      attachmentAttempt.release()
     }
   }
 
-  return current
+  return invoked ? materializeDraft(current) : draft
 }
 
 /** Attach-menu entries contributed by plugins/core, with stable render keys. */

--- a/apps/desktop/src/app/chat/composer/direct-draft.test.ts
+++ b/apps/desktop/src/app/chat/composer/direct-draft.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { createDirectDraftAdmission, directDraftIsValid } from './direct-draft'
+
+describe('exact direct draft admission', () => {
+  it('matches the gateway canonical UTF-8 digest for exact Unicode and whitespace', async () => {
+    const admission = await createDirectDraftAdmission({ text: '  Unicode Ω\nsecond line  ', attachments: [] })
+
+    expect(admission).toEqual({
+      attachmentManifest: [],
+      contextText: '  Unicode Ω\nsecond line  ',
+      payloadDigest: '95219f53e0234f302ac3a97eae0aa7d1d28f78096e0a15cfbcaae626b6f9d15c',
+      sourceText: '  Unicode Ω\nsecond line  '
+    })
+  })
+
+  it('binds every ordered relayed attachment integrity field without paths', async () => {
+    const admission = await createDirectDraftAdmission({
+      text: 'inspect',
+      attachments: [
+        {
+          id: 'file-1',
+          kind: 'file',
+          mediaType: 'text/plain',
+          name: 'notes.txt',
+          occurrenceId: 'occ-1',
+          order: 0,
+          provenance: { authorizedAt: 1234, kind: 'composer', occurrenceId: 'occ-1', sourceId: 'file-1' },
+          refText: '@file:attachments/notes.txt',
+          runtimeSessionId: 'runtime-1',
+          sha256: 'a'.repeat(64),
+          size: 5,
+          storedName: 'notes-2.txt'
+        }
+      ]
+    })
+
+    expect(admission.contextText).toBe('@file:attachments/notes.txt\n\ninspect')
+    expect(admission.attachmentManifest).toEqual([
+      {
+        id: 'file-1',
+        kind: 'file',
+        mediaType: 'text/plain',
+        name: 'notes.txt',
+        occurrenceId: 'occ-1',
+        order: 0,
+        refText: '@file:attachments/notes.txt',
+        runtimeSessionId: 'runtime-1',
+        sha256: 'a'.repeat(64),
+        size: 5,
+        storedName: 'notes-2.txt',
+        sourceId: 'file-1'
+      }
+    ])
+    expect(JSON.stringify(admission)).not.toMatch(/[A-Z]:\/|\\\\server|private/i)
+    expect(admission.payloadDigest).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('uses the normal image-only fallback and rejects malformed or oversized drafts', async () => {
+    await expect(
+      createDirectDraftAdmission({
+        text: '',
+        attachments: [
+          {
+            id: 'image-1',
+            kind: 'image',
+            mediaType: 'image/png',
+            name: 'image.png',
+            occurrenceId: null,
+            order: 0,
+            provenance: { authorizedAt: 1, kind: 'composer', occurrenceId: null, sourceId: 'image-1' },
+            runtimeSessionId: 'runtime-1',
+            sha256: 'b'.repeat(64),
+            size: 4,
+            storedName: 'upload-1.png'
+          }
+        ]
+      })
+    ).resolves.toMatchObject({ contextText: 'What do you see in this image?' })
+    expect(directDraftIsValid({ text: 'x'.repeat(64_001) })).toBe(false)
+    expect(directDraftIsValid({ text: 'ok', attachments: [] })).toBe(true)
+    expect(directDraftIsValid({ text: '', attachments: [] })).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/direct-draft.ts
+++ b/apps/desktop/src/app/chat/composer/direct-draft.ts
@@ -1,0 +1,137 @@
+import type { ComposerAttachment } from '@/store/composer'
+
+import type { RelayAttachmentTarget, RelayedAttachment } from './attachment-relay'
+
+const MAX_EXACT_SOURCE_CHARS = 64_000
+const HEX_DIGEST = /^[0-9a-f]{64}$/
+
+export interface DirectDraft {
+  text: string
+  attachments?: ComposerAttachment[]
+}
+
+export interface RelayedDirectDraft {
+  text: string
+  attachments?: RelayedAttachment[]
+}
+
+export interface DirectDraftTarget extends RelayAttachmentTarget {
+  composerScope: string
+  composerTarget: string
+}
+
+export interface DirectDraftTargetQuery {
+  connectionId: string
+  profile: string
+  runtimeSessionId: string
+  storedSessionId: string
+}
+
+export interface DirectDraftAttachmentManifestEntry {
+  id: string
+  kind: 'file' | 'image'
+  mediaType: string
+  name: string
+  occurrenceId: null | string
+  order: number
+  refText?: string
+  runtimeSessionId: string
+  sha256: string
+  size: number
+  sourceId: string
+  storedName: string
+}
+
+export interface DirectDraftAdmission {
+  attachmentManifest: DirectDraftAttachmentManifestEntry[]
+  contextText: string
+  payloadDigest: string
+  sourceText: string
+}
+
+export type DirectDraftReceipt =
+  | { state: 'acknowledgement_uncertain'; submissionId: string; payloadDigest: string }
+  | { state: 'durably_accepted'; submissionId: string; payloadDigest: string }
+  | {
+      state: 'rejected'
+      submissionId: string
+      reason:
+        | 'busy-target'
+        | 'invalid-draft'
+        | 'invalid-submission-id'
+        | 'stale-target'
+        | 'target-unavailable'
+        | 'unauthorized-attachment'
+        | 'unsupported-capability'
+    }
+
+export interface DirectDraftSubmitOptions {
+  submissionId?: string
+}
+
+function attachmentManifest(attachments: RelayedAttachment[]): DirectDraftAttachmentManifestEntry[] {
+  return attachments.map((attachment, order) => ({
+    id: attachment.id,
+    kind: attachment.kind,
+    mediaType: attachment.mediaType,
+    name: attachment.name,
+    occurrenceId: attachment.occurrenceId,
+    order,
+    ...(attachment.refText ? { refText: attachment.refText } : {}),
+    runtimeSessionId: attachment.runtimeSessionId,
+    sha256: attachment.sha256,
+    size: attachment.size,
+    sourceId: attachment.provenance.sourceId,
+    storedName: attachment.storedName
+  }))
+}
+
+function validAttachment(attachment: RelayedAttachment, order: number): boolean {
+  return (
+    attachment.order === order &&
+    attachment.provenance.sourceId === attachment.id &&
+    attachment.size > 0 &&
+    Number.isSafeInteger(attachment.size) &&
+    HEX_DIGEST.test(attachment.sha256) &&
+    Boolean(attachment.runtimeSessionId) &&
+    Boolean(attachment.name) &&
+    Boolean(attachment.mediaType) &&
+    Boolean(attachment.storedName)
+  )
+}
+
+export function directDraftIsValid(draft: RelayedDirectDraft): boolean {
+  if (!draft || typeof draft.text !== 'string' || draft.text.length > MAX_EXACT_SOURCE_CHARS) {
+    return false
+  }
+
+  const attachments = draft.attachments ?? []
+
+  return (
+    (draft.text.length > 0 || attachments.length > 0) &&
+    attachments.length <= 32 &&
+    attachments.every(validAttachment)
+  )
+}
+
+async function digestJson(value: unknown): Promise<string> {
+  const bytes = new TextEncoder().encode(JSON.stringify(value))
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+
+  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('')
+}
+
+export async function createDirectDraftAdmission(draft: RelayedDirectDraft): Promise<DirectDraftAdmission> {
+  if (!directDraftIsValid(draft)) {
+    throw new Error('invalid exact direct draft')
+  }
+
+  const attachments = attachmentManifest(draft.attachments ?? [])
+  const refs = attachments.flatMap(attachment => (attachment.refText ? [attachment.refText] : []))
+  const contextText = refs.length
+    ? `${refs.join('\n')}\n\n${draft.text || 'What do you see in this image?'}`
+    : draft.text || 'What do you see in this image?'
+  const payloadDigest = await digestJson({ text: draft.text, contextText, attachments })
+
+  return { attachmentManifest: attachments, contextText, payloadDigest, sourceText: draft.text }
+}

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -56,6 +56,8 @@ function renderSubmitHook({
   const onSteer = vi.fn(async () => true)
   const onSubmit = vi.fn(async () => true)
   const queueCurrentDraft = vi.fn(() => true)
+  const loadIntoComposer = vi.fn()
+  const stashAt = vi.fn()
   let updatePaneVisible: Dispatch<SetStateAction<boolean>> | undefined
 
   const clearDraft = vi.fn(() => {
@@ -106,7 +108,7 @@ function renderSubmitHook({
         exitQueuedEdit: vi.fn(() => false),
         focusInput: vi.fn(),
         inputDisabled,
-        loadIntoComposer: vi.fn(),
+        loadIntoComposer,
         onCancel,
         onSteer,
         onSubmit,
@@ -115,7 +117,7 @@ function renderSubmitHook({
         queuedPrompts: [],
         sessionId: 'runtime-session',
         setComposerText: vi.fn(),
-        stashAt: vi.fn()
+        stashAt
       }),
     { wrapper: Wrapper }
   )
@@ -123,11 +125,13 @@ function renderSubmitHook({
   return {
     clearDraft,
     hook,
+    loadIntoComposer,
     onCancel,
     onSteer,
     onSubmit,
     queueCurrentDraft,
     composerSurfaceId: resolvedSurfaceId,
+    stashAt,
     setPaneVisible(nextVisible: boolean) {
       if (!updatePaneVisible) {
         throw new Error('Pane visibility setter was not initialized')
@@ -137,6 +141,37 @@ function renderSubmitHook({
     }
   }
 }
+
+describe('useComposerSubmit accepted/rejected draft parity', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('restores the exact draft and attachments when the send rejects', async () => {
+    const attachment: ComposerAttachment = { id: 'file-1', kind: 'file', label: 'notes.txt' }
+    const harness = renderSubmitHook({ attachments: [attachment], text: '  keep Ω\nline two  ' })
+    harness.onSubmit.mockResolvedValueOnce(false)
+
+    act(() => harness.hook.result.current.submitDraft())
+
+    await waitFor(() =>
+      expect(harness.loadIntoComposer).toHaveBeenCalledWith('  keep Ω\nline two  ', [attachment])
+    )
+    expect(harness.stashAt).toHaveBeenCalledWith('stored-session', '  keep Ω\nline two  ', [attachment])
+  })
+
+  it('does not restore a successfully consumed send', async () => {
+    const harness = renderSubmitHook({ text: 'consumed once' })
+    harness.onSubmit.mockResolvedValueOnce(true)
+
+    act(() => harness.hook.result.current.submitDraft())
+
+    await waitFor(() => expect(harness.onSubmit).toHaveBeenCalledTimes(1))
+    expect(harness.loadIntoComposer).not.toHaveBeenCalled()
+    expect(harness.stashAt).not.toHaveBeenCalled()
+  })
+})
 
 describe('useComposerSubmit external request routing', () => {
   afterEach(() => {

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -34,7 +34,7 @@ import {
   slashArgStage
 } from './composer-utils'
 import { ContextMenu } from './context-menu'
-import { COMPOSER_AREAS, runComposerMiddleware } from './contrib'
+import { COMPOSER_AREAS, isComposerTerminalRunResult, runComposerMiddleware } from './contrib'
 import { ComposerControls } from './controls'
 import { ComposerDirectiveActions } from './directive-actions'
 import { COMPOSER_DROP_ACTIVE_CLASS, COMPOSER_DROP_FADE_CLASS } from './drop-affordance'
@@ -139,6 +139,10 @@ export function ChatBar({
 
       if (!draft) {
         return false
+      }
+
+      if (isComposerTerminalRunResult(draft)) {
+        return draft.disposition === 'consume'
       }
 
       return onSubmitProp(draft.text, { ...options, attachments: draft.attachments })

--- a/apps/desktop/src/contrib/plugins-store.test.ts
+++ b/apps/desktop/src/contrib/plugins-store.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  dropPlugin,
+  pluginStatus,
+  publishPlugin,
+  setPluginEnabled,
+  subscribePluginStatus
+} from './plugins-store'
+
+const uniqueId = (name: string) => `status-test-${name}-${crypto.randomUUID()}`
+
+describe('public plugin status contract', () => {
+  it('reports unavailable for absent and inherited record names', () => {
+    const id = uniqueId('missing')
+
+    expect(pluginStatus(id)).toEqual({ id, state: 'unavailable' })
+    expect(pluginStatus('toString')).toEqual({ id: 'toString', state: 'unavailable' })
+    expect(pluginStatus('__proto__')).toEqual({ id: '__proto__', state: 'unavailable' })
+  })
+
+  it('maps internal states to a closed non-secret public vocabulary', () => {
+    const id = uniqueId('states')
+    const base = { id, name: 'Private path must not leak', kind: 'disk' as const, file: 'C:/secret/plugin.js' }
+
+    publishPlugin({ ...base, status: 'disabled' })
+    expect(pluginStatus(id)).toEqual({ id, state: 'disabled' })
+    publishPlugin({ ...base, status: 'loading' })
+    expect(pluginStatus(id)).toEqual({ id, state: 'loading' })
+    publishPlugin({ ...base, status: 'loaded' })
+    expect(pluginStatus(id)).toEqual({ id, state: 'enabled' })
+    publishPlugin({ ...base, status: 'error', error: 'token=must-not-leak' })
+    expect(pluginStatus(id)).toEqual({ id, state: 'failed' })
+    expect(JSON.stringify(pluginStatus(id))).not.toMatch(/secret|token|path|error/i)
+  })
+
+  it('publishes loading then enabled around asynchronous activation', async () => {
+    const id = uniqueId('enable')
+    let resolveActivation: (() => void) | undefined
+    const activation = new Promise<void>(resolve => {
+      resolveActivation = resolve
+    })
+
+    publishPlugin(
+      { id, name: id, kind: 'runtime', status: 'disabled' },
+      {
+        activate: async () => {
+          await activation
+          publishPlugin({ id, name: id, kind: 'runtime', status: 'loaded' })
+        },
+        deactivate: vi.fn()
+      }
+    )
+
+    const enabling = setPluginEnabled(id, true)
+    expect(pluginStatus(id)).toEqual({ id, state: 'loading' })
+    resolveActivation?.()
+    await enabling
+    expect(pluginStatus(id)).toEqual({ id, state: 'enabled' })
+  })
+
+  it('publishes failed while preserving the private activation rejection', async () => {
+    const id = uniqueId('failure')
+    const failure = new Error('private activation failure')
+
+    publishPlugin(
+      { id, name: id, kind: 'runtime', status: 'disabled' },
+      { activate: async () => Promise.reject(failure), deactivate: vi.fn() }
+    )
+
+    await expect(setPluginEnabled(id, true)).rejects.toBe(failure)
+    expect(pluginStatus(id)).toEqual({ id, state: 'failed' })
+  })
+
+  it('emits only scoped transitions, immediately, and supports unsubscribe', () => {
+    const id = uniqueId('events')
+    const other = uniqueId('other')
+    const states: string[] = []
+    const unsubscribe = subscribePluginStatus(id, status => states.push(status.state))
+
+    publishPlugin({ id: other, name: other, kind: 'runtime', status: 'loaded' })
+    publishPlugin({ id, name: id, kind: 'runtime', status: 'disabled' })
+    publishPlugin({ id, name: id, kind: 'runtime', status: 'loading' })
+    publishPlugin({ id, name: id, kind: 'runtime', status: 'loaded' })
+    dropPlugin(id)
+    unsubscribe()
+    publishPlugin({ id, name: id, kind: 'runtime', status: 'loaded' })
+
+    expect(states).toEqual(['unavailable', 'disabled', 'loading', 'enabled', 'unavailable'])
+  })
+
+  it('isolates one subscriber exception from lifecycle and sibling observers', () => {
+    const id = uniqueId('listener-failure')
+    const states: string[] = []
+    const stopBroken = subscribePluginStatus(id, () => {
+      throw new Error('broken observer')
+    })
+    const stopHealthy = subscribePluginStatus(id, status => states.push(status.state))
+
+    expect(() => publishPlugin({ id, name: id, kind: 'runtime', status: 'loaded' })).not.toThrow()
+    expect(pluginStatus(id).state).toBe('enabled')
+    expect(states).toEqual(['unavailable', 'enabled'])
+    stopBroken()
+    stopHealthy()
+  })
+})

--- a/apps/desktop/src/contrib/plugins-store.ts
+++ b/apps/desktop/src/contrib/plugins-store.ts
@@ -11,7 +11,13 @@
 import { atom } from 'nanostores'
 
 export type PluginKind = 'bundled' | 'disk' | 'runtime'
-export type PluginStatus = 'disabled' | 'error' | 'loaded'
+export type PluginStatus = 'disabled' | 'error' | 'loaded' | 'loading'
+export type PublicPluginState = 'disabled' | 'enabled' | 'failed' | 'loading' | 'unavailable'
+
+export interface PublicPluginStatus {
+  id: string
+  state: PublicPluginState
+}
 
 export interface PluginRecord {
   id: string
@@ -60,7 +66,7 @@ export const $pluginDecisions = atom<Record<string, boolean>>(loadDecisions())
 export function pluginActive(id: string, defaultEnabled = true): boolean {
   const decisions = $pluginDecisions.get()
 
-  return id in decisions ? decisions[id] : defaultEnabled
+  return Object.prototype.hasOwnProperty.call(decisions, id) ? decisions[id] : defaultEnabled
 }
 
 function saveDecisions(next: Record<string, boolean>) {
@@ -75,6 +81,64 @@ function saveDecisions(next: Record<string, boolean>) {
 
 export const $pluginRecords = atom<Record<string, PluginRecord>>({})
 
+const statusListeners = new Map<string, Set<(status: PublicPluginStatus) => void>>()
+
+export function pluginStatus(id: string): PublicPluginStatus {
+  const records = $pluginRecords.get()
+  const record = Object.prototype.hasOwnProperty.call(records, id) ? records[id] : undefined
+  const state: PublicPluginState =
+    record?.status === 'loaded'
+      ? 'enabled'
+      : record?.status === 'disabled'
+        ? 'disabled'
+        : record?.status === 'loading'
+          ? 'loading'
+          : record?.status === 'error'
+            ? 'failed'
+            : 'unavailable'
+
+  return { id, state }
+}
+
+function emitPluginStatus(id: string, before: PublicPluginState): void {
+  const next = pluginStatus(id)
+
+  if (before === next.state) {
+    return
+  }
+
+  for (const listener of statusListeners.get(id) ?? []) {
+    try {
+      listener(next)
+    } catch {
+      // Public observers are isolated from loader lifecycle and one another.
+    }
+  }
+}
+
+export function subscribePluginStatus(
+  id: string,
+  listener: (status: PublicPluginStatus) => void
+): () => void {
+  const listeners = statusListeners.get(id) ?? new Set()
+  listeners.add(listener)
+  statusListeners.set(id, listeners)
+
+  try {
+    listener(pluginStatus(id))
+  } catch {
+    // Initial delivery has the same isolation guarantee as later transitions.
+  }
+
+  return () => {
+    const current = statusListeners.get(id)
+    current?.delete(listener)
+    if (!current?.size) {
+      statusListeners.delete(id)
+    }
+  }
+}
+
 /** Loader-owned lifecycle controls for a plugin (activate/deactivate). */
 interface PluginHandle {
   activate: () => Promise<void> | void
@@ -86,25 +150,31 @@ const handles = new Map<string, PluginHandle>()
 
 /** Publish/refresh a plugin's record + its activate/deactivate handles. */
 export function publishPlugin(record: PluginRecord, handle?: PluginHandle): void {
+  const before = pluginStatus(record.id).state
   $pluginRecords.set({ ...$pluginRecords.get(), [record.id]: record })
 
   if (handle) {
     handles.set(record.id, handle)
   }
+  emitPluginStatus(record.id, before)
 }
 
 export function patchPlugin(id: string, patch: Partial<PluginRecord>): void {
   const current = $pluginRecords.get()[id]
 
   if (current) {
+    const before = pluginStatus(id).state
     $pluginRecords.set({ ...$pluginRecords.get(), [id]: { ...current, ...patch } })
+    emitPluginStatus(id, before)
   }
 }
 
 export function dropPlugin(id: string): void {
+  const before = pluginStatus(id).state
   const { [id]: _dropped, ...rest } = $pluginRecords.get()
   $pluginRecords.set(rest)
   handles.delete(id)
+  emitPluginStatus(id, before)
 }
 
 /** Live toggle: deactivate + remember, or forget + reactivate. */
@@ -118,7 +188,13 @@ export async function setPluginEnabled(id: string, enabled: boolean): Promise<vo
   }
 
   if (enabled) {
-    await handle.activate()
+    patchPlugin(id, { status: 'loading' })
+    try {
+      await handle.activate()
+    } catch (error) {
+      patchPlugin(id, { status: 'error' })
+      throw error
+    }
   } else {
     handle.deactivate()
     patchPlugin(id, { status: 'disabled' })

--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -179,6 +179,76 @@ describe('watchRuntimePlugins dir watch (#66899)', () => {
   })
 })
 
+describe('public plugin status SDK', () => {
+  it('is own-property feature-detectable and emits credential-free transitions to a runtime plugin', async () => {
+    const target = `sdk-target-${crypto.randomUUID()}`
+    const consumer = `sdk-consumer-${crypto.randomUUID()}`
+    const seen: unknown[] = []
+
+    ;(globalThis as unknown as { __pluginStatusSeen: unknown }).__pluginStatusSeen = seen
+    publishPlugin({ id: target, name: 'Sensitive display name', kind: 'disk', status: 'disabled', file: 'C:/secret.js' })
+
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(
+        blob =>
+          `data:text/javascript;base64,${Buffer.from((blob as unknown as { parts: string[] }).parts.join('')).toString('base64')}`
+      )
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+    const RealBlob = globalThis.Blob
+    vi.stubGlobal(
+      'Blob',
+      class {
+        parts: string[]
+        constructor(parts: string[]) {
+          this.parts = parts
+        }
+      }
+    )
+
+    try {
+      await loadRuntimePlugin(
+        `import { host } from '@hermes/plugin-sdk'
+         export default {
+           id: '${consumer}',
+           register() {
+             globalThis.__pluginStatusSeen.push(host.capabilityVersion('plugin-status'))
+             globalThis.__pluginStatusSeen.push(host.capabilityVersion('composer-disposition'))
+             globalThis.__pluginStatusSeen.push(host.capabilityVersion('exact-session-submit'))
+             globalThis.__pluginStatusSeen.push(host.capabilityVersion('attachment-relay'))
+             globalThis.__pluginStatusSeen.push(host.capabilityVersion('direct-draft-submit'))
+             globalThis.__pluginStatusSeen.push(host.capabilityVersion('toString'))
+             globalThis.__pluginStatusSeen.push(host.pluginStatus('${target}'))
+             globalThis.__pluginStatusSeen.push(host.onPluginStatus('${target}', value => globalThis.__pluginStatusSeen.push(value)))
+           }
+         }`,
+        consumer
+      )
+
+      publishPlugin({ id: target, name: 'Sensitive display name', kind: 'disk', status: 'loaded', file: 'C:/secret.js' })
+
+      expect(seen.slice(0, 8)).toEqual([
+        1,
+        2,
+        2,
+        1,
+        0,
+        0,
+        { id: target, state: 'disabled' },
+        { id: target, state: 'disabled' }
+      ])
+      expect(seen[8]).toEqual(expect.any(Function))
+      expect(seen.at(-1)).toEqual({ id: target, state: 'enabled' })
+      expect(JSON.stringify(seen)).not.toContain('secret')
+    } finally {
+      createObjectURL.mockRestore()
+      revokeObjectURL.mockRestore()
+      vi.stubGlobal('Blob', RealBlob)
+      delete (globalThis as unknown as { __pluginStatusSeen?: unknown }).__pluginStatusSeen
+    }
+  })
+})
+
 describe('bundled-shadowed disk copies', () => {
   it('skips a disk copy of a bundled plugin but publishes a visible inventory row', async () => {
     // The bundled twin is already registered (build-time glob).

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -21,6 +21,20 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 import type { ReactNode } from 'react'
 
+import {
+  type RelayAttachmentTarget,
+  relayComposerAttachments,
+  type RelayedAttachment,
+  type RelayStageReceipt
+} from '@/app/chat/composer/attachment-relay'
+import {
+  createDirectDraftAdmission,
+  type DirectDraft,
+  type DirectDraftReceipt,
+  type DirectDraftSubmitOptions,
+  type DirectDraftTarget,
+  type DirectDraftTargetQuery
+} from '@/app/chat/composer/direct-draft'
 import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import type { ClientSessionState } from '@/app/types'
@@ -32,6 +46,11 @@ import {
   revealTreePane
 } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
+import {
+  pluginStatus,
+  type PublicPluginStatus,
+  subscribePluginStatus
+} from '@/contrib/plugins-store'
 import { registry } from '@/contrib/registry'
 import { deleteProfile, getLogs, getStatus, type HermesGateway } from '@/hermes'
 import {
@@ -68,6 +87,8 @@ import {
   $sessions,
   rememberedSessionProfile,
   requestSessionResume,
+  resolveComposerSessionKey,
+  sessionMatchesStoredId,
   setResumeExhaustedSessionId
 } from '@/store/session'
 import {
@@ -380,7 +401,423 @@ async function awaitProfileActivation(
   // by mutation: removing it changed no test outcome.
 }
 
+export type PluginSdkCapability =
+  | 'plugin-status'
+  | 'composer-disposition'
+  | 'exact-session-submit'
+  | 'attachment-relay'
+
+export const PLUGIN_SDK_CAPABILITY_VERSIONS: Readonly<Record<PluginSdkCapability, number>> = Object.freeze({
+  'plugin-status': 1,
+  'composer-disposition': 2,
+  'exact-session-submit': 2,
+  'attachment-relay': 1
+})
+const LOCAL_CONNECTION_ID = 'local'
+const SUBMISSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$/
+const RELAY_MAX_BYTES = 64 * 1024 * 1024
+
+interface ExactSessionIdentity {
+  busy: boolean
+  capabilities: Record<string, number>
+  lineage_root_id: string
+  runtime_session_id: string
+  stored_session_id: string
+}
+
+const directDraftTargetForSession = (query: DirectDraftTargetQuery): DirectDraftTarget | null => {
+  const sessions = $sessions.get()
+  const profile = normalizeProfileKey(query.profile)
+  const row = sessions.find(
+    session =>
+      sessionMatchesStoredId(session, query.storedSessionId) &&
+      normalizeProfileKey(session.profile) === profile &&
+      (session.connection_id ?? activeGatewayConnectionId() ?? LOCAL_CONNECTION_ID) === query.connectionId
+  )
+  const state = $sessionStates.get()[query.runtimeSessionId]
+
+  if (!row || !state || state.storedSessionId !== row.id) {
+    return null
+  }
+
+  const lineageRootId = row._lineage_root_id ?? row.id
+  const isFocusedMain =
+    ($focusedRuntimeId.get() ?? $activeSessionId.get()) === query.runtimeSessionId &&
+    sessionMatchesStoredId(row, $selectedStoredSessionId.get() ?? '')
+
+  return {
+    composerScope: resolveComposerSessionKey(row.id, sessions) ?? lineageRootId,
+    composerTarget: isFocusedMain ? 'main' : `tile:${row.id}`,
+    connectionId: query.connectionId,
+    lineageRootId,
+    profile,
+    runtimeSessionId: query.runtimeSessionId,
+    storedSessionId: row.id
+  }
+}
+
+const directDraftTargetForFocusedSession = (): DirectDraftTarget | null => {
+  const runtimeSessionId = $focusedRuntimeId.get() ?? $activeSessionId.get()
+  const storedSessionId = $focusedStoredSessionId.get() ?? $selectedStoredSessionId.get()
+
+  if (!runtimeSessionId || !storedSessionId) {
+    return null
+  }
+  const row = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+
+  if (!row) {
+    return null
+  }
+
+  return directDraftTargetForSession({
+    connectionId: row.connection_id ?? activeGatewayConnectionId() ?? LOCAL_CONNECTION_ID,
+    profile: normalizeProfileKey(row.profile ?? $focusedSessionProfile.get()),
+    runtimeSessionId,
+    storedSessionId
+  })
+}
+
+const directDraftTargetIsCurrent = (target: RelayAttachmentTarget): boolean => {
+  const current = directDraftTargetForSession({
+    connectionId: target.connectionId,
+    profile: target.profile,
+    runtimeSessionId: target.runtimeSessionId,
+    storedSessionId: target.storedSessionId
+  })
+
+  return Boolean(current && current.lineageRootId === target.lineageRootId)
+}
+
+const requestExactSessionIdentity = (target: RelayAttachmentTarget): Promise<ExactSessionIdentity> =>
+  requestGatewayForAgent<ExactSessionIdentity>(target.connectionId, target.profile, 'session.identity', {
+    session_id: target.runtimeSessionId
+  })
+
+const exactIdentityMatches = (identity: ExactSessionIdentity, target: RelayAttachmentTarget): boolean =>
+  identity.runtime_session_id === target.runtimeSessionId &&
+  identity.stored_session_id === target.storedSessionId &&
+  identity.lineage_root_id === target.lineageRootId
+
+const ownsCapability = (identity: ExactSessionIdentity, name: string): boolean =>
+  Object.prototype.hasOwnProperty.call(identity.capabilities, name) && identity.capabilities[name] === 1
+
+async function requireExactTarget(target: RelayAttachmentTarget, capability: string): Promise<ExactSessionIdentity> {
+  if (!directDraftTargetIsCurrent(target)) {
+    throw new Error('stale exact target')
+  }
+  const identity = await requestExactSessionIdentity(target)
+  if (!exactIdentityMatches(identity, target)) {
+    throw new Error('stale exact target')
+  }
+  if (identity.busy) {
+    throw new Error('busy exact target')
+  }
+  if (!ownsCapability(identity, capability)) {
+    throw new Error('unsupported exact target capability')
+  }
+  return identity
+}
+
+function dataUrlParts(value: string): { bytes: Uint8Array; mediaType: string } {
+  const match = /^data:([^;,]+);base64,([\s\S]*)$/i.exec(value)
+  if (!match) {
+    throw new Error('attachment reader returned an invalid data URL')
+  }
+  const binary = atob(match[2]!.replace(/\s+/g, ''))
+  return { bytes: Uint8Array.from(binary, character => character.charCodeAt(0)), mediaType: match[1]! }
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000))
+  }
+  return btoa(binary)
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value as object)
+      .sort()
+      .map(key => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+async function sha256Text(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value))
+  return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('')
+}
+
+function mapRelayReceipt(value: Record<string, unknown>): RelayStageReceipt {
+  return {
+    attached: value.attached === true,
+    bytes: Number(value.bytes),
+    mediaType: String(value.media_type ?? ''),
+    name: String(value.name ?? ''),
+    order: Number(value.order),
+    ...(value.ref_text ? { refText: String(value.ref_text) } : {}),
+    runtimeSessionId: String(value.runtime_session_id ?? ''),
+    sha256: String(value.sha256 ?? ''),
+    storedName: String(value.stored_name ?? '')
+  }
+}
+
+function closedExactReceiptState(
+  value: unknown,
+  binding: Record<string, unknown>
+): 'durably_accepted' | 'rejected' | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== null && prototype !== Object.prototype) {
+    return null
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(value) as Record<string, PropertyDescriptor>
+  if (Reflect.ownKeys(descriptors).some(key => typeof key !== 'string' || !('value' in descriptors[key]!))) {
+    return null
+  }
+  const state = descriptors.state?.value
+  if (state !== 'durably_accepted' && state !== 'rejected') {
+    return null
+  }
+  const expectedKeys = new Set([
+    ...Object.keys(binding),
+    'version',
+    'state',
+    'accepted_at',
+    ...(state === 'rejected' ? ['reason'] : [])
+  ])
+  const keys = Object.keys(descriptors)
+  if (keys.length !== expectedKeys.size || keys.some(key => !expectedKeys.has(key))) {
+    return null
+  }
+  if (
+    descriptors.version?.value !== 1 ||
+    typeof descriptors.accepted_at?.value !== 'string' ||
+    !descriptors.accepted_at.value ||
+    (state === 'rejected' && (typeof descriptors.reason?.value !== 'string' || !descriptors.reason.value))
+  ) {
+    return null
+  }
+  if (Object.entries(binding).some(([key, expected]) => descriptors[key]?.value !== expected)) {
+    return null
+  }
+
+  return state
+}
+
 export const host = {
+  /** Versioned additive feature probe; inherited names never count. */
+  capabilityVersion: (capability: string): number =>
+    typeof capability === 'string' &&
+    capability.length > 0 &&
+    Object.prototype.hasOwnProperty.call(PLUGIN_SDK_CAPABILITY_VERSIONS, capability)
+      ? PLUGIN_SDK_CAPABILITY_VERSIONS[capability as PluginSdkCapability]
+      : 0,
+
+  /** Credential-free current state of one Desktop plugin. */
+  pluginStatus: (id: string): PublicPluginStatus => pluginStatus(id),
+
+  /** Immediate + reactive state subscription, isolated from loader lifecycle. */
+  onPluginStatus: (id: string, listener: (status: PublicPluginStatus) => void): (() => void) =>
+    subscribePluginStatus(id, listener),
+
+  /** Exact non-secret identity of the focused persisted session, or null. */
+  focusedSessionTarget: (): DirectDraftTarget | null => directDraftTargetForFocusedSession(),
+
+  /** Resolve an explicit connection/profile/runtime/stored binding. */
+  sessionTarget: (query: DirectDraftTargetQuery): DirectDraftTarget | null => directDraftTargetForSession(query),
+
+  /** Relay only current middleware-authorized composer attachments. */
+  relayAttachments: async (
+    target: RelayAttachmentTarget,
+    attachments: DirectDraft['attachments'] = []
+  ): Promise<RelayedAttachment[]> =>
+    relayComposerAttachments(target, attachments, {
+      maxBytes: RELAY_MAX_BYTES,
+      now: Date.now,
+      revalidate: async current => {
+        await requireExactTarget(current, 'attachment_relay')
+      },
+      read: async attachment => {
+        const bridge = window.hermesDesktop?.readFileDataUrlForAttach
+        if (!bridge || !attachment.path) {
+          throw new Error('attachment bytes are unavailable through the Desktop bridge')
+        }
+        return dataUrlParts(await bridge(attachment.path))
+      },
+      stage: async (current, attachment) => {
+        const relay = {
+          stored_session_id: current.storedSessionId,
+          lineage_root_id: current.lineageRootId,
+          name: attachment.name,
+          media_type: attachment.mediaType,
+          bytes: attachment.bytes.byteLength,
+          sha256: attachment.sha256,
+          order: attachment.order
+        }
+        const result = await requestGatewayForAgent<Record<string, unknown>>(
+          current.connectionId,
+          current.profile,
+          attachment.kind === 'image' ? 'image.attach_bytes' : 'file.attach',
+          attachment.kind === 'image'
+            ? {
+                session_id: current.runtimeSessionId,
+                content_base64: `data:${attachment.mediaType};base64,${bytesToBase64(attachment.bytes)}`,
+                filename: attachment.name,
+                relay
+              }
+            : {
+                session_id: current.runtimeSessionId,
+                data_url: `data:${attachment.mediaType};base64,${bytesToBase64(attachment.bytes)}`,
+                name: attachment.name,
+                relay
+              }
+        )
+        return mapRelayReceipt(result)
+      }
+    }),
+
+  /** Exact direct submission below composer middleware; never queues, redirects, retargets, or blindly retries. */
+  submitDraft: async (
+    target: DirectDraftTarget,
+    draft: DirectDraft,
+    options: DirectDraftSubmitOptions = {}
+  ): Promise<DirectDraftReceipt> => {
+    const submissionId = options.submissionId ?? `submit_${crypto.randomUUID().replaceAll('-', '')}`
+    const reject = (reason: Extract<DirectDraftReceipt, { state: 'rejected' }>['reason']): DirectDraftReceipt => ({
+      state: 'rejected',
+      submissionId,
+      reason
+    })
+
+    if (!SUBMISSION_ID_PATTERN.test(submissionId)) {
+      return reject('invalid-submission-id')
+    }
+    if (!draft || typeof draft.text !== 'string' || draft.text.length > 64_000 || (!draft.text && !draft.attachments?.length)) {
+      return reject('invalid-draft')
+    }
+
+    let identity: ExactSessionIdentity
+    try {
+      if (!directDraftTargetIsCurrent(target)) {
+        return reject('stale-target')
+      }
+      identity = await requestExactSessionIdentity(target)
+    } catch {
+      return reject('target-unavailable')
+    }
+    if (!exactIdentityMatches(identity, target)) {
+      return reject('stale-target')
+    }
+    if (identity.busy) {
+      return reject('busy-target')
+    }
+    if (!ownsCapability(identity, 'exact_submission') || !ownsCapability(identity, 'attachment_relay')) {
+      return reject('unsupported-capability')
+    }
+
+    let relayed: RelayedAttachment[] = []
+    try {
+      if (draft.attachments?.length) {
+        relayed = await host.relayAttachments(target, draft.attachments)
+      }
+    } catch (error) {
+      return reject(error instanceof Error && /authorized/i.test(error.message) ? 'unauthorized-attachment' : 'stale-target')
+    }
+
+    let admission
+    try {
+      admission = await createDirectDraftAdmission({ text: draft.text, attachments: relayed })
+      await requireExactTarget(target, 'exact_submission')
+    } catch (error) {
+      return reject(error instanceof Error && /invalid exact direct draft/i.test(error.message) ? 'invalid-draft' : 'stale-target')
+    }
+
+    const exactSubmission = {
+      submission_id: submissionId,
+      connection_id: target.connectionId,
+      profile: target.profile,
+      stored_session_id: target.storedSessionId,
+      lineage_root_id: target.lineageRootId,
+      payload_digest: admission.payloadDigest,
+      source_digest: await sha256Text(admission.sourceText),
+      context_digest: await sha256Text(admission.contextText),
+      attachment_manifest_digest: await sha256Text(stableJson(admission.attachmentManifest)),
+      attachment_count: admission.attachmentManifest.length,
+      source_text: admission.sourceText,
+      context_text: admission.contextText,
+      attachments: admission.attachmentManifest
+    }
+    const receiptBinding = {
+      submission_id: submissionId,
+      connection_id: target.connectionId,
+      profile: target.profile,
+      runtime_session_id: target.runtimeSessionId,
+      stored_session_id: target.storedSessionId,
+      lineage_root_id: target.lineageRootId,
+      payload_digest: admission.payloadDigest,
+      source_digest: exactSubmission.source_digest,
+      context_digest: exactSubmission.context_digest,
+      attachment_manifest_digest: exactSubmission.attachment_manifest_digest,
+      attachment_count: exactSubmission.attachment_count
+    }
+
+    try {
+      const response = await requestGatewayForAgent<{ receipt?: Record<string, unknown> }>(
+        target.connectionId,
+        target.profile,
+        'prompt.submit',
+        { session_id: target.runtimeSessionId, text: admission.contextText, exact_submission: exactSubmission }
+      )
+      const receipt = response.receipt
+      if (closedExactReceiptState(receipt, receiptBinding) === 'durably_accepted') {
+        return { state: 'durably_accepted', submissionId, payloadDigest: admission.payloadDigest }
+      }
+    } catch {
+      // Admission may have crossed the durable boundary. Reconcile exactly once;
+      // never resend prompt.submit from this path.
+    }
+
+    try {
+      const lookup = await requestGatewayForAgent<{ receipt?: Record<string, unknown> }>(
+        target.connectionId,
+        target.profile,
+        'prompt.receipt',
+        {
+          session_id: target.runtimeSessionId,
+          submission_id: submissionId,
+          connection_id: target.connectionId,
+          profile: target.profile,
+          stored_session_id: target.storedSessionId,
+          lineage_root_id: target.lineageRootId,
+          payload_digest: admission.payloadDigest,
+          source_digest: exactSubmission.source_digest,
+          context_digest: exactSubmission.context_digest,
+          attachment_manifest_digest: exactSubmission.attachment_manifest_digest,
+          attachment_count: exactSubmission.attachment_count
+        }
+      )
+      const receiptState = closedExactReceiptState(lookup.receipt, receiptBinding)
+      if (receiptState === 'durably_accepted') {
+        return { state: 'durably_accepted', submissionId, payloadDigest: admission.payloadDigest }
+      }
+      if (receiptState === 'rejected') {
+        return reject('stale-target')
+      }
+    } catch {
+      // The only honest state is uncertain; caller retains its draft.
+    }
+
+    return { state: 'acknowledgement_uncertain', submissionId, payloadDigest: admission.payloadDigest }
+  },
+
   state: {
     /** Runtime id of the active chat session (null on a fresh draft). */
     activeSessionId: readonlyAtom<null | string>($activeSessionId),
@@ -875,13 +1312,27 @@ export const host = {
 // Every contribution surface, plugin-reachable: register keybinds, palette
 // commands, routes, themes, panes, composer extensions, and bar items with
 // the same area ids + payload types core uses.
+export type {
+  RelayAttachmentTarget,
+  RelayedAttachment
+} from '@/app/chat/composer/attachment-relay'
 export {
   COMPOSER_AREAS,
   type ComposerAtCompletionItem,
   type ComposerAtCompletionSource,
   type ComposerAttachmentProvider,
+  type ComposerConsumeDisposition,
+  type ComposerDisposition,
+  type ComposerDraft,
   type ComposerMiddleware
 } from '@/app/chat/composer/contrib'
+export type {
+  DirectDraft,
+  DirectDraftReceipt,
+  DirectDraftSubmitOptions,
+  DirectDraftTarget,
+  DirectDraftTargetQuery
+} from '@/app/chat/composer/direct-draft'
 
 // -- ui: the design language --------------------------------------------------
 
@@ -991,6 +1442,7 @@ export type {
   PluginRestOptions,
   PluginStorage
 } from '@/contrib/plugin'
+export type { PublicPluginState, PublicPluginStatus } from '@/contrib/plugins-store'
 /** Mount-scoped contribution: while the rendering component is mounted, its
  *  children render in the target area's slot; unmount disposes it. Use for
  *  page-owned chrome (a page's titlebar control leaves with the page) —

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -31,7 +31,15 @@ vi.mock('@/store/session', async () => {
     $sessions: atom([]),
     rememberedSessionProfile: (_sessions: unknown, _sessionId: null | string, activeProfile: null | string) =>
       (activeProfile ?? '').trim() || 'default',
+    resolveComposerSessionKey: (
+      storedSessionId: null | string,
+      sessions: Array<{ _lineage_root_id?: null | string; id: string }> = []
+    ) =>
+      sessions.find(session => session.id === storedSessionId || session._lineage_root_id === storedSessionId)
+        ?._lineage_root_id ?? storedSessionId,
     requestSessionResume: vi.fn(),
+    sessionMatchesStoredId: (session: { _lineage_root_id?: null | string; id: string }, storedSessionId: string) =>
+      session.id === storedSessionId || session._lineage_root_id === storedSessionId,
     setResumeExhaustedSessionId: vi.fn()
   }
 })
@@ -79,6 +87,7 @@ vi.mock('@/store/gateway', async () => {
 
   return {
     $gateway: atom(null),
+    activeGatewayConnectionId: vi.fn(() => 'connection-local'),
     ensureGatewayForAgent: vi.fn(),
     openGatewayForAgent: vi.fn(),
     openGatewayForProfile: vi.fn(),
@@ -99,7 +108,12 @@ vi.mock('@/store/gateway', async () => {
   }
 })
 
-const { host } = await import('./index')
+const sdk = await import('./index')
+const { host } = sdk
+const { captureHostComposerAttachmentAuthority, createComposerAttachmentAttempt } =
+  await import('@/app/chat/composer/attachment-relay')
+const { COMPOSER_AREAS } = await import('@/app/chat/composer/contrib')
+const { registry } = await import('@/contrib/registry')
 const { openSession: openSessionCore } = await import('@/app/open-session')
 const { deleteProfile } = await import('@/hermes')
 
@@ -115,10 +129,17 @@ const {
   setShowAllProfiles
 } = await import('@/store/profile')
 
-const { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId } = await import('@/store/session-states')
+const { $focusedRuntimeId, $focusedSessionState, $focusedStoredSessionId, $sessionStates } =
+  await import('@/store/session-states')
 
-const { $activeSessionId, $messages, $selectedStoredSessionId, requestSessionResume, setResumeExhaustedSessionId } =
-  await import('@/store/session')
+const {
+  $activeSessionId,
+  $messages,
+  $selectedStoredSessionId,
+  $sessions,
+  requestSessionResume,
+  setResumeExhaustedSessionId
+} = await import('@/store/session')
 
 const setMockAtom = <T>(store: unknown, value: T) => (store as { set(next: T): void }).set(value)
 
@@ -134,6 +155,19 @@ const profile = (name: string): ProfileInfo => ({
 
 afterEach(() => {
   vi.clearAllMocks()
+  vi.mocked(requestGatewayForAgent).mockReset().mockImplementation(
+    async (
+      connectionId: null | string,
+      profileName: string,
+      method: string,
+      params?: Record<string, unknown>
+    ) => ({
+      connectionId,
+      method,
+      params: params ?? {},
+      profile: profileName
+    })
+  )
   $activeGatewayProfile.set('remote-worker')
   $gatewaySwapTarget.set(null)
   setMockAtom($focusedRuntimeId, null)
@@ -142,11 +176,421 @@ afterEach(() => {
   setMockAtom($activeSessionId, null)
   setMockAtom($selectedStoredSessionId, null)
   setMockAtom($messages, [])
+  setMockAtom($sessions, [])
+  setMockAtom($sessionStates, {})
   $profiles.set([profile('cached-only')])
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
 })
 
 describe('connection-aware plugin host APIs', () => {
+  const exactIdentity = (overrides: Record<string, unknown> = {}) => ({
+    runtime_session_id: 'runtime-1',
+    stored_session_id: 'tip-1',
+    lineage_root_id: 'root-1',
+    busy: false,
+    capabilities: { exact_submission: 1, attachment_relay: 1 },
+    ...overrides
+  })
+
+  const exactTarget = () => {
+    setMockAtom($sessions, [
+      { id: 'tip-1', _lineage_root_id: 'root-1', profile: 'worker', connection_id: 'connection-a' }
+    ])
+    setMockAtom($sessionStates, { 'runtime-1': { storedSessionId: 'tip-1' } })
+
+    return host.sessionTarget({
+      connectionId: 'connection-a',
+      profile: 'worker',
+      runtimeSessionId: 'runtime-1',
+      storedSessionId: 'tip-1'
+    })!
+  }
+
+  const exactReceipt = (
+    params: Record<string, unknown>,
+    state: 'durably_accepted' | 'rejected' = 'durably_accepted'
+  ) => {
+    const exact = (params.exact_submission as Record<string, unknown> | undefined) ?? params
+    return {
+      version: 1,
+      state,
+      accepted_at: '2026-08-21T00:00:00Z',
+      submission_id: exact.submission_id,
+      connection_id: exact.connection_id,
+      profile: exact.profile,
+      runtime_session_id: params.session_id,
+      stored_session_id: exact.stored_session_id,
+      lineage_root_id: exact.lineage_root_id,
+      payload_digest: exact.payload_digest,
+      source_digest: exact.source_digest,
+      context_digest: exact.context_digest,
+      attachment_manifest_digest: exact.attachment_manifest_digest,
+      attachment_count: exact.attachment_count,
+      ...(state === 'rejected' ? { reason: 'stale-target' } : {})
+    }
+  }
+
+  it('publishes the exact canonical SDK capability table and versions', () => {
+    const versions = (
+      sdk as unknown as {
+        PLUGIN_SDK_CAPABILITY_VERSIONS: Readonly<Record<string, number>>
+      }
+    ).PLUGIN_SDK_CAPABILITY_VERSIONS
+
+    expect.soft(host.capabilityVersion('composer-disposition')).toBe(2)
+    expect.soft(host.capabilityVersion('exact-session-submit')).toBe(2)
+    expect.soft(host.capabilityVersion('direct-draft-submit')).toBe(0)
+    expect(versions).toEqual({
+      'plugin-status': 1,
+      'composer-disposition': 2,
+      'exact-session-submit': 2,
+      'attachment-relay': 1
+    })
+    expect(Object.isFrozen(versions)).toBe(true)
+    expect(Reflect.ownKeys(versions)).toEqual([
+      'plugin-status',
+      'composer-disposition',
+      'exact-session-submit',
+      'attachment-relay'
+    ])
+  })
+
+  it('returns zero for unknown, malformed, empty, symbol, inherited, and prototype-collision names', () => {
+    const capabilityVersion = host.capabilityVersion as (capability: unknown) => number
+    const coercion = vi.fn()
+    const hostile = Object.defineProperty({}, Symbol.toPrimitive, {
+      get: () => {
+        coercion()
+        throw new Error('capability names must not be coerced')
+      }
+    })
+
+    for (const value of [
+      '',
+      'unknown-capability',
+      'toString',
+      '__proto__',
+      'constructor',
+      Symbol('plugin-status'),
+      null,
+      undefined,
+      1,
+      hostile,
+      Object.create({ capability: 'plugin-status' })
+    ]) {
+      expect(capabilityVersion(value)).toBe(0)
+    }
+    expect(coercion).not.toHaveBeenCalled()
+  })
+
+  it('projects exact connection, profile, runtime, stored, lineage, and focus identity', () => {
+    setMockAtom($focusedRuntimeId, 'runtime-1')
+    setMockAtom($focusedStoredSessionId, 'root-1')
+    setMockAtom($selectedStoredSessionId, 'root-1')
+
+    expect(exactTarget()).toEqual({
+      composerScope: 'root-1',
+      composerTarget: 'main',
+      connectionId: 'connection-a',
+      lineageRootId: 'root-1',
+      profile: 'worker',
+      runtimeSessionId: 'runtime-1',
+      storedSessionId: 'tip-1'
+    })
+  })
+
+  it('submits directly without recursively running composer middleware', async () => {
+    const target = exactTarget()
+    const middleware = vi.fn((draft: { text: string }) => draft)
+    const dispose = registry.register({
+      id: 'no-recursion-guard',
+      area: COMPOSER_AREAS.middleware,
+      data: { handler: middleware }
+    })
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connection, _profile, method, params) => {
+      if (method === 'session.identity') {
+        return exactIdentity()
+      }
+      if (method === 'prompt.submit') {
+        return { receipt: exactReceipt(params ?? {}) }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    try {
+      await expect(
+        host.submitDraft(target, { text: '  Unicode Ω\nsecond line  ' }, { submissionId: 'submit_exact_00000001' })
+      ).resolves.toMatchObject({ state: 'durably_accepted', submissionId: 'submit_exact_00000001' })
+      expect(middleware).not.toHaveBeenCalled()
+      expect(vi.mocked(requestGatewayForAgent).mock.calls.filter(call => call[2] === 'prompt.submit')).toHaveLength(1)
+    } finally {
+      dispose()
+    }
+  })
+
+  it('fails closed on inherited backend capabilities', async () => {
+    const target = exactTarget()
+    const inherited = Object.create({ exact_submission: 1, attachment_relay: 1 })
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce(exactIdentity({ capabilities: inherited }))
+
+    await expect(
+      host.submitDraft(target, { text: 'exact' }, { submissionId: 'submit_exact_00000002' })
+    ).resolves.toMatchObject({ state: 'rejected', reason: 'unsupported-capability' })
+    expect(vi.mocked(requestGatewayForAgent).mock.calls.some(call => call[2] === 'prompt.submit')).toBe(false)
+  })
+
+  it('does not retry, recover, queue, or retarget a busy exact session', async () => {
+    const target = exactTarget()
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce(exactIdentity({ busy: true }))
+
+    await expect(
+      host.submitDraft(target, { text: 'exact' }, { submissionId: 'submit_exact_00000003' })
+    ).resolves.toMatchObject({ state: 'rejected', reason: 'busy-target' })
+    expect(requestGatewayForAgent).toHaveBeenCalledTimes(1)
+    expect(requestGatewayForAgent).toHaveBeenCalledWith(
+      'connection-a',
+      'worker',
+      'session.identity',
+      { session_id: 'runtime-1' }
+    )
+  })
+
+  it('returns acknowledgement uncertain without blind retry when admission cannot be reconciled', async () => {
+    const target = exactTarget()
+    vi.mocked(requestGatewayForAgent)
+      .mockResolvedValueOnce(exactIdentity())
+      .mockResolvedValueOnce(exactIdentity())
+      .mockRejectedValueOnce(new Error('transport timeout'))
+      .mockRejectedValueOnce(new Error('receipt lookup timeout'))
+
+    await expect(
+      host.submitDraft(target, { text: 'exact' }, { submissionId: 'submit_exact_00000004' })
+    ).resolves.toMatchObject({ state: 'acknowledgement_uncertain', submissionId: 'submit_exact_00000004' })
+    expect(vi.mocked(requestGatewayForAgent).mock.calls.filter(call => call[2] === 'prompt.submit')).toHaveLength(1)
+    expect(vi.mocked(requestGatewayForAgent).mock.calls.filter(call => call[2] === 'prompt.receipt')).toHaveLength(1)
+  })
+
+  it('sends complete receipt lookup identity and rejects a partial accepted receipt', async () => {
+    const target = exactTarget()
+    let lookupParams: Record<string, unknown> | undefined
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connection, _profile, method, params) => {
+      if (method === 'session.identity') {
+        return exactIdentity()
+      }
+      if (method === 'prompt.submit') {
+        throw new Error('transport timeout')
+      }
+      if (method === 'prompt.receipt') {
+        lookupParams = params
+        return {
+          receipt: {
+            state: 'durably_accepted',
+            submission_id: 'submit_exact_00000006',
+            payload_digest: params?.payload_digest
+          }
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    await expect(
+      host.submitDraft(target, { text: 'exact' }, { submissionId: 'submit_exact_00000006' })
+    ).resolves.toMatchObject({ state: 'acknowledgement_uncertain' })
+    expect(Object.keys(lookupParams ?? {}).sort()).toEqual(
+      [
+        'attachment_count',
+        'attachment_manifest_digest',
+        'connection_id',
+        'context_digest',
+        'lineage_root_id',
+        'payload_digest',
+        'profile',
+        'session_id',
+        'source_digest',
+        'stored_session_id',
+        'submission_id'
+      ].sort()
+    )
+  })
+
+  it('rejects an accepted prompt receipt with one mismatched bound digest', async () => {
+    const target = exactTarget()
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connection, _profile, method, params) => {
+      if (method === 'session.identity') {
+        return exactIdentity()
+      }
+      if (method === 'prompt.submit') {
+        const exact = params?.exact_submission as Record<string, unknown>
+        return {
+          receipt: {
+            version: 1,
+            state: 'durably_accepted',
+            accepted_at: '2026-08-21T00:00:00Z',
+            submission_id: exact.submission_id,
+            connection_id: exact.connection_id,
+            profile: exact.profile,
+            runtime_session_id: params?.session_id,
+            stored_session_id: exact.stored_session_id,
+            lineage_root_id: exact.lineage_root_id,
+            payload_digest: exact.payload_digest,
+            source_digest: '0'.repeat(64),
+            context_digest: exact.context_digest,
+            attachment_manifest_digest: exact.attachment_manifest_digest,
+            attachment_count: exact.attachment_count
+          }
+        }
+      }
+      if (method === 'prompt.receipt') {
+        throw new Error('receipt unavailable')
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    await expect(
+      host.submitDraft(target, { text: 'exact' }, { submissionId: 'submit_exact_00000007' })
+    ).resolves.toMatchObject({ state: 'acknowledgement_uncertain' })
+  })
+
+  it.each([
+    ['inherited', 'durably_accepted'],
+    ['accessor', 'durably_accepted'],
+    ['polluted', 'durably_accepted'],
+    ['extra', 'durably_accepted'],
+    ['mistyped', 'durably_accepted'],
+    ['inherited', 'rejected'],
+    ['accessor', 'rejected'],
+    ['polluted', 'rejected'],
+    ['extra', 'rejected'],
+    ['mistyped', 'rejected']
+  ] as const)('keeps %s %s receipts acknowledgement uncertain', async (shape, state) => {
+    const target = exactTarget()
+    let getterCalls = 0
+    const hostile = (base: Record<string, unknown>): Record<string, unknown> => {
+      if (shape === 'inherited') {
+        const { state: inheritedState, ...own } = base
+        return Object.assign(Object.create({ state: inheritedState }), own)
+      }
+      if (shape === 'accessor') {
+        const { state: accessorState, ...own } = base
+        Object.defineProperty(own, 'state', {
+          enumerable: true,
+          get: () => {
+            getterCalls += 1
+            return accessorState
+          }
+        })
+        return own
+      }
+      if (shape === 'polluted') {
+        return Object.assign(Object.create({ polluted: true }), base)
+      }
+      if (shape === 'extra') {
+        return { ...base, extra: true }
+      }
+      return { ...base, version: '1' }
+    }
+
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connection, _profile, method, params) => {
+      if (method === 'session.identity') {
+        return exactIdentity()
+      }
+      if (method === 'prompt.submit') {
+        if (state === 'rejected') {
+          throw new Error('transport timeout')
+        }
+        return { receipt: hostile(exactReceipt(params ?? {}, state)) }
+      }
+      if (method === 'prompt.receipt') {
+        if (state === 'durably_accepted') {
+          throw new Error('receipt unavailable')
+        }
+        return { receipt: hostile(exactReceipt(params ?? {}, state)) }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    await expect(
+      host.submitDraft(target, { text: 'exact' }, { submissionId: `submit_${shape}_${state}` })
+    ).resolves.toMatchObject({ state: 'acknowledgement_uncertain' })
+    expect(getterCalls).toBe(0)
+  })
+
+  it('reconciles one valid closed completely bound rejected receipt', async () => {
+    const target = exactTarget()
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connection, _profile, method, params) => {
+      if (method === 'session.identity') {
+        return exactIdentity()
+      }
+      if (method === 'prompt.submit') {
+        throw new Error('transport timeout')
+      }
+      if (method === 'prompt.receipt') {
+        return { receipt: exactReceipt(params ?? {}, 'rejected') }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    await expect(
+      host.submitDraft(target, { text: 'exact' }, { submissionId: 'submit_exact_rejected_0001' })
+    ).resolves.toMatchObject({ state: 'rejected', reason: 'stale-target' })
+  })
+
+  it('rejects stale identity at the final prompt mutation boundary', async () => {
+    const target = exactTarget()
+    vi.mocked(requestGatewayForAgent)
+      .mockResolvedValueOnce(exactIdentity())
+      .mockResolvedValueOnce(exactIdentity({ lineage_root_id: 'other-root' }))
+
+    await expect(
+      host.submitDraft(target, { text: 'exact' }, { submissionId: 'submit_exact_00000005' })
+    ).resolves.toMatchObject({ state: 'rejected', reason: 'stale-target' })
+    expect(vi.mocked(requestGatewayForAgent).mock.calls.some(call => call[2] === 'prompt.submit')).toBe(false)
+  })
+
+  it('relays authorized bytes with repeated target probes and exact response integrity', async () => {
+    const target = exactTarget()
+    const item = {
+      id: 'file-1',
+      occurrenceId: 'occ-1',
+      kind: 'file' as const,
+      label: 'notes.txt',
+      path: 'C:/private/notes.txt'
+    }
+    const authority = captureHostComposerAttachmentAuthority([item])
+    const attempt = createComposerAttachmentAttempt(authority, [item], [item])
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = {
+      readFileDataUrlForAttach: async () => 'data:text/plain;base64,aGVsbG8='
+    }
+    vi.mocked(requestGatewayForAgent).mockImplementation(async (_connection, _profile, method, params) => {
+      if (method === 'session.identity') {
+        return exactIdentity()
+      }
+      if (method === 'file.attach') {
+        return {
+          attached: true,
+          bytes: 5,
+          media_type: 'text/plain',
+          name: 'notes.txt',
+          order: 0,
+          ref_text: '@file:notes.txt',
+          runtime_session_id: 'runtime-1',
+          sha256: (params?.relay as { sha256?: string } | undefined)?.sha256,
+          stored_name: 'notes.txt'
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+
+    try {
+      await expect(host.relayAttachments(target, attempt.attachments)).resolves.toEqual([
+        expect.objectContaining({ name: 'notes.txt', order: 0, runtimeSessionId: 'runtime-1', size: 5 })
+      ])
+      expect(vi.mocked(requestGatewayForAgent).mock.calls.filter(call => call[2] === 'session.identity').length).toBeGreaterThanOrEqual(5)
+    } finally {
+      attempt.release()
+    }
+  })
+
   it('retires a profile gateway before deleting it', async () => {
     const order: string[] = []
 

--- a/tests/tui_gateway/test_attach_does_not_wait_for_agent.py
+++ b/tests/tui_gateway/test_attach_does_not_wait_for_agent.py
@@ -14,7 +14,9 @@ event is still unset, and the staged image must still reach the turn.
 from __future__ import annotations
 
 import base64
+import hashlib
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -136,3 +138,238 @@ def test_sess_building_does_not_wait_but_sess_does(session, monkeypatch):
 
     server._sess({"session_id": sid}, "rid-sess")
     assert waited == ["rid-sess"]
+
+
+def relay_binding(sid, *, data: bytes, name="notes.txt", media_type="text/plain", order=0):
+    return {
+        "stored_session_id": sid,
+        "lineage_root_id": sid,
+        "name": name,
+        "media_type": media_type,
+        "bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "order": order,
+    }
+
+
+def relay_request(method: str, sid: str, data: bytes) -> dict:
+    if method == "image.attach_bytes":
+        return {
+            "session_id": sid,
+            "content_base64": "data:image/png;base64," + base64.b64encode(data).decode(),
+            "filename": "shot.png",
+            "relay": relay_binding(sid, data=data, name="shot.png", media_type="image/png"),
+        }
+    return {
+        "session_id": sid,
+        "data_url": "data:text/plain;base64," + base64.b64encode(data).decode(),
+        "name": "notes.txt",
+        "relay": relay_binding(sid, data=data),
+    }
+
+
+@pytest.mark.parametrize("method,data", [("file.attach", b"hello"), ("image.attach_bytes", PNG_BYTES)])
+@pytest.mark.parametrize("busy_field", ["running", "_compute_host_active"])
+def test_exact_relay_rejects_every_busy_state_before_mutation(session, tmp_path, method, data, busy_field):
+    sid, record = session
+    record[busy_field] = True
+
+    response = call(method, relay_request(method, sid, data))
+
+    assert response["error"]["code"] == 4009
+    assert record["attached_images"] == []
+    assert not (tmp_path / "attachments").exists()
+
+
+@pytest.mark.parametrize("method,data", [("file.attach", b"hello"), ("image.attach_bytes", PNG_BYTES)])
+@pytest.mark.parametrize("busy_field", ["running", "_compute_host_active"])
+def test_exact_relay_rechecks_busy_state_immediately_before_mutation(
+    session, tmp_path, monkeypatch, method, data, busy_field
+):
+    sid, record = session
+    real_integrity = server._relay_integrity
+
+    def become_busy(*args, **kwargs):
+        result = real_integrity(*args, **kwargs)
+        record[busy_field] = True
+        return result
+
+    monkeypatch.setattr(server, "_relay_integrity", become_busy)
+
+    response = call(method, relay_request(method, sid, data))
+
+    assert response["error"]["code"] == 4009
+    assert record["attached_images"] == []
+    assert not (tmp_path / "attachments").exists()
+
+
+def test_exact_file_relay_verifies_and_echoes_complete_integrity_without_path(session):
+    sid, _record = session
+    data = b"hello"
+    response = call(
+        "file.attach",
+        {
+            "session_id": sid,
+            "data_url": "data:text/plain;base64," + base64.b64encode(data).decode(),
+            "name": "notes.txt",
+            "relay": relay_binding(sid, data=data),
+        },
+    )
+
+    assert "error" not in response, response
+    assert response["result"] == {
+        "attached": True,
+        "bytes": 5,
+        "media_type": "text/plain",
+        "name": "notes.txt",
+        "stored_name": "notes.txt",
+        "order": 0,
+        "runtime_session_id": sid,
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "ref_text": "@file:attachments/notes.txt",
+    }
+    assert "path" not in response["result"]
+
+
+def test_exact_image_relay_uses_the_same_closed_integrity_contract(session):
+    sid, record = session
+    response = call(
+        "image.attach_bytes",
+        {
+            "session_id": sid,
+            "content_base64": "data:image/png;base64," + base64.b64encode(PNG_BYTES).decode(),
+            "filename": "shot.png",
+            "relay": relay_binding(
+                sid,
+                data=PNG_BYTES,
+                name="shot.png",
+                media_type="image/png",
+                order=1,
+            ),
+        },
+    )
+
+    assert "error" not in response, response
+    stored_name = Path(record["attached_images"][0]).name
+    assert response["result"] == {
+        "attached": True,
+        "bytes": len(PNG_BYTES),
+        "media_type": "image/png",
+        "name": "shot.png",
+        "stored_name": stored_name,
+        "order": 1,
+        "runtime_session_id": sid,
+        "sha256": hashlib.sha256(PNG_BYTES).hexdigest(),
+    }
+    assert len(record["attached_images"]) == 1
+    assert "path" not in response["result"]
+
+
+def test_exact_file_relay_authenticates_collision_generated_target_name(session, tmp_path):
+    sid, _record = session
+    attachments = tmp_path / "attachments"
+    attachments.mkdir()
+    (attachments / "notes.txt").write_text("existing", encoding="utf-8")
+
+    response = call("file.attach", relay_request("file.attach", sid, b"hello"))
+
+    assert "error" not in response, response
+    assert response["result"]["name"] == "notes.txt"
+    assert response["result"]["stored_name"] != "notes.txt"
+    assert response["result"]["ref_text"].endswith(response["result"]["stored_name"])
+    staged = attachments / response["result"]["stored_name"]
+    assert staged.read_bytes() == b"hello"
+
+
+def test_exact_file_relay_rejects_post_stage_byte_mutation(session, monkeypatch):
+    sid, _record = session
+    real_stage = server._stage_session_file_attachment
+
+    def mutate_after_stage(*args, **kwargs):
+        stored_path, uploaded = real_stage(*args, **kwargs)
+        stored_path.write_bytes(b"tampered")
+        return stored_path, uploaded
+
+    monkeypatch.setattr(server, "_stage_session_file_attachment", mutate_after_stage)
+
+    response = call("file.attach", relay_request("file.attach", sid, b"hello"))
+
+    assert response["error"]["code"] == 4017
+
+
+def test_exact_image_relay_rejects_post_stage_byte_mutation(session, monkeypatch):
+    sid, record = session
+    real_queue = server._queue_attached_image
+
+    def mutate_after_stage(*args, **kwargs):
+        stored_path = real_queue(*args, **kwargs)
+        stored_path.write_bytes(b"tampered")
+        return stored_path
+
+    monkeypatch.setattr(server, "_queue_attached_image", mutate_after_stage)
+
+    response = call("image.attach_bytes", relay_request("image.attach_bytes", sid, PNG_BYTES))
+
+    assert response["error"]["code"] == 4017
+    assert record["attached_images"] == []
+
+
+def test_exact_image_relay_binds_media_type_to_actual_image_bytes(session):
+    sid, record = session
+    request = relay_request("image.attach_bytes", sid, PNG_BYTES)
+    request["content_base64"] = "data:image/gif;base64," + base64.b64encode(PNG_BYTES).decode()
+    request["relay"]["media_type"] = "image/gif"
+
+    response = call("image.attach_bytes", request)
+
+    assert response["error"]["code"] == 4017
+    assert record["attached_images"] == []
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("stored_session_id", "other"),
+        ("lineage_root_id", "other"),
+        ("name", "other.txt"),
+        ("media_type", "application/json"),
+        ("bytes", 999),
+        ("sha256", "0" * 64),
+        ("order", -1),
+    ],
+)
+def test_exact_file_relay_rejects_any_integrity_or_session_mismatch(session, field, value):
+    sid, record = session
+    data = b"hello"
+    relay = relay_binding(sid, data=data)
+    relay[field] = value
+
+    response = call(
+        "file.attach",
+        {
+            "session_id": sid,
+            "data_url": "data:text/plain;base64," + base64.b64encode(data).decode(),
+            "name": "notes.txt",
+            "relay": relay,
+        },
+    )
+
+    assert response["error"]["code"] in {4004, 4017, 4018}
+    assert not list(record.get("attached_files", []))
+
+
+@pytest.mark.parametrize("name", ["../escape", "..\\escape", "C:stream", "\\\\server\\share", "NUL", "trailing."])
+def test_exact_relay_rejects_cross_platform_unsafe_names_before_staging(session, name):
+    sid, _record = session
+    data = b"hello"
+    response = call(
+        "file.attach",
+        {
+            "session_id": sid,
+            "data_url": "data:text/plain;base64," + base64.b64encode(data).decode(),
+            "name": name,
+            "relay": relay_binding(sid, data=data, name=name),
+        },
+    )
+
+    assert response["error"]["code"] == 4004

--- a/tests/tui_gateway/test_auto_continue.py
+++ b/tests/tui_gateway/test_auto_continue.py
@@ -127,6 +127,145 @@ def test_marker_survives_corrupt_sidecar(tmp_path):
     assert read_turn_marker(tmp_path, "abc")["prompt"] == "prompt"
 
 
+def test_terminal_retirement_always_targets_the_matching_exact_submission(monkeypatch, marker_home):
+    calls = []
+    monkeypatch.setattr(
+        server,
+        "clear_turn_marker",
+        lambda home, key, submission_id=None: calls.append((home, key, submission_id)),
+    )
+    session = _session(
+        profile_home=str(marker_home),
+        _exact_active_submission_id="submit_exact_00000001",
+    )
+
+    server._retire_turn_marker(session)
+
+    assert calls == [(marker_home, "session-key", "submit_exact_00000001")]
+    assert "_exact_active_submission_id" not in session
+
+
+@pytest.mark.parametrize("terminal_type", ["turn.end", "turn.error"])
+def test_authenticated_compute_terminal_selectively_retires_matching_exact_marker(
+    monkeypatch, marker_home, terminal_type
+):
+    from tui_gateway import exact_admission
+
+    def binding(submission_id, digest):
+        return {
+            "submission_id": submission_id,
+            "connection_id": "connection-a",
+            "profile": "worker",
+            "runtime_session_id": "runtime-1",
+            "stored_session_id": "session-key",
+            "lineage_root_id": "session-key",
+            "payload_digest": digest,
+            "source_digest": "b" * 64,
+            "context_digest": "c" * 64,
+            "attachment_manifest_digest": "d" * 64,
+            "attachment_count": 0,
+        }
+
+    exact_admission.record_exact_admission(
+        marker_home,
+        binding=binding("submit_exact_00000001", "a" * 64),
+        prompt="first context",
+        persist_user_text="first source",
+    )
+    exact_admission.record_exact_admission(
+        marker_home,
+        binding=binding("submit_exact_00000002", "e" * 64),
+        prompt="second context",
+        persist_user_text="second source",
+    )
+    session = _session(
+        profile_home=str(marker_home),
+        running=True,
+        _exact_active_submission_id="submit_exact_00000002",
+    )
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_emit", lambda *_args: None)
+    monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_args: None)
+
+    nonterminal = {
+        "type": "turn.started",
+        "sid": "sid",
+        "request_id": "request-1",
+        "exact_submission_id": "submit_exact_00000001",
+    }
+    server._on_compute_host_turn_done("request-1", "sid", session, nonterminal)
+    assert exact_admission._read_record(
+        exact_admission._record_path(marker_home, "submit_exact_00000001"), "submit_exact_00000001"
+    )["turn"] is not None
+
+    server._on_compute_host_turn_done(
+        "request-1",
+        "sid",
+        session,
+        {
+            "type": terminal_type,
+            "sid": "sid",
+            "request_id": "request-1",
+            "exact_submission_id": "submit_exact_00000001",
+        },
+        exact_submission_id="submit_exact_00000001",
+    )
+
+    first = exact_admission._read_record(
+        exact_admission._record_path(marker_home, "submit_exact_00000001"), "submit_exact_00000001"
+    )
+    second = exact_admission._read_record(
+        exact_admission._record_path(marker_home, "submit_exact_00000002"), "submit_exact_00000002"
+    )
+    assert first["turn"] is None
+    assert second["turn"] is not None
+    assert exact_admission.get_exact_receipt(marker_home, "submit_exact_00000001")["state"] == "durably_accepted"
+    assert exact_admission.get_exact_receipt(marker_home, "submit_exact_00000002")["state"] == "durably_accepted"
+    assert session["_exact_active_submission_id"] == "submit_exact_00000002"
+
+
+def test_compute_terminal_with_conflicting_identity_cannot_retire_exact_marker(monkeypatch, marker_home):
+    from tui_gateway import exact_admission
+
+    binding = {
+        "submission_id": "submit_exact_00000001",
+        "connection_id": "connection-a",
+        "profile": "worker",
+        "runtime_session_id": "runtime-1",
+        "stored_session_id": "session-key",
+        "lineage_root_id": "session-key",
+        "payload_digest": "a" * 64,
+        "source_digest": "b" * 64,
+        "context_digest": "c" * 64,
+        "attachment_manifest_digest": "d" * 64,
+        "attachment_count": 0,
+    }
+    exact_admission.record_exact_admission(
+        marker_home, binding=binding, prompt="context", persist_user_text="source"
+    )
+    session = _session(profile_home=str(marker_home), running=True)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(server, "_emit", lambda *_args: None)
+    monkeypatch.setattr(server, "_drain_queued_prompt", lambda *_args: None)
+
+    server._on_compute_host_turn_done(
+        "request-1",
+        "sid",
+        session,
+        {
+            "type": "turn.end",
+            "sid": "sid",
+            "request_id": "request-1",
+            "exact_submission_id": "submit_exact_conflict",
+        },
+        exact_submission_id="submit_exact_00000001",
+    )
+
+    assert exact_admission._read_record(
+        exact_admission._record_path(marker_home, "submit_exact_00000001"), "submit_exact_00000001"
+    )["turn"] is not None
+
+
 # ── Turn lifecycle owns the marker ─────────────────────────────────────
 
 
@@ -261,6 +400,39 @@ def test_fresh_marker_schedules_continuation(emits, schedule_env, marker_home):
     assert "fix the flaky test" in text
     assert kwargs["display_kind"] == "auto_continue"
     assert ("message.start", "sid", None) in [(e, s, p) for e, s, p in emits]
+
+
+def test_exact_atomic_marker_carries_original_source_into_auto_continue(
+    emits, schedule_env, marker_home
+):
+    from tui_gateway.exact_admission import record_exact_admission
+
+    binding = {
+        "submission_id": "submit_exact_00000001",
+        "connection_id": "connection-a",
+        "profile": "worker",
+        "runtime_session_id": "sid",
+        "stored_session_id": "session-key",
+        "lineage_root_id": "session-key",
+        "payload_digest": "a" * 64,
+        "source_digest": "b" * 64,
+        "context_digest": "c" * 64,
+        "attachment_manifest_digest": "d" * 64,
+        "attachment_count": 1,
+    }
+    record_exact_admission(
+        marker_home,
+        binding=binding,
+        prompt="@file:attachments/notes.txt\n\n  exact source  ",
+        persist_user_text="  exact source  ",
+    )
+    session = _session()
+
+    result = server._maybe_schedule_auto_continue("sid", session, "session-key")
+
+    assert result is not None
+    assert session["_auto_continue_persist_user_text"] == "  exact source  "
+    assert "@file:attachments/notes.txt" in schedule_env[0][0]
 
 
 def test_stale_marker_is_cleared_not_continued(schedule_env, marker_home, monkeypatch):

--- a/tests/tui_gateway/test_compute_host.py
+++ b/tests/tui_gateway/test_compute_host.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from tui_gateway import server
 from tui_gateway.compute_host import ComputeHost, HostSession
 
 
@@ -126,3 +127,54 @@ def test_compute_host_interrupt_uses_explicit_stop_compatibility(kind):
 
     assert calls == ["hard" if kind == "hard-only" else "legacy"]
     assert emitted[-1]["applied"] is True
+
+
+def test_real_compute_turn_carries_exact_identity_without_changing_prompt_bytes(monkeypatch):
+    host = ComputeHost(heartbeat_secs=0)
+    emitted = []
+    captured = {}
+    session = {
+        "agent": object(),
+        "session_key": "stored-1",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "inflight_turn": None,
+        "attached_images": [],
+    }
+    monkeypatch.setattr(host, "_ensure_server_session", lambda _server, _frame: session)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *_args: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda *_args: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+
+    def run_prompt(request_id, sid, current, text, **kwargs):
+        captured.update({"request_id": request_id, "sid": sid, "text": text, **kwargs})
+        current["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", run_prompt)
+    host.emit = emitted.append
+    text = "@file:attachments/notes.txt\n\n  exact source  "
+    try:
+        host._run_real_turn(
+            {
+                "type": "turn.start",
+                "sid": "runtime-1",
+                "request_id": "request-1",
+                "session_key": "stored-1",
+                "text": text,
+                "persist_user_text": "  exact source  ",
+                "exact_admitted": True,
+                "exact_submission_id": "submit_exact_00000001",
+            }
+        )
+    finally:
+        host.close()
+
+    assert captured["text"] == text
+    assert captured["persist_user_text"] == "  exact source  "
+    assert captured["exact_admitted"] is True
+    assert captured["exact_submission_id"] == "submit_exact_00000001"
+    terminal = [frame for frame in emitted if frame.get("type") == "turn.end"][-1]
+    assert terminal["exact_submission_id"] == "submit_exact_00000001"

--- a/tests/tui_gateway/test_exact_admission.py
+++ b/tests/tui_gateway/test_exact_admission.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+
+def binding(**overrides):
+    value = {
+        "submission_id": "submit_exact_00000001",
+        "connection_id": "connection-a",
+        "profile": "worker",
+        "runtime_session_id": "runtime-1",
+        "stored_session_id": "stored-1",
+        "lineage_root_id": "root-1",
+        "payload_digest": "a" * 64,
+        "source_digest": "b" * 64,
+        "context_digest": "c" * 64,
+        "attachment_manifest_digest": "d" * 64,
+        "attachment_count": 2,
+    }
+    value.update(overrides)
+    return value
+
+
+def test_one_atomic_record_contains_crash_marker_and_complete_receipt(tmp_path, monkeypatch):
+    from tui_gateway import exact_admission
+
+    replacements = []
+    real_replace = exact_admission.os.replace
+    monkeypatch.setattr(
+        exact_admission.os,
+        "replace",
+        lambda source, destination: replacements.append((source, destination)) or real_replace(source, destination),
+    )
+
+    receipt, created = exact_admission.record_exact_admission(
+        tmp_path,
+        binding=binding(),
+        prompt="attachment context\n\n  exact source  ",
+        persist_user_text="  exact source  ",
+    )
+
+    assert created is True
+    assert len(replacements) == 1
+    assert receipt == exact_admission.get_exact_receipt(tmp_path, binding()["submission_id"])
+    marker = exact_admission.read_exact_turn_marker(tmp_path, "stored-1")
+    assert marker == {
+        "submission_id": "submit_exact_00000001",
+        "prompt": "attachment context\n\n  exact source  ",
+        "persist_user_text": "  exact source  ",
+        "attempts": 0,
+        "started_at": pytest.approx(marker["started_at"], abs=0),
+    }
+    assert set(receipt) == {
+        "version",
+        "submission_id",
+        "connection_id",
+        "profile",
+        "runtime_session_id",
+        "stored_session_id",
+        "lineage_root_id",
+        "payload_digest",
+        "source_digest",
+        "context_digest",
+        "attachment_manifest_digest",
+        "attachment_count",
+        "state",
+        "accepted_at",
+    }
+    assert receipt["state"] == "durably_accepted"
+    assert "path" not in str(receipt).lower()
+    assert "token" not in str(receipt).lower()
+
+
+def test_clearing_crash_marker_preserves_receipt(tmp_path):
+    from tui_gateway.exact_admission import (
+        clear_exact_turn_marker,
+        get_exact_receipt,
+        read_exact_turn_marker,
+        record_exact_admission,
+    )
+
+    record_exact_admission(tmp_path, binding=binding(), prompt="context", persist_user_text="source")
+    clear_exact_turn_marker(tmp_path, "stored-1", "submit_exact_00000001")
+
+    assert read_exact_turn_marker(tmp_path, "stored-1") is None
+    assert get_exact_receipt(tmp_path, "submit_exact_00000001")["state"] == "durably_accepted"
+
+
+def test_clearing_matching_marker_preserves_conflicting_active_admission(tmp_path):
+    from tui_gateway import exact_admission
+
+    exact_admission.record_exact_admission(
+        tmp_path,
+        binding=binding(submission_id="submit_exact_00000001"),
+        prompt="first",
+        persist_user_text="first",
+    )
+    exact_admission.record_exact_admission(
+        tmp_path,
+        binding=binding(submission_id="submit_exact_00000002", payload_digest="e" * 64),
+        prompt="second",
+        persist_user_text="second",
+    )
+
+    exact_admission.clear_exact_turn_marker(tmp_path, "stored-1", "submit_exact_00000001")
+
+    first = exact_admission._read_record(
+        exact_admission._record_path(tmp_path, "submit_exact_00000001"), "submit_exact_00000001"
+    )
+    second = exact_admission._read_record(
+        exact_admission._record_path(tmp_path, "submit_exact_00000002"), "submit_exact_00000002"
+    )
+    assert first["turn"] is None
+    assert second["turn"]["submission_id"] == "submit_exact_00000002"
+    assert exact_admission.get_exact_receipt(tmp_path, "submit_exact_00000001")["state"] == "durably_accepted"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("connection_id", "connection-b"),
+        ("profile", "other-worker"),
+        ("runtime_session_id", "runtime-2"),
+        ("stored_session_id", "stored-2"),
+        ("lineage_root_id", "root-2"),
+        ("payload_digest", "0" * 64),
+        ("source_digest", "1" * 64),
+        ("context_digest", "2" * 64),
+        ("attachment_manifest_digest", "3" * 64),
+        ("attachment_count", 3),
+    ],
+)
+def test_every_receipt_binding_field_conflicts_without_overwrite(tmp_path, field, value):
+    from tui_gateway.exact_admission import ExactAdmissionConflict, record_exact_admission
+
+    first, _ = record_exact_admission(tmp_path, binding=binding(), prompt="context", persist_user_text="source")
+
+    with pytest.raises(ExactAdmissionConflict):
+        record_exact_admission(
+            tmp_path,
+            binding=binding(**{field: value}),
+            prompt="context",
+            persist_user_text="source",
+        )
+
+    replay, created = record_exact_admission(tmp_path, binding=binding(), prompt="context", persist_user_text="source")
+    assert created is False
+    assert replay == first
+
+
+def test_concurrent_replay_admits_once(tmp_path):
+    from tui_gateway.exact_admission import record_exact_admission
+
+    with ThreadPoolExecutor(max_workers=12) as pool:
+        results = list(
+            pool.map(
+                lambda _index: record_exact_admission(
+                    tmp_path,
+                    binding=binding(),
+                    prompt="context",
+                    persist_user_text="source",
+                ),
+                range(24),
+            )
+        )
+
+    assert sum(created for _receipt, created in results) == 1
+    assert len({receipt["accepted_at"] for receipt, _created in results}) == 1
+
+
+def test_rejected_receipt_is_bound_and_has_no_active_turn(tmp_path):
+    from tui_gateway.exact_admission import get_exact_receipt, read_exact_turn_marker, record_exact_rejection
+
+    receipt, created = record_exact_rejection(tmp_path, binding=binding(), reason="busy-target")
+
+    assert created is True
+    assert receipt["state"] == "rejected"
+    assert receipt["reason"] == "busy-target"
+    assert get_exact_receipt(tmp_path, binding()["submission_id"]) == receipt
+    assert read_exact_turn_marker(tmp_path, "stored-1") is None
+
+
+def test_invalid_ids_corrupt_records_and_capacity_fail_closed(tmp_path, monkeypatch):
+    from tui_gateway import exact_admission
+
+    with pytest.raises(exact_admission.ExactAdmissionInvalid):
+        exact_admission.record_exact_admission(
+            tmp_path,
+            binding=binding(submission_id="../escape"),
+            prompt="context",
+            persist_user_text="source",
+        )
+
+    monkeypatch.setattr(exact_admission, "_MAX_RECORDS", 1)
+    exact_admission.record_exact_admission(tmp_path, binding=binding(), prompt="context", persist_user_text="source")
+    with pytest.raises(exact_admission.ExactAdmissionError, match="capacity"):
+        exact_admission.record_exact_admission(
+            tmp_path,
+            binding=binding(submission_id="submit_exact_00000002"),
+            prompt="context",
+            persist_user_text="source",
+        )

--- a/tests/tui_gateway/test_exact_prompt_submit.py
+++ b/tests/tui_gateway/test_exact_prompt_submit.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server
+
+
+class FakeDB:
+    def __init__(self, root="root-1"):
+        self.root = root
+
+    def get_conversation_root(self, _session_id):
+        return self.root
+
+
+class CapturingThread:
+    starts = []
+
+    def __init__(self, *, target, daemon):
+        self.target = target
+        self.daemon = daemon
+
+    def start(self):
+        self.starts.append(self.target)
+
+    def is_alive(self):
+        return True
+
+
+def session(tmp_path, *, running=False):
+    return {
+        "agent": types.SimpleNamespace(),
+        "agent_ready": None,
+        "agent_error": None,
+        "attached_images": [],
+        "cwd": str(tmp_path),
+        "history": [],
+        "history_lock": threading.RLock(),
+        "history_version": 0,
+        "inflight_turn": None,
+        "last_active": 0,
+        "profile_home": str(tmp_path),
+        "running": running,
+        "session_key": "stored-1",
+        "transport": None,
+    }
+
+
+@pytest.fixture
+def exact_env(tmp_path, monkeypatch):
+    sid = "runtime-1"
+    record = session(tmp_path)
+    server._sessions[sid] = record
+    CapturingThread.starts = []
+    monkeypatch.setattr(server, "_ensure_active_session_slot", lambda *_args: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda *_args: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda *_args: None)
+    monkeypatch.setattr(server, "_load_dashboard_process_isolation_config", lambda: {})
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_args: False)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: None)
+    monkeypatch.setattr(server.threading, "Thread", CapturingThread)
+
+    @contextlib.contextmanager
+    def fake_db(_session):
+        yield FakeDB()
+
+    monkeypatch.setattr(server, "_session_db", fake_db)
+    yield sid, record, tmp_path
+    server._sessions.pop(sid, None)
+
+
+def exact_params(sid="runtime-1", **overrides):
+    source_text = overrides.pop("source_text", "  Unicode Ω\nsecond line  ")
+    attachments = overrides.pop("attachments", [])
+    context_text = overrides.pop("context_text", source_text)
+    source_digest = hashlib.sha256(source_text.encode("utf-8")).hexdigest()
+    context_digest = hashlib.sha256(context_text.encode("utf-8")).hexdigest()
+    attachment_bytes = json.dumps(attachments, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    attachment_manifest_digest = hashlib.sha256(attachment_bytes).hexdigest()
+    material = json.dumps(
+        {"text": source_text, "contextText": context_text, "attachments": attachments},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    exact = {
+        "submission_id": "submit_exact_00000001",
+        "connection_id": "connection-a",
+        "profile": "worker",
+        "stored_session_id": "stored-1",
+        "lineage_root_id": "root-1",
+        "payload_digest": hashlib.sha256(material).hexdigest(),
+        "source_digest": source_digest,
+        "context_digest": context_digest,
+        "attachment_manifest_digest": attachment_manifest_digest,
+        "attachment_count": len(attachments),
+        "source_text": source_text,
+        "context_text": context_text,
+        "attachments": attachments,
+    }
+    exact.update(overrides.pop("exact", {}))
+    return {"session_id": sid, "text": context_text, "exact_submission": exact, **overrides}
+
+
+def call(method, params):
+    return server._methods[method]("request-1", params)
+
+
+def receipt_params(**overrides):
+    request = exact_params()
+    exact = request["exact_submission"]
+    params = {
+        "session_id": request["session_id"],
+        "submission_id": exact["submission_id"],
+        "connection_id": exact["connection_id"],
+        "profile": exact["profile"],
+        "stored_session_id": exact["stored_session_id"],
+        "lineage_root_id": exact["lineage_root_id"],
+        "payload_digest": exact["payload_digest"],
+        "source_digest": exact["source_digest"],
+        "context_digest": exact["context_digest"],
+        "attachment_manifest_digest": exact["attachment_manifest_digest"],
+        "attachment_count": exact["attachment_count"],
+    }
+    params.update(overrides)
+    return params
+
+
+def test_exact_submit_atomically_admits_receipt_and_turn_before_dispatch(exact_env):
+    _sid, record, home = exact_env
+    from tui_gateway.exact_admission import get_exact_receipt, read_exact_turn_marker
+
+    response = call("prompt.submit", exact_params())
+
+    assert "error" not in response, response
+    receipt = response["result"]["receipt"]
+    assert receipt["state"] == "durably_accepted"
+    assert receipt["connection_id"] == "connection-a"
+    assert receipt["profile"] == "worker"
+    assert response["result"]["idempotent_replay"] is False
+    assert get_exact_receipt(home, "submit_exact_00000001") == receipt
+    marker = read_exact_turn_marker(home, "stored-1")
+    assert marker["prompt"] == "  Unicode Ω\nsecond line  "
+    assert marker["persist_user_text"] == "  Unicode Ω\nsecond line  "
+    assert CapturingThread.starts, "dispatch starts only after durable admission"
+    assert record["running"] is True
+
+
+def test_exact_submit_receipt_binds_source_context_and_complete_attachment_manifest(exact_env):
+    attachment = {
+        "id": "file-1",
+        "occurrenceId": "occ-1",
+        "sourceId": "file-1",
+        "kind": "file",
+        "name": "notes.txt",
+        "mediaType": "text/plain",
+        "refText": "@file:attachments/notes.txt",
+        "runtimeSessionId": "runtime-1",
+        "sha256": "a" * 64,
+        "size": 5,
+        "storedName": "notes.txt",
+        "order": 0,
+    }
+    source = "  exact Ω source  "
+    context = f"{attachment['refText']}\n\n{source}"
+
+    response = call("prompt.submit", exact_params(source_text=source, context_text=context, attachments=[attachment]))
+
+    assert "error" not in response, response
+    receipt = response["result"]["receipt"]
+    assert receipt["attachment_count"] == 1
+    assert receipt["source_digest"] == hashlib.sha256(source.encode()).hexdigest()
+    assert receipt["context_digest"] == hashlib.sha256(context.encode()).hexdigest()
+    assert receipt["attachment_manifest_digest"] == hashlib.sha256(
+        json.dumps([attachment], ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+
+
+def test_exact_submit_preserves_source_and_atomic_admission_through_compute_host(exact_env, monkeypatch):
+    _sid, _record, _home = exact_env
+    captured = {}
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_args: True)
+
+    def submit_compute(rid, sid, session, text, **kwargs):
+        captured.update({"rid": rid, "sid": sid, "text": text, **kwargs})
+        return server._ok(rid, {"status": "streaming", "turn_isolation": True})
+
+    monkeypatch.setattr(server, "_submit_prompt_to_compute_host", submit_compute)
+    source = "  exact compute source  "
+    context = "@file:attachments/notes.txt\n\n" + source
+
+    response = call("prompt.submit", exact_params(source_text=source, context_text=context))
+
+    assert "error" not in response, response
+    assert captured["text"] == context
+    assert captured["persist_user_text"] == source
+    assert captured["exact_admitted"] is True
+    assert captured["exact_submission_id"] == "submit_exact_00000001"
+    assert response["result"]["receipt"]["state"] == "durably_accepted"
+
+
+def test_exact_submit_replay_is_idempotent_even_while_session_is_busy(exact_env):
+    _sid, record, _home = exact_env
+    first = call("prompt.submit", exact_params())
+    starts = len(CapturingThread.starts)
+    assert record["running"] is True
+
+    replay = call("prompt.submit", exact_params())
+
+    assert replay["result"]["receipt"] == first["result"]["receipt"]
+    assert replay["result"]["idempotent_replay"] is True
+    assert len(CapturingThread.starts) == starts
+    assert record.get("queued_prompt") is None
+
+
+def test_exact_submit_conflict_rejects_without_dispatch_or_overwrite(exact_env):
+    _sid, record, _home = exact_env
+    call("prompt.submit", exact_params())
+    starts = len(CapturingThread.starts)
+
+    conflict = call("prompt.submit", exact_params(source_text="changed", context_text="changed"))
+
+    assert conflict["error"]["code"] == 4091
+    assert len(CapturingThread.starts) == starts
+    assert record.get("queued_prompt") is None
+
+
+def test_exact_submit_busy_rejects_before_native_redirect_queue_or_receipt(exact_env, monkeypatch):
+    _sid, record, home = exact_env
+    from tui_gateway.exact_admission import get_exact_receipt
+
+    record["running"] = True
+    busy_handler = pytest.fail
+    monkeypatch.setattr(server, "_handle_busy_submit", busy_handler)
+
+    response = call("prompt.submit", exact_params())
+
+    assert response["error"]["code"] == 4009
+    assert get_exact_receipt(home, "submit_exact_00000001")["state"] == "rejected"
+    assert record.get("queued_prompt") is None
+    assert record.get("inflight_turn") is None
+    assert not CapturingThread.starts
+
+
+@pytest.mark.parametrize(
+    "exact",
+    [
+        {"stored_session_id": "wrong"},
+        {"lineage_root_id": "wrong"},
+        {"payload_digest": "0" * 64},
+        {"source_digest": "1" * 64},
+        {"context_digest": "2" * 64},
+        {"attachment_manifest_digest": "3" * 64},
+        {"attachment_count": 3},
+        {"submission_id": "../escape"},
+        {"unexpected": True},
+    ],
+)
+def test_exact_submit_rejects_stale_malformed_or_incompletely_bound_requests(exact_env, exact):
+    _sid, record, _home = exact_env
+
+    response = call("prompt.submit", exact_params(exact=exact))
+
+    assert response["error"]["code"] in {4004, 4017, 4018}
+    assert record["running"] is False
+    assert record.get("inflight_turn") is None
+    assert not CapturingThread.starts
+
+
+def test_receipt_query_is_profile_scoped_closed_and_non_secret(exact_env):
+    call("prompt.submit", exact_params())
+
+    response = call("prompt.receipt", receipt_params())
+
+    assert response["result"]["receipt"]["state"] == "durably_accepted"
+    assert "path" not in str(response["result"]).lower()
+    assert "token" not in str(response["result"]).lower()
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("connection_id", "connection-b"),
+        ("profile", "other-worker"),
+        ("session_id", "runtime-2"),
+        ("stored_session_id", "stored-2"),
+        ("lineage_root_id", "root-2"),
+        ("payload_digest", "0" * 64),
+        ("source_digest", "1" * 64),
+        ("context_digest", "2" * 64),
+        ("attachment_manifest_digest", "3" * 64),
+        ("attachment_count", 1),
+    ],
+)
+def test_receipt_query_rejects_every_target_and_payload_binding_mismatch(exact_env, field, value):
+    call("prompt.submit", exact_params())
+
+    response = call("prompt.receipt", receipt_params(**{field: value}))
+
+    assert response["error"]["code"] in {4001, 4018, 4091}
+
+
+def test_receipt_query_rejects_partial_lookup_identity(exact_env):
+    call("prompt.submit", exact_params())
+
+    response = call("prompt.receipt", {"session_id": "runtime-1", "submission_id": "submit_exact_00000001"})
+
+    assert response["error"]["code"] == 4004
+
+
+@pytest.mark.parametrize("shape", ["subclass", "partial", "extra", "mistyped"])
+def test_receipt_query_rejects_non_closed_or_mistyped_stored_receipts(exact_env, monkeypatch, shape):
+    call("prompt.submit", exact_params())
+    from tui_gateway import exact_admission
+
+    valid = exact_admission.get_exact_receipt(
+        exact_env[2], "submit_exact_00000001"
+    )
+    assert valid is not None
+
+    if shape == "subclass":
+        class HostileReceipt(dict):
+            calls = 0
+
+            def get(self, key, default=None):
+                type(self).calls += 1
+                return super().get(key, default)
+
+        hostile = HostileReceipt(valid)
+    elif shape == "partial":
+        hostile = {key: value for key, value in valid.items() if key != "source_digest"}
+    elif shape == "extra":
+        hostile = {**valid, "extra": True}
+    else:
+        hostile = {**valid, "version": "1"}
+
+    monkeypatch.setattr(exact_admission, "get_exact_receipt", lambda *_args: hostile)
+
+    response = call("prompt.receipt", receipt_params())
+
+    assert response["error"]["code"] == 4004
+    if shape == "subclass":
+        assert HostileReceipt.calls == 0
+
+
+def test_session_identity_is_closed_lineage_aware_busy_and_versioned(exact_env):
+    _sid, record, _home = exact_env
+
+    idle = call("session.identity", {"session_id": "runtime-1"})
+    assert idle["result"] == {
+        "runtime_session_id": "runtime-1",
+        "stored_session_id": "stored-1",
+        "lineage_root_id": "root-1",
+        "busy": False,
+        "capabilities": {"exact_submission": 1, "attachment_relay": 1},
+    }
+    record["running"] = True
+    assert call("session.identity", {"session_id": "runtime-1"})["result"]["busy"] is True

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -437,6 +437,22 @@ class ComputeHost:
     def _run_real_turn(self, frame: dict[str, Any]) -> None:
         sid = str(frame.get("sid") or "")
         request_id = str(frame.get("request_id") or uuid.uuid4().hex)
+        exact_submission_id = None
+        if frame.get("exact_admitted"):
+            try:
+                from tui_gateway.exact_admission import validate_submission_id
+
+                exact_submission_id = validate_submission_id(frame.get("exact_submission_id"))
+            except Exception:
+                self.emit(
+                    {
+                        "type": "turn.error",
+                        "sid": sid,
+                        "request_id": request_id,
+                        "message": "invalid exact submission identity",
+                    }
+                )
+                return
         if not sid:
             self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "message": "sid required"})
             return
@@ -458,11 +474,20 @@ class ComputeHost:
                             "request_id": request_id,
                             "interrupted": True,
                             "ended_ns": now_ns(),
+                            **({"exact_submission_id": exact_submission_id} if exact_submission_id else {}),
                         }
                     )
                     return
                 if session.get("running"):
-                    self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "message": "session busy"})
+                    self.emit(
+                        {
+                            "type": "turn.error",
+                            "sid": sid,
+                            "request_id": request_id,
+                            "message": "session busy",
+                            **({"exact_submission_id": exact_submission_id} if exact_submission_id else {}),
+                        }
+                    )
                     return
                 session["running"] = True
                 session["_turn_cancel_requested"] = False
@@ -490,6 +515,9 @@ class ComputeHost:
                 session,
                 text,
                 display_kind=frame.get("display_kind") or None,
+                persist_user_text=frame.get("persist_user_text"),
+                exact_admitted=bool(frame.get("exact_admitted")),
+                exact_submission_id=exact_submission_id,
             )
             run_thread = session.get("_run_thread")
             if run_thread is not None and hasattr(run_thread, "join"):
@@ -513,6 +541,7 @@ class ComputeHost:
                     "ended_ns": now_ns(),
                     "session_info": session_info,
                     "session_info_emitted": True,
+                    **({"exact_submission_id": exact_submission_id} if exact_submission_id else {}),
                 }
             )
         except Exception as exc:
@@ -526,7 +555,16 @@ class ComputeHost:
                         server._clear_inflight_turn(session)
             except Exception:
                 pass
-            self.emit({"type": "turn.error", "sid": sid, "request_id": request_id, "reason": "exception", "message": str(exc)})
+            self.emit(
+                {
+                    "type": "turn.error",
+                    "sid": sid,
+                    "request_id": request_id,
+                    "reason": "exception",
+                    "message": str(exc),
+                    **({"exact_submission_id": exact_submission_id} if exact_submission_id else {}),
+                }
+            )
 
     def _ensure_server_session(self, server: Any, frame: dict[str, Any]) -> dict:
         sid = str(frame.get("sid") or "")

--- a/tui_gateway/exact_admission.py
+++ b/tui_gateway/exact_admission.py
@@ -1,0 +1,315 @@
+"""Atomic crash admission and durable receipts for exact prompt submissions.
+
+One record owns both facts that must become durable before dispatch: the
+payload/session-bound receipt and the active-turn recovery marker. The initial
+admission is one fsynced temp-file replacement, never two independently durable
+writes. Clearing a concluded turn removes only the marker; the receipt remains
+for reconciliation and idempotency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_SUBMISSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$")
+_HEX_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_VERSION = 1
+_MAX_RECORDS = 4096
+_MAX_PROMPT_CHARS = 64_000
+_LOCK = threading.RLock()
+_BINDING_FIELDS = (
+    "submission_id",
+    "connection_id",
+    "profile",
+    "runtime_session_id",
+    "stored_session_id",
+    "lineage_root_id",
+    "payload_digest",
+    "source_digest",
+    "context_digest",
+    "attachment_manifest_digest",
+    "attachment_count",
+)
+
+
+class ExactAdmissionError(RuntimeError):
+    """Base class for exact-admission persistence failures."""
+
+
+class ExactAdmissionConflict(ExactAdmissionError):
+    """A submission id is already bound to a different immutable request."""
+
+
+class ExactAdmissionInvalid(ExactAdmissionError):
+    """An identifier, binding, or persisted record is malformed."""
+
+
+def _identifier(value: Any, field: str, *, maximum: int = 256) -> str:
+    if not isinstance(value, str) or not value or len(value) > maximum or "\x00" in value:
+        raise ExactAdmissionInvalid(f"invalid {field}")
+    return value
+
+
+def _submission_id(value: Any) -> str:
+    if not isinstance(value, str) or not _SUBMISSION_ID_RE.fullmatch(value):
+        raise ExactAdmissionInvalid("invalid submission_id")
+    return value
+
+
+def validate_submission_id(value: Any) -> str:
+    return _submission_id(value)
+
+
+def _digest(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not _HEX_DIGEST_RE.fullmatch(value):
+        raise ExactAdmissionInvalid(f"invalid {field}")
+    return value
+
+
+def validate_binding(binding: Any) -> dict[str, Any]:
+    if type(binding) is not dict or set(binding) != set(_BINDING_FIELDS):
+        raise ExactAdmissionInvalid("invalid exact admission binding")
+    clean = {
+        "submission_id": _submission_id(binding.get("submission_id")),
+        "connection_id": _identifier(binding.get("connection_id"), "connection_id"),
+        "profile": _identifier(binding.get("profile"), "profile"),
+        "runtime_session_id": _identifier(binding.get("runtime_session_id"), "runtime_session_id"),
+        "stored_session_id": _identifier(binding.get("stored_session_id"), "stored_session_id"),
+        "lineage_root_id": _identifier(binding.get("lineage_root_id"), "lineage_root_id"),
+        "payload_digest": _digest(binding.get("payload_digest"), "payload_digest"),
+        "source_digest": _digest(binding.get("source_digest"), "source_digest"),
+        "context_digest": _digest(binding.get("context_digest"), "context_digest"),
+        "attachment_manifest_digest": _digest(
+            binding.get("attachment_manifest_digest"), "attachment_manifest_digest"
+        ),
+    }
+    count = binding.get("attachment_count")
+    if isinstance(count, bool) or not isinstance(count, int) or count < 0 or count > 32:
+        raise ExactAdmissionInvalid("invalid attachment_count")
+    clean["attachment_count"] = count
+    return clean
+
+
+def validate_exact_receipt(receipt: Any, binding: dict) -> dict:
+    clean = validate_binding(binding)
+    if type(receipt) is not dict:
+        raise ExactAdmissionInvalid("invalid exact receipt")
+    state = receipt.get("state")
+    expected_fields = {"version", *_BINDING_FIELDS, "state", "accepted_at"}
+    if state == "rejected":
+        expected_fields.add("reason")
+    if set(receipt) != expected_fields or type(receipt.get("version")) is not int or receipt.get("version") != _VERSION:
+        raise ExactAdmissionInvalid("invalid exact receipt fields")
+    if state not in {"durably_accepted", "rejected"}:
+        raise ExactAdmissionInvalid("invalid exact receipt state")
+    if any(receipt.get(field) != clean[field] for field in _BINDING_FIELDS):
+        raise ExactAdmissionInvalid("exact receipt binding mismatch")
+    _identifier(receipt.get("accepted_at"), "accepted_at")
+    if state == "rejected":
+        _identifier(receipt.get("reason"), "reason", maximum=128)
+    return dict(receipt)
+
+
+def _record_dir(home: Path | str) -> Path:
+    directory = Path(home) / "desktop" / "exact-admissions"
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _record_path(home: Path | str, submission_id: str) -> Path:
+    safe = _submission_id(submission_id)
+    return _record_dir(home) / f"{hashlib.sha256(safe.encode('utf-8')).hexdigest()}.json"
+
+
+def _atomic_replace(path: Path, payload: bytes) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        if os.name != "nt":
+            descriptor = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _encode(record: dict) -> bytes:
+    return (json.dumps(record, ensure_ascii=True, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
+
+
+def _validate_record(value: Any, expected_submission_id: str | None = None) -> dict:
+    if not isinstance(value, dict) or set(value) != {"version", "binding", "receipt", "turn"}:
+        raise ExactAdmissionInvalid("invalid stored exact admission")
+    if value.get("version") != _VERSION:
+        raise ExactAdmissionInvalid("unsupported exact admission version")
+    binding = validate_binding(value.get("binding"))
+    if expected_submission_id is not None and binding["submission_id"] != expected_submission_id:
+        raise ExactAdmissionInvalid("exact admission identity mismatch")
+    receipt = validate_exact_receipt(value.get("receipt"), binding)
+    state = receipt["state"]
+    if state == "rejected":
+        if value.get("turn") is not None:
+            raise ExactAdmissionInvalid("rejected receipt cannot own a turn marker")
+    elif value.get("turn") is not None:
+        turn = value["turn"]
+        if not isinstance(turn, dict) or set(turn) != {
+            "submission_id",
+            "stored_session_id",
+            "prompt",
+            "persist_user_text",
+            "attempts",
+            "started_at",
+        }:
+            raise ExactAdmissionInvalid("invalid exact turn marker")
+        if turn["submission_id"] != binding["submission_id"] or turn["stored_session_id"] != binding["stored_session_id"]:
+            raise ExactAdmissionInvalid("exact turn marker binding mismatch")
+    return {"version": _VERSION, "binding": binding, "receipt": receipt, "turn": value.get("turn")}
+
+
+def _read_record(path: Path, expected_submission_id: str | None = None) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ExactAdmissionInvalid("stored exact admission is unreadable") from exc
+    return _validate_record(value, expected_submission_id)
+
+
+def get_exact_receipt(home: Path | str, submission_id: str) -> dict | None:
+    safe = _submission_id(submission_id)
+    with _LOCK:
+        record = _read_record(_record_path(home, safe), safe)
+    return None if record is None else record["receipt"]
+
+
+def _new_receipt(binding: dict, state: str, *, reason: str | None = None) -> dict:
+    receipt = {
+        "version": _VERSION,
+        **binding,
+        "state": state,
+        "accepted_at": datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z"),
+    }
+    if reason is not None:
+        receipt["reason"] = _identifier(reason, "reason", maximum=128)
+    return receipt
+
+
+def _check_capacity(path: Path) -> None:
+    if sum(1 for candidate in path.parent.iterdir() if candidate.is_file() and candidate.suffix == ".json") >= _MAX_RECORDS:
+        raise ExactAdmissionError("exact admission capacity reached")
+
+
+def record_exact_admission(
+    home: Path | str,
+    *,
+    binding: dict,
+    prompt: str,
+    persist_user_text: str,
+    attempts: int = 0,
+) -> tuple[dict, bool]:
+    clean = validate_binding(binding)
+    if not isinstance(prompt, str) or not prompt or len(prompt) > _MAX_PROMPT_CHARS:
+        raise ExactAdmissionInvalid("invalid exact prompt")
+    if not isinstance(persist_user_text, str) or len(persist_user_text) > _MAX_PROMPT_CHARS:
+        raise ExactAdmissionInvalid("invalid exact persisted source")
+    if isinstance(attempts, bool) or not isinstance(attempts, int) or attempts < 0:
+        raise ExactAdmissionInvalid("invalid exact attempts")
+    path = _record_path(home, clean["submission_id"])
+
+    with _LOCK:
+        existing = _read_record(path, clean["submission_id"])
+        if existing is not None:
+            if existing["binding"] != clean:
+                raise ExactAdmissionConflict("submission_id is already bound to another exact request")
+            return existing["receipt"], False
+        _check_capacity(path)
+        now = time.time()
+        receipt = _new_receipt(clean, "durably_accepted")
+        record = {
+            "version": _VERSION,
+            "binding": clean,
+            "receipt": receipt,
+            "turn": {
+                "submission_id": clean["submission_id"],
+                "stored_session_id": clean["stored_session_id"],
+                "prompt": prompt,
+                "persist_user_text": persist_user_text,
+                "attempts": attempts,
+                "started_at": now,
+            },
+        }
+        _atomic_replace(path, _encode(record))
+        return _validate_record(record, clean["submission_id"])["receipt"], True
+
+
+def record_exact_rejection(home: Path | str, *, binding: dict, reason: str) -> tuple[dict, bool]:
+    clean = validate_binding(binding)
+    path = _record_path(home, clean["submission_id"])
+    with _LOCK:
+        existing = _read_record(path, clean["submission_id"])
+        if existing is not None:
+            if existing["binding"] != clean:
+                raise ExactAdmissionConflict("submission_id is already bound to another exact request")
+            return existing["receipt"], False
+        _check_capacity(path)
+        receipt = _new_receipt(clean, "rejected", reason=reason)
+        record = {"version": _VERSION, "binding": clean, "receipt": receipt, "turn": None}
+        _atomic_replace(path, _encode(record))
+        return _validate_record(record, clean["submission_id"])["receipt"], True
+
+
+def read_exact_turn_marker(home: Path | str, stored_session_id: str) -> dict | None:
+    stored = _identifier(stored_session_id, "stored_session_id")
+    newest = None
+    with _LOCK:
+        directory = _record_dir(home)
+        for path in directory.glob("*.json"):
+            record = _read_record(path)
+            turn = record and record.get("turn")
+            if not turn or turn.get("stored_session_id") != stored:
+                continue
+            if newest is None or float(turn.get("started_at") or 0) > float(newest.get("started_at") or 0):
+                newest = turn
+    return None if newest is None else {
+        "submission_id": newest["submission_id"],
+        "prompt": newest["prompt"],
+        "persist_user_text": newest["persist_user_text"],
+        "attempts": newest["attempts"],
+        "started_at": newest["started_at"],
+    }
+
+
+def clear_exact_turn_marker(home: Path | str, stored_session_id: str, submission_id: str) -> None:
+    stored = _identifier(stored_session_id, "stored_session_id")
+    submission = _submission_id(submission_id)
+    with _LOCK:
+        path = _record_path(home, submission)
+        record = _read_record(path, submission)
+        turn = record and record.get("turn")
+        if (
+            not turn
+            or turn.get("stored_session_id") != stored
+            or turn.get("submission_id") != submission
+        ):
+            return
+        record["turn"] = None
+        _atomic_replace(path, _encode(record))

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -12,6 +12,247 @@ _registry = HandlerRegistry()
 method = _registry.method
 _profile_scoped = _registry.profile_scoped
 
+_EXACT_KEYS = {
+    "submission_id",
+    "connection_id",
+    "profile",
+    "stored_session_id",
+    "lineage_root_id",
+    "payload_digest",
+    "source_digest",
+    "context_digest",
+    "attachment_manifest_digest",
+    "attachment_count",
+    "source_text",
+    "context_text",
+    "attachments",
+}
+_EXACT_ATTACHMENT_KEYS = {
+    "id",
+    "occurrenceId",
+    "sourceId",
+    "kind",
+    "name",
+    "mediaType",
+    "runtimeSessionId",
+    "sha256",
+    "size",
+    "storedName",
+    "order",
+}
+_RELAY_KEYS = {
+    "stored_session_id",
+    "lineage_root_id",
+    "name",
+    "media_type",
+    "bytes",
+    "sha256",
+    "order",
+}
+_RECEIPT_LOOKUP_KEYS = {
+    "session_id",
+    "submission_id",
+    "connection_id",
+    "profile",
+    "stored_session_id",
+    "lineage_root_id",
+    "payload_digest",
+    "source_digest",
+    "context_digest",
+    "attachment_manifest_digest",
+    "attachment_count",
+}
+
+
+def _safe_relay_name(value) -> str | None:
+    import re
+
+    if not isinstance(value, str) or not value or len(value) > 255:
+        return None
+    if re.search(r"[\x00-\x1f\x7f\\/:]", value) or value in {".", ".."}:
+        return None
+    if value.endswith((".", " ")) or re.match(
+        r"^(?:aux|con|nul|prn|com[1-9]|lpt[1-9])(?:\.|$)", value, re.I
+    ):
+        return None
+    return value
+
+
+def _relay_busy_error(rid, session: dict):
+    if session.get("running") or session.get("_compute_host_active"):
+        return _err(rid, 4009, "exact attachment relay target is busy")
+    return None
+
+
+def _relay_staged_integrity(rid, session: dict, relay_result: dict, stored_path):
+    import hashlib
+
+    path = Path(stored_path)
+    try:
+        stored_name = _safe_relay_name(path.name)
+        payload = path.read_bytes() if path.is_file() else b""
+    except Exception:
+        stored_name = None
+        payload = b""
+    if (
+        stored_name is None
+        or len(payload) != relay_result.get("bytes")
+        or hashlib.sha256(payload).hexdigest() != relay_result.get("sha256")
+    ):
+        session["attached_images"] = [value for value in session.get("attached_images", []) if value != str(path)]
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return None, _err(rid, 4017, "staged attachment integrity mismatch")
+    return {**relay_result, "stored_name": stored_name}, None
+
+
+def _relay_integrity(
+    rid, sid: str, session: dict, relay, payload: bytes, *, name: str, media_type: str
+):
+    import hashlib
+    import re
+
+    if relay is None:
+        return None, None
+    if busy_err := _relay_busy_error(rid, session):
+        return None, busy_err
+    if not isinstance(relay, dict) or set(relay) != _RELAY_KEYS:
+        return None, _err(rid, 4004, "invalid attachment relay fields")
+    safe_name = _safe_relay_name(name)
+    if safe_name is None or relay.get("name") != safe_name:
+        return None, _err(rid, 4004, "invalid attachment relay name")
+    if not isinstance(media_type, str) or not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*",
+        media_type,
+    ):
+        return None, _err(rid, 4004, "invalid attachment relay media type")
+    stored = str(session.get("session_key") or sid)
+    lineage = _exact_lineage(session, stored)
+    order = relay.get("order")
+    digest = hashlib.sha256(payload).hexdigest()
+    if (
+        relay.get("stored_session_id") != stored
+        or relay.get("lineage_root_id") != lineage
+        or relay.get("media_type") != media_type
+        or relay.get("bytes") != len(payload)
+        or relay.get("sha256") != digest
+        or isinstance(order, bool)
+        or not isinstance(order, int)
+        or order < 0
+        or order > 31
+    ):
+        return None, _err(rid, 4017, "attachment relay integrity or session mismatch")
+    return {
+        "attached": True,
+        "bytes": len(payload),
+        "media_type": media_type,
+        "name": safe_name,
+        "order": order,
+        "runtime_session_id": str(sid),
+        "sha256": digest,
+    }, None
+
+
+def _exact_lineage(session: dict, stored: str) -> str:
+    lineage = stored
+    try:
+        with _session_db(session) as db:
+            resolver = getattr(db, "get_conversation_root", None)
+            if callable(resolver):
+                lineage = str(resolver(stored) or stored)
+    except Exception:
+        lineage = str(session.get("lineage_root_id") or stored)
+    return lineage
+
+
+def _exact_request(rid, sid: str, session: dict, value):
+    """Validate and canonicalize a closed exact-submission envelope."""
+    import hashlib
+    import json
+
+    if not isinstance(value, dict) or set(value) != _EXACT_KEYS:
+        return None, _err(rid, 4004, "invalid exact_submission fields")
+    source = value.get("source_text")
+    context = value.get("context_text")
+    attachments = value.get("attachments")
+    if not isinstance(source, str) or not isinstance(context, str):
+        return None, _err(rid, 4004, "exact source/context must be strings")
+    if len(source) > 64000 or len(context) > 128000 or (not source and not attachments):
+        return None, _err(rid, 4004, "invalid exact source/context length")
+    if not isinstance(attachments, list) or len(attachments) > 32:
+        return None, _err(rid, 4004, "invalid exact attachment manifest")
+    for order, attachment in enumerate(attachments):
+        keys = set(attachment) if isinstance(attachment, dict) else set()
+        allowed = _EXACT_ATTACHMENT_KEYS | {"refText"}
+        if not _EXACT_ATTACHMENT_KEYS <= keys or not keys <= allowed:
+            return None, _err(rid, 4004, "invalid exact attachment fields")
+        if (
+            attachment.get("order") != order
+            or attachment.get("runtimeSessionId") != sid
+            or attachment.get("sourceId") != attachment.get("id")
+            or attachment.get("kind") not in {"file", "image"}
+            or not isinstance(attachment.get("name"), str)
+            or _safe_relay_name(attachment.get("storedName")) is None
+            or not isinstance(attachment.get("mediaType"), str)
+            or isinstance(attachment.get("size"), bool)
+            or not isinstance(attachment.get("size"), int)
+            or attachment.get("size") <= 0
+        ):
+            return None, _err(rid, 4004, "invalid exact attachment integrity")
+        digest = attachment.get("sha256")
+        if not isinstance(digest, str) or len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+            return None, _err(rid, 4004, "invalid exact attachment digest")
+    stored = str(session.get("session_key") or sid)
+    lineage = _exact_lineage(session, stored)
+    if value.get("stored_session_id") != stored or value.get("lineage_root_id") != lineage:
+        return None, _err(rid, 4018, "exact session target is stale")
+    if value.get("attachment_count") != len(attachments):
+        return None, _err(rid, 4017, "exact attachment count mismatch")
+    source_digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    context_digest = hashlib.sha256(context.encode("utf-8")).hexdigest()
+    manifest_digest = hashlib.sha256(
+        json.dumps(attachments, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    payload_digest = hashlib.sha256(
+        json.dumps(
+            {"text": source, "contextText": context, "attachments": attachments},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    expected = {
+        "payload_digest": payload_digest,
+        "source_digest": source_digest,
+        "context_digest": context_digest,
+        "attachment_manifest_digest": manifest_digest,
+    }
+    if any(value.get(field) != digest for field, digest in expected.items()):
+        return None, _err(rid, 4017, "exact submission digest mismatch")
+    binding = {
+        "submission_id": value.get("submission_id"),
+        "connection_id": value.get("connection_id"),
+        "profile": value.get("profile"),
+        "runtime_session_id": sid,
+        "stored_session_id": stored,
+        "lineage_root_id": lineage,
+        **expected,
+        "attachment_count": len(attachments),
+    }
+    try:
+        from tui_gateway.exact_admission import validate_binding
+
+        binding = validate_binding(binding)
+    except Exception as exc:
+        return None, _err(rid, 4004, str(exc))
+    return {
+        "binding": binding,
+        "source_text": source,
+        "context_text": context,
+        "attachments": attachments,
+    }, None
+
 
 def _history_user_indices(history: list) -> list:
     """Indices of model-visible user turns (excludes display_kind timeline markers)."""
@@ -271,7 +512,12 @@ def _(rid, params: dict) -> dict:
 
     sid = params.get("session_id", "")
     raw_text = params.get("text", "")
-    text = sanitize_user_prompt_text(raw_text) if isinstance(raw_text, str) else raw_text
+    exact_value = params.get("exact_submission")
+    text = (
+        raw_text
+        if exact_value is not None
+        else sanitize_user_prompt_text(raw_text) if isinstance(raw_text, str) else raw_text
+    )
     # Off-screen sends (widget intents): type the persisted user row so no
     # client renders it as a bubble. Whitelisted to "hidden" — display_kind
     # is a DB-only sidecar and this RPC must not mint arbitrary kinds.
@@ -318,6 +564,51 @@ def _(rid, params: dict) -> dict:
         return err
     if (limit_message := _ensure_active_session_slot(sid, session)) is not None:
         return _err(rid, 4090, limit_message)
+    exact = None
+    exact_receipt = None
+    exact_created = False
+    if exact_value is not None:
+        exact, err = _exact_request(rid, str(sid), session, exact_value)
+        if err:
+            return err
+        text = exact["context_text"]
+        if any(
+            params.get(field) is not None
+            for field in (
+                "truncate_before_user_ordinal",
+                "truncate_before_row_id",
+                "truncate_before_message_id",
+                "queued",
+                "interrupted",
+            )
+        ):
+            return _err(rid, 4004, "exact submission does not support recovery, queue, redirect, or truncation fields")
+        from tui_gateway.exact_admission import (
+            ExactAdmissionConflict,
+            get_exact_receipt,
+            record_exact_rejection,
+        )
+
+        try:
+            existing = get_exact_receipt(session.get("profile_home") or _hermes_home, exact["binding"]["submission_id"])
+        except Exception as exc:
+            return _err(rid, 5008, f"exact receipt lookup failed: {exc}")
+        if existing is not None:
+            if any(existing.get(key) != value for key, value in exact["binding"].items()):
+                return _err(rid, 4091, "submission_id conflicts with an existing exact receipt")
+            if existing.get("state") == "durably_accepted":
+                return _ok(rid, {"status": "streaming", "receipt": existing, "idempotent_replay": True})
+            return _err(rid, 4009, existing.get("reason") or "exact submission rejected", data={"receipt": existing})
+        if session.get("running") or session.get("_compute_host_active"):
+            try:
+                rejected, _ = record_exact_rejection(
+                    session.get("profile_home") or _hermes_home,
+                    binding=exact["binding"],
+                    reason="busy-target",
+                )
+            except ExactAdmissionConflict:
+                return _err(rid, 4091, "submission_id conflicts with an existing exact receipt")
+            return _err(rid, 4009, "exact session is busy", data={"receipt": rejected})
     # Which desktop window this message was typed into. Rewritten on every
     # submit, because one session can be driven from the app window and the HUD
     # in turn: a stale "hud" would tell the model the user is still floating
@@ -347,6 +638,15 @@ def _(rid, params: dict) -> dict:
         busy_transport = None
         with session["history_lock"]:
             if session.get("running"):
+                if exact is not None:
+                    from tui_gateway.exact_admission import record_exact_rejection
+
+                    rejected, _ = record_exact_rejection(
+                        session.get("profile_home") or _hermes_home,
+                        binding=exact["binding"],
+                        reason="busy-target",
+                    )
+                    return _err(rid, 4009, "exact session is busy", data={"receipt": rejected})
                 # Don't reject a mid-turn prompt — queue it (and, by default,
                 # interrupt the live turn) so it runs as the next turn. The
                 # provider interrupt itself must happen after this lock is
@@ -369,6 +669,37 @@ def _(rid, params: dict) -> dict:
     # rowId rebinding (see comment at the assignment site).
     survivor_user_row_ids = None
     with session["history_lock"]:
+        if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
+            return _err(rid, 4009, "subagent still running — wait for it to finish")
+        if exact is not None:
+            current_stored = str(session.get("session_key") or sid)
+            current_lineage = _exact_lineage(session, current_stored)
+            if (
+                current_stored != exact["binding"]["stored_session_id"]
+                or current_lineage != exact["binding"]["lineage_root_id"]
+                or session.get("running")
+            ):
+                return _err(rid, 4018, "exact session target changed before admission")
+            from tui_gateway.exact_admission import (
+                ExactAdmissionConflict,
+                ExactAdmissionError,
+                record_exact_admission,
+            )
+
+            try:
+                exact_receipt, exact_created = record_exact_admission(
+                    session.get("profile_home") or _hermes_home,
+                    binding=exact["binding"],
+                    prompt=exact["context_text"],
+                    persist_user_text=exact["source_text"],
+                )
+            except ExactAdmissionConflict:
+                return _err(rid, 4091, "submission_id conflicts with an existing exact receipt")
+            except ExactAdmissionError as exc:
+                return _err(rid, 5008, f"exact admission failed: {exc}")
+            if not exact_created:
+                return _ok(rid, {"status": "streaming", "receipt": exact_receipt, "idempotent_replay": True})
+            session["_exact_active_submission_id"] = exact["binding"]["submission_id"]
         # A watch session's run lives in the PARENT turn, so its own running
         # flag is False — without this, typing mid-run builds a second agent
         # racing the in-flight child on the same stored session (interleaved
@@ -725,9 +1056,20 @@ def _(rid, params: dict) -> dict:
 
     if turn_isolation:
         isolated_response = _submit_prompt_to_compute_host(
-            rid, sid, session, text, display_kind=display_kind
+            rid,
+            sid,
+            session,
+            text,
+            display_kind=display_kind,
+            persist_user_text=exact["source_text"] if exact is not None else None,
+            exact_admitted=exact is not None,
+            exact_submission_id=exact["binding"]["submission_id"] if exact is not None else None,
         )
         if not isolated_response.get("error"):
+            if exact_receipt is not None:
+                isolated_response["result"].update(
+                    {"receipt": exact_receipt, "idempotent_replay": False}
+                )
             if survivor_user_row_ids is not None:
                 # The truncation already happened inline above (memory + DB),
                 # before compute-host dispatch — the rebind payload applies to
@@ -815,7 +1157,16 @@ def _(rid, params: dict) -> dict:
                     },
                 )
                 return
-        _run_prompt_submit(rid, sid, session, text, display_kind=display_kind)
+        _run_prompt_submit(
+            rid,
+            sid,
+            session,
+            text,
+            display_kind=display_kind,
+            persist_user_text=exact["source_text"] if exact is not None else None,
+            exact_admitted=exact is not None,
+            exact_submission_id=exact["binding"]["submission_id"] if exact is not None else None,
+        )
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck
@@ -827,12 +1178,64 @@ def _(rid, params: dict) -> dict:
         {
             "status": "streaming",
             **(
+                {"receipt": exact_receipt, "idempotent_replay": False}
+                if exact_receipt is not None
+                else {}
+            ),
+            **(
                 {"survivor_user_row_ids": survivor_user_row_ids}
                 if survivor_user_row_ids is not None
                 else {}
             ),
         },
     )
+
+
+@method("prompt.receipt")
+def _(rid, params: dict) -> dict:
+    session, err = _sess_building(params, rid)
+    if err:
+        return err
+    if not isinstance(params, dict) or set(params) != _RECEIPT_LOOKUP_KEYS:
+        return _err(rid, 4004, "complete exact receipt lookup identity required")
+    sid = str(params.get("session_id") or "")
+    stored = str(session.get("session_key") or sid)
+    lineage = _exact_lineage(session, stored)
+    if params.get("stored_session_id") != stored or params.get("lineage_root_id") != lineage:
+        return _err(rid, 4018, "exact receipt target is stale")
+    binding = {
+        "submission_id": params.get("submission_id"),
+        "connection_id": params.get("connection_id"),
+        "profile": params.get("profile"),
+        "runtime_session_id": sid,
+        "stored_session_id": stored,
+        "lineage_root_id": lineage,
+        "payload_digest": params.get("payload_digest"),
+        "source_digest": params.get("source_digest"),
+        "context_digest": params.get("context_digest"),
+        "attachment_manifest_digest": params.get("attachment_manifest_digest"),
+        "attachment_count": params.get("attachment_count"),
+    }
+    try:
+        from tui_gateway.exact_admission import get_exact_receipt, validate_binding
+
+        binding = validate_binding(binding)
+        receipt = get_exact_receipt(
+            session.get("profile_home") or _hermes_home,
+            binding["submission_id"],
+        )
+    except Exception as exc:
+        return _err(rid, 4004, str(exc))
+    if receipt is not None:
+        try:
+            from tui_gateway.exact_admission import validate_exact_receipt
+
+            receipt = validate_exact_receipt(receipt, binding)
+        except Exception as exc:
+            if "binding mismatch" in str(exc):
+                return _err(rid, 4091, "exact receipt lookup identity mismatch")
+            return _err(rid, 4004, str(exc))
+    return _ok(rid, {"receipt": receipt, "state": receipt.get("state") if receipt else "unknown"})
 
 
 @method("clipboard.paste")
@@ -960,11 +1363,52 @@ def _(rid, params: dict) -> dict:
     if ext not in _allowed_image_extensions():
         return _err(rid, 4016, f"unsupported image extension: {ext}")
 
+    relay_result = None
+    relay = params.get("relay")
+    if relay is not None:
+        import re
+
+        match = re.match(r"^data:([^;,]+)", raw_b64, re.I)
+        media_type = match.group(1) if match else {
+            ".gif": "image/gif",
+            ".jpeg": "image/jpeg",
+            ".jpg": "image/jpeg",
+            ".png": "image/png",
+            ".webp": "image/webp",
+        }.get(ext, "application/octet-stream")
+        actual_media_type = {
+            ".gif": "image/gif",
+            ".jpeg": "image/jpeg",
+            ".jpg": "image/jpeg",
+            ".png": "image/png",
+            ".webp": "image/webp",
+        }.get(ext)
+        if actual_media_type is None or media_type.lower() != actual_media_type:
+            return _err(rid, 4017, "attachment relay media type does not match image bytes")
+        relay_result, relay_err = _relay_integrity(
+            rid,
+            str(params.get("session_id") or ""),
+            session,
+            relay,
+            img_bytes,
+            name=filename,
+            media_type=media_type,
+        )
+        if relay_err:
+            return relay_err
+
     try:
+        if relay_result is not None and (busy_err := _relay_busy_error(rid, session)):
+            return busy_err
         img_path = _queue_attached_image(session, img_bytes, ext, prefix="upload")
     except Exception as e:
         return _err(rid, 5027, f"write failed: {e}")
 
+    if relay_result is not None:
+        relay_result, relay_err = _relay_staged_integrity(rid, session, relay_result, img_path)
+        if relay_err:
+            return relay_err
+        return _ok(rid, relay_result)
     return _ok(
         rid,
         {
@@ -1132,11 +1576,45 @@ def _(rid, params: dict) -> dict:
     name = str(params.get("name", "") or "").strip()
     if not raw and not data_url:
         return _err(rid, 4015, "path or data_url required")
+    relay = params.get("relay")
+    relay_result = None
+    if relay is not None:
+        if raw or not data_url:
+            return _err(rid, 4004, "exact attachment relay requires uploaded bytes, not a path")
+        try:
+            import re
+
+            payload = _decode_attachment_data_url(data_url)
+            match = re.match(r"^data:([^;,]+)", data_url, re.I)
+            media_type = match.group(1) if match else "application/octet-stream"
+        except Exception as exc:
+            return _err(rid, 4017, str(exc))
+        relay_result, relay_err = _relay_integrity(
+            rid,
+            str(params.get("session_id") or ""),
+            session,
+            relay,
+            payload,
+            name=name,
+            media_type=media_type,
+        )
+        if relay_err:
+            return relay_err
     try:
+        if relay_result is not None and (busy_err := _relay_busy_error(rid, session)):
+            return busy_err
         stored_path, uploaded = _stage_session_file_attachment(
             session, raw_path=raw, data_url=data_url, name=name
         )
         ref_path = _attachment_ref_path(session, stored_path)
+        if relay_result is not None:
+            relay_result, relay_err = _relay_staged_integrity(rid, session, relay_result, stored_path)
+            if relay_err:
+                return relay_err
+            return _ok(
+                rid,
+                {**relay_result, "ref_text": f"@file:{_format_ref_value(ref_path)}"},
+            )
         return _ok(
             rid,
             {
@@ -1548,7 +2026,21 @@ def register(server) -> None:
     # them. Rebind onto server globals so handler bodies (and server.py call
     # sites) resolve the same free names after the split.
     g = vars(server)
+    g.update(
+        {
+            "_EXACT_KEYS": _EXACT_KEYS,
+            "_EXACT_ATTACHMENT_KEYS": _EXACT_ATTACHMENT_KEYS,
+            "_RELAY_KEYS": _RELAY_KEYS,
+            "_RECEIPT_LOOKUP_KEYS": _RECEIPT_LOOKUP_KEYS,
+        }
+    )
     for helper in (
+        _safe_relay_name,
+        _relay_busy_error,
+        _relay_staged_integrity,
+        _relay_integrity,
+        _exact_lineage,
+        _exact_request,
         _history_user_indices,
         _message_row_id,
         _mem_db_pair_agrees,

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1032,6 +1032,34 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"cwd": resolved, "branch": branch, "git_repo_root": root})
 
 
+@method("session.identity")
+def _(rid, params: dict) -> dict:
+    """Return one closed, non-secret exact-session identity snapshot."""
+    sid = params.get("session_id", "")
+    session, err = _sess_building(params, rid)
+    if err:
+        return err
+    stored = str(session.get("session_key") or sid)
+    lineage = stored
+    try:
+        with _session_db(session) as db:
+            resolver = getattr(db, "get_conversation_root", None)
+            if callable(resolver):
+                lineage = str(resolver(stored) or stored)
+    except Exception:
+        lineage = str(session.get("lineage_root_id") or stored)
+    return _ok(
+        rid,
+        {
+            "runtime_session_id": str(sid),
+            "stored_session_id": stored,
+            "lineage_root_id": lineage,
+            "busy": bool(session.get("running") or session.get("_compute_host_active")),
+            "capabilities": {"exact_submission": 1, "attachment_relay": 1},
+        },
+    )
+
+
 @method("session.active_list")
 def _(rid, params: dict) -> dict:
     """Return live TUI sessions in this gateway process.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1769,7 +1769,14 @@ def _compute_host_turn_frame(
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
     display_kind: str | None = None,
+    persist_user_text: str | None = None,
+    exact_admitted: bool = False,
+    exact_submission_id: str | None = None,
 ) -> dict:
+    if exact_admitted:
+        from tui_gateway.exact_admission import validate_submission_id
+
+        exact_submission_id = validate_submission_id(exact_submission_id)
     with session["history_lock"]:
         history = list(session.get("history", []))
         history_version = int(session.get("history_version", 0))
@@ -1784,6 +1791,9 @@ def _compute_host_turn_frame(
         "request_id": rid,
         "session_key": session.get("session_key") or sid,
         "text": text,
+        **({"persist_user_text": persist_user_text} if persist_user_text is not None else {}),
+        **({"exact_admitted": True} if exact_admitted else {}),
+        **({"exact_submission_id": exact_submission_id} if exact_submission_id is not None else {}),
         **({"display_kind": display_kind} if display_kind else {}),
         "history": history,
         "history_version": history_version,
@@ -1837,7 +1847,22 @@ def _apply_compute_host_metadata_mirror(session: dict, frame: dict | None) -> No
         session["_metadata_mirror_updated_at"] = time.time()
 
 
-def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -> None:
+def _on_compute_host_turn_done(
+    rid: str,
+    sid: str,
+    session: dict,
+    frame: dict,
+    *,
+    exact_submission_id: str | None = None,
+) -> None:
+    if (
+        not isinstance(frame, dict)
+        or frame.get("type") not in {"turn.end", "turn.error"}
+        or frame.get("sid") != sid
+        or frame.get("request_id") != rid
+    ):
+        return
+    marker_key = str(session.get("session_key") or sid)
     is_error = frame.get("type") == "turn.error"
     with session["history_lock"]:
         if frame.get("session_key"):
@@ -1853,6 +1878,8 @@ def _on_compute_host_turn_done(rid: str, sid: str, session: dict, frame: dict) -
         session["running"] = False
         session["last_active"] = time.time()
         _clear_inflight_turn(session)
+    if exact_submission_id is not None and frame.get("exact_submission_id") == exact_submission_id:
+        _retire_turn_marker(session, marker_key, submission_id=exact_submission_id)
     if is_error:
         message = str(frame.get("message") or "compute host turn failed")
         _emit("message.complete", sid, {"text": f"Error: {message}", "status": "error"})
@@ -1874,6 +1901,9 @@ def _submit_prompt_to_compute_host(
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
     display_kind: str | None = None,
+    persist_user_text: str | None = None,
+    exact_admitted: bool = False,
+    exact_submission_id: str | None = None,
 ) -> dict:
     cfg = _load_dashboard_process_isolation_config()
     frame = _compute_host_turn_frame(
@@ -1884,6 +1914,9 @@ def _submit_prompt_to_compute_host(
         image_paths=image_paths,
         queued_prompt_generation=queued_prompt_generation,
         display_kind=display_kind,
+        persist_user_text=persist_user_text,
+        exact_admitted=exact_admitted,
+        exact_submission_id=exact_submission_id,
     )
 
     def _complete(done: dict) -> None:
@@ -1893,7 +1926,13 @@ def _submit_prompt_to_compute_host(
         # duplicate terminal error.
         if done.get("reason") == "send_failed":
             return
-        _on_compute_host_turn_done(rid, sid, session, done)
+        _on_compute_host_turn_done(
+            rid,
+            sid,
+            session,
+            done,
+            exact_submission_id=exact_submission_id,
+        )
 
     try:
         _get_compute_host_supervisor(cfg).submit_turn(frame, on_complete=_complete)
@@ -7982,7 +8021,11 @@ def _session_home(session: dict) -> Path:
     return Path(profile_home) if profile_home else Path(_hermes_home)
 
 
-def _retire_turn_marker(session: dict, *keys: str) -> None:
+def _retire_turn_marker(
+    session: dict,
+    *keys: str,
+    submission_id: str | None = None,
+) -> None:
     """Drop the crash marker for a turn whose outcome is about to reach the client.
 
     Called immediately before the terminal frame rather than at the end of the
@@ -7993,9 +8036,13 @@ def _retire_turn_marker(session: dict, *keys: str) -> None:
     compression rotated mid-turn.
     """
     home = _session_home(session)
+    active_submission_id = session.get("_exact_active_submission_id")
+    selected_submission_id = submission_id if submission_id is not None else active_submission_id
     for key in dict.fromkeys((*keys, str(session.get("session_key") or ""))):
         if key:
-            clear_turn_marker(home, key)
+            clear_turn_marker(home, key, selected_submission_id)
+    if selected_submission_id and active_submission_id == selected_submission_id:
+        session.pop("_exact_active_submission_id", None)
 
 
 def _auto_continue_note(prompt: str) -> str:
@@ -8031,7 +8078,7 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
     if not enabled or age > freshness_secs or marker["attempts"] >= max_attempts:
         # Stale, disabled, or crash-looping: stop trying. The journal/partial
         # transcript still shows what happened; a manual message continues it.
-        clear_turn_marker(home, session_key)
+        clear_turn_marker(home, session_key, marker.get("submission_id"))
         return None
     if session.get("_auto_continue_scheduled"):
         return None
@@ -8067,6 +8114,8 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
             # behind for a racing user turn to inherit.
             session["_auto_continue_attempt"] = attempt
             session["_auto_continue_prompt"] = marker["prompt"]
+            if marker.get("persist_user_text") is not None:
+                session["_auto_continue_persist_user_text"] = marker["persist_user_text"]
         try:
             _emit(
                 "status.update",
@@ -10719,7 +10768,19 @@ def _run_prompt_submit(
     display_metadata: dict | None = None,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    persist_user_text: str | None = None,
+    exact_admitted: bool = False,
+    exact_submission_id: str | None = None,
 ) -> bool:
+    if exact_admitted:
+        try:
+            from tui_gateway.exact_admission import validate_submission_id
+
+            validate_submission_id(exact_submission_id)
+        except Exception:
+            with session["history_lock"]:
+                session["running"] = False
+            return False
     with session["history_lock"]:
         if session.get("_closing"):
             session["running"] = False
@@ -10800,7 +10861,7 @@ def _run_prompt_submit(
         marker_key = str(session.get("session_key") or "")
         marker_attempt = int(session.pop("_auto_continue_attempt", 0) or 0)
         marker_text = session.pop("_auto_continue_prompt", None) or text
-        if isinstance(marker_text, str) and marker_text.strip():
+        if not exact_admitted and isinstance(marker_text, str) and marker_text.strip():
             record_turn_start(marker_home, marker_key, marker_text, attempts=marker_attempt)
         try:
             from tools.approval import (
@@ -11029,11 +11090,21 @@ def _run_prompt_submit(
             else:
                 agent.interim_assistant_callback = None
 
+            recovery_persist_user_text = session.pop("_auto_continue_persist_user_text", None)
+            persisted_source = (
+                persist_user_text
+                if persist_user_text is not None
+                else recovery_persist_user_text
+                if recovery_persist_user_text is not None
+                else prompt
+            )
             run_kwargs = {
                 "conversation_history": list(history),
                 "stream_callback": _stream,
                 "persist_user_message": (
-                    _build_persist_user_message(prompt, images, run_message) if images else prompt
+                    _build_persist_user_message(persisted_source, images, run_message)
+                    if images
+                    else persisted_source
                 ),
             }
             # Type a synthesized turn at turn START so the crash persist writes

--- a/tui_gateway/turn_marker.py
+++ b/tui_gateway/turn_marker.py
@@ -121,7 +121,7 @@ def record_turn_start(
         logger.debug("failed to record turn marker for %s", session_key, exc_info=True)
 
 
-def clear_turn_marker(home: Path | str, session_key: str) -> None:
+def clear_turn_marker(home: Path | str, session_key: str, submission_id: str | None = None) -> None:
     """Remove the marker once its turn concluded (any outcome the client saw)."""
     if not session_key:
         return
@@ -129,12 +129,19 @@ def clear_turn_marker(home: Path | str, session_key: str) -> None:
         with _lock:
             path = _marker_path(home)
             entries = _load(path)
-            if session_key not in entries:
-                return
-            del entries[session_key]
-            _store(path, entries)
+            if session_key in entries:
+                del entries[session_key]
+                _store(path, entries)
     except Exception:
         logger.debug("failed to clear turn marker for %s", session_key, exc_info=True)
+    if submission_id is None:
+        return
+    try:
+        from tui_gateway.exact_admission import clear_exact_turn_marker
+
+        clear_exact_turn_marker(home, session_key, submission_id)
+    except Exception:
+        logger.debug("failed to clear exact turn marker for %s", session_key, exc_info=True)
 
 
 def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | None:
@@ -147,7 +154,12 @@ def read_turn_marker(home: Path | str, session_key: str) -> dict[str, Any] | Non
     except Exception:
         return None
     if not isinstance(entry, dict):
-        return None
+        try:
+            from tui_gateway.exact_admission import read_exact_turn_marker
+
+            return read_exact_turn_marker(home, session_key)
+        except Exception:
+            return None
     prompt = str(entry.get("prompt") or "")
     if not prompt.strip():
         return None

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -386,7 +386,151 @@ plugin is the worked example.
 `COMPOSER_AREAS` (`top`, `bottom`, `leading`, `actions`, `attachments`,
 `middleware`) let a plugin add controls around the message composer, provide an
 attachment source, or transform a draft before it is sent (`ComposerMiddleware`
-with a `handler(draft) => draft | null`).
+with a `handler(draft) => draft | null`). That legacy draft/`null` contract is
+unchanged. Newer hosts additionally accept own-property dispositions:
+
+```ts
+type ComposerDisposition =
+  | { disposition: 'pass'; draft?: ComposerDraft }
+  | { disposition: 'reject'; reason?: string }
+  | { disposition: 'consume'; receipt?: unknown }
+```
+
+`pass` continues in contribution order, optionally with a rewrite. `reject`
+stops later middleware and restores the submitted draft. `consume` stops later
+middleware and reports a successful plugin-owned send, so the ordinary composer
+clears exactly as it does after an accepted native send. A thrown handler is
+isolated as pass-through. Dispositions inherited from a prototype are ignored.
+Disposition recognition is closed: only own data-property `pass`, `reject`, or
+`consume` shapes with no extra keys are interpreted. Accessors, hostile getters,
+custom/polluted prototypes, and inherited values are not dispositions. A legacy
+draft may still inherit a property named `disposition` and remains a legacy
+draft after its own data shape is validated. Each middleware invocation receives
+a new detached draft, real dense attachment array, and detached attachment views;
+authoritative drafts, arrays, host attachment objects, and prior attempts are
+never exposed. A throw or invalid result discards the complete attempt, so
+freeze, seal, preventExtensions, non-configurable descriptors, prototype changes,
+nested freezes, replacements, and combinations require no rollback and cannot
+affect later handlers. A successful valid mutation or replacement is normalized
+into fresh host-owned data before the next attempt.
+
+An optional `pass.draft` is validated before any semantic field is read. It must
+be a closed plain/null-prototype own-data shape with own string `text`, optional
+ordinary dense array `attachments`, and no accessors, inherited semantics,
+symbols, extras, sparse/exotic arrays, or malformed attachment fields. Invalid
+nested drafts invoke no getters and leave the current authoritative draft
+unchanged.
+
+### Optional SDK capabilities, exact sessions, and attachment relay
+
+Probe every additive contract before use:
+
+```javascript
+const hasStatus = host.capabilityVersion('plugin-status') >= 1
+const hasDisposition = host.capabilityVersion('composer-disposition') >= 2
+const hasDirect = host.capabilityVersion('exact-session-submit') >= 2
+const hasRelay = host.capabilityVersion('attachment-relay') >= 1
+```
+
+The canonical capability table is exactly `plugin-status` version 1,
+`composer-disposition` version 2, `exact-session-submit` version 2, and
+`attachment-relay` version 1. `direct-draft-submit` was never a released or
+accepted capability name and returns `0`; it is not an alias. Unknown, empty,
+malformed, symbol, inherited, and prototype-collision names also return `0`
+without coercion. The public plugin-status API returns
+only `{ id, state }`, where state is `enabled`, `disabled`, `unavailable`,
+`loading`, or `failed`; paths, loader errors, settings, credentials, and toggle
+authority are never exposed. `host.onPluginStatus(id, listener)` delivers the
+current state immediately and then meaningful transitions; its disposer
+unsubscribes.
+
+`host.focusedSessionTarget()` returns the exact focused connection/profile,
+runtime session, stored session, compression-lineage root, composer scope, and
+surface target, or `null` when unresolved. `host.sessionTarget(query)` resolves
+the explicit connection/profile/runtime/stored tuple without title or same-name
+fallback. Both return non-secret targets.
+
+`host.relayAttachments(target, attachments)` accepts only the exact composer
+attachment object identities authorized for the currently awaited middleware
+handler. Private host provenance maps an unchanged attempt-local view back to
+its exact host-originated attachment without exposing that source object.
+Authority is minted once from the trusted host composer input, not from a
+middleware result: fabricated, copied, deserialized, replaced, mutated,
+prototype-derived, or arbitrary-path objects never acquire it. Exact unchanged
+views may survive a valid rewrite and removals remain valid. Authorization
+is short-lived and is checked before and after every
+read/stage boundary, including immediately after target validation and before
+the native read or gateway stage call. The target is re-probed before every
+mutation, and the gateway independently rejects both in-process and compute-host
+busy states immediately before writing. The result preserves order, source name,
+the authenticated generated target filename, media type derived from actual
+image bytes, byte size, SHA-256, exact runtime session, and non-path provenance.
+Copies, deferred use, mutation, revocation, expiry, traversal names, unsafe media
+types, oversize payloads, stale/busy targets, inherited capabilities, post-stage
+byte changes, and target-side integrity mismatches fail closed.
+
+`host.submitDraft(target, draft, { submissionId })` bypasses composer middleware
+(no recursion) but enters the normal gateway prompt/persistence pipeline. It
+preserves exact source whitespace/Unicode separately from attachment-expanded
+model context. The caller-generated id is immutably bound to runtime/stored/
+lineage identity, source/context/payload digests, and the complete ordered
+attachment-manifest digest. Both the immediate response and the one permitted
+receipt lookup must match every connection, profile, runtime, stored, lineage,
+submission/request, payload, source, context, attachment-manifest, and count
+field. Receipt state and every binding field must be a closed own data-property
+shape with exact types and no extra keys; inherited, accessor, polluted,
+partial, extra, or mistyped receipts remain acknowledgement-uncertain. It never
+redirects, queues, retargets, retries a busy session, performs stale-target
+recovery, or blindly re-sends after timeout. The receipt state is `rejected`, `durably_accepted`, or
+`acknowledgement_uncertain`; only `durably_accepted` may justify `consume`.
+
+The backend writes one crash-safe atomic admission record containing both the
+bound durable receipt and interrupted-turn marker before dispatch. Every terminal
+completion clears only its matching submission marker, even when no ordinary
+marker exists; a conflicting active admission for the same stored session is
+left intact. For isolated turns, the submission identity travels beside — never
+inside — the model-visible or cache-key prompt bytes, is echoed on the
+authenticated compute-host terminal frame, and only then retires that exact
+marker. Receipts remain for idempotent reconciliation.
+This preserves prompt-cache prefixes and strict user/assistant role alternation:
+no past context, toolset, system prompt, or synthetic mid-loop user turn is
+mutated.
+
+Generic conflict/send example:
+
+```javascript
+ctx.register({
+  id: 'exact-send',
+  area: COMPOSER_AREAS.middleware,
+  data: {
+    handler: async draft => {
+      if (host.capabilityVersion('plugin-status') < 1 ||
+          host.pluginStatus('another-sender').state === 'enabled') {
+        return { disposition: 'reject', reason: 'another sender owns this draft' }
+      }
+      if (host.capabilityVersion('exact-session-submit') < 2 ||
+          host.capabilityVersion('attachment-relay') < 1) {
+        return draft // legacy host: preserve the ordinary send unchanged
+      }
+      const target = host.focusedSessionTarget()
+      if (!target) return { disposition: 'reject', reason: 'no exact session' }
+
+      const receipt = await host.submitDraft(target, draft, {
+        submissionId: `example_${crypto.randomUUID().replaceAll('-', '')}`
+      })
+      return receipt.state === 'durably_accepted'
+        ? { disposition: 'consume', receipt }
+        : { disposition: 'reject', reason: receipt.state }
+    }
+  }
+})
+```
+
+Migration is additive: keep returning legacy drafts/`null` until the relevant
+capability version is present; never inspect private stores, `localStorage`,
+connection configuration, or loader internals. Never disable another plugin
+programmatically. Direct submission and relay are not arbitrary-path APIs: only
+the host-authorized current composer objects can be read.
 
 ### Transcript directives — inline components the model addresses
 
@@ -512,6 +656,13 @@ host.onEvent(type, fn)                     // gateway event stream ('*' = all); 
 host.logs(...)                             // tail an app log file
 host.status()                              // one-shot system status snapshot
 host.restartGateway()                      // restart the backend gateway
+host.capabilityVersion(name)               // additive own-property capability version, else 0
+host.pluginStatus(id)                      // { id, state }, credential-free
+host.onPluginStatus(id, listener)          // immediate + reactive; returns disposer
+host.focusedSessionTarget()                // exact non-secret focused target or null
+host.sessionTarget(query)                  // explicit connection/profile/runtime/stored target
+host.relayAttachments(target, attachments) // authorized exact-session relay
+host.submitDraft(target, draft, options)   // no-middleware exact submit + bound receipt
 host.profileRoutes()                       // [{ profile, targetProfile, connectionId, mode }]
 host.requestProfile<T>(route, method, params?)   // registry-routed RPC; no foreground swap
 host.requestProfile<T>(profile, method, params?) // legacy v1/local overload


### PR DESCRIPTION
## Motivation

Desktop plugins can currently contribute composer middleware, but they cannot safely coordinate an exact one-shot send across profile/session routing without private imports or ambiguous retry behavior. This adds a narrow, versioned public SDK surface for plugin status, composer dispositions, exact-session submission, and trusted attachment relay.

## Public API

- `plugin-status` v1: closed `enabled | disabled | unavailable | loading | failed` state and scoped subscriptions.
- `composer-disposition` v2: legacy draft/`null` plus closed `pass`, `reject`, and `consume` results.
- `exact-session-submit` v2: exact target resolution, direct draft submission, atomic durable admission, and fully bound receipts.
- `attachment-relay` v1: short-lived authority for exact unchanged host-composer attachment views.

The registry is frozen and own-property-only. `direct-draft-submit` was never released and remains absent/no-alias/zero.

## Compatibility

- Legacy middleware draft and `null` behavior remains unchanged.
- Invalid or throwing middleware attempts are discarded from detached attempt-local views.
- Exact submission does not queue, retry, recover stale targets, redirect, fall back, or retarget.
- Prompt-visible and cache-key bytes remain unchanged; exact submission identity travels as control metadata only.
- Current-main structured error-surface behavior in `methods_prompt.py` and `server.py` is preserved.

## Security boundaries

- Attachment authority originates only at the trusted host composer boundary.
- Copied, deserialized, fabricated, modified, prototype-derived, expired, revoked, or arbitrary-path attachments receive no authority.
- Dispositions, nested drafts, attachments, and receipts require closed own-data-property shapes with complete exact binding.
- Attachment authority and exact targets are revalidated at every I/O/mutation boundary; staged filename, bytes, digest, media type, ordering, and session receipt are authenticated.
- No private plugin imports, local storage probing, plugin disabling, credentials, arbitrary public paths, or extra authority are introduced.

## Native behavior preserved

- Native Bots and Groups remain authoritative and their source is not modified by this PR.
- Cron Bot Chat delivery, browser control, compaction display, tab-strip behavior, and current-main layered error surfaces remain intact.
- This PR does not implement a Workrooms runtime, Group Bridge, Group interception, native mention interception, or product-specific public IDs.

## Verification

- Desktop typecheck: pass.
- Focused SDK/profile/status/composer: 152 tests pass.
- Full composer: 430 tests pass.
- Exact admission/receipt/attachment/marker/auto-continue/busy: 132 tests pass.
- Gateway server/cancellation: 588 tests pass.
- Prompt cache and role alternation: 143 tests pass.
- Native bundled plugins, including current Bots/Groups behavior: 391 tests pass.
- Lint: 0 errors (existing warnings remain).
- Desktop production build: pass.
- Documentation build: pass with the two existing `llms.txt` link warnings.

### Windows baseline

The candidate and a clean checkout of the exact upstream base reproduce the same compute-host PID-wrapper, concurrent-log-write, and shutdown-drain timing failures. The candidate adds one passing exact-identity test. The Desktop Electron suite differs by one non-reproducible PowerShell handoff timeout; isolated candidate and clean-base runs both pass. No candidate-only product failure was found.

## Review state

This PR is intentionally opened as a draft. Local verification above is recorded, but this description does not claim GitHub CI is green and does not authorize merge or readiness.
