### PR TITLE
fix(desktop): keep nested explicit project sessions out of the parent project drill-in

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -154,6 +154,7 @@ import { ProjectDialog } from './project-dialog'
 import {
   excludeProjectSessions,
   liveSessionProjectId,
+  liveSessionsForProject,
   orderProjectsByIds,
   overlayLiveLanes,
   overlayLivePreviews,
@@ -1011,9 +1012,23 @@ export function ChatSidebar({
   // renders immediately — same optimistic layer as the overview previews. The
   // backend now seeds each project folder as an (empty) repo, so the overlay
   // always has a lane to place a new in-project session into.
+  //
+  // The overlay is path-only: without an ownership filter it would also inject
+  // sessions of a NESTED explicit project (a child folder project under this
+  // project's path) into this project's lanes, rendering them under both.
+  // Filter the live list by the authoritative owner first (the same rule
+  // `overlayLivePreviews` applies to the overview), then overlay.
+  const enteredProjectLiveSessions = useMemo(
+    () => (enteredProject ? liveSessionsForProject(enteredProject, agentSessions, projects) : agentSessions),
+    [enteredProject, agentSessions, projects]
+  )
+
   const enteredProjectContent = useMemo(
-    () => (enteredProject ? overlayLiveLanes(enteredProject, agentSessions, removedSessionIds) : undefined),
-    [enteredProject, agentSessions, removedSessionIds]
+    () =>
+      enteredProject
+        ? overlayLiveLanes(enteredProject, enteredProjectLiveSessions, removedSessionIds)
+        : undefined,
+    [enteredProject, enteredProjectLiveSessions, removedSessionIds]
   )
 
   const scopedRepoPaths = useMemo(
@@ -1788,7 +1803,7 @@ export function ChatSidebar({
                     ) : undefined
                   ) : undefined
                 }
-                liveSessions={inProject ? agentSessions : undefined}
+                liveSessions={inProject ? enteredProjectLiveSessions : undefined}
                 manualOrderIds={agentOrderManual ? agentOrderIds : sortOrderIds}
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -13,6 +13,7 @@ export { SidebarWorkspaceGroup } from './workspace-group'
 export {
   excludeProjectSessions,
   liveSessionProjectId,
+  liveSessionsForProject,
   overlayLiveLanes,
   overlayLivePreviews,
   sessionRecency,

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -9,6 +9,7 @@ import {
   excludeProjectSessions,
   kanbanWorktreeDir,
   liveSessionProjectId,
+  liveSessionsForProject,
   mergeRepoWorktreeGroups,
   NO_PROJECT_ID,
   overlayLiveLanes,
@@ -972,6 +973,100 @@ describe('overlayLiveLanes', () => {
     // Session must appear only in the worktree lane
     expect(featureLane?.sessions.map(s => s.id)).toEqual(['moved'])
     expect(overlaid.sessionCount).toBe(1)
+  })
+})
+
+describe('liveSessionsForProject', () => {
+  const ws = '/work/ws'
+  const child = `${ws}/child`
+
+  it('excludes sessions of a nested explicit child project from the parent auto project', () => {
+    // Regression for the nested-path duplicate: the parent workspace's drill-in
+    // must NOT list sessions whose authoritative owner is the child project,
+    // even though their cwd is under the parent's path.
+    const parent = projectNode({ id: ws, isAuto: true })
+    const session = makeCwdSession(child, { id: 'child-session' })
+    const explicit = [makeProject('p_child', [child])]
+
+    expect(liveSessionProjectId(session, explicit)).toBe('p_child')
+    expect(liveSessionsForProject(parent, [session], explicit)).toEqual([])
+  })
+
+  it('excludes nested child sessions from an explicit parent project too', () => {
+    const parent = projectNode({ id: 'p_parent' })
+    const session = makeCwdSession(child, { id: 'child-session' })
+    const explicit = [makeProject('p_parent', [ws]), makeProject('p_child', [child])]
+
+    expect(liveSessionsForProject(parent, [session], explicit)).toEqual([])
+  })
+
+  it('keeps the child sessions when the entered project IS the nested child', () => {
+    const entered = projectNode({ id: 'p_child' })
+    const session = makeCwdSession(child, { id: 'child-session' })
+    const explicit = [makeProject('p_child', [child])]
+
+    expect(liveSessionsForProject(entered, [session], explicit)).toEqual([session])
+  })
+
+  it('keeps sessions the entered project owns', () => {
+    const parent = projectNode({ id: ws, isAuto: true })
+    const owned = makeCwdSession(ws, { id: 'owned' })
+    const explicit = [makeProject('p_child', [child])]
+
+    expect(liveSessionsForProject(parent, [owned], explicit)).toEqual([owned])
+  })
+
+  it('keeps sessions of a nested AUTO subfolder project only under that subfolder project', () => {
+    // Same nesting shape without any explicit project: the subfolder's own auto
+    // project owns the session; the parent workspace must not receive it.
+    const parent = projectNode({ id: ws, isAuto: true })
+    const subfolderProject = projectNode({ id: child, isAuto: true })
+    const session = makeCwdSession(child, { id: 'sub-session' })
+
+    expect(liveSessionsForProject(parent, [session], [])).toEqual([])
+    expect(liveSessionsForProject(subfolderProject, [session], [])).toEqual([session])
+  })
+
+  it('keeps detached and kanban-task sessions for the path-only overlay to place', () => {
+    const parent = projectNode({ id: ws, isAuto: true })
+    const detached = makeCwdSession(null, { id: 'detached' })
+    const kanban = makeCwdSession('/repo/.worktrees/t_abc12345', { id: 'task' })
+
+    expect(liveSessionsForProject(parent, [detached, kanban], [])).toEqual([detached, kanban])
+  })
+
+  it('end-to-end: overlayLiveLanes no longer injects nested child sessions into the parent drill-in', () => {
+    const root = '/work/ws'
+    const childRoot = `${root}/child`
+    const childSession = makeCwdSession(childRoot, { id: 'child-session' })
+    const explicit = [makeProject('p_child', [childRoot])]
+
+    const parent = projectNode({
+      id: root,
+      isAuto: true,
+      path: root,
+      repos: [
+        {
+          id: root,
+          label: 'ws',
+          path: root,
+          sessionCount: 0,
+          groups: [lane({ id: root, label: 'ws', isMain: true, path: root })]
+        }
+      ]
+    })
+
+    // Without the filter the path-only overlay injects the child session into
+    // the parent lane (the pre-fix duplicate).
+    const unfiltered = overlayLiveLanes(parent, [childSession])
+    expect(unfiltered.repos[0].groups[0].sessions.map(s => s.id)).toEqual(['child-session'])
+
+    // With the filter the parent drill-in stays clean; the child project owns it.
+    const filtered = liveSessionsForProject(parent, [childSession], explicit)
+    const overlaid = overlayLiveLanes(parent, filtered)
+
+    expect(overlaid.repos[0].groups[0].sessions).toEqual([])
+    expect(overlaid.sessionCount).toBe(0)
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -728,6 +728,34 @@ export function overlayLiveLanes(
   return { ...project, repos, sessionCount: repos.reduce((n, repo) => n + repo.sessionCount, 0) }
 }
 
+/**
+ * The subset of live sessions the optimistic overlay may place into a
+ * project's lanes.
+ *
+ * Membership is owned by the backend: a session belongs to the explicit
+ * project whose folder is the longest prefix of its cwd/repo-root, else to
+ * its repo-root auto project. The path-only lane overlay
+ * ({@link overlayRepoLanes}) cannot see that rule — for a session whose cwd
+ * sits under ANOTHER project's path (a nested explicit project, e.g. a child
+ * folder project inside a non-git workspace root) it would inject the row
+ * into the wrong project's lanes and the session would render under both
+ * projects until the next tree refresh. Filter the live list by the
+ * authoritative owner before overlaying: keep only sessions with no
+ * resolvable owner (detached rows, kanban-task worktrees — the overlay
+ * handles those by path) or whose owner IS this project.
+ */
+export function liveSessionsForProject(
+  project: SidebarProjectTree,
+  live: SessionInfo[],
+  explicitProjects: ProjectInfo[]
+): SessionInfo[] {
+  return live.filter(session => {
+    const owner = liveSessionProjectId(session, explicitProjects)
+
+    return owner === null || owner === project.id
+  })
+}
+
 interface PreviewOverlayOptions {
   removed?: ReadonlySet<string>
   /** The active sort key as an id order; recency when empty. */


### PR DESCRIPTION
## Summary

Fixes the persistent cross-project duplicate from #91932: when an **explicit project's folder is nested inside another project's path** (e.g. a child folder project under a non-git workspace root, or under a git repo project), the parent project's drill-in view also listed the child project's sessions.

### Root cause

The backend owns membership (`tui_gateway/project_tree.py`: longest explicit-project folder prefix wins), and the tree RPCs assign each session to exactly one project. The desktop's **optimistic live overlay** (`overlayRepoLanes` → `liveLaneForRepo`) is path-only: it places every sidebar session into a project's lanes by `isPathUnder(repoRoot, cwd)`. A session whose cwd sits under a **nested explicit project's folder** therefore also matched the parent's path prefix and was injected into the parent's lanes on every render — duplicating the row. The existing eviction guard only dedupes lanes *within one repo*, so the cross-project copy never reconciled.

### Fix

Filter the live session list by the **authoritative owner** before overlaying, using the same rule the overview path already applies (`liveSessionProjectId` in `overlayLivePreviews`):

- New `liveSessionsForProject(project, live, explicitProjects)` in `workspace-groups.ts`: keeps sessions with no resolvable owner (detached rows, kanban-task worktrees — the path overlay still handles those) and sessions whose owner **is** the entered project; drops sessions owned by any other project.
- `sidebar/index.tsx` feeds the filtered list to both the entered-project overlay (`overlayLiveLanes`) and `EnteredProjectContent`, so the per-repo overlay in `RepoFlatSection` sees the same filtered set.

Only nested-path projects are affected and fixed; sibling/non-nested projects were and remain unaffected.

## Tests

7 new regression tests in `workspace-groups.test.ts`:

- nested explicit child project → excluded from the parent auto project's live list
- nested explicit child → excluded from an explicit parent project too
- child sessions kept when the entered project IS the nested child
- sessions owned by the entered project kept
- nested AUTO subfolder project (no explicit project) → session stays under the subfolder project
- detached / kanban-task sessions kept for the path-only overlay
- end-to-end: `overlayLiveLanes` no longer injects the child session into the parent drill-in (asserts the pre-fix duplicate is gone)

Verified: `workspace-groups.test.ts` 67/67 pass, sidebar suite 202/202 pass, `tsc --noEmit` clean, eslint clean on all touched files.

Closes #91932
