### PR TITLE
fix(kanban): run auto-decompose tick on every dispatch path, warn when no dispatcher (#87283)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -57,6 +57,32 @@ def _resolve_auto_decompose_settings(
     return enabled, per_tick
 
 
+def _make_auto_decompose_tick() -> "Callable[[int], int]":
+    """Build the dispatcher's per-tick auto-decompose callable.
+
+    Thin adapter over the canonical shared implementation
+    (``hermes_cli.kanban_decompose.run_auto_decompose_tick``, #87283) so
+    the gateway, dashboard nudge, CLI dispatch, and legacy daemon all run
+    the same pass and cannot drift. Kept as a module-level factory so the
+    delegation is directly testable without a live GatewayRunner.
+    """
+    def _auto_decompose_tick(auto_decompose_per_tick: int) -> int:
+        """Run the auto-decomposer for up to N triage tasks across all
+        boards. Returns the number of triage tasks that were successfully
+        decomposed or specified this tick.
+        """
+        try:
+            from hermes_cli.kanban_decompose import run_auto_decompose_tick
+        except Exception as exc:  # pragma: no cover
+            logger.warning(
+                "kanban auto-decompose: import failed (%s); skipping", exc,
+            )
+            return 0
+        return run_auto_decompose_tick(per_tick=auto_decompose_per_tick)
+
+    return _auto_decompose_tick
+
+
 def _kanban_dispatch_allowed() -> bool:
     """Return False while the global emergency stop (`hermes pause`) is engaged.
 
@@ -1597,82 +1623,9 @@ class GatewayKanbanWatchersMixin:
             """Re-resolve (enabled, per_tick) from current config each tick."""
             return _resolve_auto_decompose_settings(_load_config)
 
-        def _auto_decompose_tick(auto_decompose_per_tick: int) -> int:
-            """Run the auto-decomposer for up to N triage tasks across all
-            boards. Returns the number of triage tasks that were
-            successfully decomposed or specified this tick.
-            """
-            try:
-                from hermes_cli import kanban_decompose as _decomp
-            except Exception as exc:  # pragma: no cover
-                logger.warning(
-                    "kanban auto-decompose: import failed (%s); skipping", exc,
-                )
-                return 0
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
-            attempted = 0
-            successes = 0
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
-                if attempted >= auto_decompose_per_tick:
-                    break
-                # Pin this board for the duration of the call — same
-                # pattern as the dashboard specify endpoint. The
-                # decomposer module connects with no board kwarg and
-                # relies on the env var.
-                prev_env = os.environ.get("HERMES_KANBAN_BOARD")
-                try:
-                    os.environ["HERMES_KANBAN_BOARD"] = slug
-                    try:
-                        triage_ids = _decomp.list_triage_ids()
-                    except Exception as exc:
-                        logger.debug(
-                            "kanban auto-decompose: list_triage_ids failed on board %s (%s)",
-                            slug, exc,
-                        )
-                        triage_ids = []
-                    for tid in triage_ids:
-                        if attempted >= auto_decompose_per_tick:
-                            break
-                        attempted += 1
-                        try:
-                            outcome = _decomp.decompose_task(
-                                tid, author="auto-decomposer",
-                            )
-                        except Exception:
-                            logger.exception(
-                                "kanban auto-decompose: decompose_task crashed on %s",
-                                tid,
-                            )
-                            continue
-                        if outcome.ok:
-                            successes += 1
-                            if outcome.fanout and outcome.child_ids:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → %d children",
-                                    slug, tid, len(outcome.child_ids),
-                                )
-                            else:
-                                logger.info(
-                                    "kanban auto-decompose [%s]: %s → single task (no fanout)",
-                                    slug, tid,
-                                )
-                        else:
-                            # Common no-op reasons (no aux client configured) shouldn't
-                            # spam logs every tick. Log at debug.
-                            logger.debug(
-                                "kanban auto-decompose [%s]: %s skipped: %s",
-                                slug, tid, outcome.reason,
-                            )
-                finally:
-                    if prev_env is None:
-                        os.environ.pop("HERMES_KANBAN_BOARD", None)
-                    else:
-                        os.environ["HERMES_KANBAN_BOARD"] = prev_env
-            return successes
+        # The dispatcher's auto-decompose pass delegates to the canonical
+        # shared implementation (#87283) — see ``_make_auto_decompose_tick``.
+        _auto_decompose_tick = _make_auto_decompose_tick()
 
         logger.info(
             "kanban dispatcher: embedded in gateway (interval=%.1fs)", interval

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2658,6 +2658,18 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         max_in_progress_per_profile = None
         max_in_progress = None
         max_spawn = getattr(args, "max", None)
+    if not getattr(args, "dry_run", False):
+        # Same auto-decompose pass the gateway-embedded dispatcher runs
+        # before every tick (#87283), so `hermes kanban dispatch` promotes
+        # fresh triage cards instead of silently skipping them. Skipped
+        # under --dry-run so an inspection pass never mutates the board.
+        # Best-effort: the tick never raises, but guard anyway so a broken
+        # decomposer can't fail the dispatch.
+        try:
+            from hermes_cli.kanban_decompose import run_auto_decompose_tick
+            run_auto_decompose_tick()
+        except Exception:
+            pass
     with kb.connect_closing() as conn:
         res = kb.dispatch_once(
             conn,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10967,6 +10967,18 @@ def run_daemon(
 
     while not stop_event.is_set():
         try:
+            # Auto-decompose fresh triage tasks before claiming/spawning —
+            # the same pass the gateway-embedded dispatcher runs every tick
+            # (#87283), so the standalone daemon doesn't strand triage
+            # cards the way the bare dispatch_once loop did. Lazy import:
+            # kanban_decompose imports this module at its own module level.
+            # The tick is best-effort and never raises; the guard keeps a
+            # broken decomposer from killing the daemon either.
+            try:
+                from hermes_cli.kanban_decompose import run_auto_decompose_tick
+                run_auto_decompose_tick()
+            except Exception:
+                pass
             # Resolve the global concurrency cap the same way the gateway
             # dispatcher and `hermes kanban dispatch` do (OOF-30): explicit
             # kanban.max_in_progress wins, otherwise the memory-derived

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -41,7 +41,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Callable, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import profiles as profiles_mod
@@ -466,3 +466,142 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
             limit=1000,
         )
     return [row.id for row in rows]
+
+
+def resolve_auto_decompose_settings(
+    load_config: Optional[Callable[[], Any]] = None,
+) -> "tuple[bool, int]":
+    """Resolve the live ``(enabled, per_tick)`` auto-decompose settings.
+
+    Canonical implementation shared by EVERY dispatcher entry point —
+    gateway watcher, dashboard ``POST /dispatch`` nudge,
+    ``hermes kanban dispatch``, and the legacy standalone daemon
+    (#87283) — so the gating cannot drift between them. (The gateway's
+    ``gateway/kanban_watchers._resolve_auto_decompose_settings`` is a
+    verbatim twin kept for its import-free call site; a parity test in
+    ``tests/gateway/test_kanban_auto_decompose_live.py`` pins the two
+    together.)
+
+    Read fresh from config on every tick (#49638) so that flipping
+    ``kanban.auto_decompose: false`` to STOP runaway fan-out takes effect
+    on the next tick instead of requiring a restart of whichever process
+    hosts the dispatcher. Auto-decompose is a safety toggle — a user who
+    sees it create and launch tasks they didn't intend reaches for this
+    flag to halt it, and a stale boot-captured value silently ignoring
+    that change is the bug reported in #49638.
+
+    Fails **safe**: if the config read raises, return ``(False, 3)`` — a
+    transient read error must never re-enable a feature the user turned
+    off, nor fall back to the burst-prone default-on behaviour.
+    ``per_tick`` is clamped to ``>= 1``.
+    """
+    if load_config is None:
+        load_config = _load_config
+    try:
+        cfg = load_config()
+    except Exception:
+        return False, 3
+    kcfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+    enabled = bool(kcfg.get("auto_decompose", True))
+    try:
+        per_tick = int(kcfg.get("auto_decompose_per_tick", 3) or 3)
+    except (TypeError, ValueError):
+        per_tick = 3
+    if per_tick < 1:
+        per_tick = 1
+    return enabled, per_tick
+
+
+def run_auto_decompose_tick(*, per_tick: Optional[int] = None) -> int:
+    """Run the auto-decomposer over fresh triage tasks on every
+    non-archived board. Returns the number of triage tasks that were
+    successfully decomposed or specified this tick.
+
+    This is the shared auto-decompose pass that the gateway-embedded
+    dispatcher has always run before each :func:`dispatch_once` tick.
+    Every other dispatch entry point (dashboard ``POST /dispatch``
+    nudge, ``hermes kanban dispatch``, the legacy standalone daemon)
+    now calls it too (#87283), so triage cards no longer stall forever
+    on dashboard-only installs with no gateway running.
+
+    Gating (resolved fresh from config on every call, #49638):
+
+    * ``kanban.auto_decompose`` (default True) — when off this is an
+      immediate no-op returning 0.
+    * ``kanban.auto_decompose_per_tick`` (default 3) — caps how many
+      triage tasks one tick may attempt so a bulk-load doesn't
+      burst-spend the aux LLM; the remainder defers to subsequent ticks.
+
+    Error isolation: import failure, board-listing failure, and any
+    single-card crash are logged and skipped — one bad card must never
+    kill the dispatch tick that follows. This function never raises;
+    callers can invoke it bare before their ``dispatch_once``.
+    """
+    enabled, configured_cap = resolve_auto_decompose_settings()
+    if not enabled:
+        return 0
+    cap = per_tick if per_tick is not None else configured_cap
+    if cap < 1:
+        cap = 1
+    try:
+        boards = kb.list_boards(include_archived=False)
+    except Exception:
+        boards = [kb.read_board_metadata(kb.DEFAULT_BOARD)]
+    attempted = 0
+    successes = 0
+    for b in boards:
+        slug = b.get("slug") or kb.DEFAULT_BOARD
+        if attempted >= cap:
+            break
+        # Pin this board for the duration of the call — same
+        # pattern as the dashboard specify endpoint. The decomposer
+        # helpers connect with no board kwarg and rely on the env var.
+        prev_env = os.environ.get("HERMES_KANBAN_BOARD")
+        try:
+            os.environ["HERMES_KANBAN_BOARD"] = slug
+            try:
+                triage_ids = list_triage_ids()
+            except Exception as exc:
+                logger.debug(
+                    "kanban auto-decompose: list_triage_ids failed on "
+                    "board %s (%s)", slug, exc,
+                )
+                triage_ids = []
+            for tid in triage_ids:
+                if attempted >= cap:
+                    break
+                attempted += 1
+                try:
+                    outcome = decompose_task(tid, author="auto-decomposer")
+                except Exception:
+                    logger.exception(
+                        "kanban auto-decompose: decompose_task crashed on %s",
+                        tid,
+                    )
+                    continue
+                if outcome.ok:
+                    successes += 1
+                    if outcome.fanout and outcome.child_ids:
+                        logger.info(
+                            "kanban auto-decompose [%s]: %s → %d children",
+                            slug, tid, len(outcome.child_ids),
+                        )
+                    else:
+                        logger.info(
+                            "kanban auto-decompose [%s]: %s → single task "
+                            "(no fanout)",
+                            slug, tid,
+                        )
+                else:
+                    # Common no-op reasons (no aux client configured)
+                    # shouldn't spam logs every tick. Log at debug.
+                    logger.debug(
+                        "kanban auto-decompose [%s]: %s skipped: %s",
+                        slug, tid, outcome.reason,
+                    )
+        finally:
+            if prev_env is None:
+                os.environ.pop("HERMES_KANBAN_BOARD", None)
+            else:
+                os.environ["HERMES_KANBAN_BOARD"] = prev_env
+    return successes

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2287,14 +2287,44 @@ def dispatch(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        if not dry_run:
+            # Same auto-decompose pass the gateway-embedded dispatcher runs
+            # before every tick (#87283): without it, a dashboard-only
+            # install (no gateway) leaves triage cards stalled forever.
+            # Skipped under dry_run so an inspection pass never mutates the
+            # board. Best-effort — never raises, and a failure here must
+            # not block the dispatch itself.
+            try:
+                from hermes_cli.kanban_decompose import run_auto_decompose_tick
+                run_auto_decompose_tick()
+            except Exception:
+                log.exception("kanban auto-decompose failed during dispatch nudge")
         result = kanban_db.dispatch_once(
             conn, dry_run=dry_run, max_spawn=max_n, board=board,
         )
         # DispatchResult is a dataclass.
         try:
-            return asdict(result)
+            body = asdict(result)
         except TypeError:
-            return {"result": str(result)}
+            body = {"result": str(result)}
+        # Dispatcher-presence probe, same helper create-time uses: when no
+        # long-lived dispatcher will pick work up after this one-off nudge,
+        # say so instead of leaving the user with silent nothingness
+        # (#87283 / #90277). Fails open internally — a broken probe adds
+        # no warning rather than a false one.
+        try:
+            from hermes_cli.kanban import _check_dispatcher_presence
+            from hermes_constants import get_hermes_home
+
+            running, message = _check_dispatcher_presence(
+                hermes_home=get_hermes_home()
+            )
+            if not running and message:
+                body["warning"] = message
+        except Exception:
+            # Probe failure must never break the nudge response.
+            pass
+        return body
     finally:
         conn.close()
 

--- a/tests/gateway/test_kanban_auto_decompose_live.py
+++ b/tests/gateway/test_kanban_auto_decompose_live.py
@@ -27,3 +27,67 @@ def test_disabled_when_flag_false():
     assert enabled is False
 
 
+# ---------------------------------------------------------------------------
+# Shared tick wiring (#87283)
+#
+# The auto-decompose pass now lives in
+# ``hermes_cli.kanban_decompose.run_auto_decompose_tick`` and is called by
+# every dispatch entry point. The gateway's module-level resolver stays a
+# verbatim twin (its call site must not depend on a hermes_cli import), so
+# these tests pin the twin and the canonical resolver together, and pin
+# the watcher closure's delegation.
+# ---------------------------------------------------------------------------
+
+
+def _shared_resolver(cfg):
+    from hermes_cli.kanban_decompose import resolve_auto_decompose_settings
+
+    return resolve_auto_decompose_settings(lambda: cfg)
+
+
+def test_gateway_resolver_matches_shared_resolver():
+    """Drift-guard: the import-free gateway twin and the canonical shared
+    resolver must agree on every representative config shape."""
+    cases = [
+        {},
+        {"kanban": {}},
+        {"kanban": {"auto_decompose": True}},
+        {"kanban": {"auto_decompose": False}},
+        {"kanban": {"auto_decompose_per_tick": 7}},
+        {"kanban": {"auto_decompose_per_tick": 0}},
+        {"kanban": {"auto_decompose_per_tick": -2}},
+        {"kanban": {"auto_decompose_per_tick": "5"}},
+        {"kanban": {"auto_decompose_per_tick": "junk"}},
+    ]
+    for cfg in cases:
+        gateway = _resolve_auto_decompose_settings(lambda c=cfg: c)
+        shared = _shared_resolver(cfg)
+        assert gateway == shared, f"drift on cfg={cfg!r}: {gateway} != {shared}"
+
+
+def test_gateway_resolver_fails_safe_on_config_error():
+    def _raises():
+        raise RuntimeError("config unreadable")
+
+    # Fails CLOSED: a transient read error must not re-enable a feature
+    # the user may have turned off.
+    assert _resolve_auto_decompose_settings(_raises) == (False, 3)
+
+
+def test_watcher_closure_delegates_to_shared_tick(monkeypatch):
+    """The dispatcher-watcher closure must route through
+    ``run_auto_decompose_tick`` so the four entry points cannot drift."""
+    import gateway.kanban_watchers as kw_mod
+
+    calls: list[int] = []
+    import hermes_cli.kanban_decompose as decomp_mod
+
+    monkeypatch.setattr(
+        decomp_mod, "run_auto_decompose_tick",
+        lambda *, per_tick=None: calls.append(per_tick) or 3,
+    )
+    tick = kw_mod._make_auto_decompose_tick()
+    assert tick(2) == 3
+    assert calls == [2]
+
+

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1408,3 +1408,128 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         conn.close()
 
 
+# ---------------------------------------------------------------------------
+# Auto-decompose on every dispatch entry point (#87283)
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_ns(**overrides) -> argparse.Namespace:
+    ns = argparse.Namespace(
+        dry_run=False, max=None, json=True,
+        failure_limit=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
+    )
+    for k, v in overrides.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def test_cmd_dispatch_decomposes_triage_card_outside_gateway(
+    kanban_home, monkeypatch, capsys,
+):
+    """`hermes kanban dispatch` must run the same auto-decompose pass the
+    gateway-embedded dispatcher runs (#87283): one CLI pass specifies a
+    fresh triage card (real decompose path, aux LLM mocked) AND dispatches
+    it — worker spawn stubbed — instead of the card silently stalling in
+    the triage column."""
+    import hermes_cli.kanban as kb_cli
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="rough idea", triage=True)
+
+    fake_profiles = [
+        SimpleNamespace(
+            name="orchestrator", is_default=True, description="d",
+            description_auto=False, model="m", provider="p", skill_count=1,
+        ),
+    ]
+    monkeypatch.setattr("hermes_cli.profiles.list_profiles",
+                        lambda: fake_profiles)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profile_exists",
+        lambda x: x == "orchestrator",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name",
+        lambda: "orchestrator",
+    )
+    llm_payload = json.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Polished idea",
+        "body": "**Goal**\nDo it.",
+    })
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=llm_payload))]
+    )
+    monkeypatch.setattr(
+        "agent.auxiliary_client.call_llm", lambda **kw: resp,
+    )
+    # Stub the worker spawner so the post-decompose dispatch_once can run
+    # its real claim path without launching a real `hermes -p` subprocess.
+    monkeypatch.setattr(kb, "_default_spawn", lambda *a, **k: 4242)
+
+    rc = kb_cli._cmd_dispatch(_dispatch_ns())
+    captured = capsys.readouterr()
+    assert rc == 0
+
+    # The tick fired BEFORE dispatch_once: the card was specified out of
+    # triage and then claimed+spawned in the same pass.
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.title == "Polished idea"
+    assert task.status == "running"
+    payload = json.loads(captured.out)
+    assert any(row["task_id"] == tid for row in payload["spawned"])
+
+
+def test_cmd_dispatch_dry_run_does_not_mutate_board(kanban_home, monkeypatch):
+    """--dry-run is an inspection mode: it must NOT create child tasks or
+    promote triage cards as a side effect."""
+    import hermes_cli.kanban as kb_cli
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="inspect me", triage=True)
+
+    called: list[int] = []
+    import hermes_cli.kanban_decompose as decomp_mod
+    monkeypatch.setattr(
+        decomp_mod, "run_auto_decompose_tick",
+        lambda *a, **kw: called.append(1) or 0,
+    )
+
+    rc = kb_cli._cmd_dispatch(_dispatch_ns(dry_run=True))
+    assert rc == 0
+    assert called == []
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_run_daemon_runs_auto_decompose_tick_before_dispatch_once(
+    kanban_home, monkeypatch,
+):
+    """The legacy standalone daemon loop must run the shared auto-decompose
+    tick ahead of each dispatch_once, in that order, like the gateway."""
+    sequence: list[str] = []
+
+    import hermes_cli.kanban_decompose as decomp_mod
+    monkeypatch.setattr(
+        decomp_mod, "run_auto_decompose_tick",
+        lambda *a, **kw: sequence.append("auto-decompose") or 0,
+    )
+
+    stop_event = threading.Event()
+
+    def _on_tick(_res):
+        sequence.append("dispatch")
+        stop_event.set()
+
+    kb.run_daemon(
+        interval=5.0,
+        stop_event=stop_event,
+        on_tick=_on_tick,
+    )
+    assert sequence == ["auto-decompose", "dispatch"], (
+        f"expected [auto-decompose, dispatch], got {sequence!r}"
+    )
+
+

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -8,6 +8,7 @@ and the assignee-fallback logic.
 from __future__ import annotations
 
 import json as jsonlib
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -159,5 +160,156 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
             p.stop()
     assert outcome.ok is False
     assert "not in triage" in outcome.reason
+
+
+# ---------------------------------------------------------------------------
+# Shared auto-decompose tick (#87283) — the pass every dispatch entry
+# point (gateway watcher, dashboard nudge, CLI dispatch, legacy daemon)
+# now runs before its dispatch_once.
+# ---------------------------------------------------------------------------
+
+
+def _tick_triage_task(title: str) -> str:
+    with kb.connect() as conn:
+        return kb.create_task(conn, title=title, triage=True)
+
+
+def _ok_outcome(tid: str, fanout: bool = False):
+    return decomp.DecomposeOutcome(tid, True, "ok", fanout=fanout)
+
+
+def test_tick_disabled_flag_is_a_noop(kanban_home, monkeypatch):
+    """kanban.auto_decompose=false must stop the shared tick everywhere,
+    not just in the gateway (#49638 contract, now enforced at the shared
+    choke point)."""
+    tid = _tick_triage_task("should stay put")
+    stub = MagicMock(return_value=_ok_outcome(tid))
+    monkeypatch.setattr(decomp, "decompose_task", stub)
+    monkeypatch.setattr(
+        decomp, "_load_config",
+        lambda: {"kanban": {"auto_decompose": False}},
+    )
+    assert decomp.run_auto_decompose_tick() == 0
+    stub.assert_not_called()
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_tick_enabled_by_default_and_counts_successes(kanban_home, monkeypatch):
+    _tick_triage_task("a")
+    _tick_triage_task("b")
+    monkeypatch.setattr(decomp, "_load_config", lambda: {"kanban": {}})
+    monkeypatch.setattr(
+        decomp, "decompose_task",
+        lambda tid, **kw: _ok_outcome(tid),
+    )
+    assert decomp.run_auto_decompose_tick() == 2
+
+
+def test_tick_respects_per_tick_cap(kanban_home, monkeypatch):
+    ids = [_tick_triage_task(f"bulk {i}") for i in range(5)]
+    calls: list[str] = []
+
+    def _stub(tid, **kw):
+        calls.append(tid)
+        return _ok_outcome(tid)
+
+    monkeypatch.setattr(
+        decomp, "_load_config",
+        lambda: {"kanban": {"auto_decompose_per_tick": 2}},
+    )
+    monkeypatch.setattr(decomp, "decompose_task", _stub)
+    assert decomp.run_auto_decompose_tick() == 2
+    assert len(calls) == 2
+    assert set(calls) <= set(ids)
+
+
+def test_tick_explicit_per_tick_overrides_config(kanban_home, monkeypatch):
+    for i in range(3):
+        _tick_triage_task(f"t{i}")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        decomp, "_load_config",
+        lambda: {"kanban": {"auto_decompose_per_tick": 1}},
+    )
+
+    def _stub(tid, **kw):
+        calls.append(tid)
+        return _ok_outcome(tid)
+
+    monkeypatch.setattr(decomp, "decompose_task", _stub)
+    assert decomp.run_auto_decompose_tick(per_tick=3) == 3
+    assert len(calls) == 3
+
+
+def test_tick_error_isolation_one_bad_card_doesnt_kill_the_rest(
+    kanban_home, monkeypatch,
+):
+    """One crashing card must never take down the tick or its siblings —
+    every triage card still gets attempted despite the first crash."""
+    bad = _tick_triage_task("crashes")
+    good = _tick_triage_task("survives")
+    attempted: list[str] = []
+
+    def _stub(tid, **kw):
+        attempted.append(tid)
+        if tid == bad:
+            raise RuntimeError("aux LLM exploded")
+        return _ok_outcome(tid)
+
+    monkeypatch.setattr(decomp, "_load_config", lambda: {"kanban": {}})
+    monkeypatch.setattr(decomp, "decompose_task", _stub)
+    assert decomp.run_auto_decompose_tick() == 1
+    # Both cards were attempted; the crash on `bad` didn't stop `good`.
+    assert sorted(attempted) == sorted([bad, good])
+
+
+def test_tick_restores_board_env_var(kanban_home, monkeypatch):
+    """The per-board HERMES_KANBAN_BOARD pinning must be undone after the
+    tick so a caller's active-board selection survives."""
+    _tick_triage_task("env probe")
+    monkeypatch.setattr(decomp, "_load_config", lambda: {"kanban": {}})
+    monkeypatch.setattr(
+        decomp, "decompose_task",
+        lambda tid, **kw: _ok_outcome(tid),
+    )
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    decomp.run_auto_decompose_tick()
+    assert os.environ["HERMES_KANBAN_BOARD"] == "default"
+
+
+def test_tick_end_to_end_specifies_triage_card_via_mocked_llm(
+    kanban_home, monkeypatch,
+):
+    """Real decompose path (only the aux LLM mocked): a triage card that
+    the LLM tightens into a single spec lands in ``todo`` — outside any
+    gateway."""
+    tid = _tick_triage_task("rough idea")
+    patches = _patch_list_profiles(["orchestrator"])
+    for p in patches:
+        p.start()
+    try:
+        llm_payload = jsonlib.dumps({
+            "fanout": False,
+            "rationale": "single unit",
+            "title": "Polished idea",
+            "body": "**Goal**\nDo it.",
+        })
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=_fake_aux_response(llm_payload),
+        ):
+            assert decomp.run_auto_decompose_tick() == 1
+    finally:
+        for p in patches:
+            p.stop()
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    # specify_triage_task lands in `todo`; recompute_ready promotes a
+    # parent-free todo to `ready` in the same write — either way the card
+    # is out of triage and dispatchable.
+    assert task.status in {"todo", "ready"}
+    assert task.title == "Polished idea"
 
 

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1226,6 +1226,122 @@ def test_specify_happy_path(client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# POST /dispatch — auto-decompose + dispatcher-presence warning (#87283)
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_nudge_runs_auto_decompose_tick(client, monkeypatch):
+    """The nudge endpoint must run the shared auto-decompose tick before
+    its dispatch_once, like the gateway-embedded dispatcher does."""
+    import hermes_cli.kanban_decompose as decomp_mod
+
+    called: list[int] = []
+    monkeypatch.setattr(
+        decomp_mod, "run_auto_decompose_tick",
+        lambda *a, **kw: called.append(1) or 0,
+    )
+    r = client.post("/api/plugins/kanban/dispatch")
+    assert r.status_code == 200
+    assert called, "POST /dispatch must invoke the auto-decompose tick"
+
+
+def test_dispatch_nudge_decomposes_triage_card_without_gateway(
+    client, monkeypatch,
+):
+    """Dashboard-only install (no gateway): nudging dispatch decomposes a
+    fresh triage card instead of leaving it stalled forever (#87283 /
+    #90277). Real decompose path, aux LLM mocked."""
+    t = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "rough idea", "triage": True},
+    ).json()["task"]
+    assert t["status"] == "triage"
+
+    _patch_specifier_response(
+        monkeypatch,
+        content=json.dumps({
+            "fanout": False,
+            "rationale": "single unit",
+            "title": "Polished idea",
+            "body": "**Goal**\nDo the thing.",
+        }),
+    )
+
+    r = client.post("/api/plugins/kanban/dispatch")
+    assert r.status_code == 200
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{t['id']}").json()["task"]
+    assert detail["status"] != "triage"
+    assert detail["title"] == "Polished idea"
+
+
+def test_dispatch_dry_run_does_not_auto_decompose(client, monkeypatch):
+    """dry_run is an inspection pass: no board mutation, no tick."""
+    import hermes_cli.kanban_decompose as decomp_mod
+
+    called: list[int] = []
+    monkeypatch.setattr(
+        decomp_mod, "run_auto_decompose_tick",
+        lambda *a, **kw: called.append(1) or 0,
+    )
+    r = client.post("/api/plugins/kanban/dispatch?dry_run=true&max=4")
+    assert r.status_code == 200
+    assert called == []
+
+
+def test_dispatch_nudge_warns_when_no_dispatcher(client, monkeypatch):
+    """With nothing long-lived to pick work up, the nudge response says so
+    instead of returning silence (#90277)."""
+    import hermes_cli.kanban as kb_cli
+
+    monkeypatch.setattr(
+        kb_cli, "_check_dispatcher_presence",
+        lambda hermes_home=None: (False, "No gateway is running — start it."),
+    )
+    r = client.post("/api/plugins/kanban/dispatch")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["warning"] == "No gateway is running — start it."
+
+
+def test_dispatch_nudge_no_warning_when_dispatcher_present(
+    client, monkeypatch,
+):
+    import hermes_cli.kanban as kb_cli
+
+    monkeypatch.setattr(
+        kb_cli, "_check_dispatcher_presence",
+        lambda hermes_home=None: (True, "gateway pid=42, dispatch enabled"),
+    )
+    r = client.post("/api/plugins/kanban/dispatch")
+    assert r.status_code == 200
+    assert "warning" not in r.json()
+
+
+def test_dispatch_nudge_survives_probe_and_tick_failures(
+    client, monkeypatch,
+):
+    """A crashing decomposer or presence probe must never turn the nudge
+    into a 500 — dispatch still runs."""
+    import hermes_cli.kanban as kb_cli
+    import hermes_cli.kanban_decompose as decomp_mod
+
+    def _boom(*a, **kw):
+        raise RuntimeError("decomposer down")
+
+    monkeypatch.setattr(decomp_mod, "run_auto_decompose_tick", _boom)
+    monkeypatch.setattr(kb_cli, "_check_dispatcher_presence", _boom)
+
+    client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "work", "assignee": "researcher"},
+    )
+    r = client.post("/api/plugins/kanban/dispatch")
+    assert r.status_code == 200
+    assert isinstance(r.json(), dict)
+
+
+# ---------------------------------------------------------------------------
 # Final result visibility for Done cards
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #87283 (also resolves the duplicate report #90277)

## Problem
Auto-decompose of triage cards ran only inside the gateway-embedded dispatcher watcher. The three sibling dispatch paths — dashboard nudge `POST /dispatch`, `hermes kanban dispatch`, and the legacy standalone daemon — called `dispatch_once()` bare, so dashboard-only installs silently stalled triage cards forever.

## Fix
- Extracted the tick into reusable `resolve_auto_decompose_settings()` + `run_auto_decompose_tick()` in `hermes_cli/kanban_decompose.py`, preserving current gating (`kanban.auto_decompose` re-read every call per the #49638 contract, per-tick cap, full error isolation). ~75 lines of duplicated closure logic deleted from the gateway watcher, with a parity pin between the shared resolver and the gateway's import-free twin.
- All three sibling paths now run the tick before their `dispatch_once()` (CLI skips it under `--dry-run`: inspection must not mutate the board).
- The dashboard nudge response now carries a `warning` from the existing `_check_dispatcher_presence()` helper when no dispatcher is running, instead of silence.
No new config keys, env vars, or schema changes.

## Verification
New tests: shared-tick unit contracts (enabled gate, cap, override, error isolation) + mocked-LLM E2E moving a card out of triage; tick-fires assertions for all three paths with strict ordering; dry-run non-mutation; nudge warning present/absent/crash-tolerant. Suites: auto-decompose-live + core-functionality + decompose + dashboard-plugin via `scripts/run_tests.sh` — all green modulo pre-existing Windows-env failures verified identical on clean main via stash.