### PR TITLE
fix(desktop): escape lone tildes and unknown html-like tokens in markdown prose

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.prose-safety.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.prose-safety.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { MarkdownTextContent } from './markdown-text'
+
+// Render-level regression for the prose-safety preprocessor fixes that landed
+// on 2026-08-22 (upstream #50871 lone-tilde strikethrough, #53953 unknown
+// html-like tokens swallowing the message tail). The preprocessor unit tests
+// in markdown-text.test.ts assert on the transformed string; these mount the
+// REAL production component and assert on the rendered DOM, so a wrapper that
+// stopped applying the preprocess cannot pass here.
+afterEach(cleanup)
+
+describe('markdown prose renders tilde ranges and unknown tags literally', () => {
+  it.each([
+    [
+      'CJK range list',
+      '分组：奇数 1~10,11~20，其余另列。',
+      (text: string) => {
+        expect(text).toContain('1~10,11~20')
+      }
+    ],
+    [
+      'approximation prefixes in one paragraph',
+      '收益为 3~5 倍，成本约 ~¥0.089。',
+      (text: string) => {
+        expect(text).toContain('3~5')
+        expect(text).toContain('~¥0.089')
+      }
+    ]
+  ])('renders %s without a strikethrough element', (_label, source, assertText) => {
+    const { container } = render(<MarkdownTextContent isRunning={false} text={source} />)
+
+    expect(container.querySelectorAll('del, s').length, `no strikethrough for: ${source}`).toBe(0)
+    assertText(container.textContent || '')
+  })
+
+  it('renders unknown html-like tokens as literal text and keeps the tail visible', () => {
+    const text =
+      'The proxy wraps calls in <tool_call> and results in <observation> blocks. ' +
+      'Keep the rest visible after the tag. The message tail must NOT vanish.'
+    const { container } = render(<MarkdownTextContent isRunning={false} text={text} />)
+
+    expect(container.textContent).toContain('<tool_call>')
+    expect(container.textContent).toContain('<observation>')
+    expect(container.textContent).toContain('The message tail must NOT vanish.')
+    expect(container.querySelector('tool_call')).toBeNull()
+    expect(container.querySelector('observation')).toBeNull()
+  })
+
+  it('leaves math comparisons untouched', () => {
+    const { container } = render(
+      <MarkdownTextContent isRunning={false} text={'如果 a < b 且 2<3 则原样保留。'} />
+    )
+
+    expect(container.textContent).toContain('a < b')
+    expect(container.textContent).toContain('2<3')
+  })
+
+  it('renders autolinks for urls (tilde-in-url is a streamdown remend quirk, asserted loosely)', () => {
+    const { container } = render(
+      <MarkdownTextContent isRunning={false} text={'Docs at https://example.com/a_b/c~d/page'} />
+    )
+
+    const link = container.querySelector('a')
+
+    expect(link).not.toBeNull()
+    // Streamdown's tailBoundedRemend escapes `~` even inside autolinks
+    // (pre-existing library behaviour, unchanged by this fix) — assert the link
+    // itself mounted and points at the host, not byte-exact URL round-trip.
+    expect(link?.getAttribute('href')).toContain('example.com')
+  })
+
+  it('still renders intentional ~~strikethrough~~', () => {
+    const { container } = render(<MarkdownTextContent isRunning={false} text={'保留 ~~deleted~~ 删除线。'} />)
+
+    expect(container.querySelectorAll('del, s').length).toBeGreaterThan(0)
+    expect(container.textContent).toContain('deleted')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -202,6 +202,58 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('<https://example.com/a_b/c~d/page>')
   })
 
+  it('escapes lone tildes in CJK ranges without touching strikethrough syntax', () => {
+    const output = preprocessMarkdown('Ranges: 1~10,11~20 and ~~deleted~~ text.')
+
+    expect(output).toContain('1\\~10,11\\~20')
+    expect(output).toContain('~~deleted~~')
+  })
+
+  it('escapes lone-tilde approximation prefixes so they cannot pair up mid-paragraph', () => {
+    const output = preprocessMarkdown('收益为 3~5 倍，成本约 ~¥0.089。')
+
+    expect(output).toContain('3\\~5 倍')
+    expect(output).toContain('\\~¥0.089')
+  })
+
+  it('does not escape lone tildes inside inline or fenced code', () => {
+    const input = ['Use `1~10` as a literal.', '', '```txt', '1~10,11~20', '```'].join('\n')
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toContain('`1~10`')
+    expect(output).toContain(['```txt', '1~10,11~20', '```'].join('\n'))
+  })
+
+  it('escapes unknown html-like prose tokens before they reach the renderer', () => {
+    const output = preprocessMarkdown(
+      'The proxy uses <tool_call> and <observation> blocks. Keep the rest of the sentence visible.'
+    )
+
+    expect(output).toContain(
+      'The proxy uses &lt;tool_call&gt; and &lt;observation&gt; blocks. Keep the rest of the sentence visible.'
+    )
+    expect(output).not.toContain('<tool_call>')
+    expect(output).not.toContain('<observation>')
+  })
+
+  it('preserves known html tags and autolinks while escaping unknown tags', () => {
+    const output = preprocessMarkdown(
+      'Use <strong>bold</strong> and visit https://example.com/page, then <span>ok</span> and <unk> text.'
+    )
+
+    expect(output).toContain('<strong>bold</strong>')
+    expect(output).toContain('<https://example.com/page>')
+    expect(output).toContain('<span>ok</span>')
+    expect(output).toContain('&lt;unk&gt;')
+  })
+
+  it('leaves math comparisons like a < b and 2<3 untouched', () => {
+    const output = preprocessMarkdown('If a < b and 2<3 then keep it as text.')
+
+    expect(output).toContain('a < b and 2<3')
+  })
+
   it('handles a fenced block larger than V8 spread-argument limit', () => {
     // A single huge code block (e.g. a logged minified bundle) used to throw
     // `RangeError: Maximum call stack size exceeded` via `out.push(...lines)`.

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -48,6 +48,27 @@ const RAW_URL_RE = /https?:\/\/[^\s<>"'`*]+[^\s<>"'`*.,;:!?]/g
 const LOCAL_PREVIEW_URL_RE = /(^|\s)https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?[^\s<>"'`]*/gi
 const LOCAL_PREVIEW_ONLY_RE = /^https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(?::\d+)?\/?$/i
 const URL_ONLY_LINE_RE = /^\s*https?:\/\/\S+\s*$/i
+// Autolink-shaped spans (bare or angle-bracketed http(s) URLs) that must be
+// skipped by lone-tilde escaping: `~` is legal in URL paths and must survive.
+const URL_LIKE_SPLIT_RE = /(<https?:\/\/[^>\s]+>|https?:\/\/[^\s<>"'`*]+[^\s<>"'`*.,;:!?])/g
+// A `~` that is neither part of `~~~` fence, part of `~~` strikethrough, nor
+// an already-escaped `\~`. Escaping it with `\~` makes `marked` render a
+// literal tilde, so CJK ranges (`1~10`) and approximation prefixes (`~¥0.089`)
+// no longer pair up into a GFM strikethrough span.
+const LONE_TILDE_RE = /(?<![\\~])~(?!~)/g
+// HTML-shaped prose tokens (`<tool_call>`, `<observation>`...) that are NOT
+// real inline elements get swallowed by the HTML-aware renderer (parse5 sees
+// an unclosed tag and consumes the rest of the message). Match unknown tag-like
+// runs and escape them to entities; known safe tags pass through untouched.
+const HTML_TAG_RE = /<\/?([A-Za-z][A-Za-z0-9:_-]*)(?:\s+[^<>]*?)?\/?>/g
+
+const SAFE_HTML_TAG_NAMES = new Set([
+  'a', 'abbr', 'b', 'blockquote', 'br', 'cite', 'code', 'data', 'del', 'details',
+  'div', 'em', 'figcaption', 'figure', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr',
+  'i', 'img', 'ins', 'kbd', 'li', 'mark', 'ol', 'p', 'pre', 'q', 'rp', 'rt',
+  'ruby', 's', 'samp', 'small', 'span', 'strong', 'sub', 'summary', 'sup', 'table',
+  'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'u', 'ul', 'var', 'wbr'
+])
 const CITATION_MARKER_RE = /(?<=[\p{L}\p{N})\].,!?:;"'”’])\[(?:\d+(?:\s*,\s*\d+)*)\](?!\()/gu
 // Markdown links whose target is a filesystem path on the agent's machine:
 // `[report](/home/user/report.md)`, `[notes](file:///srv/notes.txt)`,
@@ -173,6 +194,23 @@ function autoLinkRawUrls(text: string): string {
   })
 }
 
+function escapeLoneTildes(text: string): string {
+  return text
+    .split(URL_LIKE_SPLIT_RE)
+    .map(part => (/^<?https?:\/\//i.test(part) ? part : part.replace(LONE_TILDE_RE, '\\~')))
+    .join('')
+}
+
+function escapeUnknownHtmlLikeTags(text: string): string {
+  return text.replace(HTML_TAG_RE, (tag: string, name: string) => {
+    if (SAFE_HTML_TAG_NAMES.has(name.toLowerCase())) {
+      return tag
+    }
+
+    return tag.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+  })
+}
+
 // Rewrite filesystem-path links to the renderer's hash-href door (#82140).
 // A plain path/file: href names a file on the AGENT's machine: Streamdown's
 // URL hardening blocks `file:`/`~/` outright, and an absolute path renders
@@ -195,9 +233,13 @@ function routeFileLinksToPreview(text: string): string {
 
 function rewriteProseSegment(segment: string): string {
   return linkifySessionRefs(
-    autoLinkRawUrls(
-      routeFileLinksToPreview(
-        segment.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+    escapeLoneTildes(
+      autoLinkRawUrls(
+        routeFileLinksToPreview(
+          escapeUnknownHtmlLikeTags(
+            segment.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
+          )
+        )
       )
     )
   )


### PR DESCRIPTION
## Summary

Fixes two Desktop markdown renderer bugs in different prose-safety families, both reported with exact repros:

- **#50871** — lone `~` rendered as GFM strikethrough. `1~10,11~20` and CJK approximation prefixes (`~¥0.089` next to `3~5 倍` in the same paragraph) pair up via `~~(.+?)~~` and strike a chunk of text. `~` is extremely common as a range separator / approximation prefix in CJK prose.
- **#53953** — unknown HTML-shaped tokens (`<tool_call>`, `<observation>`, `<unk>`, …) are parsed by the HTML-aware renderer (allowDangerousHtml) as unclosed elements, silently **consuming the rest of the message** with no error indicator.

## Approach

Both are handled in `preprocessMarkdown` (via `rewriteProseSegment`, the prose pipeline that already shields inline/fenced code, URLs, file-preview links, and math spans):

1. `escapeLoneTildes` — escapes only `~` that is neither part of `~~` strikethrough, `~~~` fence, nor already-escaped, to `\~` (renders as a literal tilde). Autolink-shaped spans (bare or angle-bracketed `http(s)` URLs) are split off first so `~` in URL paths survives.
2. `escapeUnknownHtmlLikeTags` — matches tag-shaped runs (`<name …>`, `</name>`, `<name/>`) and escapes unknown ones to `&lt;…&gt;` against a 55-element safe-tag allowlist (`a`, `strong`, `span`, `br`, `img`, …), so intentional inline HTML keeps working while model-emitted pseudo-tags stay literal.

This consolidates the earlier contributions #50920 (lone-tilde escaping, `PR: #50920`) and #53964 (unknown-tag allowlist; #58113 is the closed duplicate of #53964), integrated as one coherent pipeline on current `main` (includes the newer `rewriteProseSegment`/math-span/file-link structure). Comments in `#50871` and `#53953` confirm the repro persists on the 2026-08-20+ desktop build.

## What's beyond the two upstream PRs

- Regression test for the **approximation-prefix pairing** case (`3~5 倍` + `~¥0.089` in one paragraph — the actual reported scenario at #50871), not covered by either PR.
- Regression test proving math comparisons (`a < b`, `2<3`) are not mistaken for tags.
- Render-level DOM tests (`markdown-text.prose-safety.test.tsx`) mounting the real `MarkdownTextContent` component: assert zero `del`/`s` elements for range text, literal rendering + message-tail visibility for unknown tokens, and `~~…~~` still renders as strikethrough.

## Verification

- Preprocess-level: the new unit tests in `markdown-text.test.ts` (ranges, approximation prefixes, inline/fenced code shielding, known-tag preservation, unknown-tag escaping, math comparisons, URL-tilde survival).
- Render-level: `markdown-text.prose-safety.test.tsx` (real component DOM assertions, 6 cases).
- Local full desktop suite (assistant-ui): 44 files / 384 tests green before final main rebase; the direct-code verification of this exact branch's implementation (16 assertions) also passes.

## Files

- `apps/desktop/src/lib/markdown-preprocess.ts` — constants + two functions + pipeline wiring
- `apps/desktop/src/components/assistant-ui/markdown-text.test.ts` — +6 unit tests
- `apps/desktop/src/components/assistant-ui/markdown-text.prose-safety.test.tsx` — render-level DOM regression suite

Relates to #49822 (URL-link corruption in the same file, untouched here) — tracked separately.
