### PR TITLE
fix(desktop): portal dropdown submenu content into dialog container (#80798)

### DIFF
--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
+import { DialogPortalContainerContext } from '@/components/ui/dialog-portal-context'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,11 +20,15 @@ beforeAll(() => {
 
 afterEach(() => {
   cleanup()
+  document.querySelectorAll('[data-dialog-portal-container]').forEach(node => node.remove())
   vi.clearAllMocks()
 })
 
 // Render the submenu inside an open menu/sub so its content (switches) mounts.
+// `container` stands in for a Dialog's content node (what dialog.tsx publishes
+// through DialogPortalContainerContext); null means "not inside a dialog".
 function renderSubmenu(opts: {
+  container?: HTMLElement | null
   defaultEffort?: string
   effort?: string
   fastControl: FastControl
@@ -33,24 +38,26 @@ function renderSubmenu(opts: {
   reasoning: boolean
 }) {
   return render(
-    <DropdownMenu open>
-      <DropdownMenuContent>
-        <DropdownMenuSub open>
-          <DropdownMenuSubTrigger>edit</DropdownMenuSubTrigger>
-          <ModelEditSubmenu
-            defaultEffort={opts.defaultEffort ?? 'medium'}
-            effort={opts.effort ?? 'medium'}
-            fastControl={opts.fastControl}
-            isActive={opts.isActive ?? true}
-            model="m1"
-            onSelectModel={opts.onSelectModel ?? vi.fn()}
-            onSetOptions={opts.onSetOptions}
-            provider="p1"
-            reasoning={opts.reasoning}
-          />
-        </DropdownMenuSub>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <DialogPortalContainerContext.Provider value={opts.container ?? null}>
+      <DropdownMenu open>
+        <DropdownMenuContent>
+          <DropdownMenuSub open>
+            <DropdownMenuSubTrigger>edit</DropdownMenuSubTrigger>
+            <ModelEditSubmenu
+              defaultEffort={opts.defaultEffort ?? 'medium'}
+              effort={opts.effort ?? 'medium'}
+              fastControl={opts.fastControl}
+              isActive={opts.isActive ?? true}
+              model="m1"
+              onSelectModel={opts.onSelectModel ?? vi.fn()}
+              onSetOptions={opts.onSetOptions}
+              provider="p1"
+              reasoning={opts.reasoning}
+            />
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </DialogPortalContainerContext.Provider>
   )
 }
 
@@ -127,5 +134,45 @@ describe('ModelEditSubmenu reports edits without performing them', () => {
     fireEvent.click(screen.getByRole('switch'))
 
     expect(onSelectModel).toHaveBeenCalledWith('m1-fast')
+  })
+})
+
+// #80798: the thinking/effort panel used to portal to document.body even
+// inside a Dialog, landing BEHIND the dialog + parent menu (separate stacking
+// siblings) — dimmed and unclickable. The submenu must share the dialog's DOM
+// subtree when one encloses it, and keep the bare body portal otherwise (that
+// escape is what keeps submenus unclipped by scrollable hosts outside dialogs).
+describe('ModelEditSubmenu lands in the right stacking world', () => {
+  const SUB_SELECTOR = '[data-slot="dropdown-menu-sub-content"]'
+
+  const baseProps = { fastControl: { kind: 'param', on: true } as FastControl, onSetOptions: vi.fn(), reasoning: true }
+
+  it('inside a dialog: mounts within the dialog container, not as a body-level sibling (#80798)', () => {
+    // Stand-in for the DialogContent shell node that dialog.tsx publishes.
+    const dialogNode = document.createElement('div')
+    dialogNode.setAttribute('data-dialog-portal-container', '')
+    document.body.appendChild(dialogNode)
+
+    renderSubmenu({ ...baseProps, container: dialogNode })
+
+    const sub = document.querySelector(SUB_SELECTOR)
+    expect(sub).not.toBeNull()
+    // A DOM descendant of the dialog: it inherits the dialog's stacking
+    // context, so it paints and receives events above the parent menu.
+    expect(dialogNode.contains(sub)).toBe(true)
+  })
+
+  it('outside a dialog: keeps the document.body portal so overflow-clip escapes still work', () => {
+    renderSubmenu(baseProps)
+
+    const sub = document.querySelector(SUB_SELECTOR)
+    expect(sub).not.toBeNull()
+
+    // No container was provided, so the portal chain must terminate at
+    // document.body exactly as the bare Radix Portal did before.
+    let node: Node | null = sub
+    while (node && node !== document.body) node = node.parentNode
+
+    expect(node).toBe(document.body)
   })
 })

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -171,7 +171,9 @@ describe('ModelEditSubmenu lands in the right stacking world', () => {
     // No container was provided, so the portal chain must terminate at
     // document.body exactly as the bare Radix Portal did before.
     let node: Node | null = sub
-    while (node && node !== document.body) node = node.parentNode
+    while (node && node !== document.body) {
+      node = node.parentNode
+    }
 
     expect(node).toBe(document.body)
   })

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -249,12 +249,19 @@ function DropdownMenuSubContent({
   collisionPadding = 8,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  // Same container rule as DropdownMenuContent: inside a dialog, portal into
+  // the dialog's node so the submenu shares its stacking context — a
+  // body-level submenu paints BEHIND the dialog + parent menu, dimmed and
+  // unclickable (#80798). Outside a dialog this is null/undefined and Radix
+  // falls back to document.body, preserving the overflow-clip escape.
+  const container = usePopoverPortalContainer()
+
   return (
     // Portal the submenu out of the parent Content so it escapes that Content's
     // `overflow` clip. Without this, a submenu opening from a scrollable menu
     // gets visually cut off at the parent's edges. Radix Popper still anchors
     // it to the SubTrigger and handles collision/flip, so portaling is safe.
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Portal container={container}>
       <DropdownMenuPrimitive.SubContent
         // `dt-portal-scrollbar` reproduces the themed scrollbar for portaled
         // overlays (rendered under document.body). Use a fixed `max-h-80`


### PR DESCRIPTION
Fixes #80798

## Root cause
`DropdownMenuContent` portals into the enclosing dialog via `usePopoverPortalContainer()`, but `DropdownMenuSubContent` still used a bare Radix portal to `document.body` with z-50. The Kanban New Task dialog is a separate stacking sibling at z-modal, so the model row's Thinking/effort submenu painted behind it — dimmed and pointer-blocked.

## Fix
`DropdownMenuSubContent` now honors `usePopoverPortalContainer()` exactly like Content/Select/Popover already do. With no container (outside dialogs) the Radix fallback keeps the bare body portal byte-for-byte, preserving the overflow-clip escape hatches elsewhere. Verified against the installed Radix source that `container || document.body` makes the no-container path identical; only SubContent renders a portal among the Sub* primitives, so nothing else needed touching.

## Verification
Extended `model-edit-submenu.test.tsx` ("lands in the right stacking world"): inside a dialog the submenu mounts within the dialog container node; without a container the portal chain still terminates at document.body. All 5 suites exercising the primitive pass (76 tests), `tsc --noEmit` exit 0.