### PR TITLE
feat(sessions): filter list by start date

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13312,6 +13312,18 @@ def main():
         help="Only sessions in one workspace: a git repo root or project dir "
         "(matched by path substring or basename).",
     )
+    sessions_list.add_argument(
+        "--after",
+        metavar="TIME",
+        help="Only sessions started at/after TIME "
+        "(duration ago like '5h', or ISO timestamp)",
+    )
+    sessions_list.add_argument(
+        "--before",
+        metavar="TIME",
+        help="Only sessions started before TIME "
+        "(duration ago like '5h', or ISO timestamp like '2026-07-05 14:30')",
+    )
 
     def _add_session_filter_args(p, default_older_help):
         p.add_argument(

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -327,10 +327,21 @@ def cmd_sessions(args, sessions_parser=None):
     _exclude = None if _source else ["tool"]
 
     if action == "list":
+        from hermes_cli.session_filters import build_prune_filters
         from hermes_state import workspace_key as _ws_key
 
+        try:
+            _time_filters = build_prune_filters(args)
+        except ValueError as e:
+            print(f"Error: {e}")
+            db.close()
+            return 1
         sessions = db.list_sessions_rich(
-            source=args.source, exclude_sources=_exclude, limit=args.limit
+            source=args.source,
+            exclude_sources=_exclude,
+            limit=args.limit,
+            started_after=_time_filters["started_after"],
+            started_before=_time_filters["started_before"],
         )
 
         # Workspace filter: match a session by its workspace key (git repo

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8947,6 +8947,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_pinned: bool = False,
         session_key: str = None,
         include_hidden: bool = False,
+        started_after: Optional[float] = None,
+        started_before: Optional[float] = None,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -9001,6 +9003,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Pass ``session_key`` to restrict results to one stable gateway
         conversation scope (DM, group, channel, or thread, including the
         configured per-user isolation policy).
+
+        ``started_after`` is inclusive and ``started_before`` is exclusive.
+        Both are applied in SQL before ``LIMIT``/``OFFSET``.
         """
         # Rows carry token/cost totals — drain queued deltas first so
         # listings (sidebar, /resume, dashboards) show exact counters.
@@ -9042,6 +9047,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clause, clause_params = _cwd_prefix_clause(cwd_prefix)
             where_clauses.append(clause)
             params.extend(clause_params)
+        if started_after is not None:
+            where_clauses.append("s.started_at >= ?")
+            params.append(started_after)
+        if started_before is not None:
+            where_clauses.append("s.started_at < ?")
+            params.append(started_before)
         if min_message_count > 0:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)

--- a/tests/hermes_cli/test_sessions_list_date_range.py
+++ b/tests/hermes_cli/test_sessions_list_date_range.py
@@ -1,0 +1,82 @@
+"""Date-range regressions for ``hermes sessions list`` (issue #91900)."""
+
+from argparse import Namespace
+
+import hermes_cli.sessions_cmd as sessions_cmd
+import hermes_state
+from hermes_state import SessionDB
+
+
+def _list_args(**overrides):
+    values = {
+        "sessions_action": "list",
+        "source": None,
+        "limit": 20,
+        "workspace": None,
+        "after": None,
+        "before": None,
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def _seed_session(db, session_id, *, started_at, source="cli", cwd="/work/alpha"):
+    db.create_session(session_id, source, cwd=cwd)
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = ?",
+        (started_at, session_id),
+    )
+    db._conn.commit()
+
+
+def test_list_date_bounds_are_inclusive_exclusive_and_compose(
+    tmp_path, monkeypatch, capsys
+):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    try:
+        _seed_session(db, "at-after", started_at=100, source="cli")
+        _seed_session(db, "inside", started_at=150, source="cli")
+        _seed_session(db, "at-before", started_at=200, source="cli")
+        _seed_session(db, "wrong-source", started_at=150, source="telegram")
+        _seed_session(db, "wrong-workspace", started_at=150, cwd="/work/beta")
+    finally:
+        db.close()
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: SessionDB(db_path))
+
+    sessions_cmd.cmd_sessions(
+        _list_args(
+            after="1970-01-01T00:01:40+00:00",
+            before="1970-01-01T00:03:20+00:00",
+            source="cli",
+            workspace="alpha",
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "at-after" in output
+    assert "inside" in output
+    assert "at-before" not in output
+    assert "wrong-source" not in output
+    assert "wrong-workspace" not in output
+
+
+def test_list_filters_date_before_limit(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path)
+    try:
+        _seed_session(db, "newer-out-of-range", started_at=300)
+        _seed_session(db, "matching-newer", started_at=200)
+        _seed_session(db, "matching-older", started_at=100)
+    finally:
+        db.close()
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: SessionDB(db_path))
+
+    sessions_cmd.cmd_sessions(
+        _list_args(before="1970-01-01T00:04:10+00:00", limit=2)
+    )
+
+    output = capsys.readouterr().out
+    assert "newer-out-of-range" not in output
+    assert "matching-newer" in output
+    assert "matching-older" in output

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -317,6 +317,10 @@ hermes sessions list --source telegram
 
 # Show more sessions
 hermes sessions list --limit 50
+
+# List sessions that started in an explicit date/time window.
+# --after is inclusive; --before is exclusive.
+hermes sessions list --after "2026-08-01" --before "2026-08-08"
 ```
 
 When sessions have titles, the output shows titles, previews, and relative timestamps:


### PR DESCRIPTION
## What does this PR do?

Adds non-mutating start-date bounds to `hermes sessions list`, so a user can browse session metadata within an explicit interval:

```bash
hermes sessions list --after "2026-08-01" --before "2026-08-08"
```

It reuses the established `sessions` time parser. `--after` is inclusive, `--before` is exclusive, and both apply to `sessions.started_at`. The predicates run in SQL before pagination, so out-of-range newer sessions cannot consume `--limit` slots.

## Related Issue

Fixes #91900

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/main.py`: register `sessions list --after` and `--before`.
- `hermes_cli/sessions_cmd.py`: parse bounds using the existing shared filter helper and pass them to the list query.
- `hermes_state.py`: apply inclusive/exclusive start-time predicates before SQL `LIMIT` / `OFFSET`.
- `tests/hermes_cli/test_sessions_list_date_range.py`: cover boundaries, source/workspace composition, and pre-limit filtering.
- `website/docs/user-guide/sessions.md`: document the date-window listing command.

## How to Test

1. Run the focused regression suite:
   ```bash
   uv run --extra dev pytest tests/hermes_cli/test_session_filters.py tests/hermes_cli/test_sessions_list_date_range.py tests/hermes_cli/test_session_listing.py tests/hermes_cli/test_session_browse.py tests/hermes_cli/test_console_engine.py -q
   ```
   Result: `40 passed`.
2. Run lint and whitespace validation:
   ```bash
   uv run --extra dev ruff check hermes_cli/main.py hermes_cli/sessions_cmd.py hermes_state.py tests/hermes_cli/test_sessions_list_date_range.py
   git diff --check
   ```
   Result: both passed.
3. Verify CLI discovery:
   ```bash
   uv run hermes sessions list --help
   ```
   Expected: `--after TIME` and `--before TIME` appear with the documented inclusive/exclusive semantics.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(sessions): filter list by start date`)
- [x] I searched existing issues/PRs; this complements, rather than duplicates, #13056 / #13058 because those target message-level `session_search` retrieval rather than CLI metadata listing
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; the focused relevant suite above passed
- [x] I've added tests for my changes
- [x] I've tested on Linux 7.0.0-27-generic (x86_64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A; no architecture/workflow changed
- [x] I've considered cross-platform impact — this is portable Python/SQLite query and argparse work, with no platform-specific I/O
- [x] I've updated tool descriptions/schemas — N/A; no model tool changed

## Screenshots / Logs

```text
40 passed in 0.86s
All checks passed!
```
