### PR TITLE
fix(telegram): honor the direct-messages-topic alias in the anchor-retry gate

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -1741,8 +1741,11 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         # Synthetic / resumed sends route via ``direct_messages_topic_id``
         # instead of a reply anchor. If Telegram rejects the topic id, fall
-        # back to a plain DM send.
-        if metadata.get("direct_messages_topic_id"):
+        # back to a plain DM send. Route through the canonical accessor so
+        # the documented ``telegram_``-prefixed alias (gateway/delivery.py
+        # treats the two keys as equivalent) also degrades gracefully
+        # instead of hard-failing the send.
+        if cls._metadata_direct_messages_topic_id(metadata):
             topic_markers = (
                 "direct_messages_topic",
                 "message thread not found",

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -408,6 +408,44 @@ def test_prefers_fresh_final_streaming_for_dm_topic_tables():
     ) is True
 
 
+# ----------------------------------------------------------------------
+# _should_retry_without_dm_topic_reply_anchor: a synthetic/resumed DM-topic
+# send (loop wakeup, watch notification, restart-resumed follow-up) routes
+# via direct_messages_topic_id instead of a reply anchor. If Telegram rejects
+# that topic id, the send must degrade to a plain DM instead of hard-failing.
+# The alias-only case (telegram_direct_messages_topic_id, same key the
+# fresh-final gate above accepts per bad2ed866c) must be honored too.
+# ----------------------------------------------------------------------
+def test_should_retry_without_dm_topic_reply_anchor_honors_alias_only_metadata():
+    base_metadata = {"telegram_dm_topic_reply_fallback": True}
+    topic_error = BadRequest("Bad Request: TOPIC_DELETED")
+
+    # Raw key (pre-existing, must keep working).
+    assert TelegramAdapter._should_retry_without_dm_topic_reply_anchor(
+        topic_error, {**base_metadata, "direct_messages_topic_id": "20189"}, None,
+    ) is True
+
+    # Alias-only metadata (telegram_-prefixed) must be honored through the
+    # same canonical accessor the send path uses (_thread_kwargs_for_send),
+    # not a raw dict lookup that only recognizes the unprefixed key.
+    assert TelegramAdapter._should_retry_without_dm_topic_reply_anchor(
+        topic_error, {**base_metadata, "telegram_direct_messages_topic_id": "20189"}, None,
+    ) is True
+
+    # No dm-topic-fallback flag at all: never retries, alias or not.
+    assert TelegramAdapter._should_retry_without_dm_topic_reply_anchor(
+        topic_error, {"telegram_direct_messages_topic_id": "20189"}, None,
+    ) is False
+
+    # Alias present, but the error text isn't a topic/thread rejection:
+    # must not retry on an unrelated BadRequest.
+    assert TelegramAdapter._should_retry_without_dm_topic_reply_anchor(
+        BadRequest("Bad Request: chat not found"),
+        {**base_metadata, "telegram_direct_messages_topic_id": "20189"},
+        None,
+    ) is False
+
+
 @pytest.mark.asyncio
 async def test_legacy_draft_stream_finalizes_with_persistent_rich_message():
     """A plain draft must not force the persistent final to MarkdownV2."""


### PR DESCRIPTION
## What this fixes

`_should_retry_without_dm_topic_reply_anchor()` decides whether a failed DM-topic send should be retried without routing (falling back to a plain DM) instead of hard-failing. It checked the raw `direct_messages_topic_id` key directly:

```python
if metadata.get("direct_messages_topic_id"):
```

The adapter's canonical accessor, `_metadata_direct_messages_topic_id()`, also accepts the documented `telegram_direct_messages_topic_id` alias — the two keys are treated as equivalent in `gateway/delivery.py`, and the send path itself (`_thread_kwargs_for_send`) already routes through this same accessor. Only this retry-decision gate used the raw key.

## Trigger

A synthetic/resumed DM-topic send (loop wakeup, watch notification, restart-resumed follow-up) whose metadata carries the topic id **only** via the `telegram_`-prefixed alias sends correctly (the send path resolves it fine). If Telegram then rejects that topic — deleted, closed, or not found, exactly the case this gate exists to handle — the gate misses the alias-only metadata and the send hard-fails instead of degrading gracefully to a plain DM.

## Why this wasn't caught earlier

This is the same shape as `bad2ed866c`, merged earlier today, which fixed the identical raw-key gap in `prefers_fresh_final_streaming()` — 30 lines above this function in the same file. That fix's own scope was the fresh-final streaming gate; it didn't touch this sibling retry-decision gate.

## Fix

One-line swap to the existing accessor, matching `bad2ed866c`'s approach exactly:

```python
if cls._metadata_direct_messages_topic_id(metadata):
```

## Tests

`_should_retry_without_dm_topic_reply_anchor()` had zero direct test coverage before this change (confirmed via repo-wide grep). Added `test_should_retry_without_dm_topic_reply_anchor_honors_alias_only_metadata`, covering:
- the raw key (pre-existing behavior, must keep working)
- the alias-only case (the actual regression — fails without the fix)
- two negative controls: no `telegram_dm_topic_reply_fallback` flag, and an unrelated `BadRequest` text that isn't a topic/thread rejection

**Mutation-verify:** reverted the production fix and confirmed the new test fails with `AssertionError: assert False is True` on the alias-only case, then restored the fix and confirmed all 38 tests in the file pass.

Also ran the broader neighboring Telegram test suite (`test_telegram_rich_messages.py`, `test_telegram_error_redaction.py`, `test_telegram_media_read_timeout.py`, `test_telegram_thread_fallback.py`, `test_telegram_topic_mode.py`, `test_telegram_forum_commands.py` — 88 tests) and `ruff check` on both changed files; all clean.

## Competing-PR note

Open PR #51085 touches the sibling function `_send_with_dm_topic_reply_anchor_retry()` in the same file (adding stale-topic-binding pruning), but at a different location — inside the `except` block, between the `reset_media()` call and `retry_kwargs = dict(send_kwargs)` — not the gate function this PR changes. No line-level overlap; textual proximity only, flagging for reviewer awareness.