### PR TITLE
fix(logging): always attempt stream recovery when _ManagedRotatingFileHandler stream is None

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -514,7 +514,7 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
     def emit(self, record: logging.LogRecord) -> None:
         # Cheap-ish stat-per-record check; the kernel caches inode metadata
         # so the syscall is sub-microsecond on a hot file.
-        if self.stream is not None or os.path.exists(self.baseFilename):
+        if self.stream is None or os.path.exists(self.baseFilename):
             self._reopen_if_externally_rotated()
         super().emit(record)
 
@@ -798,3 +798,5 @@ def _read_logging_config():
     except Exception:
         pass
     return (None, None, None)
+
+


### PR DESCRIPTION
﻿## Summary

`_ManagedRotatingFileHandler.emit()` skips `_reopen_if_externally_rotated()` when `self.stream is None` AND the log file doesn't exist on disk. This leaves `self.stream = None`, and `super().emit()` raises `AttributeError` when trying to write.

## The Bug

```python
# hermes_logging.py, line 517
def emit(self, record: logging.LogRecord) -> None:
    if self.stream is not None or os.path.exists(self.baseFilename):
        self._reopen_if_externally_rotated()
    super().emit(record)
```

**Problem:** When `self.stream is None` AND `os.path.exists(self.baseFilename)` is `False`, the condition is `False`. Recovery is skipped, and `super().emit(record)` is called with `self.stream = None`, raising `AttributeError`.

## Trigger Scenario

1. External rotation (logrotate, manual `mv`) renames the log file
2. `_reopen_if_externally_rotated()` detects mismatch, tries to reopen
3. `self._open()` fails (permissions, directory temporarily unavailable)
4. `self.stream` is left as `None`
5. On next `emit()`, if file still doesn't exist → condition is `False` → recovery skipped → `AttributeError`

## Impact

- Log records are silently lost (or traceback dumped to stderr)
- The condition is backwards: when `stream` is `None`, we should ALWAYS attempt recovery

## Fix

Change the condition from:
```python
if self.stream is not None or os.path.exists(self.baseFilename):
```
to:
```python
if self.stream is None or os.path.exists(self.baseFilename):
```

This ensures that when `stream` is `None`, `_reopen_if_externally_rotated()` always runs and tries to create a fresh file. The tradeoff is minimal: when `stream` is not `None` but the file doesn't exist, the rotation check is skipped for one emit (the write goes to the old inode, which still works).
