### PR TITLE
fix(opencode): separate paid, subscription, and keyless catalogs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -495,7 +495,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # discovery floor — live entries lead in the picker and stale curated
     # names never pollute the top.
     "opencode-zen": [
-        "x-preview-f-free",  # "Ox Alpha" stealth model — free, 1M ctx, ZDR
         "kimi-k3",
         "kimi-k2.5",
         "kimi-k2.6",
@@ -551,16 +550,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2.7-code",
         "deepseek-v4-pro",
         "deepseek-v4-flash",
-        "deepseek-v4-flash-free",
         "qwen3.6-plus",
         "qwen3.5-plus",
-        "big-pickle",
-        "mimo-v2.5-free",
-        "hy3-free",
-        "laguna-s-2.1-free",
-        "nemotron-3-ultra-free",
-        "nemotron-3.5-lightning-free",
-        "muse-spark-1.2-contributor-free",
     ],
     # OpenCode free tier — keyless (no OpenCode account needed). Synced
     # against live GET /zen/v1/models + anonymous probes (2026-08-21);
@@ -593,8 +584,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "glm-5",
         "mimo-v2.5-pro",
         "mimo-v2.5",
-        "mimo-v2-pro",
-        "mimo-v2-omni",
         "minimax-m3",
         "minimax-m2.7",
         "minimax-m2.5",
@@ -606,7 +595,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen3.6-plus",
         "qwen3.5-plus",
         "hy3",
-        "hy3-preview",
         "muse-spark-1.2-contributor",
         # Go-subscription twin of the Zen keyless Ox Alpha (live go/v1
         # catalog 2026-08-21; NOT keyless — Go relay requires a Go key).

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -26,6 +26,22 @@ _ATTRIBUTION_HEADERS = {
     "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
 }
 
+# Zen's live catalog mixes paid models, currently usable anonymous models, and
+# expired promotional IDs. Hermes exposes the usable anonymous subset through
+# the dedicated keyless opencode-free provider, so none of these IDs should be
+# offered through the credentialed Zen picker.
+_ZEN_FREE_TIER_MODELS = frozenset({
+    "x-preview-f-free",
+    "hy3-free",
+    "laguna-s-2.1-free",
+    "nemotron-3-ultra-free",
+    "nemotron-3.5-lightning-free",
+    "muse-spark-1.2-contributor-free",
+    "big-pickle",
+    "mimo-v2.5-free",
+    "deepseek-v4-flash-free",
+})
+
 
 def _flat_model_name(model: str | None) -> str:
     """Return the bare OpenCode model ID, tolerating aggregator prefixes."""
@@ -51,6 +67,22 @@ def _is_glm_5_2_model(model: str | None) -> bool:
 
 class OpenCodeGoProfile(ProviderProfile):
     """OpenCode Go - model-specific reasoning controls."""
+
+    # The relay still advertises these IDs from /v1/models, but rejects every
+    # request for them and the current Go documentation no longer lists them.
+    _UNAVAILABLE_MODELS = frozenset({
+        "hy3-preview",
+        "mimo-v2-omni",
+        "mimo-v2-pro",
+    })
+
+    def fetch_models(self, **kwargs) -> list[str]:
+        models = super().fetch_models(**kwargs)
+        return [
+            model
+            for model in models
+            if _flat_model_name(model) not in self._UNAVAILABLE_MODELS
+        ]
 
     # Per-model completion-token cap. The opencode-go relay's default is
     # too large for mimo-v2.5-pro — it sends max_tokens=262144 but Xiaomi
@@ -192,6 +224,14 @@ def _build_ox_alpha_reasoning_extras(
 
 class OpenCodeZenProfile(ProviderProfile):
     """OpenCode Zen - model-specific reasoning controls."""
+
+    def fetch_models(self, **kwargs) -> list[str]:
+        models = super().fetch_models(**kwargs)
+        return [
+            model
+            for model in models
+            if _flat_model_name(model) not in _ZEN_FREE_TIER_MODELS
+        ]
 
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context

--- a/tests/hermes_cli/test_opencode_go_in_model_list.py
+++ b/tests/hermes_cli/test_opencode_go_in_model_list.py
@@ -15,11 +15,11 @@ _OPENCODE_GO_REQUIRED = {
     "kimi-k2.5",
     "glm-5.1",
     "glm-5",
-    "mimo-v2-pro",
-    "mimo-v2-omni",
     "minimax-m2.7",
     "minimax-m2.5",
 }
+
+_OPENCODE_GO_UNAVAILABLE = {"hy3-preview", "mimo-v2-pro", "mimo-v2-omni"}
 
 
 @patch.dict(os.environ, {"OPENCODE_GO_API_KEY": "test-key"}, clear=False)
@@ -40,6 +40,10 @@ def test_opencode_go_appears_when_api_key_set():
     assert not missing, (
         f"opencode-go picker should include the curated floor; missing: {sorted(missing)}. "
         f"Got: {opencode_go['models']}"
+    )
+    assert not (_OPENCODE_GO_UNAVAILABLE & present), (
+        "opencode-go picker must hide relay-advertised models that reject "
+        f"generation requests: {sorted(_OPENCODE_GO_UNAVAILABLE & present)}"
     )
     # opencode-go can appear as "built-in" (from PROVIDER_TO_MODELS_DEV when
     # models.dev is reachable) or "hermes" (from HERMES_OVERLAYS fallback when

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 
@@ -25,6 +27,41 @@ def opencode_zen_profile():
     profile = providers.get_provider_profile("opencode-zen")
     assert profile is not None, "opencode-zen provider profile must be registered"
     return profile
+
+
+class TestOpenCodeGoCatalogFiltering:
+    def test_live_catalog_hides_models_rejected_by_go(self, opencode_go_profile):
+        live = [
+            "glm-5.3",
+            "mimo-v2-pro",
+            "mimo-v2-omni",
+            "hy3-preview",
+            "ox-alpha-free",
+        ]
+
+        with patch("providers.base.ProviderProfile.fetch_models", return_value=live):
+            assert opencode_go_profile.fetch_models(
+                api_key="test-key",
+                base_url="https://opencode.ai/zen/go/v1",
+            ) == ["glm-5.3", "ox-alpha-free"]
+
+    def test_zen_catalog_leaves_free_models_to_keyless_provider(
+        self, opencode_zen_profile
+    ):
+        live = [
+            "gpt-5.6-sol",
+            "x-preview-f-free",
+            "hy3-free",
+            "big-pickle",
+            "deepseek-v4-flash-free",
+            "mimo-v2.5-free",
+        ]
+
+        with patch("providers.base.ProviderProfile.fetch_models", return_value=live):
+            assert opencode_zen_profile.fetch_models(
+                api_key="test-key",
+                base_url="https://opencode.ai/zen/v1",
+            ) == ["gpt-5.6-sol"]
 
 
 class TestOpenCodeZenOxReasoning:


### PR DESCRIPTION
## Summary

OpenCode's live model endpoints currently mix three runtime contracts in ways that make a picker entry unsafe to trust directly:

- Zen pay-as-you-go models require a Zen credential and credits.
- Go subscription models require a Go credential.
- The dedicated `opencode-free` models must be called anonymously.

This PR keeps those catalogs separate and hides three Go IDs that the relay advertises but rejects for generation.

## Problem reproduced

A Desktop selection of `x-preview-f-free` under the credentialed `opencode` alias reloaded an OpenCode credential. The Zen relay returned HTTP 401 `Invalid API key`; the same model returned HTTP 200 when called anonymously through `opencode-free`.

The live Go `/models` endpoint also returned these IDs, but minimal generation returned HTTP 400 for each, and none appears in the current [OpenCode Go documentation](https://opencode.ai/docs/go/):

- `hy3-preview`: model unavailable
- `mimo-v2-pro`: unsupported model
- `mimo-v2-omni`: unsupported model

## Changes

- Filter the three rejected IDs from `OpenCodeGoProfile.fetch_models()` and the curated Go floor.
- Filter free and expired promotional IDs from `OpenCodeZenProfile.fetch_models()` and the credentialed Zen floor.
- Keep the six verified anonymous models exclusively in `opencode-free`.
- Add regression coverage for live-catalog filtering and picker boundaries.

The Go model named `ox-alpha-free` is intentionally not treated as anonymous: despite the suffix, it is a keyed Go-subscription model.

## Verification

- OpenCode focused suite: **81 passed, 0 failed** across 10 test files.
- Live Go audit: **26/26** remaining catalog models completed a minimal request across chat completions, Anthropic messages, and Responses transports.
- Live anonymous Free audit: **6/6** completed with HTTP 200.
- Live Zen paid catalog: 55 paid entries after filtering; generation could not be validated because the test account returned `Insufficient balance`.
- `git diff --check`: passed.

No default-model, fallback, or credential-storage behavior is changed.
