### PR TITLE
fix(tools): make DaemonThreadPoolExecutor compatible with Python 3.14+ worker context

### DIFF
--- a/tests/tools/test_daemon_pool.py
+++ b/tests/tools/test_daemon_pool.py
@@ -69,6 +69,27 @@ def test_wedged_worker_does_not_block_interpreter_exit():
     assert "main-done" in proc.stdout
 
 
+def test_compatible_with_current_interpreters_worker_signature():
+    """_adjust_thread_count must match this interpreter's _worker() signature.
+
+    CPython 3.14 replaced concurrent.futures.thread._worker's
+    (executor_reference, work_queue, initializer, initargs) shape with
+    (executor_reference, ctx, work_queue), sourcing ctx from
+    self._create_worker_context() instead of self._initializer/_initargs
+    (which no longer exist as attributes on 3.14+). A pool hardcoded to the
+    pre-3.14 shape raises AttributeError on the very first submit() on
+    3.14+, and a pool hardcoded to the 3.14+ shape would do the same on
+    3.8-3.13. This exercises whichever branch this interpreter needs and
+    asserts the pool actually completes work end-to-end.
+    """
+    pool = DaemonThreadPoolExecutor(max_workers=1)
+    try:
+        result = pool.submit(lambda: 1 + 1).result(timeout=10)
+        assert result == 2
+    finally:
+        pool.shutdown(wait=True)
+
+
 def _repo_root():
     import pathlib
 

--- a/tools/daemon_pool.py
+++ b/tools/daemon_pool.py
@@ -38,7 +38,7 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
     """ThreadPoolExecutor variant whose workers do not block process exit."""
 
     def _adjust_thread_count(self) -> None:
-        # Mirrors CPython's implementation (3.8–3.13) with two changes:
+        # Mirrors CPython's implementation (3.8–3.14+) with two changes:
         # daemon=True and no _threads_queues registration.
         if self._idle_semaphore.acquire(timeout=0):
             return
@@ -49,16 +49,30 @@ class DaemonThreadPoolExecutor(ThreadPoolExecutor):
         num_threads = len(self._threads)
         if num_threads < self._max_workers:
             thread_name = "%s_%d" % (self._thread_name_prefix or self, num_threads)
-            t = threading.Thread(
-                name=thread_name,
-                target=_worker,
-                args=(
-                    weakref.ref(self, weakref_cb),
-                    self._work_queue,
-                    self._initializer,
-                    self._initargs,
-                ),
-                daemon=True,
-            )
+            if hasattr(self, "_create_worker_context"):
+                # Python 3.14+
+                t = threading.Thread(
+                    name=thread_name,
+                    target=_worker,
+                    args=(
+                        weakref.ref(self, weakref_cb),
+                        self._create_worker_context(),
+                        self._work_queue,
+                    ),
+                    daemon=True,
+                )
+            else:
+                # Python 3.8–3.13
+                t = threading.Thread(
+                    name=thread_name,
+                    target=_worker,
+                    args=(
+                        weakref.ref(self, weakref_cb),
+                        self._work_queue,
+                        self._initializer,
+                        self._initargs,
+                    ),
+                    daemon=True,
+                )
             t.start()
             self._threads.add(t)


### PR DESCRIPTION


This may overlap with #65182, which appears to fix the same root cause. Opening this anyway per maintainer request so the fix has independent verification and a linked issue attached; happy to have this closed in favor of #65182 if maintainers prefer consolidating there -- just flag it and it's gone.

## Summary

- Closes #91916
- `concurrent.futures.thread._worker`'s signature changed in CPython 3.14 from `(executor_reference, work_queue, initializer, initargs)` to `(executor_reference, ctx, work_queue)`, sourcing `ctx` from `self._create_worker_context()`. `self._initializer` / `self._initargs` no longer exist as attributes on 3.14+.
- `DaemonThreadPoolExecutor._adjust_thread_count` mirrors this stdlib internal (to spawn daemon-mode workers that skip the `_threads_queues` atexit-join) and was hardcoded to the pre-3.14 argument shape. On Python 3.14+, **every** `submit()` call raises `AttributeError` -- this isn't a degradation, it's total breakage of concurrent tool execution, subagent timeout wrappers, and background memory sync (per this module's own docstring).
- Fix: branch on `hasattr(self, "_create_worker_context")` to build the right `_worker()` call for whichever interpreter is running.

## Proof

**Pre-fix crash**, isolating the exact code path as it exists on `main` today:

```python
class OldDaemonThreadPoolExecutor(ThreadPoolExecutor):
    def _adjust_thread_count(self):
        ...
        args=(weakref.ref(self, weakref_cb), self._work_queue, self._initializer, self._initargs)
        ...

ex = OldDaemonThreadPoolExecutor(max_workers=2)
fut = ex.submit(lambda: 1 + 1)
fut.result(timeout=5)
```

```
Traceback (most recent call last):
  File "...\concurrent\futures\thread.py", line 215, in submit
    self._adjust_thread_count()
  File "<string>", line 18, in _adjust_thread_count
    args=(weakref.ref(self, weakref_cb), self._work_queue, self._initializer, self._initargs),
                                                           ^^^^^^^^^^^^^^^^^
AttributeError: 'OldDaemonThreadPoolExecutor' object has no attribute '_initializer'
```

**Post-fix**, this branch, live on Python 3.14.1:

```python
from tools.daemon_pool import DaemonThreadPoolExecutor
from concurrent.futures.thread import _threads_queues
import threading

ex = DaemonThreadPoolExecutor(max_workers=2)
fut = ex.submit(lambda: threading.current_thread().daemon)
print('worker thread is daemon:', fut.result(timeout=5))
print('registered in _threads_queues:', any(t in _threads_queues for t in ex._threads))
ex.shutdown(wait=False)
```

```
worker thread is daemon: True
registered in _threads_queues: False
```

## Diagram

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[🩸 pool.submit called] --> B{Idle worker available?}
    B -->|Yes| C[⚔️ Reuse existing daemon thread]
    B -->|No| D[_adjust_thread_count spawns worker]
    D --> E{Interpreter version}
    E -->|"BEFORE: always 3.8-3.13 shape"| F[🔥 args uses self._initializer/_initargs]
    F -->|Python 3.14+| G[❌ AttributeError: no _initializer attribute]
    E -->|"AFTER: hasattr check"| H{hasattr self._create_worker_context}
    H -->|True, 3.14+| I[✅ args uses self._create_worker_context]
    H -->|False, 3.8-3.13| J[✅ args uses _initializer/_initargs]
    I --> K[⚰️ Worker thread spawns, daemon=True, skips _threads_queues]
    J --> K
```

## Test plan

- [x] New regression test: `test_compatible_with_current_interpreters_worker_signature` in `tests/tools/test_daemon_pool.py`
- [x] `pytest tests/tools/test_daemon_pool.py` -- 4 passed (Python 3.14.1)
- [x] Manual reproduction of the pre-fix crash and post-fix success shown above