### PR TITLE
fix(powerpoint): surface likely body-placeholder overflow in pptx_create.py output

### DIFF
--- a/skills/productivity/powerpoint/SKILL.md
+++ b/skills/productivity/powerpoint/SKILL.md
@@ -173,6 +173,22 @@ say so rather than approximating.
 
 ## Pitfalls
 
+- **Body-placeholder overflow is silent**: PowerPoint clips whatever
+  extends past the content placeholder frame while the outline and
+  `pptx_read.py` output still show every bullet. The default template
+  inherits large body sizes from its master (32pt at level 0, shrinking
+  per level), so a placeholder holds far less than it seems.
+  `pptx_create.py` estimates rendered height per slide and reports
+  `overflow_warnings` in its JSON output (`slide_index` is zero-based;
+  empty list when everything fits). A warning means content LIKELY
+  clips: render-verify the flagged slide first (Verification step 3),
+  and only then split across slides, shorten bullets, or set smaller
+  per-bullet `"size"` values. The estimator is heuristic — it may warn
+  on borderline slides that render fine, but warnings on fixed-frame
+  placeholders should never be ignored without checking a render.
+  Note: bullets on layouts without a body placeholder go into an
+  auto-fitting textbox that grows instead of clipping, so no warning
+  is emitted there.
 - **Run splitting**: PowerPoint fragments paragraph text into runs at
   spell-check and edit boundaries. `--replace-text` first merges adjacent
   runs whose formatting is identical, so matches split across such runs
@@ -211,6 +227,9 @@ say so rather than approximating.
 
 1. After any create/edit, run `pptx_read.py OUT.pptx --outline` and check
    slide count, texts, tables, notes, and chart values match intent.
+   If `pptx_create.py` reported `overflow_warnings`, render-verify each
+   flagged slide (step 3) before shipping — a clean outline does not
+   mean the text renders.
 2. `--images DIR` then file-size check confirms pictures embedded.
 3. Render every slide with `pptx_render.py deck.pptx --outdir ./render`
    and review each PNG with `vision_analyze` — this catches overlapping

--- a/skills/productivity/powerpoint/SKILL.md
+++ b/skills/productivity/powerpoint/SKILL.md
@@ -186,9 +186,11 @@ say so rather than approximating.
   per-bullet `"size"` values. The estimator is heuristic — it may warn
   on borderline slides that render fine, but warnings on fixed-frame
   placeholders should never be ignored without checking a render.
-  Note: bullets on layouts without a body placeholder go into an
-  auto-fitting textbox that grows instead of clipping, so no warning
-  is emitted there.
+  Note: the estimate applies only to `title_content` slides (the one
+  layout whose level sizing matches the master); other layouts override
+  level styles in their own XML, and bullets that land in an
+  auto-fitting textbox grow instead of clipping — no warning is
+  emitted in either case.
 - **Run splitting**: PowerPoint fragments paragraph text into runs at
   spell-check and edit boundaries. `--replace-text` first merges adjacent
   runs whose formatting is identical, so matches split across such runs

--- a/skills/productivity/powerpoint/SKILL.md
+++ b/skills/productivity/powerpoint/SKILL.md
@@ -173,15 +173,19 @@ say so rather than approximating.
 
 ## Pitfalls
 
-- **Body-placeholder overflow is silent**: PowerPoint clips whatever
-  extends past the content placeholder frame while the outline and
-  `pptx_read.py` output still show every bullet. The default template
-  inherits large body sizes from its master (32pt at level 0, shrinking
-  per level), so a placeholder holds far less than it seems.
-  `pptx_create.py` estimates rendered height per slide and reports
+- **Body-placeholder overfill is silent**: the outline and
+  `pptx_read.py` output still show every bullet when content exceeds the
+  nominal capacity of the content placeholder. PowerPoint normally
+  auto-shrinks that text to fit; other renderers or templates may clip it.
+  Either result can make a dense slide unreadable. The default template
+  inherits large nominal body sizes from its master (32pt at level 0,
+  shrinking per level), so a placeholder holds far less than it seems.
+  `pptx_create.py` estimates unscaled rendered height per slide and reports
   `overflow_warnings` in its JSON output (`slide_index` is zero-based;
-  empty list when everything fits). A warning means content LIKELY
-  clips: render-verify the flagged slide first (Verification step 3),
+  empty list when each estimate fits its nominal frame). A warning means
+  the content LIKELY needs shrinking or clipping: render-verify the flagged
+  slide first
+  (Verification step 3),
   and only then split across slides, shorten bullets, or set smaller
   per-bullet `"size"` values. The estimator is heuristic — it may warn
   on borderline slides that render fine, but warnings on fixed-frame
@@ -231,7 +235,7 @@ say so rather than approximating.
    slide count, texts, tables, notes, and chart values match intent.
    If `pptx_create.py` reported `overflow_warnings`, render-verify each
    flagged slide (step 3) before shipping — a clean outline does not
-   mean the text renders.
+   mean the text renders at a readable size or without clipping.
 2. `--images DIR` then file-size check confirms pictures embedded.
 3. Render every slide with `pptx_render.py deck.pptx --outdir ./render`
    and review each PNG with `vision_analyze` — this catches overlapping

--- a/skills/productivity/powerpoint/scripts/pptx_create.py
+++ b/skills/productivity/powerpoint/scripts/pptx_create.py
@@ -109,8 +109,8 @@ def copy_layout_placeholder(slide, ph_idx):
 
 
 def build_slide(prs, spec, warnings=None):
-    layout_idx = LAYOUTS.get(spec.get("layout", "title_content"), 1)
     layout_name = spec.get("layout", "title_content")
+    layout_idx = LAYOUTS.get(layout_name, 1)
     slide = prs.slides.add_slide(prs.slide_layouts[layout_idx])
 
     if spec.get("background"):
@@ -147,8 +147,9 @@ def build_slide(prs, spec, warnings=None):
             # is supported by the estimator. Other layouts override level
             # styles in their layout XML (`title` subtitle is 18pt, `section`
             # uses 20/18/16..., `two_content` 28/24/20...), so estimating
-            # them with master sizes produces false positives.
-            if warnings is not None and layout_name == "title_content":
+            # them with master sizes produces false positives. Gate on the
+            # RESOLVED index: unknown layout names fall back to layout 1.
+            if warnings is not None and layout_idx == LAYOUTS["title_content"]:
                 est = estimate_bullets_overflow(
                     spec["bullets"],
                     frame_width_in=(body.width or 0) / 914400 or None,

--- a/skills/productivity/powerpoint/scripts/pptx_create.py
+++ b/skills/productivity/powerpoint/scripts/pptx_create.py
@@ -110,6 +110,7 @@ def copy_layout_placeholder(slide, ph_idx):
 
 def build_slide(prs, spec, warnings=None):
     layout_idx = LAYOUTS.get(spec.get("layout", "title_content"), 1)
+    layout_name = spec.get("layout", "title_content")
     slide = prs.slides.add_slide(prs.slide_layouts[layout_idx])
 
     if spec.get("background"):
@@ -142,7 +143,12 @@ def build_slide(prs, spec, warnings=None):
             add_bullets(body.text_frame, spec["bullets"])
         else:
             add_bullets(body.text_frame, spec["bullets"])
-            if warnings is not None:
+            # Only the master-body sizing model (32/28/24/20/20pt by level)
+            # is supported by the estimator. Other layouts override level
+            # styles in their layout XML (`title` subtitle is 18pt, `section`
+            # uses 20/18/16..., `two_content` 28/24/20...), so estimating
+            # them with master sizes produces false positives.
+            if warnings is not None and layout_name == "title_content":
                 est = estimate_bullets_overflow(
                     spec["bullets"],
                     frame_width_in=(body.width or 0) / 914400 or None,

--- a/skills/productivity/powerpoint/scripts/pptx_create.py
+++ b/skills/productivity/powerpoint/scripts/pptx_create.py
@@ -39,6 +39,14 @@ import json
 import sys
 
 from pptx import Presentation
+
+try:
+    from pptx_overflow import estimate_bullets_overflow
+except ImportError:  # direct-script import fallback
+    import os as _os
+    import sys as _sys
+    _sys.path.insert(0, _os.path.dirname(_os.path.abspath(__file__)))
+    from pptx_overflow import estimate_bullets_overflow
 from pptx.chart.data import CategoryChartData
 from pptx.dml.color import RGBColor
 from pptx.enum.chart import XL_CHART_TYPE
@@ -100,7 +108,7 @@ def copy_layout_placeholder(slide, ph_idx):
     return None
 
 
-def build_slide(prs, spec):
+def build_slide(prs, spec, warnings=None):
     layout_idx = LAYOUTS.get(spec.get("layout", "title_content"), 1)
     slide = prs.slides.add_slide(prs.slide_layouts[layout_idx])
 
@@ -126,9 +134,24 @@ def build_slide(prs, spec):
         body = next((ph for ph in slide.placeholders
                      if ph.placeholder_format.idx != 0), None)
         if body is None:
+            # Fallback textbox: python-pptx gives it spAutoFit + wrap=none,
+            # so it GROWS with content instead of clipping — no overflow
+            # warning applies (the estimator models fixed frames only).
             body = slide.shapes.add_textbox(Inches(0.5), Inches(1.5),
                                             Inches(9), Inches(5))
-        add_bullets(body.text_frame, spec["bullets"])
+            add_bullets(body.text_frame, spec["bullets"])
+        else:
+            add_bullets(body.text_frame, spec["bullets"])
+            if warnings is not None:
+                est = estimate_bullets_overflow(
+                    spec["bullets"],
+                    frame_width_in=(body.width or 0) / 914400 or None,
+                    frame_height_in=(body.height or 0) / 914400 or None)
+                if est:
+                    warnings.append({"slide_index":
+                                     len(prs.slides._sldIdLst) - 1,
+                                     "title": spec.get("title", ""),
+                                     **est})
 
     for img in spec.get("images", []):
         kwargs = {}
@@ -201,12 +224,17 @@ def main(argv=None):
     else:
         prs.slide_width, prs.slide_height = Inches(10), Inches(7.5)
 
+    overflow_warnings = []
     for slide_spec in spec.get("slides", []):
-        build_slide(prs, slide_spec)
+        build_slide(prs, slide_spec, warnings=overflow_warnings)
 
     prs.save(args.output)
-    print(json.dumps({"ok": True, "output": args.output,
-                      "slides": len(prs.slides._sldIdLst)}))
+    result = {"ok": True, "output": args.output,
+              "slides": len(prs.slides._sldIdLst),
+              # slide_index values are zero-based; empty when every
+              # placeholder fits its estimated rendered height.
+              "overflow_warnings": overflow_warnings}
+    print(json.dumps(result))
     return 0
 
 

--- a/skills/productivity/powerpoint/scripts/pptx_overflow.py
+++ b/skills/productivity/powerpoint/scripts/pptx_overflow.py
@@ -1,0 +1,174 @@
+"""Text-overflow estimation for pptx body placeholders.
+
+python-pptx cannot measure rendered text, and rendered overflow is silent:
+the outline reads fine while PowerPoint clips whatever extends past the
+placeholder frame. This module provides a conservative *estimate* of the
+rendered height of bullet text in a body placeholder so callers (and the
+agent) get an explicit warning instead of a silently clipped slide.
+
+The estimate is heuristic on purpose: it uses per-character width factors
+(no font files needed) and mirrors the default python-pptx template's
+master text styles, which inherit font sizes of 32/28/24/20/20pt for
+bullet levels 0-4 unless a run sets an explicit size. Estimates are
+biased to OVER-predict height (warnings may fire on borderline slides;
+missed overflow defeats the guardrail's purpose). It is only meaningful
+for the fixed-frame placeholders pptx_create.py writes into — not for
+auto-fitting textboxes, which grow instead of clipping.
+"""
+
+# Rough advance-width per character as a fraction of font size, tuned for
+# Calibri/Arial-class sans faces at mixed-case prose. Deliberately rounded
+# up: false positives are cheap (an extra look), false negatives hide bugs.
+_DEFAULT_WIDTH = 0.52
+_WIDE_CHARS = set("MWmw@%")
+_NARROW_CHARS = set("iljtfIr.,:;'|!()[] ")
+# CJK / full-width ideographs and kana render at ~1em advance width.
+_CJK_THRESHOLD = 0x2E80
+
+# Default-template master bodyStyle: inherited run size (pt) and left
+# margin (inches, includes the bullet hang) per bullet level 0-4.
+INHERITED_SIZE_PT = {0: 32.0, 1: 28.0, 2: 24.0, 3: 20.0, 4: 20.0}
+INHERITED_INDENT_IN = {0: 0.375, 1: 0.8125, 2: 1.25, 3: 1.75, 4: 2.25}
+
+# Master bodyStyle adds spcBef of 20% of the line before each paragraph;
+# single line spacing for sans faces approximates 1.22 x size.
+_LINE_FACTOR = 1.22
+_SPC_BEFORE = 0.20
+
+
+def _char_width(char, size_pt):
+    if ord(char) >= _CJK_THRESHOLD:
+        return size_pt * 1.0
+    if char in _WIDE_CHARS:
+        return size_pt * 0.85
+    if char in _NARROW_CHARS:
+        return size_pt * 0.30
+    return size_pt * _DEFAULT_WIDTH
+
+
+def text_width_pt(text, size_pt=18.0):
+    """Estimated rendered width of `text` in points."""
+    return sum(_char_width(c, size_pt) for c in text)
+
+
+def _wrap_segment(text, wrap_width_pt, size_pt):
+    """Greedy wrap of one hard-line segment; splits oversized tokens."""
+    lines, current = 0, ""
+    space = _char_width(" ", size_pt)
+    for word in text.split():
+        while text_width_pt(word, size_pt) > wrap_width_pt:
+            # Unbreakable token longer than the frame: flush what fits.
+            if current:
+                lines += 1
+                current = ""
+            cut = len(word)
+            while cut > 1 and text_width_pt(word[:cut], size_pt) > wrap_width_pt:
+                cut -= 1
+            lines += 1
+            word = word[cut:]
+        candidate = f"{current} {word}".strip()
+        if not current:
+            current = word
+        elif text_width_pt(candidate, size_pt) <= wrap_width_pt:
+            current = candidate
+        else:
+            lines += 1
+            current = word
+    if current:
+        lines += 1
+    return max(lines, 1)
+
+
+def wrapped_line_count(text, wrap_width_pt, size_pt=18.0):
+    """Greedy word-wrap line count using the estimated widths.
+
+    Honors hard line breaks ('\\n') as mandatory line boundaries.
+    """
+    total = 0
+    for segment in text.split("\n"):
+        if not segment.strip():
+            total += 1  # empty line still occupies one row
+        else:
+            total += _wrap_segment(segment, wrap_width_pt, size_pt)
+    return max(total, 1)
+
+
+def effective_size_pt(item):
+    """Effective run size for a bullet spec item: explicit `size` when
+    truthy (same semantics as style_run), else the level's inherited
+    master size. Accepts a bare string for convenience."""
+    if isinstance(item, str):
+        item = {"text": item}
+    explicit = item.get("size")
+    if explicit:
+        return float(explicit)
+    level = int(item.get("level", 0))
+    return INHERITED_SIZE_PT.get(min(level, 4), 20.0)
+
+
+def effective_indent_in(level):
+    return INHERITED_INDENT_IN.get(min(int(level), 4), 2.25)
+
+
+def paragraph_height_pt(text, size_pt=None, level=0, wrap_width_pt=612.0,
+                        indent_in=None):
+    """Estimated height of one bullet paragraph in points.
+
+    Default wrap width matches the default template's content placeholder
+    (9.0in wide minus ~0.2in of side insets); the level's master indent is
+    subtracted from the wrap width automatically unless `indent_in` is
+    given explicitly.
+    """
+    if size_pt is None:
+        size_pt = INHERITED_SIZE_PT.get(min(int(level), 4), 20.0)
+    if indent_in is None:
+        indent_in = effective_indent_in(level)
+    usable = max(wrap_width_pt - indent_in * 72.0, wrap_width_pt * 0.35)
+    lines = wrapped_line_count(text, usable, size_pt)
+    return lines * size_pt * _LINE_FACTOR * (1.0 + _SPC_BEFORE)
+
+
+def estimate_bullets_overflow(bullets, frame_width_in=None,
+                              frame_height_in=None):
+    """Estimate whether bullet content overflows its body placeholder.
+
+    `bullets` is the create-script spec list (strings or dicts with
+    `text`, optional `level`/`size`). Frame dimensions come from the
+    placeholder when known; defaults mirror the default template's
+    title_content body placeholder (9.0in wide x 4.95in tall).
+
+    Returns None when there is nothing to report (no bullets, no known
+    frame, or the estimate fits), otherwise a dict with the estimated
+    vs. fitted heights and a remediation hint.
+    """
+    # Default template content placeholder: 9.0in wide x 4.95in tall.
+    width_in = frame_width_in if frame_width_in else 9.0
+    height_in = frame_height_in if frame_height_in else 4.95
+    if not bullets:
+        return None
+
+    wrap_pt = (width_in - 0.2) * 72.0
+    total = 0.0
+    for item in bullets:
+        if isinstance(item, str):
+            item = {"text": item}
+        total += paragraph_height_pt(
+            item.get("text", ""),
+            size_pt=effective_size_pt(item),
+            level=int(item.get("level", 0)),
+            wrap_width_pt=wrap_pt)
+
+    # Usable frame height subtracts the 0.05in top/bottom text insets.
+    # Warn slightly BEFORE the theoretical fit (2% early) so borderline
+    # slides surface instead of silently clipping.
+    fitted = max(height_in * 72.0 - 0.1 * 72.0, 1.0)
+    if total <= fitted * 0.98:
+        return None
+    return {
+        "estimated_text_height_pt": round(total, 1),
+        "frame_usable_height_pt": round(fitted, 1),
+        "hint": ("content likely overflows the body placeholder and will be "
+                 "clipped in PowerPoint; verify with a render, then split "
+                 "across slides, shorten bullets, or set smaller per-bullet "
+                 "\"size\" values"),
+    }

--- a/skills/productivity/powerpoint/scripts/pptx_overflow.py
+++ b/skills/productivity/powerpoint/scripts/pptx_overflow.py
@@ -1,10 +1,11 @@
-"""Text-overflow estimation for pptx body placeholders.
+"""Nominal text-capacity estimation for pptx body placeholders.
 
-python-pptx cannot measure rendered text, and rendered overflow is silent:
-the outline reads fine while PowerPoint clips whatever extends past the
-placeholder frame. This module provides a conservative *estimate* of the
-rendered height of bullet text in a body placeholder so callers (and the
-agent) get an explicit warning instead of a silently clipped slide.
+python-pptx cannot measure rendered text, and overfilling a placeholder is
+silent in the outline. PowerPoint normally auto-shrinks fixed-placeholder
+text to fit; other renderers or templates may clip it. This module provides
+a conservative *estimate* of the unscaled rendered height of bullet text so
+callers (and the agent) get an explicit warning before either failure mode
+produces an unreadable slide.
 
 The estimate is heuristic on purpose: it uses per-character width factors
 (no font files needed) and mirrors the default python-pptx template's
@@ -138,8 +139,10 @@ def estimate_bullets_overflow(bullets, frame_width_in=None,
     title_content body placeholder (9.0in wide x 4.95in tall).
 
     Returns None when there is nothing to report (no bullets, no known
-    frame, or the estimate fits), otherwise a dict with the estimated
-    vs. fitted heights and a remediation hint.
+    frame, or the unscaled estimate fits), otherwise a dict with the
+    estimated vs. fitted heights and a remediation hint. The warning is a
+    nominal-capacity guardrail: PowerPoint may shrink the text rather than
+    clip it, so callers must verify the rendered slide.
     """
     # Default template content placeholder: 9.0in wide x 4.95in tall.
     width_in = frame_width_in if frame_width_in else 9.0
@@ -160,15 +163,15 @@ def estimate_bullets_overflow(bullets, frame_width_in=None,
 
     # Usable frame height subtracts the 0.05in top/bottom text insets.
     # Warn slightly BEFORE the theoretical fit (2% early) so borderline
-    # slides surface instead of silently clipping.
+    # overfill surfaces instead of silently shrinking or clipping.
     fitted = max(height_in * 72.0 - 0.1 * 72.0, 1.0)
     if total <= fitted * 0.98:
         return None
     return {
         "estimated_text_height_pt": round(total, 1),
         "frame_usable_height_pt": round(fitted, 1),
-        "hint": ("content likely overflows the body placeholder and will be "
-                 "clipped in PowerPoint; verify with a render, then split "
-                 "across slides, shorten bullets, or set smaller per-bullet "
-                 "\"size\" values"),
+        "hint": ("content exceeds the body placeholder's nominal text "
+                 "capacity and may be auto-shrunk or clipped; verify with a "
+                 "render, then split across slides, shorten bullets, or set "
+                 "smaller per-bullet \"size\" values"),
     }

--- a/skills/productivity/powerpoint/tests/test_pptx_overflow.py
+++ b/skills/productivity/powerpoint/tests/test_pptx_overflow.py
@@ -13,6 +13,8 @@ import sys
 
 import pytest
 
+from pptx import Presentation
+
 SKILL = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCRIPTS = os.path.join(SKILL, "scripts")
 sys.path.insert(0, SCRIPTS)
@@ -46,8 +48,21 @@ def write_spec(tmp_path, spec):
 # --- inherited sizing matches the default-template master -------------------
 
 def test_inherited_sizes_match_default_master():
-    # Default python-pptx master bodyStyle: 32/28/24/20/20pt by level.
-    assert INHERITED_SIZE_PT == {0: 32.0, 1: 28.0, 2: 24.0, 3: 20.0, 4: 20.0}
+    # Ground truth from the default python-pptx template's slide master
+    # bodyStyle (lvl1pPr..lvl5pPr defRPr sz): 3200/2800/2400/2000/2000.
+    prs = Presentation()
+    ns = {"a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+          "p": "http://schemas.openxmlformats.org/presentationml/2006/main"}
+    body_style = prs.slide_masters[0].element.find(
+        "{http://schemas.openxmlformats.org/presentationml/2006/main}txStyles"
+    ).find("p:bodyStyle", ns)
+    for level, size in INHERITED_SIZE_PT.items():
+        lvl = body_style.find(f"a:lvl{level + 1}pPr", ns)
+        rpr = lvl.find("a:defRPr", ns)
+        actual = int(rpr.get("sz")) / 100.0
+        assert actual == size, (
+            f"level {level}: estimator assumes {size}pt, master says "
+            f"{actual}pt — update INHERITED_SIZE_PT")
 
 
 def test_effective_size_uses_level_inheritance_when_unspecified():
@@ -218,20 +233,16 @@ def test_blank_layout_textbox_fallback_does_not_warn(tmp_path):
     assert result["overflow_warnings"] == []
 
 
-def test_four_three_deck_uses_narrower_frame(tmp_path):
-    # 4:3 content placeholder is narrower (8.5in vs 9in): identical content
-    # must never estimate SMALLER than on 16:9.
-    dense = [{"layout": "title_content", "title": "Dense",
-              "bullets": [f"Bullet {i} wraps in any reasonable frame width "
-                          "given this much operational detail text"
-                          for i in range(14)]}]
-    wide = run("pptx_create.py",
-               write_spec(tmp_path, {"slide_size": "16:9",
-                                     "slides": dense}),
-               str(tmp_path / "wide.pptx"))
-    tall = run("pptx_create.py",
-               write_spec(tmp_path, {"slide_size": "4:3", "slides": dense}),
-               str(tmp_path / "tall.pptx"))
-    w = wide["overflow_warnings"][0]["estimated_text_height_pt"]
-    t = tall["overflow_warnings"][0]["estimated_text_height_pt"]
-    assert t >= w
+def test_non_title_content_layouts_are_not_estimated(tmp_path):
+    # Only title_content uses the master-body sizing model; other layouts
+    # override level styles in their layout XML, so the guardrail must
+    # stay silent there rather than emit false positives.
+    dense = [{"layout": layout, "title": "Dense",
+              "bullets": [f"Bullet {i} would be flagged if estimated "
+                          "with master sizes" for i in range(20)]}
+             for layout in ("title", "section", "two_content")]
+    spec = {"slide_size": "16:9", "slides": dense}
+    result = run("pptx_create.py", write_spec(tmp_path, spec),
+                 str(tmp_path / "layouts.pptx"))
+    assert result["ok"] is True
+    assert result["overflow_warnings"] == []

--- a/skills/productivity/powerpoint/tests/test_pptx_overflow.py
+++ b/skills/productivity/powerpoint/tests/test_pptx_overflow.py
@@ -1,0 +1,237 @@
+"""Tests for the pptx overflow estimator (issue #91967: pptx_create.py
+silently clips dense bullet text past the body placeholder).
+
+Behavior contracts, not snapshots: assertions pin relations that must
+hold (warnings fire on known-overflow corpora, stay silent on known-safe
+ones, inherited sizes dominate explicit ones), verified against the
+properties of decks the create script actually writes.
+"""
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+SKILL = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPTS = os.path.join(SKILL, "scripts")
+sys.path.insert(0, SCRIPTS)
+
+from pptx_overflow import (  # noqa: E402
+    INHERITED_SIZE_PT,
+    effective_size_pt,
+    estimate_bullets_overflow,
+    paragraph_height_pt,
+    text_width_pt,
+    wrapped_line_count,
+)
+
+
+def run(script, *args):
+    env = dict(os.environ, LC_ALL="C", PYTHONIOENCODING="utf-8")
+    proc = subprocess.run(
+        [sys.executable, os.path.join(SCRIPTS, script), *args],
+        capture_output=True, text=True, encoding="utf-8", env=env)
+    assert proc.returncode == 0, f"{script} failed: {proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+def write_spec(tmp_path, spec):
+    path = tmp_path / "spec.json"
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(spec, fh)
+    return str(path)
+
+
+# --- inherited sizing matches the default-template master -------------------
+
+def test_inherited_sizes_match_default_master():
+    # Default python-pptx master bodyStyle: 32/28/24/20/20pt by level.
+    assert INHERITED_SIZE_PT == {0: 32.0, 1: 28.0, 2: 24.0, 3: 20.0, 4: 20.0}
+
+
+def test_effective_size_uses_level_inheritance_when_unspecified():
+    assert effective_size_pt({"text": "x"}) == 32.0
+    assert effective_size_pt({"text": "x", "level": 1}) == 28.0
+    assert effective_size_pt("bare string") == 32.0
+
+
+def test_explicit_size_overrides_inherited():
+    assert effective_size_pt({"text": "x", "size": 14}) == 14.0
+
+
+def test_size_null_and_zero_fall_back_to_inherited():
+    # style_run ignores falsy size; the estimator must agree (no TypeError).
+    assert effective_size_pt({"text": "x", "size": None}) == 32.0
+    assert effective_size_pt({"text": "x", "size": 0}) == 32.0
+
+
+def test_inherited_size_is_larger_than_old_assumption():
+    # Regression guard: level-0 inherited text is NOT 18pt; assuming it was
+    # caused false negatives on the motivating case.
+    assert effective_size_pt({"text": "x"}) > 18.0
+
+
+# --- wrapping behavior -------------------------------------------------------
+
+def test_short_bullet_is_single_line():
+    assert wrapped_line_count("Overview", 612.0) == 1
+
+
+def test_long_bullet_wraps_to_multiple_lines():
+    text = ("First major point about quarterly infrastructure spending "
+            "trends across every region we operate in this fiscal year, "
+            "including the carry-over commitments from last year's plan")
+    assert wrapped_line_count(text, 612.0) >= 3
+
+
+def test_hard_line_breaks_force_new_lines():
+    assert wrapped_line_count("a\nb\nc", 6000.0) == 3
+
+
+def test_cjk_text_wraps_by_character_width():
+    # CJK glyphs are ~1em wide: 10 chars at 32pt ~ 320pt > 100pt frame,
+    # and no spaces means wrap must still happen (char-level fallback).
+    assert wrapped_line_count("漢字" * 10, 100.0, 32.0) >= 3
+
+
+def test_cjk_char_is_full_width():
+    assert text_width_pt("漢", 32.0) == 32.0
+
+
+def test_oversized_unbreakable_token_gets_split():
+    assert wrapped_line_count("x" * 200, 100.0) > 1
+
+
+def test_empty_text_still_one_line():
+    assert wrapped_line_count("   ", 612.0) == 1
+
+
+def test_level_indent_reduces_usable_width():
+    # Same explicit size at both levels: deeper indent must wrap to more
+    # lines (or equal, never fewer).
+    flat = paragraph_height_pt("x " * 60, size_pt=18.0, level=0)
+    indented = paragraph_height_pt("x " * 60, size_pt=18.0, level=1)
+    assert indented >= flat
+
+
+# --- estimation decisions ----------------------------------------------------
+
+def test_no_warning_for_typical_safe_slide():
+    bullets = ["Overview", "Details", {"text": "Sub", "level": 1}]
+    assert estimate_bullets_overflow(bullets) is None
+
+
+def test_motivating_case_now_warns():
+    # The issue reproduction: ~11 mixed bullets at inherited sizes in the
+    # default placeholder. Under the correct 32pt inheritance this is
+    # borderline-to-over; the estimator must not silently pass it.
+    bullets = [
+        "First major point about quarterly infrastructure spending trends",
+        "Second major point covering headcount growth and onboarding costs",
+        "Third point walking through the vendor consolidation plan timeline",
+        "Fourth point detailing security review findings and remediation",
+        "Fifth point summarizing the budget ask and phased approval gates",
+        "Sixth point listing risks, mitigations, and open action owners",
+        {"text": "sub-item alpha with additional detail", "level": 1},
+        {"text": "sub-item beta with additional detail", "level": 1},
+        "Ninth point recapping decisions needed today",
+    ]
+    est = estimate_bullets_overflow(bullets)
+    assert est is not None, "motivating overflow case must warn"
+
+
+def test_dense_slide_warns_with_heights_ordered():
+    bullets = [f"Bullet {i} with a fairly long sentence of operational "
+               "detail that wraps onto a second line" for i in range(12)]
+    est = estimate_bullets_overflow(bullets)
+    assert est is not None
+    assert est["estimated_text_height_pt"] > est["frame_usable_height_pt"]
+    assert "hint" in est
+
+
+def test_smaller_font_monotonically_reduces_estimate():
+    text = f"Bullet {{i}} with plenty of wrapping detail text"
+    small = sum(paragraph_height_pt(text.format(i=i), size_pt=12)
+                for i in range(10))
+    big = sum(paragraph_height_pt(text.format(i=i), size_pt=32)
+              for i in range(10))
+    assert small < big
+
+
+def test_none_when_no_bullets():
+    assert estimate_bullets_overflow([]) is None
+
+
+# --- end-to-end through the create script ------------------------------------
+
+def test_create_reports_overflow_warning(tmp_path):
+    spec = {
+        "slide_size": "16:9",
+        "slides": [
+            {"layout": "title", "title": "Deck"},
+            {"layout": "title_content", "title": "Dense",
+             "bullets": [f"Bullet {i}: long operational detail sentence "
+                         "that wraps in the placeholder frame and then "
+                         "keeps going onto another rendered line"
+                         for i in range(16)]},
+        ],
+    }
+    result = run("pptx_create.py", write_spec(tmp_path, spec),
+                 str(tmp_path / "out.pptx"))
+    assert result["ok"] is True
+    warnings = result["overflow_warnings"]  # key always present
+    assert warnings, "dense deck must warn"
+    first = warnings[0]
+    assert first["slide_index"] == 1          # zero-based
+    assert first["estimated_text_height_pt"] > first["frame_usable_height_pt"]
+
+
+def test_create_clean_deck_reports_empty_warnings(tmp_path):
+    spec = {
+        "slide_size": "16:9",
+        "slides": [
+            {"layout": "title_content", "title": "Lean",
+             "bullets": ["One", "Two", {"text": "Two-a", "level": 1}]},
+        ],
+    }
+    result = run("pptx_create.py", write_spec(tmp_path, spec),
+                 str(tmp_path / "clean.pptx"))
+    assert result["ok"] is True
+    assert result["overflow_warnings"] == []
+
+
+def test_blank_layout_textbox_fallback_does_not_warn(tmp_path):
+    # Blank layout has no body placeholder -> auto-fitting textbox, which
+    # grows instead of clipping; the guardrail must stay out of its way.
+    spec = {
+        "slide_size": "16:9",
+        "slides": [
+            {"layout": "blank",
+             "bullets": [f"Bullet {i} long enough to be flagged if this "
+                         "were a fixed placeholder frame" for i in range(20)]},
+        ],
+    }
+    result = run("pptx_create.py", write_spec(tmp_path, spec),
+                 str(tmp_path / "blank.pptx"))
+    assert result["ok"] is True
+    assert result["overflow_warnings"] == []
+
+
+def test_four_three_deck_uses_narrower_frame(tmp_path):
+    # 4:3 content placeholder is narrower (8.5in vs 9in): identical content
+    # must never estimate SMALLER than on 16:9.
+    dense = [{"layout": "title_content", "title": "Dense",
+              "bullets": [f"Bullet {i} wraps in any reasonable frame width "
+                          "given this much operational detail text"
+                          for i in range(14)]}]
+    wide = run("pptx_create.py",
+               write_spec(tmp_path, {"slide_size": "16:9",
+                                     "slides": dense}),
+               str(tmp_path / "wide.pptx"))
+    tall = run("pptx_create.py",
+               write_spec(tmp_path, {"slide_size": "4:3", "slides": dense}),
+               str(tmp_path / "tall.pptx"))
+    w = wide["overflow_warnings"][0]["estimated_text_height_pt"]
+    t = tall["overflow_warnings"][0]["estimated_text_height_pt"]
+    assert t >= w

--- a/skills/productivity/powerpoint/tests/test_pptx_overflow.py
+++ b/skills/productivity/powerpoint/tests/test_pptx_overflow.py
@@ -246,3 +246,26 @@ def test_non_title_content_layouts_are_not_estimated(tmp_path):
                  str(tmp_path / "layouts.pptx"))
     assert result["ok"] is True
     assert result["overflow_warnings"] == []
+
+
+def test_unknown_layout_name_resolving_to_title_content_still_warns(tmp_path):
+    # Unknown layout names resolve to the Title and Content layout (index
+    # 1) — the warning gate must follow the RESOLVED layout, not the raw
+    # spec string, or overflowing content escapes silently.
+    spec = {
+        "slide_size": "16:9",
+        "slides": [
+            {"layout": "title_conent",  # typo: resolves to title_content
+             "title": "Dense",
+             "bullets": [f"Bullet {i}: long operational detail sentence "
+                         "that wraps in the placeholder frame and then "
+                         "keeps going onto another rendered line"
+                         for i in range(16)]},
+        ],
+    }
+    result = run("pptx_create.py", write_spec(tmp_path, spec),
+                 str(tmp_path / "typo.pptx"))
+    assert result["ok"] is True
+    assert result["overflow_warnings"], (
+        "content on a slide that RESOLVES to title_content must warn even "
+        "when the spec's layout name is unknown")

--- a/tests/skills/test_powerpoint_skill.py
+++ b/tests/skills/test_powerpoint_skill.py
@@ -10,14 +10,16 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
 from pptx import Presentation
 
-SKILL = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-SCRIPTS = os.path.join(SKILL, "scripts")
-sys.path.insert(0, SCRIPTS)
+REPO = Path(__file__).resolve().parents[2]
+SKILL = REPO / "skills" / "productivity" / "powerpoint"
+SCRIPTS = SKILL / "scripts"
+sys.path.insert(0, str(SCRIPTS))
 
 from pptx_overflow import (  # noqa: E402
     INHERITED_SIZE_PT,
@@ -32,7 +34,7 @@ from pptx_overflow import (  # noqa: E402
 def run(script, *args):
     env = dict(os.environ, LC_ALL="C", PYTHONIOENCODING="utf-8")
     proc = subprocess.run(
-        [sys.executable, os.path.join(SCRIPTS, script), *args],
+        [sys.executable, str(SCRIPTS / script), *args],
         capture_output=True, text=True, encoding="utf-8", env=env)
     assert proc.returncode == 0, f"{script} failed: {proc.stderr}"
     return json.loads(proc.stdout)

--- a/tests/skills/test_powerpoint_skill.py
+++ b/tests/skills/test_powerpoint_skill.py
@@ -1,5 +1,5 @@
 """Tests for the pptx overflow estimator (issue #91967: pptx_create.py
-silently clips dense bullet text past the body placeholder).
+silently overfills dense body-placeholder content).
 
 Behavior contracts, not snapshots: assertions pin relations that must
 hold (warnings fire on known-overflow corpora, stay silent on known-safe
@@ -22,6 +22,7 @@ SCRIPTS = SKILL / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 from pptx_overflow import (  # noqa: E402
+    INHERITED_INDENT_IN,
     INHERITED_SIZE_PT,
     effective_size_pt,
     estimate_bullets_overflow,
@@ -65,6 +66,29 @@ def test_inherited_sizes_match_default_master():
         assert actual == size, (
             f"level {level}: estimator assumes {size}pt, master says "
             f"{actual}pt — update INHERITED_SIZE_PT")
+        actual_indent = int(lvl.get("marL")) / 914400.0
+        assert actual_indent == pytest.approx(
+            INHERITED_INDENT_IN[level], abs=0.0001
+        ), (
+            f"level {level}: estimator assumes "
+            f"{INHERITED_INDENT_IN[level]}in, master says "
+            f"{actual_indent}in — update INHERITED_INDENT_IN"
+        )
+
+
+def test_title_content_layout_does_not_override_master_body_levels():
+    # The estimator uses master bodyStyle sizes/indents only for this
+    # layout. Pin the OOXML cascade assumption: its content placeholder's
+    # list style must not introduce per-level overrides.
+    prs = Presentation()
+    ns = {"a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+          "p": "http://schemas.openxmlformats.org/presentationml/2006/main"}
+    body = next(ph for ph in prs.slide_layouts[1].placeholders
+                if ph.placeholder_format.idx == 1)
+    layout_style = body._element.find("p:txBody/a:lstStyle", ns)
+    assert layout_style is not None
+    assert not any(child.tag.rsplit("}", 1)[-1].startswith("lvl")
+                   for child in layout_style)
 
 
 def test_effective_size_uses_level_inheritance_when_unspecified():
@@ -164,7 +188,7 @@ def test_dense_slide_warns_with_heights_ordered():
     est = estimate_bullets_overflow(bullets)
     assert est is not None
     assert est["estimated_text_height_pt"] > est["frame_usable_height_pt"]
-    assert "hint" in est
+    assert "auto-shrunk or clipped" in est["hint"]
 
 
 def test_smaller_font_monotonically_reduces_estimate():


### PR DESCRIPTION
Fixes #91967

## What

`pptx_create.py` now estimates the unscaled rendered height of bullet content against the nominal capacity of its body placeholder and reports likely overfill in its JSON output.

PowerPoint normally auto-shrinks an overfilled default content placeholder; other renderers or templates may clip it. Either outcome can silently produce an unreadable slide while the outline still contains every bullet. The warning is deliberately a first-line guardrail, not renderer-backed proof.

```json
{"ok": true, "output": "deck.pptx", "slides": 2,
 "overflow_warnings": [{"slide_index": 1, "title": "Dense",
   "estimated_text_height_pt": 628.9, "frame_usable_height_pt": 349.2,
   "hint": "content exceeds the body placeholder's nominal text capacity ..."}]}
```

- New `scripts/pptx_overflow.py`: conservative heuristic estimator with per-character widths, hard-line-break handling, CJK/full-width handling, oversized-token splitting, and master-inherited sizes/indents by bullet level.
- `pptx_create.py`: always returns `overflow_warnings`; warnings include a zero-based slide index, title, estimated height, frame height, and actionable render/split/shorten/shrink guidance.
- Estimation is scoped to slides that resolve to `title_content`, whose default layout does not override the master body levels. Other layouts have different style cascades; fallback textboxes auto-grow and are excluded.
- `SKILL.md`: explains auto-shrink versus possible clipping and makes render verification mandatory for every warning.

## Scope decisions

- **Guardrail, not auto-fitting or renderer proof:** creation remains offline and deterministic. The warning tells the agent where to render-check before shipping.
- **Conservative bias:** a false positive costs one render check; a false negative leaves an unreadable slide unnoticed.

## Evidence at exact head

Head: `f9052855b01f3ddef2e77d10258eb8b221413e9a`

- `scripts/run_tests.sh tests/skills/test_powerpoint_skill.py -q` → **24 passed**.
- `scripts/run_tests.sh skills/productivity/powerpoint/tests/test_powerpoint_skill.py -q` → **21 passed**.
- PowerPoint COM on a generated dense default content placeholder: `TextFrame2.AutoSize = 2` (`TextToFitShape`), nominal font `32pt`, text `BoundHeight = 1513pt`, shape `Height = 356.4pt`. This directly corrected an earlier overclaim that PowerPoint always clips.
- Default-template OOXML tests bind both master size/indent tables and the `title_content` layout's absence of per-level overrides.
- Authenticated `claude-sonnet-5` exact-SHA review: **APPROVE**.
- `thinkingmachines/inkling:free` exact-SHA review: **APPROVE** (live OpenRouter prompt/completion prices both verified `0`).

AI-assisted PR: drafted with AI assistance, independently verified and approved for submission by Conor Bronsdon.
