### PR TITLE
fix(wake): stop a timed-out halt from double-opening the microphone

### DIFF
--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -781,3 +781,157 @@ def test_feed_audio_rejects_wrong_owner(monkeypatch, tmp_path):
     ww.start_listening(lambda: None, owner=owner, config={}, external_audio=True)
     assert ww.feed_audio(owner=object(), pcm_int16=b"\x00\x00") is False
     assert ww.stop_listening(owner=owner) is True
+
+# --- #91987: a halt that times out must not report success ----------------
+#
+# The capture thread owns the PortAudio stream and closes it in its own
+# `finally`, so "the thread exited" and "the microphone was released" are the
+# same statement. `_halt_thread` used to clear `self._thread` after a join
+# timeout regardless, which split them: the caller was told the mic was free
+# while a live thread still held it, and the next `start()` -- seeing no
+# thread handle -- opened a SECOND stream on the same device. On Windows/MME
+# that second open succeeds and then delivers nothing but silence, which is
+# why the reported symptom is a permanently deaf wake word rather than an
+# error.
+#
+# `stream.read()` blocks, and a device the browser's WebRTC capture is
+# releasing at the same moment can hold it past the grace period. That is
+# exactly the pause/resume a hands-free voice turn performs.
+
+
+class _WedgedStream(_FakeStream):
+    """A stream whose `read()` blocks until the test lets it go.
+
+    Stands in for a PortAudio device that will not return promptly while it is
+    being contended -- the condition the halt's join timeout exists for.
+    """
+
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.release = threading.Event()
+
+    def read(self, n):
+        # Long enough to outlast the (monkeypatched) join grace period.
+        self.release.wait(timeout=10.0)
+        return [0] * n, False
+
+
+def _wedged_audio(monkeypatch):
+    """Fake sounddevice that records every stream it is asked to open."""
+    opened: list[_WedgedStream] = []
+
+    def _open(**kw):
+        stream = _WedgedStream(**kw)
+        opened.append(stream)
+        return stream
+
+    monkeypatch.setattr(ww, "_import_audio", lambda: (types.SimpleNamespace(InputStream=_open), None))
+    # Keep the timeout paths fast; the bug is about how a timeout is
+    # interpreted, not about how long it is.
+    monkeypatch.setattr(ww, "_HALT_JOIN_SECONDS", 0.05)
+    return opened
+
+
+def test_a_halt_that_cannot_stop_the_thread_says_so(monkeypatch):
+    opened = _wedged_audio(monkeypatch)
+    det = ww.WakeWordDetector(_FakeEngine(fire=False), lambda: None)
+    det.start()
+    try:
+        assert det._halt_thread() is False
+        assert det._thread is not None and det._thread.is_alive(), (
+            "the thread handle must survive a failed halt -- dropping it is "
+            "what lets the next start() open a second stream"
+        )
+    finally:
+        opened[0].release.set()
+        det.stop()
+
+
+def test_resume_over_a_wedged_thread_does_not_open_a_second_stream(monkeypatch):
+    """The #91987 failure in one assertion.
+
+    Two live streams on one device is the wedge. Refusing is the fix; the
+    caller side already treats a raise as transient and retries.
+    """
+    opened = _wedged_audio(monkeypatch)
+    det = ww.WakeWordDetector(_FakeEngine(fire=False), lambda: None)
+    det.start()
+    try:
+        det.pause()
+        assert len(opened) == 1
+
+        with pytest.raises(TimeoutError):
+            det.resume()
+
+        assert len(opened) == 1, (
+            f"opened {len(opened)} streams; the first one is still held by the "
+            "capture thread that has not exited"
+        )
+    finally:
+        opened[0].release.set()
+        det.stop()
+
+
+def test_the_microphone_reopens_once_the_stale_thread_finally_exits(monkeypatch):
+    """Refusing must not be permanent -- the retry has to have something to win."""
+    opened = _wedged_audio(monkeypatch)
+    det = ww.WakeWordDetector(_FakeEngine(fire=False), lambda: None)
+    det.start()
+    try:
+        det.pause()
+        with pytest.raises(TimeoutError):
+            det.resume()
+
+        # The contended device lets go; the stale thread leaves its read, sees
+        # the stop flag and closes the stream on its way out.
+        opened[0].release.set()
+        for _ in range(200):
+            if not opened[0].closed:
+                time.sleep(0.01)
+        assert opened[0].closed, "the stale thread must close the stream it owns"
+
+        det.resume()
+        assert len(opened) == 2, "a resume after a clean exit must reopen the mic"
+        assert det._thread is not None and det._thread.is_alive()
+    finally:
+        for stream in opened:
+            stream.release.set()
+        det.stop()
+
+
+def test_stop_leaves_the_engine_open_while_a_thread_is_still_processing(monkeypatch):
+    """`engine.close()` under a live capture thread feeds a closed engine.
+
+    The read loop swallows the exception that follows, so this degrades
+    silently rather than crashing -- worth pinning for that reason.
+    """
+    opened = _wedged_audio(monkeypatch)
+    engine = _FakeEngine(fire=False)
+    det = ww.WakeWordDetector(engine, lambda: None)
+    det.start()
+    try:
+        det.stop()
+        assert engine.closed is False, (
+            "the capture thread is still calling engine.process() every frame"
+        )
+    finally:
+        opened[0].release.set()
+
+
+def test_a_clean_pause_resume_cycle_is_unchanged(monkeypatch):
+    """Guardrail: the ordinary path must keep releasing and reclaiming the mic."""
+    opened = _wedged_audio(monkeypatch)
+    det = ww.WakeWordDetector(_FakeEngine(fire=False), lambda: None)
+    det.start()
+    try:
+        opened[0].release.set()  # a healthy device returns from read()
+        det.pause()
+        assert det._thread is None, "a successful halt clears the thread handle"
+
+        det.resume()
+        assert len(opened) == 2
+        assert det._thread is not None and det._thread.is_alive()
+    finally:
+        for stream in opened:
+            stream.release.set()
+        det.stop()

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -1147,7 +1147,8 @@ class WakeWordDetector:
         else:
             logger.warning(
                 "wake word: leaving the engine open -- the capture thread is "
-                "still running and would be processing frames against it."
+                "still running and would be processing frames against it. "
+                "A later stop() closes it, once that thread has exited."
             )
 
     def _halt_thread(self) -> bool:

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -49,6 +49,14 @@ SAMPLE_RATE = 16000
 _FIRE_COOLDOWN_SECONDS = 2.0
 _START_TIMEOUT_SECONDS = 5.0
 
+# How long a halt waits for the capture thread to leave its blocking
+# ``stream.read()`` and close the microphone. Deliberately short: the halt runs
+# on the ``wake.pause``/``wake.stop`` RPC path, and the desktop is holding a
+# voice turn open behind it. What matters is not the length of this window but
+# that a timeout is reported as a failure rather than assumed to be a success
+# -- see :meth:`WakeWordDetector._halt_thread`.
+_HALT_JOIN_SECONDS = 2.0
+
 # Ambient-speech rejection: openWakeWord scores one ~80ms frame at a time, and a
 # stray phoneme in background conversation can spike a single frame over the
 # threshold. A real utterance of the phrase holds the score high across several
@@ -1073,10 +1081,38 @@ class WakeWordDetector:
                     pass
 
     def start(self) -> None:
-        """Open the mic (or client feeder) and begin listening. Idempotent."""
+        """Open the mic (or client feeder) and begin listening. Idempotent.
+
+        Raises :class:`TimeoutError` when a previous capture thread is still
+        holding the microphone. That is a transient condition and the callers
+        that matter already treat it as one: the gateway's
+        ``_wake_resume_if_owner`` retries a raising resume in the background
+        for 15s, and the desktop's ``resumeWakeAfterVoice`` falls through to
+        its next spaced attempt. Both are better outcomes than the alternative
+        below.
+        """
         with self._lock:
-            if self._thread is not None and self._thread.is_alive():
-                return
+            t = self._thread
+            if t is not None and t.is_alive():
+                if not self._stop.is_set():
+                    return
+                # A halt timed out and this thread is still on its way out of
+                # a blocking read. It owns the PortAudio stream and closes it
+                # in its own ``finally``, so until it exits the microphone is
+                # taken. Opening a second stream on that device is what wedges
+                # it until the app restarts (#91987): on Windows/MME the
+                # second open succeeds and then delivers nothing but silence,
+                # which is why the symptom is "mic delivers only silence"
+                # forever rather than an error. Give the old thread the rest
+                # of its grace period, then refuse rather than double-open.
+                t.join(timeout=_HALT_JOIN_SECONDS)
+                if t.is_alive():
+                    raise TimeoutError(
+                        "The previous wake-word capture thread still holds the "
+                        "microphone; refusing to open a second stream on it."
+                    )
+                if self._thread is t:
+                    self._thread = None
             self._stop.clear()
             ready = threading.Event()
             startup_errors: list[BaseException] = []
@@ -1102,17 +1138,53 @@ class WakeWordDetector:
         self.start()
 
     def stop(self) -> None:
-        self._halt_thread()
-        self.engine.close()
+        # Only close the engine once the capture thread is provably gone: it
+        # calls ``engine.process()`` every frame, and closing underneath it
+        # feeds a closed engine (the loop swallows the resulting exception, so
+        # this would degrade silently rather than crash).
+        if self._halt_thread():
+            self.engine.close()
+        else:
+            logger.warning(
+                "wake word: leaving the engine open -- the capture thread is "
+                "still running and would be processing frames against it."
+            )
 
-    def _halt_thread(self) -> None:
+    def _halt_thread(self) -> bool:
+        """Stop the capture thread. ``True`` only when it actually exited.
+
+        The thread owns the PortAudio stream and closes it in its own
+        ``finally``, so "the thread is gone" and "the microphone is released"
+        are the same statement. This used to clear ``self._thread``
+        unconditionally after a join timeout, which made them different
+        statements: the caller was told the mic was free while a live thread
+        still held it, and the next ``start()`` -- seeing no thread handle --
+        opened a second stream on the same device (#91987).
+
+        The join can time out for an ordinary reason. ``stream.read()`` is
+        blocking, and on Windows/MME a device that the browser's WebRTC
+        capture is releasing at the same moment can hold it well past the
+        grace period. That is exactly the pause/resume cycle a hands-free
+        voice turn performs, which is why the report is intermittent and
+        follows a barge-in.
+        """
         with self._lock:
             self._stop.set()
             t = self._thread
             if t is not None and t is not threading.current_thread():
-                t.join(timeout=2.0)
+                t.join(timeout=_HALT_JOIN_SECONDS)
+                if t.is_alive():
+                    logger.warning(
+                        "wake word: capture thread did not exit within %.1fs; "
+                        "the microphone is still held. Keeping the thread "
+                        "handle so a resume cannot open a second stream over "
+                        "it.",
+                        _HALT_JOIN_SECONDS,
+                    )
+                    return False
             if self._thread is t:
                 self._thread = None
+            return True
 
     def _dispatch_wake(self) -> None:
         try:


### PR DESCRIPTION
## What does this PR do?

The wake-word capture thread owns its PortAudio stream and closes it in its own
`finally`. So "the thread exited" and "the microphone was released" are the same
statement — and `_halt_thread()` split them apart:

```python
def _halt_thread(self) -> None:
    with self._lock:
        self._stop.set()
        t = self._thread
        if t is not None and t is not threading.current_thread():
            t.join(timeout=2.0)      # <- result never checked
        if self._thread is t:
            self._thread = None      # <- cleared even when the thread is alive
```

`start()` decides whether to open the mic from exactly that handle:

```python
if self._thread is not None and self._thread.is_alive():
    return
```

So after a join timeout, the handle is gone, `start()` believes nothing is
listening, and opens a **second** `sd.InputStream` on a device the first thread
still holds.

On Windows/MME the second open does not fail — it succeeds and delivers
silence. That is why #91987's symptom is a permanently deaf wake word rather
than an error:

```
gui.log     : wake.resume: detector resumed=False
errors.log  : wake word: mic delivers only silence (peak<=10 for 10s); ... (MME)   [every ~10s, 10+ min]
desktop.log : AudioContext encountered an error from the audio device
```

and only a full app restart clears it, because only process exit frees both
streams.

### Why it is intermittent, and why after a barge-in

The join times out for a completely ordinary reason. `stream.read()` is
blocking, and a device the browser's WebRTC capture is releasing at the same
instant can hold it well past two seconds. A hands-free voice turn performs
exactly that pause/resume cycle against exactly that contended device, once per
turn. So the bug needs no unusual state — just losing a race that is run
constantly. That matches the report: ~5–6 times across a day of heavy use,
following an interruption, on an external USB mic.

### The fix

`_halt_thread()` now returns whether the thread is **provably** gone, and keeps
the handle when it is not. `start()` refuses to open over a live capture thread,
raising `TimeoutError` rather than double-opening.

Refusing is recoverable and wedging the device is not — and both callers that
matter already treat a raise as transient:

- `tui_gateway/server.py::_wake_resume_if_owner` catches an exception from
  `resume_listening` and retries in a background thread for 15s at 1s intervals.
  Its docstring says a `False` return is final and an exception is retryable;
  this makes the wedged-device case take the retryable branch, which is what
  that machinery was built for.
- `apps/desktop/src/store/wake-word.ts::resumeWakeAfterVoice` catches and falls
  through to its next spaced attempt (3 attempts, 1.5s apart).

Neither of them needed changing. The wedge was reachable only because the failure
was reported as a success.

`stop()` additionally no longer calls `engine.close()` while a capture thread may
still be running `engine.process()` against it. The read loop swallows the
resulting exception, so that path degraded silently.

## Related Issue

Fixes #91987

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/wake_word.py`
  - `_halt_thread()` returns `bool`; clears `self._thread` only when the thread
    actually exited, and logs a warning when it did not.
  - `start()` joins a stale thread for the remaining grace period and raises
    `TimeoutError` rather than opening a second stream on a held device.
  - `stop()` closes the engine only after a confirmed halt.
  - The 2.0s magic number is now `_HALT_JOIN_SECONDS` with a comment on why it
    is short.
- `tests/tools/test_wake_word.py`: 5 tests.

## How to Test

1. `pytest tests/tools/test_wake_word.py -q` → 31 passed, 3 skipped.
2. Mutation proofs, so the tests bind the fix and not the shape of it — each
   half of the change was reverted separately:
   - Drop the `is_alive()` check from `_halt_thread` (restore the original
     unconditional clear) → **4 of the 5 fail**.
   - Keep the honest halt but let `start()` clear the handle and open anyway →
     **2 fail**, including
     `test_resume_over_a_wedged_thread_does_not_open_a_second_stream`.
3. Neighbouring suites: `tests/tools/test_wake_word.py`,
   `tests/test_tui_gateway_server.py`, `tests/gateway/test_kanban_wake_scope.py`
   → **628 passed, 3 skipped**.

The tests use a `_WedgedStream` whose `read()` blocks on an `Event` until the
test releases it, and monkeypatch `_HALT_JOIN_SECONDS` down to 0.05s. That
reproduces the contended-device condition deterministically with no audio
hardware and no sleeping.

### A decision I did not make on your behalf

`pause_listening()` still returns `True` whenever the caller owns the lease,
even if `pause()` could not actually release the mic. That is the same class of
statement this PR is fixing, one layer up — but making it honest changes the
`wake.pause` RPC contract, whose only failure vocabulary today is
`reason: "not_owner"`, which would be a *wrong* reason for "still held". It
wants a new reason code and a decision about what the desktop should do with it,
so it is a maintainer call rather than something to fold in quietly here. The
wedge this PR closes is on the resume side and is reachable on its own.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #91987 had no linked PR and no cross-references when I claimed it
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — the three suites above; the full run is not something I can complete locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro 26200, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings only; this is internal lifecycle
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the double-open is worst on Windows/MME, where a second open succeeds and yields silence. On macOS and Linux the second open typically raises, which surfaced as an error rather than a deaf listener; the fix removes the double-open on all three, and the tests are hardware-free
- [x] N/A — no tool descriptions or schemas touched

## What I could not verify

I do not have the reporter's setup — external USB microphone on MME, sherpa with
a Chinese wake phrase, faster-whisper STT — so I have not reproduced the original
timeout against a real contended PortAudio device. What the tests prove is the
consequence: that a capture thread which does not exit within the grace period no
longer causes a second stream to be opened on the same device.

@reporter of #91987 — if you can run this branch through the same hands-free
cycle, the log line to watch for is the new
`wake word: capture thread did not exit within 2.0s`. If it appears and the wake
word still recovers afterwards, that is this bug confirmed and fixed. If the wake
word still goes deaf **without** that line appearing, the halt is succeeding and
the mic is being held by something else — which would point at the desktop's
capture teardown instead, and I would want to know that too.
