### PR TITLE
fix(desktop): add visible browser preview close button

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx
@@ -10,6 +10,7 @@ const baseProps = {
   devToolsOpen: false,
   loading: false,
   onBack: vi.fn(),
+  onClose: vi.fn(),
   onForward: vi.fn(),
   onNavigate: vi.fn(),
   onOpenExternal: vi.fn(),
@@ -89,6 +90,7 @@ describe('PreviewBrowserBar', () => {
     expect(rendered.getByRole('button', { name: 'Open in browser' })).toBeTruthy()
     expect(rendered.getByRole('button', { name: 'Show preview console' })).toBeTruthy()
     expect(rendered.getByRole('button', { name: 'Open preview DevTools' })).toBeTruthy()
+    expect(rendered.getByRole('button', { name: 'Close preview pane' })).toBeTruthy()
     expect(address(rendered)).toBeTruthy()
   })
 
@@ -118,6 +120,15 @@ describe('PreviewBrowserBar', () => {
     fireEvent.click(rendered.getByRole('button', { name: label }))
 
     expect(spy).toHaveBeenCalledOnce()
+  })
+
+  it('closes the preview from the visible toolbar control', () => {
+    const onClose = vi.fn()
+    const rendered = render(<PreviewBrowserBar {...baseProps} onClose={onClose} />)
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Close preview pane' }))
+
+    expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('toggles the console and DevTools, and labels them by current state', () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
@@ -29,6 +29,7 @@ interface PreviewBrowserBarProps {
   devToolsOpen: boolean
   loading: boolean
   onBack: () => void
+  onClose?: () => void
   onForward: () => void
   onNavigate: (url: string) => void
   onOpenExternal: () => void
@@ -92,6 +93,7 @@ export function PreviewBrowserBar({
   devToolsOpen,
   loading,
   onBack,
+  onClose,
   onForward,
   onNavigate,
   onOpenExternal,
@@ -197,6 +199,13 @@ export function PreviewBrowserBar({
         label={devToolsOpen ? copy.hideDevTools : copy.openDevTools}
         onSelect={onToggleDevTools}
       />
+      {onClose && (
+        <PaneStripGlyph
+          icon={<Codicon name="close" size="0.8125rem" />}
+          label={t.preview.closePane}
+          onSelect={onClose}
+        />
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -82,6 +82,7 @@ interface GuestContextMenuParams {
 
 interface PreviewPaneProps {
   embedded?: boolean
+  onClose?: () => void
   onRestartServer?: (url: string, context?: string) => Promise<string>
   reloadRequest?: number
   /** The preview tab this pane renders. Keys the per-tab console store the
@@ -196,7 +197,7 @@ function PreviewLoadError({
   )
 }
 
-export function PreviewPane({ embedded = false, onRestartServer, reloadRequest = 0, tabId, target }: PreviewPaneProps) {
+export function PreviewPane({ embedded = false, onClose, onRestartServer, reloadRequest = 0, tabId, target }: PreviewPaneProps) {
   const { t } = useI18n()
   const copy = t.preview.web
   // The console store belongs to the TAB, not this render: the toggles live on
@@ -956,6 +957,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
             devToolsOpen={devtoolsOpen}
             loading={loading}
             onBack={goBack}
+            onClose={onClose}
             onForward={goForward}
             onNavigate={navigateTo}
             onOpenExternal={() => void window.hermesDesktop?.openExternal(currentUrl)}

--- a/apps/desktop/src/app/chat/right-rail/preview.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview.tsx
@@ -1,7 +1,7 @@
 import { useStore } from '@nanostores/react'
 
 import { $restartPreviewServer } from '@/app/contrib/panes'
-import { $previewReloadRequest, $previewTabs } from '@/store/preview'
+import { $previewReloadRequest, $previewTabs, closeRightRailTab } from '@/store/preview'
 
 import { PreviewPane } from './preview-pane'
 
@@ -35,6 +35,7 @@ export function PreviewTilePane({ tabId }: PreviewTilePaneProps) {
   return (
     <PreviewPane
       embedded
+      onClose={() => closeRightRailTab(tabId)}
       onRestartServer={target.kind === 'url' ? (restartPreviewServer ?? undefined) : undefined}
       reloadRequest={previewReloadRequest}
       tabId={tabId}


### PR DESCRIPTION
## Summary

Add an always-visible **×** at the far right of the in-app Browser preview toolbar.

The preview pane currently exposes Back, Forward, Reload, address, Open in browser, Console, and DevTools, but no visible way to close the pane. Keyboard close also becomes unreliable once the embedded webview owns focus. This gives the Browser surface a direct mouse-accessible exit in the chrome the user is already looking at.

## Implementation

- Add an optional `onClose` action to `PreviewBrowserBar` and render it with the existing close codicon and localized `preview.closePane` label.
- Thread the close callback through `PreviewPane`.
- Wire `PreviewTilePane` directly to `closeRightRailTab(tabId)`.
- Keep non-tile/standalone preview renders unchanged when no close action is supplied.

## Verification

- Regression test was added first and failed against the previous toolbar because no `Close preview pane` button existed.
- Targeted suite: **59 passed** across the browser bar, preview pane, and preview store.
- `npm run check`: **passed** on exact commit `e0a63ce618` (typecheck, lint, full UI/platform/Desktop tests, production build, and macOS packaging).
- Live isolated Electron proof:
  - Browser toolbar rendered accessible controls including `Close preview pane`.
  - Clicking the × removed the Browser tab, address field, and close control from the live DOM.

## Scope and related work

This is deliberately narrower than #83051, which adds general pane-tab close controls with focus recovery and is currently merge-conflicted. It is also complementary to the closed #89243 attempt: this control lives inside the Browser toolbar shown beside the page, remains visible without hovering a separate tab strip, and works even when the embedded page owns focus.

No session, layout, webview navigation, or persistence behavior changes.
