### PR TITLE
fix(tools): resolve task_id in cleanup_vm to match environment creation key (#91440)

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2209,6 +2209,11 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     via this function), so persist-mode idle envs are similarly no-op'd —
     only the orphan reaper at next startup reclaims them.
     """
+    # Resolve the task_id to the same key used during environment creation.
+    # Without this, cleanup called with a raw session UUID won't find the
+    # environment stored under the resolved key (e.g. "default").
+    task_id = _resolve_container_task_id(task_id)
+
     # Remove from tracking dicts while holding the lock, but defer the
     # actual (potentially slow) env.cleanup() call to outside the lock
     # so other tool calls aren't blocked.


### PR DESCRIPTION
## Summary

Fixes #91440.

`cleanup_vm()` used the raw `task_id` (session UUID) to look up environments in `_active_environments`, but environments are stored under the resolved key (e.g. `"default"`) returned by `_resolve_container_task_id()`. This caused cleanup to silently miss the environment, leaving stale entries that leaked into subsequent sessions.

## Changes

- `tools/terminal_tool.py`: Add `_resolve_container_task_id(task_id)` call at the start of `cleanup_vm()` so the dict lookup matches the key used during environment creation.

## Testing

- `python3 -m py_compile tools/terminal_tool.py` passes
- With a session UUID that resolves to `"default"`, cleanup now correctly finds and removes the environment
