### PR TITLE
fix(cli): route deferred update notice through prompt_toolkit cprint

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -692,7 +692,7 @@ def get_update_result(timeout: float = 0.5) -> Optional[int]:
 
 
 def _format_update_notice(behind: int) -> str:
-    """Render the update warning line for a non-zero ``behind`` result."""
+    """Render the update warning line for Rich Console output."""
     from hermes_cli.config import get_managed_update_command, recommended_update_command
     if behind > 0:
         commits_word = "commit" if behind == 1 else "commits"
@@ -707,6 +707,33 @@ def _format_update_notice(behind: int) -> str:
     line = "[bold yellow]⚠ update available[/]"
     if managed_cmd:
         line += f"[dim yellow] — run [bold]{managed_cmd}[/bold][/]"
+    return line
+
+
+def _format_update_notice_ansi(behind: int) -> str:
+    """Render the deferred update warning as ANSI for prompt_toolkit.
+
+    ``patch_stdout(raw=False)`` replaces raw ESC bytes written through
+    stdout/stderr with ``?``.  Deferred update notices can fire after the
+    prompt_toolkit application starts, so they must be routed through
+    ``cprint()`` instead of Rich's ``Console.print()``.
+    """
+    from hermes_cli.config import get_managed_update_command, recommended_update_command
+    yellow_bold = "\033[1;33m"
+    yellow_dim = "\033[2;33m"
+    yellow_bold_dim = "\033[1;2;33m"
+    reset = "\033[0m"
+    if behind > 0:
+        commits_word = "commit" if behind == 1 else "commits"
+        return (
+            f"{yellow_bold}⚠ {behind} {commits_word} behind{reset}"
+            f"{yellow_dim} — run {yellow_bold_dim}{recommended_update_command()}{reset}"
+            f"{yellow_dim} to update{reset}"
+        )
+    managed_cmd = get_managed_update_command()
+    line = f"{yellow_bold}⚠ update available{reset}"
+    if managed_cmd:
+        line += f"{yellow_dim} — run {yellow_bold_dim}{managed_cmd}{reset}"
     return line
 
 
@@ -731,7 +758,7 @@ def _defer_update_notice(console: "Console", max_wait: float = 30.0) -> None:
             behind = _update_result
             if behind is None or behind == 0:
                 return
-            console.print(_format_update_notice(behind))
+            cprint(_format_update_notice_ansi(behind))
         except Exception:
             pass  # never break the session over an update notice
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -19,6 +19,43 @@ def test_cprint_falls_back_to_plain_print_when_prompt_toolkit_has_no_console(cap
     assert capsys.readouterr().out == "fallback text\n"
 
 
+def test_deferred_update_notice_uses_prompt_toolkit_cprint(monkeypatch):
+    """Late update notices must not write raw Rich ANSI through patch_stdout."""
+    calls = []
+    monkeypatch.setattr(banner, "cprint", calls.append)
+
+    notice = banner._format_update_notice_ansi(89)
+    banner.cprint(notice)
+
+    assert calls == [notice]
+    assert "\x1b[1;33m⚠ 89 commits behind\x1b[0m" in calls[0]
+    assert "?[" not in calls[0]
+    assert "[bold yellow]" not in calls[0]
+
+
+def test_deferred_update_notice_path_does_not_use_rich_console(monkeypatch):
+    console = Console()
+
+    def fail_print(*_args, **_kwargs):
+        raise AssertionError("deferred update notice used Rich Console.print")
+
+    monkeypatch.setattr(console, "print", fail_print)
+    banner._deferred_update_notice_started = False
+    monkeypatch.setattr(banner, "_update_result", 89)
+    banner._update_check_done.set()
+
+    calls = []
+    monkeypatch.setattr(banner, "cprint", calls.append)
+
+    banner._defer_update_notice(console, max_wait=0.01)
+    import time
+    deadline = time.time() + 1
+    while not calls and time.time() < deadline:
+        time.sleep(0.01)
+
+    assert calls
+    assert "?[" not in calls[0]
+    banner._deferred_update_notice_started = False
 
 
 


### PR DESCRIPTION
# [Bug]: Deferred update notice renders as ANSI garbage (`?[1;33m...`) in interactive CLI

## Bug Description

When the background update check finishes AFTER the interactive prompt starts, the
deferred update notice prints as raw garbage instead of a readable colored line:

```
?[1;33m⚠ ?[0m?[1;33m89?[0m?[1;33m commits behind?[0m?[2;33m — run ?[0m?[1;2;33mhermes update?[0m?[2;33m to update?[0m
```

instead of:

```
⚠ 89 commits behind — run hermes update to update
```

The rest of the UI (banner, prompt, status bar) renders correctly.

## Environment

- Install method: git checkout (`~/.hermes/hermes-agent`)
- macOS, Terminal.app, TERM=xterm-256color
- Hermes v0.20.5

## Root cause

`_defer_update_notice()` (hermes_cli/banner.py) prints the late notice via Rich's
`Console.print()`. By the time the background thread runs, the interactive loop has
already wrapped stdout with `prompt_toolkit.patch_stdout(raw=False)`. The StdoutProxy
sanitizes raw ESC bytes (deliberately, to protect the rendered UI), replacing ESC with
`?`. Rich writes raw ANSI directly to stdout and bypasses prompt_toolkit's
`print_formatted_text` path, so every color escape becomes visible garbage.

This only triggers when the live git/network check does not finish within the banner's
~50ms wait window (`get_update_result(timeout=0.05)`) — i.e. stale 6h cache + slow
network. Most users never hit the late path, which is why it went unnoticed.

## Steps to Reproduce

1. Delete `~/.hermes/.update_check` (force a live check).
2. Run `hermes` interactively on a network where `git fetch` takes >1s.
3. The notice prints after the prompt appears, as `?[1;33m...` garbage.

## Proposed fix

Route the deferred notice through `cprint()` (prompt_toolkit's `print_formatted_text`)
with a plain ANSI string instead of Rich markup. Same rendering, but through the
path prompt_toolkit understands:

```python
def _format_update_notice_ansi(behind: int) -> str:
    yellow_bold = "\033[1;33m"
    ...
    return f"{yellow_bold}⚠ {behind} commits behind{reset} ..."

# in _defer_update_notice:
cprint(_format_update_notice_ansi(behind))
```

Attached: banner-fix.diff (banner.py) + regression tests (tests-added.txt)
that assert the notice goes through cprint, contains no `?[` and no Rich markup.