### PR TITLE
fix(whatsapp-bridge): exponential backoff with jitter for reconnects

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -36,6 +36,7 @@ import { classifyOwnerMessageGate } from './owner_message_gate.js';
 import {
   buildPollPayload,
   createReconnectScheduler,
+  createReconnectBackoff,
   createVersionResolver,
   buildLocationPayload,
   buildTextSendPayload,
@@ -396,6 +397,7 @@ function emitPairEvent(event) {
 }
 
 const scheduleReconnect = createReconnectScheduler(() => startSocket());
+const reconnectBackoff = createReconnectBackoff();
 const getWAVersion = createVersionResolver(fetchLatestBaileysVersion);
 
 async function startSocket() {
@@ -447,17 +449,22 @@ async function startSocket() {
       } else {
         // 515 = restart requested (common after pairing). Always reconnect.
         emitPairEvent({ event: 'disconnected', reason });
+        // Exponential backoff with jitter for every other disconnect — a fixed
+        // 3s retry hammers the server during outages, and pure exponential
+        // retries thundering-herd after shared outages. Reset on open.
+        const delayMs = reason === 515 ? 1000 : reconnectBackoff.next();
         if (!PAIR_JSON) {
           if (reason === 515) {
             console.log('↻ WhatsApp requested restart (code 515). Reconnecting...');
           } else {
-            console.log(`⚠️  Connection closed (reason: ${reason}). Reconnecting in 3s...`);
+            console.log(`⚠️  Connection closed (reason: ${reason}). Reconnecting in ${delayMs / 1000}s...`);
           }
         }
-        scheduleReconnect(reason === 515 ? 1000 : 3000);
+        scheduleReconnect(delayMs);
       }
     } else if (connection === 'open') {
       connectionState = 'connected';
+      reconnectBackoff.reset();
       const connectedUser = sock?.user
         ? {
             id: sock.user.id || null,

--- a/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.reconnect.test.mjs
@@ -18,6 +18,7 @@ import { strict as assert } from 'node:assert';
 import {
   createReconnectScheduler,
   createVersionResolver,
+  createReconnectBackoff,
 } from './bridge_helpers.js';
 
 const tick = () => new Promise(resolve => setImmediate(resolve));
@@ -148,3 +149,66 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 }
 
 console.log('bridge.reconnect.test.mjs: all assertions passed');
+
+// -- createReconnectBackoff ------------------------------------------------
+
+// Exponential sequence with no jitter (random -> 0.5 keeps the midpoint).
+{
+  const backoff = createReconnectBackoff({ random: () => 0.5 });
+  const delays = [3000, 6000, 12000, 24000, 48000, 96000, 192000, 300000, 300000];
+  for (const expected of delays) {
+    assert.equal(backoff.next(), expected, `expected ${expected}ms`);
+  }
+}
+
+// Cap holds at maxMs and does not grow past it.
+{
+  const backoff = createReconnectBackoff({ maxMs: 10000, random: () => 0.5 });
+  for (let i = 0; i < 10; i += 1) {
+    assert.ok(backoff.next() <= 10000, 'delay must never exceed maxMs');
+  }
+}
+
+// Jitter bounds: random() in [0, 1) must keep every delay within ±jitterFactor.
+{
+  const baseMs = 3000, maxMs = 30000;
+  const factor = 0.2;
+  // worst cases: random() -> 0 (min) and random() -> 0.999... (max)
+  for (const r of [0, 0.999999]) {
+    const backoff = createReconnectBackoff({ baseMs, maxMs, jitterFactor: factor, random: () => r });
+    for (let i = 0; i < 50; i += 1) {
+      const d = backoff.next();
+      assert.ok(d >= 0, `delay must not be negative (got ${d})`);
+      // every delay must be within ±20% of SOME exponential step <= maxMs,
+      // where the capped step is included and repeats once the cap is hit
+      let ok = false;
+      let exp = baseMs;
+      while (true) {
+        const step = Math.min(exp, maxMs);
+        const lo = step * (1 - factor), hi = step * (1 + factor);
+        if (d >= lo && d <= hi) { ok = true; break; }
+        if (step >= maxMs) break; // every later step is the cap; checked once
+        exp *= 2;
+      }
+      assert.ok(ok, `delay ${d} outside ±20% of any exponential step`);
+    }
+  }
+}
+
+// reset() restarts the sequence.
+{
+  const backoff = createReconnectBackoff({ random: () => 0.5 });
+  assert.equal(backoff.next(), 3000);
+  assert.equal(backoff.next(), 6000);
+  backoff.reset();
+  assert.equal(backoff.next(), 3000, 'reset must restart from baseMs');
+}
+
+// Deterministic per-call jitter: same random() -> same delay for a fixed step.
+{
+  const a = createReconnectBackoff({ random: () => 0.1 });
+  const b = createReconnectBackoff({ random: () => 0.1 });
+  assert.equal(a.next(), b.next());
+}
+
+console.log('createReconnectBackoff: all assertions passed');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -595,6 +595,42 @@ export function createReconnectScheduler(startFn, {
 }
 
 /**
+ * Exponential backoff with jitter for reconnect delays.
+ *
+ * Why: a fixed retry delay (e.g. 3s) hammers the server during any sustained
+ * outage, and pure exponential backoff makes every client retry in lockstep
+ * after a shared outage (thundering herd). Jitter (± jitterFactor, default
+ * ±20%) spreads retries so a fleet of bridges does not synchronise.
+ *
+ * Returns { next(), reset() }:
+ *   - next(): next delay in ms. Sequence: base, base*2, base*4, ... capped at
+ *     maxMs, each randomised by ±jitterFactor (inclusive bounds).
+ *   - reset(): restart the sequence (call after a successful connection).
+ *
+ * `random` is injectable for deterministic tests (default Math.random, which
+ * is fine at call-site scale and never used for security).
+ */
+export function createReconnectBackoff({
+  baseMs = 3000,
+  maxMs = 300000,
+  jitterFactor = 0.2,
+  random = Math.random,
+} = {}) {
+  let attempts = 0;
+  function next() {
+    const exp = Math.min(baseMs * Math.pow(2, attempts), maxMs);
+    attempts += 1;
+    const range = exp * jitterFactor;
+    // [exp - range, exp + range]; random() in [0,1) keeps the upper bound inclusive-ish
+    return Math.round(exp - range + random() * 2 * range);
+  }
+  function reset() {
+    attempts = 0;
+  }
+  return { next, reset };
+}
+
+/**
  * Version resolution guard. fetchLatestBaileysVersion() is a plain fetch to
  * raw.githubusercontent.com with no AbortSignal; a stalled connection can
  * pend forever and wedge the reconnect path (the scheduler above cannot


### PR DESCRIPTION
## The bug

`scripts/whatsapp-bridge/bridge.js` schedules every non-515 reconnect at a
**fixed 3-second delay**:

```js
scheduleReconnect(reason === 515 ? 1000 : 3000);
```

When the Baileys socket drops (network blip, server-side close, service
unavailable), the bridge reconnects every 3s **forever, with no backoff and no
attempt cap**. During any sustained outage this produces rapid, repeated
connection attempts — observed in the field as a reconnect storm (139
disconnect events in a short window: 111× 408 `connectionLost/timedOut`, 24×
428 `connectionClosed`, 2× 405, 2× 503 — no 401/403/440, so not auth, ban, or
session-replaced).

## Why a fixed 3s retry is harmful

1. **It hammers the server.** Rapid reconnect churn is exactly the behaviour
   associated with numbers being rate-limited or flagged. A bridge in a
   flaky-network loop can retry ~1,200 times/hour (3s cadence), even when the
   server has already said it is unavailable (503) or closed the socket (428).
2. **It never backs off.** The retry pressure stays constant regardless of how
   long the outage lasts.
3. **It thundering-herds after shared outages.** Pure exponential backoff
   fixes the hammer but makes every client retry in lockstep at the same
   moments — a fleet of bridges all hitting 6s, then 12s, then 24s together.
   This is why jitter is part of the fix.
4. **The 515 (`restartRequired`) path is correctly immediate** (1s) — that is
   a server-directed restart and should stay fast. Only the generic error
   path needs throttle.

## The fix

Pure helper in `bridge_helpers.js` (beside the scheduler, same module pattern):

```js
export function createReconnectBackoff({
  baseMs = 3000,
  maxMs = 300000,
  jitterFactor = 0.2,
  random = Math.random,
} = {}) {
  let attempts = 0;
  function next() {
    const exp = Math.min(baseMs * Math.pow(2, attempts), maxMs);
    attempts += 1;
    const range = exp * jitterFactor;
    return Math.round(exp - range + random() * 2 * range);
  }
  function reset() { attempts = 0; }
  return { next, reset };
}
```

Call-site wiring in `bridge.js`:

```js
const reconnectBackoff = createReconnectBackoff();
// in the close handler:
const delayMs = reason === 515 ? 1000 : reconnectBackoff.next();
scheduleReconnect(delayMs);
// in the open handler:
reconnectBackoff.reset();
```

- Sequence: 3s → 6s → 12s → 24s → 48s → 96s → 192s → **300s (cap)** → 300s…
- Every delay randomised ±20% (jitter) — inclusive of the cap, never negative.
- Reset to 3s on successful connect.
- `random` is injectable so tests are deterministic (never used for security).

**Implementation notes:**
- The backoff is stateful, so the call site computes the delay **once** per
  close and reuses it for both the log line and `scheduleReconnect` — calling
  `next()` twice skips a step and makes the log disagree with the schedule.
- The scheduler (`createReconnectScheduler`) is unchanged and stays pure; the
  policy belongs at the call site where the disconnect reason is known.

## Test coverage

Added to `bridge.reconnect.test.mjs` (all deterministic via injected random):

1. **Exponential sequence**: 3000, 6000, 12000, 24000, 48000, 96000, 192000,
   300000, 300000 (cap holds).
2. **Cap invariant**: with `maxMs: 10000`, every delay ≤ 10000 across 10 calls.
3. **Jitter bounds**: with `random` pinned to 0 and 0.999999, every delay over
   50 calls is within ±20% of some exponential step, capped step included.
4. **reset()**: restarts the sequence at baseMs.
5. **Determinism**: two backoffs with the same injected random agree.

Verified: `node --check` clean on both changed JS files; bridge test suites
21/21 pass excluding `bridge.native.test.mjs`; gateway WhatsApp suites 8 passed.

**Note on `bridge.native.test.mjs`:** it imports `@whiskeysockets/baileys` and
requires `npm install` in `scripts/whatsapp-bridge/` first. In a scratch clone
without installed dependencies it fails with `ERR_MODULE_NOT_FOUND` — that is
an environment issue, not a test failure; it passes in a properly-installed
checkout. All 22 bridge suites pass there.

## Notes for maintainers

- This branch sits slightly behind tip; it merges into current `main` with
  zero conflicts (verified three-way). Happy to rebase if preferred.
- No config surface added; base/cap/jitter are named constants in one place if
  configurability is wanted later.
- 515 restart-requested path intentionally unchanged (immediate).