### PR TITLE
refactor(bot-mode): add shadow control-plane contracts

### DIFF
--- a/agent/bot_control_plane.py
+++ b/agent/bot_control_plane.py
@@ -90,20 +90,13 @@ class LegacyMessageAgentReason(str, Enum):
 
 @dataclass(frozen=True)
 class BotAddress:
-    """One exact source-qualified Bot Mode profile instance."""
+    """One durable Bot Mode actor; aliases and routes never authorize."""
 
     install_id: str
-    gateway_instance_id: str
-    connection_id: str
     profile_id: str
 
     def __post_init__(self) -> None:
-        for field_name in (
-            "install_id",
-            "gateway_instance_id",
-            "connection_id",
-            "profile_id",
-        ):
+        for field_name in ("install_id", "profile_id"):
             object.__setattr__(
                 self,
                 field_name,
@@ -111,12 +104,37 @@ class BotAddress:
             )
 
     @property
-    def identity_tuple(self) -> Tuple[str, str, str, str]:
+    def identity_tuple(self) -> Tuple[str, str]:
+        return (self.install_id, self.profile_id)
+
+
+@dataclass(frozen=True)
+class BotRoute:
+    """A non-authoritative selector inside one namespaced route table."""
+
+    route_namespace_id: str
+    connection_id: str
+    gateway_instance_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        for field_name in ("route_namespace_id", "connection_id"):
+            object.__setattr__(
+                self,
+                field_name,
+                _required_str(getattr(self, field_name), field_name),
+            )
+        object.__setattr__(
+            self,
+            "gateway_instance_id",
+            _optional_str(self.gateway_instance_id, "gateway_instance_id"),
+        )
+
+    @property
+    def route_tuple(self) -> Tuple[str, str, Optional[str]]:
         return (
-            self.install_id,
-            self.gateway_instance_id,
+            self.route_namespace_id,
             self.connection_id,
-            self.profile_id,
+            self.gateway_instance_id,
         )
 
 
@@ -253,6 +271,7 @@ class BotExecutionContext:
     cancellation_scope_id: str
     budget_id: str
     trace_id: str
+    selected_route: Optional[BotRoute] = None
     revocation_epoch: int = 0
     hop_count: int = 0
     source_chat_id: Optional[str] = None
@@ -265,6 +284,10 @@ class BotExecutionContext:
     def __post_init__(self) -> None:
         if not isinstance(self.address, BotAddress):
             raise TypeError("address must be a BotAddress")
+        if self.selected_route is not None and not isinstance(
+            self.selected_route, BotRoute
+        ):
+            raise TypeError("selected_route must be a BotRoute or None")
         for field_name in (
             "profile_config_revision",
             "session_id",
@@ -324,7 +347,9 @@ class BotPolicyDecision:
         object.__setattr__(
             self, "decision_id", _required_str(self.decision_id, "decision_id")
         )
-        object.__setattr__(self, "operation", _required_str(self.operation, "operation"))
+        object.__setattr__(
+            self, "operation", _required_str(self.operation, "operation")
+        )
         if not isinstance(self.verdict, BotPolicyVerdict):
             raise TypeError("verdict must be a BotPolicyVerdict")
         if not isinstance(self.reason, BotPolicyReason):
@@ -335,12 +360,10 @@ class BotPolicyDecision:
         for entry in self.constraints:
             if not isinstance(entry, tuple) or len(entry) != 2:
                 raise TypeError("constraints must contain (key, value) tuples")
-            normalized.append(
-                (
-                    _required_str(entry[0], "constraint key"),
-                    _required_str(entry[1], "constraint value"),
-                )
-            )
+            normalized.append((
+                _required_str(entry[0], "constraint key"),
+                _required_str(entry[1], "constraint value"),
+            ))
         object.__setattr__(self, "constraints", tuple(normalized))
 
     @property
@@ -401,7 +424,9 @@ class LegacyAuthorityDecision:
     reason: LegacyMessageAgentReason
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "operation", _required_str(self.operation, "operation"))
+        object.__setattr__(
+            self, "operation", _required_str(self.operation, "operation")
+        )
         _strict_bool(self.allowed, "allowed")
         if not isinstance(self.reason, LegacyMessageAgentReason):
             raise TypeError("reason must be a LegacyMessageAgentReason")
@@ -552,6 +577,7 @@ __all__ = [
     "BotAddress",
     "BotCapability",
     "BotExecutionContext",
+    "BotRoute",
     "BotPolicyDecision",
     "BotPolicyReason",
     "BotPolicyVerdict",

--- a/agent/bot_control_plane.py
+++ b/agent/bot_control_plane.py
@@ -1,0 +1,566 @@
+"""Immutable Bot Mode identity, runtime, and policy proof objects.
+
+This module is the shadow-only foundation for the Bot Mode control plane. It
+performs no I/O and is not wired into production execution yet. Consumers can
+compare a typed policy decision with a legacy gate, but the comparison keeps
+the legacy result authoritative until a boundary explicitly migrates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import FrozenSet, Iterable, Optional, Tuple, Union
+
+
+BOT_CONTROL_PLANE_CONTRACT_VERSION = "hermes.bot_control_plane.v1"
+
+
+def _required_str(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be non-empty")
+    return normalized
+
+
+def _optional_str(value: object, field_name: str) -> Optional[str]:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string or None")
+    return value.strip() or None
+
+
+def _non_negative_int(value: object, field_name: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise TypeError(f"{field_name} must be an integer")
+    if value < 0:
+        raise ValueError(f"{field_name} must be non-negative")
+    return value
+
+
+def _strict_bool(value: object, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{field_name} must be a bool")
+    return value
+
+
+class BotCapability(str, Enum):
+    """Stable restrictive capability classes, independent of tool names."""
+
+    LOCAL_READ = "local.read"
+    LOCAL_WRITE = "local.write"
+    NETWORK_READ = "network.read"
+    NETWORK_WRITE = "network.write"
+    EXTERNAL_MESSAGE = "external.message"
+    PEER_MESSAGE = "peer.message"
+    PROCESS_SPAWN = "process.spawn"
+    CREDENTIAL_USE = "credential.use"
+    PROFILE_CONFIGURE = "profile.configure"
+    DESTRUCTIVE = "destructive"
+
+
+class BotPolicyVerdict(str, Enum):
+    ALLOW = "allow"
+    DENY = "deny"
+    APPROVAL_REQUIRED = "approval_required"
+
+
+class BotPolicyReason(str, Enum):
+    CAPABILITY_GRANTED = "capability_granted"
+    CAPABILITY_MISSING = "capability_missing"
+    PROFILE_MISMATCH = "profile_mismatch"
+    PROFILE_REVISION_MISMATCH = "profile_revision_mismatch"
+    GRANT_MISMATCH = "grant_mismatch"
+    REVOCATION_EPOCH_MISMATCH = "revocation_epoch_mismatch"
+    RUNTIME_SNAPSHOT_MISMATCH = "runtime_snapshot_mismatch"
+
+
+class LegacyMessageAgentReason(str, Enum):
+    """Reason codes for the current #91802 injection/dispatch gates."""
+
+    PROTOCOL_DISABLED = "protocol_disabled"
+    SCHEMA_ALREADY_PRESENT = "schema_already_present"
+    NOT_CANONICAL_BOT_CHAT = "not_canonical_bot_chat"
+    UNMANAGED_INSTALL = "unmanaged_install"
+    LEGACY_GATE_ALLOW = "legacy_gate_allow"
+
+
+@dataclass(frozen=True)
+class BotAddress:
+    """One exact source-qualified Bot Mode profile instance."""
+
+    install_id: str
+    gateway_instance_id: str
+    connection_id: str
+    profile_id: str
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "install_id",
+            "gateway_instance_id",
+            "connection_id",
+            "profile_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _required_str(getattr(self, field_name), field_name),
+            )
+
+    @property
+    def identity_tuple(self) -> Tuple[str, str, str, str]:
+        return (
+            self.install_id,
+            self.gateway_instance_id,
+            self.connection_id,
+            self.profile_id,
+        )
+
+
+CapabilityInput = Union[BotCapability, str]
+
+
+def _capability(value: CapabilityInput) -> BotCapability:
+    if isinstance(value, BotCapability):
+        return value
+    if isinstance(value, str):
+        try:
+            return BotCapability(value.strip())
+        except ValueError as exc:
+            raise ValueError(f"unknown Bot Mode capability: {value!r}") from exc
+    raise TypeError("capability must be a BotCapability or string")
+
+
+@dataclass(frozen=True)
+class RuntimeCapabilitySnapshot:
+    """Effective runtime and revocable grant for one profile generation."""
+
+    grant_id: str
+    profile_id: str
+    profile_config_revision: str
+    runtime_snapshot_id: str
+    effective_provider: str
+    effective_model: str
+    api_mode: str
+    revocation_epoch: int
+    capabilities: FrozenSet[BotCapability]
+    configured_provider: Optional[str] = None
+    requested_provider: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+    service_tier: Optional[str] = None
+    credential_source_id: Optional[str] = None
+    fallback_reason: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "grant_id",
+            "profile_id",
+            "profile_config_revision",
+            "runtime_snapshot_id",
+            "effective_provider",
+            "effective_model",
+            "api_mode",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _required_str(getattr(self, field_name), field_name),
+            )
+        for field_name in (
+            "configured_provider",
+            "requested_provider",
+            "reasoning_effort",
+            "service_tier",
+            "credential_source_id",
+            "fallback_reason",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _optional_str(getattr(self, field_name), field_name),
+            )
+        object.__setattr__(
+            self,
+            "revocation_epoch",
+            _non_negative_int(self.revocation_epoch, "revocation_epoch"),
+        )
+        object.__setattr__(
+            self,
+            "capabilities",
+            frozenset(_capability(item) for item in self.capabilities),
+        )
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        grant_id: str,
+        profile_id: str,
+        profile_config_revision: str,
+        runtime_snapshot_id: str,
+        effective_provider: str,
+        effective_model: str,
+        api_mode: str,
+        revocation_epoch: int = 0,
+        capabilities: Iterable[CapabilityInput] = (),
+        configured_provider: Optional[str] = None,
+        requested_provider: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        service_tier: Optional[str] = None,
+        credential_source_id: Optional[str] = None,
+        fallback_reason: Optional[str] = None,
+    ) -> "RuntimeCapabilitySnapshot":
+        return cls(
+            grant_id=grant_id,
+            profile_id=profile_id,
+            profile_config_revision=profile_config_revision,
+            runtime_snapshot_id=runtime_snapshot_id,
+            effective_provider=effective_provider,
+            effective_model=effective_model,
+            api_mode=api_mode,
+            revocation_epoch=revocation_epoch,
+            capabilities=frozenset(capabilities),
+            configured_provider=configured_provider,
+            requested_provider=requested_provider,
+            reasoning_effort=reasoning_effort,
+            service_tier=service_tier,
+            credential_source_id=credential_source_id,
+            fallback_reason=fallback_reason,
+        )
+
+    def allows(self, capability: CapabilityInput) -> bool:
+        return _capability(capability) in self.capabilities
+
+
+@dataclass(frozen=True)
+class BotExecutionContext:
+    """Immutable proof object carried by one authenticated Bot Mode turn."""
+
+    address: BotAddress
+    profile_config_revision: str
+    session_id: str
+    session_key: str
+    turn_id: str
+    task_id: str
+    authenticated_principal: str
+    source_platform: str
+    runtime_snapshot_id: str
+    capability_grant_id: str
+    cancellation_scope_id: str
+    budget_id: str
+    trace_id: str
+    revocation_epoch: int = 0
+    hop_count: int = 0
+    source_chat_id: Optional[str] = None
+    source_thread_id: Optional[str] = None
+    source_user_id: Optional[str] = None
+    inbound_event_id: Optional[str] = None
+    parent_event_id: Optional[str] = None
+    contract_version: str = BOT_CONTROL_PLANE_CONTRACT_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.address, BotAddress):
+            raise TypeError("address must be a BotAddress")
+        for field_name in (
+            "profile_config_revision",
+            "session_id",
+            "session_key",
+            "turn_id",
+            "task_id",
+            "authenticated_principal",
+            "source_platform",
+            "runtime_snapshot_id",
+            "capability_grant_id",
+            "cancellation_scope_id",
+            "budget_id",
+            "trace_id",
+            "contract_version",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _required_str(getattr(self, field_name), field_name),
+            )
+        for field_name in (
+            "source_chat_id",
+            "source_thread_id",
+            "source_user_id",
+            "inbound_event_id",
+            "parent_event_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _optional_str(getattr(self, field_name), field_name),
+            )
+        object.__setattr__(
+            self,
+            "revocation_epoch",
+            _non_negative_int(self.revocation_epoch, "revocation_epoch"),
+        )
+        object.__setattr__(
+            self,
+            "hop_count",
+            _non_negative_int(self.hop_count, "hop_count"),
+        )
+
+
+@dataclass(frozen=True)
+class BotPolicyDecision:
+    """Structured, content-free authorization result for one operation."""
+
+    decision_id: str
+    operation: str
+    verdict: BotPolicyVerdict
+    reason: BotPolicyReason
+    required_capability: BotCapability
+    constraints: Tuple[Tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "decision_id", _required_str(self.decision_id, "decision_id")
+        )
+        object.__setattr__(self, "operation", _required_str(self.operation, "operation"))
+        if not isinstance(self.verdict, BotPolicyVerdict):
+            raise TypeError("verdict must be a BotPolicyVerdict")
+        if not isinstance(self.reason, BotPolicyReason):
+            raise TypeError("reason must be a BotPolicyReason")
+        if not isinstance(self.required_capability, BotCapability):
+            raise TypeError("required_capability must be a BotCapability")
+        normalized = []
+        for entry in self.constraints:
+            if not isinstance(entry, tuple) or len(entry) != 2:
+                raise TypeError("constraints must contain (key, value) tuples")
+            normalized.append(
+                (
+                    _required_str(entry[0], "constraint key"),
+                    _required_str(entry[1], "constraint value"),
+                )
+            )
+        object.__setattr__(self, "constraints", tuple(normalized))
+
+    @property
+    def allowed(self) -> bool:
+        return self.verdict is BotPolicyVerdict.ALLOW
+
+
+@dataclass(frozen=True)
+class ShadowPolicyComparison:
+    """Policy parity evidence whose effective result remains legacy-owned."""
+
+    legacy_allowed: bool
+    decision: BotPolicyDecision
+
+    def __post_init__(self) -> None:
+        _strict_bool(self.legacy_allowed, "legacy_allowed")
+        if not isinstance(self.decision, BotPolicyDecision):
+            raise TypeError("decision must be a BotPolicyDecision")
+
+    @property
+    def policy_allowed(self) -> bool:
+        return self.decision.allowed
+
+    @property
+    def matches(self) -> bool:
+        return self.legacy_allowed is self.policy_allowed
+
+    @property
+    def effective_allowed(self) -> bool:
+        """Never alter behavior during the shadow phase."""
+
+        return self.legacy_allowed
+
+
+@dataclass(frozen=True)
+class LegacyMessageAgentState:
+    """Inputs used by the current `message_agent` containment checks."""
+
+    protocol_enabled: bool
+    schema_present: bool
+    canonical_bot_chat: bool
+    managed_install: bool
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "protocol_enabled",
+            "schema_present",
+            "canonical_bot_chat",
+            "managed_install",
+        ):
+            _strict_bool(getattr(self, field_name), field_name)
+
+
+@dataclass(frozen=True)
+class LegacyAuthorityDecision:
+    operation: str
+    allowed: bool
+    reason: LegacyMessageAgentReason
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "operation", _required_str(self.operation, "operation"))
+        _strict_bool(self.allowed, "allowed")
+        if not isinstance(self.reason, LegacyMessageAgentReason):
+            raise TypeError("reason must be a LegacyMessageAgentReason")
+
+
+def evaluate_capability(
+    *,
+    context: BotExecutionContext,
+    snapshot: RuntimeCapabilitySnapshot,
+    operation: str,
+    required_capability: CapabilityInput,
+    decision_id: str,
+) -> BotPolicyDecision:
+    """Fail closed unless identity and every bound generation match exactly."""
+
+    capability = _capability(required_capability)
+    operation = _required_str(operation, "operation")
+    decision_id = _required_str(decision_id, "decision_id")
+    checks = (
+        (
+            context.address.profile_id != snapshot.profile_id,
+            BotPolicyReason.PROFILE_MISMATCH,
+        ),
+        (
+            context.profile_config_revision != snapshot.profile_config_revision,
+            BotPolicyReason.PROFILE_REVISION_MISMATCH,
+        ),
+        (
+            context.capability_grant_id != snapshot.grant_id,
+            BotPolicyReason.GRANT_MISMATCH,
+        ),
+        (
+            context.revocation_epoch != snapshot.revocation_epoch,
+            BotPolicyReason.REVOCATION_EPOCH_MISMATCH,
+        ),
+        (
+            context.runtime_snapshot_id != snapshot.runtime_snapshot_id,
+            BotPolicyReason.RUNTIME_SNAPSHOT_MISMATCH,
+        ),
+    )
+    for failed, reason in checks:
+        if failed:
+            return BotPolicyDecision(
+                decision_id=decision_id,
+                operation=operation,
+                verdict=BotPolicyVerdict.DENY,
+                reason=reason,
+                required_capability=capability,
+            )
+    if not snapshot.allows(capability):
+        return BotPolicyDecision(
+            decision_id=decision_id,
+            operation=operation,
+            verdict=BotPolicyVerdict.DENY,
+            reason=BotPolicyReason.CAPABILITY_MISSING,
+            required_capability=capability,
+        )
+    return BotPolicyDecision(
+        decision_id=decision_id,
+        operation=operation,
+        verdict=BotPolicyVerdict.ALLOW,
+        reason=BotPolicyReason.CAPABILITY_GRANTED,
+        required_capability=capability,
+    )
+
+
+def compare_legacy_authority(
+    *, legacy_allowed: bool, decision: BotPolicyDecision
+) -> ShadowPolicyComparison:
+    return ShadowPolicyComparison(
+        legacy_allowed=legacy_allowed,
+        decision=decision,
+    )
+
+
+def legacy_message_agent_injection_decision(
+    state: LegacyMessageAgentState,
+) -> LegacyAuthorityDecision:
+    """Map `ensure_message_agent_tool()` in its current source order.
+
+    The schema-present early return intentionally precedes title/managed-install
+    checks because that is current behavior. The mapping records it; it does
+    not endorse it or make it authoritative anywhere new.
+    """
+
+    if not state.protocol_enabled:
+        return LegacyAuthorityDecision(
+            "message_agent.inject",
+            False,
+            LegacyMessageAgentReason.PROTOCOL_DISABLED,
+        )
+    if state.schema_present:
+        return LegacyAuthorityDecision(
+            "message_agent.inject",
+            True,
+            LegacyMessageAgentReason.SCHEMA_ALREADY_PRESENT,
+        )
+    if not state.canonical_bot_chat:
+        return LegacyAuthorityDecision(
+            "message_agent.inject",
+            False,
+            LegacyMessageAgentReason.NOT_CANONICAL_BOT_CHAT,
+        )
+    if not state.managed_install:
+        return LegacyAuthorityDecision(
+            "message_agent.inject",
+            False,
+            LegacyMessageAgentReason.UNMANAGED_INSTALL,
+        )
+    return LegacyAuthorityDecision(
+        "message_agent.inject",
+        True,
+        LegacyMessageAgentReason.LEGACY_GATE_ALLOW,
+    )
+
+
+def legacy_message_agent_dispatch_decision(
+    state: LegacyMessageAgentState,
+) -> LegacyAuthorityDecision:
+    """Map `message_agent_tool()` dispatch containment exactly.
+
+    Dispatch currently rechecks title and managed-install status, but not the
+    protocol toggle or schema presence. This asymmetry is preserved as evidence
+    until a later migration PR selects one authoritative contract.
+    """
+
+    if not state.canonical_bot_chat:
+        return LegacyAuthorityDecision(
+            "message_agent.dispatch",
+            False,
+            LegacyMessageAgentReason.NOT_CANONICAL_BOT_CHAT,
+        )
+    if not state.managed_install:
+        return LegacyAuthorityDecision(
+            "message_agent.dispatch",
+            False,
+            LegacyMessageAgentReason.UNMANAGED_INSTALL,
+        )
+    return LegacyAuthorityDecision(
+        "message_agent.dispatch",
+        True,
+        LegacyMessageAgentReason.LEGACY_GATE_ALLOW,
+    )
+
+
+__all__ = [
+    "BOT_CONTROL_PLANE_CONTRACT_VERSION",
+    "BotAddress",
+    "BotCapability",
+    "BotExecutionContext",
+    "BotPolicyDecision",
+    "BotPolicyReason",
+    "BotPolicyVerdict",
+    "LegacyAuthorityDecision",
+    "LegacyMessageAgentReason",
+    "LegacyMessageAgentState",
+    "RuntimeCapabilitySnapshot",
+    "ShadowPolicyComparison",
+    "compare_legacy_authority",
+    "evaluate_capability",
+    "legacy_message_agent_dispatch_decision",
+    "legacy_message_agent_injection_decision",
+]

--- a/agent/bot_control_plane.py
+++ b/agent/bot_control_plane.py
@@ -71,7 +71,7 @@ class BotPolicyVerdict(str, Enum):
 class BotPolicyReason(str, Enum):
     CAPABILITY_GRANTED = "capability_granted"
     CAPABILITY_MISSING = "capability_missing"
-    PROFILE_MISMATCH = "profile_mismatch"
+    ADDRESS_MISMATCH = "address_mismatch"
     PROFILE_REVISION_MISMATCH = "profile_revision_mismatch"
     GRANT_MISMATCH = "grant_mismatch"
     REVOCATION_EPOCH_MISMATCH = "revocation_epoch_mismatch"
@@ -139,7 +139,7 @@ class RuntimeCapabilitySnapshot:
     """Effective runtime and revocable grant for one profile generation."""
 
     grant_id: str
-    profile_id: str
+    address: BotAddress
     profile_config_revision: str
     runtime_snapshot_id: str
     effective_provider: str
@@ -155,9 +155,10 @@ class RuntimeCapabilitySnapshot:
     fallback_reason: Optional[str] = None
 
     def __post_init__(self) -> None:
+        if not isinstance(self.address, BotAddress):
+            raise TypeError("address must be a BotAddress")
         for field_name in (
             "grant_id",
-            "profile_id",
             "profile_config_revision",
             "runtime_snapshot_id",
             "effective_provider",
@@ -198,7 +199,7 @@ class RuntimeCapabilitySnapshot:
         cls,
         *,
         grant_id: str,
-        profile_id: str,
+        address: BotAddress,
         profile_config_revision: str,
         runtime_snapshot_id: str,
         effective_provider: str,
@@ -215,7 +216,7 @@ class RuntimeCapabilitySnapshot:
     ) -> "RuntimeCapabilitySnapshot":
         return cls(
             grant_id=grant_id,
-            profile_id=profile_id,
+            address=address,
             profile_config_revision=profile_config_revision,
             runtime_snapshot_id=runtime_snapshot_id,
             effective_provider=effective_provider,
@@ -421,8 +422,8 @@ def evaluate_capability(
     decision_id = _required_str(decision_id, "decision_id")
     checks = (
         (
-            context.address.profile_id != snapshot.profile_id,
-            BotPolicyReason.PROFILE_MISMATCH,
+            context.address != snapshot.address,
+            BotPolicyReason.ADDRESS_MISMATCH,
         ),
         (
             context.profile_config_revision != snapshot.profile_config_revision,

--- a/docs/design/bot-mode-control-plane.md
+++ b/docs/design/bot-mode-control-plane.md
@@ -1,0 +1,188 @@
+# Bot Mode control plane
+
+## Status
+
+Foundation contract. The first implementation is shadow-only: it does not
+change runtime authorization, delivery, cancellation, provider selection, or
+Desktop behavior.
+
+Tracking issue: #91911.
+
+## Problem
+
+Bot Mode currently derives identity and authority independently from profile
+names, canonical `Bot Chat` titles, gateway profile routes, Desktop connection
+state, session-store placement, runtime provider/model/tool configuration,
+background completion ownership, and local versus remote teammate delivery.
+
+Those coordinates locate a candidate actor. They are not a current proof that
+the actor owns the profile, runtime generation, credential, or side effect.
+That produces one recurring class of defects: stale identity, configured intent
+that differs from effective capability, lost completion ownership, incomplete
+cancellation, and remote trust-boundary drift.
+
+> Coordinates select. Current proof objects authorize.
+
+## Foundation contracts
+
+### `BotAddress`
+
+```text
+(install_id, gateway_instance_id, connection_id, profile_id)
+```
+
+Profile names and handles remain editable aliases. Durable room membership,
+sessions, notifications, routines, mutations, cancellation targets, delivery
+events, and audit records should converge on this exact address.
+
+### `BotExecutionContext`
+
+One authenticated turn binds:
+
+```text
+BotAddress
+profile_config_revision
+session_id / session_key / turn_id / task_id
+authenticated_principal
+source platform / user / chat / thread
+runtime_snapshot_id
+capability_grant_id / revocation_epoch
+cancellation_scope_id
+budget_id
+trace_id / inbound_event_id / parent_event_id / hop_count
+contract_version
+```
+
+The context is constructed only after authentication, route resolution, and
+current owner resolution. Consumers must not recreate it from prompt text,
+environment variables, cached roster rows, display names, or session titles.
+
+### `RuntimeCapabilitySnapshot`
+
+One immutable snapshot records the exact profile/runtime generation:
+
+```text
+grant_id
+profile_id / profile_config_revision
+runtime_snapshot_id / revocation_epoch
+configured / requested / effective provider
+effective model / API mode / reasoning / service tier
+credential source identity (never secret material)
+fallback reason
+capabilities
+```
+
+The initial capability vocabulary is intentionally smaller and more stable than
+the tool registry:
+
+```text
+local.read
+local.write
+network.read
+network.write
+external.message
+peer.message
+process.spawn
+credential.use
+profile.configure
+destructive
+```
+
+Tools, MCP servers, and provider actions project onto these classes. Prompt
+content may request an operation; it cannot manufacture a grant.
+
+### `BotPolicyDecision`
+
+A content-free result records the decision ID, operation, verdict, reason,
+required capability, and bounded constraints. The evaluator fails closed on
+profile, profile-revision, grant, revocation-epoch, runtime-snapshot, or
+capability mismatch.
+
+### `ShadowPolicyComparison`
+
+During migration:
+
+```text
+legacy_allowed
+policy_allowed
+matches
+effective_allowed = legacy_allowed
+```
+
+A mismatch is evidence. It cannot grant or deny work until the consuming
+boundary explicitly migrates and its parity matrix is green.
+
+## Current `message_agent` mapping
+
+Phase 1 records the current #91802 gate order exactly, including two
+asymmetries. It does not endorse or silently repair them.
+
+Injection (`ensure_message_agent_tool`):
+
+1. disabled Bot protocol denies;
+2. an already-present schema allows before title/install revalidation;
+3. otherwise the exact `Bot Chat` title is required;
+4. then a Bot-Mode-managed install is required.
+
+Dispatch (`message_agent_tool`):
+
+1. the exact `Bot Chat` title is required;
+2. a Bot-Mode-managed install is required;
+3. the protocol toggle and schema presence are not consulted.
+
+Parity tests import the current implementation and prove the typed mapping
+tracks those semantics. A later boundary-migration PR must select one canonical
+contract and delete the superseded gate in the same change.
+
+## Rollout
+
+1. **Foundation:** immutable proof objects, pure fail-closed evaluation, exact
+   legacy mapping, and parity tests. No production call sites.
+2. **Authenticated shadow construction:** build context at gateway ingress,
+   derive one effective snapshot, and emit bounded content-free mismatch
+   evidence while legacy remains authoritative.
+3. **Boundary migration:** migrate `message_agent`, tool/MCP injection, profile
+   mutation, group interruption, peer delivery, completion ownership, and
+   destructive/file/network operations one at a time.
+4. **Durable settlement:** extend the shared delivery ledger into an
+   at-least-once, idempotent Bot mailbox and add a cancellation tree spanning
+   room turns, member turns, delegated children, background jobs, waits, and
+   queued events.
+5. **Canonical read model:** Desktop, mobile, API, logs, and `/status` consume
+   one revisioned projection of exact owner, lifecycle, effective runtime,
+   capability, budget, pending work, and terminal failure reason.
+
+## Interlocks
+
+Preserve existing contributor ownership and compose it onto this spine:
+
+- #91802 — structured `message_agent`;
+- #90329 — source-qualified cross-connection room identity;
+- #89455 — effective toolset/MCP runtime truth;
+- #90954 — completion-loss evidence and immediate stopgap;
+- #91889 — visible group interruption and late-reply fencing;
+- #91862 — authenticated Bot roster/read model;
+- #88819 — peer credential redirect boundary;
+- #91832 — permanent configuration refusal; and
+- #73923 — shared delivery-ledger substrate.
+
+## Acceptance invariants
+
+The completed class must prove:
+
+1. no profile crosses another profile without an explicit current grant;
+2. no side effect commits without a decision tied to the exact context;
+3. every accepted event reaches a terminal state;
+4. cancelled or superseded work cannot append a late visible reply;
+5. displayed owner/runtime/capability equals what actually ran;
+6. message content cannot increase authority;
+7. restart between delivery states does not lose the event;
+8. duplicate or reordered delivery does not duplicate a side effect;
+9. remote redirects cannot move credentials to another origin; and
+10. deleting a profile prevents late work from resurrecting it.
+
+## Non-goals of this PR
+
+No production wiring, transport rewrite, durable inbox schema, Desktop change,
+approval UI, provider/catalog behavior change, profile-ID migration, or switch
+away from legacy authority.

--- a/docs/design/bot-mode-control-plane.md
+++ b/docs/design/bot-mode-control-plane.md
@@ -4,7 +4,9 @@
 
 Foundation contract. The first implementation is shadow-only: it does not
 change runtime authorization, delivery, cancellation, provider selection, or
-Desktop behavior.
+Desktop behavior. The contract is intentionally split between durable actor
+identity and non-authoritative route selection; current Desktop connection IDs
+cannot mint actor authority.
 
 Tracking issue: #91911.
 
@@ -28,12 +30,27 @@ cancellation, and remote trust-boundary drift.
 ### `BotAddress`
 
 ```text
-(install_id, gateway_instance_id, connection_id, profile_id)
+(install_id, profile_id)
 ```
 
 Profile names and handles remain editable aliases. Durable room membership,
 sessions, notifications, routines, mutations, cancellation targets, delivery
-events, and audit records should converge on this exact address.
+events, and audit records should converge on this actor identity plus the
+relevant generation proof.
+
+### `BotRoute`
+
+```text
+(route_namespace_id, connection_id, optional gateway_instance_id)
+```
+
+A route selects where an operation should travel inside one named route table.
+It does not identify or authorize the actor. Current Desktop `connection_id`
+values are local to a Desktop registry; different Desktops may assign different
+IDs to the same gateway, and non-Desktop ingress may have no Desktop route at
+all. `route_namespace_id` prevents an unscoped connection coordinate from being
+mistaken for a global identity. Gateway ingress leaves `selected_route` empty
+unless a real namespaced route proof exists.
 
 ### `BotExecutionContext`
 
@@ -45,6 +62,7 @@ profile_config_revision
 session_id / session_key / turn_id / task_id
 authenticated_principal
 source platform / user / chat / thread
+optional selected BotRoute
 runtime_snapshot_id
 capability_grant_id / revocation_epoch
 cancellation_scope_id
@@ -95,8 +113,10 @@ content may request an operation; it cannot manufacture a grant.
 
 A content-free result records the decision ID, operation, verdict, reason,
 required capability, and bounded constraints. The evaluator fails closed on
-exact BotAddress, profile-revision, grant, revocation-epoch,
-runtime-snapshot, or capability mismatch.
+exact durable BotAddress, profile-revision, grant, revocation-epoch,
+runtime-snapshot, or capability mismatch. It deliberately does not compare
+`selected_route`: a client route coordinate cannot grant actor authority. A
+delivery boundary may constrain a route separately after actor authorization.
 
 ### `ShadowPolicyComparison`
 
@@ -131,16 +151,37 @@ Dispatch (`message_agent_tool`):
 3. the protocol toggle and schema presence are not consulted.
 
 Parity tests import the current implementation and prove the typed mapping
-tracks those semantics. A later boundary-migration PR must select one canonical
-contract and delete the superseded gate in the same change.
+tracks those semantics. They also pin the post-#92784 managed-install behavior:
+a legacy SOUL protocol heading suppresses duplicate prompt text but does not
+remove `message_agent`. Gate-adjacent comments point contributors to the typed
+mapping while the current source remains authoritative. A later
+boundary-migration PR must select one canonical contract and delete the
+superseded gate in the same change.
+
+## Phase 2 entry criteria
+
+Current production state can supply an install ID and profile-name/session
+coordinates, but it cannot yet supply every canonical proof required by this
+contract. In particular, it lacks a stable opaque profile ID with explicit
+rename/clone/import semantics, a server-owned gateway runtime generation, and
+the grant/revocation/runtime/cancellation IDs. Desktop relay roster rows are a
+cached selection projection, not authenticated identity.
+
+Phase 2 must first establish those server-owned producers. It can then bind one
+context after authentication and current profile resolution at gateway/session
+ingress, compare one consuming boundary in shadow, record only bounded
+content-free mismatch evidence, and keep the legacy result effective. It must
+not substitute profile names, Desktop connection IDs, user/chat IDs, task IDs,
+or hashes of ambient runtime tuples for missing proof IDs.
 
 ## Rollout
 
 1. **Foundation:** immutable proof objects, pure fail-closed evaluation, exact
    legacy mapping, and parity tests. No production call sites.
-2. **Authenticated shadow construction:** build context at gateway ingress,
-   derive one effective snapshot, and emit bounded content-free mismatch
-   evidence while legacy remains authoritative.
+2. **Authenticated shadow construction:** establish stable server-owned actor
+   and generation IDs, build context at gateway ingress, derive one effective
+   snapshot, and emit bounded content-free mismatch evidence while legacy
+   remains authoritative.
 3. **Boundary migration:** migrate `message_agent`, tool/MCP injection, profile
    mutation, group interruption, peer delivery, completion ownership, and
    destructive/file/network operations one at a time.
@@ -157,11 +198,16 @@ contract and delete the superseded gate in the same change.
 Preserve existing contributor ownership and compose it onto this spine:
 
 - #91802 — structured `message_agent`;
+- #92784 — one structured local/peer/cross-connection delivery path;
+- #90198 and #92731 — current connection/profile owner routing;
 - #90329 — source-qualified cross-connection room identity;
 - #89455 — effective toolset/MCP runtime truth;
 - #90954 — completion-loss evidence and immediate stopgap;
-- #91889 — visible group interruption and late-reply fencing;
+- #91889 — closed unmerged; group interruption and late-reply fencing still
+  need an active owner;
 - #91862 — authenticated Bot roster/read model;
+- #92857 — bounded relay/DM artifact hygiene, not durable settlement;
+- #92861 — bounded in-process completion linger, not restart durability;
 - #88819 — peer credential redirect boundary;
 - #91832 — permanent configuration refusal; and
 - #73923 — shared delivery-ledger substrate.
@@ -184,5 +230,5 @@ The completed class must prove:
 ## Non-goals of this PR
 
 No production wiring, transport rewrite, durable inbox schema, Desktop change,
-approval UI, provider/catalog behavior change, profile-ID migration, or switch
+approval UI, provider/catalog behavior change, stable-ID migration, or switch
 away from legacy authority.

--- a/docs/design/bot-mode-control-plane.md
+++ b/docs/design/bot-mode-control-plane.md
@@ -63,7 +63,7 @@ One immutable snapshot records the exact profile/runtime generation:
 
 ```text
 grant_id
-profile_id / profile_config_revision
+BotAddress / profile_config_revision
 runtime_snapshot_id / revocation_epoch
 configured / requested / effective provider
 effective model / API mode / reasoning / service tier
@@ -95,8 +95,8 @@ content may request an operation; it cannot manufacture a grant.
 
 A content-free result records the decision ID, operation, verdict, reason,
 required capability, and bounded constraints. The evaluator fails closed on
-profile, profile-revision, grant, revocation-epoch, runtime-snapshot, or
-capability mismatch.
+exact BotAddress, profile-revision, grant, revocation-epoch,
+runtime-snapshot, or capability mismatch.
 
 ### `ShadowPolicyComparison`
 

--- a/tests/agent/test_bot_control_plane.py
+++ b/tests/agent/test_bot_control_plane.py
@@ -9,6 +9,7 @@ from agent.bot_control_plane import (
     BotExecutionContext,
     BotPolicyReason,
     BotPolicyVerdict,
+    BotRoute,
     LegacyMessageAgentReason,
     LegacyMessageAgentState,
     RuntimeCapabilitySnapshot,
@@ -20,7 +21,7 @@ from agent.bot_control_plane import (
 
 
 def _address(profile_id="profile-123"):
-    return BotAddress("install-a", "gateway-a", "local", profile_id)
+    return BotAddress("install-a", profile_id)
 
 
 def _context(
@@ -30,6 +31,7 @@ def _context(
     grant_id="grant-7",
     runtime_id="runtime-9",
     epoch=3,
+    selected_route=None,
 ):
     return BotExecutionContext(
         address=_address(profile_id),
@@ -47,6 +49,7 @@ def _context(
         cancellation_scope_id="cancel-1",
         budget_id="budget-1",
         trace_id="trace-1",
+        selected_route=selected_route,
     )
 
 
@@ -73,20 +76,27 @@ def _snapshot(
     )
 
 
+def _legacy_state(*, protocol, schema, canonical, managed):
+    return LegacyMessageAgentState(
+        protocol_enabled=protocol,
+        schema_present=schema,
+        canonical_bot_chat=canonical,
+        managed_install=managed,
+    )
+
+
 class TestIdentityAndRuntimeProofs:
-    def test_address_keeps_four_independent_axes(self):
-        address = BotAddress(" install ", " gateway ", " local ", " profile ")
-        assert address.identity_tuple == ("install", "gateway", "local", "profile")
+    def test_address_keeps_durable_actor_axes(self):
+        address = BotAddress(" install ", " profile ")
+        assert address.identity_tuple == ("install", "profile")
 
     @pytest.mark.parametrize(
         "field_name",
-        ("install_id", "gateway_instance_id", "connection_id", "profile_id"),
+        ("install_id", "profile_id"),
     )
     def test_empty_address_axis_is_rejected(self, field_name):
         values = dict(
             install_id="install",
-            gateway_instance_id="gateway",
-            connection_id="local",
             profile_id="profile",
         )
         values[field_name] = " "
@@ -95,14 +105,38 @@ class TestIdentityAndRuntimeProofs:
 
     def test_non_string_identity_is_rejected(self):
         with pytest.raises(TypeError, match="profile_id"):
-            BotAddress("install", "gateway", "local", 7)  # type: ignore[arg-type]
+            BotAddress("install", 7)  # type: ignore[arg-type]
+
+    def test_route_is_explicitly_namespaced_and_optional(self):
+        route = BotRoute(" desktop-registry-1 ", " cloud ", " gateway-7 ")
+        assert route.route_tuple == (
+            "desktop-registry-1",
+            "cloud",
+            "gateway-7",
+        )
+        assert _context().selected_route is None
+        assert _context(selected_route=route).selected_route is route
+
+    @pytest.mark.parametrize("field_name", ("route_namespace_id", "connection_id"))
+    def test_unscoped_or_empty_route_is_rejected(self, field_name):
+        values = dict(route_namespace_id="desktop-1", connection_id="local")
+        values[field_name] = " "
+        with pytest.raises(ValueError, match=field_name):
+            BotRoute(**values)
+
+    def test_context_rejects_untyped_route(self):
+        with pytest.raises(TypeError, match="selected_route"):
+            _context(selected_route="local")  # type: ignore[arg-type]
 
     def test_proof_objects_are_immutable(self):
         address = _address()
+        route = BotRoute("desktop-1", "local")
         context = _context()
         snapshot = _snapshot()
         with pytest.raises(FrozenInstanceError):
             address.profile_id = "other"  # type: ignore[misc]
+        with pytest.raises(FrozenInstanceError):
+            route.connection_id = "other"  # type: ignore[misc]
         with pytest.raises(FrozenInstanceError):
             context.revocation_epoch = 9  # type: ignore[misc]
         with pytest.raises(FrozenInstanceError):
@@ -128,9 +162,7 @@ class TestIdentityAndRuntimeProofs:
                 _context(epoch=-1)
 
     def test_snapshot_normalizes_stable_capability_ids(self):
-        snapshot = _snapshot(
-            capabilities=("peer.message", BotCapability.NETWORK_READ)
-        )
+        snapshot = _snapshot(capabilities=("peer.message", BotCapability.NETWORK_READ))
         assert snapshot.allows("peer.message")
         assert snapshot.allows(BotCapability.NETWORK_READ)
 
@@ -157,18 +189,29 @@ class TestFailClosedPolicyEvaluation:
     @pytest.mark.parametrize(
         "address",
         (
-            BotAddress("other-install", "gateway-a", "local", "profile-123"),
-            BotAddress("install-a", "other-gateway", "local", "profile-123"),
-            BotAddress("install-a", "gateway-a", "remote", "profile-123"),
-            BotAddress("install-a", "gateway-a", "local", "other-profile"),
+            BotAddress("other-install", "profile-123"),
+            BotAddress("install-a", "other-profile"),
         ),
     )
-    def test_every_address_axis_is_authoritative(self, address):
+    def test_every_durable_address_axis_is_authoritative(self, address):
         snapshot = _snapshot()
         data = dict(snapshot.__dict__)
         data["address"] = address
         decision = self._decision(snapshot=RuntimeCapabilitySnapshot(**data))
         assert decision.reason is BotPolicyReason.ADDRESS_MISMATCH
+
+    @pytest.mark.parametrize(
+        "route",
+        (
+            None,
+            BotRoute("desktop-a", "local", "gateway-a"),
+            BotRoute("desktop-b", "remote", "gateway-b"),
+        ),
+    )
+    def test_route_selection_does_not_mint_actor_authority(self, route):
+        decision = self._decision(context=_context(selected_route=route))
+        assert decision.verdict is BotPolicyVerdict.ALLOW
+        assert decision.reason is BotPolicyReason.CAPABILITY_GRANTED
 
     @pytest.mark.parametrize(
         ("context", "snapshot", "reason"),
@@ -234,27 +277,52 @@ class TestLegacyMessageAgentMapping:
         ("state", "allowed", "reason"),
         (
             (
-                LegacyMessageAgentState(False, True, True, True),
+                _legacy_state(
+                    protocol=False,
+                    schema=True,
+                    canonical=True,
+                    managed=True,
+                ),
                 False,
                 LegacyMessageAgentReason.PROTOCOL_DISABLED,
             ),
             (
-                LegacyMessageAgentState(True, True, False, False),
+                _legacy_state(
+                    protocol=True,
+                    schema=True,
+                    canonical=False,
+                    managed=False,
+                ),
                 True,
                 LegacyMessageAgentReason.SCHEMA_ALREADY_PRESENT,
             ),
             (
-                LegacyMessageAgentState(True, False, False, True),
+                _legacy_state(
+                    protocol=True,
+                    schema=False,
+                    canonical=False,
+                    managed=True,
+                ),
                 False,
                 LegacyMessageAgentReason.NOT_CANONICAL_BOT_CHAT,
             ),
             (
-                LegacyMessageAgentState(True, False, True, False),
+                _legacy_state(
+                    protocol=True,
+                    schema=False,
+                    canonical=True,
+                    managed=False,
+                ),
                 False,
                 LegacyMessageAgentReason.UNMANAGED_INSTALL,
             ),
             (
-                LegacyMessageAgentState(True, False, True, True),
+                _legacy_state(
+                    protocol=True,
+                    schema=False,
+                    canonical=True,
+                    managed=True,
+                ),
                 True,
                 LegacyMessageAgentReason.LEGACY_GATE_ALLOW,
             ),
@@ -269,25 +337,38 @@ class TestLegacyMessageAgentMapping:
         ("state", "allowed", "reason"),
         (
             (
-                LegacyMessageAgentState(False, False, True, True),
+                _legacy_state(
+                    protocol=False,
+                    schema=False,
+                    canonical=True,
+                    managed=True,
+                ),
                 True,
                 LegacyMessageAgentReason.LEGACY_GATE_ALLOW,
             ),
             (
-                LegacyMessageAgentState(True, True, False, True),
+                _legacy_state(
+                    protocol=True,
+                    schema=True,
+                    canonical=False,
+                    managed=True,
+                ),
                 False,
                 LegacyMessageAgentReason.NOT_CANONICAL_BOT_CHAT,
             ),
             (
-                LegacyMessageAgentState(True, True, True, False),
+                _legacy_state(
+                    protocol=True,
+                    schema=True,
+                    canonical=True,
+                    managed=False,
+                ),
                 False,
                 LegacyMessageAgentReason.UNMANAGED_INSTALL,
             ),
         ),
     )
-    def test_dispatch_mapping_preserves_current_asymmetry(
-        self, state, allowed, reason
-    ):
+    def test_dispatch_mapping_preserves_current_asymmetry(self, state, allowed, reason):
         decision = legacy_message_agent_dispatch_decision(state)
         assert decision.allowed is allowed
         assert decision.reason is reason

--- a/tests/agent/test_bot_control_plane.py
+++ b/tests/agent/test_bot_control_plane.py
@@ -1,0 +1,277 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from agent.bot_control_plane import (
+    BOT_CONTROL_PLANE_CONTRACT_VERSION,
+    BotAddress,
+    BotCapability,
+    BotExecutionContext,
+    BotPolicyReason,
+    BotPolicyVerdict,
+    LegacyMessageAgentReason,
+    LegacyMessageAgentState,
+    RuntimeCapabilitySnapshot,
+    compare_legacy_authority,
+    evaluate_capability,
+    legacy_message_agent_dispatch_decision,
+    legacy_message_agent_injection_decision,
+)
+
+
+def _address(profile_id="profile-123"):
+    return BotAddress("install-a", "gateway-a", "local", profile_id)
+
+
+def _context(
+    *,
+    profile_id="profile-123",
+    profile_revision="profile-rev-4",
+    grant_id="grant-7",
+    runtime_id="runtime-9",
+    epoch=3,
+):
+    return BotExecutionContext(
+        address=_address(profile_id),
+        profile_config_revision=profile_revision,
+        session_id="session-1",
+        session_key="agent:main:desktop:dm:1",
+        turn_id="turn-1",
+        task_id="task-1",
+        authenticated_principal="user-42",
+        source_platform="desktop",
+        source_user_id="user-42",
+        runtime_snapshot_id=runtime_id,
+        capability_grant_id=grant_id,
+        revocation_epoch=epoch,
+        cancellation_scope_id="cancel-1",
+        budget_id="budget-1",
+        trace_id="trace-1",
+    )
+
+
+def _snapshot(
+    *,
+    profile_id="profile-123",
+    profile_revision="profile-rev-4",
+    grant_id="grant-7",
+    runtime_id="runtime-9",
+    epoch=3,
+    capabilities=(BotCapability.PEER_MESSAGE,),
+):
+    return RuntimeCapabilitySnapshot.build(
+        grant_id=grant_id,
+        profile_id=profile_id,
+        profile_config_revision=profile_revision,
+        runtime_snapshot_id=runtime_id,
+        effective_provider="nous",
+        effective_model="hermes-5.6",
+        api_mode="chat_completions",
+        reasoning_effort="high",
+        revocation_epoch=epoch,
+        capabilities=capabilities,
+    )
+
+
+class TestIdentityAndRuntimeProofs:
+    def test_address_keeps_four_independent_axes(self):
+        address = BotAddress(" install ", " gateway ", " local ", " profile ")
+        assert address.identity_tuple == ("install", "gateway", "local", "profile")
+
+    @pytest.mark.parametrize(
+        "field_name",
+        ("install_id", "gateway_instance_id", "connection_id", "profile_id"),
+    )
+    def test_empty_address_axis_is_rejected(self, field_name):
+        values = dict(
+            install_id="install",
+            gateway_instance_id="gateway",
+            connection_id="local",
+            profile_id="profile",
+        )
+        values[field_name] = " "
+        with pytest.raises(ValueError, match=field_name):
+            BotAddress(**values)
+
+    def test_non_string_identity_is_rejected(self):
+        with pytest.raises(TypeError, match="profile_id"):
+            BotAddress("install", "gateway", "local", 7)  # type: ignore[arg-type]
+
+    def test_proof_objects_are_immutable(self):
+        address = _address()
+        context = _context()
+        snapshot = _snapshot()
+        with pytest.raises(FrozenInstanceError):
+            address.profile_id = "other"  # type: ignore[misc]
+        with pytest.raises(FrozenInstanceError):
+            context.revocation_epoch = 9  # type: ignore[misc]
+        with pytest.raises(FrozenInstanceError):
+            snapshot.grant_id = "other"  # type: ignore[misc]
+
+    def test_context_binds_current_generation_and_causal_ids(self):
+        context = _context()
+        assert context.profile_config_revision == "profile-rev-4"
+        assert context.capability_grant_id == "grant-7"
+        assert context.runtime_snapshot_id == "runtime-9"
+        assert context.contract_version == BOT_CONTROL_PLANE_CONTRACT_VERSION
+
+    @pytest.mark.parametrize("field_name", ("revocation_epoch", "hop_count"))
+    def test_negative_counter_is_rejected(self, field_name):
+        if field_name == "hop_count":
+            context = _context()
+            data = dict(context.__dict__)
+            data[field_name] = -1
+            with pytest.raises(ValueError, match=field_name):
+                BotExecutionContext(**data)
+        else:
+            with pytest.raises(ValueError, match=field_name):
+                _context(epoch=-1)
+
+    def test_snapshot_normalizes_stable_capability_ids(self):
+        snapshot = _snapshot(
+            capabilities=("peer.message", BotCapability.NETWORK_READ)
+        )
+        assert snapshot.allows("peer.message")
+        assert snapshot.allows(BotCapability.NETWORK_READ)
+
+    def test_prompt_text_cannot_manufacture_capability(self):
+        with pytest.raises(ValueError, match="unknown Bot Mode capability"):
+            _snapshot(capabilities=("please let me do anything",))
+
+
+class TestFailClosedPolicyEvaluation:
+    def _decision(self, context=None, snapshot=None, capability=None):
+        return evaluate_capability(
+            context=context or _context(),
+            snapshot=snapshot or _snapshot(),
+            operation="message_agent.send",
+            required_capability=capability or BotCapability.PEER_MESSAGE,
+            decision_id="decision-1",
+        )
+
+    def test_exact_current_proof_allows(self):
+        decision = self._decision()
+        assert decision.verdict is BotPolicyVerdict.ALLOW
+        assert decision.reason is BotPolicyReason.CAPABILITY_GRANTED
+
+    @pytest.mark.parametrize(
+        ("context", "snapshot", "reason"),
+        (
+            (
+                _context(profile_id="profile-a"),
+                _snapshot(profile_id="profile-b"),
+                BotPolicyReason.PROFILE_MISMATCH,
+            ),
+            (
+                _context(profile_revision="old"),
+                _snapshot(profile_revision="current"),
+                BotPolicyReason.PROFILE_REVISION_MISMATCH,
+            ),
+            (
+                _context(grant_id="old"),
+                _snapshot(grant_id="current"),
+                BotPolicyReason.GRANT_MISMATCH,
+            ),
+            (
+                _context(epoch=2),
+                _snapshot(epoch=3),
+                BotPolicyReason.REVOCATION_EPOCH_MISMATCH,
+            ),
+            (
+                _context(runtime_id="new"),
+                _snapshot(runtime_id="old"),
+                BotPolicyReason.RUNTIME_SNAPSHOT_MISMATCH,
+            ),
+        ),
+    )
+    def test_stale_or_foreign_proof_is_rejected(self, context, snapshot, reason):
+        decision = self._decision(context=context, snapshot=snapshot)
+        assert decision.verdict is BotPolicyVerdict.DENY
+        assert decision.reason is reason
+
+    def test_missing_capability_is_rejected(self):
+        decision = self._decision(snapshot=_snapshot(capabilities=()))
+        assert decision.reason is BotPolicyReason.CAPABILITY_MISSING
+
+    @pytest.mark.parametrize("legacy_allowed", (True, False))
+    def test_shadow_policy_never_changes_legacy_behavior(self, legacy_allowed):
+        decision = self._decision(snapshot=_snapshot(capabilities=()))
+        comparison = compare_legacy_authority(
+            legacy_allowed=legacy_allowed,
+            decision=decision,
+        )
+        assert comparison.effective_allowed is legacy_allowed
+
+    def test_shadow_disagreement_is_explicit(self):
+        decision = self._decision(snapshot=_snapshot(capabilities=()))
+        comparison = compare_legacy_authority(
+            legacy_allowed=True,
+            decision=decision,
+        )
+        assert comparison.matches is False
+        assert comparison.policy_allowed is False
+        assert comparison.effective_allowed is True
+
+
+class TestLegacyMessageAgentMapping:
+    @pytest.mark.parametrize(
+        ("state", "allowed", "reason"),
+        (
+            (
+                LegacyMessageAgentState(False, True, True, True),
+                False,
+                LegacyMessageAgentReason.PROTOCOL_DISABLED,
+            ),
+            (
+                LegacyMessageAgentState(True, True, False, False),
+                True,
+                LegacyMessageAgentReason.SCHEMA_ALREADY_PRESENT,
+            ),
+            (
+                LegacyMessageAgentState(True, False, False, True),
+                False,
+                LegacyMessageAgentReason.NOT_CANONICAL_BOT_CHAT,
+            ),
+            (
+                LegacyMessageAgentState(True, False, True, False),
+                False,
+                LegacyMessageAgentReason.UNMANAGED_INSTALL,
+            ),
+            (
+                LegacyMessageAgentState(True, False, True, True),
+                True,
+                LegacyMessageAgentReason.LEGACY_GATE_ALLOW,
+            ),
+        ),
+    )
+    def test_injection_order_matches_current_source(self, state, allowed, reason):
+        decision = legacy_message_agent_injection_decision(state)
+        assert decision.allowed is allowed
+        assert decision.reason is reason
+
+    @pytest.mark.parametrize(
+        ("state", "allowed", "reason"),
+        (
+            (
+                LegacyMessageAgentState(False, False, True, True),
+                True,
+                LegacyMessageAgentReason.LEGACY_GATE_ALLOW,
+            ),
+            (
+                LegacyMessageAgentState(True, True, False, True),
+                False,
+                LegacyMessageAgentReason.NOT_CANONICAL_BOT_CHAT,
+            ),
+            (
+                LegacyMessageAgentState(True, True, True, False),
+                False,
+                LegacyMessageAgentReason.UNMANAGED_INSTALL,
+            ),
+        ),
+    )
+    def test_dispatch_mapping_preserves_current_asymmetry(
+        self, state, allowed, reason
+    ):
+        decision = legacy_message_agent_dispatch_decision(state)
+        assert decision.allowed is allowed
+        assert decision.reason is reason

--- a/tests/agent/test_bot_control_plane.py
+++ b/tests/agent/test_bot_control_plane.py
@@ -61,7 +61,7 @@ def _snapshot(
 ):
     return RuntimeCapabilitySnapshot.build(
         grant_id=grant_id,
-        profile_id=profile_id,
+        address=_address(profile_id),
         profile_config_revision=profile_revision,
         runtime_snapshot_id=runtime_id,
         effective_provider="nous",
@@ -155,12 +155,28 @@ class TestFailClosedPolicyEvaluation:
         assert decision.reason is BotPolicyReason.CAPABILITY_GRANTED
 
     @pytest.mark.parametrize(
+        "address",
+        (
+            BotAddress("other-install", "gateway-a", "local", "profile-123"),
+            BotAddress("install-a", "other-gateway", "local", "profile-123"),
+            BotAddress("install-a", "gateway-a", "remote", "profile-123"),
+            BotAddress("install-a", "gateway-a", "local", "other-profile"),
+        ),
+    )
+    def test_every_address_axis_is_authoritative(self, address):
+        snapshot = _snapshot()
+        data = dict(snapshot.__dict__)
+        data["address"] = address
+        decision = self._decision(snapshot=RuntimeCapabilitySnapshot(**data))
+        assert decision.reason is BotPolicyReason.ADDRESS_MISMATCH
+
+    @pytest.mark.parametrize(
         ("context", "snapshot", "reason"),
         (
             (
                 _context(profile_id="profile-a"),
                 _snapshot(profile_id="profile-b"),
-                BotPolicyReason.PROFILE_MISMATCH,
+                BotPolicyReason.ADDRESS_MISMATCH,
             ),
             (
                 _context(profile_revision="old"),

--- a/tests/tools/test_bot_control_plane_message_agent_parity.py
+++ b/tests/tools/test_bot_control_plane_message_agent_parity.py
@@ -1,0 +1,133 @@
+"""Parity pins between typed legacy mapping and current #91802 gates."""
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from agent.bot_control_plane import (
+    LegacyMessageAgentState,
+    legacy_message_agent_dispatch_decision,
+    legacy_message_agent_injection_decision,
+)
+from tools import bot_mode_dm, bot_mode_probe
+
+
+@pytest.fixture(autouse=True)
+def _fresh_probe_cache():
+    bot_mode_probe._reset_cache_for_tests()
+    yield
+    bot_mode_probe._reset_cache_for_tests()
+
+
+def _home(tmp_path: Path, *, managed: bool) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    if managed:
+        profile = home / "profiles" / "researcher"
+        profile.mkdir(parents=True)
+        (profile / "profile.yaml").write_text(
+            textwrap.dedent(
+                """\
+                description: teammate for parity tests
+                ui_meta:
+                  hermes-bots:
+                    shape: cloud
+                """
+            ),
+            encoding="utf-8",
+        )
+    return home
+
+
+class _FakeDB:
+    def __init__(self, home: Path, title: str):
+        self.db_path = str(home / "state.db")
+        self.title = title
+
+    def get_session_title(self, _session_id):
+        return self.title
+
+
+class _FakeAgent:
+    def __init__(
+        self,
+        home: Path,
+        *,
+        title: str,
+        protocol_enabled: bool,
+        schema_present: bool,
+    ):
+        self._session_db = _FakeDB(home, title)
+        self._session_title_hint = None
+        self._bot_mode_protocol = protocol_enabled
+        self.session_id = "session-parity"
+        self.tools = [bot_mode_dm.message_agent_tool_schema()] if schema_present else []
+        self.valid_tool_names = set()
+
+
+@pytest.mark.parametrize(
+    ("protocol", "schema", "canonical", "managed"),
+    (
+        (False, True, True, True),
+        (True, True, False, False),
+        (True, False, True, True),
+        (True, False, True, False),
+        (True, False, False, True),
+    ),
+)
+def test_injection_mapping_matches_current_gate(
+    tmp_path, protocol, schema, canonical, managed
+):
+    title = "Bot Chat" if canonical else "Ordinary chat"
+    agent = _FakeAgent(
+        _home(tmp_path, managed=managed),
+        title=title,
+        protocol_enabled=protocol,
+        schema_present=schema,
+    )
+    mapped = legacy_message_agent_injection_decision(
+        LegacyMessageAgentState(protocol, schema, canonical, managed)
+    )
+    assert bot_mode_dm.ensure_message_agent_tool(agent) is mapped.allowed
+
+
+@pytest.mark.parametrize(
+    ("protocol", "schema", "canonical", "managed"),
+    (
+        (False, False, True, True),
+        (True, True, False, True),
+        (True, False, True, False),
+    ),
+)
+def test_dispatch_mapping_matches_current_gate(
+    tmp_path, monkeypatch, protocol, schema, canonical, managed
+):
+    title = "Bot Chat" if canonical else "Ordinary chat"
+    agent = _FakeAgent(
+        _home(tmp_path, managed=managed),
+        title=title,
+        protocol_enabled=protocol,
+        schema_present=schema,
+    )
+
+    import tools.terminal_tool as terminal_tool_module
+
+    monkeypatch.setattr(
+        terminal_tool_module,
+        "terminal_tool",
+        lambda *_args, **_kwargs: json.dumps({"session_id": "proc-parity"}),
+    )
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(
+            target="researcher",
+            message="parity probe",
+            agent=agent,
+        )
+    )
+    actual_allowed = result.get("status") == "sent"
+    mapped = legacy_message_agent_dispatch_decision(
+        LegacyMessageAgentState(protocol, schema, canonical, managed)
+    )
+    assert actual_allowed is mapped.allowed

--- a/tests/tools/test_bot_control_plane_message_agent_parity.py
+++ b/tests/tools/test_bot_control_plane_message_agent_parity.py
@@ -21,7 +21,7 @@ def _fresh_probe_cache():
     bot_mode_probe._reset_cache_for_tests()
 
 
-def _home(tmp_path: Path, *, managed: bool) -> Path:
+def _home(tmp_path: Path, *, managed: bool, legacy_soul: bool = False) -> Path:
     home = tmp_path / ".hermes"
     home.mkdir()
     if managed:
@@ -36,6 +36,11 @@ def _home(tmp_path: Path, *, managed: bool) -> Path:
                     shape: cloud
                 """
             ),
+            encoding="utf-8",
+        )
+    if legacy_soul:
+        (home / "SOUL.md").write_text(
+            "# Existing bot identity\n\n## Messaging other agents\nlegacy protocol\n",
             encoding="utf-8",
         )
     return home
@@ -88,9 +93,30 @@ def test_injection_mapping_matches_current_gate(
         schema_present=schema,
     )
     mapped = legacy_message_agent_injection_decision(
-        LegacyMessageAgentState(protocol, schema, canonical, managed)
+        LegacyMessageAgentState(
+            protocol_enabled=protocol,
+            schema_present=schema,
+            canonical_bot_chat=canonical,
+            managed_install=managed,
+        )
     )
     assert bot_mode_dm.ensure_message_agent_tool(agent) is mapped.allowed
+
+
+def test_legacy_soul_dedupe_still_injects_on_managed_install(tmp_path):
+    home = _home(tmp_path, managed=True, legacy_soul=True)
+    agent = _FakeAgent(
+        home,
+        title="Bot Chat",
+        protocol_enabled=True,
+        schema_present=False,
+    )
+
+    # #92784-era injection is gated on managed-install identity, not on
+    # whether the prompt probe emits text. A legacy SOUL heading suppresses
+    # duplicate prompt text but must not silently remove message_agent.
+    assert bot_mode_probe.get_bot_mode_protocol_section(home) == ""
+    assert bot_mode_dm.ensure_message_agent_tool(agent) is True
 
 
 @pytest.mark.parametrize(
@@ -128,6 +154,11 @@ def test_dispatch_mapping_matches_current_gate(
     )
     actual_allowed = result.get("status") == "sent"
     mapped = legacy_message_agent_dispatch_decision(
-        LegacyMessageAgentState(protocol, schema, canonical, managed)
+        LegacyMessageAgentState(
+            protocol_enabled=protocol,
+            schema_present=schema,
+            canonical_bot_chat=canonical,
+            managed_install=managed,
+        )
     )
     assert actual_allowed is mapped.allowed

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -136,6 +136,11 @@ def ensure_message_agent_tool(agent: Any) -> bool:
     sees the schema. Never raises.
     """
     try:
+        # Shadow contract: keep this source order synchronized with
+        # agent.bot_control_plane.legacy_message_agent_injection_decision.
+        # The schema-present return intentionally precedes title/install
+        # revalidation; the parity suite records that asymmetry without
+        # changing which result remains authoritative.
         if not getattr(agent, "_bot_mode_protocol", True):
             return False
         tools = getattr(agent, "tools", None)
@@ -252,6 +257,10 @@ def message_agent_tool(
     try:
         from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
 
+        # Shadow contract: keep these authoritative checks synchronized with
+        # agent.bot_control_plane.legacy_message_agent_dispatch_decision.
+        # Dispatch deliberately does not recheck protocol/schema state; the
+        # parity suite records that current asymmetry without changing it.
         title = _session_title(agent)
         if title != BOT_CHAT_TITLE:
             return _err(


### PR DESCRIPTION
## Summary

Phase 1 of #91911: immutable, shadow-only Bot Mode proof contracts plus an exact legacy `message_agent` parity map. This revision is rebased onto current `main` and incorporates the delivery-plane reality established by #92784 without treating relay coordinates as authority.

The governing invariant remains:

> Coordinates select. Current proof objects authorize.

## Contract correction

#92784 made one distinction concrete: Desktop `connection_id` is scoped to one Desktop route registry. It may select a gateway, but it is not a globally durable or gateway-authenticated actor fact.

This PR therefore separates:

- `BotAddress(install_id, profile_id)` — durable actor identity;
- `BotRoute(route_namespace_id, connection_id, gateway_instance_id?)` — optional, non-authoritative route selection;
- `BotExecutionContext.selected_route` — routing evidence carried separately from actor authority.

`evaluate_capability()` compares the durable actor plus profile revision, grant, revocation epoch, and runtime snapshot. It deliberately does not allow a client route coordinate to mint actor authority. Because this contract is unmerged and has no production consumers, the false four-axis model is removed now with no compatibility shim.

## Shadow contracts

`agent/bot_control_plane.py` provides pure-stdlib, immutable contracts for:

- durable Bot actor identity and namespaced route selection;
- authenticated per-turn execution context;
- effective runtime/capability snapshots;
- content-free policy decisions and stable reason codes;
- fail-closed generation/grant/capability evaluation; and
- shadow comparison whose effective result always remains the legacy result.

This PR has no production imports or authorization switch. It cannot grant, deny, deliver, cancel, or mutate work.

## Exact current `message_agent` mapping

The PR records current behavior rather than silently repairing it.

**Injection**

1. disabled protocol denies;
2. an already-present schema allows before title/install revalidation;
3. otherwise exact `Bot Chat` title is required;
4. then a Bot-Mode-managed install is required.

**Dispatch**

1. exact `Bot Chat` title is required;
2. a Bot-Mode-managed install is required;
3. protocol toggle and schema presence are not consulted.

Gate-adjacent comments now point contributors to the typed mapping, resolving the discoverability concern without making the shadow model authoritative. The live parity suite also pins the post-#92784 legacy-SOUL case: suppressing duplicate protocol prompt text must not remove `message_agent` from a managed install. Positional four-boolean fixtures were replaced with named facts.

## Phase 2 boundary

Current production state cannot truthfully construct the complete proof object. It still lacks a stable opaque profile ID with explicit rename/clone/import semantics, a server-owned gateway runtime generation, and canonical grant/revocation/runtime/cancellation IDs.

The next slice must establish those server-owned producers, then bind one context after authentication and current profile resolution at gateway/session ingress. It may compare one consuming boundary in shadow and emit bounded content-free mismatch evidence while legacy remains effective. It must not substitute profile names, Desktop connection IDs, relay-roster rows, user/chat IDs, task IDs, or ambient-runtime hashes for missing proofs.

## Interlocks

Preserved implementation ownership:

- #91802 / #92784 — structured send and unified delivery path;
- #90198 / #92731 — current connection/profile owner routing;
- #90329 — source-qualified roster/group identity;
- #89455 — effective tool/MCP runtime truth;
- #90954 — completion-loss evidence;
- #91862 — authenticated roster/read model;
- #88819 — peer credential redirect boundary;
- #91832 — permanent configuration refusal; and
- #73923 — shared delivery-ledger substrate.

State corrections are explicit in the design record: #91889 is closed unmerged; #92857 is artifact hygiene rather than terminal settlement; #92861 is bounded in-process linger rather than restart durability.

## Verification

Exact base and published head:

```text
base: 891ec3fb6c41e912e9d2120dd4009534814a9e7a
head: 7a7daa806685f02271c64da7171243a0759e555d
compare: ahead 8, behind 0
files: 5
```

Canonical local runner on the exact rebased file objects:

```text
scripts/run_tests.sh \
  tests/agent/test_bot_control_plane.py \
  tests/tools/test_bot_control_plane_message_agent_parity.py \
  tests/tools/test_bot_mode_dm.py

85 passed, 0 failed
```

Additional checks:

```text
ruff check: passed
ruff format --check (new contract/test files): passed
scripts/audit_pr_attribution.py: all contributor emails mapped
git diff --check: passed
```

Exact-head GitHub Actions:

- [CI #32636614078](https://github.com/NousResearch/hermes-agent/actions/runs/32636614078): success;
- [Docker #32636613869](https://github.com/NousResearch/hermes-agent/actions/runs/32636613869): success; and
- [Nix #32636613856](https://github.com/NousResearch/hermes-agent/actions/runs/32636613856): success.

All three receipts bind to `7a7daa806685f02271c64da7171243a0759e555d`; no adjacent or pre-rebase green is transferred.

## Risk / non-goals

Behavior-neutral Phase 1 only: no proof construction at ingress, no production policy consumer, no transport rewrite, no durable mailbox, no cancellation tree, no Desktop behavior change, no stable-ID migration, and no switch away from legacy authority.

Refs #91911
Refs #91802
Refs #92784