### PR TITLE
fix(desktop): show live streamed context gauge during turns (frozen-gauge fix)

### DIFF
--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.gauge.test.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.gauge.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ContextBreakdown, UsageStats } from '@/types/hermes'
+
+import { resolveContextGaugeUsage } from './use-statusbar-items'
+
+// Regression for #70871's frozen-gauge half: while a turn is streaming the
+// pre-turn context breakdown must NOT overlay the live streamed usage —
+// otherwise the bar stays frozen at the turn-start value and jumps at turn end.
+const CURRENT: UsageStats = {
+  calls: 1,
+  context_max: 1_000_000,
+  context_percent: 27,
+  context_used: 267_700,
+  input: 10_000,
+  output: 5_000,
+  total: 15_000
+}
+
+const BREAKDOWN: ContextBreakdown = {
+  categories: [],
+  context_max: 1_000_000,
+  context_percent: 30,
+  context_used: 320_000,
+  estimated_total: 350_000,
+  model: 'test-model'
+}
+
+describe('resolveContextGaugeUsage', () => {
+  it('keeps the live streamed usage mid-turn even when a breakdown is held', () => {
+    const out = resolveContextGaugeUsage({ busy: true, breakdown: BREAKDOWN, current: CURRENT })
+
+    expect(out.context_used).toBe(267_700)
+    expect(out.context_percent).toBe(27)
+    expect(out.input).toBe(10_000)
+  })
+
+  it('falls back to the streamed usage mid-turn when no breakdown is held', () => {
+    const out = resolveContextGaugeUsage({ busy: true, breakdown: null, current: CURRENT })
+
+    expect(out).toBe(CURRENT)
+  })
+
+  it('lets the breakdown win when the turn is idle', () => {
+    const out = resolveContextGaugeUsage({ busy: false, breakdown: BREAKDOWN, current: CURRENT })
+
+    expect(out.context_used).toBe(320_000)
+    expect(out.context_percent).toBe(30)
+    expect(out.context_max).toBe(1_000_000)
+    // Non-context fields still come from the streamed usage object.
+    expect(out.input).toBe(10_000)
+    expect(out.calls).toBe(1)
+  })
+
+  it('keeps the streamed usage when idle without a breakdown', () => {
+    const out = resolveContextGaugeUsage({ busy: false, breakdown: undefined, current: CURRENT })
+
+    expect(out).toBe(CURRENT)
+  })
+})

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -48,12 +48,40 @@ import {
   $updateStatus,
   openUpdateOverlayFor
 } from '@/store/updates'
-import type { StatusResponse, UsageStats } from '@/types/hermes'
+import type { ContextBreakdown, StatusResponse, UsageStats } from '@/types/hermes'
 
 import { CRON_ROUTE, SETTINGS_ROUTE, WEBHOOKS_ROUTE } from '../../routes'
 import type { StatusbarItem } from '../statusbar-controls'
 
 const EMPTY_USAGE: UsageStats = { calls: 0, input: 0, output: 0, total: 0 }
+
+/**
+ * Pick which usage figure the context gauge should paint.
+ *
+ * While a turn is in flight the backend streams live ``session.usage``
+ * snapshots (tui_gateway/server.py `_start_usage_ticker`, 1s interval) and
+ * the pre-turn breakdown would freeze the bar at the turn-start value — the
+ * "context meter frozen during streaming, jumps at turn end" bug (#70871,
+ * named in the #87903 discussion). Streamed usage wins mid-turn. Only when
+ * the turn is idle does the breakdown win: a resumed session's streamed
+ * store has no context fields, and the idle breakdown answers for it.
+ */
+export function resolveContextGaugeUsage(opts: {
+  busy: boolean
+  breakdown: ContextBreakdown | null | undefined
+  current: UsageStats
+}): UsageStats {
+  const { busy, breakdown, current } = opts
+
+  return !busy && breakdown
+    ? {
+        ...current,
+        context_max: breakdown.context_max,
+        context_percent: breakdown.context_percent,
+        context_used: breakdown.context_used
+      }
+    : current
+}
 
 interface StatusbarItemsOptions {
   agentsOpen: boolean
@@ -244,24 +272,14 @@ export function useStatusbarItems({
     sessionId: activeSessionId
   })
 
-  // The breakdown wins whenever we have one, for two reasons: it reports the
-  // MEASURED occupancy once the backend has it (falling back to the estimate
-  // only before that), and it is keyed to the session it describes. The global
-  // `$currentUsage` is neither — a resumed session reports no context fields,
-  // and the store merges rather than replaces, so the PREVIOUS session's gauge
-  // numbers survive the switch. Mid-turn there's no breakdown by design and
-  // the streamed usage carries the gauge.
+  // NOTE: the original "breakdown wins whenever we have one" is now gated on
+  // `busy` — the breakdown could report MEASURED occupancy (or an estimate)
+  // keyed to the session it describes, but it is a PRE-TURN value once a turn
+  // is streaming, and overlaying it would freeze the live streamed gauge.
+  // Mid-turn the streamed usage carries the gauge (see resolveContextGaugeUsage).
   const gaugeUsage = useMemo<UsageStats>(
-    () =>
-      contextBreakdown
-        ? {
-            ...currentUsage,
-            context_max: contextBreakdown.context_max,
-            context_percent: contextBreakdown.context_percent,
-            context_used: contextBreakdown.context_used
-          }
-        : currentUsage,
-    [contextBreakdown, currentUsage]
+    () => resolveContextGaugeUsage({ busy, breakdown: contextBreakdown, current: currentUsage }),
+    [busy, contextBreakdown, currentUsage]
   )
 
   const contextUsage = useMemo(() => usageContextLabel(gaugeUsage), [gaugeUsage])


### PR DESCRIPTION
## Summary

The Desktop status-bar context meter freezes for the whole turn at the turn-**start** value and jumps only when the turn completes — even though the backend streams live usage:

- `_start_usage_ticker` (tui_gateway/server.py:10524) emits `session.usage` **every second** while a turn runs (only when counters change);
- `useContextBreakdown` skips refetching while `busy` (apps/desktop/.../use-context-breakdown.ts:34), so the held `contextBreakdown` is a **pre-turn** value;
- `useStatusbarItems`'s `gaugeUsage` then overlays `contextBreakdown` over the streamed `currentUsage` whenever a breakdown is non-null — unfreezing the stream and pinning the bar to the stale value (the comment above it even says "Mid-turn there's no breakdown by design and the streamed usage carries the gauge", which is not what the code did).

This is the frozen-gauge half of **#70871**, with the mechanism named in the **#87903** discussion (jackulau's note: "the same retained `fetched` means `contextBreakdown` is non-null mid-turn, so `use-statusbar-items.tsx` overrides the live streamed `context_used`/`context_percent` with the pre-turn breakdown for the whole turn").

## Fix

Extract a pure resolver and gate the breakdown override on `busy`:

- **busy (turn streaming)** → streamed `currentUsage` always wins → the gauge updates live every second with measured values from the backend;
- **idle** → breakdown may still override (it answers for resumed sessions whose streamed `$currentUsage` carries no context fields, and for the moment before a resumed session's first response).

`resolveContextGaugeUsage({ busy, breakdown, current })` is exported and covered by four unit tests (busy+breakdown → streamed wins; busy without breakdown; idle+breakdown → breakdown wins with non-context fields preserved; idle without breakdown).

## Behavior change for the user

- First value now appears as soon as the **first provider response** arrives (mid-turn), not after the full turn — the gauge tracks growth during long multi-tool turns.
- Before any response there is still no gauge (backend reports no real occupancy yet — `context_used` comes from `last_prompt_tokens`, which is 0 until `update_from_response` runs; the breakdown-answer path only kicks in when idle).
- Intentional `~~strikethrough~~` / prose renders identically on the #87903 path — untouched here.

## Verification

- 4 new unit tests + existing context-usage panel suite (11 tests green).
- Local full desktop assistant-ui suite ran green on the same logic; upstream CI runs the desktop JS checks.

Files: `apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx`, `apps/desktop/src/app/shell/hooks/use-statusbar-items.gauge.test.tsx`.

Note: #87903/#87925 (conversation category hidden until first turn completes) is a separate bug — kept out of scope here.
