### PR TITLE
feat(desktop): show full model id on hover in model picker

### DIFF
--- a/apps/desktop/src/components/model-picker.test.tsx
+++ b/apps/desktop/src/components/model-picker.test.tsx
@@ -1,0 +1,126 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ModelPickerDialog } from './model-picker'
+
+// cmdk observes its list with ResizeObserver / scrollIntoView; jsdom implements
+// neither, so stub them to let the command list mount in tests.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+})
+
+// The picker truncates each row (`min-w-0 flex-1 truncate`) so long provider
+// model ids fit on one line for keyboard nav + cmdk highlight. The escape
+// hatch that keeps the full id reachable is a native `title` attribute on the
+// row. This test pins that contract: a future refactor that drops `title`
+// (the reason the fix exists) must fail here.
+
+const requestModelOptions = vi.fn()
+
+vi.mock('@/lib/model-options', () => ({
+  modelOptionsQueryKey: (profile: null | string | undefined, sessionId?: null | string) => [
+    'model-options',
+    profile ?? 'default',
+    sessionId ?? null
+  ],
+  requestModelOptions: () => requestModelOptions()
+}))
+
+vi.mock('@/store/onboarding', () => ({
+  startManualOnboarding: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { cancel: 'Cancel' },
+      modelPicker: {
+        title: 'Select model',
+        current: 'Current:',
+        unknown: 'unknown',
+        search: 'Search models',
+        noModels: 'No models',
+        addProvider: 'Add provider',
+        pro: 'PRO',
+        proNeedsSubscription: 'Pro needs subscription',
+        free: 'FREE',
+        freeTier: 'Free tier',
+        priceTitle: 'In / Out $/Mtok',
+        wasPrice: 'was',
+        loadFailed: 'Load failed',
+        noAuthenticatedProviders: 'No authenticated providers'
+      }
+    }
+  })
+}))
+
+// Two ids that share the full `ri.language-model-service..language-model.`
+// prefix — the exact real-world case that motivated the tooltip.
+const LONG_OPUS = 'ri.language-model-service..language-model.anthropic-claude-4-8-opus'
+const LONG_SONNET = 'ri.language-model-service..language-model.anthropic-claude-4-6-sonnet'
+
+function renderPicker() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return render(
+    <ModelPickerDialog
+      currentModel={LONG_OPUS}
+      currentProvider="palantir-claude"
+      onOpenChange={() => {}}
+      onSelect={() => {}}
+      open
+    />,
+    { wrapper }
+  )
+}
+
+beforeEach(() => {
+  requestModelOptions.mockResolvedValue({
+    providers: [
+      {
+        name: 'Palantir Claude',
+        slug: 'palantir-claude',
+        models: [LONG_OPUS, LONG_SONNET],
+        authenticated: true
+      }
+    ]
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('ModelPickerDialog row tooltip', () => {
+  it('exposes the full model id via a native title attribute on each row', async () => {
+    renderPicker()
+
+    // cmdk lowercases data-value; match rows by their title attribute instead,
+    // which is exactly the contract under test.
+    const opusRow = await waitFor(() => {
+      const el = document.querySelector<HTMLElement>(`[title="${LONG_OPUS}"]`)
+      if (!el) {
+        throw new Error('opus row not rendered yet')
+      }
+      return el
+    })
+    const sonnetRow = document.querySelector<HTMLElement>(`[title="${LONG_SONNET}"]`)
+
+    expect(opusRow).not.toBeNull()
+    expect(sonnetRow).not.toBeNull()
+    // Finding each row by its [title="<full id>"] selector *is* the assertion:
+    // the whole id is recoverable on hover even though the visible text truncates.
+    expect(opusRow.getAttribute('title')).toBe(LONG_OPUS)
+    expect(sonnetRow?.getAttribute('title')).toBe(LONG_SONNET)
+  })
+})

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -96,7 +96,7 @@ export function ModelPickerDialog({
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent
         bodyClassName="gap-0 overflow-hidden p-0"
-        className={cn('max-h-[85vh] max-w-2xl', contentClassName)}
+        className={cn('max-h-[85vh] max-w-4xl', contentClassName)}
       >
         <DialogHeader className="border-b border-border px-4 py-3">
           <DialogTitle>{copy.title}</DialogTitle>
@@ -227,6 +227,7 @@ function ModelResults({
                       onSelectModel(provider, model)
                     }
                   }}
+                  title={model}
                   value={`${provider.slug}:${model}`}
                 >
                   <span className="min-w-0 flex-1 truncate">
@@ -340,7 +341,7 @@ function ProviderHeading({ provider }: { provider: ModelOptionProvider }) {
     ) : null
 
   return (
-    <span className="flex min-w-0 items-center gap-2">
+    <span className="flex min-w-0 items-center gap-2" title={`${provider.name} · ${provider.slug}`}>
       <span className="truncate">{provider.name}</span>
       <span className="font-mono text-xs font-normal normal-case tracking-normal text-muted-foreground">
         {provider.slug} · {provider.total_models ?? provider.models?.length ?? 0}


### PR DESCRIPTION
## Problem

Some providers ship model ids that are long enough for the picker's row `truncate` to hide the only distinguishing suffix. Users then can't tell two rows apart from the visible text alone.

Concrete example from the field (Palantir Foundry LLM proxy), where every model in the picker shows as:

```
ri.language-model-service..language-model.anthropic-claude-4-8-opus
ri.language-model-service..language-model.anthropic-claude-4-7-opus
ri.language-model-service..language-model.anthropic-claude-4-6-sonnet
ri.language-model-service..language-model.gpt-5-4
ri.language-model-service..language-model.gpt-5-5
```

At `max-w-2xl` (672px) the shared `ri.language-model-service..language-model.` prefix eats the row and the meaningful part gets truncated. Same pattern also hits LiteLLM proxy setups (`openrouter/anthropic/…`, `bedrock/anthropic.claude-3-…`) and long HuggingFace repo names.

## Fix

Three tiny changes to `apps/desktop/src/components/model-picker.tsx` (+3 / -2):

1. **`title={model}` on each `CommandItem`** — hover reveals the full model id via the browser's native tooltip. No new import, no Radix `Tooltip` wrapper, no delay/duration decisions to make.
2. **`title` on the provider heading** — same trick for the provider row, where `provider.name` also lives inside a `truncate`.
3. **Dialog widened from `max-w-2xl` (672px) to `max-w-4xl` (896px)** — buys ~224px of horizontal room so more of the id fits before the truncate kicks in.

The row `truncate` is intentionally kept: rows must stay a single line so keyboard navigation and cmdk's `HighlightMatches` render correctly. The tooltip is the right escape hatch — same shape as e.g. tab titles elsewhere in the shell.

## Why native `title` and not Radix `<Tooltip>`

- Radix Tooltip forces a wrapper around every row and a portal per row, plus a delay decision that would differ from the rest of the picker.
- `cmdk`'s `CommandItem` already forwards HTML attrs, so `title` just works.
- Consistent with how other agent UIs surface truncated model ids.

## Testing

- Local build: `npm run build` in `apps/desktop` — clean, no new warnings tied to this diff.
- Manual verification against a provider config with the ids above:
  - Hover over each row → full `ri.language-model-service..language-model.<name>` visible in tooltip.
  - Wider dialog shows the suffix inline without needing the hover.
  - Provider heading hover shows full name and slug.
- No layout regressions on shorter model ids (`gpt-4o`, `claude-sonnet-4.6`, `gemini-3-1-pro`): the row just doesn't need to truncate.

## Not in scope

- Removing/relocating provider-slug prefixes from ids — that's the provider's data, not the picker's job.
- Full Radix Tooltip migration — larger diff, unrelated concern, better as a follow-up if the team wants richer hover cards (pricing table etc.).

## Invariants

- No change to backend contract, model ordering, filtering, or keyboard navigation.
- No new deps, no new imports.
- Prompt-cache / role-alternation invariants not touched (renderer-only cosmetic fix).
