### PR TITLE
fix(agent): guard missing session_tag in RedactingFormatter (#91348)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -1423,5 +1423,9 @@ class RedactingFormatter(logging.Formatter):
         super().__init__(fmt, datefmt, style, **kwargs)
 
     def format(self, record: logging.LogRecord) -> str:
+        # Ensure session_tag exists — a third-party plugin may have replaced
+        # the global LogRecord factory without preserving Hermes' injector.
+        if not hasattr(record, "session_tag"):
+            record.session_tag = ""  # type: ignore[attr-defined]
         original = super().format(record)
         return redact_sensitive_text(original)


### PR DESCRIPTION
## Summary

Fixes #91348.

Third-party plugins can replace the global `LogRecord` factory without preserving Hermes' `session_tag` injector. When that happens, every log record fails with `ValueError: "Formatting field not found in record: 'session_tag'"`, silently killing all file logging for 15+ hours.

## Changes

- `agent/redact.py`: Add `hasattr(record, "session_tag")` guard in `RedactingFormatter.format()` that sets a default empty string when the attribute is missing.

## Testing

- `python3 -m py_compile agent/redact.py` passes
- When `session_tag` is present (normal case), behavior is unchanged
- When `session_tag` is missing (plugin replaced factory), logging continues with empty tag instead of crashing
