### PR TITLE
fix(agent): fail-fast subdirectory hint reads on iCloud/FileProvider paths

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -17,6 +17,7 @@ import hashlib
 import logging
 import os
 import shlex
+import threading
 from pathlib import Path
 from typing import Dict, Any, Optional, Set
 
@@ -36,6 +37,11 @@ _HINT_FILENAMES = [
 
 # Maximum chars per hint file to prevent context bloat
 _MAX_HINT_CHARS = 8_000
+
+# Hard cap on how long a single hint-file open/read may block the tool path.
+# Evicted FileProvider placeholders (iCloud Drive, etc.) hang forever on
+# open/read; a short timeout treats them as missing so the gateway stays live.
+_HINT_READ_TIMEOUT_SECONDS = 2.0
 
 # Tool argument keys that typically contain file paths
 _PATH_ARG_KEYS = {"path", "file_path", "workdir"}
@@ -59,6 +65,23 @@ _EXCLUDED_DIR_NAMES = frozenset({
     "vendor", "third_party",
 })
 
+# Directory names that sit directly under a `Library` path component and mark
+# a FileProvider-backed subtree. Mirrors cron/lifecycle_guard.py so iCloud
+# Drive (`Mobile Documents`) and third-party providers under `CloudStorage`
+# (Dropbox / OneDrive / Google Drive / Box) are refused before open.
+_CLOUD_PLACEHOLDER_MARKERS = frozenset({"Mobile Documents", "CloudStorage"})
+
+# Broader refuse-list substrings from the 2026-08-18 gateway wedge
+# (task 20260818_092117_51a51a54): bare Path.read_text hung 53+ min on an
+# iCloud-backed AGENTS.md. Match anywhere in the path string.
+_CLOUD_PATH_REFUSE_SUBSTRINGS = (
+    "Mobile Documents",
+    "iCloud",
+    ".icloud",
+    "com.apple.fileprovider",
+    "CloudStorage",
+)
+
 
 def _is_ancestor_or_same(a: Path, b: Path) -> bool:
     """Check if *a* is the same as or an ancestor of *b* (parent directory check)."""
@@ -67,6 +90,72 @@ def _is_ancestor_or_same(a: Path, b: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _is_cloud_backed_path(path: Path) -> bool:
+    """True when *path* is under a macOS FileProvider / iCloud subtree.
+
+    Opening an evicted placeholder can block indefinitely. Refuse from path
+    metadata alone — never open, stat, or resolve into the cloud tree first.
+    """
+    parts = path.parts
+    if any(
+        parts[index - 1] == "Library" and part in _CLOUD_PLACEHOLDER_MARKERS
+        for index, part in enumerate(parts)
+        if index
+    ):
+        return True
+    path_str = str(path)
+    return any(marker in path_str for marker in _CLOUD_PATH_REFUSE_SUBSTRINGS)
+
+
+def _read_hint_text(path: Path) -> Optional[str]:
+    """Bounded UTF-8 read of a hint file. Returns None on refuse/timeout/error.
+
+    Never uses bare ``Path.read_text``: iCloud / FileProvider placeholders
+    hang forever on open (gateway wedge 2026-08-18). Preflight refuse + a
+    short timeout treat the file as missing so the tool call path stays live.
+    """
+    if _is_cloud_backed_path(path):
+        logger.debug("Skipping iCloud/FileProvider-backed hint file: %s", path)
+        return None
+
+    box: Dict[str, Any] = {"content": None, "error": None}
+
+    def _do_read() -> None:
+        try:
+            # Explicit open/read (not Path.read_text) so the blocking call is
+            # confined to this daemon worker and can be abandoned on timeout.
+            with open(path, "r", encoding="utf-8") as fh:
+                box["content"] = fh.read().strip()
+        except BaseException as exc:  # noqa: BLE001 — marshalled back to caller
+            box["error"] = exc
+
+    thread = threading.Thread(
+        target=_do_read,
+        name="subdirectory-hint-read",
+        daemon=True,
+    )
+    thread.start()
+    thread.join(timeout=_HINT_READ_TIMEOUT_SECONDS)
+    if thread.is_alive():
+        logger.warning(
+            "Timed out reading hint file after %.1fs (treating as missing): %s",
+            _HINT_READ_TIMEOUT_SECONDS,
+            path,
+        )
+        return None
+
+    err = box["error"]
+    if err is not None:
+        if isinstance(err, (OSError, UnicodeDecodeError)):
+            logger.debug("Could not read %s: %s", path, err)
+            return None
+        # Unexpected errors should still surface in tests / logs as debug and
+        # behave like a missing hint — never wedge the tool path.
+        logger.debug("Could not read %s: %s", path, err)
+        return None
+    return box["content"]
 
 
 class SubdirectoryHintTracker:
@@ -102,12 +191,20 @@ class SubdirectoryHintTracker:
         """
         for filename in _HINT_FILENAMES:
             candidate = self.working_dir / filename
+            # Refuse cloud paths before is_file()/open — both can hang on
+            # FileProvider placeholders (same class of wedge as the load path).
+            if _is_cloud_backed_path(candidate):
+                logger.debug(
+                    "Skipping iCloud/FileProvider-backed CWD hint seed: %s",
+                    candidate,
+                )
+                continue
             try:
                 if not candidate.is_file():
                     continue
-                content = candidate.read_text(encoding="utf-8").strip()
-            except (OSError, UnicodeDecodeError):
+            except OSError:
                 continue
+            content = _read_hint_text(candidate)
             if content:
                 self._loaded_digests.add(
                     hashlib.sha256(content.encode("utf-8")).hexdigest()
@@ -279,13 +376,20 @@ class SubdirectoryHintTracker:
         found_hints = []
         for filename in _HINT_FILENAMES:
             hint_path = directory / filename
+            # Preflight refuse before is_file()/open — FileProvider paths hang.
+            if _is_cloud_backed_path(hint_path):
+                logger.debug(
+                    "Skipping iCloud/FileProvider-backed hint file: %s",
+                    hint_path,
+                )
+                continue
             try:
                 if not hint_path.is_file():
                     continue
             except OSError:
                 continue
             try:
-                content = hint_path.read_text(encoding="utf-8").strip()
+                content = _read_hint_text(hint_path)
                 if not content:
                     continue
                 # Skip content we've already injected. The same AGENTS.md is

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -297,3 +297,138 @@ class TestExcludedDirectories:
         assert result is not None
         assert "Personal backend override" in result
         assert "Committed backend rules" not in result
+
+
+class TestCloudBackedPathRefuse:
+    """iCloud / FileProvider paths must never be opened (gateway wedge 2026-08-18)."""
+
+    def test_is_cloud_backed_mobile_documents(self):
+        from agent.subdirectory_hints import _is_cloud_backed_path
+
+        p = Path.home() / "Library" / "Mobile Documents" / "com~apple~CloudDocs" / "AGENTS.md"
+        assert _is_cloud_backed_path(p) is True
+
+    def test_is_cloud_backed_cloudstorage(self):
+        from agent.subdirectory_hints import _is_cloud_backed_path
+
+        p = Path.home() / "Library" / "CloudStorage" / "Dropbox" / "AGENTS.md"
+        assert _is_cloud_backed_path(p) is True
+
+    def test_is_cloud_backed_substring_icloud(self):
+        from agent.subdirectory_hints import _is_cloud_backed_path
+
+        assert _is_cloud_backed_path(Path("/Users/x/iCloudDrive/proj/AGENTS.md")) is True
+        assert _is_cloud_backed_path(Path("/tmp/foo.icloud")) is True
+        assert _is_cloud_backed_path(Path("/tmp/com.apple.fileprovider/x")) is True
+
+    def test_local_path_not_refused(self, tmp_path):
+        from agent.subdirectory_hints import _is_cloud_backed_path
+
+        assert _is_cloud_backed_path(tmp_path / "AGENTS.md") is False
+
+    def test_load_skips_icloud_named_path_without_open(self, tmp_path):
+        """Even inside working_dir, cloud-shaped names are refused preflight."""
+        from agent.subdirectory_hints import _read_hint_text
+
+        # Synthetic path string containing refuse markers — never open.
+        cloudish = Path("/Users/test/Library/Mobile Documents/com~apple~CloudDocs/AGENTS.md")
+        assert _read_hint_text(cloudish) is None
+
+    def test_seed_skips_cloud_cwd_hint(self):
+        """Startup digest seed must not open a cloud-backed CWD hint file."""
+        from agent import subdirectory_hints as mod
+
+        calls = {"open": 0}
+        real_open = open
+
+        def counting_open(*args, **kwargs):
+            calls["open"] += 1
+            return real_open(*args, **kwargs)
+
+        cloud_root = Path(
+            "/Users/x/Library/Mobile Documents/com~apple~CloudDocs/proj"
+        )
+        tracker = object.__new__(mod.SubdirectoryHintTracker)
+        tracker.working_dir = cloud_root
+        tracker._loaded_dirs = {cloud_root}
+        tracker._loaded_digests = set()
+        with patch("builtins.open", side_effect=counting_open):
+            tracker._seed_working_dir_digest()
+        assert calls["open"] == 0
+        assert tracker._loaded_digests == set()
+
+
+class TestBoundedHintRead:
+    """Slow/hanging hint files must not wedge the tool path."""
+
+    def test_normal_local_file_still_loads(self, tmp_path):
+        sub = tmp_path / "backend"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("Backend rules safe")
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        result = tracker.check_tool_call(
+            "read_file", {"path": str(sub / "f.py")}
+        )
+        assert result is not None
+        assert "Backend rules safe" in result
+
+    def test_fifo_read_times_out_fast(self, tmp_path):
+        """A FIFO with no writer hangs bare read_text forever — must return fast."""
+        import os
+        import time
+
+        from agent.subdirectory_hints import (
+            _HINT_READ_TIMEOUT_SECONDS,
+            _read_hint_text,
+        )
+
+        fifo = tmp_path / "AGENTS.md"
+        os.mkfifo(fifo)
+
+        started = time.monotonic()
+        content = _read_hint_text(fifo)
+        elapsed = time.monotonic() - started
+
+        assert content is None
+        # Allow generous slack over the 2s cap, but nowhere near a wedge.
+        assert elapsed < _HINT_READ_TIMEOUT_SECONDS + 2.0
+
+    def test_load_hints_survives_slow_file(self, tmp_path):
+        """_load_hints_for_directory must hit bounded read and return fast.
+
+        FIFOs make Path.is_file() False, so they never reach _read_hint_text.
+        Hang open() on a real regular file to exercise the load-path timeout.
+
+        Important: pass a *resolved* directory. On macOS tmp paths often live
+        under /var -> /private/var; SubdirectoryHintTracker resolves working_dir,
+        and an unresolved subdir fails is_relative_to and returns before open.
+        """
+        import time
+
+        from agent.subdirectory_hints import _HINT_READ_TIMEOUT_SECONDS
+
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        # Use a path under the tracker's resolved working_dir, not raw tmp_path.
+        sub = tracker.working_dir / "slowdir"
+        sub.mkdir()
+        hint = sub / "AGENTS.md"
+        # Real regular file so path construction is normal; open is mocked hang.
+        hint.write_text("should never be returned if open hangs")
+
+        def hanging_open(*_args, **_kwargs):
+            time.sleep(30)
+            raise AssertionError("open should have been abandoned on timeout")
+
+        started = time.monotonic()
+        with patch("builtins.open", side_effect=hanging_open):
+            result = tracker._load_hints_for_directory(sub)
+        elapsed = time.monotonic() - started
+
+        assert result is None
+        # Must actually wait near the timeout (proves we reached _read_hint_text),
+        # but nowhere near a multi-minute wedge.
+        # macOS default APFS is case-insensitive, so AGENTS.md and agents.md are
+        # the same inode and the load loop may pay the timeout twice (~4s).
+        assert elapsed >= _HINT_READ_TIMEOUT_SECONDS - 0.5
+        assert elapsed < (_HINT_READ_TIMEOUT_SECONDS * 2) + 2.0

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -416,7 +416,10 @@ class TestBoundedHintRead:
         # Real regular file so path construction is normal; open is mocked hang.
         hint.write_text("should never be returned if open hangs")
 
+        open_calls = {"n": 0}
+
         def hanging_open(*_args, **_kwargs):
+            open_calls["n"] += 1
             time.sleep(30)
             raise AssertionError("open should have been abandoned on timeout")
 
@@ -426,6 +429,7 @@ class TestBoundedHintRead:
         elapsed = time.monotonic() - started
 
         assert result is None
+        assert open_calls["n"] >= 1  # load path actually reached bounded open/read
         # Must actually wait near the timeout (proves we reached _read_hint_text),
         # but nowhere near a multi-minute wedge.
         # macOS default APFS is case-insensitive, so AGENTS.md and agents.md are


### PR DESCRIPTION
## Problem

On macOS, `agent/subdirectory_hints.py` reads `AGENTS.md`-style hint files by
walking subdirectories. When any of those paths live under an iCloud Drive or
FileProvider-backed tree, `open()`/`read()` on an evicted placeholder does not
fail — it **blocks indefinitely**. The gateway wedges with no error and no
timeout.

This is not hypothetical. On an affected machine the entire
`~/Library/Mobile Documents` tree returns `EINTR` (errno 4) on `listdir`, and
`open()` hangs past any reasonable bound. Because the hang happens inside a
plain file read, existing "skip if the path is slow or missing" style guards
never fire — a hang is neither slow nor missing.

Observed impact: wedged `add-witness.sh`, agent file tools, and evolution/critic
reads, reproduced independently across three separate agent profiles.

## Change

- Add a short read timeout (`_HINT_READ_TIMEOUT_SECONDS = 2.0`) so an evicted
  placeholder is treated as missing rather than blocking the gateway.
- Detect cloud-backed subtrees by path marker (`Mobile Documents`,
  `CloudStorage`, `iCloud`, `.icloud`, `com.apple.fileprovider`), mirroring the
  approach already used in `cron/lifecycle_guard.py`.
- Cover the load path with a test asserting the timeout actually surfaces the
  slow-path hint rather than hanging.

## Notes

`main` currently has no iCloud/FileProvider protection in
`agent/subdirectory_hints.py`. Related hardening exists elsewhere in the tree
(`fix(terminal): avoid FileProvider reads in lifecycle guard`, and the cron
cloud-placeholder refusals), so this brings the hint reader in line with that
pattern.
