### PR TITLE
fix(gateway): isolate kanban dispatcher context

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -71,6 +71,22 @@ def is_delegated_child_context() -> bool:
 
 
 @contextmanager
+def parent_process_context() -> Iterator[None]:
+    """Restore trusted parent identity around process-owned background work.
+
+    ``asyncio.to_thread`` copies the caller's ContextVars. A gateway service
+    scheduled from child-owned work can therefore inherit delegated identity
+    even though the service belongs to the parent process. Keep this override
+    narrow: it is for internal infrastructure, never work done for a child.
+    """
+    token = _DELEGATED_CHILD_CONTEXT.set(False)
+    try:
+        yield
+    finally:
+        _DELEGATED_CHILD_CONTEXT.reset(token)
+
+
+@contextmanager
 def non_dispatcher_owned_context() -> Iterator[None]:
     """Mark in-process execution that does NOT own the dispatcher's Kanban task.
 

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -25,6 +25,14 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+def _run_parent_process_call(fn, *args):
+    """Run gateway-owned blocking work without copied child identity."""
+    from agent.delegation_context import parent_process_context
+
+    with parent_process_context():
+        return fn(*args)
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -1681,7 +1689,9 @@ class GatewayKanbanWatchersMixin:
             try:
                 # Reap zombie children before per-board work so a board DB
                 # failure cannot block cleanup of unrelated workers.
-                pids = await asyncio.to_thread(_kb.reap_worker_zombies)
+                pids = await asyncio.to_thread(
+                    _run_parent_process_call, _kb.reap_worker_zombies
+                )
                 if pids:
                     logger.info(
                         "kanban dispatcher: reaped %d zombie worker(s), pids=%s",
@@ -1704,8 +1714,14 @@ class GatewayKanbanWatchersMixin:
                     # takes effect on the next tick, not on gateway restart (#49638).
                     _ad_enabled, _ad_per_tick = _read_auto_decompose_settings()
                     if _ad_enabled:
-                        await asyncio.to_thread(_auto_decompose_tick, _ad_per_tick)
-                    results = await asyncio.to_thread(_tick_once)
+                        await asyncio.to_thread(
+                            _run_parent_process_call,
+                            _auto_decompose_tick,
+                            _ad_per_tick,
+                        )
+                    results = await asyncio.to_thread(
+                        _run_parent_process_call, _tick_once
+                    )
                     any_spawned = False
                     for slug, res in (results or []):
                         if res is not None and getattr(res, "spawned", None):
@@ -1724,7 +1740,9 @@ class GatewayKanbanWatchersMixin:
                                 len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                             )
                     # Health telemetry (aggregate across boards)
-                    ready_pending = await asyncio.to_thread(_ready_nonempty)
+                    ready_pending = await asyncio.to_thread(
+                        _run_parent_process_call, _ready_nonempty
+                    )
                     if ready_pending and not any_spawned:
                         bad_ticks += 1
                     else:

--- a/tests/gateway/test_kanban_dispatcher_context.py
+++ b/tests/gateway/test_kanban_dispatcher_context.py
@@ -1,0 +1,39 @@
+import asyncio
+
+import pytest
+
+from agent.delegation_context import delegated_child_context
+from gateway.kanban_watchers import _run_parent_process_call
+from hermes_cli import kanban_db as kb
+
+
+def test_gateway_dispatcher_does_not_inherit_delegated_child_context(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+
+    def dispatch_once():
+        conn = kb.connect()
+        try:
+            return kb.create_task(conn, title="gateway-owned dispatch")
+        finally:
+            conn.close()
+
+    def child_write():
+        conn = kb.connect()
+        try:
+            return kb.create_task(conn, title="forbidden child write")
+        finally:
+            conn.close()
+
+    async def exercise_boundary():
+        with delegated_child_context("child-session"):
+            with pytest.raises(PermissionError, match="delegate_task child contexts"):
+                await asyncio.to_thread(child_write)
+
+            assert await asyncio.to_thread(_run_parent_process_call, dispatch_once)
+
+            with pytest.raises(PermissionError, match="delegate_task child contexts"):
+                await asyncio.to_thread(child_write)
+
+    asyncio.run(exercise_boundary())


### PR DESCRIPTION
## What does this PR do?

Fixes #91958. The embedded Kanban dispatcher now runs its gateway-owned blocking callbacks in parent-process context. This prevents `asyncio.to_thread` from carrying a delegated-child ContextVar into dispatcher database writes while keeping the child mutation guard intact everywhere else.

## Baseline and fix evidence

Exact base: `b6bcb3e791c673e63974029bbab40cc9326803ff`
Exact head: `ed5951d0e92ce94a0ba1a73207e868bd0f500f53`

On the base, a real delegated context calling `asyncio.to_thread(kb.connect)` against a fresh Kanban database raises `PermissionError: delegate_task child contexts cannot mutate Kanban tasks or boards`. The regression exercises the stronger write boundary: a delegated `create_task` is denied, the same SQLite write succeeds through the gateway dispatcher boundary, and another delegated write remains denied after the override exits.

The production boundary covers zombie reaping, auto-decomposition, dispatch, and ready-queue health checks. It does not clear the subprocess environment marker or weaken delegated child guards. The older #87668 concerns a stale inherited environment marker; #91958 reports that marker absent and reproduces through the separate ContextVar path.

## Validation

- `scripts/run_tests.sh tests/gateway/test_kanban_dispatcher_context.py tests/hermes_cli/test_kanban_core_functionality.py -q` - 24 passed, 1 skipped
- `scripts/run_tests.sh tests/tools/test_delegate_kanban_isolation.py tests/gateway/test_delegation_session_id_leak.py tests/gateway/test_kanban_dispatcher_context.py -q` - 14 passed
- `ruff check` on all changed files - passed
- `git diff --check` - passed
- TruffleHog on all changed files - 0 verified or unverified secrets

## Scope

Three files: one scoped context manager, one gateway callback wrapper applied to the four dispatcher offloads, and one real SQLite/to_thread regression. No config, schema, protocol, or child-tool behavior changes.

## Competing ownership approach

PR #91971 addresses the same report at a broader boundary: it creates supervised watcher tasks and their respawns from a fresh `contextvars.Context`. This PR instead resets only the four gateway-owned Kanban dispatcher offloads immediately around their blocking database callbacks.

The tradeoff is explicit for maintainer selection: #91971 prevents request-local context from entering any supervised watcher; this PR leaves watcher task semantics unchanged and prevents delegated identity from crossing the concrete Kanban write boundary. The exact-head SQLite regression proves the reported dispatcher writes succeed while delegated writes immediately before and after remain denied. These approaches overlap for #91958 and should not be merged independently without choosing the intended ownership boundary.