### PR TITLE
fix(agent): route session_persistence_failed reasons to the disk layer

### DIFF
--- a/agent/error_surface.py
+++ b/agent/error_surface.py
@@ -53,6 +53,16 @@ _REASON_TO_LAYER = {
     "billing_unverified": LAYER_BILLING,
 }
 
+# turn_finalizer stamps failure_reason as
+# "session_persistence_failed:<cause>" (see hermes_state.PERSISTENCE_ERROR_CAUSES
+# for the cause vocabulary — locked/compression/compression_closed/turn_lease/
+# corrupt/disk/unknown) when a turn dies because the local SessionDB write
+# failed. The cause varies per turn, so this can't be a fixed key in
+# _REASON_TO_LAYER; every one of those causes is a local-storage fault, never
+# a provider verdict, which is exactly what LAYER_DISK's own docstring
+# entry ("local disk full / persistence failure") already promises.
+_PERSISTENCE_FAILURE_REASON_PREFIX = "session_persistence_failed:"
+
 # Transport-ish reasons: the failure is between us and the base_url, not a
 # verdict the provider returned. On a custom/local endpoint these point at
 # the user's endpoint config, so they surface as LAYER_ENDPOINT there.
@@ -191,7 +201,9 @@ def build_error_surface_from_result(
 
         layer = _REASON_TO_LAYER.get(reason)
         if layer is None:
-            if reason in _TRANSPORT_REASONS and _is_custom_endpoint(provider):
+            if reason.startswith(_PERSISTENCE_FAILURE_REASON_PREFIX):
+                layer = LAYER_DISK
+            elif reason in _TRANSPORT_REASONS and _is_custom_endpoint(provider):
                 layer = LAYER_ENDPOINT
             elif _looks_like_stream_drop(error_text):
                 layer = LAYER_STREAMING

--- a/tests/agent/test_error_surface.py
+++ b/tests/agent/test_error_surface.py
@@ -152,6 +152,31 @@ def test_result_disk_full_wins_over_reason():
     assert surface["retryable"] is False
 
 
+def test_result_session_persistence_failed_maps_to_disk_layer():
+    """turn_finalizer stamps failure_reason as
+    "session_persistence_failed:<cause>" (hermes_state.PERSISTENCE_ERROR_CAUSES)
+    with a generic error string that never trips the disk-full text check.
+    Every cause is a local-storage fault, not a provider verdict, so all of
+    them — not just the "disk" cause — must land on LAYER_DISK instead of
+    falling through to the exact-match _REASON_TO_LAYER miss and defaulting
+    to LAYER_PROVIDER (which would offer a nonsensical "Switch provider"
+    action for a SQLite lock/corruption/lease problem). Iterates the real
+    cause tuple rather than a hardcoded list, per hermes_state's own note
+    that consumers enumerating causes must not desync from it."""
+    from hermes_state import PERSISTENCE_ERROR_CAUSES
+
+    generic_error = (
+        "session storage could not be written — check the state database "
+        "health (`hermes doctor`), then send your message again"
+    )
+    for cause in PERSISTENCE_ERROR_CAUSES:
+        surface = build_error_surface_from_result(
+            _failed_result(f"session_persistence_failed:{cause}", error=generic_error)
+        )
+        assert surface["layer"] == LAYER_DISK, cause
+        assert surface["code"] == f"session_persistence_failed:{cause}"
+
+
 # ── build_error_surface_from_exception ───────────────────────────────────
 
 


### PR DESCRIPTION
## What this fixes

`agent/error_surface.py::build_error_surface_from_result()` maps a turn's `failure_reason` onto a UI layer descriptor (`{layer, code, retryable}`) that the desktop error card reads to decide its label and recovery actions.

`agent/turn_finalizer.py` stamps `failure_reason` as `"session_persistence_failed:<cause>"` when a turn dies because the local SessionDB write itself failed — `<cause>` is one of `hermes_state.PERSISTENCE_ERROR_CAUSES` (`locked`, `compression`, `compression_closed`, `turn_lease`, `corrupt`, `disk`, `unknown`), and it's always paired with the same generic wrapper text ("session storage could not be written…") regardless of which cause fired.

`_REASON_TO_LAYER` is an exact-match dict, so a suffixed reason like `session_persistence_failed:locked` never matches any of its keys — a dict `.get()` can't do prefix matching. The module's earlier disk-full text check doesn't catch it either, since the generic wrapper message contains none of `hermes_state`'s ENOSPC/SQLITE_FULL markers. Every one of these reasons therefore falls through to the `LAYER_PROVIDER` default.

The module's own docstring already documents the intended mapping for exactly this case:

```
disk       — local disk full / persistence failure
```

— it was just never wired up.

## Concrete, 100%-reproducible impact

The desktop error card labels every local SessionDB write failure (a locked DB, a corrupt DB, a turn-lease conflict, a session merely closed by compression) as **"Provider error"** and offers a **"Switch provider"** action (`assistant-message.tsx`'s `showSwitchProvider` triggers on `layer === 'provider'`) — nonsensical guidance for what is actually a local SQLite/storage problem the user should instead resolve with `hermes doctor`. This is deterministic, not a race: any turn that hits this exit path gets this exact mislabel.

## Fix

Recognize the `"session_persistence_failed:"` prefix and route it to `LAYER_DISK`, alongside the existing exact-match table:

```python
layer = _REASON_TO_LAYER.get(reason)
if layer is None:
    if reason.startswith(_PERSISTENCE_FAILURE_REASON_PREFIX):
        layer = LAYER_DISK
    elif reason in _TRANSPORT_REASONS and _is_custom_endpoint(provider):
        ...
```

Scoped narrowly to the `layer` field. `retryable` keeps its existing fallback behavior for this reason family (`True`, since none of the prefixed strings are literally in `_NON_RETRYABLE_REASONS`) — I found no evidence that's wrong (offering a Retry button for a transient lock/compression contention is reasonable, and it's a low-risk action even for the less-transient causes), so I left it alone rather than speculating on new per-cause retry semantics beyond the confirmed bug.

## Tests

Added `test_result_session_persistence_failed_maps_to_disk_layer`, iterating the real `hermes_state.PERSISTENCE_ERROR_CAUSES` tuple (not a hardcoded list — that module's own comment notes consumers enumerating causes must not desync from it) and asserting every cause lands on `LAYER_DISK` with the full prefixed reason preserved as `code`.

**Mutation-verify:** reverted the production fix and confirmed the new test fails immediately with `AssertionError: locked / assert 'provider' == 'disk'`, then restored the fix and confirmed all 19 tests in `tests/agent/test_error_surface.py` pass, plus the neighboring `tests/agent/test_turn_finalizer_final_response_persistence.py` (4 tests, unaffected).

`ruff check` on both changed files: clean.

## Competing-PR check

Searched for `"error_surface disk layer"`, `"session_persistence_failed provider error"`, `"LAYER_DISK persistence"` — no open PRs found touching this mapping.