### PR TITLE
fix(gemini): disable thinking tokens by default for auxiliary title generation

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8684,6 +8684,11 @@ def _build_call_kwargs(
     # ``extra_body.reasoning``. Profiles are the source of truth for those wire
     # shapes. Providers without a reasoning-aware profile retain the generic
     # ``extra_body.reasoning`` fallback used by Codex-compatible adapters.
+    effective_reasoning_config = reasoning_config
+    if effective_reasoning_config is None and isinstance(extra_body, dict):
+        if "reasoning" in extra_body and isinstance(extra_body["reasoning"], dict):
+            effective_reasoning_config = extra_body["reasoning"]
+
     effective_base = base_url or (
         _current_custom_base_url() if provider == "custom" else ""
     )
@@ -8700,12 +8705,12 @@ def _build_call_kwargs(
             profile_body = profile.build_extra_body(
                 model=model,
                 base_url=effective_base,
-                reasoning_config=reasoning_config,
+                reasoning_config=effective_reasoning_config,
             ) or {}
             profile_reasoning_extra, profile_top_level = (
                 profile.build_api_kwargs_extras(
-                    reasoning_config=reasoning_config,
-                    supports_reasoning=reasoning_config is not None,
+                    reasoning_config=effective_reasoning_config,
+                    supports_reasoning=effective_reasoning_config is not None,
                     model=model,
                     base_url=effective_base,
                 )
@@ -8728,17 +8733,19 @@ def _build_call_kwargs(
 
     kwargs.update(profile_top_level)
     merged_extra = dict(extra_body or {})
+    if profile_handles_reasoning and effective_reasoning_config is not None:
+        merged_extra.pop("reasoning", None)
     merged_extra.update(profile_body)
     merged_extra.update(profile_reasoning_extra)
     if (
-        reasoning_config
-        and isinstance(reasoning_config, dict)
+        effective_reasoning_config
+        and isinstance(effective_reasoning_config, dict)
         and not profile_handles_reasoning
     ):
-        if reasoning_config.get("enabled") is False:
+        if effective_reasoning_config.get("enabled") is False:
             merged_extra["reasoning"] = {"enabled": False}
         else:
-            effort = reasoning_config.get("effort") or "medium"
+            effort = effective_reasoning_config.get("effort") or "medium"
             merged_extra["reasoning"] = {"enabled": True, "effort": effort}
     # Portal product tags + sticky session_id. The provider profile usually
     # supplies both; this fallback covers profile-load failures and alias
@@ -8766,7 +8773,7 @@ def _build_call_kwargs(
     # ``extra_body.reasoning``). Do not expose this private kwarg to ordinary
     # OpenAI-compatible SDK clients, which would reject it. Portal Claude is
     # dual-wire — include it when the catalog id selects /v1/messages.
-    if reasoning_config and isinstance(reasoning_config, dict):
+    if effective_reasoning_config and isinstance(effective_reasoning_config, dict):
         provider_norm = str(provider or "").strip().lower()
         effective_base = base_url or ""
         _nous_on_messages = False
@@ -8780,7 +8787,7 @@ def _build_call_kwargs(
             or _endpoint_speaks_anthropic_messages(effective_base)
             or _is_anthropic_compat_endpoint(provider_norm, effective_base)
         ):
-            kwargs["_reasoning_config"] = dict(reasoning_config)
+            kwargs["_reasoning_config"] = dict(effective_reasoning_config)
 
     return kwargs
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -133,14 +133,28 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if not normalized_model.startswith("gemini"):
         return None
 
-    if reasoning_config.get("enabled") is False:
-        # Gemini can hide thought parts even when internal thinking still
-        # happens; omit thinkingLevel to avoid model-specific validation quirks.
-        return {"includeThoughts": False}
-
     effort = str(reasoning_config.get("effort", "medium") or "medium").strip().lower()
-    if effort == "none":
-        return {"includeThoughts": False}
+
+    if (
+        reasoning_config.get("enabled") is False
+        or effort == "none"
+        or (
+            isinstance(reasoning_config.get("thinking_budget"), (int, float))
+            and reasoning_config.get("thinking_budget") <= 0
+        )
+        or (
+            isinstance(reasoning_config.get("thinkingBudget"), (int, float))
+            and reasoning_config.get("thinkingBudget") <= 0
+        )
+        or (
+            isinstance(reasoning_config.get("budget"), (int, float))
+            and reasoning_config.get("budget") <= 0
+        )
+    ):
+        # Gemini can hide thought parts even when internal thinking still
+        # happens; setting thinkingBudget: 0 ensures thinking is disabled so
+        # tokens are not spent on internal reasoning.
+        return {"includeThoughts": False, "thinkingBudget": 0}
 
     thinking_config: Dict[str, Any] = {"includeThoughts": True}
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1117,7 +1117,7 @@ DEFAULT_CONFIG = {
             "api_key": "",
             "timeout": 30,
             "extra_body": {},
-            "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
+            "reasoning_effort": "none",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (default none for titles)
             "language": "",
         },
         "memory_query_rewrite": {

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -44,6 +44,7 @@ def test_title_generation_present_in_default_config():
     assert tg["prefer_fast_model"] is False
     assert tg["timeout"] > 0
     assert tg["extra_body"] == {}
+    assert tg["reasoning_effort"] == "none"
 
 
 

--- a/tests/plugins/model_providers/test_gemini_profile.py
+++ b/tests/plugins/model_providers/test_gemini_profile.py
@@ -25,3 +25,65 @@ def test_native_gemini_auxiliary_default_is_in_curated_catalog(gemini_profile):
     from hermes_cli.models import _PROVIDER_MODELS
 
     assert gemini_profile.default_aux_model in _PROVIDER_MODELS["gemini"]
+
+
+def test_gemini_build_extra_body_disabled_reasoning_sets_zero_thinking_budget(gemini_profile):
+    """When reasoning is disabled (enabled=False or effort=none), GeminiProfile
+    must emit thinkingBudget: 0 to ensure thinking tokens do not consume
+    the output token budget (e.g. for concise auxiliary title generation)."""
+    extra_disabled = gemini_profile.build_extra_body(
+        model="gemini-3.6-flash",
+        reasoning_config={"enabled": False},
+    )
+    assert extra_disabled == {
+        "thinking_config": {"includeThoughts": False, "thinkingBudget": 0}
+    }
+
+    extra_none = gemini_profile.build_extra_body(
+        model="gemini-3.6-flash",
+        reasoning_config={"effort": "none"},
+    )
+    assert extra_none == {
+        "thinking_config": {"includeThoughts": False, "thinkingBudget": 0}
+    }
+
+
+def test_gemini_openai_compat_disabled_reasoning_sets_zero_thinking_budget(gemini_profile):
+    """On OpenAI-compatible Gemini endpoints, disabled reasoning translates to
+    google.thinking_config with include_thoughts=False and thinking_budget=0."""
+    extra = gemini_profile.build_extra_body(
+        model="gemini-3.6-flash",
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        reasoning_config={"enabled": False},
+    )
+    assert extra == {
+        "extra_body": {
+            "google": {
+                "thinking_config": {
+                    "include_thoughts": False,
+                    "thinking_budget": 0,
+                }
+            }
+        }
+    }
+
+
+def test_auxiliary_build_call_kwargs_propagates_task_reasoning_effort_to_profile():
+    """_build_call_kwargs must extract extra_body['reasoning'] into
+    effective_reasoning_config so provider profiles (Gemini, Vertex, etc.)
+    receive task reasoning config and translate it."""
+    from agent.auxiliary_client import _build_call_kwargs
+
+    kwargs = _build_call_kwargs(
+        provider="gemini",
+        model="gemini-3.6-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        extra_body={"reasoning": {"enabled": False}},
+        task="title_generation",
+    )
+    assert kwargs.get("extra_body", {}).get("thinking_config") == {
+        "includeThoughts": False,
+        "thinkingBudget": 0,
+    }
+    # Raw 'reasoning' dict is handled by profile and stripped from extra_body
+    assert "reasoning" not in kwargs.get("extra_body", {})


### PR DESCRIPTION
## What does this PR do?

When using Gemini models (e.g. gemini-2.5-flash, gemini-3.6-flash, gemini-flash-latest) with Hermes Agent, auto-generated session titles get mangled into unparsed markdown artifacts like '```json', '{', or '```' (with '#2', '#3' deduplication suffixes).

Session titles generated with Gemini models fail to complete within the 64-token budget because internal reasoning tokens consume the budget. The fallback extractor then parses the opening markdown fence as the title.

## Related Issue

Fixes #91927 <https://github.com/NousResearch/hermes-agent/issues/91927>

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Session titles generated with Gemini models fail to complete within the 64-token budget because internal reasoning tokens consume the budget. The fallback extractor then parses the opening markdown fence as the title.

Root Cause:
1. Gemini models enable internal thinking/reasoning tokens by default.
2. In chat_completions._build_gemini_thinking_config(), disabling reasoning emitted only {"includeThoughts": False}. In Gemini's API, includeThoughts only hides thought parts from response candidates; internal reasoning tokens still execute and consume output tokens from max_tokens=64.
3. auxiliary_client._build_call_kwargs() did not propagate reasoning config from extra_body['reasoning'] into provider profiles (such as GeminiProfile).
4. hermes_cli/config_defaults.py defaulted title_generation.reasoning_effort to empty string instead of "none".

Fix:
- Emit thinkingBudget: 0 in _build_gemini_thinking_config() when reasoning is disabled or effort is "none".
- In auxiliary_client._build_call_kwargs(), resolve effective_reasoning_config from extra_body['reasoning'] when not explicitly passed, passing it to provider profiles and stripping raw reasoning dict if handled.
- Default auxiliary.title_generation.reasoning_effort to "none" in config_defaults.py.



## How to Test

Reproduce #91927 and verify this fixes that.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A