### PR TITLE
feat(kanban): operator attribution on assignment/completion events + dashboard assign dry-run (#82689)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -211,6 +211,29 @@ def _profile_author() -> str:
         return "user"
 
 
+def _cli_operator() -> str:
+    """Operator identity stamped on state-changing kanban events (#82689).
+
+    Format: ``cli:<user>@<host>`` — the OS user and host driving this
+    CLI/gateway-slash-command process. Best-effort on both parts so a
+    exotic platform can never break a mutating verb. The value rides the
+    ``assigned`` / ``claimed`` / ``completed`` event payloads additively;
+    post-incident forensics reads it straight off ``task_events``.
+    """
+    import getpass
+    import socket
+
+    try:
+        user = getpass.getuser() or "unknown"
+    except Exception:
+        user = "unknown"
+    try:
+        host = socket.gethostname() or "unknown"
+    except Exception:
+        host = "unknown"
+    return f"cli:{user}@{host}"
+
+
 _DELEGATED_CHILD_DENIED_ACTIONS: frozenset[str] = frozenset({
     "init", "create", "swarm", "assign", "reclaim", "reassign", "link", "unlink",
     "claim", "comment", "attach", "attach-rm", "complete", "edit", "block",
@@ -572,7 +595,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
 def _cmd_assign(args: argparse.Namespace) -> int:
     profile = _none_profile(args.profile)
     with kbc.connect_closing() as conn:
-        ok = kb.assign_task(conn, args.task_id, profile)
+        ok = kb.assign_task(conn, args.task_id, profile, operator=_cli_operator())
     return _ok_or_err(ok, f"no such task: {args.task_id}",
                       f"Assigned {args.task_id} to {profile or '(unassigned)'}")
 
@@ -608,7 +631,7 @@ def _cmd_reassign(args: argparse.Namespace) -> int:
     profile = _none_profile(args.profile)
     reclaim = bool(getattr(args, "reclaim", False))
     with kbc.connect_closing() as conn:
-        ok = kb.reassign_task(conn, args.task_id, profile, reclaim_first=reclaim, reason=getattr(args, "reason", None))
+        ok = kb.reassign_task(conn, args.task_id, profile, reclaim_first=reclaim, reason=getattr(args, "reason", None), operator=_cli_operator())
     return _ok_or_err(
         ok,
         f"cannot reassign {args.task_id} (unknown id, or still running — pass --reclaim to release first)",
@@ -712,7 +735,7 @@ def _cmd_unlink(args: argparse.Namespace) -> int:
 
 def _cmd_claim(args: argparse.Namespace) -> int:
     with kbc.connect_closing() as conn:
-        task = kb.claim_task(conn, args.task_id, ttl_seconds=args.ttl)
+        task = kb.claim_task(conn, args.task_id, ttl_seconds=args.ttl, operator=_cli_operator())
         if task is None:
             existing = kb.get_task(conn, args.task_id)
             if existing is None:
@@ -881,7 +904,7 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 return False
             fail_msg[tid] = f"cannot complete {tid} (unknown id or terminal state)"
             return kb.complete_task(conn, tid, result=args.result, summary=summary, metadata=metadata,
-                                    expected_run_id=_worker_run_id_for(tid))
+                                    expected_run_id=_worker_run_id_for(tid), operator=_cli_operator())
 
         return _bulk_apply(ids, op, lambda tid: f"Completed {tid}", fail_msg.__getitem__)
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1070,6 +1070,25 @@ def _host_prefix() -> str:
     return f"{_claimer_id().split(':', 1)[0]}:"
 
 
+def _with_operator(
+    operator: Optional[str], payload: Optional[dict]
+) -> Optional[dict]:
+    """Return ``payload`` with an additive ``operator`` key (issue #82689).
+
+    Operator attribution on state-changing events must never change what
+    existing consumers see: callers that don't pass an operator get the
+    exact legacy payload back (unchanged rows/keys), while callers that do
+    get a copy with one extra ``operator`` key. The value is a surface-
+    prefixed identity string, e.g. ``cli:<user>@<host>``,
+    ``dashboard:<session>``, or ``dispatcher:<host:pid>``.
+    """
+    if not operator:
+        return payload
+    merged = dict(payload) if payload else {}
+    merged["operator"] = operator
+    return merged
+
+
 # --- Task creation / mutation ---
 
 def _validate_model_override(model: Optional[str], provider: Optional[str]) -> tuple[Optional[str], Optional[str]]:
@@ -1497,8 +1516,18 @@ def list_tasks(
     return [Task.from_row(r) for r in rows]
 
 
-def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:
-    """Assign/reassign; raises RuntimeError while the task is running under a claim."""
+def assign_task(
+    conn: sqlite3.Connection, task_id: str, profile: Optional[str],
+    *,
+    operator: Optional[str] = None,
+) -> bool:
+    """Assign/reassign; raises RuntimeError while the task is running under a claim.
+
+    ``operator`` is an optional surface-prefixed identity string recorded
+    additively on the ``assigned`` event payload (issue #82689) — e.g.
+    ``cli:<user>@<host>`` or ``dashboard:<session>``. Omitting it produces
+    the exact legacy payload (no new key), so old consumers are unaffected.
+    """
     profile = _canonical_assignee(profile)
     with write_txn(conn):
         row = conn.execute(
@@ -1519,7 +1548,10 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
             )
         else:
             conn.execute("UPDATE tasks SET assignee = ? WHERE id = ?", (profile, task_id))
-        _append_event(conn, task_id, "assigned", {"assignee": profile})
+        _append_event(
+            conn, task_id, "assigned",
+            _with_operator(operator, {"assignee": profile}),
+        )
     # Observer fires AFTER commit so subscribers see durable state.
     notify_task_updated(conn, task_id, ("assignee",))
     return True
@@ -2130,11 +2162,17 @@ def _claim_and_open_run(
 def claim_task(
     conn: sqlite3.Connection, task_id: str, *, ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    operator: Optional[str] = None,
 ) -> Optional[Task]:
     """Atomically transition ``ready -> running``.
 
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``ready`` status).
+
+    ``operator`` is an optional surface-prefixed identity string recorded
+    additively on the ``claimed`` event payload (issue #82689); the
+    dispatcher passes ``dispatcher:<host:pid>``. Omitting it produces the
+    exact legacy payload.
     """
     now = int(time.time())
     lock = claimer or _claimer_id()
@@ -2154,7 +2192,10 @@ def claim_task(
         _reclaim_dangling_run(
             conn, task_id, statuses=("ready",), now=now, note="invariant recovery on re-claim",
         )
-        run_id = _claim_and_open_run(conn, task_id, "ready", lock, expires, now)
+        run_id = _claim_and_open_run(
+            conn, task_id, "ready", lock, expires, now,
+            event_extra={"operator": operator} if operator else None,
+        )
         if run_id is None:
             return None
         claimed = get_task(conn, task_id)
@@ -2165,10 +2206,17 @@ def claim_task(
 def claim_review_task(
     conn: sqlite3.Connection, task_id: str, *, ttl_seconds: Optional[int] = None,
     claimer: Optional[str] = None,
+    operator: Optional[str] = None,
 ) -> Optional[Task]:
     """Atomic ``review -> running`` (None when lost). Parents are re-checked
     (one may have reopened meanwhile) and a NEW run tracks the reviewer
-    separately from the implementer."""
+    separately from the implementer.
+
+    ``operator`` is an optional surface-prefixed identity string recorded
+    additively on the ``claimed`` event payload (issue #82689); the
+    dispatcher passes ``dispatcher:<host:pid>``. Omitting it produces the
+    exact legacy payload.
+    """
     now = int(time.time())
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
@@ -2185,7 +2233,11 @@ def claim_review_task(
                 )
             return None
         run_id = _claim_and_open_run(
-            conn, task_id, "review", lock, expires, now, event_extra={"source_status": "review"},
+            conn, task_id, "review", lock, expires, now,
+            event_extra={
+                "source_status": "review",
+                **({"operator": operator} if operator else {}),
+            },
         )
         if run_id is None:
             return None
@@ -2441,15 +2493,19 @@ def reclaim_task(
 def reassign_task(
     conn: sqlite3.Connection, task_id: str, profile: Optional[str], *, reclaim_first: bool = False,
     reason: Optional[str] = None,
+    operator: Optional[str] = None,
 ) -> bool:
     """Reassign (None unassigns); a running task is refused unless
-    ``reclaim_first`` releases its claim — the "this profile's model is broken" path."""
+    ``reclaim_first`` releases its claim — the "this profile's model is broken" path.
+
+    ``operator`` rides the ``assigned`` event payload additively (issue #82689).
+    """
     if reclaim_first:
         # Safe to call even if nothing to reclaim.
         reclaim_task(conn, task_id, reason=reason or "reassign")
     # assign_task handles its own txn + the still-running guard.
     try:
-        return assign_task(conn, task_id, profile)
+        return assign_task(conn, task_id, profile, operator=operator)
     except RuntimeError:
         # Task is still running and reclaim_first was False; caller
         # needs to decide whether to retry with reclaim.
@@ -2531,6 +2587,7 @@ def complete_task(
     summary: Optional[str] = None, metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None, expected_run_id: Optional[int] = None,
     fire_lifecycle_hook: bool = True,
+    operator: Optional[str] = None,
 ) -> bool:
     """``running|ready|blocked|review -> done``; records ``result``.
 
@@ -2541,6 +2598,11 @@ def complete_task(
     ``created_cards`` are verified first — a phantom id raises
     :class:`HallucinatedCardsError` after an auditable event; afterwards the
     prose is scanned for unresolvable ``t_<hex>`` refs (advisory event only).
+
+    ``operator`` is an optional surface-prefixed identity string recorded
+    additively on the ``completed`` event payload (issue #82689) — e.g.
+    ``cli:<user>@<host>`` for a manual completion or ``worker:...`` from a
+    spawned worker. Omitting it produces the exact legacy payload.
     """
     now = int(time.time())
     # Cheap pre-check; re-checked inside the txn to close the parent-reopen race.
@@ -2602,7 +2664,10 @@ def complete_task(
             event_summary = _REVIEW_APPROVED_NOTE
         _append_event(
             conn, task_id, "completed",
-            _completed_event_payload(result, event_summary, verified_cards, metadata),
+            _with_operator(
+                operator,
+                _completed_event_payload(result, event_summary, verified_cards, metadata),
+            ),
             run_id=run_id,
         )
     _flag_phantom_prose_refs(conn, task_id, run_id, summary, result, verified_cards)

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1548,7 +1548,13 @@ def _dispatch_lane_task(
         _count_spawn(assignee)
         return True
     claim = _kb.claim_review_task if lane == "review" else _kb.claim_task
-    claimed = claim(conn, task_id, ttl_seconds=ttl_seconds)
+    # Operator attribution (issue #82689): the dispatcher is the actor
+    # on auto-spawn claims — stamp it so post-incident forensics can
+    # tell dispatcher-driven claims from manual ``hermes kanban claim``.
+    claimed = claim(
+        conn, task_id, ttl_seconds=ttl_seconds,
+        operator=f"dispatcher:{_kb._claimer_id()}",
+    )
     if claimed is None:
         return False
     try:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -10,11 +10,15 @@ dispatcher's write txns); it carries its credential in the query string (browser
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib
 import json
 import logging
+import os
 import re
+import socket
 import sqlite3
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing, contextmanager
@@ -506,6 +510,12 @@ class UpdateTaskBody(BaseModel):
     clear_model_override: bool = False
     reasoning_effort: Optional[str] = None
     clear_reasoning_effort: bool = False
+    # Opt-in confirmation probe (#82689): with ``dry_run=true`` and an
+    # ``assignee`` field, nothing is mutated — the handler returns what
+    # WOULD happen (target profile exists, task state, current claim,
+    # whether assignment starts execution immediately) so the UI can ask
+    # before applying. Default false keeps today's behavior byte-for-byte.
+    dry_run: bool = False
 
 
 class BulkTaskBody(BaseModel):
@@ -549,7 +559,9 @@ def _drag_to(conn, task_id: str, s: str) -> bool:
 # payload) -> ok. ``review`` uses request_review (never a block, so it can't trip unblock-loop
 # detection) with ``force=True``: a dashboard action is a human override of a live worker claim.
 _STATUS_HANDLERS: dict[str, Any] = {
-    "done": lambda conn, tid, p: kanban_db.complete_task(conn, tid, result=p.result, summary=p.summary, metadata=p.metadata),
+    "done": lambda conn, tid, p: kanban_db.complete_task(
+        conn, tid, result=p.result, summary=p.summary, metadata=p.metadata,
+        operator=_dashboard_operator()),
     "blocked": lambda conn, tid, p: kanban_db.block_task(conn, tid, reason=getattr(p, "block_reason", None)),
     "scheduled": lambda conn, tid, p: kanban_db.schedule_task(conn, tid, reason=getattr(p, "block_reason", None)),
     "review": lambda conn, tid, p: kanban_db.request_review(
@@ -607,7 +619,8 @@ def _patch_status(conn, task_id: str, payload: UpdateTaskBody, review_assignee_d
         with _map_errors(400, _StatusRejected):
             ok = _apply_status(conn, task_id, s, payload, f"unknown status: {s}")
         if s == "review" and ok and review_assignee_deferred and not payload.assignee:
-            ok = kanban_db.assign_task(conn, task_id, None)
+            ok = kanban_db.assign_task(
+                conn, task_id, None, operator=_dashboard_operator())
     if ok:
         return
     blockers = _parents_blocking_ready(conn, task_id) if s == "ready" else []
@@ -639,6 +652,147 @@ def _patch_title_body(conn, task_id: str, payload: UpdateTaskBody, board: Option
         conn, task_id, [f for f in ("title", "body") if getattr(payload, f) is not None], board=board)
 
 
+# ---------------------------------------------------------------------------
+# Operator attribution + assign dry-run probe (issue #82689)
+# ---------------------------------------------------------------------------
+
+_DASHBOARD_OPERATOR: Optional[str] = None
+
+
+def _dashboard_operator() -> str:
+    """Operator identity stamped on mutating kanban events from this dashboard.
+
+    Format: ``dashboard:<session>`` where <session> is a short hash of the
+    dashboard server's ephemeral session token — all REST writes from one
+    dashboard process share that token, so it IS the session identity. The
+    token is hashed, never logged raw: it grants full dashboard access and
+    must not leak into the audit log. When plugin_api runs outside the
+    dashboard server process (tests, direct ASGI mounts) there is no token
+    to hash, so identity falls back to the serving process's ``host:pid``.
+    Cached per-process; the token is fixed for the server's lifetime.
+    """
+    global _DASHBOARD_OPERATOR
+    if _DASHBOARD_OPERATOR:
+        return _DASHBOARD_OPERATOR
+
+    token: Optional[str] = None
+    ws_mod = sys.modules.get("hermes_cli.web_server")
+    if ws_mod is not None:
+        token = getattr(ws_mod, "_SESSION_TOKEN", None) or None
+    if token:
+        session = hashlib.sha256(str(token).encode("utf-8")).hexdigest()[:12]
+        operator = f"dashboard:{session}"
+    else:
+        try:
+            host = socket.gethostname() or "unknown"
+        except Exception:
+            host = "unknown"
+        operator = f"dashboard:{host}:{os.getpid()}"
+
+    _DASHBOARD_OPERATOR = operator
+    return operator
+
+
+def _profile_exists(name: Optional[str]) -> Optional[bool]:
+    """Whether ``name`` resolves to a real Hermes profile. ``None`` when no
+    profile was requested (unassign). Best-effort: an import failure must
+    never break the probe."""
+    if not name:
+        return None
+    try:
+        from hermes_cli.profiles import profile_exists
+
+        return bool(profile_exists(name))
+    except Exception:
+        return None
+
+
+def _assign_probe(
+    conn,
+    task_id: str,
+    profile: Optional[str],
+    *,
+    reclaim_first: bool = False,
+) -> dict:
+    """Read-only dry-run probe for an assign/reassign (#82689).
+
+    Returns what WOULD happen without touching any row, so the UI can ask
+    for confirmation before applying an assign that starts execution
+    immediately (unassigned cards are never dispatched — assigning one is
+    the moment work begins).
+    """
+    row = conn.execute(
+        "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+
+    probe: dict[str, Any] = {
+        "task_id": task_id,
+        "task_exists": row is not None,
+        "current_status": row["status"] if row else None,
+        "current_assignee": row["assignee"] if row else None,
+        "claim_locked": bool(row and row["claim_lock"]),
+        "running": bool(
+            row and row["claim_lock"] is not None and row["status"] == "running"
+        ),
+        "target_profile": profile,
+        "target_profile_exists": _profile_exists(profile),
+        "would_reclaim": False,
+        "would_refuse": False,
+        "parents_satisfied": True,
+        "dispatchable_after_assign": False,
+        "warnings": [],
+    }
+
+    if row is None:
+        probe["would_refuse"] = True
+        probe["warnings"].append(f"no such task: {task_id}")
+        return probe
+
+    running = probe["running"]
+    if running:
+        # Mirrors assign_task's guard: refuses while claimed+running.
+        if reclaim_first:
+            probe["would_reclaim"] = True
+            probe["warnings"].append(
+                "the active worker claim would be released before reassigning"
+            )
+        else:
+            probe["would_refuse"] = True
+            probe["warnings"].append(
+                "task is currently running — assignment would be refused "
+                "(pass reclaim_first to release the claim)"
+            )
+
+    # Parent invariant from claim_task: a ready task with undone parents is
+    # demoted back to todo instead of being claimed.
+    if profile is not None:
+        undone = conn.execute(
+            "SELECT 1 FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        probe["parents_satisfied"] = undone is None
+
+    effective_status = "ready" if (
+        not running or reclaim_first
+    ) else probe["current_status"]
+    probe["dispatchable_after_assign"] = bool(
+        not probe["would_refuse"]
+        and effective_status == "ready"
+        and profile is not None
+        and probe["target_profile_exists"]
+        and probe["parents_satisfied"]
+    )
+    if probe["dispatchable_after_assign"]:
+        probe["warnings"].append(
+            "assignment starts execution immediately: the dispatcher will "
+            "claim this task and spawn the assigned profile on its next tick"
+        )
+    return probe
+
+
 @router.patch("/tasks/{task_id}")
 def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Query(None)):
     with _board_conn(board) as (board, conn):
@@ -646,9 +800,30 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         # For a combined assignee+review patch, request_review must capture the
         # current implementer before the task is routed to the reviewer.
         review_assignee_deferred = payload.status == "review" and payload.assignee is not None
+        # --- dry-run probe (#82689) ---------------------------------------
+        # Confirmation is opt-in per request: only the assign path supports
+        # it, and nothing below runs when it fires.
+        if payload.dry_run:
+            if payload.assignee is None or payload.status is not None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "dry_run=true is only supported for a pure assignee "
+                        "patch (no status/other fields)"
+                    ),
+                )
+            probe = _assign_probe(conn, task_id, payload.assignee or None)
+            return {
+                "ok": bool(probe["task_exists"] and not probe["would_refuse"]),
+                "dry_run": True,
+                "task_id": task_id,
+                "probe": probe,
+            }
         if payload.assignee is not None and not review_assignee_deferred:
             with _map_errors(409, RuntimeError):
-                _require_ok(kanban_db.assign_task(conn, task_id, payload.assignee or None))
+                _require_ok(kanban_db.assign_task(
+                    conn, task_id, payload.assignee or None,
+                    operator=_dashboard_operator()))
         if payload.status is not None:
             _patch_status(conn, task_id, payload, review_assignee_deferred)
         for wanted, apply, _refused in _OVERRIDE_OPS:
@@ -785,8 +960,13 @@ def _bulk_apply_one(conn, tid: str, payload: BulkTaskBody, board: Optional[str],
             entry.update(ok=False, error=f"transition to {s!r} refused")
     if payload.assignee is not None:
         try:
-            ok = (kanban_db.reassign_task(conn, tid, payload.assignee or None, reclaim_first=True) if payload.reclaim_first
-                  else kanban_db.assign_task(conn, tid, payload.assignee or None))
+            ok = (kanban_db.reassign_task(
+                      conn, tid, payload.assignee or None, reclaim_first=True,
+                      operator=_dashboard_operator())
+                  if payload.reclaim_first
+                  else kanban_db.assign_task(
+                      conn, tid, payload.assignee or None,
+                      operator=_dashboard_operator()))
             if not ok:
                 entry.update(ok=False, error="assign refused")
         except RuntimeError as e:
@@ -981,15 +1161,39 @@ class ReassignBody(BaseModel):
     profile: Optional[str] = None  # "" or None = unassign
     reclaim_first: bool = False
     reason: Optional[str] = None
+    # Opt-in confirmation probe (#82689): with dry_run=true nothing is
+    # mutated — the response reports what WOULD happen (task state, current
+    # claim, target profile existence, whether assignment starts execution
+    # immediately) so the UI can confirm before applying.
+    dry_run: bool = False
 
 
 @router.post("/tasks/{task_id}/reassign")
 def reassign_task_endpoint(task_id: str, payload: ReassignBody, board: Optional[str] = Query(None)):
     """Reassign to another profile, optionally reclaiming first
-    (``hermes kanban reassign <task_id> <profile> [--reclaim]``)."""
+    (``hermes kanban reassign <task_id> <profile> [--reclaim]``).
+
+    With ``dry_run=true`` the endpoint is a read-only probe: it returns
+    ``{ok, dry_run, task_id, probe}`` describing what the real call would
+    do — including whether the assign would be refused (running claim,
+    unknown task) and whether the dispatcher would pick the card up on its
+    next tick. The default (dry_run=false) behavior is unchanged.
+    """
     with _board_conn(board) as (board, conn):
+        if payload.dry_run:
+            probe = _assign_probe(
+                conn, task_id, payload.profile or None,
+                reclaim_first=bool(payload.reclaim_first),
+            )
+            return {
+                "ok": bool(probe["task_exists"] and not probe["would_refuse"]),
+                "dry_run": True,
+                "task_id": task_id,
+                "probe": probe,
+            }
         ok = kanban_db.reassign_task(
-            conn, task_id, payload.profile or None, reclaim_first=bool(payload.reclaim_first), reason=payload.reason)
+            conn, task_id, payload.profile or None, reclaim_first=bool(payload.reclaim_first), reason=payload.reason,
+            operator=_dashboard_operator())
         if not ok:
             raise _conflict(
                 f"cannot reassign {task_id}: unknown id, or still "

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -669,7 +669,11 @@ def _dashboard_operator() -> str:
     must not leak into the audit log. When plugin_api runs outside the
     dashboard server process (tests, direct ASGI mounts) there is no token
     to hash, so identity falls back to the serving process's ``host:pid``.
-    Cached per-process; the token is fixed for the server's lifetime.
+    A token-derived identity is cached per-process because the token is fixed
+    for the server's lifetime.  The fallback is deliberately not cached: this
+    module can be imported before ``web_server`` creates ``_SESSION_TOKEN``,
+    and freezing a ``host:pid`` fallback would misattribute every later call
+    once a real token exists (#82689 follow-up, credit @benperry6).
     """
     global _DASHBOARD_OPERATOR
     if _DASHBOARD_OPERATOR:
@@ -682,15 +686,14 @@ def _dashboard_operator() -> str:
     if token:
         session = hashlib.sha256(str(token).encode("utf-8")).hexdigest()[:12]
         operator = f"dashboard:{session}"
-    else:
-        try:
-            host = socket.gethostname() or "unknown"
-        except Exception:
-            host = "unknown"
-        operator = f"dashboard:{host}:{os.getpid()}"
+        _DASHBOARD_OPERATOR = operator
+        return operator
 
-    _DASHBOARD_OPERATOR = operator
-    return operator
+    try:
+        host = socket.gethostname() or "unknown"
+    except Exception:
+        host = "unknown"
+    return f"dashboard:{host}:{os.getpid()}"
 
 
 def _profile_exists(name: Optional[str]) -> Optional[bool]:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -182,3 +182,53 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+
+
+# ---------------------------------------------------------------------------
+# Operator attribution on CLI verbs (issue #82689)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_assign_claim_complete_stamp_operator(kanban_home):
+    """The mutating CLI verbs record a ``cli:<user>@<host>`` operator on
+    the assigned / claimed / completed event payloads (issue #82689)."""
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="audit me")
+
+    assert "Assigned" in kc.run_slash(f"assign {tid} bob")
+    assert "Claimed" in kc.run_slash(f"claim {tid}")
+    assert f"Completed {tid}" in kc.run_slash(f"complete {tid} --result done")
+
+    expected = kc._cli_operator()
+    assert expected.startswith("cli:")
+    assert "@" in expected
+
+    with kb.connect_closing() as conn:
+        payloads = {}
+        for e in kb.list_events(conn, tid):
+            if e.kind in {"assigned", "claimed", "completed"}:
+                payloads.setdefault(e.kind, []).append(e.payload)
+
+    assert len(payloads["assigned"]) == 1
+    assert payloads["assigned"][0]["operator"] == expected
+    assert payloads["assigned"][0]["assignee"] == "bob"
+    assert len(payloads["claimed"]) == 1
+    assert payloads["claimed"][0]["operator"] == expected
+    assert len(payloads["completed"]) == 1
+    assert payloads["completed"][0]["operator"] == expected
+
+
+def test_cli_reassign_stamps_operator(kanban_home):
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="reassign me")
+
+    assert "Reassigned" in kc.run_slash(f"reassign {tid} carol")
+
+    with kb.connect_closing() as conn:
+        assigned = [
+            e.payload for e in kb.list_events(conn, tid)
+            if e.kind == "assigned"
+        ]
+    assert len(assigned) == 1
+    assert assigned[0]["operator"] == kc._cli_operator()
+    assert assigned[0]["assignee"] == "carol"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1656,3 +1656,92 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Operator attribution on state-changing events (issue #82689)
+# ---------------------------------------------------------------------------
+
+
+def _payloads_of_kind(conn: sqlite3.Connection, task_id: str, kind: str):
+    return [
+        e.payload for e in kb.list_events(conn, task_id) if e.kind == kind
+    ]
+
+
+def test_assign_event_operator_is_additive(kanban_home):
+    """operator= rides the ``assigned`` payload additively; a caller that
+    omits it must get the exact legacy payload (no new key), so old rows
+    and old consumers are unaffected (issue #82689)."""
+    with kb.connect() as conn:
+        t_new = kb.create_task(conn, title="with operator")
+        assert kb.assign_task(
+            conn, t_new, "bob", operator="cli:amy@box"
+        ) is True
+        t_old = kb.create_task(conn, title="legacy caller")
+        assert kb.assign_task(conn, t_old, "carol") is True
+
+    assert _payloads_of_kind(conn, t_new, "assigned") == [
+        {"assignee": "bob", "operator": "cli:amy@box"}
+    ]
+    # Backward compat: byte-identical legacy payload when no operator given.
+    assert _payloads_of_kind(conn, t_old, "assigned") == [
+        {"assignee": "carol"}
+    ]
+
+
+def test_claim_and_complete_events_carry_operator(kanban_home):
+    """claimed / completed payloads gain ``operator`` only when the caller
+    passes one; the legacy key sets are untouched otherwise."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="attributed")
+        claimed = kb.claim_task(
+            conn, t, claimer="box:1", operator="cli:a@b"
+        )
+        assert claimed is not None
+        assert kb.complete_task(
+            conn, t, result="done", operator="worker:b@box:2"
+        ) is True
+
+        t_legacy = kb.create_task(conn, title="legacy")
+        legacy_claim = kb.claim_task(conn, t_legacy)
+        assert legacy_claim is not None
+        assert kb.complete_task(conn, t_legacy, result="done") is True
+
+    claim_payloads = _payloads_of_kind(conn, t, "claimed")
+    done_payloads = _payloads_of_kind(conn, t, "completed")
+    assert len(claim_payloads) == 1 and len(done_payloads) == 1
+    assert claim_payloads[0]["operator"] == "cli:a@b"
+    assert set(claim_payloads[0]) == {"lock", "expires", "run_id", "operator"}
+    assert done_payloads[0]["operator"] == "worker:b@box:2"
+    assert set(done_payloads[0]) == {"result_len", "summary", "operator"}
+
+    # Legacy callers keep the exact legacy payloads.
+    legacy_claim_payloads = _payloads_of_kind(conn, t_legacy, "claimed")
+    legacy_done_payloads = _payloads_of_kind(conn, t_legacy, "completed")
+    assert set(legacy_claim_payloads[0]) == {"lock", "expires", "run_id"}
+    assert "operator" not in legacy_claim_payloads[0]
+    assert set(legacy_done_payloads[0]) == {"result_len", "summary"}
+
+
+def test_dispatcher_claim_stamps_dispatcher_operator(
+    kanban_home, all_assignees_spawnable,
+):
+    """Auto-spawn claims must record dispatcher identity so forensics can
+    tell them apart from manual ``hermes kanban claim`` (issue #82689)."""
+    spawns: list[str] = []
+
+    def fake_spawn(task, workspace, board=None):
+        spawns.append(task.id)
+        return 42
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="auto-spawned", assignee="alice")
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert res.spawned and spawns == [tid]
+    payloads = _payloads_of_kind(conn, tid, "claimed")
+    assert len(payloads) == 1
+    operator = payloads[0]["operator"]
+    assert operator == f"dispatcher:{kb._claimer_id()}"
+    assert operator.startswith("dispatcher:")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1232,3 +1232,131 @@ def test_specify_happy_path(client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+
+
+# ---------------------------------------------------------------------------
+# Assign confirmation probe (dry_run) + operator attribution (#82689)
+# ---------------------------------------------------------------------------
+
+
+def test_reassign_dry_run_probe_reports_without_mutating(client):
+    r = client.post("/api/plugins/kanban/tasks", json={"title": "probe me"})
+    assert r.status_code == 200, r.text
+    task_id = r.json()["task"]["id"]
+    assert r.json()["task"]["status"] == "ready"  # no parents -> ready
+
+    resp = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/reassign",
+        json={"profile": "ghost-profile", "dry_run": True},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["dry_run"] is True
+    assert body["task_id"] == task_id
+
+    probe = body["probe"]
+    assert probe["task_exists"] is True
+    assert probe["current_status"] == "ready"
+    assert probe["target_profile"] == "ghost-profile"
+    # Isolated HERMES_HOME has no profile dirs -> target doesn't exist, so
+    # the assignment would NOT hand the card to the dispatcher.
+    assert probe["target_profile_exists"] is False
+    assert probe["would_refuse"] is False
+    assert probe["would_reclaim"] is False
+    assert probe["dispatchable_after_assign"] is False
+    assert isinstance(probe["warnings"], list)
+
+    # Nothing was mutated: task still unassigned, no assigned event.
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).assignee is None
+        assert [
+            e for e in kb.list_events(conn, task_id) if e.kind == "assigned"
+        ] == []
+
+
+def test_reassign_dry_run_flags_running_claim(client):
+    """A running claim without reclaim_first must surface would_refuse."""
+    r = client.post("/api/plugins/kanban/tasks", json={"title": "busy"})
+    task_id = r.json()["task"]["id"]
+    with kb.connect() as conn:
+        kb.claim_task(conn, task_id, claimer="box:1")
+
+    resp = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/reassign",
+        json={"profile": "builder", "dry_run": True},
+    )
+    probe = resp.json()["probe"]
+    assert probe["running"] is True
+    assert probe["claim_locked"] is True
+    assert probe["would_refuse"] is True
+    assert resp.json()["ok"] is False
+
+    # With reclaim_first the same probe flips to would_reclaim.
+    resp = client.post(
+        f"/api/plugins/kanban/tasks/{task_id}/reassign",
+        json={"profile": "builder", "reclaim_first": True, "dry_run": True},
+    )
+    probe = resp.json()["probe"]
+    assert probe["would_refuse"] is False
+    assert probe["would_reclaim"] is True
+
+
+def test_reassign_dry_run_missing_task_reports_not_found(client):
+    resp = client.post(
+        "/api/plugins/kanban/tasks/t_deadbeef/reassign",
+        json={"profile": "x", "dry_run": True},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["probe"]["task_exists"] is False
+    assert body["probe"]["would_refuse"] is True
+
+
+def test_patch_assign_dry_run_then_apply_stamps_operator(client):
+    """PATCH dry_run probes an assignee change; the real (default) PATCH
+    behavior is unchanged and stamps a dashboard: operator."""
+    r = client.post("/api/plugins/kanban/tasks", json={"title": "card"})
+    task_id = r.json()["task"]["id"]
+    url = f"/api/plugins/kanban/tasks/{task_id}"
+
+    # Probe: nothing mutates.
+    resp = client.patch(url, json={"assignee": "builder", "dry_run": True})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["dry_run"] is True and body["task_id"] == task_id
+    probe = body["probe"]
+    assert probe["target_profile"] == "builder"
+    assert probe["task_exists"] is True
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).assignee is None
+
+    # Real assign (default behavior unchanged) — event carries operator.
+    resp = client.patch(url, json={"assignee": "builder"})
+    assert resp.status_code == 200, resp.text
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).assignee == "builder"
+        assigned = [
+            e.payload for e in kb.list_events(conn, task_id)
+            if e.kind == "assigned"
+        ]
+    assert len(assigned) == 1
+    assert assigned[0]["operator"].startswith("dashboard:")
+    assert assigned[0]["assignee"] == "builder"
+
+
+def test_patch_dry_run_requires_pure_assignee_patch(client):
+    r = client.post("/api/plugins/kanban/tasks", json={"title": "card"})
+    task_id = r.json()["task"]["id"]
+    resp = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"assignee": "builder", "status": "ready", "dry_run": True},
+    )
+    assert resp.status_code == 400
+    # And without an assignee there is nothing to probe.
+    resp = client.patch(
+        f"/api/plugins/kanban/tasks/{task_id}",
+        json={"dry_run": True},
+    )
+    assert resp.status_code == 400

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -161,6 +161,24 @@ def _stamp_worker_session_metadata(task_id: str, metadata: Optional[dict]) -> Op
     return {**(metadata or {}), "worker_session_id": session_id} if session_id else metadata
 
 
+def _worker_operator() -> str:
+    """Operator identity for state-changing events this process writes (#82689).
+
+    Spawned workers carry ``HERMES_PROFILE``; the ``host:pid`` suffix
+    disambiguates concurrent workers for the same profile. Rides the
+    ``completed`` event payload additively (``worker:<profile>@<host:pid>``).
+    """
+    import socket
+
+    try:
+        host = socket.gethostname() or "unknown"
+    except Exception:
+        host = "unknown"
+    who = f"{host}:{os.getpid()}"
+    profile = (os.environ.get("HERMES_PROFILE") or "").strip()
+    return f"worker:{profile}@{who}" if profile else f"worker:{who}"
+
+
 def _enforce_worker_task_ownership(tid: str) -> None:
     """A dispatcher-spawned worker may only mutate its own HERMES_KANBAN_TASK; a
     prompt-injected ``task_id`` must not corrupt sibling/cross-tenant runs.
@@ -565,7 +583,8 @@ def _handle_complete(args: dict, **kw) -> str:
         try:
             ok = kb.complete_task(
                 conn, tid, result=result, summary=summary, metadata=metadata,
-                created_cards=created_cards, expected_run_id=_worker_run_id(tid))
+                created_cards=created_cards, expected_run_id=_worker_run_id(tid),
+                operator=_worker_operator())
         except kb.ArtifactPreservationError as artifact_err:
             # Structured rejection — surface the phantom ids so the worker can retry with a corrected list
             # or drop the field. Audit event already landed in the DB. The task itself was NOT mutated (the

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -628,7 +628,7 @@ hermes dashboard        # "Kanban" tab appears in the nav, after "Skills"
 - Cards show the task id, title, priority badge, tenant tag, assigned profile, comment/link counts, a **progress pill** (`N/M` children done when the task has dependents), and "created N ago". A per-card checkbox enables multi-select.
 - **Per-profile lanes inside Running** — toolbar checkbox toggles sub-grouping of the Running column by assignee.
 - **Live updates via WebSocket** — the plugin tails the append-only `task_events` table on a short poll interval; the board reflects changes the instant any profile (CLI, gateway, or another dashboard tab) acts. Reloads are debounced so a burst of events triggers a single refetch.
-- **Drag-drop** cards between columns to change status. The drop sends `PATCH /api/plugins/kanban/tasks/:id` which routes through the same `kanban_db` code the CLI uses — the three surfaces can never drift. Moves into destructive statuses (`done`, `archived`, `blocked`) prompt for confirmation. Touch devices use a pointer-based fallback so the board is usable from a tablet.
+- **Drag-drop** cards between columns to change status. The drop sends `PATCH /api/plugins/kanban/tasks/:id` which routes through the same `kanban_db` code the CLI uses — the three surfaces can never drift. Moves into destructive statuses (`done`, `archived`, `blocked`) prompt for confirmation. Touch devices use a pointer-based fallback so the board is usable from a tablet. Assignments can be confirmed before applying via the opt-in [dry-run probe](#assign-confirmation-probe-dry-run) — assigning a ready card starts execution on the dispatcher's next tick.
 - **Create-task dialog** — click `+` on any column header to open a modal with labeled fields: title, assignee, priority, skills, workspace kind/path (seeded from the board's project directory; per-task override), goal mode, and (optionally) a parent task from a dropdown over every existing task. Press Enter to create the task, Shift+Enter to insert a newline in the title field, or Escape to cancel. Creating from the Triage column automatically parks the new task in triage.
 - **Multi-select with bulk actions** — shift/ctrl-click a card or tick its checkbox to add it to the selection. A bulk action bar appears at the top with batch status transitions, archive, and reassign (by profile dropdown, or "(unassign)"). Destructive batches confirm first. Per-id partial failures are reported without aborting the rest.
 - **Click a card** (without shift/ctrl) to open a side drawer (Escape or click-outside closes) with:
@@ -721,8 +721,9 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `GET` | `/board?tenant=<name>&include_archived=…` | Full board grouped by status column, plus tenants + assignees for filter dropdowns |
 | `GET` | `/tasks/:id` | Task + comments + events + links |
 | `POST` | `/tasks` | Create (wraps `kanban_db.create_task`, accepts `triage: bool` and `parents: [id, …]`) |
-| `PATCH` | `/tasks/:id` | Status / assignee / priority / title / body / result |
+| `PATCH` | `/tasks/:id` | Status / assignee / priority / title / body / result. A pure assignee patch also accepts `dry_run: true` — see [Assign confirmation probe](#assign-confirmation-probe-dry-run) |
 | `POST` | `/tasks/bulk` | Apply the same patch (status / archive / assignee / priority) to every id in `ids`. Per-id failures reported without aborting siblings |
+| `POST` | `/tasks/:id/reassign` | Reassign with optional reclaim-first (recovery popover). Accepts `dry_run: true` — see [Assign confirmation probe](#assign-confirmation-probe-dry-run) |
 | `POST` | `/tasks/:id/comments` | Append a comment |
 | `POST` | `/tasks/:id/specify` | Run the triage specifier — auxiliary LLM fleshes out the task body and promotes it from `triage` to `todo`. Returns `{ok, task_id, reason, new_title}`; `ok=false` with a human-readable reason on "not in triage" / no aux client / LLM error is a 200, not a 4xx |
 | `POST` | `/tasks/:id/decompose` | Run the kanban decomposer — auxiliary LLM produces a task graph and the helper atomically creates the children + links the root + flips `triage → todo`. Returns `{ok, task_id, reason, fanout, child_ids, new_title}`. Same 200-on-LLM-error convention as `/specify`. |
@@ -738,6 +739,50 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `WS` | `/events?since=<event_id>` | Live stream of `task_events` rows |
 
 Every handler is a thin wrapper — the plugin is ~700 lines of Python (router + WebSocket tail + bulk batcher + config reader) and adds no new business logic. A tiny `_conn()` helper auto-initializes `kanban.db` on every read and write, so a fresh install works whether the user opened the dashboard first, hit the REST API directly, or ran `hermes kanban init`.
+
+### Assign confirmation probe (`dry_run`)
+
+Assigning a card is the moment work begins: unassigned cards are never dispatched, but an assigned+ready card is claimed and its worker spawned on the dispatcher's next tick. To let the UI (or any API client) confirm before that happens, both assign endpoints accept an opt-in `dry_run: true`:
+
+- `PATCH /api/plugins/kanban/tasks/:id` with a body of `{"assignee": "<profile>", "dry_run": true}` (a pure assignee patch only), or
+- `POST /api/plugins/kanban/tasks/:id/reassign` with `{"profile": "<profile>", "reclaim_first": false, "dry_run": true}`.
+
+Neither mutates anything. Both return `{ok, dry_run: true, task_id, probe}` where `probe` reports what WOULD happen:
+
+```json
+{
+  "task_id": "t_ab12cd34",
+  "task_exists": true,
+  "current_status": "ready",
+  "current_assignee": null,
+  "claim_locked": false,
+  "running": false,
+  "target_profile": "ops",
+  "target_profile_exists": true,
+  "would_reclaim": false,
+  "would_refuse": false,
+  "parents_satisfied": true,
+  "dispatchable_after_assign": true,
+  "warnings": [
+    "assignment starts execution immediately: the dispatcher will claim this task and spawn the assigned profile on its next tick"
+  ]
+}
+```
+
+`dispatchable_after_assign` is the headline field: it is true when the assignment would put the card in front of the dispatcher immediately (ready status after the assign, target profile exists, parents satisfied). `would_refuse` mirrors the DB layer's guards (unknown task id; running claim without `reclaim_first`). Omitting `dry_run` keeps today's apply-immediately behavior — confirmation is opt-in per request.
+
+### Operator audit trail
+
+State-changing kanban events record **who** acted, as an additive `operator` key on the event payload (issue #82689). The formats are surface-prefixed:
+
+| Surface | `operator` format | Where it appears |
+|---|---|---|
+| CLI / gateway `/kanban` | `cli:<user>@<host>` | `assigned`, `claimed`, `completed` events |
+| Dashboard plugin API | `dashboard:<session-hash>` | `assigned`, `completed` events |
+| Dispatcher auto-spawn | `dispatcher:<host>:<pid>` | `claimed` events |
+| Spawned worker tools | `worker:<profile>@<host:pid>` | `completed` events |
+
+The dashboard's session hash is a short SHA-256 prefix of the server's ephemeral session token — stable per dashboard process, never the raw token. Events written by callers predating this field (or by third-party tools calling `kanban_db` directly) simply carry no `operator` key; nothing else about the payload changed, so old consumers and old rows are unaffected. Read the trail with `hermes kanban show <id>` (events section) or `hermes kanban tail`.
 
 ### Dashboard config
 


### PR DESCRIPTION
Refs #82689 — addresses the audit halves (#1 operator audit, #3 assign confirmation); the authz gate and process-tree kill remain open.

Addresses the audit halves of #82689 (#1 operator audit + #3 assign confirmation). The authorization gate (#2) is a needs-decision design change and the process-tree kill (#4) belongs with #37689 — both intentionally out of scope here.  ## Operator audit State-changing events (assign/reassign/claim/complete) gain an ADDITIVE operator payload key — old callers produce byte-identical legacy payloads. Identity formats: cli:<user>@<host>, dashboard:<sha256(token)[:12]> (hash only — raw token never enters logs), dispatcher:<host:pid> stamped automatically on auto-spawn claims, worker:<profile>@<host:pid> from the completion tool.  ## Assign confirmation Dashboard PATCH/POST assign+reassign accept dry_run=true returning what WOULD happen (profile existence, current claim, would_refuse/would_reclaim) so UIs can confirm before applying; default behavior unchanged. The dashboard frontend ships as built dist-only JS, so this lands as API capability + docs.  ## Verification New tests across kanban_db (legacy-payload equality, dispatcher stamping), dashboard plugin (probe shape, claim-flip cases, dry-run->apply, 400 guards), CLI verbs (operator stamping) — green via scripts/run_tests.sh modulo pre-existing Windows-env failures (stash-verified on clean main).