### PR TITLE
feat(kanban): exclude profiles from generic auto-decomposition via config (#83046)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2668,6 +2668,21 @@ DEFAULT_CONFIG = {
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.
         "auto_decompose_per_tick": 3,
+        # Profiles excluded from GENERIC auto-decomposition (#83046).
+        # Excluded names are removed from both the decomposer's prompt
+        # roster and its valid-assignee set, so free-form decomposition
+        # children can never be routed to them — use this for
+        # contract-bound profiles whose cards must arrive through an
+        # explicit dispatcher hand-off instead. Entries are matched
+        # case-insensitively against profile ids. The scope is
+        # deliberately narrow: directly created / explicitly assigned
+        # cards dispatch unchanged and never consult this list.
+        # Fail-closed: if exclusion empties the roster or excludes the
+        # resolved ``default_assignee``, decomposition is skipped — the
+        # root card stays in Triage with one board notice explaining why
+        # — rather than creating children that would land somewhere
+        # forbidden.
+        "auto_decompose_excluded_profiles": [],
         # Stale detection: running tasks that have exceeded this many
         # seconds without a heartbeat (since ``last_heartbeat_at``) are
         # auto-reclaimed to ``ready`` on the next dispatcher tick. The

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -32,6 +32,16 @@ Design notes
 * If the LLM picks an assignee that doesn't exist as a profile, we
   rewrite it to the configured ``default_assignee`` (or the default
   profile if unset). A child task NEVER ends up with ``assignee=None``.
+
+* Exclusions: ``kanban.auto_decompose_excluded_profiles`` (#83046)
+  removes profiles from BOTH the prompt roster and the valid-assignee
+  set so contract-bound profiles are never routed free-form children.
+  Fail-closed semantics: if the exclusion empties the roster or
+  excludes the resolved ``default_assignee``, decomposition is skipped —
+  the root stays in Triage with exactly one board notice (a comment,
+  which carries its own board event) explaining why — instead of
+  creating children that would land somewhere forbidden. Directly
+  created / explicitly assigned cards never consult this list.
 """
 
 from __future__ import annotations
@@ -214,12 +224,51 @@ def _resolve_default_assignee(cfg: dict) -> str:
         return "default"
 
 
-def _build_roster() -> tuple[list[dict], set[str]]:
+def _resolve_excluded_profiles(kanban_cfg: dict) -> frozenset[str]:
+    """Normalize ``kanban.auto_decompose_excluded_profiles`` to a name set.
+
+    Entries are canonicalized with ``profiles.normalize_profile_name``
+    so padded or mixed-case config values (``" Reviewer "``, ``"REVIEWER"``)
+    match how profile ids are stored on disk (#18498 convention).
+    Unparseable entries are ignored leniently — this module never raises
+    on expected failure modes — while genuinely dangerous configurations
+    (excluded default assignee, fully emptied roster) are handled
+    fail-closed by :func:`decompose_task`.
+    """
+    raw = (
+        kanban_cfg.get("auto_decompose_excluded_profiles")
+        if isinstance(kanban_cfg, dict)
+        else None
+    )
+    if not raw:
+        return frozenset()
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple, set)):
+        return frozenset()
+    excluded: set[str] = set()
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        try:
+            excluded.add(profiles_mod.normalize_profile_name(entry))
+        except ValueError:
+            continue
+    return frozenset(excluded)
+
+
+def _build_roster(
+    excluded: frozenset[str] = frozenset(),
+) -> tuple[list[dict], set[str]]:
     """Return (roster_for_prompt, valid_assignee_names).
 
     Each roster entry is ``{name, description, has_description}``. The
     valid-set is used after the LLM responds to rewrite invalid
     assignees to the default fallback.
+
+    ``excluded`` carries normalized profile names (see
+    ``_resolve_excluded_profiles``) that are dropped from BOTH surfaces,
+    so an excluded profile is neither prompted nor routable (#83046).
     """
     roster: list[dict] = []
     valid: set[str] = set()
@@ -229,6 +278,8 @@ def _build_roster() -> tuple[list[dict], set[str]]:
         logger.warning("decompose: failed to list profiles: %s", exc)
         return roster, valid
     for p in all_profiles:
+        if excluded and profiles_mod.normalize_profile_name(p.name) in excluded:
+            continue
         desc = (p.description or "").strip()
         roster.append({
             "name": p.name,
@@ -268,6 +319,26 @@ def _normalize_assignee_choice(
     return chosen
 
 
+def _record_skip_notice(task_id: str, reason: str, author: str) -> None:
+    """Leave exactly one durable notice that decomposition was skipped.
+
+    Reuses the existing comment surface — which appends its own board
+    event row — matching the ``BLOCKED:``/``SCHEDULED:`` CLI notice
+    convention; no new event kind or surface (#83046). A warning is also
+    logged so headless dispatcher ticks are visible in gateway.log.
+    """
+    logger.warning("decompose: %s", reason)
+    try:
+        with kb.connect_closing() as conn:
+            kb.add_comment(conn, task_id, author, f"DECOMPOSE SKIPPED: {reason}")
+    except Exception as exc:
+        # The skip decision itself must never crash the caller (the
+        # auto-decompose tick) — the root card simply stays in Triage.
+        logger.warning(
+            "decompose: could not record skip notice on %s: %s", task_id, exc,
+        )
+
+
 def decompose_task(
     task_id: str,
     *,
@@ -295,7 +366,35 @@ def decompose_task(
     default_assignee = _resolve_default_assignee(cfg)
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
     auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
-    roster, valid_names = _build_roster()
+    audit_author = author or _profile_author()
+    excluded = _resolve_excluded_profiles(kanban_cfg)
+    roster, valid_names = _build_roster(excluded=excluded)
+
+    # Fail-closed guards for GENERIC decomposition (#83046). The
+    # exclusion list is an invariant, not prompt advice: rather than
+    # risk free-form children reaching a contract-bound profile through
+    # the default fallback, skip the decomposition entirely, leave the
+    # root in Triage, and record one board notice explaining why. These
+    # checks live only on this path — directly created / explicitly
+    # assigned cards are untouched (the dispatcher never consults the
+    # exclusion list, and an already-assigned triage card keeps its
+    # assignee below).
+    if excluded:
+        if profiles_mod.normalize_profile_name(default_assignee) in excluded:
+            reason = (
+                "auto-decompose skipped: default_assignee "
+                f"{default_assignee!r} is listed in "
+                "kanban.auto_decompose_excluded_profiles"
+            )
+            _record_skip_notice(task_id, reason, audit_author)
+            return DecomposeOutcome(task_id, False, reason)
+        if not roster:
+            reason = (
+                "auto-decompose skipped: no routable profiles remain "
+                "after kanban.auto_decompose_excluded_profiles"
+            )
+            _record_skip_notice(task_id, reason, audit_author)
+            return DecomposeOutcome(task_id, False, reason)
 
     try:
         from agent.auxiliary_client import call_llm  # type: ignore
@@ -342,7 +441,6 @@ def decompose_task(
         return DecomposeOutcome(task_id, False, "LLM returned malformed JSON")
 
     fanout = bool(parsed.get("fanout"))
-    audit_author = author or _profile_author()
 
     if not fanout:
         # Fall back to single-task spec promotion (same effect as specify).

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1488,6 +1488,38 @@ def test_default_config_kanban_block_not_dropped_by_duplicate_key():
     assert "auto_decompose" in kanban
 
 
+def test_auto_decompose_excluded_profiles_defaults_to_empty_list():
+    """#83046: the exclusion list must default to empty — current behavior
+    (every installed profile is generically routable) is the contract."""
+    excluded = DEFAULT_CONFIG["kanban"].get("auto_decompose_excluded_profiles")
+    assert isinstance(excluded, list)
+    assert excluded == []
+
+
+def test_auto_decompose_excluded_profiles_deep_merges_from_user_yaml(
+    tmp_path, monkeypatch
+):
+    """A user-supplied exclusion list merges over the additive default via
+    the deep-merge path — no _config_version bump or migration required."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({
+        "kanban": {"auto_decompose_excluded_profiles": ["reviewer"]},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli import config as cfg_mod
+    cfg_mod._cached_config = None  # type: ignore[attr-defined]
+
+    try:
+        loaded = load_config()
+    finally:
+        cfg_mod._cached_config = None  # type: ignore[attr-defined]
+
+    assert loaded["kanban"]["auto_decompose_excluded_profiles"] == ["reviewer"]
+    # Invariant: loading leaves the user on the current latest version —
+    # an additive key never forces a migration.
+    assert loaded["_config_version"] == DEFAULT_CONFIG["_config_version"]
+
+
 def test_default_config_has_no_duplicate_top_level_keys():
     """Guard against any duplicate key silently shadowing a default."""
     import ast

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -161,3 +161,305 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+# ---------------------------------------------------------------------------
+# auto_decompose_excluded_profiles (#83046)
+# ---------------------------------------------------------------------------
+
+def _capturing_aux(content: str):
+    """Patch call_llm with a side_effect that records the prompt messages.
+
+    Returns ``(patcher, captured)`` — ``captured["messages"]`` holds the
+    [system, user] message list the decomposer actually sent.
+    """
+    captured: dict = {}
+
+    def _fake_call_llm(*, task, messages, **kwargs):
+        captured["messages"] = messages
+        return _fake_aux_response(content)
+
+    return (
+        patch("agent.auxiliary_client.call_llm", side_effect=_fake_call_llm),
+        captured,
+    )
+
+
+def test_excluded_profile_absent_from_roster_prompt_and_valid_set(kanban_home):
+    """The reporter's core invariant: an excluded profile appears in NEITHER
+    the roster the LLM is prompted with NOR the post-hoc valid-assignee set
+    — so a response that names it anyway cannot create a child for it."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a feature", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "test split",
+        "tasks": [
+            {"title": "research", "body": "look it up", "assignee": "worker", "parents": []},
+            # The LLM disobeys the (now shorter) roster and names the
+            # excluded profile directly.
+            {"title": "review it", "body": "check the work", "assignee": "reviewer", "parents": []},
+        ],
+    })
+
+    aux_patch, captured = _capturing_aux(llm_payload)
+    # Mixed-case + padding in config must match the on-disk id.
+    cfg_patch = patch(
+        "hermes_cli.kanban_decompose._load_config",
+        return_value={
+            "kanban": {
+                "default_assignee": "worker",
+                "auto_decompose_excluded_profiles": [" Reviewer "],
+            },
+        },
+    )
+
+    patches = _patch_list_profiles(["orchestrator", "reviewer", "worker"]) + [
+        aux_patch,
+        cfg_patch,
+    ]
+    for p in patches:
+        p.start()
+    try:
+        outcome = decomp.decompose_task(tid, author="me")
+
+        # Unit-level: the valid-assignee surface excludes the profile too.
+        excluded = decomp._resolve_excluded_profiles(
+            {"auto_decompose_excluded_profiles": [" Reviewer "]}
+        )
+        assert excluded == frozenset({"reviewer"})
+        roster, valid = decomp._build_roster(excluded=excluded)
+        assert {e["name"] for e in roster} == {"orchestrator", "worker"}
+        assert "reviewer" not in valid
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    user_msg = next(
+        m["content"] for m in captured["messages"] if m["role"] == "user"
+    )
+    assert "reviewer" not in user_msg  # absent from the prompted roster
+    assert "orchestrator" in user_msg and "worker" in user_msg
+
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        children = [kb.get_task(conn, cid) for cid in outcome.child_ids]
+    assert root.status == "todo"
+    by_title = {c.title: c for c in children}
+    assert by_title["review it"].assignee == "worker"
+
+
+def test_fanout_false_naming_excluded_profile_falls_back_to_default(kanban_home):
+    """Single-task promotion shares the routing guarantee: an LLM assignee
+    naming an excluded profile falls back to default_assignee, never to
+    the excluded card."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="route me safely", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Tightened title",
+        "body": "Route to fallback.",
+        "assignee": "REVIEWER",  # excluded (case-insensitively)
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "reviewer", "fallback"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={
+                "kanban": {
+                    "default_assignee": "fallback",
+                    "auto_decompose_excluded_profiles": ["reviewer"],
+                },
+            },
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.assignee == "fallback"
+
+
+def test_directly_assigned_card_ignores_exclusions(kanban_home):
+    """Scope guarantee: explicit assignment is never rewritten by the
+    exclusion list. A triage card already assigned to the excluded profile
+    promotes with its assignee intact; a non-triage card assigned to it is
+    simply none of the decomposer's business."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="pre-assigned", assignee="reviewer", triage=True)
+        other_tid = kb.create_task(conn, title="explicit ready card", assignee="reviewer")
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Tightened title",
+        "body": "Keep the existing assignee.",
+        "assignee": None,
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "reviewer", "fallback"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={
+                "kanban": {
+                    "default_assignee": "fallback",
+                    "auto_decompose_excluded_profiles": ["reviewer"],
+                },
+            },
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+            skipped = decomp.decompose_task(other_tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    with kb.connect() as conn:
+        promoted = kb.get_task(conn, tid)
+        untouched = kb.get_task(conn, other_tid)
+    # Parentless specified tasks flip straight to ready (recompute_ready
+    # runs inline after specify) — the point here is the assignee.
+    assert promoted.status == "ready"
+    assert promoted.assignee == "reviewer"
+    assert skipped.ok is False
+    assert "not in triage" in skipped.reason
+    assert untouched.status == "ready"
+    assert untouched.assignee == "reviewer"
+
+
+def test_excluded_default_assignee_fails_closed(kanban_home):
+    """Excluding the resolved default_assignee would silently route every
+    unmatched child at the forbidden profile — fail closed instead: no
+    LLM call, no children, root stays in Triage, one board notice."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="dangerous config", triage=True)
+
+    aux_mock = MagicMock(return_value=_fake_aux_response("{}"))
+    aux_patch = patch("agent.auxiliary_client.call_llm", aux_mock)
+    cfg_patch = patch(
+        "hermes_cli.kanban_decompose._load_config",
+        return_value={
+            "kanban": {
+                "default_assignee": "fallback",
+                "auto_decompose_excluded_profiles": ["fallback"],
+            },
+        },
+    )
+    patches = _patch_list_profiles(["orchestrator", "fallback"]) + [
+        aux_patch,
+        cfg_patch,
+    ]
+    for p in patches:
+        p.start()
+    try:
+        outcome = decomp.decompose_task(tid, author="auto-decomposer")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert "auto_decompose_excluded_profiles" in outcome.reason
+
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        comments = kb.list_comments(conn, tid)
+        events = kb.list_events(conn, tid)
+    assert root.status == "triage"  # fail-closed: root untouched
+    assert len(comments) == 1
+    assert comments[0].body.startswith("DECOMPOSE SKIPPED:")
+    assert comments[0].author == "auto-decomposer"
+    assert sum(1 for e in events if e.kind == "commented") == 1
+    aux_mock.assert_not_called()
+
+
+def test_exclusion_emptying_roster_fails_closed(kanban_home):
+    """Excluding every installed profile leaves nothing routable — skip
+    loudly rather than prompting the LLM with an empty roster."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="no one left", triage=True)
+
+    aux_mock = MagicMock(
+        return_value=_fake_aux_response(jsonlib.dumps({"fanout": True, "tasks": []}))
+    )
+    aux_patch = patch("agent.auxiliary_client.call_llm", aux_mock)
+    cfg_patch = patch(
+        "hermes_cli.kanban_decompose._load_config",
+        return_value={"kanban": {"auto_decompose_excluded_profiles": ["solo"]}},
+    )
+    # For the roster-empty guard (not the default-assignee guard) to fire,
+    # the resolved default assignee must sit outside BOTH the exclusion set
+    # and the roster. Simulate the real shape where the active profile
+    # resolves to a name absent from list_profiles() (list_profiles omits
+    # the built-in default when the default home dir doesn't exist).
+    # Started after _patch_list_profiles' version so this one wins.
+    active_patch = patch(
+        "hermes_cli.profiles.get_active_profile_name",
+        return_value="default",
+    )
+    patches = (
+        _patch_list_profiles(["solo"]) + [aux_patch, cfg_patch, active_patch]
+    )
+    for p in patches:
+        p.start()
+    try:
+        outcome = decomp.decompose_task(tid, author="auto-decomposer")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert "no routable profiles remain" in outcome.reason
+
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        comments = kb.list_comments(conn, tid)
+    assert root.status == "triage"
+    assert len(comments) == 1
+    assert comments[0].body.startswith("DECOMPOSE SKIPPED:")
+    aux_mock.assert_not_called()
+
+
+def test_empty_exclusion_list_preserves_existing_behavior(kanban_home):
+    """The default (empty) list is a no-op: every profile stays routable
+    and fan-out proceeds exactly as before #83046."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a feature", triage=True)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "test split",
+        "tasks": [
+            {"title": "review it", "body": "check the work", "assignee": "reviewer", "parents": []},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "reviewer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={"kanban": {"auto_decompose_excluded_profiles": []}},
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    with kb.connect() as conn:
+        child = kb.get_task(conn, outcome.child_ids[0])
+    assert child.assignee == "reviewer"
+
+

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -611,6 +611,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 |---|---|---|
 | `auto_decompose` | `true` | Dispatcher auto-runs the built-in decomposer for Triage tasks every tick. It does not gate profile-driven `kanban_create` calls or creator wake turns. |
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
+| `auto_decompose_excluded_profiles` | `[]` | Profiles removed from generic decomposition: excluded names never appear in the decomposer's roster prompt or valid-assignee set, so free-form children can't be routed at them. Use it for contract-bound profiles whose cards must arrive through an explicit dispatcher hand-off. Directly created / explicitly assigned cards are unaffected. Fail-closed: if exclusion empties the roster or excludes the resolved default assignee, decomposition is skipped and the root card stays in Triage with one board notice. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When `kanban_create` runs inside a persistent gateway/TUI session, terminal events resume that originating agent with a synthetic status turn. Set to `false` for passive completion or to require explicit `kanban_notify-subscribe` calls. Independent of `auto_decompose`. |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -433,6 +433,7 @@ hermes dashboard        # 导航栏中出现 "Kanban" 标签页，位于 "Skills
 |---|---|---|
 | `auto_decompose` | `true` | 调度器每 tick 为 Triage 任务运行内置分解器；它不会限制配置文件驱动的 `kanban_create` 或创建者唤醒回合。 |
 | `auto_decompose_per_tick` | `3` | 每个调度器 tick 的分解上限。超出部分推迟到下一个 tick。 |
+| `auto_decompose_excluded_profiles` | `[]` | 从通用分解中排除的配置文件：被排除的名称既不会出现在分解器的名册提示中，也不会出现在有效受让人集合中，因此自由格式的子任务无法路由到它们。适用于必须通过显式调度交接才能接收卡片的契约绑定配置文件。直接创建/显式指派的卡片不受影响。失败关闭：若排除后名册为空，或排除了已解析的默认受让人，则跳过分解，根卡片保留在 Triage 并附带一条看板通知。 |
 | `orchestrator_profile` | `""` | 拥有分解权的配置文件。空 = 回退到活动默认配置文件。 |
 | `default_assignee` | `""` | LLM 选择未知配置文件时子任务的落地位置。空 = 回退到活动默认配置文件。 |
 | `auto_subscribe_on_create` | `true` | 当 `kanban_create` 在持久 gateway/TUI 会话中运行时，终止事件会通过合成状态回合恢复原始 agent。设为 `false` 可让完成保持被动，或要求显式调用 `kanban_notify-subscribe`。此设置独立于 `auto_decompose`。 |


### PR DESCRIPTION
Fixes #83046

## Problem
Generic auto-decomposition treated every installed profile as routable, so free-form children landed on contract-bound profiles (reporter's reviewer profile received 23 blocked runs).

## Fix
New additive config key `kanban.auto_decompose_excluded_profiles: []` (no version bump — deep-merge handles new keys):
- Excluded names are canonicalized like profile ids elsewhere and removed from BOTH the prompt roster and the valid-assignee set, so an LLM naming an excluded profile simply falls back to the default assignee (identical to hallucinated-name handling).
- Fail-closed: if exclusion empties the roster or excludes the resolved default assignee, decomposition is skipped entirely — root stays in Triage with exactly one durable board notice + one warning log, zero LLM calls.
- Directly-assigned cards never consult the list. Empty config = byte-identical behavior to today.

## Verification
Implements the reporter's acceptance matrix as tests in `tests/hermes_cli/test_kanban_decompose.py` (excluded name absent from prompt+valid set incl. case-normalization, fallback-not-child for named-excluded, direct assignment unaffected, excluded-default fails closed with single notice, empty-list parity). Plus invariant-style DEFAULT_CONFIG coverage in `tests/hermes_cli/test_config.py`. All green via `scripts/run_tests.sh`.