### PR TITLE
fix(state): apply macOS write barriers to session-recovery's destination connection

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -25,6 +25,7 @@ from hermes_state import (
     SCHEMA_VERSION,
     SessionDB,
     _db_opens_cleanly,
+    _reapply_durability_barriers,
 )
 
 
@@ -1439,6 +1440,17 @@ def _recover_via_lost_and_found(
     destination_conn = sqlite3.connect(
         str(output), isolation_level=None, timeout=1.0
     )
+    # This connection is what performs the FTS5 rebuild + row-mapping bulk
+    # write below (the class of operation _connect_repair_durable's own
+    # docstring calls out: "rewrites nearly every page of the file"). This
+    # is a fresh raw sqlite3.connect — whatever journal mode the earlier
+    # SessionDB(db_path=output) init settled on (WAL, or DELETE if this
+    # SQLite build is WAL-reset-vulnerable), a raw connect inherits
+    # sqlite3's synchronous=NORMAL default with no macOS full-fsync
+    # barrier, which cannot guarantee this write survives an interrupted
+    # checkpoint (see hermes_state._connect_repair_durable, the same
+    # documented gap for the in-place repair path). No-op elsewhere.
+    _reapply_durability_barriers(destination_conn)
     try:
         destination_conn.execute("PRAGMA foreign_keys=OFF")
         mapping = map_lost_and_found_rows(lf_conn, destination_conn)
@@ -1609,6 +1621,13 @@ def recover_session_database(
                 isolation_level=None,
                 timeout=1.0,
             )
+            # Same reasoning as the lost_and_found salvage path above: this
+            # connection performs the canonical-table row-by-row copy below,
+            # which rewrites the file page by page, via a fresh raw
+            # sqlite3.connect that inherits synchronous=NORMAL with no
+            # macOS full-fsync barrier regardless of the journal mode the
+            # SessionDB init just above settled on. No-op elsewhere.
+            _reapply_durability_barriers(destination_conn)
             destination_conn.execute("PRAGMA foreign_keys=OFF")
 
             copy_report: dict[str, dict[str, Any]] = {}

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -487,6 +487,67 @@ def test_partial_recovery_keeps_messages_when_sessions_are_unsalvageable(
 
 
 
+def test_recovery_applies_macos_durability_barriers_to_destination_connection(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """The destination connection that performs the canonical-table bulk
+    copy must go through hermes_state._reapply_durability_barriers.
+
+    The `sqlite3.connect(str(output), ...)` at this call site is a fresh raw
+    connection against a file already left in WAL mode by the preceding
+    `SessionDB(db_path=output)` init a few lines above — a raw connect
+    against an already-WAL file inherits WAL's `synchronous=NORMAL` default
+    with no `checkpoint_fullfsync`, which is exactly the gap
+    `hermes_state._connect_repair_durable`'s docstring documents as unsafe
+    on macOS for connections that go on to rewrite the file page by page
+    (which the row-by-row canonical-table copy below does).
+
+    This spies on the REAL `_reapply_durability_barriers` (not a mock that
+    replaces it) so the test proves two things: the call site is wired, and
+    the pragma is genuinely accepted on the live connection — not silently
+    swallowed by the function's own best-effort exception handling.
+    """
+    source = tmp_path / "sessions-source.db"
+    output = tmp_path / "sessions-recovered.db"
+    _make_source(source)
+
+    # PRAGMA synchronous/checkpoint_fullfsync are per-connection state, not
+    # persisted in the file, so they must be read WHILE the connection is
+    # still open — capture inside the spy itself, not after
+    # recover_session_database() returns and the connection is closed.
+    observed: list[dict[str, int]] = []
+    real_reapply = hermes_state._reapply_durability_barriers
+
+    def spy(conn: sqlite3.Connection) -> bool:
+        result = real_reapply(conn)
+        observed.append({
+            "synchronous": conn.execute("PRAGMA synchronous").fetchone()[0],
+            "checkpoint_fullfsync": conn.execute(
+                "PRAGMA checkpoint_fullfsync"
+            ).fetchone()[0],
+        })
+        return result
+
+    monkeypatch.setattr(session_recovery, "_reapply_durability_barriers", spy)
+
+    recover_session_database(source, output, work_dir=tmp_path, chunk_size=16)
+
+    assert len(observed) == 1, (
+        "expected exactly one destination connection to go through the "
+        "durability-barrier helper for this (non-lost-and-found) recovery path"
+    )
+    pragmas = observed[0]
+    if sys.platform == "darwin":
+        # This dev/CI box is real macOS: assert the pragmas actually took,
+        # not just that the (best-effort, never-raising) helper ran.
+        assert pragmas["synchronous"] == 2, f"expected synchronous=FULL (2), got {pragmas}"
+        assert pragmas["checkpoint_fullfsync"] == 1, f"expected checkpoint_fullfsync=1, got {pragmas}"
+    else:
+        # Elsewhere the pragmas are documented no-ops; the call-site wiring
+        # (proven above) is the whole fix on non-Darwin platforms.
+        assert pragmas["synchronous"] == 1, "sqlite3's own WAL default (NORMAL) unaffected off-Darwin"
+
+
 def test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf(
     tmp_path: Path,
 ) -> None:

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import shutil
 import sqlite3
+import sys
 from pathlib import Path
 
 import pytest
@@ -300,6 +301,59 @@ def test_lost_and_found_lane_recovers_schema_unreadable_source(
         assert len(sessions) == expected["sessions"]
     finally:
         recovered_db.close()
+
+
+@pytest.mark.skipif(
+    not HAVE_SQLITE3_CLI,
+    reason="sqlite3 CLI not on PATH; .recover is a shell-only feature",
+)
+def test_lost_and_found_lane_applies_macos_durability_barriers(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """The lost_and_found lane's destination connection — the one that runs
+    the FTS5 rebuild + row-mapping bulk write in _recover_via_lost_and_found
+    — must go through hermes_state._reapply_durability_barriers, same as the
+    plain row-by-row recovery path (see
+    test_session_recovery.py::test_recovery_applies_macos_durability_barriers_to_destination_connection).
+    This lane rewrites even more of the file than the plain path (FTS5
+    `rebuild` on top of the row mapping), so it is at least as exposed to
+    the documented macOS fsync-ordering gap."""
+    import hermes_state
+
+    source = tmp_path / "schemaless.db"
+    output = tmp_path / "schemaless-recovered.db"
+    _make_schema_unreadable_source(source)
+
+    observed: list[dict[str, int]] = []
+    real_reapply = hermes_state._reapply_durability_barriers
+
+    def spy(conn: sqlite3.Connection) -> bool:
+        result = real_reapply(conn)
+        observed.append({
+            "synchronous": conn.execute("PRAGMA synchronous").fetchone()[0],
+            "checkpoint_fullfsync": conn.execute(
+                "PRAGMA checkpoint_fullfsync"
+            ).fetchone()[0],
+        })
+        return result
+
+    monkeypatch.setattr(session_recovery, "_reapply_durability_barriers", spy)
+
+    report = recover_session_database(
+        source, output, work_dir=tmp_path, allow_partial=True,
+    )
+
+    assert report["mode"] == "lost_and_found_salvage"
+    assert len(observed) == 1, (
+        "expected exactly one destination connection to go through the "
+        "durability-barrier helper for the lost_and_found lane"
+    )
+    pragmas = observed[0]
+    if sys.platform == "darwin":
+        assert pragmas["synchronous"] == 2, f"expected synchronous=FULL (2), got {pragmas}"
+        assert pragmas["checkpoint_fullfsync"] == 1, f"expected checkpoint_fullfsync=1, got {pragmas}"
+    else:
+        assert pragmas["synchronous"] == 1, "sqlite3's own WAL default (NORMAL) unaffected off-Darwin"
 
 
 # ── mapper unit tests (no sqlite3 CLI required) ─────────────────────────────


### PR DESCRIPTION
## What this fixes

`ca28a69ada` (merged today) added `hermes_state._connect_repair_durable()` / `_reapply_durability_barriers()` so every connection inside the in-place `state.db` repair path (`VACUUM`/`REINDEX`/`writable_schema` surgery — the operations that rewrite nearly every page of the file) gets macOS's `checkpoint_fullfsync=1` + `synchronous=FULL`. Its own docstring explains why:

> On Darwin, `synchronous=NORMAL` only calls `fsync()`, which Apple's fsync(2) man page explicitly states does *not* guarantee data-on-platter or write-ordering. During a WAL checkpoint race with process termination (e.g., launchd shutdown), this can leave the main DB with half-written btree pages.

The 2026-08-19 recurrence this hardened against tore the `messages` table and its index during in-place repair.

`hermes_cli/session_recovery.py` is a **separate module** implementing the exact same class of operation for offline recovery — `hermes sessions recover`, the tool `hermes doctor`'s own repair-failure output recommends as the next step when in-place repair fails — but it was never covered. It opens its destination database with a bare `sqlite3.connect()` and then:
- runs an FTS5 `rebuild` special command (`INSERT INTO messages_fts VALUES ('rebuild')` — confirmed by reading `session_lost_and_found.py::rebuild_fts_indexes`), and
- copies every row of every canonical table through it (`_copy_table`/`_copy_table_salvage`),

both of which rewrite the file page by page, on a connection with no durability protection.

## Fix

Two call sites write to the **persistent** recovery output and needed the fix:
- `_recover_via_lost_and_found()`'s `destination_conn` (the page-level `.recover` salvage lane: row mapping + FTS rebuild)
- `recover_session_database()`'s `destination_conn` (the plain row-by-row canonical-table copy lane)

```python
_reapply_durability_barriers(destination_conn)
```
right after each connect, reusing `hermes_state`'s existing best-effort, never-raising helper (this module already imports another private `hermes_state` helper, `_db_opens_cleanly`, so this follows an established pattern).

## Deliberately NOT touched

I read every other raw `sqlite3.connect()` in this module and its sibling (`session_lost_and_found.py`) before scoping this fix, and none of the rest write to a file that outlives the recovery run:

- `_snapshot_and_inspect()`'s inspection connection — opens a disposable working copy purely to read table stats; the copy is discarded via `temp_dir.cleanup()`.
- `_verify_recovered_database()`'s connection — opens the **already-fully-written** `output` purely to run `integrity_check`/`foreign_key_check`/read `schema_version`; no writes.
- `source_conn` / `lf_conn` (the read side of both copy lanes) — verified by reading `_copy_table()`'s body: it issues `SELECT`/`fetchmany` against `source` and `BEGIN IMMEDIATE`/`executemany INSERT`/`COMMIT`/`ROLLBACK` exclusively against `destination`. The source connection never writes to its own file.
- `session_lost_and_found.py`'s two `sqlite3.connect()` calls — one is a throwaway CLI-capability probe DB deleted immediately after use; the other is a read-only `sqlite_master` check against a file the external `sqlite3` CLI subprocess (not Python's `sqlite3` module) wrote — a Python-connection-level PRAGMA can't influence a separate process's writes anyway.

Applying the barriers to any of these would add PRAGMA overhead without protecting anything real.

## Tests

One regression test per write site (`test_session_recovery.py`, `test_session_recovery_lost_and_found.py`), each spying on the **real** `hermes_state._reapply_durability_barriers` (not mocking it away) so the test proves two things at once: the call site is wired, and the pragma is genuinely accepted on the live connection. The pragma values are captured **inside the spy, while the connection is still open** — `PRAGMA synchronous`/`checkpoint_fullfsync` are per-connection state, not persisted in the file, so they can't be read after `recover_session_database()` returns and closes the connection (I hit this mistake myself on the first pass — fixed before landing).

This dev/CI machine is real macOS, so both tests assert the pragmas actually took (`synchronous == 2` i.e. FULL, `checkpoint_fullfsync == 1`) rather than just that the best-effort helper ran without raising; off-Darwin they fall back to asserting only the call-site wiring, since the pragmas are documented no-ops there.

**Mutation-verify:** reverted the fix and confirmed both new tests fail immediately (`AttributeError: ... has no attribute '_reapply_durability_barriers'` — the import/call site doesn't exist without it), then restored the fix and re-ran green.

Ran the full `test_session_recovery.py` + `test_session_recovery_lost_and_found.py` suite (13 tests) and the `hermes_state.py` durability/repair-adjacent suite (`test_state_db_write_durability.py`, `test_state_db_repair_live_writer_guard.py`, `test_hermes_state.py` — 242 passed, 3 skipped) and `ruff check` on all three changed files; all clean.

## Safety note

`session_recovery.py` never reads or writes via `get_hermes_home()` — `source`/`output` are always explicit CLI-supplied paths (confirmed by grep across both files: zero hits). No `HERMES_HOME`/system-config risk in this fix or its tests; both use `tmp_path` exclusively for source and output.

## Competing-PR check

Searched `"session_recovery durability macos fsync"`, `"_reapply_durability_barriers session recovery"`, `"hermes sessions recover checkpoint_fullfsync"`, `"session_recovery.py destination_conn"` — no open PRs found touching this.