### PR TITLE
fix(desktop): reconcile and optionally hide compaction summaries

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -725,6 +725,79 @@ describe('reconcileResumeMessages', () => {
 })
 
 describe('preserveLocalPendingTurnMessages', () => {
+  it('drops an optimistic user turn when compression replaced it with a summary row', () => {
+    const summary = msg(
+      '9-user',
+      'user',
+      '[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted. User request: "the original question".'
+    )
+
+    const next = [summary, msg('10-assistant', 'assistant', 'post-compaction answer')]
+
+    const previous = [
+      msg('1-user', 'user', 'first'),
+      msg('2-assistant', 'assistant', 'first answer'),
+      msg('user-optimistic', 'user', 'the original question')
+    ]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toEqual([
+      '9-user',
+      '10-assistant'
+    ])
+  })
+
+  it('drops the optimistic user turn for LCM-style recent-summary rows too', () => {
+    const summary = msg(
+      '9-user',
+      'user',
+      '[Recent Summary (d0, node 66)]\n## User requests verbatim\n- "the original question"'
+    )
+
+    const next = [summary]
+    const previous = [msg('user-optimistic', 'user', 'the original question')]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toEqual(['9-user'])
+  })
+
+  it('drops a represented optimistic user turn after newer post-compaction turns', () => {
+    const original = 'the original question with enough detail to identify the turn'
+
+    const summary = msg('9-user', 'user', `[Recent Summary (d0, node 66)]\n## User requests verbatim\n- "${original}"`)
+
+    const next = [
+      summary,
+      msg('10-assistant', 'assistant', 'post-compaction answer'),
+      msg('11-user', 'user', 'a newer question'),
+      msg('12-assistant', 'assistant', 'a newer answer')
+    ]
+
+    const previous = [...next, msg('user-optimistic-stale', 'user', original)]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toEqual([
+      '9-user',
+      '10-assistant',
+      '11-user',
+      '12-assistant'
+    ])
+  })
+
+  it('keeps a new optimistic turn that an older compaction summary does not represent', () => {
+    const summary = msg(
+      '9-user',
+      'user',
+      '[Recent Summary (d0, node 66)]\n## User requests verbatim\n- "an older question"'
+    )
+
+    const next = [summary, msg('10-assistant', 'assistant', 'post-compaction answer')]
+    const previous = [...next, msg('user-optimistic-new', 'user', 'a genuinely new question')]
+
+    expect(preserveLocalPendingTurnMessages(next, previous).map(message => message.id)).toEqual([
+      '9-user',
+      '10-assistant',
+      'user-optimistic-new'
+    ])
+  })
+
   it('keeps an optimistic user turn and pending assistant when the server projection is behind', () => {
     const next = [msg('1-user', 'user', 'first'), msg('2-assistant', 'assistant', 'first answer')]
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -2,6 +2,7 @@ import { textWithoutReferenceLines } from '@/components/assistant-ui/reference-k
 import { getSession } from '@/hermes'
 import { assistantTextPart, type ChatMessage, chatMessageText, textPart } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
+import { isCompressionSummaryText } from '@/lib/compression-summary'
 import { embeddedImageUrls, textWithoutEmbeddedImages } from '@/lib/embedded-images'
 import { parseErrorSurface } from '@/lib/error-surface'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
@@ -436,6 +437,26 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
 const isGatewaySystemMarker = (message: ChatMessage): boolean =>
   message.role === 'user' && chatMessageText(message).trimStart().startsWith('[System:')
 
+/** True only when a synthetic summary actually carries this optimistic turn.
+ * LCM's "User requests verbatim" entries are JSON-style quoted strings. The
+ * direct-text fallback covers legacy summaries while requiring enough text to
+ * avoid treating a fresh short reply such as "ok" as an old summarized turn. */
+const compressionSummaryRepresentsUserMessage = (summary: ChatMessage, message: ChatMessage): boolean => {
+  if (!isCompressionSummaryText(chatMessageText(summary))) {
+    return false
+  }
+
+  const userText = textWithoutReferenceLines(chatMessageText(message)).trim()
+
+  if (!userText) {
+    return false
+  }
+
+  const summaryText = chatMessageText(summary)
+
+  return summaryText.includes(JSON.stringify(userText)) || (userText.length >= 32 && summaryText.includes(userText))
+}
+
 /**
  * Does the row carry anything a viewer would miss — streamed answer text, or
  * the reasoning / tool-call structure the gateway's flat dump cannot express?
@@ -596,8 +617,9 @@ export function preserveLocalPendingTurnMessages(
     if (
       isOptimisticUser &&
       latestAuthoritativeUser &&
-      textWithoutReferenceLines(chatMessageText(latestAuthoritativeUser)) ===
-        textWithoutReferenceLines(chatMessageText(message))
+      (textWithoutReferenceLines(chatMessageText(latestAuthoritativeUser)) ===
+        textWithoutReferenceLines(chatMessageText(message)) ||
+        nextMessages.some(candidate => compressionSummaryRepresentsUserMessage(candidate, message)))
     ) {
       continue
     }

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -14,6 +14,7 @@ import { selectableCardClass } from '@/lib/selectable-card'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { $backdrop, setBackdrop } from '@/store/backdrop'
+import { $showCompactionSummaries, setShowCompactionSummaries } from '@/store/compaction-summary-visibility'
 import { $composerPopoutGesturesEnabled, setComposerPopoutGesturesEnabled } from '@/store/composer-popout'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
 import { $introSplash, setIntroSplash } from '@/store/intro-splash'
@@ -345,6 +346,7 @@ export function AppearanceSettings() {
   const { themeName, mode, resolvedMode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
   const reasoningCollapsedByDefault = useStore($reasoningCollapsedByDefault)
+  const showCompactionSummaries = useStore($showCompactionSummaries)
   const sessionListDensity = useStore($sessionListDensity)
   const tabStripDefault = useStore($tabStripDefault)
   const zoomPercent = useStore($zoomPercent)
@@ -785,6 +787,13 @@ export function AppearanceSettings() {
             }
             description={a.reasoningCollapsedDesc}
             title={a.reasoningCollapsedTitle}
+          />
+
+          <ToggleRow
+            checked={showCompactionSummaries}
+            description={a.compactionSummariesDesc}
+            label={a.compactionSummariesTitle}
+            onChange={setShowCompactionSummaries}
           />
 
           <ListRow

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -10,11 +10,37 @@ import {
   type MessageGroup,
   resolveThreadScrollTarget,
   subscribeToThreadForeground,
+  threadStructuralSignature,
   transcriptPaneBudget
 } from './list'
 
 afterEach(() => {
   vi.restoreAllMocks()
+})
+
+describe('threadStructuralSignature', () => {
+  const messages = [
+    {
+      content: [{ type: 'text', text: '[Recent Summary (d0, node 66)]\nEarlier context' }],
+      id: 'summary',
+      role: 'user'
+    },
+    { content: [{ type: 'text', text: 'answer' }], id: 'answer', role: 'assistant' }
+  ]
+
+  it('keeps compaction summaries and real indices by default', () => {
+    expect(threadStructuralSignature(messages)).toBe('0:summary:user\n1:answer:assistant')
+  })
+
+  it('omits only the synthetic summary when the preference is off', () => {
+    expect(threadStructuralSignature(messages, false)).toBe('1:answer:assistant')
+  })
+
+  it('does not hide an ordinary user message that merely mentions compression', () => {
+    const ordinary = [{ content: [{ type: 'text', text: 'What did compression do?' }], id: 'user', role: 'user' }]
+
+    expect(threadStructuralSignature(ordinary, false)).toBe('0:user:user')
+  })
 })
 
 describe('subscribeToThreadForeground', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -19,8 +19,10 @@ import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
 import { usePaneLifecycle } from '@/components/pane-shell/pane-visibility'
 import { useI18n } from '@/i18n'
+import { isCompressionSummaryText } from '@/lib/compression-summary'
 import { messagePaintWeight } from '@/lib/render-weight'
 import { cn } from '@/lib/utils'
+import { $showCompactionSummaries } from '@/store/compaction-summary-visibility'
 import {
   onScrollToBottomRequest,
   onThreadEditClose,
@@ -63,6 +65,34 @@ export type MessageGroup = { id: string; weight: number } & (
 // What the DOM can hold is bounded above by the store window regardless
 // (TRANSCRIPT_WINDOW_BUDGET), so this cannot admit more than one window's
 // content.
+interface StructuralThreadMessage {
+  content: readonly { text?: string; type: string }[]
+  id: string
+  role: string
+}
+
+function threadMessageText(message: StructuralThreadMessage): string {
+  return message.content
+    .filter(part => part.type === 'text' && typeof part.text === 'string')
+    .map(part => part.text)
+    .join('')
+}
+
+/** Keep assistant-ui's real message indices while omitting presentation-only rows. */
+export function threadStructuralSignature(
+  messages: readonly StructuralThreadMessage[],
+  showCompactionSummaries = true
+): string {
+  return messages
+    .flatMap((message, index) => {
+      const hiddenSummary =
+        !showCompactionSummaries && message.role === 'user' && isCompressionSummaryText(threadMessageText(message))
+
+      return hiddenSummary ? [] : [`${index}:${message.id}:${message.role}`]
+    })
+    .join('\n')
+}
+
 const RENDER_BUDGET = 600
 // Every mounted transcript list registers here (see the mount effect). The
 // budget above is sized for ONE full-height pane; a grid split shows several
@@ -371,9 +401,9 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // new resetKey per appended part, which reconciled every turn's subtree on
   // every tick (measured: 540 wasted Block renders per explain() sample with
   // two threads streaming).
-  const structuralSignature = useAuiState(s =>
-    s.thread.messages.map((message, index) => `${index}:${message.id}:${message.role}`).join('\n')
-  )
+  const showCompactionSummaries = useStore($showCompactionSummaries)
+
+  const structuralSignature = useAuiState(s => threadStructuralSignature(s.thread.messages, showCompactionSummaries))
 
   const weightSignature = useAuiState(s =>
     s.thread.messages.map(message => messagePaintWeight(message.content)).join(',')

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -419,6 +419,9 @@ export const ar = defineLocale({
       toolViewDesc: 'تحكم في كيفية عرض نشاط الأدوات داخل المحادثة.',
       reasoningCollapsedTitle: 'طي التفكير افتراضيًا',
       reasoningCollapsedDesc: 'أبقِ التفكير المتدفق متاحًا دون توسيعه حتى تفتحه.',
+      compactionSummariesTitle: 'إظهار ملخصات ضغط السياق',
+      compactionSummariesDesc:
+        'اعرض صفوف الملخص الاصطناعية في المحادثة. إخفاؤها لا يغيّر السجل المحفوظ أو سياق النموذج.',
       translucencyTitle: 'شفافية النافذة',
       translucencyDesc: 'إظهار سطح المكتب من خلال النافذة بالكامل، بما في ذلك النص.',
       translucencyGlassDesc: 'زجاج غير لامع: يظهر سطح المكتب كضبابية ناعمة بينما يبقى النص واضحًا.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -516,6 +516,9 @@ export const en: Translations = {
       toolViewDesc: 'Product hides raw tool payloads; Technical shows full input/output.',
       reasoningCollapsedTitle: 'Collapse thinking by default',
       reasoningCollapsedDesc: 'Keep streamed reasoning available without expanding it until you open it.',
+      compactionSummariesTitle: 'Show context-compaction summaries',
+      compactionSummariesDesc:
+        'Display synthetic summary rows in the transcript. Hiding them does not change stored history or model context.',
       uiScaleTitle: 'UI Scale',
       uiScaleDesc: (percent: number) =>
         `Scales text and controls across the whole app. Cmd/Ctrl with +, - and 0 also works. Current: ${percent}%.`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -339,6 +339,9 @@ export const ja = defineLocale({
       toolViewDesc: 'プロダクト表示は生のツールペイロードを隠し、テクニカル表示は入出力をすべて表示します。',
       reasoningCollapsedTitle: '思考ブロックをデフォルトで折りたたむ',
       reasoningCollapsedDesc: 'ストリーミング中の推論を、開くまで折りたたんだまま利用できるようにします。',
+      compactionSummariesTitle: 'コンテキスト圧縮の要約を表示',
+      compactionSummariesDesc:
+        '会話履歴に合成された要約行を表示します。非表示にしても保存済み履歴やモデルのコンテキストは変わりません。',
       uiScaleTitle: 'UI スケール',
       uiScaleDesc: (percent: number) =>
         `アプリ全体の文字と UI を拡大縮小します。Cmd/Ctrl と +、-、0 でも変更できます。現在: ${percent}%`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -413,6 +413,8 @@ export interface Translations {
       toolViewDesc: string
       reasoningCollapsedTitle: string
       reasoningCollapsedDesc: string
+      compactionSummariesTitle: string
+      compactionSummariesDesc: string
       uiScaleTitle: string
       uiScaleDesc: (percent: number) => string
       sessionDensityTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -330,6 +330,8 @@ export const zhHant = defineLocale({
       toolViewDesc: '產品模式會隱藏原始工具 payload；技術模式會顯示完整輸入/輸出。',
       reasoningCollapsedTitle: '預設摺疊推理過程',
       reasoningCollapsedDesc: '保留串流推理內容，但在您開啟前維持摺疊。',
+      compactionSummariesTitle: '顯示上下文壓縮摘要',
+      compactionSummariesDesc: '在對話記錄中顯示合成摘要列。隱藏它們不會變更已儲存的歷史或模型上下文。',
       uiScaleTitle: '介面縮放',
       uiScaleDesc: (percent: number) =>
         `縮放整個應用程式的文字與介面。也可使用 Cmd/Ctrl 加 +、- 或 0 調整。目前：${percent}%`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -504,6 +504,8 @@ export const zh: Translations = {
       toolViewDesc: '产品模式隐藏原始工具数据；技术模式显示完整输入/输出。',
       reasoningCollapsedTitle: '默认折叠推理过程',
       reasoningCollapsedDesc: '保留流式推理内容，但在您打开前保持折叠。',
+      compactionSummariesTitle: '显示上下文压缩摘要',
+      compactionSummariesDesc: '在对话记录中显示合成摘要行。隐藏它们不会更改已存储的历史或模型上下文。',
       uiScaleTitle: '界面缩放',
       uiScaleDesc: (percent: number) =>
         `缩放整个应用的文字和界面。也可使用 Cmd/Ctrl 加 +、- 或 0 调整。当前：${percent}%`,

--- a/apps/desktop/src/lib/compression-summary.ts
+++ b/apps/desktop/src/lib/compression-summary.ts
@@ -1,0 +1,13 @@
+/** Synthetic user rows emitted by Hermes context-compaction engines. */
+const COMPRESSION_SUMMARY_PREFIXES = [
+  '[CONTEXT COMPACTION',
+  '[CONTEXT SUMMARY]',
+  '[Recent Summary',
+  '[Session Arc Summary'
+] as const
+
+export function isCompressionSummaryText(text: string): boolean {
+  const normalized = text.trimStart()
+
+  return COMPRESSION_SUMMARY_PREFIXES.some(prefix => normalized.startsWith(prefix))
+}

--- a/apps/desktop/src/store/compaction-summary-visibility.ts
+++ b/apps/desktop/src/store/compaction-summary-visibility.ts
@@ -1,0 +1,15 @@
+import { type Codec, persistentAtom } from '@/lib/persisted'
+
+const STORAGE_KEY = 'hermes.desktop.transcript.showCompactionSummaries'
+
+const booleanCodec: Codec<boolean> = {
+  decode: raw => raw !== 'false',
+  encode: value => String(value)
+}
+
+/** Desktop-local presentation only; summaries remain in authoritative history and model context. */
+export const $showCompactionSummaries = persistentAtom<boolean>(STORAGE_KEY, true, booleanCodec)
+
+export function setShowCompactionSummaries(show: boolean) {
+  $showCompactionSummaries.set(show)
+}


### PR DESCRIPTION
## Summary

- stop stale optimistic user rows from reappearing after a compaction summary when newer turns follow it
- match only summaries that actually represent the optimistic prompt, preserving genuinely new prompts
- add a persisted Appearance toggle that hides synthetic compaction-summary rows without changing stored history or model context

## Root cause

Desktop reconciled pending local `user-*` rows against only the latest authoritative user row. Once a real user turn followed an LCM `[Recent Summary ...]` row, the summary safeguard no longer ran, so a stale optimistic prompt was appended at the transcript bottom on session re-entry.

## Verification

- focused Vitest: 150 passed
- Desktop TypeScript typecheck: passed
- Desktop production build: passed
- ESLint and Prettier on all changed files: passed