### PR TITLE
fix(photon): skip empty-text messages and poison lines instead of wedging (#55105)

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1165,6 +1165,14 @@ class PhotonAdapter(BasePlatformAdapter):
         except json.JSONDecodeError:
             logger.debug("[photon] skipping non-JSON inbound line")
             return
+        if not isinstance(event, dict):
+            # Valid JSON but not an object (null / list / string). Consume it
+            # as a poison LINE: raising here would propagate into
+            # _inbound_loop, tear down the /inbound stream as if the sidecar
+            # had died, and reconnect-churn on every redelivery of the same
+            # line (#55105). The next good line must proceed.
+            logger.debug("[photon] skipping non-object inbound line")
+            return
         msg_id = event.get("messageId")
         if msg_id and self._is_duplicate(msg_id):
             return
@@ -1363,6 +1371,19 @@ class PhotonAdapter(BasePlatformAdapter):
                 "[photon] suppressing rich-link preview attachment: %s",
                 _richlink_preview_label(content),
             )
+            return
+        # A text envelope with a blank body is not user input. The sidecar
+        # normalizes a missing/empty body to "" (partial sends, unsend
+        # rehydrations, provider glitches), and dispatching it would wake —
+        # or post-restart, RESUME — the chat's session with a blank prompt,
+        # burning a full agent turn for nothing (#55105). That phantom turn
+        # is the reported wedge: while it spins, every further inbound lands
+        # on the busy guard and interrupts-and-requeues forever. Skip before
+        # _record_last_inbound so it never becomes the reaction target,
+        # mirroring the U+FFFC placeholder above; same bug class as Signal's
+        # contentless-envelope skip.
+        if ctype == "text" and not (content.get("text") or "").strip():
+            logger.debug("[photon] ignoring empty text event")
             return
         # Anything past here is a real (reactable) message — remember it as
         # the chat's latest inbound so `add_reaction` can target it when the

--- a/tests/plugins/platforms/photon/test_inbound.py
+++ b/tests/plugins/platforms/photon/test_inbound.py
@@ -221,3 +221,91 @@ async def test_disconnect_cancels_pending_fffc_tasks(
     await adapter.disconnect()
 
     assert len(adapter._pending_fffc) == 0
+
+
+# ---------------------------------------------------------------------------
+# Empty-text + poison-line guards (#55105)
+#
+# A blank text envelope (the sidecar normalizes a missing body to "") used to
+# dispatch as a real user turn: it woke — or post-restart, resumed — the
+# chat's session with a blank prompt and burned a full agent turn for nothing.
+# While that phantom turn spun, every further inbound interrupted-and-requeued
+# behind it (the reported "stuck after restart / typing dots forever"). Same
+# bug class as Signal's contentless-envelope skip.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_text_event_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty/whitespace text events dispatch nothing and are not recorded as
+    the chat's reactable last-inbound."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_dm_event("", msg_id="spc-msg-empty"))
+    await adapter._dispatch_inbound(_dm_event("   ", msg_id="spc-msg-blank"))
+
+    assert captured == []
+    assert adapter._last_inbound_by_chat == {}
+
+
+@pytest.mark.asyncio
+async def test_resume_proceeds_past_previously_in_flight_empty_item(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After a restart the fresh adapter's loop must get PAST the item that
+    was in flight when the old process died: blank items are consumed without
+    producing a turn, and the next real message dispatches normally."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    # The previously-in-flight blank item (redelivered or replayed).
+    await adapter._on_inbound_line(json.dumps(_dm_event("", msg_id="stuck-1")))
+    await adapter._on_inbound_line(json.dumps(_dm_event("   ", msg_id="stuck-2")))
+    # Life goes on.
+    await adapter._on_inbound_line(json.dumps(_dm_event("ahoj", msg_id="real-1")))
+
+    assert [e.text for e in captured] == ["ahoj"]
+    assert captured[0].message_id == "real-1"
+
+
+@pytest.mark.asyncio
+async def test_poison_line_skipped_without_requeue_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid-JSON non-object line is poison-consumed, not raised: it must
+    not tear down the inbound stream (reconnect-churn forever on a repeated
+    bad line). Subsequent good lines proceed."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._on_inbound_line("null")
+    await adapter._on_inbound_line('["not","an","object"]')
+    await adapter._on_inbound_line('"bare string"')
+    # A repeat of the same poison line must also be harmless (no requeue).
+    await adapter._on_inbound_line("null")
+    await adapter._on_inbound_line(json.dumps(_dm_event("still here")))
+
+    assert [e.text for e in captured] == ["still here"]
+
+
+@pytest.mark.asyncio
+async def test_fffc_placeholder_still_dispatches_after_empty_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The empty-text guard must not swallow the U+FFFC placeholder path:
+    \\ufffc is not whitespace and still arms the attachment wait."""
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    event = _dm_event("", msg_id="spc-msg-empty")
+    chat_key = event["space"]["id"]
+    await adapter._dispatch_inbound(event)
+    fffc = dict(event, messageId="spc-msg-fffc")
+    fffc["content"] = {"type": "text", "text": "\ufffc"}
+    await adapter._dispatch_inbound(fffc)
+
+    assert captured == []
+    assert chat_key in adapter._pending_fffc


### PR DESCRIPTION
Fixes #55105

## Root cause
Two wedge paths on current main: (1) the sidecar normalizes missing bodies to "" and adapter.py processed them as real user turns — after restart each blank event resumed the broken transcript (iteration spin + interrupt/requeue churn); (2) a valid-JSON non-object inbound line raised outside the per-line try, tore down /inbound as a stream failure, and re-churned on every redelivery. The zombie-resume freshness gate from #46934 is present but doesn't stop the blank-turn trigger.

## Fix
- Empty-text inbound items are skipped (debug log) before last-inbound bookkeeping, mirroring sibling adapters' contentless-envelope idioms.
- Non-object JSON lines are skipped with a warning instead of escaping into the inbound loop.
Deliberately no overlap with #56006's send/reaction persistence work (same plugin, different mechanism); coordination noted in commit body.

## Verification
4 new tests in tests/plugins/platforms/photon/test_inbound.py (blank text skipped without wedging, poison line survives, U+FFFC guard interaction regression); full photon suite green except one pre-existing Windows geteuid env failure (stash-verified on pristine main).