### PR TITLE
fix(memory): strip channel/topic auto-loaded skill bodies from memory fan-out

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -52,6 +52,10 @@ _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 # tests/openviking_plugin/test_openviking.py::test_skill_markers_match_hermes_scaffolding.
 # ---------------------------------------------------------------------------
 _SKILL_INVOCATION_PREFIX = "[IMPORTANT: The user has invoked the "
+# Gateway channel/topic auto-load note ("[IMPORTANT: The \"X\" skill is
+# auto-loaded. ...]"). Distinct from the slash-skill prefix at the first
+# quoted span; must stay byte-identical to the builder in gateway/run.py.
+_AUTO_LOAD_PREFIX = '[IMPORTANT: The "'
 _SINGLE_SKILL_MARKER = "The full skill content is loaded below.]"
 _SINGLE_SKILL_INSTRUCTION = (
     "The user has provided the following instruction alongside the skill invocation: "
@@ -105,9 +109,21 @@ def extract_user_instruction_from_skill_message(content: Any) -> Optional[str]:
           instruction (i.e. a bare ``/skill`` invocation). Callers that feed
           memory providers should skip the turn in that case — there is no
           user content worth storing.
+
+    Gateway channel/topic auto-loaded turns (Discord channel_skill_bindings,
+    Telegram topic bindings) use a different activation note but carry the
+    same scaffolding risk: the framework injects whole skill bodies as user
+    role. They are recognized here too, so memory providers only ever see
+    the user-authored tail (#92036).
     """
     if not isinstance(content, str):
         return None
+
+    if content.startswith(_AUTO_LOAD_PREFIX):
+        # The gateway appends the user's original text after the last skill
+        # payload, prefixed by the same instruction marker the single-skill
+        # builder uses — the last-occurrence extraction applies unchanged.
+        return _extract_single_skill_user_instruction(content)
 
     if not content.startswith(_SKILL_INVOCATION_PREFIX):
         return content

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -54,8 +54,11 @@ _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 _SKILL_INVOCATION_PREFIX = "[IMPORTANT: The user has invoked the "
 # Gateway channel/topic auto-load note ("[IMPORTANT: The \"X\" skill is
 # auto-loaded. ...]"). Distinct from the slash-skill prefix at the first
-# quoted span; must stay byte-identical to the builder in gateway/run.py.
-_AUTO_LOAD_PREFIX = '[IMPORTANT: The "'
+# quoted span; the fixed "skill is auto-loaded." continuation keeps a user
+# turn that merely starts with '[IMPORTANT: The "' from being swallowed.
+# Must stay compatible with the note literal in gateway/run.py (pinned by
+# tests/agent/test_memory_skill_scaffolding.py).
+_AUTO_LOAD_NOTE_RE = re.compile(r'\[IMPORTANT: The "[^"]+" skill is auto-loaded\.')
 _SINGLE_SKILL_MARKER = "The full skill content is loaded below.]"
 _SINGLE_SKILL_INSTRUCTION = (
     "The user has provided the following instruction alongside the skill invocation: "
@@ -119,7 +122,7 @@ def extract_user_instruction_from_skill_message(content: Any) -> Optional[str]:
     if not isinstance(content, str):
         return None
 
-    if content.startswith(_AUTO_LOAD_PREFIX):
+    if _AUTO_LOAD_NOTE_RE.match(content):
         # The gateway appends the user's original text after the last skill
         # payload, prefixed by the same instruction marker the single-skill
         # builder uses — the last-occurrence extraction applies unchanged.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19109,7 +19109,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if _is_new_session and _auto:
             _skill_names = [_auto] if isinstance(_auto, str) else list(_auto)
             try:
-                from agent.skill_commands import _load_skill_payload, _build_skill_message
+                from agent.skill_commands import (
+                    _SINGLE_SKILL_INSTRUCTION,
+                    _build_skill_message,
+                    _load_skill_payload,
+                )
                 _combined_parts: list[str] = []
                 _loaded_names: list[str] = []
                 for _sname in _skill_names:
@@ -19127,8 +19131,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     else:
                         logger.warning("[Gateway] Auto-skill '%s' not found", _sname)
                 if _combined_parts:
-                    # Append the user's original text after all skill payloads
-                    _combined_parts.append(event.text)
+                    # Append the user's original text after all skill payloads,
+                    # behind the shared instruction marker so
+                    # extract_user_instruction_from_skill_message can recover
+                    # it — otherwise memory providers store the whole injected
+                    # skill body as user speech (#92036).
+                    _combined_parts.append(
+                        f"{_SINGLE_SKILL_INSTRUCTION}{event.text}"
+                    )
                     event.text = "\n\n".join(_combined_parts)
                     logger.info(
                         "[Gateway] Auto-loaded skill(s) %s for session %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19135,10 +19135,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # behind the shared instruction marker so
                     # extract_user_instruction_from_skill_message can recover
                     # it — otherwise memory providers store the whole injected
-                    # skill body as user speech (#92036).
-                    _combined_parts.append(
-                        f"{_SINGLE_SKILL_INSTRUCTION}{event.text}"
-                    )
+                    # skill body as user speech (#92036). Skip the marker on an
+                    # empty tail so the composed prompt has no dangling fragment.
+                    if event.text.strip():
+                        _combined_parts.append(
+                            f"{_SINGLE_SKILL_INSTRUCTION}{event.text}"
+                        )
                     event.text = "\n\n".join(_combined_parts)
                     logger.info(
                         "[Gateway] Auto-loaded skill(s) %s for session %s",

--- a/tests/agent/test_memory_skill_scaffolding.py
+++ b/tests/agent/test_memory_skill_scaffolding.py
@@ -125,3 +125,78 @@ class TestMemoryManagerStripsScaffolding:
         mgr.flush_pending(timeout=5.0)
         assert provider.synced == []
 
+
+# ---------------------------------------------------------------------------
+# Gateway channel/topic auto-loaded turns (#92036)
+# ---------------------------------------------------------------------------
+
+_AUTO_LOAD_NOTE = (
+    '[IMPORTANT: The "example-skill" skill is auto-loaded. '
+    "Follow its instructions for this session.]"
+)
+
+_INSTRUCTION_MARKER = (
+    "The user has provided the following instruction alongside the skill invocation: "
+)
+
+_AUTO_LOAD_SINGLE = (
+    f"{_AUTO_LOAD_NOTE}\n\n"
+    "# Example Skill\n\n"
+    "Framework-injected procedure text that must never reach memory.\n\n"
+    f"{_INSTRUCTION_MARKER}remember only this sentence"
+)
+
+_AUTO_LOAD_MULTI = (
+    f"{_AUTO_LOAD_NOTE}\n\n"
+    "# Example Skill\n\n"
+    "First injected body.\n\n"
+    f'{_AUTO_LOAD_NOTE.replace("example-skill", "second-skill")}\n\n'
+    "# Second Skill\n\n"
+    "Second injected body.\n\n"
+    f"{_INSTRUCTION_MARKER}remember only this sentence"
+)
+
+_BARE_AUTO_LOAD = (
+    f"{_AUTO_LOAD_NOTE}\n\n# Example Skill\n\nInjected body, no user text."
+)
+
+
+class TestGatewayAutoLoadScaffolding:
+    def test_single_auto_load_extraction(self):
+        assert (
+            extract_user_instruction_from_skill_message(_AUTO_LOAD_SINGLE)
+            == "remember only this sentence"
+        )
+
+    def test_multi_auto_load_extraction(self):
+        assert (
+            extract_user_instruction_from_skill_message(_AUTO_LOAD_MULTI)
+            == "remember only this sentence"
+        )
+
+    def test_bare_auto_load_returns_none(self):
+        assert extract_user_instruction_from_skill_message(_BARE_AUTO_LOAD) is None
+
+    def test_ordinary_message_unchanged(self):
+        assert (
+            extract_user_instruction_from_skill_message("remember only this sentence")
+            == "remember only this sentence"
+        )
+
+    def test_prefetch_all_strips_auto_load(self):
+        mgr, provider = _manager_with_recorder()
+        mgr.prefetch_all(_AUTO_LOAD_SINGLE)
+        assert provider.prefetched == ["remember only this sentence"]
+
+    def test_sync_all_strips_auto_load(self):
+        mgr, provider = _manager_with_recorder()
+        mgr.sync_all(_AUTO_LOAD_SINGLE, "Done.")
+        mgr.flush_pending(timeout=5.0)
+        assert provider.synced == ["remember only this sentence"]
+
+    def test_sync_all_skips_bare_auto_load(self):
+        mgr, provider = _manager_with_recorder()
+        mgr.sync_all(_BARE_AUTO_LOAD, "Done.")
+        mgr.flush_pending(timeout=5.0)
+        assert provider.synced == []
+

--- a/tests/agent/test_memory_skill_scaffolding.py
+++ b/tests/agent/test_memory_skill_scaffolding.py
@@ -10,6 +10,8 @@ See: agent.skill_commands.extract_user_instruction_from_skill_message and
 MemoryManager._strip_skill_scaffolding.
 """
 
+from pathlib import Path
+
 from agent.memory_manager import MemoryManager
 from agent.memory_provider import MemoryProvider
 from agent.skill_commands import extract_user_instruction_from_skill_message
@@ -199,4 +201,30 @@ class TestGatewayAutoLoadScaffolding:
         mgr.sync_all(_BARE_AUTO_LOAD, "Done.")
         mgr.flush_pending(timeout=5.0)
         assert provider.synced == []
+
+    def test_quoted_prefix_without_continuation_falls_through(self):
+        # A user turn that merely begins with the auto-load opening (e.g. a
+        # pasted note) must stay intact instead of silently vanishing from
+        # every memory provider.
+        quoted = '[IMPORTANT: The "quoted" note the user pasted verbatim'
+        assert extract_user_instruction_from_skill_message(quoted) == quoted
+
+
+def test_auto_load_discriminator_tracks_gateway_builder():
+    # The extractor regex and the gateway note literal live in different
+    # modules; drift would reintroduce the #92036 leak with no signal, so pin
+    # the source literal against the regex directly.
+    import re as _re
+
+    from agent.skill_commands import _AUTO_LOAD_NOTE_RE
+
+    source = (
+        Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+    ).read_text()
+    literal = _re.search(
+        r"'\[IMPORTANT: The \"\{[^}]+\}\" skill is auto-loaded\.", source
+    )
+    assert literal, "auto-load note literal moved or changed in gateway/run.py"
+    note = literal.group(0)[1:].replace("{_display_name}", "example-skill")
+    assert _AUTO_LOAD_NOTE_RE.match(note) is not None
 


### PR DESCRIPTION
## What does this PR do?

Gateway channel/topic skill bindings (Discord `channel_skill_bindings`, Telegram topic bindings) prepend whole skill bodies to the first user message of a new session. The shared memory sanitizer (`extract_user_instruction_from_skill_message`) only recognized the slash-skill invocation prefix (`[IMPORTANT: The user has invoked the ...`), so the auto-load envelope (`[IMPORTANT: The "X" skill is auto-loaded. ...]`) took the normal-message branch and passed through verbatim — recording memory providers (Hindsight/Honcho auto-sync, any `sync_all` consumer) could store the complete framework-injected skill body as user speech and later derive "user facts" from skill policy text (#92036; same class as #43733/#32662 on a still-uncovered path).

Two coordinated changes, both in the shared path (no provider-specific filters):

1. **Boundary**: when the gateway appends the user's original text after the auto-loaded payloads, it now goes in behind the existing `_SINGLE_SKILL_INSTRUCTION` marker — the same invariant the single-skill builder already guarantees ("the returned prefix ends exactly at the instruction marker").
2. **Recognition**: the canonical extractor recognizes the auto-load activation note (distinguishable from the slash-skill prefix at the first quoted span) and reuses the last-occurrence instruction extraction. A bare auto-load payload (no user text) extracts to `None`, which `MemoryManager` already treats as skip-the-turn for every provider — matching the issue's expected behavior.

## Related Issue

Fixes #92036

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (memory hygiene: framework-injected scaffolding must not be persisted as user speech)

## Changes Made

- `gateway/run.py`: the auto-load payload builder appends `event.text` behind `_SINGLE_SKILL_INSTRUCTION` so the sanitizer has an explicit boundary; comment cites #92036
- `agent/skill_commands.py`: new `_AUTO_LOAD_PREFIX` constant (documented as byte-identical to the gateway builder) + an early branch in `extract_user_instruction_from_skill_message` that routes auto-load envelopes to the existing single-skill extraction; docstring documents the gateway path
- `tests/agent/test_memory_skill_scaffolding.py`: seven regression tests covering the issue's list — single auto-loaded skill + user message, multiple auto-loaded skills + user message, bare auto-load (skip), ordinary message unchanged, `prefetch_all` and `sync_all` both receiving only the original user text, and sync skipping the bare payload

## How to Test

1. `pytest tests/agent/test_memory_skill_scaffolding.py tests/agent/test_skill_commands.py`
2. Observed result: 12 + 29 passed (5 pre-existing + 7 new scaffolding tests; skill_commands regression untouched).
3. The new tests fail on pre-fix code exactly as the issue describes: `extract_user_instruction_from_skill_message` returned the whole payload for auto-load envelopes, and `sync_all` delivered the full injected skill body to the recording provider.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (marker invariant, prefix distinctness)
- [x] Tests added/updated and passing (41 passed locally across the two files)
- [x] No new warnings introduced
- [x] Memory hygiene is fail-closed: unrecognized bare scaffolding extracts to None → providers skip the turn
- [x] Tested on macOS (arm64) via unit tests; the changed paths are pure-Python message construction
