### PR TITLE
fix(tools): allow max_spawn_depth=0 to disable subagent spawning (#91765)

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -129,10 +129,11 @@ _HIGH_CONCURRENCY_WARNED = False
 MAX_DEPTH = 1  # flat by default: parent (0) -> child (1); grandchild rejected unless max_spawn_depth raised.
 # Configurable depth cap consulted by _get_max_spawn_depth; MAX_DEPTH
 # stays as the default fallback and is still the symbol tests import.
-_MIN_SPAWN_DEPTH = 1
+_MIN_SPAWN_DEPTH = 0
 # No upper ceiling on spawn depth — like max_concurrent_children, depth has a
-# floor of 1 and no ceiling. Deeper trees multiply API cost, so the default
+# floor of 0 and no ceiling. Deeper trees multiply API cost, so the default
 # stays flat (MAX_DEPTH = 1); raising the config knob is an explicit opt-in.
+# max_spawn_depth=0 disables spawning entirely (parent-only mode).
 
 
 # ---------------------------------------------------------------------------
@@ -971,7 +972,7 @@ def _get_child_timeout() -> Optional[float]:
 
 
 def _get_max_spawn_depth() -> int:
-    """Read delegation.max_spawn_depth from config, floored at 1 (no ceiling).
+    """Read delegation.max_spawn_depth from config, floored at 0 (no ceiling).
 
     depth 0 = parent agent.  max_spawn_depth = N means agents at depths
     0..N-1 can spawn; depth N is the leaf floor.  Default 1 is flat:


### PR DESCRIPTION
## Summary

Fixes #91765.

`delegation.max_spawn_depth: 0` was silently coerced to `1` because `_MIN_SPAWN_DEPTH = 1`. This defeated the documented "0 = parent-only, disable spawning" semantics — operators who explicitly set `max_spawn_depth: 0` for cost containment or capability scoping had no way to actually disable subagent spawning.

## Changes

- `tools/delegate_tool.py`: Lower `_MIN_SPAWN_DEPTH` from `1` to `0` so that `0` passes through unclamped. Only negative values get clamped up to `0`. Updated docstring and comments to reflect the new floor.

## Testing

- `python3 -m py_compile tools/delegate_tool.py` passes
- With `max_spawn_depth: 0`, `_get_max_spawn_depth()` now returns `0` (was `1`)
- The depth gate `if depth >= max_spawn` correctly blocks spawning for the top-level agent (depth=0, max=0: `0 >= 0` = True)
