### PR TITLE
fix(dashboard): allow named hosts and base path behind a loopback proxy

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1628,6 +1628,17 @@ DEFAULT_CONFIG = {
         # falls through to request reconstruction rather than breaking
         # the login flow.
         "public_url": "",
+        # Opt-in Host allowlist when the dashboard stays bound to
+        # loopback but is reached through a reverse proxy under a real
+        # hostname (Tailscale MagicDNS, nginx). Empty keeps the
+        # GHSA-ppp5-vxwm-4cf7 default (loopback names only). ``*`` is
+        # ignored. Env: ``HERMES_DASHBOARD_ALLOWED_HOSTS`` (comma-separated)
+        # wins when set.
+        "allowed_hosts": [],
+        # Path prefix used when the proxy does not send
+        # ``X-Forwarded-Prefix`` (common with ``tailscale serve``).
+        # Header still wins when present. Env: ``HERMES_DASHBOARD_BASE_PATH``.
+        "base_path": "",
     },
 
     # Privacy settings

--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -132,10 +132,17 @@ def normalise_prefix(raw: Optional[str]) -> str:
 
 
 def prefix_from_request(request) -> str:
-    """Convenience wrapper that reads the header off a Starlette/FastAPI
-    Request and normalises it. Returns ``""`` when no prefix.
+    """Read X-Forwarded-Prefix, then fall back to the operator base path.
+
+    Several common proxies (``tailscale serve``, unconfigured nginx/Caddy)
+    do not inject the header. ``dashboard.base_path`` /
+    ``HERMES_DASHBOARD_BASE_PATH`` fills that gap. The header still wins
+    when present so a correctly configured proxy is not shadowed.
     """
-    return normalise_prefix(request.headers.get("x-forwarded-prefix"))
+    header = normalise_prefix(request.headers.get("x-forwarded-prefix"))
+    if header:
+        return header
+    return resolve_base_path()
 
 
 # ---------------------------------------------------------------------------
@@ -230,3 +237,64 @@ def resolve_public_url() -> str:
     if not cfg_clean:
         _warn_if_malformed("dashboard.public_url in config.yaml", cfg_raw)
     return cfg_clean
+
+
+_HOST_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789.-")
+
+
+def _normalise_allowed_host(raw: object) -> str:
+    """Return a lowercase hostname, or empty if the entry is unsafe."""
+    host = str(raw or "").strip().lower()
+    if not host or host == "*":
+        return ""
+    if host.startswith("["):
+        close = host.find("]")
+        host = host[1:close] if close != -1 else host.strip("[]")
+    elif host.count(":") == 1:
+        host = host.rsplit(":", 1)[0]
+    if not host or host == "*" or ".." in host:
+        return ""
+    if not set(host) <= _HOST_CHARS:
+        return ""
+    return host
+
+
+def resolve_allowed_hosts() -> tuple[str, ...]:
+    """Opt-in Host allowlist for a loopback-bound dashboard behind a proxy.
+
+    Precedence: ``HERMES_DASHBOARD_ALLOWED_HOSTS`` (comma-separated), then
+    ``dashboard.allowed_hosts`` in config.yaml. Empty / ``*`` entries are
+    dropped so the GHSA-ppp5-vxwm-4cf7 default stays fail-closed.
+    """
+    env_raw = os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "")
+    if env_raw.strip():
+        values = env_raw.split(",")
+    else:
+        cfg = _load_dashboard_section().get("allowed_hosts", [])
+        if isinstance(cfg, str):
+            values = cfg.split(",")
+        elif isinstance(cfg, (list, tuple)):
+            values = cfg
+        else:
+            values = []
+    hosts = []
+    seen = set()
+    for item in values:
+        host = _normalise_allowed_host(item)
+        if host and host not in seen:
+            seen.add(host)
+            hosts.append(host)
+    return tuple(hosts)
+
+
+def resolve_base_path() -> str:
+    """Operator-declared dashboard path prefix when the proxy omits the header.
+
+    Precedence: ``HERMES_DASHBOARD_BASE_PATH``, then ``dashboard.base_path``.
+    Values go through :func:`normalise_prefix`.
+    """
+    env_raw = os.environ.get("HERMES_DASHBOARD_BASE_PATH", "")
+    env_clean = normalise_prefix(env_raw)
+    if env_clean:
+        return env_clean
+    return normalise_prefix(str(_load_dashboard_section().get("base_path", "") or ""))

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,7 +48,7 @@ import zipfile
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
 
 import yaml
 
@@ -660,12 +660,19 @@ def should_require_auth(host: str, allow_public: bool = False) -> bool:
     return host not in _LOOPBACK_HOST_VALUES
 
 
-def _is_accepted_host(host_header: str, bound_host: str) -> bool:
+def _is_accepted_host(
+    host_header: str,
+    bound_host: str,
+    allowed_hosts: Optional[Sequence[str]] = None,
+) -> bool:
     """True if the Host header targets the interface we bound to.
 
     Accepts:
     - Exact bound host (with or without port suffix)
     - Loopback aliases when bound to loopback
+    - Operator-allowlisted hostnames when bound to loopback (so a
+      Tailscale/nginx name can reach a 127.0.0.1 bind without opening
+      0.0.0.0)
     - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
       no protection possible at this layer)
     """
@@ -695,10 +702,23 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     if bound_host in {"0.0.0.0", "::"}:
         return True
 
-    # Loopback bind: accept the loopback names
+    # Loopback bind: accept the loopback names, plus an opt-in allowlist
+    # of named hosts (MagicDNS, public hostname in front of a loopback
+    # bind). Wildcards never expand this set.
     bound_lc = bound_host.lower()
     if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+        if host_only in _LOOPBACK_HOST_VALUES:
+            return True
+        if allowed_hosts is None:
+            from hermes_cli.dashboard_auth.prefix import resolve_allowed_hosts
+
+            allowed_hosts = resolve_allowed_hosts()
+        allow = {
+            str(item).strip().lower()
+            for item in allowed_hosts
+            if str(item).strip() and str(item).strip() != "*"
+        }
+        return host_only in allow
 
     # Explicit non-loopback bind: require exact host match
     return host_only == bound_lc
@@ -17396,6 +17416,8 @@ def mount_spa(application: FastAPI):
     and the SPA's runtime ``__HERMES_BASE_PATH__`` honour that prefix
     without rebuilding the bundle.
     """
+    from hermes_cli.dashboard_auth.prefix import prefix_from_request
+
     # `hermes serve` is the headless backend: it must NEVER serve the browser
     # SPA, even if a dist is lying around from a prior `dashboard`/build. Take
     # the no-frontend path so only the JSON-RPC/WS/API surface is reachable.
@@ -17497,7 +17519,7 @@ def mount_spa(application: FastAPI):
             WEB_DIST.resolve()
         ):
             return JSONResponse({"error": "not found"}, status_code=404)
-        prefix = _normalise_prefix(request.headers.get("x-forwarded-prefix"))
+        prefix = prefix_from_request(request)
         css = css_path.read_text(encoding="utf-8")
         if prefix:
             for asset_dir in ("/fonts/", "/fonts-terminal/", "/ds-assets/", "/assets/"):
@@ -17533,7 +17555,7 @@ def mount_spa(application: FastAPI):
 
     @application.get("/{full_path:path}")
     async def serve_spa(full_path: str, request: Request):
-        prefix = _normalise_prefix(request.headers.get("x-forwarded-prefix"))
+        prefix = prefix_from_request(request)
         # An unmatched /api/* path is a missing/renamed endpoint, NOT a
         # client-side route. Falling through to index.html here returns
         # `<!doctype html>` with status 200, which makes JSON clients (the

--- a/tests/hermes_cli/test_dashboard_auth_prefix.py
+++ b/tests/hermes_cli/test_dashboard_auth_prefix.py
@@ -148,6 +148,32 @@ class TestForwardedPrefixNormalisation:
         assert "longer than 256 characters" in warnings[0].getMessage()
 
 
+class _HeaderRequest:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+class TestBasePathFallback:
+    def test_configured_base_path_used_when_header_absent(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DASHBOARD_BASE_PATH", raising=False)
+        monkeypatch.setattr(prefix_mod, "resolve_base_path", lambda: "/hermes")
+        assert prefix_mod.prefix_from_request(_HeaderRequest({})) == "/hermes"
+
+    def test_header_wins_over_configured_base_path(self, monkeypatch):
+        monkeypatch.setattr(prefix_mod, "resolve_base_path", lambda: "/from-config")
+        assert (
+            prefix_mod.prefix_from_request(
+                _HeaderRequest({"x-forwarded-prefix": "/from-header"})
+            )
+            == "/from-header"
+        )
+
+    def test_resolve_base_path_reads_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_BASE_PATH", "/hermes")
+        monkeypatch.setattr(prefix_mod, "_load_dashboard_section", lambda: {})
+        assert prefix_mod.resolve_base_path() == "/hermes"
+
+
 # ---------------------------------------------------------------------------
 # Gate middleware: Location: header and 401 envelope respect prefix
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -47,6 +47,33 @@ class TestHostHeaderValidator:
         # Loopback — reject (we bound to a specific non-loopback name)
         assert not _is_accepted_host("localhost", "my-server.corp.net")
 
+    def test_loopback_bind_rejects_named_host_without_allowlist(self):
+        from hermes_cli.web_server import _is_accepted_host
+
+        assert not _is_accepted_host(
+            "don-vps.tailnet.ts.net", "127.0.0.1", allowed_hosts=()
+        )
+
+    def test_loopback_bind_accepts_allowlisted_host(self):
+        from hermes_cli.web_server import _is_accepted_host
+
+        assert _is_accepted_host(
+            "don-vps.tailnet.ts.net:9119",
+            "127.0.0.1",
+            allowed_hosts=("don-vps.tailnet.ts.net",),
+        )
+        assert not _is_accepted_host(
+            "evil.example",
+            "127.0.0.1",
+            allowed_hosts=("don-vps.tailnet.ts.net",),
+        )
+
+    def test_wildcard_allowlist_is_ignored(self):
+        from hermes_cli.web_server import _is_accepted_host
+
+        assert not _is_accepted_host(
+            "evil.example", "127.0.0.1", allowed_hosts=("*",)
+        )
 
 
 class TestHostHeaderMiddleware:

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -947,6 +947,23 @@ Same precedence as the other dashboard settings — env wins over `config.yaml`:
 | `HERMES_DASHBOARD_PUBLIC_URL` env var | — | Hosting-platform secrets / CI |
 | (unset) | — | Default — reconstruct from `X-Forwarded-*` headers |
 
+### Loopback bind behind a reverse proxy
+
+The dashboard Host check (GHSA-ppp5-vxwm-4cf7) rejects any hostname that is not the bound interface. That is correct for DNS rebinding, but it also rejects a Tailscale/nginx name in front of a `127.0.0.1` bind — so the only remaining workaround used to be binding `0.0.0.0`, which is a larger exposure.
+
+Keep the loopback bind and name the host(s) you trust:
+
+```yaml
+dashboard:
+  allowed_hosts:
+    - don-vps.tailnet.ts.net
+  base_path: /hermes
+```
+
+`allowed_hosts` is opt-in and fail-closed: empty keeps the old loopback-only rule, and `*` is ignored. `base_path` is used only when the proxy does not send `X-Forwarded-Prefix` (`tailscale serve` is the common case). The header still wins when present.
+
+Env overrides (same precedence as `public_url`): `HERMES_DASHBOARD_ALLOWED_HOSTS` (comma-separated) and `HERMES_DASHBOARD_BASE_PATH`.
+
 Validation rejects values without `http://` / `https://` scheme, without a host, or containing quote / angle / whitespace / control characters. A malformed value silently falls through to header reconstruction so the login flow keeps working rather than dispatching the user to a hostile URL.
 
 > **Note:** `public_url` overrides the OAuth callback URL only. The `Secure` cookie flag is still controlled by `request.url.scheme` (X-Forwarded-Proto under proxy_headers), so an `http://` `public_url` on a TLS-terminated public deploy will produce non-Secure cookies. This is an operator footgun — pair `public_url` with proper TLS termination upstream.


### PR DESCRIPTION
## Bug Description

Fixes #91658

Behind a reverse proxy the dashboard was unusable without binding `0.0.0.0`:

1. GHSA-ppp5-vxwm-4cf7 Host checks reject a MagicDNS/nginx hostname on a loopback bind.
2. Asset/base path is derived only from `X-Forwarded-Prefix`, which `tailscale serve` and many nginx/Caddy setups do not send.

## Root Cause

`_is_accepted_host` only accepted loopback aliases when bound to `127.0.0.1`. SPA/CSS prefix rewriting only read the forwarded-prefix header.

## Fix

- Opt-in `dashboard.allowed_hosts` / `HERMES_DASHBOARD_ALLOWED_HOSTS` (comma-separated). Empty default keeps the GHSA rule. `*` is ignored.
- `dashboard.base_path` / `HERMES_DASHBOARD_BASE_PATH` used only when the header is absent. Header still wins.
- SPA + CSS mounts go through `prefix_from_request` so they share the same fallback.

## How to Verify

1. Bind dashboard to `127.0.0.1`.
2. `Host: don-vps.tailnet.ts.net` is 400 until that name is allowlisted, then 200.
3. `Host: evil.example` stays 400 even with another name allowlisted.
4. Missing `X-Forwarded-Prefix` + `HERMES_DASHBOARD_BASE_PATH=/hermes` injects `/hermes`. Header still overrides.

## Test Plan

- [x] Added regression tests for allowlist + base-path fallback
- [x] Existing host-header and prefix tests still pass (25)
- [ ] CI on this PR

## Risk Assessment

Medium — Host-header path is a security control. Default allowlist is empty (byte-identical reject of named hosts). Wildcards cannot open the gate. Prefix fallback uses the same normaliser as the header.