### PR TITLE
fix(telegram): omit topic routing from rich edits

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2363,15 +2363,10 @@ class TelegramAdapter(BasePlatformAdapter):
             "message_id": int(message_id),
             "rich_message": self._rich_message_payload(content),
         }
-        thread_id = self._metadata_thread_id(metadata)
-        thread_kwargs = self._thread_kwargs_for_send(
-            chat_id,
-            thread_id,
-            metadata,
-            reply_to_message_id=None,
-            reply_to_mode=self._reply_to_mode,
-        )
-        payload.update({k: v for k, v in thread_kwargs.items() if v is not None})
+        # Edits target an existing message by chat_id + message_id. Topic
+        # routing belongs only on send endpoints; forwarding message_thread_id
+        # or direct_messages_topic_id makes Telegram reject this rich edit and
+        # sends the caller through the legacy table-to-bullets fallback.
         if getattr(self, "_disable_link_previews", False):
             payload["link_preview_options"] = {"is_disabled": True}
         try:

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -678,6 +678,41 @@ async def test_finalize_edit_uses_rich_for_table_content():
 
 
 @pytest.mark.asyncio
+async def test_finalize_edit_dm_topic_omits_send_only_routing_fields():
+    """DM-topic metadata must not make a rich edit look like a new send.
+
+    Telegram identifies an edit by chat_id + message_id. Passing topic-routing
+    fields on editMessageText rejects the rich request, after which the legacy
+    formatter permanently rewrites the table into bullet groups.
+    """
+    adapter = _make_adapter()
+
+    async def _api(endpoint, api_kwargs=None, **kwargs):
+        assert endpoint == "editMessageText"
+        has_send_routing = (
+            "message_thread_id" in api_kwargs
+            or "direct_messages_topic_id" in api_kwargs
+        )
+        if has_send_routing:
+            raise BadRequest("unexpected topic routing on editMessageText")
+        return True
+
+    adapter._bot.do_api_request = AsyncMock(side_effect=_api)
+
+    result = await adapter.edit_message(
+        "12345", "555", TOPIC_TABLE, finalize=True, metadata=TOPIC_METADATA,
+    )
+
+    assert result.success is True
+    api_kwargs = _rich_edit_kwargs(adapter)
+    assert api_kwargs["message_id"] == 555
+    assert "message_thread_id" not in api_kwargs
+    assert "direct_messages_topic_id" not in api_kwargs
+    assert "| F1 |" in api_kwargs["rich_message"]["markdown"]
+    adapter._bot.edit_message_text.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_legacy_edit_error_logs_redacted_bot_token_without_traceback(monkeypatch, caplog):
     import agent.redact as redact
 


### PR DESCRIPTION
## What does this PR do?

Keeps Telegram DM-topic tables on the rich edit path instead of silently degrading them to legacy MarkdownV2 bullet groups.

`editMessageText` identifies its target with `chat_id` and `message_id`. The rich finalize path was also forwarding `message_thread_id` or `direct_messages_topic_id`, even though those are send-routing fields. Telegram can reject that payload, after which `_try_edit_rich()` returns `None` and `edit_message()` runs `format_message()`, permanently rewriting the table as bullets.

This removes the send-only routing fields from rich edits. Send and draft routing are unchanged.

## Related Issue

Follow-up to #91847.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: omit topic-routing fields from rich `editMessageText` payloads.
- `tests/gateway/test_telegram_rich_messages.py`: add a DM-topic regression that makes the old payload reject and proves the raw table stays on the rich edit path.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_telegram_rich_messages.py -q -j 4`.
2. Enable `rich_messages: true` and leave `rich_drafts: false` for Telegram.
3. In a Telegram DM topic, request a Markdown table with a blank line before it and verify the completed response remains a native table instead of becoming bullet groups.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing configuration or workflow changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Telegram API payload construction is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not included. The regression test reproduces the payload rejection without publishing support artifacts.
