### PR TITLE
feat(skills): add eli5 visual-explainer skill

### DIFF
--- a/skills/creative/eli5/SKILL.md
+++ b/skills/creative/eli5/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 Turn a topic into a beginner-friendly visual explanation delivered as one self-contained HTML file. The output reads like a picture book for adults: large headings, big diagrams, very few words.
 
-This skill does not produce prose essays, slide decks, or production web pages. For designed one-off artifacts use the design-taste sibling skill; for dense educational SVG diagrams use `concept-diagrams`; for software architecture use `architecture-diagram`.
+This skill does not produce prose essays, slide decks, or production web pages. For designed one-off artifacts use `claude-design`; for dense educational SVG diagrams use `concept-diagrams`; for software architecture use `architecture-diagram`.
 
 ## When to Use
 
@@ -51,7 +51,7 @@ None. The skill uses only native Hermes tools and produces a single offline HTML
 2. **Outline first.** Before writing HTML, list 3 to 7 sections, each carrying exactly one idea, in the order a beginner needs them.
 3. **Preserve identifiers exactly.** Code, commands, URLs, file paths, error messages, and names must appear verbatim. Never paraphrase a command or "fix" an identifier while explaining it.
 4. **Write the artifact.** Create one self-contained `.html` file at an absolute path (for example `/opt/data/eli5/dns-explainer.html`) using `write_file`.
-5. **Verify, then report** per Verification below, quoting the path in the final reply.
+5. **Verify, then report** per Verification below. End the final reply with the bare absolute path on its own line: do not wrap it in backticks or inline code, because gateway deliverable mode ignores paths inside backticks.
 
 The bare absolute path is enough: gateway deliverable mode detects `.html` paths in replies and uploads the file as a native attachment on messaging platforms.
 
@@ -80,7 +80,7 @@ The generated file must satisfy all of these:
 Before claiming success, confirm with `read_file` or `search_files` that:
 
 1. the file exists at the stated absolute path;
-2. the file contains no `http://` or `https://` resource references inside markup attributes (`src=`, `href=` pointing to remote assets), meaning it truly renders offline;
+2. the file contains no remote resource references, meaning it truly renders offline. Check all of: `src=` and `href=` attribute values (`href="#..."` same-page anchors are allowed), CSS `url(...)`, `@import` rules, `srcset` attributes, and protocol-relative URLs starting with `//`;
 3. every outlined section appears in the file;
 4. identifiers quoted from sources match the originals character-for-character.
 

--- a/skills/creative/eli5/SKILL.md
+++ b/skills/creative/eli5/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: eli5
+description: Explain any topic as a simple visual HTML page.
+version: 1.0.0
+author: Neutize (Minji)
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [eli5, explainer, html, visualization, education, artifact]
+    related_skills: [claude-design, concept-diagrams, architecture-diagram, sketch]
+---
+
+# ELI5 Skill
+
+Turn a topic into a beginner-friendly visual explanation delivered as one self-contained HTML file. The output reads like a picture book for adults: large headings, big diagrams, very few words.
+
+This skill does not produce prose essays, slide decks, or production web pages. For designed one-off artifacts use the design-taste sibling skill; for dense educational SVG diagrams use `concept-diagrams`; for software architecture use `architecture-diagram`.
+
+## When to Use
+
+Load this skill when the user:
+
+- types `/eli5 <topic>`;
+- asks to "explain X like I'm 5" or "explain X simply and visually";
+- wants a concept made obvious at a glance after reading code, docs, or an incident.
+
+Do not load it for short chat answers, API references, or when the user asks for normal prose.
+
+## Prerequisites
+
+None. The skill uses only native Hermes tools and produces a single offline HTML file with no external dependencies.
+
+## How to Run
+
+1. Load the topic from the slash-command arguments or the current conversation.
+2. Follow the Procedure below.
+3. Reply with a two-to-four sentence summary plus the absolute `.html` path on its own line so the gateway can deliver the file natively.
+
+## Quick Reference
+
+| Input | Output |
+|-------|--------|
+| `/eli5 how does DNS work` | `dns-eli5.html`: resolver chain drawn as labeled boxes |
+| `/eli5 why did this deploy fail` | Timeline of the incident with cause highlighted |
+| `/eli5 this module` | Data-flow diagram of the module's real functions |
+
+## Procedure
+
+1. **Ground the facts.** Read the supplied files with `read_file`, search with `search_files`, or fetch sources with `web_extract`. Do not invent architecture, commands, names, causes, or numbers that are not in the conversation or sources.
+2. **Outline first.** Before writing HTML, list 3 to 7 sections, each carrying exactly one idea, in the order a beginner needs them.
+3. **Preserve identifiers exactly.** Code, commands, URLs, file paths, error messages, and names must appear verbatim. Never paraphrase a command or "fix" an identifier while explaining it.
+4. **Write the artifact.** Create one self-contained `.html` file at an absolute path (for example `/opt/data/eli5/dns-explainer.html`) using `write_file`.
+5. **Verify, then report** per Verification below, quoting the path in the final reply.
+
+The bare absolute path is enough: gateway deliverable mode detects `.html` paths in replies and uploads the file as a native attachment on messaging platforms.
+
+### Artifact contract
+
+The generated file must satisfy all of these:
+
+- Single self-contained `.html` file; inline CSS and inline SVG only.
+- No external assets: no CDN, no remote fonts, no images fetched over the network, no JavaScript required to understand the page.
+- Opens correctly via double-click in any modern browser, fully offline.
+- A TL;DR strip at the top: what this is, why it matters, in two sentences maximum.
+- 3 to 7 numbered sections following the outline; each has one large heading, one visual (SVG diagram, flow arrows, timeline, comparison boxes), and captions under 25 words each.
+- Sentence-case text everywhere; body text at least 16px; high-contrast colors; meaningful `alt`/`aria-label` text on visuals; no decorative animation.
+- Any claim you could not ground in step 1 is marked visibly in the page as `[unverified]`.
+
+## Pitfalls
+
+- Do not pad sections to look complete; cut a section rather than dilute it.
+- Do not invent plausible architecture when evidence is missing; label the gap `[unverified]` instead.
+- Do not reword commands, paths, or error strings into friendlier forms; quote them exactly.
+- Do not rely on CDNs or webfonts; if typography matters, use system font stacks.
+- Do not dump the whole HTML into the chat reply; give the path and a summary.
+
+## Verification
+
+Before claiming success, confirm with `read_file` or `search_files` that:
+
+1. the file exists at the stated absolute path;
+2. the file contains no `http://` or `https://` resource references inside markup attributes (`src=`, `href=` pointing to remote assets), meaning it truly renders offline;
+3. every outlined section appears in the file;
+4. identifiers quoted from sources match the originals character-for-character.
+
+If browser tools are available, additionally open the file and visually check layout; otherwise state plainly that visual verification was skipped. Never claim visual verification that did not happen.

--- a/tests/skills/test_eli5_skill.py
+++ b/tests/skills/test_eli5_skill.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = REPO_ROOT / "skills" / "creative" / "eli5" / "SKILL.md"
+
+
+def _load_skill() -> tuple[dict, str]:
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    assert text.startswith("---"), "SKILL.md must start with YAML frontmatter"
+    parts = text.split("---", 2)
+    assert len(parts) == 3, "SKILL.md frontmatter is malformed"
+    frontmatter = yaml.safe_load(parts[1]) or {}
+    body = parts[2]
+    return frontmatter, body
+
+
+def test_skill_file_exists():
+    assert SKILL_PATH.is_file(), f"missing skill file: {SKILL_PATH}"
+
+
+def test_frontmatter_declares_eli5_name():
+    fm, _ = _load_skill()
+    assert fm.get("name") == "eli5"
+
+
+def test_description_is_single_short_sentence():
+    fm, _ = _load_skill()
+    description = str(fm.get("description", "")).strip()
+    assert description, "description must not be empty"
+    assert len(description) <= 60, f"description too long ({len(description)} chars): {description!r}"
+    assert description.endswith("."), "description must end with a period"
+    sentences = re.split(r"(?<=[.!?])\s+", description)
+    assert len(sentences) == 1, "description must be exactly one sentence"
+
+
+def test_body_uses_modern_section_order():
+    _, body = _load_skill()
+    required = [
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    ]
+    positions = []
+    for section in required:
+        assert section in body, f"missing required section: {section}"
+        positions.append(body.index(section))
+    assert positions == sorted(positions), "sections appear out of order"
+
+
+def test_procedure_requires_absolute_selfcontained_html_path():
+    _, body = _load_skill()
+    assert "absolute path" in body, "procedure must demand an absolute output path"
+    assert ".html" in body, "procedure must name the .html deliverable"
+    assert "self-contained" in body, "output must be self-contained"
+
+
+def test_procedure_preserves_exact_identifiers():
+    _, body = _load_skill()
+    assert "exactly" in body.lower(), "procedure must demand exact preservation of identifiers, commands, URLs, and code"
+
+
+def test_procedure_demands_evidence_over_invention():
+    _, body = _load_skill()
+    assert "do not invent" in body.lower(), "skill must forbid invented architecture or facts"
+
+
+def test_no_claude_or_anthropic_runtime_dependency():
+    _, body = _load_skill()
+    lowered = body.lower()
+    assert "claude" not in lowered, "skill must not depend on Claude"
+    assert "anthropic" not in lowered, "skill must not depend on Anthropic"
+
+
+def test_no_new_runtime_surface_required():
+    _, body = _load_skill()
+    lowered = body.lower()
+    assert "mcp" not in lowered, "skill must not require an MCP server"
+    assert "api key" not in lowered, "skill must not require an API key"
+
+
+def test_procedure_uses_native_hermes_tools():
+    _, body = _load_skill()
+    assert "`write_file`" in body, "procedure must use the native write_file tool"
+    assert "`read_file`" in body, "procedure must use the native read_file tool"
+    assert "`terminal`" not in body, "skill must not need shell commands for the core workflow"
+    for shell_utility in ("`grep`", "`cat`", "`sed`", "`awk`", "`find`", "`ls`"):
+        assert shell_utility not in body, f"use native Hermes tools instead of {shell_utility}"
+
+
+def test_no_remote_assets_required():
+    _, body = _load_skill()
+    lowered = body.lower()
+    assert "cdn" in lowered, "skill must explicitly forbid CDN dependencies"
+    assert "no external" in lowered, "skill must forbid external runtime dependencies"
+
+
+def test_visual_sequence_contract_present():
+    _, body = _load_skill()
+    assert "TL;DR" in body, "artifact contract must include a TL;DR"
+    assert "3 to 7" in body, "artifact contract must bound the section count at 3 to 7"
+
+
+def test_uncertainty_must_be_labeled():
+    _, body = _load_skill()
+    assert "[unverified]" in body, "skill must require labeling uncertain claims"
+
+
+def test_deliverable_mode_path_mentioned():
+    _, body = _load_skill()
+    assert "deliverable" in body.lower(), "skill should explain gateway deliverable handling of the .html path"

--- a/tests/skills/test_eli5_skill.py
+++ b/tests/skills/test_eli5_skill.py
@@ -1,22 +1,94 @@
+"""Structural contract tests for the bundled eli5 visual-explainer skill.
+
+Contracts are anchored to specific parsed structures (frontmatter fields,
+numbered Procedure items, Artifact-contract bullets, generated docs page),
+not to free-floating phrase scans, so harmless rewording cannot break them
+and an unrelated word cannot accidentally satisfy them.
+"""
+
 from __future__ import annotations
 
 import re
+import shutil
 from pathlib import Path
 
-import yaml
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SKILL_PATH = REPO_ROOT / "skills" / "creative" / "eli5" / "SKILL.md"
+SKILL_DIR = REPO_ROOT / "skills" / "creative" / "eli5"
+SKILL_PATH = SKILL_DIR / "SKILL.md"
+GENERATED_PAGE = (
+    REPO_ROOT
+    / "website"
+    / "docs"
+    / "user-guide"
+    / "skills"
+    / "bundled"
+    / "creative"
+    / "creative-eli5.md"
+)
+
+REQUIRED_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+]
 
 
 def _load_skill() -> tuple[dict, str]:
-    text = SKILL_PATH.read_text(encoding="utf-8")
-    assert text.startswith("---"), "SKILL.md must start with YAML frontmatter"
-    parts = text.split("---", 2)
-    assert len(parts) == 3, "SKILL.md frontmatter is malformed"
-    frontmatter = yaml.safe_load(parts[1]) or {}
-    body = parts[2]
+    """Parse SKILL.md with the production frontmatter parser (stdlib-only reuse)."""
+    from tools.skills_tool import _parse_frontmatter
+
+    content = SKILL_PATH.read_text(encoding="utf-8")
+    assert content.startswith("---"), "SKILL.md must start with YAML frontmatter"
+    frontmatter, body = _parse_frontmatter(content)
+    assert isinstance(frontmatter, dict) and frontmatter, "frontmatter must parse to a mapping"
     return frontmatter, body
+
+
+def _section(body: str, heading: str) -> str:
+    """Return the text under `heading` up to the next heading of any level."""
+    lines = body.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == heading:
+            start = i + 1
+            break
+    assert start is not None, f"missing required section: {heading}"
+    collected: list[str] = []
+    for line in lines[start:]:
+        if line.startswith("#"):
+            break
+        collected.append(line)
+    return "\n".join(collected)
+
+
+def _procedure_items(body: str) -> dict[int, str]:
+    """Parse the ordered Procedure list into {index: full item text}."""
+    proc = _section(body, "## Procedure")
+    items: dict[int, list[str]] = {}
+    current = None
+    for line in proc.splitlines():
+        m = re.match(r"^(\d+)\.\s+(.*)$", line)
+        if m:
+            current = int(m.group(1))
+            items[current] = [m.group(2)]
+        elif current is not None and line.strip() and not line.startswith("#"):
+            items[current].append(line.strip())
+    return {k: " ".join(v) for k, v in items.items()}
+
+
+def _contract_bullets(body: str) -> list[str]:
+    """Parse the Artifact-contract bullet list."""
+    block = _section(body, "### Artifact contract")
+    return [line.lstrip("- ").strip() for line in block.splitlines() if line.startswith("- ")]
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter contracts
+# ---------------------------------------------------------------------------
 
 
 def test_skill_file_exists():
@@ -38,82 +110,191 @@ def test_description_is_single_short_sentence():
     assert len(sentences) == 1, "description must be exactly one sentence"
 
 
+def test_no_runtime_dependencies_declared():
+    """The skill must declare zero dependencies and zero required env vars."""
+    fm, _ = _load_skill()
+    assert not fm.get("dependencies"), f"unexpected dependencies: {fm.get('dependencies')}"
+    prereq = fm.get("prerequisites")
+    env_vars = prereq.get("env_vars") if isinstance(prereq, dict) else None
+    assert not env_vars, f"unexpected required env vars: {env_vars}"
+
+
+# ---------------------------------------------------------------------------
+# Section structure
+# ---------------------------------------------------------------------------
+
+
 def test_body_uses_modern_section_order():
     _, body = _load_skill()
-    required = [
-        "## When to Use",
-        "## Prerequisites",
-        "## How to Run",
-        "## Quick Reference",
-        "## Procedure",
-        "## Pitfalls",
-        "## Verification",
-    ]
     positions = []
-    for section in required:
+    for section in REQUIRED_SECTIONS:
         assert section in body, f"missing required section: {section}"
         positions.append(body.index(section))
     assert positions == sorted(positions), "sections appear out of order"
 
 
-def test_procedure_requires_absolute_selfcontained_html_path():
+def test_related_skills_resolve_in_repo():
+    """Every related_skills entry must exist in-repo (bundled or optional)."""
+    fm, _ = _load_skill()
+    related = ((fm.get("metadata") or {}).get("hermes") or {}).get("related_skills") or []
+    assert related, "related_skills should point at sibling creative skills"
+    for name in related:
+        found = any(
+            p.parent.name == name
+            for base in ("skills", "optional-skills")
+            for p in (REPO_ROOT / base).rglob("SKILL.md")
+        )
+        assert found, f"related skill does not resolve in-repo: {name}"
+
+
+# ---------------------------------------------------------------------------
+# Procedure contracts (structure-scoped, per numbered item)
+# ---------------------------------------------------------------------------
+
+
+def test_ground_facts_item_names_native_tools_and_forbids_invention():
     _, body = _load_skill()
-    assert "absolute path" in body, "procedure must demand an absolute output path"
-    assert ".html" in body, "procedure must name the .html deliverable"
-    assert "self-contained" in body, "output must be self-contained"
+    first = _procedure_items(body)[1]
+    assert first.startswith("**Ground the facts.**")
+    for tool in ("read_file", "search_files", "web_extract"):
+        assert f"`{tool}`" in first, f"grounding step must name `{tool}`"
+    assert "Do not invent" in first, "grounding step must forbid invented facts"
 
 
-def test_procedure_preserves_exact_identifiers():
+def test_preserve_identifiers_item_demands_verbatim_quotes():
     _, body = _load_skill()
-    assert "exactly" in body.lower(), "procedure must demand exact preservation of identifiers, commands, URLs, and code"
+    third = _procedure_items(body)[3]
+    assert third.startswith("**Preserve identifiers exactly.**")
+    assert "verbatim" in third
 
 
-def test_procedure_demands_evidence_over_invention():
+def test_write_artifact_item_demands_absolute_selfcontained_html():
     _, body = _load_skill()
-    assert "do not invent" in body.lower(), "skill must forbid invented architecture or facts"
+    fourth = _procedure_items(body)[4]
+    assert fourth.startswith("**Write the artifact.**")
+    assert "`write_file`" in fourth, "artifact step must use the native write_file tool"
+    assert ".html" in fourth and "self-contained" in fourth
+    examples = re.findall(r"`([^`]+)`", fourth)
+    html_examples = [e for e in examples if e.endswith(".html") and "/" in e]
+    assert html_examples, "artifact step must show an example output file path"
+    for example in html_examples:
+        assert example.startswith("/") and len(example) > 1, (
+            f"example output path must be POSIX-absolute: {example!r}"
+        )
 
 
-def test_no_claude_or_anthropic_runtime_dependency():
+def test_report_item_requires_bare_path_not_backticked():
+    """Gateway delivery extracts bare paths only; inline-code paths are ignored."""
+    _, body = _load_skill()
+    fifth = _procedure_items(body)[5]
+    lowered = fifth.lower()
+    assert "bare absolute path" in lowered
+    assert "backticks" in lowered, "step must warn against wrapping the path in backticks"
+
+
+# ---------------------------------------------------------------------------
+# Artifact-contract bullets
+# ---------------------------------------------------------------------------
+
+
+def test_contract_bullet_selfcontained_single_file():
+    _, body = _load_skill()
+    assert any(b.startswith("Single self-contained") for b in _contract_bullets(body))
+
+
+def test_contract_bullet_no_external_assets():
+    _, body = _load_skill()
+    bullets = [b.lower() for b in _contract_bullets(body)]
+    assert any("no cdn" in b and "offline" not in b for b in bullets), (
+        "a bullet must prohibit CDNs/external assets outright"
+    )
+
+
+def test_contract_bullet_tldr_strip():
+    _, body = _load_skill()
+    assert any("tl;dr strip" in b.lower() for b in _contract_bullets(body))
+
+
+def test_contract_bullet_bounds_sections_three_to_seven():
+    _, body = _load_skill()
+    assert any("3 to 7 numbered sections" in b for b in _contract_bullets(body))
+
+
+def test_contract_bullet_labels_unverified_claims():
+    _, body = _load_skill()
+    assert any("[unverified]" in b for b in _contract_bullets(body))
+
+
+# ---------------------------------------------------------------------------
+# No unconverted external-plugin surface
+# ---------------------------------------------------------------------------
+
+
+def test_no_unconverted_claude_plugin_markers():
+    """Reject Claude-plugin conversion leftovers ($ARGUMENTS context blocks,
+    vendor URLs). These are precise markers; ordinary prose stays untouched."""
     _, body = _load_skill()
     lowered = body.lower()
-    assert "claude" not in lowered, "skill must not depend on Claude"
-    assert "anthropic" not in lowered, "skill must not depend on Anthropic"
+    for marker in ("$arguments", "<context>", "claude.ai", "anthropic.com"):
+        assert marker not in lowered, f"unconverted Claude-plugin marker found: {marker}"
 
 
-def test_no_new_runtime_surface_required():
+# ---------------------------------------------------------------------------
+# Verification-section contracts
+# ---------------------------------------------------------------------------
+
+
+def test_verification_offline_check_has_full_remote_surface():
+    """The offline check must cover src/href, CSS url(), @import, srcset,
+    protocol-relative URLs, while allowing same-page hash anchors."""
     _, body = _load_skill()
-    lowered = body.lower()
-    assert "mcp" not in lowered, "skill must not require an MCP server"
-    assert "api key" not in lowered, "skill must not require an API key"
+    verification = _section(body, "## Verification")
+    for token in ('href="#', "url(...)", "@import", "srcset", "//"):
+        assert token in verification, f"offline check must mention {token!r}"
 
 
-def test_procedure_uses_native_hermes_tools():
-    _, body = _load_skill()
-    assert "`write_file`" in body, "procedure must use the native write_file tool"
-    assert "`read_file`" in body, "procedure must use the native read_file tool"
-    assert "`terminal`" not in body, "skill must not need shell commands for the core workflow"
-    for shell_utility in ("`grep`", "`cat`", "`sed`", "`awk`", "`find`", "`ls`"):
-        assert shell_utility not in body, f"use native Hermes tools instead of {shell_utility}"
+# ---------------------------------------------------------------------------
+# Generated docs page must stay in sync with SKILL.md
+# ---------------------------------------------------------------------------
 
 
-def test_no_remote_assets_required():
-    _, body = _load_skill()
-    lowered = body.lower()
-    assert "cdn" in lowered, "skill must explicitly forbid CDN dependencies"
-    assert "no external" in lowered, "skill must forbid external runtime dependencies"
+def test_generated_page_reflects_current_skill_version_and_content():
+    page_text = GENERATED_PAGE.read_text(encoding="utf-8")
+    fm, body = _load_skill()
+    assert f"| Version | `{fm['version']}` |" in page_text, (
+        "generated page version row is stale; rerun website/scripts/generate-skill-docs.py"
+    )
+    closing_sentence = "Never claim visual verification that did not happen."
+    assert closing_sentence in body
+    assert closing_sentence in page_text, (
+        "generated page body is stale relative to SKILL.md; rerun website/scripts/generate-skill-docs.py"
+    )
 
 
-def test_visual_sequence_contract_present():
-    _, body = _load_skill()
-    assert "TL;DR" in body, "artifact contract must include a TL;DR"
-    assert "3 to 7" in body, "artifact contract must bound the section count at 3 to 7"
+# ---------------------------------------------------------------------------
+# Production discovery path (hermetic)
+# ---------------------------------------------------------------------------
 
 
-def test_uncertainty_must_be_labeled():
-    _, body = _load_skill()
-    assert "[unverified]" in body, "skill must require labeling uncertain claims"
+def test_production_discovery_lists_eli5_with_expected_metadata(tmp_path, monkeypatch):
+    """tools.skills_tool._find_all_skills must discover eli5 through the real
+    scanner, in a hermetic temp skills tree with external dirs patched out."""
+    import tools.skills_tool as skills_tool
 
+    category_dir = tmp_path / "creative"
+    category_dir.mkdir(parents=True)
+    shutil.copytree(SKILL_DIR, category_dir / "eli5")
 
-def test_deliverable_mode_path_mentioned():
-    _, body = _load_skill()
-    assert "deliverable" in body.lower(), "skill should explain gateway deliverable handling of the .html path"
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", tmp_path)
+    monkeypatch.setattr("agent.skill_utils.get_external_skills_dirs", lambda: [])
+
+    entries = [
+        s
+        for s in skills_tool._find_all_skills(skip_disabled=True)
+        if s["name"] == "eli5"
+    ]
+
+    assert len(entries) == 1, f"expected exactly one eli5 discovery, got {entries}"
+    entry = entries[0]
+    assert entry["category"] == "creative"
+    assert entry["description"] == "Explain any topic as a simple visual HTML page."

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -220,6 +220,7 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
+| [**cloudflare-temporary-deploy**](/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy) | Deploy a Worker live, no account, via wrangler --temporary. |
 | [**page-agent**](/docs/user-guide/skills/optional/web-development/web-development-page-agent) | Embed alibaba/page-agent into your own web application — a pure-JavaScript in-page GUI agent that ships as a single &lt;script> tag or npm package and lets end-users of your site drive the UI with natural language ("click login, fill userna... |
 
 ---

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -220,7 +220,6 @@ hermes skills uninstall <skill-name>
 
 | Skill | Description |
 |-------|-------------|
-| [**cloudflare-temporary-deploy**](/docs/user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy) | Deploy a Worker live, no account, via wrangler --temporary. |
 | [**page-agent**](/docs/user-guide/skills/optional/web-development/web-development-page-agent) | Embed alibaba/page-agent into your own web application — a pure-JavaScript in-page GUI agent that ships as a single &lt;script> tag or npm package and lets end-users of your site drive the UI with natural language ("click login, fill userna... |
 
 ---

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -20,7 +20,6 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`apple-reminders`](/docs/user-guide/skills/bundled/apple/apple-apple-reminders) | Apple Reminders via remindctl: add, list, complete. | `apple/apple-reminders` |
 | [`findmy`](/docs/user-guide/skills/bundled/apple/apple-findmy) | Track Apple devices/AirTags via FindMy.app on macOS. | `apple/findmy` |
 | [`imessage`](/docs/user-guide/skills/bundled/apple/apple-imessage) | Send and receive iMessages/SMS via the imsg CLI on macOS. | `apple/imessage` |
-| [`macos-computer-use`](/docs/user-guide/skills/bundled/apple/apple-macos-computer-use) | Drive the macOS desktop in the background — screenshots, mouse, keyboard, scroll, drag — without stealing the user's cursor, keyboard focus, or Space. Works with any tool-capable model. Load this skill whenever the `computer_use` tool is... | `apple/macos-computer-use` |
 
 ## autonomous-ai-agents
 
@@ -30,6 +29,12 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`codex`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex) | Delegate coding to OpenAI Codex CLI (features, PRs). | `autonomous-ai-agents/codex` |
 | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent) | Configure, extend, or contribute to Hermes Agent. | `autonomous-ai-agents/hermes-agent` |
 | [`opencode`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-opencode) | Delegate coding to OpenCode CLI (features, PR review). | `autonomous-ai-agents/opencode` |
+
+## computer-use
+
+| Skill | Description | Path |
+|-------|-------------|------|
+| [`computer-use`](/docs/user-guide/skills/bundled/computer-use/computer-use-computer-use) | Drive the user's desktop in the background — clicking, typing, scrolling, dragging — without stealing the cursor, keyboard focus, or switching virtual desktops / Spaces. Cross-platform: macOS, Windows, Linux. Works with any tool-capable... | `computer-use` |
 
 ## creative
 
@@ -42,6 +47,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design) | Design one-off HTML artifacts (landing, deck, prototype). | `creative/claude-design` |
 | [`comfyui`](/docs/user-guide/skills/bundled/creative/creative-comfyui) | Generate images, video, and audio with ComfyUI — install, launch, manage nodes/models, run workflows with parameter injection. Uses the official comfy-cli for lifecycle and direct REST/WebSocket API for execution. | `creative/comfyui` |
 | [`design-md`](/docs/user-guide/skills/bundled/creative/creative-design-md) | Author/validate/export Google's DESIGN.md token spec files. | `creative/design-md` |
+| [`eli5`](/docs/user-guide/skills/bundled/creative/creative-eli5) | Explain any topic as a simple visual HTML page. | `creative/eli5` |
 | [`excalidraw`](/docs/user-guide/skills/bundled/creative/creative-excalidraw) | Hand-drawn Excalidraw JSON diagrams (arch, flow, seq). | `creative/excalidraw` |
 | [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer) | Humanize text: strip AI-isms and add real voice. | `creative/humanizer` |
 | [`manim-video`](/docs/user-guide/skills/bundled/creative/creative-manim-video) | Manim CE animations: 3Blue1Brown math/algo videos. | `creative/manim-video` |
@@ -57,12 +63,6 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | Skill | Description | Path |
 |-------|-------------|------|
 | [`jupyter-live-kernel`](/docs/user-guide/skills/bundled/data-science/data-science-jupyter-live-kernel) | Iterative Python via live Jupyter kernel (hamelnb). | `data-science/jupyter-live-kernel` |
-
-## devops
-
-| Skill | Description | Path |
-|-------|-------------|------|
-
 
 ## dogfood
 
@@ -154,7 +154,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
-| [`hermes-agent-skill-authoring`](/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring) | Author in-repo SKILL.md: frontmatter, validator, structure. | `software-development/hermes-agent-skill-authoring` |
+| [`hermes-agent-skill-authoring`](/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring) | Author in-repo SKILL.md: frontmatter, validator, structure, and writing-quality principles. | `software-development/hermes-agent-skill-authoring` |
 | [`node-inspect-debugger`](/docs/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger) | Debug Node.js via --inspect + Chrome DevTools Protocol CLI. | `software-development/node-inspect-debugger` |
 | [`plan`](/docs/user-guide/skills/bundled/software-development/software-development-plan) | Plan mode: write an actionable markdown plan to .hermes/plans/, no execution. Bite-sized tasks, exact paths, complete code. | `software-development/plan` |
 | [`python-debugpy`](/docs/user-guide/skills/bundled/software-development/software-development-python-debugpy) | Debug Python: pdb REPL + debugpy remote (DAP). | `software-development/python-debugpy` |

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -20,6 +20,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`apple-reminders`](/docs/user-guide/skills/bundled/apple/apple-apple-reminders) | Apple Reminders via remindctl: add, list, complete. | `apple/apple-reminders` |
 | [`findmy`](/docs/user-guide/skills/bundled/apple/apple-findmy) | Track Apple devices/AirTags via FindMy.app on macOS. | `apple/findmy` |
 | [`imessage`](/docs/user-guide/skills/bundled/apple/apple-imessage) | Send and receive iMessages/SMS via the imsg CLI on macOS. | `apple/imessage` |
+| [`macos-computer-use`](/docs/user-guide/skills/bundled/apple/apple-macos-computer-use) | Drive the macOS desktop in the background — screenshots, mouse, keyboard, scroll, drag — without stealing the user's cursor, keyboard focus, or Space. Works with any tool-capable model. Load this skill whenever the `computer_use` tool is... | `apple/macos-computer-use` |
 
 ## autonomous-ai-agents
 
@@ -29,12 +30,6 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | [`codex`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex) | Delegate coding to OpenAI Codex CLI (features, PRs). | `autonomous-ai-agents/codex` |
 | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent) | Configure, extend, or contribute to Hermes Agent. | `autonomous-ai-agents/hermes-agent` |
 | [`opencode`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-opencode) | Delegate coding to OpenCode CLI (features, PR review). | `autonomous-ai-agents/opencode` |
-
-## computer-use
-
-| Skill | Description | Path |
-|-------|-------------|------|
-| [`computer-use`](/docs/user-guide/skills/bundled/computer-use/computer-use-computer-use) | Drive the user's desktop in the background — clicking, typing, scrolling, dragging — without stealing the cursor, keyboard focus, or switching virtual desktops / Spaces. Cross-platform: macOS, Windows, Linux. Works with any tool-capable... | `computer-use` |
 
 ## creative
 
@@ -63,6 +58,12 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 | Skill | Description | Path |
 |-------|-------------|------|
 | [`jupyter-live-kernel`](/docs/user-guide/skills/bundled/data-science/data-science-jupyter-live-kernel) | Iterative Python via live Jupyter kernel (hamelnb). | `data-science/jupyter-live-kernel` |
+
+## devops
+
+| Skill | Description | Path |
+|-------|-------------|------|
+
 
 ## dogfood
 
@@ -154,7 +155,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
-| [`hermes-agent-skill-authoring`](/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring) | Author in-repo SKILL.md: frontmatter, validator, structure, and writing-quality principles. | `software-development/hermes-agent-skill-authoring` |
+| [`hermes-agent-skill-authoring`](/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring) | Author in-repo SKILL.md: frontmatter, validator, structure. | `software-development/hermes-agent-skill-authoring` |
 | [`node-inspect-debugger`](/docs/user-guide/skills/bundled/software-development/software-development-node-inspect-debugger) | Debug Node.js via --inspect + Chrome DevTools Protocol CLI. | `software-development/node-inspect-debugger` |
 | [`plan`](/docs/user-guide/skills/bundled/software-development/software-development-plan) | Plan mode: write an actionable markdown plan to .hermes/plans/, no execution. Bite-sized tasks, exact paths, complete code. | `software-development/plan` |
 | [`python-debugpy`](/docs/user-guide/skills/bundled/software-development/software-development-python-debugpy) | Debug Python: pdb REPL + debugpy remote (DAP). | `software-development/python-debugpy` |

--- a/website/docs/user-guide/skills/bundled/creative/creative-eli5.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-eli5.md
@@ -1,0 +1,105 @@
+---
+title: "Eli5 — Explain any topic as a simple visual HTML page"
+sidebar_label: "Eli5"
+description: "Explain any topic as a simple visual HTML page"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Eli5
+
+Explain any topic as a simple visual HTML page.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/creative/eli5` |
+| Version | `1.0.0` |
+| Author | Neutize (Minji) |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `eli5`, `explainer`, `html`, `visualization`, `education`, `artifact` |
+| Related skills | [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design), [`concept-diagrams`](/docs/user-guide/skills/optional/creative/creative-concept-diagrams), [`architecture-diagram`](/docs/user-guide/skills/bundled/creative/creative-architecture-diagram), [`sketch`](/docs/user-guide/skills/bundled/creative/creative-sketch) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# ELI5 Skill
+
+Turn a topic into a beginner-friendly visual explanation delivered as one self-contained HTML file. The output reads like a picture book for adults: large headings, big diagrams, very few words.
+
+This skill does not produce prose essays, slide decks, or production web pages. For designed one-off artifacts use the design-taste sibling skill; for dense educational SVG diagrams use `concept-diagrams`; for software architecture use `architecture-diagram`.
+
+## When to Use
+
+Load this skill when the user:
+
+- types `/eli5 <topic>`;
+- asks to "explain X like I'm 5" or "explain X simply and visually";
+- wants a concept made obvious at a glance after reading code, docs, or an incident.
+
+Do not load it for short chat answers, API references, or when the user asks for normal prose.
+
+## Prerequisites
+
+None. The skill uses only native Hermes tools and produces a single offline HTML file with no external dependencies.
+
+## How to Run
+
+1. Load the topic from the slash-command arguments or the current conversation.
+2. Follow the Procedure below.
+3. Reply with a two-to-four sentence summary plus the absolute `.html` path on its own line so the gateway can deliver the file natively.
+
+## Quick Reference
+
+| Input | Output |
+|-------|--------|
+| `/eli5 how does DNS work` | `dns-eli5.html`: resolver chain drawn as labeled boxes |
+| `/eli5 why did this deploy fail` | Timeline of the incident with cause highlighted |
+| `/eli5 this module` | Data-flow diagram of the module's real functions |
+
+## Procedure
+
+1. **Ground the facts.** Read the supplied files with `read_file`, search with `search_files`, or fetch sources with `web_extract`. Do not invent architecture, commands, names, causes, or numbers that are not in the conversation or sources.
+2. **Outline first.** Before writing HTML, list 3 to 7 sections, each carrying exactly one idea, in the order a beginner needs them.
+3. **Preserve identifiers exactly.** Code, commands, URLs, file paths, error messages, and names must appear verbatim. Never paraphrase a command or "fix" an identifier while explaining it.
+4. **Write the artifact.** Create one self-contained `.html` file at an absolute path (for example `/opt/data/eli5/dns-explainer.html`) using `write_file`.
+5. **Verify, then report** per Verification below, quoting the path in the final reply.
+
+The bare absolute path is enough: gateway deliverable mode detects `.html` paths in replies and uploads the file as a native attachment on messaging platforms.
+
+### Artifact contract
+
+The generated file must satisfy all of these:
+
+- Single self-contained `.html` file; inline CSS and inline SVG only.
+- No external assets: no CDN, no remote fonts, no images fetched over the network, no JavaScript required to understand the page.
+- Opens correctly via double-click in any modern browser, fully offline.
+- A TL;DR strip at the top: what this is, why it matters, in two sentences maximum.
+- 3 to 7 numbered sections following the outline; each has one large heading, one visual (SVG diagram, flow arrows, timeline, comparison boxes), and captions under 25 words each.
+- Sentence-case text everywhere; body text at least 16px; high-contrast colors; meaningful `alt`/`aria-label` text on visuals; no decorative animation.
+- Any claim you could not ground in step 1 is marked visibly in the page as `[unverified]`.
+
+## Pitfalls
+
+- Do not pad sections to look complete; cut a section rather than dilute it.
+- Do not invent plausible architecture when evidence is missing; label the gap `[unverified]` instead.
+- Do not reword commands, paths, or error strings into friendlier forms; quote them exactly.
+- Do not rely on CDNs or webfonts; if typography matters, use system font stacks.
+- Do not dump the whole HTML into the chat reply; give the path and a summary.
+
+## Verification
+
+Before claiming success, confirm with `read_file` or `search_files` that:
+
+1. the file exists at the stated absolute path;
+2. the file contains no `http://` or `https://` resource references inside markup attributes (`src=`, `href=` pointing to remote assets), meaning it truly renders offline;
+3. every outlined section appears in the file;
+4. identifiers quoted from sources match the originals character-for-character.
+
+If browser tools are available, additionally open the file and visually check layout; otherwise state plainly that visual verification was skipped. Never claim visual verification that did not happen.

--- a/website/docs/user-guide/skills/bundled/creative/creative-eli5.md
+++ b/website/docs/user-guide/skills/bundled/creative/creative-eli5.md
@@ -33,7 +33,7 @@ The following is the complete skill definition that Hermes loads when this skill
 
 Turn a topic into a beginner-friendly visual explanation delivered as one self-contained HTML file. The output reads like a picture book for adults: large headings, big diagrams, very few words.
 
-This skill does not produce prose essays, slide decks, or production web pages. For designed one-off artifacts use the design-taste sibling skill; for dense educational SVG diagrams use `concept-diagrams`; for software architecture use `architecture-diagram`.
+This skill does not produce prose essays, slide decks, or production web pages. For designed one-off artifacts use `claude-design`; for dense educational SVG diagrams use `concept-diagrams`; for software architecture use `architecture-diagram`.
 
 ## When to Use
 
@@ -69,7 +69,7 @@ None. The skill uses only native Hermes tools and produces a single offline HTML
 2. **Outline first.** Before writing HTML, list 3 to 7 sections, each carrying exactly one idea, in the order a beginner needs them.
 3. **Preserve identifiers exactly.** Code, commands, URLs, file paths, error messages, and names must appear verbatim. Never paraphrase a command or "fix" an identifier while explaining it.
 4. **Write the artifact.** Create one self-contained `.html` file at an absolute path (for example `/opt/data/eli5/dns-explainer.html`) using `write_file`.
-5. **Verify, then report** per Verification below, quoting the path in the final reply.
+5. **Verify, then report** per Verification below. End the final reply with the bare absolute path on its own line: do not wrap it in backticks or inline code, because gateway deliverable mode ignores paths inside backticks.
 
 The bare absolute path is enough: gateway deliverable mode detects `.html` paths in replies and uploads the file as a native attachment on messaging platforms.
 
@@ -98,7 +98,7 @@ The generated file must satisfy all of these:
 Before claiming success, confirm with `read_file` or `search_files` that:
 
 1. the file exists at the stated absolute path;
-2. the file contains no `http://` or `https://` resource references inside markup attributes (`src=`, `href=` pointing to remote assets), meaning it truly renders offline;
+2. the file contains no remote resource references, meaning it truly renders offline. Check all of: `src=` and `href=` attribute values (`href="#..."` same-page anchors are allowed), CSS `url(...)`, `@import` rules, `srcset` attributes, and protocol-relative URLs starting with `//`;
 3. every outlined section appears in the file;
 4. identifiers quoted from sources match the originals character-for-character.
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -141,7 +141,6 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/apple/apple-apple-reminders',
                     'user-guide/skills/bundled/apple/apple-findmy',
                     'user-guide/skills/bundled/apple/apple-imessage',
-                    'user-guide/skills/bundled/apple/apple-macos-computer-use',
                   ],
                 },
                 {
@@ -158,6 +157,15 @@ const sidebars: SidebarsConfig = {
                 },
                 {
                   type: 'category',
+                  label: 'computer-use',
+                  key: 'skills-bundled-computer-use',
+                  collapsed: true,
+                  items: [
+                    'user-guide/skills/bundled/computer-use/computer-use-computer-use',
+                  ],
+                },
+                {
+                  type: 'category',
                   label: 'creative',
                   key: 'skills-bundled-creative',
                   collapsed: true,
@@ -169,6 +177,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/creative/creative-claude-design',
                     'user-guide/skills/bundled/creative/creative-comfyui',
                     'user-guide/skills/bundled/creative/creative-design-md',
+                    'user-guide/skills/bundled/creative/creative-eli5',
                     'user-guide/skills/bundled/creative/creative-excalidraw',
                     'user-guide/skills/bundled/creative/creative-humanizer',
                     'user-guide/skills/bundled/creative/creative-manim-video',
@@ -587,6 +596,7 @@ const sidebars: SidebarsConfig = {
                   key: 'skills-optional-web-development',
                   collapsed: true,
                   items: [
+                    'user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy',
                     'user-guide/skills/optional/web-development/web-development-page-agent',
                   ],
                 },

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -141,6 +141,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/apple/apple-apple-reminders',
                     'user-guide/skills/bundled/apple/apple-findmy',
                     'user-guide/skills/bundled/apple/apple-imessage',
+                    'user-guide/skills/bundled/apple/apple-macos-computer-use',
                   ],
                 },
                 {
@@ -153,15 +154,6 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex',
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent',
                     'user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-opencode',
-                  ],
-                },
-                {
-                  type: 'category',
-                  label: 'computer-use',
-                  key: 'skills-bundled-computer-use',
-                  collapsed: true,
-                  items: [
-                    'user-guide/skills/bundled/computer-use/computer-use-computer-use',
                   ],
                 },
                 {
@@ -596,7 +588,6 @@ const sidebars: SidebarsConfig = {
                   key: 'skills-optional-web-development',
                   collapsed: true,
                   items: [
-                    'user-guide/skills/optional/web-development/web-development-cloudflare-temporary-deploy',
                     'user-guide/skills/optional/web-development/web-development-page-agent',
                   ],
                 },


### PR DESCRIPTION
## What

Adds a bundled creative skill `skills/creative/eli5/SKILL.md` that implements `/eli5 <topic>`: a beginner-first visual explanation rendered as **one self-contained HTML file** (inline CSS + inline SVG, no CDN, no JS required), following the pattern popularized by the Claude Code community ELI5 plugin but implemented purely with Hermes-native primitives.

Inspired by [@trq212's post](https://x.com/trq212/status/2090884854590382515) about the `/eli5` skill people at Anthropic use. This PR ports the *workflow*, not the plugin: no Claude dependency, no new core tool, no MCP server, no API key.

## Why a skill (footprint reasoning)

Per the contribution rubric footprint ladder this lands on rung 2 (CLI command + skill):

- The capability is expressible as instructions + native tools (`read_file`, `search_files`, `web_extract`, `write_file`).
- Output delivery rides the existing gateway deliverable mode: the skill returns an absolute `.html` path and messaging platforms get it as a file attachment automatically. The skill now explicitly requires the **bare path on its own line** (no backticks), matching the gateway's bare-path extraction in `gateway/platforms/base.py`.
- Zero model-tool schema growth. The only always-in-context cost is the ≤60-char description.

## Skill behavior contract

- Grounds facts in supplied files/conversation/sources first; ungrounded claims must be visibly marked `[unverified]` in the artifact.
- Preserves code, commands, URLs, paths, error strings character-for-character.
- TL;DR strip at top; 3-7 one-idea numbered sections; each with one visual (SVG diagram, flow arrows, timeline, comparison boxes) and captions under 25 words.
- Single self-contained `.html` at an absolute path; renders fully offline.
- Sentence case, ≥16px body text, high contrast, meaningful alt/aria-labels, no decorative animation.
- Offline verification covers `src=`/`href=`, CSS `url(...)`, `@import`, `srcset`, and protocol-relative URLs, with same-page `href="#..."` anchors explicitly allowed.

## Testing

TDD, per repo standards (canonical runner `scripts/run_tests.sh`):

1. Contract tests written first (red), then the skill (green). Final suite: **449 tests passed, 0 failed** across `tests/skills/` + `tests/tools/test_skills_tool.py|test_skills_sync.py|test_skills_guard.py`.
2. Tests are structure-scoped, per review feedback: assertions anchor to parsed frontmatter fields, numbered Procedure items, Artifact-contract bullets, and the Verification section instead of free-floating phrase greps. No direct `yaml` import (production `_parse_frontmatter` reused). Negative dependency checks parse declared `dependencies`/`prerequisites.env_vars` fields rather than scanning prose for vendor words.
3. Hermetic production-discovery test: copies only the eli5 skill into a temp categorized tree, patches external dirs to `[]`, runs the real `_find_all_skills(skip_disabled=True)` scanner, asserts discovered name/category/description.
4. Sync guard: generated docs page must contain the current frontmatter version row and closing Verification sentence, so page drift fails CI.
5. E2E smoke (from the first iteration, unchanged by this pass): isolated `HERMES_HOME`, `hermes skills list` shows eli5 enabled; live `/eli5 what is a Hermes cron job` run produced `/opt/data/eli5/hermes-cron-job.html` (valid doctype, inline `<style>`, zero remote references, TL;DR strip, 5 sections, honest `[unverified]` marks); visual check via headless Chrome screenshot showed clean layout, no overflow or contrast defects.

## Docs

`website/scripts/generate-skill-docs.py` regenerated the eli5 page from the updated SKILL.md. Shared catalog/sidebar files were restored to `origin/main` and re-edited to contain exactly one eli5 hunk each:

- `website/docs/reference/skills-catalog.md`: +1 row in the creative table
- `website/docs/reference/optional-skills-catalog.md`: untouched (identical to main)
- `website/sidebars.ts`: +1 entry in the bundled-creative list

Branch diff touches exactly 5 files: the skill, its test, the catalog row, the generated page, the sidebar entry. Unrelated regeneration drift from other skills' local edits (computer-use relocation, cloudflare-temporary-deploy row, empty devops section) is excluded.

## Review response

Addressing @Enough1122's automated review:
1. PR-description/diff contradiction: fixed as above; every non-eli5 hunk removed, verified via `git diff origin/main..HEAD --name-only` allowlist and hunk inspection of all three shared files.
2. Brittle phrase tests: replaced with structure-scoped contracts + hermetic discovery test + page-sync guard (see Testing).
3. Anchor clarification: Verification now states `href="#..."` same-page anchors are allowed, and extends the offline surface to `url()`, `@import`, `srcset`, protocol-relative.

## Out of scope (explicitly)

First-class artifact preview/lifecycle (structured artifact events, versioned artifacts, sandboxed inline preview, client capability negotiation) remains future work better discussed against #19489 / #53194 rather than folded into a first skill PR.