### PR TITLE
feat(kanban): hard-enforce forbidden_tools and require_summary on created tasks (#46582)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21255,6 +21255,30 @@ def main(
                 except Exception as _exc:
                     # Best-effort enrichment; never block worker startup on it.
                     logger.debug("kanban image-ref extraction failed: %s", _exc)
+
+            # Kanban worker behavioral constraints (#46582): install the
+            # mechanical forbidden-tools guard for THIS dispatcher-spawned
+            # worker session before any turn runs. The constraint lives on
+            # the task row (forbidden_tools column) and is read through the
+            # board DB — no env propagation. From here until session end,
+            # any call to a constrained tool (kanban or otherwise, terminal
+            # included) is refused with an error naming the constraint.
+            # Quiet-only: interactive sessions never get a deny-guard just
+            # because HERMES_KANBAN_TASK happens to be set.
+            _kanban_forbidden_tools: list = []
+            if _kanban_task_id and quiet:
+                try:
+                    from tools.kanban_tools import (
+                        install_task_constraint_guard as _install_constraint_guard,
+                    )
+
+                    _kanban_forbidden_tools = (
+                        _install_constraint_guard() or []
+                    )
+                except Exception as _guard_exc:
+                    logger.debug(
+                        "kanban constraint guard skipped: %s", _guard_exc
+                    )
             if quiet:
                 # Quiet mode: suppress banner, spinner, tool previews.
                 # Only print the final response and parseable session info.
@@ -21317,6 +21341,24 @@ def main(
                                 query,
                                 single_query_images,
                                 announce=False,
+                            )
+                    # Surface the forbidden list in the worker's own task
+                    # context (#46582) — documentation, not enforcement: the
+                    # mechanical refusal happens in the pre-tool-call guard.
+                    if _kanban_forbidden_tools:
+                        _constraint_note = (
+                            "[Task constraints] Forbidden tools for this "
+                            "task: " + ", ".join(_kanban_forbidden_tools)
+                            + ". Calls to them are refused mechanically; "
+                            "complete the task without them."
+                        )
+                        if isinstance(effective_query, str):
+                            effective_query = (
+                                f"{effective_query}\n\n{_constraint_note}"
+                            )
+                        elif isinstance(effective_query, list):
+                            effective_query.append(
+                                {"type": "text", "text": _constraint_note}
                             )
                     turn_route = cli._resolve_turn_agent_config(effective_query)
                     if turn_route["signature"] != cli._active_agent_route_signature:
@@ -21435,6 +21477,17 @@ def main(
                 cli._print_exit_summary(clear_screen=False)
         finally:
             _finalize_single_query(cli)
+            # Lift the #46582 forbidden-tools guard installed for this
+            # worker session. Runs on every exit path above (normal,
+            # sys.exit, KeyboardInterrupt) — a no-op when never installed.
+            try:
+                from tools.kanban_tools import (
+                    clear_task_constraint_guard as _clear_constraint_guard,
+                )
+
+                _clear_constraint_guard()
+            except Exception:
+                pass
         return
     
     # Run interactive mode

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -134,6 +134,38 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
+# Hard completion gate (#46582): when a task sets ``require_summary``, the
+# completing handoff (summary, or result when summary is omitted) must carry
+# at least this many characters. The point is substance, not length for its
+# own sake — one short sentence clears the bar; an empty string does not.
+REQUIRE_SUMMARY_MIN_CHARS = 40
+
+
+def require_summary_rejection(
+    require_summary_enabled: bool,
+    summary: Optional[str],
+    result: Optional[str],
+) -> Optional[str]:
+    """Return a refusal message when a completion violates ``require_summary``.
+
+    Pure predicate shared by every completion surface so the gate reads
+    identically everywhere: ``None`` means the handoff is acceptable, a
+    string is the reason it is not (empty or under
+    ``REQUIRE_SUMMARY_MIN_CHARS`` characters). Flag unset → always ``None``
+    (classic behaviour).
+    """
+    if not require_summary_enabled:
+        return None
+    text = (summary if summary is not None else result) or ""
+    if len(text.strip()) >= REQUIRE_SUMMARY_MIN_CHARS:
+        return None
+    return (
+        f"task requires a substantive summary: the summary/result handoff "
+        f"must be at least {REQUIRE_SUMMARY_MIN_CHARS} characters "
+        f"(got {len(text.strip())}). Describe what was done and how to "
+        f"verify it, then retry kanban_complete."
+    )
+
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
@@ -1141,6 +1173,13 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Tools the dispatched worker must not call while on this task
+    # (#46582). Stored as a JSON array; the worker session installs them
+    # as a mechanical pre-tool-call deny-list. None = unconstrained.
+    forbidden_tools: Optional[list] = None
+    # When True, ``complete_task`` refuses completions whose summary/result
+    # handoff text is empty or under ``REQUIRE_SUMMARY_MIN_CHARS`` (#46582).
+    require_summary: bool = False
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1154,6 +1193,15 @@ class Task:
                     skills_value = [str(s) for s in parsed if s]
             except Exception:
                 skills_value = None
+        # Parse forbidden_tools JSON blob if present (same shape as skills).
+        forbidden_tools_value: Optional[list] = None
+        if "forbidden_tools" in keys and row["forbidden_tools"]:
+            try:
+                parsed = json.loads(row["forbidden_tools"])
+                if isinstance(parsed, list):
+                    forbidden_tools_value = [str(s) for s in parsed if s]
+            except Exception:
+                forbidden_tools_value = None
         return cls(
             id=row["id"],
             title=row["title"],
@@ -1234,6 +1282,12 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            forbidden_tools=forbidden_tools_value,
+            require_summary=(
+                bool(row["require_summary"])
+                if "require_summary" in keys and row["require_summary"]
+                else False
             ),
         )
 
@@ -1422,7 +1476,16 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Behavioral constraints for the dispatched worker (#46582). Stored as a
+    -- JSON array of tool names; the worker session installs them as a
+    -- mechanical pre-tool-call deny-list so a constrained call is refused
+    -- with an error naming the constraint. NULL = unconstrained.
+    forbidden_tools      TEXT,
+    -- When 1, ``complete_task`` refuses completions whose summary/result
+    -- handoff text is empty or under REQUIRE_SUMMARY_MIN_CHARS. Opt-in hard
+    -- completion gate; 0 (the default) preserves classic behaviour.
+    require_summary      INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2679,6 +2742,22 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "forbidden_tools" not in cols:
+        # Worker behavioral constraint (#46582): JSON array of tool names the
+        # dispatched worker must not call. NULL on legacy rows = unconstrained,
+        # which is exactly the behaviour they had before the column existed.
+        _add_column_if_missing(conn, "tasks", "forbidden_tools", "forbidden_tools TEXT")
+
+    if "require_summary" not in cols:
+        # Opt-in hard completion gate (#46582). 0 (the default) keeps the
+        # classic behaviour existing rows had — any completion accepted.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "require_summary",
+            "require_summary INTEGER NOT NULL DEFAULT 0",
+        )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -3183,6 +3262,8 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    forbidden_tools: Optional[Iterable[str]] = None,
+    require_summary: bool = False,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3216,6 +3297,17 @@ def create_task(
     (``minimal``…``ultra``, or ``none`` to disable thinking), passed as
     ``--reasoning <level>``. It is independent of ``model_override``: a task
     can run the profile's own model at a different depth.
+
+    ``forbidden_tools`` is an optional list of tool names the dispatched
+    worker must not call while on this task (#46582). Stored as JSON; the
+    worker session installs it as a mechanical pre-tool-call deny-list, so a
+    constrained call is refused with an error naming the constraint — not a
+    soft body-text instruction.
+
+    ``require_summary=True`` turns on the hard completion gate: the worker's
+    ``kanban_complete`` handoff must carry a substantive summary/result
+    (at least ``REQUIRE_SUMMARY_MIN_CHARS`` characters) or completion is
+    refused with a clear message.
 
     ``project_source_task_id`` is an internal cross-profile fallback for a
     worker-created child. When the active profile cannot resolve ``project_id``
@@ -3393,6 +3485,33 @@ def create_task(
             )
         skills_list = cleaned
 
+    # Normalise + validate forbidden_tools (#46582): same strip/dedupe
+    # discipline as skills. A tool name that isn't a plain string would never
+    # match any dispatch, silently turning "hard" into "no" enforcement —
+    # refuse instead of coercing.
+    forbidden_tools_list: Optional[list[str]] = None
+    if forbidden_tools is not None:
+        cleaned_ft: list[str] = []
+        seen_ft: set[str] = set()
+        for ft in forbidden_tools:
+            if not isinstance(ft, str):
+                raise ValueError(
+                    f"forbidden_tools must be tool-name strings, got "
+                    f"{type(ft).__name__}: {ft!r}"
+                )
+            name = ft.strip()
+            if not name:
+                continue
+            if name not in seen_ft:
+                seen_ft.add(name)
+                cleaned_ft.append(name)
+        if not cleaned_ft:
+            raise ValueError(
+                "forbidden_tools must contain at least one tool name "
+                "(pass None to leave the worker unconstrained)"
+            )
+        forbidden_tools_list = cleaned_ft
+
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -3497,8 +3616,9 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id,
+                        forbidden_tools, require_summary
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3524,6 +3644,12 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        (
+                            json.dumps(forbidden_tools_list)
+                            if forbidden_tools_list is not None
+                            else None
+                        ),
+                        1 if require_summary else 0,
                     ),
                 )
                 for pid in parents:
@@ -3552,6 +3678,12 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "forbidden_tools": (
+                            list(forbidden_tools_list)
+                            if forbidden_tools_list
+                            else None
+                        ),
+                        "require_summary": bool(require_summary) or None,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -5393,6 +5525,24 @@ def complete_task(
     and never blocks.
     """
     now = int(time.time())
+    # Hard completion gate (#46582): refuse under-substantiated handoffs
+    # BEFORE anything else — no audit event, no run row, no state change.
+    # The caller surfaces the message verbatim (tool_error on the worker
+    # toolset, stderr + exit 1 on the CLI), so the refusal is retryable:
+    # the task is untouched and the completer can re-complete with prose.
+    # Unknown ids fall through to the ordinary failure paths below.
+    _gate = conn.execute(
+        "SELECT require_summary FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if (
+        _gate is not None
+        and "require_summary" in _gate.keys()
+        and _gate["require_summary"]
+    ):
+        rejection = require_summary_rejection(True, summary, result)
+        if rejection is not None:
+            raise ValueError(f"kanban_complete refused: {rejection}")
     # Fail before validating cards or staging artifacts; re-check inside the
     # final write transaction below to close the parent-reopen race.
     if not _parents_satisfied(conn, task_id):

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -34,6 +34,7 @@ so plugin-defined tools appear alongside the built-in tools.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import copy
 import hashlib
 import importlib.metadata
@@ -51,7 +52,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import wraps
 from pathlib import Path
-from typing import (Any, Callable, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Type, Union)
+from typing import (Any, Callable, Dict, FrozenSet, Iterable, List, Mapping, Optional, Set, Tuple, Type, Union)
 
 from hermes_constants import (
     get_hermes_home,
@@ -5977,6 +5978,24 @@ def fire_pre_command_hook(
 
 _thread_tool_whitelist = threading.local()
 
+# Forbidden-tools guard (kanban task constraints, #46582).
+#
+# A ``ContextVar``, not a ``threading.local`` like the whitelist above:
+# concurrent tool batches fan out onto DaemonThreadPoolExecutor workers via
+# ``tools.thread_context.propagate_context_to_thread``, which snapshots
+# ``contextvars.copy_context()`` but does NOT copy thread-locals. A deny-list
+# stored here is therefore visible on BOTH dispatch paths — sequential tool
+# calls (same thread) and parallel batches (pool worker running the copied
+# context) — while never leaking sideways into unrelated threads that did not
+# inherit this context (delegate children snapshot their own context before
+# the guard is installed).
+_forbidden_tools_cv: "contextvars.ContextVar[Optional[FrozenSet[str]]]" = (
+    contextvars.ContextVar("hermes_forbidden_tools", default=None)
+)
+_forbidden_tools_fmt_cv: "contextvars.ContextVar[Optional[str]]" = (
+    contextvars.ContextVar("hermes_forbidden_tools_fmt", default=None)
+)
+
 
 @dataclass(frozen=True)
 class _PreToolCallDirective:
@@ -5996,6 +6015,31 @@ def set_thread_tool_whitelist(
 
 def clear_thread_tool_whitelist() -> None:
     _thread_tool_whitelist.allowed = None
+
+
+def set_forbidden_tools(
+    forbidden: Optional[Set[str]],
+    deny_msg_fmt: str = (
+        "Tool '{tool_name}' refused: forbidden by the active task constraints"
+    ),
+) -> None:
+    """Forbid the named tools for every call dispatched inside this context.
+
+    Complement of :func:`set_thread_tool_whitelist`: allow-list semantics need
+    the caller to enumerate every permitted tool (and any enumeration miss
+    becomes a false denial), while behavioral constraints such as kanban
+    ``forbidden_tools`` (#46582) are naturally deny-list shaped — refuse these
+    named tools, let everything else through. Stored as a ``ContextVar`` so
+    the constraint survives the executor fan-out described above.
+    """
+    _forbidden_tools_cv.set(frozenset(forbidden) if forbidden else None)
+    _forbidden_tools_fmt_cv.set(deny_msg_fmt)
+
+
+def clear_forbidden_tools() -> None:
+    """Lift the forbidden-tools constraint installed by :func:`set_forbidden_tools`."""
+    _forbidden_tools_cv.set(None)
+    _forbidden_tools_fmt_cv.set(None)
 
 
 def _get_pre_tool_call_directive_details(
@@ -6037,6 +6081,19 @@ def _get_pre_tool_call_directive_details(
     allowed = getattr(_thread_tool_whitelist, "allowed", None)
     if allowed is not None and tool_name not in allowed:
         fmt = getattr(_thread_tool_whitelist, "fmt", "Tool '{tool_name}' denied")
+        return _PreToolCallDirective(
+            action="block",
+            message=fmt.format(tool_name=tool_name),
+        )
+
+    # Forbidden-tools constraint (#46582) — deny-list complement of the
+    # whitelist above, resolved before plugin hooks so a mechanical task
+    # constraint cannot be overridden by an ``approve`` directive.
+    forbidden = _forbidden_tools_cv.get()
+    if forbidden and tool_name in forbidden:
+        fmt = _forbidden_tools_fmt_cv.get() or (
+            "Tool '{tool_name}' refused: forbidden by the active task constraints"
+        )
         return _PreToolCallDirective(
             action="block",
             message=fmt.format(tool_name=tool_name),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -897,12 +897,18 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             s = payload.status
             ok = True
             if s == "done":
-                ok = kanban_db.complete_task(
-                    conn, task_id,
-                    result=payload.result,
-                    summary=payload.summary,
-                    metadata=payload.metadata,
-                )
+                try:
+                    ok = kanban_db.complete_task(
+                        conn, task_id,
+                        result=payload.result,
+                        summary=payload.summary,
+                        metadata=payload.metadata,
+                    )
+                except ValueError as e:
+                    # Hard completion gate (#46582): require_summary tasks
+                    # refuse under-substantiated handoffs. Surface the
+                    # reason instead of a bare transition failure.
+                    raise HTTPException(status_code=409, detail=str(e))
             elif s == "blocked":
                 ok = kanban_db.block_task(conn, task_id, reason=payload.block_reason)
             elif s == "scheduled":

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1614,3 +1614,159 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# Worker behavioral constraints (#46582): forbidden_tools + require_summary
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_round_trips_worker_constraints(kanban_home):
+    """forbidden_tools / require_summary persist and parse back losslessly.
+
+    forbidden_tools follows the skills precedent: JSON array on the row,
+    parsed list on the Task. Normalisation strips whitespace and dedupes
+    (order-preserving) so '["a", " a ", "b"]' cannot store phantom entries.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="constrained",
+            assignee="coder",
+            forbidden_tools=["delegate_task", " terminal ", "delegate_task"],
+            require_summary=True,
+        )
+        task = kb.get_task(conn, tid)
+        assert task.forbidden_tools == ["delegate_task", "terminal"]
+        assert task.require_summary is True
+
+        # Defaults: unconstrained + classic completion behaviour.
+        plain_tid = kb.create_task(conn, title="plain", assignee="coder")
+        plain = kb.get_task(conn, plain_tid)
+        assert plain.forbidden_tools is None
+        assert plain.require_summary is False
+    finally:
+        conn.close()
+
+
+def test_create_task_validates_forbidden_tools(kanban_home):
+    """Non-string names and empty lists are refused at creation time.
+
+    A name that isn't a string would never match any dispatch, silently
+    turning hard enforcement into no enforcement — refuse instead.
+    """
+    conn = kb.connect()
+    try:
+        with pytest.raises(ValueError, match="tool-name strings"):
+            kb.create_task(
+                conn, title="bad", assignee="coder",
+                forbidden_tools=["delegate_task", 42],
+            )
+        with pytest.raises(ValueError, match="at least one tool name"):
+            kb.create_task(
+                conn, title="empty", assignee="coder", forbidden_tools=[],
+            )
+        # Whitespace-only collapses to empty → same refusal.
+        with pytest.raises(ValueError, match="at least one tool name"):
+            kb.create_task(
+                conn, title="blank", assignee="coder",
+                forbidden_tools=["   "],
+            )
+    finally:
+        conn.close()
+
+
+def test_complete_task_require_summary_gate(kanban_home):
+    """require_summary tasks refuse under-substantiated handoffs (#46582).
+
+    The gate must be retryable: a refusal leaves the task untouched (still
+    running, still completable once real prose arrives).
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn, title="gated", assignee="coder", require_summary=True,
+        )
+        # Empty summary/result refused.
+        with pytest.raises(ValueError, match="substantive summary"):
+            kb.complete_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
+
+        # Short handoff refused.
+        with pytest.raises(ValueError, match="substantive summary"):
+            kb.complete_task(conn, tid, summary="done")
+        # Boundary: one character under the bar is still refused.
+        short = "x" * (kb.REQUIRE_SUMMARY_MIN_CHARS - 1)
+        with pytest.raises(ValueError, match="substantive summary"):
+            kb.complete_task(conn, tid, summary=short)
+
+        # result counts as the handoff when summary is omitted...
+        ok = kb.complete_task(
+            conn, tid,
+            result="Refactored the parser and verified with the full test suite.",
+        )
+        assert ok is True
+        assert kb.get_task(conn, tid).status == "done"
+
+        # Unflagged tasks keep classic behaviour (no summary needed).
+        free_tid = kb.create_task(conn, title="free", assignee="coder")
+        assert kb.complete_task(conn, free_tid) is True
+    finally:
+        conn.close()
+
+
+def test_connect_migrates_legacy_db_adds_constraint_columns(tmp_path):
+    """Boards predating #46582 gain both constraint columns on open.
+
+    Legacy rows read back unconstrained (NULL / 0), which is exactly the
+    behaviour they had before the columns existed.
+    """
+    db_path = tmp_path / "legacy-constraints.db"
+    conn = sqlite3.connect(str(db_path))
+    # Pre-#46582 ``tasks`` shape: stops after block_recurrences.
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER,
+            block_recurrences INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('legacy', 'old board task', 'ready', 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    with kb.connect(db_path) as migrated:
+        cols = {
+            row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")
+        }
+        assert "forbidden_tools" in cols
+        assert "require_summary" in cols
+        legacy = kb.get_task(migrated, "legacy")
+        assert legacy is not None
+        assert legacy.forbidden_tools is None
+        assert legacy.require_summary is False

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import subprocess
+from pathlib import Path
+
+import pytest
 
 
 def _make_task(kb, *, assignee: str):
@@ -161,3 +164,116 @@ toolsets:
     assert "web" in resolved
     assert "kanban" in resolved  # recovered worker lifecycle surface
     assert resolved != ["kanban"]
+
+
+# ---------------------------------------------------------------------------
+# Worker behavioral constraints (#46582): forbidden_tools enforcement rides
+# the pre-tool-call block-directive pipeline. The dispatcher persists the
+# constraint on the task row; the WORKER session installs it from the board
+# DB at boot (no env propagation). These tests exercise that worker-session
+# path with a real board DB and the same HERMES_KANBAN_* env pins
+# _default_spawn sets.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_board_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an initialized default-board kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from hermes_cli import kanban_db as kb
+
+    kb.init_db()
+    return home
+
+
+def _create_constrained_task(kb, conn, *, forbidden, require_summary=False):
+    return kb.create_task(
+        conn,
+        title="hard-constrained card",
+        assignee="elias",
+        forbidden_tools=forbidden,
+        require_summary=require_summary,
+    )
+
+
+def test_worker_session_installs_forbidden_tools_guard(kanban_board_home, monkeypatch):
+    """A spawned-worker session refuses constrained tool calls — mechanically.
+
+    Mirrors the worker bootstrap: the task row carries forbidden_tools, the
+    worker process has only the spawn env pins, and
+    ``install_task_constraint_guard()`` reads the board and installs the deny
+    directive. The constrained call is refused with an error naming the
+    constraint and the task; every other tool flows. Clearing restores
+    today's behaviour.
+    """
+    from hermes_cli import kanban_db as kb
+    from tools.kanban_tools import (
+        install_task_constraint_guard,
+        clear_task_constraint_guard,
+    )
+    from hermes_cli.plugins import get_pre_tool_call_directive
+
+    conn = kb.connect()
+    try:
+        tid = _create_constrained_task(
+            kb, conn, forbidden=["delegate_task", "kanban_create"]
+        )
+    finally:
+        conn.close()
+
+    # The only worker-side signal is the env pin the dispatcher sets.
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+
+    installed = install_task_constraint_guard()
+    try:
+        assert installed == ["delegate_task", "kanban_create"]
+
+        directive, message = get_pre_tool_call_directive("delegate_task", {})
+        assert directive == "block"
+        assert "delegate_task" in message
+        assert tid in message
+
+        directive, message = get_pre_tool_call_directive(
+            "kanban_create", {"title": "x"}
+        )
+        assert directive == "block"
+
+        # Everything else — terminal included — passes through untouched.
+        assert get_pre_tool_call_directive("terminal", {}) == (None, None)
+        assert get_pre_tool_call_directive("write_file", {}) == (None, None)
+    finally:
+        clear_task_constraint_guard()
+
+    assert get_pre_tool_call_directive("delegate_task", {}) == (None, None)
+
+
+def test_worker_session_without_constraints_is_unconstrained(kanban_board_home, monkeypatch):
+    """Tasks created without forbidden_tools leave workers exactly as before."""
+    from hermes_cli import kanban_db as kb
+    from tools.kanban_tools import install_task_constraint_guard
+    from hermes_cli.plugins import get_pre_tool_call_directive
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="free card", assignee="elias")
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+
+    assert install_task_constraint_guard() is None
+    assert get_pre_tool_call_directive("terminal", {}) == (None, None)
+
+
+def test_worker_session_guard_survives_unknown_task_gracefully(kanban_board_home, monkeypatch):
+    """A missing task / broken board must degrade to no guard, never wedge
+    worker startup (dispatcher claim-TTL is the backstop)."""
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_nonexistent")
+
+    from tools.kanban_tools import install_task_constraint_guard
+    from hermes_cli.plugins import get_pre_tool_call_directive
+
+    assert install_task_constraint_guard() is None
+    assert get_pre_tool_call_directive("terminal", {}) == (None, None)

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1370,6 +1370,135 @@ class TestThreadToolWhitelist:
             clear_thread_tool_whitelist()
 
 
+class TestForbiddenTools:
+    """Tests for the ContextVar forbidden-tools guard (kanban #46582).
+
+    Complement of the whitelist above: deny-list semantics — named tools are
+    refused, everything else passes through to plugin hooks untouched.
+    """
+
+    def test_forbidden_tool_is_blocked_with_named_message(self, monkeypatch):
+        from hermes_cli.plugins import (
+            set_forbidden_tools,
+            clear_forbidden_tools,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+        set_forbidden_tools(
+            {"delegate_task", "terminal"},
+            deny_msg_fmt="Tool '{tool_name}' refused: forbidden by task t_x constraints",
+        )
+        try:
+            msg = get_pre_tool_call_block_message("delegate_task", {})
+            assert msg is not None
+            assert "delegate_task" in msg
+            assert "forbidden by task t_x constraints" in msg
+            msg = get_pre_tool_call_block_message("terminal", {})
+            assert msg is not None and "terminal" in msg
+        finally:
+            clear_forbidden_tools()
+
+    def test_unlisted_tool_passes_through(self, monkeypatch):
+        from hermes_cli.plugins import (
+            set_forbidden_tools,
+            clear_forbidden_tools,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+        set_forbidden_tools({"delegate_task"})
+        try:
+            # Only the named tools are constrained; everything else flows.
+            assert get_pre_tool_call_block_message("write_file", {}) is None
+            assert get_pre_tool_call_block_message("kanban_complete", {}) is None
+        finally:
+            clear_forbidden_tools()
+
+    def test_clear_restores_unconstrained_behavior(self, monkeypatch):
+        from hermes_cli.plugins import (
+            set_forbidden_tools,
+            clear_forbidden_tools,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+        set_forbidden_tools({"terminal"})
+        clear_forbidden_tools()
+        assert get_pre_tool_call_block_message("terminal", {}) is None
+
+    def test_constraint_wins_over_plugin_approve_directive(self, monkeypatch):
+        """A mechanical task constraint must not be overridable by a hook."""
+        from hermes_cli.plugins import (
+            get_pre_tool_call_directive,
+            set_forbidden_tools,
+            clear_forbidden_tools,
+        )
+
+        def approving_hook(hook_name, **kwargs):
+            return [{"action": "approve", "message": "plugin says ok"}]
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook", approving_hook
+        )
+        set_forbidden_tools({"terminal"})
+        try:
+            directive, message = get_pre_tool_call_directive(
+                "terminal", {}
+            )
+            assert directive == "block"
+            assert message is not None and "terminal" in message
+        finally:
+            clear_forbidden_tools()
+
+    def test_guard_survives_copied_context_thread_fanout(self, monkeypatch):
+        """Concurrent tool batches run on pool threads via copied contexts.
+
+        The guard is a ContextVar precisely so ``tools.thread_context.
+        propagate_context_to_thread`` (contextvars.copy_context) carries it
+        into DaemonThreadPoolExecutor workers. This asserts that contract:
+        the block must be visible inside a thread running a context copied
+        AFTER the guard was installed.
+        """
+        import contextvars
+        import threading
+
+        from hermes_cli.plugins import (
+            set_forbidden_tools,
+            clear_forbidden_tools,
+        )
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [],
+        )
+        set_forbidden_tools(
+            {"delegate_task"},
+            deny_msg_fmt="'{tool_name}' is forbidden here",
+        )
+        try:
+            seen = {}
+
+            def pool_worker():
+                seen["msg"] = get_pre_tool_call_block_message(
+                    "delegate_task", {}
+                )
+
+            ctx = contextvars.copy_context()
+            t = threading.Thread(target=lambda: ctx.run(pool_worker))
+            t.start()
+            t.join()
+            assert seen["msg"] is not None
+            assert "forbidden here" in seen["msg"]
+        finally:
+            clear_forbidden_tools()
+
 # ── TestPluginContext ──────────────────────────────────────────────────────
 
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -357,6 +357,68 @@ def heartbeat_current_worker_from_env() -> bool:
         return False
 
 
+def install_task_constraint_guard() -> Optional[list]:
+    """Install the mechanical forbidden-tools guard for THIS worker session.
+
+    Called once from the CLI quiet path before ``run_conversation`` when
+    ``HERMES_KANBAN_TASK`` is set (#46582). Reads the task row's
+    ``forbidden_tools`` constraint and installs it as a pre-tool-call deny
+    directive (``hermes_cli.plugins.set_forbidden_tools``) so any constrained
+    tool call — kanban or otherwise, terminal included — is refused with an
+    error naming the constraint for the rest of this session.
+
+    Returns the forbidden tool names (for prompt documentation), or None when
+    there is nothing to enforce (no env task, unknown task, unconstrained
+    task). Never raises into worker startup; a failed install degrades to
+    today's behaviour.
+    """
+    tid = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    if not tid:
+        return None
+    try:
+        kb, conn = _connect()
+        try:
+            task = kb.get_task(conn, tid)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        names = getattr(task, "forbidden_tools", None) if task else None
+        if not names:
+            return None
+        from hermes_cli.plugins import set_forbidden_tools
+
+        set_forbidden_tools(
+            set(str(n) for n in names),
+            deny_msg_fmt=(
+                f"Tool '{{tool_name}}' refused: forbidden by task {tid} "
+                f"constraints (forbidden_tools)"
+            ),
+        )
+        return [str(n) for n in names]
+    except Exception as exc:
+        # Enforcement is best-effort at install time by design: a missing or
+        # locked board must never wedge worker startup (the dispatcher's
+        # claim TTL / failure counter is the backstop). The guard itself,
+        # once installed, is mechanical.
+        logger.warning(
+            "kanban constraint guard install failed (continuing without): %s",
+            exc,
+        )
+        return None
+
+
+def clear_task_constraint_guard() -> None:
+    """Best-effort lift of the forbidden-tools guard (worker session teardown)."""
+    try:
+        from hermes_cli.plugins import clear_forbidden_tools
+
+        clear_forbidden_tools()
+    except Exception:
+        pass
+
+
 # Live operator-note injection: poll the worker's task for new comments and
 # fold them into the running agent via the OUT-OF-BAND steer channel, so a user
 # can "talk to" a running kanban task without the block → comment → unblock
@@ -1409,6 +1471,18 @@ def _handle_create(args: dict, **kw) -> str:
     if goal_bool_error:
         return tool_error(goal_bool_error)
     goal_max_turns = args.get("goal_max_turns")
+    require_summary, rs_bool_error = _parse_bool_arg(args, "require_summary")
+    if rs_bool_error:
+        return tool_error(rs_bool_error)
+    forbidden_tools = args.get("forbidden_tools")
+    if isinstance(forbidden_tools, str):
+        # Accept a single tool name as a string for convenience.
+        forbidden_tools = [forbidden_tools]
+    if forbidden_tools is not None and not isinstance(forbidden_tools, (list, tuple)):
+        return tool_error(
+            f"forbidden_tools must be a list of tool names, got "
+            f"{type(forbidden_tools).__name__}"
+        )
     model_override = args.get("model")
     provider_override = args.get("provider")
     if provider_override and not model_override:
@@ -1458,6 +1532,8 @@ def _handle_create(args: dict, **kw) -> str:
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
                 ),
+                forbidden_tools=forbidden_tools,
+                require_summary=require_summary,
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
@@ -1470,6 +1546,16 @@ def _handle_create(args: dict, **kw) -> str:
                 workspace_kind=new_task.workspace_kind if new_task else None,
                 workspace_path=new_task.workspace_path if new_task else None,
                 project_id=new_task.project_id if new_task else None,
+                forbidden_tools=(
+                    list(new_task.forbidden_tools)
+                    if new_task and new_task.forbidden_tools
+                    else None
+                ),
+                require_summary=(
+                    bool(new_task.require_summary)
+                    if new_task
+                    else False
+                ),
                 subscribed=subscribed,
             )
         finally:
@@ -2307,6 +2393,29 @@ KANBAN_CREATE_SCHEMA = {
         },
         "required": ["title", "assignee"],
     },
+}
+
+# Appended after the main schema body so the constraint properties read as
+# one block (#46582).
+KANBAN_CREATE_SCHEMA["parameters"]["properties"]["forbidden_tools"] = {
+    "type": "array",
+    "items": {"type": "string"},
+    "description": (
+        "Tool names the dispatched worker must NOT call while on this "
+        "task — enforced mechanically, not as prose: any call to a listed "
+        "tool is refused with an error naming the constraint. Use for "
+        "behavioral guardrails the worker must not be able to talk itself "
+        "out of (e.g. ['delegate_task'] so a doc-writer cannot spawn "
+        "sub-agents that complete out of order)."
+    ),
+}
+KANBAN_CREATE_SCHEMA["parameters"]["properties"]["require_summary"] = {
+    "type": "boolean",
+    "description": (
+        "Hard completion gate. When true, kanban_complete on this task is "
+        "refused unless the summary/result handoff carries at least 40 "
+        "characters of substance. Defaults to false."
+    ),
 }
 
 KANBAN_UNBLOCK_SCHEMA = {


### PR DESCRIPTION
Refs #46582 — implements the forbidden_tools + require_summary slice; forbidden_paths / full completion_mode matrix remain open on the issue.

Implements the two mechanically-enforceable slices of #46582 (forbidden_paths / full completion_mode matrix intentionally deferred — they need core file-tool middleware and a design pass).  ## Mechanism Rides the existing pre-tool-call directive chokepoint that every tool call passes through. Because kanban workers are separate subprocesses, dispatcher-side state can't reach them — the worker itself installs a task-scoped deny-list at session start by reading its task row from the board DB. Enforcement is ContextVar-based (survives the concurrent tool-dispatch thread fan-out where threading.local does not), checked before plugin hooks so a mechanical constraint cannot be plugin-approved away.  ## Surface - New typed columns forbidden_tools / require_summary via the standard optional-column migration; create_task validates; kanban_create tool params + echo. - complete_task hard gate: require_summary tasks refuse empty/<40-char completions with an actionable message (CLI exit 1, dashboard HTTP 409). - Worker bootstrapping installs the guard, documents constraints in the first prompt, clears in finally.  ## Verification New tests: DB round-trip/validation/migration/gate refusals; worker-session guard install/refusal/no-constraint/broken-board; plugins guard semantics incl. copied-context fan-out and constraint-beats-plugin-approve. Green via scripts/run_tests.sh modulo pre-existing Windows-env failures (stash-verified).