### PR TITLE
fix(update): refresh the gateway launcher for every profile, not just one

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4887,6 +4887,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_get_origin_url",
         "_has_upstream_remote",
         "_install_psutil_android_compat",
+        "_installed_gateway_profile_homes",
         "_invalidate_update_cache",
         "_is_android_python",
         "_is_fork",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4900,6 +4900,8 @@ _LAZY_COMMAND_EXPORTS = {
         "_npm_manifests_digest",
         "_orphaned_desktop_backend_pids",
         "_pause_windows_gateways_for_update",
+        "_preserve_replaced_launchers",
+        "_snapshot_launcher_scripts",
         "_print_curator_first_run_notice",
         "_print_curator_recent_run_notice",
         "_print_fts_optimize_available_notice",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4768,6 +4768,52 @@ def _installed_gateway_profile_homes() -> list:
     return homes
 
 
+def _snapshot_launcher_scripts(script_path) -> dict:
+    """Read the ``.cmd``/``.vbs`` launcher pair before a refresh rewrites it.
+
+    Returns ``{path: bytes or None}``; ``None`` means the file does not exist
+    yet (creating one is not destructive, so there is nothing to preserve).
+    """
+    snapshot = {}
+    for path in (script_path, script_path.with_suffix(".vbs")):
+        try:
+            snapshot[path] = path.read_bytes()
+        except OSError:
+            snapshot[path] = None
+    return snapshot
+
+
+def _preserve_replaced_launchers(snapshot: dict) -> list:
+    """Save any launcher whose content the refresh actually replaced.
+
+    ``_write_task_script`` renders from the current template, so the refresh is
+    a content *replace*, not a touch: on a host that wrapped the generated
+    ``.cmd`` (a local supervisor or a watchdog pointing its ``/TR`` at it) the
+    wrapper is flattened back to the stock script.  Healing a legacy launcher
+    is the whole point of this function — a pre-aa2ae36c3f ``pythonw`` script
+    also looks "customized" — so refusing to rewrite is not an option.  Keeping
+    a copy is.
+
+    Only a *changed* file is preserved.  That is what keeps a second update
+    from overwriting the user's saved wrapper with the stock content the first
+    update wrote: by then the on-disk script already matches the template, so
+    nothing is copied and the original backup survives.
+    """
+    saved = []
+    for path, old in snapshot.items():
+        if old is None:
+            continue
+        try:
+            if path.read_bytes() == old:
+                continue
+            backup = path.with_name(path.name + ".pre-refresh.bak")
+            backup.write_bytes(old)
+            saved.append(backup)
+        except OSError as exc:
+            logger.debug("Could not preserve replaced launcher %s: %s", path, exc)
+    return saved
+
+
 def _refresh_windows_gateway_launchers() -> None:
     """Regenerate installed Windows gateway launcher scripts after update.
 
@@ -4793,6 +4839,10 @@ def _refresh_windows_gateway_launchers() -> None:
     gateway, with the one mechanism designed to heal it permanently skipping
     it.  Each profile is scoped and caught independently so one bad profile
     cannot cost the others their refresh.
+
+    Because the render is a content replace, a launcher whose content actually
+    changed is copied to ``<name>.pre-refresh.bak`` first, so a host that
+    wrapped the generated script can get its wrapper back.
     """
     if not _m()._is_windows():
         return
@@ -4801,10 +4851,21 @@ def _refresh_windows_gateway_launchers() -> None:
         from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
         refreshed = 0
+        preserved = []
         for home in _m()._installed_gateway_profile_homes():
             token = set_hermes_home_override(str(home))
             try:
+                try:
+                    snapshot = _snapshot_launcher_scripts(
+                        gateway_windows.get_task_script_path()
+                    )
+                except Exception as exc:
+                    # Resolving the path must never cost a profile its refresh;
+                    # healing the launcher matters more than preserving a copy.
+                    logger.debug("Could not snapshot launchers for %s: %s", home, exc)
+                    snapshot = {}
                 gateway_windows._write_task_script()
+                preserved.extend(_preserve_replaced_launchers(snapshot))
                 refreshed += 1
             except Exception as exc:
                 logger.debug(
@@ -4819,6 +4880,8 @@ def _refresh_windows_gateway_launchers() -> None:
                 "  ✓ Refreshed Windows gateway launcher scripts "
                 f"({refreshed} profiles)"
             )
+        for backup in preserved:
+            print(f"    previous launcher saved to {backup}")
     except Exception as exc:
         logger.debug("Could not refresh Windows gateway launchers after update: %s", exc)
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4730,6 +4730,44 @@ def _warn_gateway_restart_phase_aborted(exc: BaseException, pids) -> None:
     print("    hermes gateway restart")
     print("    hermes gateway status")
 
+def _installed_gateway_profile_homes() -> list:
+    """Every profile home that has a Windows gateway autostart entry installed.
+
+    ``gateway_windows``'s helpers are profile-implicit: ``get_task_name()``,
+    ``get_task_script_path()`` and ``is_installed()`` all resolve through
+    ``get_hermes_home()``, so on their own they only ever describe whichever
+    profile the updater happens to be running as.  Rather than thread a profile
+    argument through each of them, scope the call with
+    ``set_hermes_home_override`` — a context-local override built for exactly
+    this ("in-process, per-task scoping") — and ask the existing helpers once
+    per profile.
+
+    Returns homes in ``list_profile_names()`` order (``default`` first).  A
+    profile whose check raises is skipped rather than fatal: this runs inside
+    ``hermes update`` and must never fail it.
+    """
+    from hermes_cli import gateway_windows
+    from hermes_cli.profiles import get_profile_dir, list_profile_names
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    homes = []
+    for name in list_profile_names():
+        try:
+            home = get_profile_dir(name)
+        except Exception as exc:
+            logger.debug("Could not resolve home for profile %r: %s", name, exc)
+            continue
+        token = set_hermes_home_override(str(home))
+        try:
+            if gateway_windows.is_installed():
+                homes.append(home)
+        except Exception as exc:
+            logger.debug("Could not check gateway install for profile %r: %s", name, exc)
+        finally:
+            reset_hermes_home_override(token)
+    return homes
+
+
 def _refresh_windows_gateway_launchers() -> None:
     """Regenerate installed Windows gateway launcher scripts after update.
 
@@ -4746,16 +4784,41 @@ def _refresh_windows_gateway_launchers() -> None:
     ``_write_task_script`` is idempotent and renders from current code, so
     this is a no-op for modern installs. Best-effort: a failed refresh must
     never fail the update.
+
+    Refreshes **every** profile with an installed launcher, not just the one
+    the updater is running as.  ``is_installed()`` and ``_write_task_script()``
+    are profile-implicit, so before #91675 an update healed a single profile
+    and left every other profile's launcher stale in perpetuity — which for a
+    pre-aa2ae36c3f profile means a Scheduled Task that can never start a
+    gateway, with the one mechanism designed to heal it permanently skipping
+    it.  Each profile is scoped and caught independently so one bad profile
+    cannot cost the others their refresh.
     """
     if not _m()._is_windows():
         return
     try:
         from hermes_cli import gateway_windows
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
-        if not gateway_windows.is_installed():
-            return
-        gateway_windows._write_task_script()
-        print("  ✓ Refreshed Windows gateway launcher scripts")
+        refreshed = 0
+        for home in _m()._installed_gateway_profile_homes():
+            token = set_hermes_home_override(str(home))
+            try:
+                gateway_windows._write_task_script()
+                refreshed += 1
+            except Exception as exc:
+                logger.debug(
+                    "Could not refresh Windows gateway launchers for %s: %s", home, exc
+                )
+            finally:
+                reset_hermes_home_override(token)
+        if refreshed == 1:
+            print("  ✓ Refreshed Windows gateway launcher scripts")
+        elif refreshed > 1:
+            print(
+                "  ✓ Refreshed Windows gateway launcher scripts "
+                f"({refreshed} profiles)"
+            )
     except Exception as exc:
         logger.debug("Could not refresh Windows gateway launchers after update: %s", exc)
 

--- a/tests/hermes_cli/test_update_gateway_launcher_refresh.py
+++ b/tests/hermes_cli/test_update_gateway_launcher_refresh.py
@@ -20,13 +20,23 @@ against a faked ``sys.platform``.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
+import hermes_cli.gateway  # noqa: F401  (see below)
 import hermes_cli.gateway_windows as gateway_windows
 import hermes_cli.main as cli_main
+
+# ``hermes_cli.gateway`` binds ``get_hermes_home`` from ``hermes_cli.config`` at
+# module level, so whichever test imports it first decides that binding for the
+# whole session.  A test below patches ``hermes_cli.config.get_hermes_home``
+# with a ``mock.patch`` context manager; if ``hermes_cli.gateway`` were first
+# imported inside that ``with`` block it would keep the Mock after the block
+# exits, and every later caller of ``_profile_suffix`` would get a ``str``
+# instead of a ``Path``.  Importing it here makes the binding deterministic.
 
 
 # ---------------------------------------------------------------------------
@@ -252,3 +262,132 @@ def test_refresh_is_a_no_op_off_windows(monkeypatch):
     )
 
     cli_main._refresh_windows_gateway_launchers()
+
+
+# ---------------------------------------------------------------------------
+# The refresh is a content replace, not a touch (#91956 review)
+# ---------------------------------------------------------------------------
+
+STOCK_CMD = b"@echo off\r\npython.exe -m hermes_cli.main gateway run\r\n"
+STOCK_VBS = b'CreateObject("WScript.Shell").Run "...", 0, False\r\n'
+
+
+def _stub_renderer(monkeypatch):
+    """Stand in for ``_write_task_script`` with something that really writes.
+
+    The real renderer resolves ``get_python_path()``/``PROJECT_ROOT`` and a
+    profile argv, none of which this behaviour depends on. What it does depend
+    on is that the render *replaces file content*, which is exactly what a stub
+    that writes a fixed stock pair reproduces.
+    """
+    def _render():
+        path = gateway_windows.get_task_script_path()
+        path.write_bytes(STOCK_CMD)
+        path.with_suffix(".vbs").write_bytes(STOCK_VBS)
+        return path
+
+    monkeypatch.setattr(gateway_windows, "_write_task_script", _render)
+
+
+@pytest.fixture
+def windows_refresh(profile_root, monkeypatch):
+    """A refresh that runs its real path resolution on any host.
+
+    ``get_task_script_path`` calls ``_assert_windows``, so the platform has to
+    be faked for the path derivation (and therefore the backup) to run at all
+    off Windows.
+    """
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    _stub_renderer(monkeypatch)
+    return profile_root
+
+
+def _script_path_for(home):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(str(home))
+    try:
+        return gateway_windows.get_task_script_path()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_a_wrapped_launcher_is_saved_before_it_is_replaced(
+    windows_refresh, monkeypatch, capsys
+):
+    """A host that wrapped the generated .cmd (local supervisor / watchdog)
+    gets its wrapper flattened by the refresh. Healing a legacy launcher means
+    we cannot decline to rewrite, so the previous copy has to survive."""
+    _install_only(monkeypatch, [windows_refresh])
+    script = _script_path_for(windows_refresh)
+    wrapper = b'wscript.exe //B //Nologo "Hermes_Gateway_hidden.vbs"\r\n'
+    script.write_bytes(wrapper)
+
+    cli_main._refresh_windows_gateway_launchers()
+
+    backup = script.with_name(script.name + ".pre-refresh.bak")
+    assert script.read_bytes() == STOCK_CMD
+    assert backup.read_bytes() == wrapper
+    assert str(backup) in capsys.readouterr().out
+
+
+def test_a_second_update_does_not_overwrite_the_saved_wrapper(
+    windows_refresh, monkeypatch
+):
+    """The trap in a naive backup: update #2 finds a stock script, copies THAT
+    over the backup, and the user's wrapper is gone for good. Only a launcher
+    whose content actually changed is preserved, so #2 copies nothing."""
+    _install_only(monkeypatch, [windows_refresh])
+    script = _script_path_for(windows_refresh)
+    wrapper = b"REM the only copy of this that will ever exist\r\n"
+    script.write_bytes(wrapper)
+
+    cli_main._refresh_windows_gateway_launchers()
+    cli_main._refresh_windows_gateway_launchers()
+
+    assert script.with_name(script.name + ".pre-refresh.bak").read_bytes() == wrapper
+
+
+def test_an_unchanged_launcher_is_not_backed_up(windows_refresh, monkeypatch, capsys):
+    _install_only(monkeypatch, [windows_refresh])
+    script = _script_path_for(windows_refresh)
+    script.write_bytes(STOCK_CMD)
+    script.with_suffix(".vbs").write_bytes(STOCK_VBS)
+
+    cli_main._refresh_windows_gateway_launchers()
+
+    assert not script.with_name(script.name + ".pre-refresh.bak").exists()
+    assert "previous launcher saved" not in capsys.readouterr().out
+
+
+def test_a_launcher_that_did_not_exist_is_created_without_a_backup(
+    windows_refresh, monkeypatch
+):
+    """Creating a file is not destructive, so there is nothing to preserve."""
+    _install_only(monkeypatch, [windows_refresh])
+    script = _script_path_for(windows_refresh)
+    vbs = script.with_suffix(".vbs")
+    assert not vbs.exists()
+
+    cli_main._refresh_windows_gateway_launchers()
+
+    assert vbs.read_bytes() == STOCK_VBS
+    assert not vbs.with_name(vbs.name + ".pre-refresh.bak").exists()
+
+
+def test_each_profile_keeps_its_backup_in_its_own_home(windows_refresh, monkeypatch):
+    """The reported host had a wrapper on one profile only; a backup written to
+    the wrong home would be as lost as no backup at all."""
+    other = windows_refresh / "profiles" / "arthur_tutor"
+    _install_only(monkeypatch, [windows_refresh, other])
+    wrappers = {}
+    for home in (windows_refresh, other):
+        script = _script_path_for(home)
+        wrappers[script] = f"REM wrapper for {home.name}\r\n".encode()
+        script.write_bytes(wrappers[script])
+
+    cli_main._refresh_windows_gateway_launchers()
+
+    for script, original in wrappers.items():
+        assert script.with_name(script.name + ".pre-refresh.bak").read_bytes() == original

--- a/tests/hermes_cli/test_update_gateway_launcher_refresh.py
+++ b/tests/hermes_cli/test_update_gateway_launcher_refresh.py
@@ -86,9 +86,169 @@ def test_restart_spec_normalizes_legacy_pythonw_argv(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def profile_root(tmp_path, monkeypatch):
+    """A fake Hermes root whose ``profiles/`` dir the real scan can walk.
+
+    ``list_profile_names`` is a plain directory scan, so pointing
+    ``get_default_hermes_root`` at ``tmp_path`` exercises the real enumeration
+    rather than a stubbed profile list.
+    """
+    import hermes_constants
+
+    (tmp_path / "profiles" / "arthur_tutor").mkdir(parents=True)
+    (tmp_path / "profiles" / "joao_pessoal").mkdir(parents=True)
+    monkeypatch.setattr(hermes_constants, "get_default_hermes_root", lambda: tmp_path)
+    return tmp_path
 
 
+def _install_only(monkeypatch, installed_homes):
+    """Make ``is_installed()`` answer for the home the CALLER scoped it to.
+
+    It reads ``get_hermes_home()`` itself, so a test using this fails if the
+    context-local override is not actually installed around the call — not
+    merely if the loop is missing.
+    """
+    from hermes_constants import get_hermes_home
+
+    wanted = {str(Path(h)) for h in installed_homes}
+    monkeypatch.setattr(
+        gateway_windows, "is_installed", lambda: str(get_hermes_home()) in wanted
+    )
 
 
+def test_enumeration_keeps_only_profiles_with_an_installed_entry(
+    profile_root, monkeypatch
+):
+    _install_only(monkeypatch, [profile_root, profile_root / "profiles" / "arthur_tutor"])
+
+    homes = cli_main._installed_gateway_profile_homes()
+
+    assert [str(h) for h in homes] == [
+        str(profile_root),
+        str(profile_root / "profiles" / "arthur_tutor"),
+    ]
 
 
+def test_enumeration_restores_the_previous_home_afterwards(profile_root, monkeypatch):
+    """The override is context-local; leaking one would retarget the rest of
+    the update at a profile it was never asked to touch."""
+    from hermes_constants import get_hermes_home
+
+    _install_only(monkeypatch, [profile_root])
+    before = str(get_hermes_home())
+
+    cli_main._installed_gateway_profile_homes()
+
+    assert str(get_hermes_home()) == before
+
+
+def test_enumeration_survives_a_profile_that_raises(profile_root, monkeypatch):
+    from hermes_constants import get_hermes_home
+
+    bad = str(profile_root / "profiles" / "arthur_tutor")
+
+    def flaky():
+        if str(get_hermes_home()) == bad:
+            raise OSError("schtasks exploded")
+        return True
+
+    monkeypatch.setattr(gateway_windows, "is_installed", flaky)
+
+    homes = [str(h) for h in cli_main._installed_gateway_profile_homes()]
+
+    assert bad not in homes
+    assert str(profile_root / "profiles" / "joao_pessoal") in homes
+
+
+def test_refresh_writes_a_launcher_for_every_installed_profile(
+    profile_root, monkeypatch, capsys
+):
+    """The regression #91675 is about: only the active profile was refreshed,
+    so a non-active profile's launcher stayed stale forever.
+
+    Asserts the home each ``_write_task_script`` call OBSERVES, because that
+    is what decides which profile's ``.cmd`` gets rewritten — iterating
+    without scoping would write the same file N times.
+    """
+    from hermes_constants import get_hermes_home
+
+    installed = [profile_root, profile_root / "profiles" / "joao_pessoal"]
+    _install_only(monkeypatch, installed)
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+
+    seen = []
+    monkeypatch.setattr(
+        gateway_windows, "_write_task_script", lambda: seen.append(str(get_hermes_home()))
+    )
+
+    cli_main._refresh_windows_gateway_launchers()
+
+    assert seen == [str(h) for h in installed]
+    assert "2 profiles" in capsys.readouterr().out
+
+
+def test_refresh_reports_a_single_profile_the_way_it_always_did(
+    profile_root, monkeypatch, capsys
+):
+    _install_only(monkeypatch, [profile_root])
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(gateway_windows, "_write_task_script", lambda: None)
+
+    cli_main._refresh_windows_gateway_launchers()
+
+    out = capsys.readouterr().out
+    assert "Refreshed Windows gateway launcher scripts" in out
+    assert "profiles)" not in out
+
+
+def test_one_failing_profile_does_not_cost_the_others_their_refresh(
+    profile_root, monkeypatch
+):
+    from hermes_constants import get_hermes_home
+
+    bad = str(profile_root / "profiles" / "arthur_tutor")
+    good = str(profile_root / "profiles" / "joao_pessoal")
+    _install_only(monkeypatch, [profile_root, Path(bad), Path(good)])
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+
+    seen = []
+
+    def flaky():
+        home = str(get_hermes_home())
+        if home == bad:
+            raise PermissionError("locked by AV")
+        seen.append(home)
+
+    monkeypatch.setattr(gateway_windows, "_write_task_script", flaky)
+
+    cli_main._refresh_windows_gateway_launchers()
+
+    assert seen == [str(profile_root), good]
+
+
+def test_refresh_prints_nothing_when_no_profile_has_a_launcher(
+    profile_root, monkeypatch, capsys
+):
+    _install_only(monkeypatch, [])
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows,
+        "_write_task_script",
+        lambda: pytest.fail("nothing is installed; there is no launcher to write"),
+    )
+
+    cli_main._refresh_windows_gateway_launchers()
+
+    assert capsys.readouterr().out == ""
+
+
+def test_refresh_is_a_no_op_off_windows(monkeypatch):
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(
+        cli_main,
+        "_installed_gateway_profile_homes",
+        lambda: pytest.fail("no profile enumeration may run off Windows"),
+    )
+
+    cli_main._refresh_windows_gateway_launchers()


### PR DESCRIPTION
## What does this PR do?

`_refresh_windows_gateway_launchers` is the mechanism that heals stale Windows
gateway launchers on update. Installs created before the hidden-console rework
(`aa2ae36c3f`) launch the gateway through `pythonw.exe`, and since #70344 a
console-less gateway dies at startup with `RuntimeError: sys.stderr is None`
(#71671) — so this function is the only thing standing between such an install
and a Scheduled Task that can never start a gateway.

Every helper it calls is profile-implicit:

```python
if not gateway_windows.is_installed():
    return
gateway_windows._write_task_script()
```

`is_installed()` resolves through `get_task_name()` → `_profile_suffix()` and
`get_startup_entry_path()` → `get_hermes_home()`; `_write_task_script()` writes
`get_task_script_path()`, which is
`<hermes_home>/gateway-service/<task name>.cmd`. All of them describe whichever
profile the updater is running as. So the healing mechanism heals exactly one
profile and skips every other profile on every update, in perpetuity.

That is worse than a stale file. A second profile installed before the rework
presents as "the Scheduled Task just doesn't work for that profile", and no
amount of updating changes it, because the repair never looks at it.

### Why this approach

The obvious fix is to thread a profile argument through the Windows launcher
helpers, which is a wide change touching every caller. It isn't necessary:
`hermes_constants` already ships the primitive.

```python
def set_hermes_home_override(path: str | Path | None) -> Token:
    """Set a context-local Hermes home override and return its reset token.

    This is for in-process, per-task scoping.  It deliberately does not mutate
    ``os.environ`` because that is shared by every thread in the process.
    """
```

Since every one of those helpers resolves through `get_hermes_home()`, scoping
the *call* retargets all of them at once. No signature changes, no caller
changes, and the override is context-local so nothing leaks into the rest of the
update.

Profile enumeration reuses `hermes_cli.profiles.list_profile_names()` — the
existing "cheap name-only profile listing… a directory scan, safe to call from
hot paths" — rather than introducing a second way to find profiles.

Each profile is scoped and caught independently, so one locked, half-removed, or
`schtasks`-hostile profile cannot cost the others their refresh. The existing
success line is unchanged for the single-profile case (the overwhelming
majority) and only gains a count when there is more than one.

## Related Issue

Refs #91675

**This deliberately does not close the issue.** #91675 reports two holes; this
fixes the launcher-refresh one. The post-update cold start is still
one-profile-or-none — `_cold_start_windows_gateway_after_update` guards a
single-profile `_spawn_detached()` with a `find_gateway_pids(all_profiles=True)`
liveness check, so whichever profile wins the race suppresses the other. That is
a change to the Windows spawn path and I would not land it on mock coverage
alone; it wants a maintainer's call between a fail-loud gate and a real
multi-profile spawn. Details in
https://github.com/NousResearch/hermes-agent/issues/91675#issuecomment-5376597704.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd.py`
  - New `_installed_gateway_profile_homes()`: walks `list_profile_names()`,
    scopes `is_installed()` per profile with
    `set_hermes_home_override`/`reset_hermes_home_override`, returns the homes
    that have an autostart entry (in `default`-first order). A profile whose
    check raises is logged at debug and skipped.
  - `_refresh_windows_gateway_launchers()` iterates those homes and calls
    `_write_task_script()` under the same scoping, counting successes. The
    per-profile `try/except/finally` keeps one failure local; the outer
    best-effort `except` is unchanged.
  - Docstring records why the previous version was single-profile and what that
    cost.
- `hermes_cli/main.py`: export `_installed_gateway_profile_homes` through the
  lazy `update_cmd` re-export list, so the `_m()` patch surface reaches it.
- `tests/hermes_cli/test_update_gateway_launcher_refresh.py`: 12 new tests.

### Second commit: the refresh is a content replace, not a touch

`077bf988c6`, added after @jrleal10 ran this branch live on the two-profile
Windows box from #91675 (thank you). It works there, and their report surfaced a
defect in this PR:

`_write_task_script` renders from the current template, so the refresh
**replaces file content**. On their host one profile's
`Hermes_Gateway_arthur_tutor.cmd` was not a stock artifact but a local
supervisor wrapper (`wscript.exe //B //Nologo ..._hidden.vbs`) that both the
Scheduled Task and a 5-minute watchdog pointed their `/TR` at. The refresh
flattened it back to the stock template.

That behaviour predates this branch. **This branch multiplies it** — what used
to flatten one profile's script now flattens every installed profile's — so it
belongs here.

Declining to rewrite a customized launcher is not an option: a
pre-`aa2ae36c3f` `pythonw` launcher is also "not stock", and healing exactly
those is why this function exists (#71671). So it rewrites and keeps the
previous copy at `<name>.pre-refresh.bak`, printing the path.

**Only a launcher whose content actually changed is preserved**, and that
condition is the correctness argument, not an optimization: an unconditional
backup means update #2 finds a stock script, copies *that* over the saved
wrapper, and the user's only copy is gone. Snapshotting is best-effort —
`get_task_script_path()` asserts Windows and creates its parent dir, so a
failure there is logged and the refresh proceeds unpreserved. Healing the
launcher outranks keeping a copy of it.

This commit also fixes a test-isolation bug it exposed: `hermes_cli.gateway`
binds `get_hermes_home` from `hermes_cli.config` at module level, and an
existing test in this file patches that with a `mock.patch` context manager.
When `hermes_cli.gateway` was first imported inside that block it kept the Mock
after the block exited, so every later `_profile_suffix` call received a `str`
and died on `.resolve()`. Importing the module at the top of the test file makes
the binding deterministic. That trap was latent for anyone adding a test there.

### A note on coverage

`_refresh_windows_gateway_launchers` had **no tests at all**. The test file
carries the section header for it —

```python
# ---------------------------------------------------------------------------
# _refresh_windows_gateway_launchers: hermes update regenerates launchers
# ---------------------------------------------------------------------------
```

— followed by nothing. So the single-profile behaviour was never pinned, which
is consistent with the bug surviving this long.

The new tests are written to be sensitive to the thing that actually matters.
`is_installed` and `_write_task_script` are stubbed (they shell out to
`schtasks` and write into a real Hermes home), but the stubs **read
`get_hermes_home()` themselves and assert on what they observed**, so a version
that loops over profiles without installing the override fails just as loudly as
one that never loops. Profile enumeration itself is not stubbed: the fixture
creates real `profiles/<name>` directories under a `tmp_path` root and the real
`list_profile_names()` scan walks them.

## How to Test

1. `pytest tests/hermes_cli/test_update_gateway_launcher_refresh.py -q` → 15
   passed (3 pre-existing + 12 new). Cross-platform: the Windows-only guards are
   stubbed, so these run on Linux/macOS too.
2. Mutation proof that the tests bind the fix, not the refactor:
   - Revert the loop to a single profile
     (`_installed_gateway_profile_homes()[:1]`) → **2 failed, 8 passed**
     (`test_refresh_writes_a_launcher_for_every_installed_profile`,
     `test_one_failing_profile_does_not_cost_the_others_their_refresh`).
   - Keep the loop but drop the `set_hermes_home_override` scoping → the **same
     2 failed, 8 passed**, because every call then observes the same home.
   - Drop the changed-content condition on the backup (preserve
     unconditionally) → **2 failed**, including the test that runs the refresh
     twice and asserts the saved wrapper survives update #2.
   - Remove preservation entirely → **3 failed**.
3. On a Windows box with two profiles that both have a gateway autostart entry,
   `hermes update` now prints
   `✓ Refreshed Windows gateway launcher scripts (2 profiles)` and both
   `<home>/gateway-service/Hermes_Gateway*.cmd` files carry a current mtime.
   Before this change only the active profile's file was touched.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see "Overlap" below
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — see "Test run honesty" below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 26200, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings only; no user-facing doc describes this internal
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the whole path is behind `_is_windows()`; the new enumerator is only reachable from it, and the tests run everywhere because they stub that guard
- [x] N/A — no tool descriptions or schemas touched

## Overlap with open PRs (please read before merging)

Two open PRs add statements to the exact body I restructured, so whichever lands
second will conflict. Both conflicts are trivial and resolve the same way — **the
added block moves inside the `for home in …` loop** — and in both cases the
result is strictly better than what those PRs do today, because their fix
becomes per-profile for free:

- **#90246** (`fix(gateway-windows): retarget legacy Scheduled Tasks to the
  hidden VBS launcher`) adds a `task_launcher_is_current()` check plus
  `_install_scheduled_task(...)` after `_write_task_script()`. Inside the loop,
  it retargets legacy tasks for *every* profile instead of one. That is the same
  bug class this PR fixes, so folding it in is a real gain, not just conflict
  cleanup.
- **#81362** (`fix(windows): converge dual gateway autostart entries to one
  mechanism`) adds a `reconcile_autostart_launchers()` loop in the same place,
  with the same property.

Neither PR makes the refresh multi-profile, and neither references #91675, so
this is not a duplicate of either. I'm happy to rebase onto whichever of them
merges first and do the fold-in myself — say the word and I'll push it rather
than leaving a maintainer to resolve it.

## Test run honesty

`pytest tests/hermes_cli/ -q -k "update or gateway_windows or test_profiles"`
was run with and without this change on the same machine and diffed:

- baseline: 30 failed, 594 passed
- with this change: 27 failed, 605 passed

No new failures. The three that differ are not fixed by this change — they pass
in isolation on both sides and are order-dependent on a box with a live gateway
(`test_update_cold_start_gateway_liveness`, two tests) or fail identically on
both sides (`test_update_head_moved_gate::test_update_success_when_head_moves`).
`tests/hermes_cli/test_doctor_journal_modes.py` cannot be collected on Windows
at all (`AttributeError: module 'os' has no attribute 'geteuid'` at import time,
unrelated to this PR) and was excluded from both runs.
