### PR TITLE
fix(a2a): expose structured JSON interoperability

### DIFF
--- a/plugins/platforms/a2a/DESIGN.md
+++ b/plugins/platforms/a2a/DESIGN.md
@@ -77,8 +77,14 @@ Peers resolved from `config.yaml` → `a2a_agents`, or a direct URL.
   extract_text renders file/data Parts into the text stream (URL +
   filename for files, JSON for data) so the agent sees them; it also
   accepts v0.3 (kind) and pre-0.3 (type) shapes from older peers.
-  Outbound replies are still text-only — the agent produces text, and
-  file/data Parts are for inbound richness.
+  Completed and streamed outbound artifacts retain the full text Part for
+  compatibility and add data Parts for valid fenced JSON; consumers should
+  prefer data Parts when present. Extraction accepts a fence info string of
+  exactly `json` (ignoring surrounding horizontal whitespace), so attributes
+  and `jsonc` remain text-only, and skips payloads over 1 MiB of UTF-8 data.
+- Every generated skill advertises `text/plain` and `application/json` as its
+  input and output modes. These describe the platform boundary shared by all
+  current toolsets rather than toolset-specific file or media capabilities.
 - Push notification config: full CRUD — create (inline in message/send
   via configuration.taskPushNotificationConfig, or via the create
   method), get, list, delete. Each config has a configId and createdAt.

--- a/plugins/platforms/a2a/DESIGN.md
+++ b/plugins/platforms/a2a/DESIGN.md
@@ -81,7 +81,8 @@ Peers resolved from `config.yaml` → `a2a_agents`, or a direct URL.
   compatibility and add data Parts for valid fenced JSON; consumers should
   prefer data Parts when present. Extraction accepts a fence info string of
   exactly `json` (ignoring surrounding horizontal whitespace), so attributes
-  and `jsonc` remain text-only, and skips payloads over 1 MiB of UTF-8 data.
+  and `jsonc` remain text-only. Unsafe Unicode, nesting deeper than 100
+  containers, and payloads over 1 MiB of UTF-8 data also remain text-only.
 - Every generated skill advertises `text/plain` and `application/json` as its
   input and output modes. These describe the platform boundary shared by all
   current toolsets rather than toolset-specific file or media capabilities.

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -266,7 +266,9 @@ def data_part(data: Any, media_type: str = "application/json") -> dict:
 
 
 _JSON_FENCE_RE = re.compile(
-    r"```json[ \t]*\r?\n(?P<payload>.*?)\r?\n?[ \t]*```",
+    r"(?m:^[ \t]{0,3}```json[ \t]*\r?\n)"
+    r"(?P<payload>.*?)"
+    r"(?m:^[ \t]{0,3}```[ \t]*\r?$)",
     re.IGNORECASE | re.DOTALL,
 )
 

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -279,11 +279,11 @@ def _artifact_parts(agent_text: str) -> list[dict]:
     parts = [text_part(agent_text)]
     for match in _JSON_FENCE_RE.finditer(agent_text):
         payload = match.group("payload")
-        if len(payload.encode("utf-8")) > _MAX_STRUCTURED_JSON_BYTES:
-            continue
         try:
+            if len(payload.encode("utf-8")) > _MAX_STRUCTURED_JSON_BYTES:
+                continue
             data = json.loads(payload)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, UnicodeEncodeError, RecursionError):
             continue
         parts.append(data_part(data))
     return parts

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -266,7 +266,7 @@ def data_part(data: Any, media_type: str = "application/json") -> dict:
 
 
 _JSON_FENCE_RE = re.compile(
-    r"(?m:^[ ]{0,3}(?P<fence>\x60{3,})json[ \t]*\r?\n)"
+    r"(?m:^[ ]{0,3}(?P<fence>\x60{3,})[ \t]*json[ \t]*\r?\n)"
     r"(?P<payload>.*?)"
     r"(?m:^[ ]{0,3}(?P=fence)\x60*[ \t]*\r?$)",
     re.IGNORECASE | re.DOTALL,

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -266,9 +266,9 @@ def data_part(data: Any, media_type: str = "application/json") -> dict:
 
 
 _JSON_FENCE_RE = re.compile(
-    r"(?m:^[ ]{0,3}```json[ \t]*\r?\n)"
+    r"(?m:^[ ]{0,3}(?P<fence>\x60{3,})json[ \t]*\r?\n)"
     r"(?P<payload>.*?)"
-    r"(?m:^[ ]{0,3}```[ \t]*\r?$)",
+    r"(?m:^[ ]{0,3}(?P=fence)\x60*[ \t]*\r?$)",
     re.IGNORECASE | re.DOTALL,
 )
 

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import copy
 import os
+import re
 import threading
 import time
 import uuid
@@ -160,6 +161,8 @@ def skills_from_toolsets(toolsets: "list[str] | dict[str, list[str]] | None") ->
                 "name": ts_name,
                 "description": f"Hermes '{ts_name}' capabilities",
                 "tags": [ts_name] + tool_names[:10],
+                "inputModes": ["text/plain", "application/json"],
+                "outputModes": ["text/plain", "application/json"],
             })
     else:
         for ts in sorted(set(toolsets or [])):
@@ -168,6 +171,8 @@ def skills_from_toolsets(toolsets: "list[str] | dict[str, list[str]] | None") ->
                 "name": ts,
                 "description": f"Hermes '{ts}' capabilities",
                 "tags": [ts],
+                "inputModes": ["text/plain", "application/json"],
+                "outputModes": ["text/plain", "application/json"],
             })
     if not skills:
         skills.append({
@@ -175,6 +180,8 @@ def skills_from_toolsets(toolsets: "list[str] | dict[str, list[str]] | None") ->
             "name": "general",
             "description": "General-purpose conversational agent",
             "tags": ["general"],
+            "inputModes": ["text/plain", "application/json"],
+            "outputModes": ["text/plain", "application/json"],
         })
     return skills
 
@@ -256,6 +263,24 @@ def file_part(url: str = "", raw: str = "", filename: str = "",
 def data_part(data: Any, media_type: str = "application/json") -> dict:
     """Build a v1.0 data Part (structured data, no ``kind`` field)."""
     return {"data": data, "mediaType": media_type}
+
+
+_JSON_FENCE_RE = re.compile(
+    r"```json[ \t]*\r?\n(?P<payload>.*?)\r?\n?[ \t]*```",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _artifact_parts(agent_text: str) -> list[dict]:
+    """Preserve reply text and expose valid fenced JSON as structured Parts."""
+    parts = [text_part(agent_text)]
+    for match in _JSON_FENCE_RE.finditer(agent_text):
+        try:
+            data = json.loads(match.group("payload"))
+        except (TypeError, ValueError):
+            continue
+        parts.append(data_part(data))
+    return parts
 
 
 def text_message(role: str, text: str, context_id: str = "") -> dict:
@@ -391,7 +416,7 @@ def build_task(
         if state == STATE_COMPLETED:
             task["artifacts"] = [{
                 "artifactId": uuid.uuid4().hex,
-                "parts": [text_part(agent_text)],
+                "parts": _artifact_parts(agent_text),
             }]
     return task
 
@@ -416,7 +441,7 @@ def artifact_update(task_id: str, context_id: str, text: str) -> dict:
             "contextId": context_id,
             "artifact": {
                 "artifactId": uuid.uuid4().hex,
-                "parts": [text_part(text)],
+                "parts": _artifact_parts(text),
             },
         }
     }

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -272,6 +272,29 @@ _JSON_FENCE_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 _MAX_STRUCTURED_JSON_BYTES = 1_048_576
+_MAX_STRUCTURED_JSON_DEPTH = 100
+
+
+def _safe_structured_json(data: Any) -> bool:
+    """Return whether data is safe to embed in the outbound JSON envelope."""
+    stack = [(data, 0)]
+    try:
+        while stack:
+            value, depth = stack.pop()
+            if isinstance(value, str):
+                value.encode("utf-8")
+            elif isinstance(value, list):
+                if depth >= _MAX_STRUCTURED_JSON_DEPTH:
+                    return False
+                stack.extend((item, depth + 1) for item in value)
+            elif isinstance(value, dict):
+                if depth >= _MAX_STRUCTURED_JSON_DEPTH:
+                    return False
+                stack.extend((item, depth + 1) for pair in value.items() for item in pair)
+        encoded = json.dumps(data, ensure_ascii=False, allow_nan=False).encode("utf-8")
+    except (TypeError, ValueError, UnicodeEncodeError, RecursionError):
+        return False
+    return len(encoded) <= _MAX_STRUCTURED_JSON_BYTES
 
 
 def _artifact_parts(agent_text: str) -> list[dict]:
@@ -285,7 +308,8 @@ def _artifact_parts(agent_text: str) -> list[dict]:
             data = json.loads(payload)
         except (TypeError, ValueError, UnicodeEncodeError, RecursionError):
             continue
-        parts.append(data_part(data))
+        if _safe_structured_json(data):
+            parts.append(data_part(data))
     return parts
 
 

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -266,9 +266,9 @@ def data_part(data: Any, media_type: str = "application/json") -> dict:
 
 
 _JSON_FENCE_RE = re.compile(
-    r"(?m:^[ \t]{0,3}```json[ \t]*\r?\n)"
+    r"(?m:^[ ]{0,3}```json[ \t]*\r?\n)"
     r"(?P<payload>.*?)"
-    r"(?m:^[ \t]{0,3}```[ \t]*\r?$)",
+    r"(?m:^[ ]{0,3}```[ \t]*\r?$)",
     re.IGNORECASE | re.DOTALL,
 )
 

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -271,14 +271,18 @@ _JSON_FENCE_RE = re.compile(
     r"(?m:^[ ]{0,3}(?P=fence)\x60*[ \t]*\r?$)",
     re.IGNORECASE | re.DOTALL,
 )
+_MAX_STRUCTURED_JSON_BYTES = 1_048_576
 
 
 def _artifact_parts(agent_text: str) -> list[dict]:
     """Preserve reply text and expose valid fenced JSON as structured Parts."""
     parts = [text_part(agent_text)]
     for match in _JSON_FENCE_RE.finditer(agent_text):
+        payload = match.group("payload")
+        if len(payload.encode("utf-8")) > _MAX_STRUCTURED_JSON_BYTES:
+            continue
         try:
-            data = json.loads(match.group("payload"))
+            data = json.loads(payload)
         except (TypeError, ValueError):
             continue
         parts.append(data_part(data))

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -131,6 +131,16 @@ class TestStreamResponseFormat:
             {"text": reply, "mediaType": "text/plain"},
         ]
 
+    def test_artifact_update_keeps_deeply_nested_json_fence_as_text(self):
+        payload = "[" * 2_000 + "0" + "]" * 2_000
+        reply = f"```json\n{payload}\n```"
+
+        ev = protocol.artifact_update("task-json", "ctx-json", reply)
+
+        assert ev["artifactUpdate"]["artifact"]["parts"] == [
+            {"text": reply, "mediaType": "text/plain"},
+        ]
+
     def test_status_update_shape(self):
         ev = protocol.status_update("task-1", "ctx-1", protocol.STATE_WORKING)
         assert set(ev.keys()) == {"statusUpdate"}

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -116,6 +116,15 @@ class TestStreamResponseFormat:
             },
         ]
 
+    def test_artifact_update_keeps_tab_indented_closing_fence_as_text(self):
+        reply = 'Literal example:\n```json\n[1, 2, 3]\n\t```'
+
+        ev = protocol.artifact_update("task-json", "ctx-json", reply)
+
+        assert ev["artifactUpdate"]["artifact"]["parts"] == [
+            {"text": reply, "mediaType": "text/plain"},
+        ]
+
     def test_status_update_shape(self):
         ev = protocol.status_update("task-1", "ctx-1", protocol.STATE_WORKING)
         assert set(ev.keys()) == {"statusUpdate"}

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -132,7 +132,8 @@ class TestStreamResponseFormat:
         ]
 
     def test_artifact_update_keeps_deeply_nested_json_fence_as_text(self):
-        payload = "[" * 2_000 + "0" + "]" * 2_000
+        depth = protocol._MAX_STRUCTURED_JSON_DEPTH + 1
+        payload = "[" * depth + "0" + "]" * depth
         reply = f"```json\n{payload}\n```"
 
         ev = protocol.artifact_update("task-json", "ctx-json", reply)
@@ -140,6 +141,17 @@ class TestStreamResponseFormat:
         assert ev["artifactUpdate"]["artifact"]["parts"] == [
             {"text": reply, "mediaType": "text/plain"},
         ]
+
+    def test_artifact_update_serializes_unpaired_surrogate_json_as_text(self):
+        reply = '```json\n"\\ud800"\n```'
+
+        ev = protocol.artifact_update("task-json", "ctx-json", reply)
+        encoded = protocol.sse_data(ev, 7).encode("utf-8")
+
+        assert ev["artifactUpdate"]["artifact"]["parts"] == [
+            {"text": reply, "mediaType": "text/plain"},
+        ]
+        assert encoded
 
     def test_status_update_shape(self):
         ev = protocol.status_update("task-1", "ctx-1", protocol.STATE_WORKING)

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -104,13 +104,16 @@ def _send_body(text, ctx="", method="message/send"):
 
 class TestStreamResponseFormat:
     def test_artifact_update_exposes_fenced_json_as_structured_data(self):
-        reply = 'Summary\n```json\n[1, 2, 3]\n```'
+        reply = 'Summary\n```json\n[1, {"markdown": "```"}, 3]\n```'
 
         ev = protocol.artifact_update("task-json", "ctx-json", reply)
 
         assert ev["artifactUpdate"]["artifact"]["parts"] == [
             {"text": reply, "mediaType": "text/plain"},
-            {"data": [1, 2, 3], "mediaType": "application/json"},
+            {
+                "data": [1, {"markdown": "```"}, 3],
+                "mediaType": "application/json",
+            },
         ]
 
     def test_status_update_shape(self):

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -103,8 +103,14 @@ def _send_body(text, ctx="", method="message/send"):
 
 
 class TestStreamResponseFormat:
-    def test_artifact_update_exposes_fenced_json_as_structured_data(self):
-        reply = 'Summary\n````json\n[1, {"markdown": "```"}, 3]\n````'
+    @pytest.mark.parametrize("info_separator", ["", " ", "\t"])
+    def test_artifact_update_exposes_fenced_json_as_structured_data(
+        self, info_separator,
+    ):
+        reply = (
+            'Summary\n````'
+            f'{info_separator}json\n[1, {{"markdown": "```"}}, 3]\n````'
+        )
 
         ev = protocol.artifact_update("task-json", "ctx-json", reply)
 

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -103,6 +103,16 @@ def _send_body(text, ctx="", method="message/send"):
 
 
 class TestStreamResponseFormat:
+    def test_artifact_update_exposes_fenced_json_as_structured_data(self):
+        reply = 'Summary\n```json\n[1, 2, 3]\n```'
+
+        ev = protocol.artifact_update("task-json", "ctx-json", reply)
+
+        assert ev["artifactUpdate"]["artifact"]["parts"] == [
+            {"text": reply, "mediaType": "text/plain"},
+            {"data": [1, 2, 3], "mediaType": "application/json"},
+        ]
+
     def test_status_update_shape(self):
         ev = protocol.status_update("task-1", "ctx-1", protocol.STATE_WORKING)
         assert set(ev.keys()) == {"statusUpdate"}

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -104,7 +104,7 @@ def _send_body(text, ctx="", method="message/send"):
 
 class TestStreamResponseFormat:
     def test_artifact_update_exposes_fenced_json_as_structured_data(self):
-        reply = 'Summary\n```json\n[1, {"markdown": "```"}, 3]\n```'
+        reply = 'Summary\n````json\n[1, {"markdown": "```"}, 3]\n````'
 
         ev = protocol.artifact_update("task-json", "ctx-json", reply)
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -383,7 +383,7 @@ class TestV1Parts:
 
 class TestV1Task:
     def test_completed_task_exposes_fenced_json_as_structured_data(self):
-        reply = 'Result:\n```json\n{"answer": 42, "markdown": "```"}\n```'
+        reply = 'Result:\n```json\n{"answer": 42, "markdown": "```"}\n````'
 
         task = protocol.build_task("t-json", "c-json", protocol.STATE_COMPLETED, reply)
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -382,8 +382,14 @@ class TestV1Parts:
 
 
 class TestV1Task:
-    def test_completed_task_exposes_fenced_json_as_structured_data(self):
-        reply = 'Result:\n```json\n{"answer": 42, "markdown": "```"}\n````'
+    @pytest.mark.parametrize("info_separator", ["", " ", "\t"])
+    def test_completed_task_exposes_fenced_json_as_structured_data(
+        self, info_separator,
+    ):
+        reply = (
+            'Result:\n```'
+            f'{info_separator}json\n{{"answer": 42, "markdown": "```"}}\n````'
+        )
 
         task = protocol.build_task("t-json", "c-json", protocol.STATE_COMPLETED, reply)
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -410,6 +410,16 @@ class TestV1Task:
             {"text": reply, "mediaType": "text/plain"},
         ]
 
+    def test_completed_task_keeps_oversized_json_fence_as_text(self):
+        payload = json.dumps("x" * protocol._MAX_STRUCTURED_JSON_BYTES)
+        reply = f"```json\n{payload}\n```"
+
+        task = protocol.build_task("t-json", "c-json", protocol.STATE_COMPLETED, reply)
+
+        assert task["artifacts"][0]["parts"] == [
+            {"text": reply, "mediaType": "text/plain"},
+        ]
+
     def test_completed_task_shape(self):
         task = protocol.build_task("t1", "c1", protocol.STATE_COMPLETED, "the answer")
         assert task["status"]["state"] == "TASK_STATE_COMPLETED"

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -252,6 +252,12 @@ class TestAgentCardV1:
         assert "web_search" in web["tags"]
         assert "web_extract" in web["tags"]
 
+    def test_skills_advertise_supported_io_modes(self):
+        skills = protocol.skills_from_toolsets(["web"])
+
+        assert skills[0]["inputModes"] == ["text/plain", "application/json"]
+        assert skills[0]["outputModes"] == ["text/plain", "application/json"]
+
     def test_skills_default_when_empty(self):
         assert protocol.skills_from_toolsets([])[0]["id"] == "general"
         assert protocol.skills_from_toolsets({})[0]["id"] == "general"
@@ -376,6 +382,16 @@ class TestV1Parts:
 
 
 class TestV1Task:
+    def test_completed_task_exposes_fenced_json_as_structured_data(self):
+        reply = 'Result:\n```json\n{"answer": 42}\n```'
+
+        task = protocol.build_task("t-json", "c-json", protocol.STATE_COMPLETED, reply)
+
+        assert task["artifacts"][0]["parts"] == [
+            {"text": reply, "mediaType": "text/plain"},
+            {"data": {"answer": 42}, "mediaType": "application/json"},
+        ]
+
     def test_completed_task_shape(self):
         task = protocol.build_task("t1", "c1", protocol.STATE_COMPLETED, "the answer")
         assert task["status"]["state"] == "TASK_STATE_COMPLETED"

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -420,6 +420,16 @@ class TestV1Task:
             {"text": reply, "mediaType": "text/plain"},
         ]
 
+    def test_completed_task_keeps_deeply_nested_json_fence_as_text(self):
+        payload = "[" * 2_000 + "0" + "]" * 2_000
+        reply = f"```json\n{payload}\n```"
+
+        task = protocol.build_task("t-json", "c-json", protocol.STATE_COMPLETED, reply)
+
+        assert task["artifacts"][0]["parts"] == [
+            {"text": reply, "mediaType": "text/plain"},
+        ]
+
     def test_completed_task_shape(self):
         task = protocol.build_task("t1", "c1", protocol.STATE_COMPLETED, "the answer")
         assert task["status"]["state"] == "TASK_STATE_COMPLETED"

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -383,13 +383,16 @@ class TestV1Parts:
 
 class TestV1Task:
     def test_completed_task_exposes_fenced_json_as_structured_data(self):
-        reply = 'Result:\n```json\n{"answer": 42}\n```'
+        reply = 'Result:\n```json\n{"answer": 42, "markdown": "```"}\n```'
 
         task = protocol.build_task("t-json", "c-json", protocol.STATE_COMPLETED, reply)
 
         assert task["artifacts"][0]["parts"] == [
             {"text": reply, "mediaType": "text/plain"},
-            {"data": {"answer": 42}, "mediaType": "application/json"},
+            {
+                "data": {"answer": 42, "markdown": "```"},
+                "mediaType": "application/json",
+            },
         ]
 
     def test_completed_task_shape(self):

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -421,8 +421,18 @@ class TestV1Task:
         ]
 
     def test_completed_task_keeps_deeply_nested_json_fence_as_text(self):
-        payload = "[" * 2_000 + "0" + "]" * 2_000
+        depth = protocol._MAX_STRUCTURED_JSON_DEPTH + 1
+        payload = "[" * depth + "0" + "]" * depth
         reply = f"```json\n{payload}\n```"
+
+        task = protocol.build_task("t-json", "c-json", protocol.STATE_COMPLETED, reply)
+
+        assert task["artifacts"][0]["parts"] == [
+            {"text": reply, "mediaType": "text/plain"},
+        ]
+
+    def test_completed_task_keeps_unpaired_surrogate_json_as_text(self):
+        reply = '```json\n"\\ud800"\n```'
 
         task = protocol.build_task("t-json", "c-json", protocol.STATE_COMPLETED, reply)
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -395,6 +395,15 @@ class TestV1Task:
             },
         ]
 
+    def test_completed_task_keeps_tab_indented_json_fence_as_text(self):
+        reply = 'Literal example:\n\t```json\n{"answer": 42}\n\t```'
+
+        task = protocol.build_task("t-json", "c-json", protocol.STATE_COMPLETED, reply)
+
+        assert task["artifacts"][0]["parts"] == [
+            {"text": reply, "mediaType": "text/plain"},
+        ]
+
     def test_completed_task_shape(self):
         task = protocol.build_task("t1", "c1", protocol.STATE_COMPLETED, "the answer")
         assert task["status"]["state"] == "TASK_STATE_COMPLETED"


### PR DESCRIPTION
## Summary

- preserve the full textual reply while adding structured `data` Parts for valid fenced JSON in completed and streamed artifacts
- advertise `text/plain` and `application/json` input/output modes on every generated A2A skill
- retain the standard `JSONRPC` core binding token: A2A v1.0 defines URI identifiers for custom bindings, while the v1.0 proto, specification examples, and official SDK use `JSONRPC`

## Verification

- `scripts/run_tests.sh tests/plugins/test_a2a_plugin.py tests/plugins/test_a2a_phase23.py tests/plugins/test_a2a_schema_registration.py -k 'not forward_to_profile_first_contact_creates_then_resumes_fake_hermes' -q` (154 passed; excluded test also fails unchanged on `main` on Windows)
- `scripts/run_tests.sh tests/plugins/test_a2a_plugin.py tests/plugins/test_a2a_phase23.py -m integration -q` (17 passed)
- `a2a-sdk==1.1.0` ProtoJSON parsing accepted the generated Agent Card skill modes and completed Task data Part

Closes #91976
