### PR TITLE
fix(bot-mode): a bot row opens the bot's canonical Bot Chat

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4437,9 +4437,17 @@ function isCanonicalBotChatHistory(history) {
 /** The bot's newest VISIBLE conversation when it should win over the pin, else
  *  null.
  *
- *  A bot row is a workspace entry point, so it must land on what the user was
- *  last saying to that bot — not on a pin frozen weeks ago. Guards, all of
- *  which matter:
+ *  RETAINED FOR THE DEAD-PIN RECOVERY PATH ONLY. This is deliberately NOT
+ *  consulted while the pin is alive: Bot Mode's documented contract is "click
+ *  a Bot to land in its chat — every Bot has a canonical, persistent Bot Chat
+ *  conversation that is created (and pinned) the moment the Bot is born", and
+ *  canonical Bot Chats are ALWAYS hidden from the Sessions sidebar
+ *  (session.create passes hidden:true unconditionally — see
+ *  hide-bot-chats.test.mjs). The bot row is therefore the ONLY door to the
+ *  forever-chat; preferring a newer session here walls the relationship off
+ *  behind a door that no longer leads to it.
+ *
+ *  Guards, all of which matter:
  *   - the canonical Bot Chat itself is never "newer" (it IS the pin), so
  *     plumbing can't shadow itself;
  *   - an empty draft is skipped: clicking a bot right after a stray ⌘N would
@@ -4464,7 +4472,7 @@ function newerVisibleBotChat(pinned, history) {
   return id
 }
 
-async function openBotCanonicalChat(name, pinned, history, latestVisible) {
+async function openBotCanonicalChat(name, pinned, history) {
   if (!pinned) {
     // Grandfather only an actual Bot Chat. `last_session` is merely the most
     // recent row for the profile; adopting it blindly can claim an unrelated
@@ -4506,38 +4514,29 @@ async function openBotCanonicalChat(name, pinned, history, latestVisible) {
   }
 
   if (preferred && isCanonicalBotChatHistory(preferred)) {
-    // The pin is alive and healthy — but it is not necessarily where the user
-    // left off. Prefer their MOST RECENT real conversation with this bot.
+    // The pin is alive and healthy — open it. This is the whole contract:
+    // "Click a Bot to land in its chat — every Bot has a canonical,
+    // persistent Bot Chat conversation that is created (and pinned) the
+    // moment the Bot is born."
     //
-    // "One bot = one forever chat" welded each row to a single session: start
-    // a new chat with a bot, click another bot, click back, and the new chat
-    // was stranded behind the pinned transcript ("세션을 다시 만들어도 다른 봇
-    // 갔다가 다시 누르면 그 전 세션으로 돌아와"). A bot row is a workspace
-    // entry point here, so it should land on the live conversation. The pin
-    // keeps owning plumbing — creation, hide sweep, DM delivery — and stays
-    // untouched; it just stops overriding newer work.
+    // A newer-visible-session preference used to sit here, so that a bot row
+    // landed on the user's most recent conversation instead of the pin. It
+    // was reverted (2026-08-22) because it is unsound given how Bot Mode
+    // stores these chats: canonical Bot Chats are ALWAYS hidden from the
+    // Sessions sidebar (session.create passes hidden:true unconditionally,
+    // and hideOwnedBotSessions sweeps any that were born visible). The bot
+    // row is therefore the ONLY door to the forever-chat, so preferring a
+    // newer session did not merely re-order two equal entry points — it made
+    // the pinned relationship unreachable from anywhere in the UI. Reported
+    // symptom: a bot's whole build history became invisible, while the row
+    // previewed one session and opened another.
     //
-    // Deliberately AFTER the verification above: with a dead or unverified
-    // pin, adopting the profile's latest row would claim an unrelated user
-    // conversation as the bot's chat (see the "dead pin" safety tests).
-    //
-    // Uses `latestVisible` (the roster's freshest visible session), NOT
-    // `history` — the caller's `history` prefers the pin so preview identity
-    // matches click identity, which means it can never BE the newer chat.
-    // Falls back to `history` for callers that pass only three arguments.
-    const newer = newerVisibleBotChat(pinned, latestVisible ?? history)
-
-    if (newer) {
-      try {
-        await openStoredBotChat(name, newer, history)
-
-        return newer
-      } catch {
-        // Deleted or unreachable — fall back to the verified pin below so the
-        // row is never dead.
-      }
-    }
-
+    // The bug that motivated the preference — "I start a new chat with a bot,
+    // click another bot, click back, and my new chat is gone" — has a
+    // non-destructive answer: scratch sessions started via "New chat with
+    // this agent" are NOT plumbing-titled, so the hide sweep leaves them in
+    // the Sessions sidebar. They are reachable there; they simply are not the
+    // bot row's target, which is by design.
     try {
       await openStoredBotChat(name, preferred.resolved_id || preferred.id, preferred)
       return pinned
@@ -6430,13 +6429,13 @@ function BotRow({ bot, onDelete, onEdit, onGroup }) {
     }
 
     try {
-      // `previewSession` prefers the PIN (preview identity must match click
-      // identity), so it can never carry the newer conversation. Pass the
-      // roster's freshest VISIBLE session (`last`) separately — that is what
-      // "open where I left off" needs. Without this the newer-chat preference
-      // was dead code: it always received the pin and short-circuited on
-      // "same id".
-      const id = await openBotCanonicalChat(bot.name, pinnedChat, previewSession, last)
+      // `previewSession` prefers the PIN, and so does the click — preview
+      // identity and click identity are the same session by construction
+      // (#88200). The roster's freshest visible session is deliberately NOT
+      // passed: the row's job is to land in the bot's forever-chat, which is
+      // the only door to it (canonical Bot Chats are always hidden from the
+      // Sessions sidebar).
+      const id = await openBotCanonicalChat(bot.name, pinnedChat, previewSession)
 
       if (generation === botOpenGeneration && id) {
         return

--- a/apps/desktop/src/plugins/hermes-bots/tests/bot-row-opens-canonical-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/bot-row-opens-canonical-chat.test.mjs
@@ -6,15 +6,25 @@ import vm from 'node:vm'
 const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
 
 /**
- * A bot row must open the conversation the user was LAST having with that bot.
+ * A bot row must open the bot's canonical, pinned Bot Chat.
  *
- * Symptom (2026-08-21): every bot was welded to one session. Start a new chat
- * with 기획총괄, click 시스템총괄, click back — and the new chat was gone,
- * replaced by the pinned transcript. "세션을 다시 만들어도 다른 봇 갔다가 다시
- * 누르면 그 전 세션으로 다시 돌아와."
+ * This file previously asserted the opposite — that a row opens the user's
+ * NEWEST visible conversation — after a report that a freshly started chat
+ * seemed to vanish when clicking away and back. That preference was reverted
+ * (2026-08-22): canonical Bot Chats are ALWAYS hidden from the Sessions
+ * sidebar (see hide-bot-chats.test.mjs), so the bot row is the ONLY door to
+ * the forever-chat. Preferring a newer session made the pinned relationship
+ * unreachable from anywhere in the UI — a user lost an entire bot-building
+ * history behind a row that previewed one session and opened another.
  *
- * The pin still owns plumbing (creation, hide sweep, DM delivery); it just
- * must not override a newer real conversation.
+ * The original complaint has a non-destructive answer: scratch sessions from
+ * "New chat with this agent" are not plumbing-titled, so the hide sweep leaves
+ * them visible in the Sessions sidebar. They are reachable there; they are
+ * simply not what the bot row targets.
+ *
+ * Documented contract (docs/user-guide/bot-mode): "Click a Bot to land in its
+ * chat — every Bot has a canonical, persistent Bot Chat conversation that is
+ * created (and pinned) the moment the Bot is born."
  */
 function loadOpenPath({ openSession, request }) {
   const start = source.indexOf('const canonicalCreations = new Map()')
@@ -68,18 +78,20 @@ const healthyPin =
     return {}
   }
 
-test('bot row opens the NEWER real conversation instead of the pinned chat', async () => {
+test('a healthy pin wins over a newer conversation — the row lands in the Bot Chat', async () => {
   const runtime = loadOpenPath({ openSession: async () => undefined, request: healthyPin() })
 
   // The roster's freshest visible session is a real conversation the user
-  // started after the pin was made.
+  // started after the pin was made. It must NOT displace the forever-chat:
+  // the pinned chat is hidden from Sessions, so the row is its only door,
+  // while this newer session remains reachable in the Sessions sidebar.
   const history = { id: 'new-chat', title: '릴시아 카피 회의', message_count: 12, last_active: 9000 }
 
   const result = await runtime.openBotCanonicalChat('plan', 'pinned-bot-chat', history, history)
 
-  assert.equal(result, 'new-chat', 'should return the newer conversation')
+  assert.equal(result, 'pinned-bot-chat', 'should return the pinned Bot Chat')
   assert.equal(runtime.opened.length, 1)
-  assert.equal(runtime.opened[0].id, 'new-chat', 'must not reopen the pinned transcript')
+  assert.equal(runtime.opened[0].id, 'pinned-bot-chat', 'must open the pinned forever-chat')
   assert.equal(runtime.opened[0].options.profile, 'plan')
   assert.equal(
     runtime.opened[0].options.keepAllProfilesScope,
@@ -89,25 +101,41 @@ test('bot row opens the NEWER real conversation instead of the pinned chat', asy
 })
 
 /**
- * The REAL call shape from the roster row — this is what the first fix got
- * wrong. `previewSession` is `bot.preferred_session || last`, so on a pinned
- * bot it resolves to the PIN (preview identity must match click identity).
- * Feeding that as the "newer" candidate made the whole preference dead code:
- * it always saw the pin and short-circuited on "same id", and the user still
- * got the old session back ("다른 봇 눌렀다가 다시 그 봇 누르면 그 전 세션 열림").
- * The freshest visible session has to arrive as its own argument.
+ * The REAL call shape from the roster row: `previewSession` is
+ * `bot.preferred_session || last`, so on a pinned bot it resolves to the PIN.
+ * Preview identity and click identity are the same session by construction
+ * (#88200) — which is exactly the property the reverted newer-session
+ * preference broke.
  */
-test('real roster call: previewSession is the pin, latest arrives separately', async () => {
+test('real roster call: preview identity and click identity are the same session', async () => {
   const runtime = loadOpenPath({ openSession: async () => undefined, request: healthyPin('pin-1') })
 
   const pinnedPreview = { id: 'pin-1', title: 'Bot Chat', preview: 'plumbing' }
-  const last = { id: 'user-newest', title: '오늘 기획 회의', message_count: 8, last_active: 9999 }
 
-  // Mirrors: openBotCanonicalChat(bot.name, pinnedChat, previewSession, last)
-  const result = await runtime.openBotCanonicalChat('plan', 'pin-1', pinnedPreview, last)
+  // Mirrors: openBotCanonicalChat(bot.name, pinnedChat, previewSession)
+  const result = await runtime.openBotCanonicalChat('plan', 'pin-1', pinnedPreview)
 
-  assert.equal(result, 'user-newest', 'must open the newest real conversation, not the pin')
-  assert.equal(runtime.opened[0].id, 'user-newest')
+  assert.equal(result, 'pin-1', 'must open the pinned Bot Chat the row previewed')
+  assert.equal(runtime.opened[0].id, 'pin-1')
+})
+
+/** Regression guard for the revert: the open path must not consult the
+ *  newer-visible-session predicate while the pin is alive. Bot Chats are
+ *  hidden from Sessions, so a row that prefers a newer session strands the
+ *  forever-chat with no reachable entry point. */
+test('the healthy-pin branch never prefers a newer visible session', () => {
+  const start = source.indexOf('if (preferred && isCanonicalBotChatHistory(preferred)) {')
+  const end = source.indexOf('if (preferred) {', start)
+
+  assert.notEqual(start, -1, 'healthy-pin branch is missing')
+
+  const branch = source.slice(start, end)
+
+  assert.equal(
+    branch.includes('newerVisibleBotChat('),
+    false,
+    'a healthy pin must be opened directly — no newer-session preference'
+  )
 })
 
 test('the canonical Bot Chat itself never counts as "newer" (it IS the pin)', () => {
@@ -203,25 +231,26 @@ test('the post-kickoff retry open also follows the bot', async () => {
   )
 })
 
-test('a failed open of the newer session falls back to the pin (row never dies)', async () => {
+/** With the newer-session preference gone there is no "try the newer chat,
+ *  fall back to the pin" dance: a verified pin is opened directly, and a
+ *  failed open of a JUST-verified session is transient (reconnect, backend
+ *  restart), so it propagates rather than forking the forever-chat. */
+test('a failed open of a verified pin surfaces instead of forking the chat', async () => {
   const runtime = loadOpenPath({
-    openSession: async id => {
-      if (id === 'deleted-chat') {
-        throw new Error('session not found')
-      }
-
-      return undefined
+    openSession: async () => {
+      throw new Error('session not found')
     },
     request: healthyPin('pin-1')
   })
 
-  const history = { id: 'deleted-chat', title: '지워진 대화', message_count: 3 }
+  await assert.rejects(
+    () => runtime.openBotCanonicalChat('ops', 'pin-1', { id: 'pin-1', title: 'Bot Chat' }),
+    /session not found/
+  )
 
-  const result = await runtime.openBotCanonicalChat('ops', 'pin-1', history)
-
-  const ids = runtime.opened.map(entry => entry.id)
-
-  assert.ok(ids.includes('deleted-chat'), 'tries the newer session first')
-  assert.ok(ids.includes('pin-1'), 'falls back to the verified pin')
-  assert.equal(result, 'pin-1', 'row resolves to the pin rather than failing')
+  assert.deepEqual(
+    runtime.saved,
+    [],
+    'a transient failure must not clear the pin or mint a replacement'
+  )
 })


### PR DESCRIPTION
## Summary

A bot row opens the bot's canonical, pinned **Bot Chat** again. Partially reverts the newer-visible-session preference from #91791 (salvage of #91258), which made that chat unreachable.

Fixes #92040.

## Root cause

Canonical Bot Chats are **unconditionally hidden** from the Sessions sidebar — `session.create` passes `hidden:true` and `hideOwnedBotSessions()` sweeps any born visible. This is stated as an invariant in `tests/hide-bot-chats.test.mjs`:

> Bot Mode sessions are ALWAYS hidden from the global Sessions sidebar … There is no user pref.

So the bot row is the **only** entry point to a bot's forever-chat. Preferring the profile's freshest visible session did not re-order two equivalent doors — it removed the only one:

```
Bot Chat (pinned)  ──hidden from Sessions──✗
                   ──bot row──✗  (prefers newest visible)
                   = unreachable
```

Reported symptom: a 106-message bot-building conversation with no reachable entry point anywhere in the UI, while the row previewed one session and opened another — a regression of the preview/click identity #88200 established (`BotRow` still previews `bot.preferred_session || last`).

This also matches the documented contract:

> Click a Bot to land in its chat — every Bot has a canonical, persistent Bot Chat conversation that is created (and pinned) the moment the Bot is born.

## The #91791 report was real — and still is

The complaint (ryphez via Discord; #91258) is legitimate: *"chat with a bot, switch to another bot, come back → intro message again, and the chat missing from that profile's sessions."*

It has a non-destructive answer. Scratch sessions from **New chat with this agent** are **not** plumbing-titled, so neither `hideOwnedBotSessions()` nor `sweepBotProfileSessions()` hides them — the sweep matches the exact titles `Bot Chat` / `Agent Inbox` / `Group: …`. They stay listed in the Sessions sidebar and are reachable there; they simply are not the bot row's target, which is by design.

If part of that report was those scratch sessions *also* missing from Sessions, that is a separate hide-sweep false positive and should be fixed there rather than by repointing the row.

**The `keepAllProfilesScope: false` half of #91791 is untouched** — that fix was correct and stays.

## Changes

- **`openBotCanonicalChat`** — when the pin is alive and verified, open it directly. The `newerVisibleBotChat` preference is removed from that branch only; the helper stays for the dead-pin recovery path, with a comment on why it must not run while the pin is alive.
- Drop the now-unused `latestVisible` parameter and its argument at the `BotRow` call site (the second call site already passed three args).
- **`tests/bot-row-opens-latest.test.mjs` → `tests/bot-row-opens-canonical-chat.test.mjs`** — the old filename asserted the opposite of the contract. The two tests encoding the newer-session behaviour are **rewritten rather than deleted**, so the reasoning stays in the suite:
  - `bot row opens the NEWER real conversation` → `a healthy pin wins over a newer conversation`
  - `previewSession is the pin, latest arrives separately` → `preview identity and click identity are the same session`
  - **new:** `the healthy-pin branch never prefers a newer visible session` — a source-level guard that greps the branch for `newerVisibleBotChat(`, so this cannot silently regress
  - the deleted-newer-session fallback test covered a path that no longer exists; replaced with one asserting a failed open of a *verified* pin propagates instead of forking the forever-chat

## Validation

| | Before | After |
|---|---|---|
| Plugin suite (`npm run check:test:plugins`) | 395 pass | **392 pass, 0 fail** |

(392 not 395: three tests covered behaviour that no longer exists — two rewritten, one replaced.)

Verified on a real install (agent v0.20.5, macOS 26.6.1, `default` + 2 profiles): before, a `default` row whose pin was 50 minutes older than the newest session previewed the pin's text and opened the newer session, with the pinned chat listed nowhere (`hidden=1`). After, both rows land in their Bot Chats and preview matches click.

Sabotage-checked: restoring the `newerVisibleBotChat` call in the healthy-pin branch fails 3 tests, including the source-level guard.

## Compatibility

- Dead/unverified pins keep the existing recovery path unchanged (`newerVisibleBotChat` still used there).
- Older gateways without `preferred_session` keep the try-the-pin escape hatch.
- No schema, config, or storage change. Plugin-only diff.
