### PR TITLE
Persist the parent transcript before compaction rotates the session

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1379,6 +1379,50 @@ def _compression_lock_holder(agent: Any) -> str:
     )
 
 
+def _persist_pre_compaction_transcript(agent: Any, messages: Any) -> None:
+    """Write the parent's messages before compaction rotates the session.
+
+    Compaction ends the current session with reason ``compression`` and creates
+    a child with ``parent_session_id`` set. Because messages are serialized only
+    at clean session end, the parent exports ``messages: []`` and every turn
+    before the compaction is lost. The generated summary is not a substitute: it
+    comes from a separate ``call_llm(task="compression", ...)``, so it is
+    synthetic text that exists nowhere in the input.
+
+    Called only once compression is confirmed to have made progress, so the
+    no-op and abort paths (which return early above) write nothing.
+    """
+    session_id = getattr(agent, "session_id", None)
+    if not session_id or not messages:
+        return
+    try:
+        from hermes_constants import get_hermes_home
+
+        dest_dir = get_hermes_home() / "transcripts"
+        os.makedirs(dest_dir, exist_ok=True)
+        index = getattr(agent, "_precompact_index", 0) + 1
+        agent._precompact_index = index
+        dest = os.path.join(
+            dest_dir, f"precompact_{session_id}_{index:03d}.json"
+        )
+        tmp = dest + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            json.dump(
+                {
+                    "session_id": str(session_id),
+                    "compaction_index": index,
+                    "message_count": len(messages),
+                    "messages": messages,
+                },
+                fh,
+            )
+        os.replace(tmp, dest)
+    except Exception as exc:
+        # Loud, not silent: a pre-compaction dump that is quietly not written
+        # leaves a session that looks archived and is not.
+        logger.warning("pre-compaction transcript not saved: %s", exc)
+
+
 def _supported_compression_kwargs(
     compress_fn: Any,
     *,
@@ -3202,6 +3246,10 @@ def compress_context(
                 _existing_sp = agent._build_system_prompt(system_message)
             _release_lock()
             return messages, _existing_sp
+
+        # Compression made real progress and the session is about to rotate:
+        # this is the last point at which the parent's history still exists.
+        _persist_pre_compaction_transcript(agent, messages_before_compression)
 
         if commit_fence is not None:
             _commit_fence_entered = commit_fence.begin_commit(_hard_cancel_event)


### PR DESCRIPTION
## What does this PR do?

Context compaction rotates the session: it ends the current session with reason `compression` and creates a child with `parent_session_id` set. Because messages are serialized only at clean session end, the parent exports `messages: []` and every turn before the compaction is permanently lost.

A user who compacts a long conversation keeps the summary and loses the history it was made from. The summary is not a substitute — it comes from a separate `call_llm(task="compression", ...)`, so it is synthetic text that exists nowhere in the input and cannot be used to reconstruct what was said.

Closes #92080. Same underlying cause as #92079, but the trigger here is a routine, expected operation rather than an abrupt kill.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py`: add `_persist_pre_compaction_transcript()` and call it once compression is confirmed to have made progress, immediately before the commit fence and the session rotation.

The flow already builds `messages_before_compression = copy.deepcopy(messages)`, so this persists a snapshot that exists rather than taking a new one.

## Placement, and why it is after the compress call rather than before

The obvious spot is beside the existing `_memory_manager.on_pre_compress(messages)` notification. I put it later on purpose. Two paths above return early without rotating anything:

- `compressed == messages_before_compression` — the engine made no progress
- `not compressed` — the engine returned an empty transcript, and the code explicitly refuses to rotate so the parent stays resumable

In both cases no compaction happened, so there is no parent history at risk and a dump would be a misleading artifact. Writing after those checks means a `precompact_*` file exists if and only if a rotation is actually about to destroy the parent's messages.

Files are written to `<hermes home>/transcripts/precompact_<session_id>_<NNN>.json`, temp file plus `os.replace`, with an incrementing index so repeated compactions in one session do not overwrite each other.

## How to Test

1. Run a conversation long enough to cross the compaction threshold (`threshold_tokens = max(int(context_length * threshold_percent), min_context_length)`, `MINIMUM_CONTEXT_LENGTH = 64_000`).
2. Let compaction fire.
3. Before this change the parent session exports `messages: []`. After it, the pre-compaction turns are on disk alongside the child session, and `end_reason="compression"` plus `parent_session_id` still link the two.
4. Force the abort path (an engine that returns its input unchanged) and confirm no `precompact_*` file is written.

I was not able to run `scripts/run_tests.sh` against this change, and I have not reproduced a live compaction on current `main` — the behaviour was observed on v2026.5.29.2, and the code path above is unchanged as far as I can read it. Worth a maintainer confirming the placement against the commit-fence logic, which is more intricate than it was.
