### PR TITLE
fix(dashboard): isolate chat terminal config by profile

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3528,6 +3528,25 @@ def _terminal_env_value(value: Any) -> str:
     return str(value)
 
 
+def _terminal_config_value_is_bridgeable(key: str, value: Any) -> bool:
+    """Return whether a terminal config value owns its mirrored env var."""
+    if key == "cwd" and str(value or "").strip() in {".", "auto", "cwd"}:
+        return False
+    return True
+
+
+def terminal_config_owned_env_vars(terminal_config: Any) -> Set[str]:
+    """Return env vars explicitly owned by a raw ``terminal`` config section."""
+    if not isinstance(terminal_config, dict):
+        return set()
+    return {
+        env_var
+        for key, env_var in TERMINAL_CONFIG_ENV_MAP.items()
+        if key in terminal_config
+        and _terminal_config_value_is_bridgeable(key, terminal_config[key])
+    }
+
+
 def terminal_config_env_var_for_key(key: str) -> Optional[str]:
     """Return the env var mirrored by a ``terminal.*`` config key."""
     prefix = "terminal."
@@ -3598,10 +3617,10 @@ def apply_terminal_config_to_env(
         if cfg_key not in terminal_cfg:
             continue
         value = terminal_cfg[cfg_key]
+        if not _terminal_config_value_is_bridgeable(cfg_key, value):
+            continue
         if cfg_key == "cwd":
             raw_cwd = str(value or "").strip()
-            if raw_cwd in {".", "auto", "cwd"}:
-                continue
             if isinstance(value, str) and not _is_ssh_remote_tilde_cwd(
                 terminal_backend, raw_cwd
             ):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16157,12 +16157,29 @@ def _resolve_chat_argv(
     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
     # Hermes TUI child: build via the single spawn-env factory (profile-home
     # contract applied; secrets kept — the spawned agent needs provider creds).
-    # An explicit profile scope below still overrides HERMES_HOME afterwards.
+    # An explicit profile scope still overrides HERMES_HOME before config is
+    # bridged into the child environment.
     from tools.environments.local import build_subprocess_env
     env = build_subprocess_env(scrub_secrets=False, inherit_profile_home=True)
+    if profile_dir is not None:
+        env["HERMES_HOME"] = str(profile_dir)
     try:
-        from hermes_cli.config import apply_terminal_config_to_env
-        apply_terminal_config_to_env(env=env)
+        from hermes_cli.config import (
+            TERMINAL_CONFIG_ENV_MAP,
+            apply_terminal_config_to_env,
+        )
+
+        if profile_dir is not None:
+            # The dashboard process already bridged its own terminal config
+            # into os.environ at startup. build_subprocess_env() snapshots that
+            # process env, so remove every bridged value before applying the
+            # selected profile or omitted keys leak from the launch profile.
+            for env_var in TERMINAL_CONFIG_ENV_MAP.values():
+                env.pop(env_var, None)
+            with _config_profile_scope(requested):
+                apply_terminal_config_to_env(env=env)
+        else:
+            apply_terminal_config_to_env(env=env)
     except Exception:
         _log.debug("Failed to apply terminal config bridge for dashboard chat", exc_info=True)
     _apply_tui_python_env(env)
@@ -16187,9 +16204,6 @@ def _resolve_chat_argv(
     # setdefault so an explicit operator value still wins.
     env.setdefault("COLORTERM", "truecolor")
     env["HERMES_TUI_DASHBOARD"] = "1"
-
-    if profile_dir is not None:
-        env["HERMES_HOME"] = str(profile_dir)
 
     if resume:
         _resume_db = _open_session_db_for_profile(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16165,9 +16165,9 @@ def _resolve_chat_argv(
         env["HERMES_HOME"] = str(profile_dir)
     try:
         from hermes_cli.config import (
-            TERMINAL_CONFIG_ENV_MAP,
             apply_terminal_config_to_env,
             read_raw_config,
+            terminal_config_owned_env_vars,
         )
 
         if profile_dir is not None:
@@ -16177,12 +16177,7 @@ def _resolve_chat_argv(
             # exported by the operator for keys omitted from the launch profile
             # remain valid fallbacks, matching apply_terminal_config_to_env().
             raw_launch_terminal = read_raw_config().get("terminal")
-            if not isinstance(raw_launch_terminal, dict):
-                raw_launch_terminal = {}
-            for config_key in raw_launch_terminal:
-                env_var = TERMINAL_CONFIG_ENV_MAP.get(config_key)
-                if env_var is None:
-                    continue
+            for env_var in terminal_config_owned_env_vars(raw_launch_terminal):
                 env.pop(env_var, None)
             with _config_profile_scope(requested):
                 apply_terminal_config_to_env(env=env)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16167,21 +16167,29 @@ def _resolve_chat_argv(
         from hermes_cli.config import (
             TERMINAL_CONFIG_ENV_MAP,
             apply_terminal_config_to_env,
+            read_raw_config,
         )
 
         if profile_dir is not None:
             # The dashboard process already bridged its own terminal config
-            # into os.environ at startup. build_subprocess_env() snapshots that
-            # process env, so remove every bridged value before applying the
-            # selected profile or omitted keys leak from the launch profile.
-            for env_var in TERMINAL_CONFIG_ENV_MAP.values():
+            # into os.environ at startup. Remove only keys explicitly owned by
+            # that launch profile before applying the selected profile. Values
+            # exported by the operator for keys omitted from the launch profile
+            # remain valid fallbacks, matching apply_terminal_config_to_env().
+            raw_launch_terminal = read_raw_config().get("terminal")
+            if not isinstance(raw_launch_terminal, dict):
+                raw_launch_terminal = {}
+            for config_key in raw_launch_terminal:
+                env_var = TERMINAL_CONFIG_ENV_MAP.get(config_key)
+                if env_var is None:
+                    continue
                 env.pop(env_var, None)
             with _config_profile_scope(requested):
                 apply_terminal_config_to_env(env=env)
         else:
             apply_terminal_config_to_env(env=env)
     except Exception:
-        _log.debug("Failed to apply terminal config bridge for dashboard chat", exc_info=True)
+        _log.warning("Failed to apply terminal config bridge for dashboard chat", exc_info=True)
     _apply_tui_python_env(env)
     env.setdefault("NODE_ENV", "production")
     # Browser-embedded chat should prefer stable wheel-based scrollback over

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -655,6 +655,12 @@ class TestProfileScopedChatPty:
     ):
         import hermes_cli.web_server as web_server
 
+        (isolated_profiles["default"] / "config.yaml").write_text(
+            "terminal:\n"
+            "  backend: docker\n"
+            "  docker_image: launch-profile-image\n",
+            encoding="utf-8",
+        )
         (isolated_profiles["worker_beta"] / "config.yaml").write_text(
             "terminal:\n"
             "  backend: ssh\n"
@@ -664,7 +670,7 @@ class TestProfileScopedChatPty:
         )
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "launch-profile-image")
-        monkeypatch.setenv("TERMINAL_SSH_USER", "launch-profile-user")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "operator-user")
         monkeypatch.setattr(
             "hermes_cli.main._make_tui_argv",
             lambda root, tui_dev=False: (["cat"], None),
@@ -679,7 +685,56 @@ class TestProfileScopedChatPty:
         assert env["TERMINAL_SSH_HOST"] == "worker.example.test"
         assert env["TERMINAL_CWD"] == "~"
         assert env["TERMINAL_DOCKER_IMAGE"] != "launch-profile-image"
-        assert "TERMINAL_SSH_USER" not in env
+        assert env["TERMINAL_SSH_USER"] == "operator-user"
+
+    def test_chat_argv_default_profile_preserves_exported_terminal_values(
+        self, isolated_profiles, monkeypatch
+    ):
+        import hermes_cli.web_server as web_server
+
+        (isolated_profiles["default"] / "config.yaml").write_text(
+            "terminal:\n  backend: docker\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "operator-user")
+        monkeypatch.setattr(
+            "hermes_cli.main._make_tui_argv",
+            lambda root, tui_dev=False: (["cat"], None),
+            raising=False,
+        )
+
+        _argv, _cwd, env = web_server._resolve_chat_argv()
+
+        assert env is not None
+        assert env["TERMINAL_ENV"] == "docker"
+        assert env["TERMINAL_SSH_USER"] == "operator-user"
+
+    def test_chat_argv_warns_when_profile_terminal_bridge_fails(
+        self, isolated_profiles, monkeypatch, caplog
+    ):
+        import logging
+
+        import hermes_cli.config as config_mod
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            "hermes_cli.main._make_tui_argv",
+            lambda root, tui_dev=False: (["cat"], None),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            config_mod,
+            "apply_terminal_config_to_env",
+            lambda **kwargs: (_ for _ in ()).throw(RuntimeError("bridge failed")),
+        )
+
+        with caplog.at_level(logging.WARNING, logger=web_server._log.name):
+            _argv, _cwd, env = web_server._resolve_chat_argv(profile="worker_beta")
+
+        assert env is not None
+        assert env["HERMES_HOME"] == str(isolated_profiles["worker_beta"])
+        assert "Failed to apply terminal config bridge for dashboard chat" in caplog.text
 
 
 class TestProfileScopedAudio:

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -710,6 +710,34 @@ class TestProfileScopedChatPty:
         assert env["TERMINAL_ENV"] == "docker"
         assert env["TERMINAL_SSH_USER"] == "operator-user"
 
+    @pytest.mark.parametrize("placeholder", [".", "auto", "cwd"])
+    def test_chat_argv_placeholder_cwd_preserves_exported_value(
+        self, isolated_profiles, monkeypatch, placeholder
+    ):
+        import hermes_cli.web_server as web_server
+
+        (isolated_profiles["default"] / "config.yaml").write_text(
+            f"terminal:\n  backend: docker\n  cwd: {placeholder}\n",
+            encoding="utf-8",
+        )
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "terminal:\n  backend: ssh\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_CWD", "/operator/work")
+        monkeypatch.setattr(
+            "hermes_cli.main._make_tui_argv",
+            lambda root, tui_dev=False: (["cat"], None),
+            raising=False,
+        )
+
+        _argv, _cwd, env = web_server._resolve_chat_argv(profile="worker_beta")
+
+        assert env is not None
+        assert env["TERMINAL_ENV"] == "ssh"
+        assert env["TERMINAL_CWD"] == "/operator/work"
+
     def test_chat_argv_warns_when_profile_terminal_bridge_fails(
         self, isolated_profiles, monkeypatch, caplog
     ):
@@ -718,6 +746,11 @@ class TestProfileScopedChatPty:
         import hermes_cli.config as config_mod
         import hermes_cli.web_server as web_server
 
+        (isolated_profiles["default"] / "config.yaml").write_text(
+            "terminal:\n  backend: docker\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
         monkeypatch.setattr(
             "hermes_cli.main._make_tui_argv",
             lambda root, tui_dev=False: (["cat"], None),
@@ -734,6 +767,7 @@ class TestProfileScopedChatPty:
 
         assert env is not None
         assert env["HERMES_HOME"] == str(isolated_profiles["worker_beta"])
+        assert "TERMINAL_ENV" not in env
         assert "Failed to apply terminal config bridge for dashboard chat" in caplog.text
 
 

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -650,6 +650,37 @@ class TestProfileScopedChatPty:
         # Scoped chat must NOT attach to the dashboard's in-memory gateway.
         assert "HERMES_TUI_GATEWAY_URL" not in env
 
+    def test_chat_argv_bridges_selected_profile_terminal_config(
+        self, isolated_profiles, monkeypatch
+    ):
+        import hermes_cli.web_server as web_server
+
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "terminal:\n"
+            "  backend: ssh\n"
+            "  ssh_host: worker.example.test\n"
+            "  cwd: '~'\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "launch-profile-image")
+        monkeypatch.setenv("TERMINAL_SSH_USER", "launch-profile-user")
+        monkeypatch.setattr(
+            "hermes_cli.main._make_tui_argv",
+            lambda root, tui_dev=False: (["cat"], None),
+            raising=False,
+        )
+
+        _argv, _cwd, env = web_server._resolve_chat_argv(profile="worker_beta")
+
+        assert env is not None
+        assert env["HERMES_HOME"] == str(isolated_profiles["worker_beta"])
+        assert env["TERMINAL_ENV"] == "ssh"
+        assert env["TERMINAL_SSH_HOST"] == "worker.example.test"
+        assert env["TERMINAL_CWD"] == "~"
+        assert env["TERMINAL_DOCKER_IMAGE"] != "launch-profile-image"
+        assert "TERMINAL_SSH_USER" not in env
+
 
 class TestProfileScopedAudio:
     """Audio endpoints must honor ``profile`` like the rest of the dashboard.


### PR DESCRIPTION
## What does this PR do?

Fixes Dashboard chat PTYs inheriting terminal backend settings from the profile that launched the Dashboard instead of the profile selected for the chat.

`_resolve_chat_argv()` previously copied the Dashboard process environment and bridged terminal configuration before assigning the selected profile's `HERMES_HOME`. Since the Dashboard process already contains its own bridged `TERMINAL_*` values, a selected SSH profile could launch with the Dashboard profile's Docker backend.

For profile-scoped chats, this change now assigns the selected `HERMES_HOME` first, removes terminal values explicitly owned by the Dashboard launch profile using the canonical terminal env map, and reapplies terminal configuration under the selected profile's config context. Operator-exported values for keys omitted by the launch profile remain available as fallbacks. Unscoped/current-profile chats retain the existing behavior.

## Related Issue

No public issue. Reported through support.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Set the selected profile's `HERMES_HOME` before bridging terminal configuration in `hermes_cli/web_server.py`.
- Clear only `TERMINAL_*` values explicitly owned by the launch profile before applying the selected profile, preserving unrelated operator-exported fallbacks.
- Warn when the selected profile's terminal config cannot be bridged.
- Add regressions covering a Docker-launched Dashboard opening an SSH-profile chat, preservation of unrelated exported values, the unchanged default-profile path, and bridge-failure diagnostics.

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_web_server_profile_unification.py -q`.
2. Launch the Dashboard under a profile configured with `terminal.backend: docker`.
3. Open a chat for a second profile configured with `terminal.backend: ssh` and confirm its child environment uses the selected profile's `HERMES_HOME`, SSH backend, host, and cwd without launch-profile-only values.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused verification on Windows 11:

- `29 passed` in `tests/hermes_cli/test_web_server_profile_unification.py`
- `9 passed` in `tests/tools/test_terminal_env_bridge.py`
- `160 passed, 5 skipped` in `tests/hermes_cli/test_web_server.py`
- Ruff passed for all three changed files
- `git diff --check` passed
