### PR TITLE
fix(bedrock): route 3 non-runtime call sites through the region chokepoint

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -555,10 +555,13 @@ def _interactive_auth() -> None:
 
     # Show AWS Bedrock credential status (not in the pool — uses boto3 chain)
     try:
-        from agent.bedrock_adapter import has_aws_credentials, resolve_aws_auth_env_var, resolve_bedrock_region
+        from agent.bedrock_adapter import has_aws_credentials, resolve_aws_auth_env_var, resolve_bedrock_runtime_region
         if has_aws_credentials():
             auth_source = resolve_aws_auth_env_var() or "unknown"
-            region = resolve_bedrock_region()
+            # Config-first resolver, matching what the runtime actually uses —
+            # the bare env/profile-only resolver can disagree with a pinned
+            # bedrock.region in config.yaml and display the wrong region.
+            region = resolve_bedrock_runtime_region()
             print("bedrock (AWS SDK credential chain):")
             print(f"  Auth: {auth_source}")
             print(f"  Region: {region}")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2692,14 +2692,18 @@ def run_doctor(args):
             from agent.bedrock_adapter import (
                 has_aws_credentials,
                 resolve_aws_auth_env_var,
-                resolve_bedrock_region,
+                resolve_bedrock_runtime_region,
             )
         except ImportError:
             return _ConnectivityResult("AWS Bedrock", [], [])
         if not has_aws_credentials():
             return _ConnectivityResult("AWS Bedrock", [], [])
         auth_var = resolve_aws_auth_env_var()
-        region = resolve_bedrock_region()
+        # Config-first resolver (bedrock.region, then AWS env/profile), not
+        # the bare env/profile-only resolver — otherwise a user who pinned
+        # bedrock.region in config.yaml sees doctor probe (and report "✓
+        # for") a different region than the one the runtime actually calls.
+        region = resolve_bedrock_runtime_region()
         label = "AWS Bedrock".ljust(20)
         try:
             import boto3

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2453,7 +2453,7 @@ def _model_flow_bedrock(config, current_model=""):
         from agent.bedrock_adapter import (
             has_aws_credentials,
             resolve_aws_auth_env_var,
-            resolve_bedrock_region,
+            resolve_bedrock_runtime_region,
             discover_bedrock_models,
         )
     except ImportError:
@@ -2474,8 +2474,12 @@ def _model_flow_bedrock(config, current_model=""):
         print("  AWS credentials: boto3 default chain (instance role / SSO)")
     print()
 
-    # 2. Region selection
-    current_region = resolve_bedrock_region()
+    # 2. Region selection. Config-first resolver: on a reconfigure, a
+    # bedrock.region already pinned in config.yaml must win over the ambient
+    # AWS env/profile default, or an accepted default here (bare Enter)
+    # re-saves the wrong region below and silently regresses a previously
+    # correct config-pinned region.
+    current_region = resolve_bedrock_runtime_region()
     try:
         region_input = line_input(f"  AWS Region [{current_region}]: ").strip()
     except (KeyboardInterrupt, EOFError):

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -840,3 +840,31 @@ def test_auth_remove_env_seeded_dotenv_with_bom_no_shell_hint(tmp_path, monkeypa
     out = capsys.readouterr().out
     assert "Cleared DEEPSEEK_API_KEY from .env" in out
     assert "still set in your shell environment" not in out
+
+
+def test_interactive_auth_bedrock_region_uses_runtime_resolver(tmp_path, monkeypatch, capsys):
+    """`hermes auth`'s bare Bedrock status line must show the same region the
+    runtime actually calls (config-first resolve_bedrock_runtime_region), not
+    the bare env/profile-only resolve_bedrock_region — otherwise a user who
+    pinned bedrock.region in config.yaml sees a different region here than
+    what inference/model-discovery actually use."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    import agent.bedrock_adapter as ba
+
+    monkeypatch.setattr(ba, "has_aws_credentials", lambda: True)
+    monkeypatch.setattr(ba, "resolve_aws_auth_env_var", lambda: "AWS_BEARER_TOKEN_BEDROCK")
+    # Deliberately distinct sentinels: the config-first resolver must win.
+    monkeypatch.setattr(ba, "resolve_bedrock_runtime_region", lambda: "eu-central-1")
+    monkeypatch.setattr(ba, "resolve_bedrock_region", lambda: "us-east-1")
+
+    # Short-circuit the trailing interactive menu.
+    monkeypatch.setattr("builtins.input", lambda *a, **kw: (_ for _ in ()).throw(EOFError()))
+
+    from hermes_cli.auth_commands import _interactive_auth
+    _interactive_auth()
+
+    out = capsys.readouterr().out
+    assert "Region: eu-central-1" in out
+    assert "us-east-1" not in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -947,6 +947,67 @@ def test_run_doctor_dashscope_retries_china_endpoint_after_intl_unauthorized(mon
     )
 
 
+def test_run_doctor_bedrock_probe_uses_runtime_region_resolver(monkeypatch, tmp_path):
+    """AWS Bedrock connectivity probe must show/probe the same region the
+    runtime actually calls (config-first resolve_bedrock_runtime_region),
+    not the bare env/profile-only resolve_bedrock_region — otherwise doctor
+    can show a green ✓ for a region the runtime never talks to."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    import agent.bedrock_adapter as ba
+    monkeypatch.setattr(ba, "has_aws_credentials", lambda: True)
+    monkeypatch.setattr(ba, "resolve_aws_auth_env_var", lambda: "AWS_BEARER_TOKEN_BEDROCK")
+    # Deliberately distinct sentinels: the config-first resolver must win.
+    monkeypatch.setattr(ba, "resolve_bedrock_runtime_region", lambda: "eu-central-1")
+    monkeypatch.setattr(ba, "resolve_bedrock_region", lambda: "us-east-1")
+
+    calls: list[tuple] = []
+
+    class _FakeBedrockClient:
+        def list_foundation_models(self):
+            return {"modelSummaries": [{"modelId": "anthropic.claude-3"}]}
+
+    import boto3
+
+    def fake_boto3_client(service_name, region_name=None, config=None):
+        calls.append((service_name, region_name))
+        return _FakeBedrockClient()
+
+    monkeypatch.setattr(boto3, "client", fake_boto3_client)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert ("bedrock", "eu-central-1") in calls
+    assert not any(region == "us-east-1" for _svc, region in calls)
+    assert "eu-central-1" in out
+    assert "us-east-1" not in out
+
+
 @pytest.mark.parametrize("base_url", [None, "https://opencode.ai/zen/go/v1"])
 def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path, base_url):
     home = tmp_path / ".hermes"

--- a/tests/hermes_cli/test_model_flow_pooled_credentials.py
+++ b/tests/hermes_cli/test_model_flow_pooled_credentials.py
@@ -71,3 +71,35 @@ def test_bedrock_flow_sees_pool_key_when_no_env(monkeypatch, capsys):
     out = capsys.readouterr().out
     # The flow should show the pool-backed key, not prompt for a new one
     assert "pool-secret" in out[:200] or "pool-sec" in out[:200]
+
+
+def test_bedrock_flow_region_prompt_uses_runtime_resolver(monkeypatch, capsys):
+    """The interactive Bedrock setup/reconfigure wizard's region-prompt
+    default must come from the config-first resolve_bedrock_runtime_region,
+    not the bare env/profile-only resolve_bedrock_region — otherwise
+    reconfiguring an already-configured Bedrock provider (bedrock.region
+    pinned in config.yaml, but a different ambient AWS_REGION/profile set)
+    shows the wrong default, and accepting it with a bare Enter re-saves the
+    wrong region, silently regressing the config-pinned one (#199 in
+    _model_flow_bedrock writes bedrock_cfg["region"] = region verbatim)."""
+    from hermes_cli.model_setup_flows import _model_flow_bedrock
+
+    import agent.bedrock_adapter as ba
+
+    monkeypatch.setattr(ba, "has_aws_credentials", lambda: True)
+    monkeypatch.setattr(ba, "resolve_aws_auth_env_var", lambda: "AWS_BEARER_TOKEN_BEDROCK")
+    # Deliberately distinct sentinels: the config-first resolver must win.
+    monkeypatch.setattr(ba, "resolve_bedrock_runtime_region", lambda: "eu-central-1")
+    monkeypatch.setattr(ba, "resolve_bedrock_region", lambda: "us-east-1")
+
+    captured_prompts: list[str] = []
+
+    def fake_input(prompt_text="", *a, **kw):
+        captured_prompts.append(prompt_text)
+        raise EOFError()  # bail out right after the region prompt renders
+
+    with patch("builtins.input", side_effect=fake_input):
+        _model_flow_bedrock({}, "")
+
+    assert any("[eu-central-1]" in p for p in captured_prompts), captured_prompts
+    assert not any("us-east-1" in p for p in captured_prompts), captured_prompts


### PR DESCRIPTION
## What this fixes

`resolve_bedrock_runtime_region()` (`5cb7b521cf`, merged this week) became the single Bedrock region chokepoint: `bedrock.region` from config first, then the bare env/profile-only `resolve_bedrock_region()` as fallback. Its own docstring states the intended scope directly:

> Every non-runtime call site that constructs a Bedrock endpoint (auxiliary client resolution, model discovery for the picker) must use this helper — using bare `resolve_bedrock_region()` there lets auxiliary calls leave the primary runtime's configured region when `bedrock.region` and the ambient AWS env/profile disagree.

Three call sites still used the bare resolver directly:

### 1. `hermes_cli/doctor.py::_probe_bedrock()`
`hermes doctor`'s AWS Bedrock connectivity probe resolves region with the bare resolver, then both prints it in the success line **and uses it for the actual `boto3.client("bedrock", region_name=region)` call**. If a user has `bedrock.region: eu-central-1` pinned in `config.yaml` while their ambient `AWS_REGION`/botocore profile says something else, `doctor` probes and reports "✓" for a region the runtime never actually calls.

### 2. `hermes_cli/auth_commands.py::_interactive_auth()`
Bare `hermes auth` prints a `Region: <region>` line (and calls `sts.get_caller_identity()` in that region) using the bare resolver — same divergence risk, purely informational display.

### 3. `hermes_cli/model_setup_flows.py::_model_flow_bedrock()`
The interactive Bedrock setup/reconfigure wizard's region prompt (`AWS Region [{current_region}]:`) defaults from the bare resolver. This one is **not just cosmetic**: on a reconfigure of an already-configured Bedrock provider, the chosen region — the wrong default on a bare Enter — gets written straight back into config a few lines later:

```python
bedrock_cfg["region"] = region
save_config(cfg)
```

A user re-running setup (e.g. to switch auth method or model) with a divergent ambient AWS region would silently regress their previously-correct `bedrock.region` back to the ambient value on a plain Enter.

## Fix

Swap all three to `resolve_bedrock_runtime_region()` (no required args — it self-loads config read-only when none is passed), matching the pattern the docstring already prescribes.

## Tests

One regression test per site, each patching `resolve_bedrock_runtime_region` and `resolve_bedrock_region` to **distinct sentinel regions** and asserting only the runtime-resolver's value appears in the observable output:
- `test_run_doctor_bedrock_probe_uses_runtime_region_resolver` — asserts the mocked `boto3.client(region_name=...)` call and the printed probe line both use the runtime-resolved region.
- `test_interactive_auth_bedrock_region_uses_runtime_resolver` — asserts the printed `Region:` line.
- `test_bedrock_flow_region_prompt_uses_runtime_resolver` — asserts the rendered `AWS Region [...]:` prompt text.

**Mutation-verify:** stashed all three production fixes together and confirmed all three new tests fail, each showing the wrong (bare-resolver) region reaching the observable surface (e.g. `assert ('bedrock', 'eu-central-1') in [('bedrock', 'us-east-1')]`).

Ran the broader Bedrock-adjacent suite — `test_doctor.py`, `test_auth_commands.py`, `test_model_flow_pooled_credentials.py`, `test_bedrock_adapter.py`, `test_bedrock_model_picker.py`, `test_bedrock_region_scoped_picker.py`, `test_bedrock_integration.py` (194 tests) — and `ruff check` on all six changed files; both clean.

## Deliberately out of scope

`agent/model_metadata.py`'s Bedrock context-length probe has a fourth bare `resolve_bedrock_region()` call (the base_url-less fallback path), reachable via `auxiliary_client._candidate_context_window()` for a first-class `provider: bedrock` fallback-chain entry. Left out of this PR on purpose — it sits on a live-network probe path with a static-table fallback that softens the concrete wrong-data impact, and it's a separate, less-certain finding from a different investigation than the three sites above.

## Competing-PR note

Open PR #87215 ("mark Bedrock connectivity probe as control-plane only") touches the same `_probe_bedrock()` function — it moves it to module level and adds a "control plane only" annotation, but its version **still calls the bare `resolve_bedrock_region()`** (doesn't fix this bug). Textual overlap on the same function body is likely; whichever lands first, the other will need a small rebase. No semantic conflict — the two changes are complementary (annotation clarity vs. region correctness).