### PR TITLE
Warn on unknown keys in the model config block

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3611,6 +3611,61 @@ def apply_terminal_config_to_env(
     return target
 
 
+#: Keys recognized inside the top-level ``model:`` block. ``api_base``,
+#: ``base_url``, ``context_length``, ``default``, ``model``, ``name`` and
+#: ``provider`` are consumed by :func:`_normalize_root_model_keys`;
+#: ``timeout_seconds`` and ``stale_timeout_seconds`` are read in
+#: ``hermes_cli/timeouts.py``.
+_KNOWN_MODEL_KEYS = {
+    "api_base",
+    "base_url",
+    "context_length",
+    "default",
+    "model",
+    "name",
+    "provider",
+    "stale_timeout_seconds",
+    "timeout_seconds",
+}
+
+#: Dedup set for the model-block warning, mirroring
+#: ``_PROVIDER_NORMALIZE_WARNED``.
+_MODEL_NORMALIZE_WARNED: set = set()
+
+
+def _warn_unknown_model_keys(user_config: Any) -> None:
+    """Warn about unrecognized keys in the user's ``model:`` block.
+
+    ``providers.*`` already validates its keys and logs the ones it drops;
+    the ``model:`` block did not, so a misspelled or unsupported key there was
+    ignored in complete silence and the user had no way to tell it had not
+    taken effect.
+
+    Deliberately reads the USER's config rather than the merged result: the
+    merged config carries ``DEFAULT_CONFIG`` keys too, and warning about those
+    would be noise. Also deliberately not placed in
+    :func:`_normalize_root_model_keys`, which returns early when a config needs
+    no normalization -- a check there would skip exactly the already-canonical
+    configs it is supposed to cover.
+    """
+    if not isinstance(user_config, dict):
+        return
+    model_block = user_config.get("model")
+    if not isinstance(model_block, dict):
+        # ``model: "some/model-id"`` is a valid shorthand, not a block.
+        return
+    unknown = set(model_block.keys()) - _KNOWN_MODEL_KEYS
+    if not unknown:
+        return
+    signature = ",".join(sorted(unknown))
+    if signature in _MODEL_NORMALIZE_WARNED:
+        return
+    _MODEL_NORMALIZE_WARNED.add(signature)
+    logger.warning(
+        "model: unknown config keys ignored: %s", ", ".join(sorted(unknown))
+    )
+
+
 def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
     with _CONFIG_LOCK:
         ensure_hermes_home()
@@ -3674,6 +3729,8 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                         agent_user_config["max_turns"] = user_config["max_turns"]
                     user_config["agent"] = agent_user_config
                     user_config.pop("max_turns", None)
+
+                _warn_unknown_model_keys(user_config)
 
                 config = _deep_merge(config, user_config)
             except Exception as e:


### PR DESCRIPTION
## What does this PR do?

Unknown keys under `providers.*` are validated against a known-key set and logged as "unknown config keys ignored" (`hermes_cli/config.py:1410`), which is exactly the right behavior. The top-level `model:` block had no equivalent check, so a misspelled or unsupported key there was dropped in complete silence.

The failure mode is a user who sets something under `model:`, sees no warning, and reasonably concludes it took effect. `seed` is the case that prompted this: it looks plausible, it is silently ignored, and the run is then irreproducible in a way nothing in the logs reveals.

Closes #92082.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: add `_KNOWN_MODEL_KEYS` and `_warn_unknown_model_keys()`, and call it from `_load_config_impl` immediately before the user config is merged into the defaults.

Two placement decisions worth reviewing:

- It validates the **user's** `model:` block, not the merged result. The merged config also carries `DEFAULT_CONFIG` keys, and warning about those would be noise.
- It does **not** live in `_normalize_root_model_keys`. That function returns early when a config needs no normalization, so a check placed there would skip exactly the already-canonical configs this is meant to cover.

Warnings are deduplicated by key signature, mirroring `_warn_once_per_provider`.

## Known-key set — please sanity check this

The set is `api_base`, `base_url`, `context_length`, `default`, `model`, `name`, `provider` (all consumed by `_normalize_root_model_keys`) plus `timeout_seconds` and `stale_timeout_seconds` (read in `hermes_cli/timeouts.py`). I derived it by reading those consumers rather than from a schema, so if the `model:` block legitimately accepts keys handled elsewhere, this list needs extending. An incomplete list would warn on valid config, which is worse than the silent drop it replaces — I would rather a maintainer confirm it than have it guessed.

## How to Test

1. Add an unsupported key such as `seed: 42` under `model:` in `config.yaml`.
2. Start Hermes; the log now names the ignored key.
3. With only recognized keys present, nothing is logged.

Behaviour covered while developing: warns once for an unknown key; silent on a repeat of the same signature; silent when every key is known; silent for the `model: "provider/model-id"` string shorthand; silent when there is no `model:` block; silent for a non-dict config.

I was not able to run the project's test suite against this change, so it has not been through `scripts/run_tests.sh`.
