### PR TITLE
feat(kanban): snapshot worker worktree state on iteration-budget exhaustion (#73234)

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -22,8 +22,10 @@ keep the exact logger name (``"agent.conversation_loop"``).
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+from pathlib import Path
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.message_content import flatten_message_text
@@ -56,6 +58,148 @@ _VERIFICATION_CONTINUATION_FLAGS = (
 )
 
 
+# ── Kanban worktree snapshot (#73234) ──────────────────────────────────
+# When a kanban worker dies on iteration-budget exhaustion, whatever it
+# had staged/uncommitted in its workspace used to be invisible to
+# recovery: the dispatcher reclaims the released claim and the next
+# attempt starts from a worktree nobody described. We append ONE durable
+# comment to the card carrying a compact machine-readable summary (a
+# ``[kanban:worktree-snapshot] `` prefixed JSON payload, same pattern as
+# the swarm blackboard comments) plus a human-readable handoff hint and
+# the tracked diff stat. Pure git plumbing — no LLM calls, best-effort,
+# and silent on clean / non-git workspaces so ordinary completions stay
+# zero-noise.
+_KANBAN_WORKTREE_SNAPSHOT_PREFIX = "[kanban:worktree-snapshot] "
+_KANBAN_WORKTREE_SNAPSHOT_AUTHOR = "worktree-snapshot"
+_KANBAN_SNAPSHOT_MAX_FILES = 50
+_KANBAN_SNAPSHOT_DIFF_STAT_MAX_CHARS = 2000
+_KANBAN_SNAPSHOT_GIT_TIMEOUT = 10
+
+
+def _git_in_workspace(args: list, workspace: str) -> "subprocess.CompletedProcess | None":
+    """Run a read-only git command inside ``workspace``; None on any failure."""
+    import subprocess
+    try:
+        return subprocess.run(
+            ["git", "-C", workspace, *args],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=_KANBAN_SNAPSHOT_GIT_TIMEOUT,
+            check=False,
+        )
+    except Exception:
+        return None
+
+
+def _snapshot_kanban_worktree_state(
+    kanban_task: str,
+    api_call_count: int,
+    max_iterations: int,
+    logger: logging.Logger,
+) -> None:
+    """Best-effort durable snapshot of a dying worker's worktree state.
+
+    Appends one comment to kanban task ``kanban_task`` describing the
+    staged/uncommitted changes in ``$HERMES_KANBAN_WORKSPACE`` (worktree
+    path, changed-file list capped at :data:`_KANBAN_SNAPSHOT_MAX_FILES`,
+    tracked diff stat, handoff hint). Clean worktrees, missing
+    workspaces, and non-git directories produce NO comment — zero noise
+    outside the exact recovery scenario. Never raises.
+    """
+    workspace = (os.environ.get("HERMES_KANBAN_WORKSPACE") or "").strip()
+    if not workspace:
+        return
+
+    status = _git_in_workspace(["status", "--porcelain"], workspace)
+    if status is None or status.returncode != 0:
+        # Not a git checkout (scratch workspace) or git is broken/unavailable
+        # — nothing git-recoverable to describe.
+        return
+    porcelain_lines = [
+        ln for ln in (status.stdout or "").splitlines() if ln.strip()
+    ]
+    if not porcelain_lines:
+        # Clean worktree — the dispatcher can reclaim without losing work.
+        return
+
+    files = [ln[3:].strip().strip('"') for ln in porcelain_lines]
+    untracked_count = sum(1 for ln in porcelain_lines if ln.startswith("??"))
+    staged_count = sum(
+        1 for ln in porcelain_lines
+        if ln[0] not in (" ", "?") and not ln.startswith("??")
+    )
+    files_truncated = len(files) > _KANBAN_SNAPSHOT_MAX_FILES
+    listed_files = files[:_KANBAN_SNAPSHOT_MAX_FILES]
+
+    # Tracked-change summary (staged + unstaged vs HEAD). Best-effort: an
+    # unborn HEAD or a failed diff just omits the stat section.
+    diff_stat = ""
+    diff = _git_in_workspace(["diff", "--stat", "HEAD"], workspace)
+    if diff is not None and diff.returncode == 0:
+        diff_stat = (diff.stdout or "").strip()
+
+    from hermes_cli import kanban_db as _kb
+    branch = _kb._git_current_branch(Path(workspace))
+
+    payload = {
+        "type": "worktree_snapshot",
+        "reason": "iteration_budget_exhausted",
+        "budget_used": api_call_count,
+        "budget_max": max_iterations,
+        "workspace": workspace,
+        "branch": branch,
+        "changed_files": len(files),
+        "staged_files": staged_count,
+        "untracked_files": untracked_count,
+        "files": listed_files,
+        "files_truncated": files_truncated,
+    }
+    parts = [
+        _KANBAN_WORKTREE_SNAPSHOT_PREFIX
+        + json.dumps(payload, ensure_ascii=False, sort_keys=True),
+        "",
+        (
+            f"Worker exhausted its iteration budget "
+            f"({api_call_count}/{max_iterations}) with {len(files)} "
+            "uncommitted change(s) still in the workspace above. Handoff: "
+            "inspect the workspace, then commit, stash, or discard the "
+            "listed files before re-dispatching or completing this card."
+        ),
+    ]
+    if diff_stat:
+        stat_block = diff_stat
+        truncated = False
+        if len(stat_block) > _KANBAN_SNAPSHOT_DIFF_STAT_MAX_CHARS:
+            stat_block = stat_block[:_KANBAN_SNAPSHOT_DIFF_STAT_MAX_CHARS]
+            truncated = True
+        parts += [
+            "",
+            "Diff stat (tracked changes vs HEAD)" + (" (truncated):" if truncated else ":"),
+            "```text",
+            stat_block,
+            "```",
+        ]
+    elif untracked_count:
+        parts += [
+            "",
+            "No tracked modifications — all listed files are untracked.",
+        ]
+
+    conn = _kb.connect()
+    try:
+        _kb.add_comment(
+            conn,
+            kanban_task,
+            _KANBAN_WORKTREE_SNAPSHOT_AUTHOR,
+            "\n".join(parts),
+        )
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
 def _record_kanban_budget_exhausted(
     kanban_task: str,
     api_call_count: int,
@@ -65,11 +209,27 @@ def _record_kanban_budget_exhausted(
     """Record a terminal ``timed_out`` outcome for a kanban worker that
     exhausted its iteration budget.
 
+    Before releasing the claim (#73234), snapshot whatever the worker
+    left staged/uncommitted in its workspace into a durable task comment
+    so recovery does not have to guess what was in flight. The snapshot
+    is independently guarded — a failure there never skips the failure
+    record below.
+
     This is a bounded fallback (#87096): the CAS invariant in ``_end_run``
     (``WHERE ended_at IS NULL``) guarantees idempotence — if another path
     already closed the run this is a no-op — so it is safe to call from
     multiple exit paths.
     """
+    try:
+        _snapshot_kanban_worktree_state(
+            kanban_task, api_call_count, max_iterations, logger,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to snapshot worktree state for task %s",
+            kanban_task,
+            exc_info=True,
+        )
     try:
         from hermes_cli import kanban_db as _kb
         _conn = _kb.connect()

--- a/tests/agent/test_turn_finalizer_kanban_worktree_snapshot.py
+++ b/tests/agent/test_turn_finalizer_kanban_worktree_snapshot.py
@@ -1,0 +1,249 @@
+"""Kanban worktree snapshot on iteration-budget exhaustion (#73234).
+
+When a kanban worker dies on budget exhaustion, whatever it left
+staged/uncommitted in ``$HERMES_KANBAN_WORKSPACE`` must be snapshotted
+into ONE durable task comment (worktree path, changed-file list, diff
+stat, handoff hint) BEFORE the failure record releases the claim.
+Clean worktrees and non-git workspaces stay zero-noise, and any
+snapshot failure must never break the exit path.
+
+Models the worker-path patterns of
+``tests/hermes_cli/test_kanban_goal_mode.py`` (temp HERMES_HOME +
+real kanban DB) and ``test_turn_finalizer_iteration_limit_exit.py``
+(stub agent driving ``finalize_turn`` — no live model).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from agent.turn_finalizer import (
+    _KANBAN_WORKTREE_SNAPSHOT_PREFIX,
+    finalize_turn,
+)
+from tests.agent.test_turn_finalizer_iteration_limit_exit import _LimitAgent
+
+
+@pytest.fixture
+def kanban_task_id(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME + real kanban DB containing ONE fresh card.
+
+    Returns the card id — tests point ``HERMES_KANBAN_TASK`` at it.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_cli import kanban_db as kb
+    kb.init_db()
+    with kb.connect() as conn:
+        return kb.create_task(conn, title="snapshot me")
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """A minimal git repo usable as a worker workspace."""
+    repo = tmp_path / "ws"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "worker@example.com")
+    _git(repo, "config", "user.name", "worker")
+    (repo / "tracked.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "initial")
+    return repo
+
+
+def _exhaust_budget(monkeypatch):
+    """Drive a budget-exhausted worker turn through the real finalizer."""
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent()
+    return finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=60,
+        interrupted=False,
+        failed=False,
+        messages=[{"role": "user", "content": "task"}],
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="task",
+        original_user_message="task",
+        _should_review_memory=False,
+        _turn_exit_reason="unknown",
+    )
+
+
+def _snapshot_bodies(conn, task_id):
+    from hermes_cli import kanban_db as kb
+    bodies = [
+        c.body for c in kb.list_comments(conn, task_id)
+        if c.body.startswith(_KANBAN_WORKTREE_SNAPSHOT_PREFIX)
+    ]
+    return bodies
+
+
+def _parse_snapshot(body: str) -> dict:
+    first_line = body.splitlines()[0]
+    return json.loads(first_line[len(_KANBAN_WORKTREE_SNAPSHOT_PREFIX):])
+
+
+def test_dirty_worktree_snapshots_one_comment(kanban_task_id, git_repo, monkeypatch):
+    """Budget exhaustion on a dirty worktree appends exactly ONE durable
+    comment carrying the machine-readable recovery summary."""
+    from hermes_cli import kanban_db as kb
+
+    # One tracked modification + one staged new file + one untracked file.
+    (git_repo / "tracked.py").write_text("x = 2\n", encoding="utf-8")
+    (git_repo / "staged.py").write_text("y = 1\n", encoding="utf-8")
+    _git(git_repo, "add", "staged.py")
+    (git_repo / "notes.md").write_text("wip\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", kanban_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(git_repo))
+
+    result = _exhaust_budget(monkeypatch)
+
+    assert result["completed"] is False
+    with kb.connect() as conn:
+        bodies = _snapshot_bodies(conn, kanban_task_id)
+    assert len(bodies) == 1, "exactly ONE snapshot comment per exhaustion"
+    body = bodies[0]
+
+    payload = _parse_snapshot(body)
+    assert payload["type"] == "worktree_snapshot"
+    assert payload["reason"] == "iteration_budget_exhausted"
+    assert payload["workspace"] == str(git_repo)
+    assert payload["changed_files"] == 3
+    assert payload["staged_files"] == 1
+    assert payload["untracked_files"] == 1
+    assert payload["files_truncated"] is False
+    assert sorted(payload["files"]) == ["notes.md", "staged.py", "tracked.py"]
+    assert payload["budget_used"] == 60
+    assert payload["budget_max"] == 60
+    assert isinstance(payload["branch"], str)
+
+    # Human handoff notes ride along with the machine-readable header.
+    assert "iteration budget (60/60)" in body
+    assert "Handoff:" in body
+    # Tracked diff stat covers the modified file.
+    assert "```text" in body
+    assert "tracked.py" in body
+
+
+def test_clean_worktree_stays_silent(kanban_task_id, git_repo, monkeypatch):
+    """A clean worktree produces NO snapshot comment — zero noise."""
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", kanban_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(git_repo))
+
+    result = _exhaust_budget(monkeypatch)
+
+    assert isinstance(result, dict)
+    with kb.connect() as conn:
+        assert _snapshot_bodies(conn, kanban_task_id) == []
+
+
+def test_non_git_workspace_fails_safe(kanban_task_id, tmp_path, monkeypatch):
+    """A scratch (non-git) workspace must not raise and must not block the
+    terminal failure record — the dispatcher contract still runs."""
+    from unittest.mock import MagicMock
+
+    from hermes_cli import kanban_db as kb
+
+    scratch = tmp_path / "scratch-ws"
+    scratch.mkdir()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", kanban_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(scratch))
+    record = MagicMock(name="record_task_failure")
+    monkeypatch.setattr(kb, "_record_task_failure", record)
+
+    result = _exhaust_budget(monkeypatch)
+
+    assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
+    record.assert_called_once()
+    args, kwargs = record.call_args
+    assert args[1] == kanban_task_id
+    assert kwargs["outcome"] == "timed_out"
+    with kb.connect() as conn:
+        assert _snapshot_bodies(conn, kanban_task_id) == []
+
+
+def test_snapshot_failure_never_breaks_exit_path(
+    kanban_task_id, git_repo, monkeypatch
+):
+    """If appending the snapshot comment blows up, the exit path still
+    completes normally and the failure record still lands."""
+    from unittest.mock import MagicMock
+
+    from hermes_cli import kanban_db as kb
+
+    (git_repo / "tracked.py").write_text("x = 3\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", kanban_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(git_repo))
+    record = MagicMock(name="record_task_failure")
+    monkeypatch.setattr(kb, "_record_task_failure", record)
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("db locked")
+
+    monkeypatch.setattr(kb, "add_comment", _boom)
+
+    result = _exhaust_budget(monkeypatch)
+
+    assert isinstance(result, dict)
+    assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
+    record.assert_called_once()
+
+
+def test_file_list_capped_with_truncation_flag(
+    kanban_task_id, git_repo, monkeypatch
+):
+    """More changed files than the cap → list capped, count exact, flag set."""
+    from hermes_cli import kanban_db as kb
+    from agent.turn_finalizer import _KANBAN_SNAPSHOT_MAX_FILES
+
+    for i in range(_KANBAN_SNAPSHOT_MAX_FILES + 5):
+        (git_repo / f"f{i:03}.txt").write_text(f"{i}\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", kanban_task_id)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(git_repo))
+
+    _exhaust_budget(monkeypatch)
+
+    with kb.connect() as conn:
+        bodies = _snapshot_bodies(conn, kanban_task_id)
+    assert len(bodies) == 1
+    payload = _parse_snapshot(bodies[0])
+    assert payload["changed_files"] == _KANBAN_SNAPSHOT_MAX_FILES + 5
+    assert len(payload["files"]) == _KANBAN_SNAPSHOT_MAX_FILES
+    assert payload["files_truncated"] is True
+
+
+def test_no_workspace_env_no_snapshot(kanban_task_id, monkeypatch):
+    """No HERMES_KANBAN_WORKSPACE → nothing to inspect, no comment."""
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", kanban_task_id)
+    monkeypatch.delenv("HERMES_KANBAN_WORKSPACE", raising=False)
+
+    result = _exhaust_budget(monkeypatch)
+
+    assert isinstance(result, dict)
+    with kb.connect() as conn:
+        assert _snapshot_bodies(conn, kanban_task_id) == []


### PR DESCRIPTION
Fixes #73234

## Problem
When a kanban worker died on iteration-budget exhaustion, its staged/uncommitted worktree changes were invisible to recovery: the failure record released the claim without recording worktree state, so the reap classifier treated the unknown-state worker as protocol-violation/gave_up.

## Fix
`agent/turn_finalizer.py::_record_kanban_budget_exhausted` (the chokepoint both budget-exhaustion branches funnel through) now snapshots the workspace first: one durable task comment with a machine-readable `[kanban:worktree-snapshot]` JSON header (branch, budget used/max, changed/staged/untracked counts, file list capped at 50) plus a human diff stat. Clean worktrees stay silent. Best-effort by construction — independently guarded so a snapshot failure can never skip the failure record; git subprocesses capped at 10s (~50ms typical). No LLM calls, no new config/env surface.

## Verification
New suite `tests/agent/test_turn_finalizer_kanban_worktree_snapshot.py` (dirty → one comment with expected fields; clean → silent; non-git → failsafe; add_comment raising → exit path intact; >50 files capped; no env → silent) plus regression sweeps over turn-finalizer and kanban worker suites — green via `scripts/run_tests.sh`, failures limited to the known Windows baseline (stash-verified on clean main).