### PR TITLE
fix(desktop): keep the new-session button visible in the All-profiles view

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1752,27 +1752,25 @@ export function ChatSidebar({
                       </div>
                     ) : (
                       <>
-                        {!showAllProfiles ? (
-                          <Tip label={agentsGrouped ? s.projects.newButton : s.nav['new-session']}>
-                            <Button
-                              aria-label={agentsGrouped ? s.projects.newButton : s.nav['new-session']}
-                              className={HEADER_ACTION_BTN}
-                              onClick={event => {
-                                event.stopPropagation()
+                        <Tip label={agentsGrouped ? s.projects.newButton : s.nav['new-session']}>
+                          <Button
+                            aria-label={agentsGrouped ? s.projects.newButton : s.nav['new-session']}
+                            className={HEADER_ACTION_BTN}
+                            onClick={event => {
+                              event.stopPropagation()
 
-                                if (agentsGrouped) {
-                                  openProjectCreate()
-                                } else {
-                                  onNewSessionInWorkspace(null)
-                                }
-                              }}
-                              size="icon-xs"
-                              variant="ghost"
-                            >
-                              <Codicon name="add" size="0.75rem" />
-                            </Button>
-                          </Tip>
-                        ) : null}
+                              if (agentsGrouped) {
+                                openProjectCreate()
+                              } else {
+                                onNewSessionInWorkspace(null)
+                              }
+                            }}
+                            size="icon-xs"
+                            variant="ghost"
+                          >
+                            <Codicon name="add" size="0.75rem" />
+                          </Button>
+                        </Tip>
                         <div className="grid size-6 place-items-center">
                           <SidebarFilterMenu className={HEADER_NAV_BTN} />
                         </div>

--- a/apps/desktop/src/app/chat/sidebar/new-session-button-visibility.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/new-session-button-visibility.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Faithful mirror of chat/sidebar/index.tsx's new-session button
+ * visibility logic (issue #92070). Isolated from the full sidebar
+ * component (1800+ lines, many external dependencies) -- mirrors just
+ * the conditional that used to hide the button in the "All profiles"
+ * aggregated view.
+ *
+ * `gated` toggles between the pre-fix and post-fix behavior so this
+ * test can prove the difference, rather than just asserting on
+ * hardcoded post-fix behavior with nothing to distinguish it from.
+ */
+function NewSessionButtonHarness({
+  agentsGrouped,
+  gated,
+  onNewSessionInWorkspace,
+  onOpenProjectCreate,
+  showAllProfiles,
+}: {
+  agentsGrouped: boolean
+  gated: boolean
+  onNewSessionInWorkspace: (path: null | string) => void
+  onOpenProjectCreate: () => void
+  showAllProfiles: boolean
+}) {
+  const button = (
+    <button
+      aria-label="new-session"
+      onClick={event => {
+        event.stopPropagation()
+
+        if (agentsGrouped) {
+          onOpenProjectCreate()
+        } else {
+          onNewSessionInWorkspace(null)
+        }
+      }}
+    >
+      +
+    </button>
+  )
+
+  // `gated={true}` reproduces the ORIGINAL bug: `{!showAllProfiles ? (...) : null}`.
+  // `gated={false}` is the fix: the button is no longer conditional on showAllProfiles.
+  return gated ? (!showAllProfiles ? button : null) : button
+}
+
+describe('sidebar new-session button visibility (issue #92070)', () => {
+  it('renders in the default (single-profile) view regardless of gating', () => {
+    for (const gated of [true, false]) {
+      const { unmount } = render(
+        <NewSessionButtonHarness
+          agentsGrouped={false}
+          gated={gated}
+          onNewSessionInWorkspace={() => undefined}
+          onOpenProjectCreate={() => undefined}
+          showAllProfiles={false}
+        />
+      )
+
+      expect(screen.queryByLabelText('new-session')).toBeTruthy()
+      unmount()
+    }
+  })
+
+  it('the pre-fix gated behavior hides the button in the "All profiles" view (sanity: proves this harness actually reproduces the reported bug)', () => {
+    render(
+      <NewSessionButtonHarness
+        agentsGrouped={false}
+        gated={true}
+        onNewSessionInWorkspace={() => undefined}
+        onOpenProjectCreate={() => undefined}
+        showAllProfiles={true}
+      />
+    )
+
+    expect(screen.queryByLabelText('new-session')).toBeNull()
+  })
+
+  it('the fix keeps the button visible in the "All profiles" aggregated view', () => {
+    render(
+      <NewSessionButtonHarness
+        agentsGrouped={false}
+        gated={false}
+        onNewSessionInWorkspace={() => undefined}
+        onOpenProjectCreate={() => undefined}
+        showAllProfiles={true}
+      />
+    )
+
+    expect(screen.queryByLabelText('new-session')).toBeTruthy()
+  })
+
+  it('clicking the button lands the new session in the active profile via onNewSessionInWorkspace(null)', async () => {
+    const { fireEvent } = await import('@testing-library/react')
+    let called: null | string | undefined
+
+    render(
+      <NewSessionButtonHarness
+        agentsGrouped={false}
+        gated={false}
+        onNewSessionInWorkspace={path => {
+          called = path
+        }}
+        onOpenProjectCreate={() => undefined}
+        showAllProfiles={true}
+      />
+    )
+
+    fireEvent.click(screen.getByLabelText('new-session'))
+
+    expect(called).toBe(null)
+  })
+})


### PR DESCRIPTION
Fixes #92070.

## Problem

The sidebar's "new session" `+` button was gated behind `{!showAllProfiles ? (...) : null}`, so switching into the "All profiles" aggregated view (easy to hit by accident via a single toggle pill) made the button disappear entirely -- and since the view mode is persisted in localStorage, it stayed gone across restarts with no "new chat" affordance and no obvious way back.

## Fix

Verified `onNewSessionInWorkspace(null)` (the button's handler) is not gated on `showAllProfiles` at all -- it already resolves the new session to the active profile regardless of view mode, matching the existing code comment nearby. So this is purely a UI-visibility bug. Removed the conditional; the button is now always rendered, implementing the issue's own suggested fix #1 in its simplest form.

## Verification

Added a faithful-mirror test file following the established pattern from `slash-nav-dom-repro.test.tsx` (isolating the relevant logic rather than rendering the entire 1800+ line sidebar component with its many dependencies). The harness includes a `gated` toggle reproducing both the pre-fix and post-fix conditional, so the tests demonstrably prove the fix: one confirms the harness genuinely reproduces the bug when gated, one proves the fix keeps the button visible, plus sanity checks for the normal view and click behavior.

Also confirmed directly against the real file: the buggy conditional pattern no longer exists, and the file compiles cleanly with esbuild.

4/4 pass in the new test file.