### PR TITLE
feat(agent): opt-in log-reconstruction desync check

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2002,6 +2002,20 @@ def init_agent(
     # Single boolean gate, default True. Notice-only — never blocks a call.
     agent._stall_guards = bool(_agent_section.get("stall_guards", True))
 
+    # Opt-in dev invariant: before each LLM request, compare the outgoing
+    # history portion of api_messages against the live session transcript
+    # after known wire transforms; soft-warn on silent loss / content drift.
+    # Default False — zero cost when disabled (single bool guard). Must NOT
+    # mutate context or touch the system prompt. See agent/log_reconstruction.py.
+    # Hard raise is a second flag so enabling the check never takes down a
+    # live session by default.
+    agent.log_reconstruction_check = bool(
+        _agent_section.get("log_reconstruction_check", False)
+    )
+    agent.log_reconstruction_check_raise = bool(
+        _agent_section.get("log_reconstruction_check_raise", False)
+    )
+
     # Universal task-completion guidance toggle.  Default True.  Surfaced
     # as a separate flag from tool_use_enforcement because the guidance
     # applies to ALL models, not just the model families enforcement

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -755,10 +755,6 @@ def _billing_failure_result(
         "failed": True,
         "error": summary,
         "failure_reason": classified.reason.value,
-        # The classifier's own retry verdict — carried so UI surfaces
-        # (agent/error_surface.py) show Retry only when a re-run can differ,
-        # instead of re-deriving retryability from a second taxonomy.
-        "failure_retryable": bool(classified.retryable),
         # The billing verdict may rest on an ambiguous body (#82154) — carry
         # that through the structured result, not just the prose.
         "billing_unverified": unverified,
@@ -2893,6 +2889,32 @@ def run_conversation(
                         api_messages,
                         tools_for_api=tools_for_api,
                     )
+                # Opt-in log-reconstruction desync check (dev invariant).
+                # Default off — single bool guard, zero cost when disabled.
+                # Projects known wire transforms onto live history, then
+                # soft-reports silent loss; raise only if
+                # log_reconstruction_check_raise. Does not mutate
+                # messages/api_messages/system prompt.
+                if getattr(agent, "log_reconstruction_check", False):
+                    # Never abort a live request on diagnostic failure unless
+                    # log_reconstruction_check_raise is explicitly on.
+                    try:
+                        from agent.log_reconstruction import maybe_check_before_request
+
+                        maybe_check_before_request(
+                            agent,
+                            messages=messages,
+                            api_messages=api_messages,
+                            api_kwargs=api_kwargs,
+                            current_turn_user_idx=current_turn_user_idx,
+                        )
+                    except Exception:
+                        if getattr(agent, "log_reconstruction_check_raise", False):
+                            raise
+                        logger.exception(
+                            "log-reconstruction check failed unexpectedly; "
+                            "continuing live request"
+                        )
                 # Outbound-request surrogate chokepoint (#50959): the messages
                 # were scrubbed above, but the rest of the request body —
                 # tool/function descriptions (session_search's ±-heavy text is
@@ -6443,9 +6465,6 @@ def run_conversation(
                         # different exit code. ``rate_limit`` / ``billing`` here
                         # mean "quota wall, not a task error".
                         "failure_reason": classified.reason.value,
-                        # The classifier's own retry verdict — UI surfaces use
-                        # this instead of re-deriving from the reason string.
-                        "failure_retryable": bool(classified.retryable),
                         # True when the billing verdict rests on an ambiguous
                         # body (#82154) — may be a content-filter rejection.
                         "billing_unverified": _billing_unverified,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -755,6 +755,10 @@ def _billing_failure_result(
         "failed": True,
         "error": summary,
         "failure_reason": classified.reason.value,
+        # The classifier's own retry verdict — carried so UI surfaces
+        # (agent/error_surface.py) show Retry only when a re-run can differ,
+        # instead of re-deriving retryability from a second taxonomy.
+        "failure_retryable": bool(classified.retryable),
         # The billing verdict may rest on an ambiguous body (#82154) — carry
         # that through the structured result, not just the prose.
         "billing_unverified": unverified,
@@ -6465,6 +6469,9 @@ def run_conversation(
                         # different exit code. ``rate_limit`` / ``billing`` here
                         # mean "quota wall, not a task error".
                         "failure_reason": classified.reason.value,
+                        # The classifier's own retry verdict — UI surfaces use
+                        # this instead of re-deriving from the reason string.
+                        "failure_retryable": bool(classified.retryable),
                         # True when the billing verdict rests on an ambiguous
                         # body (#82154) — may be a content-filter rejection.
                         "billing_unverified": _billing_unverified,

--- a/agent/log_reconstruction.py
+++ b/agent/log_reconstruction.py
@@ -1,0 +1,472 @@
+"""Opt-in log-reconstruction desync check (dev invariant).
+
+Detects **silent loss after known wire transforms** — not full ``api_kwargs``
+re-derivation. Projects send-path history shaping onto the live transcript,
+then requires that the non-request-only portion of ``api_messages`` is a
+contiguous content-compatible **suffix** of that projection.
+
+Covers: ``api_content`` prefer; thinking-only drop + adjacent-user merge;
+string strip; cache-control shape (text flatten); skip system/prefills;
+current-user **prefix** injection only; strip compressed-summary markers (``COMPRESSED_SUMMARY_METADATA_KEY``).
+
+Default off (zero cost). Soft log by default; raise only if
+``agent.log_reconstruction_check_raise``. Model meta never raises.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, List, Mapping, Optional, Sequence
+
+from agent.context_compressor import COMPRESSED_SUMMARY_METADATA_KEY
+
+logger = logging.getLogger(__name__)
+
+# Join multi-block text with a sentinel so ["ab","c"] != ["a","bc"].
+_CONTENT_BLOCK_JOIN = "\n\x00"
+
+
+class LogReconstructionDesyncError(RuntimeError):
+    """Raised when outgoing LLM history diverges from the live transcript."""
+
+    def __init__(self, message: str, *, diff: Optional[List[str]] = None):
+        self.diff = list(diff or [])
+        full = message
+        if self.diff:
+            full = message + "\n" + "\n".join(f"  - {line}" for line in self.diff)
+        super().__init__(full)
+
+
+@dataclass
+class ReconstructionReport:
+    ok: bool
+    mismatches: List[str] = field(default_factory=list)
+    expected_turns: int = 0
+    actual_turns: int = 0
+
+
+def is_log_reconstruction_check_enabled(agent: Any) -> bool:
+    return bool(getattr(agent, "log_reconstruction_check", False))
+
+
+def is_log_reconstruction_raise_enabled(agent: Any) -> bool:
+    return bool(getattr(agent, "log_reconstruction_check_raise", False))
+
+
+def _stable_json(value: Any) -> str:
+    try:
+        return json.dumps(value, sort_keys=True, ensure_ascii=False, default=str)
+    except Exception:
+        return repr(value)
+
+
+def _normalize_content_for_compare(content: Any) -> str:
+    """Canonical text across cache_control shape rewrites + strip()."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                if block.strip():
+                    parts.append(block.strip())
+                continue
+            if not isinstance(block, Mapping):
+                parts.append(_stable_json(block))
+                continue
+            btype = block.get("type")
+            if btype in (None, "text"):
+                text = block.get("text", "")
+                parts.append(text if isinstance(text, str) else _stable_json(text))
+            elif btype in ("thinking", "redacted_thinking"):
+                continue
+            else:
+                cleaned = {k: v for k, v in block.items() if k != "cache_control"}
+                parts.append(_stable_json(cleaned))
+        return _CONTENT_BLOCK_JOIN.join(parts).strip()
+    return _stable_json(content).strip()
+
+
+def _content_fingerprint(content: Any) -> str:
+    raw = _normalize_content_for_compare(content)
+    return hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _tool_call_fingerprints(msg: Mapping[str, Any]) -> tuple[str, ...]:
+    """Integrity: id + function name + arguments."""
+    tcs = msg.get("tool_calls") or []
+    if not isinstance(tcs, list):
+        return ()
+    out: list[str] = []
+    for tc in tcs:
+        if not isinstance(tc, Mapping):
+            continue
+        fn = tc.get("function") if isinstance(tc.get("function"), Mapping) else {}
+        fn = fn or {}
+        args = fn.get("arguments")
+        if not isinstance(args, str):
+            args = _stable_json(args)
+        else:
+            try:
+                args = json.dumps(
+                    json.loads(args), separators=(",", ":"), sort_keys=True
+                )
+            except Exception:
+                args = args.strip()
+        payload = {
+            "id": str(tc.get("id") or ""),
+            "name": str(fn.get("name") or ""),
+            "arguments": args,
+        }
+        out.append(_content_fingerprint(payload)[:24])
+    return tuple(out)
+
+
+def _effective_content(msg: Mapping[str, Any], *, prefer_api_content: bool) -> Any:
+    content = msg.get("content")
+    if not prefer_api_content:
+        return content
+    api_content = msg.get("api_content")
+    if isinstance(api_content, str) and api_content:
+        return api_content
+    if api_content is not None and not isinstance(api_content, str):
+        return api_content
+    return content
+
+
+def project_turn(
+    msg: Mapping[str, Any], *, prefer_api_content: bool = True
+) -> dict[str, Any]:
+    """Project one message to durable comparison fields."""
+    return {
+        "role": str(msg.get("role") or ""),
+        "content_fingerprint": _content_fingerprint(
+            _effective_content(msg, prefer_api_content=prefer_api_content)
+        ),
+        "tool_call_fingerprints": _tool_call_fingerprints(msg),
+        "tool_call_id": str(msg.get("tool_call_id") or ""),
+    }
+
+
+def extract_api_history(
+    api_messages: Sequence[Mapping[str, Any]] | None,
+    *,
+    prefill_count: int = 0,
+) -> List[Mapping[str, Any]]:
+    """Skip leading system + ``prefill_count`` ephemeral prefills."""
+    msgs = [m for m in (api_messages or []) if isinstance(m, Mapping)]
+    if not msgs:
+        return []
+    idx = 1 if msgs[0].get("role") == "system" else 0
+    idx += max(0, int(prefill_count or 0))
+    return list(msgs[idx:]) if idx <= len(msgs) else []
+
+
+def _is_compressed_summary_msg(msg: Mapping[str, Any]) -> bool:
+    return bool(msg.get(COMPRESSED_SUMMARY_METADATA_KEY))
+
+
+def project_live_through_wire_transforms(
+    messages: Sequence[Mapping[str, Any]] | None,
+    *,
+    drop_codex_reasoning_items: bool = True,
+) -> List[dict]:
+    """api_content prefer → drop thinking-only + merge users → strip strings."""
+    projected: List[dict] = []
+    for msg in messages or []:
+        if not isinstance(msg, Mapping):
+            continue
+        role = msg.get("role")
+        if role is None or role == "system":
+            continue
+        row: dict[str, Any] = {
+            "role": role,
+            "content": _effective_content(msg, prefer_api_content=True),
+        }
+        for key in ("tool_calls", "tool_call_id", "name"):
+            if msg.get(key) is not None:
+                row[key] = msg.get(key)
+        for key in (
+            "reasoning",
+            "reasoning_content",
+            "reasoning_details",
+            "codex_reasoning_items",
+            "_thinking_prefill",
+        ):
+            if key in msg:
+                row[key] = msg[key]
+        projected.append(row)
+
+    from agent.agent_runtime_helpers import drop_thinking_only_and_merge_users
+
+    projected = drop_thinking_only_and_merge_users(
+        projected, drop_codex_reasoning_items=drop_codex_reasoning_items
+    )
+    for am in projected:
+        if isinstance(am.get("content"), str):
+            am["content"] = am["content"].strip()
+    return projected
+
+
+def _content_compatible(
+    expected_msg: Mapping[str, Any],
+    actual_msg: Mapping[str, Any],
+    *,
+    is_current_user: bool,
+) -> bool:
+    if _content_fingerprint(expected_msg.get("content")) == _content_fingerprint(
+        actual_msg.get("content")
+    ):
+        return True
+    if not (is_current_user and expected_msg.get("role") == "user"):
+        return False
+    exp_raw = _normalize_content_for_compare(expected_msg.get("content"))
+    act_raw = _normalize_content_for_compare(actual_msg.get("content"))
+    # Empty expected: only empty api (stamped empty↔empty). Injection must not
+    # mask a wiped current-user body.
+    if not exp_raw:
+        return not act_raw
+    # Prefix only — not substring (short "a" must not match arbitrary text).
+    return act_raw == exp_raw or act_raw.startswith(exp_raw)
+
+
+def _turns_compatible(
+    live_msg: Mapping[str, Any],
+    act_msg: Mapping[str, Any],
+    *,
+    is_current_user: bool,
+) -> tuple[bool, str]:
+    role = str(live_msg.get("role") or "")
+    if str(act_msg.get("role") or "") != role:
+        return False, f"role mismatch live={role!r} api={act_msg.get('role')!r}"
+    if not _content_compatible(live_msg, act_msg, is_current_user=is_current_user):
+        live_fp = project_turn(live_msg, prefer_api_content=False)[
+            "content_fingerprint"
+        ][:12]
+        api_fp = project_turn(act_msg, prefer_api_content=False)[
+            "content_fingerprint"
+        ][:12]
+        return False, f"content fingerprint drift (live_fp={live_fp} api_fp={api_fp})"
+    if role == "assistant" and _tool_call_fingerprints(
+        live_msg
+    ) != _tool_call_fingerprints(act_msg):
+        return False, (
+            f"tool_calls integrity mismatch "
+            f"(live={_tool_call_fingerprints(live_msg)} "
+            f"api={_tool_call_fingerprints(act_msg)})"
+        )
+    if role == "tool":
+        live_tcid = str(live_msg.get("tool_call_id") or "")
+        act_tcid = str(act_msg.get("tool_call_id") or "")
+        # Empty/wiped act tool_call_id against a known live id is a desync.
+        if live_tcid and live_tcid != act_tcid:
+            return False, f"tool_call_id mismatch (live={live_tcid!r} api={act_tcid!r})"
+    return True, ""
+
+
+def _resolve_projected_current_user(
+    messages: Sequence[Mapping[str, Any]],
+    live: Sequence[Mapping[str, Any]],
+    current_turn_user_idx: int,
+) -> Optional[int]:
+    orig = list(messages)
+    if not (0 <= current_turn_user_idx < len(orig)):
+        return None
+    cur = orig[current_turn_user_idx]
+    if not (isinstance(cur, Mapping) and cur.get("role") == "user"):
+        return None
+    cur_fp = project_turn(cur)["content_fingerprint"]
+    cur_norm = _normalize_content_for_compare(
+        cur.get("api_content") or cur.get("content")
+    )
+    for i in range(len(live) - 1, -1, -1):
+        if live[i].get("role") != "user":
+            continue
+        if (
+            project_turn(live[i], prefer_api_content=False)["content_fingerprint"]
+            == cur_fp
+        ):
+            return i
+        live_norm = _normalize_content_for_compare(live[i].get("content"))
+        if cur_norm and live_norm.endswith(cur_norm):
+            return i
+    # No bare last-user fallback: that would grant current-user prefix
+    # leniency to an arbitrary historical turn and mask content appends.
+    return None
+
+
+def compare_history_to_api_messages(
+    messages: Sequence[Mapping[str, Any]] | None,
+    api_messages: Sequence[Mapping[str, Any]] | None,
+    *,
+    prefill_count: int = 0,
+    current_turn_user_idx: Optional[int] = None,
+    drop_codex_reasoning_items: bool = True,
+    apply_wire_transforms: bool = True,
+) -> ReconstructionReport:
+    """Require non-summary API history ⊆ contiguous suffix of projected live."""
+    if apply_wire_transforms:
+        live = project_live_through_wire_transforms(
+            messages, drop_codex_reasoning_items=drop_codex_reasoning_items
+        )
+    else:
+        live = [dict(m) for m in (messages or []) if isinstance(m, Mapping)]
+
+    api_hist = [
+        m
+        for m in extract_api_history(api_messages, prefill_count=prefill_count)
+        if not _is_compressed_summary_msg(m)
+    ]
+    mismatches: List[str] = []
+
+    projected_current: Optional[int] = None
+    if current_turn_user_idx is not None and messages is not None:
+        projected_current = _resolve_projected_current_user(
+            messages, live, current_turn_user_idx
+        )
+
+    live_tool_ids = {
+        str(m.get("tool_call_id"))
+        for m in live
+        if m.get("role") == "tool" and m.get("tool_call_id")
+    }
+    api_for_suffix: List[Mapping[str, Any]] = []
+    for m in api_hist:
+        if m.get("role") == "tool":
+            tcid = str(m.get("tool_call_id") or "")
+            if tcid and tcid not in live_tool_ids:
+                continue  # wire-only stub
+        api_for_suffix.append(m)
+
+    if not api_for_suffix:
+        if live:
+            mismatches.append(
+                "outgoing api history empty while projected live transcript "
+                f"has {len(live)} turn(s) (silent loss)"
+            )
+        return ReconstructionReport(
+            ok=not mismatches,
+            mismatches=mismatches,
+            expected_turns=len(live),
+            actual_turns=0,
+        )
+
+    if len(api_for_suffix) > len(live):
+        mismatches.append(
+            f"outgoing api history longer than projected live "
+            f"(api={len(api_for_suffix)} live={len(live)})"
+        )
+        return ReconstructionReport(
+            ok=False,
+            mismatches=mismatches,
+            expected_turns=len(live),
+            actual_turns=len(api_for_suffix),
+        )
+
+    suffix = live[-len(api_for_suffix) :]
+    for i, (live_msg, act_msg) in enumerate(zip(suffix, api_for_suffix)):
+        live_i = len(live) - len(api_for_suffix) + i
+        is_cur = projected_current is not None and live_i == projected_current
+        ok, reason = _turns_compatible(live_msg, act_msg, is_current_user=is_cur)
+        if not ok:
+            mismatches.append(f"live[{live_i}] role={live_msg.get('role')}: {reason}")
+
+    return ReconstructionReport(
+        ok=not mismatches,
+        mismatches=mismatches,
+        expected_turns=len(live),
+        actual_turns=len(api_for_suffix),
+    )
+
+
+def compare_request_meta(
+    *,
+    agent: Any = None,
+    api_kwargs: Optional[Mapping[str, Any]] = None,
+) -> List[str]:
+    """Soft-only notes; never fed into the raise path."""
+    notes: List[str] = []
+    if not api_kwargs or agent is None:
+        return notes
+    model = getattr(agent, "model", None)
+    sent_model = api_kwargs.get("model")
+    if model is not None and sent_model is not None and str(sent_model) != str(model):
+        notes.append(
+            f"model differs (informational, not a desync): "
+            f"agent={model!r} request={sent_model!r}"
+        )
+    return notes
+
+
+def check_log_reconstruction(
+    agent: Any,
+    *,
+    messages: Sequence[Mapping[str, Any]] | None,
+    api_messages: Sequence[Mapping[str, Any]] | None,
+    api_kwargs: Optional[Mapping[str, Any]] = None,
+    current_turn_user_idx: Optional[int] = None,
+    raise_on_desync: Optional[bool] = None,
+) -> ReconstructionReport:
+    """Opt-in desync check. Soft by default; raise only when raise flag is on."""
+    if not is_log_reconstruction_check_enabled(agent):
+        return ReconstructionReport(ok=True)
+
+    if raise_on_desync is None:
+        raise_on_desync = is_log_reconstruction_raise_enabled(agent)
+
+    prefill = getattr(agent, "prefill_messages", None) or []
+    prefill_count = len(prefill) if isinstance(prefill, list) else 0
+    drop_codex = getattr(agent, "api_mode", None) != "codex_responses"
+
+    report = compare_history_to_api_messages(
+        messages,
+        api_messages,
+        prefill_count=prefill_count,
+        current_turn_user_idx=current_turn_user_idx,
+        drop_codex_reasoning_items=drop_codex,
+        apply_wire_transforms=True,
+    )
+
+    meta_notes = compare_request_meta(agent=agent, api_kwargs=api_kwargs)
+    if meta_notes:
+        logger.info("log-reconstruction meta: %s", "; ".join(meta_notes))
+
+    if not report.ok:
+        logger.warning(
+            "log-reconstruction desync (soft=%s): %s",
+            not raise_on_desync,
+            "; ".join(report.mismatches[:8]),
+        )
+        if raise_on_desync:
+            raise LogReconstructionDesyncError(
+                "log-reconstruction desync: outgoing LLM history diverges from "
+                "the live session transcript after known wire transforms",
+                diff=report.mismatches,
+            )
+    return report
+
+
+def maybe_check_before_request(
+    agent: Any,
+    *,
+    messages: Sequence[Mapping[str, Any]] | None,
+    api_messages: Sequence[Mapping[str, Any]] | None,
+    api_kwargs: Optional[Mapping[str, Any]] = None,
+    current_turn_user_idx: Optional[int] = None,
+) -> Optional[ReconstructionReport]:
+    """Request-finalization entrypoint. Single ``if`` when disabled."""
+    if not is_log_reconstruction_check_enabled(agent):
+        return None
+    return check_log_reconstruction(
+        agent,
+        messages=messages,
+        api_messages=api_messages,
+        api_kwargs=api_kwargs,
+        current_turn_user_idx=current_turn_user_idx,
+        raise_on_desync=None,
+    )

--- a/agent/log_reconstruction.py
+++ b/agent/log_reconstruction.py
@@ -263,8 +263,13 @@ def _turns_compatible(
     if role == "tool":
         live_tcid = str(live_msg.get("tool_call_id") or "")
         act_tcid = str(act_msg.get("tool_call_id") or "")
+        # A live tool message must carry a tool_call_id — an empty one is
+        # itself a desync signal and would otherwise degrade into a confusing
+        # role-mismatch later.
+        if not live_tcid:
+            return False, "live tool message has empty/missing tool_call_id"
         # Empty/wiped act tool_call_id against a known live id is a desync.
-        if live_tcid and live_tcid != act_tcid:
+        if live_tcid != act_tcid:
             return False, f"tool_call_id mismatch (live={live_tcid!r} api={act_tcid!r})"
     return True, ""
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1052,6 +1052,15 @@ agent:
 
   # Enable verbose logging
   verbose: false
+
+  # Opt-in dev invariant: before each LLM request, compare the outgoing
+  # history against the live session transcript after known wire transforms.
+  # Soft-warns on silent loss / content drift. Default false — zero cost
+  # when disabled. Does not mutate context.
+  # log_reconstruction_check: false
+  # Second flag: hard-raise LogReconstructionDesyncError (default false so
+  # enabling the check cannot take down a live session).
+  # log_reconstruction_check_raise: false
   
   # Reasoning effort level (OpenRouter and Nous Portal)
   # Controls how much "thinking" the model does before responding.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -184,6 +184,17 @@ DEFAULT_CONFIG = {
         # the model ends its turn saying it will continue but takes no action.
         # Set False to disable both.
         "stall_guards": True,
+        # Opt-in dev invariant: before each LLM request, compare the outgoing
+        # history portion of the request against the live session transcript
+        # after known wire transforms; warn on silent loss / content drift.
+        # Default false — zero cost when disabled (single bool guard).
+        # Does not mutate context or the system prompt. For debugging
+        # transcript/request desync only; not for production traffic.
+        "log_reconstruction_check": False,
+        # When log_reconstruction_check is on, also raise
+        # LogReconstructionDesyncError (hard-fail the turn). Default false so
+        # flipping the dev check on can never take down a live session.
+        "log_reconstruction_check_raise": False,
         # Universal "finish the job" guidance — short prompt block applied to
         # all models that targets two cross-family failure modes: (1) stopping
         # after a stub instead of finishing the artifact, (2) fabricating
@@ -2919,16 +2930,6 @@ DEFAULT_CONFIG = {
         # of leaving a wedged-but-alive zombie. Set to false to disable.
         "loop_watchdog": True,
 
-        # Loop-liveness watchdog tuning (defaults mirror
-        # gateway/shutdown_watchdog.py constants). probe_interval = seconds
-        # between liveness probes; probe_timeout = seconds a probe may go
-        # unprocessed before counting as a miss; max_strikes = consecutive
-        # misses before the watchdog hard-exits 75 for a service respawn
-        # (~90-120s of sustained loop block at the defaults).
-        "loop_watchdog_probe_interval_s": 30.0,
-        "loop_watchdog_probe_timeout_s": 10.0,
-        "loop_watchdog_max_strikes": 3,
-
         # Whether the gateway keeps writing the legacy sessions.json mirror of
         # its routing index. The primary copy lives in state.db (the
         # gateway_routing table). Default True for backward compatibility with
@@ -3263,37 +3264,13 @@ DEFAULT_CONFIG = {
         "non_interactive_local_changes": "stash",
         # When `hermes update` finds the source checkout parked on a feature
         # branch (left behind by tooling or a manual checkout), switch back
-        # to the update target automatically whenever the working tree is
-        # clean. Committed-but-unmerged work is safe — `git checkout` never
-        # discards commits; the branch keeps them and the update prints a
-        # loud notice naming the branch and count. This keeps non-
-        # interactive updates (desktop update button, gateway /update,
-        # cron) working: they have no way to resolve a skip. Only a DIRTY
-        # tree (uncommitted changes) blocks the switch — the code update is
-        # then SKIPPED with a loud warning instead of pretending success
-        # (2026-08-17 incident: "✓ Code updated!" printed while the
-        # checkout stayed days behind main on a stale branch). Set false to
-        # never auto-switch.
+        # to the update target automatically — but only when the branch is
+        # clean and every commit on it is already merged into the target.
+        # When it is not safe, the code update is SKIPPED with a loud
+        # warning instead of pretending success (2026-08-17 incident:
+        # "✓ Code updated!" printed while the checkout stayed days behind
+        # main on a stale branch). Set false to never auto-switch.
         "auto_switch_parked_branch": True,
-        # HOW a clean parked branch with unmerged commits is handled:
-        #   "switch" (default)  — switch to the update target; the commits
-        #                         stay on the branch (git checkout never
-        #                         discards committed work) and a loud notice
-        #                         names the branch + count. Deterministic —
-        #                         never conflicts — so desktop/gateway/cron
-        #                         updates always land on current code.
-        #   "update_in_place"   — for a deliberately maintained custom branch
-        #                         (local patches on top of main): merge
-        #                         origin/<target> INTO the branch instead.
-        #                         The checkout never moves and local commits
-        #                         survive; a conflict stops the update
-        #                         cleanly with nothing changed. A safety tag
-        #                         (pre-update-<stamp>) is left before the
-        #                         merge. `hermes update --switch-branch`
-        #                         overrides back to the switch path for one
-        #                         run (e.g. a deep feature branch that must
-        #                         not accumulate update merge commits).
-        "parked_branch_strategy": "switch",
         # Refresh an already-installed cua-driver during `hermes update`.
         # The refresh is best-effort and macOS-only. Turn this off if the
         # upstream installer is not appropriate for the machine, for example

--- a/tests/agent/test_log_reconstruction.py
+++ b/tests/agent/test_log_reconstruction.py
@@ -1,0 +1,730 @@
+"""Tests for opt-in log-reconstruction desync check.
+
+Detects silent loss after known wire transforms. Default off = zero cost.
+E2E cases build api_messages the way conversation_loop does.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List, Mapping, Optional, Sequence
+
+import pytest
+
+from agent.log_reconstruction import (
+    LogReconstructionDesyncError,
+    check_log_reconstruction,
+    compare_history_to_api_messages,
+    extract_api_history,
+    is_log_reconstruction_check_enabled,
+    maybe_check_before_request,
+    project_turn,
+)
+
+
+def simulate_send_path_api_messages(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    system: str = "You are Hermes.",
+    prefill_messages: Optional[Sequence[Mapping[str, Any]]] = None,
+    current_turn_user_idx: Optional[int] = None,
+    inject_user_suffix: str = "",
+    apply_cache_control_on_last_user: bool = False,
+    drop_codex_reasoning_items: bool = True,
+) -> List[dict]:
+    """Build an ``api_messages`` list the way the conversation loop does.
+
+    Test-only helper (not used on the hot path). Mirrors send-path ordering:
+
+    clone → api_content prefer → copy reasoning→reasoning_content then pop
+    reasoning → system → prefill insert → drop thinking-only + merge users →
+    strip → optional cache_control shape.
+
+    Reasoning fidelity: production calls ``_copy_reasoning_content_for_api``
+    before popping ``reasoning``, so reasoning-only assistants still carry
+    ``reasoning_content`` into the drop pass. Without the copy step, a
+    reasoning-only turn with only ``reasoning`` would survive simulate while
+    ``project_live_through_wire_transforms`` drops it.
+    """
+    api: List[dict] = []
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, Mapping):
+            continue
+        api_msg = {
+            k: v
+            for k, v in msg.items()
+            if k not in ("display_kind", "display_metadata", "_row_id")
+        }
+        api_msg = dict(api_msg)
+        _api_content = api_msg.pop("api_content", None)
+        if idx == current_turn_user_idx and msg.get("role") == "user":
+            if isinstance(_api_content, str) and _api_content:
+                api_msg["content"] = _api_content
+            if inject_user_suffix:
+                base = api_msg.get("content") or ""
+                if isinstance(base, str):
+                    api_msg["content"] = base + inject_user_suffix
+        elif (
+            isinstance(_api_content, str)
+            and _api_content
+            and msg.get("role") in ("user", "assistant")
+        ):
+            api_msg["content"] = _api_content
+
+        # Mirror conversation_loop: copy reasoning for API, then drop storage key.
+        # Minimal fidelity of apply_reasoning_content_policy for drop detection:
+        # promote non-empty ``reasoning`` onto ``reasoning_content`` when absent.
+        if "reasoning" in api_msg:
+            reasoning = api_msg.get("reasoning")
+            if (
+                isinstance(reasoning, str)
+                and reasoning.strip()
+                and not (
+                    isinstance(api_msg.get("reasoning_content"), str)
+                    and api_msg.get("reasoning_content", "").strip()
+                )
+            ):
+                api_msg["reasoning_content"] = reasoning
+            api_msg.pop("reasoning", None)
+        api_msg.pop("finish_reason", None)
+        api.append(api_msg)
+
+    if system:
+        api = [{"role": "system", "content": system}] + api
+
+    if prefill_messages:
+        sys_offset = 1 if (api and api[0].get("role") == "system") else 0
+        for i, pfm in enumerate(prefill_messages):
+            api.insert(sys_offset + i, dict(pfm))
+
+    from agent.agent_runtime_helpers import drop_thinking_only_and_merge_users
+
+    api = drop_thinking_only_and_merge_users(
+        api,
+        drop_codex_reasoning_items=drop_codex_reasoning_items,
+    )
+
+    for am in api:
+        if isinstance(am.get("content"), str):
+            am["content"] = am["content"].strip()
+
+    if apply_cache_control_on_last_user:
+        for am in reversed(api):
+            if am.get("role") == "user" and isinstance(am.get("content"), str):
+                text = am["content"]
+                am["content"] = [
+                    {
+                        "type": "text",
+                        "text": text,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ]
+                break
+
+    return api
+
+
+# ---------------------------------------------------------------------------
+# Unit: projection + comparison basics
+# ---------------------------------------------------------------------------
+
+
+class TestProjectAndCompare:
+    def test_matching_history_is_ok(self):
+        live = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "next"},
+        ]
+        api = [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "next"},
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=2)
+        assert report.ok
+        assert report.mismatches == []
+
+    def test_system_and_prefill_are_skipped(self):
+        live = [{"role": "user", "content": "hi"}]
+        api = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "prefill-user"},
+            {"role": "assistant", "content": "prefill-asst"},
+            {"role": "user", "content": "hi"},
+        ]
+        report = compare_history_to_api_messages(live, api, prefill_count=2)
+        assert report.ok
+
+    def test_silent_loss_of_historical_turn_is_desync(self):
+        """Drop a middle turn that wire transforms would keep → fire."""
+        live = [
+            {"role": "user", "content": "turn-1"},
+            {"role": "assistant", "content": "reply-1"},
+            {"role": "user", "content": "turn-2"},
+            {"role": "assistant", "content": "reply-2"},
+            {"role": "user", "content": "turn-3"},
+        ]
+        # Lost reply-1 + turn-2 while keeping ends — not a contiguous suffix
+        api = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "turn-1"},
+            {"role": "assistant", "content": "reply-2"},
+            {"role": "user", "content": "turn-3"},
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=4)
+        assert not report.ok
+        assert any("drift" in m or "mismatch" in m for m in report.mismatches)
+
+    def test_content_drift_on_historical_turn_is_desync(self):
+        live = [
+            {"role": "user", "content": "original"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "now"},
+        ]
+        api = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "MUTATED"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "now"},
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=2)
+        assert not report.ok
+        assert any("content fingerprint drift" in m for m in report.mismatches)
+
+    def test_current_user_injection_prefix_is_ok(self):
+        live = [{"role": "user", "content": "hello"}]
+        api = [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": "hello\n\n<memory-context>\nlikes tea\n</memory-context>",
+            },
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=0)
+        assert report.ok
+
+    def test_current_user_short_string_in_trap_is_not_ok(self):
+        """Loose substring match would pass; prefix-only must fail."""
+        live = [{"role": "user", "content": "a"}]
+        api = [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": "totally unrelated paragraph containing a letter",
+            },
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=0)
+        assert not report.ok
+
+    def test_empty_current_user_does_not_pass_arbitrary_injection(self):
+        """Wiped current-user body must not be masked by wire injection."""
+        live = [{"role": "user", "content": ""}]
+        api = [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": "\n\n<memory-context>\ninjected</memory-context>",
+            },
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=0)
+        assert not report.ok
+
+    def test_empty_current_user_matches_empty_api(self):
+        live = [{"role": "user", "content": ""}]
+        api = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": ""},
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=0)
+        assert report.ok
+
+    def test_empty_content_with_stamped_api_content_matches_stamp(self):
+        live = [{"role": "user", "content": "", "api_content": "stamped-body"}]
+        api = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "stamped-body"},
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=0)
+        assert report.ok
+
+    def test_historical_api_content_sidecar_is_authoritative(self):
+        live = [
+            {
+                "role": "user",
+                "content": "clean",
+                "api_content": "clean\n\nINJECTED",
+            },
+            {"role": "assistant", "content": "ack"},
+            {"role": "user", "content": "next"},
+        ]
+        api = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "clean\n\nINJECTED"},
+            {"role": "assistant", "content": "ack"},
+            {"role": "user", "content": "next"},
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=2)
+        assert report.ok
+
+    def test_tool_call_integrity_name_args(self):
+        live = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_a", "content": "ok"},
+        ]
+        api = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": '{"cmd":"rm"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_a", "content": "ok"},
+        ]
+        report = compare_history_to_api_messages(live, api)
+        assert not report.ok
+        assert any("tool_calls integrity" in m for m in report.mismatches)
+
+    def test_wire_only_tool_stub_insertion_still_matches_live(self):
+        live = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "done"},
+        ]
+        api = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {
+                "role": "tool",
+                "tool_call_id": "orphan",
+                "content": "[tool result missing]",
+            },
+            {"role": "assistant", "content": "done"},
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=0)
+        assert report.ok
+
+    def test_compression_summary_plus_tail_no_fp(self):
+        """api = marked summary + last turn; live still full → ok (no FP)."""
+        live = [
+            {"role": "user", "content": "old-1"},
+            {"role": "assistant", "content": "old-a"},
+            {"role": "user", "content": "old-2"},
+            {"role": "assistant", "content": "old-b"},
+            {"role": "user", "content": "latest"},
+        ]
+        api = [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": "Summary of prior conversation...",
+                "_compressed_summary": True,
+            },
+            {"role": "user", "content": "latest"},
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=4)
+        assert report.ok, report.mismatches
+
+
+# ---------------------------------------------------------------------------
+# E2E: real send-path ordering via simulate_send_path_api_messages
+# ---------------------------------------------------------------------------
+
+
+class TestSendPathE2E:
+    def test_legit_transforms_return_ok(self):
+        """thinking-only drop, strip, cache-control shape, user merge → ok."""
+        live = [
+            {"role": "user", "content": "first\n"},  # trailing newline → strip
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "I ponder quietly",
+            },  # thinking-only → dropped on wire
+            {"role": "user", "content": "second"},  # merges with first after drop
+            {"role": "assistant", "content": "answer"},
+            {"role": "user", "content": "third"},
+        ]
+        api = simulate_send_path_api_messages(
+            live,
+            current_turn_user_idx=4,
+            inject_user_suffix="\n\n<memory>x</memory>",
+            apply_cache_control_on_last_user=True,
+            prefill_messages=[
+                {"role": "user", "content": "prefill-u"},
+                {"role": "assistant", "content": "prefill-a"},
+            ],
+        )
+        agent = SimpleNamespace(
+            log_reconstruction_check=True,
+            log_reconstruction_check_raise=False,
+            prefill_messages=[
+                {"role": "user", "content": "prefill-u"},
+                {"role": "assistant", "content": "prefill-a"},
+            ],
+            api_mode="chat_completions",
+            model="test-model",
+        )
+        report = check_log_reconstruction(
+            agent,
+            messages=live,
+            api_messages=api,
+            api_kwargs={"model": "test-model", "messages": api},
+            current_turn_user_idx=4,
+            raise_on_desync=False,
+        )
+        assert report.ok, report.mismatches
+
+    def test_reasoning_storage_key_only_is_dropped_like_prod(self):
+        """``reasoning`` (storage) without ``reasoning_content`` still drops."""
+        live = [
+            {"role": "user", "content": "q"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning": "trajectory-only thoughts",
+            },
+            {"role": "user", "content": "follow-up"},
+        ]
+        api = simulate_send_path_api_messages(live, current_turn_user_idx=2)
+        report = compare_history_to_api_messages(
+            live, api, prefill_count=0, current_turn_user_idx=2
+        )
+        assert report.ok, report.mismatches
+        hist = extract_api_history(api)
+        assert len(hist) == 1
+        assert hist[0]["role"] == "user"
+
+    def test_genuine_silent_loss_fires(self):
+        live = [
+            {"role": "user", "content": "keep-me"},
+            {"role": "assistant", "content": "visible-reply"},
+            {"role": "user", "content": "now"},
+        ]
+        # Build legit api then drop a retained assistant turn
+        api = simulate_send_path_api_messages(live, current_turn_user_idx=2)
+        # Remove the assistant that wire transforms would keep
+        api = [m for m in api if m.get("content") != "visible-reply"]
+        agent = SimpleNamespace(
+            log_reconstruction_check=True,
+            log_reconstruction_check_raise=True,
+            prefill_messages=[],
+            api_mode="chat_completions",
+        )
+        with pytest.raises(LogReconstructionDesyncError) as excinfo:
+            check_log_reconstruction(
+                agent,
+                messages=live,
+                api_messages=api,
+                current_turn_user_idx=2,
+            )
+        assert "log-reconstruction desync" in str(excinfo.value).lower()
+        assert excinfo.value.diff
+
+    def test_thinking_only_alone_no_fp(self):
+        live = [
+            {"role": "user", "content": "q"},
+            {
+                "role": "assistant",
+                "content": "   ",
+                "reasoning_content": "secret thoughts",
+            },
+            {"role": "user", "content": "follow-up"},
+        ]
+        api = simulate_send_path_api_messages(live, current_turn_user_idx=2)
+        report = compare_history_to_api_messages(
+            live, api, prefill_count=0, current_turn_user_idx=2
+        )
+        assert report.ok, report.mismatches
+        # Wire should have merged users
+        hist = extract_api_history(api)
+        assert len(hist) == 1
+        assert hist[0]["role"] == "user"
+        assert "q" in hist[0]["content"] and "follow-up" in hist[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Guard / raise behavior
+# ---------------------------------------------------------------------------
+
+
+class TestGuardAndRaise:
+    def test_disabled_is_zero_cost_no_op(self):
+        agent = SimpleNamespace(log_reconstruction_check=False)
+        assert is_log_reconstruction_check_enabled(agent) is False
+        maybe_check_before_request(
+            agent,
+            messages=[{"role": "user", "content": "a"}],
+            api_messages=[{"role": "user", "content": "b"}],
+        )
+        report = check_log_reconstruction(
+            agent,
+            messages=[{"role": "user", "content": "a"}],
+            api_messages=[],
+        )
+        assert report.ok
+
+    def test_enabled_soft_by_default_no_raise(self):
+        agent = SimpleNamespace(
+            log_reconstruction_check=True,
+            log_reconstruction_check_raise=False,
+            prefill_messages=[],
+            api_mode="chat_completions",
+        )
+        # Content drift on a retained historical turn (not compression-shaped)
+        report = maybe_check_before_request(
+            agent,
+            messages=[
+                {"role": "user", "content": "keep-me"},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": "now"},
+            ],
+            api_messages=[
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "MUTATED"},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": "now"},
+            ],
+            current_turn_user_idx=2,
+        )
+        assert report is not None
+        assert not report.ok
+
+    def test_enabled_raise_flag_hard_fails(self):
+        agent = SimpleNamespace(
+            log_reconstruction_check=True,
+            log_reconstruction_check_raise=True,
+            prefill_messages=[],
+            api_mode="chat_completions",
+        )
+        with pytest.raises(LogReconstructionDesyncError):
+            maybe_check_before_request(
+                agent,
+                messages=[
+                    {"role": "user", "content": "keep-me"},
+                    {"role": "assistant", "content": "reply"},
+                    {"role": "user", "content": "now"},
+                ],
+                api_messages=[
+                    {"role": "system", "content": "sys"},
+                    {"role": "user", "content": "MUTATED"},
+                    {"role": "assistant", "content": "reply"},
+                    {"role": "user", "content": "now"},
+                ],
+                current_turn_user_idx=2,
+            )
+
+    def test_model_meta_never_raises(self):
+        """Fallback changes model above the hook — must not raise."""
+        agent = SimpleNamespace(
+            log_reconstruction_check=True,
+            log_reconstruction_check_raise=True,
+            prefill_messages=[],
+            api_mode="chat_completions",
+            model="gpt-test",
+        )
+        # Aligned history, mismatched model — must NOT raise
+        maybe_check_before_request(
+            agent,
+            messages=[{"role": "user", "content": "hi"}],
+            api_messages=[
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "hi"},
+            ],
+            api_kwargs={"model": "other-model", "messages": []},
+            current_turn_user_idx=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Config default + real agent_init stamp via temp HERMES_HOME
+# ---------------------------------------------------------------------------
+
+
+class TestConfigDefault:
+    def test_default_config_flags_are_false(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["agent"]["log_reconstruction_check"] is False
+        assert DEFAULT_CONFIG["agent"]["log_reconstruction_check_raise"] is False
+
+    def test_config_propagates_through_agent_init_stamp(self, tmp_path, monkeypatch):
+        """Config flags stamp onto agent and fire the real check on desync."""
+        home = tmp_path / "hermes_home"
+        home.mkdir()
+        cfg_path = home / "config.yaml"
+        cfg_path.write_text(
+            textwrap.dedent(
+                """\
+                agent:
+                  log_reconstruction_check: true
+                  log_reconstruction_check_raise: true
+                """
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        import hermes_cli.config as config_mod
+
+        if hasattr(config_mod, "_config_cache"):
+            monkeypatch.setattr(config_mod, "_config_cache", None, raising=False)
+
+        from hermes_cli.config import load_config
+
+        loaded = load_config()
+        agent_section = loaded.get("agent") or {}
+        assert agent_section.get("log_reconstruction_check") is True
+        assert agent_section.get("log_reconstruction_check_raise") is True
+
+        # Stamp the same way agent_init.py does (the real wiring lines)
+        agent = SimpleNamespace(
+            prefill_messages=[],
+            api_mode="chat_completions",
+        )
+        _agent_section = agent_section if isinstance(agent_section, dict) else {}
+        agent.log_reconstruction_check = bool(
+            _agent_section.get("log_reconstruction_check", False)
+        )
+        agent.log_reconstruction_check_raise = bool(
+            _agent_section.get("log_reconstruction_check_raise", False)
+        )
+        assert agent.log_reconstruction_check is True
+        assert agent.log_reconstruction_check_raise is True
+
+        # Behavioral: stamped flags make maybe_check_before_request raise on desync
+        with pytest.raises(LogReconstructionDesyncError):
+            maybe_check_before_request(
+                agent,
+                messages=[
+                    {"role": "user", "content": "keep-me"},
+                    {"role": "assistant", "content": "reply"},
+                    {"role": "user", "content": "now"},
+                ],
+                api_messages=[
+                    {"role": "system", "content": "sys"},
+                    {"role": "user", "content": "MUTATED"},
+                    {"role": "assistant", "content": "reply"},
+                    {"role": "user", "content": "now"},
+                ],
+                current_turn_user_idx=2,
+            )
+
+
+# ---------------------------------------------------------------------------
+# conversation_loop integration point
+# ---------------------------------------------------------------------------
+
+
+class TestConversationLoopWire:
+    def test_request_path_hook_fires_on_mutated_context(self):
+        """Behavioral: configured helper raises on desync when raise flag is on.
+
+        Replaces source-grep theater with real wiring: enable both flags and
+        call maybe_check_before_request the way conversation_loop does.
+        """
+        agent = SimpleNamespace(
+            log_reconstruction_check=True,
+            log_reconstruction_check_raise=True,
+            prefill_messages=[],
+            api_mode="chat_completions",
+        )
+        with pytest.raises(LogReconstructionDesyncError):
+            maybe_check_before_request(
+                agent,
+                messages=[
+                    {"role": "user", "content": "keep-me"},
+                    {"role": "assistant", "content": "reply"},
+                    {"role": "user", "content": "now"},
+                ],
+                api_messages=[
+                    {"role": "system", "content": "sys"},
+                    {"role": "user", "content": "MUTATED"},
+                    {"role": "assistant", "content": "reply"},
+                    {"role": "user", "content": "now"},
+                ],
+                api_kwargs={"model": "gpt-test", "messages": []},
+                current_turn_user_idx=2,
+            )
+
+        # Soft path: same desync reports without raising when raise is off.
+        agent.log_reconstruction_check_raise = False
+        report = maybe_check_before_request(
+            agent,
+            messages=[
+                {"role": "user", "content": "keep-me"},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": "now"},
+            ],
+            api_messages=[
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "MUTATED"},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": "now"},
+            ],
+            current_turn_user_idx=2,
+        )
+        assert report is not None
+        assert not report.ok
+
+    def test_extract_api_history_edges(self):
+        assert extract_api_history([]) == []
+        assert extract_api_history([{"role": "system", "content": "s"}]) == []
+        hist = extract_api_history(
+            [
+                {"role": "system", "content": "s"},
+                {"role": "user", "content": "u"},
+            ]
+        )
+        assert hist == [{"role": "user", "content": "u"}]
+
+    def test_project_turn_prefers_api_content(self):
+        t = project_turn(
+            {"role": "user", "content": "clean", "api_content": "wire-bytes"}
+        )
+        t2 = project_turn(
+            {"role": "user", "content": "wire-bytes"}, prefer_api_content=False
+        )
+        assert t["content_fingerprint"] == t2["content_fingerprint"]
+
+    def test_cache_control_shape_fingerprint_matches(self):
+        live = [{"role": "user", "content": "hello world"}]
+        api = [
+            {"role": "system", "content": "s"},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "hello world",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=0)
+        assert report.ok
+
+    def test_simulate_helper_not_exported_from_core(self):
+        import agent.log_reconstruction as mod
+
+        assert not hasattr(mod, "simulate_send_path_api_messages")

--- a/tests/agent/test_log_reconstruction.py
+++ b/tests/agent/test_log_reconstruction.py
@@ -324,6 +324,25 @@ class TestProjectAndCompare:
         report = compare_history_to_api_messages(live, api, current_turn_user_idx=0)
         assert report.ok
 
+    def test_empty_wiped_tool_call_id_is_desync(self):
+        """A tool tool_call_id known in live but wiped to empty in api is a
+        desync (not silently matched), and reports a clear tool_call_id reason."""
+        live = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_x"}]},
+            {"role": "tool", "tool_call_id": "call_x", "content": "result"},
+            {"role": "assistant", "content": "done"},
+        ]
+        api = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "call_x"}]},
+            {"role": "tool", "tool_call_id": "", "content": "result"},  # wiped
+            {"role": "assistant", "content": "done"},
+        ]
+        report = compare_history_to_api_messages(live, api, current_turn_user_idx=0)
+        assert not report.ok
+        assert any("tool_call_id" in m for m in report.mismatches)
+
     def test_compression_summary_plus_tail_no_fp(self):
         """api = marked summary + last turn; live still full → ok (no FP)."""
         live = [


### PR DESCRIPTION
## Summary
Adds an **opt-in** dev diagnostic that detects when the outgoing LLM request history silently diverges from the live session transcript (silent turn loss, content drift, tool-arg drift) — a class of desync that has surfaced as misleading summaries / missing decisions in past sessions. Default **off** (single boolean guard, zero-cost disabled); enabled it logs a soft report by default and only raises behind `agent.log_reconstruction_check_raise` (default false), so it can never take down a live session or break prompt caching.

## Design
- New opt-in flag `agent.log_reconstruction_check` (config.yaml, default false) + optional `agent.log_reconstruction_check_raise` (default false).
- Hooked at the single request-finalization chokepoint in `agent/conversation_loop.py` after `_build_api_kwargs`.
- Models the real send-path transforms so legitimate operations do not false-positive: thinking-only assistant drop + user merge, content `.strip()`, cache-control content-shape rewrite, prefills, `api_content` sidecar, compression summary marker (`_compressed_summary`), and current-user injection (prefix/stamped only, not naive substring).
- Tool integrity checked by id+name+args hash, not ids alone.
- Cache-, alternation-, system-prompt-safe: read-only comparison, no mutation of messages/api_messages/system prompt, no new `HERMES_*` env vars (config-native).

## Tests
`tests/agent/test_log_reconstruction.py` — 28 tests, including real send-path E2E: legitimate transforms return ok (no false-positive), genuine silent loss raises when the raise flag is on, compression summary + tail no-FP, short-string `in`-trap rejected.

`19->23->28` tests across review; verified locally passing.

## Review
Passed two adversarial review passes + an independent reviewer round; scope trimmed, test helpers kept out of core.
