### PR TITLE
fix(desktop): resolve a Hermes-capable interpreter for the .desktop Exec

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -70,20 +70,58 @@ def resolve_exec_command() -> str:
     if bin_path:
         resolved = Path(bin_path).resolve()
         if _needs_interpreter(resolved):
-            # The resolved launcher is a Python script whose shebang points at
-            # a NON-venv interpreter (e.g. the repo's `hermes` script with
+            # The resolved launcher is a Python script whose shebang points
+            # at a NON-venv interpreter (e.g. the repo's `hermes` script with
             # `#!/usr/bin/env python3` when argv[0] came from the shell
             # installer's bash wrapper). Launched from the .desktop entry that
-            # shebang resolves to the SYSTEM python and dies on the first
-            # third-party import (#90292) — silently, since Terminal=false.
-            # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # shebang resolves to an interpreter that may NOT have hermes_cli
+            # importable — silently failing under Terminal=false. Prefix it
+            # with an interpreter that can actually run Hermes: prefer
+            # sys.executable only when it can import hermes_cli, otherwise
+            # the installed venv-backed wrapper on PATH, otherwise run as a
+            # module under sys.executable.
+            argv = _interpreter_for(resolved)
         else:
             argv = [str(resolved), "desktop"]
     else:
         argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _interpreter_for(script: Path) -> "list[str]":
+    """Build an argv prefix that runs *script* under a Hermes-capable python.
+
+    Resolution order, first match wins:
+      1. ``sys.executable`` — but only when it can import ``hermes_cli``.
+         Depending on how Hermes was launched (uv shim, system python, a
+         non-venv interpreter), ``sys.executable`` itself may lack
+         hermes_cli, in which case prefixing it would reproduce the same
+         silent failure the .desktop is trying to avoid.
+      2. The installed ``hermes`` wrapper on PATH (e.g. ~/.local/bin/hermes),
+         which exec's the project venv python.
+      3. Fall back to ``sys.executable -m hermes_cli.main``.
+    """
+    if _can_import_hermes_cli(Path(sys.executable).resolve()):
+        return [str(Path(sys.executable).resolve()), str(script), "desktop"]
+    wrapper = shutil.which("hermes")
+    if wrapper:
+        return [str(Path(wrapper).resolve()), "desktop"]
+    return [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+
+
+def _can_import_hermes_cli(interpreter: Path) -> bool:
+    """Whether *interpreter* can import ``hermes_cli`` (the venv gate)."""
+    try:
+        result = subprocess.run(
+            [str(interpreter), "-c", "import hermes_cli"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
 
 
 def _needs_interpreter(bin_path: Path) -> bool:
@@ -133,7 +171,7 @@ def render_desktop_entry(exec_command: str, icon: str) -> str:
         f"Icon={icon}\n"
         "Terminal=false\n"
         "Categories=Utility;\n"
-        "StartupNotify=true\n"
+        "StartupNotify=false\n"
         "StartupWMClass=Hermes\n"
     )
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 import stat
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from hermes_cli import linux_desktop_entry as lde
 
+# Original subprocess.run, captured so tests can selectively stub the
+# hermes_cli import-probe without disturbing other subprocess calls.
+_orig_run = subprocess.run
+
+
+class _FakeReturn:
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
 
 @pytest.fixture
 def xdg_home(tmp_path, monkeypatch) -> Path:
@@ -264,3 +273,67 @@ def test_exec_arg_quoting_handles_spaces(tmp_path, xdg_home, monkeypatch):
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
     assert exec_line == f'"{spaced}" desktop'
+
+
+def test_exec_prefers_venv_wrapper_over_resolved_bin(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    # The bare launcher from the checkout: a python shebang whose interpreter
+    # is not the one that can import hermes_cli. resolve_hermes_bin() may still
+    # return it (e.g. when Hermes was launched via a uv/system python shim),
+    # but the generated entry must NOT exec it directly.
+    bare = tmp_path / "checkout" / "hermes"
+    bare.parent.mkdir(parents=True)
+    bare.write_text("#!/usr/bin/env python3\nfrom hermes_cli.main import main\n", encoding="utf-8")
+    # Installed venv-backed wrapper on PATH (e.g. ~/.local/bin/hermes).
+    wrapper = tmp_path / "bin" / "hermes"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text("#!/usr/bin/env bash\nexec venv/bin/python hermes \"$@\"\n", encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(bare))
+    monkeypatch.setattr(lde.shutil, "which", lambda name: str(wrapper) if name == "hermes" else None)
+    # Simulate sys.executable not being able to import hermes_cli (uv/system
+    # shim), so the resolver must fall through to the PATH wrapper.
+    monkeypatch.setattr(
+        lde.subprocess, "run",
+        lambda *a, **k: _FakeReturn(1) if "import hermes_cli" in str(a) else _orig_run(*a, **k),
+    )
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # The venv wrapper must win over the bare launcher, otherwise the entry
+    # fails silently (ModuleNotFoundError: hermes_cli) under Terminal=false.
+    assert exec_line == f"{wrapper} desktop"
+
+
+def test_exec_falls_back_to_module_when_no_wrapper(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    bare = tmp_path / "checkout" / "hermes"
+    bare.parent.mkdir(parents=True)
+    bare.write_text("#!/usr/bin/env python3\nfrom hermes_cli.main import main\n", encoding="utf-8")
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(bare))
+    monkeypatch.setattr(lde.shutil, "which", lambda name: None)
+    # No working interpreter on the system path: fall back to -m.
+    monkeypatch.setattr(
+        lde.subprocess, "run",
+        lambda *a, **k: _FakeReturn(1) if "import hermes_cli" in str(a) else _orig_run(*a, **k),
+    )
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # Run via sys.executable -m as the last resort.
+    assert exec_line.endswith("-m hermes_cli.main desktop")
+    assert Path(exec_line.split(" ")[0]).is_absolute()
+
+
+def test_rendered_entry_disables_startup_notify(tmp_path, monkeypatch):
+    # StartupNotify must be false: the Electron startup token never reaches
+    # the desktop environment through the wrapper, so a true value leaves a
+    # pinned launcher spinning forever even when the app starts.
+    monkeypatch.setattr(lde.sys, "platform", "linux")
+    text = lde.render_desktop_entry("/opt/hermes desktop", "/opt/icon.png")
+    values = _parse(text)
+    assert values["StartupNotify"] == "false"
+    assert values["StartupWMClass"] == "Hermes"


### PR DESCRIPTION
## Summary
Fixes the Linux `.desktop` launcher failing silently when Hermes is launched via an interpreter that cannot import `hermes_cli` (e.g. a uv-managed or system python shim). Closes #92086.

`resolve_exec_command()` previously prefixed the resolved launcher with `sys.executable` whenever the script's shebang pointed outside the running interpreter's directory. When `sys.executable` itself lacks `hermes_cli`, the generated entry dies on `import hermes_cli` — invisibly, because `Terminal=false`. Clicking the pinned launcher does nothing.

## Fix
The prefix interpreter is now chosen by **capability**, not blindly from `sys.executable`:
1. `sys.executable`, only if it can import `hermes_cli`
2. the installed venv-backed wrapper on PATH (e.g. `~/.local/bin/hermes`)
3. `sys.executable -m hermes_cli.main`

Also sets `StartupNotify=false`: the Electron startup token does not propagate through the wrapper, so `true` leaves a pinned launcher spinning forever.

## Test plan
- Added regression tests for the "sys.executable lacks hermes_cli" path (falls to wrapper) and the "no wrapper available" path (falls to `-m`).
- Full `tests/hermes_cli/test_linux_desktop_entry.py` passes (18 passed, 2 platform-skipped) on a venv install where `sys.executable` is a uv shim.
