### PR TITLE
feat: add native Fly Sprites terminal backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), OpenR
 <tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
 <tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
 <tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
-<tr><td><b>Runs anywhere, not just your laptop</b></td><td>Seven terminal backends — local, Docker, SSH, Singularity, Modal, Daytona, and Vercel Sandbox. Daytona and Modal offer serverless persistence — your agent's environment hibernates when idle and wakes on demand, costing nearly nothing between sessions. Run it on a $5 VPS or a GPU cluster.</td></tr>
+<tr><td><b>Runs anywhere, not just on your laptop</b></td><td>Eight terminal backends — local, Docker, SSH, Singularity, Modal, Daytona, Fly Sprites, and Vercel Sandbox. Cloud backends offer persistent remote execution that wakes on demand. Run it on a $5 VPS or a GPU cluster.</td></tr>
 <tr><td><b>Research-ready</b></td><td>Batch trajectory generation, trajectory compression for training the next generation of tool-calling models.</td></tr>
 </table>
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1186,7 +1186,7 @@ WSL_ENVIRONMENT_HINT = (
 # runs. For these backends, host info (Windows/Linux/macOS, $HOME, cwd) is
 # misleading — the agent should only see the machine it can actually touch.
 _REMOTE_TERMINAL_BACKENDS = frozenset({
-    "docker", "singularity", "modal", "daytona", "ssh",
+    "docker", "singularity", "modal", "daytona", "sprites", "ssh",
     "vercel_sandbox", "managed_modal",
 })
 
@@ -1309,7 +1309,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
             }
 
         container_config = None
-        if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+        if env_type in {"docker", "singularity", "modal", "daytona", "sprites", "vercel_sandbox"}:
             container_config = {
                 "container_cpu": config.get("container_cpu", 1),
                 "container_memory": config.get("container_memory", 5120),
@@ -1400,7 +1400,7 @@ def build_environment_hints() -> str:
       and a Windows-only note that `terminal` shells out to bash, not
       PowerShell).
     - For **remote / sandbox** terminal backends (docker, singularity,
-      modal, daytona, ssh, vercel_sandbox): host info is **suppressed**
+      modal, daytona, sprites, ssh, vercel_sandbox): host info is **suppressed**
       because the agent's tools can't touch the host — only the backend
       matters. A live probe inside the backend reports its OS, user, $HOME,
       and cwd. Falls back to a static summary if the probe fails.

--- a/cli.py
+++ b/cli.py
@@ -670,7 +670,7 @@ def load_cli_config() -> Dict[str, Any]:
         "ssh_user": "TERMINAL_SSH_USER",
         "ssh_port": "TERMINAL_SSH_PORT",
         "ssh_key": "TERMINAL_SSH_KEY",
-        # Container resource config (docker, singularity, modal, daytona, vercel_sandbox -- ignored for local/ssh)
+        # Container resource config (docker, singularity, modal, daytona, sprites, vercel_sandbox -- ignored for local/ssh)
         "container_cpu": "TERMINAL_CONTAINER_CPU",
         "container_memory": "TERMINAL_CONTAINER_MEMORY",
         "container_disk": "TERMINAL_CONTAINER_DISK",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4710,6 +4710,9 @@ def show_config():
         print(f"  Daytona image: {terminal.get('daytona_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
         daytona_key = get_env_value('DAYTONA_API_KEY')
         print(f"  API key:      {'configured' if daytona_key else '(not set)'}")
+    elif terminal.get('backend') == 'sprites':
+        print(f"  Sprite token: {'configured' if get_env_value('SPRITE_TOKEN') else '(not set)'}")
+        print(f"  API URL:      {get_env_value('SPRITES_API_URL') or 'https://api.sprites.dev'}")
     elif terminal.get('backend') == 'vercel_sandbox':
         print(f"  Vercel runtime: {terminal.get('vercel_runtime', 'node24')}")
         print(f"  Vercel auth:    {'configured' if get_env_value('VERCEL_OIDC_TOKEN') or (get_env_value('VERCEL_TOKEN') and get_env_value('VERCEL_PROJECT_ID') and get_env_value('VERCEL_TEAM_ID')) else '(not set)'}")

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -448,7 +448,7 @@ DEFAULT_CONFIG = {
         # Vercel Sandbox runtime (vercel_sandbox backend only).
         # Supported: node24, node22, python3.13.
         "vercel_runtime": "node24",
-        # Container resource limits (docker, singularity, modal, daytona, vercel_sandbox — ignored for local/ssh)
+        # Container resource limits (docker, singularity, modal, daytona, sprites, vercel_sandbox — ignored for local/ssh)
         "container_cpu": 1,
         "container_memory": 5120,       # MB (default 5GB)
         "container_disk": 51200,        # MB (default 50GB)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2179,6 +2179,27 @@ def run_doctor(args):
                 issues,
             )
 
+    # Fly Sprites (if using sprites backend)
+    if terminal_env == "sprites":
+        if os.getenv("SPRITE_TOKEN"):
+            check_ok("Fly Sprites token", "(configured)")
+        else:
+            _fail_and_issue(
+                "SPRITE_TOKEN not set",
+                "(required for TERMINAL_ENV=sprites)",
+                "Set SPRITE_TOKEN in ~/.hermes/.env or run `hermes setup terminal`",
+                issues,
+            )
+        if importlib.util.find_spec("sprites") is not None:
+            check_ok("sprites-py SDK", "(installed)")
+        else:
+            _fail_and_issue(
+                "sprites-py SDK not installed",
+                "(pip install 'hermes-agent[sprites]')",
+                "Install the Sprites optional dependency: pip install 'hermes-agent[sprites]'",
+                issues,
+            )
+
     # Vercel Sandbox (if using vercel_sandbox backend)
     if terminal_env == "vercel_sandbox":
         runtime = os.getenv("TERMINAL_VERCEL_RUNTIME", "node24").strip() or "node24"

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1343,11 +1343,12 @@ def setup_terminal_backend(config: dict):
         "SSH - run on a remote machine",
         "Daytona - persistent cloud development environment",
         "Vercel Sandbox - cloud microVM with snapshot filesystem persistence",
+        "Fly Sprites - persistent cloud execution environment",
     ]
-    idx_to_backend = {0: "local", 1: "docker", 2: "modal", 3: "ssh", 4: "daytona", 5: "vercel_sandbox"}
-    backend_to_idx = {"local": 0, "docker": 1, "modal": 2, "ssh": 3, "daytona": 4, "vercel_sandbox": 5}
+    idx_to_backend = {0: "local", 1: "docker", 2: "modal", 3: "ssh", 4: "daytona", 5: "vercel_sandbox", 6: "sprites"}
+    backend_to_idx = {"local": 0, "docker": 1, "modal": 2, "ssh": 3, "daytona": 4, "vercel_sandbox": 5, "sprites": 6}
 
-    next_idx = 6
+    next_idx = 7
     if is_linux:
         terminal_choices.append("Singularity/Apptainer - HPC-friendly container")
         idx_to_backend[next_idx] = "singularity"
@@ -1594,6 +1595,26 @@ def setup_terminal_backend(config: dict):
                     print_info(f"  Error: {result.stderr.strip().splitlines()[-1]}")
 
         _prompt_vercel_sandbox_settings(config)
+
+    elif selected_backend == "sprites":
+        print_success("Terminal backend: Fly Sprites")
+        print_info("Persistent Fly cloud environments. Each task gets a deterministic Sprite.")
+        print_info("Requires the optional SDK: pip install 'hermes-agent[sprites]'")
+        try:
+            __import__("sprites")
+        except ImportError:
+            from tools.lazy_deps import ensure
+
+            try:
+                ensure("terminal.sprites", prompt=False)
+                print_success("sprites-py SDK installed")
+            except Exception as exc:
+                print_warning(f"SDK install failed: {exc}")
+                print_info("Install manually: pip install 'hermes-agent[sprites]'")
+
+        token = prompt("    Sprite token", get_env_value("SPRITE_TOKEN") or "", password=True)
+        if token:
+            save_env_value("SPRITE_TOKEN", token)
 
     elif selected_backend == "ssh":
         print_success("Terminal backend: SSH")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -44,6 +44,19 @@ def redact_key(key: str) -> str:
     return mask_secret(key, empty=color("(not set)", Colors.DIM))
 
 
+def _sprites_status_lines() -> list[str]:
+    """Return non-secret status details for the Fly Sprites backend."""
+    token = bool((os.getenv("SPRITE_TOKEN") or "").strip())
+    api_url = (os.getenv("SPRITES_API_URL") or "").strip() or "https://api.sprites.dev"
+    sdk_ok = importlib.util.find_spec("sprites") is not None
+    sdk_label = "installed" if sdk_ok else "missing (install: pip install 'hermes-agent[sprites]')"
+    return [
+        f"  Token:        {'configured' if token else 'not configured'}",
+        f"  API URL:      {api_url}",
+        f"  SDK:          {sdk_label}",
+    ]
+
+
 def _format_iso_timestamp(value) -> str:
     """Format ISO timestamps for status output, converting to local timezone."""
     if not value or not isinstance(value, str):
@@ -461,6 +474,9 @@ def show_status(args):
     elif terminal_env == "daytona":
         daytona_image = os.getenv("TERMINAL_DAYTONA_IMAGE", "nikolaik/python-nodejs:python3.11-nodejs20")
         print(f"  Daytona Image: {daytona_image}")
+    elif terminal_env == "sprites":
+        for line in _sprites_status_lines():
+            print(line)
     elif terminal_env == "vercel_sandbox":
         runtime = os.getenv("TERMINAL_VERCEL_RUNTIME") or terminal_cfg.get("vercel_runtime") or "node24"
         persist = os.getenv("TERMINAL_CONTAINER_PERSISTENT")

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -147,7 +147,7 @@ TIPS = [
     "/moa routes one hard prompt through your configured Mixture of Agents model set.",
     "Terminal commands support background mode with notify_on_complete for long-running tasks.",
     "Terminal background processes support watch_patterns to alert on specific output lines.",
-    "The terminal tool supports 6 backends: local, Docker, SSH, Modal, Daytona, and Singularity.",
+    "The terminal tool supports local, Docker, SSH, Modal, Daytona, Fly Sprites, Vercel Sandbox, and Singularity backends.",
 
     # --- Profiles ---
     "Each profile gets its own config, API keys, memory, sessions, skills, and cron jobs.",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1046,7 +1046,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "terminal.backend": {
         "type": "select",
         "description": "Terminal execution backend",
-        "options": ["local", "docker", "ssh", "modal", "daytona", "vercel_sandbox", "singularity"],
+        "options": ["local", "docker", "ssh", "modal", "daytona", "sprites", "vercel_sandbox", "singularity"],
     },
     "terminal.vercel_runtime": {
         "type": "select",
@@ -15096,6 +15096,11 @@ _TERMINAL_BACKENDS: List[Dict[str, str]] = [
         "description": "Run commands in a Daytona cloud sandbox.",
     },
     {
+        "name": "sprites",
+        "label": "Fly Sprites",
+        "description": "Run commands in a persistent Fly Sprite cloud environment.",
+    },
+    {
         "name": "ssh",
         "label": "SSH",
         "description": "Run commands on a remote host over SSH.",
@@ -15202,6 +15207,17 @@ def _probe_daytona_backend() -> tuple:
     return ("needs_setup", "Set DAYTONA_API_KEY to use the Daytona backend.")
 
 
+def _probe_sprites_backend() -> tuple:
+    try:
+        from hermes_cli.config import get_env_value
+
+        if get_env_value("SPRITE_TOKEN"):
+            return ("ready", "")
+    except Exception:
+        pass
+    return ("needs_setup", "Set SPRITE_TOKEN to use the Fly Sprites backend.")
+
+
 def _probe_terminal_backend(name: str, terminal_cfg: dict) -> tuple:
     """Return ``(status, detail)`` for one backend. Never raises."""
     try:
@@ -15217,6 +15233,8 @@ def _probe_terminal_backend(name: str, terminal_cfg: dict) -> tuple:
             return _probe_modal_backend()
         if name == "daytona":
             return _probe_daytona_backend()
+        if name == "sprites":
+            return _probe_sprites_backend()
         return ("unavailable", f"Unknown backend: {name}")
     except Exception as exc:  # pragma: no cover — belt-and-braces guard
         return ("unavailable", f"Probe failed: {exc}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ fal = ["fal-client==0.13.1"]
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
+sprites = ["sprites-py==0.5.0"]
 vercel = ["vercel==0.7.2"]
 hindsight = ["hindsight-client==0.6.1"]
 dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0", "httpx2==2.7.0", "starlette==1.3.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==83.0.0"]  # starlette: CVE-2026-48710; setuptools: 83 (torch >=2.13 requires setuptools 83)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -876,7 +876,7 @@ class TestEnvironmentHints:
     def test_remote_backend_list_covers_known_sandboxes(self):
         """Regression guard: if someone adds a remote backend, they must list it here."""
         import agent.prompt_builder as _pb
-        for backend in ("docker", "singularity", "modal", "daytona", "ssh", "vercel_sandbox"):
+        for backend in ("docker", "singularity", "modal", "daytona", "sprites", "ssh", "vercel_sandbox"):
             assert backend in _pb._REMOTE_TERMINAL_BACKENDS, (
                 f"{backend!r} must be in _REMOTE_TERMINAL_BACKENDS so its host "
                 f"info is suppressed in the system prompt"

--- a/tests/hermes_cli/test_sprites_wiring.py
+++ b/tests/hermes_cli/test_sprites_wiring.py
@@ -1,0 +1,69 @@
+"""Cross-surface wiring tests for the Fly Sprites terminal backend."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+def test_sprites_dependency_is_exact_and_lazy():
+    import tomllib
+
+    from tools.lazy_deps import LAZY_DEPS
+
+    with open("pyproject.toml", "rb") as handle:
+        metadata = tomllib.load(handle)
+
+    assert metadata["project"]["optional-dependencies"]["sprites"] == [
+        "sprites-py==0.5.0"
+    ]
+    assert LAZY_DEPS["terminal.sprites"] == ("sprites-py==0.5.0",)
+
+
+def test_sprites_is_enumerated_as_remote_container_backend():
+    from agent.prompt_builder import _REMOTE_TERMINAL_BACKENDS
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+    from hermes_cli.web_server import CONFIG_SCHEMA, _TERMINAL_BACKEND_NAMES
+    from tools.terminal_tool import _CONTAINER_BACKENDS
+
+    assert DEFAULT_CONFIG["terminal"]["backend"] == "local"
+    assert "sprites" in _CONTAINER_BACKENDS
+    assert "sprites" in _REMOTE_TERMINAL_BACKENDS
+    assert "sprites" in CONFIG_SCHEMA["terminal.backend"]["options"]
+    assert "sprites" in _TERMINAL_BACKEND_NAMES
+
+
+def test_setup_sprites_saves_host_credentials(tmp_path, monkeypatch):
+    import hermes_cli.setup as setup
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("platform.system", lambda: "Darwin")
+    monkeypatch.setitem(sys.modules, "sprites", types.ModuleType("sprites"))
+    monkeypatch.setattr(setup, "prompt_choice", lambda *args, **kwargs: 6)
+    answers = iter(["sprite-token"])
+    monkeypatch.setattr(setup, "prompt", lambda *args, **kwargs: next(answers))
+    monkeypatch.setattr(setup, "save_config", lambda config: None)
+    monkeypatch.setattr(setup, "print_header", lambda *args, **kwargs: None)
+    monkeypatch.setattr(setup, "print_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(setup, "print_success", lambda *args, **kwargs: None)
+
+    config = {"terminal": {"backend": "local"}}
+    setup.setup_terminal_backend(config)
+
+    assert config["terminal"]["backend"] == "sprites"
+    assert setup.get_env_value("SPRITE_TOKEN") == "sprite-token"
+    assert setup.get_env_value("TERMINAL_ENV") == "sprites"
+
+
+def test_status_reports_sprites_without_exposing_token(monkeypatch):
+    import hermes_cli.status as status
+
+    monkeypatch.setenv("SPRITE_TOKEN", "super-secret-token")
+    monkeypatch.setenv("SPRITES_API_URL", "https://sprites.example/api")
+
+    lines = status._sprites_status_lines()
+    output = "\n".join(lines)
+
+    assert "configured" in output
+    assert "https://sprites.example/api" in output
+    assert "super-secret-token" not in output

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -69,7 +69,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "fal",
         "edge-tts", "tts-premium",
         "voice",  # faster-whisper / sounddevice / numpy
-        "modal", "daytona", "vercel",
+        "modal", "daytona", "sprites", "vercel",
         "messaging", "slack", "matrix", "dingtalk", "feishu",
         "honcho", "hindsight",
         "supermemory", "mem0",

--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -33,8 +33,23 @@ class TestIsUnusableContainerCwd:
 
     def test_container_backends_set(self):
         assert tt._CONTAINER_BACKENDS == frozenset(
-            {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
+            {"docker", "singularity", "modal", "daytona", "sprites", "vercel_sandbox"}
         )
+
+    def test_sprites_uses_actual_remote_home_by_default(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_ENV", "sprites")
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.setattr(tt, "_ensure_terminal_env_bridged", lambda: None)
+
+        assert tt._get_env_config()["cwd"] == "/home/sprite"
+
+    def test_sprites_home_subdirectory_is_valid_remote_cwd(self):
+        assert tt._is_unusable_container_cwd(
+            "/home/sprite/project", "sprites"
+        ) is False
+        assert tt._is_unusable_container_cwd(
+            "/home/host-user/project", "sprites"
+        ) is True
 
 
 class TestOverrideCwdSanitizedAtCallSite:

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -574,7 +574,7 @@ def test_container_backends_still_bypass(clean_session):
 
     Hardline only protects environments with real host impact (local, ssh).
     """
-    for env in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
+    for env in ("docker", "singularity", "modal", "daytona", "sprites", "vercel_sandbox"):
         r1 = check_dangerous_command("rm -rf /", env)
         assert r1["approved"] is True, f"container {env} should still bypass"
         r2 = check_all_command_guards("rm -rf /", env)
@@ -666,7 +666,7 @@ def test_sudo_stdin_guard_detects_without_password():
 
 def test_sudo_stdin_guard_container_bypass(clean_session):
     """Containerized backends still bypass — they can't touch the host."""
-    for env in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
+    for env in ("docker", "singularity", "modal", "daytona", "sprites", "vercel_sandbox"):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
             assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -704,7 +704,7 @@ class TestSkillViewPrerequisites:
 
     @pytest.mark.parametrize(
         "backend",
-        ["ssh", "daytona", "docker", "singularity", "modal", "vercel_sandbox"],
+        ["ssh", "daytona", "docker", "singularity", "modal", "sprites", "vercel_sandbox"],
     )
     def test_remote_backend_becomes_available_after_local_secret_capture(
         self, tmp_path, monkeypatch, backend

--- a/tests/tools/test_sprites_environment.py
+++ b/tests/tools/test_sprites_environment.py
@@ -1,0 +1,278 @@
+"""Contract tests for the Fly Sprites terminal backend."""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class FakeNotFoundError(Exception):
+    pass
+
+
+@dataclass
+class FakeSpriteConfig:
+    ram_mb: int | None = None
+    cpus: int | None = None
+    storage_gb: int | None = None
+
+
+class FakePath:
+    def __init__(self, store: dict[str, bytes], path: str):
+        self.store = store
+        self.path = path
+
+    def write_bytes(self, data: bytes, mode: int = 0o644, mkdir_parents: bool = True):
+        self.store[self.path] = data
+
+    def read_bytes(self):
+        return self.store[self.path]
+
+    def unlink(self, missing_ok: bool = False):
+        if missing_ok:
+            self.store.pop(self.path, None)
+        else:
+            del self.store[self.path]
+
+
+class FakeFilesystem:
+    def __init__(self, store: dict[str, bytes]):
+        self.store = store
+
+    def path(self, path: str):
+        return FakePath(self.store, path)
+
+
+class FakeSprite:
+    def __init__(self, name: str):
+        self.name = name
+        self.files: dict[str, bytes] = {}
+        self.run = MagicMock(side_effect=self._run)
+
+    @staticmethod
+    def _run(*args, **kwargs):
+        if args == ("bash", "-c", 'printf %s "$HOME"'):
+            return SimpleNamespace(stdout=b"/home/sprite", stderr=b"", returncode=0)
+        # Match sprites-py 0.5's CompletedProcess contract exactly.
+        return SimpleNamespace(
+            stdout=b"hello\n", stderr=b"warning\n", returncode=7
+        )
+
+    def filesystem(self, working_dir: str = "/"):
+        return FakeFilesystem(self.files)
+
+
+class FakeClient:
+    existing: dict[str, FakeSprite] = {}
+    instances: list["FakeClient"] = []
+
+    def __init__(self, token: str, base_url: str = "https://api.sprites.dev", **kwargs):
+        self.token = token
+        self.base_url = base_url
+        self.create_sprite = MagicMock(side_effect=self._create)
+        self.destroy_sprite = MagicMock(side_effect=self.existing.pop)
+        self.close = MagicMock()
+        self.instances.append(self)
+
+    def get_sprite(self, name: str):
+        try:
+            return self.existing[name]
+        except KeyError as exc:
+            raise FakeNotFoundError(name) from exc
+
+    def _create(self, name: str, **kwargs):
+        sprite = FakeSprite(name)
+        self.existing[name] = sprite
+        return sprite
+
+
+@pytest.fixture(autouse=True)
+def fake_sdk(monkeypatch):
+    FakeClient.existing = {}
+    FakeClient.instances = []
+    module = types.ModuleType("sprites")
+    module.SpritesClient = FakeClient
+    module.SpriteConfig = FakeSpriteConfig
+    module.NotFoundError = FakeNotFoundError
+    monkeypatch.setitem(sys.modules, "sprites", module)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *args, **kwargs: None)
+    monkeypatch.setattr("tools.environments.base.BaseEnvironment.init_session", lambda self: None)
+    monkeypatch.setattr("tools.environments.file_sync.FileSyncManager.sync", lambda self, **kw: None)
+    monkeypatch.setattr("tools.environments.file_sync.FileSyncManager.sync_back", lambda self, **kw: None)
+
+
+def test_task_name_is_deterministic_sanitized_and_bounded():
+    from tools.environments.sprites import sprite_name_for_task
+
+    first = sprite_name_for_task("Task / With ! Unsafe Ünicode")
+    second = sprite_name_for_task("Task / With ! Unsafe Ünicode")
+
+    assert first == second
+    assert first.startswith("hermes-task-with-unsafe-nicode-")
+    assert len(first) <= 63
+    assert first.replace("-", "").isalnum()
+    assert first == first.lower()
+    assert sprite_name_for_task("same", namespace="profile-a") != sprite_name_for_task(
+        "same", namespace="profile-b"
+    )
+
+
+def test_constructor_uses_host_credentials_and_resumes_existing_sprite(monkeypatch):
+    from tools.environments.sprites import SpritesEnvironment, sprite_name_for_task
+
+    task_id = "Session 123"
+    name = sprite_name_for_task(task_id)
+    existing = FakeSprite(name)
+    FakeClient.existing[name] = existing
+    monkeypatch.setenv("SPRITE_TOKEN", "host-secret")
+    monkeypatch.setenv("SPRITES_API_URL", "https://sprites.internal.example/v1")
+
+    env = SpritesEnvironment(
+        cwd="/workspace", timeout=30, cpu=2, memory=4096, disk=20480,
+        persistent_filesystem=True, task_id=task_id,
+    )
+
+    client = FakeClient.instances[-1]
+    assert client.token == "host-secret"
+    assert client.base_url == "https://sprites.internal.example/v1"
+    assert env._sprite is existing
+    client.create_sprite.assert_not_called()
+    assert "SPRITE_TOKEN" not in existing.run.call_args_list
+
+
+def test_constructor_creates_sprite_with_resource_config(monkeypatch):
+    from tools.environments.sprites import SpritesEnvironment
+
+    monkeypatch.setenv("SPRITE_TOKEN", "token")
+    env = SpritesEnvironment(
+        cwd="/workspace", timeout=30, cpu=2, memory=4096, disk=20480,
+        persistent_filesystem=False, task_id="new-task",
+    )
+
+    kwargs = FakeClient.instances[-1].create_sprite.call_args.kwargs
+    assert kwargs["config"] == FakeSpriteConfig(ram_mb=4096, cpus=2, storage_gb=20)
+    assert env.cwd == "/workspace"
+
+
+def test_constructor_detects_sprite_home_and_maps_root_default(monkeypatch):
+    from tools.environments.sprites import SpritesEnvironment
+
+    monkeypatch.setenv("SPRITE_TOKEN", "token")
+    env = SpritesEnvironment(cwd="/root", task_id="home")
+
+    assert env._remote_home == "/home/sprite"
+    assert env.cwd == "/home/sprite"
+
+
+def test_missing_token_fails_before_sdk_client_creation(monkeypatch):
+    from tools.environments.sprites import SpritesEnvironment
+
+    monkeypatch.delenv("SPRITE_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="SPRITE_TOKEN"):
+        SpritesEnvironment(task_id="x")
+    assert FakeClient.instances == []
+
+
+def test_execute_returns_combined_command_output_and_exit_code(monkeypatch):
+    from tools.environments.sprites import SpritesEnvironment
+
+    monkeypatch.setenv("SPRITE_TOKEN", "token")
+    env = SpritesEnvironment(cwd="/workspace", task_id="execute")
+
+    result = env.execute("printf hello")
+
+    assert "hello" in result["output"]
+    assert "warning" in result["output"]
+    assert result["returncode"] == 7
+    args, kwargs = env._sprite.run.call_args
+    assert args[0] == "bash"
+    assert "-c" in args
+    assert kwargs["capture_output"] is True
+    assert kwargs["timeout"] > 0
+    assert "SPRITE_TOKEN" not in (kwargs.get("env") or {})
+
+
+def test_sdk_filesystem_callbacks_upload_and_delete(monkeypatch, tmp_path):
+    from tools.environments.sprites import SpritesEnvironment
+
+    monkeypatch.setenv("SPRITE_TOKEN", "token")
+    env = SpritesEnvironment(task_id="files")
+    source = tmp_path / "skill.md"
+    source.write_bytes(b"content")
+
+    env._sprite_upload(str(source), "/home/sprite/.hermes/skills/demo/SKILL.md")
+    assert env._sprite.files["/home/sprite/.hermes/skills/demo/SKILL.md"] == b"content"
+
+    env._sprite_delete(["/home/sprite/.hermes/skills/demo/SKILL.md"])
+    assert "/home/sprite/.hermes/skills/demo/SKILL.md" not in env._sprite.files
+
+
+def test_sync_sources_exclude_credential_mounts(monkeypatch):
+    from tools.environments.sprites import iter_sprite_sync_files
+
+    credential_mounts = MagicMock(side_effect=AssertionError("credentials must not be enumerated"))
+    monkeypatch.setattr("tools.credential_files.get_credential_file_mounts", credential_mounts)
+    monkeypatch.setattr(
+        "tools.credential_files.iter_skills_files",
+        lambda **kw: [{"host_path": "/host/skill", "container_path": "/home/sprite/.hermes/skills/s"}],
+    )
+    monkeypatch.setattr(
+        "tools.credential_files.iter_cache_files",
+        lambda **kw: [{"host_path": "/host/cache", "container_path": "/home/sprite/.hermes/cache/c"}],
+    )
+
+    assert iter_sprite_sync_files() == [
+        ("/host/skill", "/home/sprite/.hermes/skills/s"),
+        ("/host/cache", "/home/sprite/.hermes/cache/c"),
+    ]
+    credential_mounts.assert_not_called()
+
+
+def test_cleanup_keeps_persistent_sprite_and_deletes_ephemeral(monkeypatch):
+    from tools.environments.sprites import SpritesEnvironment
+
+    monkeypatch.setenv("SPRITE_TOKEN", "token")
+    persistent = SpritesEnvironment(task_id="keep", persistent_filesystem=True)
+    keep_name = persistent._sprite.name
+    persistent.cleanup()
+    assert keep_name in FakeClient.existing
+    assert FakeClient.instances[-1].close.called
+
+    ephemeral = SpritesEnvironment(task_id="delete", persistent_filesystem=False)
+    delete_name = ephemeral._sprite.name
+    client = FakeClient.instances[-1]
+    ephemeral.cleanup()
+    client.destroy_sprite.assert_called_once_with(delete_name)
+    assert delete_name not in FakeClient.existing
+
+
+def test_terminal_factory_selects_sprites_backend(monkeypatch):
+    from tools import terminal_tool
+
+    sentinel = object()
+    module = types.ModuleType("tools.environments.sprites")
+    ctor = MagicMock(return_value=sentinel)
+    module.SpritesEnvironment = ctor
+    monkeypatch.setitem(sys.modules, "tools.environments.sprites", module)
+
+    result = terminal_tool._create_environment(
+        "sprites", "ignored", "/workspace", 45,
+        container_config={
+            "container_cpu": 2,
+            "container_memory": 4096,
+            "container_disk": 20480,
+            "container_persistent": False,
+        },
+        task_id="abc",
+    )
+
+    assert result is sentinel
+    ctor.assert_called_once_with(
+        cwd="/workspace", timeout=45, cpu=2, memory=4096, disk=20480,
+        persistent_filesystem=False, task_id="abc",
+    )

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3711,7 +3711,7 @@ def _should_skip_container_guards(env_type: str, has_host_access: bool = False) 
     """
     if env_type == "docker":
         return not has_host_access
-    return env_type in ("singularity", "modal", "daytona", "vercel_sandbox")
+    return env_type in ("singularity", "modal", "daytona", "sprites", "vercel_sandbox")
 
 
 def check_dangerous_command(command: str, env_type: str,

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -833,7 +833,7 @@ def _get_or_create_env(task_id: str):
         cwd = overrides.get("cwd") or config["cwd"]
 
         container_config = None
-        if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+        if env_type in {"docker", "singularity", "modal", "daytona", "sprites", "vercel_sandbox"}:
             container_config = {
                 "container_cpu": config.get("container_cpu", 1),
                 "container_memory": config.get("container_memory", 5120),

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -73,7 +73,7 @@ _WAIT_ALREADY_TIMED_OUT = False
 # Duplicated rather than imported to avoid a circular import (prompt_builder
 # imports nothing from tools).
 _REMOTE_BACKENDS = frozenset({
-    "docker", "singularity", "modal", "daytona", "ssh", "managed_modal",
+    "docker", "singularity", "modal", "daytona", "sprites", "ssh", "managed_modal",
     "vercel_sandbox",
 })
 

--- a/tools/environments/sprites.py
+++ b/tools/environments/sprites.py
@@ -1,0 +1,249 @@
+"""Fly Sprites cloud execution environment.
+
+The backend uses the official ``sprites-py`` distribution (imported as
+``sprites``). Authentication remains host-side: Sprites receives only shell
+commands and the narrow skills/cache file set managed by FileSyncManager.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+import os
+import re
+import shlex
+import threading
+import uuid
+from pathlib import Path
+
+from tools.environments.base import BaseEnvironment, _ThreadedProcessHandle
+from tools.environments.file_sync import FileSyncManager
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_API_URL = "https://api.sprites.dev"
+_DEFAULT_SPRITE_HOME = "/home/sprite"
+_MAX_SPRITE_NAME_LENGTH = 63
+
+
+def sprite_name_for_task(task_id: str, *, namespace: str | None = None) -> str:
+    """Return a deterministic, profile-scoped Sprites-safe task name."""
+    if namespace is None:
+        from hermes_constants import get_hermes_home
+
+        namespace = str(get_hermes_home().resolve())
+    raw = str(task_id or "default")
+    slug = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-") or "task"
+    digest = hashlib.sha256(f"{namespace}\0{raw}".encode("utf-8")).hexdigest()[:10]
+    suffix = f"-{digest}"
+    prefix = "hermes-"
+    slug_budget = _MAX_SPRITE_NAME_LENGTH - len(prefix) - len(suffix)
+    slug = slug[:slug_budget].rstrip("-") or "task"
+    return f"{prefix}{slug}{suffix}"
+
+
+def iter_sprite_sync_files(
+    container_base: str = f"{_DEFAULT_SPRITE_HOME}/.hermes",
+) -> list[tuple[str, str]]:
+    """Enumerate the narrow host file set allowed into a Sprite.
+
+    Deliberately excludes ``get_credential_file_mounts``. The SDK token and all
+    other host credentials remain on the host; only skills and non-secret cache
+    files use the shared remote-filesystem synchronization contract.
+    """
+    from tools.credential_files import iter_cache_files, iter_skills_files
+
+    files: list[tuple[str, str]] = []
+    for entry in iter_skills_files(container_base=container_base):
+        files.append((entry["host_path"], entry["container_path"]))
+    for entry in iter_cache_files(container_base=container_base):
+        files.append((entry["host_path"], entry["container_path"]))
+    return files
+
+
+class SpritesEnvironment(BaseEnvironment):
+    """Execute commands in a persistent Fly Sprite via ``sprites-py`` 0.5.0."""
+
+    _stdin_mode = "heredoc"
+
+    def __init__(
+        self,
+        cwd: str = _DEFAULT_SPRITE_HOME,
+        timeout: int = 60,
+        cpu: int | float = 1,
+        memory: int = 5120,
+        disk: int = 51200,
+        persistent_filesystem: bool = True,
+        task_id: str = "default",
+    ):
+        from agent.secret_scope import get_secret
+
+        token = (get_secret("SPRITE_TOKEN") or "").strip()
+        if not token:
+            raise ValueError(
+                "SPRITE_TOKEN is required for the Sprites terminal backend. "
+                "Store it in ~/.hermes/.env or the host process environment."
+            )
+
+        requested_cwd = cwd
+        super().__init__(cwd=cwd, timeout=timeout)
+
+        from tools.lazy_deps import ensure as _lazy_ensure
+
+        _lazy_ensure("terminal.sprites", prompt=False)
+        from sprites import NotFoundError, SpriteConfig, SpritesClient  # ty: ignore[unresolved-import]
+
+        self._persistent = persistent_filesystem
+        self._task_id = task_id
+        self._name = sprite_name_for_task(task_id)
+        self._lock = threading.Lock()
+        self._client = SpritesClient(
+            token=token,
+            base_url=(os.getenv("SPRITES_API_URL") or _DEFAULT_API_URL).strip().rstrip("/"),
+        )
+        self._sprite = None
+
+        try:
+            try:
+                self._sprite = self._client.get_sprite(self._name)
+                logger.info("Sprites: resumed %s for task %s", self._name, task_id)
+            except NotFoundError:
+                config = SpriteConfig(
+                    cpus=max(1, int(math.ceil(float(cpu)))),
+                    ram_mb=max(256, int(memory)),
+                    storage_gb=max(1, int(math.ceil(int(disk) / 1024))),
+                )
+                self._sprite = self._client.create_sprite(
+                    self._name,
+                    config=config,
+                    labels=["hermes-agent"],
+                )
+                logger.info("Sprites: created %s for task %s", self._name, task_id)
+        except Exception:
+            self._client.close()
+            raise
+
+        self._remote_home = self._detect_remote_home()
+        if requested_cwd in {"~", "/root", _DEFAULT_SPRITE_HOME}:
+            self.cwd = self._remote_home
+        logger.info("Sprites: resolved home to %s, cwd to %s", self._remote_home, self.cwd)
+
+        self._filesystem = self._sprite.filesystem("/")
+        self._sync_manager = FileSyncManager(
+            get_files_fn=lambda: iter_sprite_sync_files(f"{self._remote_home}/.hermes"),
+            upload_fn=self._sprite_upload,
+            delete_fn=self._sprite_delete,
+            bulk_download_fn=self._sprite_bulk_download,
+        )
+        self._sync_manager.sync(force=True)
+        self.init_session()
+
+    @staticmethod
+    def _decode_output(value: bytes | str | None) -> str:
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        return value or ""
+
+    def _detect_remote_home(self) -> str:
+        """Resolve HOME from the Sprite rather than assuming a root user."""
+        try:
+            sprite = self._sprite
+            if sprite is None:
+                return _DEFAULT_SPRITE_HOME
+            result = sprite.run(
+                "bash", "-c", 'printf %s "$HOME"',
+                capture_output=True,
+                timeout=min(self.timeout, 30),
+            )
+            home = self._decode_output(result.stdout).strip()
+            if result.returncode == 0 and home.startswith("/"):
+                return home.rstrip("/") or "/"
+        except Exception as exc:
+            logger.warning("Sprites: could not detect remote HOME: %s", exc)
+        return _DEFAULT_SPRITE_HOME
+
+    def _sprite_upload(self, host_path: str, remote_path: str) -> None:
+        data = Path(host_path).read_bytes()
+        self._filesystem.path(remote_path).write_bytes(
+            data, mode=0o600, mkdir_parents=True
+        )
+
+    def _sprite_delete(self, remote_paths: list[str]) -> None:
+        for remote_path in remote_paths:
+            self._filesystem.path(remote_path).unlink(missing_ok=True)
+
+    def _sprite_bulk_download(self, dest: Path) -> None:
+        remote_tar = f"/tmp/.hermes-sync-{uuid.uuid4().hex}.tar"
+        hermes_dir = f"{self._remote_home}/.hermes"
+        archive_path = hermes_dir.lstrip("/")
+        command = (
+            f"if [ -d {shlex.quote(hermes_dir)} ]; then "
+            f"tar cf {shlex.quote(remote_tar)} -C / {shlex.quote(archive_path)}; "
+            "else tar cf "
+            f"{shlex.quote(remote_tar)} --files-from /dev/null; fi"
+        )
+        sprite = self._sprite
+        if sprite is None:
+            raise RuntimeError("Sprite is unavailable (environment already cleaned up)")
+        result = sprite.run(
+            "bash", "-c", command, capture_output=True, timeout=self.timeout
+        )
+        if result.returncode != 0:
+            error = self._decode_output(result.stderr or result.stdout)
+            raise RuntimeError(f"Sprites filesystem archive failed: {error.strip()}")
+        try:
+            dest.write_bytes(self._filesystem.path(remote_tar).read_bytes())
+        finally:
+            self._filesystem.path(remote_tar).unlink(missing_ok=True)
+
+    def _before_execute(self) -> None:
+        self._sync_manager.sync()
+
+    def _run_bash(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ):
+        sprite = self._sprite
+        if sprite is None:
+            raise RuntimeError("Sprite is unavailable (environment already cleaned up)")
+        shell_args = ("bash", "-l", "-c", cmd_string) if login else (
+            "bash", "-c", cmd_string
+        )
+
+        def exec_fn() -> tuple[str, int]:
+            result = sprite.run(
+                *shell_args,
+                capture_output=True,
+                timeout=timeout,
+            )
+            stdout = self._decode_output(result.stdout)
+            stderr = self._decode_output(result.stderr)
+            return stdout + stderr, int(result.returncode)
+
+        return _ThreadedProcessHandle(exec_fn)
+
+    def cleanup(self) -> None:
+        with self._lock:
+            if self._sprite is None:
+                return
+            try:
+                self._sync_manager.sync_back()
+            except Exception as exc:
+                logger.warning("Sprites: sync_back failed for %s: %s", self._name, exc)
+            try:
+                if not self._persistent:
+                    self._client.destroy_sprite(self._name)
+                    logger.info("Sprites: destroyed ephemeral sprite %s", self._name)
+            except Exception as exc:
+                logger.warning("Sprites: cleanup failed for %s: %s", self._name, exc)
+            finally:
+                try:
+                    self._client.close()
+                except Exception:
+                    pass
+                self._sprite = None

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3,7 +3,7 @@
 File Operations Module
 
 Provides file manipulation capabilities (read, write, patch, search) that work
-across all terminal backends (local, docker, ssh, singularity, modal, daytona, vercel_sandbox).
+across all terminal backends (local, docker, ssh, singularity, modal, daytona, sprites, vercel_sandbox).
 
 The key insight is that all file operations can be expressed as shell commands,
 so we wrap the terminal backend's execute() interface to provide a unified file API.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -169,7 +169,7 @@ def _resolve_path(filepath: str, task_id: str = "default") -> Path | PurePosixPa
 # (gateway/run.py); the file/terminal-tool layer must do likewise so CLI
 # sessions get the same protection. See references/worktree-cwd-discipline.md.
 _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
-_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "sprites", "vercel_sandbox"})
 
 
 def _terminal_env_type_for_task(task_id: str = "default") -> str:
@@ -1513,7 +1513,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             # bypass the guard.  Valid in-container override paths (RL/benchmark
             # sandboxes that set cwd to /workspace, /root, etc.) are absolute
             # non-host paths and pass through untouched.
-            if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
+            if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd, env_type):
                 if cwd != config["cwd"]:
                     logger.info(
                         "Ignoring host/relative cwd override %r for %s backend "
@@ -1524,7 +1524,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
 
             container_config = None
-            if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+            if env_type in {"docker", "singularity", "modal", "daytona", "sprites", "vercel_sandbox"}:
                 container_config = {
                     "container_cpu": config.get("container_cpu", 1),
                     "container_memory": config.get("container_memory", 5120),

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -255,6 +255,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),
     "terminal.daytona": ("daytona==0.155.0",),
+    "terminal.sprites": ("sprites-py==0.5.0",),
     "terminal.vercel": ("vercel==0.7.2",),
 
     # ─── Skills ────────────────────────────────────────────────────────────

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -172,7 +172,7 @@ _PLATFORM_MAP = {
 }
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _REMOTE_ENV_BACKENDS = frozenset(
-    {"docker", "singularity", "modal", "ssh", "daytona", "vercel_sandbox"}
+    {"docker", "singularity", "modal", "ssh", "daytona", "sprites", "vercel_sandbox"}
 )
 _secret_capture_callback = None
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1491,10 +1491,10 @@ def _safe_getcwd() -> str:
 # cwd looks when it leaks toward a Linux container's ``-w`` flag.
 _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 
-_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "sprites", "vercel_sandbox"})
 
 
-def _is_unusable_container_cwd(cwd: str) -> bool:
+def _is_unusable_container_cwd(cwd: str, env_type: str | None = None) -> bool:
     """Return True if *cwd* is a host/relative path that won't work as the
     working directory inside a container sandbox.
 
@@ -1504,6 +1504,13 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     ``docker run -w`` and makes the container fail to start (exit 125).
     """
     if not cwd:
+        return False
+    # Sprites run as the non-root ``sprite`` user. Its real in-sandbox home
+    # must not be mistaken for a leaked Linux host cwd merely because it lives
+    # under /home.
+    if env_type == "sprites" and (
+        cwd == "/home/sprite" or cwd.startswith("/home/sprite/")
+    ):
         return False
     if any(cwd.startswith(p) for p in _HOST_CWD_PREFIXES):
         return True
@@ -1577,7 +1584,7 @@ def _get_env_config() -> Dict[str, Any]:
     env_type = os.getenv("TERMINAL_ENV", "local")
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
-    container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
+    container_backend = env_type in {"docker", "singularity", "modal", "daytona", "sprites", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
     # Docker/container-only env vars may be bridged from config.yaml even when
@@ -1606,13 +1613,15 @@ def _get_env_config() -> Dict[str, Any]:
         docker_extra_args = []
         docker_shm_size = "1g"
 
-    # Default cwd: local uses the host's current directory, ssh uses the
-    # remote home, Vercel uses its documented workspace root, and everything
-    # else starts in the backend's default root-like cwd.
+    # Default cwd: local uses the host's current directory, SSH uses the
+    # remote home, and cloud runtimes with a documented non-root user use
+    # that runtime's home/workspace. Everything else starts at /root.
     if env_type == "local":
         default_cwd = _safe_getcwd()
     elif env_type == "ssh":
         default_cwd = "~"
+    elif env_type == "sprites":
+        default_cwd = "/home/sprite"
     elif env_type == "vercel_sandbox":
         default_cwd = _VERCEL_SANDBOX_DEFAULT_CWD
     else:
@@ -1638,7 +1647,7 @@ def _get_env_config() -> Dict[str, Any]:
             cwd = "/workspace"
     elif env_type in _CONTAINER_BACKENDS and cwd:
         # Host paths and relative paths that won't work inside containers
-        if _is_unusable_container_cwd(cwd) and cwd != default_cwd:
+        if _is_unusable_container_cwd(cwd, env_type) and cwd != default_cwd:
             logger.info("Ignoring TERMINAL_CWD=%r for %s backend "
                         "(host/relative path won't work in sandbox). Using %r instead.",
                         cwd, env_type, default_cwd)
@@ -1672,7 +1681,7 @@ def _get_env_config() -> Dict[str, Any]:
         ).lower() in {"true", "1", "yes"},
         "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
         # Container resource config (applies to docker, singularity, modal,
-        # daytona, and vercel_sandbox -- ignored for local/ssh)
+        # daytona, sprites, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
@@ -1763,7 +1772,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     
     Args:
         env_type: One of "local", "docker", "singularity", "modal",
-            "daytona", "vercel_sandbox", "ssh"
+            "daytona", "sprites", "vercel_sandbox", "ssh"
         image: Docker/Singularity/Modal image name (ignored for local/ssh/vercel)
         cwd: Working directory
         timeout: Default command timeout
@@ -1911,6 +1920,14 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             persistent_filesystem=persistent, task_id=task_id,
         )
 
+    elif env_type == "sprites":
+        from tools.environments.sprites import SpritesEnvironment as _SpritesEnvironment
+        return _SpritesEnvironment(
+            cwd=cwd, timeout=timeout,
+            cpu=cpu, memory=memory, disk=disk,
+            persistent_filesystem=persistent, task_id=task_id,
+        )
+
     elif env_type == "vercel_sandbox":
         from tools.environments.vercel_sandbox import (
             VercelSandboxEnvironment as _VercelSandboxEnvironment,
@@ -1941,7 +1958,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     else:
         raise ValueError(
             f"Unknown environment type: {env_type}. Use 'local', 'docker', "
-            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', or 'ssh'"
+            f"'singularity', 'modal', 'daytona', 'sprites', 'vercel_sandbox', or 'ssh'"
         )
 
 
@@ -2590,7 +2607,7 @@ def _resolve_command_cwd(
     if (
         recorded
         and env_type in _CONTAINER_BACKENDS
-        and _is_unusable_container_cwd(recorded)
+        and _is_unusable_container_cwd(recorded, env_type)
     ):
         logger.info(
             "Ignoring recorded session cwd %r for %s backend "
@@ -2705,7 +2722,7 @@ def terminal_tool(
         # Valid in-container override paths (RL/benchmark sandboxes that set
         # cwd to /workspace, /root, etc.) are absolute non-host paths and pass
         # through untouched.
-        if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
+        if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd, env_type):
             remapped = "/workspace" if host_cwd else config["cwd"]
             if cwd != remapped:
                 logger.info(
@@ -3789,6 +3806,18 @@ def check_terminal_requirements() -> bool:
 
             return True
 
+        elif env_type == "sprites":
+            from agent.secret_scope import get_secret
+
+            if not get_secret("SPRITE_TOKEN"):
+                logger.error(
+                    "Sprites backend selected but SPRITE_TOKEN is not configured. "
+                    "Run `hermes setup terminal` or store it in ~/.hermes/.env."
+                )
+                return False
+            # sprites-py is deliberately lazy-installed by environment creation.
+            return True
+
         elif env_type == "vercel_sandbox":
             return _check_vercel_sandbox_requirements(config)
 
@@ -3800,7 +3829,7 @@ def check_terminal_requirements() -> bool:
         else:
             logger.error(
                 "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, vercel_sandbox, ssh.",
+                "modal, daytona, sprites, vercel_sandbox, ssh.",
                 env_type,
             )
             return False
@@ -3843,7 +3872,7 @@ if __name__ == "__main__":
     print(
         "  TERMINAL_ENV: "
         f"{os.getenv('TERMINAL_ENV', 'local')} "
-        "(local/docker/singularity/modal/daytona/vercel_sandbox/ssh)"
+        "(local/docker/singularity/modal/daytona/sprites/vercel_sandbox/ssh)"
     )
     print(f"  TERMINAL_DOCKER_IMAGE: {os.getenv('TERMINAL_DOCKER_IMAGE', default_img)}")
     print(f"  TERMINAL_SINGULARITY_IMAGE: {os.getenv('TERMINAL_SINGULARITY_IMAGE', f'docker://{default_img}')}")

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -217,7 +217,7 @@ When the agent triggers a dangerous command approval (`rm -rf`, `DROP TABLE`, et
 Hermes checks every command against a curated list of dangerous patterns before execution. This includes recursive deletes, SQL drops, piping curl to shell, and more. Don't disable this in production — it exists for good reasons.
 
 :::warning
-When running in a container backend (Docker, Singularity, Modal, Daytona), dangerous command checks are **skipped** because the container is the security boundary. Make sure your container images are properly locked down.
+When running in an isolated backend (Docker, Singularity, Modal, Daytona, Sprites, or Vercel Sandbox), dangerous command checks are **skipped** because the remote/container boundary protects the Hermes host. Provider sandboxes can still have outbound network access and their hardening differs from Docker, so review the selected backend's security and credential-sync behavior.
 :::
 
 ### Use Allowlists for Messaging Bots

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -232,7 +232,7 @@ These variables configure the [Tool Gateway](/user-guide/features/tool-gateway) 
 
 | Variable | Description |
 |----------|-------------|
-| `TERMINAL_ENV` | Backend: `local`, `docker`, `ssh`, `singularity`, `modal`, `daytona`, `vercel_sandbox` |
+| `TERMINAL_ENV` | Backend: `local`, `docker`, `ssh`, `singularity`, `modal`, `daytona`, `sprites`, `vercel_sandbox` |
 | `HERMES_DOCKER_BINARY` | Override the container binary Hermes shells out to (e.g. `podman`, `/usr/local/bin/docker`). When unset, Hermes auto-discovers `docker` or `podman` on `PATH`. Needed when both are installed and you want the non-default, or when the binary lives outside `PATH`. |
 | `TERMINAL_DOCKER_IMAGE` | Docker image (default: `nikolaik/python-nodejs:python3.11-nodejs20`) |
 | `TERMINAL_DOCKER_FORWARD_ENV` | JSON array of env var names to explicitly forward into Docker terminal sessions. Note: skill-declared `required_environment_variables` are forwarded automatically — you only need this for vars not declared by any skill. |
@@ -243,6 +243,8 @@ These variables configure the [Tool Gateway](/user-guide/features/tool-gateway) 
 | `TERMINAL_SINGULARITY_IMAGE` | Singularity image or `.sif` path |
 | `TERMINAL_MODAL_IMAGE` | Modal container image |
 | `TERMINAL_DAYTONA_IMAGE` | Daytona sandbox image |
+| `SPRITE_TOKEN` | Fly Sprites API token. Kept host-side and never forwarded into Sprite commands. |
+| `SPRITES_API_URL` | Advanced override for the Sprites API base URL (default: `https://api.sprites.dev`). |
 | `TERMINAL_VERCEL_RUNTIME` | Vercel Sandbox runtime (`node24`, `node22`, `python3.13`) |
 | `TERMINAL_TIMEOUT` | Command timeout in seconds |
 | `TERMINAL_LIFETIME_SECONDS` | Max lifetime for terminal sessions in seconds |
@@ -261,7 +263,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TERMINAL_SSH_KEY` | Path to private key |
 | `TERMINAL_SSH_PERSISTENT` | Override persistent shell for SSH (default: follows `TERMINAL_PERSISTENT_SHELL`) |
 
-## Container Resources (Docker, Singularity, Modal, Daytona)
+## Container Resources (Docker, Singularity, Modal, Daytona, Sprites, Vercel Sandbox)
 
 | Variable | Description |
 |----------|-------------|

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -139,7 +139,7 @@ Hermes supports seven terminal backends. Each determines where the agent's shell
 
 ```yaml
 terminal:
-  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
+  backend: local    # local | docker | ssh | modal | daytona | sprites | vercel_sandbox | singularity
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   font_family: ""   # Desktop terminal font; e.g. "MesloLGS NF"
   timeout: 180      # Per-command timeout in seconds

--- a/website/docs/user-guide/features/tools.md
+++ b/website/docs/user-guide/features/tools.md
@@ -72,6 +72,7 @@ The terminal tool can execute commands in different environments:
 | `singularity` | HPC containers | Cluster computing, rootless |
 | `modal` | Cloud execution | Serverless, scale |
 | `daytona` | Cloud sandbox workspace | Persistent remote dev environments |
+| `sprites` | Fly Sprite cloud environment | Persistent per-task cloud execution |
 | `vercel_sandbox` | Vercel Sandbox cloud microVM | Cloud execution with snapshot-backed filesystem persistence |
 
 ### Configuration
@@ -79,7 +80,7 @@ The terminal tool can execute commands in different environments:
 ```yaml
 # In ~/.hermes/config.yaml
 terminal:
-  backend: local    # or: docker, ssh, singularity, modal, daytona, vercel_sandbox
+  backend: local    # or: docker, ssh, singularity, modal, daytona, sprites, vercel_sandbox
   cwd: "."          # Working directory
   timeout: 180      # Command timeout in seconds
 ```
@@ -156,6 +157,31 @@ modal setup
 hermes config set terminal.backend modal
 ```
 
+### Fly Sprites
+
+```bash
+pip install 'hermes-agent[sprites]'
+hermes setup terminal  # choose Fly Sprites and enter SPRITE_TOKEN
+```
+
+Hermes creates or resumes one deterministically named Sprite per task. Sprite
+names are scoped to the active Hermes profile, and the runtime's actual home
+directory (normally `/home/sprite`) is detected before shell state or files are
+initialized. With `container_persistent: false`, Hermes destroys the Sprite at
+cleanup; otherwise it leaves the Sprite available for the next task session.
+
+The Sprite token stays in the host process and is never forwarded to commands.
+Unlike the other remote sync backends, Sprites intentionally synchronizes only
+skills and non-secret cache files—not credential files. Commands still have the
+Sprite's normal outbound network access, so treat downloaded or untrusted code
+as capable of reaching external services. Hermes skips host-dangerous-command
+guards for Sprites because commands cannot access the Hermes host filesystem.
+
+The native backend targets the official `sprites-py==0.5.0` API. The SDK does
+not expose per-command cancellation in that release; Hermes enforces command
+timeouts, but killing a foreground process handle cannot signal the remote
+command independently.
+
 ### Vercel Sandbox
 
 ```bash
@@ -190,7 +216,7 @@ Configure CPU, memory, disk, and persistence for all container backends:
 
 ```yaml
 terminal:
-  backend: docker  # or singularity, modal, daytona, vercel_sandbox
+  backend: docker  # or singularity, modal, daytona, sprites, vercel_sandbox
   container_cpu: 1              # CPU cores (default: 1)
   container_memory: 5120        # Memory in MB (default: 5GB)
   container_disk: 51200         # Disk in MB (default: 50GB)
@@ -201,7 +227,7 @@ When `container_persistent: true`, installed packages, files, and config survive
 
 ### Container Security
 
-All container backends run with security hardening:
+Isolation and hardening vary by backend. Docker applies:
 
 - Read-only root filesystem (Docker)
 - All Linux capabilities dropped
@@ -211,6 +237,10 @@ All container backends run with security hardening:
 - Persistent workspace via volumes, not writable root layer
 
 Docker can optionally receive an explicit env allowlist via `terminal.docker_forward_env`, but forwarded variables are visible to commands inside the container and should be treated as exposed to that session.
+
+Remote cloud backends rely on their provider's isolation boundary. Review each
+backend's credential and network behavior above rather than assuming Docker's
+capability, namespace, or read-only-root settings apply to it.
 
 ## Background Process Management
 

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -190,7 +190,7 @@ The following patterns trigger approval prompts (defined in `tools/approval.py`)
 | `podman --remote`/`-r`/`--url`/`--connection`/`--identity`, `CONTAINER_HOST=` | Podman remote daemon redirect |
 
 :::info
-**Container bypass**: When running in `docker`, `singularity`, `modal`, `daytona`, or `vercel_sandbox` backends, dangerous command checks are **skipped** because the container itself is the security boundary. Destructive commands inside a container can't harm the host.
+**Sandbox bypass**: When running in `docker`, `singularity`, `modal`, `daytona`, `sprites`, or `vercel_sandbox` backends, dangerous command checks are **skipped** because the container/provider boundary protects the Hermes host. Provider sandboxes may still have outbound network access and do not necessarily inherit Docker's hardening.
 :::
 
 ### Approval Flow (CLI)
@@ -495,7 +495,7 @@ terminal:
 - **Ephemeral mode** (`container_persistent: false`): Uses tmpfs for workspace — everything is lost on cleanup
 
 :::tip
-For production gateway deployments, use `docker`, `modal`, `daytona`, or `vercel_sandbox` backend to isolate agent commands from your host system. This eliminates the need for dangerous command approval entirely.
+For production gateway deployments, use a sandboxed backend such as `docker`, `modal`, `daytona`, `sprites`, or `vercel_sandbox` to isolate agent commands from your host system. This eliminates host-dangerous-command approval, but you must still account for provider credentials and outbound network access.
 :::
 
 :::warning


### PR DESCRIPTION
## Problem
Hermes needs a first-class Fly Sprites execution backend so autonomous coding tasks can run in isolated, task-scoped cloud environments without forwarding broad host credentials.

## Summary
- add a native `sprites` `BaseEnvironment` backed by `sprites-py==0.5.0`
- create/reuse deterministic task-scoped Sprites and execute commands with normal stdout/stderr/exit semantics
- detect the remote home directory and synchronize only the established skills/cache file sets
- keep `SPRITE_TOKEN` host-side via Hermes secret scope
- wire config, CLI mappings, setup, status, doctor, web setup, lazy dependencies, and optional package extras
- extend sandbox cwd and hardline handling to cover Sprites
- document configuration, security boundaries, and lifecycle behavior

## Verification
- `371 passed, 5 subtests passed` across the backend and affected integration suites
- `ty check tools/environments/sprites.py` passed
- Ruff passed
- `sprites-py 0.5.0` public API contract verified
- `git diff --check` passed

## Not exercised
No live Sprite was created because this environment has no `SPRITE_TOKEN`; SDK behavior is covered through typed fakes and contract verification.