### PR TITLE
fix(update): refuse ZIP fallback when the working tree is dirty

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1231,14 +1231,65 @@ def _write_gateway_update_exit_code(ok: bool) -> None:
         pass
 
 
+def _zip_overlay_block_reason(root: Path) -> Optional[str]:
+    """Why overlaying a ZIP onto ``root`` would destroy work, or None if safe.
+
+    The ZIP path swaps every top-level entry (except a tiny preserve set) and
+    then deletes the backups, so uncommitted edits and untracked files under
+    a replaced directory are gone. Fail closed when git status cannot run:
+    unknown dirtiness is not a license to clobber the tree (#91962).
+    """
+    if not (root / ".git").exists():
+        return None
+    git_cmd = ["git"]
+    if sys.platform == "win32":
+        git_cmd = ["git", "-c", "windows.appendAtomically=false"]
+    result = subprocess.run(
+        git_cmd + ["status", "--porcelain", "--untracked-files=all"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        suffix = f" ({detail[0]})" if detail else ""
+        return f"could not check the working tree{suffix}"
+    if result.stdout.strip():
+        return "the working tree has uncommitted changes or untracked files"
+    return None
+
+
+def _abort_zip_update_if_dirty_tree() -> None:
+    """Refuse to overlay a ZIP onto a dirty git checkout (#91962)."""
+    reason = _zip_overlay_block_reason(_m().PROJECT_ROOT)
+    if reason is None:
+        return
+    print(f"✗ ZIP fallback refused: {reason}.")
+    print(
+        "  Overlaying the ZIP would overwrite uncommitted edits and permanently "
+        "delete untracked files."
+    )
+    print(
+        "  Commit, stash, or clean up your local changes manually, then rerun "
+        "`hermes update`."
+    )
+    print("  To inspect: git status --porcelain")
+    _m().sys.exit(1)
+
+
 def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> bool:
     """Update Hermes Agent by downloading a ZIP archive.
 
     Used on Windows when git file I/O is broken (antivirus, NTFS filter
-    drivers causing 'Invalid argument' errors on file creation).
+    drivers causing 'Invalid argument' errors on file creation). Refuses to
+    overlay a dirty git checkout: the extract-over-working-tree path would
+    silently destroy uncommitted edits and then report success (#91962).
 
     Returns ``False`` when a Desktop rebuild ran and failed; ``True`` otherwise.
     """
+    _abort_zip_update_if_dirty_tree()
     active_tool_dependencies = _m()._capture_active_tool_dependencies()
 
     import tempfile

--- a/tests/hermes_cli/test_update_zip_dirty_tree.py
+++ b/tests/hermes_cli/test_update_zip_dirty_tree.py
@@ -1,0 +1,116 @@
+"""ZIP fallback must refuse a dirty checkout instead of silently clobbering it.
+
+Issue #91962: on Windows, ``_update_via_zip`` extracted a release archive
+over the working tree and moved HEAD. Uncommitted edits were overwritten,
+``git status`` went clean, and the update reported success. The git path
+already aborts when it cannot stash; the ZIP path must match that floor.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as hermes_main
+from hermes_cli import update_cmd
+
+
+def _porcelain_run(stdout: str, returncode: int = 0):
+    def fake_run(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+        if "status" in joined and "--porcelain" in joined:
+            return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    return fake_run
+
+
+def test_zip_overlay_allowed_without_git(tmp_path):
+    assert update_cmd._zip_overlay_block_reason(tmp_path) is None
+
+
+def test_zip_overlay_blocked_on_modified_file(tmp_path, monkeypatch):
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(
+        update_cmd.subprocess, "run", _porcelain_run(" M hermes_cli/update_cmd.py\n")
+    )
+    reason = update_cmd._zip_overlay_block_reason(tmp_path)
+    assert reason is not None
+    assert "uncommitted" in reason
+
+
+def test_zip_overlay_blocked_on_untracked_file(tmp_path, monkeypatch):
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(update_cmd.subprocess, "run", _porcelain_run("?? notes.md\n"))
+    reason = update_cmd._zip_overlay_block_reason(tmp_path)
+    assert reason is not None
+    assert "untracked" in reason
+
+
+def test_zip_overlay_blocked_when_git_status_fails(tmp_path, monkeypatch):
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(
+        update_cmd.subprocess,
+        "run",
+        _porcelain_run("", returncode=128),
+    )
+    reason = update_cmd._zip_overlay_block_reason(tmp_path)
+    assert reason is not None
+    assert "could not check" in reason
+
+
+def test_zip_overlay_allowed_on_clean_git_checkout(tmp_path, monkeypatch):
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(update_cmd.subprocess, "run", _porcelain_run(""))
+    assert update_cmd._zip_overlay_block_reason(tmp_path) is None
+
+
+def test_zip_status_asks_for_all_untracked_files(tmp_path, monkeypatch):
+    """A user-level status.showUntrackedFiles=no must not blind the guard."""
+    (tmp_path / ".git").mkdir()
+    seen = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append([str(c) for c in cmd])
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    assert update_cmd._zip_overlay_block_reason(tmp_path) is None
+    assert any("--untracked-files=all" in cmd for cmd in seen)
+
+
+def test_update_via_zip_aborts_before_download_when_dirty(
+    tmp_path, monkeypatch, capsys
+):
+    """The live tree must not be touched, and the ZIP must not be fetched."""
+    fake_root = tmp_path / "install"
+    fake_root.mkdir()
+    (fake_root / ".git").mkdir()
+    local = fake_root / "keep-me.txt"
+    local.write_text("local work\n", encoding="utf-8")
+    untracked_dir = fake_root / "agent" / "scratch"
+    untracked_dir.mkdir(parents=True)
+    (untracked_dir / "wip.py").write_text("print('wip')\n", encoding="utf-8")
+
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", fake_root)
+    monkeypatch.setattr(
+        update_cmd.subprocess,
+        "run",
+        _porcelain_run(" M keep-me.txt\n?? agent/scratch/wip.py\n"),
+    )
+
+    with patch("urllib.request.urlretrieve") as download:
+        with pytest.raises(SystemExit) as exc_info:
+            update_cmd._update_via_zip(SimpleNamespace(branch=None))
+
+    assert exc_info.value.code == 1
+    download.assert_not_called()
+    assert local.read_text(encoding="utf-8") == "local work\n"
+    assert (untracked_dir / "wip.py").read_text(encoding="utf-8") == "print('wip')\n"
+    out = capsys.readouterr().out
+    assert "ZIP fallback refused" in out
+    assert "Commit, stash, or clean up your local changes" in out
+    assert "Downloading latest version" not in out


### PR DESCRIPTION
## Summary
- On Windows, `hermes update` can fall back to a ZIP overlay that extracts over the working tree and then moves HEAD. Uncommitted local patches were overwritten with no warning, `git status` went clean, and the update reported success.
- The git path already aborts when it cannot stash ("Commit, stash, or clean up your local changes"). The ZIP path did none of that.
- Abort before download when `git status --porcelain --untracked-files=all` is dirty, or when status cannot be checked. Fail closed rather than clobber unknown work.

Fixes #91962

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_update_zip_dirty_tree.py` — dirty / untracked / status-failed trees abort; clean tree and non-git roots are allowed; overlay is refused before `urlretrieve`
- [x] `scripts/run_tests.sh tests/hermes_cli/test_update_zip_two_phase.py tests/hermes_cli/test_update_zip_symlink_reject.py` — existing ZIP path tests still pass
- [ ] On Windows with a dirty checkout, force the ZIP path (`hermes update` after git I/O breakage) and confirm it prints `ZIP fallback refused` and leaves local edits intact
