### PR TITLE
fix(windows): restore dedicated CLI launchers on update

### DIFF
--- a/hermes_cli/_install_repair.py
+++ b/hermes_cli/_install_repair.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -115,6 +116,55 @@ def _venv_scripts_dir(root: Path) -> Path | None:
 
     scripts = venv_bin_dir(venv_dir, windows=_is_windows())
     return scripts if scripts.is_dir() else None
+
+
+def _sync_windows_cli_launchers(root: Path) -> list[Path]:
+    """Copy the venv's Hermes launchers into the dedicated PATH directory.
+
+    Windows installs expose ``<root>\\bin`` on PATH instead of the full
+    ``venv\\Scripts`` directory, which would shadow the user's Python.  Keep
+    that narrow PATH layout usable after an update by restoring launchers that
+    are missing from the dedicated directory.
+
+    ``hermes.exe`` is required; ``hermes-acp.exe`` is copied when available.
+    Existing files are left alone because ``bin\\hermes.exe`` may be the
+    executable currently running this process.
+    """
+    if not _is_windows():
+        return []
+
+    root = Path(root)
+    scripts_dir = _venv_scripts_dir(root)
+    required_source = (
+        scripts_dir / "hermes.exe"
+        if scripts_dir is not None
+        else root / "venv" / "Scripts" / "hermes.exe"
+    )
+    if scripts_dir is None or not required_source.is_file():
+        raise FileNotFoundError(
+            f"required Hermes launcher not found: {required_source}"
+        )
+
+    bin_dir = root / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[Path] = []
+    for name in ("hermes.exe", "hermes-acp.exe"):
+        source = scripts_dir / name
+        if not source.is_file():
+            continue
+        destination = bin_dir / name
+        if destination.exists():
+            continue
+        shutil.copy2(source, destination)
+        copied.append(destination)
+
+    required_destination = bin_dir / "hermes.exe"
+    if not required_destination.is_file():
+        raise FileNotFoundError(
+            f"Hermes launcher was not installed: {required_destination}"
+        )
+    return copied
 
 
 def _load_console_script_names(root: Path) -> list[str]:

--- a/hermes_cli/_install_repair.py
+++ b/hermes_cli/_install_repair.py
@@ -135,12 +135,12 @@ def _sync_windows_cli_launchers(root: Path) -> list[Path]:
 
     root = Path(root)
     scripts_dir = _venv_scripts_dir(root)
-    required_source = (
-        scripts_dir / "hermes.exe"
-        if scripts_dir is not None
-        else root / "venv" / "Scripts" / "hermes.exe"
-    )
-    if scripts_dir is None or not required_source.is_file():
+    if scripts_dir is None:
+        raise FileNotFoundError(
+            f"project venv executable directory not found under: {root}"
+        )
+    required_source = scripts_dir / "hermes.exe"
+    if not required_source.is_file():
         raise FileNotFoundError(
             f"required Hermes launcher not found: {required_source}"
         )

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3410,7 +3410,12 @@ def _ensure_fhs_path_guard() -> None:
         print("    (reload your shell or run 'source ~/.bashrc' to pick it up)")
 
 def _ensure_acp_launcher() -> None:
-    """Self-heal: install a ``hermes-acp`` launcher next to the ``hermes`` one.
+    """Self-heal the platform launchers exposed on PATH.
+
+    On Windows, restore missing ``hermes.exe`` / ``hermes-acp.exe`` copies in
+    the dedicated ``<install>\\bin`` directory.  Existing files are not
+    overwritten because ``bin\\hermes.exe`` may be the currently running
+    update launcher.
 
     Mirrors the launcher block in ``scripts/install.sh`` so existing installs
     gain the ACP command on ``hermes update`` without a reinstall.  ACP hosts
@@ -3424,14 +3429,21 @@ def _ensure_acp_launcher() -> None:
     (venv wrapper, FHS symlink, pipx/pip console script) without having to
     reconstruct interpreter/entrypoint paths.
 
-    No-op on Windows (install.ps1 copies ``hermes.exe`` + ``hermes-acp.exe``
-    into ``$InstallDir\bin`` and puts THAT on the user PATH — never the whole
-    ``venv\Scripts`` dir, which would shadow the user's ``python`` (#83797) —
-    so ``hermes-acp.exe`` already resolves) and wherever a ``hermes-acp`` is
-    already present next to the ``hermes`` command.  Unwritable directories
+    On POSIX, the ACP shim is skipped wherever a ``hermes-acp`` is already
+    present next to the ``hermes`` command.  Unwritable POSIX directories
     (e.g. ``/usr/local/bin`` as non-root) are skipped silently.  Idempotent.
     """
     if _m().sys.platform == "win32":
+        from hermes_cli._install_repair import _sync_windows_cli_launchers
+
+        try:
+            copied = _sync_windows_cli_launchers(Path(_m().PROJECT_ROOT))
+        except OSError as exc:
+            print(f"  ⚠ Could not restore Windows command launchers: {exc}")
+            return
+        if copied:
+            names = ", ".join(path.name for path in copied)
+            print(f"  ✓ Restored Windows command launcher(s): {names}")
         return
     for bin_dir in (Path.home() / ".local" / "bin", Path("/usr/local/bin")):
         hermes_cmd = bin_dir / "hermes"
@@ -7030,9 +7042,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
         except Exception as e:
             logger.debug("FHS PATH guard check failed: %s", e)
 
-        # Self-heal the hermes-acp launcher for installs that predate it, so
-        # ACP hosts (Zed, JetBrains, Buzz) can resolve Hermes on PATH without
-        # a reinstall.  No-op on Windows and when already present.
+        # Self-heal the launchers exposed on PATH: the POSIX hermes-acp shim
+        # and missing copies in Windows' dedicated bin directory.
         try:
             _ensure_acp_launcher()
         except Exception as e:

--- a/scripts/ci/test_install_ps1_cli_launchers.ps1
+++ b/scripts/ci/test_install_ps1_cli_launchers.ps1
@@ -1,0 +1,115 @@
+# Behavioral test for install.ps1's dedicated Hermes launcher directory.
+#
+# Run: powershell.exe -NoProfile -File scripts/ci/test_install_ps1_cli_launchers.ps1
+#
+# The test lifts the real Install-HermesCommandLaunchers function from the
+# PowerShell AST and executes it against a temporary install tree. It never
+# reads or changes the user's PATH.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$installPs1 = Join-Path (Join-Path $PSScriptRoot '..') 'install.ps1' | Resolve-Path
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $installPs1, [ref]$null, [ref]$null)
+
+$fn = $ast.Find({
+    param($n)
+    $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+    $n.Name -eq 'Install-HermesCommandLaunchers'
+}, $true)
+
+if (-not $fn) {
+    throw "Install-HermesCommandLaunchers not found in $installPs1"
+}
+
+Invoke-Expression $fn.Extent.Text
+
+$tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$caseRoot = [System.IO.Path]::GetFullPath((Join-Path $tempBase (
+    'hermes-cli-launcher-test-' + [guid]::NewGuid().ToString('N')
+)))
+if (-not $caseRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Refusing to create test directory outside the system temp directory: $caseRoot"
+}
+
+$script:Failures = 0
+
+function Assert-True {
+    param([bool]$Condition, [string]$Name)
+    if ($Condition) {
+        Write-Host "  PASS  $Name"
+    } else {
+        Write-Host "  FAIL  $Name"
+        $script:Failures++
+    }
+}
+
+function Assert-BytesEqual {
+    param([byte[]]$Expected, [byte[]]$Actual, [string]$Name)
+    $same = $Expected.Length -eq $Actual.Length
+    if ($same) {
+        for ($i = 0; $i -lt $Expected.Length; $i++) {
+            if ($Expected[$i] -ne $Actual[$i]) {
+                $same = $false
+                break
+            }
+        }
+    }
+    Assert-True $same $Name
+}
+
+try {
+    New-Item -ItemType Directory -Force -Path $caseRoot | Out-Null
+
+    $missingThrew = $false
+    try {
+        Install-HermesCommandLaunchers -Root $caseRoot | Out-Null
+    } catch {
+        $missingThrew = $_.Exception.Message -like '*required launcher not found*'
+    }
+    Assert-True $missingThrew 'missing hermes.exe fails the launcher stage'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $caseRoot 'bin'))) `
+        'failure does not create an empty PATH directory'
+
+    $scriptsDir = Join-Path $caseRoot 'venv\Scripts'
+    New-Item -ItemType Directory -Force -Path $scriptsDir | Out-Null
+    $hermesV1 = [byte[]](77, 90, 1)
+    $hermesV2 = [byte[]](77, 90, 2)
+    $acp = [byte[]](77, 90, 3)
+    [System.IO.File]::WriteAllBytes((Join-Path $scriptsDir 'hermes.exe'), $hermesV1)
+
+    $binDir = Install-HermesCommandLaunchers -Root $caseRoot
+    Assert-BytesEqual $hermesV1 `
+        ([System.IO.File]::ReadAllBytes((Join-Path $binDir 'hermes.exe'))) `
+        'required launcher is copied into the dedicated bin directory'
+    Assert-True (-not (Test-Path -LiteralPath (Join-Path $binDir 'hermes-acp.exe'))) `
+        'optional ACP launcher may be absent'
+
+    [System.IO.File]::WriteAllBytes((Join-Path $scriptsDir 'hermes.exe'), $hermesV2)
+    [System.IO.File]::WriteAllBytes((Join-Path $scriptsDir 'hermes-acp.exe'), $acp)
+    Install-HermesCommandLaunchers -Root $caseRoot | Out-Null
+    Assert-BytesEqual $hermesV2 `
+        ([System.IO.File]::ReadAllBytes((Join-Path $binDir 'hermes.exe'))) `
+        'installer refreshes an existing Hermes launcher'
+    Assert-BytesEqual $acp `
+        ([System.IO.File]::ReadAllBytes((Join-Path $binDir 'hermes-acp.exe'))) `
+        'installer copies the optional ACP launcher when present'
+} finally {
+    if (Test-Path -LiteralPath $caseRoot) {
+        $resolvedCase = [System.IO.Path]::GetFullPath($caseRoot)
+        if (-not $resolvedCase.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing to remove test directory outside the system temp directory: $resolvedCase"
+        }
+        Remove-Item -LiteralPath $resolvedCase -Recurse -Force
+    }
+}
+
+if ($script:Failures -gt 0) {
+    Write-Host ""
+    Write-Host "$script:Failures assertion(s) failed"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "all assertions passed"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3013,7 +3013,8 @@ function Set-PathVariable {
     if ($NoVenv) {
         $hermesBin = "$InstallDir"
     } else {
-        $hermesBin = Install-HermesCommandLaunchers -Root $InstallDir
+        $hermesBin = "$InstallDir\bin"
+        Install-HermesCommandLaunchers -Root $InstallDir | Out-Null
     }
     
     $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2977,29 +2977,43 @@ print(','.join(scripts))
     Write-Success "All dependencies installed"
 }
 
+function Install-HermesCommandLaunchers {
+    param(
+        [Parameter(Mandatory=$true)] [string]$Root
+    )
+
+    # Expose ONLY the Hermes launchers on PATH -- never the whole
+    # venv\Scripts directory. Requiring hermes.exe before creating bin keeps
+    # the PATH stage from reporting success with an unusable command.
+    $scriptsDir = Join-Path $Root "venv\Scripts"
+    $requiredSource = Join-Path $scriptsDir "hermes.exe"
+    if (-not (Test-Path -LiteralPath $requiredSource -PathType Leaf)) {
+        throw "Cannot set up the hermes command: required launcher not found: $requiredSource"
+    }
+
+    $hermesBin = Join-Path $Root "bin"
+    New-Item -ItemType Directory -Force -Path $hermesBin | Out-Null
+    foreach ($launcher in @("hermes.exe", "hermes-acp.exe")) {
+        $src = Join-Path $scriptsDir $launcher
+        if (Test-Path -LiteralPath $src -PathType Leaf) {
+            Copy-Item -Force -LiteralPath $src -Destination (Join-Path $hermesBin $launcher)
+        }
+    }
+
+    $requiredDestination = Join-Path $hermesBin "hermes.exe"
+    if (-not (Test-Path -LiteralPath $requiredDestination -PathType Leaf)) {
+        throw "Cannot set up the hermes command: launcher was not installed: $requiredDestination"
+    }
+    return $hermesBin
+}
+
 function Set-PathVariable {
     Write-Info "Setting up hermes command..."
     
     if ($NoVenv) {
         $hermesBin = "$InstallDir"
     } else {
-        # Expose ONLY the hermes launchers on PATH -- never the whole
-        # venv\Scripts directory. venv\Scripts contains python.exe /
-        # pythonw.exe / pip.exe, and putting it on the user PATH silently
-        # hijacks the `python` command in every terminal on the machine
-        # (#83797): unrelated projects start resolving python to Hermes'
-        # runtime interpreter. A dedicated bin dir with copies of the
-        # launcher exes keeps `hermes` globally available without
-        # shadowing anything. (Launcher exes embed the venv interpreter
-        # path, so they work from any location and survive updates.)
-        $hermesBin = "$InstallDir\bin"
-        New-Item -ItemType Directory -Force -Path $hermesBin | Out-Null
-        foreach ($launcher in @("hermes.exe", "hermes-acp.exe")) {
-            $src = "$InstallDir\venv\Scripts\$launcher"
-            if (Test-Path $src) {
-                Copy-Item -Force $src "$hermesBin\$launcher"
-            }
-        }
+        $hermesBin = Install-HermesCommandLaunchers -Root $InstallDir
     }
     
     $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")

--- a/tests/hermes_cli/test_windows_cli_launcher_repair.py
+++ b/tests/hermes_cli/test_windows_cli_launcher_repair.py
@@ -1,0 +1,81 @@
+"""Regression coverage for Windows' dedicated Hermes launcher directory."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import _install_repair as install_repair
+from hermes_cli import update_cmd
+
+
+def _make_windows_launchers(tmp_path):
+    root = tmp_path / "hermes-agent"
+    scripts = root / "venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "hermes.exe").write_bytes(b"MZ-hermes")
+    (scripts / "hermes-acp.exe").write_bytes(b"MZ-hermes-acp")
+    return root
+
+
+def _force_windows(monkeypatch, root):
+    fake_main = SimpleNamespace(
+        sys=SimpleNamespace(platform="win32"),
+        PROJECT_ROOT=root,
+    )
+    monkeypatch.setattr(update_cmd, "_m", lambda: fake_main)
+    monkeypatch.setattr(install_repair, "_is_windows", lambda: True)
+
+
+def test_update_restores_missing_dedicated_launchers(tmp_path, monkeypatch):
+    root = _make_windows_launchers(tmp_path)
+    _force_windows(monkeypatch, root)
+
+    update_cmd._ensure_acp_launcher()
+
+    assert (root / "bin" / "hermes.exe").read_bytes() == b"MZ-hermes"
+    assert (root / "bin" / "hermes-acp.exe").read_bytes() == b"MZ-hermes-acp"
+
+
+def test_update_does_not_overwrite_running_launcher(tmp_path, monkeypatch):
+    root = _make_windows_launchers(tmp_path)
+    bin_dir = root / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "hermes.exe").write_bytes(b"MZ-running")
+    _force_windows(monkeypatch, root)
+
+    update_cmd._ensure_acp_launcher()
+
+    assert (bin_dir / "hermes.exe").read_bytes() == b"MZ-running"
+    assert (bin_dir / "hermes-acp.exe").read_bytes() == b"MZ-hermes-acp"
+
+
+def test_missing_required_source_is_visible_and_does_not_create_bin(
+    tmp_path, monkeypatch, capsys
+):
+    root = tmp_path / "hermes-agent"
+    (root / "venv" / "Scripts").mkdir(parents=True)
+    _force_windows(monkeypatch, root)
+
+    update_cmd._ensure_acp_launcher()
+
+    assert "Could not restore Windows command launchers" in capsys.readouterr().out
+    assert not (root / "bin").exists()
+
+
+def test_sync_helper_is_noop_off_windows(tmp_path, monkeypatch):
+    monkeypatch.setattr(install_repair, "_is_windows", lambda: False)
+
+    assert install_repair._sync_windows_cli_launchers(tmp_path) == []
+
+
+def test_sync_helper_requires_hermes_source(tmp_path, monkeypatch):
+    root = tmp_path / "hermes-agent"
+    (root / "venv" / "Scripts").mkdir(parents=True)
+    _force_windows(monkeypatch, root)
+
+    with pytest.raises(FileNotFoundError, match="required Hermes launcher"):
+        install_repair._sync_windows_cli_launchers(root)
+
+    assert not (root / "bin").exists()


### PR DESCRIPTION
## What does this PR do?

Windows installs expose only copied `hermes.exe` and `hermes-acp.exe` launchers from `<install>\bin` on PATH so the venv's `python.exe` does not shadow the user's Python. If the dedicated `hermes.exe` copy disappeared, the PATH installer stage could skip the missing source, retain the empty `bin` directory on PATH, and still print `hermes command ready`. `hermes update` also explicitly skipped launcher repair on Windows.

This makes the PATH stage require and verify `hermes.exe` before changing PATH, and makes `hermes update` restore missing dedicated launcher copies from the venv. Update-time repair never overwrites an existing launcher because `bin\hermes.exe` may be the executable running the update.

## Related Issue

No GitHub issue. Reproduced from a Windows Discord support report where `venv\Scripts\hermes.exe` existed, `<install>\bin\hermes.exe` did not, and rerunning the installer PATH stage restored the command.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a stdlib-only Windows launcher synchronization helper in `hermes_cli/_install_repair.py`.
- Run the missing-only launcher repair from the existing post-update launcher self-heal in `hermes_cli/update_cmd.py`.
- Make `scripts/install.ps1` fail before PATH mutation when the required venv launcher is absent, and verify the copied destination before reporting success.
- Add Python regression coverage for missing-launcher repair, current-launcher preservation, visible repair failure, and non-Windows no-op behavior.
- Add a PowerShell 5.1 behavioral test that executes the real installer helper against an isolated temporary install tree.

## How to Test

1. Run `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\ci\test_install_ps1_cli_launchers.ps1` on Windows PowerShell 5.1.
2. Run `scripts/run_tests.sh tests/hermes_cli/test_windows_cli_launcher_repair.py -q -j 4` in an authorized Python test environment.
3. On a managed Windows install, remove only `<install>\bin\hermes.exe` while keeping `venv\Scripts\hermes.exe`, run the updater through the venv executable, and verify the dedicated launcher is restored. Verify an existing `bin\hermes.exe` is not overwritten by update-time repair.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 with Windows PowerShell 5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing workflow change; affected docstrings were updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — POSIX launcher behavior is unchanged and explicitly covered by the no-op branch
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool changes

## Screenshots / Logs

Focused local validation:

```text
PASS  missing hermes.exe fails the launcher stage
PASS  failure does not create an empty PATH directory
PASS  required launcher is copied into the dedicated bin directory
PASS  optional ACP launcher may be absent
PASS  installer refreshes an existing Hermes launcher
PASS  installer copies the optional ACP launcher when present

all assertions passed
No Windows footguns found (3 files scanned).
```

Also passed: PowerShell AST parse, ASCII-only check for `scripts/install.ps1`, Python syntax compilation for changed Python files, and `git diff --check`.

Focused Python validation passed locally through `scripts/run_tests.sh` with `-j 4`: 25 tests across `test_update_zip_two_phase.py`, `test_windows_native_docs.py`, and `test_windows_cli_launcher_repair.py`.
