### PR TITLE
fix(desktop): surface guarded model switch confirmation

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -22,6 +22,7 @@ import { useModelControls } from './use-model-controls'
 
 const setGlobalModel = vi.fn()
 const notifyError = vi.fn()
+const confirmModelSwitch = vi.fn()
 
 vi.mock('@/hermes', () => ({
   getGlobalModelInfo: vi.fn(),
@@ -41,8 +42,12 @@ vi.mock('@/store/session-states', async importOriginal => {
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
     t: {
+      common: {
+        confirm: 'Confirm'
+      },
       desktop: {
-        modelSwitchFailed: 'Model switch failed'
+        modelSwitchFailed: 'Model switch failed',
+        modelSwitchConfirmTitle: 'Confirm model switch'
       }
     }
   })
@@ -50,6 +55,10 @@ vi.mock('@/i18n', () => ({
 
 vi.mock('@/store/notifications', () => ({
   notifyError: (...args: Parameters<typeof notifyError>) => notifyError(...args)
+}))
+
+vi.mock('@/store/confirm', () => ({
+  confirm: (...args: Parameters<typeof confirmModelSwitch>) => confirmModelSwitch(...args)
 }))
 
 type Controls = ReturnType<typeof useModelControls>
@@ -73,6 +82,7 @@ function Harness({
 
 describe('useModelControls', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
     setCurrentModel('')
@@ -269,6 +279,68 @@ describe('useModelControls', () => {
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
   })
 
+  it('asks for confirmation and retries a guarded model switch', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('gpt-5.6-sol')
+    setCurrentProvider('openai-codex')
+    confirmModelSwitch.mockResolvedValueOnce(true)
+
+    const requestGateway = vi
+      .fn()
+      .mockResolvedValueOnce({
+        confirm_required: true,
+        confirm_message: 'This contributor model may use prompts and completions for training.'
+      })
+      .mockResolvedValueOnce({ confirm_required: false, value: 'muse-spark-1.2-contributor-free' })
+
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(
+      controls.selectModel({ model: 'muse-spark-1.2-contributor-free', provider: 'opencode-free' })
+    ).resolves.toBe(true)
+
+    expect(confirmModelSwitch).toHaveBeenCalledWith({
+      confirmLabel: 'Confirm',
+      description: 'This contributor model may use prompts and completions for training.',
+      title: 'Confirm model switch'
+    })
+    expect(requestGateway).toHaveBeenNthCalledWith(2, 'config.set', {
+      confirm_expensive_model: true,
+      session_id: 'session-1',
+      key: 'model',
+      value: 'muse-spark-1.2-contributor-free --provider opencode-free --global'
+    })
+    expect($currentModel.get()).toBe('muse-spark-1.2-contributor-free')
+    expect($currentProvider.get()).toBe('opencode-free')
+  })
+
+  it('rolls back a guarded model switch when confirmation is declined', async () => {
+    $activeSessionId.set('session-1')
+    setCurrentModel('gpt-5.6-sol')
+    setCurrentProvider('openai-codex')
+    confirmModelSwitch.mockResolvedValueOnce(false)
+
+    const requestGateway = vi.fn().mockResolvedValueOnce({
+      confirm_required: true,
+      confirm_message: 'This contributor model may use prompts and completions for training.'
+    })
+
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(
+      controls.selectModel({ model: 'muse-spark-1.2-contributor-free', provider: 'opencode-free' })
+    ).resolves.toBe(false)
+
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect($currentModel.get()).toBe('gpt-5.6-sol')
+    expect($currentProvider.get()).toBe('openai-codex')
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
   it('keeps a mid-turn pick painted and skips the refetch that would repaint the old model', async () => {
     // The gateway queues a switch made during a turn and applies it at the next
     // turn start. Invalidating now would answer with the still-running model
@@ -365,8 +437,8 @@ describe('useModelControls', () => {
     })
   })
 
-  it('stores a no-session pick as UI state with no gateway or global write', async () => {
-    const requestGateway = vi.fn()
+  it('preflights a no-session pick without writing the profile default', async () => {
+    const requestGateway = vi.fn(async () => ({ confirm_required: false }) as never)
     let controls!: Controls
 
     render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
@@ -378,13 +450,49 @@ describe('useModelControls', () => {
       })
     ).resolves.toBe(true)
 
-    // The pick is plain UI state; session.create ships it later. Nothing touches
-    // the gateway or the profile default here.
+    // The gateway call only resolves model guards. --session with no session
+    // cannot persist the profile default; session.create ships the UI pick later.
     expect($currentModel.get()).toBe('claude-sonnet-4.6')
     expect($currentProvider.get()).toBe('anthropic')
     expect(getCurrentModelSource()).toBe('manual')
-    expect(requestGateway).not.toHaveBeenCalled()
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      session_id: '',
+      key: 'model',
+      value: 'claude-sonnet-4.6 --provider anthropic --session'
+    })
     expect(setGlobalModel).not.toHaveBeenCalled()
+  })
+
+  it('asks for confirmation before keeping a guarded no-session pick', async () => {
+    setCurrentModel('gpt-5.6-sol')
+    setCurrentProvider('openai-codex')
+    confirmModelSwitch.mockResolvedValueOnce(true)
+
+    const requestGateway = vi
+      .fn()
+      .mockResolvedValueOnce({
+        confirm_required: true,
+        confirm_message: 'This contributor model may use prompts and completions for training.'
+      })
+      .mockResolvedValueOnce({ confirm_required: false })
+
+    let controls!: Controls
+
+    render(<Harness onReady={value => (controls = value)} requestGateway={requestGateway} />)
+
+    await expect(
+      controls.selectModel({ model: 'muse-spark-1.2-contributor-free', provider: 'opencode-free' })
+    ).resolves.toBe(true)
+
+    expect(confirmModelSwitch).toHaveBeenCalledTimes(1)
+    expect(requestGateway).toHaveBeenNthCalledWith(2, 'config.set', {
+      confirm_expensive_model: true,
+      session_id: '',
+      key: 'model',
+      value: 'muse-spark-1.2-contributor-free --provider opencode-free --session'
+    })
+    expect($currentModel.get()).toBe('muse-spark-1.2-contributor-free')
+    expect($currentProvider.get()).toBe('opencode-free')
   })
 
   it('updates only the active profile new-chat cache', async () => {

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -6,6 +6,7 @@ import { getGlobalModelInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { isBusySessionModelSwitch } from '@/lib/gateway-rpc'
 import { manualPickRemoved, modelOptionsQueryKey } from '@/lib/model-options'
+import { confirm } from '@/store/confirm'
 import { notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import {
@@ -25,6 +26,12 @@ import type { ModelOptionsResponse } from '@/types/hermes'
 interface ModelControlsOptions {
   queryClient: QueryClient
   requestGateway: <T = unknown>(method: string, params?: Record<string, unknown>) => Promise<T>
+}
+
+interface ModelSwitchResponse {
+  confirm_message?: string
+  confirm_required?: boolean
+  deferred?: boolean
 }
 
 export function useModelControls({ queryClient, requestGateway }: ModelControlsOptions) {
@@ -211,10 +218,55 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         liveGatewayProfile
       )
 
-      // No live session yet: the pick is pure UI state. session.create reads
-      // $currentModel/$currentProvider and applies it as that session's override.
-      if (!liveSessionId) {
-        return true
+      const rollbackSelection = () => {
+        if (touchesPrimary) {
+          setCurrentModel(prevModel)
+          setCurrentProvider(prevProvider)
+          setCurrentModelSource(prevSource)
+        } else {
+          sessionTileDelegate()?.updateSession(liveSessionId, state => ({
+            ...state,
+            model: prevModel,
+            provider: prevProvider
+          }))
+        }
+
+        updateModelOptionsCache(
+          liveSessionId,
+          prevProvider,
+          prevModel,
+          touchesPrimary && !liveSessionId,
+          liveGatewayProfile
+        )
+      }
+
+      const requestConfirmedSwitch = async (params: Record<string, unknown>) => {
+        let result = await requestGateway<ModelSwitchResponse>('config.set', params)
+
+        if (!result?.confirm_required) {
+          return result
+        }
+
+        const confirmed = await confirm({
+          title: copy.modelSwitchConfirmTitle,
+          description: result.confirm_message?.trim() || copy.modelSwitchFailed,
+          confirmLabel: t.common.confirm
+        })
+
+        if (!confirmed) {
+          return null
+        }
+
+        result = await requestGateway<ModelSwitchResponse>('config.set', {
+          ...params,
+          confirm_expensive_model: true
+        })
+
+        if (result?.confirm_required) {
+          throw new Error(result.confirm_message?.trim() || copy.modelSwitchFailed)
+        }
+
+        return result
       }
 
       try {
@@ -232,14 +284,29 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
         //  - MoA (mixture-of-agents) presets: a transient orchestration choice
         //    that must never become the persisted global gateway default.
         const isSessionOnlyPreset = (selection.provider || '').toLowerCase() === 'moa'
-        const persistsAsDefault = touchesPrimary && !isSessionOnlyPreset
+        const persistsAsDefault = Boolean(liveSessionId) && touchesPrimary && !isSessionOnlyPreset
         const scope = persistsAsDefault ? '--global' : '--session'
 
-        const result = await requestGateway<{ deferred?: boolean }>('config.set', {
-          session_id: liveSessionId,
+        const params = {
+          session_id: liveSessionId || '',
           key: 'model',
           value: `${selection.model} --provider ${selection.provider} ${scope}`
-        })
+        }
+
+        const result = await requestConfirmedSwitch(params)
+
+        if (result === null) {
+          rollbackSelection()
+
+          return false
+        }
+
+        // A draft selection has now passed the same model guards as a live
+        // switch. session.create reads the optimistic UI state and applies it
+        // as the new session's override; this preflight must not persist it.
+        if (!liveSessionId) {
+          return true
+        }
 
         // A pick made DURING a turn is queued by the gateway and applied at the
         // next turn start (`deferred`). Re-fetching now would answer with the
@@ -261,31 +328,20 @@ export function useModelControls({ queryClient, requestGateway }: ModelControlsO
           return true
         }
 
-        if (touchesPrimary) {
-          setCurrentModel(prevModel)
-          setCurrentProvider(prevProvider)
-          setCurrentModelSource(prevSource)
-        } else if (liveSessionId) {
-          sessionTileDelegate()?.updateSession(liveSessionId, state => ({
-            ...state,
-            model: prevModel,
-            provider: prevProvider
-          }))
-        }
-
-        updateModelOptionsCache(
-          liveSessionId,
-          prevProvider,
-          prevModel,
-          touchesPrimary && !liveSessionId,
-          liveGatewayProfile
-        )
+        rollbackSelection()
         notifyError(err, copy.modelSwitchFailed)
 
         return false
       }
     },
-    [copy.modelSwitchFailed, queryClient, requestGateway, updateModelOptionsCache]
+    [
+      copy.modelSwitchConfirmTitle,
+      copy.modelSwitchFailed,
+      queryClient,
+      requestGateway,
+      t.common.confirm,
+      updateModelOptionsCache
+    ]
   )
 
   return { applySavedMainModel, refreshCurrentModel, selectModel }

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2719,6 +2719,7 @@ export const ar = defineLocale({
     cwdStagedTitle: 'تم تجهيز مجلد العمل',
     cwdStagedMessage: 'سيطبق مجلد العمل على الرسالة التالية.',
     modelSwitchFailed: 'فشل تبديل النموذج',
+    modelSwitchConfirmTitle: 'تأكيد تبديل النموذج',
     sessionExported: 'تم تصدير الجلسة',
     sessionExportFailed: 'فشل تصدير الجلسة',
     imageSaved: 'تم حفظ الصورة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3317,6 +3317,7 @@ export const en: Translations = {
     cwdStagedTitle: 'Working directory staged',
     cwdStagedMessage: 'Restart the desktop backend to apply cwd changes to this active session.',
     modelSwitchFailed: 'Model switch failed',
+    modelSwitchConfirmTitle: 'Confirm model switch',
     sessionExported: 'Session exported',
     sessionExportFailed: 'Could not export session',
     imageSaved: 'Image saved',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2966,6 +2966,7 @@ export const ja = defineLocale({
     cwdStagedMessage:
       'このアクティブなセッションへの cwd の変更を適用するにはデスクトップバックエンドを再起動してください。',
     modelSwitchFailed: 'モデルの切り替えに失敗しました',
+    modelSwitchConfirmTitle: 'モデル切り替えの確認',
     sessionExported: 'セッションをエクスポートしました',
     sessionExportFailed: 'セッションをエクスポートできませんでした',
     imageSaved: '画像を保存しました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2849,6 +2849,7 @@ export interface Translations {
     cwdStagedTitle: string
     cwdStagedMessage: string
     modelSwitchFailed: string
+    modelSwitchConfirmTitle: string
     sessionExported: string
     sessionExportFailed: string
     imageSaved: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2844,6 +2844,7 @@ export const zhHant = defineLocale({
     cwdStagedTitle: '工作目錄已暫存',
     cwdStagedMessage: '重新啟動桌面後端後，工作目錄變更才會套用至此作用中工作階段。',
     modelSwitchFailed: '模型切換失敗',
+    modelSwitchConfirmTitle: '確認切換模型',
     sessionExported: '工作階段已匯出',
     sessionExportFailed: '無法匯出工作階段',
     imageSaved: '圖片已儲存',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3466,6 +3466,7 @@ export const zh: Translations = {
     cwdStagedTitle: '工作目录已暂存',
     cwdStagedMessage: '重启桌面后端后，工作目录更改才会应用到当前活跃会话。',
     modelSwitchFailed: '模型切换失败',
+    modelSwitchConfirmTitle: '确认切换模型',
     sessionExported: '会话已导出',
     sessionExportFailed: '无法导出会话',
     imageSaved: '图片已保存',

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12395,6 +12395,15 @@ def test_config_set_model_defers_while_running(monkeypatch):
         return {"value": raw, "warning": ""}
 
     monkeypatch.setattr(server, "_apply_model_switch", _fake_apply)
+    monkeypatch.setattr(
+        server,
+        "_preflight_deferred_model_switch",
+        lambda *_args, **_kwargs: {
+            "value": "anthropic/claude-sonnet-4.6",
+            "warning": "",
+            "confirm_required": False,
+        },
+    )
 
     server._sessions["sid"] = _session(running=True)
     try:
@@ -12419,6 +12428,77 @@ def test_config_set_model_defers_while_running(monkeypatch):
         )
         pending = server._sessions["sid"].get("pending_model_switch")
         assert pending and pending["raw"] == "anthropic/claude-sonnet-4.6"
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_config_set_model_requires_confirmation_before_deferring_while_running(monkeypatch):
+    """A guarded model must not be queued mid-turn until the caller confirms."""
+
+    def _fake_preflight(raw, *, parsed_flags, confirm_expensive_model):
+        assert raw == "muse-spark-1.2-contributor-free --provider opencode-free"
+        assert parsed_flags.explicit_provider == "opencode-free"
+        assert confirm_expensive_model is False
+        return {
+            "value": "muse-spark-1.2-contributor-free",
+            "warning": "Training data warning",
+            "confirm_required": True,
+            "confirm_message": "Training data warning",
+        }
+
+    monkeypatch.setattr(server, "_preflight_deferred_model_switch", _fake_preflight)
+    server._sessions["sid"] = _session(running=True)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {
+                    "session_id": "sid",
+                    "key": "model",
+                    "value": "muse-spark-1.2-contributor-free --provider opencode-free",
+                },
+            }
+        )
+        assert not resp.get("error")
+        assert resp["result"]["confirm_required"] is True
+        assert resp["result"]["confirm_message"] == "Training data warning"
+        assert "pending_model_switch" not in server._sessions["sid"]
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_config_set_model_defers_guarded_model_after_confirmation(monkeypatch):
+    """The confirmed retry keeps the acknowledgement with the queued switch."""
+
+    def _fake_preflight(raw, *, parsed_flags, confirm_expensive_model):
+        assert confirm_expensive_model is True
+        return {
+            "value": parsed_flags.model_input,
+            "warning": "",
+            "confirm_required": False,
+        }
+
+    monkeypatch.setattr(server, "_preflight_deferred_model_switch", _fake_preflight)
+    server._sessions["sid"] = _session(running=True)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {
+                    "session_id": "sid",
+                    "key": "model",
+                    "value": "muse-spark-1.2-contributor-free --provider opencode-free",
+                    "confirm_expensive_model": True,
+                },
+            }
+        )
+        assert not resp.get("error")
+        assert resp["result"]["deferred"] is True
+        pending = server._sessions["sid"]["pending_model_switch"]
+        assert pending["confirm_expensive_model"] is True
+        assert pending["display_model"] == "muse-spark-1.2-contributor-free"
     finally:
         server._sessions.pop("sid", None)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5276,6 +5276,24 @@ def _apply_pending_model_switch(sid: str, session: dict) -> None:
         )
 
 
+def _preflight_deferred_model_switch(
+    raw: str,
+    *,
+    parsed_flags: Any,
+    confirm_expensive_model: bool,
+) -> dict:
+    """Resolve and guard a busy-session switch without touching its live agent."""
+    return _apply_model_switch(
+        "",
+        {"agent": None},
+        raw,
+        confirm_expensive_model=confirm_expensive_model,
+        pin_session_override=False,
+        parsed_flags=parsed_flags,
+        persist_override=False,
+    )
+
+
 class CompressionLockHeld(Exception):
     """Raised by _compress_session_history when compression skipped due
     to a concurrent lock on the session's compression_locks row."""
@@ -12030,8 +12048,30 @@ def _(rid, params: dict) -> dict:
                 # the new model without waiting for the swap or interrupting.
                 if session.get("running"):
                     parsed = parse_model_switch_args(value)
+                    preflight = _preflight_deferred_model_switch(
+                        value,
+                        parsed_flags=parsed,
+                        confirm_expensive_model=bool(
+                            params.get("confirm_expensive_model", False)
+                        ),
+                    )
+                    if preflight.get("confirm_required"):
+                        return _ok(
+                            rid,
+                            {
+                                "key": key,
+                                "value": preflight["value"],
+                                "warning": preflight.get("warning", ""),
+                                "confirm_required": True,
+                                "confirm_message": preflight.get(
+                                    "confirm_message", ""
+                                ),
+                                "scope": "session",
+                                "deferred": False,
+                            },
+                        )
                     try:
-                        pending_model = parsed.model_input
+                        pending_model = preflight.get("value") or parsed.model_input
                     except Exception:
                         pending_model = str(value)
                     session["pending_model_switch"] = {


### PR DESCRIPTION
## Summary

Hermes Desktop currently ignores a successful `config.set` response when the gateway returns `confirm_required: true`. A guarded model row therefore appears to do nothing: the optimistic label is eventually replaced by the old model, but Desktop shows no confirmation dialog and no error.

This is easy to reproduce with `muse-spark-1.2-contributor`, whose data-training warning was introduced by #85917.

## Root cause

- `tui_gateway.server._apply_model_switch()` correctly refuses to apply the model and returns `confirm_required` plus `confirm_message`.
- `useModelControls.selectModel()` typed the response as `{ deferred?: boolean }`, ignored both confirmation fields, and returned success.
- Busy-session switches were queued before selection guards ran, so an unconfirmed guarded model could also be dropped at the next turn boundary.
- Draft/new-session picks returned before consulting the gateway, bypassing the same guard entirely.

## Changes

- Route gateway confirmation responses through Desktop's existing shared `ConfirmHost`.
- Retry exactly once with `confirm_expensive_model: true` after explicit confirmation.
- Roll optimistic model/provider state back when the user cancels or the confirmed retry fails.
- Preflight draft picks with `--session`, so selection guards run without persisting the profile default.
- Preflight busy-session switches against a detached agent state before queueing; the live streaming agent is never mutated.
- Add localized confirmation titles for all Desktop locales.

## Validation

- Desktop model-control tests: 23 passed
- TUI gateway full file on the production branch: 586 passed
- Rebased PR branch focused gateway tests: 4 passed
- Desktop TypeScript typecheck: passed
- ESLint: 0 errors
- Ruff: passed
- macOS Desktop build and unpacked package: passed
- Live Desktop acceptance: contributor-tier selection displayed the warning dialog; confirmation switched in place to `opencode-go: muse-spark-1.2-contributor` with `xhigh` reasoning

Closes the Desktop surface gap left by #85917.
