### PR TITLE
feat(desktop): contribution area for plugin sections in Settings ▸ Plugins

### DIFF
--- a/apps/desktop/src/app/settings/plugins-settings.test.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.test.tsx
@@ -19,6 +19,8 @@ vi.mock('@/hermes', async importOriginal => ({
 }))
 
 import { $pluginRecords } from '@/contrib/plugins-store'
+import { registry } from '@/contrib/registry'
+import type { Contribution } from '@/contrib/types'
 import { queryClient } from '@/lib/query-client'
 import {
   $agentPluginBusy,
@@ -30,7 +32,7 @@ import {
 import { $activeGatewayProfile } from '@/store/profile'
 import { $connection, $gatewayState } from '@/store/session'
 
-import { PluginsSettings } from './plugins-settings'
+import { PluginsSettings, SETTINGS_PLUGINS_AREA } from './plugins-settings'
 
 const legacyRow = {
   name: 'Legacy plugin',
@@ -229,5 +231,26 @@ describe('PluginsSettings', () => {
         profile: 'work'
       })
     )
+  })
+})
+
+describe('settings.plugins contribution area', () => {
+  it('renders plugin-contributed sections after the installed lists', async () => {
+    $gatewayState.set('open')
+
+    const dispose = registry.register({
+      id: 'marketplace-test',
+      area: SETTINGS_PLUGINS_AREA,
+      source: 'test',
+      title: 'Marketplace (test)',
+      render: () => <div data-testid="marketplace-test-body">Browse plugins here</div>
+    } satisfies Contribution)
+
+    renderSettings()
+
+    expect(await screen.findByText('Marketplace (test)')).toBeTruthy()
+    expect(screen.getByTestId('marketplace-test-body')).toBeTruthy()
+
+    dispose()
   })
 })

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
+import { useContributions } from '@/contrib/react/use-contributions'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { getProfiles } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -43,6 +44,12 @@ const agentPluginRowKey = (row: AgentPluginRow) =>
 
 /** Deep-link anchor for a plugin row (`?tab=plugins&plugin=<id>`). */
 export const pluginElementId = (target: string) => `plugin-${target}`
+
+/** Contribution area for plugin-provided sections inside Settings ▸ Plugins.
+ *  Rendered as SettingsSection blocks after the installed lists. Plugins
+ *  feature-detect it via the SDK export; on older builds the export is
+ *  undefined and the plugin should fall back to its own route page. */
+export const SETTINGS_PLUGINS_AREA = 'settings.plugins'
 
 function reveal(file: string) {
   void window.hermesDesktop?.revealPath?.(file)?.catch(() => undefined)
@@ -372,6 +379,8 @@ export function PluginsSettings() {
     (a, b) => KIND_ORDER[a.kind] - KIND_ORDER[b.kind] || a.name.localeCompare(b.name)
   )
 
+  const contributed = useContributions(SETTINGS_PLUGINS_AREA)
+
   return (
     <SettingsContent>
       <SettingsSection icon={Monitor} meta={p.count(rows.length)} title={p.title}>
@@ -408,6 +417,18 @@ export function PluginsSettings() {
       </SettingsSection>
 
       <AgentPluginsSection />
+
+      {contributed.map(contribution => {
+        const meta = typeof (contribution.data as { meta?: unknown } | undefined)?.meta === 'string'
+          ? (contribution.data as { meta: string }).meta
+          : undefined
+
+        return (
+          <SettingsSection icon={Package} key={contribution.id} meta={meta} title={contribution.title ?? contribution.id}>
+            {contribution.render?.()}
+          </SettingsSection>
+        )
+      })}
     </SettingsContent>
   )
 }

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -892,6 +892,7 @@ export { type RouteContribution, ROUTES_AREA, SIDEBAR_NAV_AREA, type SidebarNavC
  *  decoupled (the "manage keys" deep link is a no-op outside the router); pass
  *  `toolset`, optional `onConfiguredChange`, and an optional `profile`. */
 export { ToolsetConfigPanel } from '@/app/settings/toolset-config-panel'
+export { SETTINGS_PLUGINS_AREA } from '@/app/settings/plugins-settings'
 /** THE model catalog menu — the same searchable, provider-grouped, family-
  *  collapsing picker the chat composer uses, including the per-row
  *  thinking/effort/fast submenu. Drive it with a `ModelMenuController`: the


### PR DESCRIPTION
## Summary

Adds a contribution area for plugin-provided sections inside Settings ▸ Plugins. Plugins can register a `render` + `title` under `SETTINGS_PLUGINS_AREA` and the settings page renders each as a `SettingsSection` block after the installed lists (desktop plugins, agent plugins). This is the seam a plugin marketplace needs to present its catalog where users manage plugins.

## Why

Plugins can contribute panes, routes, statusbar items, palette commands, themes, and keybinds, but there is no way to extend the Plugins settings page itself. A marketplace plugin that wants to live in Settings ▸ Plugins currently has no door; it would have to ship a separate route and send users elsewhere. This adds the smallest possible seam: one exported area constant, rendered by the settings page in its own section chrome.

## Design

- `SETTINGS_PLUGINS_AREA = 'settings.plugins'` exported from `app/settings/plugins-settings.tsx` and re-exported by the SDK (`@hermes/plugin-sdk`).
- `PluginsSettings` consumes the area through `useContributions` and renders each contribution with `SettingsSection` (title from the contribution, optional `meta` string from `contribution.data.meta`, `Package` icon).
- Plugins feature-detect the area through the SDK export. On builds that predate this change the export is undefined, so older hosts degrade to the plugin's fallback surface (its own route page).

## Tests

- `plugins-settings.test.tsx`: new test registers a contribution under the area and asserts the section title and rendered body appear.

Not run locally: nothing beyond the file's own test suite and `tsc -p . --noEmit` (both pass). CI will run the full matrix.