### PR TITLE
fix(desktop): spare concurrently starting backends

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -838,6 +838,20 @@ def _lock_owned_serve_pids(base_dir: Path | None = None) -> set[int]:
     return owned
 
 
+# Grace window before an orphaned-looking backend may be reaped. Covers the
+# gap between process start and the Desktop client writing backend.lock.json.
+_REAP_MIN_AGE_SECONDS = 180.0
+
+
+def _process_age_seconds(pid: int) -> float:
+    """Return a process age using psutil's cross-platform start timestamp."""
+    import time as _time
+
+    import psutil as _psutil
+
+    return max(0.0, _time.time() - _psutil.Process(pid).create_time())
+
+
 def _reap_orphaned_desktop_local_serves(
     *,
     reason: str = "orphaned desktop-local hermes serve",
@@ -845,6 +859,7 @@ def _reap_orphaned_desktop_local_serves(
     signal_kill=None,
     sleep_fn=None,
     lock_owned_pids_fn=None,
+    process_age_seconds_fn=None,
 ) -> dict[str, list]:
     """Kill leftover Desktop-local ``hermes serve`` backends with no parent.
 
@@ -880,6 +895,8 @@ def _reap_orphaned_desktop_local_serves(
         sleep_fn = _time.sleep
     if lock_owned_pids_fn is None:
         lock_owned_pids_fn = _lock_owned_serve_pids
+    if process_age_seconds_fn is None:
+        process_age_seconds_fn = _process_age_seconds
 
     if sys.platform == "win32":
         # Windows desktop uses taskkill tree teardown; orphan scan here is POSIX.
@@ -925,6 +942,21 @@ def _reap_orphaned_desktop_local_serves(
             continue
         # Orphaned under init/launchd.
         if ppid not in (0, 1):
+            continue
+        # Spare backends that are still starting up. backend.lock.json is
+        # written by the *Desktop client* only after the backend reports
+        # HERMES_BACKEND_READY, so a sibling spawned seconds ago is not yet
+        # lock-owned and is invisible to the owned_now guard above. When
+        # Desktop opens several profiles at once (each its own SSH spawn),
+        # every new backend reaped its concurrently-starting siblings, whose
+        # clients then reconnected and reaped the next batch -- a mutual-reap
+        # storm. A genuine corpse from a previous Desktop session is always
+        # older than this grace window; anything younger is a live sibling.
+        try:
+            if process_age_seconds_fn(pid) < _REAP_MIN_AGE_SECONDS:
+                continue
+        except Exception:
+            # Never let a liveness probe failure widen the reap.
             continue
         targets.append((pid, cmd))
 

--- a/tests/hermes_cli/test_orphan_desktop_serve_reap.py
+++ b/tests/hermes_cli/test_orphan_desktop_serve_reap.py
@@ -84,6 +84,7 @@ def test_reap_only_kills_ppid1_local_serves():
             sleep_fn=lambda _s: None,
             signal_term=15,
             signal_kill=9,
+            process_age_seconds_fn=lambda _pid: 600.0,
         )
 
     assert set(result["matched"]) == {111, 444}
@@ -234,6 +235,7 @@ def test_reap_spare_lock_owned_ssh_remote_backend_of_foreign_client():
             signal_term=15,
             signal_kill=9,
             lock_owned_pids_fn=lambda: lock_owned,
+            process_age_seconds_fn=lambda _pid: 600.0,
         )
 
     # Only the genuine orphan (666) is reaped; the lock-owned remote (555) lives.
@@ -241,6 +243,107 @@ def test_reap_spare_lock_owned_ssh_remote_backend_of_foreign_client():
     assert set(terms) == {666}
     assert 555 not in terms
     assert set(result["killed"]) == {666}
+
+
+def test_reap_spares_young_backend_until_desktop_can_write_lock():
+    """A concurrently-starting sibling has no lock yet but is not an orphan."""
+    scanned = [(777, "hermes serve --isolated --host 127.0.0.1 --port 0")]
+    terms: list[int] = []
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            return None
+        if sig == 15:
+            terms.append(pid)
+        return None
+
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=scanned,
+        ),
+        patch("hermes_cli.dashboard_procs._process_ppid", return_value=1),
+        patch("os.kill", side_effect=fake_kill),
+        patch("sys.platform", "darwin"),
+    ):
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            process_age_seconds_fn=lambda _pid: 2.0,
+        )
+
+    assert result["matched"] == []
+    assert result["killed"] == []
+    assert terms == []
+
+
+def test_reap_spares_backend_when_process_age_is_unknown():
+    scanned = [(778, "hermes serve --isolated --host 127.0.0.1 --port 0")]
+    terms: list[int] = []
+
+    def fake_age(_pid):
+        raise RuntimeError("process disappeared during age probe")
+
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=scanned,
+        ),
+        patch("hermes_cli.dashboard_procs._process_ppid", return_value=1),
+        patch("os.kill", side_effect=lambda pid, sig: terms.append(pid) if sig == 15 else None),
+        patch("sys.platform", "darwin"),
+    ):
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            process_age_seconds_fn=fake_age,
+        )
+
+    assert result["matched"] == []
+    assert result["killed"] == []
+    assert terms == []
+
+
+def test_reap_age_boundary_makes_180_second_orphan_eligible():
+    scanned = [
+        (779, "hermes serve --isolated --host 127.0.0.1 --port 0"),
+        (780, "hermes serve --isolated --host 127.0.0.1 --port 0"),
+    ]
+    terms: list[int] = []
+    live = {779, 780}
+
+    def fake_kill(pid, sig):
+        if sig == 0:
+            if pid in live:
+                return None
+            raise ProcessLookupError()
+        if sig == 15:
+            terms.append(pid)
+            live.discard(pid)
+        return None
+
+    ages = {779: 179.999, 780: 180.0}
+    with (
+        patch(
+            "hermes_cli.dashboard_procs._scan_dashboard_processes",
+            return_value=scanned,
+        ),
+        patch("hermes_cli.dashboard_procs._process_ppid", return_value=1),
+        patch("os.kill", side_effect=fake_kill),
+        patch("sys.platform", "darwin"),
+    ):
+        result = _reap_orphaned_desktop_local_serves(
+            sleep_fn=lambda _s: None,
+            signal_term=15,
+            signal_kill=9,
+            process_age_seconds_fn=lambda pid: ages[pid],
+        )
+
+    assert result["matched"] == [780]
+    assert result["killed"] == [780]
+    assert terms == [780]
 
 
 def test_reap_spare_lock_owned_backend_even_without_exclude_match(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Prevents concurrently starting Desktop profile backends from reaping each other before Electron has written their `backend.lock.json` files.

Bot Mode can start several SSH-hosted profile backends within the same second. Each backend announces `HERMES_BACKEND_READY` before the Desktop client persists its lock. During that registration gap, sibling startup orphan scans see a PPID-1 `hermes serve --host 127.0.0.1 --port 0` process with no lock owner and kill it. The client reconnects, the next batch repeats the race, and killed turns may leave session-turn leases behind.

In a live multi-profile deployment this produced repeated backend reap/reconnect cycles, hundreds of SSH connections in short bursts, and multi-minute waits on leases held by dead processes.

This change adds a bounded 180-second minimum process age before an unowned backend is eligible for orphan reaping. If age cannot be determined, cleanup fails closed and spares the process. Existing lock ownership, PPID and command-shape checks remain unchanged.

## Related Issue

Fixes #92008

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/dashboard_procs.py`
  - Add a 180-second startup grace period for orphan-looking Desktop backends.
  - Use an injectable process-age probe for deterministic tests.
  - Preserve fail-closed behavior when process age cannot be read.
- `tests/hermes_cli/test_orphan_desktop_serve_reap.py`
  - Keep old-orphan and lock-owned scenarios explicitly old enough to reap.
  - Add regression coverage for young concurrent siblings.
  - Add unknown-age fail-closed coverage.
  - Add exact 180-second boundary coverage.

## How to Test

1. Run the focused race/reaper suite:
   ```bash
   pytest tests/hermes_cli/test_orphan_desktop_serve_reap.py -q
   ```
   Expected: `11 passed`.
2. Run directly dependent files in isolated processes, matching the repository's preferred per-file isolation:
   ```bash
   pytest tests/hermes_cli/test_update_stale_dashboard.py -q
   pytest tests/hermes_cli/test_lazy_command_exports.py -q
   ```
   Expected: `35 passed, 2 skipped` and `3 passed`.
3. Start several named Desktop profile backends concurrently over SSH. Backends younger than 180 seconds must survive until their lock files are registered; genuinely old, unowned PPID-1 backends remain reapable.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs and issues for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run the full `pytest tests/ -q` suite
- [x] I've added regression tests for the bug
- [x] I've tested on Ubuntu 24.04 with Windows and macOS Desktop SSH clients

### Documentation & Housekeeping

- [x] Documentation changes are N/A; the safety contract is documented in code and tests
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact was considered; the reap remains POSIX-only and Windows keeps its existing early return
- [x] Tool descriptions/schemas are N/A

## Verification

- Focused suite: **11 passed**
- Other directly dependent test files: **38 passed, 2 skipped**
- `py_compile`: passed
- `git diff --check`: passed
- Static secret/injection scan of added lines: clean
- Independent review: passed with no security concerns or logic errors

A combined same-process run of the three test files reproduces an existing import-identity failure in `test_lazy_command_exports.py`; the same failure occurs on clean `origin/main`. Running the files independently, as the repository's preferred test runner does, is green.
