### PR TITLE
feat(gateway): expose Codex reasoning summary titles

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -17,6 +17,7 @@ resolved through :func:`_ra` so those patches keep working.
 from __future__ import annotations
 
 import json
+import inspect
 import logging
 import os
 import random
@@ -117,6 +118,62 @@ RUN_BUDGET_WRAPUP_NOTICE = (
     "now. Produce the required final deliverable (answer/JSON/summary) from "
     "the state you already have, completing only mandatory writes."
 )
+
+
+def _tool_progress_callback_accepts_titles(callback: Any) -> bool:
+    try:
+        parameters = inspect.signature(callback).parameters.values()
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.name == "titles"
+        or parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters
+    )
+
+
+def _notify_reasoning_progress(agent: Any, assistant_message: Any) -> None:
+    callback = getattr(agent, "tool_progress_callback", None)
+    if callback is None:
+        return
+    think_text = (getattr(assistant_message, "content", None) or "").strip()
+    think_text = re.sub(
+        r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', think_text
+    ).strip()
+    summary_text = ""
+    summary_titles = []
+    if getattr(agent, "api_mode", None) == "codex_responses":
+        summary_text = (getattr(assistant_message, "reasoning", None) or "").strip()
+        summary_titles = reasoning_summary_titles(summary_text)
+    first_line = think_text.split('\n')[0][:80] if think_text else ""
+    if getattr(agent, '_delegate_depth', 0) > 0:
+        if first_line:
+            try:
+                callback("_thinking", first_line)
+            except Exception:
+                logger.debug(
+                    "tool_progress_callback raised while relaying delegated thinking",
+                    exc_info=True,
+                )
+        return
+    if not (think_text or summary_titles):
+        return
+    kwargs = {}
+    if summary_titles and _tool_progress_callback_accepts_titles(callback):
+        kwargs["titles"] = summary_titles
+    try:
+        callback(
+            "reasoning.available",
+            "_thinking",
+            (summary_text or think_text)[:500],
+            None,
+            **kwargs,
+        )
+    except Exception:
+        logger.debug(
+            "tool_progress_callback raised while emitting reasoning metadata",
+            exc_info=True,
+        )
 
 
 def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) -> bool:
@@ -6717,40 +6774,7 @@ def run_conversation(
                 else:
                     agent._vprint(f"{agent.log_prefix}🤖 Assistant: {assistant_message.content[:100]}{'...' if len(assistant_message.content) > 100 else ''}")
 
-            # Notify progress callback of model's thinking (used by subagent
-            # delegation to relay the child's reasoning to the parent display).
-            if agent.tool_progress_callback:
-                _think_text = (assistant_message.content or "").strip()
-                # Strip reasoning XML tags that shouldn't leak to parent display
-                _think_text = re.sub(
-                    r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
-                ).strip()
-                _summary_text = ""
-                _summary_titles = []
-                if agent.api_mode == "codex_responses":
-                    _summary_text = (getattr(assistant_message, "reasoning", None) or "").strip()
-                    _summary_titles = reasoning_summary_titles(_summary_text)
-                # For subagents: relay first line to parent display (existing behaviour).
-                # For all agents with a structured callback: emit reasoning.available event.
-                first_line = _think_text.split('\n')[0][:80] if _think_text else ""
-                if getattr(agent, '_delegate_depth', 0) > 0:
-                    if first_line:
-                        try:
-                            agent.tool_progress_callback("_thinking", first_line)
-                        except Exception:
-                            pass
-                elif _think_text or _summary_titles:
-                    try:
-                        kwargs = {"titles": _summary_titles} if _summary_titles else {}
-                        agent.tool_progress_callback(
-                            "reasoning.available",
-                            "_thinking",
-                            (_summary_text or _think_text)[:500],
-                            None,
-                            **kwargs,
-                        )
-                    except Exception:
-                        pass
+            _notify_reasoning_progress(agent, assistant_message)
             
             # Check for incomplete <REASONING_SCRATCHPAD> (opened but never closed)
             # This means the model ran out of output tokens mid-reasoning — retry up to 2 times

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -88,6 +88,7 @@ from agent.retry_utils import (
     zai_coding_overload_retry_ceiling,
 )
 from agent.repetition_guard import is_repetition_dominated
+from agent.reasoning_summaries import reasoning_summary_titles
 from agent.trajectory import has_incomplete_scratchpad
 # Bind before the turn starts so a source-tree swap cannot load a skewed
 # finalizer at turn end.
@@ -6718,23 +6719,36 @@ def run_conversation(
 
             # Notify progress callback of model's thinking (used by subagent
             # delegation to relay the child's reasoning to the parent display).
-            if (assistant_message.content and agent.tool_progress_callback):
-                _think_text = assistant_message.content.strip()
+            if agent.tool_progress_callback:
+                _think_text = (assistant_message.content or "").strip()
                 # Strip reasoning XML tags that shouldn't leak to parent display
                 _think_text = re.sub(
                     r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
                 ).strip()
+                _summary_text = ""
+                _summary_titles = []
+                if agent.api_mode == "codex_responses":
+                    _summary_text = (getattr(assistant_message, "reasoning", None) or "").strip()
+                    _summary_titles = reasoning_summary_titles(_summary_text)
                 # For subagents: relay first line to parent display (existing behaviour).
                 # For all agents with a structured callback: emit reasoning.available event.
                 first_line = _think_text.split('\n')[0][:80] if _think_text else ""
-                if first_line and getattr(agent, '_delegate_depth', 0) > 0:
+                if getattr(agent, '_delegate_depth', 0) > 0:
+                    if first_line:
+                        try:
+                            agent.tool_progress_callback("_thinking", first_line)
+                        except Exception:
+                            pass
+                elif _think_text or _summary_titles:
                     try:
-                        agent.tool_progress_callback("_thinking", first_line)
-                    except Exception:
-                        pass
-                elif _think_text:
-                    try:
-                        agent.tool_progress_callback("reasoning.available", "_thinking", _think_text[:500], None)
+                        kwargs = {"titles": _summary_titles} if _summary_titles else {}
+                        agent.tool_progress_callback(
+                            "reasoning.available",
+                            "_thinking",
+                            (_summary_text or _think_text)[:500],
+                            None,
+                            **kwargs,
+                        )
                     except Exception:
                         pass
             

--- a/agent/reasoning_summaries.py
+++ b/agent/reasoning_summaries.py
@@ -31,7 +31,28 @@ stream in line with the path that keeps the structure.
 
 from __future__ import annotations
 
-__all__ = ["separate_glued_reasoning_blocks"]
+__all__ = ["reasoning_summary_titles", "separate_glued_reasoning_blocks"]
+
+
+def reasoning_summary_titles(text: object) -> list[str]:
+    """Extract display titles from a provider-supplied reasoning summary.
+
+    Codex summary parts conventionally start with a complete bold heading. If
+    a provider returns plain summary text instead, its first non-empty line is
+    already the provider's display summary and is used as the sole title.
+    """
+    lines = [line.strip() for line in str(text or "").splitlines() if line.strip()]
+    headings = [line[2:-2].strip() for line in lines if line.startswith("**") and line.endswith("**")]
+    candidates = headings or lines[:1]
+    titles: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        title = " ".join(candidate.split())
+        key = title.casefold()
+        if title and key not in seen:
+            seen.add(key)
+            titles.append(title)
+    return titles
 
 
 def separate_glued_reasoning_blocks(previous: str, delta: str) -> str:

--- a/agent/reasoning_summaries.py
+++ b/agent/reasoning_summaries.py
@@ -31,7 +31,15 @@ stream in line with the path that keeps the structure.
 
 from __future__ import annotations
 
-__all__ = ["reasoning_summary_titles", "separate_glued_reasoning_blocks"]
+REASONING_SUMMARY_MAX_TITLES = 8
+REASONING_SUMMARY_MAX_TITLE_CHARS = 120
+
+__all__ = [
+    "REASONING_SUMMARY_MAX_TITLE_CHARS",
+    "REASONING_SUMMARY_MAX_TITLES",
+    "reasoning_summary_titles",
+    "separate_glued_reasoning_blocks",
+]
 
 
 def reasoning_summary_titles(text: object) -> list[str]:
@@ -42,16 +50,24 @@ def reasoning_summary_titles(text: object) -> list[str]:
     already the provider's display summary and is used as the sole title.
     """
     lines = [line.strip() for line in str(text or "").splitlines() if line.strip()]
-    headings = [line[2:-2].strip() for line in lines if line.startswith("**") and line.endswith("**")]
+    headings = [
+        line[2:-2].strip().strip("*").strip()
+        for line in lines
+        if line.startswith("**") and line.endswith("**")
+    ]
     candidates = headings or lines[:1]
     titles: list[str] = []
     seen: set[str] = set()
     for candidate in candidates:
         title = " ".join(candidate.split())
+        if len(title) > REASONING_SUMMARY_MAX_TITLE_CHARS:
+            title = title[: REASONING_SUMMARY_MAX_TITLE_CHARS - 3].rstrip() + "..."
         key = title.casefold()
         if title and key not in seen:
             seen.add(key)
             titles.append(title)
+            if len(titles) == REASONING_SUMMARY_MAX_TITLES:
+                break
     return titles
 
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7434,12 +7434,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     "error": kwargs.get("is_error", False),
                 })
             elif event_type == "reasoning.available":
-                _push({
+                event = {
                     "event": "reasoning.available",
                     "run_id": run_id,
                     "timestamp": ts,
                     "text": preview or "",
-                })
+                }
+                titles = kwargs.get("titles")
+                if isinstance(titles, list) and titles:
+                    event["titles"] = titles
+                _push(event)
             elif event_type in {"subagent.start", "subagent.complete"}:
                 event = {
                     "event": event_type,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -122,6 +122,10 @@ from gateway.platforms.base import (
     validate_media_delivery_path,
 )
 from agent.redact import redact_sensitive_text
+from agent.reasoning_summaries import (
+    REASONING_SUMMARY_MAX_TITLE_CHARS,
+    REASONING_SUMMARY_MAX_TITLES,
+)
 from agent.interrupt_compat import request_hard_interrupt
 from gateway.readiness import collect_runtime_readiness
 from gateway.browser_control_artifacts import (
@@ -7441,8 +7445,17 @@ class APIServerAdapter(BasePlatformAdapter):
                     "text": preview or "",
                 }
                 titles = kwargs.get("titles")
-                if isinstance(titles, list) and titles:
-                    event["titles"] = titles
+                if (
+                    isinstance(titles, list)
+                    and 0 < len(titles) <= REASONING_SUMMARY_MAX_TITLES
+                    and all(
+                        isinstance(title, str)
+                        and bool(title.strip())
+                        and len(title) <= REASONING_SUMMARY_MAX_TITLE_CHARS
+                        for title in titles
+                    )
+                ):
+                    event["titles"] = list(titles)
                 _push(event)
             elif event_type in {"subagent.start", "subagent.complete"}:
                 event = {

--- a/tests/agent/test_reasoning_summaries.py
+++ b/tests/agent/test_reasoning_summaries.py
@@ -1,6 +1,19 @@
 """Reasoning summary-part boundary repair (agent/reasoning_summaries.py)."""
 
-from agent.reasoning_summaries import separate_glued_reasoning_blocks
+from agent.reasoning_summaries import reasoning_summary_titles, separate_glued_reasoning_blocks
+
+
+def test_reasoning_summary_titles_prefers_ordered_unique_headings():
+    assert reasoning_summary_titles(
+        "**Inspecting files**\nDetails\n\n**Running tests**\nMore details\n\n**inspecting files**"
+    ) == ["Inspecting files", "Running tests"]
+
+
+def test_reasoning_summary_titles_uses_plain_provider_summary():
+    assert reasoning_summary_titles("  Planning the implementation  \nSupporting detail") == [
+        "Planning the implementation"
+    ]
+    assert reasoning_summary_titles(None) == []
 
 
 def _stream(deltas):

--- a/tests/agent/test_reasoning_summaries.py
+++ b/tests/agent/test_reasoning_summaries.py
@@ -1,6 +1,11 @@
 """Reasoning summary-part boundary repair (agent/reasoning_summaries.py)."""
 
-from agent.reasoning_summaries import reasoning_summary_titles, separate_glued_reasoning_blocks
+from agent.reasoning_summaries import (
+    REASONING_SUMMARY_MAX_TITLE_CHARS,
+    REASONING_SUMMARY_MAX_TITLES,
+    reasoning_summary_titles,
+    separate_glued_reasoning_blocks,
+)
 
 
 def test_reasoning_summary_titles_prefers_ordered_unique_headings():
@@ -14,6 +19,19 @@ def test_reasoning_summary_titles_uses_plain_provider_summary():
         "Planning the implementation"
     ]
     assert reasoning_summary_titles(None) == []
+
+
+def test_reasoning_summary_titles_bound_output_and_clean_emphasis():
+    titles = reasoning_summary_titles(
+        "\n".join(
+            ["***Italic heading***"]
+            + [f"**Title {index} {'x' * 200}**" for index in range(20)]
+        )
+    )
+
+    assert titles[0] == "Italic heading"
+    assert len(titles) == REASONING_SUMMARY_MAX_TITLES
+    assert all(len(title) <= REASONING_SUMMARY_MAX_TITLE_CHARS for title in titles)
 
 
 def _stream(deltas):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -647,6 +647,27 @@ class TestRunEventCallback:
         assert titled["titles"] == ["Inspecting files", "Running tests"]
 
     @pytest.mark.asyncio
+    async def test_reasoning_titles_reject_malformed_public_metadata(self, adapter):
+        run_id = "run_reasoning_titles_invalid"
+        loop = asyncio.get_running_loop()
+        queue = asyncio.Queue()
+        adapter._run_streams[run_id] = queue
+        callback = adapter._make_run_event_callback(run_id, loop)
+
+        callback("reasoning.available", "_thinking", "Mixed", None, titles=["valid", 7])
+        callback("reasoning.available", "_thinking", "Long", None, titles=["x" * 121])
+        callback(
+            "reasoning.available",
+            "_thinking",
+            "Many",
+            None,
+            titles=[f"title-{index}" for index in range(9)],
+        )
+
+        events = [await asyncio.wait_for(queue.get(), timeout=1.0) for _ in range(3)]
+        assert all("titles" not in event for event in events)
+
+    @pytest.mark.asyncio
     async def test_subagent_events_redact_secrets_and_carry_child_session(self, adapter):
         """Free-text fields (goal/summary/output_tail/preview) must pass the
         forced secret redaction before hitting the public /v1/runs stream,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -625,6 +625,28 @@ class TestDisconnectedAgentReap:
 class TestRunEventCallback:
 
     @pytest.mark.asyncio
+    async def test_reasoning_titles_are_optional_additive_metadata(self, adapter):
+        run_id = "run_reasoning_titles"
+        loop = asyncio.get_running_loop()
+        queue = asyncio.Queue()
+        adapter._run_streams[run_id] = queue
+
+        callback = adapter._make_run_event_callback(run_id, loop)
+        callback("reasoning.available", "_thinking", "First summary", None)
+        callback(
+            "reasoning.available",
+            "_thinking",
+            "Second summary",
+            None,
+            titles=["Inspecting files", "Running tests"],
+        )
+
+        legacy = await asyncio.wait_for(queue.get(), timeout=1.0)
+        titled = await asyncio.wait_for(queue.get(), timeout=1.0)
+        assert "titles" not in legacy
+        assert titled["titles"] == ["Inspecting files", "Running tests"]
+
+    @pytest.mark.asyncio
     async def test_subagent_events_redact_secrets_and_carry_child_session(self, adapter):
         """Free-text fields (goal/summary/output_tail/preview) must pass the
         forced secret redaction before hitting the public /v1/runs stream,

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1697,6 +1697,59 @@ def test_run_conversation_exposes_codex_summary_titles(monkeypatch):
     assert titled[1]["titles"] == ["Inspecting files", "Running tests"]
 
 
+def test_reasoning_progress_keeps_titles_additive_and_delegation_content_based():
+    from agent.conversation_loop import _notify_reasoning_progress
+
+    message = SimpleNamespace(
+        content="Visible first line\nmore",
+        reasoning="**Provider summary**\nDetails",
+    )
+
+    fixed_events = []
+    fixed_callback = lambda event, name, preview, args: fixed_events.append(
+        (event, name, preview, args)
+    )
+    _notify_reasoning_progress(
+        SimpleNamespace(
+            tool_progress_callback=fixed_callback,
+            api_mode="codex_responses",
+            _delegate_depth=0,
+        ),
+        message,
+    )
+    assert fixed_events == [
+        ("reasoning.available", "_thinking", "**Provider summary**\nDetails", None)
+    ]
+
+    non_codex_events = []
+    _notify_reasoning_progress(
+        SimpleNamespace(
+            tool_progress_callback=lambda *args, **kwargs: non_codex_events.append(
+                (args, kwargs)
+            ),
+            api_mode="chat_completions",
+            _delegate_depth=0,
+        ),
+        message,
+    )
+    assert non_codex_events == [
+        (("reasoning.available", "_thinking", "Visible first line\nmore", None), {})
+    ]
+
+    delegated_events = []
+    _notify_reasoning_progress(
+        SimpleNamespace(
+            tool_progress_callback=lambda *args, **kwargs: delegated_events.append(
+                (args, kwargs)
+            ),
+            api_mode="codex_responses",
+            _delegate_depth=1,
+        ),
+        message,
+    )
+    assert delegated_events == [(('_thinking', 'Visible first line'), {})]
+
+
 
 
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1655,6 +1655,48 @@ def test_run_conversation_codex_replay_payload_keeps_call_id(monkeypatch):
     assert function_output["call_id"] == "call_1"
 
 
+def test_run_conversation_exposes_codex_summary_titles(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    responses = [
+        SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="reasoning",
+                    id="rs_1",
+                    encrypted_content="enc_1",
+                    summary=[
+                        SimpleNamespace(text="**Inspecting files**\nDetails"),
+                        SimpleNamespace(text="**Running tests**\nMore details"),
+                    ],
+                ),
+                SimpleNamespace(
+                    type="function_call",
+                    id="fc_1",
+                    call_id="call_1",
+                    name="terminal",
+                    arguments="{}",
+                ),
+            ],
+            usage=SimpleNamespace(input_tokens=12, output_tokens=4, total_tokens=16),
+            status="completed",
+            model="gpt-5-codex",
+        ),
+        _codex_message_response("done"),
+    ]
+    events = []
+    agent.tool_progress_callback = lambda *args, **kwargs: events.append((args, kwargs))
+    monkeypatch.setattr(agent, "_interruptible_api_call", lambda _kwargs: responses.pop(0))
+    monkeypatch.setattr(agent, "_execute_tool_calls", lambda *_args, **_kwargs: None)
+
+    result = agent.run_conversation("inspect and test")
+
+    assert result["completed"] is True
+    reasoning = [event for event in events if event[0][0] == "reasoning.available"]
+    titled = next(event for event in reasoning if event[1].get("titles"))
+    assert titled[0][2].startswith("**Inspecting files**")
+    assert titled[1]["titles"] == ["Inspecting files", "Running tests"]
+
+
 
 
 
@@ -2108,7 +2150,7 @@ def test_dump_api_request_debug_uses_responses_url(monkeypatch, tmp_path):
 
     dump_file = agent._dump_api_request_debug(_codex_request_kwargs(), reason="preflight")
 
-    payload = json.loads(dump_file.read_text())
+    payload = json.loads(dump_file.read_text(encoding="utf-8"))
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/responses"
 
 
@@ -2132,7 +2174,7 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
         reason="preflight",
     )
 
-    payload = json.loads(dump_file.read_text())
+    payload = json.loads(dump_file.read_text(encoding="utf-8"))
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
 
 


### PR DESCRIPTION
## What changed

- Extract ordered, deduplicated display titles from provider-supplied Codex reasoning summaries.
- Attach those titles to the existing `/v1/runs` `reasoning.available` event as optional additive metadata.
- Emit the structured summary text as the reasoning preview when titles are available, including tool-call responses with no assistant prose.
- Preserve the existing event shape byte-for-byte for models and providers that do not supply summaries.

Example event:

```json
{
  "event": "reasoning.available",
  "text": "**Inspecting files**\nDetails",
  "titles": ["Inspecting files", "Running tests"]
}
```

## Why

The Codex Responses adapter already captures model-generated `summary_text` parts, but the Gateway currently drops that structured presentation metadata before `/v1/runs` clients can consume it. This exposes the existing data without generating summaries in Hermes or changing behavior for agents that do not provide them.

Related prior work: #79727, #59609, #21655, #50156, and #84279.

## Validation

- `scripts/run_tests.sh tests/agent/test_reasoning_summaries.py tests/run_agent/test_run_agent_codex_responses.py tests/gateway/test_api_server.py -q` — 178 passed on the Python 3.11 CI dependency set.
- The same focused command — 178 passed on Python 3.13.
- `ruff check` on all six changed files — passed.
- `scripts/check-windows-footguns.py --diff upstream/main` — passed.
- `git diff --check upstream/main...HEAD` — passed.

The full local macOS suite also completed. It reported 21 unrelated failures in 12 platform/environment suites (systemd/Linux desktop, WSL voice, wake-word runtime, local provider discovery, and similar host-specific coverage); all changed and adjacent suites passed.
