### PR TITLE
fix(agent): disable reasoning on the title-generation pass

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -410,6 +410,13 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
+            # The module contract above promises thinking-disabled operation,
+            # but nothing enforced it: with the aux default reasoning_effort
+            # "" (provider default), Gemini enables internal thinking and
+            # bills thought tokens against max_tokens=64 — the JSON payload
+            # never lands, and the prose fallback stores the opening fence
+            # ("```json") as the session title (#91927).
+            reasoning_config={"enabled": False},
         )
         content = response.choices[0].message.content or ""
         title = _clean_title(_extract_title_text(content))

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -46,6 +46,29 @@ class TestGenerateTitle:
         assert captured_kwargs["task"] == "title_generation"
         assert captured_kwargs["timeout"] is None
 
+    def test_generate_title_disables_reasoning(self):
+        """The titling pass must explicitly disable thinking (#91927).
+
+        With the aux default reasoning_effort "" (provider default), Gemini
+        bills internal thought tokens against max_tokens=64, the JSON payload
+        never lands, and the prose fallback stores the opening fence
+        ("```json") as the title. Enforce the module's documented
+        thinking-disabled contract at the call site.
+        """
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = '{"title": "Reasoning Off"}'
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question") == "Reasoning Off"
+
+        assert captured_kwargs.get("reasoning_config") == {"enabled": False}
+
 
 
     def test_strips_think_blocks(self):


### PR DESCRIPTION
## What does this PR do?

Stops Gemini-backed session titles from being mangled into ` ```json ` / `{` artifacts (#91927) by making the title-generation pass actually honor its own documented "thinking disabled" contract.

`agent/title_generator.py`'s docstring promises *"Runs on a cheap/fast tier, with thinking disabled"*, but `generate_title()` never passed any reasoning configuration — with the auxiliary default `reasoning_effort: ""` (provider default), Gemini enables internal thinking and bills thought tokens against `max_tokens=64`. The JSON payload (`{"title": "..."}`) is truncated before it lands, `json.loads` and the loose regex both fail, and the prose fallback in `_extract_title_text()` stores the first non-empty line — the opening fence — as the session title (then `#2`, `#3`… dedup suffixes pile up).

The fix passes `reasoning_config={"enabled": False}` on the existing `call_llm(task="title_generation", ...)` call. This is the enforcement of a contract the module already documents: titling needs no chain-of-thought, and the constraint is provider-neutral — each wire already translates the config (Anthropic `thinking` off, OpenAI-family no reasoning request, Gemini `includeThoughts: false`). The issue's second suggestion (mapping Gemini's disabled state to `thinkingBudget: 0` in `_build_gemini_thinking_config`) changes disabled-reasoning semantics for every Gemini call in the codebase and is left to maintainers; this PR closes the title-mangling path with a one-line call-site fix.

## Related Issue

Fixes #91927

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/title_generator.py` — `generate_title()`: pass `reasoning_config={"enabled": False}` to `call_llm`, with a comment explaining the 64-token starvation mechanism.
- `tests/agent/test_title_generator.py` — `test_generate_title_disables_reasoning`: kwargs-capture test pinning that the titling pass always sends the disabled config (regression guard for the fence-as-title path).

## How to Test

1. Automated: `.venv/bin/python -m pytest tests/agent/test_title_generator.py -q` — should pass (observed result: 37 passed on macOS arm64).
2. Manual (issue's environment): configure `model.provider: gemini` / `gemini-flash-latest`, start a session, and check the auto title in the sidebar — a clean 3-7 word title instead of `` ```json ``.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted title-generator suite: 37 passed, 0 failures)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment documents the mechanism)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (provider-neutral request field)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
