### PR TITLE
fix(kanban): allow complete after gave_up when evidence present (#91833)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5452,7 +5452,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked', 'review')
+                   AND (status IN ('running', 'ready', 'blocked', 'review') OR (status = 'gave_up' AND EXISTS (SELECT 1 FROM task_comments WHERE task_id = tasks.id AND author = tasks.assignee)))
                 """,
                 (result, now, task_id),
             )
@@ -5469,7 +5469,7 @@ def complete_task(
                        block_kind   = NULL,
                        block_recurrences = 0
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked', 'review')
+                   AND ( (status IN ('running', 'ready', 'blocked', 'review') OR (status = 'gave_up' AND EXISTS (SELECT 1 FROM task_comments WHERE task_id = tasks.id AND author = tasks.assignee))) )
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),


### PR DESCRIPTION
Fixes #91833. complete_task aceita transição de gave_up quando o worker tem evidência de conclusão — cartões com evidência não forçam mais fechamento manual.