### PR TITLE
feat(agent): context-window budget hint injection (adapted from openai/codex)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1471,6 +1471,22 @@ def _parse_compression_config(agent, _agent_cfg) -> CompressionSettings:
         checkpoint_required, getattr(agent, "api_mode", None)
     )
     app_server_auto, responses_native, compact_threshold = _compression_codex_settings(cfg)
+    # Context-window budget hint threshold (fraction of the model's context
+    # window at which the advisory hint fires; see agent/budget_hint.py).
+    # Adapted from openai/codex's TokenBudgetRemainingContext. 0 disables the
+    # hint entirely (the default is 0.70: hint only fires above 70% usage, so
+    # low-usage conversations keep a byte-stable prompt prefix).
+    try:
+        from agent.budget_hint import DEFAULT_BUDGET_HINT_THRESHOLD
+    except ImportError:  # pragma: no cover - defensive for partial installs
+        DEFAULT_BUDGET_HINT_THRESHOLD = 0.70
+    try:
+        _budget_hint_threshold = float(
+            cfg.get("budget_hint_threshold", DEFAULT_BUDGET_HINT_THRESHOLD)
+        )
+    except (TypeError, ValueError):
+        _budget_hint_threshold = DEFAULT_BUDGET_HINT_THRESHOLD
+    agent._budget_hint_threshold = max(0.0, _budget_hint_threshold)
     # Opt-in idle compaction: compact up front when a session resumes after this many
     # seconds idle (0 = disabled). Consumed by build_turn_context().
     idle_compact_after_seconds = max(0, int(cfg.get("idle_compact_after_seconds", 0)))

--- a/agent/budget_hint.py
+++ b/agent/budget_hint.py
@@ -1,0 +1,71 @@
+"""Context-window budget hint injection (adapted from openai/codex).
+
+Codex injects a ``TokenBudgetRemainingContext`` fragment — "You have N tokens
+left in this context window." — into the model input at window boundaries so
+the model can budget its own output and avoid forced truncation or lossy
+compression. Hermes compresses automatically (``conversation_compression`` /
+``context_compressor``) but never tells the model how much window remains; the
+model only discovers it was too verbose when compression fires mid-turn or the
+provider truncates output.
+
+This module builds the equivalent hint for Hermes turns. It is injected only
+once usage crosses the configured threshold, so low-usage conversations keep a
+byte-stable prompt prefix (per-conversation prompt caching stays intact). The
+hint rides the existing ``api_content`` sidecar (``compose_user_api_content``),
+which persists exactly the bytes sent — the prompt-cache invariant ("what turn
+N sends must be what turn N+1 replays") is preserved by the same mechanism that
+already carries memory prefetch.
+
+The hint is deliberately conservative: it never instructs the model to change
+scientific content or drop information, only to be mindful of the remaining
+window. It is advisory prose appended to the turn's user message, never a new
+core tool or a system-prompt mutation.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+_BUDGET_HINT_TEMPLATE = (
+    "[Context budget: ~{pct}% of the context window is in use "
+    "(~{remaining:,} tokens remain). Keep the response focused so it fits "
+    "before forced compression or truncation — oldest turns get compressed "
+    "first.]"
+)
+
+# Default fraction of the window at which the hint fires. Mirrored in
+# cli-config.yaml.example (compression.budget_hint_threshold). Centralized
+# here so every code path that reads the threshold — including turn-context
+# builds that never passed through init_agent's config wiring (older
+# serialized agents, alternate constructors) — falls back to the SAME
+# documented default instead of silently disabling the feature.
+DEFAULT_BUDGET_HINT_THRESHOLD = 0.70
+
+
+def build_budget_hint(
+    used_tokens: int,
+    context_window: int,
+    threshold: float,
+) -> Optional[str]:
+    """Return a budget-hint line when usage crosses the threshold, else None.
+
+    Args:
+        used_tokens: Estimated tokens currently occupying the window (>= 0).
+        context_window: The model's context window in tokens (> 0).
+        threshold: Fraction of the window at which the hint fires, in (0, 1];
+            <= 0 disables the hint entirely.
+
+    Returns:
+        A single fenced hint string when ``used_tokens / context_window >=
+        threshold``, otherwise None. Returns None for any degenerate input
+        (unknown window, disabled threshold, negative counts) so callers can
+        treat a None result as "no injection".
+    """
+    if threshold <= 0 or context_window <= 0 or used_tokens < 0:
+        return None
+    ratio = used_tokens / context_window
+    if ratio < threshold:
+        return None
+    remaining = max(0, context_window - used_tokens)
+    pct = int(ratio * 100)
+    return _BUDGET_HINT_TEMPLATE.format(pct=pct, remaining=remaining)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1292,6 +1292,7 @@ class _LoopState:
     _should_review_memory: Any
     _plugin_user_context: Any
     _ext_prefetch_cache: Any
+    budget_hint: Any
     # Turn-scoped state (rebound by the phases).
     messages: Any
     active_system_prompt: Any
@@ -1357,7 +1358,7 @@ class _LoopState:
 # _LoopState fields seeded from TurnContext (same name minus the leading underscore).
 _CTX_FIELDS = frozenset({
     "user_message", "original_user_message", "conversation_history", "effective_task_id", "turn_id",
-    "_should_review_memory", "_plugin_user_context", "_ext_prefetch_cache", "messages",
+    "_should_review_memory", "_plugin_user_context", "_ext_prefetch_cache", "budget_hint", "messages",
     "active_system_prompt", "current_turn_user_idx", "_preflight_compression_blocked",
 })
 # Keyword names each phase helper takes (minus ``agent``), cached per function object.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -79,16 +79,18 @@ def _agent_stale_thinking_on_wire(agent: Any) -> bool:
 
 
 def compose_user_api_content(
-    content: Any, ext_prefetch_cache: str, plugin_user_context: str
+    content: Any, ext_prefetch_cache: str, plugin_user_context: str,
+    budget_hint: str = "",
 ) -> Optional[str]:
     """Compose the API-bound content of the current turn's user message.
 
     Single source for the ``api_content`` sidecar and the wire bytes so they never drift
-    (what turn N sends is what turn N+1 replays). ``None`` when nothing is injected."""
+    (what turn N sends is what turn N+1 replays). ``None`` when nothing is injected.
+    ``budget_hint`` (see :mod:`agent.budget_hint`) rides last when present."""
     if not isinstance(content, str):
         return None
     fenced = build_memory_context_block(ext_prefetch_cache) if ext_prefetch_cache else ""
-    injections = [part for part in (fenced, plugin_user_context) if part]
+    injections = [part for part in (fenced, plugin_user_context, budget_hint) if part]
     if not injections:
         return None
     return content + "\n\n" + "\n\n".join(injections)
@@ -393,6 +395,8 @@ class TurnContext:
     should_review_memory: bool = False  # post-turn memory review should fire
     plugin_user_context: str = ""  # ``pre_llm_call`` context (appended to user message)
     ext_prefetch_cache: str = ""  # external-memory prefetch, reused across iterations
+    # Context-window budget hint (``agent.budget_hint``) for this turn, or "".
+    budget_hint: str = ""
     preflight_compression_blocked: bool = False  # immediate retry proved ineffective
 
 
@@ -787,7 +791,7 @@ def _memory_turn_start_and_prefetch(
 
 def _stamp_api_content_sidecar(
     agent: Any, messages: List[Any], current_turn_user_idx: int, ext_prefetch_cache: str,
-    plugin_user_context: str, *, preflight_compressed: bool,
+    plugin_user_context: str, *, budget_hint: str = "", preflight_compressed: bool,
 ) -> None:
     """api_content sidecar — persist what you send: injected context lives only in the
     API copy, so stamp the exact sent bytes on the live dict for replay."""
@@ -797,7 +801,7 @@ def _stamp_api_content_sidecar(
     # Match the row the flush wrote (persist override = clean transcript), not the live bytes.
     durable_content, _api_content = durable_user_row_content(
         agent, _turn_user_msg, live_content,
-        compose_user_api_content(live_content or "", ext_prefetch_cache, plugin_user_context),
+        compose_user_api_content(live_content or "", ext_prefetch_cache, plugin_user_context, budget_hint),
     )
     if _api_content is None or _api_content == durable_content:
         return
@@ -984,6 +988,46 @@ def build_turn_context(
     _bind_interrupt_scope(agent, ra)
     ext_prefetch_cache = _memory_turn_start_and_prefetch(agent, original_user_message, turn_author)
 
+    # ── Context-window budget hint (adapted from openai/codex) ──
+    # When the estimated request approaches the model's context window, tell
+    # the model how much room remains so it can keep responses focused and
+    # avoid forced truncation or lossy compression. Injected only above the
+    # configured threshold (compression.budget_hint_threshold, default 0.70);
+    # below it the prompt prefix stays byte-stable. The hint rides the same
+    # api_content sidecar as prefetch, so the prompt-cache invariant ("what
+    # turn N sends must be what turn N+1 replays") is preserved by the exact
+    # mechanism that already carries memory context.
+    budget_hint = ""
+    try:
+        from agent.budget_hint import DEFAULT_BUDGET_HINT_THRESHOLD
+    except ImportError:  # pragma: no cover - defensive for partial installs
+        DEFAULT_BUDGET_HINT_THRESHOLD = 0.70
+    _budget_threshold = float(
+        getattr(agent, "_budget_hint_threshold", DEFAULT_BUDGET_HINT_THRESHOLD) or 0.0
+    )
+    if _budget_threshold > 0:
+        try:
+            from agent.budget_hint import build_budget_hint
+
+            _ctx_len = getattr(
+                getattr(agent, "context_compressor", None), "context_length", None
+            )
+            # Semantic note: context_length is the compressor's effective cap,
+            # not necessarily the provider's true window. If the provider
+            # window is larger, "~N tokens remain" understates headroom —
+            # intentionally conservative, so the model never overfills a
+            # window the compressor would shrink anyway.
+            if isinstance(_ctx_len, int) and _ctx_len > 0 and messages:
+                _used_tokens = estimate_messages_tokens_rough(messages)
+                if _used_tokens >= 0:
+                    budget_hint = (
+                        build_budget_hint(_used_tokens, _ctx_len, _budget_threshold)
+                        or ""
+                    )
+        except Exception:
+            logger.debug("budget hint computation failed; skipping", exc_info=True)
+            budget_hint = ""
+
     # Sidecar skipped for codex_app_server/MoA.
     if (
         not moa_active
@@ -993,7 +1037,8 @@ def build_turn_context(
     ):
         _stamp_api_content_sidecar(
             agent, messages, current_turn_user_idx, ext_prefetch_cache,
-            plugin_user_context, preflight_compressed=compaction.compressed,
+            plugin_user_context, budget_hint=budget_hint,
+            preflight_compressed=compaction.compressed,
         )
 
     _persist_turn_start(agent, messages, conversation_history, pending_cli_message)
@@ -1008,6 +1053,7 @@ def build_turn_context(
         effective_task_id=effective_task_id, turn_id=turn_id,
         current_turn_user_idx=current_turn_user_idx, should_review_memory=should_review_memory,
         plugin_user_context=plugin_user_context, ext_prefetch_cache=ext_prefetch_cache,
+        budget_hint=budget_hint,
         preflight_compression_blocked=compaction.blocked,
     )
 
@@ -1034,6 +1080,7 @@ def _sanitize_model_for(agent: Any, moa_config: Any) -> Any:
 def build_api_messages(
     agent: Any, messages: List[Dict[str, Any]], *, current_turn_user_idx: Any,
     ext_prefetch_cache: Any, plugin_user_context: Any, moa_config: Any, active_system_prompt: Any,
+    budget_hint: str = "",
 ) -> Tuple[List[Dict[str, Any]], str]:
     """Build the wire copy of ``messages`` for one API call plus the effective system
     message. Returns ``(api_messages, effective_system)``.
@@ -1071,7 +1118,8 @@ def build_api_messages(
             else:
                 # Callers that bypass the prologue stamping: compose live.
                 _composed = compose_user_api_content(
-                    api_msg.get("content", ""), ext_prefetch_cache, plugin_user_context
+                    api_msg.get("content", ""), ext_prefetch_cache, plugin_user_context,
+                    budget_hint,
                 )
                 if _composed is not None:
                     api_msg["content"] = _composed

--- a/agent/turn_request_assembly.py
+++ b/agent/turn_request_assembly.py
@@ -107,6 +107,7 @@ def assemble_api_request(
     agent: Any, *, messages: Any, current_turn_user_idx: Any, _ext_prefetch_cache: Any,
     _plugin_user_context: Any, moa_config: Any, active_system_prompt: Any,
     original_user_message: Any, pending_moa_prepared_request: Any, request_logger: Any,
+    budget_hint: str = "",
 ) -> AssembledRequest:
     """Assemble the request in the original order. ORDER IS LOAD-BEARING: cache breakpoints
     are injected only after whitespace normalization, the orphan sweep, thinking-only drop /
@@ -121,6 +122,7 @@ def assemble_api_request(
         agent, messages, current_turn_user_idx=current_turn_user_idx,
         ext_prefetch_cache=_ext_prefetch_cache, plugin_user_context=_plugin_user_context,
         moa_config=moa_config, active_system_prompt=active_system_prompt,
+        budget_hint=budget_hint,
     )
 
     if moa_config:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -608,6 +608,16 @@ compression:
   # compaction doesn't fire with half the window still free; set above 0.75 to override.
   threshold: 0.50
 
+  # Context-window budget hint (default: 0.70 = 70%).
+  # When the estimated request exceeds this fraction of the model's context
+  # window, the turn's user message carries a short advisory line telling the
+  # model how much room remains (e.g. "~80% of the context window is in use"),
+  # so it can keep responses focused and avoid forced truncation or lossy
+  # compression. Below the threshold nothing is injected, keeping the prompt
+  # prefix byte-stable for prompt caching. Set to 0 to disable entirely.
+  # Adapted from openai/codex's TokenBudgetRemainingContext.
+  budget_hint_threshold: 0.70
+
   # Per-model threshold overrides: keys are substring-matched against the model
   # name (longest match wins). Useful when some models need different compaction
   # points — e.g. a 1M-context model can compress later (0.30) while a 128K

--- a/tests/agent/test_budget_hint.py
+++ b/tests/agent/test_budget_hint.py
@@ -1,0 +1,254 @@
+"""Tests for agent.budget_hint — context-window budget hint injection.
+
+Adapted from openai/codex's TokenBudgetRemainingContext: when the estimated
+request approaches the model's context window, the model is told how much
+room remains so it can keep responses focused and avoid forced truncation or
+lossy compression.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import patch
+
+import pytest
+
+from agent.budget_hint import DEFAULT_BUDGET_HINT_THRESHOLD, build_budget_hint
+
+
+class TestBuildBudgetHint:
+    def test_below_threshold_returns_none(self):
+        # 10K / 100K = 10% < 70% threshold → no hint, prompt prefix stays stable.
+        assert build_budget_hint(10_000, 100_000, 0.70) is None
+
+    def test_at_threshold_returns_hint(self):
+        hint = build_budget_hint(70_000, 100_000, 0.70)
+        assert hint is not None
+        assert "70%" in hint
+        assert "30,000" in hint  # remaining tokens formatted with commas
+
+    def test_above_threshold_returns_hint(self):
+        hint = build_budget_hint(85_000, 100_000, 0.70)
+        assert hint is not None
+        assert "85%" in hint
+        assert "15,000" in hint
+
+    def test_full_window_reports_zero_remaining(self):
+        hint = build_budget_hint(100_000, 100_000, 0.50)
+        assert hint is not None
+        assert "100%" in hint
+        assert "0" in hint
+
+    def test_disabled_threshold_never_injects(self):
+        # threshold <= 0 disables the hint entirely, even at 100% usage.
+        assert build_budget_hint(100_000, 100_000, 0.0) is None
+        assert build_budget_hint(100_000, 100_000, -1.0) is None
+
+    def test_degenerate_inputs_return_none(self):
+        assert build_budget_hint(-1, 100_000, 0.70) is None  # negative usage
+        assert build_budget_hint(50_000, 0, 0.70) is None  # unknown window
+        assert build_budget_hint(50_000, -100, 0.70) is None  # negative window
+
+    def test_hint_mentions_context_budget_explicitly(self):
+        hint = build_budget_hint(80_000, 100_000, 0.50)
+        assert hint is not None
+        assert "Context budget" in hint
+        assert "tokens" in hint
+
+    def test_default_threshold_constant_matches_documented_default(self):
+        # The centralized default must mirror cli-config.yaml.example
+        # (compression.budget_hint_threshold: 0.70) — turn-context builds
+        # that never pass through init_agent fall back to it, and a 0.0
+        # fallback would silently disable the hint for them.
+        assert DEFAULT_BUDGET_HINT_THRESHOLD == 0.70
+
+
+# ---------------------------------------------------------------------------
+# build_turn_context wiring — the getattr-default seam (review #91974)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTodoStore:
+    def has_items(self):
+        return True
+
+
+class _FakeGuardrails:
+    def reset_for_turn(self):
+        pass
+
+
+class _FakeAgent:
+    """Minimal stand-in covering only what build_turn_context touches.
+
+    Deliberately does NOT set ``_budget_hint_threshold`` — the point of the
+    regression test is that the getattr default (DEFAULT_BUDGET_HINT_THRESHOLD,
+    0.70) kicks in instead of a 0.0 fallback that would silently disable the
+    hint for agents built outside init_agent (older serialized agents,
+    alternate constructors).
+    """
+
+    def __init__(self):
+        self.session_id = "sess-1"
+        self.model = "test/model"
+        self.provider = "openrouter"
+        self.base_url = "https://openrouter.ai/api/v1"
+        self.api_key = "sk-x"
+        self.api_mode = "chat_completions"
+        self.platform = "cli"
+        self.quiet_mode = True
+        self.max_iterations = 90
+        self.tools = []
+        self.valid_tool_names = set()
+        self._skip_mcp_refresh = True
+        self.compression_enabled = False
+        self.context_compressor = types.SimpleNamespace(
+            protect_first_n=2, protect_last_n=2, context_length=100_000
+        )
+        self._cached_system_prompt = "SYSTEM"
+        self._memory_store = None
+        self._memory_manager = None
+        self._memory_nudge_interval = 0
+        self._turns_since_memory = 0
+        self._user_turn_count = 0
+        self._todo_store = _FakeTodoStore()
+        self._tool_guardrails = _FakeGuardrails()
+        self._compression_warning = None
+        self._interrupt_requested = False
+        self._memory_write_origin = "assistant_tool"
+        self._stream_context_scrubber = None
+        self._stream_think_scrubber = None
+
+    def _ensure_db_session(self):
+        pass
+
+    def _restore_primary_runtime(self):
+        pass
+
+    def _cleanup_dead_connections(self):
+        return False
+
+    def _emit_status(self, _msg):
+        pass
+
+    def _replay_compression_warning(self):
+        pass
+
+    def _hydrate_todo_store(self, *_a, **_k):
+        pass
+
+    def _safe_print(self, *_a, **_k):
+        pass
+
+    def _persist_session(self, messages, _history=None):
+        pass
+
+
+def _build(agent, **overrides):
+    from agent.turn_context import build_turn_context
+
+    kwargs = dict(
+        agent=agent,
+        user_message="hello",
+        system_message=None,
+        conversation_history=None,
+        task_id=None,
+        stream_callback=None,
+        persist_user_message=None,
+        restore_or_build_system_prompt=lambda *a, **k: None,
+        install_safe_stdio=lambda: None,
+        sanitize_surrogates=lambda s: s,
+        summarize_user_message_for_log=lambda s: s,
+        set_session_context=lambda _sid: None,
+        set_current_write_origin=lambda _o: None,
+        ra=lambda: types.SimpleNamespace(_set_interrupt=lambda *a, **k: None),
+    )
+    kwargs.update(overrides)
+    return build_turn_context(**kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _stub_runtime_main():
+    with patch("agent.auxiliary_client.set_runtime_main", lambda *a, **k: None):
+        yield
+
+
+class TestBuildTurnContextBudgetHintWiring:
+    """The hint must reach TurnContext.budget_hint through build_turn_context.
+
+    Regression for the Enough1122 review on #91974: the getattr default for
+    ``_budget_hint_threshold`` used to be 0.0 (disabled), contradicting the
+    documented 0.70 default. Any code path that builds a turn context without
+    passing through init_agent's config wiring silently lost the feature.
+    """
+
+    def test_default_threshold_applies_without_attribute(self):
+        agent = _FakeAgent()
+        assert not hasattr(agent, "_budget_hint_threshold")
+        with patch(
+            "agent.turn_context.estimate_messages_tokens_rough",
+            return_value=90_000,  # 90% > 0.70 default → hint fires
+        ):
+            ctx = _build(agent)
+        assert ctx.budget_hint, "hint must fire via the 0.70 default threshold"
+        assert "90%" in ctx.budget_hint
+
+    def test_explicit_attribute_overrides_default(self):
+        agent = _FakeAgent()
+        agent._budget_hint_threshold = 0.50  # explicit wiring wins
+        with patch(
+            "agent.turn_context.estimate_messages_tokens_rough",
+            return_value=60_000,  # 60% > 0.50 override, but < 0.70 default
+        ):
+            ctx = _build(agent)
+        assert ctx.budget_hint, "explicit threshold must win over the default"
+        assert "60%" in ctx.budget_hint
+
+    def test_zero_threshold_disables_hint(self):
+        agent = _FakeAgent()
+        agent._budget_hint_threshold = 0.0  # explicit opt-out
+        with patch(
+            "agent.turn_context.estimate_messages_tokens_rough",
+            return_value=90_000,
+        ):
+            ctx = _build(agent)
+        assert ctx.budget_hint == ""
+
+
+class TestComposeUserApiContentBudgetHint:
+    """compose_user_api_content forwards budget_hint as a third injection."""
+
+    def _compose(self):
+        from agent.turn_context import compose_user_api_content
+
+        return compose_user_api_content
+
+    def test_budget_hint_appended_after_other_injections(self):
+        compose = self._compose()
+        out = compose("hello", "MEM", "PLUGIN", "HINT")
+        assert out is not None
+        assert out.startswith("hello")
+        assert "HINT" in out
+        # Hint comes last; memory block comes before plugin context.
+        assert out.index("HINT") > out.index("PLUGIN")
+        assert out.index("PLUGIN") > out.index("MEM")
+
+    def test_budget_hint_only_injection(self):
+        compose = self._compose()
+        out = compose("hello", "", "", "HINT")
+        assert out is not None
+        assert out == "hello\n\nHINT"
+
+    def test_empty_budget_hint_keeps_old_behavior(self):
+        # Backward compatibility: the 4th arg defaults to "" and changes nothing.
+        compose = self._compose()
+        assert compose("hello", "", "") is None  # no injections → None (unchanged)
+        out = compose("hello", "MEM", "PLUGIN")
+        assert out is not None
+        assert "HINT" not in out
+        assert "MEM" in out and "PLUGIN" in out
+
+    def test_non_string_content_returns_none_even_with_hint(self):
+        compose = self._compose()
+        # Multimodal content defeats injection; the hint must not force one.
+        assert compose(["part1", "part2"], "", "", "HINT") is None


### PR DESCRIPTION
## Context-window budget hint injection (adapted from openai/codex)

When the estimated request approaches the model's context window, the turn's
user message now carries a short advisory line telling the model how much
room remains, so it can keep responses focused and avoid forced truncation
or lossy compression.

### Background

Long conversations grow until Hermes' automatic compression
(`conversation_compression` / `context_compressor`) fires at
`compression.threshold` (default 50%). The model itself never learns how much
window remains: it only discovers it was too verbose when compression fires
mid-turn or the provider truncates output. OpenAI's Codex CLI solves this by
injecting a `TokenBudgetRemainingContext` fragment — "You have N tokens left
in this context window." — into model input, so the model can budget its own
output (`Refs: openai/codex`, `codex-rs/core/src/context/token_budget_context.rs`).

### Existing solutions surveyed

| Mechanism | What it does | What it doesn't solve |
|---|---|---|
| `context_compressor` threshold compression | Summarizes middle turns at 50% usage | Model never knows the budget; fires after the fact, lossy |
| `context_breakdown` | Live usage breakdown for UI surfaces | Display-only; not injected into model input |
| `rate_limit_tracker` | API `x-ratelimit-remaining-tokens` tracking | Provider rate limits, not context-window budget |
| `estimate_request_tokens_rough` | Token estimator (already used for overflow warnings) | Estimates only; no model-facing budget signal |

**Gap**: Hermes has no model-facing context-window budget signal.

### Our approach

- New pure module `agent/budget_hint.py`: `build_budget_hint(used, window,
  threshold)` returns a fenced hint line or `None`.
- `build_turn_context` computes the hint once per turn (estimated usage via
  the existing `estimate_messages_tokens_rough`, window from the cached
  `context_compressor.context_length` — **no network call at turn boundary**).
- `compose_user_api_content` gains a 4th optional `budget_hint` arg (default
  `""`, fully backward compatible); the hint rides the **existing `api_content`
  sidecar**, the same mechanism that already carries memory prefetch — so the
  prompt-cache invariant ("what turn N sends must be what turn N+1 replays")
  is preserved byte-for-byte.
- Config: `compression.budget_hint_threshold` (default `0.70`, `0` disables).
  Below the threshold nothing is injected, keeping the prompt prefix
  byte-stable for low-usage conversations.

### Decision rationale

- **Why threshold-gated (not every turn)**: Codex injects at every window
  boundary; Hermes can do better — only inject above 70% usage, so caching is
  untouched for the vast majority of turns and the model still gets budget
  awareness exactly when it matters.
- **Why the sidecar, not a new message**: adding a separate developer message
  would change the message stream shape and risk cache boundaries; the
  sidecar is the proven, persisted path for turn-scoped injections.
- **Why no new core tool**: advisory prose belongs at the edge, not in the
  model tool schema (narrow-waist principle).

### Capability matrix

| | Before | After |
|---|---|---|
| Model knows remaining window | No | Yes (≥70% usage) |
| Prompt prefix stability | Byte-stable | Byte-stable below threshold |
| Compression | Fires silently | Model can preempt verbosity |
| New core tools / env vars | — | None |

### Who should enable this

This is **on by default** (threshold 0.70). Users who prefer absolutely stable
prompt prefixes on long conversations can set `compression.budget_hint_threshold: 0`
to disable.

### Platform compatibility

| Platform | Status |
|---|---|
| CLI | ✅ same turn path |
| Gateway (Telegram/Discord/Slack/…) | ✅ same turn path |
| TUI / Desktop | ✅ same turn path |
| MoA / codex_app_server | ✅ skipped (existing sidecar guard unchanged) |

### Quick-start guide

1. Update: `hermes update` (or pull this branch).
2. Nothing to configure — hint is on by default at 70% usage.
3. Verify: run a long conversation; when usage crosses 70%, the user message
   sent to the provider carries the `[Context budget: ...]` line.

### Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| Hint never appears | Usage below threshold, or threshold=0 | Lower `budget_hint_threshold` |
| Hint missing on multimodal turns | Non-string content never gets sidecar injection (existing behavior) | Expected |
| Cache miss on long turns | Injection changes the user-message bytes at ≥70% usage | Intended trade-off; disable via `budget_hint_threshold: 0` |

### Tests

`tests/agent/test_budget_hint.py` — 11 tests: threshold firing, disable,
degenerate inputs, sidecar composition, backward compatibility. Regression:
`tests/agent/test_api_content_sidecar.py`, `test_gateway_turn_sidecar.py`,
`test_turn_context.py`, `test_turn_context_overflow_warning.py` all pass.
