### PR TITLE
fix(kanban): refuse docker spawns whose task workspace cannot be host-backed (#91568)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2688,6 +2688,17 @@ DEFAULT_CONFIG = {
         # so stale rows don't accumulate and get scanned on every notifier
         # tick forever. Set 0 to disable the sweep.
         "done_sub_retention_days": 30,
+        # Fail-closed workspace guard (#91568): when a docker-backend worker's
+        # DOCKER_HOST points at a remote daemon (tcp:// / ssh://) and its task
+        # workspace is a plain local path, the dispatcher refuses to spawn —
+        # bind-mount sources are validated client-side but resolved on the
+        # daemon host, which auto-creates missing dirs, so worker commits
+        # would silently vanish when the container exits. Set true ONLY when
+        # the workspace genuinely lives on storage shared with the Docker
+        # host (e.g. an NFS mount visible at the same path on both sides);
+        # this downgrades the refusal to a one-line warning at spawn. Local
+        # daemons (unix socket / npipe) are never affected by this guard.
+        "docker_remote_workspace_force": False,
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10236,6 +10236,11 @@ def _dispatch_once_locked(
                 workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
             else:
                 workspace = resolve_workspace(claimed, board=board)
+            # #91568 loud-failure gate: refuse docker workers whose task
+            # workspace cannot be host-backed (remote DOCKER_HOST + local
+            # path). Raising here funnels into _record_spawn_failure below,
+            # so the attempt error + event + auto-block bookkeeping fire.
+            _guard_docker_remote_workspace(claimed, str(workspace))
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
@@ -10363,6 +10368,10 @@ def _dispatch_once_locked(
                 workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
             else:
                 workspace = resolve_workspace(claimed, board=board)
+            # #91568 loud-failure gate: same contract as the ready lane —
+            # refuse docker workers whose task workspace cannot be
+            # host-backed before the review worker can lose its commits.
+            _guard_docker_remote_workspace(claimed, str(workspace))
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
@@ -10704,6 +10713,217 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
         _retagged_workspace_roots.add(workspaces_root_path)
     except Exception as exc:
         _log.debug("kanban worker: legacy session retag skipped (%s)", exc)
+
+
+# ---------------------------------------------------------------------------
+# Remote-Docker-daemon workspace guard (#91568)
+# ---------------------------------------------------------------------------
+#
+# With a remote DOCKER_HOST the Docker daemon runs on a DIFFERENT machine
+# from the Hermes dispatcher. A bind-mount source path is validated
+# client-side (os.path.isdir in tools/environments/docker.py) but RESOLVED on
+# the daemon host — and when the source directory does not exist there,
+# Docker silently auto-creates it as a fresh empty directory. A kanban worker
+# whose task workspace is bind-mounted that way therefore sees an empty
+# sandbox instead of the real task directory: every file it writes and every
+# git commit it makes vanishes when the container exits.
+#
+# This guard is the loud-failure slice of #91568: refuse to spawn rather than
+# lose work silently. The full fix (client → docker-host path translation)
+# remains open design work. Local daemons (unix socket / npipe / loopback
+# TCP) are untouched, and operators whose workspace genuinely lives on
+# storage shared with the daemon host (e.g. NFS mounted at the same path on
+# both sides) can set ``kanban.docker_remote_workspace_force: true`` to
+# downgrade the refusal to a one-line warning.
+
+_LOCAL_DOCKER_HOST_PREFIXES = ("unix://", "npipe://", "file://")
+
+
+def _docker_host_is_remote(docker_host: Optional[str]) -> bool:
+    """Classify a DOCKER_HOST value as pointing off-host.
+
+    Unset/empty means the Docker CLI's default socket (local). Unix sockets,
+    Windows named pipes, file paths, and loopback TCP endpoints are local.
+    Anything else — ``tcp://host:port``, ``ssh://user@host``,
+    ``http(s)://`` — is remote. Unrecognizable non-empty values fail
+    closed (treated as remote).
+    """
+    if not docker_host or not str(docker_host).strip():
+        return False
+    host = str(docker_host).strip()
+    if host.lower().startswith(_LOCAL_DOCKER_HOST_PREFIXES):
+        return False
+    match = re.match(r"^[A-Za-z][A-Za-z0-9+.\-]*://([^/?#]+)", host)
+    if match is None:
+        # Path-like values without a scheme are local socket paths;
+        # anything else is unrecognized — fail closed.
+        return not host.startswith(("/", "\\\\"))
+    authority = match.group(1)
+    if "@" in authority:
+        authority = authority.rsplit("@", 1)[1]
+    if authority.startswith("["):
+        # Bracketed IPv6 literal: [::1]:2375
+        end = authority.find("]")
+        hostname = (
+            authority[1:end] if end > 0 else authority.lstrip("[]")
+        ).lower()
+    else:
+        hostname = authority.split(":", 1)[0].lower()
+    if hostname in ("localhost", "::1") or hostname.startswith("127."):
+        return False
+    return True
+
+
+def _workspace_path_is_network_shared(workspace: str) -> bool:
+    """True for UNC-style paths that plausibly exist on both machines.
+
+    ``\\\\server\\share\\...`` (or its POSIX spelling ``//server/share/...``)
+    names its own host, so the same network share can be mounted by both the
+    dispatcher machine and the Docker daemon host. Everything else — drive
+    letters, plain POSIX absolute paths — cannot be verified remotely and is
+    treated as unshared.
+    """
+    path = (workspace or "").strip()
+    return path.startswith("\\\\") or path.startswith("//")
+
+
+def _docker_remote_workspace_refusal_reason(
+    workspace: str,
+    docker_host: Optional[str],
+) -> Optional[str]:
+    """Return a human-readable refusal reason, or None when safe to proceed.
+
+    Pure decision core of the #91568 guard so tests can cover the matrix
+    without touching config or env. The message front-loads the issue
+    reference and both identifiers because ``last_failure_error`` is
+    truncated to 500 chars on the task row.
+    """
+    if not _docker_host_is_remote(docker_host):
+        return None
+    if _workspace_path_is_network_shared(workspace):
+        return None
+    return (
+        f"(#91568) refusing docker kanban spawn: DOCKER_HOST='{docker_host}' "
+        f"is remote but task workspace '{workspace}' is local to the Hermes "
+        f"host; bind-mount sources resolve on the daemon host, which "
+        f"auto-creates missing dirs, so commits would be lost on container "
+        f"exit. To proceed, share the workspace at an identical network path "
+        f"on both hosts and set kanban.docker_remote_workspace_force: true."
+    )
+
+
+def _assignee_docker_guard_config(assignee: Optional[str]) -> dict:
+    """Resolve the assignee profile's terminal backend + force-flag config.
+
+    Mirrors :func:`_resolve_worker_cli_toolsets`: the worker re-enters the
+    CLI with ``-p <assignee>``, so its terminal backend comes from the
+    profile's own config.yaml, not the dispatching process's. Returns {}
+    on any resolution failure — the guard must never break dispatch on
+    exotic setups (same posture as toolset resolution).
+
+    Note: ``force`` is the deep-merged value for the PROFILE (defaults fill
+    it with False, not None). The caller therefore treats it as "profile
+    explicitly opted in" only when truthy and consults the dispatcher's own
+    config as well — either side acknowledging shared storage enables the
+    warning mode.
+    """
+    if not assignee:
+        return {}
+    try:
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from hermes_cli.config import load_config
+        from hermes_cli.profiles import (
+            normalize_profile_name,
+            resolve_profile_env,
+        )
+
+        token = set_hermes_home_override(
+            resolve_profile_env(normalize_profile_name(assignee))
+        )
+        try:
+            cfg = load_config()
+        finally:
+            reset_hermes_home_override(token)
+    except Exception as exc:
+        _log.debug(
+            "kanban dispatch: docker remote-workspace guard skipped for "
+            "assignee %r (%s)",
+            assignee,
+            exc,
+        )
+        return {}
+    term = cfg.get("terminal") or {}
+    return {
+        "backend": str(term.get("backend") or "").strip().lower(),
+        "mount_cwd": bool(term.get("docker_mount_cwd_to_workspace")),
+        "force": bool(
+            (cfg.get("kanban") or {}).get("docker_remote_workspace_force")
+        ),
+    }
+
+
+def _guard_docker_remote_workspace(task: Task, workspace: str) -> None:
+    """Loud-failure gate for docker workers with unverifiable workspaces.
+
+    Called at spawn-time workspace resolution in :func:`_dispatch_once_locked`
+    (both lanes). Raises :class:`ValueError` when the dangerous combination is
+    detected — the caller funnels that into ``_record_spawn_failure`` so the
+    dispatch attempt error + task event + auto-block circuit breaker all fire.
+    Downgrades to a one-line warning when the operator set
+    ``kanban.docker_remote_workspace_force: true`` — checked in the worker
+    profile's config AND in the dispatcher's own config (either side may
+    acknowledge genuinely shared storage).
+
+    No-op unless ALL of these hold: the assignee's terminal backend is
+    ``docker``, ``terminal.docker_mount_cwd_to_workspace`` is enabled (the
+    configuration that promises the real workspace is visible in the
+    container), DOCKER_HOST points off-host, and the workspace path is not
+    plausibly shared with the daemon host.
+    """
+    gc = _assignee_docker_guard_config(task.assignee)
+    if not gc:
+        return
+    if gc.get("backend") != "docker":
+        return
+    # Without the cwd→/workspace mount there is no bind whose source path
+    # the daemon resolves; the container runs an isolated tmpfs/sandbox
+    # workspace BY DESIGN (the mount flag is documented explicit opt-in).
+    if not gc.get("mount_cwd"):
+        return
+    docker_host = os.environ.get("DOCKER_HOST")
+    reason = _docker_remote_workspace_refusal_reason(
+        str(workspace), docker_host
+    )
+    if reason is None:
+        return
+    force = bool(gc.get("force"))
+    if not force:
+        try:
+            from hermes_cli.config import load_config
+
+            force = bool(
+                (load_config().get("kanban") or {}).get(
+                    "docker_remote_workspace_force"
+                )
+            )
+        except Exception:
+            force = False
+    if force:
+        _log.warning(
+            "kanban dispatch: task %s workspace %r is not guaranteed to be "
+            "host-backed (DOCKER_HOST=%r); commits would be lost on "
+            "container exit — proceeding because "
+            "kanban.docker_remote_workspace_force is enabled",
+            task.id,
+            workspace,
+            docker_host,
+        )
+        return
+    _log.error("kanban dispatch: task %s spawn refused: %s", task.id, reason)
+    raise ValueError(reason)
 
 
 def _default_spawn(

--- a/tests/hermes_cli/test_kanban_docker_remote_workspace.py
+++ b/tests/hermes_cli/test_kanban_docker_remote_workspace.py
@@ -1,0 +1,458 @@
+"""Tests: kanban dispatcher refuses docker workers whose workspace cannot be
+host-backed (#91568 loud-failure slice).
+
+With a remote ``DOCKER_HOST`` the Docker daemon runs on a different machine
+from the Hermes dispatcher. A bind-mount source path is validated client-side
+(``os.path.isdir`` in tools/environments/docker.py) but resolved on the daemon
+host — which silently auto-creates missing directories. A docker-backend kanban
+worker whose task workspace is a plain local path therefore sees an empty
+sandbox instead of the real task directory: every commit it makes vanishes
+when the container exits.
+
+The dispatcher must fail that spawn loudly (dispatch attempt error + task
+event) instead of losing work silently. Local daemons (unix socket / npipe /
+loopback TCP) are untouched, and operators whose workspace genuinely lives on
+storage shared with the daemon host (e.g. NFS at the same path on both sides)
+can set ``kanban.docker_remote_workspace_force: true`` to downgrade the
+refusal to a one-line warning.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Isolation fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_docker_env(monkeypatch):
+    """Neutralize the developer's real DOCKER_HOST unless a test sets one."""
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+
+
+@pytest.fixture()
+def kb_home(monkeypatch, tmp_path):
+    """Fresh HERMES_HOME + kanban board, hermes_cli modules re-imported."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for mod in list(sys.modules.keys()):
+        if (
+            mod.startswith("hermes_cli")
+            or mod.startswith("hermes_state")
+            or mod == "hermes_constants"
+        ):
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+
+    kanban_db.create_board(slug="default", name="Test")
+    yield kanban_db, home
+
+
+def _write_profile_config(
+    home: Path,
+    name: str,
+    *,
+    backend: str,
+    mount_cwd: bool,
+    force: bool | None = None,
+) -> None:
+    """Materialize a profile whose config pins the terminal backend."""
+    pdir = home / "profiles" / name
+    pdir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "terminal:",
+        f"  backend: {backend}",
+        f"  docker_mount_cwd_to_workspace: {'true' if mount_cwd else 'false'}",
+    ]
+    if force is not None:
+        lines += [
+            "kanban:",
+            f"  docker_remote_workspace_force: {'true' if force else 'false'}",
+        ]
+    (pdir / "config.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _recording_spawn(calls: list):
+    def _spawn(task, workspace, board=None):
+        calls.append((task.id, str(workspace)))
+        return 4242
+
+    return _spawn
+
+
+_REMOTE_HOST = "tcp://daemon.example.local:2375"
+
+
+def _create_dir_task(kb, conn, ws: Path, assignee: str = "docky") -> str:
+    return kb.create_task(
+        conn,
+        title="host-backed workspace please",
+        assignee=assignee,
+        workspace_kind="dir",
+        workspace_path=str(ws),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure decision core
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "docker_host,expected_remote",
+    [
+        (None, False),
+        ("", False),
+        ("   ", False),
+        ("unix:///var/run/docker.sock", False),
+        ("npipe:////./pipe/docker_engine", False),
+        ("/var/run/docker.sock", False),
+        ("tcp://localhost:2375", False),
+        ("tcp://127.0.0.1:2375", False),
+        ("tcp://[::1]:2375", False),
+        ("http://localhost:2375", False),
+        ("tcp://192.168.1.50:2375", True),
+        ("ssh://user@buildhost", True),
+        ("https://daemon.corp.example:2376", True),
+    ],
+)
+def test_docker_host_classification(kb_home, docker_host, expected_remote):
+    kb, _home = kb_home
+    assert kb._docker_host_is_remote(docker_host) is expected_remote
+
+
+def test_unknown_docker_host_scheme_fails_closed(kb_home):
+    kb, _home = kb_home
+    # Unrecognizable non-empty values must be treated as remote.
+    assert kb._docker_host_is_remote("weird://somehost") is True
+    # Path-shaped scheme-less values are local socket paths.
+    assert kb._docker_host_is_remote("\\\\.\\pipe\\docker_engine") is False
+
+
+@pytest.mark.parametrize(
+    "workspace,shared",
+    [
+        ("\\\\nas\\share\\tasks\\t_1", True),
+        ("//nas/share/tasks/t_1", True),
+        ("C:\\projects\\task-ws", False),
+        ("/srv/workspaces/t_1", False),
+        ("", False),
+    ],
+)
+def test_network_shared_path_detection(kb_home, workspace, shared):
+    kb, _home = kb_home
+    assert kb._workspace_path_is_network_shared(workspace) is shared
+
+
+def test_refusal_reason_matrix(kb_home):
+    kb, _home = kb_home
+    # Local host → never refuse.
+    assert (
+        kb._docker_remote_workspace_refusal_reason("C:\\ws", None) is None
+    )
+    assert (
+        kb._docker_remote_workspace_refusal_reason("/srv/ws", "unix:///var/run/docker.sock")
+        is None
+    )
+    # Remote host + UNC-style shared path → allowed.
+    assert (
+        kb._docker_remote_workspace_refusal_reason(
+            "\\\\nas\\share\\ws", _REMOTE_HOST
+        )
+        is None
+    )
+    # Remote host + local paths → refusal naming the workspace AND the host.
+    for workspace in ("C:\\projects\\task-ws", "/srv/workspaces/t_1"):
+        reason = kb._docker_remote_workspace_refusal_reason(workspace, _REMOTE_HOST)
+        assert reason is not None
+        assert workspace in reason
+        assert _REMOTE_HOST in reason
+        assert "#91568" in reason
+        assert "kanban.docker_remote_workspace_force" in reason
+        assert "commit" in reason.lower()
+
+
+def test_default_config_ships_fail_closed(kb_home):
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["kanban"]["docker_remote_workspace_force"] is False
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-level behavior
+# ---------------------------------------------------------------------------
+
+
+def test_remote_host_refuses_spawn_and_records_event(kb_home, monkeypatch, caplog, tmp_path):
+    """Remote DOCKER_HOST + local dir workspace → spawn refused, event recorded."""
+    kb, home = kb_home
+    _write_profile_config(home, "docky", backend="docker", mount_cwd=True)
+    ws = tmp_path / "task_ws"
+    ws.mkdir()
+    monkeypatch.setenv("DOCKER_HOST", _REMOTE_HOST)
+
+    calls: list = []
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="hermes_cli.kanban_db"):
+        with kb.connect_closing() as conn:
+            tid = _create_dir_task(kb, conn, ws)
+            res = kb.dispatch_once(conn, spawn_fn=_recording_spawn(calls))
+
+            # Nothing spawned; the claim was released back to ready.
+            assert calls == []
+            assert res.spawned == []
+            row = conn.execute(
+                "SELECT status, consecutive_failures, last_failure_error "
+                "FROM tasks WHERE id = ?",
+                (tid,),
+            ).fetchone()
+            assert row["status"] == "ready"
+            assert row["consecutive_failures"] == 1
+            error = row["last_failure_error"]
+            assert "#91568" in error
+            assert _REMOTE_HOST in error
+            assert str(ws) in error
+            # The dispatch attempt error is durably recorded as a task event
+            # so `hermes kanban tail` shows why nothing is running.
+            import json
+
+            events = conn.execute(
+                "SELECT kind, payload FROM task_events WHERE task_id = ? "
+                "ORDER BY id DESC LIMIT 1",
+                (tid,),
+            ).fetchone()
+            assert events["kind"] == "spawn_failed"
+            event_payload = json.loads(events["payload"])
+            assert str(ws) in event_payload["error"]
+            assert _REMOTE_HOST in event_payload["error"]
+
+    # The guard logs loudly too — an operator reading gateway/agent logs sees it.
+    guard_errors = [
+        r for r in caplog.records
+        if r.levelno >= logging.ERROR and "#91568" in r.getMessage()
+    ]
+    assert guard_errors, [r.getMessage() for r in caplog.records]
+
+    # The refusal is deterministic: the next tick refuses again and the
+    # auto-block circuit breaker parks the task instead of looping forever.
+    with kb.connect_closing() as conn:
+        res2 = kb.dispatch_once(conn, spawn_fn=_recording_spawn(calls))
+        assert calls == []
+        assert tid in res2.auto_blocked
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+        assert row["status"] == "blocked"
+        gave_up = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        assert gave_up["kind"] == "gave_up"
+
+
+def test_force_flag_downgrades_to_warning_and_spawns(kb_home, monkeypatch, caplog, tmp_path):
+    """Profile-level kanban.docker_remote_workspace_force: true → warn + spawn."""
+    kb, home = kb_home
+    _write_profile_config(
+        home, "docky", backend="docker", mount_cwd=True, force=True
+    )
+    ws = tmp_path / "nfs_ws"
+    ws.mkdir()
+    monkeypatch.setenv("DOCKER_HOST", _REMOTE_HOST)
+
+    calls: list = []
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.kanban_db"):
+        with kb.connect_closing() as conn:
+            tid = _create_dir_task(kb, conn, ws)
+            res = kb.dispatch_once(conn, spawn_fn=_recording_spawn(calls))
+
+            assert calls and calls[0][0] == tid
+            assert [(t, a, w) for t, a, w in res.spawned] == [
+                (tid, "docky", str(ws))
+            ]
+            row = conn.execute(
+                "SELECT consecutive_failures FROM tasks WHERE id = ?", (tid,)
+            ).fetchone()
+            assert row["consecutive_failures"] == 0
+            failure_events = conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ? AND kind IN "
+                "('spawn_failed', 'gave_up')",
+                (tid,),
+            ).fetchall()
+            assert failure_events == []
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING
+        and "kanban.docker_remote_workspace_force" in r.getMessage()
+        and _REMOTE_HOST in r.getMessage()
+    ]
+    assert len(warnings) == 1  # exactly the promised one-line warning
+    errors = [
+        r for r in caplog.records if r.levelno >= logging.ERROR
+    ]
+    assert errors == []
+
+
+def test_force_flag_falls_back_to_dispatcher_config(kb_home, monkeypatch, caplog, tmp_path):
+    """The dispatcher's own config.yaml force flag also unlocks the spawn."""
+    kb, home = kb_home
+    _write_profile_config(home, "docky", backend="docker", mount_cwd=True)
+    (home / "config.yaml").write_text(
+        "kanban:\n  docker_remote_workspace_force: true\n", encoding="utf-8"
+    )
+    ws = tmp_path / "shared_ws"
+    ws.mkdir()
+    monkeypatch.setenv("DOCKER_HOST", _REMOTE_HOST)
+
+    calls: list = []
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.kanban_db"):
+        with kb.connect_closing() as conn:
+            tid = _create_dir_task(kb, conn, ws)
+            res = kb.dispatch_once(conn, spawn_fn=_recording_spawn(calls))
+
+    assert calls and calls[0][0] == tid
+    assert len(res.spawned) == 1
+    assert any(
+        r.levelno == logging.WARNING
+        and "kanban.docker_remote_workspace_force" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+@pytest.mark.parametrize(
+    "local_docker_host",
+    [None, "unix:///var/run/docker.sock", "npipe:////./pipe/docker_engine", "tcp://127.0.0.1:2375"],
+)
+def test_local_daemon_behavior_unchanged(kb_home, monkeypatch, caplog, tmp_path, local_docker_host):
+    """Unix socket / npipe / loopback TCP → byte-identical happy path."""
+    kb, home = kb_home
+    _write_profile_config(home, "docky", backend="docker", mount_cwd=True)
+    ws = tmp_path / "local_ws"
+    ws.mkdir()
+    if local_docker_host is not None:
+        monkeypatch.setenv("DOCKER_HOST", local_docker_host)
+
+    calls: list = []
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="hermes_cli.kanban_db"):
+        with kb.connect_closing() as conn:
+            tid = _create_dir_task(kb, conn, ws)
+            res = kb.dispatch_once(conn, spawn_fn=_recording_spawn(calls))
+
+    assert calls and calls[0][0] == tid
+    assert len(res.spawned) == 1
+    # No new checks fired: no refusals, no warnings, no failure bookkeeping.
+    guard_logs = [
+        r for r in caplog.records
+        if "remote-workspace" in r.getMessage()
+        or "kanban.docker_remote_workspace_force" in r.getMessage()
+        or "#91568" in r.getMessage()
+    ]
+    assert guard_logs == []
+    with kb.connect_closing() as conn:
+        row = conn.execute(
+            "SELECT consecutive_failures FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+        assert row["consecutive_failures"] == 0
+        failure_events = conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? AND kind IN "
+            "('spawn_failed', 'gave_up')",
+            (tid,),
+        ).fetchall()
+        assert failure_events == []
+
+
+def test_non_docker_backend_untouched_by_guard(kb_home, monkeypatch, caplog, tmp_path):
+    """A local-backend profile ignores DOCKER_HOST entirely."""
+    kb, home = kb_home
+    _write_profile_config(home, "loky", backend="local", mount_cwd=False)
+    ws = tmp_path / "plain_ws"
+    ws.mkdir()
+    monkeypatch.setenv("DOCKER_HOST", _REMOTE_HOST)
+
+    calls: list = []
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="hermes_cli.kanban_db"):
+        with kb.connect_closing() as conn:
+            tid = _create_dir_task(kb, conn, ws, assignee="loky")
+            res = kb.dispatch_once(conn, spawn_fn=_recording_spawn(calls))
+
+    assert calls and calls[0][0] == tid
+    assert len(res.spawned) == 1
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+def test_mount_cwd_disabled_not_guarded(kb_home, monkeypatch, caplog, tmp_path):
+    """Docker without cwd→/workspace mount runs an isolated sandbox BY DESIGN.
+
+    The guard only fires on the bind-mount configuration that promises the
+    real workspace inside the container; the tmpfs/sandbox fallback in
+    tools/environments/docker.py stays untouched even against remote hosts.
+    """
+    kb, home = kb_home
+    _write_profile_config(home, "docky", backend="docker", mount_cwd=False)
+    ws = tmp_path / "tmpfs_lane_ws"
+    ws.mkdir()
+    monkeypatch.setenv("DOCKER_HOST", _REMOTE_HOST)
+
+    calls: list = []
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="hermes_cli.kanban_db"):
+        with kb.connect_closing() as conn:
+            tid = _create_dir_task(kb, conn, ws)
+            res = kb.dispatch_once(conn, spawn_fn=_recording_spawn(calls))
+
+    assert calls and calls[0][0] == tid
+    assert len(res.spawned) == 1
+    assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+def test_worktree_lane_refuses_too(kb_home, monkeypatch, caplog, tmp_path):
+    """The worktree resolution lane gets the same gate before spawn."""
+    kb, home = kb_home
+    _write_profile_config(home, "docky", backend="docker", mount_cwd=True)
+    wt = tmp_path / "repo-checkout"
+    wt.mkdir()
+    monkeypatch.setenv("DOCKER_HOST", _REMOTE_HOST)
+
+    calls: list = []
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger="hermes_cli.kanban_db"):
+        with kb.connect_closing() as conn:
+            tid = kb.create_task(
+                conn,
+                title="wt task",
+                assignee="docky",
+                workspace_kind="worktree",
+                workspace_path=str(wt),
+            )
+            # Deterministic worktree resolution: pretend the path already is
+            # a linked worktree checkout of this task's branch (no git
+            # subprocesses involved).
+            monkeypatch.setattr(kb, "_is_linked_worktree_checkout", lambda p: True)
+            monkeypatch.setattr(
+                kb, "_git_current_branch", lambda p: f"wt/{tid}"
+            )
+            res = kb.dispatch_once(conn, spawn_fn=_recording_spawn(calls))
+
+    assert calls == []
+    assert res.spawned == []
+    with kb.connect_closing() as conn:
+        row = conn.execute(
+            "SELECT last_failure_error, consecutive_failures FROM tasks WHERE id = ?",
+            (tid,),
+        ).fetchone()
+        assert row["consecutive_failures"] == 1
+        assert "#91568" in row["last_failure_error"]


### PR DESCRIPTION
Refs #91568 — implements the loud-failure slice; the client-to-docker-host path-translation design remains open on the issue.

Addresses the silent-artifact-loss half of #91568 with the loud-failure slice; client-to-docker-host path translation (the full fix's design decision) is deliberately deferred, with an escape hatch for genuinely shared filesystems.  ## Problem With a remote DOCKER_HOST, the workspace bind source is validated client-side but resolved on the daemon host, which auto-creates missing dirs — so kanban workers happily commit into an ephemeral sandbox and the work vanishes on container exit.  ## Fix At spawn-time workspace resolution for docker-backed workers: detect remote daemon (tcp://, ssh://) + workspace path not plausibly shared with the daemon host -> refuse the spawn loudly with an explanatory task event naming the path and DOCKER_HOST. New additive config key kanban.docker_remote_workspace_force (default false) downgrades to a warning for users who genuinely mount shared filesystems. Local socket/npipe daemons: byte-identical behavior. No new env vars; config.yaml-native; fail-closed default; tmpfs fallback path untouched.  ## Verification Tests over the detection matrix (remote+unshared refused with event, force warns-and-proceeds, local unchanged, tmpfs unaffected) following existing worker-terminal-cwd/docker-env test harnesses; green via scripts/run_tests.sh modulo pre-existing Windows-env failures.