### PR TITLE
perf(web): cache configured gateway platforms

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3428,6 +3428,107 @@ def _collect_profile_gateway_topology_cached() -> Dict[str, Any]:
         return data
 
 
+_CONFIGURED_PLATFORM_CACHE: Dict[str, Dict[str, Any]] = {}
+_CONFIGURED_PLATFORM_CACHE_LOCK = threading.Lock()
+_CONFIGURED_PLATFORM_CACHE_TTL = 30.0
+_CONFIGURED_PLATFORM_CACHE_MAX_KEYS = 32
+_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT = 30.0
+# Longest a registered flight may keep new callers queued behind it.  Past this
+# age the next caller detaches it and builds a replacement instead of parking on
+# a load that may never finish.
+_CONFIGURED_PLATFORM_CACHE_FLIGHT_MAX_AGE = 30.0
+# Hard ceiling on how many ``load_gateway_config()`` calls may be running at
+# once for one profile, counting abandoned ones whose thread has not returned.
+# Callers run in Starlette's shared worker pool and a wedged discovery cannot be
+# cancelled, so without this a fingerprint that churns once per poll would let
+# every poll spawn its own unkillable builder and drain the pool.  Two is the
+# minimum that still recovers from one permanently wedged builder: the survivor
+# permit is recycled by every subsequent build.
+_CONFIGURED_PLATFORM_CACHE_MAX_BUILDERS = 2
+# The per-profile ceiling alone is not a bound on the pool: profile names come
+# from the request (``/api/status?profile=...``), so an unbounded number of
+# profiles could each hold their own permits.  This is the real backstop -- a
+# process-wide ceiling on concurrent discoveries across every profile.  It also
+# transitively bounds the in-flight, builder, and generation bookkeeping, none
+# of which is constrained by ``_CONFIGURED_PLATFORM_CACHE_MAX_KEYS``.  Kept well
+# under Starlette's default 40-thread worker pool so wedged loads can never
+# starve unrelated endpoints.
+_CONFIGURED_PLATFORM_CACHE_MAX_TOTAL_BUILDERS = 8
+# Ceiling on *total* worker-pool occupancy from this cache: builders plus
+# callers parked on a flight.  Bounding builders alone is not enough -- a single
+# hung load below the builder ceiling can still absorb unlimited waiters, each
+# holding a worker thread for up to ``_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT``.
+# Comfortably above the builder ceiling so waiters can never starve the builders
+# that actually make progress, and well under Starlette's default 40-thread
+# pool so unrelated endpoints keep their headroom.
+_CONFIGURED_PLATFORM_CACHE_MAX_OCCUPANCY = 16
+# Callers currently parked on a flight, process-wide.  Guarded by the cache
+# lock; released on every exit path including BaseException.
+_CONFIGURED_PLATFORM_CACHE_WAITERS = 0
+# At most one flight per profile is ever registered, so this stays bounded even
+# when the source fingerprint churns while a load is stuck.
+_CONFIGURED_PLATFORM_CACHE_IN_FLIGHT: Dict[str, Dict[str, Any]] = {}
+# Live builder threads per profile (registered *and* abandoned-but-running).
+# Entries are dropped at zero, so this is bounded by the worker pool.
+_CONFIGURED_PLATFORM_CACHE_BUILDERS: Dict[str, int] = {}
+_CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION: Dict[str, int] = {}
+_CONFIGURED_PLATFORM_CACHE_GENERATION = 0
+
+
+def _configured_platform_total_builders() -> int:
+    """Live discovery threads across every profile.  Caller holds the cache lock.
+
+    Derived rather than tracked so it cannot drift out of step with the
+    per-profile counts that gate and release the permits.  ``_BUILDERS`` never
+    holds more entries than the process-wide ceiling, so this stays cheap.
+    """
+    return sum(_CONFIGURED_PLATFORM_CACHE_BUILDERS.values())
+
+
+def _configured_platform_occupancy() -> int:
+    """Worker-pool threads this cache is holding.  Caller holds the cache lock.
+
+    A parked waiter costs the pool exactly what a builder does, so both count
+    against ``_CONFIGURED_PLATFORM_CACHE_MAX_OCCUPANCY``.
+    """
+    return _configured_platform_total_builders() + _CONFIGURED_PLATFORM_CACHE_WAITERS
+
+
+def _abandon_configured_platform_flight(key: str, flight: Dict[str, Any]) -> None:
+    """Detach a superseded or stalled flight.  Caller must hold the cache lock.
+
+    The flight's thread may still be running and cannot be cancelled, so it is
+    only unregistered: bookkeeping stays at one entry per profile, the next
+    caller is free to build a replacement, and anyone already parked on the
+    event wakes up to retry rather than waiting out the full timeout.  The
+    generation high-water mark is untouched, so a late finisher can still
+    publish if nothing newer superseded it.
+    """
+    flight["abandoned"] = True
+    if _CONFIGURED_PLATFORM_CACHE_IN_FLIGHT.get(key) is flight:
+        del _CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[key]
+    flight["event"].set()
+
+
+def _configured_platform_source_version(home: Path) -> tuple:
+    """Cheap version for every on-disk input that can change platform status."""
+    versions = []
+    for path in (
+        home / "config.yaml",
+        home / "gateway.json",
+        home / ".env",
+        home / "plugins",
+    ):
+        try:
+            stat_result = path.stat()
+            versions.append(
+                (str(path), stat_result.st_ino, stat_result.st_mtime_ns, stat_result.st_size)
+            )
+        except OSError:
+            versions.append((str(path), None, None, None))
+    return tuple(versions)
+
+
 def _load_configured_gateway_platforms() -> set[str]:
     """Load connected platform names away from the asyncio event loop.
 
@@ -3435,11 +3536,253 @@ def _load_configured_gateway_platforms() -> set[str]:
     can take longer than Desktop's WebSocket connect timeout on Windows.  This
     helper is synchronous by design; ``get_status`` runs it in Starlette's
     worker pool so a concurrent ``/api/ws`` handshake can still complete.
+
+    ``/api/status`` is polled frequently and ``load_gateway_config()`` repeats
+    plugin discovery plus YAML parsing on every call. Cache the small derived
+    set per profile for a short window, and collapse same-profile concurrent
+    misses so polling tabs cannot duplicate the scan. Home config, credential,
+    and top-level plugin add/remove fingerprints invalidate immediately. The
+    30-second TTL bounds staleness for other inputs such as managed config,
+    process environment, registry data, and edits inside an existing plugin.
+    Different profiles never wait on one another's slow plugin discovery.
+    The loader identity is part of the entry so monkeypatched tests and runtime
+    reloads remain isolated.
+
+    A flight cannot be cancelled, so it is instead *abandoned*: a caller that
+    finds a flight built for a different fingerprint or loader, or one that has
+    outlived ``_CONFIGURED_PLATFORM_CACHE_FLIGHT_MAX_AGE``, unregisters it and
+    builds a replacement.  A caller that exhausts its own wait budget does the
+    same before giving up.  That keeps a single wedged ``load_gateway_config()``
+    from stalling every later poll for another full timeout, and keeps
+    ``_CONFIGURED_PLATFORM_CACHE_IN_FLIGHT`` at one entry per profile under
+    fingerprint churn.  An abandoned flight that finishes late still cannot
+    remove or overwrite its replacement, nor publish once a newer generation
+    exists.
+
+    Abandoning bounds the bookkeeping but not the threads, so replacing a
+    flight also requires a builder permit, gated at two levels: at most
+    ``_CONFIGURED_PLATFORM_CACHE_MAX_BUILDERS`` loads per profile, and at most
+    ``_CONFIGURED_PLATFORM_CACHE_MAX_TOTAL_BUILDERS`` across the whole process --
+    both counting abandoned loads whose thread has not returned.  The global
+    ceiling is the load-bearing one: profile names arrive from the request, so a
+    per-profile cap alone would let arbitrarily many profiles each wedge their
+    own quota and drain the shared worker pool.
+
+    Bounding builders alone still leaves the pool exposed, because a parked
+    caller costs a worker thread exactly as much as a running load does: one
+    hung flight, well below the builder ceiling, could otherwise absorb
+    unlimited waiters for ``_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT`` apiece.
+    So builders *and* waiters are counted together against
+    ``_CONFIGURED_PLATFORM_CACHE_MAX_OCCUPANCY``, and both are gated on it; the
+    waiter slot is claimed under the same lock that selects the flight, so the
+    ceiling cannot be overshot by callers racing between check and wait.
+
+    A caller without a permit therefore parks on a registered flight for its own
+    profile only while the process has spare capacity on both counts.  Once
+    either ceiling is reached, no new caller waits on any flight, matching or
+    superseded, and none spawns: it serves the profile's last known platform set
+    if there is one, and otherwise fails fast.  Threads already building or
+    parked are unaffected, and a waiter slot is released on every exit path --
+    success, timeout, abandonment, builder error, or ``BaseException``.
+
+    So N pollers across arbitrarily many profiles, under sustained fingerprint
+    churn and with every load wedged, produce at most
+    ``_CONFIGURED_PLATFORM_CACHE_MAX_TOTAL_BUILDERS`` stuck worker-pool threads,
+    not N.  Each of ``_CONFIGURED_PLATFORM_CACHE_IN_FLIGHT`` and
+    ``_CONFIGURED_PLATFORM_CACHE_BUILDERS`` is likewise capped at that many
+    entries, since neither outlives its builder, and
+    ``_CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION`` at that plus
+    ``_CONFIGURED_PLATFORM_CACHE_MAX_KEYS``, since a mark is retained only for a
+    cached profile or one with a live builder.
     """
+    global _CONFIGURED_PLATFORM_CACHE_GENERATION
+    global _CONFIGURED_PLATFORM_CACHE_WAITERS
+
     from gateway.config import load_gateway_config
 
-    gateway_config = load_gateway_config()
-    return {platform.value for platform in gateway_config.get_connected_platforms()}
+    home = Path(get_hermes_home())
+    key = str(home)
+    loader = load_gateway_config
+    wait_deadline = time.monotonic() + _CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT
+    while True:
+        source_version = _configured_platform_source_version(home)
+        with _CONFIGURED_PLATFORM_CACHE_LOCK:
+            now = time.monotonic()
+            entry = _CONFIGURED_PLATFORM_CACHE.get(key)
+            if (
+                entry is not None
+                and entry["loader"] is loader
+                and entry["source_version"] == source_version
+                and now - entry["ts"] < _CONFIGURED_PLATFORM_CACHE_TTL
+            ):
+                return set(entry["platforms"])
+            flight = _CONFIGURED_PLATFORM_CACHE_IN_FLIGHT.get(key)
+            superseded = flight is not None and (
+                flight["loader"] is not loader
+                or flight["source_version"] != source_version
+                or now - flight["started"] >= _CONFIGURED_PLATFORM_CACHE_FLIGHT_MAX_AGE
+            )
+            # Both checked for every path below, not just the build path:
+            # parking on a flight ties up a worker-pool thread exactly like
+            # running a load does.  Once either ceiling is reached, no new
+            # caller may build *or* wait on any flight, matching or superseded.
+            # Threads already building or parked are unaffected.
+            saturated_globally = (
+                _configured_platform_total_builders()
+                >= _CONFIGURED_PLATFORM_CACHE_MAX_TOTAL_BUILDERS
+            )
+            saturated_occupancy = (
+                _configured_platform_occupancy()
+                >= _CONFIGURED_PLATFORM_CACHE_MAX_OCCUPANCY
+            )
+            if flight is None or superseded:
+                builders = _CONFIGURED_PLATFORM_CACHE_BUILDERS.get(key, 0)
+                if (
+                    builders < _CONFIGURED_PLATFORM_CACHE_MAX_BUILDERS
+                    and not saturated_globally
+                    and not saturated_occupancy
+                ):
+                    if flight is not None:
+                        _abandon_configured_platform_flight(key, flight)
+                    _CONFIGURED_PLATFORM_CACHE_GENERATION += 1
+                    generation = _CONFIGURED_PLATFORM_CACHE_GENERATION
+                    flight = {
+                        "event": threading.Event(),
+                        "error": None,
+                        "abandoned": False,
+                        "generation": generation,
+                        "loader": loader,
+                        "source_version": source_version,
+                        "started": now,
+                    }
+                    _CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[key] = flight
+                    _CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION[key] = generation
+                    _CONFIGURED_PLATFORM_CACHE_BUILDERS[key] = builders + 1
+                    break
+            if saturated_occupancy or saturated_globally or flight is None:
+                # Nothing safe left to do without committing another worker
+                # thread: the process is at its occupancy or discovery ceiling,
+                # or this profile is saturated with no flight left to join.
+                # Serving the profile's last known platform set beats occupying
+                # a thread behind a load that may never finish.  A caller with
+                # no prior result at all fails fast rather than waiting for one.
+                if entry is not None and entry["loader"] is loader:
+                    return set(entry["platforms"])
+                if saturated_occupancy:
+                    scope = "process-wide occupancy"
+                elif saturated_globally:
+                    scope = "process-wide"
+                else:
+                    scope = "per-profile"
+                raise TimeoutError(
+                    "gateway platform configuration discovery is at the "
+                    f"{scope} limit"
+                )
+            # Otherwise the process has spare capacity, so parking is safe: this
+            # is either a matching flight to collapse onto, or a superseded one
+            # for a profile at its own limit.  Waiting costs no extra builder,
+            # and finishing it frees a permit to rebuild.  Claim the slot while
+            # still holding the lock, so the ceiling cannot be overshot by
+            # callers racing between the check and the wait.
+            _CONFIGURED_PLATFORM_CACHE_WAITERS += 1
+
+        # One wait budget for the whole call, so retries after a superseded
+        # flight cannot extend how long a worker-pool thread is tied up.
+        try:
+            remaining = wait_deadline - time.monotonic()
+            if remaining > 0:
+                flight["event"].wait(timeout=remaining)
+        finally:
+            with _CONFIGURED_PLATFORM_CACHE_LOCK:
+                # Single release point, reached on every exit: success, wait
+                # timeout, abandonment/retry, builder error, or BaseException.
+                _CONFIGURED_PLATFORM_CACHE_WAITERS -= 1
+                settled = flight["event"].is_set()
+                abandoned = flight["abandoned"]
+                error = flight["error"]
+                # Detach the flight only when the *flight* outlived a full wait
+                # budget, not merely because this caller joined late and ran out
+                # of its own.  Otherwise impatient pollers would keep tearing
+                # down a slow-but-healthy build and re-running the expensive
+                # discovery.
+                if (
+                    not settled
+                    and time.monotonic() - flight["started"]
+                    >= _CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT
+                ):
+                    _abandon_configured_platform_flight(key, flight)
+        if not settled:
+            raise TimeoutError("gateway platform configuration load timed out")
+        if abandoned:
+            continue
+        if error is not None:
+            raise RuntimeError("gateway platform configuration load failed") from error
+
+    failure: BaseException | None = None
+    try:
+        gateway_config = loader()
+        platforms = frozenset(
+            platform.value for platform in gateway_config.get_connected_platforms()
+        )
+        loaded_at = time.monotonic()
+        publish_version = _configured_platform_source_version(home)
+
+        with _CONFIGURED_PLATFORM_CACHE_LOCK:
+            is_newest = (
+                _CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION.get(key)
+                == flight["generation"]
+            )
+            if publish_version == source_version and is_newest:
+                if (
+                    key not in _CONFIGURED_PLATFORM_CACHE
+                    and len(_CONFIGURED_PLATFORM_CACHE)
+                    >= _CONFIGURED_PLATFORM_CACHE_MAX_KEYS
+                ):
+                    oldest = min(
+                        _CONFIGURED_PLATFORM_CACHE,
+                        key=lambda cache_key: _CONFIGURED_PLATFORM_CACHE[cache_key]["ts"],
+                    )
+                    _CONFIGURED_PLATFORM_CACHE.pop(oldest, None)
+                    if (
+                        oldest not in _CONFIGURED_PLATFORM_CACHE_IN_FLIGHT
+                        and oldest not in _CONFIGURED_PLATFORM_CACHE_BUILDERS
+                    ):
+                        _CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION.pop(oldest, None)
+                _CONFIGURED_PLATFORM_CACHE[key] = {
+                    "ts": loaded_at,
+                    "loader": loader,
+                    "source_version": source_version,
+                    "platforms": platforms,
+                    "generation": flight["generation"],
+                }
+        return set(platforms)
+    except BaseException as exc:
+        failure = exc
+        raise
+    finally:
+        with _CONFIGURED_PLATFORM_CACHE_LOCK:
+            if failure is not None:
+                flight["error"] = failure
+            # Release the builder permit first: the generation-mark cleanup
+            # below must see this thread as gone.
+            builders = _CONFIGURED_PLATFORM_CACHE_BUILDERS.get(key, 1) - 1
+            if builders > 0:
+                _CONFIGURED_PLATFORM_CACHE_BUILDERS[key] = builders
+            else:
+                _CONFIGURED_PLATFORM_CACHE_BUILDERS.pop(key, None)
+            # Only ever retire our own registration: if this flight was
+            # abandoned, the slot now belongs to its replacement.
+            if _CONFIGURED_PLATFORM_CACHE_IN_FLIGHT.get(key) is flight:
+                del _CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[key]
+            # Keep the high-water mark while any builder for the profile is
+            # still running, so a genuinely newest late finisher can publish.
+            if (
+                key not in _CONFIGURED_PLATFORM_CACHE
+                and key not in _CONFIGURED_PLATFORM_CACHE_IN_FLIGHT
+                and key not in _CONFIGURED_PLATFORM_CACHE_BUILDERS
+            ):
+                _CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION.pop(key, None)
+            flight["event"].set()
 
 
 @app.get("/api/ssh/ownership")

--- a/tests/test_web_server_status_platform_cache.py
+++ b/tests/test_web_server_status_platform_cache.py
@@ -1,0 +1,1765 @@
+"""Regression tests for the frequently-polled /api/status platform-config read."""
+
+import concurrent.futures
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import web_server
+
+
+@pytest.fixture(autouse=True)
+def clear_platform_cache():
+    def reset():
+        web_server._CONFIGURED_PLATFORM_CACHE_WAITERS = 0
+        web_server._CONFIGURED_PLATFORM_CACHE.clear()
+        web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT.clear()
+        web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS.clear()
+        web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION.clear()
+
+    reset()
+    yield
+    reset()
+
+
+def test_configured_gateway_platforms_are_cached_within_poll_window(monkeypatch):
+    calls = 0
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        return FakeGatewayConfig()
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert calls == 1
+
+
+def test_configured_gateway_platform_cache_is_profile_scoped(monkeypatch):
+    home = "/tmp/hermes-default"
+    calls = []
+
+    class FakeGatewayConfig:
+        def __init__(self, platform):
+            self.platform = platform
+
+        def get_connected_platforms(self):
+            return [SimpleNamespace(value=self.platform)]
+
+    def load_gateway_config():
+        calls.append(home)
+        return FakeGatewayConfig("discord" if home.endswith("default") else "telegram")
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: home)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    home = "/tmp/hermes-worker"
+    assert web_server._load_configured_gateway_platforms() == {"telegram"}
+    home = "/tmp/hermes-default"
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    home = "/tmp/hermes-worker"
+    assert web_server._load_configured_gateway_platforms() == {"telegram"}
+    assert calls == ["/tmp/hermes-default", "/tmp/hermes-worker"]
+
+
+def test_configured_gateway_platform_cache_collapses_concurrent_misses(monkeypatch):
+    calls = 0
+    entered = threading.Event()
+    release = threading.Event()
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        entered.set()
+        assert release.wait(timeout=2)
+        return FakeGatewayConfig()
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as pool:
+        futures = [pool.submit(web_server._load_configured_gateway_platforms) for _ in range(5)]
+        assert entered.wait(timeout=2)
+        time.sleep(0.05)
+        release.set()
+        assert [future.result(timeout=2) for future in futures] == [{"discord"}] * 5
+
+    assert calls == 1
+
+
+def test_configured_gateway_platform_cache_does_not_serialize_profiles(monkeypatch):
+    local = threading.local()
+    both_loaders_entered = threading.Barrier(2)
+
+    class FakeGatewayConfig:
+        def __init__(self, platform):
+            self.platform = platform
+
+        def get_connected_platforms(self):
+            return [SimpleNamespace(value=self.platform)]
+
+    def load_gateway_config():
+        both_loaders_entered.wait(timeout=1)
+        return FakeGatewayConfig(local.platform)
+
+    def load_for(home, platform):
+        local.home = home
+        local.platform = platform
+        return web_server._load_configured_gateway_platforms()
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: local.home)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        default = pool.submit(load_for, "/tmp/hermes-default", "discord")
+        worker = pool.submit(load_for, "/tmp/hermes-worker", "telegram")
+        assert default.result(timeout=2) == {"discord"}
+        assert worker.result(timeout=2) == {"telegram"}
+
+
+def test_configured_gateway_platform_cache_refreshes_after_ttl(monkeypatch):
+    calls = 0
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        return FakeGatewayConfig()
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    entry = web_server._CONFIGURED_PLATFORM_CACHE[str(web_server.get_hermes_home())]
+    entry["ts"] -= web_server._CONFIGURED_PLATFORM_CACHE_TTL + 0.1
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert calls == 2
+
+
+def test_configured_gateway_platform_cache_invalidates_on_source_change(monkeypatch):
+    calls = 0
+    source_version = (("config.yaml", 1, 1, 10),)
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        return FakeGatewayConfig()
+
+    monkeypatch.setattr(
+        web_server,
+        "_configured_platform_source_version",
+        lambda _home: source_version,
+    )
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    source_version = (("config.yaml", 1, 2, 11),)
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert calls == 2
+
+
+def test_configured_gateway_platform_cache_does_not_poison_on_error(monkeypatch):
+    calls = 0
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("temporary config failure")
+        return FakeGatewayConfig()
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    with pytest.raises(RuntimeError, match="temporary config failure"):
+        web_server._load_configured_gateway_platforms()
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert calls == 2
+
+
+def test_configured_gateway_platform_cache_wakes_waiters_after_base_exception(
+    monkeypatch, tmp_path
+):
+    calls = 0
+    entered = threading.Event()
+    release = threading.Event()
+    outcomes = []
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            entered.set()
+            assert release.wait(timeout=2)
+            raise SystemExit("plugin exited during discovery")
+        return FakeGatewayConfig()
+
+    def load_platforms():
+        try:
+            outcomes.append(web_server._load_configured_gateway_platforms())
+        except BaseException as exc:
+            outcomes.append(exc)
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    builder = threading.Thread(target=load_platforms, daemon=True)
+    waiter = threading.Thread(target=load_platforms, daemon=True)
+    builder.start()
+    assert entered.wait(timeout=2)
+    waiter.start()
+    time.sleep(0.05)
+    release.set()
+    builder.join(timeout=2)
+    waiter.join(timeout=0.5)
+    waiter_was_stuck = waiter.is_alive()
+
+    # Ensure a failing implementation cannot strand a daemon thread after the
+    # assertion records the defect.
+    for flight in web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT.values():
+        event = flight["event"] if isinstance(flight, dict) else flight
+        event.set()
+    waiter.join(timeout=2)
+
+    assert not waiter_was_stuck
+    assert any(isinstance(outcome, SystemExit) for outcome in outcomes)
+    assert any(isinstance(outcome, RuntimeError) for outcome in outcomes)
+    assert calls == 1
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert calls == 2
+
+
+def test_configured_gateway_platform_cache_wakes_waiters_after_cache_write_failure(
+    monkeypatch, tmp_path
+):
+    calls = 0
+    entered = threading.Event()
+    release = threading.Event()
+    outcomes = []
+
+    class FailOnceCache(dict):
+        failed = False
+
+        def __setitem__(self, key, value):
+            if not self.failed:
+                self.failed = True
+                raise MemoryError("simulated cache write failure")
+            super().__setitem__(key, value)
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            entered.set()
+            assert release.wait(timeout=2)
+        return FakeGatewayConfig()
+
+    def load_platforms():
+        try:
+            outcomes.append(web_server._load_configured_gateway_platforms())
+        except BaseException as exc:
+            outcomes.append(exc)
+
+    monkeypatch.setattr(web_server, "_CONFIGURED_PLATFORM_CACHE", FailOnceCache())
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    builder = threading.Thread(target=load_platforms, daemon=True)
+    waiter = threading.Thread(target=load_platforms, daemon=True)
+    builder.start()
+    assert entered.wait(timeout=2)
+    waiter.start()
+    time.sleep(0.05)
+    release.set()
+    builder.join(timeout=2)
+    waiter.join(timeout=0.5)
+    waiter_was_stuck = waiter.is_alive()
+
+    for flight in web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT.values():
+        event = flight["event"] if isinstance(flight, dict) else flight
+        event.set()
+    waiter.join(timeout=2)
+
+    assert not waiter_was_stuck
+    assert any(isinstance(outcome, MemoryError) for outcome in outcomes)
+    assert any(isinstance(outcome, RuntimeError) for outcome in outcomes)
+    assert calls == 1
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert calls == 2
+
+
+def test_configured_gateway_platform_cache_ttl_starts_after_slow_load(
+    monkeypatch, tmp_path
+):
+    calls = 0
+    now = 100.0
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls, now
+        calls += 1
+        now += web_server._CONFIGURED_PLATFORM_CACHE_TTL + 1
+        return FakeGatewayConfig()
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(web_server.time, "monotonic", lambda: now)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert calls == 1
+
+
+def test_configured_gateway_platform_cache_checks_ttl_after_fingerprint(
+    monkeypatch, tmp_path
+):
+    calls = 0
+    fingerprint_checks = 0
+    now = 100.0
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        return FakeGatewayConfig()
+
+    def source_version(_home):
+        nonlocal fingerprint_checks, now
+        fingerprint_checks += 1
+        if fingerprint_checks == 2:
+            now += web_server._CONFIGURED_PLATFORM_CACHE_TTL + 1
+        return (("config.yaml", 1, 1, 10),)
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(web_server.time, "monotonic", lambda: now)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert calls == 2
+
+
+def test_configured_gateway_platform_cache_broadcasts_failure_to_waiters(
+    monkeypatch, tmp_path
+):
+    calls = 0
+    entered = threading.Event()
+    release = threading.Event()
+    outcomes = []
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        entered.set()
+        assert release.wait(timeout=2)
+        raise RuntimeError("persistent config failure")
+
+    def load_platforms():
+        try:
+            outcomes.append(web_server._load_configured_gateway_platforms())
+        except Exception as exc:
+            outcomes.append(exc)
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    threads = [threading.Thread(target=load_platforms) for _ in range(4)]
+    threads[0].start()
+    assert entered.wait(timeout=2)
+    for thread in threads[1:]:
+        thread.start()
+    time.sleep(0.05)
+    release.set()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert calls == 1
+    assert len(outcomes) == 4
+    assert all(isinstance(outcome, RuntimeError) for outcome in outcomes)
+
+
+def test_configured_gateway_platform_cache_waiters_time_out_on_hung_builder(
+    monkeypatch, tmp_path
+):
+    entered = threading.Event()
+    release = threading.Event()
+    waiter_outcomes = []
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        entered.set()
+        assert release.wait(timeout=2)
+        return FakeGatewayConfig()
+
+    def wait_for_platforms():
+        try:
+            waiter_outcomes.append(web_server._load_configured_gateway_platforms())
+        except Exception as exc:
+            waiter_outcomes.append(exc)
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        web_server,
+        "_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT",
+        0.05,
+        raising=False,
+    )
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    builder = threading.Thread(target=web_server._load_configured_gateway_platforms)
+    waiter = threading.Thread(target=wait_for_platforms)
+    builder.start()
+    assert entered.wait(timeout=2)
+    waiter.start()
+    waiter.join(timeout=0.25)
+    waiter_was_stuck = waiter.is_alive()
+    release.set()
+    builder.join(timeout=2)
+    waiter.join(timeout=2)
+
+    assert not waiter_was_stuck
+    assert len(waiter_outcomes) == 1
+    assert isinstance(waiter_outcomes[0], TimeoutError)
+
+
+def test_configured_gateway_platform_cache_real_source_change_invalidates(
+    monkeypatch, tmp_path
+):
+    calls = 0
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        return FakeGatewayConfig()
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    before = web_server._configured_platform_source_version(tmp_path)
+    assert before[0] == (str(tmp_path / "config.yaml"), None, None, None)
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+
+    (tmp_path / "config.yaml").write_text("gateway: {}\n")
+    after = web_server._configured_platform_source_version(tmp_path)
+
+    assert after != before
+    assert after[0][0] == str(tmp_path / "config.yaml")
+    assert all(value is not None for value in after[0][1:])
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert calls == 2
+
+
+def test_configured_gateway_platform_cache_does_not_publish_superseded_build(
+    monkeypatch, tmp_path
+):
+    calls = 0
+    version = 1
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    outcomes = []
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            first_entered.set()
+            assert release_first.wait(timeout=2)
+        return FakeGatewayConfig()
+
+    def source_version(_home):
+        return (("config.yaml", 1, version, 10),)
+
+    def load_platforms():
+        outcomes.append(web_server._load_configured_gateway_platforms())
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    older = threading.Thread(target=load_platforms)
+    newer = threading.Thread(target=load_platforms)
+    older.start()
+    assert first_entered.wait(timeout=2)
+    version = 2
+    newer.start()
+    newer.join(timeout=2)
+    assert not newer.is_alive()
+    version = 1
+    release_first.set()
+    older.join(timeout=2)
+
+    assert not older.is_alive()
+    assert outcomes == [{"discord"}, {"discord"}]
+    entry = web_server._CONFIGURED_PLATFORM_CACHE[str(tmp_path)]
+    assert entry["source_version"] == (("config.yaml", 1, 2, 10),)
+    assert calls == 2
+
+
+def test_configured_gateway_platform_cache_suppresses_older_build_while_newer_runs(
+    monkeypatch, tmp_path
+):
+    calls = 0
+    version = 1
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+    release_second = threading.Event()
+    outcomes = {}
+
+    class FakeGatewayConfig:
+        def __init__(self, platform):
+            self.platform = platform
+
+        def get_connected_platforms(self):
+            return [SimpleNamespace(value=self.platform)]
+
+    def load_gateway_config():
+        nonlocal calls
+        calls += 1
+        call = calls
+        if call == 1:
+            first_entered.set()
+            assert release_first.wait(timeout=2)
+        else:
+            second_entered.set()
+            assert release_second.wait(timeout=2)
+        return FakeGatewayConfig("discord" if call == 1 else "telegram")
+
+    def source_version(_home):
+        return (("config.yaml", 1, version, 10),)
+
+    def load_platforms(name):
+        outcomes[name] = web_server._load_configured_gateway_platforms()
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    older = threading.Thread(target=load_platforms, args=("older",))
+    newer = threading.Thread(target=load_platforms, args=("newer",))
+    older.start()
+    assert first_entered.wait(timeout=2)
+    version = 2
+    newer.start()
+    assert second_entered.wait(timeout=2)
+
+    # Return the source fingerprint to v1 while the newer v2 build is still
+    # running. The older generation must not publish merely because no newer
+    # cache entry exists yet.
+    version = 1
+    release_first.set()
+    older.join(timeout=2)
+
+    assert not older.is_alive()
+    assert outcomes["older"] == {"discord"}
+    older_published = str(tmp_path) in web_server._CONFIGURED_PLATFORM_CACHE
+
+    version = 2
+    release_second.set()
+    newer.join(timeout=2)
+
+    assert not newer.is_alive()
+    assert not older_published
+    assert outcomes["newer"] == {"telegram"}
+    entry = web_server._CONFIGURED_PLATFORM_CACHE[str(tmp_path)]
+    assert entry["source_version"] == (("config.yaml", 1, 2, 10),)
+    assert entry["platforms"] == frozenset({"telegram"})
+    assert calls == 2
+
+
+def test_configured_gateway_platform_cache_stays_bounded(monkeypatch, tmp_path):
+    home = tmp_path / "profile-0"
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: home)
+    monkeypatch.setattr(
+        "gateway.config.load_gateway_config",
+        lambda: FakeGatewayConfig(),
+    )
+
+    for index in range(web_server._CONFIGURED_PLATFORM_CACHE_MAX_KEYS + 1):
+        home = tmp_path / f"profile-{index}"
+        assert web_server._load_configured_gateway_platforms() == {"discord"}
+
+    assert (
+        len(web_server._CONFIGURED_PLATFORM_CACHE)
+        == web_server._CONFIGURED_PLATFORM_CACHE_MAX_KEYS
+    )
+    assert str(tmp_path / "profile-0") not in web_server._CONFIGURED_PLATFORM_CACHE
+    assert (
+        len(web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION)
+        == web_server._CONFIGURED_PLATFORM_CACHE_MAX_KEYS
+    )
+    assert (
+        str(tmp_path / "profile-0")
+        not in web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION
+    )
+
+
+def test_configured_gateway_platform_cache_replaces_persistently_hung_flight(
+    monkeypatch, tmp_path
+):
+    """A wedged builder must not stall every later poll for a full timeout."""
+    calls = 0
+    calls_lock = threading.Lock()
+    first_entered = threading.Event()
+    release_first = threading.Event()
+
+    class FakeGatewayConfig:
+        def __init__(self, platform):
+            self.platform = platform
+
+        def get_connected_platforms(self):
+            return [SimpleNamespace(value=self.platform)]
+
+    def load_gateway_config():
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            call = calls
+        if call == 1:
+            first_entered.set()
+            release_first.wait(timeout=10)
+            return FakeGatewayConfig("discord")
+        return FakeGatewayConfig("telegram")
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        web_server, "_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT", 0.05, raising=False
+    )
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    hung = threading.Thread(target=web_server._load_configured_gateway_platforms)
+    hung.start()
+    try:
+        assert first_entered.wait(timeout=10)
+
+        # The first waiter gives up on the hung flight...
+        with pytest.raises(TimeoutError):
+            web_server._load_configured_gateway_platforms()
+
+        # ...and must have detached it, so the next poll builds a replacement
+        # instead of queueing behind the same hang for another full timeout.
+        assert web_server._load_configured_gateway_platforms() == {"telegram"}
+        assert calls == 2
+        assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT == {}
+    finally:
+        release_first.set()
+        hung.join(timeout=10)
+
+    # The late stale builder must not clobber the replacement's entry, remove
+    # its bookkeeping, or publish its own superseded result.
+    assert not hung.is_alive()
+    entry = web_server._CONFIGURED_PLATFORM_CACHE[str(tmp_path)]
+    assert entry["platforms"] == frozenset({"telegram"})
+    assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT == {}
+    assert web_server._load_configured_gateway_platforms() == {"telegram"}
+    assert calls == 2
+
+
+def test_configured_gateway_platform_cache_abandons_stale_flight_without_waiting(
+    monkeypatch, tmp_path
+):
+    """A caller arriving past the max flight age refuses to queue behind it."""
+    calls = 0
+    calls_lock = threading.Lock()
+    first_entered = threading.Event()
+    release_first = threading.Event()
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            call = calls
+        if call == 1:
+            first_entered.set()
+            release_first.wait(timeout=10)
+        return FakeGatewayConfig()
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        web_server, "_CONFIGURED_PLATFORM_CACHE_FLIGHT_MAX_AGE", 0.05, raising=False
+    )
+    # Long enough that a caller which parks on the hung flight is unmistakably
+    # stuck rather than merely slow.
+    monkeypatch.setattr(
+        web_server, "_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT", 2.0, raising=False
+    )
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    hung = threading.Thread(target=web_server._load_configured_gateway_platforms)
+    hung.start()
+    try:
+        assert first_entered.wait(timeout=10)
+        time.sleep(0.06)
+
+        started = time.monotonic()
+        platforms = web_server._load_configured_gateway_platforms()
+        elapsed = time.monotonic() - started
+    finally:
+        release_first.set()
+        hung.join(timeout=10)
+
+    assert platforms == {"discord"}
+    assert elapsed < 1.0
+    assert calls == 2
+    assert not hung.is_alive()
+
+
+def test_configured_gateway_platform_cache_bounds_builders_under_version_churn(
+    monkeypatch, tmp_path
+):
+    """Churn plus indefinitely-held loaders must not spawn a builder per poll.
+
+    Every poller sees a brand-new fingerprint, so none of them can reuse a cache
+    entry or join a same-fingerprint flight -- each one *wants* to build.  The
+    loaders never return, so a thread that reaches ``load_gateway_config()``
+    stays parked in the worker pool for the rest of the test and the count of
+    entries is a direct, race-free measure of how many builders were spawned.
+    """
+    home = str(tmp_path)
+    pollers = 8
+    entries = 0
+    entries_lock = threading.Lock()
+    release = threading.Event()
+    version = 0
+    version_lock = threading.Lock()
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def source_version(_home):
+        nonlocal version
+        with version_lock:
+            version += 1
+            return (("config.yaml", 1, version, 10),)
+
+    def load_gateway_config():
+        nonlocal entries
+        with entries_lock:
+            entries += 1
+        release.wait(timeout=30)
+        return FakeGatewayConfig()
+
+    returned = threading.Semaphore(0)
+
+    def poll():
+        try:
+            web_server._load_configured_gateway_platforms()
+        except BaseException:  # pragma: no cover - being turned away is the point
+            pass
+        finally:
+            returned.release()
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr(
+        web_server, "_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT", 0.05, raising=False
+    )
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    threads = [threading.Thread(target=poll) for _ in range(pollers)]
+    try:
+        for thread in threads:
+            thread.start()
+        # Drain returns until they stop coming; whatever has not returned is
+        # wedged inside the loader.  Cheaper and just as strict as joining the
+        # wedged threads, which by construction never finish on their own.
+        returns = 0
+        while returns < pollers and returned.acquire(timeout=1.0):
+            returns += 1
+        with entries_lock:
+            builders_spawned = entries
+        still_running = [thread for thread in threads if thread.is_alive()]
+
+        # The load is unkillable and holds a worker-pool thread, so the bound
+        # has to be on how many are ever started -- not just on dict size.
+        assert builders_spawned < pollers
+        assert len(still_running) < pollers
+        # Turned-away pollers must return rather than pile up behind the wedge.
+        assert len(still_running) == builders_spawned
+        assert builders_spawned == web_server._CONFIGURED_PLATFORM_CACHE_MAX_BUILDERS
+        assert (
+            web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS[home] == builders_spawned
+        )
+        # Bookkeeping stays bounded alongside the threads.
+        assert len(web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT) <= 1
+        assert len(web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION) == 1
+    finally:
+        release.set()
+        for thread in threads:
+            thread.join(timeout=30)
+
+    assert all(not thread.is_alive() for thread in threads)
+    # Once the wedged loads return, every permit and bookkeeping entry is
+    # reclaimed -- nothing leaked by the pollers that were turned away.
+    assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS == {}
+    assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT == {}
+    assert web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION == {}
+
+
+def test_configured_gateway_platform_cache_recovers_from_one_wedged_builder(
+    monkeypatch, tmp_path
+):
+    """One permanently wedged builder must not stop the profile refreshing."""
+    entries = 0
+    entries_lock = threading.Lock()
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    version = 1
+
+    class FakeGatewayConfig:
+        def __init__(self, platform):
+            self.platform = platform
+
+        def get_connected_platforms(self):
+            return [SimpleNamespace(value=self.platform)]
+
+    def source_version(_home):
+        return (("config.yaml", 1, version, 10),)
+
+    def load_gateway_config():
+        nonlocal entries
+        with entries_lock:
+            entries += 1
+            entry = entries
+        if entry == 1:
+            first_entered.set()
+            release_first.wait(timeout=30)
+            return FakeGatewayConfig("discord")
+        return FakeGatewayConfig("telegram")
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr(
+        web_server, "_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT", 0.05, raising=False
+    )
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    wedged = threading.Thread(target=web_server._load_configured_gateway_platforms)
+    wedged.start()
+    try:
+        assert first_entered.wait(timeout=10)
+        # Move the fingerprint on so later polls genuinely need a new build
+        # rather than joining the wedged same-version flight.
+        version = 2
+
+        # The surviving permit must be recycled, not consumed once: repeated
+        # refreshes keep succeeding while the first builder stays stuck.
+        for _ in range(4):
+            web_server._CONFIGURED_PLATFORM_CACHE.clear()
+            assert web_server._load_configured_gateway_platforms() == {"telegram"}
+            assert (
+                web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS[str(tmp_path)] == 1
+            ), "the wedged builder should hold exactly one permit"
+    finally:
+        release_first.set()
+        wedged.join(timeout=30)
+
+    assert not wedged.is_alive()
+    assert entries == 5
+    assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS == {}
+    assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT == {}
+
+
+def test_configured_gateway_platform_cache_late_builder_cannot_touch_current_generation(
+    monkeypatch, tmp_path
+):
+    """A late stale builder may neither unregister nor publish over its successor."""
+    home = str(tmp_path)
+    entries = 0
+    entries_lock = threading.Lock()
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+    release_second = threading.Event()
+    version = 1
+    outcomes = {}
+
+    class FakeGatewayConfig:
+        def __init__(self, platform):
+            self.platform = platform
+
+        def get_connected_platforms(self):
+            return [SimpleNamespace(value=self.platform)]
+
+    def source_version(_home):
+        return (("config.yaml", 1, version, 10),)
+
+    def load_gateway_config():
+        nonlocal entries
+        with entries_lock:
+            entries += 1
+            entry = entries
+        if entry == 1:
+            first_entered.set()
+            release_first.wait(timeout=30)
+            return FakeGatewayConfig("discord")
+        second_entered.set()
+        release_second.wait(timeout=30)
+        return FakeGatewayConfig("telegram")
+
+    def load_platforms(name):
+        outcomes[name] = web_server._load_configured_gateway_platforms()
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    older = threading.Thread(target=load_platforms, args=("older",))
+    newer = threading.Thread(target=load_platforms, args=("newer",))
+    older.start()
+    try:
+        assert first_entered.wait(timeout=10)
+        version = 2
+        newer.start()
+        assert second_entered.wait(timeout=10)
+
+        current_flight = web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[home]
+        current_generation = web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION[home]
+        assert current_flight["source_version"] == (("config.yaml", 1, 2, 10),)
+        assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS[home] == 2
+
+        # Restore the older build's fingerprint so its own publish guard passes:
+        # only the generation high-water mark can stop it now.
+        version = 1
+        release_first.set()
+        older.join(timeout=30)
+        assert not older.is_alive()
+
+        # The late builder left its successor's flight, mark, and permit alone,
+        # and published nothing.
+        assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[home] is current_flight
+        assert (
+            web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION[home]
+            == current_generation
+        )
+        assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS[home] == 1
+        assert home not in web_server._CONFIGURED_PLATFORM_CACHE
+    finally:
+        release_first.set()
+        version = 2
+        release_second.set()
+        newer.join(timeout=30)
+
+    assert not newer.is_alive()
+    assert outcomes == {"older": {"discord"}, "newer": {"telegram"}}
+    entry = web_server._CONFIGURED_PLATFORM_CACHE[home]
+    assert entry["platforms"] == frozenset({"telegram"})
+    assert entry["source_version"] == (("config.yaml", 1, 2, 10),)
+    assert entry["generation"] == current_generation
+    assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT == {}
+    assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS == {}
+
+
+def test_configured_gateway_platform_cache_serves_last_known_when_saturated(
+    monkeypatch, tmp_path
+):
+    """With every permit wedged, fall back to the profile's last result."""
+    home = str(tmp_path)
+    entered = threading.Semaphore(0)
+    release = threading.Event()
+    version = 1
+
+    class FakeGatewayConfig:
+        def __init__(self, platform):
+            self.platform = platform
+
+        def get_connected_platforms(self):
+            return [SimpleNamespace(value=self.platform)]
+
+    def source_version(_home):
+        return (("config.yaml", 1, version, 10),)
+
+    def load_gateway_config():
+        if version == 1:
+            return FakeGatewayConfig("discord")
+        entered.release()
+        release.wait(timeout=30)
+        return FakeGatewayConfig("telegram")
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr(
+        web_server, "_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT", 0.05, raising=False
+    )
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+
+    max_builders = web_server._CONFIGURED_PLATFORM_CACHE_MAX_BUILDERS
+    wedged = [
+        threading.Thread(target=web_server._load_configured_gateway_platforms)
+        for _ in range(max_builders)
+    ]
+    try:
+        for index, thread in enumerate(wedged):
+            # A distinct fingerprint per thread, otherwise same-version
+            # single-flight would collapse them onto one builder.
+            version = 2 + index
+            thread.start()
+            assert entered.acquire(timeout=10)
+        assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS[home] == max_builders
+
+        # First poll parks on the registered flight and gives up on it...
+        with pytest.raises(TimeoutError):
+            web_server._load_configured_gateway_platforms()
+        # ...after which there is no flight and no permit, so the stale entry is
+        # served rather than raising or adding another builder.
+        assert web_server._load_configured_gateway_platforms() == {"discord"}
+        assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS[home] == max_builders
+    finally:
+        release.set()
+        for thread in wedged:
+            thread.join(timeout=30)
+
+    assert all(not thread.is_alive() for thread in wedged)
+    assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS == {}
+    # The profile refreshes normally once the wedged loads drain.
+    assert web_server._load_configured_gateway_platforms() == {"telegram"}
+
+
+def test_configured_gateway_platform_cache_bounds_builders_across_profiles(
+    monkeypatch, tmp_path
+):
+    """Many profiles with wedged loaders must not each claim their own quota.
+
+    Profile names reach this code from the request, so a per-profile ceiling is
+    not a bound on Starlette's shared worker pool -- only a process-wide one is.
+    Every loader here is held for the whole test, so the number of loader
+    entries is a direct, race-free count of how many worker threads were
+    committed to discovery.
+    """
+    attempts = 14
+    local = threading.local()
+    entries = 0
+    entries_lock = threading.Lock()
+    release = threading.Event()
+    returned = threading.Semaphore(0)
+    outcomes = []
+    outcomes_lock = threading.Lock()
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def load_gateway_config():
+        nonlocal entries
+        with entries_lock:
+            entries += 1
+        release.wait(timeout=30)
+        return FakeGatewayConfig()
+
+    def poll(home):
+        local.home = home
+        try:
+            result = web_server._load_configured_gateway_platforms()
+        except BaseException as exc:  # pragma: no cover - being turned away
+            result = exc
+        with outcomes_lock:
+            outcomes.append(result)
+        returned.release()
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: local.home)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    threads = [
+        threading.Thread(target=poll, args=(tmp_path / f"profile-{index}",))
+        for index in range(attempts)
+    ]
+    try:
+        started = time.monotonic()
+        for thread in threads:
+            thread.start()
+        # Drain returns until they stop coming; whatever has not returned is
+        # wedged inside a loader and by construction never finishes on its own.
+        returns = 0
+        while returns < attempts and returned.acquire(timeout=1.0):
+            returns += 1
+        elapsed = time.monotonic() - started
+        with entries_lock:
+            builders_spawned = entries
+        still_running = [thread for thread in threads if thread.is_alive()]
+
+        # The behavioural bound: distinct profiles cannot each start a builder.
+        assert builders_spawned < attempts
+        assert len(still_running) < attempts
+
+        cap = web_server._CONFIGURED_PLATFORM_CACHE_MAX_TOTAL_BUILDERS
+        assert attempts > cap, "raise `attempts` above the process-wide cap"
+        assert builders_spawned == cap
+        assert len(still_running) == cap
+        # Everyone turned away returned rather than parking on a worker thread.
+        assert returns == attempts - cap
+        with outcomes_lock:
+            assert len(outcomes) == attempts - cap
+            assert all(isinstance(outcome, TimeoutError) for outcome in outcomes)
+        assert elapsed < 3.0
+
+        # Global bookkeeping ceilings, none of which _MAX_KEYS constrains.
+        assert len(web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS) == cap
+        assert (
+            sum(web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS.values()) == cap
+        )
+        assert len(web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT) == cap
+        assert len(web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION) == cap
+        assert len(
+            web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION
+        ) <= web_server._CONFIGURED_PLATFORM_CACHE_MAX_KEYS + cap
+    finally:
+        release.set()
+        for thread in threads:
+            thread.join(timeout=30)
+
+    assert all(not thread.is_alive() for thread in threads)
+    # Every permit and bookkeeping entry is reclaimed once the loads return.
+    assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS == {}
+    assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT == {}
+
+
+def test_configured_gateway_platform_cache_global_saturation_serves_or_fails_fast(
+    monkeypatch, tmp_path
+):
+    """Saturated process-wide: serve the profile's stale entry, else fail fast."""
+    primed = tmp_path / "primed"
+    unknown = tmp_path / "unknown"
+    local = threading.local()
+    local.home = primed
+    entries = 0
+    entries_lock = threading.Lock()
+    release = threading.Event()
+    entered = threading.Semaphore(0)
+    version = 1
+
+    class FakeGatewayConfig:
+        def __init__(self, platform):
+            self.platform = platform
+
+        def get_connected_platforms(self):
+            return [SimpleNamespace(value=self.platform)]
+
+    def source_version(_home):
+        return (("config.yaml", 1, version, 10),)
+
+    def load_gateway_config():
+        nonlocal entries
+        with entries_lock:
+            entries += 1
+        if local.home == primed:
+            return FakeGatewayConfig("discord")
+        entered.release()
+        release.wait(timeout=30)
+        return FakeGatewayConfig("telegram")
+
+    def wedge(home):
+        local.home = home
+        try:
+            web_server._load_configured_gateway_platforms()
+        except BaseException:  # pragma: no cover - not expected
+            pass
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: local.home)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    assert str(primed) in web_server._CONFIGURED_PLATFORM_CACHE
+
+    wedged_profiles = 8
+    wedged = [
+        threading.Thread(target=wedge, args=(tmp_path / f"other-{index}",))
+        for index in range(wedged_profiles)
+    ]
+    try:
+        for thread in wedged:
+            thread.start()
+            assert entered.acquire(timeout=10)
+        assert (
+            sum(web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS.values())
+            == wedged_profiles
+        )
+        with entries_lock:
+            entries_while_saturated = entries
+
+        # Move the fingerprint on so the primed profile is now a genuine miss.
+        version = 2
+
+        # A profile with a prior result is served stale rather than blocking or
+        # adding another unkillable thread.
+        local.home = primed
+        started = time.monotonic()
+        assert web_server._load_configured_gateway_platforms() == {"discord"}
+        stale_elapsed = time.monotonic() - started
+        assert stale_elapsed < 1.0
+        with entries_lock:
+            # Serving stale must not have started a discovery.
+            assert entries == entries_while_saturated
+
+        # A profile with nothing safe to serve fails fast instead of waiting or
+        # spawning.  (Checked second: on an unbounded build it would wedge.)
+        local.home = unknown
+        started = time.monotonic()
+        with pytest.raises(TimeoutError, match="process-wide"):
+            web_server._load_configured_gateway_platforms()
+        failure_elapsed = time.monotonic() - started
+        assert failure_elapsed < 1.0
+        with entries_lock:
+            assert entries == entries_while_saturated
+
+        cap = web_server._CONFIGURED_PLATFORM_CACHE_MAX_TOTAL_BUILDERS
+        assert wedged_profiles == cap, "wedged profiles must match the global cap"
+        assert sum(web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS.values()) == cap
+        assert str(unknown) not in web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT
+    finally:
+        release.set()
+        for thread in wedged:
+            thread.join(timeout=30)
+
+    assert all(not thread.is_alive() for thread in wedged)
+    assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS == {}
+    assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT == {}
+
+    # Normal service resumes for both profiles once the permits are released.
+    local.home = primed
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    local.home = unknown
+    assert web_server._load_configured_gateway_platforms() == {"telegram"}
+
+
+def test_configured_gateway_platform_cache_no_parking_on_matching_flight_at_cap(
+    monkeypatch, tmp_path
+):
+    """At the global cap, a *matching* hung flight must not absorb new waiters.
+
+    Parking is only free while the process has spare discovery capacity: a
+    parked caller still holds a worker-pool thread for the whole wait budget.
+    The wait timeout is left at its real value here, so a caller that parks is
+    unmistakably stuck rather than merely slow -- the pollers must come back
+    without ever reaching the wait.
+    """
+    cached = tmp_path / "cached"
+    uncached = tmp_path / "uncached"
+    pollers = 12
+    local = threading.local()
+    local.home = cached
+    entries = 0
+    entries_lock = threading.Lock()
+    priming = True
+    entered = threading.Semaphore(0)
+    release = threading.Event()
+    returned = threading.Semaphore(0)
+    outcomes = []
+    outcomes_lock = threading.Lock()
+    version = 1
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def source_version(_home):
+        return (("config.yaml", 1, version, 10),)
+
+    def load_gateway_config():
+        nonlocal entries
+        with entries_lock:
+            entries += 1
+        if priming:
+            return FakeGatewayConfig()
+        entered.release()
+        release.wait(timeout=30)
+        return FakeGatewayConfig()
+
+    def wedge(home):
+        local.home = home
+        try:
+            web_server._load_configured_gateway_platforms()
+        except BaseException:  # pragma: no cover - not expected
+            pass
+
+    def poll(home):
+        local.home = home
+        try:
+            result = web_server._load_configured_gateway_platforms()
+        except BaseException as exc:
+            result = exc
+        with outcomes_lock:
+            outcomes.append((home, result))
+        returned.release()
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: local.home)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    # Give `cached` a result, then move the fingerprint on so its entry is stale
+    # and the hung flight registered next genuinely matches later pollers.
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    priming = False
+    version = 2
+
+    cap = web_server._CONFIGURED_PLATFORM_CACHE_MAX_TOTAL_BUILDERS
+    homes = [cached, uncached] + [tmp_path / f"filler-{i}" for i in range(cap - 2)]
+    wedged = [threading.Thread(target=wedge, args=(home,)) for home in homes]
+    threads = []
+    try:
+        for thread in wedged:
+            thread.start()
+            assert entered.acquire(timeout=10)
+
+        # Both target profiles now have a registered, *matching*, hung flight,
+        # and every discovery permit in the process is consumed.
+        assert sum(web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS.values()) == cap
+        cached_flight = web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[str(cached)]
+        uncached_flight = web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[str(uncached)]
+        assert cached_flight["source_version"] == (("config.yaml", 1, 2, 10),)
+        assert uncached_flight["source_version"] == (("config.yaml", 1, 2, 10),)
+        assert str(cached) in web_server._CONFIGURED_PLATFORM_CACHE
+        assert str(uncached) not in web_server._CONFIGURED_PLATFORM_CACHE
+        with entries_lock:
+            entries_at_cap = entries
+        in_flight_at_cap = dict(web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT)
+        builders_at_cap = dict(web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS)
+        generations_at_cap = dict(
+            web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION
+        )
+
+        started = time.monotonic()
+        for index in range(pollers):
+            home = cached if index % 2 == 0 else uncached
+            thread = threading.Thread(target=poll, args=(home,))
+            thread.start()
+            threads.append(thread)
+        returns = 0
+        while returns < pollers and returned.acquire(timeout=2.0):
+            returns += 1
+        elapsed = time.monotonic() - started
+
+        # None of them parked behind the matching hung flights.
+        assert returns == pollers
+        assert all(not thread.is_alive() for thread in threads)
+        assert elapsed < 2.0
+
+        with outcomes_lock:
+            results = list(outcomes)
+        assert len(results) == pollers
+        # Stale-cache callers are served; uncached callers fail fast.
+        assert all(
+            result == {"discord"}
+            for home, result in results
+            if home == cached
+        )
+        assert all(
+            isinstance(result, TimeoutError) and "process-wide" in str(result)
+            for home, result in results
+            if home == uncached
+        )
+
+        # And none of them spawned a builder or disturbed the bookkeeping.
+        with entries_lock:
+            assert entries == entries_at_cap
+        assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS == builders_at_cap
+        assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT == in_flight_at_cap
+        assert (
+            web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION
+            == generations_at_cap
+        )
+        # The hung flights were neither abandoned nor replaced.
+        assert (
+            web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[str(cached)]
+            is cached_flight
+        )
+        assert (
+            web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[str(uncached)]
+            is uncached_flight
+        )
+        assert not cached_flight["abandoned"]
+        assert not uncached_flight["abandoned"]
+    finally:
+        release.set()
+        for thread in wedged + threads:
+            thread.join(timeout=30)
+
+    assert all(not thread.is_alive() for thread in wedged)
+    assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS == {}
+    assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT == {}
+
+    # Normal collapse-onto-a-matching-flight behaviour returns once the process
+    # is back under its ceiling.
+    local.home = uncached
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+
+
+def _wait_for(predicate, timeout=10.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+def test_configured_gateway_platform_cache_bounds_total_worker_occupancy(
+    monkeypatch, tmp_path
+):
+    """One hung flight far below the builder cap must not absorb every poller.
+
+    A parked caller holds a worker-pool thread exactly like a running load does,
+    so with a single builder wedged there are still only
+    ``_MAX_OCCUPANCY - 1`` slots left before new callers must be turned away.
+    The wait timeout is left at its real value, so anything that parks is
+    unmistakably stuck rather than merely slow.
+    """
+    cached = tmp_path / "cached"
+    unknown = tmp_path / "unknown"
+    pollers = 24
+    local = threading.local()
+    local.home = cached
+    entries = 0
+    entries_lock = threading.Lock()
+    priming = True
+    entered = threading.Event()
+    release = threading.Event()
+    returned = threading.Semaphore(0)
+    outcomes = []
+    outcomes_lock = threading.Lock()
+    version = 1
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def source_version(_home):
+        return (("config.yaml", 1, version, 10),)
+
+    def load_gateway_config():
+        nonlocal entries
+        with entries_lock:
+            entries += 1
+        if priming:
+            return FakeGatewayConfig()
+        entered.set()
+        release.wait(timeout=30)
+        return FakeGatewayConfig()
+
+    def wedge():
+        local.home = cached
+        web_server._load_configured_gateway_platforms()
+
+    def poll():
+        local.home = cached
+        try:
+            result = web_server._load_configured_gateway_platforms()
+        except BaseException as exc:
+            result = exc
+        with outcomes_lock:
+            outcomes.append(result)
+        returned.release()
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: local.home)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    # Give the profile a result, then move the fingerprint on so the hung flight
+    # registered next genuinely matches the pollers that follow it.
+    assert web_server._load_configured_gateway_platforms() == {"discord"}
+    priming = False
+    version = 2
+
+    builder = threading.Thread(target=wedge)
+    threads = []
+    try:
+        builder.start()
+        assert entered.wait(timeout=10)
+
+        # A single builder -- far below the builder ceiling, which stays free.
+        assert sum(web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS.values()) == 1
+        assert 1 < web_server._CONFIGURED_PLATFORM_CACHE_MAX_TOTAL_BUILDERS
+        hung_flight = web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[str(cached)]
+        with entries_lock:
+            entries_at_cap = entries
+
+        started = time.monotonic()
+        for _ in range(pollers):
+            thread = threading.Thread(target=poll)
+            thread.start()
+            threads.append(thread)
+
+        # Drain returns until they stop coming; whatever has not come back is
+        # parked behind the one hung flight.
+        returns = 0
+        while returns < pollers and returned.acquire(timeout=2.0):
+            returns += 1
+        elapsed = time.monotonic() - started
+
+        # The behavioural bound: a single hung flight must not swallow every
+        # poller just because the builder ceiling is nowhere near reached.
+        assert returns > 0, "every poller parked behind one hung flight"
+        assert elapsed < 10.0
+
+        occupancy_cap = web_server._CONFIGURED_PLATFORM_CACHE_MAX_OCCUPANCY
+        expected_waiters = occupancy_cap - 1
+        assert pollers > expected_waiters, "raise `pollers` above the occupancy cap"
+        assert returns == pollers - expected_waiters
+        assert web_server._CONFIGURED_PLATFORM_CACHE_WAITERS == expected_waiters
+        assert (
+            sum(web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS.values())
+            + web_server._CONFIGURED_PLATFORM_CACHE_WAITERS
+            == occupancy_cap
+        )
+        # Overflow callers were served the profile's stale entry, not blocked.
+        with outcomes_lock:
+            assert len(outcomes) == returns
+            assert all(outcome == {"discord"} for outcome in outcomes)
+
+        # A profile with nothing safe to serve fails fast on the same ceiling,
+        # even though six builder permits are still free.
+        local.home = unknown
+        started = time.monotonic()
+        with pytest.raises(TimeoutError, match="occupancy"):
+            web_server._load_configured_gateway_platforms()
+        assert time.monotonic() - started < 2.0
+        local.home = cached
+
+        # None of that started a discovery or disturbed the hung flight.
+        with entries_lock:
+            assert entries == entries_at_cap
+        assert sum(web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS.values()) == 1
+        assert (
+            web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[str(cached)] is hung_flight
+        )
+        assert not hung_flight["abandoned"]
+        assert str(unknown) not in web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT
+    finally:
+        release.set()
+        builder.join(timeout=30)
+        for thread in threads:
+            thread.join(timeout=30)
+
+    assert not builder.is_alive()
+    assert all(not thread.is_alive() for thread in threads)
+    # Everything parked drains and every slot is reclaimed.
+    with outcomes_lock:
+        assert len(outcomes) == pollers
+        assert all(outcome == {"discord"} for outcome in outcomes)
+    assert web_server._CONFIGURED_PLATFORM_CACHE_WAITERS == 0
+    assert web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS == {}
+    assert web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT == {}
+
+
+def test_configured_gateway_platform_cache_waiter_slot_released_on_every_exit(
+    monkeypatch, tmp_path
+):
+    """A waiter slot must never leak, whatever ends the wait."""
+    calls = 0
+    calls_lock = threading.Lock()
+    entered = threading.Event()
+    release = threading.Event()
+    outcome = {}
+    mode = "success"
+    version = 1
+
+    class FakeGatewayConfig:
+        @staticmethod
+        def get_connected_platforms():
+            return [SimpleNamespace(value="discord")]
+
+    def source_version(_home):
+        return (("config.yaml", 1, version, 10),)
+
+    def load_gateway_config():
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+        entered.set()
+        release.wait(timeout=30)
+        if mode == "error":
+            raise RuntimeError("config failure")
+        return FakeGatewayConfig()
+
+    def wait_for_platforms(name):
+        try:
+            outcome[name] = web_server._load_configured_gateway_platforms()
+        except BaseException as exc:
+            outcome[name] = exc
+
+    monkeypatch.setattr(web_server, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(web_server, "_configured_platform_source_version", source_version)
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_gateway_config)
+
+    def run_phase(name, finish):
+        """Park a waiter behind a wedged builder, then end the wait via `finish`."""
+        entered.clear()
+        release.clear()
+        outcome.clear()
+        builder = threading.Thread(target=wait_for_platforms, args=("builder",))
+        builder.start()
+        assert entered.wait(timeout=10)
+        waiter = threading.Thread(target=wait_for_platforms, args=("waiter",))
+        waiter.start()
+        assert _wait_for(
+            lambda: web_server._CONFIGURED_PLATFORM_CACHE_WAITERS == 1
+        ), f"{name}: waiter never registered"
+        try:
+            finish()
+        finally:
+            release.set()
+            builder.join(timeout=30)
+            waiter.join(timeout=30)
+        assert not builder.is_alive() and not waiter.is_alive()
+        assert web_server._CONFIGURED_PLATFORM_CACHE_WAITERS == 0, f"{name}: leaked"
+        web_server._CONFIGURED_PLATFORM_CACHE.clear()
+        web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT.clear()
+        web_server._CONFIGURED_PLATFORM_CACHE_BUILDERS.clear()
+        web_server._CONFIGURED_PLATFORM_CACHE_LATEST_GENERATION.clear()
+
+    # 1. Success: the builder publishes and the waiter picks the result up.
+    run_phase("success", lambda: release.set())
+    assert outcome["waiter"] == {"discord"}
+
+    # 2. Builder error: the waiter is woken with a failure.
+    mode = "error"
+    run_phase("error", lambda: release.set())
+    assert isinstance(outcome["waiter"], RuntimeError)
+    mode = "success"
+
+    # 3. Wait timeout: the waiter gives up on a builder that has not returned.
+    monkeypatch.setattr(
+        web_server, "_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT", 0.05, raising=False
+    )
+    run_phase(
+        "timeout",
+        lambda: _wait_for(lambda: isinstance(outcome.get("waiter"), TimeoutError)),
+    )
+    assert isinstance(outcome["waiter"], TimeoutError)
+    monkeypatch.setattr(
+        web_server, "_CONFIGURED_PLATFORM_CACHE_WAIT_TIMEOUT", 30.0, raising=False
+    )
+
+    # 4. Abandonment: a superseding caller wakes the waiter, which retries.
+    def supersede():
+        nonlocal version
+        flight = web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[str(tmp_path)]
+        version = 2
+        with web_server._CONFIGURED_PLATFORM_CACHE_LOCK:
+            web_server._abandon_configured_platform_flight(str(tmp_path), flight)
+        # The waiter retries, finds no flight and a free permit, and rebuilds.
+        assert _wait_for(lambda: web_server._CONFIGURED_PLATFORM_CACHE_WAITERS == 0)
+        assert _wait_for(lambda: calls >= 3)
+
+    run_phase("abandonment", supersede)
+    assert outcome["waiter"] == {"discord"}
+    version = 1
+
+    # 5. BaseException while parked: swap in an event whose wait() explodes.
+    class ExplodingEvent:
+        def __init__(self):
+            self._set = False
+
+        def wait(self, timeout=None):
+            raise KeyboardInterrupt("interrupted while parked")
+
+        def is_set(self):
+            return self._set
+
+        def set(self):
+            self._set = True
+
+    # Driven directly rather than through `run_phase`: swapping the flight's
+    # event would orphan any waiter already parked on the original one.
+    entered.clear()
+    release.clear()
+    outcome.clear()
+    builder = threading.Thread(target=wait_for_platforms, args=("builder",))
+    builder.start()
+    try:
+        assert entered.wait(timeout=10)
+        web_server._CONFIGURED_PLATFORM_CACHE_IN_FLIGHT[str(tmp_path)][
+            "event"
+        ] = ExplodingEvent()
+        interrupted = threading.Thread(target=wait_for_platforms, args=("interrupted",))
+        interrupted.start()
+        interrupted.join(timeout=10)
+        assert not interrupted.is_alive()
+        assert isinstance(outcome["interrupted"], KeyboardInterrupt)
+        assert web_server._CONFIGURED_PLATFORM_CACHE_WAITERS == 0, (
+            "base-exception: leaked"
+        )
+    finally:
+        release.set()
+        builder.join(timeout=30)
+
+    assert not builder.is_alive()
+    assert web_server._CONFIGURED_PLATFORM_CACHE_WAITERS == 0


### PR DESCRIPTION
## Summary
- cache the expensive gateway platform discovery used by frequently-polled `/api/status`
- invalidate per profile from cheap source fingerprints plus a 30-second TTL
- collapse normal concurrent misses while bounding stuck discovery builders and parked waiters process-wide
- protect late/superseded completions with generation high-water marks and BaseException-safe cleanup
- serve last-known data or fail fast when bounded discovery capacity is exhausted

## Why
`/api/status` called `load_gateway_config()` on every poll, repeatedly running plugin discovery and YAML/config loading. An authenticated 10-minute canary of the original exact patch reduced dashboard CPU mean to 5.51% and kept `/status` p99 at 225.6 ms.

## Tests
- `scripts/run_tests.sh tests/test_web_server_status_platform_cache.py -q` — 28 passed
- `scripts/run_tests.sh tests/test_web_server.py tests/test_web_server_status_topology_cache.py tests/test_web_server_sessiondb_eventloop.py tests/hermes_cli/test_web_server.py -q` — 178 passed, 3 skipped
- `uv run ruff check hermes_cli/web_server.py tests/test_web_server_status_platform_cache.py`
- `git diff --check`

Independent exact-head Codex review: PASS. Earlier review iterations found and drove fixes for hung-flight replacement, cross-profile builder bounds, and parked-waiter bounds.