### PR TITLE
fix(acp): expose a configured context engine's tools on the ACP platform

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -632,10 +632,23 @@ class SessionManager:
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
 
+        # Mirror hermes_cli/tools_config.py::_get_platform_tools -- a configured
+        # non-default context engine keeps its recovery/status tools available.
+        # ACP builds its own toolset list rather than calling that resolver, so
+        # without this the ``context_engine`` marker is absent and the gate in
+        # agent_init never attaches the engine's tool schemas.
+        _acp_seed_toolsets = ["hermes-acp"]
+        _context_cfg = config.get("context") or {}
+        if not isinstance(_context_cfg, dict):
+            _context_cfg = {}
+        _engine_name = str(_context_cfg.get("engine") or "compressor").strip().lower()
+        if _engine_name and _engine_name != "compressor":
+            _acp_seed_toolsets.append("context_engine")
+
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                _acp_seed_toolsets,
                 mcp_server_names=configured_mcp_servers,
             ),
             "quiet_mode": True,

--- a/contributors/emails/travisfinch1983@gmail.com
+++ b/contributors/emails/travisfinch1983@gmail.com
@@ -1,0 +1,1 @@
+travisfinch1983

--- a/tests/acp_adapter/test_context_engine_toolset.py
+++ b/tests/acp_adapter/test_context_engine_toolset.py
@@ -1,0 +1,63 @@
+"""ACP must expose a configured context engine's toolset marker.
+
+Regression test: an ACP agent with a plugin context engine received none of that
+engine's tools, because ``acp_adapter.session._make_agent`` built
+``enabled_toolsets`` directly instead of consulting the shared per-platform
+resolver, so the ``context_engine`` marker was never present and the gate in
+``agent_init`` skipped attaching the engine's schemas.
+
+The seeding rule mirrors ``hermes_cli.tools_config._get_platform_tools``: add the
+marker when a non-default engine is configured, withhold it for the built-in
+compressor.
+"""
+
+import pytest
+
+from acp_adapter.session import _expand_acp_enabled_toolsets
+
+
+def _acp_seed(config):
+    """The seeding rule as applied in ``_make_agent``."""
+    seed = ["hermes-acp"]
+    context_cfg = config.get("context") or {}
+    if not isinstance(context_cfg, dict):
+        context_cfg = {}
+    engine = str(context_cfg.get("engine") or "compressor").strip().lower()
+    if engine and engine != "compressor":
+        seed.append("context_engine")
+    return _expand_acp_enabled_toolsets(seed, mcp_server_names=[])
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        ({"context": {"engine": "lcm"}}, True),
+        ({"context": {"engine": "LCM"}}, True),           # case-insensitive
+        ({"context": {"engine": "  lcm  "}}, True),       # whitespace tolerant
+        ({"context": {"engine": "compressor"}}, False),   # built-in unchanged
+        ({"context": {"engine": ""}}, False),
+        ({"context": {}}, False),
+        ({}, False),
+        ({"context": "not-a-dict"}, False),               # malformed config is safe
+    ],
+)
+def test_context_engine_marker_matches_resolver_semantics(config, expected):
+    assert ("context_engine" in _acp_seed(config)) is expected
+
+
+def test_marker_grants_no_tools_by_itself():
+    """``context_engine`` is a marker toolset; it must not widen the tool surface."""
+    from toolsets import resolve_toolset
+
+    assert resolve_toolset("context_engine") == []
+    assert not set(resolve_toolset("context_engine")) & set(resolve_toolset("hermes-acp"))
+
+
+def test_mcp_server_toolsets_still_expand():
+    """Seeding the marker must not disturb existing ``mcp-*`` expansion."""
+    out = _expand_acp_enabled_toolsets(
+        ["hermes-acp", "context_engine"], mcp_server_names=["example"]
+    )
+    assert "hermes-acp" in out
+    assert "context_engine" in out
+    assert "mcp-example" in out


### PR DESCRIPTION
Fixes #92047

## Summary
On the **ACP platform**, an agent with a plugin context engine configured receives **none of
that engine's tools**. The engine loads and runs normally — it captures messages and compacts —
but the model is never offered its tools. Asked to call one, the agent replies `TOOL NOT FOUND`.

ACP constructs its toolset list directly instead of using the shared per-platform resolver, and
the hardcoded list omits the `context_engine` marker toolset that the gate downstream requires.

## Root cause
`agent/agent_init.py` attaches context-engine schemas only when the toolset **name** is present:

```python
if (hasattr(agent, "context_compressor") and agent.context_compressor
        and agent.tools is not None
        and (agent.enabled_toolsets is None
             or "context_engine" in agent.enabled_toolsets)):
```

`acp_adapter/session.py::_make_agent` supplied that list itself as `["hermes-acp"]`, and
`_expand_acp_enabled_toolsets` only appends `mcp-*` entries — so the marker is never present.

## Why this looks unintended rather than an opt-out
`hermes_cli/tools_config.py::_get_platform_tools` already encodes "a configured non-default
engine keeps its tools", platform-agnostically:

```python
if context_engine_name and context_engine_name != "compressor" and not explicit_empty_selection:
    enabled_toolsets.add("context_engine")
```

Asked about **acp** with a plugin engine configured, that resolver includes the marker:

```
_get_platform_tools(cfg, "gateway") -> context_engine present: True   (n=24)
_get_platform_tools(cfg, "cli")     -> context_engine present: True   (n=23)
_get_platform_tools(cfg, "acp")     -> context_engine present: True   (n=14)
_get_platform_tools(cfg, "discord") -> context_engine present: True   (n=22)

_expand_acp_enabled_toolsets(["hermes-acp"], mcp_server_names=["example"])
    -> ['hermes-acp', 'mcp-example']       # marker absent
```

(The measured profile has `platform_toolsets.acp` unset per-profile and globally, so the `True`
for acp comes from the engine-configured branch, not a saved toolset list.)

Other platforms reach that resolver — e.g. `gateway/session.py:415`. ACP is the only path I
found that builds the list without consulting it. There is also no config workaround, because
`platform_toolsets` is never read on the ACP path: adding `context_engine` to
`platform_toolsets.acp` has no effect (verified).

## The change
Mirror the resolver's own condition rather than seeding unconditionally, so behaviour matches
`_get_platform_tools` and profiles on the built-in compressor are untouched.

`context_engine` is a zero-member marker toolset (`resolve_toolset("context_engine") == []`), so
it grants no tools by itself — only the gate consumes the name. Zero overlap with `hermes-acp`.

## Verification
| scenario | before | after |
|---|---|---|
| ACP agent, plugin engine, asked to CALL a tool | `TOOL NOT FOUND` | tool executes and returns |
| ACP agent, built-in compressor | normal | normal — no new tools, no errors |

Seed resolution:
```
plugin-engine profile       -> ['hermes-acp', 'context_engine']
built-in profile            -> ['hermes-acp']
profile with no context key -> ['hermes-acp']
```

Tests added in `tests/acp_adapter/test_context_engine_toolset.py` covering both branches,
case/whitespace handling, malformed config, the marker granting no tools, and `mcp-*` expansion
being undisturbed.

Reproduced with a third-party context engine (hermes-lcm v0.21.0-rc2), but nothing in the fix is
plugin-specific — any engine implementing `get_tool_schemas()` is affected.

## Known remaining gap (deliberately out of scope)
`acp_adapter/server.py::_register_acp_mcp_servers` rebuilds `agent.tools` via
`get_tool_definitions(...)` when the ACP **client** passes `mcpServers` in `session/new`.
`get_tool_definitions` cannot regenerate context-engine schemas (marker toolset with no members;
schemas are attached post-hoc at init), so that path drops them again even with this change.
Clients sending no `mcpServers` are unaffected, which is why the verification above passes.

`refresh_agent_mcp_tools` (`tools/mcp_tool.py`) already appears to be the additive-preserving
helper for exactly this. Happy to switch that rebuild over in this PR if you'd prefer a single
change — kept separate to keep this one minimal and easy to review.

---

### Provenance — please read
This PR was written and submitted by **Claude** (Anthropic's Claude Code) using
@travisfinch1983's GitHub account, with the account owner's knowledge and approval.

It is **actively monitored by both the AI agent and a human** (the account owner). Automated
monitoring notifies us of any comment or review on this PR, and we will respond to questions or
requested changes. This is not a drive-by submission — if you want changes, tests, a different
approach, or the scoped-out gap folded in, say so and we will follow through.
