### PR TITLE
perf(agent): batch read-only tool result persistence

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -41,6 +41,7 @@ from agent.tool_dispatch_helpers import (
     _plan_tool_batch_segments,
     make_tool_result_message,
 )
+from agent.tool_result_classification import tool_may_have_side_effect
 from tools.terminal_tool import (
     get_active_env,
 )
@@ -1184,6 +1185,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             (tool_call, function_name, function_args, [], None, _ts_scope_block)
         )
 
+    all_resolved_names_are_no_effect = bool(parsed_calls) and all(
+        not tool_may_have_side_effect(name)
+        for _, name, _, _, _, _ in parsed_calls
+    )
+
     # ── Logging / callbacks ──────────────────────────────────────────
     tool_names_str = ", ".join(name for _, name, _, _, _, _ in parsed_calls)
     if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
@@ -1663,6 +1669,74 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             total_dur = sum(r[3] for r in results if r is not None)
             spinner.stop(f"⚡ {completed}/{num_tools} tools completed in {total_dur:.1f}s total")
 
+    deferred_completion_projections = []
+
+    def _project_tool_completion(
+        i,
+        tc,
+        name,
+        args,
+        tool_duration,
+        is_error,
+        blocked,
+        progress_function_name,
+        display_function_result,
+        risk_metadata,
+    ) -> None:
+        # Every completion surface is downstream of the canonical append. If
+        # the UI bridge or process dies while projecting one of these events,
+        # resume can reconstruct the tool result that was already visible.
+        if not blocked and agent.tool_progress_callback:
+            try:
+                agent.tool_progress_callback(
+                    "tool.completed", progress_function_name, None, None,
+                    duration=tool_duration, is_error=is_error,
+                    result=display_function_result,
+                )
+            except Exception as cb_err:
+                logging.debug("Tool progress callback error: %s", cb_err)
+
+        # Print cute message per tool
+        if agent._should_emit_quiet_tool_messages():
+            cute_msg = _get_cute_tool_message_impl(
+                name, args, tool_duration, result=display_function_result,
+            )
+            agent._safe_print(f"  {cute_msg}")
+        elif not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
+            _preview_str = _multimodal_text_summary(display_function_result)
+            if agent.verbose_logging:
+                print(f"  ✅ Tool {i+1} completed in {tool_duration:.2f}s")
+                print(agent._wrap_verbose("Result: ", _preview_str))
+            else:
+                response_preview = _preview_str[:agent.log_prefix_chars] + "..." if len(_preview_str) > agent.log_prefix_chars else _preview_str
+                print(f"  ✅ Tool {i+1} completed in {tool_duration:.2f}s - {response_preview}")
+
+        if not blocked and agent.tool_complete_callback:
+            try:
+                display_args = _redact_tool_args_for_display(name, args) or args
+                agent.tool_complete_callback(
+                    tc.id, name, display_args, display_function_result,
+                )
+            except Exception as cb_err:
+                logging.debug("Tool complete callback error: %s", cb_err)
+
+        if (
+            risk_metadata is not None
+            and risk_metadata.get("risk") != "low"
+            and agent.tool_progress_callback
+        ):
+            try:
+                agent.tool_progress_callback(
+                    "tool.output_risk",
+                    name,
+                    None,
+                    None,
+                    tool_call_id=tc.id,
+                    risk_metadata=risk_metadata,
+                )
+            except Exception as cb_err:
+                logging.debug("Tool output risk callback error: %s", cb_err)
+
     # ── Post-execution: display per-tool results ─────────────────────
     for i, (tc, name, args, middleware_trace, _parse_error, _scope_block) in enumerate(
         parsed_calls
@@ -1815,66 +1889,38 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         )
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
+        projection_args = (
+            i,
+            tc,
+            name,
+            args,
+            tool_duration,
+            is_error,
+            blocked,
+            progress_function_name,
+            display_function_result,
+            risk_metadata,
+        )
+        if all_resolved_names_are_no_effect:
+            deferred_completion_projections.append(projection_args)
+            continue
         if not _flush_session_db_after_tool_progress(
             agent,
             messages,
             stage=f"tool result {name}",
         ):
             return
+        _project_tool_completion(*projection_args)
 
-        # Every completion surface is downstream of the canonical append. If
-        # the UI bridge or process dies while projecting one of these events,
-        # resume can reconstruct the tool result that was already visible.
-        if not blocked and agent.tool_progress_callback:
-            try:
-                agent.tool_progress_callback(
-                    "tool.completed", progress_function_name, None, None,
-                    duration=tool_duration, is_error=is_error,
-                    result=display_function_result,
-                )
-            except Exception as cb_err:
-                logging.debug("Tool progress callback error: %s", cb_err)
-
-        # Print cute message per tool
-        if agent._should_emit_quiet_tool_messages():
-            cute_msg = _get_cute_tool_message_impl(
-                name, args, tool_duration, result=display_function_result,
-            )
-            agent._safe_print(f"  {cute_msg}")
-        elif not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
-            _preview_str = _multimodal_text_summary(display_function_result)
-            if agent.verbose_logging:
-                print(f"  ✅ Tool {i+1} completed in {tool_duration:.2f}s")
-                print(agent._wrap_verbose("Result: ", _preview_str))
-            else:
-                response_preview = _preview_str[:agent.log_prefix_chars] + "..." if len(_preview_str) > agent.log_prefix_chars else _preview_str
-                print(f"  ✅ Tool {i+1} completed in {tool_duration:.2f}s - {response_preview}")
-
-        if not blocked and agent.tool_complete_callback:
-            try:
-                display_args = _redact_tool_args_for_display(name, args) or args
-                agent.tool_complete_callback(
-                    tc.id, name, display_args, display_function_result,
-                )
-            except Exception as cb_err:
-                logging.debug("Tool complete callback error: %s", cb_err)
-
-        if (
-            risk_metadata is not None
-            and risk_metadata.get("risk") != "low"
-            and agent.tool_progress_callback
+    if all_resolved_names_are_no_effect:
+        if not _flush_session_db_after_tool_progress(
+            agent,
+            messages,
+            stage="tool result batch",
         ):
-            try:
-                agent.tool_progress_callback(
-                    "tool.output_risk",
-                    name,
-                    None,
-                    None,
-                    tool_call_id=tc.id,
-                    risk_metadata=risk_metadata,
-                )
-            except Exception as cb_err:
-                logging.debug("Tool output risk callback error: %s", cb_err)
+            return
+        for projection_args in deferred_completion_projections:
+            _project_tool_completion(*projection_args)
 
     # ── Per-turn aggregate budget enforcement ─────────────────────────
     # Keep /steer pending until the final post-budget drain below.  The model

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -9,7 +9,9 @@ results that were produced before it fired.  These tests pin the contract:
        restarts/kills the process never orphans the tool-call block).
     2. The SEQUENTIAL tool path flushes each tool result to the session DB
        immediately after appending it — BEFORE the next tool dispatches.
-    3. The CONCURRENT tool path flushes each tool result in append order.
+    3. The CONCURRENT tool path batches explicitly no-effect results in
+       append order, while retaining per-result durability for effect-capable
+       or unknown tools.
 
 These exercise the REAL production dispatch surfaces:
 
@@ -535,15 +537,28 @@ def test_failed_tool_result_persist_blocks_completion_projection(executor_mode):
 
 def test_segmented_batch_stops_before_later_segment_after_persist_failure():
     agent = _make_agent()
-    first = _mock_tool_call(call_id="first")
-    second = _mock_tool_call(call_id="second")
-    assistant_message = SimpleNamespace(tool_calls=[first, second])
+    first = _mock_tool_call(name="web_search", call_id="first")
+    second = _mock_tool_call(name="web_search", call_id="second")
+    later = _mock_tool_call(
+        name="write_file",
+        arguments='{"path":"later.txt","content":"later"}',
+        call_id="later",
+    )
+    assistant_message = SimpleNamespace(tool_calls=[first, second, later])
     messages: list = []
-    agent._flush_messages_to_session_db = MagicMock(return_value=False)
+    flushed_batches: list[list[str]] = []
+
+    def _failed_flush(flush_messages, conversation_history=None):
+        flushed_batches.append(
+            [message["tool_call_id"] for message in flush_messages if message.get("role") == "tool"]
+        )
+        return False
+
+    agent._flush_messages_to_session_db = MagicMock(side_effect=_failed_flush)
 
     with (
-        patch.object(agent, "_invoke_tool", return_value="first result") as invoke,
-        patch("run_agent.handle_function_call", return_value="second result") as dispatch,
+        patch.object(agent, "_invoke_tool", return_value="read-only result") as invoke,
+        patch("run_agent.handle_function_call", return_value="later result") as dispatch,
         patch(
             "agent.tool_executor.maybe_persist_tool_result",
             side_effect=lambda **kwargs: kwargs["content"],
@@ -554,20 +569,93 @@ def test_segmented_batch_stops_before_later_segment_after_persist_failure():
             assistant_message,
             messages,
             "task-1",
-            segments=[("parallel", [first]), ("sequential", [second])],
+            segments=[("parallel", [first, second]), ("sequential", [later])],
         )
 
-    invoke.assert_called_once()
+    assert invoke.call_count == 2
     dispatch.assert_not_called()
+    assert [message["tool_call_id"] for message in messages] == ["first", "second"]
+    assert flushed_batches == [["first", "second"]]
     assert getattr(agent, "_incremental_persistence_failed", False) is True
 
 
+def test_segmented_batch_batches_read_only_segment_and_flushes_later_side_effects_per_result():
+    agent = _make_agent()
+    first = _mock_tool_call(name="web_search", call_id="first")
+    second = _mock_tool_call(name="web_search", call_id="second")
+    third = _mock_tool_call(
+        name="write_file",
+        arguments='{"path":"first.txt","content":"first"}',
+        call_id="third",
+    )
+    fourth = _mock_tool_call(
+        name="write_file",
+        arguments='{"path":"second.txt","content":"second"}',
+        call_id="fourth",
+    )
+    assistant_message = SimpleNamespace(tool_calls=[first, second, third, fourth])
+    messages: list = []
+    flushed_batches: list[list[str]] = []
+    invoked_ids: list[str] = []
+    dispatched_ids: list[str] = []
+
+    def _fake_invoke(function_name, function_args, effective_task_id, tool_call_id, **kwargs):
+        invoked_ids.append(tool_call_id)
+        return f"result-{tool_call_id}"
+
+    def _fake_dispatch(function_name, function_args, effective_task_id, **kwargs):
+        tool_call_id = kwargs["tool_call_id"]
+        dispatched_ids.append(tool_call_id)
+        return f"result-{tool_call_id}"
+
+    def _record_flush(flush_messages, conversation_history=None):
+        flushed_batches.append(
+            [message["tool_call_id"] for message in flush_messages if message.get("role") == "tool"]
+        )
+
+    agent._flush_messages_to_session_db = MagicMock(side_effect=_record_flush)
+
+    with (
+        patch.object(agent, "_invoke_tool", side_effect=_fake_invoke),
+        patch("run_agent.handle_function_call", side_effect=_fake_dispatch),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        execute_tool_calls_segmented(
+            agent,
+            assistant_message,
+            messages,
+            "task-1",
+            segments=[
+                ("parallel", [first, second]),
+                ("sequential", [third, fourth]),
+            ],
+        )
+
+    assert sorted(invoked_ids) == ["first", "second"]
+    assert dispatched_ids == ["third", "fourth"]
+    assert [message["tool_call_id"] for message in messages] == [
+        "first",
+        "second",
+        "third",
+        "fourth",
+    ]
+    assert flushed_batches == [
+        ["first", "second"],
+        ["first", "second", "third"],
+        ["first", "second", "third", "fourth"],
+    ]
+
+
 # ---------------------------------------------------------------------------
-# Contract 3: the CONCURRENT path flushes each collected tool result in append
-# order.  Dispatch goes through agent._invoke_tool (the real concurrent
-# surface), which we mock for determinism.
+# Contract 3: the CONCURRENT path batches no-effect tool results before
+# projecting completions, while effect-capable/unknown batches retain
+# per-result durability. Dispatch goes through agent._invoke_tool (the real
+# concurrent surface), which we mock for determinism.
 # ---------------------------------------------------------------------------
-def test_execute_tool_calls_concurrent_flushes_each_tool_result_in_order():
+def test_execute_tool_calls_concurrent_batches_no_effect_results_before_completion_projections():
     agent = _make_agent()
     tool_calls = [
         _mock_tool_call(name="web_search", call_id="c1"),
@@ -576,22 +664,32 @@ def test_execute_tool_calls_concurrent_flushes_each_tool_result_in_order():
     messages: list = []
     assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
 
-    invoked_ids: list = []
+    event_order: list[tuple] = []
 
     def _fake_invoke(function_name, function_args, effective_task_id, tool_call_id, **kwargs):
-        invoked_ids.append(tool_call_id)
-        return f"result-{tool_call_id}"
+        return f"read-only result {tool_call_id}"
 
-    # Each flush must observe exactly one more tool result than the previous
-    # flush, in append order — i.e. the tail tool_call_id sequence is c1, c2.
-    flushed_tool_ids: list = []
-    flush_lengths: list = []
+    flushed_batches: list[list[tuple[str, str]]] = []
 
     def _record_flush(flush_messages, conversation_history=None):
-        flushed_tool_ids.append(flush_messages[-1]["tool_call_id"])
-        flush_lengths.append(len([m for m in flush_messages if m.get("role") == "tool"]))
+        batch = [
+            (message["tool_call_id"], message["content"])
+            for message in flush_messages
+            if message.get("role") == "tool"
+        ]
+        flushed_batches.append(batch)
+        event_order.append(("flush", tuple(tool_call_id for tool_call_id, _ in batch)))
+
+    def _record_progress(event, function_name, *_args, **_kwargs):
+        if event == "tool.completed":
+            event_order.append(("progress", function_name))
+
+    def _record_completion(tool_call_id, function_name, *_args):
+        event_order.append(("complete", tool_call_id))
 
     agent._flush_messages_to_session_db = MagicMock(side_effect=_record_flush)
+    agent.tool_progress_callback = _record_progress
+    agent.tool_complete_callback = _record_completion
 
     with (
         patch.object(agent, "_invoke_tool", side_effect=_fake_invoke) as inv,
@@ -602,15 +700,159 @@ def test_execute_tool_calls_concurrent_flushes_each_tool_result_in_order():
     ):
         agent._execute_tool_calls_concurrent(assistant_message, messages, "task-1")
 
-    # Proves the real concurrent dispatch surface was exercised.
     assert inv.call_count == 2, "concurrent path did not dispatch via _invoke_tool"
-    assert sorted(invoked_ids) == ["c1", "c2"]
+    assert [message["tool_call_id"] for message in messages] == ["c1", "c2"]
+    assert flushed_batches == [[
+        ("c1", "read-only result c1"),
+        ("c2", "read-only result c2"),
+    ]]
+    agent._flush_messages_to_session_db.assert_called_once()
+    assert event_order == [
+        ("flush", ("c1", "c2")),
+        ("progress", "web_search"),
+        ("complete", "c1"),
+        ("progress", "web_search"),
+        ("complete", "c2"),
+    ]
 
-    # Results appended in deterministic order.
-    assert [m["tool_call_id"] for m in messages] == ["c1", "c2"]
 
-    # Each tool result was flushed exactly once, in append order, with the
-    # running tool count growing by one each time (1 then 2).  Removing either
-    # production flush call breaks one of these assertions.
-    assert flushed_tool_ids == ["c1", "c2"]
-    assert flush_lengths == [1, 2]
+def test_execute_tool_calls_concurrent_tool_search_unwraps_read_only_name_before_batch_flush():
+    agent = _make_agent()
+    tool_calls = [
+        _mock_tool_call(
+            name="tool_call",
+            arguments='{"name":"read_file","arguments":{"path":"notes.md"}}',
+            call_id="c1",
+        ),
+        _mock_tool_call(
+            name="web_search",
+            arguments='{"query":"direct read"}',
+            call_id="c2",
+        ),
+    ]
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+    invoked: dict[str, tuple[str, dict]] = {}
+    flushed_batches: list[list[str]] = []
+
+    def _fake_invoke(function_name, function_args, effective_task_id, tool_call_id, **kwargs):
+        invoked[tool_call_id] = (function_name, function_args)
+        return f"result-{tool_call_id}"
+
+    def _record_flush(flush_messages, conversation_history=None):
+        flushed_batches.append(
+            [message["tool_call_id"] for message in flush_messages if message.get("role") == "tool"]
+        )
+
+    agent._flush_messages_to_session_db = MagicMock(side_effect=_record_flush)
+
+    with (
+        patch(
+            "tools.tool_search.resolve_underlying_call",
+            return_value=("read_file", {"path": "notes.md"}, None),
+        ),
+        patch(
+            "agent.tool_executor._tool_search_scoped_names",
+            return_value=frozenset({"read_file"}),
+        ),
+        patch.object(agent, "_invoke_tool", side_effect=_fake_invoke),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_concurrent(assistant_message, messages, "task-1")
+
+    assert invoked["c1"] == ("read_file", {"path": "notes.md"})
+    assert invoked["c2"] == ("web_search", {"query": "direct read"})
+    assert [message["tool_call_id"] for message in messages] == ["c1", "c2"]
+    assert flushed_batches == [["c1", "c2"]]
+    agent._flush_messages_to_session_db.assert_called_once()
+
+
+@pytest.mark.parametrize("effect_capable_name", ["write_file", "mcp_test_fs_write"])
+def test_execute_tool_calls_concurrent_retains_per_result_flush_when_any_tool_may_have_side_effect(
+    effect_capable_name,
+):
+    agent = _make_agent()
+    tool_calls = [
+        _mock_tool_call(name="web_search", call_id="c1"),
+        _mock_tool_call(
+            name=effect_capable_name,
+            arguments='{"path":"target.txt","content":"changed"}',
+            call_id="c2",
+        ),
+    ]
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+    flushed_batches: list[list[str]] = []
+
+    def _fake_invoke(function_name, function_args, effective_task_id, tool_call_id, **kwargs):
+        return f"result-{tool_call_id}"
+
+    def _record_flush(flush_messages, conversation_history=None):
+        flushed_batches.append(
+            [message["tool_call_id"] for message in flush_messages if message.get("role") == "tool"]
+        )
+
+    agent._flush_messages_to_session_db = MagicMock(side_effect=_record_flush)
+
+    with (
+        patch.object(agent, "_invoke_tool", side_effect=_fake_invoke) as invoke,
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_concurrent(assistant_message, messages, "task-1")
+
+    assert invoke.call_count == 2
+    assert [message["tool_call_id"] for message in messages] == ["c1", "c2"]
+    assert flushed_batches == [["c1"], ["c1", "c2"]]
+    assert agent._flush_messages_to_session_db.call_count == 2
+
+
+def test_execute_tool_calls_concurrent_read_only_batch_flush_failure_blocks_completion_projections():
+    agent = _make_agent()
+    tool_calls = [
+        _mock_tool_call(name="web_search", call_id="c1"),
+        _mock_tool_call(name="web_search", call_id="c2"),
+    ]
+    messages: list = []
+    assistant_message = SimpleNamespace(content="", tool_calls=tool_calls)
+    flushed_batches: list[list[str]] = []
+    completion_events: list[str] = []
+
+    def _fake_invoke(function_name, function_args, effective_task_id, tool_call_id, **kwargs):
+        return f"result-{tool_call_id}"
+
+    def _failed_flush(flush_messages, conversation_history=None):
+        flushed_batches.append(
+            [message["tool_call_id"] for message in flush_messages if message.get("role") == "tool"]
+        )
+        return False
+
+    def _record_progress(event, *_args, **_kwargs):
+        if event == "tool.completed":
+            completion_events.append(event)
+
+    agent._flush_messages_to_session_db = MagicMock(side_effect=_failed_flush)
+    agent.tool_progress_callback = _record_progress
+    agent.tool_complete_callback = MagicMock()
+
+    with (
+        patch.object(agent, "_invoke_tool", side_effect=_fake_invoke) as invoke,
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        agent._execute_tool_calls_concurrent(assistant_message, messages, "task-1")
+
+    assert invoke.call_count == 2
+    assert [message["tool_call_id"] for message in messages] == ["c1", "c2"]
+    assert flushed_batches == [["c1", "c2"]]
+    agent._flush_messages_to_session_db.assert_called_once()
+    assert getattr(agent, "_incremental_persistence_failed", False) is True
+    assert completion_events == []
+    agent.tool_complete_callback.assert_not_called()


### PR DESCRIPTION
## Summary

- Batch explicitly no-effect concurrent tool results into one SQLite session flush.
- Preserve per-result durability for side-effect-capable, unknown, plugin, and MCP tools.
- Keep completion/progress/risk projections downstream of successful persistence.

## Problem

`SessionDB.append_messages_batch()` already persists multiple rows in one transaction, but `execute_tool_calls_concurrent()` still called `_flush_session_db_after_tool_progress()` after every individual tool result. A concurrent batch of N read-only tools therefore caused N session flushes.

## Approach

The concurrent executor now classifies the resolved tool names with the existing `tool_may_have_side_effect()` authority:

- if every resolved tool is explicitly no-effect, it assembles results in declaration order, flushes once, then emits completion projections in order;
- if any tool may have side effects or is unknown, the existing per-result append → flush → projection behavior is retained;
- a failed batch flush emits no completion projection and stops later segmented execution through the existing persistence-failure flag.

No queue, thread, configuration, SQLite schema, or persistence API is added.

## Test plan

- `scripts/run_tests.sh tests/run_agent/test_tool_call_incremental_persistence.py` — 18 passed
- `scripts/run_tests.sh tests/run_agent/test_tool_call_incremental_persistence.py tests/run_agent/test_tool_batch_segmentation.py` — 51 passed
- `python -m ruff check agent/tool_executor.py tests/run_agent/test_tool_call_incremental_persistence.py` — passed
- `git diff --check` — passed

## Risk

The optimization is fail-conservative: unknown/plugin/MCP names remain effect-capable and retain per-result durability. Sequential execution and pre-execution assistant persistence are unchanged.
