### PR TITLE
fix(desktop-entry): keep the venv interpreter in Exec= instead of its symlink target

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -57,6 +57,25 @@ def icon_path(project_root: Path) -> Path:
     return project_root / "apps" / "desktop" / "assets" / "icon.png"
 
 
+def _running_interpreter() -> Path:
+    """The interpreter to name in ``Exec=``: absolute, but NOT symlink-resolved.
+
+    ``sys.executable`` inside a venv is normally a *symlink* to the base
+    interpreter -- that is the default for ``python -m venv`` on POSIX and
+    for ``uv venv``.  Following it (``Path(...).resolve()``) lands on the
+    base interpreter, which has none of the venv's site-packages, so a
+    ``.desktop`` entry built from it dies on ``import hermes_cli`` the
+    moment the desktop environment launches it -- silently, because the
+    entry sets ``Terminal=false`` (#92086).
+
+    ``abspath`` gives the absolute path the entry needs without leaving the
+    environment that can actually run Hermes.  The venv's ``bin/python``
+    *is* the right answer here; it is only a symlink in the filesystem
+    sense.
+    """
+    return Path(os.path.abspath(sys.executable))
+
+
 def resolve_exec_command() -> str:
     """Build the absolute ``Exec=`` command line for ``hermes desktop``.
 
@@ -78,11 +97,11 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            argv = [str(_running_interpreter()), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(_running_interpreter()), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 
@@ -106,8 +125,23 @@ def _needs_interpreter(bin_path: Path) -> bool:
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
     # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
-    return exe_dir not in shebang
+    #
+    # Both spellings of "inside" count.  A console script installed into a
+    # venv carries the venv's own ``bin/python`` in its shebang, while a
+    # script installed against the base interpreter carries the resolved
+    # one.  Comparing against only the resolved form -- what this did
+    # before #92086 -- classified a correct venv shebang as foreign,
+    # because ``sys.executable`` resolves out of the venv through its
+    # symlink.  The entry then got an interpreter prefix it did not need,
+    # naming the interpreter that cannot import Hermes.
+    # ``shebang`` was lowercased above, so lowercase this side too. Without
+    # that, an install path carrying any uppercase (``/home/User/...``, or
+    # anything on Windows) never matched and every wrapper was classified as
+    # foreign.
+    for candidate in (_running_interpreter(), Path(sys.executable).resolve()):
+        if str(candidate.parent).lower() in shebang:
+            return False
+    return True
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -6,6 +6,7 @@ import stat
 from pathlib import Path
 
 import pytest
+import sys
 
 from hermes_cli import linux_desktop_entry as lde
 
@@ -94,6 +95,7 @@ def test_exec_falls_back_to_interpreter_module(tmp_path, xdg_home, monkeypatch):
 # silent (Terminal=false). The Exec line must prefix sys.executable for any
 # resolved bin that is a python script escaping the running venv.
 def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_home, monkeypatch):
+    import os
     import sys
 
     root = _make_project(tmp_path)
@@ -107,7 +109,14 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    # Deliberately NOT ``Path(sys.executable).resolve()``. That was this
+    # assertion before #92086, and it is the bug: on POSIX a venv's
+    # ``bin/python`` is a symlink to the base interpreter, so resolving it
+    # named an interpreter without ``hermes_cli`` and the test agreed with
+    # the code. Written independently of the implementation, from what the
+    # Exec line is FOR -- an absolute path to an interpreter that can import
+    # Hermes -- rather than by calling the helper back.
+    interpreter = os.path.abspath(sys.executable)
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
@@ -135,6 +144,13 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
+    # Despite this test's name, `.resolve()` is the BASE interpreter on any
+    # POSIX venv -- `bin/python` is a symlink to it (#92086), which is how
+    # this test managed to pass against the bug it looks like it covers.
+    # Kept as-is, because a console script installed against the base
+    # interpreter is a real case that must keep working. The venv spelling
+    # the name promises is covered by
+    # `test_needs_interpreter_accepts_a_shebang_naming_the_venv_python`.
     interpreter = str(Path(sys.executable).resolve())
     hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
@@ -264,3 +280,137 @@ def test_exec_arg_quoting_handles_spaces(tmp_path, xdg_home, monkeypatch):
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
     assert exec_line == f'"{spaced}" desktop'
+
+# ── #92086: sys.executable is a symlink inside a venv ───────────────────────
+#
+# `python -m venv` on POSIX and `uv venv` both create `bin/python` as a
+# SYMLINK to the base interpreter. Resolving it leaves the venv, and the base
+# interpreter has none of the venv's site-packages -- so a `.desktop` entry
+# built from the resolved path dies on `import hermes_cli`, silently, because
+# the entry sets Terminal=false.
+#
+# These tests drive `resolve_exec_command` / `_needs_interpreter` directly
+# rather than through `install_desktop_entry`, so they assert on the decision
+# instead of on a rendered Exec line with platform-specific quoting.
+
+
+def _symlinked_venv(tmp_path):
+    """A base interpreter plus a venv whose `python` is a symlink to it."""
+    import os
+
+    # Deliberately mixed-case: `_needs_interpreter` lowercases the shebang it
+    # reads, so an install path with any uppercase in it is where a
+    # case-blind comparison stops matching.
+    base_dir = tmp_path / "Uv" / "cpython-3.11" / "bin"
+    base_dir.mkdir(parents=True)
+    base = base_dir / "python3.11"
+    base.write_text("", encoding="utf-8")
+
+    venv_dir = tmp_path / "Projects" / "venv" / "bin"
+    venv_dir.mkdir(parents=True)
+    venv = venv_dir / "python"
+    try:
+        os.symlink(base, venv)
+    except (OSError, NotImplementedError) as exc:  # unprivileged Windows
+        pytest.skip(f"symlinks unavailable: {exc}")
+    return base, venv
+
+
+def test_running_interpreter_keeps_the_venv_python(tmp_path, monkeypatch):
+    """The whole bug in one assertion.
+
+    `Path(sys.executable).resolve()` answers with the base interpreter, which
+    cannot import `hermes_cli`. The venv's own `bin/python` can, and it is
+    what belongs in `Exec=`.
+    """
+    base, venv = _symlinked_venv(tmp_path)
+    monkeypatch.setattr(sys, "executable", str(venv))
+
+    assert lde._running_interpreter() == Path(venv)
+    assert Path(sys.executable).resolve() == Path(base).resolve(), (
+        "precondition: this venv python really does resolve out of the venv"
+    )
+
+
+def test_needs_interpreter_accepts_a_shebang_naming_the_venv_python(
+    tmp_path, monkeypatch
+):
+    """A console script installed INTO the venv is already correct.
+
+    Before #92086 this answered True: the shebang named the venv's `bin`, the
+    comparison used the resolved base `bin`, they did not match, and the entry
+    was prefixed with an interpreter that cannot import Hermes.
+    """
+    _base, venv = _symlinked_venv(tmp_path)
+    monkeypatch.setattr(sys, "executable", str(venv))
+
+    script = tmp_path / "local-bin" / "hermes"
+    script.parent.mkdir()
+    script.write_text(f"#!{venv}\nfrom hermes_cli.main import main\n", encoding="utf-8")
+
+    assert lde._needs_interpreter(script) is False
+
+
+def test_needs_interpreter_accepts_a_shebang_naming_the_resolved_interpreter(
+    tmp_path, monkeypatch
+):
+    """Both spellings of "inside this environment" still count.
+
+    A script installed against the base interpreter carries the resolved path,
+    and that was always accepted. Widening the check must not narrow it.
+    """
+    base, venv = _symlinked_venv(tmp_path)
+    monkeypatch.setattr(sys, "executable", str(venv))
+
+    script = tmp_path / "local-bin" / "hermes"
+    script.parent.mkdir()
+    script.write_text(f"#!{base}\nfrom hermes_cli.main import main\n", encoding="utf-8")
+
+    assert lde._needs_interpreter(script) is False
+
+
+def test_needs_interpreter_still_flags_env_python3(tmp_path, monkeypatch):
+    """#90292 must keep working: a foreign shebang still gets the prefix."""
+    _base, venv = _symlinked_venv(tmp_path)
+    monkeypatch.setattr(sys, "executable", str(venv))
+
+    script = tmp_path / "checkout" / "hermes"
+    script.parent.mkdir()
+    script.write_text(
+        "#!/usr/bin/env python3\nfrom hermes_cli.main import main\n", encoding="utf-8"
+    )
+
+    assert lde._needs_interpreter(script) is True
+
+
+def test_exec_prefix_names_the_venv_python_not_its_target(tmp_path, monkeypatch):
+    """The prefixed form must carry the interpreter that has hermes_cli."""
+    base, venv = _symlinked_venv(tmp_path)
+    monkeypatch.setattr(sys, "executable", str(venv))
+
+    script = tmp_path / "checkout" / "hermes"
+    script.parent.mkdir()
+    script.write_text(
+        "#!/usr/bin/env python3\nfrom hermes_cli.main import main\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "hermes_cli.relaunch.resolve_hermes_bin", lambda: str(script)
+    )
+
+    exec_command = lde.resolve_exec_command()
+
+    assert lde._quote_exec_arg(str(venv)) in exec_command
+    assert str(base) not in exec_command
+
+
+def test_module_fallback_names_the_venv_python_too(tmp_path, monkeypatch):
+    """The no-launcher branch builds from sys.executable as well."""
+    base, venv = _symlinked_venv(tmp_path)
+    monkeypatch.setattr(sys, "executable", str(venv))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: None)
+
+    exec_command = lde.resolve_exec_command()
+
+    assert lde._quote_exec_arg(str(venv)) in exec_command
+    assert str(base) not in exec_command
+    assert "-m hermes_cli.main" in exec_command


### PR DESCRIPTION
## What does this PR do?

`hermes desktop` regenerates `~/.local/share/applications/hermes.desktop` on
every launch. Its `Exec=` line was built from `Path(sys.executable).resolve()`.

On POSIX a venv's `bin/python` is a **symlink** to the base interpreter - the
default for both `python -m venv` and `uv venv` - so `.resolve()` follows it out
of the venv and names an interpreter that has none of the venv's site-packages:

```
as-is   : .../venv/bin/python
resolved: .../uv/cpython-3.11/bin/python3.11   <- what went into Exec=
```

The desktop environment then launches an entry that dies on
`import hermes_cli`. Because the entry sets `Terminal=false`, the traceback goes
nowhere: clicking the pinned launcher does nothing at all - no window, no error,
no spinner. #92086 reports exactly that, and its "uv-managed python3.11 shim" is
not a stray interpreter that happened to launch Hermes; it is the reporter's own
venv python with the symlink followed.

### The same call broke the guard above it

`_needs_interpreter()` decides whether the launcher script needs an explicit
interpreter prefix, by checking whether its shebang points inside the running
interpreter's environment:

```python
exe_dir = str(Path(sys.executable).resolve().parent)
return exe_dir not in shebang
```

`exe_dir` is the **base** interpreter's directory, so a console script carrying
`#!/.../venv/bin/python` - the correct interpreter - fails the comparison and is
classified as needing a prefix. The two failures compose: the code decides to
prefix, and then prefixes the interpreter that cannot import Hermes. Without the
`.resolve()`, that wrapper is recognised as already correct and the entry is
left as a plain `Exec=<wrapper> desktop`, which works.

### And a third defect the tests surfaced

`shebang` is lowercased when it is read; the interpreter path it was compared
against was not. So any install path containing an uppercase character
(`/home/User/...`, `~/Projects/...`, anything on Windows) never matched, and
every wrapper on such a host was classified as foreign. The comparison is now
case-folded on both sides.

### Why not the fix suggested in the issue

The issue proposes preferring `shutil.which("hermes")` over `resolve_hermes_bin()`.
That works on the reporter's host, but it resolves the launcher through `PATH`
rather than through "which Hermes is running", so on a machine with more than
one install the entry can end up pointing at a different install than the one
that wrote it. `resolve_hermes_bin()` prefers `sys.argv[0]` precisely for that
reason. This fixes the corrupted interpreter path instead of reordering the
preference around it.

`StartupNotify=false`, also suggested there, is deliberately **not** included:
it is a separate UX question about token propagation that I cannot observe, and
it should not ride along on a correctness fix.

## Related Issue

Fixes #92086

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/linux_desktop_entry.py`
  - New `_running_interpreter()`: `os.path.abspath(sys.executable)` - absolute,
    as the entry requires, without following the venv symlink. Both `Exec=`
    branches (the interpreter prefix and the `-m hermes_cli.main` fallback) now
    use it.
  - `_needs_interpreter()` accepts a shebang naming **either** spelling of the
    interpreter, so a script installed against the base interpreter is still
    recognised, and case-folds the comparison.
- `tests/hermes_cli/test_linux_desktop_entry.py`: 6 new tests.

## How to Test

1. `pytest tests/hermes_cli/test_linux_desktop_entry.py -q`
2. Mutation proofs that the tests bind the fix rather than the refactor:
   - Restore `Path(sys.executable).resolve()` in `_running_interpreter` →
     **4 of the new tests fail**, including
     `test_running_interpreter_keeps_the_venv_python` and both `Exec=` tests.
   - Keep the fix but drop the case-fold → the two
     `test_needs_interpreter_accepts_*` tests fail.
3. On a Linux host whose Hermes runs from a venv created by `uv venv` or
   `python -m venv` (symlinked `bin/python`):
   ```
   $ hermes desktop
   $ grep '^Exec=' ~/.local/share/applications/hermes.desktop
   ```
   The path before `desktop` should be the venv's own `bin/python` (or the
   wrapper, unprefixed), not the interpreter `readlink -f` reports for it.
   `gtk-launch hermes.desktop` should open the app.

### On coverage and what I could not run

The new tests build a real base-interpreter-plus-symlinked-venv tree in
`tmp_path` and drive `resolve_exec_command()` / `_needs_interpreter()` directly,
rather than going through `install_desktop_entry()`, so they assert on the
decision instead of on a rendered `Exec` line with platform-specific quoting.
They skip if the platform cannot create symlinks.

The venv path in the fixture deliberately contains an uppercase segment, so the
case-fold guard binds on Linux CI and not only on Windows.

**I have not run this on Linux.** I am on Windows 11, where venvs copy the
interpreter instead of symlinking it, which is exactly why this bug has never
shown up on this platform. Everything above is source reasoning plus tests that
reproduce the symlink topology; the end-to-end `gtk-launch` check in step 3 is
for someone with the affected host. @the reporter of #92086 - if you run step 3
against this branch I will fold in whatever it shows.

Worth noting the existing `test_exec_leaves_venv_shebang_scripts_alone` did not
catch this: it builds the script's shebang from `Path(sys.executable).resolve()`,
the same corrupted value the code used, so the test agreed with the bug.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #92086 had no linked PR and no cross-references when I claimed it
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — see "Test run honesty" below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 26200, Python 3.13 — see the caveat above; the affected path is POSIX-only

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings only; no user-facing doc describes this internal
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the module is gated behind `is_supported()` (Linux/BSD). macOS venvs symlink too, so the same defect existed there for anyone reaching this code; Windows venvs copy the interpreter, so `abspath` and `resolve` agree and nothing changes
- [x] N/A — no tool descriptions or schemas touched

## Test run honesty

`pytest tests/hermes_cli/test_linux_desktop_entry.py -q` was run with and
without this change on the same machine:

- baseline: 7 failed, 9 passed, 1 skipped
- with this change: 7 failed, 15 passed, 1 skipped

The same 7 fail on both sides. They are the pre-existing Windows-quoting
mismatches in this file (`Exec` escapes backslashes, so an assertion comparing
against a raw `WindowsPath` cannot match) and are unrelated to this change.
