### PR TITLE
feat(webhook): Standard Webhooks senders now authenticate (fixes #47451, salvage #47849)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -27,6 +27,9 @@ Security:
     binds a timestamp into the signed data for replay protection; the
     legacy body-only V1 (X-Webhook-Signature) is deprecated but still
     accepted with a warning, since it has no replay protection
+  - Standard Webhooks (webhook-id/webhook-timestamp/webhook-signature)
+    is accepted via the Svix-compatible validator: same signed content
+    "{id}.{timestamp}.{raw_body}" and "v1,<base64-hmac>" format
   - Set secret to "INSECURE_NO_AUTH" to skip validation (testing only)
 """
 
@@ -833,7 +836,10 @@ class WebhookAdapter(BasePlatformAdapter):
             "X-GitHub-Delivery",
             request.headers.get(
                 "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                request.headers.get(
+                    "webhook-id",
+                    request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                ),
             ),
         )
 
@@ -1074,15 +1080,17 @@ class WebhookAdapter(BasePlatformAdapter):
                 or request.headers.get(name.upper(), "")
             )
 
-        # Svix / AgentMail:
+        # Svix / AgentMail / Standard Webhooks:
         #   svix-id: msg_...
         #   svix-timestamp: unix seconds
         #   svix-signature: v1,<base64-hmac> [v1,<base64-hmac> ...]
+        # Standard Webhooks providers such as GitLab use the same signed
+        # content and v1 signature format with webhook-* header names.
         # Signed content is: "{id}.{timestamp}.{raw_body}".  Svix secrets
         # usually start with "whsec_" and the remainder is base64-encoded.
-        svix_id = _header("svix-id")
-        svix_timestamp = _header("svix-timestamp")
-        svix_signature = _header("svix-signature")
+        svix_id = _header("svix-id") or _header("webhook-id")
+        svix_timestamp = _header("svix-timestamp") or _header("webhook-timestamp")
+        svix_signature = _header("svix-signature") or _header("webhook-signature")
         if svix_id or svix_timestamp or svix_signature:
             return self._validate_svix_signature(
                 body=body,

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -122,6 +122,15 @@ def _svix_signature(body: bytes, secret: str, msg_id: str, timestamp: str) -> st
     return "v1," + base64.b64encode(digest).decode()
 
 
+def _standard_webhook_signature(
+    body: bytes, secret: str, webhook_id: str, timestamp: str
+) -> str:
+    """Compute a Standard Webhooks v1 signature header for *body*."""
+    signed = webhook_id.encode() + b"." + timestamp.encode() + b"." + body
+    digest = hmac.new(secret.encode(), signed, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode()
+
+
 # ===================================================================
 # Signature validation
 # ===================================================================
@@ -299,6 +308,69 @@ class TestValidateSignature:
             }
         )
         assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_standard_webhooks_signature_valid(self):
+        """Valid Standard Webhooks headers (webhook-*) are accepted."""
+        adapter = _make_adapter()
+        body = b'{"object_kind":"push"}'
+        secret = "gitlab-signing-secret"
+        webhook_id = "msg_gitlab_123"
+        timestamp = str(int(time.time()))
+        sig = _standard_webhook_signature(body, secret, webhook_id, timestamp)
+        req = _mock_request(
+            headers={
+                "webhook-id": webhook_id,
+                "webhook-timestamp": timestamp,
+                "webhook-signature": sig,
+            }
+        )
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_standard_webhooks_signature_wrong_body_rejects(self):
+        """Standard Webhooks signatures are bound to the exact raw body."""
+        adapter = _make_adapter()
+        signed_body = b'{"object_kind":"push"}'
+        received_body = b'{"object_kind":"merge_request"}'
+        secret = "gitlab-signing-secret"
+        webhook_id = "msg_gitlab_123"
+        timestamp = str(int(time.time()))
+        sig = _standard_webhook_signature(
+            signed_body, secret, webhook_id, timestamp
+        )
+        req = _mock_request(
+            headers={
+                "webhook-id": webhook_id,
+                "webhook-timestamp": timestamp,
+                "webhook-signature": sig,
+            }
+        )
+        assert adapter._validate_signature(req, received_body, secret) is False
+
+    def test_validate_standard_webhooks_old_timestamp_rejects(self):
+        """Standard Webhooks timestamps outside the ±300s replay window reject."""
+        adapter = _make_adapter()
+        body = b'{"object_kind":"push"}'
+        secret = "gitlab-signing-secret"
+        webhook_id = "msg_gitlab_123"
+        timestamp = str(int(time.time()) - 301)
+        sig = _standard_webhook_signature(body, secret, webhook_id, timestamp)
+        req = _mock_request(
+            headers={
+                "webhook-id": webhook_id,
+                "webhook-timestamp": timestamp,
+                "webhook-signature": sig,
+            }
+        )
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_standard_webhooks_incomplete_headers_fail_closed(self):
+        """webhook-id alone selects the Svix-style path and must fail closed —
+        never fall through to weaker generic branches."""
+        adapter = _make_adapter()
+        body = b'{"object_kind":"push"}'
+        secret = "gitlab-signing-secret"
+        req = _mock_request(headers={"webhook-id": "msg_only_id"})
+        assert adapter._validate_signature(req, body, secret) is False
 
 
 # ===================================================================
@@ -537,6 +609,25 @@ class TestIdempotency:
             assert resp2.status == 200
             data = await resp2.json()
             assert data["status"] == "duplicate"
+
+    @pytest.mark.asyncio
+    async def test_webhook_id_used_as_delivery_id_for_deduplication(self):
+        """Standard Webhooks retries reuse webhook-id, so use it for dedupe."""
+        routes = {"idem": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            headers = {"webhook-id": "msg_standard_duplicate"}
+            resp1 = await cli.post("/webhooks/idem", json={"a": 1}, headers=headers)
+            assert resp1.status == 202
+
+            resp2 = await cli.post("/webhooks/idem", json={"a": 1}, headers=headers)
+            assert resp2.status == 200
+            data = await resp2.json()
+            assert data["status"] == "duplicate"
+            assert data["delivery_id"] == "msg_standard_duplicate"
 
 
 # ===================================================================

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -498,6 +498,7 @@ The adapter validates incoming webhook signatures using the appropriate method f
 
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
+- **Standard Webhooks**: `webhook-id`, `webhook-timestamp`, and `webhook-signature` headers — signed content is `{id}.{timestamp}.{raw_body}` with a `v1,<base64-hmac-sha256>` signature
 - **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
 - **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.
 
@@ -529,7 +530,7 @@ Requests exceeding the limit receive a `429 Too Many Requests` response.
 
 ### Idempotency
 
-Delivery IDs (from `X-GitHub-Delivery`, `X-Request-ID`, or a timestamp fallback) are cached for **1 hour**. Duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs.
+Delivery IDs (from `X-GitHub-Delivery`, `svix-id`, `webhook-id`, `X-Request-ID`, or a timestamp fallback) are cached for **1 hour**. Duplicate deliveries (e.g. webhook retries) are silently skipped with a `200` response, preventing duplicate agent runs.
 
 ### Body size limits
 
@@ -588,7 +589,7 @@ This is the same trust model that applies to everything the agent reads: web pag
 
 ### Duplicate responses
 
-- The idempotency cache should prevent this — check that the webhook source is sending a delivery ID header (`X-GitHub-Delivery` or `X-Request-ID`)
+- The idempotency cache should prevent this — check that the webhook source is sending a delivery ID header (`X-GitHub-Delivery`, `svix-id`, `webhook-id`, or `X-Request-ID`)
 - Delivery IDs are cached for 1 hour
 
 ### `gh` CLI errors (GitHub comment delivery)


### PR DESCRIPTION
## Summary
The generic webhook gateway now authenticates [Standard Webhooks](https://www.standardwebhooks.com/) senders (`webhook-id` / `webhook-timestamp` / `webhook-signature`) — providers using that spec (GitLab and a growing set of SaaS webhooks) previously had every delivery to a secret-configured route rejected as an unrecognized signature.

Salvages #47849 by @HwangJohn (fixes #47451), rebased onto current main with the stale test-file snapshot dropped and hardening tests added on top.

## Changes
- `gateway/platforms/webhook.py`: accept `webhook-*` headers as aliases into the existing Svix-compatible validator — same signed content `{id}.{timestamp}.{raw_body}` and `v1,<base64-hmac-sha256>` format, same ±300s replay window, fail-closed when any field is missing; `webhook-id` also feeds the delivery-ID dedupe cache; module docstring documents the scheme.
- `tests/gateway/test_webhook_adapter.py`: valid-signature accept, tampered-body reject, expired-timestamp reject, incomplete-headers fail-closed, and `webhook-id` dedupe (hardening tests for replay-window and fail-closed added during salvage).
- `website/docs/user-guide/messaging/webhooks.md`: Standard Webhooks listed under signature validation and idempotency.

## Validation
| Check | Result |
|---|---|
| `tests/gateway/test_webhook_adapter.py` | 41 passed |
| `tests/gateway/test_webhook_signature_rate_limit.py` | 1 passed |
| E2E (real aiohttp app, secret-configured route) | valid sig → 202, tampered body → 401, replayed `webhook-id` → duplicate |
| `scripts/audit_pr_attribution.py --fix` | all emails mapped |

Ported context: paradigmxyz/centaur#1380 shipped the same protocol support this week (Rust, `standardwebhooks` crate) with the identical design points — five-minute tolerance, `v1` space-separated signatures for key rotation, fail closed on missing secret. Ours reuses the existing Svix validator, which already implements all of that, so the diff stays at ~30 LOC of adapter code.

## Infographic

![Standard Webhooks support](https://v3b.fal.media/files/b/0aa74eba/Eru0HEg4l3EUbCmmFEeNk_YOk4HCv9.png)
