### PR TITLE
docs: document real env-key workflow and keyed local providers

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -654,8 +654,10 @@ model:
   default: your-model-name
   provider: custom
   base_url: http://localhost:8000/v1
-  api_key: your-key-or-leave-empty-for-local
+  api_key: ${env:MY_SERVER_API_KEY}   # reference a key stored in .env
 ```
+
+Local servers that require **no** key can omit `api_key` entirely (Hermes sends a `no-key-required` placeholder). When your server does require one — llama.cpp/llama-server builds with `--api-key`, vLLM behind an auth proxy, a gateway that enforces a bearer token — store the secret in `~/.hermes/.env` (e.g. `hermes config set MY_SERVER_API_KEY <key>`) and reference it with `${env:MY_SERVER_API_KEY}` as above. See [Environment Variable Substitution](/user-guide/configuration#environment-variable-substitution) for the full mechanics and the one-command rotation flow.
 
 :::warning Legacy env vars
 `LLM_MODEL` in `.env` is **removed** — `config.yaml` is the single source of truth for model and endpoint configuration. `OPENAI_BASE_URL` is still honored, but **only** for the `openai-api` provider (it overrides the OpenAI endpoint for direct API-key access). For other providers and custom endpoints, use `hermes model` or set `model.base_url` in `config.yaml` directly. If you have stale entries in your `.env`, they are automatically cleared on the next `hermes setup` or config migration.
@@ -1271,6 +1273,12 @@ providers:
   local:
     api: http://localhost:8080/v1
     # api_key omitted — Hermes uses "no-key-required" for keyless local servers
+  local-keyed:
+    api: http://127.0.0.1:8080/v1
+    api_key: ${env:LLAMACPP_API_KEY}   # inline key, resolved from .env
+    default_model: qwen3.8-27b
+    models: [qwen3.8-27b]
+    context_length: 262144
   work:
     api: https://gpu-server.internal.corp/v1
     key_env: CORP_API_KEY
@@ -1280,6 +1288,8 @@ providers:
     key_env: ANTHROPIC_PROXY_KEY
     transport: anthropic_messages  # for Anthropic-compatible proxies
 ```
+
+A local server that **does** require a key (llama.cpp with `--api-key`, vLLM behind auth) is the `local-keyed` shape: keep the secret in `.env` and reference it inline — the reference is expanded at config load, so the key itself never appears in `config.yaml`.
 
 Each entry accepts: `api` (the endpoint base URL — `base_url`/`url` are accepted aliases), `name` (optional display name; defaults to the dict key), `key_env` or inline `api_key` or `key_cmd` (see below), `transport` (`chat_completions` / `anthropic_messages` / `codex_responses`), `default_model`, `models`, `context_length`, `discover_models`, `extra_body`, `extra_headers`, `ssl_ca_cert` / `ssl_verify`, and `enabled: false` to hide an entry without deleting it.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -103,6 +103,29 @@ delegation:
 
 Multiple references in a single value work: `url: "${HOST}:${PORT}"`. If a referenced variable is not set, the placeholder is kept verbatim (`${UNDEFINED_VAR}` stays as-is) and a warning is logged. Bare `$VAR` is not expanded.
 
+### Recommended pattern: secrets in `.env`, references in `config.yaml`
+
+For provider keys — including local servers that require one — keep the secret in `~/.hermes/.env` and reference it from `config.yaml` instead of pasting the key into the config file:
+
+```bash
+# Bare key names (no dots) that look like secrets — ending in `_API_KEY`,
+# `_TOKEN`, or `_SECRET`, or on an internal allowlist (e.g. `TELEGRAM_BOT_TOKEN`,
+# `GITHUB_TOKEN`) — are saved to .env automatically:
+hermes config set LLAMACPP_API_KEY hq-...
+```
+
+```yaml
+# Then reference it anywhere in config.yaml (both ${VAR} and ${env:VAR} work):
+model:
+  api_key: ${env:LLAMACPP_API_KEY}
+```
+
+Dotted keys such as `model.api_key` are **not** auto-routed — `hermes config set model.api_key '${env:LLAMACPP_API_KEY}'` writes the reference verbatim into `config.yaml`, which is how you wire it up. Rotating the key later is one command: re-run the bare `hermes config set LLAMACPP_API_KEY <new-key>` and every `${env:LLAMACPP_API_KEY}` reference picks up the new value on the next config load.
+
+:::note Harmless startup warning
+Even when the variable **is** set in `.env`, some commands can print `Config ref '${env:NAME}': NAME is not set (check ~/.hermes/.env); keeping the literal placeholder` at startup. A few CLI paths take an early config snapshot before the env file is loaded into the process; the config cache detects the env file arriving and re-expands, so every later read — and the running agent — resolves the value correctly. Verify with `hermes config get model` (or a one-shot `hermes chat -q ...`): if the key resolves there, the warning is cosmetic.
+:::
+
 Cursor-style SecretRef syntax is also accepted: `${env:VAR_NAME}` resolves exactly like `${VAR_NAME}` (the `env:` prefix is stripped), so MCP or provider snippets copied from Cursor / Claude configs work unchanged in both `config.yaml` and the `mcp_servers` block. Other SecretRef sources (`${file:...}`, `${vault:...}`, `${bitwarden:...}`) are **not** resolved inline — external secret backends inject their values into the environment at startup via the `secrets:` block, so reference them as `${env:NAME}` instead; unknown prefixes warn once and stay verbatim.
 
 For AI provider setup (OpenRouter, Anthropic, Copilot, custom endpoints, self-hosted LLMs, fallback models, etc.), see [AI Providers](/integrations/providers).


### PR DESCRIPTION
Docs updated to match verified behavior (traced to source).

**user-guide/configuration.md**
- Recommended ${env:VAR} workflow: bare *_API_KEY keys auto-route to .env; dotted keys like model.api_key do not (store the reference verbatim in config.yaml).
- One-command key-rotation flow.
- A note explaining the harmless pre-dotenv startup warning (config snapshot taken before .env loads; env-snapshot cache re-expands next read) with a verification recipe.

**integrations/providers.md**
- Replaced the plaintext api_key example with the ${env:MY_SERVER_API_KEY} reference pattern; note covering keyless (no-key-required) vs keyed (llama.cpp --api-key, authed vLLM) local servers.
- Added a keyed local-server entry (llama.cpp with --api-key) alongside the existing keyless example.

Every claim traced to source before writing. 2 files changed, 34 insertions(+), 1 deletion(-).