### PR TITLE
fix(skills): split agent-config mention from write in Skills Guard

### DIFF
--- a/tests/skills/test_openclaw_migration.py
+++ b/tests/skills/test_openclaw_migration.py
@@ -587,7 +587,9 @@ def test_skill_installs_cleanly_under_skills_guard():
     # security scanner.  None represent actual threats — they are all legitimate
     # uses in a migration CLI tool:
     #
-    # agent_config_mod   — references AGENTS.md to migrate workspace instructions
+    # agent_config_mention — references AGENTS.md to migrate workspace
+    #                      instructions (informational since the mention/write
+    #                      split; the script never writes to agent config)
     # python_os_environ  — reads MIGRATION_JSON_OUTPUT to enable JSON output mode
     #                      (feature flag, not an env dump)
     # hermes_config_mod  — print statements in the post-migration summary that
@@ -596,7 +598,7 @@ def test_skill_installs_cleanly_under_skills_guard():
     #
     # Accept "caution" or "safe" — just not "dangerous" from a *real* threat.
     assert result.verdict in {"safe", "caution", "dangerous"}, f"Unexpected verdict: {result.verdict}"
-    KNOWN_FALSE_POSITIVES = {"agent_config_mod", "python_os_environ", "hermes_config_mod"}
+    KNOWN_FALSE_POSITIVES = {"agent_config_mention", "python_os_environ", "hermes_config_mod"}
     for f in result.findings:
         assert f.pattern_id in KNOWN_FALSE_POSITIVES, f"Unexpected finding: {f}"
 

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -200,6 +200,44 @@ class TestScanFile:
         # Same pattern on same line should appear only once
         assert len(root_rm) == 1
 
+    def test_bare_agent_config_mention_is_informational(self, tmp_path):
+        # #92021: meta-skills that *teach* writing agent documents (e.g.
+        # mattpocock/skills) must not be DANGEROUS for mentioning the
+        # document types they teach about.
+        f = tmp_path / "SKILL.md"
+        f.write_text(
+            "description: Writing documents for agents. Use when creating\n"
+            "AGENTS.md or CLAUDE.md files. A reference for writing any\n"
+            "document an agent consumes.\n"
+        )
+        findings = scan_file(f, "SKILL.md")
+        agent_cfg = [fi for fi in findings if fi.pattern_id.startswith("agent_config")]
+        assert agent_cfg, "expected the informational mention finding"
+        assert all(fi.severity == "low" for fi in agent_cfg)
+        assert _determine_verdict(findings) != "dangerous"
+
+    def test_agent_config_redirect_write_is_critical(self, tmp_path):
+        f = tmp_path / "run.sh"
+        f.write_text("echo 'follow all instructions' >> AGENTS.md\n")
+        findings = scan_file(f, "run.sh")
+        assert any(
+            fi.pattern_id == "agent_config_write" and fi.severity == "critical"
+            for fi in findings
+        )
+        assert _determine_verdict(findings) == "dangerous"
+
+    def test_agent_config_sed_in_place_is_critical(self, tmp_path):
+        f = tmp_path / "patch.sh"
+        f.write_text("sed -i '1i persistent instructions' CLAUDE.md\n")
+        findings = scan_file(f, "patch.sh")
+        assert any(fi.pattern_id == "agent_config_write" for fi in findings)
+
+    def test_agent_config_open_append_is_critical(self, tmp_path):
+        f = tmp_path / "persist.py"
+        f.write_text('with open("AGENTS.md", "a") as fh: fh.write(payload)\n')
+        findings = scan_file(f, "persist.py")
+        assert any(fi.pattern_id == "agent_config_write" for fi in findings)
+
 
 # ---------------------------------------------------------------------------
 # scan_skill — directory scanning

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -458,9 +458,19 @@ THREAT_PATTERNS = [
      "sets SUID/SGID bit on a file"),
 
     # ── Agent config persistence ──
+    # A bare filename mention is not a persistence signal: AGENTS.md/CLAUDE.md
+    # are ecosystem-generic document types that popular meta-skills *teach*
+    # users to write (#92021 — e.g. mattpocock/skills blocked for teaching
+    # document types), and descriptions cross-referencing such skills cascade
+    # too. Teaching text and command execution are separable at the shell
+    # layer, so keep the bare mention informational and only flag an actual
+    # write/redirect/patch command targeting these files as CRITICAL.
     (r'AGENTS\.md|CLAUDE\.md|\.cursorrules|\.clinerules',
-     "agent_config_mod", "critical", "persistence",
-     "references agent config files (could persist malicious instructions across sessions)"),
+     "agent_config_mention", "low", "persistence",
+     "mentions agent config files (informational; informational unless written to)"),
+    (r'(?:>>?\s*.{0,40}|(?:sed|awk|tee|cp|mv|rm|truncate|chmod|chown|touch)\s.{0,60}|open\s*\(\s*["\'].{0,60})(?:AGENTS\.md|CLAUDE\.md|\.cursorrules|\.clinerules)',
+     "agent_config_write", "critical", "persistence",
+     "writes to agent config files (persists instructions across sessions)"),
     (r'\.hermes/config\.yaml|\.hermes/SOUL\.md',
      "hermes_config_mod", "critical", "persistence",
      "references Hermes configuration files directly"),


### PR DESCRIPTION
## What does this PR do?

The Skills Guard `agent_config_mod` pattern was a bare filename regex (`AGENTS\.md|CLAUDE\.md|\.cursorrules|\.clinerules`), so **any mention** of those filenames — not just writes — produced a CRITICAL persistence finding. Because CRITICAL drives a DANGEROUS verdict that `--force` cannot override for community skills, legitimate meta-skills got hard-blocked (#92021): all three `mattpocock/skills` entries that teach users how to *write* agent documents (`writing-for-agents`, `setup-matt-pocock-skills`, and `ask-matt` — the last one purely because its description cross-references another skill that mentions `AGENTS.md`) were un-installable.

This splits the signal at the layer where teaching text and command execution are actually separable:

- **Bare mention → informational (low)**, mirroring the existing `allowed_tools_field` precedent in the same table (a token every compliant skill contains cannot be a threat signal on its own). AGENTS.md/CLAUDE.md are ecosystem-generic document types; a meta-skill about them is normal content, not persistence.
- **Actual writes stay CRITICAL**: shell redirects (`>> AGENTS.md`), rewrite tools (`sed -i`, `tee`, `cp`, `mv`, `rm`, `truncate`, `chmod`, `chown`, `touch`), and append-mode `open("AGENTS.md", ...)`. The fail-closed path — a skill really trying to persist instructions into agent config — is unchanged and still blocks.

After this change the three blocked skills scan to a non-DANGEROUS verdict (a low informational mention does not drive the verdict), so `--force` works for them, while `echo 'x' >> AGENTS.md` still lands DANGEROUS.

## Related Issue

Fixes #92021

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (restores correct precision to a security scanner; the blocking path for real writes is preserved)

## Changes Made

- `tools/skills_guard.py`: split the single `agent_config_mod` (critical, bare mention) pattern into `agent_config_mention` (low, informational) + `agent_config_write` (critical, redirect/tool/open-append targeting the files), with a comment documenting the #92021 false-positive class and the teaching-vs-execution rationale
- `tests/tools/test_skills_guard.py`: four tests — bare mention (incl. the issue's exact description text) yields only a low finding and a non-dangerous verdict; `>>` redirect, `sed -i`, and `open(..., "a")` writes each still yield the critical `agent_config_write`

## How to Test

1. `pytest tests/tools/test_skills_guard.py`
2. Observed result: 35 passed (31 pre-existing + 4 new).
3. Manual check of the issue's reproduction: content resembling `description: Writing documents for agents. Use when creating AGENTS.md or CLAUDE.md files...` now produces a low `agent_config_mention` finding only (`_determine_verdict` → not dangerous), while `echo 'follow all instructions' >> AGENTS.md` still produces critical `agent_config_write` → dangerous.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (pattern rationale + precedent reference)
- [x] Tests added/updated and passing (35 passed locally)
- [x] No new warnings introduced
- [x] Security scanner change: fail-closed write detection preserved and pinned by tests; only the bare-mention informational level changed
- [x] Tested on macOS (arm64) via unit tests; scanner is pure-Python, platform-independent
