### PR TITLE
fix(desktop): make runtime plugin reloads authoritative

### DIFF
--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -72,6 +72,64 @@ describe('scanDiskPlugins (#66899)', () => {
     expect(readDir).not.toHaveBeenCalled()
   })
 
+  it('manual rescan reloads an already-known plugin after its source changes', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('')
+    readDir.mockResolvedValue({
+      entries: [
+        {
+          isDirectory: true,
+          name: 'manual-reload',
+          path: '/local/.hermes/desktop-plugins/manual-reload'
+        }
+      ]
+    })
+
+    const registrations: string[] = []
+
+    ;(globalThis as unknown as { __manualReload: (version: string) => void }).__manualReload = version =>
+      registrations.push(version)
+
+    let version = 'v1'
+    readFileText.mockImplementation(async () => ({
+      text: `export default { id: 'manual-reload', register() { globalThis.__manualReload('${version}') } }`
+    }))
+    watchPreviewFile.mockRejectedValue(new Error('watch unavailable'))
+
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(
+        blob =>
+          `data:text/javascript;base64,${Buffer.from((blob as unknown as { parts: string[] }).parts.join('')).toString('base64')}`
+      )
+
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+    const RealBlob = globalThis.Blob
+    vi.stubGlobal(
+      'Blob',
+      class {
+        parts: string[]
+        constructor(parts: string[]) {
+          this.parts = parts
+        }
+      }
+    )
+
+    try {
+      await discoverRuntimePlugins()
+      expect(registrations).toEqual(['v1'])
+
+      version = 'v2'
+      await discoverRuntimePlugins()
+      expect(registrations).toEqual(['v1', 'v2'])
+    } finally {
+      createObjectURL.mockRestore()
+      revokeObjectURL.mockRestore()
+      vi.stubGlobal('Blob', RealBlob)
+      delete (globalThis as unknown as { __manualReload?: unknown }).__manualReload
+    }
+  })
+
   it('probes desktop/plugin.js inside agent-plugin packages (unified packaging)', async () => {
     desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
     agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
@@ -162,20 +220,83 @@ describe('scanDiskPlugins (#66899)', () => {
 })
 
 describe('watchRuntimePlugins dir watch (#66899)', () => {
-  it('watches both Electron-resolved local roots, never the backend hermes_home', async () => {
+  it('watches both local roots and keeps a content-reconciliation poll as a watcher fallback', async () => {
     desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
     agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
-    readDir.mockResolvedValue({ entries: [] })
-    watchDirectory.mockResolvedValue({ id: 'watch-1' })
+    readDir.mockImplementation(async dir =>
+      dir === '/local/.hermes/desktop-plugins'
+        ? {
+            entries: [
+              {
+                isDirectory: true,
+                name: 'poll-reload',
+                path: '/local/.hermes/desktop-plugins/poll-reload'
+              }
+            ]
+          }
+        : { entries: [] }
+    )
+    watchDirectory
+      .mockResolvedValueOnce({ id: 'watch-desktop-root' })
+      .mockResolvedValueOnce({ id: 'watch-agent-root' })
+    watchPreviewFile.mockResolvedValue({ id: 'watch-plugin-file' })
 
-    watchRuntimePlugins()
-    // Drain the async scan + startDirWatches chains.
-    await vi.waitFor(() => expect(watchDirectory).toHaveBeenCalledTimes(2))
+    const registrations: string[] = []
 
-    expect(watchDirectory).toHaveBeenCalledWith('/local/.hermes/desktop-plugins')
-    expect(watchDirectory).toHaveBeenCalledWith('/local/.hermes/plugins')
-    expect(watchDirectory).not.toHaveBeenCalledWith('/remote/box/.hermes/desktop-plugins')
-    expect(getStatus).not.toHaveBeenCalled()
+    ;(globalThis as unknown as { __pollReload: (version: string) => void }).__pollReload = version =>
+      registrations.push(version)
+    let version = 'v1'
+    readFileText.mockImplementation(async () => ({
+      text: `export default { id: 'poll-reload', register() { globalThis.__pollReload('${version}') } }`
+    }))
+
+    const createObjectURL = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockImplementation(
+        blob =>
+          `data:text/javascript;base64,${Buffer.from((blob as unknown as { parts: string[] }).parts.join('')).toString('base64')}`
+      )
+
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined)
+    const RealBlob = globalThis.Blob
+    vi.stubGlobal(
+      'Blob',
+      class {
+        parts: string[]
+        constructor(parts: string[]) {
+          this.parts = parts
+        }
+      }
+    )
+    let poll: (() => void) | undefined
+
+    const setInterval = vi.spyOn(window, 'setInterval').mockImplementation(callback => {
+      poll = callback as () => void
+
+      return 1 as unknown as ReturnType<typeof window.setInterval>
+    })
+
+    try {
+      watchRuntimePlugins()
+      await vi.waitFor(() => expect(watchDirectory).toHaveBeenCalledTimes(2))
+      await vi.waitFor(() => expect(registrations).toEqual(['v1']))
+
+      expect(watchDirectory).toHaveBeenCalledWith('/local/.hermes/desktop-plugins')
+      expect(watchDirectory).toHaveBeenCalledWith('/local/.hermes/plugins')
+      expect(watchDirectory).not.toHaveBeenCalledWith('/remote/box/.hermes/desktop-plugins')
+      expect(getStatus).not.toHaveBeenCalled()
+      expect(poll).toBeTypeOf('function')
+
+      version = 'v2'
+      poll?.()
+      await vi.waitFor(() => expect(registrations).toEqual(['v1', 'v2']))
+    } finally {
+      setInterval.mockRestore()
+      createObjectURL.mockRestore()
+      revokeObjectURL.mockRestore()
+      vi.stubGlobal('Blob', RealBlob)
+      delete (globalThis as unknown as { __pollReload?: unknown }).__pollReload
+    }
   })
 })
 

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -275,6 +275,8 @@ interface DiskPlugin {
   id: null | string
   /** Origin label (folder name) — the toast/inventory name for load errors. */
   origin: string
+  /** Last bytes reconciled for this entry (successful or broken). */
+  source: null | string
   watchId: null | string
 }
 
@@ -283,6 +285,7 @@ interface DiskPlugin {
 const disk = new Map<string, DiskPlugin>()
 let watching = false
 let scanning = false
+let reloadExistingPending = false
 
 /** Drop a folder-named error record — unless that name is the live plugin id
  *  of ANOTHER disk entry (two roots can carry same-named folders; a broken one
@@ -297,12 +300,13 @@ function dropOriginRecord(origin: string, except: DiskPlugin): void {
   dropPlugin(origin)
 }
 
-async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
+async function loadDiskPlugin(entry: DiskPlugin, source?: string): Promise<void> {
   const desktop = window.hermesDesktop!
   const prevId = entry.id
 
   try {
-    const { text } = await desktop.readFileText(entry.file)
+    const text = source ?? (await desktop.readFileText(entry.file)).text
+    entry.source = text
 
     const id = await loadRuntimePlugin(text, entry.origin, {
       defaultEnabled: entry.defaultEnabled,
@@ -329,8 +333,12 @@ async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
   }
 }
 
-async function scanDiskPlugins(): Promise<void> {
+async function scanDiskPlugins(options: { reloadExisting?: boolean } = {}): Promise<void> {
   const desktop = window.hermesDesktop
+
+  if (options.reloadExisting) {
+    reloadExistingPending = true
+  }
 
   // Re-entrancy guard: the 5s poll must not overlap a slow in-flight scan
   // (reads/loads can exceed the interval).
@@ -339,6 +347,8 @@ async function scanDiskPlugins(): Promise<void> {
   }
 
   scanning = true
+  const reloadExisting = reloadExistingPending
+  reloadExistingPending = false
 
   try {
     const roots = await diskRoots()
@@ -362,7 +372,23 @@ async function scanDiskPlugins(): Promise<void> {
         const file = root.entry(dir.path)
         seen.add(file)
 
-        if (disk.has(file)) {
+        const existing = disk.get(file)
+
+        if (existing) {
+          try {
+            const { text } = await desktop.readFileText(file)
+
+            // Root-directory watches are not recursive on every platform and
+            // atomic-save/rename patterns can evade a per-file fs.watch. A
+            // content comparison makes both the reconciliation poll and a
+            // manual rescan authoritative for edits to known entries.
+            if (reloadExisting || text !== existing.source) {
+              await loadDiskPlugin(existing, text)
+            }
+          } catch {
+            // File vanished mid-scan — deletion reconciliation runs below.
+          }
+
           continue
         }
 
@@ -377,6 +403,7 @@ async function scanDiskPlugins(): Promise<void> {
           file,
           id: null,
           origin: dir.name,
+          source: null,
           watchId: null
         }
 
@@ -415,11 +442,18 @@ async function scanDiskPlugins(): Promise<void> {
     // No plugin roots (or no gateway yet) — nothing to reconcile.
   } finally {
     scanning = false
+
+    // A manual reload requested during an in-flight reconciliation must not be
+    // dropped by the re-entrancy guard; run it as soon as this pass completes.
+    if (reloadExistingPending) {
+      void scanDiskPlugins()
+    }
   }
 }
 
-/** Manual rescan (the ⌘K "Reload desktop plugins" fallback). */
-export const discoverRuntimePlugins = scanDiskPlugins
+/** Manual rescan (the ⌘K "Reload desktop plugins" fallback). Existing entries
+ *  must reload too — a discovery-only scan makes the command a no-op for edits. */
+export const discoverRuntimePlugins = (): Promise<void> => scanDiskPlugins({ reloadExisting: true })
 
 /** Start the self-maintaining disk door: initial scan, per-file hot reload,
  *  fs-watched folder reconciliation (poll fallback on older shells). Idempotent. */
@@ -485,25 +519,19 @@ export function watchRuntimePlugins(): void {
   }
 
   void scanDiskPlugins()
-  void startDirWatches().then(watched => {
-    if (watched) {
+  void startDirWatches()
+
+  // Keep a lightweight content reconciliation pass even when all native
+  // watchers started successfully. Linux atomic renames, editor safe-writes,
+  // and transient watcher loss can otherwise leave a known plugin stale until
+  // the whole app restarts. Unchanged sources are never re-evaluated.
+  window.setInterval(() => {
+    if (document.visibilityState !== 'visible') {
       return
     }
 
-    const timer = window.setInterval(() => {
-      if (document.visibilityState !== 'visible') {
-        return
-      }
-
-      void scanDiskPlugins()
-
-      // A root may have appeared since — upgrade to the watches and retire
-      // this poll once every root is covered.
-      void startDirWatches().then(upgraded => {
-        if (upgraded) {
-          window.clearInterval(timer)
-        }
-      })
-    }, DISK_POLL_MS)
-  })
+    void scanDiskPlugins()
+    // Retry roots that were missing/unwatchable at startup.
+    void startDirWatches()
+  }, DISK_POLL_MS)
 }


### PR DESCRIPTION
## Summary

Fixes two failure modes in the Desktop runtime-plugin reload path:

- **Manual reload was discovery-only.** `Reload desktop plugins` skipped every known entry, making the command a no-op after editing an existing `plugin.js`.
- **Native file watches were treated as infallible.** Once root watches started successfully, Desktop disabled its reconciliation poll, so atomic saves, rename-based editor writes, or a lost watcher event could leave a plugin stale until the app restarted.

The loader now:

- records the last source bytes reconciled for each disk plugin;
- force-reloads known entries when the manual reload command runs;
- compares source bytes during ordinary scans and reloads only changed entries;
- keeps a lightweight visible-window reconciliation pass even when native watches are active; and
- queues a manual reload requested during an in-flight scan instead of dropping it at the re-entrancy guard.

## Reproduction

1. Load an on-disk Desktop plugin from `~/.hermes/desktop-plugins/<id>/plugin.js`.
2. Edit an existing plugin's visible text.
3. Observe that the UI can remain stale.
4. Run **Reload desktop plugins** from the command palette.
5. Before this fix, the existing record is skipped by `scanDiskPlugins()` and remains stale.

## Test plan

- [x] Added regression coverage proving manual rescan reloads an already-known plugin after its source changes.
- [x] Added coverage proving the fallback reconciliation poll remains active with native root watches and reloads changed bytes.
- [x] `npx vitest run --project ui src/contrib/runtime-loader.test.ts` — 8 passed.
- [x] `npx tsc -p tsconfig.json --noEmit`.
- [x] `npx eslint src/contrib/runtime-loader.ts src/contrib/runtime-loader.test.ts`.
- [x] Packaged Linux Desktop build completed successfully.

## Performance

The fallback runs only while the renderer is visible, at the existing five-second interval. It reads candidate `plugin.js` files but does not re-evaluate plugins whose source is unchanged.
