### PR TITLE
fix(command_token_source): raise error when key_cmd output looks like JSON but is not valid

### DIFF
--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -107,7 +107,10 @@ def _mint(command: str, label: str) -> tuple[str, Optional[float]]:
         try:
             payload = json.loads(stdout)
         except json.JSONDecodeError:
-            payload = None
+            raise CommandTokenError(
+                f"key_cmd for provider {label!r} output starts with '{{' "
+                f"but is not valid JSON"
+            )
         if isinstance(payload, dict):
             token = str(payload.get("access_token") or "").strip()
             if not token:
@@ -188,3 +191,4 @@ def build_command_token_provider(
     if not command:
         return None
     return CommandTokenSource(command, provider_label)
+


### PR DESCRIPTION
## Summary

`_mint()` in `command_token_source.py` silently falls through to the bare-token path when `key_cmd` output starts with `{` but is not valid JSON. The entire raw output (including `{` braces) is used as the API key, which always fails with a confusing 401 error.

## The Bug

```python
# agent/command_token_source.py, lines 106-149
if stdout.lstrip().startswith("{"):
    try:
        payload = json.loads(stdout)
    except json.JSONDecodeError:
        payload = None           # ← falls through to bare token path
    if isinstance(payload, dict):
        # ... extract access_token ...

# Falls through: "{broken json output}" used as API key → confusing 401
token = stdout.strip()
return token, None
```

When `key_cmd` outputs text starting with `{` that is NOT valid JSON (error message, partial output, malformed JSON), `json.loads()` fails, `payload` becomes `None`, and execution falls through to the bare-token path. The entire raw output is used as the API key.

## Impact

1. **Confusing 401 errors** — Users with slightly misconfigured `key_cmd` commands get cryptic "invalid API key" errors instead of actionable "your key_cmd produced invalid JSON" messages
2. **Silent credential corruption** — The broken JSON string is silently accepted as a token, wasting a request cycle
3. **Hard to diagnose** — The error message says "invalid API key" but the real problem is the key_cmd output format

## Fix

After `json.JSONDecodeError`, raise `CommandTokenError` with a clear message:

```python
except json.JSONDecodeError:
    raise CommandTokenError(
        f"key_cmd for provider {label!r} output starts with '{{' "
        f"but is not valid JSON"
    )
```

This matches the existing error-handling pattern in the same function (e.g., "returned JSON without an 'access_token' field", "produced no output", "printed multiple lines").
