### PR TITLE
feat(anthropic): opt in to provider-side web_search server tool

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -471,6 +471,66 @@ def _custom_provider_extra_body_for_agent(
     return fallback
 
 
+def _custom_provider_server_tools_for_agent(
+    *,
+    provider: str,
+    base_url: str,
+    custom_providers: List[Dict[str, Any]],
+) -> Optional[List[str]]:
+    """Resolve the ``server_tools`` list for the active custom-provider route.
+
+    ``server_tools`` (``providers.<name>.server_tools: ["web_search"]``)
+    declares provider-executed tools — e.g. the native ``web_search`` server
+    tool on Anthropic-compatible endpoints — that Hermes should swap in
+    instead of the same-named client function. Same matching semantics as
+    ``_custom_provider_extra_body_for_agent`` (provider key when routed by
+    ``custom:<name>``, otherwise base_url + provider-key/name), but without
+    the model filter: the toggle is endpoint-scoped, not per-model.
+    """
+    provider_norm = (provider or "").strip().lower()
+    if provider_norm == "custom":
+        provider_key_filter = ""
+    elif provider_norm.startswith("custom:"):
+        provider_key_filter = provider_norm.split(":", 1)[1].strip()
+    else:
+        return None
+
+    target_url = _normalized_custom_base_url(base_url)
+    if not target_url:
+        return None
+
+    for entry in custom_providers or []:
+        if not isinstance(entry, dict):
+            continue
+        if provider_key_filter:
+            entry_keys = {
+                str(entry.get("provider_key", "") or "").strip().lower(),
+                str(entry.get("name", "") or "").strip().lower(),
+            }
+            if provider_key_filter not in entry_keys:
+                continue
+        if _normalized_custom_base_url(entry.get("base_url")) != target_url:
+            continue
+        server_tools = entry.get("server_tools")
+        if isinstance(server_tools, list) and server_tools:
+            return [str(t) for t in server_tools]
+    return None
+
+
+def _merge_custom_provider_server_tools(agent, custom_providers: List[Dict[str, Any]]) -> None:
+    server_tools = _custom_provider_server_tools_for_agent(
+        provider=agent.provider,
+        base_url=agent.base_url,
+        custom_providers=custom_providers,
+    )
+    if server_tools:
+        # Keep this a plain assignment, NOT an extra_body merge — Hermes'
+        # own extra_body (e.g. the OpenAI ``service_tier`` flow) is routed
+        # through the OpenAI-wire transports and would leak
+        # ``server_tools`` into chat-completions payloads on api-mode flips.
+        agent._anthropic_server_tools = server_tools
+
+
 def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
     extra_body = _custom_provider_extra_body_for_agent(
         provider=agent.provider,
@@ -2567,6 +2627,7 @@ def init_agent(
     # compression model context-length detection needs the same list).
     agent._custom_providers = _custom_providers
     _merge_custom_provider_extra_body(agent, _custom_providers)
+    _merge_custom_provider_server_tools(agent, _custom_providers)
 
     # Check custom_providers per-model context_length
     if _config_context_length is None and _custom_providers:

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2169,8 +2169,15 @@ def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         # from the fields the server tool populates — the model loses only the
         # raw result payload it already consumed, and the replay stays
         # schema-valid on endpoints that don't tolerate unknown block types.
-        # Returns None for a block with no extractable text so a bare marker
-        # is dropped rather than replayed as a blank text block (#69512).
+        # Returns None for a block with nothing to carry (no usable text
+        # parts or web_search_result rows) so a bare marker is dropped rather
+        # than replayed as a blank text block (#69512).
+        # NOTE: if #68337 (native web search/fetch) lands with overlapping
+        # branches earlier in this if-chain, this branch must be made
+        # endpoint-aware (thread base_url down from
+        # convert_messages_to_anthropic so native blocks are kept where valid
+        # and converted to the text carrier where not) or it becomes
+        # unreachable — coordinate before merging both.
         if btype == "server_tool_use":
             name = str(b.get("name") or "").strip()
             if not name:
@@ -2179,15 +2186,24 @@ def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         content = b.get("content")
         if not isinstance(content, list) or not content:
             return None
-        texts = [
-            str(part.get("text"))
-            for part in content
-            if isinstance(part, dict)
-            and part.get("type") == "text"
-            and isinstance(part.get("text"), str)
-            and part.get("text").strip()
-        ]
-        return {"type": "text", "text": "\n\n".join(texts)} if texts else None
+        # Documented shape: content is web_search_result rows ({type, url,
+        # title, encrypted_content, page_age}) with NO text parts, optionally
+        # plus a web_search_tool_result_error. Render each row as a
+        # "url — title" line (title only when present; rows without a url are
+        # skipped) alongside any usable text parts, preserving content order.
+        lines: List[str] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") == "text":
+                if isinstance(part.get("text"), str) and part["text"].strip():
+                    lines.append(part["text"])
+            elif part.get("type") == "web_search_result":
+                url = part.get("url")
+                if isinstance(url, str) and url.strip():
+                    title = part.get("title")
+                    lines.append(f"{url} — {title}" if title else url)
+        return {"type": "text", "text": "\n\n".join(lines)} if lines else None
     # Unknown/unsupported block type on the input path — drop rather than risk
     # another "Extra inputs are not permitted".
     return None

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1861,6 +1861,53 @@ def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
     return result
 
 
+# Anthropic server-executed (provider-side) tool declarations.  Same wire
+# shape the Messages API itself uses — ``type`` is the versioned server tool
+# type, ``name`` is what the model calls it by.  max_uses and the filtered
+# variants stay client-side knobs a caller can layer on top if a provider
+# ever needs them; Hermes only injects the plain declaration.
+_ANTHROPIC_SERVER_TOOL_DEFS: Dict[str, Dict[str, Any]] = {
+    "web_search": {"type": "web_search_20250305", "name": "web_search"},
+}
+
+
+def _apply_server_tools_to_anthropic(
+    anthropic_tools: List[Dict[str, Any]],
+    server_tools: Optional[List[str]],
+) -> List[Dict[str, Any]]:
+    """Swap client-side functions for provider-executed Anthropic server tools.
+
+    ``server_tools`` names tools the endpoint runs itself (declared via
+    ``providers.<name>.server_tools`` — e.g. ``["web_search"]`` on the
+    Zhipu / Kimi / DeepSeek / MiniMax Anthropic-compatible endpoints, which
+    all implement Anthropic's native ``web_search_20250305`` server tool).
+    For each name, the client-side function of the same name is dropped and
+    the server-tool declaration injected in its place — a 1:1 swap only,
+    never an additive grant (mirrors the xAI Responses web_search handling
+    in agent/transports/codex.py).  Unknown names are ignored with a warning
+    so a typo in config cannot mint an invalid ``tools`` entry.
+    """
+    if not server_tools:
+        return anthropic_tools
+    tools = list(anthropic_tools)
+    for name in server_tools:
+        if name not in _ANTHROPIC_SERVER_TOOL_DEFS:
+            logger.warning(
+                "server_tools: no Anthropic server tool named '%s' "
+                "(known: %s) — ignoring",
+                name, ", ".join(sorted(_ANTHROPIC_SERVER_TOOL_DEFS)),
+            )
+            continue
+        # 1:1 swap only — the server declaration replaces a same-named
+        # client function and is never granted additively (mirrors xAI
+        # Responses: "never an additive grant", agent/transports/codex.py).
+        if not any(t.get("name") == name for t in tools):
+            continue
+        tools = [t for t in tools if t.get("name") != name]
+        tools.append(dict(_ANTHROPIC_SERVER_TOOL_DEFS[name]))
+    return tools
+
+
 def _image_source_from_openai_url(url: str) -> Dict[str, str]:
     """Convert an OpenAI-style image URL/data URL into Anthropic image source."""
     url = str(url or "").strip()
@@ -1910,6 +1957,13 @@ def _convert_content_part_to_anthropic(part: Any) -> Optional[Dict[str, Any]]:
         url = image_value.get("url", "") if isinstance(image_value, dict) else str(image_value or "")
         block = {"type": "image", "source": _image_source_from_openai_url(url)}
     else:
+        if ptype in ("server_tool_use", "web_search_tool_result"):
+            # Same server-tool replay treatment as _sanitize_replay_block —
+            # a stored web_search turn arrives here when session history
+            # keeps list-shaped assistant content.
+            sanitized = _sanitize_replay_block(part)
+            if sanitized is not None:
+                return sanitized
         block = dict(part)
 
     if isinstance(part.get("cache_control"), dict) and "cache_control" not in block:
@@ -2108,6 +2162,32 @@ def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if btype == "image":
         src = b.get("source")
         return {"type": "image", "source": src} if isinstance(src, dict) else None
+    if btype in ("server_tool_use", "web_search_tool_result"):
+        # Provider-executed server-tool blocks (Anthropic web_search et al.).
+        # The Messages input schema has no equivalent block type, so a stored
+        # search turn cannot be replayed verbatim.  Synthesize a text carrier
+        # from the fields the server tool populates — the model loses only the
+        # raw result payload it already consumed, and the replay stays
+        # schema-valid on endpoints that don't tolerate unknown block types.
+        # Returns None for a block with no extractable text so a bare marker
+        # is dropped rather than replayed as a blank text block (#69512).
+        if btype == "server_tool_use":
+            name = str(b.get("name") or "").strip()
+            if not name:
+                return None
+            return {"type": "text", "text": f"[server tool: {name}]"}
+        content = b.get("content")
+        if not isinstance(content, list) or not content:
+            return None
+        texts = [
+            str(part.get("text"))
+            for part in content
+            if isinstance(part, dict)
+            and part.get("type") == "text"
+            and isinstance(part.get("text"), str)
+            and part.get("text").strip()
+        ]
+        return {"type": "text", "text": "\n\n".join(texts)} if texts else None
     # Unknown/unsupported block type on the input path — drop rather than risk
     # another "Extra inputs are not permitted".
     return None
@@ -2917,6 +2997,7 @@ def build_anthropic_kwargs(
     base_url: str | None = None,
     fast_mode: bool = False,
     drop_context_1m_beta: bool = False,
+    server_tools: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Build kwargs for anthropic.messages.create().
 
@@ -2955,11 +3036,17 @@ def build_anthropic_kwargs(
     fast-mode beta header for ~2.5x faster output throughput on Opus 4.6.
     Currently only supported on native Anthropic endpoints (not third-party
     compatible ones).
+
+    When *server_tools* names provider-executed Anthropic tools (e.g.
+    ``["web_search"]``), the same-named client functions are swapped for the
+    native server-tool declarations — 1:1, never additive.  See
+    ``_apply_server_tools_to_anthropic``.
     """
     system, anthropic_messages = convert_messages_to_anthropic(
         messages, base_url=base_url, model=model
     )
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
+    anthropic_tools = _apply_server_tools_to_anthropic(anthropic_tools, server_tools)
 
     # Nous Portal routes on its own catalog ids (``anthropic/claude-opus-4.8``);
     # normalizing to the bare Anthropic slug would make the model unresolvable

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1847,6 +1847,7 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
             base_url=getattr(agent, "_anthropic_base_url", None),
             fast_mode=(agent.request_overrides or {}).get("speed") == "fast",
             drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
+            server_tools=getattr(agent, "_anthropic_server_tools", None),
         )
         # Nous Portal reads ``tags`` and ``session_id`` as top-level body fields
         # on its Messages route the same way it does on /chat/completions, but

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -59,6 +59,7 @@ class AnthropicTransport(ProviderTransport):
             base_url: str | None
             fast_mode: bool
             drop_context_1m_beta: bool
+            server_tools: list[str] | None — provider-executed tool names
         """
         from agent.anthropic_adapter import build_anthropic_kwargs
 
@@ -75,6 +76,7 @@ class AnthropicTransport(ProviderTransport):
             base_url=params.get("base_url"),
             fast_mode=params.get("fast_mode", False),
             drop_context_1m_beta=params.get("drop_context_1m_beta", False),
+            server_tools=params.get("server_tools"),
         )
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1392,6 +1392,7 @@ def _normalize_custom_provider_entry(
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body", "extra_headers",
+        "server_tools",
         "ssl_ca_cert", "ssl_verify",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -1537,6 +1538,20 @@ def _normalize_custom_provider_entry(
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
 
+    # Provider-executed (server-side) tools to declare instead of the
+    # same-named client function — e.g. ``["web_search"]`` on an
+    # anthropic_messages-compatible endpoint that implements Anthropic's
+    # native ``web_search_20250305`` server tool. Shape-checked only; the
+    # consumer (agent/anthropic_adapter.py) knows the valid tool names.
+    server_tools = entry.get("server_tools")
+    if isinstance(server_tools, list) and server_tools:
+        names = [
+            str(t).strip() for t in server_tools
+            if isinstance(t, str) and t.strip()
+        ]
+        if names:
+            normalized["server_tools"] = names
+
     # Per-provider extra HTTP headers (proxies, gateways, custom auth).
     # Values may carry credentials (e.g. CF-Access-Client-Secret) — never
     # log them anywhere downstream.
@@ -1583,6 +1598,7 @@ def _custom_provider_entry_to_provider_config(
         "discover_models",
         "extra_body",
         "extra_headers",
+        "server_tools",
         "ssl_ca_cert",
         "ssl_verify",
     ):
@@ -2020,6 +2036,7 @@ _KNOWN_ROOT_KEYS = frozenset(DEFAULT_CONFIG.keys()) | _EXTRA_KNOWN_ROOT_KEYS
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
     "context_length", "rate_limit_delay", "extra_body",
+    "server_tools",
     "ssl_ca_cert", "ssl_verify",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.

--- a/tests/agent/test_anthropic_server_tools.py
+++ b/tests/agent/test_anthropic_server_tools.py
@@ -1,0 +1,201 @@
+"""Tests for provider-executed (server-side) Anthropic tool injection.
+
+``providers.<name>.server_tools: ["web_search"]`` swaps the client-side
+``web_search`` function for Anthropic's native server-tool declaration
+(``web_search_20250305``) — the tool several Anthropic-compatible endpoints
+(Zhipu, Kimi, DeepSeek, MiniMax) execute themselves.  These tests pin the
+three contracts of that swap:
+
+1. Injection is a 1:1 swap, never additive, and absent by default.
+2. The config knob flows through provider normalization to the agent attr.
+3. A server-tool turn that lands in session history (``server_tool_use`` /
+   ``web_search_tool_result`` blocks) replays as schema-valid input instead
+   of being silently dropped or rejected with HTTP 400.
+"""
+from types import SimpleNamespace
+
+from agent.agent_init import (
+    _custom_provider_server_tools_for_agent,
+    _merge_custom_provider_server_tools,
+)
+from agent.anthropic_adapter import (
+    _apply_server_tools_to_anthropic,
+    _convert_assistant_message,
+    _convert_content_part_to_anthropic,
+    _sanitize_replay_block,
+    build_anthropic_kwargs,
+)
+
+BASE = "https://open.bigmodel.cn/api/anthropic"
+
+
+def _tools(*names):
+    return [
+        {"type": "function", "function": {"name": n, "description": n, "parameters": {}}}
+        for n in names
+    ]
+
+
+def _atools(*names):
+    """Anthropic-format tool dicts, as convert_tools_to_anthropic emits."""
+    return [
+        {"name": n, "description": n, "input_schema": {"type": "object", "properties": {}}}
+        for n in names
+    ]
+
+
+def _build(tools, **over):
+    kwargs = dict(
+        model="glm-4.7",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=tools,
+        max_tokens=64,
+        reasoning_config=None,
+        base_url=BASE,
+    )
+    kwargs.update(over)
+    return build_anthropic_kwargs(**kwargs)
+
+
+class TestInjection:
+    def test_off_by_default(self):
+        kwargs = _build(_tools("web_search", "terminal"))
+        # Behavior contract: without the knob every tool stays client-side
+        # and no server-tool declaration appears.
+        names = [t["name"] for t in kwargs["tools"]]
+        assert names == ["web_search", "terminal"]
+
+    def test_web_search_swapped_for_server_tool(self):
+        kwargs = _build(_tools("web_search", "terminal"), server_tools=["web_search"])
+        by_name = {t.get("name"): t for t in kwargs["tools"]}
+        # exactly one web_search entry, and it is the server declaration
+        assert by_name["web_search"] == {"type": "web_search_20250305", "name": "web_search"}
+        # untouched sibling survives
+        assert "terminal" in by_name
+        assert len(kwargs["tools"]) == 2
+
+    def test_swap_never_additive_without_client_tool(self):
+        out = _apply_server_tools_to_anthropic(_atools("terminal"), ["web_search"])
+        names = [t.get("name") for t in out]
+        # no client web_search was present, so none is granted
+        assert names == ["terminal"]
+
+    def test_unknown_name_ignored(self):
+        out = _apply_server_tools_to_anthropic(_atools("web_search", "terminal"), ["not_a_server_tool"])
+        assert [t["name"] for t in out] == ["web_search", "terminal"]
+
+    def test_no_tools_no_injection(self):
+        kwargs = _build(None, server_tools=["web_search"])
+        assert "tools" not in kwargs
+
+
+class TestConfigPlumbing:
+    def test_resolved_by_provider_key(self):
+        got = _custom_provider_server_tools_for_agent(
+            provider="custom:zhipu",
+            base_url=BASE + "/",
+            custom_providers=[{
+                "provider_key": "zhipu",
+                "name": "Zhipu Anthropic",
+                "base_url": BASE,
+                "server_tools": ["web_search"],
+            }],
+        )
+        assert got == ["web_search"]
+
+    def test_none_when_unset(self):
+        got = _custom_provider_server_tools_for_agent(
+            provider="custom",
+            base_url=BASE,
+            custom_providers=[{"name": "zhipu", "base_url": BASE}],
+        )
+        assert got is None
+
+    def test_non_custom_provider_unaffected(self):
+        got = _custom_provider_server_tools_for_agent(
+            provider="openrouter",
+            base_url=BASE,
+            custom_providers=[{"name": "zhipu", "base_url": BASE,
+                               "server_tools": ["web_search"]}],
+        )
+        assert got is None
+
+    def test_merge_sets_agent_attr(self):
+        agent = SimpleNamespace(provider="custom", base_url=BASE)
+        _merge_custom_provider_server_tools(
+            agent, [{"name": "zhipu", "base_url": BASE, "server_tools": ["web_search"]}],
+        )
+        assert agent._anthropic_server_tools == ["web_search"]
+
+    def test_merge_noop_without_knob(self):
+        agent = SimpleNamespace(provider="custom", base_url=BASE)
+        _merge_custom_provider_server_tools(agent, [{"name": "zhipu", "base_url": BASE}])
+        assert not hasattr(agent, "_anthropic_server_tools")
+
+    def test_provider_entry_normalization_keeps_server_tools(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+
+        normalized = _normalize_custom_provider_entry({
+            "name": "zhipu",
+            "base_url": BASE,
+            "api_mode": "anthropic",
+            "server_tools": ["web_search"],
+        })
+        assert normalized["server_tools"] == ["web_search"]
+        assert normalized["api_mode"] == "anthropic_messages"
+
+
+class TestReplaySanitize:
+    def test_server_tool_use_becomes_text_marker(self):
+        out = _sanitize_replay_block({
+            "type": "server_tool_use",
+            "id": "srvtoolu_1",
+            "name": "web_search",
+            "input": {"query": "hermes"},
+        })
+        assert out == {"type": "text", "text": "[server tool: web_search]"}
+
+    def test_web_search_tool_result_becomes_text(self):
+        out = _sanitize_replay_block({
+            "type": "web_search_tool_result",
+            "tool_use_id": "srvtoolu_1",
+            "content": [
+                {"type": "web_search_result", "url": "https://example.com", "title": "Example"},
+                {"type": "text", "text": "Example — the example domain."},
+                {"type": "text", "text": "  "},
+            ],
+        })
+        # non-text result rows and blank text rows are dropped; text survives
+        assert out == {"type": "text", "text": "Example — the example domain."}
+
+    def test_bare_blocks_dropped(self):
+        assert _sanitize_replay_block({"type": "server_tool_use", "id": "x"}) is None
+        assert _sanitize_replay_block({"type": "web_search_tool_result"}) is None
+
+    def test_content_part_path_also_converted(self):
+        out = _convert_content_part_to_anthropic({
+            "type": "server_tool_use", "id": "srvtoolu_2", "name": "web_search",
+            "input": {"query": "q"},
+        })
+        assert out == {"type": "text", "text": "[server tool: web_search]"}
+
+    def test_stored_search_turn_replays_as_valid_assistant_content(self):
+        # End-to-end replay: a captured turn mixing text + server-tool blocks
+        # must come back as text/tool_use blocks the Messages input accepts.
+        m = {
+            "role": "assistant",
+            "anthropic_content_blocks": [
+                {"type": "text", "text": "Searching…"},
+                {"type": "server_tool_use", "id": "srvtoolu_1",
+                 "name": "web_search", "input": {"query": "hermes"}},
+                {"type": "web_search_tool_result", "tool_use_id": "srvtoolu_1",
+                 "content": [{"type": "text", "text": "result body"}]},
+                {"type": "tool_use", "id": "toolu_1", "name": "read_file",
+                 "input": {"path": "a"}},
+            ],
+        }
+        out = _convert_assistant_message(m)
+        types = [b["type"] for b in out["content"]]
+        assert types == ["text", "text", "text", "tool_use"]
+        assert all(b["type"] != "server_tool_use" for b in out["content"])
+        assert "result body" in out["content"][2]["text"]

--- a/tests/agent/test_anthropic_server_tools.py
+++ b/tests/agent/test_anthropic_server_tools.py
@@ -165,12 +165,60 @@ class TestReplaySanitize:
                 {"type": "text", "text": "  "},
             ],
         })
-        # non-text result rows and blank text rows are dropped; text survives
-        assert out == {"type": "text", "text": "Example — the example domain."}
+        # result rows render as "url — title" lines and text parts survive in
+        # content order; blank text rows are dropped
+        assert out == {
+            "type": "text",
+            "text": "https://example.com — Example\n\nExample — the example domain.",
+        }
+
+    def test_web_search_tool_result_documented_shape_carried_not_dropped(self):
+        # Per the Messages API the documented content is web_search_result
+        # rows ONLY (no text parts), optionally plus a
+        # web_search_tool_result_error — previously the whole block was
+        # silently dropped on this shape (#92076).
+        out = _sanitize_replay_block({
+            "type": "web_search_tool_result",
+            "tool_use_id": "srvtoolu_2",
+            "content": [
+                {"type": "web_search_result", "url": "https://example.com/a",
+                 "title": "Example A", "encrypted_content": "enc", "page_age": "2026-01-01"},
+                {"type": "web_search_result", "url": "https://example.com/b"},
+                {"type": "web_search_tool_result_error", "error_code": "max_uses_exceeded"},
+            ],
+        })
+        # title omitted → bare url; encrypted_content/page_age/error carry nothing
+        assert out == {
+            "type": "text",
+            "text": "https://example.com/a — Example A\n\nhttps://example.com/b",
+        }
+
+    def test_web_search_tool_result_mixed_content_carries_text_and_results(self):
+        out = _sanitize_replay_block({
+            "type": "web_search_tool_result",
+            "tool_use_id": "srvtoolu_3",
+            "content": [
+                {"type": "web_search_result", "url": "https://docs.example.com",
+                 "title": "Docs"},
+                {"type": "text", "text": "Top hit summarizes the domain."},
+                {"type": "text", "text": "   "},
+                {"type": "web_search_result", "title": "row without a url is skipped"},
+            ],
+        })
+        # both kinds survive in content order; blank text and url-less rows drop
+        assert out == {
+            "type": "text",
+            "text": "https://docs.example.com — Docs\n\nTop hit summarizes the domain.",
+        }
 
     def test_bare_blocks_dropped(self):
         assert _sanitize_replay_block({"type": "server_tool_use", "id": "x"}) is None
         assert _sanitize_replay_block({"type": "web_search_tool_result"}) is None
+        # rows without a url carry nothing → block still dropped
+        assert _sanitize_replay_block({
+            "type": "web_search_tool_result",
+            "content": [{"type": "web_search_result", "title": "No URL"}],
+        }) is None
 
     def test_content_part_path_also_converted(self):
         out = _convert_content_part_to_anthropic({

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -183,6 +183,19 @@ providers:
 
 Header values routinely carry credentials — Hermes never logs them. `extra_headers` applies to OpenAI-compatible routes; the `anthropic_messages` and `bedrock_converse` API modes do not use it.
 
+**`server_tools`** — (anthropic_messages routes) a list of provider-executed Anthropic tools to declare instead of the same-named client function. Several Anthropic-compatible endpoints (Zhipu `open.bigmodel.cn/api/anthropic`, Kimi `api.kimi.com/coding`, DeepSeek `api.deepseek.com/anthropic`, MiniMax `api.minimax.io/anthropic`) implement Anthropic's native server-side web search; this knob swaps Hermes' client-side `web_search` function for the endpoint's own `web_search_20250305` declaration so the search runs (and is billed) server-side:
+
+```yaml
+providers:
+  zhipu:
+    api: https://open.bigmodel.cn/api/anthropic
+    transport: anthropic_messages
+    server_tools:
+      - web_search
+```
+
+The swap is 1:1 — the server tool is declared only when the client-side `web_search` function is already in the session's toolset, so toolsets without web search stay untouched. Any turn the endpoint answers with server-tool blocks (`server_tool_use` / `web_search_tool_result`) is stored in session history and replayed as plain text, keeping later turns valid on endpoints that reject those block types as input.
+
 **`discover_models`** — set to `false` (default `true`) to skip querying the endpoint's `/models` listing and use only the `models` you configured on the entry. Handy for gateways whose model listing is slow, unreliable, or noisy:
 
 ```yaml


### PR DESCRIPTION
## Problem

Several Anthropic-compatible endpoints implement Anthropic's native server-executed `web_search_20250305` tool under the same name:

- Zhipu — `open.bigmodel.cn/api/anthropic`
- Kimi — `api.kimi.com/coding`
- DeepSeek — `api.deepseek.com/anthropic`
- MiniMax — `api.minimax.io/anthropic`

Hermes' anthropic adapter only ever sends its own client-side tool schemas (`convert_tools_to_anthropic`), so the server-side search these endpoints offer is structurally unusable from Hermes — there is no way to declare the server tool on the `tools` array.

## Solution

A per-provider knob, following the same plumbing as `extra_body` / `extra_headers`:

```yaml
providers:
  zhipu:
    api: https://open.bigmodel.cn/api/anthropic
    transport: anthropic_messages
    server_tools:
      - web_search
```

- `hermes_cli/config.py` — `server_tools` accepted in `_KNOWN_KEYS`, normalized on provider entries (both `providers.<name>` and legacy `custom_providers`), carried through `_custom_provider_entry_to_provider_config` and `_VALID_CUSTOM_PROVIDER_FIELDS`.
- `agent/agent_init.py` — `_custom_provider_server_tools_for_agent` resolves the list for the active route (provider-key match for `custom:<name>`, otherwise base_url + name/provider_key, mirroring `_custom_provider_extra_body_for_agent`); the endpoint-scoped toggle intentionally skips the per-model filter.
- `agent/anthropic_adapter.py` — `_apply_server_tools_to_anthropic` performs the injection inside `build_anthropic_kwargs` (new optional `server_tools` param): the client-side `web_search` function is dropped and the native `{"type": "web_search_20250305", "name": "web_search"}` declaration is emitted in its place. **1:1 swap only, never an additive grant** — mirroring the xAI Responses native web_search handling in `agent/transports/codex.py` (mode 1 there). Unknown names warn and are ignored; toolsets without web search are untouched.
- `agent/transports/anthropic.py` + `agent/chat_completion_helpers.py` — thread the param through the transport `build_kwargs` and the main-turn call site (`agent._anthropic_server_tools`, set at agent init).

## Replay safety

A turn answered with server-tool blocks stores `server_tool_use` / `web_search_tool_result` in history. The Messages *input* schema has no such block types, and `_sanitize_replay_block`'s whitelist previously dropped them (its `test_unknown_type_dropped` case). This PR converts them to schema-valid text carriers instead — `server_tool_use` becomes `[server tool: <name>]`, `web_search_tool_result` becomes its text rows — in both `_sanitize_replay_block` and `_convert_content_part_to_anthropic`, so the next turn replays the search turn without an HTTP 400 and without silently losing the assistant's turn shape. Bare blocks with no extractable text still drop (blank-text blocks are input-invalid, #69512).

## Tests

`tests/agent/test_anthropic_server_tools.py` (16 tests):

- injection off by default; swap only when the client tool is present (never additive); unknown name ignored; no-op with no tools
- config plumbing: resolved by provider key and by base_url; unset resolves to None; non-custom providers unaffected; merge sets the agent attr; provider-entry normalization keeps `server_tools`
- replay sanitize: server blocks become text carriers via both sanitize paths; bare blocks drop; an end-to-end stored search turn replays as valid assistant content

Verified via `scripts/run_tests.sh`: new file 16/16 green; affected suites (`test_anthropic_adapter`, `test_anthropic_output_field_leak`, `test_custom_provider_extra_body*`, `test_minimax_provider`, `test_kimi_coding_anthropic_thinking`, `test_anthropic_thinking_disable`, the custom-provider normalization/identity files, `test_ctx_halving_fix`, `test_anthropic_mcp_prefix_strip`, `test_fast_command`) all green. The two `test_nous_portal_anthropic_wire` auth-header failures reproduce on clean `main` in this environment (not touched by this change).

## Compatibility

Default off — without `server_tools` in config, request payloads are unchanged. No prompt-cache impact (the tools array only changes when the user opts in, at session start). Docs updated in `website/docs/user-guide/configuring-models.md` under "Per-provider request options".


## Related PRs

- #68337 — automatic native `web_search`/`web_fetch` binding for the direct-Anthropic transport; withholds server-only tools from third-party Anthropic-compatible endpoints. This PR is the complementary, config-gated opt-in for the third-party endpoints that do implement `web_search_20250305` (default off, 1:1 swap only). Reconciliation proposal in [this comment](https://github.com/NousResearch/hermes-agent/pull/92076#issuecomment-5378934018); happy to rebase onto or fold into #68337 per maintainer direction.
