### PR TITLE
fix(sessions): stop attachment paths from replacing chat titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -218,6 +218,29 @@ def strip_control_wrappers(text: str) -> str:
     return current
 
 
+def _strip_attachment_reference_lines(text: str) -> str:
+    """Drop standalone ``@file:`` lines while preserving surrounding prose."""
+    try:
+        from agent.context_references import parse_context_references
+    except Exception:
+        logger.debug("Context-reference parser unavailable for titling", exc_info=True)
+        return text
+
+    kept_lines = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        refs = parse_context_references(stripped)
+        if (
+            len(refs) == 1
+            and refs[0].kind == "file"
+            and refs[0].start == 0
+            and refs[0].end == len(stripped)
+        ):
+            continue
+        kept_lines.append(line)
+    return "\n".join(kept_lines).strip()
+
+
 def _summarize_user_message(user_message: str) -> str:
     """Reduce a user turn to the text worth titling.
 
@@ -225,8 +248,9 @@ def _summarize_user_message(user_message: str) -> str:
     body, so feeding it to the titler verbatim titles the session after the
     *skill's* prose — "Kick off a task in a fresh isolated git worktree" — not
     after the user's request. Reuse the canonical scaffolding parser so the
-    model sees ``/work — fix the title leak`` instead, then strip any control
-    wrappers left around it.
+    model sees ``/work — fix the title leak`` instead. Control wrappers and
+    standalone attachment references are metadata, so strip those while
+    retaining the user's surrounding prose.
     """
     if not user_message:
         return ""
@@ -238,7 +262,7 @@ def _summarize_user_message(user_message: str) -> str:
     except Exception:
         logger.debug("Skill-scaffolding summary failed; titling raw", exc_info=True)
     text = described if described is not None else user_message
-    return strip_control_wrappers(text)
+    return _strip_attachment_reference_lines(strip_control_wrappers(text))
 
 
 def is_titleable_user_message(user_message: str) -> bool:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -301,6 +301,22 @@ class TestMaybeAutoTitle:
         assert db.get_session_title("sess-1") == "fix the flaky auth test in login"
         assert db.get_session_title_source("sess-1") == "derived"
 
+    def test_attachment_reference_line_does_not_become_instant_title(self, tmp_path):
+        """Desktop attachment metadata must yield to the user's instruction."""
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="desktop")
+
+        with patch("agent.title_generator.auto_title_session"):
+            maybe_auto_title(
+                db,
+                "sess-1",
+                "@file:`C:\\Users\\alice\\AppData\\Local\\hermes\\attachments\\report.pdf`\n\nsummarize the quarterly results",
+                [],
+            )
+
+        assert db.get_session_title("sess-1") == "summarize the quarterly results"
+        assert db.get_session_title_source("sess-1") == "derived"
+
     def test_skips_machine_authored_opening_messages(self, tmp_path):
         """A compaction handoff is not a user request and must not title."""
         db = SessionDB(tmp_path / "state.db")


### PR DESCRIPTION
## What does this PR do?

Desktop sessions whose opening message starts with a standalone `@file:` attachment reference now derive their provisional title from the user's instruction instead of the staged attachment path. This keeps attachment-first conversations distinguishable in session lists while preserving inline file references that are part of user prose.

### Symptom

An opening message such as a standalone `@file:` path followed by `summarize the quarterly results` produced a truncated path title rather than the instruction.

### Impact

Attachment-first sessions can appear as nearly identical path-based entries in the sidebar, making real conversations difficult to identify.

### Bug Cause

**Trigger:** `agent/title_generator.py` / `_summarize_user_message`

**Causal chain:**
1. Desktop prepends a standalone `@file:` reference line to the opening instruction.
2. `_summarize_user_message` retained that metadata, and `derive_title` selected the first non-empty line.
3. The derived title became a truncated attachment path and could receive duplicate suffixes instead of describing the request.

**Why it is wrong:** Standalone attachment reference lines identify context supplied with the turn; they are not the user's intent to title.

**Working sibling / contrast:** Opening messages without attachment metadata already derive their title from the first instruction line. Inline references remain preserved because they can be meaningful parts of the instruction.

**Ruled out:** The Desktop sidebar is not inventing the path title. The persisted session row already contains the path with `title_source='derived'`, which locates the failure in shared title derivation.

### Fix

Filter lines that consist entirely of one parsed `@file:` reference before both deterministic and LLM title generation. The filter reuses the canonical context-reference parser so quoted Windows paths follow the same grammar as prompt expansion.

## Related Issue

Fixes #92068

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/title_generator.py` - remove standalone attachment reference lines from title input while preserving surrounding prose.
- `tests/agent/test_title_generator.py` - reproduce an attachment-first Windows Desktop opener and assert that the instruction becomes the derived title.

## How to Test

1. Start a session with a standalone `@file:` attachment reference followed by a textual instruction.
2. Confirm the derived session title uses the instruction rather than the attachment path.
3. Run the focused regression suites:

```bash
scripts/run_tests.sh tests/agent/test_context_references.py tests/agent/test_title_generator.py
```

Result: 50 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added a regression test for this bug
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not applicable; behavior and regression coverage are self-contained
- [x] Config example update is not applicable; no config keys changed
- [x] Contributor guide update is not applicable; no architecture or workflow changed
- [x] Cross-platform impact was considered; parsing uses the shared context-reference grammar and the regression covers a quoted Windows path
- [x] Tool description or schema updates are not applicable; no model tool behavior changed
