### PR TITLE
feat(google-workspace): support popup reminders for calendar events

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -211,6 +211,8 @@ $GAPI calendar create --summary "Team Standup" --start 2026-03-01T10:00:00-06:00
 $GAPI calendar create --summary "Lunch" --start 2026-03-01T12:00:00Z --end 2026-03-01T13:00:00Z --location "Cafe"
 $GAPI calendar create --summary "Review" --start 2026-03-01T14:00:00Z --end 2026-03-01T15:00:00Z --attendees "alice@co.com,bob@co.com"
 $GAPI calendar create --summary "Standup" --start 2026-03-01T10:00:00Z --end 2026-03-01T10:30:00Z --reminders 15
+# --reminders accepts one positive popup offset in minutes. Omitted or non-positive
+# values keep the calendar defaults; 0 does not silence reminders.
 
 # Delete event
 $GAPI calendar delete EVENT_ID

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -210,6 +210,7 @@ $GAPI calendar list --start 2026-03-01T00:00:00Z --end 2026-03-07T23:59:59Z
 $GAPI calendar create --summary "Team Standup" --start 2026-03-01T10:00:00-06:00 --end 2026-03-01T10:30:00-06:00
 $GAPI calendar create --summary "Lunch" --start 2026-03-01T12:00:00Z --end 2026-03-01T13:00:00Z --location "Cafe"
 $GAPI calendar create --summary "Review" --start 2026-03-01T14:00:00Z --end 2026-03-01T15:00:00Z --attendees "alice@co.com,bob@co.com"
+$GAPI calendar create --summary "Standup" --start 2026-03-01T10:00:00Z --end 2026-03-01T10:30:00Z --reminders 15
 
 # Delete event
 $GAPI calendar delete EVENT_ID

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -527,6 +527,11 @@ def calendar_create(args):
         event["description"] = args.description
     if args.attendees:
         event["attendees"] = [{"email": e.strip()} for e in args.attendees.split(",") if e.strip()]
+    if args.reminders > 0:
+        event["reminders"] = {
+            "useDefault": False,
+            "overrides": [{"method": "popup", "minutes": args.reminders}],
+        }
 
     if _gws_binary():
         result = _run_gws(
@@ -1111,6 +1116,7 @@ def main():
     p.add_argument("--location", default="")
     p.add_argument("--description", default="")
     p.add_argument("--attendees", default="", help="Comma-separated email addresses")
+    p.add_argument("--reminders", type=int, default=0, help="Popup reminder minutes before start")
     p.add_argument("--calendar", default="primary")
     p.set_defaults(func=calendar_create)
 

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -136,6 +136,100 @@ def test_api_calendar_list_uses_events_list(api_module):
     assert params["calendarId"] == "primary"
 
 
+@pytest.mark.parametrize(
+    ("reminders", "expected_reminders"),
+    [
+        (15, {"useDefault": False, "overrides": [{"method": "popup", "minutes": 15}]}),
+        (0, None),
+        (-5, None),
+    ],
+)
+def test_api_calendar_create_threads_popup_reminders_to_gws(
+    api_module, reminders, expected_reminders
+):
+    captured = {}
+
+    def capture_run(parts, **kwargs):
+        captured["parts"] = parts
+        captured["body"] = kwargs["body"]
+        return {"id": "event-1", "summary": "Standup"}
+
+    args = api_module.argparse.Namespace(
+        summary="Standup",
+        start="2026-08-23T09:00:00Z",
+        end="2026-08-23T09:30:00Z",
+        location="",
+        description="",
+        attendees="",
+        calendar="primary",
+        reminders=reminders,
+    )
+
+    with patch.object(api_module, "_run_gws", side_effect=capture_run):
+        api_module.calendar_create(args)
+
+    assert captured["parts"] == ["calendar", "events", "insert"]
+    if expected_reminders is None:
+        assert "reminders" not in captured["body"]
+    else:
+        assert captured["body"]["reminders"] == expected_reminders
+
+
+def test_api_calendar_create_threads_popup_reminders_to_python_client(api_module):
+    insert = MagicMock()
+    insert.execute.return_value = {"id": "event-1", "summary": "Standup"}
+    service = MagicMock()
+    service.events.return_value.insert.return_value = insert
+    args = api_module.argparse.Namespace(
+        summary="Standup",
+        start="2026-08-23T09:00:00Z",
+        end="2026-08-23T09:30:00Z",
+        location="",
+        description="",
+        attendees="",
+        calendar="primary",
+        reminders=15,
+    )
+
+    with patch.object(api_module, "_gws_binary", return_value=None), patch.object(
+        api_module, "build_service", return_value=service
+    ):
+        api_module.calendar_create(args)
+
+    body = service.events.return_value.insert.call_args.kwargs["body"]
+    assert body["reminders"] == {
+        "useDefault": False,
+        "overrides": [{"method": "popup", "minutes": 15}],
+    }
+
+
+@pytest.mark.parametrize(("flag", "expected"), [([], 0), (["--reminders", "15"], 15)])
+def test_api_calendar_create_parser_accepts_reminder_minutes(api_module, flag, expected):
+    captured = {}
+
+    def capture_create(args):
+        captured["reminders"] = args.reminders
+
+    argv = [
+        "google_api.py",
+        "calendar",
+        "create",
+        "--summary",
+        "Standup",
+        "--start",
+        "2026-08-23T09:00:00Z",
+        "--end",
+        "2026-08-23T09:30:00Z",
+        *flag,
+    ]
+    with patch.object(sys, "argv", argv), patch.object(
+        api_module, "calendar_create", side_effect=capture_create
+    ):
+        api_module.main()
+
+    assert captured["reminders"] == expected
+
+
 
 
 


### PR DESCRIPTION
## Summary

- add a `--reminders` minute offset to `calendar create`
- send positive values as a Google Calendar popup override through both the Python client and `gws` bridge paths
- preserve the existing request body for omitted, zero, and negative values

## Testing

- `scripts/run_tests.sh tests/skills/test_google_workspace_api.py -q` (10 passed)

## Related Issue

Closes #92097