### PR TITLE
fix(cli): Ghostty gets modifyOtherKeys level 1 — Shift+letters leak as literal '[27;2;<code>~' when IME splits the ESC byte

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4191,6 +4191,12 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
 )
 _KITTY_KEYBOARD_PUSH_SEQ = "\x1b[>1u"
 _MODIFY_OTHER_KEYS_SEQ = "\x1b[>4;2m"
+# Ghostty branch: level 1 — only control-char modified keys (Enter,
+# Backspace, Tab) are re-encoded as CSI 27;mod;code~; Shift+letters stay
+# plain. Level 2 re-encodes every modified key, and Ghostty+macOS IME can
+# split the ESC byte from the CSI body, which prompt_toolkit flushes as
+# the Escape key — leaking "[27;2;65~" literal text (Shift+letter breaks).
+_MODIFY_OTHER_KEYS_LEVEL1_SEQ = "\x1b[>4;1m"
 _EXTENDED_ENTER_KEYS_SEQ = _KITTY_KEYBOARD_PUSH_SEQ + _MODIFY_OTHER_KEYS_SEQ
 
 
@@ -4200,13 +4206,23 @@ _BACKSLASH_LINE_CONTINUATION_RE = re.compile(r"\\[ \t]*$")
 def _is_ghostty_terminal(env: Optional[Mapping[str, str]] = None) -> bool:
     """Whether the terminal is Ghostty (either detection path).
 
-    Ghostty must be pushed ONLY modifyOtherKeys, not the Kitty keyboard
-    protocol: its Kitty disambiguate-mode implementation strips the Alt
-    modifier from the Backspace key, so Option+Backspace arrives as bare
-    \\x7f instead of the CSI-u form ``\\x1b[127;3u`` the protocol calls for
-    (upstream Ghostty bug), breaking backward-kill-word (#87630
-    regression).  Ghostty implements modifyOtherKeys correctly (it then
-    emits ``\\x1b[27;3;127~``, which the alias table also maps).
+    Ghostty must be pushed ONLY modifyOtherKeys level 1, not level 2 and
+    not the Kitty keyboard protocol:
+
+    - Kitty disambiguate-mode strips the Alt modifier from Backspace, so
+      Option+Backspace arrives as bare \\x7f instead of the CSI-u form
+      ``\\x1b[127;3u`` the protocol calls for (upstream Ghostty bug),
+      breaking backward-kill-word (#87630 regression).
+    - modifyOtherKeys level 2 (``CSI >4;2m``) re-encodes EVERY modified
+      key as ``CSI 27;mod;code~``. On macOS with an IME active, Ghostty
+      can deliver that sequence with the ESC byte in a separate read
+      from the ``[27;...~`` body; prompt_toolkit's read loop flushes a
+      lone ESC as the Escape key (``flush_keys``), so the body leaks
+      into the prompt as literal ``[27;2;65~`` text — every Shift+letter
+      dies. Level 1 (``CSI >4;1m``) reports ONLY modified keys whose
+      unmodified form is a control character (Enter/Backspace/Tab), so
+      Shift+letters stay plain and every alias this CLI maps still
+      fires — Shift+Enter/Backspace/Ctrl+Enter included.
 
     Matches exactly the two conditions that admit Ghostty through
     ``_terminal_supports_extended_enter_keys``.
@@ -4277,8 +4293,10 @@ def _enable_extended_enter_keys(output=None, env: Optional[Mapping[str, str]] = 
     """
     if not _terminal_supports_extended_enter_keys(env):
         return False
-    # Ghostty exception: only modifyOtherKeys — see _is_ghostty_terminal.
-    seq = _MODIFY_OTHER_KEYS_SEQ if _is_ghostty_terminal(env) else _EXTENDED_ENTER_KEYS_SEQ
+    # Ghostty exception: level 1 modifyOtherKeys only — see
+    # _is_ghostty_terminal (level 2 re-encodes Shift+letters and leaks as
+    # literal "[27;2;<code>~" when Ghostty+IME splits the ESC byte).
+    seq = _MODIFY_OTHER_KEYS_LEVEL1_SEQ if _is_ghostty_terminal(env) else _EXTENDED_ENTER_KEYS_SEQ
     try:
         target = output
         if target is not None and hasattr(target, "write_raw"):

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -168,7 +168,10 @@ class _FakeOutput:
 
 
 def test_ghostty_uses_modify_other_keys_only():
-    """Ghostty must NOT push the Kitty keyboard protocol (CSI >1u)."""
+    """Ghostty must NOT push the Kitty keyboard protocol (CSI >1u), and must
+    push modifyOtherKeys LEVEL 1 (CSI >4;1m) — level 2 re-encodes every
+    Shift+letter, which leaks as literal '[27;2;<code>~' text when
+    Ghostty+macOS IME splits the ESC byte (see _is_ghostty_terminal)."""
     import cli as cli_mod
 
     out = _FakeOutput()
@@ -177,14 +180,17 @@ def test_ghostty_uses_modify_other_keys_only():
         env={"TERM_PROGRAM": "ghostty", "TERM": "xterm-ghostty"},
     )
     assert result is True
-    # Must contain modifyOtherKeys push ...
-    assert b"\x1b[>4;2m" in out.written
-    # ... but NOT the Kitty protocol push.
+    # Must contain the level-1 modifyOtherKeys push ...
+    assert b"\x1b[>4;1m" in out.written
+    # ... but NOT level 2 (re-encodes Shift+letters → leak) ...
+    assert b"\x1b[>4;2m" not in out.written
+    # ... and NOT the Kitty protocol push.
     assert b"\x1b[>1u" not in out.written
 
 
 def test_ghostty_via_term_var_uses_modify_other_keys_only():
-    """xterm-ghostty TERM (without TERM_PROGRAM) also skips Kitty protocol."""
+    """xterm-ghostty TERM (without TERM_PROGRAM) also skips Kitty protocol
+    and uses modifyOtherKeys level 1."""
     import cli as cli_mod
 
     out = _FakeOutput()
@@ -193,7 +199,8 @@ def test_ghostty_via_term_var_uses_modify_other_keys_only():
         env={"TERM": "xterm-ghostty"},
     )
     assert result is True
-    assert b"\x1b[>4;2m" in out.written
+    assert b"\x1b[>4;1m" in out.written
+    assert b"\x1b[>4;2m" not in out.written
     assert b"\x1b[>1u" not in out.written
 
 

--- a/tests/cli/test_modify_other_keys_aliases.py
+++ b/tests/cli/test_modify_other_keys_aliases.py
@@ -560,3 +560,47 @@ def test_lock_bits_on_cmd_backspace_alias():
     assert _parse("\x1b[127;137u") == [Keys.ControlU]  # Cmd+Backspace + NumLock
     assert _parse("\x1b[127;73u") == [Keys.ControlU]   # Cmd+Backspace + Caps
     assert _parse("\x1b[3;137~") == [Keys.ControlK]    # Cmd+FwdDel + NumLock
+
+
+def test_split_esc_delivery_does_not_leak():
+    """#91937 — Ghostty + macOS IME can deliver the modifyOtherKeys
+    sequence with the ESC byte in a *separate read* from the CSI body.
+    prompt_toolkit's read loop feeds each stdin chunk sequentially: two
+    back-to-back reads (no intervening flush) must still merge into one
+    keypress — the capital letter — and never leak ``[27;2;65~`` into
+    the prompt.
+
+    This pins the alias-table contract against the split failure mode
+    that #87511's whole-sequence fix could not surface: an edit that
+    drops the ``ESC[27;2;<cp>~`` mappings would fail these asserts even
+    while every whole-sequence test in this file still passes.
+
+    The third case documents *why* the Ghostty push is level 1: with a
+    flush between the two reads (idle gap, the IME timing), the lone ESC
+    is emitted as the Escape key and the body lands as literal
+    characters. If that case ever stops leaking, the parser gained
+    split-sequence memory and level 2 could be reconsidered — until
+    then, keep the push at level 1.
+    """
+    def _feed_chunks(chunks, flush_between):
+        out = []
+        parser = Vt100Parser(out.append)
+        for chunk in chunks:
+            parser.feed(chunk)
+            if flush_between:
+                parser.flush()
+        parser.flush()
+        return [kp.key for kp in out]
+
+    # Whole sequence in one read → 'A' (baseline contract).
+    assert _feed_chunks(["\x1b[27;2;65~"], False) == ["A"]
+    # ESC split from the CSI body across two reads, no intervening
+    # flush → still 'A'; nothing leaks as literal text.
+    assert _feed_chunks(["\x1b", "[27;2;65~"], False) == ["A"]
+    # Same split with a flush between reads (idle gap) → ESC becomes its
+    # own keypress and the body leaks as literal characters. Pinned as
+    # the documented reason the Ghostty push stays at modifyOtherKeys
+    # level 1 (#91937).
+    assert _feed_chunks(["\x1b", "[27;2;65~"], True) == [
+        Keys.Escape, "[", "2", "7", ";", "2", ";", "6", "5", "~"
+    ]


### PR DESCRIPTION
## Summary
On Ghostty, Shift+letter in the classic CLI inserts the literal text `[27;2;65~` instead of the capital (Shift+W → `[27;2;87~`, etc.). Regression class of #87390: the alias table added in #87511 fixed the whole-sequence case, but the **split-delivery** path remains broken.

## Root cause chain
1. `_enable_extended_enter_keys()` pushes xterm **modifyOtherKeys level 2** (`CSI >4;2m`) for Ghostty (allowlist entry), so Ghostty re-encodes *every* modified key (Shift+A) as `ESC[27;2;65~`.
2. On macOS with an IME active, Ghostty can deliver that sequence with the **ESC byte in a separate read** from the `[27;...~` body.
3. prompt_toolkit's read loop calls `vt100_parser.flush()` after each chunk (`Vt100Input.flush_keys` — 'Used for flushing the escape key'), so the lone `\x1b` is emitted as the **Escape key**; the body then arrives as literal characters and is inserted into the prompt.

Parser repro (prompt_toolkit 3.0.52 + current alias table):
- `feed('\x1b[27;2;65~') + flush` → `['A']` ✓
- `feed('\x1b') + flush; feed('[27;2;65~') + flush` → `[Escape,'[','2','7',';','2',';','6','5','~']` ✗ (exact symptom)

## Fix
Ghostty branch now pushes **modifyOtherKeys level 1** (`CSI >4;1m`) instead of level 2. Level 1 only re-encodes modified keys whose unmodified form is a *control character* (Enter 13, Backspace 127, Tab 9) — exactly the set this CLI decodes — while Shift+letters arrive as plain capitals again, immune to the split-ESC/IME path. Kitty protocol is still not pushed for Ghostty (keeps the #87630 Backspace-Alt workaround). Other allowlisted terminals (iTerm2, WezTerm, tmux, VS Code) keep the dual kitty+level-2 push and the full alias table.

Preserved: Shift+Enter → newline, Ctrl+Enter → newline, Cmd+Backspace kill, Shift+Tab BackTab, etc. — all level-1 control-key encodings already in `pt_input_extras.py`.

## Verification
- Reproduced the leak at parser level (above), then confirmed level-1 push output for Ghostty (`\x1b[>4;1m`) and plain-'A' delivery for Shift+A.
- Updated ghostty push assertions in `tests/cli/test_ctrl_enter_newline.py`.
- `pytest tests/cli/test_ctrl_enter_newline.py tests/cli/test_cli_shift_enter_newline.py tests/cli/test_cli_cmd_backspace.py tests/cli/test_modify_other_keys_aliases.py` → 244 passed, 2 skipped.
- Manual (local Ghostty 1.3.1, Korean IME): Shift+letters insert capitals; Shift+Enter still inserts a newline.

Closes the #87390 leftover (split-delivery path).