### PR TITLE
fix(desktop): rename duplicated toolCallIds before the runtime repository

### DIFF
--- a/apps/desktop/src/app/chat/runtime-repository.test.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.test.ts
@@ -79,4 +79,37 @@ describe('useRuntimeMessageRepository', () => {
 
     expect(windowedParents.get('a-1')).toBe(windowedParents.get('a-2'))
   })
+
+  it('renames a duplicated toolCallId instead of crashing useResources (#87857)', () => {
+    // The streaming path can append the same tool call twice (optimistic write
+    // racing the authoritative event). @assistant-ui/tap's useResources throws
+    // on duplicate resource keys, so the repository must never emit two parts
+    // of one message keyed by the same `toolCallId-<id>`.
+    const duplicated: ChatMessage = {
+      id: 'assistant-dup',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'running…' },
+        { type: 'tool-call', toolCallId: 'call_00_DUP', toolName: 'terminal', args: {}, argsText: '' },
+        { type: 'tool-call', toolCallId: 'call_00_DUP', toolName: 'terminal', args: { done: true }, argsText: '{"done":true}' }
+      ]
+    }
+
+    const { result } = renderHook(() => useRuntimeMessageRepository([text('user-1', 'user', 'go'), duplicated]))
+
+    const assistant = result.current.messages.find(item => item.message.id === 'assistant-dup')
+    expect(assistant).toBeDefined()
+
+    // Every content part now carries a distinct key derivation input.
+    const toolParts = (assistant!.message.content as readonly unknown[]).filter(
+      (part): part is { type: string; toolCallId?: string } =>
+        typeof part === 'object' && part !== null && (part as { type?: string }).type === 'tool-call'
+    )
+    expect(toolParts).toHaveLength(2)
+    const ids = new Set(toolParts.map(part => part.toolCallId))
+    expect(ids.size).toBe(2)
+
+    // And the runtime can link it end to end without throwing.
+    expect(feedToRepository(result.current).map(item => item.id)).toEqual(['user-1', 'assistant-dup'])
+  })
 })

--- a/apps/desktop/src/app/chat/runtime-repository.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.ts
@@ -3,6 +3,7 @@ import type { ExportedMessageRepository, ThreadMessage } from '@assistant-ui/rea
 import { useMemo, useRef } from 'react'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import { withUniqueToolCallIds } from '@/lib/chat-messages/tool-parts'
 import { coalesceToolOnlyAssistants, createToolMergeCache, toRuntimeMessage } from '@/lib/chat-runtime'
 
 // The exact fallback status ExportedMessageRepository.fromBranchableArray uses.
@@ -34,7 +35,15 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
     let visibleParentId: string | null = null
     let headId: string | null = null
 
-    for (const message of coalesceToolOnlyAssistants(messages, toolMergeCacheRef.current)) {
+    // Duplicate toolCallIds inside one message's parts crash @assistant-ui/tap's
+    // useResources ("Duplicate key toolCallId-… in useResources") and take the
+    // workspace pane down with it (#87857). The streaming path can emit the same
+    // tool call twice (optimistic append racing the authoritative event), and
+    // hydration's withUniqueToolCallIds pass does not reach live state. Rename
+    // later duplicates at this boundary, before conversion — same contract as
+    // the seenIds guard below: a repeated id is an upstream bug that must not
+    // become a renderer crash.
+    for (const message of withUniqueToolCallIds(coalesceToolOnlyAssistants(messages, toolMergeCacheRef.current))) {
       // A repeated id is a transcript bug upstream, but it must not reach the
       // repository: MessageRepository throws on the second link ("A message
       // with the same id already exists in the parent tree") and takes the


### PR DESCRIPTION
## Summary

Fixes the Desktop renderer crash loop from #87857 (`Duplicate key toolCallId-… in useResources` → blank/error-boundary workspace pane).

When two parts of one assistant message carry the same `toolCallId`, `@assistant-ui/tap`'s `useResources` hook throws and the workspace error boundary takes the pane down. The streaming path can emit a duplicated tool-call part when an optimistic append races the authoritative gateway event — intermittent, exactly as reported.

The hydration pipeline already ships a dedupe pass (`withUniqueToolCallIds` in `lib/chat-messages/tool-parts.ts`), but it only runs over statically converted transcript history; live streaming state never passes through it.

## Fix

Apply `withUniqueToolCallIds` at one boundary — `useRuntimeMessageRepository` in `apps/desktop/src/app/chat/runtime-repository.ts`, directly beside the existing duplicate **message**-id guard (which already exists for the same class of bug: "a repeated id is a transcript bug upstream, but it must not reach the repository"). Later duplicates get a unique suffixed id; first occurrences are untouched, so rendered tool rows are unaffected in the normal case.

This fixes the whole crash class at the last choke point before assistant-ui rather than chasing every producer that might double-append:

- optimistic append racing the authoritative tool event
- resume/structural-part preservation re-adding a carried part
- any future producer that forgets to dedupe

## Testing

- New regression test in `runtime-repository.test.ts`: feeds a message with two identical `toolCallId` parts through the repository and asserts (a) both parts survive with distinct ids, (b) `MessageRepository` links them end-to-end without throwing.
- Full desktop chat suite: **93 files / 865 tests passing.**
- `tsc -p tsconfig.json --noEmit` clean.

## Notes

- The upstream `Duplicate key` throw also exists in current `@assistant-ui/tap` (checked 0.9.14), so this is worth guarding on our side regardless of upstream behavior changes.
- Verified locally against my own install: patched the compiled renderer bundle with the equivalent skip-duplicates semantics and the previously-crashing session renders again.