### PR TITLE
fix(desktop): preserve backend session identities for shared multi-profile remote overrides (#64999)

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -27,6 +27,7 @@ import {
   cookiesHaveSession,
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
+  groupRemoteOverrideScopesByEndpoint,
   isGatewayAuthRejection,
   localProfileEntry,
   modeIsRemoteLike,
@@ -39,6 +40,8 @@ import {
   profileHasRemoteConnection,
   profileRemoteOverride,
   profileSshOverride,
+  remoteOverrideEndpointKey,
+  remoteOverrideSharedWithOtherScope,
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileApiRequest,
@@ -212,6 +215,87 @@ test('profileRemoteOverride tolerates a missing/!object profiles map', () => {
   assert.equal(profileRemoteOverride({}, 'coder'), null)
   assert.equal(profileRemoteOverride({ profiles: null }, 'coder'), null)
   assert.equal(profileRemoteOverride(null, 'coder'), null)
+})
+
+// --- shared multi-profile remote override endpoints (#64999) ---
+
+test('scopes pointing one URL at the same host share the endpoint', () => {
+  // Same backend, different URL spellings: trailing slash, scheme-less host,
+  // case — normalization must see through them.
+  const config = {
+    profiles: {
+      wife: { mode: 'remote', url: 'http://100.64.0.1:9119' },
+      dad: { mode: 'remote', url: '100.64.0.1:9119/' },
+      mom: { mode: 'cloud', url: 'HTTP://100.64.0.1:9119' }
+    }
+  }
+
+  assert.equal(remoteOverrideSharedWithOtherScope(config, 'wife'), true)
+  assert.equal(remoteOverrideSharedWithOtherScope(config, 'dad'), true)
+  assert.equal(remoteOverrideSharedWithOtherScope(config, 'mom'), true)
+
+  const groups = groupRemoteOverrideScopesByEndpoint(config)
+  assert.deepEqual([...groups.values()], [['wife', 'dad', 'mom']])
+})
+
+test('a scope alone on its endpoint is not shared', () => {
+  const config = {
+    profiles: {
+      wife: { mode: 'remote', url: 'https://family.example.com' },
+      localist: { mode: 'local', savedSsh: {} },
+      sshed: { mode: 'ssh', host: 'alice@box:2222' }
+    }
+  }
+
+  assert.equal(remoteOverrideSharedWithOtherScope(config, 'wife'), false)
+  assert.equal(remoteOverrideSharedWithOtherScope(config, 'localist'), false)
+  assert.equal(remoteOverrideSharedWithOtherScope(config, 'sshed'), false)
+})
+
+test('different credentials against one host are different endpoints', () => {
+  const config = {
+    profiles: {
+      wife: { mode: 'remote', url: 'https://host.example.com', token: { value: 'wife-token' } },
+      dad: { mode: 'remote', url: 'https://host.example.com', token: { value: 'dad-token' } }
+    }
+  }
+
+  assert.equal(remoteOverrideSharedWithOtherScope(config, 'wife'), false)
+  assert.equal(remoteOverrideSharedWithOtherScope(config, 'dad'), false)
+
+  // Identical credential material IS the same tenant.
+  const shared = {
+    profiles: {
+      wife: { mode: 'remote', url: 'https://host.example.com', authMode: 'token', token: { value: 't' } },
+      dad: { mode: 'remote', url: 'https://host.example.com/', authMode: 'token', token: { value: 't' } }
+    }
+  }
+
+  assert.equal(remoteOverrideSharedWithOtherScope(shared, 'dad'), true)
+  // The endpoint key itself is stable across URL formatting.
+  assert.equal(
+    remoteOverrideEndpointKey(profileRemoteOverride(shared, 'wife')),
+    remoteOverrideEndpointKey(profileRemoteOverride(shared, 'dad'))
+  )
+})
+
+test('shared-endpoint detection handles absent overrides and malformed URLs', () => {
+  assert.equal(remoteOverrideSharedWithOtherScope({}, 'wife'), false)
+  assert.equal(remoteOverrideSharedWithOtherScope({ profiles: {} }, 'wife'), false)
+  assert.equal(
+    remoteOverrideSharedWithOtherScope({ profiles: { wife: { mode: 'remote', url: '' } } }, 'wife'),
+    false
+  )
+
+  // Unparseable URLs still compare byte-for-byte instead of crashing.
+  const malformed = {
+    profiles: {
+      wife: { mode: 'remote', url: ':::' },
+      dad: { mode: 'remote', url: ':::' }
+    }
+  }
+
+  assert.equal(remoteOverrideSharedWithOtherScope(malformed, 'wife'), true)
 })
 
 test('SSH remains separate from URL-shaped remote modes and preserves an explicit remote profile', () => {

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -495,6 +495,86 @@ function profileRemoteOverride(config, profile) {
   }
 }
 
+/**
+ * Stable identity of one per-profile remote override ENDPOINT: normalized base
+ * URL plus the auth material that selects the tenant behind it (#64999).
+ *
+ * Several desktop scopes pointing the SAME URL at one Hermes host are sharing
+ * a MULTI-PROFILE backend — its session reads must preserve the backend's own
+ * per-row profile identity instead of relabeling rows with whichever scope
+ * selected it. Different credentials against one host count as different
+ * tenants and keep single-profile semantics. Pure: compares raw stored
+ * secrets without decrypting them, so non-deterministic ciphertext errs
+ * toward "different endpoint" (the legacy behavior).
+ */
+function remoteOverrideEndpointKey(override) {
+  if (!override || typeof override.url !== 'string' || !override.url.trim()) {
+    return null
+  }
+
+  let url = override.url.trim().toLowerCase()
+
+  try {
+    url = normalizeRemoteBaseUrl(override.url).toLowerCase()
+  } catch {
+    // Not a parseable remote URL — compare byte-for-byte below instead.
+  }
+
+  return JSON.stringify([
+    url,
+    normAuthMode(override.authMode),
+    override.token ?? null,
+    normalizeRemoteHeaders(override.headers)
+  ])
+}
+
+/** Group every desktop scope's remote override by endpoint identity (see
+ *  remoteOverrideEndpointKey). Singletons are included so callers can tell a
+ *  shared endpoint from an alone-on-it one. */
+function groupRemoteOverrideScopesByEndpoint(config) {
+  const groups = new Map()
+
+  for (const name of Object.keys(config?.profiles || {})) {
+    const key = remoteOverrideEndpointKey(profileRemoteOverride(config, name))
+
+    if (!key) {
+      continue
+    }
+
+    const scopes = groups.get(key)
+
+    if (scopes) {
+      scopes.push(name)
+    } else {
+      groups.set(key, [name])
+    }
+  }
+
+  return groups
+}
+
+/** True when `profile`'s remote override shares its endpoint with at least one
+ *  OTHER desktop scope — the endpoint must be treated as profile-capable:
+ *  session reads go through its cross-profile aggregator and keep the
+ *  backend's row identities (#64999). A scope alone on its endpoint keeps
+ *  single-profile semantics: its database has no other profile to be right
+ *  about, so the caller's scope label stays authoritative there. */
+function remoteOverrideSharedWithOtherScope(config, profile) {
+  const override = profileRemoteOverride(config, profile)
+
+  if (!override) {
+    return false
+  }
+
+  const key = remoteOverrideEndpointKey(override)
+
+  if (!key) {
+    return false
+  }
+
+  return (groupRemoteOverrideScopesByEndpoint(config).get(key)?.length ?? 0) > 1
+}
+
 export interface ProfileRouteOptions {
   /** Profile name on a separately-scoped backend when it differs from the
    * desktop's local routing label (managed SSH `remoteProfile`). */
@@ -928,6 +1008,7 @@ export {
   cookiesHaveSession,
   gatewayTicketFailure,
   gatewayWsUrlIpcResult,
+  groupRemoteOverrideScopesByEndpoint,
   hostLabelFromBaseUrl,
   isGatewayAuthRejection,
   localProfileEntry,
@@ -943,6 +1024,8 @@ export {
   profileHasRemoteConnection,
   profileRemoteOverride,
   profileSshOverride,
+  remoteOverrideEndpointKey,
+  remoteOverrideSharedWithOtherScope,
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileApiRequest,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -86,6 +86,7 @@ import {
   profileHasRemoteConnection,
   profileRemoteOverride,
   profileSshOverride,
+  remoteOverrideSharedWithOtherScope,
   remoteRequestMatchesBaseUrl,
   resolveAuthMode,
   resolveProfileApiRequest,
@@ -13463,14 +13464,23 @@ async function interceptSessionRequestForRemote(request) {
 
 const rowsOf = data => (Array.isArray(data?.sessions) ? data.sessions : [])
 
-// A remote profile's session list, read from its remote host and tagged with the
-// desktop-facing profile name (the remote's /api/sessions doesn't know it).
+// A remote profile's session list, read from its remote host. Two shapes:
+//  - genuinely single-profile endpoint (one scope alone on its database): the
+//    remote's /api/sessions doesn't know the desktop-facing name, so rows are
+//    labeled with the selecting scope (legacy behavior);
+//  - shared multi-profile backend (several scopes, one URL — #64999): rows
+//    come from the backend's cross-profile aggregator already stamped with the
+//    REAL owning profile. That identity is authoritative — overwriting it with
+//    the local scope name is what silently misattributed sessions.
 async function remoteSessionList(profile, searchParams) {
-  const data = await fetchRemoteProfileSessions(profile, searchParams, fetchJsonForProfile)
+  const sharedEndpoint = remoteOverrideSharedWithOtherScope(readDesktopConnectionConfig(), profile)
+  const data = await fetchRemoteProfileSessions(profile, searchParams, fetchJsonForProfile, { sharedEndpoint })
 
-  for (const s of rowsOf(data)) {
-    s.profile = profile
-    s.is_default_profile = false
+  if (!sharedEndpoint) {
+    for (const s of rowsOf(data)) {
+      s.profile = profile
+      s.is_default_profile = false
+    }
   }
 
   return { ...(data as any), sessions: rowsOf(data) }

--- a/apps/desktop/electron/profile-session-routing.test.ts
+++ b/apps/desktop/electron/profile-session-routing.test.ts
@@ -374,3 +374,126 @@ test('splice: registry rows dedupe by id and extend per-profile totals', () => {
   assert.equal(totals.default, 2) // untagged registry row counts under default
   assert.equal(totals.work, 1) // deduped row does not double-count
 })
+
+// --- shared multi-profile remote override endpoints (#64999) ---
+
+test('a shared endpoint reads the aggregator and keeps backend row identities', async () => {
+  const calls: Array<{ profile: string | null; path: string }> = []
+
+  const result = await fetchRemoteProfileSessions(
+    'dad-scope',
+    new URLSearchParams({ profile: 'all', limit: '20', offset: '0' }),
+    async (profile, path) => {
+      calls.push({ profile, path })
+
+      // The desktop scope label and the remote's real profiles are
+      // independent namespaces — the backend's stamps are authoritative.
+      return {
+        sessions: [
+          { id: 's-wife-remote', profile: 'hermes-claude', is_default_profile: false },
+          { id: 's-root', profile: 'default', is_default_profile: true }
+        ],
+        total: 2,
+        profile_totals: { 'hermes-claude': 1, default: 1 }
+      }
+    },
+    { sharedEndpoint: true }
+  )
+
+  // Scoped read through the cross-profile aggregator, keeping this scope.
+  assert.deepEqual(calls, [
+    { profile: 'dad-scope', path: '/api/profiles/sessions?profile=dad-scope&limit=20&offset=0' }
+  ])
+
+  // The backend's identities survive untouched — NOT overwritten with the
+  // selecting scope's name.
+  assert.deepEqual(
+    result.sessions.map(row => [(row as any).id, (row as any).profile, (row as any).is_default_profile]),
+    [
+      ['s-wife-remote', 'hermes-claude', false],
+      ['s-root', 'default', true]
+    ]
+  )
+})
+
+test('a single scope keeps the single-database read with no identity claim', async () => {
+  const calls: Array<{ profile: string | null; path: string }> = []
+  const rows = [{ id: 's-1', profile: 'whatever-the-launch-profile-was' }]
+
+  const result = await fetchRemoteProfileSessions(
+    'work-vps',
+    new URLSearchParams({ profile: 'work-vps', limit: '20' }),
+    async (profile, path) => {
+      calls.push({ profile, path })
+
+      return { sessions: rows, total: 1 }
+    }
+  )
+
+  // Legacy shape byte-for-byte: profile stripped, flat list endpoint, rows
+  // passed through as-is (main.ts labels them for exactly this path).
+  assert.deepEqual(calls, [{ profile: 'work-vps', path: '/api/sessions?limit=20' }])
+  assert.equal(result.sessions[0], rows[0])
+})
+
+test('a shared endpoint on an older remote falls back to the single-profile read and labeling', async () => {
+  const calls: string[] = []
+
+  const result = await fetchRemoteProfileSessions(
+    'wife',
+    new URLSearchParams({ limit: '20', offset: '0' }),
+    async (_profile, path) => {
+      calls.push(path)
+
+      if (path.startsWith('/api/profiles/sessions')) {
+        throw new Error('404: No such API endpoint')
+      }
+
+      return { sessions: [{ id: 'legacy-1' }, { id: 'legacy-2' }], total: 2 }
+    },
+    { sharedEndpoint: true }
+  )
+
+  assert.deepEqual(calls, ['/api/profiles/sessions?limit=20&offset=0&profile=wife', '/api/sessions?limit=20&offset=0'])
+
+  // These rows cannot prove which remote profile they belong to, so they
+  // carry the selecting scope's label — exactly the legacy behavior.
+  assert.deepEqual(
+    result.sessions.map(row => [(row as any).id, (row as any).profile, (row as any).is_default_profile]),
+    [
+      ['legacy-1', 'wife', false],
+      ['legacy-2', 'wife', false]
+    ]
+  )
+})
+
+test('shared-endpoint windows page through the aggregator at its own cap', async () => {
+  const calls: string[] = []
+  const rows = Array.from({ length: 700 }, (_, index) => ({ id: `s-${index}`, profile: 'default' }))
+
+  const result = await fetchRemoteProfileSessions(
+    'wife',
+    new URLSearchParams({ limit: '700', offset: '0' }),
+    async (_profile, path) => {
+      calls.push(path)
+
+      const url = new URL(path, 'http://desktop.test')
+      const limit = Number(url.searchParams.get('limit'))
+      const offset = Number(url.searchParams.get('offset'))
+
+      if (!path.startsWith('/api/profiles/sessions') || limit > 500) {
+        throw new Error(`aggregator rejects ${path}`)
+      }
+
+      return { sessions: rows.slice(offset, offset + limit), total: rows.length }
+    },
+    { sharedEndpoint: true }
+  )
+
+  assert.deepEqual(calls, [
+    '/api/profiles/sessions?limit=500&offset=0&profile=wife',
+    '/api/profiles/sessions?limit=200&offset=500&profile=wife'
+  ])
+  assert.equal(result.sessions.length, 700)
+  assert.equal(result.total, 700)
+})

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -273,25 +273,47 @@ export function spliceRegistrySessionRows(
   return { added }
 }
 
-export async function fetchRemoteProfileSessions(
-  profile: string,
-  searchParams: URLSearchParams,
-  fetchJsonForProfile: FetchJsonForProfile
-): Promise<SessionListResponse> {
-  const params = new URLSearchParams(searchParams)
-  params.delete('profile') // the remote serves its own database
+/** The cross-profile aggregator caps per-request pages at 500 (it fans the
+ *  query out across every profile's state.db — see web_routers/profiles.py). */
+const PROFILE_SESSIONS_PAGE_LIMIT = 500
 
+export interface RemoteProfileSessionReadOptions {
+  /** The endpoint serves more than one desktop scope (several profiles point
+   *  at the same URL — #64999), so it is a multi-profile backend: read THIS
+   *  scope through its cross-profile aggregator (?profile=<scope>), where
+   *  every row arrives stamped with the real owning profile. That identity is
+   *  authoritative and flows through untouched. An older remote without the
+   *  aggregator still serves one launch-profile database — that falls back to
+   *  the single-profile read AND its scope labeling, exactly as if the
+   *  endpoint had never been shared. */
+  sharedEndpoint?: boolean
+}
+
+type RemoteSessionPageReader = (query: string) => Promise<SessionListResponse>
+
+/**
+ * Shared windowing for both remote session endpoints: small requests stay on
+ * one call; oversized windows walk limit/offset pages of at most `pageLimit`
+ * (each endpoint caps its per-request page size), keeping ordinary rows in
+ * order and appending pinned rows that fell outside the window last — the same
+ * result one larger request would have produced.
+ */
+async function pageRemoteSessionWindow(
+  params: URLSearchParams,
+  pageLimit: number,
+  readPage: RemoteSessionPageReader
+): Promise<SessionListResponse> {
   const requestedLimit = Number(params.get('limit'))
   const requestedOffset = Number(params.get('offset') || '0')
 
   const needsPaging =
     Number.isInteger(requestedLimit) &&
-    requestedLimit > REMOTE_SESSION_PAGE_LIMIT &&
+    requestedLimit > pageLimit &&
     Number.isInteger(requestedOffset) &&
     requestedOffset >= 0
 
   if (!needsPaging) {
-    return (await fetchJsonForProfile(profile, `/api/sessions?${params}`)) as SessionListResponse
+    return readPage(params.toString())
   }
 
   const sessions: unknown[] = []
@@ -304,18 +326,20 @@ export async function fetchRemoteProfileSessions(
 
   while (pageOffset < targetOffset) {
     const pageParams = new URLSearchParams(params)
-    const pageLimit = Math.min(REMOTE_SESSION_PAGE_LIMIT, targetOffset - pageOffset)
-    pageParams.set('limit', String(pageLimit))
+    const pageLimitForCall = Math.min(pageLimit, targetOffset - pageOffset)
+    pageParams.set('limit', String(pageLimitForCall))
     pageParams.set('offset', String(pageOffset))
 
-    const page = (await fetchJsonForProfile(profile, `/api/sessions?${pageParams}`)) as SessionListResponse
+    const page = await readPage(pageParams.toString())
     firstPage ??= page
 
     const total = nonNegativeNumber(page.total)
     const pageRows = rowsOf(page)
 
     const windowedCount =
-      total !== null ? Math.min(pageLimit, Math.max(0, total - pageOffset)) : Math.min(pageLimit, pageRows.length)
+      total !== null
+        ? Math.min(pageLimitForCall, Math.max(0, total - pageOffset))
+        : Math.min(pageLimitForCall, pageRows.length)
 
     // /api/sessions appends pinned rows that fall outside the requested
     // window. Keep those aside until all ordinary pages have been joined so
@@ -353,7 +377,7 @@ export async function fetchRemoteProfileSessions(
       targetOffset = Math.min(targetOffset, total)
     }
 
-    pageOffset += pageLimit
+    pageOffset += pageLimitForCall
   }
 
   for (const row of backfilled) {
@@ -372,5 +396,59 @@ export async function fetchRemoteProfileSessions(
     total: total ?? sessions.length,
     limit: requestedLimit,
     offset: requestedOffset
+  }
+}
+
+/** One remote's OWN database (genuinely single-profile endpoint): strip the
+ *  profile param — it serves its state.db natively — and page at its API cap.
+ *  Rows are returned as-is; labeling them with the selecting scope is the
+ *  caller's call (main.ts does it for exactly this path). */
+async function fetchOwnDatabaseRemoteSessions(
+  profile: string,
+  searchParams: URLSearchParams,
+  fetchJsonForProfile: FetchJsonForProfile
+): Promise<SessionListResponse> {
+  const params = new URLSearchParams(searchParams)
+  params.delete('profile') // the remote serves its own database
+
+  return pageRemoteSessionWindow(params, REMOTE_SESSION_PAGE_LIMIT, query =>
+    fetchJsonForProfile(profile, `/api/sessions?${query}`) as Promise<SessionListResponse>
+  )
+}
+
+export async function fetchRemoteProfileSessions(
+  profile: string,
+  searchParams: URLSearchParams,
+  fetchJsonForProfile: FetchJsonForProfile,
+  options: RemoteProfileSessionReadOptions = {}
+): Promise<SessionListResponse> {
+  if (!options.sharedEndpoint) {
+    return fetchOwnDatabaseRemoteSessions(profile, searchParams, fetchJsonForProfile)
+  }
+
+  try {
+    // Multi-profile backend shared by several desktop scopes (#64999): ask its
+    // cross-profile aggregator for THIS scope's slice. Every row comes stamped
+    // by the backend with its real owning profile — that identity must reach
+    // the renderer untouched.
+    const params = new URLSearchParams(searchParams)
+    params.set('profile', profile)
+
+    return await pageRemoteSessionWindow(params, PROFILE_SESSIONS_PAGE_LIMIT, query =>
+      fetchJsonForProfile(profile, `/api/profiles/sessions?${query}`) as Promise<SessionListResponse>
+    )
+  } catch {
+    // Older remote without the aggregator: it still serves ONE launch-profile
+    // database whose rows cannot prove which remote profile they belong to —
+    // fall back to the single-profile read and its scope labeling.
+    const data = await fetchOwnDatabaseRemoteSessions(profile, searchParams, fetchJsonForProfile)
+
+    for (const s of rowsOf(data)) {
+      const session = s as Record<string, unknown>
+      session.profile = profile
+      session.is_default_profile = false
+    }
+
+    return data
   }
 }


### PR DESCRIPTION
Fixes #64999

## Root cause
Per-profile remote overrides stripped the profile param ("the remote serves its own database") and then unconditionally relabeled every returned session row with the local scope name — so two desktop profiles pointed at the same multi-profile backend both stamped their own name onto every row, destroying real per-profile identity. The newer registry path already reads ?profile=all and preserves backend stamps; the override path predated it.

## Fix
Pure detection helpers next to profileRemoteOverride(): endpoint identity = normalized base URL + auth mode + credential material. When >=2 desktop scopes resolve to one endpoint, the read switches to the registry-style scoped read (?profile=<scope> -> /api/profiles/sessions, paged at the aggregator cap) and backend-returned s.profile/s.is_default_profile are preserved verbatim. Genuinely single-scope endpoints keep today's strip+relabel byte-for-byte; remotes without the aggregator fall back to legacy behavior. Merge-path bonus: scopes no longer duplicate each other's rows in the all-merge. Resume/routing semantics untouched; main.ts logic extracted into testable pure functions.

## Verification
connection-config.test.ts (+84: endpoint-key grouping incl. different-credentials-stay-legacy) and profile-session-routing.test.ts (+123: shared-endpoint preserves stamps, single-scope legacy preserved, paging window); 130 tests pass; tsc clean across all three tsconfigs; full electron suite failures identical to clean main (stash-verified).