### PR TITLE
feat(desktop): bot-level skill assignment matrix on the skills page (#88973)

### DIFF
--- a/apps/desktop/src/app/master-detail.tsx
+++ b/apps/desktop/src/app/master-detail.tsx
@@ -419,6 +419,11 @@ export function ListStripButton({
 
 interface CapRowProps {
   active: boolean
+  /** Optional inline controls between the row button and the switch — the
+   *  Skills page's per-bot assignment chips. Rendered as SIBLINGS of the
+   *  select button, so a click on them never selects the row and interactive
+   *  elements are never nested inside it. */
+  aside?: ReactNode
   busy?: boolean
   enabled: boolean
   meta?: ReactNode
@@ -436,6 +441,7 @@ interface CapRowProps {
 // selecting first. Off rows dim; the switch itself dims when off.
 export function CapRow({
   active,
+  aside,
   busy,
   enabled,
   meta,
@@ -484,6 +490,7 @@ export function CapRow({
           </span>
         )}
       </RowButton>
+      {aside != null && <div className="mr-0.5 flex shrink-0 items-center gap-1">{aside}</div>}
       <Switch
         aria-label={toggleLabel}
         checked={enabled}

--- a/apps/desktop/src/app/skills/bot-matrix.test.ts
+++ b/apps/desktop/src/app/skills/bot-matrix.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import { buildSkillBotMatrix, scopeFromOptionValue, skillBotColumn } from './bot-matrix'
+
+describe('scopeFromOptionValue', () => {
+  it('passes legacy bare profile names through as string scopes', () => {
+    expect(scopeFromOptionValue('researcher')).toBe('researcher')
+    expect(scopeFromOptionValue('default')).toBe('default')
+  })
+
+  it('decodes roster picks into (connection, profile) pins', () => {
+    expect(scopeFromOptionValue('homelab::inbox-bot')).toEqual({ connectionId: 'homelab', profile: 'inbox-bot' })
+  })
+
+  it('keeps a local-pool roster pick pinned to local (empty connection id survives)', () => {
+    // `local::x` / `::x` decode to an explicit object whose empty connection id
+    // means "the local pool" downstream — profileScopeKey then collapses it to
+    // the bare profile, matching how capabilityScoped routes it.
+    expect(scopeFromOptionValue('::solo')).toEqual({ connectionId: '', profile: 'solo' })
+  })
+})
+
+describe('skillBotColumn', () => {
+  it('derives the cache id from the decoded scope, not the raw option value', () => {
+    // A remote roster row keeps its connection-prefixed key...
+    expect(skillBotColumn('homelab::inbox-bot', 'inbox-bot — Homelab')).toEqual({
+      id: 'homelab::inbox-bot',
+      label: 'inbox-bot — Homelab',
+      scope: { connectionId: 'homelab', profile: 'inbox-bot' }
+    })
+
+    // ...while a LOCAL pool row shares the bare-profile cache key the rest of
+    // Capabilities uses — otherwise matrix reads would duplicate fetches.
+    expect(skillBotColumn('local::default', 'Hermes (default)').id).toBe('default')
+  })
+})
+
+describe('buildSkillBotMatrix', () => {
+  const bots = [skillBotColumn('default', 'Hermes (default)'), skillBotColumn('researcher', 'researcher')]
+
+  it('maps each skill to per-bot enabled flags', () => {
+    const sets = new Map([
+      ['default', new Set(['web-research', 'forge'])],
+      ['researcher', new Set(['forge'])]
+    ])
+
+    const matrix = buildSkillBotMatrix(['web-research', 'forge'], bots, sets)
+
+    expect(matrix.get('web-research')).toEqual(new Map([
+      ['default', true],
+      ['researcher', false]
+    ]))
+    expect(matrix.get('forge')).toEqual(new Map([
+      ['default', true],
+      ['researcher', true]
+    ]))
+  })
+
+  it('marks columns whose read has not landed as null instead of guessing', () => {
+    const sets = new Map([['default', new Set(['forge'])]])
+
+    const matrix = buildSkillBotMatrix(['forge'], bots, sets)
+
+    expect(matrix.get('forge')).toEqual(new Map([
+      ['default', true],
+      ['researcher', null]
+    ]))
+  })
+
+  it('yields null rows for every column when no bot list has loaded', () => {
+    const matrix = buildSkillBotMatrix(['forge'], bots, new Map())
+
+    expect([...matrix.get('forge')!.values()]).toEqual([null, null])
+  })
+
+  it('is empty when there are no bot columns (single-profile users see nothing)', () => {
+    expect(buildSkillBotMatrix(['forge'], [], new Map()).size).toBe(0)
+  })
+})

--- a/apps/desktop/src/app/skills/bot-matrix.ts
+++ b/apps/desktop/src/app/skills/bot-matrix.ts
@@ -1,0 +1,76 @@
+import type { ProfileScope } from '@/api/client'
+import { profileScopeKey } from '@/api/client'
+
+// Bot-level skill assignment (#88973): an inverted view over the existing
+// per-profile skill management. Pure helpers only — the Skills page feeds it
+// scope-selector options and per-bot enabled-skill reads; these functions own
+// the decoding and the skill→bots mapping.
+
+/** One bot column in the Skills page's assignment matrix. */
+export interface SkillBotColumn {
+  /** Stable id — profileScopeKey(scope). Cache key + React key. */
+  id: string
+  /** Display name ("researcher", "Hermes (default)", "inbox-bot — Homelab"). */
+  label: string
+  /** Where this bot's reads/writes route. */
+  scope: ProfileScope
+}
+
+/** Decode a Capabilities scope-selector option value back into its routing
+ *  scope. Option values are bare profile names on the legacy path and
+ *  `connectionId::profile` roster picks on multi-connection desktops — exactly
+ *  what SkillsView.changeScope consumes, so matrix writes route to the same
+ *  backend a selector pick would. */
+export function scopeFromOptionValue(value: string): ProfileScope {
+  const sep = value.indexOf('::')
+
+  return sep >= 0 ? { connectionId: value.slice(0, sep), profile: value.slice(sep + 2) } : value
+}
+
+/** Build a matrix column from a selector option. The id is derived from the
+ *  DECODED scope via profileScopeKey — never the raw option string — so cache
+ *  keys stay identical to the ones the rest of the Capabilities surface uses
+ *  (a roster pick for the local pool must share the bare-profile key). */
+export function skillBotColumn(optionValue: string, label: string): SkillBotColumn {
+  const scope = scopeFromOptionValue(optionValue)
+
+  return { id: profileScopeKey(scope), label, scope }
+}
+
+/**
+ * Invert per-bot enabled-skill sets into a per-skill assignment row.
+ *
+ * @param skillNames The Skills page's own rows (the current scope's list).
+ *   Cross-profile-only skills are intentionally absent — this page manages
+ *   THIS scope's skills and shows where else each one is assigned.
+ * @param bots Columns to map, in display order.
+ * @param enabledSkillsByBotId Bot id → that profile's enabled-skill names.
+ *   A missing entry means the read hasn't landed yet.
+ * @returns skill name → bot id → enabled, with `null` marking a column whose
+ *   list is still loading or failed (rendered as a dimmed chip, not a guess).
+ */
+export function buildSkillBotMatrix(
+  skillNames: readonly string[],
+  bots: readonly SkillBotColumn[],
+  enabledSkillsByBotId: ReadonlyMap<string, ReadonlySet<string>>
+): Map<string, Map<string, boolean | null>> {
+  const matrix = new Map<string, Map<string, boolean | null>>()
+
+  if (bots.length === 0) {
+    return matrix
+  }
+
+  for (const name of skillNames) {
+    const row = new Map<string, boolean | null>()
+
+    for (const bot of bots) {
+      const enabled = enabledSkillsByBotId.get(bot.id)
+
+      row.set(bot.id, enabled ? enabled.has(name) : null)
+    }
+
+    matrix.set(name, row)
+  }
+
+  return matrix
+}

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -213,8 +213,10 @@ describe('SkillsView toolset management', () => {
       )
     })
 
-    // The selector renders on the Skills tab too (Capabilities-wide).
-    const trigger = await screen.findByRole('combobox')
+    // The selector renders on the Skills tab too (Capabilities-wide). The bot
+    // assignment matrix adds a SECOND combobox (its column filter) — wait for
+    // both, then target the scope selector, which comes first in the DOM.
+    const trigger = (await screen.findAllByRole('combobox'))[0]
     await act(async () => {
       fireEvent.click(trigger)
     })
@@ -427,5 +429,104 @@ describe('SkillsView toolset management', () => {
     } finally {
       delete (window as { hermesDesktop?: unknown }).hermesDesktop
     }
+  })
+})
+
+describe('SkillsView bot assignment matrix', () => {
+  // Two profiles → the scope selector AND the bot matrix both appear; the
+  // matrix reads every column's enabled-skills through the SAME scoped
+  // getSkills RPC the scope selector uses, keyed per profile by args.
+  function skill(name: string, enabled: boolean) {
+    return { name, description: `${name} desc`, category: 'research', enabled, usage: 0, provenance: 'bundled' }
+  }
+
+  function mockTwoProfiles() {
+    Element.prototype.scrollIntoView = vi.fn()
+    getProfiles.mockResolvedValue({
+      profiles: [
+        { name: 'default', is_default: true },
+        { name: 'researcher', is_default: false }
+      ]
+    })
+    // The current scope's list vs. researcher's — different assignments on
+    // purpose so chips must read the RIGHT profile's data.
+    getSkills.mockImplementation((profile?: null | string) =>
+      profile === 'researcher'
+        ? Promise.resolve([skill('forge', true)])
+        : Promise.resolve([skill('web-research', true), skill('forge', false)])
+    )
+  }
+
+  async function renderSkillsTab() {
+    const { SkillsView } = await import('./index')
+    await act(async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/skills?tab=skills']}>
+            <SkillsView />
+          </MemoryRouter>
+        </QueryClientProvider>
+      )
+    })
+  }
+
+  it('renders one chip per bot per skill from each profile’s scoped list', async () => {
+    mockTwoProfiles()
+    await renderSkillsTab()
+
+    // web-research: enabled here, absent for researcher → off-chip / on-chip.
+    expect(await screen.findByRole('button', { name: 'Turn web-research off for Hermes (default)' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Turn web-research on for researcher' })).toBeTruthy()
+    // forge: disabled here, enabled for researcher.
+    expect(screen.getByRole('button', { name: 'Turn forge off for researcher' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Turn forge on for Hermes (default)' })).toBeTruthy()
+  })
+
+  it('clicking a chip toggles that skill for THAT profile via the scoped toggle RPC', async () => {
+    mockTwoProfiles()
+    setSkillEnabled.mockResolvedValue({ ok: true, name: 'web-research', enabled: true })
+
+    await renderSkillsTab()
+
+    const chip = await screen.findByRole('button', { name: 'Turn web-research on for researcher' })
+    await act(async () => {
+      fireEvent.click(chip)
+    })
+
+    // Same endpoint/args shape the row switch uses — only the profile differs.
+    await waitFor(() => expect(setSkillEnabled).toHaveBeenCalledWith('web-research', true, 'researcher'))
+  })
+
+  it('the bot filter narrows the matrix columns to the picked profile', async () => {
+    mockTwoProfiles()
+    await renderSkillsTab()
+
+    await screen.findByRole('button', { name: 'Turn web-research off for Hermes (default)' })
+
+    const filter = screen.getByRole('combobox', { name: 'Filter by bot' })
+    await act(async () => {
+      fireEvent.click(filter)
+    })
+    const option = await screen.findByRole('option', { name: 'researcher' })
+    await act(async () => {
+      fireEvent.click(option)
+    })
+
+    // Only researcher columns remain; the default-profile chips are gone...
+    expect(screen.queryByRole('button', { name: /for Hermes \(default\)$/ })).toBeNull()
+    // ...and the researcher chips survive untouched.
+    expect(screen.getByRole('button', { name: 'Turn web-research on for researcher' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Turn forge off for researcher' })).toBeTruthy()
+  })
+
+  it('single-profile users get no matrix UI at all', async () => {
+    // beforeEach default: exactly one profile → feature silently absent.
+    getSkills.mockResolvedValue([skill('web-research', true)])
+
+    await renderSkillsTab()
+
+    expect(await screen.findByRole('switch', { name: 'web-research' })).toBeTruthy()
+    expect(screen.queryByRole('combobox', { name: 'Filter by bot' })).toBeNull()
+    expect(screen.queryByRole('button', { name: /for (Hermes \(default\)|researcher)/ })).toBeNull()
   })
 })

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useQuery } from '@tanstack/react-query'
+import { useQueries, useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
@@ -32,6 +32,7 @@ import { queryClient } from '@/lib/query-client'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
 import { normalize } from '@/lib/text'
 import { useStoreSelector } from '@/lib/use-session-slice'
+import { cn } from '@/lib/utils'
 import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
@@ -61,6 +62,7 @@ import { TerminalBackendPanel } from '../settings/terminal-backend-panel'
 import { ToolsetConfigPanel } from '../settings/toolset-config-panel'
 import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 
+import { buildSkillBotMatrix, scopeFromOptionValue, skillBotColumn, type SkillBotColumn } from './bot-matrix'
 import { EmbeddedHubPicker } from './embedded-hub-picker'
 import { McpTab } from './mcp-tab'
 import { $skillsSortDesc, $toolsetsSortDesc } from './store'
@@ -332,6 +334,9 @@ export function SkillsView({
   const [bulkBusy, setBulkBusy] = useState(false)
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null)
   const [selectedToolset, setSelectedToolset] = useState<string | null>(null)
+  // Bot assignment matrix column filter: 'all' or one SkillBotColumn.id.
+  // Purely this view's presentation — reset on scope/profile switches below.
+  const [botFilter, setBotFilter] = useState<string>('all')
 
   const refreshCapabilities = useCallback(async () => {
     await Promise.all([
@@ -394,6 +399,7 @@ export function SkillsView({
     toolCallsEpoch.current += 1
     setToolCalls(null)
     setScopeOverride(null)
+    setBotFilter('all')
   })
 
   const visibleSkills = useMemo(
@@ -471,6 +477,27 @@ export function SkillsView({
         current => current?.map(row => (row.name === skill.name ? { ...row, enabled: !enabled } : row)) ?? current
       )
       notifyError(err, t.skills.failedToUpdate(skill.name))
+    }
+  }
+
+  // The same toggle for ONE bot column of a row: optimistic write into THAT
+  // profile's cached list (shared with any scope-selector pick), rolled back
+  // visibly on failure with an authoritative refresh as the last word.
+  async function handleToggleBotSkill(bot: SkillBotColumn, skillName: string, enabled: boolean) {
+    const botKey = [...SKILLS_QUERY_KEY, bot.id]
+
+    const writeScoped = (fn: (cur: SkillInfo[] | undefined) => SkillInfo[] | undefined) =>
+      queryClient.setQueryData<SkillInfo[]>(botKey, prev => fn(prev) ?? prev)
+
+    writeScoped(cur => cur?.map(row => (row.name === skillName ? { ...row, enabled } : row)) ?? cur)
+
+    try {
+      await setSkillEnabled(skillName, enabled, bot.scope)
+      invalidateSlashCompletions()
+    } catch (err) {
+      writeScoped(cur => cur?.map(row => (row.name === skillName ? { ...row, enabled: !enabled } : row)) ?? cur)
+      notifyError(err, t.skills.failedToUpdate(skillName))
+      void queryClient.invalidateQueries({ queryKey: botKey })
     }
   }
 
@@ -681,12 +708,11 @@ export function SkillsView({
   // desktops (the roster path) and bare profile names otherwise, so one
   // handler decodes both.
   const changeScope = (value: string) => {
-    const sep = value.indexOf('::')
-
-    // Roster picks (`connectionId::profile`) stay objects — a `local::` pick
-    // must PIN the local pool even while a remote gateway is active. Legacy
-    // bare-name picks stay strings so cache keys and routing are unchanged.
-    const next: ProfileScope = sep >= 0 ? { connectionId: value.slice(0, sep), profile: value.slice(sep + 2) } : value
+    // Roster picks (`connectionId::profile`) decode to objects — a `local::`
+    // pick must PIN the local pool even while a remote gateway is active.
+    // Legacy bare-name picks stay strings so cache keys and routing are
+    // unchanged. Same decoder the bot matrix uses (one resolver per policy).
+    const next = scopeFromOptionValue(value)
 
     if (profileScopeKey(next) === scopeKey) {
       return
@@ -699,6 +725,7 @@ export function SkillsView({
     setSkillEditor(null)
     setSkillDraft('')
     setArchiveTarget(null)
+    setBotFilter('all')
   }
 
   // Scope-selector rows. Multi-connection desktops list every reachable
@@ -724,6 +751,63 @@ export function SkillsView({
       value: p.name
     }))
   }, [multiConnection, profilesData, rosterData])
+
+  // ── Bot assignment matrix (#88973) ──────────────────────────────────────
+  // An inverted view over the existing per-profile skill management: every
+  // configurable (connection, profile) scope gets one clickable chip on each
+  // skill row showing whether THAT bot has the skill enabled. Reads reuse the
+  // scoped GET /api/skills and writes the scoped PUT /api/skills/toggle —
+  // nothing new backend-side. Silently absent with <2 profiles so
+  // single-profile users see no extra chrome, and in pinned/embedded views
+  // (Bot Mode) where a matrix of other bots has no meaning.
+  const showBotMatrix = !fixedProfile && mode === 'skills' && scopeOptions.length > 1
+
+  const botColumns = useMemo<SkillBotColumn[]>(
+    () => (showBotMatrix ? scopeOptions.map(option => skillBotColumn(option.value, option.label)) : []),
+    [showBotMatrix, scopeOptions]
+  )
+
+  // Batched lazy read: one scoped list per bot column, cached under that
+  // profile's normal Capabilities key — deduped with any scope-selector pick,
+  // invalidated by the same SKILLS_QUERY_KEY prefix on refresh/toggles, and
+  // staleTime-gated so bouncing tabs/pages doesn't re-run every profile's
+  // full-list scan.
+  const botQueries = useQueries({
+    queries: botColumns.map(bot => ({
+      queryKey: [...SKILLS_QUERY_KEY, bot.id],
+      queryFn: () => getSkills(bot.scope),
+      enabled: showBotMatrix,
+      staleTime: 60_000
+    }))
+  })
+
+  // Which columns the matrix shows: all bots or exactly one. A scope change
+  // that removes the filtered bot resets to "all" (handlers above).
+  const shownBots = useMemo(
+    () => (botFilter === 'all' ? botColumns : botColumns.filter(bot => bot.id === botFilter)),
+    [botColumns, botFilter]
+  )
+
+  // Bot id -> that profile's enabled-skill names. Rebuilt when a column lands;
+  // cheap (a Set over an already-cached list), so no identity gymnastics here.
+  const botEnabledSets = useMemo(() => {
+    const sets = new Map<string, Set<string>>()
+
+    botColumns.forEach((bot, i) => {
+      const list = botQueries[i]?.data
+
+      if (list) {
+        sets.set(bot.id, new Set(list.filter(skill => skill.enabled).map(skill => skill.name)))
+      }
+    })
+
+    return sets
+  }, [botColumns, botQueries])
+
+  const botMatrix = useMemo(
+    () => buildSkillBotMatrix((skills ?? []).map(s => s.name), shownBots, botEnabledSets),
+    [botEnabledSets, shownBots, skills]
+  )
 
   // The selector's current value must match one option's value exactly. On the
   // roster path an ambient (non-override) scope is the active gateway's
@@ -822,7 +906,29 @@ export function SkillsView({
                   <ListColumn
                     header={
                       <ListStrip
-                        left={sortButton(skillsSortDesc, () => $skillsSortDesc.set(!$skillsSortDesc.get()))}
+                        left={
+                          <>
+                            {sortButton(skillsSortDesc, () => $skillsSortDesc.set(!$skillsSortDesc.get()))}
+                            {/* Bot filter: All bots | one profile. Narrows the
+                                matrix columns shown on every row; hidden when
+                                the matrix itself is (single profile). */}
+                            {showBotMatrix && (
+                              <Select onValueChange={setBotFilter} value={botFilter}>
+                                <SelectTrigger aria-label={t.skills.botFilterLabel} className="h-6 w-32 text-[0.68rem]">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  <SelectItem value="all">{t.skills.botFilterAllBots}</SelectItem>
+                                  {botColumns.map(bot => (
+                                    <SelectItem key={bot.id} value={bot.id}>
+                                      {bot.label}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            )}
+                          </>
+                        }
                         right={
                           <ListStripMenu
                             items={[
@@ -842,6 +948,19 @@ export function SkillsView({
                     {visibleSkills.map(skill => (
                       <CapRow
                         active={activeSkill?.name === skill.name}
+                        aside={
+                          showBotMatrix
+                            ? shownBots.map(bot => (
+                                <BotChip
+                                  bot={bot}
+                                  key={bot.id}
+                                  onToggle={next => void handleToggleBotSkill(bot, skill.name, next)}
+                                  skillName={skill.name}
+                                  state={botMatrix.get(skill.name)?.get(bot.id) ?? null}
+                                />
+                              ))
+                            : undefined
+                        }
                         busy={bulkBusy}
                         enabled={skill.enabled}
                         key={skill.name}
@@ -964,6 +1083,48 @@ export function SkillsView({
 // which is exactly the wrong-machine bug the prop exists to prevent. A static
 // property is probe-able without rendering.
 SkillsView.supportsFixedConnection = true as const
+
+// One bot cell of a skill row: a compact dot+name chip. Clicking flips THAT
+// skill for THAT profile through the same scoped toggle RPC as the row switch.
+// A dimmed chip means that bot's list hasn't landed yet — reads stay honest by
+// disabling instead of toggling against a guess; Refresh re-runs them.
+function BotChip({
+  bot,
+  onToggle,
+  skillName,
+  state
+}: {
+  bot: SkillBotColumn
+  onToggle: (next: boolean) => void
+  skillName: string
+  state: boolean | null
+}) {
+  const { t } = useI18n()
+  const next = !(state ?? false)
+
+  return (
+    <button
+      aria-label={t.skills.botAssignmentToggle(skillName, bot.label, next)}
+      className={cn(
+        'flex min-w-0 cursor-pointer items-center gap-1 rounded-full border border-(--ui-stroke-tertiary) px-1.5 py-px text-[0.6rem] leading-none text-(--ui-text-secondary) transition-colors hover:text-foreground',
+        state === null && 'cursor-default opacity-50'
+      )}
+      disabled={state === null}
+      onClick={() => onToggle(next)}
+      title={state === null ? t.skills.botAssignmentPending : undefined}
+      type="button"
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'size-1.5 shrink-0 rounded-full',
+          state === null ? 'bg-muted-foreground/40' : state ? 'bg-emerald-500' : 'border border-current opacity-60'
+        )}
+      />
+      <span className="max-w-[7ch] truncate">{bot.label}</span>
+    </button>
+  )
+}
 
 // Shared inspector header — mirrors Messaging's PlatformDetail so Skills and
 // Tools share one title/description block and tab switches don't jump.

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -981,7 +981,11 @@ export const ar = defineLocale({
     toolsetEnabled: 'تم تفعيل مجموعة الأدوات',
     toolsetDisabled: 'تم تعطيل مجموعة الأدوات',
     appliesToNewSessions: name => `ينطبق على الجلسات الجديدة في ${name}`,
-    failedToUpdate: name => `فشل تحديث ${name}`
+    failedToUpdate: name => `فشل تحديث ${name}`,
+    botFilterLabel: 'تصفية حسب البوت',
+    botFilterAllBots: 'كل البوتات',
+    botAssignmentPending: 'لم يتم تحميل مهارات هذا البوت بعد',
+    botAssignmentToggle: (skill, bot, enabled) => `${enabled ? 'تشغيل' : 'إيقاف'} ${skill} على ${bot}`
   },
   agents: {
     close: 'إغلاق الوكلاء',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1250,6 +1250,10 @@ export const en: Translations = {
     archive: 'Archive',
     skillArchivedTitle: 'Skill archived',
     skillArchivedMessage: 'Restorable via hermes curator restore.',
+    botFilterLabel: 'Filter by bot',
+    botFilterAllBots: 'All bots',
+    botAssignmentPending: "This bot's skills haven't loaded yet",
+    botAssignmentToggle: (skill, bot, enabled) => `Turn ${skill} ${enabled ? 'on' : 'off'} for ${bot}`,
     hub: {
       searchPlaceholder: 'Search the skill hub',
       search: 'Search',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1158,7 +1158,11 @@ export const ja = defineLocale({
     edit: '編集',
     archive: 'アーカイブ',
     skillArchivedTitle: 'スキルをアーカイブしました',
-    skillArchivedMessage: 'hermes curator restore で復元できます。'
+    skillArchivedMessage: 'hermes curator restore で復元できます。',
+    botFilterLabel: 'ボットで絞り込み',
+    botFilterAllBots: 'すべてのボット',
+    botAssignmentPending: 'このボットのスキルはまだ読み込まれていません',
+    botAssignmentToggle: (skill, bot, enabled) => `${bot}で${skill}を${enabled ? 'オン' : 'オフ'}にする`,
   },
 
   starmap: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1094,6 +1094,12 @@ export interface Translations {
     archive: string
     skillArchivedTitle: string
     skillArchivedMessage: string
+    // Bot assignment matrix (#88973): per-row chips showing which bots have
+    // each skill enabled. Absent entirely for single-profile users.
+    botFilterLabel: string
+    botFilterAllBots: string
+    botAssignmentPending: string
+    botAssignmentToggle: (skill: string, bot: string, enabled: boolean) => string
     hub: {
       searchPlaceholder: string
       search: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1118,7 +1118,11 @@ export const zhHant = defineLocale({
     edit: '編輯',
     archive: '封存',
     skillArchivedTitle: '技能已封存',
-    skillArchivedMessage: '可透過 hermes curator restore 還原。'
+    skillArchivedMessage: '可透過 hermes curator restore 還原。',
+    botFilterLabel: '依 Bot 篩選',
+    botFilterAllBots: '全部 Bot',
+    botAssignmentPending: '該 Bot 的技能尚未載入',
+    botAssignmentToggle: (skill, bot, enabled) => `在 ${bot} 上${enabled ? '開啟' : '關閉'} ${skill}`,
   },
 
   starmap: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1441,6 +1441,10 @@ export const zh: Translations = {
     archive: '归档',
     skillArchivedTitle: '技能已归档',
     skillArchivedMessage: '可通过 hermes curator restore 恢复。',
+    botFilterLabel: '按 Bot 筛选',
+    botFilterAllBots: '全部 Bot',
+    botAssignmentPending: '该 Bot 的技能尚未加载',
+    botAssignmentToggle: (skill, bot, enabled) => `在 ${bot} 上${enabled ? '开启' : '关闭'} ${skill}`,
     hub: {
       searchPlaceholder: '搜索技能中心',
       search: '搜索',


### PR DESCRIPTION
Fixes #88973

Renderer-only inverted view over existing per-profile skill management — zero new backend surface. Reuses GET /api/skills?profile= (enabled flags) and PUT /api/skills/toggle through the desktop api layer verbatim.

## What
- Skills page rows gain per-bot chips when >1 profile exists (siblings of the row button, never nested interactive elements); chip click flips that skill for that bot via the same toggle RPC the Capabilities page uses, optimistic-with-rollback through the shared React-Query cache keys (deduped reads, prefix invalidation, 60s staleTime).
- All-bots/per-bot filter dropdown narrows matrix columns; single-profile and Bot-Mode views render nothing extra.
- Pure helpers (scope decode, cache keys, skill-to-bot matrix build) unit-tested separately; i18n all locales + types.

## Verification
23 tests across the new bot-matrix suite and the skills page suite; i18n suites green; tsc --noEmit exit 0; full desktop suite failures identical to clean upstream/main (stash-verified electron env set).