### PR TITLE
docs: Fix "hermes --version" in GitHub Bug Report Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -122,7 +122,7 @@ body:
     id: hermes-version
     attributes:
       label: Hermes Version
-      description: Output of `hermes version`
+      description: Output of `hermes --version`
       placeholder: "2.1.0"
 
   - type: textarea


### PR DESCRIPTION
## What does this PR do?

Fix wrong `hermes version` to correct `hermes --version` in GitHub Bug Report Issue Template.


## Related Issue

N/A as only a small docs change.


## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [X] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `.github/ISSUE_TEMPLATE/bug_report.yml`
