### PR TITLE
fix(delegate): report failed status for non-retryable subagent client errors (#82599)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -667,6 +667,69 @@ class TestDelegateObservability(unittest.TestCase):
             result = json.loads(delegate_task(goal="Test empty sentinel", parent_agent=parent))
             self.assertEqual(result["results"][0]["status"], "failed")
 
+    def test_non_retryable_client_error_marks_status_failed(self):
+        """Regression (#82599): a child that aborted on a non-retryable
+        client error (HTTP 401, billing wall, ...) returns a NON-empty error
+        string as final_response with failed=True (see conversation_loop's
+        terminal abort paths). That error text must be reported as a failed
+        delegation, not dressed up as status=completed."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "glm-5.2"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "HTTP 401: token expired or incorrect",
+                "messages": [],
+                "api_calls": 1,
+                "completed": False,
+                "failed": True,
+                "error": "HTTP 401: token expired or incorrect",
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Reply with exactly: PING", parent_agent=parent))
+            entry = result["results"][0]
+
+            self.assertEqual(entry["status"], "failed")
+            self.assertEqual(entry["exit_reason"], "error")
+            # A hard abort is not truncation.
+            self.assertIs(entry["truncated"], False)
+            # The underlying error must reach the parent verbatim.
+            self.assertEqual(entry["error"], "HTTP 401: token expired or incorrect")
+
+    def test_budget_exhausted_with_summary_stays_completed(self):
+        """Contract guard for the fix above: completed=False alone does NOT
+        mean failure. A child that exhausted its iteration budget but still
+        produced a genuine summary stays status=completed with
+        exit_reason=max_iterations + truncated=True — only results explicitly
+        marked failed=True flip to failed."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 100
+            mock_child.session_completion_tokens = 50
+            mock_child.run_conversation.return_value = {
+                "final_response": "Refactored 3 of 5 modules before running out of budget",
+                "messages": [],
+                "api_calls": 10,
+                "completed": False,
+                "interrupted": False,
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Refactor modules", parent_agent=parent))
+            entry = result["results"][0]
+
+            self.assertEqual(entry["status"], "completed")
+            self.assertEqual(entry["exit_reason"], "max_iterations")
+            self.assertIs(entry["truncated"], True)
+            self.assertNotIn("error", entry)
+
 
 class TestSubagentCostRollup(unittest.TestCase):
     """Port of Kilo-Org/kilocode#9448 — parent's session_estimated_cost_usd

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3019,8 +3019,19 @@ def _run_single_child(
         # it instead of silently accepting zero-content "success".
         _empty_sentinel = summary.strip() == "(empty)"
 
+        # The conversation loop's terminal abort paths (non-retryable client
+        # errors like HTTP 401, billing walls, content-policy blocks, ...)
+        # return the error text as final_response and mark the result with
+        # ``failed=True`` (#82599). That error string must not read as usable
+        # output: report the delegation as failed. Note ``completed=False``
+        # alone does NOT mean failure — an iteration-budget-exhausted child
+        # still returns a genuine summary and stays "completed"+truncated.
+        _child_failed = bool(result.get("failed"))
+
         if interrupted:
             status = "interrupted"
+        elif _child_failed:
+            status = "failed"
         elif summary and not _empty_sentinel:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
@@ -3070,6 +3081,12 @@ def _run_single_child(
         # Determine exit reason
         if interrupted:
             exit_reason = "interrupted"
+        elif _child_failed:
+            # Terminal abort (non-retryable client error, billing wall, ...).
+            # Same vocabulary as the timeout/exception entry above; keeps
+            # ``truncated`` False and stops the transcript from reporting a
+            # contradictory exit_reason=max_iterations on a 1-call task.
+            exit_reason = "error"
         elif completed:
             exit_reason = "completed"
         else:


### PR DESCRIPTION
Fixes #82599

## Root cause
A child that aborted on a non-retryable client error (HTTP 401, billing wall, content-policy block) returns the error string as inal_response with ailed=True from un_conversation() — but _run_single_child() derived delegation status purely from summary non-emptiness. The error string qualified as "usable output", so every batch reported status=completed while the delegation was silently broken (xit_reason=max_iterations, 	runcated=true on a one-call task).

## Fix
	ools/delegate_tool.py::_run_single_child now checks esult["failed"] first: those aborts report status="failed" / xit_reason="error" (same vocabulary as the existing timeout/exception entries). completed=False alone is deliberately NOT treated as failure — iteration-budget-exhausted children still return genuine summaries and stay completed+truncated (documented intended behavior). Single, batch and background paths share this derivation point, so one fix covers all shapes; async queue copies status verbatim downstream.

## Verification
- New behavior-contract tests in 	ests/tools/test_delegate.py: non-retryable client error → failed status; budget-exhausted-with-summary → stays completed.
- scripts/run_tests.sh tests/tools/test_delegate.py → 71 passed; 8 sibling delegate/async-delegation files → 118 passed.