### PR TITLE
feat(doctor): add Windows environment preflight checks

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -910,6 +910,127 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
         check_warn("Could not verify systemd linger", f"({linger_detail})")
 
 
+def _check_windows_symlink_privilege() -> None:
+    """Doctor check: can this process create symlinks without elevation?
+
+    Windows requires Developer Mode (or an elevated process) to create
+    symlinks without SeCreateSymbolicLinkPrivilege; the failure surfaces as
+    OSError winerror 1314 deep inside whatever staged a symlinked fixture,
+    not as a message that points at the actual remedy.
+    """
+    import tempfile
+
+    probe_dir = Path(tempfile.gettempdir())
+    target = probe_dir / f"hermes-doctor-symlink-target-{os.getpid()}"
+    link = probe_dir / f"hermes-doctor-symlink-probe-{os.getpid()}"
+    try:
+        target.touch()
+        try:
+            os.symlink(target, link)
+        except OSError as exc:
+            if getattr(exc, "winerror", None) == 1314:
+                check_warn(
+                    "Symlink creation requires elevation",
+                    "(enable Developer Mode: Settings > Privacy & security > "
+                    "For developers, or run this shell elevated)",
+                )
+            else:
+                check_warn("Symlink creation failed", str(exc))
+        else:
+            check_ok("Symlink creation")
+    finally:
+        link.unlink(missing_ok=True)
+        target.unlink(missing_ok=True)
+
+
+def _check_windows_git_credential_prompt() -> None:
+    """Doctor check: will a spawned git hang waiting for a credential prompt?
+
+    Daemon-like contexts (gateway, cron jobs) spawn git non-interactively; an
+    interactive credential helper with GIT_TERMINAL_PROMPT unset can hang
+    forever instead of failing fast.
+    """
+    if _safe_which("git") is None:
+        return
+    if os.environ.get("GIT_TERMINAL_PROMPT") == "0":
+        check_ok("Git non-interactive prompts disabled (GIT_TERMINAL_PROMPT=0)")
+        return
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "credential.helper"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        helper = result.stdout.strip()
+    except Exception:
+        helper = ""
+    if helper and "manager" not in helper.lower():
+        check_info(f"Git credential helper: {helper} (GIT_TERMINAL_PROMPT unset)")
+        return
+    check_warn(
+        "Git may hang waiting for a credential prompt in non-interactive contexts",
+        "(set GIT_TERMINAL_PROMPT=0 and configure a non-interactive helper, e.g. "
+        "'git config --global credential.helper cache', for gateway/background use)",
+    )
+
+
+def _check_windows_bash_toolchain() -> None:
+    """Doctor check: is the Git Bash the terminal tool spawns actually available?"""
+    try:
+        from tools.environments.local import _find_bash
+        bash_path = _find_bash()
+    except Exception as exc:
+        check_warn("Git Bash not found", str(exc))
+        return
+    check_ok(f"Git Bash found ({bash_path})")
+
+
+def _check_windows_long_paths() -> None:
+    """Doctor check: is NTFS long path support enabled?
+
+    Deep checkouts (node_modules-depth trees) risk exceeding MAX_PATH when
+    this is off; the registry key is the only place that's recorded.
+    """
+    try:
+        import winreg
+    except ImportError:
+        return
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SYSTEM\CurrentControlSet\Control\FileSystem",
+        ) as key:
+            value, _ = winreg.QueryValueEx(key, "LongPathsEnabled")
+    except OSError:
+        value = 0
+    if value:
+        check_ok("Windows long path support enabled")
+    else:
+        check_warn(
+            "Windows long path support disabled",
+            "(deep checkouts risk exceeding MAX_PATH; enable with "
+            "'reg add HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem "
+            "/v LongPathsEnabled /t REG_DWORD /d 1 /f' elevated, then reboot)",
+        )
+
+
+def _check_windows_environment() -> None:
+    """Windows-only preflight checks; silently skipped on other platforms.
+
+    Each of these turns into a confusing downstream failure report (a test
+    suite dying mid-run, a hung background git fetch, a broken tool path)
+    when it isn't caught here at setup time.
+    """
+    if sys.platform != "win32":
+        return
+    _section("Windows Environment")
+    _check_windows_symlink_privilege()
+    _check_windows_git_credential_prompt()
+    _check_windows_bash_toolchain()
+    _check_windows_long_paths()
+
+
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
@@ -1981,6 +2102,7 @@ def run_doctor(args):
 
     _check_gateway_service_linger(issues)
     _check_s6_supervision(issues)
+    _check_windows_environment()
 
     if sys.platform != "win32":
         _section("Command Installation")

--- a/tests/hermes_cli/test_doctor_windows_preflight.py
+++ b/tests/hermes_cli/test_doctor_windows_preflight.py
@@ -1,0 +1,197 @@
+"""Tests for the Windows preflight checks in hermes doctor (#91942)."""
+
+import os
+import subprocess
+import sys
+import types
+
+import pytest
+
+import hermes_cli.doctor as doctor_mod
+
+
+class TestSymlinkPrivilegeCheck:
+    def test_ok_when_symlink_creation_succeeds(self, capsys):
+        doctor_mod._check_windows_symlink_privilege()
+
+        out = capsys.readouterr().out
+        assert "Symlink creation" in out
+        assert "elevation" not in out
+
+    def test_warns_with_dev_mode_hint_on_winerror_1314(self, monkeypatch, capsys):
+        def _raise_symlink(*args, **kwargs):
+            exc = OSError("privilege not held")
+            exc.winerror = 1314
+            raise exc
+
+        monkeypatch.setattr(doctor_mod.os, "symlink", _raise_symlink)
+
+        doctor_mod._check_windows_symlink_privilege()
+
+        out = capsys.readouterr().out
+        assert "requires elevation" in out
+        assert "Developer Mode" in out
+
+    def test_warns_generically_on_other_oserror(self, monkeypatch, capsys):
+        def _raise_symlink(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(doctor_mod.os, "symlink", _raise_symlink)
+
+        doctor_mod._check_windows_symlink_privilege()
+
+        out = capsys.readouterr().out
+        assert "Symlink creation failed" in out
+        assert "disk full" in out
+
+
+class TestGitCredentialPromptCheck:
+    def test_skips_when_git_missing(self, monkeypatch, capsys):
+        monkeypatch.setattr(doctor_mod, "_safe_which", lambda cmd: None)
+
+        doctor_mod._check_windows_git_credential_prompt()
+
+        assert capsys.readouterr().out == ""
+
+    def test_ok_when_terminal_prompt_disabled(self, monkeypatch, capsys):
+        monkeypatch.setattr(doctor_mod, "_safe_which", lambda cmd: "/usr/bin/git")
+        monkeypatch.setenv("GIT_TERMINAL_PROMPT", "0")
+
+        doctor_mod._check_windows_git_credential_prompt()
+
+        out = capsys.readouterr().out
+        assert "GIT_TERMINAL_PROMPT=0" in out
+
+    def test_warns_when_unset_and_no_helper_configured(self, monkeypatch, capsys):
+        monkeypatch.setattr(doctor_mod, "_safe_which", lambda cmd: "/usr/bin/git")
+        monkeypatch.delenv("GIT_TERMINAL_PROMPT", raising=False)
+        monkeypatch.setattr(
+            doctor_mod.subprocess,
+            "run",
+            lambda *a, **kw: types.SimpleNamespace(stdout="", stderr=""),
+        )
+
+        doctor_mod._check_windows_git_credential_prompt()
+
+        out = capsys.readouterr().out
+        assert "hang" in out
+        assert "GIT_TERMINAL_PROMPT=0" in out
+
+    def test_info_when_non_interactive_helper_already_configured(self, monkeypatch, capsys):
+        monkeypatch.setattr(doctor_mod, "_safe_which", lambda cmd: "/usr/bin/git")
+        monkeypatch.delenv("GIT_TERMINAL_PROMPT", raising=False)
+        monkeypatch.setattr(
+            doctor_mod.subprocess,
+            "run",
+            lambda *a, **kw: types.SimpleNamespace(stdout="cache\n", stderr=""),
+        )
+
+        doctor_mod._check_windows_git_credential_prompt()
+
+        out = capsys.readouterr().out
+        assert "cache" in out
+        assert "hang" not in out
+
+
+class TestBashToolchainCheck:
+    def test_ok_when_bash_found(self, monkeypatch, capsys):
+        fake_local = types.SimpleNamespace(_find_bash=lambda: r"C:\Program Files\Git\bin\bash.exe")
+        monkeypatch.setitem(sys.modules, "tools.environments.local", fake_local)
+
+        doctor_mod._check_windows_bash_toolchain()
+
+        out = capsys.readouterr().out
+        assert "Git Bash found" in out
+        assert "bash.exe" in out
+
+    def test_warns_when_bash_not_found(self, monkeypatch, capsys):
+        def _raise():
+            raise RuntimeError("Git Bash not found. Hermes Agent requires Git for Windows.")
+
+        fake_local = types.SimpleNamespace(_find_bash=_raise)
+        monkeypatch.setitem(sys.modules, "tools.environments.local", fake_local)
+
+        doctor_mod._check_windows_bash_toolchain()
+
+        out = capsys.readouterr().out
+        assert "Git Bash not found" in out
+
+
+class TestLongPathsCheck:
+    def _install_fake_winreg(self, monkeypatch, value):
+        fake = types.ModuleType("winreg")
+        fake.HKEY_LOCAL_MACHINE = object()
+
+        class _Key:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return False
+
+        fake.OpenKey = lambda hive, path: _Key()
+        fake.QueryValueEx = lambda key, name: (value, 4)
+        monkeypatch.setitem(sys.modules, "winreg", fake)
+
+    def test_skips_when_winreg_unavailable(self, monkeypatch, capsys):
+        monkeypatch.setitem(sys.modules, "winreg", None)
+
+        doctor_mod._check_windows_long_paths()
+
+        assert capsys.readouterr().out == ""
+
+    def test_ok_when_long_paths_enabled(self, monkeypatch, capsys):
+        self._install_fake_winreg(monkeypatch, 1)
+
+        doctor_mod._check_windows_long_paths()
+
+        out = capsys.readouterr().out
+        assert "long path support enabled" in out
+
+    def test_warns_when_long_paths_disabled(self, monkeypatch, capsys):
+        self._install_fake_winreg(monkeypatch, 0)
+
+        doctor_mod._check_windows_long_paths()
+
+        out = capsys.readouterr().out
+        assert "long path support disabled" in out
+        assert "LongPathsEnabled" in out
+
+    def test_warns_when_registry_key_missing(self, monkeypatch, capsys):
+        fake = types.ModuleType("winreg")
+        fake.HKEY_LOCAL_MACHINE = object()
+
+        def _raise_open_key(hive, path):
+            raise OSError("key not found")
+
+        fake.OpenKey = _raise_open_key
+        fake.QueryValueEx = lambda key, name: (0, 4)
+        monkeypatch.setitem(sys.modules, "winreg", fake)
+
+        doctor_mod._check_windows_long_paths()
+
+        out = capsys.readouterr().out
+        assert "long path support disabled" in out
+
+
+class TestWindowsEnvironmentSection:
+    def test_skipped_on_non_windows(self, monkeypatch, capsys):
+        monkeypatch.setattr(doctor_mod.sys, "platform", "linux")
+
+        doctor_mod._check_windows_environment()
+
+        assert capsys.readouterr().out == ""
+
+    def test_runs_all_checks_on_windows(self, monkeypatch, capsys):
+        monkeypatch.setattr(doctor_mod.sys, "platform", "win32")
+        calls = []
+        monkeypatch.setattr(doctor_mod, "_check_windows_symlink_privilege", lambda: calls.append("symlink"))
+        monkeypatch.setattr(doctor_mod, "_check_windows_git_credential_prompt", lambda: calls.append("git"))
+        monkeypatch.setattr(doctor_mod, "_check_windows_bash_toolchain", lambda: calls.append("bash"))
+        monkeypatch.setattr(doctor_mod, "_check_windows_long_paths", lambda: calls.append("long_paths"))
+
+        doctor_mod._check_windows_environment()
+
+        out = capsys.readouterr().out
+        assert "Windows Environment" in out
+        assert calls == ["symlink", "git", "bash", "long_paths"]

--- a/tests/hermes_cli/test_doctor_windows_preflight.py
+++ b/tests/hermes_cli/test_doctor_windows_preflight.py
@@ -77,7 +77,9 @@ class TestGitCredentialPromptCheck:
         assert "hang" in out
         assert "GIT_TERMINAL_PROMPT=0" in out
 
-    def test_info_when_non_interactive_helper_already_configured(self, monkeypatch, capsys):
+    def test_info_when_non_interactive_helper_already_configured(
+        self, monkeypatch, capsys
+    ):
         monkeypatch.setattr(doctor_mod, "_safe_which", lambda cmd: "/usr/bin/git")
         monkeypatch.delenv("GIT_TERMINAL_PROMPT", raising=False)
         monkeypatch.setattr(
@@ -95,7 +97,9 @@ class TestGitCredentialPromptCheck:
 
 class TestBashToolchainCheck:
     def test_ok_when_bash_found(self, monkeypatch, capsys):
-        fake_local = types.SimpleNamespace(_find_bash=lambda: r"C:\Program Files\Git\bin\bash.exe")
+        fake_local = types.SimpleNamespace(
+            _find_bash=lambda: r"C:\Program Files\Git\bin\bash.exe"
+        )
         monkeypatch.setitem(sys.modules, "tools.environments.local", fake_local)
 
         doctor_mod._check_windows_bash_toolchain()
@@ -106,7 +110,9 @@ class TestBashToolchainCheck:
 
     def test_warns_when_bash_not_found(self, monkeypatch, capsys):
         def _raise():
-            raise RuntimeError("Git Bash not found. Hermes Agent requires Git for Windows.")
+            raise RuntimeError(
+                "Git Bash not found. Hermes Agent requires Git for Windows."
+            )
 
         fake_local = types.SimpleNamespace(_find_bash=_raise)
         monkeypatch.setitem(sys.modules, "tools.environments.local", fake_local)
@@ -185,10 +191,22 @@ class TestWindowsEnvironmentSection:
     def test_runs_all_checks_on_windows(self, monkeypatch, capsys):
         monkeypatch.setattr(doctor_mod.sys, "platform", "win32")
         calls = []
-        monkeypatch.setattr(doctor_mod, "_check_windows_symlink_privilege", lambda: calls.append("symlink"))
-        monkeypatch.setattr(doctor_mod, "_check_windows_git_credential_prompt", lambda: calls.append("git"))
-        monkeypatch.setattr(doctor_mod, "_check_windows_bash_toolchain", lambda: calls.append("bash"))
-        monkeypatch.setattr(doctor_mod, "_check_windows_long_paths", lambda: calls.append("long_paths"))
+        monkeypatch.setattr(
+            doctor_mod,
+            "_check_windows_symlink_privilege",
+            lambda: calls.append("symlink"),
+        )
+        monkeypatch.setattr(
+            doctor_mod,
+            "_check_windows_git_credential_prompt",
+            lambda: calls.append("git"),
+        )
+        monkeypatch.setattr(
+            doctor_mod, "_check_windows_bash_toolchain", lambda: calls.append("bash")
+        )
+        monkeypatch.setattr(
+            doctor_mod, "_check_windows_long_paths", lambda: calls.append("long_paths")
+        )
 
         doctor_mod._check_windows_environment()
 

--- a/tests/hermes_cli/test_doctor_windows_preflight.py
+++ b/tests/hermes_cli/test_doctor_windows_preflight.py
@@ -11,7 +11,9 @@ import hermes_cli.doctor as doctor_mod
 
 
 class TestSymlinkPrivilegeCheck:
-    def test_ok_when_symlink_creation_succeeds(self, capsys):
+    def test_ok_when_symlink_creation_succeeds(self, monkeypatch, capsys):
+        monkeypatch.setattr(doctor_mod.os, "symlink", lambda *args, **kwargs: None)
+
         doctor_mod._check_windows_symlink_privilege()
 
         out = capsys.readouterr().out


### PR DESCRIPTION
## Summary

Closes #91942.

Adds a Windows-only `◆ Windows Environment` section to `hermes doctor`
(silently skipped on other platforms) covering the four preflight checks
requested in the issue, each printing a plain-language finding and a
copy-pasteable fix:

1. **Symlink privilege** — creates and deletes a symlink under the temp
   dir; on `OSError` winerror `1314` (privilege not held), suggests
   enabling Developer Mode or running elevated.
2. **Non-interactive git safety** — when `GIT_TERMINAL_PROMPT` is unset
   and no explicit non-interactive `credential.helper` is configured,
   warns that a spawned `git` may hang waiting for a credential prompt
   and suggests `GIT_TERMINAL_PROMPT=0` + a helper such as `cache`.
3. **Bash/MSYS toolchain** — reuses the existing `_find_bash()` resolver
   from `tools/environments/local.py` (the same Git Bash discovery the
   terminal tool already depends on) to confirm the shell the toolchain
   expects is actually reachable.
4. **Long paths** — reads `LongPathsEnabled` from
   `HKLM\SYSTEM\CurrentControlSet\Control\FileSystem` and warns when it's
   off, since deep checkouts (`node_modules`-depth trees) risk exceeding
   `MAX_PATH`.

All four are warn-only/advisory (consistent with doctor's existing
SQLite-WAL and gateway-linger checks) — none of them are Hermes bugs by
themselves, so none block the doctor run or get added to `issues`.

## Why

Windows-specific environment problems (symlink privilege, hung
non-interactive git, MSYS path mangling, MAX_PATH) currently only surface
later as confusing downstream failures instead of actionable output from
`hermes doctor`, per the issue.

## Test plan

New test file `tests/hermes_cli/test_doctor_windows_preflight.py` (15
tests) exercises each check function directly — success path, the
specific Windows failure mode, and the graceful-skip path when a
dependency (git, bash, `winreg`) isn't available — plus the
platform-gating wrapper.

Confirmed the new tests fail without the fix:

```
$ git checkout HEAD~2 -- hermes_cli/doctor.py   # (pre-fix doctor.py)
$ python -m pytest tests/hermes_cli/test_doctor_windows_preflight.py -q
...
15 failed in 0.66s   # AttributeError: module 'hermes_cli.doctor' has no
                      # attribute '_check_windows_symlink_privilege' (etc.)

$ git checkout HEAD -- hermes_cli/doctor.py     # restore the fix
$ python -m pytest tests/hermes_cli/test_doctor_windows_preflight.py -q
...
15 passed in 0.46s
```

Full doctor suite (unaffected, no regressions):

```
$ python -m pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_doctor_command_install.py \
    tests/hermes_cli/test_doctor_dedicated_provider_skip.py tests/hermes_cli/test_doctor_journal_modes.py \
    tests/hermes_cli/test_doctor_live.py tests/hermes_cli/test_doctor_windows_preflight.py -q
...
137 passed in ~19s
```

Lint:

```
$ ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor_windows_preflight.py
All checks passed!
$ ruff format --check tests/hermes_cli/test_doctor_windows_preflight.py
(clean — doctor.py has pre-existing formatting drift unrelated to this change, left untouched)
```

## AI disclosure

This PR was written by an autonomous coding agent (Claude/Anthropic)
operating under human supervision, per the repo's contribution norms for
AI-assisted PRs.
