### PR TITLE
feat(delegation): expose durable child attribution IDs

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -523,10 +523,11 @@ class TestDelegateObservability(unittest.TestCase):
 
         with patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
+            mock_child.session_id = "child-session-observability"
             mock_child.model = "claude-sonnet-4-6"
             mock_child.session_prompt_tokens = 5000
             mock_child.session_completion_tokens = 1200
-            mock_child.run_conversation.return_value = {
+            child_result = {
                 "final_response": "done",
                 "completed": True,
                 "interrupted": False,
@@ -540,12 +541,21 @@ class TestDelegateObservability(unittest.TestCase):
                     {"role": "assistant", "content": "done"},
                 ],
             }
+
+            def run_with_session_rotation(*_args, **_kwargs):
+                mock_child.session_id = "child-session-rotated"
+                return child_result
+
+            mock_child.run_conversation.side_effect = run_with_session_rotation
             MockAgent.return_value = mock_child
 
             result = json.loads(delegate_task(goal="Test observability", parent_agent=parent))
             entry = result["results"][0]
 
             # Core observability fields
+            self.assertTrue(result["delegation_id"].startswith("deleg_"))
+            self.assertEqual(entry["child_session_id"], "child-session-rotated")
+            self.assertTrue(entry["subagent_id"].startswith("sa-"))
             self.assertEqual(entry["model"], "claude-sonnet-4-6")
             self.assertEqual(entry["exit_reason"], "completed")
             self.assertEqual(entry["tokens"]["input"], 5000)
@@ -561,6 +571,57 @@ class TestDelegateObservability(unittest.TestCase):
                 {"argument_keys": ["query"], "targets": {}},
             )
             self.assertEqual(entry["tool_trace"][0]["status"], "ok")
+
+    def test_delegation_id_survives_live_transcript_initialization_failure(self):
+        parent = _make_mock_parent(depth=0)
+        with patch("run_agent.AIAgent") as MockAgent, patch(
+            "tools.delegation_live_log.create_live_transcripts",
+            return_value=(None, [None], []),
+        ):
+            mock_child = MagicMock()
+            mock_child.session_id = "child-no-live-log"
+            mock_child.model = "test/model"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(goal="Test attribution without live logs", parent_agent=parent)
+            )
+
+        self.assertTrue(result["delegation_id"].startswith("deleg_"))
+        self.assertEqual(mock_child._delegation_id, result["delegation_id"])
+        self.assertEqual(
+            result["results"][0]["child_session_id"], "child-no-live-log"
+        )
+
+    def test_outer_lifecycle_exception_preserves_child_identity(self):
+        from tools.delegate_tool import _run_single_child
+
+        child = MagicMock()
+        child._subagent_id = "sa-0-outer"
+        child.session_id = "child-session-outer"
+        child._delegate_role = "leaf"
+        child.run_conversation.return_value = []
+        parent = _make_mock_parent(depth=0)
+
+        result = _run_single_child(
+            task_index=0,
+            goal="Return a malformed child result",
+            child=child,
+            parent_agent=parent,
+        )
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["subagent_id"], "sa-0-outer")
+        self.assertEqual(result["child_session_id"], "child-session-outer")
 
     def test_tool_trace_handles_list_content_blocks(self):
         """Tool-result content blocks should not crash observability metadata."""

--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -43,6 +43,7 @@ class _StubChild:
         tool_schema=None,
     ):
         self._subagent_id = subagent_id
+        self.session_id = "child-session-timeout"
         self._delegate_depth = 1
         self._delegate_role = "leaf"
         self.model = "test/model"
@@ -200,6 +201,8 @@ class TestRunSingleChildTimeoutDump:
         result = self._invoke_with_short_timeout(child, monkeypatch)
 
         assert result["status"] == "timeout"
+        assert result["subagent_id"] == "sa-0-stubabc"
+        assert result["child_session_id"] == "child-session-timeout"
         assert result["api_calls"] == 0
         assert result["diagnostic_path"] is not None
         dump_path = Path(result["diagnostic_path"])
@@ -235,6 +238,7 @@ class TestRunSingleChildTimeoutDump:
         )
 
         assert result["status"] == "error"
+        assert result["child_session_id"] == "child-session-timeout"
         assert result["timeout_seconds"] is None
         assert result["timed_out_after_seconds"] is None
         assert result["timeout_phase"] is None

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2440,6 +2440,16 @@ def _run_single_child(
     """
     child_start = time.monotonic()
 
+    def _current_child_identity() -> Dict[str, Any]:
+        """Return current join keys, including any compression-rotated session."""
+        raw_session_id = getattr(child, "session_id", None)
+        return {
+            "subagent_id": _subagent_id,
+            "child_session_id": (
+                raw_session_id if isinstance(raw_session_id, str) else ""
+            ),
+        }
+
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, "tool_progress_callback", None)
 
@@ -2893,6 +2903,7 @@ def _run_single_child(
 
             _error_entry = {
                 "task_index": task_index,
+                **_current_child_identity(),
                 "status": "timeout" if is_timeout else "error",
                 "summary": None,
                 "error": _err,
@@ -2924,8 +2935,8 @@ def _run_single_child(
 
         # T1-24: structured-output contract validation + ONE bounded retry.
         # Runs only when a schema was attached at dispatch; schema-less
-        # delegations take none of these branches and their result entry
-        # stays byte-identical (wire-shape pinning).
+        # delegations skip validation/retry. Additive host attribution fields
+        # are emitted for every result shape.
         # Pattern from: github/copilot-cli ctx.agent(prompt, {schema}) —
         # PATTERN ONLY, no code copied.
         _output_schema = getattr(child, "_delegate_output_schema", None)
@@ -3082,6 +3093,7 @@ def _run_single_child(
 
         entry: Dict[str, Any] = {
             "task_index": task_index,
+            **_current_child_identity(),
             "status": status,
             "summary": summary,
             "api_calls": api_calls,
@@ -3276,6 +3288,7 @@ def _run_single_child(
                 logger.debug("Progress callback failure relay failed: %s", e)
         _error_entry = {
             "task_index": task_index,
+            **_current_child_identity(),
             "status": "error",
             "summary": None,
             "error": str(exc),
@@ -3790,12 +3803,21 @@ def delegate_task(
     # live_paths is empty and delegation proceeds exactly as before.
     from tools.delegation_live_log import (
         create_live_transcripts,
+        new_live_delegation_id,
         update_manifest_statuses,
         wrap_progress_callback,
     )
 
-    live_deleg_id, live_writers, live_paths = create_live_transcripts(
-        task_list, context, model=creds.get("model"), provider=creds.get("provider")
+    # Identity is part of the delegation contract, not the best-effort live-log
+    # side channel. Generate it first and pass it into transcript creation so
+    # cache/path failures cannot erase or fork the durable attribution key.
+    live_deleg_id = new_live_delegation_id()
+    _logged_deleg_id, live_writers, live_paths = create_live_transcripts(
+        task_list,
+        context,
+        delegation_id=live_deleg_id,
+        model=creds.get("model"),
+        provider=creds.get("provider"),
     )
 
     # Capture the ORIGINATING session's wake target BEFORE any child agent is
@@ -3897,6 +3919,22 @@ def delegate_task(
         results block. That is the contract: fan-out runs in the background,
         waits on each other, and returns together.
         """
+        def _child_result_identity(index: int) -> Dict[str, Any]:
+            child_obj = next(
+                (candidate for i, _task, candidate in children if i == index),
+                None,
+            )
+            raw_subagent_id = getattr(child_obj, "_subagent_id", None)
+            raw_session_id = getattr(child_obj, "session_id", None)
+            return {
+                "subagent_id": (
+                    raw_subagent_id if isinstance(raw_subagent_id, str) else None
+                ),
+                "child_session_id": (
+                    raw_session_id if isinstance(raw_session_id, str) else ""
+                ),
+            }
+
         if n_tasks == 1:
             # Single task -- run directly (no thread pool overhead)
             _i, _t, child = children[0]
@@ -3962,6 +4000,7 @@ def delegate_task(
                                 except Exception as exc:
                                     entry = {
                                         "task_index": idx,
+                                        **_child_result_identity(idx),
                                         "status": "error",
                                         "summary": None,
                                         "error": str(exc),
@@ -3974,6 +4013,7 @@ def delegate_task(
                             else:
                                 entry = {
                                     "task_index": idx,
+                                    **_child_result_identity(idx),
                                     "status": "interrupted",
                                     "summary": None,
                                     "error": "Parent agent interrupted — child did not finish in time",
@@ -3999,6 +4039,7 @@ def delegate_task(
                             idx = futures[future]
                             entry = {
                                 "task_index": idx,
+                                **_child_result_identity(idx),
                                 "status": "error",
                                 "summary": None,
                                 "error": str(exc),
@@ -4070,6 +4111,7 @@ def delegate_task(
         update_manifest_statuses(live_deleg_id, results)
 
         combined: Dict[str, Any] = {
+            "delegation_id": live_deleg_id,
             "results": results,
             "total_duration_seconds": total_duration,
         }


### PR DESCRIPTION
## Summary

Expose stable, privacy-safe attribution identifiers in delegated task results:

- top-level `delegation_id` for synchronous and background aggregation parity;
- per-task `subagent_id` and `child_session_id` on successful results;
- the same identifiers on timeout, interruption, schema-retry, and exception paths.

This lets operators join parent session → delegation → task index → child session deterministically without parsing goals or summaries. It supports outcome/cost attribution while keeping prompt and result content out of the join keys.

## Independent review fixes

An independent lifecycle/security review of the first head found three medium issues, all fixed in the current head:

1. child session identity is now read at finalization so context-compression rotation cannot return the stale parent session;
2. delegation identity is generated independently of best-effort live-transcript creation;
3. the outer lifecycle exception path now preserves `subagent_id` and `child_session_id`.

Regression tests cover all three cases.

## Tests

```text
scripts/run_tests.sh tests/tools/test_delegate*.py \
  tests/tools/test_delegation_live_log.py -q

188 passed, 0 failed
```

The focused two-file suite also passed 75/75. `git diff --check` passes.

## Current head

`ff7d4e4d215271ad2a88d91ec0d884026c473e84`

## Risk

The change is additive to the JSON result shape. Existing internal-only fields remain stripped. IDs are already generated and persisted elsewhere in Hermes; this patch exposes only the stable join keys beside task results. No goals, prompts, summaries, or credentials are added to attribution fields.
