### PR TITLE
fix(cli): stop doctor's compromised-package check claiming blanket security clearance

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1088,6 +1088,7 @@ def run_doctor(args):
     )
     try:
         from hermes_cli.security_advisories import (
+            ALL_CLEAR_MESSAGE,
             detect_compromised,
             filter_unacked,
             full_remediation_text,
@@ -1126,7 +1127,7 @@ def run_doctor(args):
                         f"(advisory {h.advisory.id} acknowledged)",
                     )
         else:
-            check_ok("No known-compromised packages detected")
+            check_ok(ALL_CLEAR_MESSAGE)
     except Exception as e:
         # Never let a bug in the advisory check block the rest of doctor.
         check_warn(f"Security advisory check failed: {e}")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1080,7 +1080,12 @@ def run_doctor(args):
     print(color("│                 🩺 Hermes Doctor                        │", Colors.CYAN))
     print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
 
-    _section("Security Advisories")
+    _section("Supply-Chain Advisories")
+    check_info(
+        "Checks for known-compromised package versions (e.g. supply-chain "
+        "worms). Run `hermes security audit` for a broader CVE scan of "
+        "installed dependencies."
+    )
     try:
         from hermes_cli.security_advisories import (
             detect_compromised,
@@ -1121,7 +1126,7 @@ def run_doctor(args):
                         f"(advisory {h.advisory.id} acknowledged)",
                     )
         else:
-            check_ok("No active security advisories")
+            check_ok("No known-compromised packages detected")
     except Exception as e:
         # Never let a bug in the advisory check block the rest of doctor.
         check_warn(f"Security advisory check failed: {e}")

--- a/hermes_cli/security_advisories.py
+++ b/hermes_cli/security_advisories.py
@@ -411,7 +411,7 @@ def render_doctor_section(hits: list[AdvisoryHit]) -> tuple[bool, list[str]]:
     """
     fresh = filter_unacked(hits)
     if not fresh:
-        return False, ["No active security advisories.  ✓"]
+        return False, ["No known-compromised packages detected.  ✓"]
 
     lines: list[str] = []
     for i, hit in enumerate(fresh):

--- a/hermes_cli/security_advisories.py
+++ b/hermes_cli/security_advisories.py
@@ -42,6 +42,11 @@ from typing import Iterable, Optional
 
 logger = logging.getLogger(__name__)
 
+# Single source of truth for the doctor all-clear wording so the message
+# shown by ``hermes doctor`` and the one returned by ``render_doctor_section``
+# can't drift apart.
+ALL_CLEAR_MESSAGE = "No known-compromised packages detected"
+
 
 # =============================================================================
 # Advisory catalog
@@ -411,7 +416,7 @@ def render_doctor_section(hits: list[AdvisoryHit]) -> tuple[bool, list[str]]:
     """
     fresh = filter_unacked(hits)
     if not fresh:
-        return False, ["No known-compromised packages detected.  ✓"]
+        return False, [f"{ALL_CLEAR_MESSAGE}.  ✓"]
 
     lines: list[str] = []
     for i, hit in enumerate(fresh):

--- a/tests/hermes_cli/test_doctor_security_advisories_section.py
+++ b/tests/hermes_cli/test_doctor_security_advisories_section.py
@@ -15,8 +15,6 @@ import types
 from argparse import Namespace
 from pathlib import Path
 
-import pytest
-
 import hermes_cli.doctor as doctor_mod
 
 
@@ -66,7 +64,6 @@ def _run_doctor():
     return buf.getvalue()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Symlink setup is Unix-only")
 class TestSecurityAdvisoriesSectionWording:
     def test_section_is_scoped_to_supply_chain_not_all_security(self, monkeypatch, tmp_path):
         _setup_doctor_env(monkeypatch, tmp_path)

--- a/tests/hermes_cli/test_doctor_security_advisories_section.py
+++ b/tests/hermes_cli/test_doctor_security_advisories_section.py
@@ -1,0 +1,87 @@
+"""Tests for the doctor "Supply-Chain Advisories" section wording.
+
+hermes doctor's advisory check only scans a small hardcoded catalog of
+known-compromised (supply-chain-worm) package versions — it is not a CVE
+scanner. Before this fix it printed the all-clear as "No active security
+advisories" under a section literally titled "Security Advisories", which
+reads as a blanket clearance even though `hermes security audit` (an OSV.dev
+CVE scan) can report active findings at the same time. See #91931.
+"""
+
+import contextlib
+import io
+import sys
+import types
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.doctor as doctor_mod
+
+
+def _setup_doctor_env(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    venv_bin_dir = project / "venv" / "bin"
+    venv_bin_dir.mkdir(parents=True, exist_ok=True)
+    hermes_bin = venv_bin_dir / "hermes"
+    hermes_bin.write_text("#!/usr/bin/env python\n# entry point\n")
+    hermes_bin.chmod(0o755)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    try:
+        import httpx
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: types.SimpleNamespace(status_code=200))
+    except Exception:
+        pass
+
+
+def _run_doctor():
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    return buf.getvalue()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Symlink setup is Unix-only")
+class TestSecurityAdvisoriesSectionWording:
+    def test_section_is_scoped_to_supply_chain_not_all_security(self, monkeypatch, tmp_path):
+        _setup_doctor_env(monkeypatch, tmp_path)
+
+        out = _run_doctor()
+
+        assert "Supply-Chain Advisories" in out
+        assert "No active security advisories" not in out
+        assert "hermes security audit" in out
+
+    def test_all_clear_message_names_compromised_packages_not_advisories(
+        self, monkeypatch, tmp_path
+    ):
+        _setup_doctor_env(monkeypatch, tmp_path)
+
+        out = _run_doctor()
+
+        assert "No known-compromised packages detected" in out


### PR DESCRIPTION
## What does this PR do?

Addresses one concrete sub-finding from #91931 (the "Notes" section):
`hermes doctor` reports `✓ No active security advisories` while
`hermes security audit` reports 9 findings on the same install — the two
tools disagree on scope, and doctor's wording doesn't say so.

Looking at the code, this isn't a bug in the check itself, it's a scope
mismatch in the messaging. `hermes_cli/security_advisories.py` only scans a
small hardcoded catalog of known-*compromised* (supply-chain-worm) package
versions — cheap, stdlib-only, run on every CLI startup and inside `doctor`.
`hermes_cli/security_audit.py` is a completely different, on-demand OSV.dev
CVE scan across the whole venv. Both are legitimate and intentionally scoped
differently (see each module's docstring), but `doctor`'s section was titled
plain "Security Advisories" and its all-clear line was "No active security
advisories" — wording that reads as a blanket clearance and will directly
mislead a user who has active CVE findings from `security audit` (e.g. the
`nanoid`/`h2`/`pydantic-settings`/etc. findings in #91931) sitting right next
to a doctor run that told them everything is fine.

**Out of scope for this PR, and why:** #91931 also asks to bump the
`nanoid` override in `package.json`/`website/package.json` and regenerate
lockfiles, and to regenerate `uv.lock` so `h2` resolves to a fixed version.
Those are dependency-manifest/lockfile changes with repo-wide blast radius
(and, per this fork's contribution norms, are treated as the maintainers'
call, not something to bundle into an unrelated CLI-messaging fix) — they're
left for a maintainer or a dedicated dependency-bump PR. The `_editable_install_is_current()`
skip and `uv pip install -e .[all]` behavior discussed in the issue are
working as designed for their actual purpose (avoiding a needless editable
reinstall / not silently doing a broader `--upgrade` on every update); changing
that update-vs-safety tradeoff is a design decision for a maintainer, not a
messaging bug.

## Changes Made

- `hermes_cli/doctor.py`: renamed the `doctor` section from "Security
  Advisories" to "Supply-Chain Advisories", added a one-line `check_info`
  explaining what the check covers and pointing to `hermes security audit`
  for a broader CVE scan, and reworded the all-clear line to
  "No known-compromised packages detected".
- `hermes_cli/security_advisories.py`: updated the matching all-clear string
  in `render_doctor_section()` for consistency.
- `tests/hermes_cli/test_doctor_security_advisories_section.py`: new test
  asserting the section no longer prints the misleading blanket message and
  does surface a pointer to `hermes security audit`.

## Related Issue

Partially addresses #91931 (the doctor/security-audit scope-disagreement
note only; see "Out of scope" above for the rest).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## How to Test

1. `git checkout HEAD~1 -- hermes_cli/doctor.py hermes_cli/security_advisories.py`
   then run the new test file — both tests fail against the old wording:
   ```
   FAILED .../test_section_is_scoped_to_supply_chain_not_all_security - assert 'Supply-Chain Advisories' in "...◆ Security Advisories\n  ✓ No active security advisories..."
   FAILED .../test_all_clear_message_names_compromised_packages_not_advisories - assert 'No known-compromised packages detected' in "...✓ No active security advisories..."
   2 failed in 1.74s
   ```
2. `git checkout HEAD -- hermes_cli/doctor.py hermes_cli/security_advisories.py` to restore the fix, then:
   ```
   $ python3 -m pytest tests/hermes_cli/test_doctor_security_advisories_section.py -q
   ..                                                                       [100%]
   2 passed in 1.67s
   ```
3. Broader regression check on everything touching this code path:
   ```
   $ python3 -m pytest tests/hermes_cli/test_security_advisories.py tests/hermes_cli/test_doctor.py \
       tests/hermes_cli/test_doctor_command_install.py tests/hermes_cli/test_doctor_live.py \
       tests/hermes_cli/test_doctor_journal_modes.py tests/hermes_cli/test_doctor_dedicated_provider_skip.py \
       tests/hermes_cli/test_doctor_security_advisories_section.py -q
   ...
   135 passed in 21.73s
   ```
4. `python3 -m ruff check hermes_cli/doctor.py hermes_cli/security_advisories.py tests/hermes_cli/test_doctor_security_advisories_section.py` → `All checks passed!`

## What platforms you tested on

Linux (x86_64, Python 3.12.14). The change is pure string/wording — no
platform-specific code paths touched.

## AI-assistance disclosure

This PR was prepared with AI assistance (an autonomous coding agent), with
the changes reviewed and verified (tests run, lint run, failure-without-fix
confirmed) before submission.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (no open PR references #91931, `_editable_install_is_current`, or this doctor section's wording)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` for the affected files and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux
