### PR TITLE
fix(desktop): serialize bot group follow-ups

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -207,6 +207,10 @@ function focusedMentionProfile() {
 /** Group-chat rooms: { [group]: { log: [{from:{kind,name},text,at}], watermarks:{[member]:idx}, epoch, running } }.
  *  Log + watermarks persist via plugin storage; epoch/running are runtime-only. */
 const $groupChats = atom({})
+// Runtime-only room drive ownership. One drain owns a room at a time; sends
+// received while it awaits a member turn coalesce by thread and run only after
+// that drain releases the member session.
+const groupChatDrives = new Map()
 /** Group whose room view is open in the Bots pane (secondary navigation
  *  inside the pane; a normal row click returns to the roster). */
 const $groupChatWorkspace = atom(null)
@@ -278,6 +282,7 @@ const GROUP_ACTIVITY_LABELS = {
   failed: 'hit an error',
   cancelled: 'turn interrupted by a newer message',
   settled: 'turn settled',
+  capped: 'reached the room limit',
   delivered: 'delivered a late reply'
 }
 
@@ -4891,8 +4896,10 @@ function trimGroupChatLog(log, watermarks, limit = GROUP_CHAT_HISTORY_LIMIT * 4)
   const drop = log.length - limit
   const trimmed = {}
 
-  for (const [name, index] of Object.entries(watermarks || {})) {
-    trimmed[name] = Math.max(0, index - drop)
+  for (const [name, boundary] of Object.entries(watermarks || {})) {
+    // Immutable ids survive positional trimming; numeric values are retained
+    // only for rooms persisted by older builds.
+    trimmed[name] = typeof boundary === 'number' ? Math.max(0, boundary - drop) : boundary
   }
 
   return { log: log.slice(drop), watermarks: trimmed }
@@ -4963,6 +4970,7 @@ async function disbandGroupChat(group, members) {
   // the user just discarded.
   const all = { ...$groupChats.get() }
   const prior = all[group] || {}
+  groupChatDrives.delete(group)
 
   delete all[group]
   // Keep a runtime-only tombstone while a drive may still be mid-turn; it
@@ -5056,6 +5064,12 @@ async function renameGroupChat(oldName, newName, members) {
 
   if (!next || next === oldName) {
     return oldName
+  }
+
+  // Re-keying runtime ownership while a submit is held can orphan queued work.
+  if (groupChatDrives.get(oldName)?.active) {
+    host.notify({ kind: 'error', message: 'Wait for the group turn to finish before renaming it.' })
+    return null
   }
 
   // Renames are explicit user intent: reject a collision honestly instead of
@@ -5652,6 +5666,7 @@ async function runGroupChatRounds(group, members, thread) {
   const startEpoch = ($groupChats.get()[group] || {}).epoch || 0
   const isCurrent = () => (($groupChats.get()[group] || {}).epoch || 0) === startEpoch
   let posted = 0
+  let outcome = 'capped'
 
   try {
     for (let round = 0; round < GROUP_CHAT_MAX_ROUNDS; round++) {
@@ -5696,10 +5711,12 @@ async function runGroupChatRounds(group, members, thread) {
         const room = $groupChats.get()[group] || { log: [], watermarks: {} }
         const memberKey = groupMemberKey(member)
         const markKey = `${thread}::${memberKey}`
-        const seen = room.watermarks[markKey] || 0
+        const boundary = room.watermarks[markKey]
+        const boundaryIndex =
+          typeof boundary === 'string' ? room.log.findIndex(entry => entry.id === boundary) + 1 : Number(boundary || 0)
         // Delta: NEW room entries, narrowed to this thread — the member's
         // turn sees only the conversation it's part of.
-        const delta = room.log.slice(seen).filter(e => groupThreadOf(e) === thread)
+        const delta = room.log.slice(Math.max(0, boundaryIndex)).filter(e => groupThreadOf(e) === thread)
 
         if (!delta.length) {
           continue
@@ -5717,6 +5734,9 @@ async function runGroupChatRounds(group, members, thread) {
         // into the member's session so the model sees the pixels, not just
         // the transcript's [attached image: …] marker.
         const deltaImages = delta.flatMap(e => (Array.isArray(e.images) ? e.images : []))
+        // Freeze the exact stable boundary included in this prompt. Entries
+        // appended during the await must remain unseen.
+        const deliveredThrough = room.log.at(-1)?.id || room.log.length
 
         // Surface WHO is on turn (runtime-only, like running/epoch) so the
         // room shows "Radar is thinking…" instead of a generic working line —
@@ -5727,30 +5747,41 @@ async function runGroupChatRounds(group, members, thread) {
         })
 
         let reply = null
+        let accepted = false
 
         try {
           reply = await runGroupChatMemberTurn(group, member, prompt, thread, deltaImages)
+          accepted = true
         } catch {
           recordGroupActivity(group, { kind: 'failed', member: member.name, thread })
           reply = null // a failed turn is a pass, never a room error
         }
 
-        // The member has now seen everything up to the pre-reply log length.
-        updateGroupChat(group, r => {
-          r.watermarks[markKey] = r.log.length
-          return r
-        })
+        if (accepted) {
+          updateGroupChat(group, r => {
+            r.watermarks[markKey] = deliveredThrough
+            return r
+          })
+        }
 
         if (reply !== null && !isGroupPassText(reply)) {
-          appendGroupChatEntry(
+          const postedEntry = appendGroupChatEntry(
             group,
             { kind: 'member', name: member.name, ...(member.remoteSource ? { source: member.connectionLabel || member.connectionId } : {}) },
             reply,
             thread
           )
-          // Its own message counts as seen too.
+          // Its own message is seen only when nothing arrived ahead of it.
           updateGroupChat(group, r => {
-            r.watermarks[markKey] = r.log.length
+            if (typeof deliveredThrough === 'number') {
+              if (r.log.length === deliveredThrough + 1) r.watermarks[markKey] = r.log.length
+              return r
+            }
+            const deliveredIndex = r.log.findIndex(entry => entry.id === deliveredThrough)
+            const nextEntry = r.log[deliveredIndex + 1]
+            if (nextEntry?.id === postedEntry.id) {
+              r.watermarks[markKey] = postedEntry.id
+            }
             return r
           })
           posted += 1
@@ -5759,12 +5790,13 @@ async function runGroupChatRounds(group, members, thread) {
       }
 
       if (spokeThisRound === 0) {
+        outcome = 'settled'
         return // everyone passed — the conversation settled
       }
     }
   } finally {
     if (isCurrent()) {
-      recordGroupActivity(group, { kind: 'settled', member: null, thread })
+      recordGroupActivity(group, { kind: outcome, member: null, thread })
       updateGroupChat(group, r => {
         r.running = false
         r.turn = null
@@ -5847,37 +5879,53 @@ function sendToGroupChat(group, members, text, thread, images) {
   })
   appendGroupChatEntry(group, { kind: 'user', name: 'You' }, trimmed, target, attached)
 
-  const wasRunning = ($groupChats.get()[group] || {}).running === true
+  recordGroupActivity(group, { kind: 'queued', member: 'You', thread: target })
+  queueGroupChatDrive(group, members, target)
 
+  return target
+}
+
+function queueGroupChatDrive(group, members, thread) {
+  let drive = groupChatDrives.get(group)
+  if (!drive) {
+    drive = { active: false, pending: new Map() }
+    groupChatDrives.set(group, drive)
+  }
+  drive.pending.set(thread, members)
+  if (drive.active) return
+
+  drive.active = true
   updateGroupChat(group, room => {
     room.epoch = (room.epoch || 0) + 1
     room.running = true
     return room
   })
-
-  recordGroupActivity(group, { kind: 'queued', member: 'You', thread: target })
-
-  if (!wasRunning) {
-    void runGroupChatRounds(group, members, target).catch(() => {
-      updateGroupChat(group, r => {
-        r.running = false
-        return r
-      })
+  void (async () => {
+    try {
+      while (drive.pending.size) {
+        const [nextThread, nextMembers] = drive.pending.entries().next().value
+        drive.pending.delete(nextThread)
+        await runGroupChatRounds(group, nextMembers, nextThread)
+        if (($groupChats.get()[group] || {}).tombstone) break
+        if (drive.pending.size) {
+          updateGroupChat(group, room => {
+            room.epoch = (room.epoch || 0) + 1
+            room.running = true
+            return room
+          })
+        }
+      }
+    } finally {
+      drive.active = false
+      if (groupChatDrives.get(group) === drive && !drive.pending.size) groupChatDrives.delete(group)
+    }
+  })().catch(() => {
+    updateGroupChat(group, room => {
+      room.running = false
+      room.turn = null
+      return room
     })
-  } else {
-    // A loop is live; it bails at its next boundary. Chain the fresh loop
-    // after a short settle so exactly one drive owns the room.
-    setTimeout(() => {
-      void runGroupChatRounds(group, members, target).catch(() => {
-        updateGroupChat(group, r => {
-          r.running = false
-          return r
-        })
-      })
-    }, 250)
-  }
-
-  return target
+  })
 }
 
 /** Share one in-flight async operation across concurrent callers. Failures

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-activity.test.mjs
@@ -158,7 +158,7 @@ test('a failed member turn records failed instead of a phantom reply', async () 
   assert.equal(events.some(e => e.kind === 'failed' && e.member === 'builder'), true)
 })
 
-test('a newer send interrupts the previous run and records cancelled in the CURRENT epoch', async () => {
+test('a newer send queues behind the active run without cancelling its epoch', async () => {
   const gates = [null, null]
   const gate = n => {
     gates[n] = gates[n] || { promise: null, resolve: null }
@@ -176,23 +176,23 @@ test('a newer send interrupts the previous run and records cancelled in the CURR
   for (let i = 0; i < 50 && gc.calls.length < 1; i++) {
     await new Promise(resolve => setImmediate(resolve))
   }
-  gc.sendToGroupChat('Busy', member, 'second ask, supersede')
+  const epoch = (gc.$groupChats.get().Busy || {}).epoch || 0
+  gc.sendToGroupChat('Busy', member, 'second ask, queue it')
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(gc.calls.length, 1, 'the queued send cannot overlap the held member session')
+  assert.equal((gc.$groupChats.get().Busy || {}).epoch || 0, epoch)
+
+  gates[1].resolve('(pass)')
   for (let i = 0; i < 50 && gc.calls.length < 2; i++) {
     await new Promise(resolve => setImmediate(resolve))
   }
-
-  gates[2].resolve('from the new run')
+  gates[2].resolve('(pass)')
   await drain(gc, 'Busy')
-  gates[1].resolve('late from the old run')
-  await new Promise(resolve => setImmediate(resolve))
-  await new Promise(resolve => setImmediate(resolve))
 
-  const epoch = (gc.$groupChats.get().Busy || {}).epoch || 0
   const events = feed(gc, 'Busy')
-  assert.equal(events.some(e => e.kind === 'cancelled'), true, 'the superseded loop reports its own interruption')
-  // The view shows only the current run: every visible event is this epoch.
-  assert.equal(gc.currentGroupActivity('Busy').every(e => (e.epoch || 0) === epoch), true)
-  assert.equal(gc.currentGroupActivity('Busy').some(e => e.kind === 'cancelled'), true)
+  assert.equal(events.some(e => e.kind === 'cancelled'), false)
+  assert.equal(gc.currentGroupActivity('Busy').some(e => e.kind === 'settled'), true)
 })
 
 test('epoch filtering drops events from a superseded run', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat.test.mjs
@@ -169,7 +169,8 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
             stored: session.stored,
             title: session.title
           })
-          const reply = turnScript(session.profile, params.text, calls.length, session)
+          const scripted = turnScript(session.profile, params.text, calls.length, session)
+          const reply = scripted && typeof scripted.then === 'function' ? await scripted : scripted
           session.messages.push({ role: 'assistant', content: reply })
           return {}
         }
@@ -196,7 +197,7 @@ function load(turnScript, { busyUntilResumeCall, clarifyUntilResumeCall, approva
     .replace(/^import .* from 'react\/jsx-runtime'\r?\n/m, '')
     .replace('export default {', 'globalThis.plugin = {')
     .concat(
-      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
+      '\nglobalThis.__gc = { sendToGroupChat, runGroupChatRounds, harvestStrandedGroupReply, resolveGroupResponders, parseGroupChatMentions, rotateGroupSpeakers, isGroupPassText, formatGroupChatLine, buildGroupChatTurnPrompt, trimGroupChatLog, groupChatSyncSnapshot, groupChatGatewayJsonSize, mergeGroupChatSyncSnapshots, mergeRemoteGroupChatSnapshotIntoRooms, scheduleGroupChatServerSync, disbandGroupChat, renameGroupChat, updateGroupChat, durableGroupChatRooms, persistGroupChatRooms, ensureGroupChatSession, uniqueGroupChatName, liveGroupChatNames, openGroupChat, closeGroupChatMainTab, shouldRenderGroupChatInPane, syncGroupClarify, clearGroupClarify, answerGroupClarify, currentGroupActivity, $groupClarify, $groupChats, $groupNeedsYou, $groupChatWorkspace, $groupMainTabsRev, $botMeta, GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES };\n'
     )
   vm.runInNewContext(source, context, { filename: 'plugin.js' })
   const storageWrites = new Map()
@@ -236,6 +237,106 @@ test('mention routing: only @-mentioned members respond; @everyone or none = all
     MEMBERS
   )
   assert.equal(everyone.length, 3)
+})
+
+test('caps are reported truthfully: chatty runs cap while all-pass runs settle', async () => {
+  const chatty = load(() => 'still working')
+  chatty.sendToGroupChat('Caps', [MEMBERS[0], MEMBERS[1]], 'go')
+  for (let i = 0; i < 200 && (chatty.$groupChats.get().Caps || {}).running; i++) {
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  assert.equal(chatty.currentGroupActivity('Caps').at(-1).kind, 'capped')
+  assert.ok(chatty.calls.length <= chatty.GROUP_CHAT_MAX_ROUNDS * 2)
+  assert.ok(chatty.calls.length > 0)
+
+  const quiet = load(() => '(pass)')
+  quiet.sendToGroupChat('Quiet', [MEMBERS[0]], 'done?')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(quiet.currentGroupActivity('Quiet').at(-1).kind, 'settled')
+})
+
+test('rename is rejected while a room drive owns a held submit', async () => {
+  let release
+  let started
+  const held = new Promise(resolve => { release = resolve })
+  const submitted = new Promise(resolve => { started = resolve })
+  const gc = load(async () => {
+    started()
+    await held
+    return '(pass)'
+  })
+
+  gc.sendToGroupChat('Core', [MEMBERS[0]], 'hold')
+  await submitted
+  assert.equal(await gc.renameGroupChat('Core', 'Renamed', [MEMBERS[0]]), null)
+  assert.ok(gc.$groupChats.get().Core)
+  assert.equal(gc.$groupChats.get().Renamed, undefined)
+  release()
+  await new Promise(resolve => setImmediate(resolve))
+})
+
+test('same-thread follow-up waits for the active submit and drains with the intervening reply in order', async () => {
+  let releaseFirst
+  let firstStarted
+  const started = new Promise(resolve => { firstStarted = resolve })
+  const held = new Promise(resolve => { releaseFirst = resolve })
+  let active = 0
+  let maxActive = 0
+  const gc = load(async (_profile, _prompt, call) => {
+    active += 1
+    maxActive = Math.max(maxActive, active)
+    if (call === 1) {
+      firstStarted()
+      await held
+      active -= 1
+      return 'first reply'
+    }
+    active -= 1
+    return '(pass)'
+  })
+
+  const thread = gc.sendToGroupChat('Core', [MEMBERS[0]], 'first')
+  await started
+  gc.sendToGroupChat('Core', [MEMBERS[0]], 'follow-up', thread)
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(gc.calls.length, 1, 'a held member session is never submitted concurrently')
+
+  releaseFirst()
+  await new Promise(resolve => setImmediate(resolve))
+  await new Promise(resolve => setImmediate(resolve))
+
+  assert.equal(maxActive, 1)
+  assert.equal(gc.calls.length, 2)
+  assert.match(gc.calls[1].prompt, /You \(user\): follow-up[\s\S]*research \(you\): first reply/)
+})
+
+test('watermark freezes at the delivered entry identity while an independent append lands', async () => {
+  let release
+  let started
+  const held = new Promise(resolve => { release = resolve })
+  const submitted = new Promise(resolve => { started = resolve })
+  const gc = load(async (_profile, _prompt, call) => {
+    if (call === 1) {
+      started()
+      await held
+      return '(pass)'
+    }
+    return '(pass)'
+  })
+
+  const thread = gc.sendToGroupChat('Core', [MEMBERS[0]], 'delivered')
+  await submitted
+  gc.updateGroupChat('Core', room => {
+    room.log.push({ id: 'independent-entry', at: Date.now(), from: { kind: 'member', name: 'builder' }, text: 'unseen', thread })
+    return room
+  })
+  release()
+  await new Promise(resolve => setImmediate(resolve))
+
+  const room = gc.$groupChats.get().Core
+  assert.notEqual(room.watermarks[`${thread}::research`], 'independent-entry')
+  await gc.runGroupChatRounds('Core', [MEMBERS[0]], thread)
+  assert.match(gc.calls.at(-1).prompt, /builder: unseen/)
 })
 
 test('mention routing: display titles resolve to the member and @user never matches a bot', () => {


### PR DESCRIPTION
## Summary

Fixes #92003.

Bot Mode group rooms now keep one runtime-only drive owner per room. User sends that arrive while a member turn is active are queued by thread and drained serially only after the active `prompt.submit` releases the member session. This removes the fixed 250 ms replacement-drive race that could overlap or interrupt the same member session.

The member watermark now records the stable entry id at the exact pre-submit boundary. Entries appended while the turn is in flight remain unseen, and a member reply is marked seen only when it immediately follows that delivered boundary. Legacy numeric watermarks remain supported and log trimming preserves stable-id boundaries.

Hard-cap exits now report `capped`; only an all-pass round reports `settled`. Rename is rejected while a room drive is active so queued ownership cannot be orphaned.

## Root cause

`sendToGroupChat()` bumped the room epoch and started another drive after a fixed delay whenever a send arrived during an active turn. The delay did not prove the first turn had released its persistent member session.

Separately, `runGroupChatRounds()` built its prompt from one room-log snapshot but advanced the watermark to the completion-time log length. A follow-up appended during the await could therefore be marked as delivered even though it was absent from the prompt.

## Tests

- Regression control against unmodified `origin/main`: **4 failures**
  - concurrent same-thread submit (`2 !== 1`)
  - watermark skips the independent append
  - active rename is accepted instead of rejected
  - hard-cap exit is mislabeled `settled`
- Full Bot Mode plugin suite: **394 passed**
- Desktop `npm run typecheck`: passed
- `node --check` and `git diff --check`: passed

## Scope and overlap

This stays inside the bundled Desktop Bot Mode plugin and its group-chat tests. PR #90933 handles timed-out/late replies; this change preserves that path and addresses the distinct live follow-up ownership and watermark boundary race.
