### PR TITLE
fix(dashboard): resolve custom endpoint ids to existing keys before slugging + duplicate base_url guard

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7975,6 +7975,21 @@ def _custom_endpoint_id(raw: str, fallback: str = "custom") -> str:
     slug = re.sub(r"[^A-Za-z0-9_-]+", "-", (raw or "").strip()).strip("-_").lower()
     return slug or fallback
 
+def _resolve_provider_key(providers: Any, raw: str) -> str:
+    """Resolve a dashboard-supplied endpoint id to a real ``providers`` key.
+
+    Exact match wins first: the dashboard round-trips the true config key
+    (``custom:sakiko-dev``), and slugging it (``custom-sakiko-dev``) silently
+    targets a non-existent entry — deletes and activates 404, and edits write
+    a brand-new duplicate key instead of updating the original. Only ids that
+    don't exactly match an existing key (hand-typed slugs, fresh names) fall
+    through to the slugger.
+    """
+    candidate = (raw or "").strip()
+    if isinstance(providers, dict) and candidate in providers:
+        return candidate
+    return _custom_endpoint_id(candidate)
+
 
 def _models_from_custom_endpoint_entry(entry: Dict[str, Any]) -> List[str]:
     models: List[str] = []
@@ -8107,7 +8122,6 @@ def _detach_main_model_from_provider(cfg: Dict[str, Any], provider_key: str) -> 
 
 
 def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> Tuple[str, Dict[str, Any]]:
-    endpoint_id = _custom_endpoint_id(body.id or body.name)
     name = (body.name or "").strip()
     base_url = (body.base_url or "").strip().rstrip("/")
     model = (body.model or "").strip()
@@ -8125,6 +8139,24 @@ def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> T
     providers = cfg.get("providers")
     if not isinstance(providers, dict):
         providers = {}
+    # Resolve against the real keys BEFORE slugging: an edit payload carries
+    # the existing key verbatim (``custom:sakiko-dev``) and must update that
+    # entry, not spawn a slugged duplicate (``custom-sakiko-dev``).
+    endpoint_id = _resolve_provider_key(providers, body.id or body.name)
+    # Duplicate guard for the NEW-endpoint path: refuse to fork a second entry
+    # for a base_url that's already configured — the sakiko / custom:sakiko-dev
+    # twin pair was born exactly this way.
+    if endpoint_id not in providers:
+        new_url = base_url.lower()
+        for pid, pentry in providers.items():
+            if not isinstance(pentry, dict):
+                continue
+            existing_url = str(pentry.get("base_url") or pentry.get("url") or pentry.get("api") or "").strip().rstrip("/").lower()
+            if existing_url and existing_url == new_url:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"base_url already configured as '{pid}'",
+                )
     existing = providers.get(endpoint_id)
     if not isinstance(existing, dict):
         existing = {}
@@ -8243,8 +8275,8 @@ def activate_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
     try:
         with _config_profile_scope(profile):
             cfg = load_config()
-            provider_key = _custom_endpoint_id(endpoint_id)
             providers = cfg.get("providers")
+            provider_key = _resolve_provider_key(providers, endpoint_id)
             entry = providers.get(provider_key) if isinstance(providers, dict) else None
             if not isinstance(entry, dict):
                 raise HTTPException(status_code=404, detail="custom endpoint not found")
@@ -8277,8 +8309,8 @@ def delete_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
     try:
         with _config_profile_scope(profile):
             cfg = load_config()
-            provider_key = _custom_endpoint_id(endpoint_id)
             providers = cfg.get("providers")
+            provider_key = _resolve_provider_key(providers, endpoint_id)
             if not isinstance(providers, dict) or provider_key not in providers:
                 raise HTTPException(status_code=404, detail="custom endpoint not found")
             providers.pop(provider_key, None)

--- a/tests/test_custom_endpoint_lifecycle.py
+++ b/tests/test_custom_endpoint_lifecycle.py
@@ -1,0 +1,154 @@
+"""Custom endpoint lifecycle: exact-key resolution and duplicate guards.
+
+The Desktop settings panel round-trips the literal ``providers`` key, which
+for older installs contains characters the slugger rewrites (e.g.
+``custom:sakiko-dev``). Slugging that id on the way back in silently targeted
+a *different* key — deletes and activates 404'd, and an edit wrote a brand
+new ``custom-sakiko-dev`` entry alongside the original, splitting the API key
+onto the twin and producing duplicate rows in the panel.
+
+These tests pin the behaviour contract:
+
+- an id that exactly matches an existing providers key resolves to that key
+  (edit/delete/activate), and only unknown ids fall through to the slugger;
+- creating an endpoint whose ``base_url`` is already configured is rejected
+  with 409 instead of forking a twin;
+- the duplicate guard never blocks editing the entry that owns the URL.
+"""
+
+import os
+
+import pytest
+import yaml
+
+from hermes_cli import web_server
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with one colon-prefixed and one plain endpoint."""
+    config = {
+        "model": {"provider": "gyz", "default": "gyz-model"},
+        "providers": {
+            "custom:sakiko-dev": {
+                "name": "Sakiko Dev",
+                "base_url": "https://sakiko.dev/v1",
+                "model": "tokenrhythm/deepseek-v4-flash-0731",
+                "api_key": "sk-test-plaintext-key",
+                "models": {"tokenrhythm/deepseek-v4-flash-0731": {}},
+            },
+            "gyz": {
+                "name": "gyz",
+                "base_url": "https://api.bailan.store",
+                "model": "gyz-model",
+                "api_key": "sk-gyz-key",
+                "models": {"gyz-model": {}},
+            },
+        },
+    }
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump(config, allow_unicode=True), encoding="utf-8")
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _load_cfg(home):
+    return yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+
+
+def _body(**kwargs):
+    defaults = dict(
+        name="Sakiko Dev", base_url="https://sakiko.dev/v1",
+        model="tokenrhythm/deepseek-v4-flash-0731",
+        discover_models=True, make_default=False,
+    )
+    defaults.update(kwargs)
+    return web_server.CustomEndpointUpdate(**defaults)
+
+
+def test_edit_preserves_colon_prefixed_key(hermes_home):
+    """Editing custom:sakiko-dev must update that entry, not fork a twin."""
+    cfg = _load_cfg(hermes_home)
+    endpoint_id, _entry = web_server._write_custom_endpoint(cfg, _body(id="custom:sakiko-dev"))
+    assert endpoint_id == "custom:sakiko-dev"
+    assert "custom-sakiko-dev" not in cfg["providers"]
+
+
+def test_edit_merges_models_onto_original_entry(hermes_home):
+    cfg = _load_cfg(hermes_home)
+    web_server._write_custom_endpoint(cfg, _body(id="custom:sakiko-dev", model="agy/gemini-3.6-flash-high"))
+    models = cfg["providers"]["custom:sakiko-dev"]["models"]
+    assert "agy/gemini-3.6-flash-high" in models
+
+
+def test_delete_resolves_exact_key(hermes_home):
+    """Deleting a colon-prefixed endpoint removes it (previously a 404)."""
+    web_server.delete_custom_endpoint("custom:sakiko-dev")
+    providers = _load_cfg(hermes_home)["providers"]
+    assert "custom:sakiko-dev" not in providers
+    assert "gyz" in providers  # siblings untouched
+
+
+def test_delete_plain_key_still_works(hermes_home):
+    web_server.delete_custom_endpoint("gyz")
+    assert "gyz" not in _load_cfg(hermes_home)["providers"]
+
+
+def test_activate_resolves_exact_key(hermes_home):
+    """Activating a colon-prefixed endpoint works (previously a 404)."""
+    result = web_server.activate_custom_endpoint("custom:sakiko-dev")
+    assert result["ok"] is True
+    assert result["provider"] == "custom:sakiko-dev"
+    assert _load_cfg(hermes_home)["model"]["provider"] == "custom:sakiko-dev"
+
+
+def test_unknown_id_still_404s(hermes_home):
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as excinfo:
+        web_server.delete_custom_endpoint("no-such-endpoint")
+    assert excinfo.value.status_code == 404
+
+
+def test_fresh_names_still_get_slugged():
+    providers = {"custom:sakiko-dev": {}}
+    assert web_server._resolve_provider_key(providers, "My New Endpoint!") == "my-new-endpoint"
+    assert web_server._resolve_provider_key(providers, "custom:sakiko-dev") == "custom:sakiko-dev"
+
+
+def test_duplicate_base_url_rejected_on_create(hermes_home):
+    """Creating a second endpoint for an existing base_url -> 409, no twin."""
+    from fastapi import HTTPException
+
+    cfg = _load_cfg(hermes_home)
+    with pytest.raises(HTTPException) as excinfo:
+        web_server._write_custom_endpoint(cfg, _body(name="sakiko-twin"))
+    assert excinfo.value.status_code == 409
+    assert "custom:sakiko-dev" in excinfo.value.detail
+    assert set(cfg["providers"]) == {"custom:sakiko-dev", "gyz"}
+
+
+def test_duplicate_base_url_normalized(hermes_home):
+    """Case and trailing-slash variants of an existing URL also 409."""
+    from fastapi import HTTPException
+
+    cfg = _load_cfg(hermes_home)
+    with pytest.raises(HTTPException) as excinfo:
+        web_server._write_custom_endpoint(cfg, _body(name="twin2", base_url="HTTPS://SAKIKO.DEV/v1/"))
+    assert excinfo.value.status_code == 409
+
+
+def test_duplicate_guard_does_not_block_editing_owner(hermes_home):
+    """Saving an endpoint that keeps its own URL is an edit, not a duplicate."""
+    cfg = _load_cfg(hermes_home)
+    endpoint_id, _ = web_server._write_custom_endpoint(cfg, _body(id="custom:sakiko-dev"))
+    assert endpoint_id == "custom:sakiko-dev"
+
+
+def test_create_with_fresh_url_succeeds(hermes_home):
+    cfg = _load_cfg(hermes_home)
+    endpoint_id, _ = web_server._write_custom_endpoint(
+        cfg, _body(name="fresh-endpoint", base_url="http://127.0.0.1:9999/v1", model="m"))
+    assert endpoint_id == "fresh-endpoint"
+    assert "fresh-endpoint" in cfg["providers"]


### PR DESCRIPTION
## Summary

Custom endpoints whose `providers` key contains a colon (e.g. `custom:sakiko-dev`, written by older builds) cannot be deleted or activated from the Desktop settings panel (404), and editing them forks a duplicate provider row. Creating an endpoint also never checks for an already-configured `base_url`, producing visible duplicates.

## Root cause

Every lifecycle path passed the dashboard-supplied id through `_custom_endpoint_id()`, which slugifies `[^A-Za-z0-9_-]+` → `-`. The panel round-trips the **literal** providers key (`custom:sakiko-dev`), so the slugged lookup (`custom-sakiko-dev`) missed the real entry:

- `DELETE /api/providers/custom-endpoints/{id}` → 404 (the row stays; looks like "delete does nothing")
- `POST .../{id}/activate` → 404 as well
- `POST /api/providers/custom-endpoints` with `id="custom:sakiko-dev"` wrote a **new** `custom-sakiko-dev` entry alongside the original — a duplicate row, and since `custom_endpoint_key_env()` maps both spellings to the same env var, the API key effectively migrated onto the twin the user isn't looking at ("my key didn't save")

Separately, `_write_custom_endpoint` only keyed off `id or name` and never compared `base_url`, so re-adding an already-configured provider created a second row for the same URL.

## Fix

- New `_resolve_provider_key(providers, raw)`: exact-match against real `providers` keys first; slugify only as a fallback for fresh names. Used by the edit, activate, and delete paths.
- `_write_custom_endpoint` now rejects a create whose normalized `base_url` (case-insensitive, trailing-slash-insensitive) already exists with **409** `base_url already configured as '<key>'`. Editing the entry that owns the URL is unaffected.

## Repro (before this patch)

1. Have `providers: custom:sakiko-dev` in config.yaml (any install that ever wrote one via the old direct-config flow).
2. Settings → Custom endpoints → delete it → 404, row persists.
3. Edit it and Save → a second `custom-sakiko-dev` row appears.
4. Add a new endpoint with the same base_url → another duplicate row appears.

## Tests

- New `tests/test_custom_endpoint_lifecycle.py` — 11 tests covering: exact-key edit/delete/activate, slug fallback for fresh names, 404 for unknown ids, 409 on duplicate base_url (incl. case/trailing-slash variants), guard not blocking the URL's owner, fresh-URL create succeeding.
- `tests/test_web_server*.py` show no regressions from this change (the one failure, `test_start_server_keeps_bare_asyncio_run_on_posix`, fails identically on clean `main` under Windows — pre-existing platform issue, unrelated).
