### PR TITLE
feat(desktop): Add SmartMedia component for unified image/video rendering

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -13,7 +13,6 @@ import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
-import { ZoomableImage } from '@/components/chat/zoomable-image'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
@@ -22,9 +21,7 @@ import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
   downloadGatewayMediaFile,
-  isFileMediaPath,
   isInlineMediaSrc,
-  isMarkdownDocumentPath,
   isRemoteGateway,
   mediaExternalUrl,
   mediaKind,
@@ -40,8 +37,7 @@ import { cn } from '@/lib/utils'
 import { ArtifactCard } from './artifact-card'
 import { SessionRefLink } from './directive-text'
 import { detectEmbed, extractAlert, MarkdownAlert, RichCodeBlock, UrlEmbed } from './embeds'
-import { ResizableMarkdownTable, ResizableMarkdownTh } from './markdown-table'
-import { paragraphPlainText, TranscriptDirectiveLeaf, useIsClaimedDirective } from './transcript-directive'
+import { SmartMedia } from './smart-media'
 
 // Math rendering plugin (KaTeX). Configured once at module scope — the
 // plugin is stateless beyond its internal cache so re-creating per-render
@@ -193,6 +189,9 @@ function MediaAttachment({ path }: { path: string }) {
   }, [kind, path])
 
   if (kind === 'image' && src) {
+    // Source already resolved by resolveMediaPlaybackSrc / resolveMediaDisplaySrc.
+    // Hand the display URL to MarkdownImageContent via an inline src so we do
+    // not re-enter MediaAttachment (which would loop on #media: image paths).
     return (
       <span className="block">
         <MarkdownImage alt={name} src={src} />
@@ -212,16 +211,13 @@ function MediaAttachment({ path }: { path: string }) {
 
   if (kind === 'video' && src) {
     return (
-      <span className="my-3 block max-w-2xl rounded-xl border border-(--ui-stroke-tertiary) bg-muted/35 p-3">
-        <span className="mb-2 block truncate text-xs font-medium text-muted-foreground">{name}</span>
-        <video
-          className="block max-h-112 w-full rounded-lg bg-black"
-          controls
-          onError={() => setFailed(true)}
-          src={src}
-        />
-        {failed && <OpenMediaButton kind="video" path={path} />}
-      </span>
+      <SmartMedia
+        kind="video"
+        name={name}
+        onOpenExternal={open}
+        openFailedNote={openFailed ? <OpenMediaFailedNote name={name} /> : undefined}
+        src={src}
+      />
     )
   }
 
@@ -258,14 +254,6 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
   const mediaPath = mediaPathFromMarkdownHref(href)
 
   if (mediaPath) {
-    // A delivered markdown document is renderable content, not an opaque
-    // download: route it to the preview rail (which renders .md with a
-    // rendered/source toggle) instead of the download-link fallback that
-    // `mediaKind() === 'file'` would produce. (#84951)
-    if (isMarkdownDocumentPath(mediaPath)) {
-      return <PreviewAttachment source="tool-result" target={mediaPath} />
-    }
-
     return <MediaAttachment path={mediaPath} />
   }
 
@@ -284,25 +272,6 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
   const target = href ? normalizeExternalUrl(href) : href
 
   if (!target || !/^https?:\/\//i.test(target)) {
-    // A plain filesystem href (`[report](/home/user/report.md)`, `file://…`,
-    // `~/notes.md`, `C:\…`) names a file on the AGENT's machine. A bare
-    // anchor is a dead link there — file:// is blocked in the renderer, and
-    // on a remote gateway the path isn't even on this disk. Route it through
-    // the preview pipeline instead: normalizeOrLocalPreviewTarget resolves at
-    // VIEW time against the session's backend (local reads the file directly;
-    // remote fetches it over the authenticated /api/fs bridge), so the same
-    // transcript works from every machine that opens it. Media extensions
-    // keep their richer inline player.
-    const fileHref = href && !href.startsWith('#') && isFileMediaPath(href) ? href : null
-
-    if (fileHref) {
-      return mediaKind(fileHref) === 'file' ? (
-        <PreviewAttachment source="explicit-link" target={fileHref} />
-      ) : (
-        <MediaAttachment path={fileHref} />
-      )
-    }
-
     return (
       <a
         className={cn('ref wrap-anywhere', className)}
@@ -418,13 +387,17 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
   // width, so the box overshoots the rendered image and strands the download
   // button — which anchors to the container — out in the margin.
   return (
-    <ZoomableImage
+    <SmartMedia
       alt={alt}
       className={cn(
         'm-0 block h-auto w-auto max-h-(--image-preview-height) max-w-full rounded-lg object-contain shadow-[0_0.0625rem_0.125rem_color-mix(in_srgb,#000_4%,transparent),0_0.625rem_1.5rem_color-mix(in_srgb,#000_5%,transparent)]',
         className
       )}
       containerClassName="my-2 block w-fit max-w-[min(100%,var(--image-preview-max-width))]"
+      kind="image"
+      name={name}
+      onOpenExternal={open}
+      openFailedNote={openFailed ? <OpenMediaFailedNote name={name} /> : undefined}
       slot="aui_markdown-image"
       src={resolvedSrc}
       {...props}
@@ -493,36 +466,6 @@ function HugeTextFallback({ containerClassName, text }: { containerClassName?: s
   )
 }
 
-/**
- * Paragraph override. Almost always a plain `<p>` — but a paragraph that is
- * exactly one `::name{...}` directive claimed by a plugin renders as that
- * plugin's transcript component instead (`transcript.directives` area). The
- * claim check subscribes to the registry, so hot-loading a plugin upgrades
- * already-rendered directives in place; unclaimed directives stay prose.
- */
-function MarkdownParagraph({
-  children,
-  className,
-  streaming,
-  ...props
-}: ComponentProps<'p'> & { streaming?: boolean }) {
-  const plain = paragraphPlainText(children)
-  const claimed = useIsClaimedDirective(plain)
-
-  if (claimed && plain !== null) {
-    return <TranscriptDirectiveLeaf streaming={streaming} text={plain} />
-  }
-
-  return (
-    // Vertical rhythm is owned by styles.css (`--paragraph-gap`), which
-    // must out-specify Tailwind Typography's `prose` margins — so no
-    // `my-*` here on purpose.
-    <p className={cn('wrap-anywhere leading-(--dt-line-height)', className)} {...props}>
-      {children}
-    </p>
-  )
-}
-
 function MarkdownTextSurface({
   containerClassName,
   containerProps,
@@ -554,7 +497,12 @@ function MarkdownTextSurface({
         h4: ({ className, ...props }: ComponentProps<'h4'>) => (
           <h4 className={cn('my-1 font-semibold', HEADING_SIZES.h4, className)} {...props} />
         ),
-        p: (props: ComponentProps<'p'>) => <MarkdownParagraph {...props} streaming={isStreaming} />,
+        p: ({ className, ...props }: ComponentProps<'p'>) => (
+          // Vertical rhythm is owned by styles.css (`--paragraph-gap`), which
+          // must out-specify Tailwind Typography's `prose` margins — so no
+          // `my-*` here on purpose.
+          <p className={cn('wrap-anywhere leading-(--dt-line-height)', className)} {...props} />
+        ),
         a: MarkdownLink,
         // Inline code must not vote when an ancestor resolves `dir="auto"`
         // (HTML's algorithm skips descendants that carry their own dir),
@@ -603,14 +551,29 @@ function MarkdownTextSurface({
         li: ({ className, ...props }: ComponentProps<'li'>) => (
           <li className={cn('leading-(--dt-line-height)', className)} {...props} />
         ),
-        // Columns are drag-resizable; the widths live outside the transcript
-        // (see markdown-table-widths.ts) so a new turn or a session switch
-        // doesn't undo a resize.
-        table: ResizableMarkdownTable,
+        table: ({ className, ...props }: ComponentProps<'table'>) => (
+          <div className="aui-md-table my-2 max-w-full overflow-x-auto rounded-[0.375rem] border border-(--ui-stroke-tertiary)">
+            <table
+              className={cn(
+                'm-0 w-full min-w-[18rem] border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
+                className
+              )}
+              {...props}
+            />
+          </div>
+        ),
         thead: ({ className, ...props }: ComponentProps<'thead'>) => (
           <thead className={cn('m-0 bg-muted/35 text-muted-foreground', className)} {...props} />
         ),
-        th: ResizableMarkdownTh,
+        th: ({ className, ...props }: ComponentProps<'th'>) => (
+          <th
+            className={cn(
+              'whitespace-nowrap px-2.5 py-1.5 text-left align-middle text-[0.75rem] font-medium text-muted-foreground',
+              className
+            )}
+            {...props}
+          />
+        ),
         td: ({ className, ...props }: ComponentProps<'td'>) => (
           <td className={cn('px-2.5 py-1.5 align-top text-[0.8125rem] leading-snug', className)} {...props} />
         ),

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -13,6 +13,7 @@ import { type ComponentProps, memo, useEffect, useMemo, useState } from 'react'
 import { ExpandableBlock } from '@/components/chat/expandable-block'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { chunkByLines, SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
+import { SmartMedia } from './smart-media'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { detectArtifact } from '@/lib/artifact-detect'
 import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/external-link'
@@ -21,7 +22,9 @@ import { parseMarkdownIntoBlocksCached } from '@/lib/markdown-blocks'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
   downloadGatewayMediaFile,
+  isFileMediaPath,
   isInlineMediaSrc,
+  isMarkdownDocumentPath,
   isRemoteGateway,
   mediaExternalUrl,
   mediaKind,
@@ -37,7 +40,8 @@ import { cn } from '@/lib/utils'
 import { ArtifactCard } from './artifact-card'
 import { SessionRefLink } from './directive-text'
 import { detectEmbed, extractAlert, MarkdownAlert, RichCodeBlock, UrlEmbed } from './embeds'
-import { SmartMedia } from './smart-media'
+import { ResizableMarkdownTable, ResizableMarkdownTh } from './markdown-table'
+import { paragraphPlainText, TranscriptDirectiveLeaf, useIsClaimedDirective } from './transcript-directive'
 
 // Math rendering plugin (KaTeX). Configured once at module scope — the
 // plugin is stateless beyond its internal cache so re-creating per-render
@@ -189,9 +193,6 @@ function MediaAttachment({ path }: { path: string }) {
   }, [kind, path])
 
   if (kind === 'image' && src) {
-    // Source already resolved by resolveMediaPlaybackSrc / resolveMediaDisplaySrc.
-    // Hand the display URL to MarkdownImageContent via an inline src so we do
-    // not re-enter MediaAttachment (which would loop on #media: image paths).
     return (
       <span className="block">
         <MarkdownImage alt={name} src={src} />
@@ -254,6 +255,14 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
   const mediaPath = mediaPathFromMarkdownHref(href)
 
   if (mediaPath) {
+    // A delivered markdown document is renderable content, not an opaque
+    // download: route it to the preview rail (which renders .md with a
+    // rendered/source toggle) instead of the download-link fallback that
+    // `mediaKind() === 'file'` would produce. (#84951)
+    if (isMarkdownDocumentPath(mediaPath)) {
+      return <PreviewAttachment source="tool-result" target={mediaPath} />
+    }
+
     return <MediaAttachment path={mediaPath} />
   }
 
@@ -272,6 +281,25 @@ function MarkdownLink({ children, className, href, ...props }: ComponentProps<'a
   const target = href ? normalizeExternalUrl(href) : href
 
   if (!target || !/^https?:\/\//i.test(target)) {
+    // A plain filesystem href (`[report](/home/user/report.md)`, `file://…`,
+    // `~/notes.md`, `C:\…`) names a file on the AGENT's machine. A bare
+    // anchor is a dead link there — file:// is blocked in the renderer, and
+    // on a remote gateway the path isn't even on this disk. Route it through
+    // the preview pipeline instead: normalizeOrLocalPreviewTarget resolves at
+    // VIEW time against the session's backend (local reads the file directly;
+    // remote fetches it over the authenticated /api/fs bridge), so the same
+    // transcript works from every machine that opens it. Media extensions
+    // keep their richer inline player.
+    const fileHref = href && !href.startsWith('#') && isFileMediaPath(href) ? href : null
+
+    if (fileHref) {
+      return mediaKind(fileHref) === 'file' ? (
+        <PreviewAttachment source="explicit-link" target={fileHref} />
+      ) : (
+        <MediaAttachment path={fileHref} />
+      )
+    }
+
     return (
       <a
         className={cn('ref wrap-anywhere', className)}
@@ -393,11 +421,11 @@ function MarkdownImageContent({ className, src, alt, ...props }: ComponentProps<
         'm-0 block h-auto w-auto max-h-(--image-preview-height) max-w-full rounded-lg object-contain shadow-[0_0.0625rem_0.125rem_color-mix(in_srgb,#000_4%,transparent),0_0.625rem_1.5rem_color-mix(in_srgb,#000_5%,transparent)]',
         className
       )}
-      containerClassName="my-2 block w-fit max-w-[min(100%,var(--image-preview-max-width))]"
       kind="image"
       name={name}
       onOpenExternal={open}
       openFailedNote={openFailed ? <OpenMediaFailedNote name={name} /> : undefined}
+      containerClassName="my-2 block w-fit max-w-[min(100%,var(--image-preview-max-width))]"
       slot="aui_markdown-image"
       src={resolvedSrc}
       {...props}
@@ -466,6 +494,36 @@ function HugeTextFallback({ containerClassName, text }: { containerClassName?: s
   )
 }
 
+/**
+ * Paragraph override. Almost always a plain `<p>` — but a paragraph that is
+ * exactly one `::name{...}` directive claimed by a plugin renders as that
+ * plugin's transcript component instead (`transcript.directives` area). The
+ * claim check subscribes to the registry, so hot-loading a plugin upgrades
+ * already-rendered directives in place; unclaimed directives stay prose.
+ */
+function MarkdownParagraph({
+  children,
+  className,
+  streaming,
+  ...props
+}: ComponentProps<'p'> & { streaming?: boolean }) {
+  const plain = paragraphPlainText(children)
+  const claimed = useIsClaimedDirective(plain)
+
+  if (claimed && plain !== null) {
+    return <TranscriptDirectiveLeaf streaming={streaming} text={plain} />
+  }
+
+  return (
+    // Vertical rhythm is owned by styles.css (`--paragraph-gap`), which
+    // must out-specify Tailwind Typography's `prose` margins — so no
+    // `my-*` here on purpose.
+    <p className={cn('wrap-anywhere leading-(--dt-line-height)', className)} {...props}>
+      {children}
+    </p>
+  )
+}
+
 function MarkdownTextSurface({
   containerClassName,
   containerProps,
@@ -497,12 +555,7 @@ function MarkdownTextSurface({
         h4: ({ className, ...props }: ComponentProps<'h4'>) => (
           <h4 className={cn('my-1 font-semibold', HEADING_SIZES.h4, className)} {...props} />
         ),
-        p: ({ className, ...props }: ComponentProps<'p'>) => (
-          // Vertical rhythm is owned by styles.css (`--paragraph-gap`), which
-          // must out-specify Tailwind Typography's `prose` margins — so no
-          // `my-*` here on purpose.
-          <p className={cn('wrap-anywhere leading-(--dt-line-height)', className)} {...props} />
-        ),
+        p: (props: ComponentProps<'p'>) => <MarkdownParagraph {...props} streaming={isStreaming} />,
         a: MarkdownLink,
         // Inline code must not vote when an ancestor resolves `dir="auto"`
         // (HTML's algorithm skips descendants that carry their own dir),
@@ -551,29 +604,14 @@ function MarkdownTextSurface({
         li: ({ className, ...props }: ComponentProps<'li'>) => (
           <li className={cn('leading-(--dt-line-height)', className)} {...props} />
         ),
-        table: ({ className, ...props }: ComponentProps<'table'>) => (
-          <div className="aui-md-table my-2 max-w-full overflow-x-auto rounded-[0.375rem] border border-(--ui-stroke-tertiary)">
-            <table
-              className={cn(
-                'm-0 w-full min-w-[18rem] border-collapse text-[0.8125rem] [&_tr]:border-b [&_tr]:border-(--ui-stroke-tertiary) last:[&_tr]:border-0',
-                className
-              )}
-              {...props}
-            />
-          </div>
-        ),
+        // Columns are drag-resizable; the widths live outside the transcript
+        // (see markdown-table-widths.ts) so a new turn or a session switch
+        // doesn't undo a resize.
+        table: ResizableMarkdownTable,
         thead: ({ className, ...props }: ComponentProps<'thead'>) => (
           <thead className={cn('m-0 bg-muted/35 text-muted-foreground', className)} {...props} />
         ),
-        th: ({ className, ...props }: ComponentProps<'th'>) => (
-          <th
-            className={cn(
-              'whitespace-nowrap px-2.5 py-1.5 text-left align-middle text-[0.75rem] font-medium text-muted-foreground',
-              className
-            )}
-            {...props}
-          />
-        ),
+        th: ResizableMarkdownTh,
         td: ({ className, ...props }: ComponentProps<'td'>) => (
           <td className={cn('px-2.5 py-1.5 align-top text-[0.8125rem] leading-snug', className)} {...props} />
         ),

--- a/apps/desktop/src/components/assistant-ui/smart-media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/smart-media.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { SmartMedia } from './smart-media'
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      desktop: {
+        resumeRetry: 'Retry',
+        openImage: 'Open image',
+        downloadImage: 'Download image',
+        savingImage: 'Saving image'
+      }
+    }
+  })
+}))
+
+vi.mock('@/hooks/use-image-download', () => ({
+  useImageDownload: () => ({ download: vi.fn(), saving: false })
+}))
+
+describe('SmartMedia', () => {
+  afterEach(cleanup)
+
+  it('forwards native image props onto the rendered <img>', () => {
+    render(
+      <SmartMedia
+        alt="shot"
+        data-testid="smart-img"
+        kind="image"
+        name="shot.png"
+        src="https://example.com/shot.png"
+        title="preview"
+      />
+    )
+
+    const image = screen.getByRole('img', { name: 'shot' })
+    expect(image.getAttribute('title')).toBe('preview')
+    expect(image.getAttribute('data-testid')).toBe('smart-img')
+  })
+
+  it('shows ErrorFallback + retry for image load failures', () => {
+    render(<SmartMedia alt="broken" kind="image" name="broken.png" src="https://example.com/broken.png" />)
+
+    fireEvent.error(screen.getByRole('img', { name: 'broken' }))
+
+    expect(screen.getByText(/Couldn't load broken.png/i)).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+
+  it('remounts the image on retry after a failure', () => {
+    const { container } = render(
+      <SmartMedia alt="broken" kind="image" name="broken.png" src="https://example.com/broken.png" />
+    )
+
+    fireEvent.error(screen.getByRole('img', { name: 'broken' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    const image = screen.getByRole('img', { name: 'broken' })
+    expect(image).toBeTruthy()
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('https://example.com/broken.png')
+  })
+
+  it('renders an inline video player for video kind', () => {
+    const { container } = render(
+      <SmartMedia kind="video" name="clip.mp4" src="hermes-media://stream/clip.mp4" />
+    )
+
+    expect(container.querySelector('video')).not.toBeNull()
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('shows ErrorFallback for video load failures and supports open external', () => {
+    const onOpenExternal = vi.fn()
+    const { container } = render(
+      <SmartMedia
+        kind="video"
+        name="clip.mp4"
+        onOpenExternal={onOpenExternal}
+        src="hermes-media://stream/clip.mp4"
+      />
+    )
+
+    const video = container.querySelector('video')
+    expect(video).not.toBeNull()
+    fireEvent.error(video as HTMLVideoElement)
+
+    expect(screen.getByText(/Couldn't load clip.mp4/i)).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }))
+    expect(onOpenExternal).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/smart-media.tsx
+++ b/apps/desktop/src/components/assistant-ui/smart-media.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { type ComponentProps, type ReactNode, useCallback, useState } from 'react'
+
+import { ZoomableImage } from '@/components/chat/zoomable-image'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+export interface SmartMediaProps extends Omit<ComponentProps<'img'>, 'src' | 'alt' | 'className'> {
+  /** Already-resolved playback/display URL (http(s)/data/blob/hermes-media). */
+  src: string
+  alt?: string
+  className?: string
+  containerClassName?: string
+  /** Explicit kind — required when `src` is a data/blob URL that has no extension. */
+  kind: 'image' | 'video'
+  /** Human label for error/retry chrome. */
+  name?: string
+  /** Optional ZoomableImage slot for images. */
+  slot?: string
+  /** Optional external-open affordance shown after a hard failure (video). */
+  onOpenExternal?: () => void
+  openFailedNote?: ReactNode
+}
+
+function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center py-4">
+      <div className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-foreground" />
+    </div>
+  )
+}
+
+function ErrorFallback({
+  name,
+  onRetry,
+  onOpenExternal,
+  openFailedNote
+}: {
+  name: string
+  onRetry: () => void
+  onOpenExternal?: () => void
+  openFailedNote?: ReactNode
+}) {
+  const { t } = useI18n()
+  const copy = t.desktop
+
+  return (
+    <div className="my-2 flex flex-col gap-1 rounded-lg border border-(--ui-stroke-tertiary) bg-muted/35 p-3 text-sm text-muted-foreground">
+      <div className="flex items-center gap-2">
+        <span aria-hidden>⚠️</span>
+        <span className="min-w-0 flex-1 truncate">Couldn&apos;t load {name}</span>
+        <button
+          className="shrink-0 text-xs font-medium text-foreground underline underline-offset-2"
+          onClick={onRetry}
+          type="button"
+        >
+          {copy.resumeRetry || 'Retry'}
+        </button>
+        {onOpenExternal ? (
+          <button
+            className="shrink-0 text-xs font-medium text-foreground underline underline-offset-2"
+            onClick={onOpenExternal}
+            type="button"
+          >
+            Open
+          </button>
+        ) : null}
+      </div>
+      {openFailedNote}
+    </div>
+  )
+}
+
+/**
+ * Shared presentation layer for already-resolved image/video sources.
+ *
+ * Source resolution (`#media:`, remote gateway, hermes-media streaming) stays in
+ * `MediaAttachment` / `resolveMedia*`. This component only handles load/error/
+ * retry chrome and image lightbox (via ZoomableImage).
+ */
+export function SmartMedia({
+  src,
+  alt,
+  className,
+  containerClassName,
+  kind,
+  name,
+  slot,
+  onOpenExternal,
+  openFailedNote,
+  style,
+  ...imgProps
+}: SmartMediaProps) {
+  const label = name || alt || 'media'
+  const [loaded, setLoaded] = useState(false)
+  const [failed, setFailed] = useState(false)
+  // Bump to force <img>/<video> remount on retry so the browser re-fetches.
+  const [retryKey, setRetryKey] = useState(0)
+
+  const handleLoad = useCallback(() => {
+    setLoaded(true)
+    setFailed(false)
+  }, [])
+
+  const handleError = useCallback(() => {
+    setFailed(true)
+    setLoaded(false)
+  }, [])
+
+  const handleRetry = useCallback(() => {
+    setFailed(false)
+    setLoaded(false)
+    setRetryKey(key => key + 1)
+  }, [])
+
+  if (kind === 'image') {
+    if (failed) {
+      return (
+        <span className={cn('block', containerClassName)}>
+          <ErrorFallback
+            name={label}
+            onOpenExternal={onOpenExternal}
+            onRetry={handleRetry}
+            openFailedNote={openFailedNote}
+          />
+        </span>
+      )
+    }
+
+    const pendingStyle =
+      !loaded && style && typeof style === 'object' && !Array.isArray(style)
+        ? { ...style, opacity: 0 }
+        : !loaded
+          ? { opacity: 0 }
+          : style
+
+    return (
+      <ZoomableImage
+        key={retryKey}
+        alt={alt}
+        className={cn(!loaded && 'animate-pulse bg-muted/35', className)}
+        containerClassName={containerClassName}
+        slot={slot}
+        src={src}
+        style={pendingStyle}
+        {...imgProps}
+        // Keep load/error ownership after imgProps so callers cannot drop retry chrome.
+        onError={handleError}
+        onLoad={handleLoad}
+      />
+    )
+  }
+
+  return (
+    <span
+      className={cn(
+        'my-3 block max-w-2xl rounded-xl border border-(--ui-stroke-tertiary) bg-muted/35 p-3',
+        containerClassName
+      )}
+    >
+      <span className="mb-2 block truncate text-xs font-medium text-muted-foreground">{label}</span>
+      {!loaded && !failed ? <LoadingSpinner /> : null}
+      {failed ? (
+        <ErrorFallback
+          name={label}
+          onOpenExternal={onOpenExternal}
+          onRetry={handleRetry}
+          openFailedNote={openFailedNote}
+        />
+      ) : (
+        <video
+          key={retryKey}
+          className={cn('block max-h-112 w-full rounded-lg bg-black', !loaded && 'hidden')}
+          controls
+          onError={handleError}
+          onLoadedData={handleLoad}
+          preload="metadata"
+          src={src}
+        />
+      )}
+    </span>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/smart-media.tsx
+++ b/apps/desktop/src/components/assistant-ui/smart-media.tsx
@@ -49,7 +49,7 @@ function ErrorFallback({
     <div className="my-2 flex flex-col gap-1 rounded-lg border border-(--ui-stroke-tertiary) bg-muted/35 p-3 text-sm text-muted-foreground">
       <div className="flex items-center gap-2">
         <span aria-hidden>⚠️</span>
-        <span className="min-w-0 flex-1 truncate">Couldn&apos;t load {name}</span>
+        <span className="min-w-0 flex-1 truncate">{copy.loadFailed ? copy.loadFailed(name) : `Couldn't load ${name}`}</span>
         <button
           className="shrink-0 text-xs font-medium text-foreground underline underline-offset-2"
           onClick={onRetry}


### PR DESCRIPTION
## Summary

Rework SmartMedia against current main. Addresses teknium1's 4 review comments from PR #46103.

## Changes

- Integrate through MediaAttachment/#media: path (fixes routing)
- Fix image failure handling with ErrorFallback + retry (fixes hidden failures)
- Match props types - SmartMediaProps extends ComponentProps<'img'> (fixes type mismatch)
- Remove unused imports, add unit tests (fixes lint error)

## Files

- apps/desktop/src/components/assistant-ui/smart-media.tsx (new, 184 lines)
- apps/desktop/src/components/assistant-ui/smart-media.test.tsx (new, 94 lines)
- apps/desktop/src/components/assistant-ui/markdown-text.tsx (updated)

## Testing

- 5 unit tests pass
- Verified integration with existing #media: path

Refs #46103