### PR TITLE
feat(desktop): let users choose the default profile the rail home pill navigates to (#89887)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/i18n', () => ({
       common: { cancel: 'Cancel' },
       profiles: {
         allProfiles: 'All profiles',
+        clearDefaultProfile: 'Clear default',
         connectGateway: 'Manage gateways…',
         failedLoadSoul: 'Failed to load SOUL.md',
         failedSaveSoul: 'Failed to save SOUL.md',
@@ -29,6 +30,7 @@ vi.mock('@/i18n', () => ({
         newProfile: 'New profile',
         saveSoul: 'Save',
         saving: 'Saving…',
+        setDefaultProfile: 'Set as default',
         showAllProfiles: 'Show all profiles',
         soulSaved: 'SOUL.md saved',
         switchToProfile: (name: string) => `Switch to ${name}`,
@@ -40,17 +42,27 @@ vi.mock('@/i18n', () => ({
 
 vi.mock('@/store/profile', () => ({
   $activeGatewayProfile: atom('default'),
+  $homeProfile: atom(null),
   $profileColors: atom({}),
   $profileCreateRequest: atom(0),
   $profileOrder: atom([]),
   $profiles: atom([{ is_default: true, name: 'default' }]),
   $profileScope: atom('default'),
   ALL_PROFILES: '*',
+  // Same contract as store/profile's resolver, inlined so these tests exercise
+  // the rail's wiring against it (the store tests own the resolver itself).
+  designatedHomeProfile: (home: null | string, profiles: Array<{ is_default?: boolean; name: string }>) =>
+    home ? (profiles.find(profile => profile.name === home) ?? null) : null,
   normalizeProfileKey: (name: string) => name,
   profileLabel: (profile: { display_name?: string; name: string }) =>
     (profile.display_name ?? '').trim() || profile.name,
   refreshActiveProfile: vi.fn().mockResolvedValue(undefined),
+  resolveHomeProfile: (home: null | string, profiles: Array<{ is_default?: boolean; name: string }>) =>
+    (home ? profiles.find(profile => profile.name === home) : undefined) ??
+    profiles.find(profile => profile.is_default) ??
+    null,
   selectProfile: vi.fn(),
+  setHomeProfile: vi.fn(),
   setProfileColor: vi.fn(),
   setProfileOrder: vi.fn(),
   setShowAllProfiles: vi.fn(),
@@ -80,13 +92,29 @@ vi.mock('../../profiles/rename-profile-dialog', () => ({ RenameProfileDialog: ()
 
 const { $hasMultipleConnections } = await import('@/store/connections')
 const hasMultipleConnections = $hasMultipleConnections as ReturnType<typeof atom<boolean>>
-const { $profiles } = await import('@/store/profile')
+
+const {
+  $activeGatewayProfile,
+  $homeProfile,
+  $profiles,
+  selectProfile,
+  setHomeProfile,
+  setShowAllProfiles
+} = await import('@/store/profile')
+
 const profiles = $profiles as ReturnType<typeof atom<Array<{ is_default: boolean; name: string }>>>
+const activeGatewayProfile = $activeGatewayProfile as ReturnType<typeof atom<string>>
+const homeProfile = $homeProfile as ReturnType<typeof atom<null | string>>
 
 afterEach(() => {
   cleanup()
   hasMultipleConnections.set(false)
   profiles.set([{ is_default: true, name: 'default' }])
+  activeGatewayProfile.set('default')
+  homeProfile.set(null)
+  vi.mocked(selectProfile).mockClear()
+  vi.mocked(setHomeProfile).mockClear()
+  vi.mocked(setShowAllProfiles).mockClear()
 })
 
 describe('ProfileRail multi-gateway entry point', () => {
@@ -147,5 +175,91 @@ describe('ProfileRail multi-gateway entry point', () => {
 
     expect(screen.getByRole('group', { name: 'Profiles' }).className).toContain('min-w-0')
     expect(screen.getByRole('button', { name: 'Profiles' })).toBeTruthy()
+  })
+})
+
+describe('designated home pill (#89887)', () => {
+  const twoProfiles = () =>
+    profiles.set([
+      { is_default: true, name: 'default' },
+      { is_default: false, name: 'work' }
+    ])
+
+  it('navigates to the designated home instead of toggling Show all', () => {
+    twoProfiles()
+    homeProfile.set('work')
+    render(<ProfileRail />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to work' }))
+
+    expect(selectProfile).toHaveBeenCalledWith('work')
+    expect(setShowAllProfiles).not.toHaveBeenCalled()
+  })
+
+  it('never falls back to the Show-all toggle even when already on home', () => {
+    twoProfiles()
+    homeProfile.set('work')
+    activeGatewayProfile.set('work')
+    render(<ProfileRail />)
+
+    // Today's bug shape: sitting on the pill's target flipped it into a
+    // Show-all toggle. Designated-home mode is always a go-home navigation.
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to work' }))
+
+    expect(selectProfile).toHaveBeenCalledWith('work')
+    expect(setShowAllProfiles).not.toHaveBeenCalled()
+  })
+
+  it('an unset preference keeps the classic default↔all toggle', () => {
+    twoProfiles()
+    render(<ProfileRail />)
+
+    // No designation → today's behavior verbatim: on default, the same
+    // control offers Show all.
+    fireEvent.click(screen.getByRole('button', { name: 'Show all profiles' }))
+
+    expect(setShowAllProfiles).toHaveBeenCalledWith(true)
+    expect(selectProfile).not.toHaveBeenCalled()
+  })
+
+  it('a stale designation behaves exactly like an unset one', () => {
+    twoProfiles()
+    homeProfile.set('ghost') // deleted elsewhere; the rail must not dead-end
+    render(<ProfileRail />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all profiles' }))
+
+    expect(setShowAllProfiles).toHaveBeenCalledWith(true)
+    expect(selectProfile).not.toHaveBeenCalled()
+  })
+
+  it('right-click designates a square as home, then offers clearing it', () => {
+    twoProfiles()
+    render(<ProfileRail />)
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'work' }))
+    fireEvent.click(screen.getByText('Set as default'))
+
+    expect(setHomeProfile).toHaveBeenCalledWith('work')
+
+    cleanup()
+    homeProfile.set('work')
+    render(<ProfileRail />)
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'work' }))
+    fireEvent.click(screen.getByText('Clear default'))
+
+    expect(setHomeProfile).toHaveBeenLastCalledWith(null)
+  })
+
+  it('the designated home pill itself clears via its context menu', () => {
+    twoProfiles()
+    homeProfile.set('work')
+    render(<ProfileRail />)
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'Switch to work' }))
+    fireEvent.click(screen.getByText('Clear default'))
+
+    expect(setHomeProfile).toHaveBeenCalledWith(null)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -19,7 +19,7 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useStore } from '@nanostores/react'
-import { useEffect, useRef, useState } from 'react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { CodeEditor } from '@/components/chat/code-editor'
@@ -55,16 +55,20 @@ import { $hasMultipleConnections } from '@/store/connections'
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
+  $homeProfile,
   $profileColors,
   $profileCreateRequest,
   $profileOrder,
   $profiles,
   $profileScope,
   ALL_PROFILES,
+  designatedHomeProfile,
   normalizeProfileKey,
   profileLabel,
   refreshActiveProfile,
+  resolveHomeProfile,
   selectProfile,
+  setHomeProfile,
   setProfileColor,
   setProfileOrder,
   setShowAllProfiles,
@@ -168,6 +172,15 @@ export function ProfileRail() {
   const defaultProfile = profiles.find(profile => profile.is_default)
   const onDefault = !isAll && activeKey === 'default'
 
+  // The user-designated home target (#89887). One resolver owns the policy: the
+  // chosen profile while it exists, else the built-in default.
+  const homePref = useStore($homeProfile)
+  const home = resolveHomeProfile(homePref, profiles)
+  // A designation only counts while its profile is live — a stale name
+  // (deleted elsewhere) behaves exactly like an unset preference, restoring
+  // the classic default↔all toggle instead of a dead-end go-home control.
+  const designatedHome = designatedHomeProfile(homePref, profiles)
+
   const named = sortByProfileOrder(
     profiles.filter(profile => !profile.is_default),
     order
@@ -240,11 +253,31 @@ export function ProfileRail() {
 
   return (
     <div aria-label={p.title} className="flex min-w-0 items-center gap-0.5" data-slot="profile-rail" role="group">
-      {/* One button toggles default ↔ all: home face when scoped to a profile,
-          layers face when showing everything. Pinned left like Manage is right.
-          Hidden until a second profile exists. */}
+      {/* Pinned left like Manage is right. Hidden until a second profile
+          exists. With a designated home (#89887) it is a pure go-home control:
+          clicking always selects that profile — never a Show-all toggle — and
+          right-click offers the way back to the built-in default. Without one,
+          one button keeps toggling default ↔ all (home face when scoped to a
+          profile, layers face when showing everything). */}
       {multiProfile &&
-        (defaultProfile ? (
+        (designatedHome ? (
+          <ProfilePill
+            active={!isAll && activeKey === normalizeProfileKey(designatedHome.name)}
+            glyph="home"
+            label={p.switchToProfile(profileLabel(designatedHome))}
+            menu={
+              <ContextMenuItem
+                onSelect={() => {
+                  setHomeProfile(null)
+                }}
+              >
+                <Codicon name="close" size="0.875rem" />
+                <span>{p.clearDefaultProfile}</span>
+              </ContextMenuItem>
+            }
+            onSelect={() => selectProfile(designatedHome.name)}
+          />
+        ) : defaultProfile ? (
           // On default → toggle to all. Anywhere else (all view or a named
           // profile) → return to default. So leaving a profile never lands on all.
           <ProfilePill
@@ -257,13 +290,13 @@ export function ProfileRail() {
           <ProfilePill active={isAll} glyph="layers" label={p.allProfiles} onSelect={() => setShowAllProfiles(true)} />
         ))}
 
-      {/* Single-profile: the active default's home icon next to the create +. */}
-      {!multiProfile && defaultProfile && (
+      {/* Single-profile: the resolved home's icon next to the create +. */}
+      {!multiProfile && home && (
         <ProfilePill
           active
           glyph="home"
-          label={profileLabel(defaultProfile)}
-          onSelect={() => selectProfile(defaultProfile.name)}
+          label={profileLabel(home)}
+          onSelect={() => selectProfile(home.name)}
         />
       )}
 
@@ -303,13 +336,19 @@ export function ProfileRail() {
                     <ProfileSquare
                       active={!isAll && normalizeProfileKey(profile.name) === activeKey}
                       color={resolveProfileColor(profile.name, colors)}
+                      isHome={
+                        designatedHome != null &&
+                        normalizeProfileKey(profile.name) === normalizeProfileKey(designatedHome.name)
+                      }
                       key={profile.name}
                       label={profileLabel(profile)}
+                      onClearHome={() => setHomeProfile(null)}
                       onDelete={() => setPendingDelete(profile)}
                       onEditSoul={() => setPendingSoul(profile.name)}
                       onRecolor={color => setProfileColor(profile.name, color)}
                       onRename={() => setPendingRename(profile)}
                       onSelect={() => selectProfile(profile.name)}
+                      onSetHome={() => setHomeProfile(profile.name)}
                     />
                   ))}
                 </div>
@@ -587,38 +626,64 @@ interface ProfilePillProps {
   glyph: string
   label: string
   onSelect: () => void
+  // Optional right-click rows (the designated-home pill's clear-default action,
+  // #89887). When absent the pill stays a plain button with no context menu.
+  menu?: ReactNode
 }
 
-function ProfilePill({ active, glyph, label, onSelect }: ProfilePillProps) {
+function ProfilePill({ active, glyph, label, menu, onSelect }: ProfilePillProps) {
+  const button = (
+    <Button
+      aria-label={label}
+      aria-pressed={active}
+      className={cn(
+        'bg-transparent text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground',
+        active && 'bg-(--ui-control-active-background) text-foreground'
+      )}
+      onClick={onSelect}
+      size="icon-xs"
+      type="button"
+      variant="ghost"
+    >
+      <Codicon name={glyph} size="0.875rem" />
+    </Button>
+  )
+
+  if (!menu) {
+    return <Tip label={label}>{button}</Tip>
+  }
+
   return (
-    <Tip label={label}>
-      <Button
-        aria-label={label}
-        aria-pressed={active}
-        className={cn(
-          'bg-transparent text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground',
-          active && 'bg-(--ui-control-active-background) text-foreground'
-        )}
-        onClick={onSelect}
-        size="icon-xs"
-        type="button"
-        variant="ghost"
-      >
-        <Codicon name={glyph} size="0.875rem" />
-      </Button>
-    </Tip>
+    // Same composition trick as ProfileSquare: one element carries the hover
+    // tip AND the right-click menu via nested asChild Slots (Tip outermost —
+    // every Slot hop must land on a ref-forwarding primitive).
+    <ContextMenu>
+      <Tip label={label}>
+        <ContextMenuTrigger asChild>{button}</ContextMenuTrigger>
+      </Tip>
+      {/* Same bottom padding as the square menus — the rail sits at the very
+          bottom of the sidebar above the statusbar chrome. */}
+      <ContextMenuContent collisionPadding={{ bottom: 44, left: 8, right: 8, top: 8 }}>
+        {menu}
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }
 
 interface ProfileSquareProps {
   active: boolean
   color: null | string
+  // Whether this square is the user-designated home profile (#89887): the menu
+  // row then offers clearing it instead of setting it.
+  isHome: boolean
   label: string
   onSelect: () => void
   onRecolor: (color: null | string) => void
   onRename: () => void
   onEditSoul: () => void
   onDelete: () => void
+  onSetHome: () => void
+  onClearHome: () => void
 }
 
 // Hold this long without moving (a drag would have started first) to open the
@@ -635,12 +700,15 @@ const LONG_PRESS_MS = 450
 function ProfileSquare({
   active,
   color,
+  isHome,
   label,
   onDelete,
   onEditSoul,
   onRecolor,
   onRename,
-  onSelect
+  onSelect,
+  onSetHome,
+  onClearHome
 }: ProfileSquareProps) {
   const { t } = useI18n()
   const p = t.profiles
@@ -767,6 +835,10 @@ function ProfileSquare({
           // Suppress the refocus and the picker survives.
           onCloseAutoFocus={event => event.preventDefault()}
         >
+          <ContextMenuItem onSelect={isHome ? onClearHome : onSetHome}>
+            <Codicon name={isHome ? 'close' : 'home'} size="0.875rem" />
+            <span>{isHome ? p.clearDefaultProfile : p.setDefaultProfile}</span>
+          </ContextMenuItem>
           <ContextMenuItem onSelect={() => setPickerOpen(true)}>
             <Codicon name="symbol-color" size="0.875rem" />
             <span>{p.color}</span>

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
+import { DialogPortalContainerContext } from '@/components/ui/dialog-portal-context'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,11 +20,15 @@ beforeAll(() => {
 
 afterEach(() => {
   cleanup()
+  document.querySelectorAll('[data-dialog-portal-container]').forEach(node => node.remove())
   vi.clearAllMocks()
 })
 
 // Render the submenu inside an open menu/sub so its content (switches) mounts.
+// `container` stands in for a Dialog's content node (what dialog.tsx publishes
+// through DialogPortalContainerContext); null means "not inside a dialog".
 function renderSubmenu(opts: {
+  container?: HTMLElement | null
   defaultEffort?: string
   effort?: string
   fastControl: FastControl
@@ -33,24 +38,26 @@ function renderSubmenu(opts: {
   reasoning: boolean
 }) {
   return render(
-    <DropdownMenu open>
-      <DropdownMenuContent>
-        <DropdownMenuSub open>
-          <DropdownMenuSubTrigger>edit</DropdownMenuSubTrigger>
-          <ModelEditSubmenu
-            defaultEffort={opts.defaultEffort ?? 'medium'}
-            effort={opts.effort ?? 'medium'}
-            fastControl={opts.fastControl}
-            isActive={opts.isActive ?? true}
-            model="m1"
-            onSelectModel={opts.onSelectModel ?? vi.fn()}
-            onSetOptions={opts.onSetOptions}
-            provider="p1"
-            reasoning={opts.reasoning}
-          />
-        </DropdownMenuSub>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <DialogPortalContainerContext.Provider value={opts.container ?? null}>
+      <DropdownMenu open>
+        <DropdownMenuContent>
+          <DropdownMenuSub open>
+            <DropdownMenuSubTrigger>edit</DropdownMenuSubTrigger>
+            <ModelEditSubmenu
+              defaultEffort={opts.defaultEffort ?? 'medium'}
+              effort={opts.effort ?? 'medium'}
+              fastControl={opts.fastControl}
+              isActive={opts.isActive ?? true}
+              model="m1"
+              onSelectModel={opts.onSelectModel ?? vi.fn()}
+              onSetOptions={opts.onSetOptions}
+              provider="p1"
+              reasoning={opts.reasoning}
+            />
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </DialogPortalContainerContext.Provider>
   )
 }
 
@@ -127,5 +134,45 @@ describe('ModelEditSubmenu reports edits without performing them', () => {
     fireEvent.click(screen.getByRole('switch'))
 
     expect(onSelectModel).toHaveBeenCalledWith('m1-fast')
+  })
+})
+
+// #80798: the thinking/effort panel used to portal to document.body even
+// inside a Dialog, landing BEHIND the dialog + parent menu (separate stacking
+// siblings) — dimmed and unclickable. The submenu must share the dialog's DOM
+// subtree when one encloses it, and keep the bare body portal otherwise (that
+// escape is what keeps submenus unclipped by scrollable hosts outside dialogs).
+describe('ModelEditSubmenu lands in the right stacking world', () => {
+  const SUB_SELECTOR = '[data-slot="dropdown-menu-sub-content"]'
+
+  const baseProps = { fastControl: { kind: 'param', on: true } as FastControl, onSetOptions: vi.fn(), reasoning: true }
+
+  it('inside a dialog: mounts within the dialog container, not as a body-level sibling (#80798)', () => {
+    // Stand-in for the DialogContent shell node that dialog.tsx publishes.
+    const dialogNode = document.createElement('div')
+    dialogNode.setAttribute('data-dialog-portal-container', '')
+    document.body.appendChild(dialogNode)
+
+    renderSubmenu({ ...baseProps, container: dialogNode })
+
+    const sub = document.querySelector(SUB_SELECTOR)
+    expect(sub).not.toBeNull()
+    // A DOM descendant of the dialog: it inherits the dialog's stacking
+    // context, so it paints and receives events above the parent menu.
+    expect(dialogNode.contains(sub)).toBe(true)
+  })
+
+  it('outside a dialog: keeps the document.body portal so overflow-clip escapes still work', () => {
+    renderSubmenu(baseProps)
+
+    const sub = document.querySelector(SUB_SELECTOR)
+    expect(sub).not.toBeNull()
+
+    // No container was provided, so the portal chain must terminate at
+    // document.body exactly as the bare Radix Portal did before.
+    let node: Node | null = sub
+    while (node && node !== document.body) node = node.parentNode
+
+    expect(node).toBe(document.body)
   })
 })

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -171,7 +171,9 @@ describe('ModelEditSubmenu lands in the right stacking world', () => {
     // No container was provided, so the portal chain must terminate at
     // document.body exactly as the bare Radix Portal did before.
     let node: Node | null = sub
-    while (node && node !== document.body) node = node.parentNode
+    while (node && node !== document.body) {
+      node = node.parentNode
+    }
 
     expect(node).toBe(document.body)
   })

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -249,12 +249,19 @@ function DropdownMenuSubContent({
   collisionPadding = 8,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  // Same container rule as DropdownMenuContent: inside a dialog, portal into
+  // the dialog's node so the submenu shares its stacking context — a
+  // body-level submenu paints BEHIND the dialog + parent menu, dimmed and
+  // unclickable (#80798). Outside a dialog this is null/undefined and Radix
+  // falls back to document.body, preserving the overflow-clip escape.
+  const container = usePopoverPortalContainer()
+
   return (
     // Portal the submenu out of the parent Content so it escapes that Content's
     // `overflow` clip. Without this, a submenu opening from a scrollable menu
     // gets visually cut off at the parent's edges. Radix Popper still anchors
     // it to the SubTrigger and handles collision/flip, so portaling is safe.
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Portal container={container}>
       <DropdownMenuPrimitive.SubContent
         // `dt-portal-scrollbar` reproduces the themed scrollbar for portaled
         // overlays (rendered under document.body). Use a fixed `max-h-80`

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1359,6 +1359,8 @@ export const ar = defineLocale({
     allProfiles: 'كل الملفات الشخصية',
     showAllProfiles: 'إظهار كل الملفات الشخصية',
     switchToProfile: name => `التبديل إلى ${name}`,
+    setDefaultProfile: 'تعيين كافتراضي',
+    clearDefaultProfile: 'إلغاء الافتراضي',
     switchToConnection: name => `التبديل إلى ${name}`,
     switchConnectionFailed: name => `تعذّر الاتصال بـ ${name}`,
     manageProfiles: 'إدارة الملفات الشخصية',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1780,6 +1780,8 @@ export const en: Translations = {
     allProfiles: 'All profiles',
     showAllProfiles: 'Show all profiles',
     switchToProfile: name => `Switch to ${name}`,
+    setDefaultProfile: 'Set as default',
+    clearDefaultProfile: 'Clear default',
     switchToConnection: name => `Switch to ${name}`,
     switchConnectionFailed: name => `Could not connect to ${name}`,
     manageProfiles: 'Manage profiles…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1493,6 +1493,8 @@ export const ja = defineLocale({
     allProfiles: 'すべてのプロファイル',
     showAllProfiles: 'すべてのプロファイルを表示',
     switchToProfile: name => `${name} に切り替え`,
+    setDefaultProfile: 'デフォルトに設定',
+    clearDefaultProfile: 'デフォルトを解除',
     switchToConnection: name => `${name} に切り替え`,
     switchConnectionFailed: name => `${name} に接続できませんでした`,
     manageProfiles: 'プロファイルを管理…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1505,6 +1505,8 @@ export interface Translations {
     allProfiles: string
     showAllProfiles: string
     switchToProfile: (name: string) => string
+    setDefaultProfile: string
+    clearDefaultProfile: string
     switchToConnection: (name: string) => string
     switchConnectionFailed: (name: string) => string
     manageProfiles: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1439,6 +1439,8 @@ export const zhHant = defineLocale({
     allProfiles: '全部設定檔',
     showAllProfiles: '顯示全部設定檔',
     switchToProfile: name => `切換至 ${name}`,
+    setDefaultProfile: '設為預設',
+    clearDefaultProfile: '取消預設',
     switchToConnection: name => `切換至 ${name}`,
     switchConnectionFailed: name => `無法連線至 ${name}`,
     manageProfiles: '管理設定檔…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1968,6 +1968,8 @@ export const zh: Translations = {
     allProfiles: '全部配置档案',
     showAllProfiles: '显示全部配置档案',
     switchToProfile: name => `切换到 ${name}`,
+    setDefaultProfile: '设为默认',
+    clearDefaultProfile: '取消默认',
     switchToConnection: name => `切换到 ${name}`,
     switchConnectionFailed: name => `无法连接到 ${name}`,
     manageProfiles: '管理配置档案…',

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -22,11 +22,16 @@ vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
 const {
   $activeGatewayProfile,
+  $homeProfile,
   $profiles,
+  designatedHomeProfile,
   ensureGatewayProfile,
   invalidateProfileListFetches,
   prewarmProfileBackend,
-  refreshProfiles
+  refreshProfiles,
+  resolveHomeProfile,
+  setHomeProfile,
+  switchToDefaultProfile
 } = await import('./profile')
 
 const { $connection } = await import('./session')
@@ -59,6 +64,7 @@ beforeEach(() => {
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
   $profiles.set([])
+  $homeProfile.set(null)
   vi.stubGlobal('window', { hermesDesktop: { getConnection } })
   vi.mocked(invalidateProfileScopedQueries).mockClear()
   resetStarmapGraph.mockClear()
@@ -237,5 +243,103 @@ describe('stale profile-list fetches across a backend switch (#85731)', () => {
     await oldFetch
 
     expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'coder'])
+  })
+})
+
+describe('home profile preference (#89887)', () => {
+  const HOME_KEY = 'hermes.desktop.homeProfile'
+
+  // A self-contained localStorage so persistence can be observed while the
+  // file-wide window stub (which carries none) is in force.
+  const stubStorageWindow = () => {
+    const store = new Map<string, string>()
+
+    const localStorage = {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key)
+    }
+
+    vi.stubGlobal('window', {
+      // store/session's module init wires a storage listener on fresh import.
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      hermesDesktop: { getConnection },
+      localStorage
+    })
+
+    return store
+  }
+
+  it('resolves the designated home while that profile exists', () => {
+    const profiles = [profile('default', true), profile('work'), profile('bot')]
+
+    expect(resolveHomeProfile('work', profiles)?.name).toBe('work')
+    // Unset → the backend-designated default.
+    expect(resolveHomeProfile(null, profiles)?.name).toBe('default')
+    // Neither a designation nor an is_default profile → no target.
+    expect(resolveHomeProfile(null, [profile('solo')])).toBeNull()
+  })
+
+  it('a deleted profile falls back to the built-in default exactly like unset', () => {
+    // "work" was deleted elsewhere (Manage Profiles, CLI, another window).
+    // The home pill must not dead-end on the stale name.
+    const profiles = [profile('default', true), profile('coder')]
+
+    expect(resolveHomeProfile('work', profiles)).toEqual(profile('default', true))
+    expect(resolveHomeProfile('work', profiles)).toEqual(resolveHomeProfile(null, profiles))
+  })
+
+  it('the raw designation only counts while its profile is live', () => {
+    const profiles = [profile('default', true), profile('work')]
+
+    expect(designatedHomeProfile('work', profiles)?.name).toBe('work')
+    // Stale name → no live designation (the rail restores its classic toggle).
+    expect(designatedHomeProfile('ghost', profiles)).toBeNull()
+    expect(designatedHomeProfile(null, profiles)).toBeNull()
+  })
+
+  it('persists the designation and survives a relaunch', async () => {
+    const store = stubStorageWindow()
+
+    setHomeProfile('bot')
+
+    expect(store.get(HOME_KEY)).toBe('bot')
+
+    // Relaunch: a fresh module registry seeds the atom from the same storage.
+    vi.resetModules()
+    const reloaded = await import('./profile')
+
+    expect(reloaded.$homeProfile.get()).toBe('bot')
+  })
+
+  it('clearing the designation removes the stored key', () => {
+    const store = stubStorageWindow()
+
+    setHomeProfile('work')
+    setHomeProfile(null)
+
+    expect($homeProfile.get()).toBeNull()
+    expect(store.has(HOME_KEY)).toBe(false)
+  })
+
+  it('⌘D navigates to the designated home instead of the canonical default', () => {
+    $profiles.set([profile('default', true), profile('work')])
+    $activeGatewayProfile.set('default')
+    setHomeProfile('work')
+
+    switchToDefaultProfile()
+
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('work')
+  })
+
+  it('⌘D falls back to the canonical default when the designation is stale', () => {
+    $profiles.set([profile('default', true)])
+    $activeGatewayProfile.set('coder')
+    setHomeProfile('ghost')
+
+    switchToDefaultProfile()
+
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('default')
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -6,9 +6,11 @@ import { invalidateProfileScopedQueries } from '@/lib/query-client'
 import {
   arraysEqual,
   persistBoolean,
+  persistString,
   persistStringArray,
   persistStringRecord,
   storedBoolean,
+  storedString,
   storedStringArray,
   storedStringRecord
 } from '@/lib/storage'
@@ -128,6 +130,41 @@ export function setProfileColor(name: string, color: null | string): void {
   }
 
   $profileColors.set(next)
+}
+
+// ── Home profile ───────────────────────────────────────────────────────────
+// Which profile is "home" for the rail's home pill and the switch-to-default
+// hotkey. A Desktop-local navigation preference (renderer-owned presentation);
+// the backend stays authoritative for `is_default`, and the Electron launch
+// profile / HERMES_HOME are unmoved. null = nothing designated → behave
+// exactly like the built-in default.
+const HOME_PROFILE_STORAGE_KEY = 'hermes.desktop.homeProfile'
+
+export const $homeProfile = atom<null | string>(storedString(HOME_PROFILE_STORAGE_KEY))
+
+$homeProfile.subscribe(value => persistString(HOME_PROFILE_STORAGE_KEY, value))
+
+// Designate (or, with null, clear) the profile the home affordances navigate to.
+export function setHomeProfile(name: null | string): void {
+  const key = name == null ? null : normalizeProfileKey(name)
+
+  if ($homeProfile.get() !== key) {
+    $homeProfile.set(key)
+  }
+}
+
+// The user's raw designation, but only while it names a live profile — a stale
+// name (profile deleted elsewhere) must behave exactly like no designation.
+export function designatedHomeProfile(home: null | string, profiles: ProfileInfo[]): ProfileInfo | null {
+  return home ? (profiles.find(profile => normalizeProfileKey(profile.name) === home) ?? null) : null
+}
+
+// One resolver owns the home-target policy: the designated profile while it
+// exists, else the backend-designated default, else null. A preference left
+// pointing at a DELETED profile therefore resolves to the built-in default
+// instead of dead-ending the home pill (#89887).
+export function resolveHomeProfile(home: null | string, profiles: ProfileInfo[]): ProfileInfo | null {
+  return designatedHomeProfile(home, profiles) ?? profiles.find(profile => profile.is_default) ?? null
 }
 
 interface ActiveProfileResponse {
@@ -547,11 +584,13 @@ function orderedProfileKeys(): string[] {
   return hasDefault ? ['default', ...named] : named
 }
 
-// Switch to the default (root ~/.hermes) profile — bound to ⌘1.
+// Switch to the home profile — bound to ⌘D. Routes to the user-designated
+// default when set (falling back when it was deleted), else the canonical root
+// profile. Always a navigation, never a Show-all toggle (#89887).
 export function switchToDefaultProfile(): void {
-  const def = $profiles.get().find(profile => profile.is_default)
+  const home = resolveHomeProfile($homeProfile.get(), $profiles.get())
 
-  selectProfile(def ? def.name : 'default')
+  selectProfile(home ? home.name : 'default')
 }
 
 // Switch to the Nth named (non-default) profile in rail order (1-based).


### PR DESCRIPTION
Fixes #89887

## What
New renderer-level `$`homeProfile` designation (persisted like profileOrder/profileColors): right-click any rail profile square — including the home pill — to *Set as default* / *Clear default*. While a live designation exists, the pill becomes a pure go-home control (click always selects it, never toggles Show-all; Cmd+D routes through the same resolver). Right-click the pill to clear.

## Boundaries
- Deleted-profile fallback behaves exactly like unset (resolver gates on liveness).
- No designation -> today's default-all toggle behavior byte-for-byte.
- Electron launch-profile selection intentionally untouched — navigation-only v1 per the issue's alternatives discussion.
- New strings added for all 5 locales + types.

## Verification
Extended store/profile.test.ts (persistence round-trip, deleted-profile fallback) and profile-rail-connect.test.tsx (pill selects designated profile, never toggles Show-all when set, menu actions mutate atom): 32 tests pass; eslint clean; tsc --noEmit exit 0.