### PR TITLE
feat(cron): expose per-job reasoning_effort in the dashboard job editor

### DIFF
--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -388,6 +388,10 @@ class CronJobCreate(BaseModel):
     enabled_toolsets: Optional[List[str]] = None
     workdir: Optional[str] = None
     no_agent: bool = False
+    # Optional per-job reasoning effort pin (none/minimal/.../ultra), same
+    # grammar cron.jobs.create_job accepts; None leaves the job following
+    # config resolution.
+    reasoning_effort: Optional[str] = None
 
 
 class CronJobUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12851,6 +12851,7 @@ def _create_cron_job_sync(body: CronJobCreate, profile: Optional[str] = None):
             enabled_toolsets=_cron_string_list(body.enabled_toolsets),
             workdir=_cron_optional_text(body.workdir),
             no_agent=no_agent,
+            reasoning_effort=body.reasoning_effort,
         )
     except HTTPException:
         raise

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2246,6 +2246,8 @@ export interface CronJobMutation {
   context_from?: string[] | null;
   enabled_toolsets?: string[] | null;
   workdir?: string | null;
+  /** Per-job reasoning effort pin (none/minimal/.../ultra); null = follow config. */
+  reasoning_effort?: string | null;
 }
 
 export interface CronJob {
@@ -2271,6 +2273,7 @@ export interface CronJob {
   context_from?: string[] | string | null;
   enabled_toolsets?: string[] | null;
   workdir?: string | null;
+  reasoning_effort?: string | null;
   last_run_at?: string | null;
   next_run_at?: string | null;
   last_status?: string | null;

--- a/web/src/lib/cron-job.test.ts
+++ b/web/src/lib/cron-job.test.ts
@@ -25,6 +25,7 @@ function form(overrides: Partial<CronJobFormState> = {}): CronJobFormState {
     continuity: false,
     enabled_toolsets: [],
     workdir: "",
+    reasoning_effort: "",
     ...overrides,
   };
 }
@@ -85,7 +86,21 @@ describe("buildCronJobPayload", () => {
       context_from: null,
       enabled_toolsets: null,
       workdir: null,
+      reasoning_effort: null,
     });
+  });
+
+  it("pins reasoning_effort only for known levels and clears otherwise", () => {
+    expect(
+      buildCronJobPayload(form({ reasoning_effort: "none" })).reasoning_effort,
+    ).toBe("none");
+    expect(
+      buildCronJobPayload(form({ reasoning_effort: "HIGH" })).reasoning_effort,
+    ).toBe("high");
+    // "" = follow config; update payloads must explicitly clear the pin.
+    expect(
+      buildCronJobPayload(form({ reasoning_effort: "" })).reasoning_effort,
+    ).toBeNull();
   });
 });
 
@@ -135,6 +150,24 @@ describe("cronJobFormFromJob", () => {
       context_from: "upstream-a",
       continuity: true,
     });
+  });
+
+  it("hydrates the reasoning effort pin and defaults to follow-config", () => {
+    expect(
+      cronJobFormFromJob({
+        id: "abc",
+        enabled: true,
+        schedule_display: "every 1h",
+        reasoning_effort: "none",
+      } as CronJob).reasoning_effort,
+    ).toBe("none");
+    expect(
+      cronJobFormFromJob({
+        id: "abc",
+        enabled: true,
+        schedule_display: "every 1h",
+      } as CronJob).reasoning_effort,
+    ).toBe("");
   });
 
   it("prefers one-shot run_at over the human display string", () => {

--- a/web/src/lib/cron-job.ts
+++ b/web/src/lib/cron-job.ts
@@ -1,4 +1,5 @@
 import type { CronJob, CronJobMutation } from "./api";
+import { VALID_EFFORTS } from "./reasoning-effort";
 
 export interface CronJobFormState {
   name: string;
@@ -15,6 +16,8 @@ export interface CronJobFormState {
   continuity: boolean;
   enabled_toolsets: string[];
   workdir: string;
+  /** Per-job reasoning effort pin. "" = follow config resolution. */
+  reasoning_effort: string;
 }
 
 /** Split a comma/newline list (or array) into trimmed, non-empty items. */
@@ -50,6 +53,9 @@ export function buildCronJobPayload(form: CronJobFormState): CronJobMutation {
   );
   if (form.continuity) contextFrom.push("self");
   const enabledToolsets = form.enabled_toolsets.filter(Boolean);
+  // "" / unknown = follow config resolution; collapse to null so an update
+  // explicitly clears the per-job pin (backend normalizes null/"" to clear).
+  const effort = String(form.reasoning_effort ?? "").trim().toLowerCase();
   return {
     name: form.name.trim(),
     prompt: form.prompt.trim(),
@@ -64,6 +70,7 @@ export function buildCronJobPayload(form: CronJobFormState): CronJobMutation {
     context_from: contextFrom.length > 0 ? contextFrom : null,
     enabled_toolsets: enabledToolsets.length > 0 ? enabledToolsets : null,
     workdir: optionalText(form.workdir),
+    reasoning_effort: VALID_EFFORTS.has(effort) ? effort : null,
   };
 }
 
@@ -100,5 +107,6 @@ export function cronJobFormFromJob(job: CronJob): CronJobFormState {
     continuity,
     enabled_toolsets: splitCronList(job.enabled_toolsets),
     workdir: asString(job.workdir),
+    reasoning_effort: asString((job as { reasoning_effort?: unknown }).reasoning_effort),
   };
 }

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -38,6 +38,7 @@ import {
   type ScheduleDescribeStrings,
 } from "@/lib/schedule";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
+import { EFFORT_OPTIONS } from "@/lib/reasoning-effort";
 import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { Toast } from "@nous-research/ui/ui/components/toast";
@@ -148,6 +149,7 @@ function emptyCronJobForm(): CronJobEditorState {
     continuity: false,
     enabled_toolsets: [],
     workdir: "",
+    reasoning_effort: "",
     scheduleState: { ...DEFAULT_SCHEDULE_STATE },
   };
 }
@@ -249,6 +251,27 @@ function CronAdvancedFields({
               )}
             </Select>
           </div>
+        </div>
+
+        <div className="grid gap-1">
+          <Label htmlFor={`${idPrefix}-reasoning-effort`}>Reasoning</Label>
+          <Select
+            id={`${idPrefix}-reasoning-effort`}
+            value={form.reasoning_effort}
+            onValueChange={(v) => update("reasoning_effort", v)}
+          >
+            <SelectOption value="">Follow config (default)</SelectOption>
+            {EFFORT_OPTIONS.map((opt) => (
+              <SelectOption key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectOption>
+            ))}
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            Pin thinking for this job only. Models without reasoning support
+            (e.g. gpt-4o-mini) need Off; a pin here overrides the global
+            reasoning config at fire time.
+          </p>
         </div>
 
         <div className="grid gap-1">


### PR DESCRIPTION
## Problem

Cron jobs pinned to models without reasoning support (e.g. `gpt-4o-mini`) fail at fire time with a provider error ("reasoning not supported for that model") whenever the global reasoning config enables thinking. The scheduler already resolves a per-job `reasoning_effort` pin — `cron/scheduler.py::_resolve_job_reasoning_config` (pin > `agent.reasoning_overrides` > `agent.reasoning_effort`) — and `cronjob`-tool/API-created jobs can set it, but the dashboard job editor could not:

- `web_models.CronJobCreate` had no `reasoning_effort` field, so POST `/api/cron/jobs` silently dropped it.
- The editor form had no control for it.

So dashboard users could pin a cheap non-reasoning model per job but had no way to disable thinking for that job.

## Fix

Wire the existing store-level capability through the dashboard API and UI — no scheduler/store changes needed.

**Backend**
- `hermes_cli/web_models.py`: add optional `reasoning_effort` to `CronJobCreate`.
- `hermes_cli/web_server.py::_create_cron_job_sync`: forward it to `jobs.create_job`, which validates via the canonical grammar (`_normalize_reasoning_effort`). The PUT path already validated through `jobs.update_job`.

**Frontend**
- `web/src/pages/CronPage.tsx`: **Reasoning** select in Advanced fields next to Provider/Model — *Follow config (default)*, *Off (no thinking)*, Minimal → Ultra (`EFFORT_OPTIONS`, same ladder as the sidebar ReasoningPicker). Helper text notes non-reasoning models like gpt-4o-mini need Off.
- `web/src/lib/cron-job.ts`: form state + payload round-trip the pin; empty/unknown collapses to `null` so updates explicitly clear it (backend treats `null`/`""` as clear).
- `web/src/lib/api.ts`: `reasoning_effort?: string | null` on `CronJobMutation` and `CronJob`.

## Behavior

| Select value | Stored / sent | Effect at fire time |
|---|---|---|
| Follow config (default) | field absent on create; `null` on update | unchanged default behavior |
| Off | `"none"` | `reasoning_config = {"enabled": false}` |
| Minimal…Ultra | level string | pinned effort, clamped downstream by transports |

## Test Plan

- [x] `npx vitest run src/lib/cron-job.test.ts` — 12 passed (new round-trip cases: pin kept, case-normalized, empty clears)
- [x] `npm run typecheck` (`tsc -p . --noEmit`) — clean
- [x] `uv run pytest tests/cron/test_cron_reasoning_effort.py` — 31 passed
- [x] `py_compile` on both touched Python files