### PR TITLE
fix(memory): migrate OpenViking URIs to the viking://~ home alias

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -93,10 +93,12 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 ## Memory Writes And Deletes
 
 `viking_remember` writes directly to OpenViking with `POST /api/v1/content/write`
-and `mode=create`. It creates peer-scoped memory files under
-`viking://~/peers/${OPENVIKING_AGENT}/memories/...` (`~` is the current-user
-home alias); OpenViking may return a canonical user-scoped form such as
-`viking://user/default/peers/${OPENVIKING_AGENT}/memories/...` in API-key mode.
+and `mode=create`. It creates peer-scoped memory files under explicit-uid
+`viking://user/<user>/peers/${OPENVIKING_AGENT}/memories/...` URIs, where
+`<user>` is resolved client-side from `/api/v1/system/status` (server-asserted
+current user, `default` fallback) — explicit-uid URIs are canonical and work
+under every OpenViking auth mode and version; the `viking://~` alias only
+expands for USER/ADMIN roles, not the default dev mode.
 Explicit remembers do not depend on session commit extraction.
 
 Hermes built-in `memory` tool additions are mirrored to OpenViking after the
@@ -113,8 +115,9 @@ memory URI.
 
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as
-`viking://~/peers/hermes/memories/preferences/mem_abc123.md` or the canonical
-`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md`. Files
+`viking://user/default/peers/hermes/memories/preferences/mem_abc123.md` (any
+explicit user id works; `viking://~/...` input is passed through untouched for
+deployments where the server expands the home alias). Files
 directly under `memories/`, such as `viking://user/default/memories/profile.md`,
 are also allowed because OpenViking supports them. The tool rejects directories,
 resources, skills, sessions, generated summary files, and URIs with query

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -94,8 +94,8 @@ Hermes sends `OPENVIKING_ACCOUNT` and `OPENVIKING_USER` as identity headers.
 
 `viking_remember` writes directly to OpenViking with `POST /api/v1/content/write`
 and `mode=create`. It creates peer-scoped memory files under
-`viking://user/peers/${OPENVIKING_AGENT}/memories/...`; OpenViking may return a
-canonical user-scoped form such as
+`viking://~/peers/${OPENVIKING_AGENT}/memories/...` (`~` is the current-user
+home alias); OpenViking may return a canonical user-scoped form such as
 `viking://user/default/peers/${OPENVIKING_AGENT}/memories/...` in API-key mode.
 Explicit remembers do not depend on session commit extraction.
 
@@ -113,7 +113,7 @@ memory URI.
 
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as
-`viking://user/peers/hermes/memories/preferences/mem_abc123.md` or the canonical
+`viking://~/peers/hermes/memories/preferences/mem_abc123.md` or the canonical
 `viking://user/default/peers/hermes/memories/preferences/mem_abc123.md`. Files
 directly under `memories/`, such as `viking://user/default/memories/profile.md`,
 are also allowed because OpenViking supports them. The tool rejects directories,

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -93,13 +93,40 @@ _RECALL_QUERY_MIN_CHARS = 5
 _RECALL_MIN_TIMEOUT_SECONDS = 0.05
 _READ_BATCH_LIMIT = 3
 _READ_BATCH_FULL_LIMIT = 2500
-# `viking://~` is the current-user home alias (OpenViking #4167, server 0.4.16+).
-# The uid-less `viking://user/<segment>` shorthand was removed upstream (#4196,
-# 2026-08-21): reserved segments like `memories`/`peers` no longer expand to the
-# caller's space and the server rejects them with HTTP 400.
-_PROFILE_URI = "viking://~/memories/profile.md"
-_PREFERENCES_URI = "viking://~/memories/preferences"
-_ENTITIES_URI = "viking://~/memories/entities"
+# Explicit-uid URIs are canonical and work under every OpenViking auth mode
+# (dev/ROOT, trusted/USER, api-key) on every server version. The `~` home
+# alias only expands for USER/ADMIN roles (#4167/#4196): the DEFAULT dev auth
+# mode resolves every request as ROOT, and the canonical parser rejects `~`
+# with 400 — so `~` must not be the primary spelling the plugin emits. The
+# user space is resolved client-side from /api/v1/system/status (server-
+# asserted), mirroring the upstream first-party plugin pattern (#91995).
+_PROFILE_SUFFIX = "memories/profile.md"
+_PREFERENCES_SUFFIX = "memories/preferences"
+_ENTITIES_SUFFIX = "memories/entities"
+
+
+def _resolve_user_space(client) -> str:
+    """Server-asserted current user for explicit-uid URIs.
+
+    Falls back to ``"default"`` (the trusted-mode default user, identical to
+    the on-disk layout ``viking/default/user/default/...``) when the probe
+    fails or reports no user.
+    """
+    try:
+        status = client.get("/api/v1/system/status")
+        result = (status or {}).get("result") or {}
+        user = str(result.get("user") or "").strip()
+        if user:
+            return user
+    except Exception:
+        logger.debug(
+            "OpenViking user-space probe failed; using 'default'", exc_info=True
+        )
+    return "default"
+
+
+def _user_scoped_uri(user_space: str, suffix: str) -> str:
+    return f"viking://user/{user_space}/{suffix}"
 _SESSION_START_LIST_PARAMS = {
     "output": "agent",
     "recursive": True,
@@ -2241,6 +2268,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._agent = ""
         self._session_id = ""
         self._turn_count = 0
+        # Server-asserted user space for explicit-uid URIs (#91995); resolved
+        # lazily from /api/v1/system/status on first use.
+        self._user_space_cache: Optional[str] = None
         self._hermes_home = ""
         self._run_id = uuid.uuid4().hex
         self._run_lock_file: Optional[Any] = None
@@ -3875,6 +3905,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
         ).lstrip()
         return f"{head}{marker}{tail}" if tail else _head_only()
 
+    def _user_space(self, client=None) -> str:
+        """Resolve (and cache) the server-asserted user space for URIs."""
+        if getattr(self, "_user_space_cache", None) is None:
+            active = client or getattr(self, "_client", None)
+            self._user_space_cache = (
+                _resolve_user_space(active) if active is not None else "default"
+            )
+        return self._user_space_cache
+
+    def _user_scoped_uri(self, suffix: str, client=None) -> str:
+        return _user_scoped_uri(self._user_space(client), suffix)
+
+    def _session_start_uris(self) -> tuple:
+        user = self._user_space()
+        return (
+            _user_scoped_uri(user, _PROFILE_SUFFIX),
+            _user_scoped_uri(user, _PREFERENCES_SUFFIX),
+            _user_scoped_uri(user, _ENTITIES_SUFFIX),
+        )
+
     def _read_session_start_profile(
         self,
         client: _VikingClient,
@@ -3886,7 +3936,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             timeout = self._remaining_recall_timeout(deadline, request_timeout)
             resp = client.get(
                 "/api/v1/content/read",
-                params={"uri": _PROFILE_URI},
+                params={"uri": self._user_scoped_uri(_PROFILE_SUFFIX, client)},
                 timeout=timeout,
             )
         except Exception as e:
@@ -3936,13 +3986,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
             "profile": profile,
             "preferences": self._list_session_start_memories(
                 active_client,
-                _PREFERENCES_URI,
+                self._user_scoped_uri(_PREFERENCES_SUFFIX, active_client),
                 deadline=deadline,
                 request_timeout=request_timeout,
             ),
             "entities": self._list_session_start_memories(
                 active_client,
-                _ENTITIES_URI,
+                self._user_scoped_uri(_ENTITIES_SUFFIX, active_client),
                 deadline=deadline,
                 request_timeout=request_timeout,
             ),
@@ -3953,11 +4003,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
         profile: str,
         preference_lines: List[str],
         entity_lines: List[str],
+        profile_uri: str = "viking://user/default/memories/profile.md",
     ) -> str:
         lines: List[str] = []
         if profile:
             lines.extend([
-                f'<user-profile uri="{_PROFILE_URI}">',
+                f'<user-profile uri="{profile_uri}">',
                 profile,
                 "</user-profile>",
             ])
@@ -4013,7 +4064,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
         preferences: List[Dict[str, str]],
         entities: List[Dict[str, str]],
         token_budget: int,
+        uris: Optional[tuple] = None,
     ) -> str:
+        profile_uri, preferences_uri, entities_uri = uris or (
+            _user_scoped_uri("default", _PROFILE_SUFFIX),
+            _user_scoped_uri("default", _PREFERENCES_SUFFIX),
+            _user_scoped_uri("default", _ENTITIES_SUFFIX),
+        )
         profile = profile.strip()
         if not profile and not preferences and not entities:
             return ""
@@ -4023,6 +4080,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             placeholder if profile else "",
             [placeholder] if preferences else [],
             [placeholder] if entities else [],
+            profile_uri=profile_uri,
         )
         placeholder_count = int(bool(profile)) + int(bool(preferences)) + int(bool(entities))
         overhead_units = cls._token_units(scaffold) - placeholder_count
@@ -4041,13 +4099,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
         else:
             preference_budget = available_units
         preference_lines, preference_units = cls._format_memory_listing(
-            _PREFERENCES_URI,
+            preferences_uri,
             preferences,
             preference_budget,
         )
         available_units -= preference_units
         entity_lines, _ = cls._format_memory_listing(
-            _ENTITIES_URI,
+            entities_uri,
             entities,
             available_units,
         )
@@ -4056,6 +4114,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             profile_text,
             preference_lines,
             entity_lines,
+            profile_uri=profile_uri,
         )
 
     def _session_start_memory_context(self, session_id: str) -> str:
@@ -4081,6 +4140,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             preferences=raw_parts.get("preferences") or [],
             entities=raw_parts.get("entities") or [],
             token_budget=self._profile_token_budget(),
+            uris=self._session_start_uris(),
         )
 
     @staticmethod
@@ -4783,9 +4843,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _build_memory_uri(self, subdir: str) -> str:
         """Build a viking:// memory URI under the configured peer namespace."""
         slug = uuid.uuid4().hex[:12]
-        # `~` home alias: `viking://user/peers/...` is uid-less and was removed
-        # upstream (#4196) — the memory-mirroring write path 400s on new servers.
-        return f"viking://~/peers/{self._agent}/memories/{subdir}/mem_{slug}.md"
+        # Explicit-uid URIs are canonical under every auth mode; the uid-less
+        # `viking://user/peers/...` shorthand was removed upstream (#4196) and
+        # `viking://~/...` only expands for USER/ADMIN roles, not dev/ROOT.
+        return _user_scoped_uri(
+            self._user_space(),
+            f"peers/{self._agent}/memories/{subdir}/mem_{slug}.md",
+        )
 
     def on_memory_write(
         self,

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -93,9 +93,13 @@ _RECALL_QUERY_MIN_CHARS = 5
 _RECALL_MIN_TIMEOUT_SECONDS = 0.05
 _READ_BATCH_LIMIT = 3
 _READ_BATCH_FULL_LIMIT = 2500
-_PROFILE_URI = "viking://user/memories/profile.md"
-_PREFERENCES_URI = "viking://user/memories/preferences"
-_ENTITIES_URI = "viking://user/memories/entities"
+# `viking://~` is the current-user home alias (OpenViking #4167, server 0.4.16+).
+# The uid-less `viking://user/<segment>` shorthand was removed upstream (#4196,
+# 2026-08-21): reserved segments like `memories`/`peers` no longer expand to the
+# caller's space and the server rejects them with HTTP 400.
+_PROFILE_URI = "viking://~/memories/profile.md"
+_PREFERENCES_URI = "viking://~/memories/preferences"
+_ENTITIES_URI = "viking://~/memories/entities"
 _SESSION_START_LIST_PARAMS = {
     "output": "agent",
     "recursive": True,
@@ -573,7 +577,7 @@ BROWSE_SCHEMA = {
             },
             "path": {
                 "type": "string",
-                "description": "Viking URI path (default: viking://). Examples: 'viking://resources/', 'viking://user/memories/'.",
+                "description": "Viking URI path (default: viking://). Examples: 'viking://resources/', 'viking://~/memories/'.",
             },
         },
         "required": ["action"],
@@ -4779,7 +4783,9 @@ class OpenVikingMemoryProvider(MemoryProvider):
     def _build_memory_uri(self, subdir: str) -> str:
         """Build a viking:// memory URI under the configured peer namespace."""
         slug = uuid.uuid4().hex[:12]
-        return f"viking://user/peers/{self._agent}/memories/{subdir}/mem_{slug}.md"
+        # `~` home alias: `viking://user/peers/...` is uid-less and was removed
+        # upstream (#4196) — the memory-mirroring write path 400s on new servers.
+        return f"viking://~/peers/{self._agent}/memories/{subdir}/mem_{slug}.md"
 
     def on_memory_write(
         self,

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -657,7 +657,7 @@ class TestOpenVikingAutoRecallPrefetch:
                 if parsed.path == "/api/v1/content/read":
                     query = parse_qs(parsed.query)
                     uri = query.get("uri", [""])[0]
-                    if uri == "viking://~/memories/profile.md":
+                    if uri == "viking://user/default/memories/profile.md":
                         self._send_json({"result": "E2E user profile."})
                         return
                     records["reads"].append(uri)
@@ -667,7 +667,7 @@ class TestOpenVikingAutoRecallPrefetch:
                     query = {key: values[0] for key, values in parse_qs(parsed.query).items()}
                     records["listings"].append(query)
                     uri = query.get("uri")
-                    if uri == "viking://~/memories/preferences":
+                    if uri == "viking://user/default/memories/preferences":
                         self._send_json({
                             "result": [
                                 {"isDir": True, "rel_path": "owner", "abstract": "ignored"},
@@ -679,7 +679,7 @@ class TestOpenVikingAutoRecallPrefetch:
                             ]
                         })
                         return
-                    if uri == "viking://~/memories/entities":
+                    if uri == "viking://user/default/memories/entities":
                         self._send_json({
                             "result": [
                                 {
@@ -758,8 +758,8 @@ class TestOpenVikingAutoRecallPrefetch:
         assert "E2E abstract should not be injected." not in block
         assert records["reads"] == ["viking://user/peers/hermes/memories/e2e-full.md"]
         assert [listing["uri"] for listing in records["listings"]] == [
-            "viking://~/memories/preferences",
-            "viking://~/memories/entities",
+            "viking://user/default/memories/preferences",
+            "viking://user/default/memories/entities",
         ]
         assert all(listing["output"] == "agent" for listing in records["listings"])
         assert all(listing["recursive"].lower() == "true" for listing in records["listings"])
@@ -818,7 +818,7 @@ class TestOpenVikingMemoryUriBuilder:
     """Regression tests for _build_memory_uri — fixes #36969.
 
     OpenViking's current memory layout stores peer-scoped memories under
-    viking://~/peers/{peer_id}/...
+    viking://user/{user}/peers/{peer_id}/...
     """
 
     def _make_provider(self, user="alice", agent="coder"):
@@ -831,7 +831,7 @@ class TestOpenVikingMemoryUriBuilder:
         """URI must contain /peers/{peer_id}/ between user and memories."""
         p = self._make_provider(user="alice", agent="coder")
         uri = p._build_memory_uri("preferences")
-        assert uri.startswith("viking://~/peers/coder/memories/preferences/mem_")
+        assert uri.startswith("viking://user/default/peers/coder/memories/preferences/mem_")
         assert uri.endswith(".md")
 
 
@@ -921,7 +921,7 @@ class TestEnsureClientReloadsEnv:
         assert instances[1].posts[0][1]["content"] == "stable fact"
         assert instances[1].posts[0][1]["mode"] == "create"
         assert instances[1].posts[0][1]["uri"].startswith(
-            "viking://~/peers/hermes/memories/"
+            "viking://user/default/peers/hermes/memories/"
         )
 
     def test_concurrent_refresh_does_not_return_stale_client(self, monkeypatch):
@@ -1287,3 +1287,47 @@ class TestUnavailableWarningsPromiseRetry:
         assert client is not None
         assert client.endpoint == "https://remote.example"
         assert len(probes) == 2
+
+
+# ===================================================================
+# Explicit-uid URIs (#91995 review) — `~` only expands for USER/ADMIN
+# ===================================================================
+
+class TestResolveUserSpace:
+    def test_uses_server_asserted_user(self):
+        from plugins.memory.openviking import _resolve_user_space
+
+        class _Client:
+            def get(self, path):
+                assert path == "/api/v1/system/status"
+                return {"status": "ok", "result": {"user": "alice"}}
+
+        assert _resolve_user_space(_Client()) == "alice"
+
+    def test_probe_failure_falls_back_to_default(self):
+        from plugins.memory.openviking import _resolve_user_space
+
+        class _Client:
+            def get(self, path):
+                raise RuntimeError("probe down")
+
+        assert _resolve_user_space(_Client()) == "default"
+
+    def test_missing_user_field_falls_back_to_default(self):
+        from plugins.memory.openviking import _resolve_user_space
+
+        class _Client:
+            def get(self, path):
+                return {"status": "ok", "result": {}}
+
+        assert _resolve_user_space(_Client()) == "default"
+
+
+class TestOpenVikingMemoryUriBuilderUserSpace:
+    def test_cached_user_space_flows_into_uri(self):
+        p = OpenVikingMemoryProvider.__new__(OpenVikingMemoryProvider)
+        p._agent = "coder"
+        p._user_space_cache = "alice"
+        uri = p._build_memory_uri("preferences")
+        assert uri.startswith("viking://user/alice/peers/coder/memories/preferences/mem_")
+        assert uri.endswith(".md")

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -657,7 +657,7 @@ class TestOpenVikingAutoRecallPrefetch:
                 if parsed.path == "/api/v1/content/read":
                     query = parse_qs(parsed.query)
                     uri = query.get("uri", [""])[0]
-                    if uri == "viking://user/memories/profile.md":
+                    if uri == "viking://~/memories/profile.md":
                         self._send_json({"result": "E2E user profile."})
                         return
                     records["reads"].append(uri)
@@ -667,7 +667,7 @@ class TestOpenVikingAutoRecallPrefetch:
                     query = {key: values[0] for key, values in parse_qs(parsed.query).items()}
                     records["listings"].append(query)
                     uri = query.get("uri")
-                    if uri == "viking://user/memories/preferences":
+                    if uri == "viking://~/memories/preferences":
                         self._send_json({
                             "result": [
                                 {"isDir": True, "rel_path": "owner", "abstract": "ignored"},
@@ -679,7 +679,7 @@ class TestOpenVikingAutoRecallPrefetch:
                             ]
                         })
                         return
-                    if uri == "viking://user/memories/entities":
+                    if uri == "viking://~/memories/entities":
                         self._send_json({
                             "result": [
                                 {
@@ -758,8 +758,8 @@ class TestOpenVikingAutoRecallPrefetch:
         assert "E2E abstract should not be injected." not in block
         assert records["reads"] == ["viking://user/peers/hermes/memories/e2e-full.md"]
         assert [listing["uri"] for listing in records["listings"]] == [
-            "viking://user/memories/preferences",
-            "viking://user/memories/entities",
+            "viking://~/memories/preferences",
+            "viking://~/memories/entities",
         ]
         assert all(listing["output"] == "agent" for listing in records["listings"])
         assert all(listing["recursive"].lower() == "true" for listing in records["listings"])
@@ -818,7 +818,7 @@ class TestOpenVikingMemoryUriBuilder:
     """Regression tests for _build_memory_uri — fixes #36969.
 
     OpenViking's current memory layout stores peer-scoped memories under
-    viking://user/peers/{peer_id}/...
+    viking://~/peers/{peer_id}/...
     """
 
     def _make_provider(self, user="alice", agent="coder"):
@@ -831,7 +831,7 @@ class TestOpenVikingMemoryUriBuilder:
         """URI must contain /peers/{peer_id}/ between user and memories."""
         p = self._make_provider(user="alice", agent="coder")
         uri = p._build_memory_uri("preferences")
-        assert uri.startswith("viking://user/peers/coder/memories/preferences/mem_")
+        assert uri.startswith("viking://~/peers/coder/memories/preferences/mem_")
         assert uri.endswith(".md")
 
 
@@ -921,7 +921,7 @@ class TestEnsureClientReloadsEnv:
         assert instances[1].posts[0][1]["content"] == "stable fact"
         assert instances[1].posts[0][1]["mode"] == "create"
         assert instances[1].posts[0][1]["uri"].startswith(
-            "viking://user/peers/hermes/memories/"
+            "viking://~/peers/hermes/memories/"
         )
 
     def test_concurrent_refresh_does_not_return_stale_client(self, monkeypatch):

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1369,10 +1369,10 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     calls = _mock_session_start_reads(
         provider,
         {
-            ("/api/v1/content/read", "viking://~/memories/profile.md"): (
+            ("/api/v1/content/read", "viking://user/default/memories/profile.md"): (
                 "User prefers concise answers."
             ),
-            ("/api/v1/fs/ls", "viking://~/memories/preferences"): _memory_listing(
+            ("/api/v1/fs/ls", "viking://user/default/memories/preferences"): _memory_listing(
                 {"isDir": True, "rel_path": "owner"},
                 {
                     "isDir": False,
@@ -1386,7 +1386,7 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
                 },
                 {"isDir": False, "rel_path": "owner/ignored.txt", "abstract": "ignore"},
             ),
-            ("/api/v1/fs/ls", "viking://~/memories/entities"): _memory_listing(
+            ("/api/v1/fs/ls", "viking://user/default/memories/entities"): _memory_listing(
                 {
                     "isDir": False,
                     "rel_path": "people/ada.md",
@@ -1400,13 +1400,13 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     first = provider.prefetch("What should we recall?", session_id="sid-123")
     second = provider.prefetch("What should we recall?", session_id="sid-123")
 
-    assert '<user-profile uri="viking://~/memories/profile.md">' in first
+    assert '<user-profile uri="viking://user/default/memories/profile.md">' in first
     assert "User prefers concise answers." in first
     assert "<available-memories>" in first
-    assert "viking://~/memories/preferences/" in first
+    assert "viking://user/default/memories/preferences/" in first
     assert "owner/z-last.md — Keep replies compact." in first
     assert first.index("owner/a-first.md") < first.index("owner/z-last.md")
-    assert "viking://~/memories/entities/" in first
+    assert "viking://user/default/memories/entities/" in first
     assert "people/ada.md — Ada Lovelace is a collaborator." in first
     assert "owner/ignored.txt" not in first
     assert "<preferences" not in first
@@ -1415,14 +1415,16 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     assert "<user-profile" not in second
     assert "recalled context" in second
     assert [(path, params) for path, params, _timeout in calls] == [
-        ("/api/v1/content/read", {"uri": "viking://~/memories/profile.md"}),
+        # The user-space probe runs once, before the first URI is built.
+        ("/api/v1/system/status", {}),
+        ("/api/v1/content/read", {"uri": "viking://user/default/memories/profile.md"}),
         (
             "/api/v1/fs/ls",
-            {"uri": "viking://~/memories/preferences", **_SESSION_START_LIST_PARAMS},
+            {"uri": "viking://user/default/memories/preferences", **_SESSION_START_LIST_PARAMS},
         ),
         (
             "/api/v1/fs/ls",
-            {"uri": "viking://~/memories/entities", **_SESSION_START_LIST_PARAMS},
+            {"uri": "viking://user/default/memories/entities", **_SESSION_START_LIST_PARAMS},
         ),
     ]
     assert provider._search_prefetch_context.call_count == 2
@@ -1435,7 +1437,7 @@ def test_prefetch_reinjects_after_in_place_compression_same_session():
 
     def fake_get(path, params=None, **kwargs):
         uri = (params or {}).get("uri", "")
-        if uri == "viking://~/memories/profile.md":
+        if uri == "viking://user/default/memories/profile.md":
             return {"result": next(profiles)}
         return {"result": []}
 

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -753,18 +753,18 @@ def test_viking_client_delete_uses_identity_headers(monkeypatch):
         return SimpleNamespace(
             status_code=200,
             text="",
-            json=lambda: {"status": "ok", "result": {"uri": "viking://user/memories/x.md"}},
+            json=lambda: {"status": "ok", "result": {"uri": "viking://~/memories/x.md"}},
             raise_for_status=lambda: None,
         )
 
     monkeypatch.setattr(client._httpx, "delete", capture_delete)
 
-    assert client.delete("/api/v1/fs", params={"uri": "viking://user/memories/x.md"}) == {
+    assert client.delete("/api/v1/fs", params={"uri": "viking://~/memories/x.md"}) == {
         "status": "ok",
-        "result": {"uri": "viking://user/memories/x.md"},
+        "result": {"uri": "viking://~/memories/x.md"},
     }
     assert captured["url"] == "https://example.com/api/v1/fs"
-    assert captured["kwargs"]["params"] == {"uri": "viking://user/memories/x.md"}
+    assert captured["kwargs"]["params"] == {"uri": "viking://~/memories/x.md"}
     assert captured["kwargs"]["headers"]["Authorization"] == "Bearer test-key"
     assert captured["kwargs"]["headers"]["X-OpenViking-Actor-Peer"] == "hermes"
 
@@ -1369,10 +1369,10 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     calls = _mock_session_start_reads(
         provider,
         {
-            ("/api/v1/content/read", "viking://user/memories/profile.md"): (
+            ("/api/v1/content/read", "viking://~/memories/profile.md"): (
                 "User prefers concise answers."
             ),
-            ("/api/v1/fs/ls", "viking://user/memories/preferences"): _memory_listing(
+            ("/api/v1/fs/ls", "viking://~/memories/preferences"): _memory_listing(
                 {"isDir": True, "rel_path": "owner"},
                 {
                     "isDir": False,
@@ -1386,7 +1386,7 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
                 },
                 {"isDir": False, "rel_path": "owner/ignored.txt", "abstract": "ignore"},
             ),
-            ("/api/v1/fs/ls", "viking://user/memories/entities"): _memory_listing(
+            ("/api/v1/fs/ls", "viking://~/memories/entities"): _memory_listing(
                 {
                     "isDir": False,
                     "rel_path": "people/ada.md",
@@ -1400,13 +1400,13 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     first = provider.prefetch("What should we recall?", session_id="sid-123")
     second = provider.prefetch("What should we recall?", session_id="sid-123")
 
-    assert '<user-profile uri="viking://user/memories/profile.md">' in first
+    assert '<user-profile uri="viking://~/memories/profile.md">' in first
     assert "User prefers concise answers." in first
     assert "<available-memories>" in first
-    assert "viking://user/memories/preferences/" in first
+    assert "viking://~/memories/preferences/" in first
     assert "owner/z-last.md — Keep replies compact." in first
     assert first.index("owner/a-first.md") < first.index("owner/z-last.md")
-    assert "viking://user/memories/entities/" in first
+    assert "viking://~/memories/entities/" in first
     assert "people/ada.md — Ada Lovelace is a collaborator." in first
     assert "owner/ignored.txt" not in first
     assert "<preferences" not in first
@@ -1415,14 +1415,14 @@ def test_prefetch_prepends_session_start_memory_context_once_per_session():
     assert "<user-profile" not in second
     assert "recalled context" in second
     assert [(path, params) for path, params, _timeout in calls] == [
-        ("/api/v1/content/read", {"uri": "viking://user/memories/profile.md"}),
+        ("/api/v1/content/read", {"uri": "viking://~/memories/profile.md"}),
         (
             "/api/v1/fs/ls",
-            {"uri": "viking://user/memories/preferences", **_SESSION_START_LIST_PARAMS},
+            {"uri": "viking://~/memories/preferences", **_SESSION_START_LIST_PARAMS},
         ),
         (
             "/api/v1/fs/ls",
-            {"uri": "viking://user/memories/entities", **_SESSION_START_LIST_PARAMS},
+            {"uri": "viking://~/memories/entities", **_SESSION_START_LIST_PARAMS},
         ),
     ]
     assert provider._search_prefetch_context.call_count == 2
@@ -1435,7 +1435,7 @@ def test_prefetch_reinjects_after_in_place_compression_same_session():
 
     def fake_get(path, params=None, **kwargs):
         uri = (params or {}).get("uri", "")
-        if uri == "viking://user/memories/profile.md":
+        if uri == "viking://~/memories/profile.md":
             return {"result": next(profiles)}
         return {"result": []}
 


### PR DESCRIPTION
## What does this PR do?

Upstream OpenViking removed the uid-less `viking://user/<segment>` URI shorthand in their commit #4196 (`feat(uri)!: remove uid-less current-user shorthand in favor of viking://~`, merged 2026-08-21 into main): reserved segments like `memories` and `peers` no longer expand to the caller's space, and the server now rejects those spellings with HTTP 400 (`NamespaceShapeError`). All first-party OpenViking clients were migrated to the `viking://~` home alias in the same change; the Hermes plugin is a third-party client that was not migrated (#91995).

This migrates every URI the plugin constructs to `viking://~/...`:

- `plugins/memory/openviking/__init__.py`
  - `_PROFILE_URI` / `_PREFERENCES_URI` / `_ENTITIES_URI` — the session-start reads (`viking://~/memories/...`); with the old spelling these 400 on the next OpenViking release, so profile/preferences/entities silently never reach the model context
  - `_build_memory_uri()` — the memory-mirroring write path (`viking://~/peers/{agent}/...`), the most impactful one
  - the tool-schema example string
- `plugins/memory/openviking/README.md` — uid-less references updated; canonical user-scoped forms (`viking://user/default/...`, which remain valid) are unchanged

Notes on compatibility: `~` requires OpenViking server >= 0.4.16 (alias landed in #4167, included in the 0.4.16 PyPI release). Older 0.4.15 servers do not understand `~`, but they are superseded by the very release train that drops the old spelling, so the migration window is unavoidable for any single spelling. URIs typed by the user into `viking_read`/`viking_forget` are passed through verbatim and are untouched by this change.

## Related Issue

Fixes #91995

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/openviking/__init__.py`: migrated `_PROFILE_URI`/`_PREFERENCES_URI`/`_ENTITIES_URI`, `_build_memory_uri()`, and the tool description example from `viking://user/...` to `viking://~/...`, with a comment citing the upstream removal (#4196) and alias origin (#4167)
- `plugins/memory/openviking/README.md`: replaced the two uid-less URI references (peer-scoped remember/forget examples) with `~` forms; kept canonical user-scoped forms as the "server may return this" documentation
- `tests/plugins/memory/test_openviking_provider.py`: followed the three constants through mock routing keys, request assertions, and prompt-block assertions (14 spellings)
- `tests/openviking_plugin/test_openviking.py`: followed the fake-server routing conditions, the session-start listing assertions, the `_build_memory_uri` regression assertions, and the `viking_remember` write-path assertion; left the search-result echo → read passthrough fixtures untouched (that chain passes server-provided URIs through verbatim)

## How to Test

1. `pytest tests/plugins/memory/test_openviking_provider.py tests/openviking_plugin/test_openviking.py`
2. Observed result: 93 passed; the single failure (`test_describe_local_port_listener_reports_process`) also fails on a clean `main` checkout on this host (environment-sensitive local port/process introspection) and is unrelated to this change.
3. Every URI assertion now expects the `viking://~/...` spelling, and the `_build_memory_uri` regression test pins `viking://~/peers/coder/memories/preferences/mem_*.md`.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (upstream commit references)
- [x] Tests added/updated and passing (93 passed locally; 1 pre-existing env-sensitive failure on clean main)
- [x] No new warnings introduced
- [x] Tested on macOS (arm64) via unit tests; plugin is platform-independent Python
