### PR TITLE
fix(cron): keep active manual runs heartbeating

### DIFF
--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -13,7 +13,6 @@ watchdog kills the parent turn at ~1800s.
 import json
 import sys
 import threading
-import time
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -229,34 +228,40 @@ class TestCronjobRunExecutesImmediately:
         finally:
             set_activity_callback(None)
 
-    def test_heartbeat_stops_at_ceiling_but_job_completes(self):
-        """Past _CRON_RUN_HEARTBEAT_CEILING the heartbeat stops (so the
-        gateway watchdog regains authority over a wedged run) while the job
-        itself keeps running to completion."""
+    def test_heartbeat_continues_while_long_job_is_running(self):
+        """Elapsed time alone must not drop watchdog protection for an active job."""
         touches = []
-        first_beat = threading.Event()
+        second_beat = threading.Event()
+        monotonic_calls = 0
 
         def record(desc):
             touches.append(desc)
-            first_beat.set()
+            if len(touches) >= 2:
+                second_beat.set()
+
+        def long_elapsed():
+            nonlocal monotonic_calls
+            monotonic_calls += 1
+            if monotonic_calls == 1:
+                return 0.0
+            return 6 * 3600.0 + monotonic_calls
 
         set_activity_callback(record)
         try:
             def slow_run(job, **kw):
-                # Ceiling=0 → the very first wake stops the loop without
-                # touching. Give it a couple of cycles to prove silence.
-                time.sleep(0.2)
+                assert second_beat.wait(timeout=5.0), \
+                    "heartbeat stopped while the cron job was still running"
                 return True
 
             with patch("tools.cronjob_tools.claim_job_for_fire", return_value={**_JOB, "fire_claim": {"by": "manual-owner"}}), \
                  patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_INTERVAL", 0.05), \
-                 patch("tools.cronjob_tools._CRON_RUN_HEARTBEAT_CEILING", 0.0), \
+                 patch("tools.cronjob_tools.time.monotonic", side_effect=long_elapsed), \
                  patch("cron.scheduler.run_one_job", side_effect=slow_run), \
                  patch("tools.cronjob_tools.get_job",
                        return_value={"last_status": "ok", "last_error": None}):
                 res = _execute_job_now(dict(_JOB))
             assert res["success"] is True, res
-            assert not first_beat.is_set(), touches   # heartbeat never fired
+            assert len(touches) >= 2, touches
         finally:
             set_activity_callback(None)
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -25,15 +25,6 @@ logger = logging.getLogger(__name__)
 # uses 30s) — comfortably below the 1800s default HERMES_AGENT_TIMEOUT.
 _CRON_RUN_HEARTBEAT_INTERVAL = 10.0
 
-# Hard ceiling on how long the heartbeat keeps the parent watchdog at bay.
-# The child cron run has its own inactivity watchdog (HERMES_CRON_TIMEOUT,
-# default 600s) that bounds a wedged job, but with HERMES_CRON_TIMEOUT=0
-# (explicit "unlimited") a truly hung run_one_job would otherwise mask the
-# gateway watchdog forever — pre-#76502 the parent was at least reaped at
-# ~1800s. After this ceiling the heartbeat stops and the gateway watchdog
-# regains authority over the turn.
-_CRON_RUN_HEARTBEAT_CEILING = 6 * 3600.0
-
 # Import from cron module (will be available when properly installed)
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -844,16 +835,6 @@ def _run_claimed_job(
                 started = time.monotonic()
                 while not _heartbeat_stop.wait(_CRON_RUN_HEARTBEAT_INTERVAL):
                     elapsed = time.monotonic() - started
-                    if elapsed > _CRON_RUN_HEARTBEAT_CEILING:
-                        # Stop masking the gateway watchdog — a run this long
-                        # with an unlimited child watchdog is likely wedged.
-                        logger.warning(
-                            "cronjob run heartbeat ceiling reached for job "
-                            "'%s' (%.0fs) — stopping heartbeat; gateway "
-                            "watchdog regains authority",
-                            job_name, elapsed,
-                        )
-                        return
                     try:
                         activity_cb(
                             f"cronjob: running job '{job_name}' ({int(elapsed)}s elapsed)"


### PR DESCRIPTION
## What does this PR do?

Keeps the calling turn's activity heartbeat alive for the full duration of an inline manual cron run.

The heartbeat currently stops after a hard-coded six-hour ceiling even when `run_one_job` is still active. Once it stops, the parent inactivity watchdog can terminate a legitimate long-running job at a deterministic wall-clock threshold. Elapsed time alone is not evidence that the child is wedged: persistent gateway sessions already dispatch manual runs through the async-delegation rail, while synchronous fallbacks remain governed by the cron run's own timeout/cancellation policy (including an explicit unlimited setting).

This removes the independent heartbeat ceiling and leaves the heartbeat tied to the actual `run_one_job` lifetime. The existing `finally` block still stops and joins the heartbeat thread as soon as the job exits.

## Related Issue

No linked issue; this is a self-found regression in the manual-run heartbeat introduced by #76675. It is distinct from the opt-in per-job caps proposed in #45809.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/cronjob_tools.py`: remove the elapsed-time gate that drops activity while an inline cron run is still executing.
- `tests/tools/test_cronjob_run_immediate.py`: replace the old ceiling contract with a deterministic monotonic-clock regression proving heartbeats continue beyond six hours until completion.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_cronjob_run_immediate.py tests/tools/test_cronjob_run_background.py tests/tools/test_cronjob_tools.py -q` (94 passed).
2. Run `scripts/run_tests.sh tests/cron/ -q` (873 passed, 1 Windows-only test skipped on Linux).
3. Run `uv run --with ruff ruff check tools/cronjob_tools.py tests/tools/test_cronjob_run_immediate.py`.

The focused regression was verified RED before the production change: the old code logged that the ceiling was reached, delivered no heartbeat, and failed while the fake job remained active. It passes after this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `tests/` suite (focused tool and cron suites above are green)
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing contract or config changed
- [x] `cli-config.yaml.example` update — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no workflow changed
- [x] Cross-platform impact considered — stdlib threading/time behavior is platform-neutral
- [x] Tool descriptions/schemas update — N/A; tool schema is unchanged
