### PR TITLE
fix(gateway): /stop leaves sibling thread runs alive under a named profile

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21034,7 +21034,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Only applies when the message originates in a thread.  In per-user
         thread mode (``thread_sessions_per_user=True``) each participant gets
         an isolated session key of the form
-        ``agent:main:{platform}:{chat_type}:{chat_id}:{thread_id}:{user_id}``,
+        ``agent:{ns}:{platform}:{chat_type}:{chat_id}:{thread_id}:{user_id}``
+        (``{ns}`` being ``main`` on the default profile, or the profile name
+        under multi-profile multiplexing),
         so a run started by another user is invisible to the caller's own
         ``/stop``.  This returns the keys of any *actually running* agents
         (not the pending sentinel, not the caller's own key) whose key shares
@@ -21049,13 +21051,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return []
         platform = source.platform.value
         chat_type = getattr(source, "chat_type", None) or ""
+        # Take the namespace slot from the caller's OWN key rather than
+        # hardcoding ``main``.  ``_session_key_namespace`` puts the profile in
+        # that slot (``agent:coder:...``) under multi-profile multiplexing, so
+        # a hardcoded ``agent:main`` prefix matched nothing for any named
+        # profile — ``/stop`` silently reported no sibling runs and left the
+        # other participants' runs alive.  Siblings share the caller's
+        # namespace by definition, so deriving it also keeps profiles
+        # isolated: a /stop in one profile must not reach another's runs.
+        own_parts = str(own_key or "").split(":")
+        namespace = (
+            own_parts[1]
+            if len(own_parts) > 1 and own_parts[0] == "agent" and own_parts[1]
+            else "main"
+        )
         # Prefix that every per-user key in this thread shares, up to and
         # including the thread_id segment.  Matching either the exact
         # shared-thread key or any key with a further (user_id) segment
         # (prefix + ":") avoids cross-matching an unrelated thread whose id
         # merely starts with this one.
         prefix = ":".join(
-            ["agent:main", platform, chat_type, str(chat_id), str(thread_id)]
+            [f"agent:{namespace}", platform, chat_type, str(chat_id), str(thread_id)]
         )
         matches = []
         for key, agent in self._running_agent_items():

--- a/tests/gateway/test_stop_thread_sibling.py
+++ b/tests/gateway/test_stop_thread_sibling.py
@@ -56,6 +56,51 @@ def test_sibling_returns_empty_for_non_thread_source():
     assert runner._sibling_thread_run_keys(nonthread, "agent:main:discord:group:chan1:userA") == []
 
 
+def test_sibling_matches_under_a_named_profile():
+    """The prefix must follow the caller's namespace, not a hardcoded ``main``.
+
+    ``_session_key_namespace`` puts a named profile in the namespace slot
+    (``agent:coder:...``), so a hardcoded ``agent:main`` prefix matched nothing
+    and ``/stop`` silently left the sibling's run alive under every profile
+    except the default one.
+    """
+    runner = object.__new__(GatewayRunner)
+    own = build_session_key(
+        _thread_source("userA"), thread_sessions_per_user=True, profile="coder"
+    )
+    sibling = build_session_key(
+        _thread_source("userB"), thread_sessions_per_user=True, profile="coder"
+    )
+    # Same chat+thread but a DIFFERENT profile must stay isolated.
+    other_profile = build_session_key(
+        _thread_source("userB"), thread_sessions_per_user=True, profile="writer"
+    )
+    # An unrelated thread whose id merely starts with this one.
+    other_thread = build_session_key(
+        _thread_source("userB", thread_id="thr11"),
+        thread_sessions_per_user=True,
+        profile="coder",
+    )
+    assert own.startswith("agent:coder:")
+    runner._running_agents = {
+        own: _FakeAgent(),
+        sibling: _FakeAgent(),
+        other_profile: _FakeAgent(),
+        other_thread: _FakeAgent(),
+    }
+    assert runner._sibling_thread_run_keys(_thread_source("userA"), own) == [sibling]
+
+
+def test_sibling_default_profile_prefix_is_unchanged():
+    """The default profile keeps the byte-identical ``agent:main`` behaviour."""
+    runner = object.__new__(GatewayRunner)
+    own = _per_user_key("userA")
+    sibling = _per_user_key("userB")
+    assert own.startswith("agent:main:")
+    runner._running_agents = {own: _FakeAgent(), sibling: _FakeAgent()}
+    assert runner._sibling_thread_run_keys(_thread_source("userA"), own) == [sibling]
+
+
 # ---------------------------------------------------------------------------
 # _handle_stop_command fallback path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
`_sibling_thread_run_keys` (used by `/stop` to find other participants' runs
in a shared thread under `thread_sessions_per_user=True`) built its match
prefix from a hardcoded `agent:main`. `_session_key_namespace` puts a named
profile in that exact slot (`agent:coder:...`), so under any profile other
than the default the prefix matched nothing: `/stop` silently reported no
sibling runs and left them running. Only the default profile ever worked.

## Fix
Derive the namespace from the caller's own key instead of hardcoding `main`.
Siblings share the caller's namespace by definition, so this also keeps
profiles isolated — a `/stop` in one profile must not reach another profile's
runs in the same thread. Default-profile keys build the byte-identical prefix
as before.

## Test plan
- `tests/gateway/test_stop_thread_sibling.py`: added the named-profile case
  (fails without this change), a profile-isolation case, a near-miss thread id
  guard (`thr11` vs `thr1`), and an explicit default-profile-unchanged guard.
- `.venv/Scripts/python.exe -m pytest tests/gateway/test_stop_thread_sibling.py -q` — 5 passed.

## Platforms tested
Windows (dev box). No platform-specific code paths touched.