### PR TITLE
fix(cron): deliver desktop-dispatched job output via direct Bot API fallback

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -23,6 +23,8 @@ import subprocess
 import sys
 import threading
 import time
+import urllib.parse
+import urllib.request
 import uuid
 from datetime import datetime, timezone
 
@@ -2264,6 +2266,56 @@ def _is_channel_dm_topic(
             job_id, chat_id,
         )
     return is_channel
+
+
+def _cron_telegram_direct(text: str) -> Optional[str]:
+    """Send a cron job alert via direct Telegram Bot API (no platform channel needed).
+
+    Used when the normal delivery channel is unavailable (desktop backend, no
+    resolvable Telegram home channel) so alerts reach the user regardless of
+    which scheduler dispatched the job.  Same pattern as gateway_probe.py.
+    Returns None on success, an error string on failure.
+    """
+    hermes_home = get_hermes_home()
+    if not hermes_home:
+        return "no HERMES_HOME"
+    env_file = hermes_home / ".env"
+    if not env_file.exists():
+        return "no .env"
+    token = chat_id = None
+    try:
+        with open(env_file, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, _, v = line.partition("=")
+                k = k.strip()
+                v = v.strip().strip('"').strip("'")
+                if k == "TELEGRAM_BOT_TOKEN":
+                    token = v
+                elif k in ("TELEGRAM_CHAT_ID", "TELEGRAM_HOME_CHANNEL"):
+                    chat_id = v
+    except OSError as e:
+        return f".env read failed: {e}"
+    if not token or not chat_id:
+        return "missing TELEGRAM_BOT_TOKEN or chat id in .env"
+    data = urllib.parse.urlencode({"chat_id": chat_id, "text": text}).encode()
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    try:
+        req = urllib.request.Request(url, data=data, method="POST")
+        with urllib.request.urlopen(req, timeout=30) as r:
+            body = json.loads(r.read().decode())
+        if body.get("ok"):
+            logger.info("cron: direct Bot API delivered (mid=%s)",
+                        body.get("result", {}).get("message_id"))
+            return None
+        msg = json.dumps(body)[:200]
+        logger.warning("cron: direct Bot API error: %s", msg)
+        return f"telegram API error: {msg}"
+    except Exception as e:
+        logger.warning("cron: direct Bot API send failed: %s", e)
+        return f"telegram send failed: {e}"
 
 
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
@@ -6051,12 +6103,19 @@ def _run_one_job_body(
                         if not owns_delivery:
                             raise _FireClaimLostDuringSideEffect
                         delivery_attempted = True
-                        delivery_error = _deliver_result(
-                            job,
-                            deliver_content,
-                            adapters=adapters,
-                            loop=loop,
-                        )
+                        if unresolved_origin:
+                            # deliver=origin with no origin or home channels
+                            # resolvable: _deliver_result() would silently skip
+                            # (output saved in last_output, nothing reaches the
+                            # user). Send via direct Bot API so alerts land.
+                            delivery_error = _cron_telegram_direct(deliver_content)
+                        else:
+                            delivery_error = _deliver_result(
+                                job,
+                                deliver_content,
+                                adapters=adapters,
+                                loop=loop,
+                            )
                 except Exception as de:
                     if isinstance(de, _FireClaimLostDuringSideEffect):
                         raise
@@ -6201,6 +6260,16 @@ def _run_one_job_body(
                 logger.error(
                     "Delivery failed for job %s: %s", job["id"], delivery_exc
                 )
+            if delivery_error:
+                # Normal delivery failed: try the direct Bot API fallback so the
+                # failure alert still reaches the user (e.g. desktop backend
+                # without a resolvable platform channel).
+                direct_err = _cron_telegram_direct(
+                    _summarize_cron_failure_for_delivery(job, _err_text)
+                )
+                if not direct_err:
+                    delivery_error = None
+                    delivery_outcome = "delivered"
             if not delivery_error and normalized_deliver == "origin":
                 unresolved_origin = not _resolve_delivery_targets(job)
             if delivery_error:


### PR DESCRIPTION
## Bug

No_agent cron jobs dispatched by the desktop app's backend (`hermes serve` /
`hermes dashboard`) produce stdout that never reaches the user. `_deliver_result()`
in `cron/scheduler.py` resolves no delivery targets when `deliver=origin` and no
origin or home channel exists, logs "skipping delivery (output saved in
last_output)" and returns `None` — so the run is recorded `not_configured` and
the user gets no alert, even though the job ran and produced output.

- **Dispatcher:** `web_server.py::_start_desktop_cron_ticker` calls
  `scheduler.tick()`, which runs `run_job()` the same way the gateway does.
  The desktop backend has no platform adapters, so `unresolved_origin` is
  true for any `deliver=origin` job it dispatches.
- **Impact:** any no_agent cron script that produces non-empty stdout (alerts,
  digests, reports, watchdog messages) may silently never reach the user,
  depending on which scheduler won the `.tick.lock`.

## Fix

Added `_cron_telegram_direct(text)` in `cron/scheduler.py` — a direct Telegram
Bot API send (urllib only, no Hermes dependency, same pattern as the external
watchdog in `scripts/gateway_probe.py`). Used in two places:

1. When `unresolved_origin` is True at the delivery point, the output is sent
   via direct Bot API instead of being skipped.
2. When a failure-alert delivery fails, the same direct fallback sends the
   failure summary.

The gateway path (which has real platform channels) is unchanged.

## Files Changed

- `cron/scheduler.py` (+75/−6):
  - `_cron_telegram_direct()` — reads `TELEGRAM_BOT_TOKEN` and
    `TELEGRAM_CHAT_ID`/`TELEGRAM_HOME_CHANNEL` from the Hermes-home `.env`,
    sends via `api.telegram.org/bot{token}/sendMessage`
  - Delivery path: when `unresolved_origin`, call `_cron_telegram_direct`
    instead of the silently-skipping `_deliver_result`
  - Failure path: if `_deliver_result` errors, retry via direct Bot API so the
    failure alert still lands

## Testing

- `tests/cron/` delivery + scheduling suites: **187 passed** against the
  current tip merge state (`test_cron_created_delivery.py`,
  `test_cron_relay_delivery_guards.py`, `test_scheduler.py`, `test_jobs.py`,
  `test_run_one_job.py`)
- `python -m py_compile cron/scheduler.py` clean
- Three-way merge vs current tip verified conflict-free (merge-tree)

## Notes

- This branch sits slightly behind tip; it merges cleanly into current `main`
  with zero conflicts and the resulting tree matches a full rebase. Happy to
  rebase if preferred.
- When no Telegram credentials exist in `.env`, `_cron_telegram_direct`
  returns without alerting — same effective behaviour as today's silent skip.