### PR TITLE
fix(approvals): log every prompt raise (birth record) — addresses #91980 suggestion 1

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3987,6 +3987,20 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         )
         return {"resolved": False, "choice": None, "notify_failed": True}
 
+    # Birth record: a prompt was RAISED and dispatched. Symmetric with the
+    # BLOCKED outcome logged on timeout/deny — without this, a prompt whose
+    # delivery silently failed (dead client transport) leaves no trace until
+    # the timeout fires, and looks identical to user silence (#91980).
+    logger.warning(
+        "Approval prompt RAISED (session=%s surface=%s pattern=%s command=%.120r) "
+        "— awaiting user decision for up to %ss",
+        session_key,
+        surface,
+        primary_key,
+        command,
+        _get_approval_timeout(),
+    )
+
     # Block until the user responds or the canonical approval timeout elapses
     # (default 300s). Poll in short slices so we can fire activity heartbeats
     # every ~10s to the agent's inactivity tracker — otherwise the gateway


### PR DESCRIPTION
## What

Adds one WARNING log line immediately after an approval prompt's notify callback succeeds:

```
Approval prompt RAISED (session=... surface=gateway pattern=... command='...') — awaiting user decision for up to 300s
```

Symmetric with the existing BLOCKED outcome that gets logged ~300s later on timeout.

## Why

As documented in #91980: when a prompt's delivery silently fails (e.g. emitted onto a dead client transport), the operator's logs show *nothing* until the timeout fires — and then it looks identical to user silence. Five occurrences across two days in one install, two of them unnoticed until the BLOCKED lines were read after the fact.

With this line, operators can distinguish "prompt raised, awaiting human" from "nothing was ever sent" — which is the diagnostic gap that made #91980 hard to spot.

## Scope

No behaviour change. Prompts still time out identically; nothing about delivery, retry, or fallback changes. This is strictly observability — #91980's suggestion 1, deliberately minimal so it can land independently of the harder ack/fallback suggestions.

`py_compile` clean.