### PR TITLE
fix(gateway): wait for api_server port before a replacement starts

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -8375,7 +8375,22 @@ class APIServerAdapter(BasePlatformAdapter):
                 reuse_address=False if sys.platform == "darwin" else None,
             )
             try:
-                await self._site.start()
+                last_exc: OSError | None = None
+                for attempt in range(5):
+                    try:
+                        await self._site.start()
+                        last_exc = None
+                        break
+                    except OSError as exc:
+                        last_exc = exc
+                        if (
+                            getattr(exc, "errno", None) != errno.EADDRINUSE
+                            or attempt == 4
+                        ):
+                            break
+                        await asyncio.sleep(0.2 * (attempt + 1))
+                if last_exc is not None:
+                    raise last_exc
             except OSError as exc:
                 await self._runner.cleanup()
                 self._runner = None

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -12,6 +12,7 @@ import os
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import textwrap
@@ -5266,6 +5267,53 @@ def _wait_for_gateway_exit(
     return True
 
 
+def _wait_for_tcp_port_free(
+    host: str,
+    port: int,
+    *,
+    timeout: float = 10.0,
+    clock=time.monotonic,
+    sleeper=time.sleep,
+    connect=None,
+) -> bool:
+    """Wait until nothing accepts TCP connections on host:port.
+
+    PID exit is not enough on macOS: api_server disables SO_REUSEADDR, so a
+    restart that wins the race logs EADDRINUSE and keeps running with no API.
+    Connection-refused means the listener is gone.
+    """
+    probe = connect
+    if probe is None:
+        def probe(target_host: str, target_port: int) -> bool:
+            with socket.create_connection((target_host, target_port), timeout=0.2):
+                return True
+
+    deadline = clock() + timeout
+    while clock() < deadline:
+        try:
+            probe(host, port)
+        except OSError:
+            return True
+        sleeper(0.1)
+    return False
+
+
+def _wait_for_api_server_port_free(*, timeout: float = 10.0) -> bool:
+    """Wait for the configured api_server listen address to stop accepting."""
+    host = os.getenv("API_SERVER_HOST", "127.0.0.1") or "127.0.0.1"
+    try:
+        port = int(os.getenv("API_SERVER_PORT", "8642"))
+    except ValueError:
+        port = 8642
+    freed = _wait_for_tcp_port_free(host, port, timeout=timeout)
+    if not freed:
+        print(
+            f"⚠ {host}:{port} still accepting connections — "
+            "new api_server may fail to bind"
+        )
+    return freed
+
+
 def _launchd_kickstart(label: str, domain: str) -> None:
     """Hard-restart ``domain/label`` via ``launchctl kickstart -k``.
 
@@ -5350,6 +5398,7 @@ def launchd_restart():
                     print(
                         f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart"
                     )
+        _wait_for_api_server_port_free()
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
         _clear_launchd_unsupported_marker()
@@ -8079,6 +8128,7 @@ def _gateway_command_inner(args):
             if total:
                 print(f"✓ Stopped {total} gateway process(es) across all profiles")
             _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+            _wait_for_api_server_port_free()
 
             # Start the current profile's service fresh
             print("Starting gateway...")
@@ -8173,6 +8223,7 @@ def _gateway_command_inner(args):
                 print("✓ Stopped gateway for this profile")
 
             _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+            _wait_for_api_server_port_free()
 
             # Start fresh
             print("Starting gateway...")

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -501,6 +501,39 @@ class TestWaitForGatewayExit:
         assert calls == [(11, True), (22, True)]
 
 
+class TestWaitForTcpPortFree:
+    def test_returns_true_once_connect_fails(self):
+        attempts = {"n": 0}
+
+        def connect(_host, _port):
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                return True
+            raise OSError("refused")
+
+        times = iter([0.0, 0.0, 0.1, 0.2, 0.3])
+        assert gateway._wait_for_tcp_port_free(
+            "127.0.0.1",
+            8642,
+            timeout=1.0,
+            clock=lambda: next(times),
+            sleeper=lambda _: None,
+            connect=connect,
+        )
+        assert attempts["n"] == 3
+
+    def test_times_out_while_port_stays_busy(self):
+        times = iter([0.0, 0.0, 0.5, 1.5])
+        assert gateway._wait_for_tcp_port_free(
+            "127.0.0.1",
+            8642,
+            timeout=1.0,
+            clock=lambda: next(times),
+            sleeper=lambda _: None,
+            connect=lambda _h, _p: True,
+        ) is False
+
+
 class TestStopProfileGateway:
     def test_stop_profile_gateway_keeps_pid_file_when_process_still_running(self, monkeypatch):
         calls = {"kill": 0, "alive_probes": 0, "remove": 0, "reap_calls": 0}


### PR DESCRIPTION
## Bug Description

Fixes #91547

A gateway replacement can print success, then lose the api_server bind (`Errno 48`) and keep running with messaging only. Status looks healthy. API clients are gone.

## Root Cause

The stop path waits for the old PID, not the listen port. On Darwin `api_server` sets `reuse_address=False` (correct — BSD SO_REUSEADDR would split traffic), so a lingering socket is a hard bind failure. That failure is logged and the process continues.

## Fix

- After stop, wait until `API_SERVER_HOST:API_SERVER_PORT` (default `127.0.0.1:8642`) refuses connections. Used on launchd, manual, and `--all` replacement paths.
- Retry `TCPSite.start()` a few times on `EADDRINUSE` before the existing fatal `api_server_port_in_use` path.

## Test Plan

- [x] Hermetic tests for `_wait_for_tcp_port_free` (frees vs timeout)
- [x] Existing gateway exit/service tests still pass (87)
- [ ] CI on this PR

## Risk Assessment

Low/Medium — wait is bounded (10s) and only delays start. Bind retries are only for `EADDRINUSE` and still fail closed. Does not enable SO_REUSEADDR on macOS.