### PR TITLE
fix(streaming): seal the segment-break bubble stripped and marked as continued

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1349,6 +1349,13 @@ class GatewayStreamConsumer:
                             and self._message_id != "__no_edit__"
                         ):
                             await self._flush_segment_tail_on_edit_failure()
+                        else:
+                            # Clean break: whatever the finalize edit above
+                            # did, seal the on-screen bubble stripped and
+                            # marked — otherwise it keeps the streaming
+                            # cursor and the fresh continuation bubble below
+                            # reads like a duplicate send (#92063).
+                            await self._seal_segment_for_continuation()
                         self._reset_segment_state(preserve_no_edit=True)
 
                 # Flush barrier satisfied: the buffered segment (if any) has now
@@ -2062,6 +2069,34 @@ class GatewayStreamConsumer:
                 self._last_sent_text = prefix
         except Exception:
             pass  # best-effort — don't let this block the fallback path
+
+    async def _seal_segment_for_continuation(self) -> None:
+        """Best-effort final edit on the bubble a segment break seals.
+
+        A clean segment break leaves the on-screen bubble at its last
+        streaming edit — cursor (▉) still attached when the break arrives
+        between edit ticks. The fresh continuation bubble below then reads
+        like a duplicate send of the same prefix (#92063). Re-edit the sealed
+        bubble with the cursor stripped and a continuation marker appended,
+        so the pair reads as one continued answer.
+        """
+        if self.cfg.buffer_only:
+            return  # uneditable platform — nothing to seal
+        if not self._message_id or self._message_id == "__no_edit__":
+            return
+        prefix = self._visible_prefix()
+        if not prefix or not prefix.strip():
+            return
+        sealed = f"{prefix.rstrip()}\n\n(continued below)"
+        try:
+            result = await self._edit_message(
+                message_id=self._message_id,
+                content=sealed,
+            )
+            if getattr(result, "success", False):
+                self._last_sent_text = sealed
+        except Exception:
+            pass  # best-effort — a failing seal edit must not stall the break
 
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2079,6 +2079,12 @@ class GatewayStreamConsumer:
         like a duplicate send of the same prefix (#92063). Re-edit the sealed
         bubble with the cursor stripped and a continuation marker appended,
         so the pair reads as one continued answer.
+
+        The marker is optimistic best-effort: it is applied at every clean
+        break, so if the turn then aborts right after the boundary the sealed
+        bubble advertises a continuation that is delivered by the fallback
+        path (or never arrives). Trading that rare stale marker for never
+        leaving the cursor frozen is the intended contract.
         """
         if self.cfg.buffer_only:
             return  # uneditable platform — nothing to seal
@@ -2087,7 +2093,15 @@ class GatewayStreamConsumer:
         prefix = self._visible_prefix()
         if not prefix or not prefix.strip():
             return
-        sealed = f"{prefix.rstrip()}\n\n(continued below)"
+        marker = "\n\n(continued below)"
+        # A segment that filled close to the adapter limit has no room for
+        # the marker — an over-limit seal edit is rejected outright (limit is
+        # hard-enforced e.g. on Telegram) and the cursor stays frozen, the
+        # exact #92063 symptom resurfacing only for long segments.
+        budget = max(self._raw_message_limit() - len(marker), 0)
+        if len(prefix) > budget:
+            prefix = prefix[:budget]
+        sealed = f"{prefix.rstrip()}{marker}"
         try:
             result = await self._edit_message(
                 message_id=self._message_id,
@@ -2095,8 +2109,11 @@ class GatewayStreamConsumer:
             )
             if getattr(result, "success", False):
                 self._last_sent_text = sealed
-        except Exception:
-            pass  # best-effort — a failing seal edit must not stall the break
+        except Exception as e:
+            # best-effort — a failing seal edit must not stall the break,
+            # but leave a trace: a platform that starts rejecting these
+            # edits is invisible otherwise when debugging stuck cursors.
+            logger.debug("Seal edit failed: %s", e)
 
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -353,6 +353,76 @@ class TestSegmentBreakOnToolBoundary:
 
 
     @pytest.mark.asyncio
+    async def test_segment_break_seals_bubble_with_continuation_marker(self):
+        """A clean segment break marks the sealed bubble as continued (#92063).
+
+        The sealed prefix plus the fresh continuation bubble must read as one
+        continued answer, not as the reply being sent twice.
+        """
+        adapter = MagicMock()
+        send_result = SimpleNamespace(success=True, message_id="msg_1")
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("Part one of the answer")
+        consumer.on_segment_break()
+        consumer.on_delta("Part two")
+        consumer.finish()
+
+        await consumer.run()
+
+        sealed = [
+            call[1].get("content", "")
+            for call in adapter.edit_message.call_args_list
+            if "(continued below)" in call[1].get("content", "")
+        ]
+        assert sealed, (
+            "expected a sealed-continuation edit; got "
+            f"{[c[1].get('content') for c in adapter.edit_message.call_args_list]!r}"
+        )
+        assert "▉" not in sealed[-1]
+        assert "Part one" in sealed[-1]
+
+
+    @pytest.mark.asyncio
+    async def test_segment_break_strips_frozen_cursor_when_nothing_accumulated(self):
+        """The #92063 race: break arrives between edit ticks with the on-screen
+        bubble still carrying the streaming cursor and nothing accumulated —
+        the seal edit must strip the cursor and mark the bubble continued."""
+        adapter = MagicMock()
+        send_result = SimpleNamespace(success=True, message_id="msg_1")
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        # Reproduce the frozen state directly: text already streamed to the
+        # screen (cursor attached), buffer empty, then the external break.
+        consumer._message_id = "msg_1"
+        consumer._last_sent_text = "Frozen mid-sentence prefix ▉"
+        consumer._accumulated = ""
+        consumer.on_segment_break()
+        consumer.finish()
+
+        await consumer.run()
+
+        contents = [
+            call[1].get("content", "")
+            for call in adapter.edit_message.call_args_list
+        ]
+        assert any(
+            "Frozen mid-sentence prefix" in c and "▉" not in c and "(continued below)" in c
+            for c in contents
+        ), f"no cursor-stripped continuation seal in {contents!r}"
+
+
+    @pytest.mark.asyncio
     async def test_segment_break_clears_failed_edit_fallback_state(self):
         """A tool boundary after edit failure must flush the undelivered tail
         without duplicating the prefix the user already saw (#8124)."""

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -423,6 +423,103 @@ class TestSegmentBreakOnToolBoundary:
 
 
     @pytest.mark.asyncio
+    async def test_segment_break_seal_truncates_prefix_near_limit(self):
+        """A prefix that already filled the adapter limit must be truncated so
+        the seal edit (prefix + continuation marker) stays within the limit —
+        an over-limit seal is rejected outright on platforms that hard-enforce
+        MAX_MESSAGE_LENGTH, re-freezing the cursor (#92063)."""
+        adapter = MagicMock()
+        send_result = SimpleNamespace(success=True, message_id="msg_1")
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 64
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer._message_id = "msg_1"
+        consumer._last_sent_text = "x" * 100
+        consumer._accumulated = ""
+        consumer.on_segment_break()
+        consumer.finish()
+
+        await consumer.run()
+
+        sealed = [
+            call[1].get("content", "")
+            for call in adapter.edit_message.call_args_list
+            if call[1].get("content", "").endswith("(continued below)")
+        ]
+        assert sealed, (
+            "expected a truncated continuation seal; got "
+            f"{[c[1].get('content') for c in adapter.edit_message.call_args_list]!r}"
+        )
+        assert len(sealed[-1]) <= 64, (
+            f"sealed edit exceeds the adapter limit: {len(sealed[-1])} > 64"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_segment_break_seal_skipped_for_buffer_only(self):
+        """buffer_only platforms have no editable bubble — the seal path must
+        not attempt a continuation edit."""
+        adapter = MagicMock()
+        send_result = SimpleNamespace(success=True, message_id="msg_1")
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(
+            edit_interval=0.01, buffer_threshold=5, buffer_only=True, cursor=" ▉"
+        )
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer._message_id = "msg_1"
+        consumer._last_sent_text = "Already on screen"
+        consumer._accumulated = ""
+        consumer.on_segment_break()
+        consumer.finish()
+
+        await consumer.run()
+
+        sealed = [
+            call[1].get("content", "")
+            for call in adapter.edit_message.call_args_list
+            if "(continued below)" in call[1].get("content", "")
+        ]
+        assert not sealed, f"buffer_only must not attempt a seal edit: {sealed!r}"
+
+
+    @pytest.mark.asyncio
+    async def test_segment_break_seal_skipped_without_editable_message(self):
+        """The ``__no_edit__`` message id marks uneditable sends — the seal
+        path must not attempt a continuation edit."""
+        adapter = MagicMock()
+        send_result = SimpleNamespace(success=True, message_id="__no_edit__")
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor=" ▉")
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer._message_id = "__no_edit__"
+        consumer._last_sent_text = "Sent without an editable message"
+        consumer._accumulated = ""
+        consumer.on_segment_break()
+        consumer.finish()
+
+        await consumer.run()
+
+        sealed = [
+            call[1].get("content", "")
+            for call in adapter.edit_message.call_args_list
+            if "(continued below)" in call[1].get("content", "")
+        ]
+        assert not sealed, f"__no_edit__ must not attempt a seal edit: {sealed!r}"
+
+
+    @pytest.mark.asyncio
     async def test_segment_break_clears_failed_edit_fallback_state(self):
         """A tool boundary after edit failure must flush the undelivered tail
         without duplicating the prefix the user already saw (#8124)."""


### PR DESCRIPTION
## What does this PR do?

On a platform with text streaming (edit-based, e.g. Feishu's default render), a multi-tool-call turn can split one answer into two adjacent bubbles: the first freezes mid-sentence **with the streaming cursor still visible**, and the complete answer arrives in a brand-new second bubble. Because the frozen bubble is a strict prefix of the second, it reads like "the reply was sent twice" (#92063 — server-side evidence in the issue shows bubble A frozen at 748 chars ending in `…▉` while bubble B carries the full 1373-char answer; `state.db` holds exactly one assistant row, so nothing was sent twice — it is purely a delivery-shape artifact).

Root cause: a clean segment break (the interim-assistant `already_streamed=True` path: `gateway/run.py` → `GatewayStreamConsumer.on_segment_break()`) seals the current bubble as-is. The finalize edit only runs when text is still accumulated; when the break arrives between edit ticks the on-screen bubble keeps its last streaming edit — cursor attached — and the next segment opens a fresh bubble below it.

This implements the issue's suggested fix 1: on a clean segment break, best-effort re-edit the sealed bubble with the cursor stripped and a `(continued below)` marker appended (same shape as the existing `_try_strip_cursor` fallback-path edit), so the pair reads as one continued answer. Buffer-only platforms (uneditable) and `__no_edit__` transports are skipped; the edit-failure tail-flush path (#8124) keeps its own continuation semantics untouched.

## Related Issue

Fixes #92063

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_consumer.py`: new `_seal_segment_for_continuation()` best-effort edit (cursor-stripped visible prefix + `(continued below)`); called from the clean-break branch of the `got_segment_break` handler (the `#8124` edit-failure tail-flush branch is unchanged)
- `tests/gateway/test_stream_consumer.py`: two regression tests — a streamed segment followed by `on_segment_break()` produces a seal edit carrying the marker and no cursor; and the issue's race state reproduced directly (frozen `_last_sent_text` with cursor attached, empty buffer, external break) is sealed stripped-and-marked

## How to Test

1. `pytest tests/gateway/test_stream_consumer.py tests/gateway/test_stream_events.py`
2. Observed result: 67 passed + 5 passed (65 pre-existing consumer tests untouched, 2 new). `tests/run_agent/test_run_agent_codex_responses.py` fails 51 tests identically on a clean `main` checkout on this host (AIAgent construction, environment-dependent) — unrelated to this change.
3. The new frozen-cursor test fails on pre-fix code exactly as the issue describes: no edit ever touches the sealed bubble, so the cursor and the duplicate-looking prefix both stay.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (seal rationale + skipped transports)
- [x] Tests added/updated and passing (72 passed across the two green files)
- [x] No new warnings introduced
- [x] Tested on macOS (arm64) via unit tests; the changed path is platform-agnostic streaming consumer logic
