### PR TITLE
fix(desktop): model picker owns its search term (no collapse to current model) + key field shows saved state

### DIFF
--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -29,6 +29,7 @@ interface EndpointForm {
   baseUrl: string
   contextLength: string
   discoverModels: boolean
+  hasApiKey: boolean
   id: string
   makeDefault: boolean
   model: string
@@ -40,6 +41,7 @@ const EMPTY_FORM: EndpointForm = {
   baseUrl: '',
   contextLength: '',
   discoverModels: true,
+  hasApiKey: false,
   id: '',
   makeDefault: true,
   model: '',
@@ -52,6 +54,7 @@ function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
     baseUrl: endpoint.base_url,
     contextLength: endpoint.context_length ? String(endpoint.context_length) : '',
     discoverModels: endpoint.discover_models,
+    hasApiKey: endpoint.has_api_key,
     id: endpoint.id,
     makeDefault: Boolean(endpoint.is_current),
     model: endpoint.model,
@@ -351,7 +354,7 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
               API Key
               <Input
                 onChange={event => setForm(current => ({ ...current, apiKey: event.target.value }))}
-                placeholder={form.id ? 'Leave blank to keep current key' : 'Optional'}
+                placeholder={form.id ? (form.hasApiKey ? 'Key saved — leave blank to keep it' : 'No key saved yet — enter one to store it') : 'Optional'}
                 type="password"
                 value={form.apiKey}
               />

--- a/apps/desktop/src/components/model-picker.test.tsx
+++ b/apps/desktop/src/components/model-picker.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// jsdom has no ResizeObserver; cmdk's CommandList requires one.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+}
+// jsdom has no scrollIntoView; cmdk scrolls the selected item into view.
+if (typeof Element.prototype.scrollIntoView !== 'function') {
+  Element.prototype.scrollIntoView = () => {}
+}
+
+import { ModelPickerDialog } from './model-picker'
+
+// cmdk pushes the selected item's `value` (`provider.slug:model`) into a
+// controlled CommandInput when the selection changes. That leaked value used
+// to survive the dialog closing, so the next open filtered the list down to
+// just the current model. The picker must own its search term: cleared on
+// select, and reset every time the dialog opens.
+
+vi.mock('@/lib/model-options', () => ({
+  modelOptionsQueryKey: () => ['test-model-options'],
+  requestModelOptions: async () => ({
+    model: 'gyz-model',
+    provider: 'gyz',
+    providers: [
+      {
+        name: 'Sakiko Dev',
+        slug: 'custom:sakiko-dev',
+        models: ['tokenrhythm/kimi-k3', 'agy/gemini-3.6-flash-high']
+      },
+      { name: 'gyz', slug: 'gyz', models: ['gyz-model'] }
+    ]
+  })
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { cancel: 'Cancel' },
+      modelPicker: {
+        addProvider: 'Add provider',
+        current: 'Current:',
+        loadFailed: 'Failed to load',
+        noAuthenticatedProviders: 'No authenticated providers.',
+        noModels: 'No matching models',
+        pro: 'PRO',
+        search: 'Search models…',
+        title: 'Switch model',
+        unknown: 'unknown'
+      }
+    }
+  })
+}))
+
+function renderPicker(overrides: Record<string, unknown> = {}) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const props = {
+    currentModel: 'gyz-model',
+    currentProvider: 'gyz',
+    onOpenChange: vi.fn(),
+    onSelect: vi.fn(),
+    open: true,
+    ...overrides
+  }
+  return {
+    onOpenChange: props.onOpenChange,
+    onSelect: props.onSelect,
+    ...render(
+      <QueryClientProvider client={client}>
+        <ModelPickerDialog {...props} />
+      </QueryClientProvider>
+    )
+  }
+}
+
+afterEach(cleanup)
+
+describe('ModelPickerDialog search ownership', () => {
+  it('clears the search box when a model is selected', async () => {
+    renderPicker()
+
+    const input = await screen.findByPlaceholderText('Search models…')
+    await screen.findByText('tokenrhythm/kimi-k3')
+    fireEvent.click(screen.getByText('tokenrhythm/kimi-k3'))
+
+    await waitFor(() => expect((input as HTMLInputElement).value).toBe(''))
+  })
+
+  it('resets the search box every time the dialog opens', async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const props = {
+      currentModel: 'gyz-model',
+      currentProvider: 'gyz',
+      onOpenChange: vi.fn(),
+      onSelect: vi.fn()
+    }
+    const view = render(
+      <QueryClientProvider client={client}>
+        <ModelPickerDialog {...props} open={true} />
+      </QueryClientProvider>
+    )
+
+    const input = await screen.findByPlaceholderText('Search models…')
+    await screen.findByText('tokenrhythm/kimi-k3')
+    fireEvent.change(input, { target: { value: 'kimi' } })
+    expect((input as HTMLInputElement).value).toBe('kimi')
+
+    view.rerender(
+      <QueryClientProvider client={client}>
+        <ModelPickerDialog {...props} open={false} />
+      </QueryClientProvider>
+    )
+    view.rerender(
+      <QueryClientProvider client={client}>
+        <ModelPickerDialog {...props} open={true} />
+      </QueryClientProvider>
+    )
+
+    // The dialog content is a fresh DOM subtree after reopening — re-query.
+    const reopened = await screen.findByPlaceholderText('Search models…')
+    await waitFor(() => expect((reopened as HTMLInputElement).value).toBe(''))
+  })
+})

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useI18n } from '@/i18n'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
@@ -57,6 +57,17 @@ export function ModelPickerDialog({
   // the `hermes model` CLI picker, which shows the curated list verbatim.
   const [search, setSearch] = useState('')
 
+  // cmdk pushes the selected item's `value` into a controlled CommandInput
+  // when the selection changes (cmdk 1.1.1 store.setState "value" branch),
+  // which would leave the box filled with `provider:model` and collapse the
+  // list to just the current model on reopen. Reset on every open — the same
+  // guard session-picker.tsx already carries.
+  useEffect(() => {
+    if (open) {
+      setSearch('')
+    }
+  }, [open])
+
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, sessionId),
     queryFn: () => requestModelOptions({ gateway: gw, sessionId }),
@@ -79,6 +90,7 @@ export function ModelPickerDialog({
     : null
 
   const selectModel = (provider: ModelOptionProvider, model: string) => {
+    setSearch('')
     onSelect({ provider: provider.slug, model })
     onOpenChange(false)
   }


### PR DESCRIPTION
## Summary

After picking a model, the desktop model picker would show **only the current model** the next time it opened. This PR makes the picker own its search term (clear on select + reset on open), and makes the custom-endpoint form's API-key field show whether a key is actually saved.

## Root cause

`ModelPickerDialog` owns its search term in React state and passes it to a **controlled** cmdk `CommandInput`. cmdk's `store.setState("value", …)` branch — fired whenever the selection changes — calls the input's `onValueChange` with the selected item's `value` (cmdk 1.1.1, `index.mjs`: `...onValueChange)==null||y.call(g,h)`). Items use `value={\`${provider.slug}:${model}\`}`, so after any selection the controlled search state becomes e.g. `custom:sakiko-dev:tokenrhythm/kimi-k3`. The dialog closes but the state survives; on reopen, the manual `matches()` filter reduces the whole list to that one entry.

`session-picker.tsx` already carries the same guard (`useEffect(() => { if (!open) setSearch('') }, [open])`) — the model picker simply never got one.

## Fix

- `selectModel` clears the search term on select.
- `useEffect(() => { if (open) setSearch('') }, [open])` resets the box every time the dialog opens, so even a hand-typed query doesn't leak across opens.
- While in the neighborhood: the custom-endpoint form's API key input used to always show "Leave blank to keep current key" when editing — even for endpoints that have **no** stored key. The placeholder now reflects `has_api_key`: `Key saved — leave blank to keep it` vs `No key saved yet — enter one to store it`.

## Repro (before this patch)

1. Open the model picker in the desktop chat composer.
2. Pick any model.
3. Reopen the picker → the list shows only the just-selected model; the search box contains `provider:model`.

## Tests

New `apps/desktop/src/components/model-picker.test.tsx` (vitest + Testing Library) pins both contracts:

- selecting a model clears the search box;
- closing and reopening the dialog resets the box (with a hand-typed query in it).

The second test fails against unfixed code and passes with the fix. File-local jsdom polyfills for `ResizeObserver` / `scrollIntoView` (both required by cmdk) — no changes to the shared `vitest.setup.ts`. `tsc --noEmit` clean.
