### PR TITLE
feat(kanban): per-task approval policy parking completed work for approver sign-off (#29457)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -78,6 +78,9 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "max_retries": t.max_retries,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
+        "approval_required": bool(t.approval_required),
+        "approver_profile": t.approver_profile,
+        "approver_skill": t.approver_skill,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
@@ -393,6 +396,23 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           metavar="N", dest="goal_max_turns",
                           help="Turn budget for --goal workers (default 20). "
                                "Ignored without --goal.")
+    p_create.add_argument("--approval-required", action="store_true",
+                          dest="approval_required",
+                          help="Require sign-off before this task can become "
+                               "done: when the worker finishes, the task parks "
+                               "in review instead. Sign-off by --approver's "
+                               "profile if given, otherwise by a human.")
+    p_create.add_argument("--approver", default=None, dest="approver_profile",
+                          help="Profile that signs off an "
+                               "--approval-required task (it is reassigned to "
+                               "this profile while parked in review). Omit for "
+                               "human-only review. May be set without the flag "
+                               "to pre-stage it.")
+    p_create.add_argument("--approver-skill", default=None,
+                          dest="approver_skill",
+                          help="Skill auto-loaded into the approver's review "
+                               "session (requires --approval-required to have "
+                               "any effect).")
     p_create.add_argument("--initial-status",
                           choices=sorted(kb.VALID_INITIAL_STATUSES),
                           default="running",
@@ -493,6 +513,31 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--provider", default=None,
         help="Provider the model belongs to (worker is spawned with "
              "--provider <name>). Cleared together with the model.",
+    )
+
+    # --- set-approval (per-task approval policy, issue #29457) ---
+    p_set_approval = sub.add_parser(
+        "set-approval",
+        help="Set or clear a task's approval policy "
+             "(checked when the task completes)",
+    )
+    p_set_approval.add_argument("task_id")
+    p_set_approval.add_argument(
+        "state",
+        choices=["on", "off"],
+        help="'on' requires sign-off before the task can become done "
+             "(completion parks it in review); 'off' lets completion "
+             "mark it done directly",
+    )
+    p_set_approval.add_argument(
+        "--approver", default=None, dest="approver_profile",
+        help="Approver profile to record. Omit to keep the current one; "
+             "'none' clears it (parked tasks then wait for a human).",
+    )
+    p_set_approval.add_argument(
+        "--skill", default=None, dest="approver_skill",
+        help="Skill auto-loaded into the approver's review session. Omit "
+             "to keep the current one; 'none' clears it.",
     )
 
     # --- reclaim / reassign (recovery) ---
@@ -1114,6 +1159,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "show":     _cmd_show,
             "assign":   _cmd_assign,
             "set-model": _cmd_set_model,
+            "set-approval": _cmd_set_approval,
             "reclaim":  _cmd_reclaim,
             "reassign": _cmd_reassign,
             "diagnostics": _cmd_diagnostics,
@@ -1585,6 +1631,9 @@ def _cmd_create(args: argparse.Namespace) -> int:
             provider_override=getattr(args, "provider_override", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
+            approval_required=bool(getattr(args, "approval_required", False)),
+            approver_profile=getattr(args, "approver_profile", None),
+            approver_skill=getattr(args, "approver_skill", None),
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
@@ -1866,6 +1915,60 @@ def _cmd_assign(args: argparse.Namespace) -> int:
         print(f"no such task: {args.task_id}", file=sys.stderr)
         return 1
     print(f"Assigned {args.task_id} to {profile or '(unassigned)'}")
+    return 0
+
+
+def _cmd_set_approval(args: argparse.Namespace) -> int:
+    """Set or clear a task's approval policy (#29457).
+
+    Omitted flags keep the stored approver fields, so flipping the flag
+    alone never silently rewrites the rest of the policy; ``none`` clears
+    a field explicitly.
+    """
+    enable = args.state == "on"
+
+    def _flag(value: Optional[str]) -> tuple[Optional[str], bool]:
+        """Return (resolved value, was-provided)."""
+        if value is None:
+            return None, False
+        v = value.strip()
+        if v.lower() in {"none", "-", "null", ""}:
+            return None, True
+        return v, True
+
+    approver, approver_given = _flag(getattr(args, "approver_profile", None))
+    skill, skill_given = _flag(getattr(args, "approver_skill", None))
+    with kb.connect_closing() as conn:
+        current = kb.get_task(conn, args.task_id)
+        if current is None:
+            print(f"no such task: {args.task_id}", file=sys.stderr)
+            return 1
+        try:
+            ok = kb.set_approval_policy(
+                conn,
+                args.task_id,
+                approval_required=enable,
+                approver_profile=(
+                    approver if approver_given else current.approver_profile
+                ),
+                approver_skill=skill if skill_given else current.approver_skill,
+            )
+        except (ValueError, RuntimeError) as exc:
+            print(f"kanban: {exc}", file=sys.stderr)
+            return 2
+        if not ok:
+            print(f"no such task: {args.task_id}", file=sys.stderr)
+            return 1
+        updated = kb.get_task(conn, args.task_id)
+    who = updated.approver_profile or "(human review)"
+    extra = f", skill={updated.approver_skill}" if updated.approver_skill else ""
+    if enable:
+        print(
+            f"Approval required on {args.task_id} — completion parks it "
+            f"in review for sign-off by {who}{extra}"
+        )
+    else:
+        print(f"Approval policy cleared on {args.task_id} (completion marks it done)")
     return 0
 
 
@@ -2298,11 +2401,26 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 summary=summary,
                 metadata=metadata,
                 expected_run_id=_worker_run_id_for(tid),
+                # CLI completions are human/anonymous actions; a spawned
+                # profile completing its own task resolves to the same
+                # identity either way (HERMES_PROFILE == assignee).
+                actor=os.environ.get("HERMES_PROFILE") or "user",
             ):
                 failed.append(tid)
                 print(f"cannot complete {tid} (unknown id or terminal state)", file=sys.stderr)
             else:
-                print(f"Completed {tid}")
+                # The approval policy (#29457) may have parked the task in
+                # review instead of letting it become done — report where
+                # it actually landed (mirrors _cmd_block's landing report).
+                landed = kb.get_task(conn, tid)
+                if landed is not None and landed.status == "review":
+                    approver = landed.approver_profile or "a human reviewer"
+                    print(
+                        f"{tid} → review (approval required — awaiting "
+                        f"sign-off by {approver})"
+                    )
+                else:
+                    print(f"Completed {tid}")
     return 0 if not failed else 1
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1141,6 +1141,17 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Per-task approval policy (#29457), owned by the creator/orchestrator.
+    # When True, complete_task routes the task into the review lane for
+    # sign-off instead of marking it done. Consulted at completion time,
+    # so it may be flipped mid-flight via set_approval_policy.
+    approval_required: bool = False
+    # Profile that must sign off. None = human review (no reviewer agent
+    # is spawned for the parked task).
+    approver_profile: Optional[str] = None
+    # Skill force-loaded into the approver's review session on top of the
+    # mandatory sdlc-review lifecycle skill.
+    approver_skill: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1234,6 +1245,21 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            approval_required=(
+                bool(row["approval_required"])
+                if "approval_required" in keys and row["approval_required"]
+                else False
+            ),
+            approver_profile=(
+                row["approver_profile"]
+                if "approver_profile" in keys and row["approver_profile"]
+                else None
+            ),
+            approver_skill=(
+                row["approver_skill"]
+                if "approver_skill" in keys and row["approver_skill"]
+                else None
             ),
         )
 
@@ -1422,7 +1448,23 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Per-task approval policy (#29457), owned by the task creator /
+    -- orchestrator. When 1, :func:`complete_task` does NOT mark the task
+    -- done — it routes through the first-class review lane
+    -- (:func:`request_review`) so the work parks in ``review`` for sign-off.
+    -- Checked at completion time, so the flag may be flipped mid-flight.
+    approval_required    INTEGER NOT NULL DEFAULT 0,
+    -- Profile that must sign off before the task becomes done. NULL =
+    -- human review: the parked task sits in ``review`` and no reviewer
+    -- agent is spawned for it. Validated against existing profiles at
+    -- creation/edit time; if the profile disappears later the parked task
+    -- degrades gracefully to human review (dispatcher skips unknown
+    -- profiles), never to auto-approval.
+    approver_profile     TEXT,
+    -- Skill force-loaded into the approver's review session (on top of the
+    -- mandatory ``sdlc-review`` lifecycle skill). NULL = lifecycle only.
+    approver_skill       TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2679,6 +2721,26 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "approval_required" not in cols:
+        # Per-task approval policy (#29457). 0 (the default) preserves the
+        # behaviour existing rows had: complete_task marks them done.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "approval_required",
+            "approval_required INTEGER NOT NULL DEFAULT 0",
+        )
+
+    if "approver_profile" not in cols:
+        # Designated approver profile. NULL = human review when the flag
+        # is set; inert while it isn't.
+        _add_column_if_missing(conn, "tasks", "approver_profile", "approver_profile TEXT")
+
+    if "approver_skill" not in cols:
+        # Skill force-loaded into the approver's review session. NULL =
+        # the mandatory sdlc-review lifecycle skill only.
+        _add_column_if_missing(conn, "tasks", "approver_skill", "approver_skill TEXT")
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -3155,6 +3217,60 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def _skill_dir_exists(name: str) -> bool:
+    """Best-effort check that a skill of this name exists on disk.
+
+    Mirrors how the skills index resolves names: any ``<name>/SKILL.md``
+    under the profile's skills dir (bundled skills are synced there at
+    startup, so repo-shipped and user-installed skills are both covered).
+    Fails OPEN when the skills root can't be resolved — validation is
+    early feedback, not a security boundary.
+    """
+    try:
+        from hermes_constants import get_skills_dir
+
+        skills_dir = get_skills_dir()
+    except Exception:
+        return True
+    if not skills_dir.is_dir():
+        return False
+    for skill_md in skills_dir.rglob("SKILL.md"):
+        if skill_md.parent.name == name:
+            return True
+    return False
+
+
+def _validate_approval_refs(
+    approver_profile: Optional[str],
+    approver_skill: Optional[str],
+) -> None:
+    """Reject approval-policy references that can never resolve (#29457).
+
+    An approver that doesn't exist would silently downgrade the policy to
+    human review (or strand the parked task), and an approver skill that
+    isn't installed would silently no-op at review spawn time. Both are
+    creator mistakes best surfaced at write time. Best-effort by design:
+    when the introspection helpers can't be imported, validation is
+    skipped rather than blocking task creation.
+    """
+    if approver_profile:
+        try:
+            from hermes_cli.profiles import profile_exists
+        except Exception:
+            profile_exists = None  # type: ignore[assignment]
+        if profile_exists is not None and not profile_exists(approver_profile):
+            raise ValueError(
+                f"approver_profile {approver_profile!r} is not an existing "
+                "profile — create it first (`hermes -p "
+                f"{approver_profile} setup`) or omit it for human-only review"
+            )
+    if approver_skill and not _skill_dir_exists(approver_skill):
+        raise ValueError(
+            f"approver_skill {approver_skill!r} does not match any installed "
+            "skill (no <skills>/<name>/SKILL.md found)"
+        )
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -3178,6 +3294,9 @@ def create_task(
     reasoning_effort: Optional[str] = None,
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
+    approval_required: bool = False,
+    approver_profile: Optional[str] = None,
+    approver_skill: Optional[str] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
     board: Optional[str] = None,
@@ -3217,6 +3336,16 @@ def create_task(
     ``--reasoning <level>``. It is independent of ``model_override``: a task
     can run the profile's own model at a different depth.
 
+    ``approval_required`` / ``approver_profile`` / ``approver_skill`` attach
+    the per-task approval policy (#29457): when the flag is set,
+    :func:`complete_task` parks finished work in the review lane for
+    sign-off instead of marking it done. ``approver_profile`` names the
+    profile that signs off (None = human review); ``approver_skill`` is
+    force-loaded into that profile's review session. Both references are
+    validated when provided — a policy pointing at a missing profile or an
+    uninstalled skill would silently downgrade to something the creator
+    did not ask for.
+
     ``project_source_task_id`` is an internal cross-profile fallback for a
     worker-created child. When the active profile cannot resolve ``project_id``
     in its own projects.db, a matching canonical project-linked task in this
@@ -3228,6 +3357,12 @@ def create_task(
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
+    approver_profile = (approver_profile or "").strip() or None
+    approver_skill = (approver_skill or "").strip() or None
+    if approval_required or approver_profile or approver_skill:
+        # Validate the references even when only the approver fields are
+        # pre-staged while the flag is still off — same fail-loud contract.
+        _validate_approval_refs(approver_profile, approver_skill)
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
@@ -3497,8 +3632,10 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns,
+                        approval_required, approver_profile, approver_skill,
+                        session_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3523,6 +3660,9 @@ def create_task(
                         reasoning_effort,
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
+                        1 if approval_required else 0,
+                        approver_profile,
+                        approver_skill,
                         session_id,
                     ),
                 )
@@ -3552,6 +3692,9 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "approval_required": bool(approval_required) or None,
+                        "approver_profile": approver_profile,
+                        "approver_skill": approver_skill,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -3819,6 +3962,71 @@ def set_reasoning_effort(
         )
     # Task-mutation observer (RFC #58548), fired AFTER the txn commits.
     notify_task_updated(conn, task_id, ("reasoning_effort",))
+    return True
+
+
+def set_approval_policy(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    approval_required: bool,
+    approver_profile: Optional[str] = None,
+    approver_skill: Optional[str] = None,
+) -> bool:
+    """Set (or clear) a task's per-task approval policy (#29457).
+
+    Writes exactly the values given: ``approver_profile=None`` clears the
+    designated approver (parked tasks will wait for human review),
+    ``approval_required=False`` disables the gate entirely. The approver
+    fields may be pre-staged while the flag is off so enabling later is a
+    single flip.
+
+    The policy is consulted when :func:`complete_task` runs, so — like the
+    model override — it may be changed mid-flight on a running task and
+    takes effect at completion time. Refused on done/archived tasks: past
+    that point there is no future completion for the policy to govern.
+    Returns True on success.
+    """
+    approver_profile = (approver_profile or "").strip() or None
+    approver_skill = (approver_skill or "").strip() or None
+    if approval_required or approver_profile or approver_skill:
+        _validate_approval_refs(approver_profile, approver_skill)
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if not row:
+            return False
+        if row["status"] in ("done", "archived"):
+            raise RuntimeError(
+                f"cannot set approval policy on {row['status']} task {task_id} "
+                "(the policy only governs a future completion)"
+            )
+        conn.execute(
+            "UPDATE tasks SET approval_required = ?, approver_profile = ?, "
+            "approver_skill = ? WHERE id = ?",
+            (
+                1 if approval_required else 0,
+                approver_profile,
+                approver_skill,
+                task_id,
+            ),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "approval_policy_set",
+            {
+                "approval_required": bool(approval_required),
+                "approver_profile": approver_profile,
+                "approver_skill": approver_skill,
+            },
+        )
+    # Task-mutation observer (RFC #58548), fired AFTER the txn commits.
+    notify_task_updated(
+        conn, task_id,
+        ("approval_required", "approver_profile", "approver_skill"),
+    )
     return True
 
 
@@ -5358,6 +5566,7 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    actor: Optional[str] = None,
     fire_lifecycle_hook: bool = True,
 ) -> bool:
     """Transition ``running|ready|blocked|review -> done`` and record ``result``.
@@ -5391,6 +5600,28 @@ def complete_task(
     Any suspected phantom references are recorded as a
     ``suspected_hallucinated_references`` event. This pass is advisory
     and never blocks.
+
+    Approval policy gate (#29457): when the task carries
+    ``approval_required`` and the completer is not the designated
+    approver, the completion request is instead routed through
+    :func:`request_review` — the work parks in the existing review lane
+    (reassigned to ``approver_profile``, or left for human review when
+    none is set) rather than becoming done. The worker's handoff
+    summary/metadata ride along on the ``review_requested`` run so the
+    approver sees exactly what would have been recorded. Completing a
+    task already IN ``review`` is the approval act itself and is never
+    re-gated, so the human/agent approval verbs are unchanged.
+
+    ``actor`` names whoever asserts completion (the worker's profile, or
+    ``"user"`` from an anonymous CLI). ``None`` falls back to the task's
+    current assignee: before parking that is always the implementer, and
+    once parked in review the assignee IS the approver
+    (:func:`request_review` reassigned it), so the fallback implements
+    the same rule without every caller having to pass an identity.
+
+    Returns True when the task ended up done OR was successfully parked
+    for approval; callers that need to distinguish should re-read the
+    task's status afterwards (both tool and CLI surfaces do).
     """
     now = int(time.time())
     # Fail before validating cards or staging artifacts; re-check inside the
@@ -5424,6 +5655,48 @@ def complete_task(
             raise HallucinatedCardsError(phantom_cards, task_id)
     else:
         verified_cards = []
+
+    # Approval-policy gate (#29457). Scoped to running/ready — exactly the
+    # states :func:`request_review` accepts — so the park rides the shared
+    # machinery unchanged. A completion arriving FROM ``review`` skips the
+    # gate: that call IS the sign-off (human or claimed reviewer).
+    gate_row = conn.execute(
+        "SELECT status, assignee, approval_required, "
+        "approver_profile, approver_skill FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if (
+        gate_row is not None
+        and gate_row["approval_required"]
+        and gate_row["status"] in ("running", "ready")
+    ):
+        approver = _canonical_assignee(gate_row["approver_profile"])
+        completer = (
+            _canonical_assignee(actor) if actor is not None
+            else gate_row["assignee"]
+        )
+        if approver is None or completer != approver:
+            park_metadata: dict = dict(metadata) if isinstance(metadata, dict) else {}
+            park_metadata["approval_policy"] = {
+                "approver_profile": approver,
+                "approver_skill": (
+                    (gate_row["approver_skill"] or "").strip() or None
+                ),
+            }
+            ok, reason = request_review(
+                conn, task_id,
+                summary=summary if summary is not None else result,
+                metadata=park_metadata,
+                reviewer=approver,
+                expected_run_id=expected_run_id,
+                # Workers prove ownership with expected_run_id; a caller
+                # without one is an explicit operator action (CLI /
+                # dashboard) and may override a live claim — mirroring how
+                # the dashboard PATCH already passes force=True.
+                force=expected_run_id is None,
+                with_reason=True,
+            )
+            return bool(ok)
 
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
@@ -10381,8 +10654,17 @@ def _dispatch_once_locked(
         # kanban lifecycle is already injected into every worker's system
         # prompt via KANBAN_GUIDANCE, so this is the only extra skill the
         # review agent needs.
+        #
+        # Tasks parked by the per-task approval policy (#29457) may also
+        # name an ``approver_skill`` to auto-load into this review session
+        # (e.g. a domain checklist the sign-off must walk). It rides ON TOP
+        # of the lifecycle skill so the reviewer still knows the approve /
+        # request-changes verbs.
+        _review_skills = ["sdlc-review"]
+        if claimed.approver_skill:
+            _review_skills.append(claimed.approver_skill)
         claimed.skills = list(
-            dict.fromkeys([*(claimed.skills or []), "sdlc-review"])
+            dict.fromkeys([*(claimed.skills or []), *_review_skills])
         )
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -851,6 +851,14 @@ class UpdateTaskBody(BaseModel):
     # override doesn't silently reset the depth the operator chose.
     reasoning_effort: Optional[str] = None
     clear_reasoning_effort: bool = False
+    # Per-task approval policy (#29457). ``approval_required=None`` means
+    # "not sent" (keep current). ``approver_profile``/``approver_skill``
+    # follow the same not-sent semantics; ``clear_approver=True`` nulls both
+    # together (parked tasks then wait for human review).
+    approval_required: Optional[bool] = None
+    approver_profile: Optional[str] = None
+    approver_skill: Optional[str] = None
+    clear_approver: bool = False
 
 
 def _reopen_if_review(conn, task_id: str, current) -> Optional[bool]:
@@ -889,6 +897,47 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 )
             except RuntimeError as e:
                 raise HTTPException(status_code=409, detail=str(e))
+            if not ok:
+                raise HTTPException(status_code=404, detail="task not found")
+
+        # --- approval policy (#29457) --------------------------------------
+        # Runs BEFORE the status block so a combined patch can disable the
+        # policy and complete in one request. Omitted fields keep their
+        # stored values; clear_approver nulls both approver fields.
+        if (
+            payload.approval_required is not None
+            or payload.approver_profile is not None
+            or payload.approver_skill is not None
+            or payload.clear_approver
+        ):
+            current = task  # fetched above; pre-status state
+            new_required = (
+                bool(payload.approval_required)
+                if payload.approval_required is not None
+                else bool(current.approval_required)
+            )
+            new_profile = None
+            new_skill = None
+            if not payload.clear_approver:
+                new_profile = (
+                    payload.approver_profile
+                    if payload.approver_profile is not None
+                    else current.approver_profile
+                )
+                new_skill = (
+                    payload.approver_skill
+                    if payload.approver_skill is not None
+                    else current.approver_skill
+                )
+            try:
+                ok = kanban_db.set_approval_policy(
+                    conn, task_id,
+                    approval_required=new_required,
+                    approver_profile=new_profile or None,
+                    approver_skill=new_skill or None,
+                )
+            except (ValueError, RuntimeError) as e:
+                raise HTTPException(status_code=400, detail=str(e))
             if not ok:
                 raise HTTPException(status_code=404, detail="task not found")
 

--- a/tests/hermes_cli/test_kanban_approval_policy.py
+++ b/tests/hermes_cli/test_kanban_approval_policy.py
@@ -1,0 +1,693 @@
+"""Per-task approval policy (#29457): flagged completions park in review.
+
+The contract these tests pin:
+
+* ``complete_task`` on a task carrying ``approval_required`` does NOT mark
+  it done — it routes through the SAME first-class review machinery
+  (:func:`request_review`) so the work parks in ``review``, reassigned to
+  the designated approver (or left for a human when none is named).
+* Completing a task already IN ``review`` is the sign-off act itself and
+  is never re-gated — the human/agent approval verbs are unchanged.
+* The completer identity check: the designated approver completing gets
+  normal completion; anyone else (implementer, anonymous user) triggers
+  the park. With no ``actor`` passed, the task's current assignee is the
+  proxy — before parking that is always the implementer, once parked it
+  is the approver.
+* Unflagged tasks are untouched: same states, same events, same outcomes.
+* The policy is editable mid-flight (``set_approval_policy`` / CLI
+  ``set-approval`` / dashboard PATCH) and is consulted at completion time.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated HERMES_HOME with an empty board, one approver profile and
+    one installable approver skill."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # A real profile dir so create-time validation accepts the approver.
+    (home / "profiles" / "reviewer-a").mkdir(parents=True)
+    # A real skill dir so approver_skill validation resolves it.
+    skill = home / "skills" / "review-checklist"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: review-checklist\ndescription: Walk the sign-off checklist.\n---\n\nChecklist.\n",
+        encoding="utf-8",
+    )
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def conn(kanban_home):
+    with kb.connect() as c:
+        yield c
+
+
+def _row(conn, tid):
+    return conn.execute(
+        "SELECT status, assignee, approval_required, approver_profile, "
+        "approver_skill, current_run_id FROM tasks WHERE id = ?",
+        (tid,),
+    ).fetchone()
+
+
+def _events(conn, tid, kind=None):
+    rows = conn.execute(
+        "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+        (tid,),
+    ).fetchall()
+    out = [
+        (r["kind"], json.loads(r["payload"]) if r["payload"] else None)
+        for r in rows
+    ]
+    if kind is not None:
+        out = [e for e in out if e[0] == kind]
+    return out
+
+
+def _last_run(conn, tid):
+    return conn.execute(
+        "SELECT status, outcome, summary, metadata FROM task_runs "
+        "WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+        (tid,),
+    ).fetchone()
+
+
+def _claimed_flagged_task(
+    conn,
+    *,
+    title="impl a feature",
+    assignee="builder",
+    approver="reviewer-a",
+    skill=None,
+):
+    tid = kb.create_task(
+        conn,
+        title=title,
+        assignee=assignee,
+        approval_required=True,
+        approver_profile=approver,
+        approver_skill=skill,
+    )
+    task = kb.claim_task(conn, tid)
+    assert task is not None
+    return tid
+
+
+# ---------------------------------------------------------------------------
+# The gate: flagged completion parks in review instead of done
+# ---------------------------------------------------------------------------
+
+
+def test_flagged_complete_parks_in_review_assigned_to_approver(kanban_home):
+    with kb.connect() as conn:
+        tid = _claimed_flagged_task(conn)
+        run_id = kb.get_task(conn, tid).current_run_id
+
+        ok = kb.complete_task(
+            conn, tid,
+            summary="Implementation complete",
+            expected_run_id=run_id,
+        )
+        assert ok is True
+
+        row = _row(conn, tid)
+        assert row["status"] == "review"
+        # Reassigned to the designated approver — this is what makes the
+        # dispatcher spawn them as the reviewer.
+        assert row["assignee"] == "reviewer-a"
+
+        # Rode the existing review machinery: closed run + standard event.
+        run = _last_run(conn, tid)
+        assert run["outcome"] == "review_requested"
+        rr = _events(conn, tid, kind="review_requested")
+        assert len(rr) == 1
+        payload = rr[0][1]
+        assert payload["implementer"] == "builder"
+        assert payload["reviewer"] == "reviewer-a"
+        assert payload["summary"] == "Implementation complete"
+
+        # The park reason is auditable on the handoff run's metadata.
+        run_meta = json.loads(run["metadata"]) if run["metadata"] else {}
+        assert run_meta["approval_policy"]["approver_profile"] == "reviewer-a"
+
+        # NOT completed: no completed event, nothing marked done.
+        assert _events(conn, tid, kind="completed") == []
+        assert kb.get_task(conn, tid).completed_at is None
+
+
+def test_park_without_approver_waits_for_human_and_keeps_assignee(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="human sign-off", assignee="builder",
+            approval_required=True,
+        )
+        task = kb.claim_task(conn, tid)
+        assert task is not None
+
+        assert kb.complete_task(
+            conn, tid, expected_run_id=task.current_run_id
+        )
+
+        row = _row(conn, tid)
+        assert row["status"] == "review"
+        # No designated agent: no reassignment, human pulls the lane.
+        assert row["assignee"] == "builder"
+
+
+def test_unflagged_task_is_byte_identical(kanban_home):
+    with kb.connect() as conn:
+        plain = kb.create_task(conn, title="plain work", assignee="builder")
+        task = kb.claim_task(conn, plain)
+        assert task is not None
+
+        ok = kb.complete_task(
+            conn, plain,
+            summary="done directly",
+            expected_run_id=task.current_run_id,
+        )
+        assert ok is True
+
+        row = _row(conn, plain)
+        assert row["status"] == "done"
+        assert row["assignee"] == "builder"
+        run = _last_run(conn, plain)
+        assert run["outcome"] == "completed"
+        assert len(_events(conn, plain, kind="completed")) == 1
+        assert _events(conn, plain, kind="review_requested") == []
+
+
+# ---------------------------------------------------------------------------
+# Approval verbs: approver completes -> done; human approve unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_designated_approver_completing_marks_done(kanban_home):
+    with kb.connect() as conn:
+        tid = _claimed_flagged_task(conn)
+        implementer_run = kb.get_task(conn, tid).current_run_id
+        assert kb.complete_task(
+            conn, tid, summary="work handed off",
+            expected_run_id=implementer_run,
+        )
+        assert _row(conn, tid)["status"] == "review"
+
+        # Approver claims from the review lane (review -> running).
+        review_claim = kb.claim_review_task(conn, tid)
+        assert review_claim is not None
+        assert review_claim.assignee == "reviewer-a"
+
+        ok = kb.complete_task(
+            conn, tid,
+            summary="sign-off",
+            actor="reviewer-a",
+            expected_run_id=review_claim.current_run_id,
+        )
+        assert ok is True
+        assert _row(conn, tid)["status"] == "done"
+        # Exactly one completion, from the approver's pass.
+        assert len(_events(conn, tid, kind="completed")) == 1
+
+
+def test_human_approval_from_review_lane_unchanged(kanban_home):
+    with kb.connect() as conn:
+        tid = _claimed_flagged_task(conn)
+        implementer_run = kb.get_task(conn, tid).current_run_id
+        assert kb.complete_task(
+            conn, tid, expected_run_id=implementer_run,
+        )
+        assert _row(conn, tid)["status"] == "review"
+
+        # Completing FROM review is the approval act — no actor needed,
+        # never re-gated, straight to done.
+        assert kb.complete_task(conn, tid, result="approved by human")
+        assert _row(conn, tid)["status"] == "done"
+
+
+def test_completer_identity_is_canonicalized(kanban_home):
+    with kb.connect() as conn:
+        tid = _claimed_flagged_task(conn, assignee="reviewer-a")
+        task = kb.get_task(conn, tid)
+
+        # Same profile, different casing — still counts as the approver.
+        assert kb.complete_task(
+            conn, tid,
+            actor="Reviewer-A",
+            expected_run_id=task.current_run_id,
+        )
+        assert _row(conn, tid)["status"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# The changes loop keeps working end-to-end under the policy
+# ---------------------------------------------------------------------------
+
+
+def test_request_changes_loop_still_works(kanban_home):
+    with kb.connect() as conn:
+        tid = _claimed_flagged_task(conn)
+        implementer_run = kb.get_task(conn, tid).current_run_id
+        assert kb.complete_task(conn, tid, expected_run_id=implementer_run)
+
+        review_claim = kb.claim_review_task(conn, tid)
+        assert review_claim is not None
+        ok, implementer = kb.request_changes(
+            conn, tid, reason="missing boundary test",
+        )
+        assert ok is True
+        assert implementer == "builder"
+
+        # Back with the implementer, out of review.
+        row = _row(conn, tid)
+        assert row["status"] == "ready"
+        assert row["assignee"] == "builder"
+
+        # Redo + re-complete: the policy parks it again.
+        redo = kb.claim_task(conn, tid)
+        assert redo is not None
+        assert kb.complete_task(
+            conn, tid, summary="addressed feedback",
+            expected_run_id=redo.current_run_id,
+        )
+        assert _row(conn, tid)["status"] == "review"
+        assert _row(conn, tid)["assignee"] == "reviewer-a"
+        assert len(_events(conn, tid, kind="review_requested")) == 2
+
+
+# ---------------------------------------------------------------------------
+# Mid-flight edits
+# ---------------------------------------------------------------------------
+
+
+def test_midflight_flip_on_respected_at_completion(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="flip me on", assignee="builder")
+        task = kb.claim_task(conn, tid)
+
+        # Policy attached AFTER the work started — still enforced, because
+        # the flag is consulted when the task naturally finishes.
+        assert kb.set_approval_policy(
+            conn, tid,
+            approval_required=True, approver_profile="reviewer-a",
+        )
+
+        assert kb.complete_task(
+            conn, tid, expected_run_id=task.current_run_id,
+        )
+        assert _row(conn, tid)["status"] == "review"
+
+
+def test_midflight_flip_off_respected_at_completion(kanban_home):
+    with kb.connect() as conn:
+        tid = _claimed_flagged_task(conn)
+        assert kb.set_approval_policy(conn, tid, approval_required=False)
+        task = kb.get_task(conn, tid)
+
+        assert kb.complete_task(
+            conn, tid, expected_run_id=task.current_run_id,
+        )
+        assert _row(conn, tid)["status"] == "done"
+
+
+def test_set_approval_policy_records_event_and_fields(conn):
+    tid = kb.create_task(conn, title="policy audit")
+
+    assert kb.set_approval_policy(
+        conn, tid,
+        approval_required=True,
+        approver_profile="reviewer-a",
+        approver_skill="review-checklist",
+    )
+    row = _row(conn, tid)
+    assert row["approval_required"] == 1
+    assert row["approver_profile"] == "reviewer-a"
+    assert row["approver_skill"] == "review-checklist"
+
+    events = _events(conn, tid, kind="approval_policy_set")
+    assert len(events) == 1
+    assert events[0][1] == {
+        "approval_required": True,
+        "approver_profile": "reviewer-a",
+        "approver_skill": "review-checklist",
+    }
+
+
+def test_set_approval_policy_refuses_terminal_tasks(conn):
+    tid = kb.create_task(conn, title="already done", assignee="builder")
+    assert kb.complete_task(conn, tid)
+
+    with pytest.raises(RuntimeError, match="done"):
+        kb.set_approval_policy(conn, tid, approval_required=True)
+
+
+def test_set_approval_policy_unknown_task(conn):
+    assert kb.set_approval_policy(
+        conn, "t_nope", approval_required=True,
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# Creation-time validation of approver references
+# ---------------------------------------------------------------------------
+
+
+def test_create_rejects_unknown_approver_profile(conn):
+    with pytest.raises(ValueError, match="not an existing profile"):
+        kb.create_task(
+            conn, title="ghost approver",
+            approval_required=True, approver_profile="who-is-this",
+        )
+
+
+def test_create_rejects_unknown_approver_skill(conn):
+    with pytest.raises(ValueError, match="does not match any installed skill"):
+        kb.create_task(
+            conn, title="ghost skill",
+            approval_required=True, approver_profile="reviewer-a",
+            approver_skill="never-installed",
+        )
+
+
+def test_created_policy_round_trips_through_get_task(conn):
+    tid = kb.create_task(
+        conn, title="flagged", assignee="builder",
+        approval_required=True,
+        approver_profile="reviewer-a",
+        approver_skill="review-checklist",
+    )
+    task = kb.get_task(conn, tid)
+    assert task.approval_required is True
+    assert task.approver_profile == "reviewer-a"
+    assert task.approver_skill == "review-checklist"
+
+
+# ---------------------------------------------------------------------------
+# Migration: fresh AND legacy boards gain the columns without data loss
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_db_has_approval_columns(kanban_home):
+    cols = {
+        r[1]
+        for r in kb.connect().execute("PRAGMA table_info(tasks)")
+    }
+    assert {"approval_required", "approver_profile", "approver_skill"} <= cols
+
+
+def test_legacy_db_gains_approval_columns_without_data_loss(tmp_path):
+    """A pre-#29457 board opens safely: columns are added, rows keep their
+    values, defaults preserve old behaviour (flag off)."""
+    import sqlite3
+
+    db_path = tmp_path / ".hermes"
+    db_path.mkdir(parents=True)
+    legacy = tmp_path / "legacy.db"
+    conn = sqlite3.connect(str(legacy))
+    conn.row_factory = sqlite3.Row
+    # Pared-down schema WITHOUT any approval column.
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('legacy', 'old work', 'ready', 123)"
+    )
+    conn.commit()
+
+    before_cols = {r[1] for r in conn.execute("PRAGMA table_info(tasks)")}
+    assert "approval_required" not in before_cols
+
+    kb._migrate_add_optional_columns(conn)
+    # Idempotent: running again must not raise or duplicate.
+    kb._migrate_add_optional_columns(conn)
+
+    after_cols = {r[1] for r in conn.execute("PRAGMA table_info(tasks)")}
+    assert {
+        "approval_required", "approver_profile", "approver_skill"
+    } <= after_cols
+
+    row = conn.execute(
+        "SELECT * FROM tasks WHERE id = 'legacy'"
+    ).fetchone()
+    keys = set(row.keys())
+    assert "approval_required" in keys
+    # Defaults preserve the behaviour the row had before the column existed.
+    assert row["approval_required"] == 0
+    assert row["approver_profile"] is None
+    assert row["approver_skill"] is None
+    # No data loss.
+    assert row["title"] == "old work"
+    assert row["status"] == "ready"
+    assert row["created_at"] == 123
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Worker tool surface: kanban_create flags + honest kanban_complete report
+# ---------------------------------------------------------------------------
+
+
+def test_kanban_create_tool_accepts_approval_flags(
+    kanban_home, monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
+    from tools import kanban_tools as tools
+
+    created = json.loads(tools._handle_create({
+        "title": "needs sign-off",
+        "assignee": "builder",
+        "approval_required": True,
+        "approver_profile": "reviewer-a",
+        "approver_skill": "review-checklist",
+    }))
+    assert created["ok"] is True
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, created["task_id"])
+        assert task.approval_required is True
+        assert task.approver_profile == "reviewer-a"
+        assert task.approver_skill == "review-checklist"
+
+
+def test_kanban_complete_tool_reports_the_park(
+    kanban_home, monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    from tools import kanban_tools as tools
+
+    with kb.connect() as conn:
+        tid = _claimed_flagged_task(conn)
+    run_id = kb.get_task(kb.connect(), tid).current_run_id
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+    result = json.loads(tools._handle_complete({"summary": "finished up"}))
+    assert result["ok"] is True
+    assert result["status"] == "review"
+    assert "reviewer-a" in result["approval"]
+
+
+# ---------------------------------------------------------------------------
+# Dashboard PATCH surface
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_patch_edits_policy_mid_flight(tmp_path, monkeypatch):
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+    import importlib.util
+    import sys
+
+    home = tmp_path / ".hermes"
+    (home / "profiles" / "reviewer-a").mkdir(parents=True)
+    (home / "skills" / "review-checklist").mkdir(parents=True)
+    (home / "skills" / "review-checklist" / "SKILL.md").write_text(
+        "---\nname: review-checklist\ndescription: Checklist.\n---\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = (
+        repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_kanban_approval_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    app = __import__("fastapi").FastAPI()
+    app.include_router(mod.router, prefix="/api/plugins/kanban")
+    client = TestClient(app)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="board card", assignee="builder")
+
+    # Flip the whole policy on from the board.
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{tid}",
+        json={
+            "approval_required": True,
+            "approver_profile": "reviewer-a",
+            "approver_skill": "review-checklist",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()["task"]
+    assert body["approval_required"] is True
+    assert body["approver_profile"] == "reviewer-a"
+    assert body["approver_skill"] == "review-checklist"
+
+    # Clear just the approver pair; the flag stays on.
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{tid}", json={"clear_approver": True},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()["task"]
+    assert body["approval_required"] is True
+    assert body["approver_profile"] is None
+    assert body["approver_skill"] is None
+
+    # Flip the flag back off.
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{tid}",
+        json={"approval_required": False},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["task"]["approval_required"] is False
+
+    # Invalid approver surfaces as a 400, not a silent write.
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{tid}",
+        json={"approval_required": True, "approver_profile": "ghost"},
+    )
+    assert r.status_code == 400
+
+    with kb.connect() as conn:
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert kinds.count("approval_policy_set") == 3
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_create_with_approval_flags_round_trips(kanban_home):
+    from hermes_cli import kanban as kc
+
+    kc.run_slash(
+        'create "flagged card" --assignee builder --approval-required '
+        "--approver reviewer-a --approver-skill review-checklist"
+    )
+    listing = json.loads(kc.run_slash("list --json"))
+    entry = next(r for r in listing if r["title"] == "flagged card")
+    assert entry["approval_required"] is True
+    assert entry["approver_profile"] == "reviewer-a"
+    assert entry["approver_skill"] == "review-checklist"
+
+
+def test_cli_set_approval_flips_policy(kanban_home):
+    from hermes_cli import kanban as kc
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="cli flip target", assignee="builder")
+
+    kc.run_slash(f"set-approval {tid} on --approver reviewer-a")
+    task = kb.get_task(kb.connect(), tid)
+    assert task.approval_required is True
+    assert task.approver_profile == "reviewer-a"
+
+    kc.run_slash(f"set-approval {tid} off --approver none")
+    task = kb.get_task(kb.connect(), tid)
+    assert task.approval_required is False
+    assert task.approver_profile is None
+
+
+def test_cli_complete_reports_the_park(kanban_home):
+    from hermes_cli import kanban as kc
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="cli park target", assignee="builder",
+            approval_required=True, approver_profile="reviewer-a",
+        )
+
+    out = kc.run_slash(f"complete {tid}")
+    assert "review" in out
+    assert "reviewer-a" in out
+    assert kb.get_task(kb.connect(), tid).status == "review"
+
+
+# ---------------------------------------------------------------------------
+# Review-lane dispatch loads the approver skill
+# ---------------------------------------------------------------------------
+
+
+def test_review_spawn_carries_sdlc_review_plus_approver_skill(
+    kanban_home,
+):
+    """A policy-parked task dispatches through the real review lane: the
+    spawned reviewer is the designated approver and its force-loaded
+    skills are sdlc-review PLUS the task's approver_skill."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="policy parked", assignee="builder",
+            approval_required=True,
+            approver_profile="reviewer-a",
+            approver_skill="review-checklist",
+        )
+        task = kb.claim_task(conn, tid)
+        assert task is not None
+        assert kb.complete_task(
+            conn, tid, expected_run_id=task.current_run_id,
+        )
+        assert _row(conn, tid)["status"] == "review"
+
+        spawned = []
+
+        def _fake_spawn(claimed, workspace, *args, **kwargs):
+            spawned.append((claimed, workspace))
+            return 4242
+
+        result = kb.dispatch_once(conn, spawn_fn=_fake_spawn)
+        assert [(tid, "reviewer-a")] == [
+            (t.id, t.assignee) for t, _ in spawned
+        ]
+        claimed = spawned[0][0]
+        assert "sdlc-review" in claimed.skills
+        assert "review-checklist" in claimed.skills
+        assert result.spawned  # the review lane produced this spawn

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -153,6 +153,10 @@ class TestCLIJudgeGate:
 
         fake_task = types.SimpleNamespace(
             goal_mode=goal_mode,
+            # _cmd_complete re-reads the task after completion to report
+            # where it landed (#29457 park reporting); real Tasks carry
+            # status.
+            status="done",
             title="Finish report",
             body="acceptance: criteria",
         )

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -803,8 +803,28 @@ def _handle_complete(args: dict, **kw) -> str:
                 return tool_error(
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
+            # The approval policy (#29457) may have parked the task in
+            # review instead of letting it become done. Tell the worker
+            # plainly — from its perspective the work is finished and
+            # handed off, but "done" would be a false report.
+            landed = kb.get_task(conn, tid)
+            parked = landed is not None and landed.status == "review"
             run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
+            return _ok(
+                task_id=tid,
+                run_id=run.id if run else None,
+                status=landed.status if landed else None,
+                **(
+                    {
+                        "approval": (
+                            f"parked for sign-off by "
+                            f"{landed.approver_profile or 'a human reviewer'}"
+                        )
+                    }
+                    if parked
+                    else {}
+                ),
+            )
         finally:
             conn.close()
     except ValueError as e:
@@ -1408,6 +1428,11 @@ def _handle_create(args: dict, **kw) -> str:
     goal_mode, goal_bool_error = _parse_bool_arg(args, "goal_mode")
     if goal_bool_error:
         return tool_error(goal_bool_error)
+    approval_required, approval_bool_error = _parse_bool_arg(args, "approval_required")
+    if approval_bool_error:
+        return tool_error(approval_bool_error)
+    approver_profile = args.get("approver_profile")
+    approver_skill = args.get("approver_skill")
     goal_max_turns = args.get("goal_max_turns")
     model_override = args.get("model")
     provider_override = args.get("provider")
@@ -1458,6 +1483,9 @@ def _handle_create(args: dict, **kw) -> str:
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
                 ),
+                approval_required=approval_required,
+                approver_profile=approver_profile,
+                approver_skill=approver_skill,
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
@@ -2245,6 +2273,33 @@ KANBAN_CREATE_SCHEMA = {
                     "require immediate human ops (R3 gate) to skip the "
                     "brief running-to-blocked transition. Defaults to "
                     "'running', which preserves the usual dispatch path."
+                ),
+            },
+            "approval_required": {
+                "type": "boolean",
+                "description": (
+                    "Per-task approval policy (#29457). When true, "
+                    "kanban_complete on this task will NOT mark it done — "
+                    "the work parks in review for sign-off by the approver "
+                    "(or a human when no approver is named). Checked at "
+                    "completion time, so it can be flipped mid-flight."
+                ),
+            },
+            "approver_profile": {
+                "type": "string",
+                "description": (
+                    "Profile that must sign off when approval_required is "
+                    "set; the task is reassigned to it while parked in "
+                    "review and the dispatcher spawns it as the reviewer. "
+                    "Omit for human-only sign-off."
+                ),
+            },
+            "approver_skill": {
+                "type": "string",
+                "description": (
+                    "Skill auto-loaded into the approver's review session "
+                    "(alongside the standard review lifecycle skill). "
+                    "Requires an installed skill name."
                 ),
             },
             "skills": {


### PR DESCRIPTION
Fixes #29457

## Design
Per-task approval policy built entirely on the existing review lane — review IS the parked state; no new statuses, lanes, or event kinds. The issue's sensitivity-scoring extension is deliberately out of scope.

## Implementation
- Typed optional columns `approval_required` / `approver_profile` / `approver_skill` via the standard migration helper (fresh + legacy boards).
- `create_task` validates approver references at write time; `set_approval_policy` flips flags mid-flight (event + notify).
- `complete_task` gate: flagged task + completer ≠ designated approver → routes through the existing `request_review` machinery to park for that approver (CAS, claim cleared, run closed as review_requested); approver completing → normal done; `request_changes` send-back loop works unchanged and re-parks on next completion. Human approval degrades gracefully when the approver profile vanishes.
- Surfaces: CLI create flags + `kanban set-approval` verb + parked-complete reporting; `kanban_create` tool params; honest park report in `kanban_complete` output; dashboard PATCH body.

## Verification
24-test suite `tests/hermes_cli/test_kanban_approval_policy.py` covering park/approve/send-back/re-park, unflagged byte-parity, mid-flight flips, migration on legacy boards, degraded-approver fallback. Review-lifecycle/promote/notify/goal-mode regressions green via `scripts/run_tests.sh`; only pre-existing Windows-env failures remain (stash-verified).