### PR TITLE
fix(update): keep Desktop SSH connections alive during remote updates

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -335,24 +335,27 @@ def _kill_stale_dashboard_processes(
     # When the Hermes Desktop Electron app spawns this dashboard as a
     # backend child, it sets HERMES_DESKTOP_CHILD_PID so that the update
     # path can skip killing the desktop-managed process.  (#37532)
-    exclude: set[int] | None = None
+    exclude: set[int] = set()
     raw_pid = os.environ.get("HERMES_DESKTOP_CHILD_PID")
     if raw_pid:
         # The desktop may manage several backends (one per active profile) and
         # passes them comma-separated; a lone int still parses for back-compat.
-        parsed: set[int] = set()
         for part in raw_pid.split(","):
             part = part.strip()
             if not part:
                 continue
             try:
-                parsed.add(int(part))
+                exclude.add(int(part))
             except (ValueError, TypeError):
                 pass
-        if parsed:
-            exclude = parsed
 
-    pids = _m()._find_stale_dashboard_pids(exclude_pids=exclude)
+    # An SSH-owned backend belongs to an attached Desktop client even when the
+    # updater runs from an unrelated remote shell with no Desktop child PID.
+    # Honor the same validated ownership records as the orphan reaper; killing
+    # one permanently strands that client's fixed SSH port-forward.
+    exclude |= _lock_owned_serve_pids()
+
+    pids = _m()._find_stale_dashboard_pids(exclude_pids=exclude or None)
     if not pids:
         return {"matched": [], "killed": [], "failed": []}
 

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -349,11 +349,12 @@ def _kill_stale_dashboard_processes(
             except (ValueError, TypeError):
                 pass
 
-    # An SSH-owned backend belongs to an attached Desktop client even when the
-    # updater runs from an unrelated remote shell with no Desktop child PID.
-    # Honor the same validated ownership records as the orphan reaper; killing
-    # one permanently strands that client's fixed SSH port-forward.
-    exclude |= _lock_owned_serve_pids()
+    if restart_managed:
+        # An SSH-owned backend belongs to an attached Desktop client even when
+        # the updater runs from an unrelated remote shell with no Desktop child
+        # PID. Honor the same validated ownership records as the orphan reaper;
+        # killing one permanently strands that client's fixed SSH port-forward.
+        exclude |= _lock_owned_serve_pids()
 
     pids = _m()._find_stale_dashboard_pids(exclude_pids=exclude or None)
     if not pids:

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -88,7 +88,7 @@ def _ps_runner(stdout: str):
     return _side_effect
 
 
-def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeypatch):
+def _write_valid_ssh_backend_lock(tmp_path, monkeypatch) -> int:
     pid = 4242
     ownership_id = "a" * 32
     spawn_nonce = "b" * 16
@@ -110,6 +110,11 @@ def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeyp
     }))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.delenv("HERMES_DESKTOP_CHILD_PID", raising=False)
+    return pid
+
+
+def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeypatch):
+    pid = _write_valid_ssh_backend_lock(tmp_path, monkeypatch)
 
     def assert_owned_pid_is_excluded(*, exclude_pids=None):
         assert exclude_pids is not None
@@ -121,6 +126,25 @@ def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeyp
         side_effect=assert_owned_pid_is_excluded,
     ):
         result = _kill_stale_dashboard_processes(restart_managed=True)
+
+    assert result == {"matched": [], "killed": [], "failed": []}
+
+
+def test_explicit_stop_does_not_spare_backend_owned_by_valid_ssh_lock(
+    tmp_path,
+    monkeypatch,
+):
+    pid = _write_valid_ssh_backend_lock(tmp_path, monkeypatch)
+
+    def assert_owned_pid_is_not_excluded(*, exclude_pids=None):
+        assert exclude_pids is None or pid not in exclude_pids
+        return []
+
+    with patch(
+        "hermes_cli.main._find_stale_dashboard_pids",
+        side_effect=assert_owned_pid_is_not_excluded,
+    ):
+        result = _kill_stale_dashboard_processes(restart_managed=False)
 
     assert result == {"matched": [], "killed": [], "failed": []}
 

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -14,6 +14,7 @@ History:
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import subprocess
 import sys
@@ -85,6 +86,43 @@ def _ps_runner(stdout: str):
         # Any other subprocess.run (e.g. taskkill) — benign success stub.
         return MagicMock(returncode=0, stdout="", stderr="")
     return _side_effect
+
+
+def test_update_cleanup_spares_backend_owned_by_valid_ssh_lock(tmp_path, monkeypatch):
+    pid = 4242
+    ownership_id = "a" * 32
+    spawn_nonce = "b" * 16
+    lock_dir = tmp_path / "desktop-ssh" / ownership_id
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "backend.lock.json").write_text(json.dumps({
+        "schemaVersion": 2,
+        "protocolVersion": 1,
+        "ownershipId": ownership_id,
+        "spawnNonce": spawn_nonce,
+        "tokenFingerprint": "c" * 32,
+        "pid": pid,
+        "port": 46369,
+        "profile": "default",
+        "hermesPath": "/opt/hermes/bin/hermes",
+        "hermesHome": str(tmp_path),
+        "logPath": f"{tmp_path}/desktop-ssh/{ownership_id}/{spawn_nonce}.log",
+        "startedAt": "2026-08-21T15:27:39Z",
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_DESKTOP_CHILD_PID", raising=False)
+
+    def assert_owned_pid_is_excluded(*, exclude_pids=None):
+        assert exclude_pids is not None
+        assert pid in exclude_pids
+        return []
+
+    with patch(
+        "hermes_cli.main._find_stale_dashboard_pids",
+        side_effect=assert_owned_pid_is_excluded,
+    ):
+        result = _kill_stale_dashboard_processes(restart_managed=True)
+
+    assert result == {"matched": [], "killed": [], "failed": []}
 
 
 class TestFindStaleDashboardPids:


### PR DESCRIPTION
## What does this PR do?

Running `hermes update` from an independent shell on an SSH-connected host no longer terminates the backend owned by Hermes Desktop. The update cleanup now honors the same validated `backend.lock.json` ownership records as the orphan reaper, so the Desktop's fixed SSH port-forward is not stranded on a dead ephemeral port.

### Symptom

After a remote update, Hermes Desktop loses its SSH-backed connection with `ECONNRESET` and remains stuck reconnecting until the application is fully quit and relaunched.

### Impact

Users updating a host while Desktop is attached over SSH lose that active Desktop connection even though the update itself succeeds and other managed Hermes services remain healthy.

### Bug Cause

**Trigger:** `hermes_cli/dashboard_procs.py:338` in `_kill_stale_dashboard_processes()` when `hermes update` runs outside the Desktop process tree.

**Causal chain:**
1. The updater starts from an independent remote shell where `HERMES_DESKTOP_CHILD_PID` is unset.
2. The stale-dashboard scan receives no exclusion for the Desktop SSH backend and selects its `hermes serve --isolated --port 0` process for termination.
3. Desktop's fixed SSH port-forward continues targeting the terminated backend's ephemeral port, so reconnect attempts cannot recover.

**Why it is wrong:** A valid `backend.lock.json` is the existing source of truth that a Desktop client owns the backend, but the update cleanup ignored those ownership records.

**Working sibling / contrast:** `_reap_orphaned_desktop_local_serves()` already calls `_lock_owned_serve_pids()` and excludes every PID claimed by a schema-validated lock.

**Ruled out:** Invalid or mismatched ownership records do not shield processes because `_valid_lockfile_payload()` rejects them before their PIDs enter the exclusion set.

### Fix

Merge validated lock-owned PIDs into the existing Desktop-child exclusion set before scanning for stale dashboard processes. The regression test writes a real valid ownership lock under an isolated `HERMES_HOME` and verifies that its PID reaches the scanner's exclusion set even when `HERMES_DESKTOP_CHILD_PID` is absent.

## Related Issue

Closes #92012

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_procs.py` - preserve SSH backends claimed by valid Desktop ownership locks during update cleanup.
- `tests/hermes_cli/test_update_stale_dashboard.py` - cover the independent-shell update topology with the real lock-file parser.

## How to Test

1. Write a valid schema-v2 `desktop-ssh/<ownership-id>/backend.lock.json` for a running backend PID.
2. Run update cleanup with `HERMES_DESKTOP_CHILD_PID` unset and verify that PID is passed to `_find_stale_dashboard_pids()` as excluded.
3. Run the related ownership and cleanup tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_stale_dashboard.py -k owned_by_valid_ssh_lock -q
scripts/run_tests.sh tests/hermes_cli/test_orphan_desktop_serve_reap.py -q
```

Result: 9 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are updated, or N/A
- [x] `cli-config.yaml.example` is updated, or N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` is updated, or N/A
- [x] Cross-platform impact was considered per the compatibility guide
- [x] Tool descriptions and schemas are updated, or N/A
