### PR TITLE
fix(gateway): stop Telegram flood penalties from freezing all inbound platforms

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -626,6 +626,13 @@ _POLLING_PROGRESS_TIMEOUT = 60.0
 # dead request is still noticed quickly. Kept modest deliberately — this is
 # also how long a user waits to be told the attachment failed.
 _MEDIA_SEND_READ_TIMEOUT = 60.0
+# A server-supplied flood penalty can be hours long.  send() is also used by
+# gateway startup recovery before the inbound restore gate is released, so
+# honoring such a penalty here freezes every platform, not only Telegram.
+# Short penalties keep the existing retry behavior; longer ones fail the send
+# immediately so the caller can persist/retry it without holding a coroutine
+# (and the global startup gate) open for the full penalty.
+_FLOOD_RETRY_SLEEP_CEILING = 30.0
 _POLLING_GENERATION_CONTEXT: ContextVar[Optional[int]] = ContextVar(
     "telegram_polling_generation", default=None
 )
@@ -5449,6 +5456,19 @@ class TelegramAdapter(BasePlatformAdapter):
                             if _send_attempt < 2:
                                 wait = float(retry_after) if retry_after is not None else 1.0
                                 safe_send_error = _redact_telegram_error_text(send_err)
+                                if wait > _FLOOD_RETRY_SLEEP_CEILING:
+                                    logger.warning(
+                                        "[%s] Telegram flood control on send "
+                                        "(attempt %d/3) requested %.1fs, exceeding "
+                                        "the %.0fs retry ceiling; failing without "
+                                        "sleeping: %s",
+                                        self.name,
+                                        _send_attempt + 1,
+                                        wait,
+                                        _FLOOD_RETRY_SLEEP_CEILING,
+                                        safe_send_error,
+                                    )
+                                    raise
                                 logger.warning(
                                     "[%s] Telegram flood control on send (attempt %d/3), retrying in %.1fs: %s",
                                     self.name,

--- a/tests/gateway/test_telegram_flood_control.py
+++ b/tests/gateway/test_telegram_flood_control.py
@@ -1,0 +1,58 @@
+"""Regression coverage for bounded Telegram flood-control retries."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram import adapter as telegram_adapter
+
+
+class _RetryAfter(Exception):
+    def __init__(self, seconds: float) -> None:
+        super().__init__(f"Flood control exceeded. Retry in {seconds} seconds")
+        self.retry_after = seconds
+
+
+def _adapter_with_send(side_effect):
+    adapter = telegram_adapter.TelegramAdapter(
+        PlatformConfig(enabled=True, token="fake-token", extra={})
+    )
+    adapter._rich_messages_enabled = False
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(side_effect=side_effect)
+    adapter._bot.send_chat_action = AsyncMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_oversized_retry_after_fails_without_sleeping_or_retrying(monkeypatch):
+    """A server penalty measured in hours must not hold the boot path open."""
+    adapter = _adapter_with_send(_RetryAfter(5827))
+    sleep = AsyncMock()
+    monkeypatch.setattr(telegram_adapter.asyncio, "sleep", sleep)
+
+    result = await adapter.send("123", "gateway restarted")
+
+    assert result.success is False
+    assert result.error_kind == "rate_limited"
+    adapter._bot.send_message.assert_awaited_once()
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_short_retry_after_remains_retryable(monkeypatch):
+    """Normal short penalties still use the existing bounded retry path."""
+    adapter = _adapter_with_send(
+        [_RetryAfter(2), SimpleNamespace(message_id=42)]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(telegram_adapter.asyncio, "sleep", sleep)
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is True
+    assert result.message_id == "42"
+    assert adapter._bot.send_message.await_count == 2
+    sleep.assert_awaited_once_with(2.0)


### PR DESCRIPTION
## What does this PR do?

A long Telegram flood-control penalty can currently freeze inbound processing on every enabled platform during gateway startup. This change rejects server-requested send sleeps above a 30-second ceiling, allowing startup recovery to record the failed delivery and continue instead of holding the global restore gate for minutes or hours.

### Symptom

After a restart, Telegram can return a flood-control response such as `Retry in 5827 seconds`. The gateway then remains inside the startup notification or obligation-redelivery send while messages arriving through Telegram, webhook, API server, and other platforms stay queued behind startup restore.

### Impact

One rate-limited Telegram destination can prevent all connected platforms from processing inbound messages for the full server penalty. Restarting does not recover service while the penalty remains active because startup re-enters the same sleep.

### Bug Cause

**Trigger:** `plugins/platforms/telegram/adapter.py:5457` / `TelegramAdapter.send()` / a send exception with a large `retry_after` value.

**Causal chain:**
1. Telegram supplies an untrusted flood-control delay, such as 5827 seconds.
2. `TelegramAdapter.send()` converts that value to a float and awaits it without a ceiling before retrying.
3. Gateway startup awaits that send before `_finish_startup_restore()` releases the inbound gate, so every platform's inbound events remain queued.

**Why it is wrong:** The provider controls how long a shared gateway startup coroutine stays suspended, and the existing startup-restore timeout only covers auto-resume tasks reached after these sends.

**Working sibling / contrast:** Short flood-control penalties are suitable for the existing retry loop and continue to retry after the requested delay. Oversized penalties should be persisted as failed delivery attempts for later recovery instead of keeping the current coroutine open.

**Ruled out:** The existing `_finish_startup_restore()` timeout does not cover this failure because restart notification and delivery-obligation sends run before that function is called.

### Fix

Add an internal 30-second ceiling for Telegram flood-control retry sleeps. Values above the ceiling fail the current send immediately without sleeping or retrying; values at or below the ceiling retain the existing bounded retry behavior. Direct adapter tests cover both the observed 5827-second penalty and a normal short penalty.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py` - reject oversized server-supplied flood-control sleeps before they can block gateway startup.
- `tests/gateway/test_telegram_flood_control.py` - verify long penalties fail immediately while short penalties still retry.

## How to Test

1. Run the focused flood-control regression tests.
2. Run the related Telegram send, restart notification, delivery ledger, and startup restore suites.
3. Confirm all related tests pass.

```bash
scripts/run_tests.sh tests/gateway/test_telegram_flood_control.py tests/gateway/test_send_error_classification.py tests/gateway/test_telegram_format.py tests/gateway/test_restart_notification.py tests/gateway/test_delivery_ledger.py tests/gateway/test_restart_resume_pending.py -q
```

Result: 124 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A because this is an internal safety bound with no user-facing configuration.
- [x] `cli-config.yaml.example` update is N/A because no configuration key changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed.
- [x] Cross-platform impact was considered; the change uses platform-independent asyncio behavior.
- [x] Tool description and schema updates are N/A because no tool contract changed.
