### PR TITLE
fix(whatsapp): load group allowlist from profile env fallback

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -449,7 +449,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             allow_raw = None
         self._allow_from = self._coerce_allow_list(allow_raw)
         self._group_policy = str(config.extra.get("group_policy") or _wenv("WHATSAPP_GROUP_POLICY", "pairing")).strip().lower()
-        self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        # Mirror DM allowlist precedence: explicit config (including an empty
+        # list) is authoritative, with the documented profile-scoped env var
+        # as a fallback for legacy/setup-created configurations.
+        if "group_allow_from" in config.extra:
+            group_allow_raw = config.extra.get("group_allow_from")
+        elif "groupAllowFrom" in config.extra:
+            group_allow_raw = config.extra.get("groupAllowFrom")
+        else:
+            group_allow_raw = _wenv("WHATSAPP_GROUP_ALLOWED_USERS")
+        self._group_allow_from = self._coerce_allow_list(group_allow_raw)
         read_receipts = config.extra.get("send_read_receipts", False)
         self._send_read_receipts = (
             read_receipts if isinstance(read_receipts, bool)

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -183,6 +183,61 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
     assert __import__("os").environ["WHATSAPP_GROUP_ALLOWED_USERS"] == "120363001234567890@g.us"
 
 
+def test_adapter_group_allowlist_falls_back_to_environment(monkeypatch):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    monkeypatch.setenv(
+        "WHATSAPP_GROUP_ALLOWED_USERS",
+        "120363000000000001@g.us,120363000000000002@g.us",
+    )
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(enabled=True, extra={"group_policy": "allowlist"})
+    )
+
+    assert adapter._group_allow_from == {
+        "120363000000000001@g.us",
+        "120363000000000002@g.us",
+    }
+
+
+def test_adapter_group_allowlist_keeps_explicit_config_over_environment(monkeypatch):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    monkeypatch.setenv(
+        "WHATSAPP_GROUP_ALLOWED_USERS", "120363000000000002@g.us"
+    )
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "group_policy": "allowlist",
+                "group_allow_from": ["120363000000000001@g.us"],
+            },
+        )
+    )
+
+    assert adapter._group_allow_from == {"120363000000000001@g.us"}
+
+
+def test_adapter_explicit_empty_group_allowlist_blocks_environment(monkeypatch):
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    monkeypatch.setenv(
+        "WHATSAPP_GROUP_ALLOWED_USERS", "120363000000000002@g.us"
+    )
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"group_policy": "allowlist", "group_allow_from": []},
+        )
+    )
+
+    assert adapter._group_allow_from == set()
+
+
 # --- Broadcast / status / newsletter pseudo-chats are always dropped ---
 
 


### PR DESCRIPTION
## Summary

Fixes a silent WhatsApp group drop: with `group_policy: allowlist` configured but `group_allow_from` absent from `config.yaml`, the adapter's group allowlist was **empty** — every group message was rejected at the Python intake gate with zero logs, even though the Node bridge (which reads `WHATSAPP_GROUP_ALLOWED_USERS` from env) accepted the same chats.

This is the group-side mirror of the DM allowlist fallback already on `main` (`_wenv` + `WHATSAPP_ALLOWED_USERS`). DM messages kept working because the DM path already had the env fallback; groups remained broken because `_group_allow_from` was still read from `config.extra` only.

## Changes

In `plugins/platforms/whatsapp/adapter.py`, mirror the existing DM allowlist precedence contract for the group allowlist:

- **Explicit config (including an intentionally empty list) is authoritative** — `group_allow_from: []` stays fail-closed and never falls through to a lower-precedence env grant.
- **Fallback** to the documented profile-scoped env var `WHATSAPP_GROUP_ALLOWED_USERS` (via `_wenv`, so multiplexed profiles see their own `.env` values).

## Tests

3 new tests in `test_whatsapp_group_gating.py` covering env fallback, explicit-config precedence, and explicit-empty fail-closed behavior.

- `test_whatsapp_group_gating.py` + `test_whatsapp_allowlist_lid_resolution.py`: **18 passed**.
- Unrelated failures in `test_whatsapp_connect.py` / `test_whatsapp_stale_bridge.py` are pre-existing on `main` (missing `pytest-asyncio` in the local venv).

## Background

Found while diagnosing a live deployment: groups were silently dropped after a gateway restart while DMs worked. The DM allowlist had already been fixed on `main`; this PR closes the group-side gap, which the original fix branch (`fix/whatsapp-adapter-env-allowlist`, commit `78393b71e`) also covered.
