### PR TITLE
feat(whatsapp): add structural outbound read-only mode

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -298,6 +298,19 @@ from gateway.platforms.base import (
 from utils import env_int
 
 
+_VALID_OUTBOUND_MODES = frozenset({"normal", "never"})
+_OUTBOUND_DISABLED_ERROR = "WhatsApp outbound sends are disabled by outbound_mode=never"
+
+
+def _normalize_outbound_mode(value: Any) -> str:
+    """Normalize the bridge send policy, failing closed on bad values."""
+    mode = str(value or "normal").strip().lower()
+    if mode in _VALID_OUTBOUND_MODES:
+        return mode
+    logger.error("Invalid WhatsApp outbound_mode %r; disabling outbound sends", value)
+    return "never"
+
+
 def _is_allowed_bridge_path(url: str) -> bool:
     """Return True only when an absolute path from the bridge resolves inside a
     known Hermes media cache directory.
@@ -428,6 +441,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
         ))
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
+        self._outbound_mode = _normalize_outbound_mode(
+            config.extra.get("outbound_mode")
+        )
         self._dm_policy = str(config.extra.get("dm_policy") or _wenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
         # Prefer config.extra, then the documented WHATSAPP_ALLOWED_USERS env
         # (setup wizard / pairing mirror). Select by key *presence* so an
@@ -505,6 +521,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not math.isfinite(parsed) or parsed < 0:
             return float(default)
         return parsed
+
+    def _effective_outbound_mode(self) -> str:
+        """Return normal for legacy test doubles that bypass ``__init__``."""
+        return getattr(self, "_outbound_mode", "normal")
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """
@@ -648,7 +668,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 running_hash = data.get("scriptHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
                                 running_read_receipts = bool(data.get("sendReadReceipts", False))
-                                config_matches = running_read_receipts == self._send_read_receipts
+                                running_outbound_mode = _normalize_outbound_mode(
+                                    data.get("outboundMode")
+                                )
+                                config_matches = (
+                                    running_read_receipts == self._send_read_receipts
+                                    and running_outbound_mode == self._effective_outbound_mode()
+                                )
                                 if (
                                     running_hash
                                     and disk_hash
@@ -664,7 +690,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 stale_reason = (
                                     f"running={running_hash or 'unversioned'}, disk={disk_hash}"
                                     if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
+                                    else "WhatsApp bridge configuration changed"
                                 )
                                 print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
                             else:
@@ -695,6 +721,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
                 "true" if self._send_read_receipts else "false"
             )
+            bridge_env["WHATSAPP_OUTBOUND_MODE"] = self._effective_outbound_mode()
             # Under multiplexing, the bridge subprocess runs with a copy of
             # os.environ that does NOT contain the secondary profile's .env
             # vars.  Inject the resolved WHATSAPP_* values so the Node bridge
@@ -935,6 +962,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         Formats markdown for WhatsApp, splits long messages into chunks
         that preserve code block boundaries, and sends each chunk sequentially.
         """
+        if self._effective_outbound_mode() == "never":
+            return SendResult(success=False, error=_OUTBOUND_DISABLED_ERROR)
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1001,6 +1030,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         finalize: bool = False,
     ) -> SendResult:
         """Edit a previously sent message via the WhatsApp bridge."""
+        if self._effective_outbound_mode() == "never":
+            return SendResult(success=False, error=_OUTBOUND_DISABLED_ERROR)
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1034,6 +1065,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         file_name: Optional[str] = None,
     ) -> SendResult:
         """Send any media file via bridge /send-media endpoint."""
+        if self._effective_outbound_mode() == "never":
+            return SendResult(success=False, error=_OUTBOUND_DISABLED_ERROR)
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1088,6 +1121,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         remain gateway-owned and add text fallback plus explicit confirmation
         semantics before approval prompts are ever mapped onto polls.
         """
+        if self._effective_outbound_mode() == "never":
+            return SendResult(success=False, error=_OUTBOUND_DISABLED_ERROR)
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1172,6 +1207,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a native WhatsApp location pin via the Baileys bridge."""
+        if self._effective_outbound_mode() == "never":
+            return SendResult(success=False, error=_OUTBOUND_DISABLED_ERROR)
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
         bridge_exit = await self._check_managed_bridge_exit()
@@ -1277,6 +1314,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""
+        if self._effective_outbound_mode() == "never":
+            return
         if not self._running or not self._http_session:
             return
         if await self._check_managed_bridge_exit():
@@ -1366,6 +1405,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     async def _send_read_receipt(self, data: Dict[str, Any]) -> None:
         """Mark a policy-accepted inbound message as read via the bridge."""
+        if self._effective_outbound_mode() == "never":
+            return
         if not self._send_read_receipts or not self._http_session:
             return
         key = data.get("readReceiptKey")
@@ -1714,6 +1755,8 @@ async def _standalone_send(
     ``/send`` message beforehand.
     """
     extra = getattr(pconfig, "extra", {}) or {}
+    if _normalize_outbound_mode(extra.get("outbound_mode")) == "never":
+        return {"error": _OUTBOUND_DISABLED_ERROR}
     try:
         import aiohttp
     except ImportError:
@@ -1846,9 +1889,9 @@ def interactive_setup() -> None:
 def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
     """Translate config.yaml whatsapp: keys into WHATSAPP_* env vars.
 
-    Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
-    whatsapp_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML. Returns None — everything flows through env.
+    Implements the apply_yaml_config_fn contract (#24849). Legacy bridge
+    settings continue to flow through env; outbound_mode is returned as a
+    type-preserving PlatformConfig extra because it is behavioral config.
     """
     import json as _json
     if "require_mention" in whatsapp_cfg and not os.getenv("WHATSAPP_REQUIRE_MENTION"):
@@ -1874,6 +1917,12 @@ def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
         if isinstance(gaf, list):
             gaf = ",".join(str(v) for v in gaf)
         os.environ["WHATSAPP_GROUP_ALLOWED_USERS"] = str(gaf)
+    if "outbound_mode" in whatsapp_cfg:
+        return {
+            "outbound_mode": _normalize_outbound_mode(
+                whatsapp_cfg.get("outbound_mode")
+            )
+        }
     return None
 
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -44,6 +44,8 @@ import {
   inboundReadReceiptKeys,
   inferMediaType,
   mediaPayloadForFile,
+  normalizeOutboundMode,
+  outboundRequestAllowed,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
@@ -83,6 +85,7 @@ const SEND_READ_RECEIPTS =
   process.env &&
   typeof process.env.WHATSAPP_SEND_READ_RECEIPTS === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_SEND_READ_RECEIPTS.toLowerCase());
+const OUTBOUND_MODE = normalizeOutboundMode(process.env.WHATSAPP_OUTBOUND_MODE);
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
@@ -813,6 +816,17 @@ app.use((req, res, next) => {
   next();
 });
 
+// Structural read-only mode. Keep this above every route so direct bridge
+// clients cannot bypass the Python adapter's policy gate.
+app.use((req, res, next) => {
+  if (!outboundRequestAllowed(OUTBOUND_MODE, req.method)) {
+    return res.status(403).json({
+      error: 'WhatsApp outbound sends are disabled by outbound_mode=never',
+    });
+  }
+  next();
+});
+
 // Poll for new messages (long-poll style)
 app.get('/messages', (req, res) => {
   const msgs = messageQueue.splice(0, messageQueue.length);
@@ -1111,6 +1125,7 @@ app.get('/health', (req, res) => {
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
+    outboundMode: OUTBOUND_MODE,
   });
 });
 

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -20,9 +20,22 @@ import {
   extractBridgeEvent,
   inboundReadReceiptKeys,
   mediaPayloadForFile,
+  normalizeOutboundMode,
+  outboundRequestAllowed,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
+
+// -- outbound policy ------------------------------------------------------
+{
+  assert.equal(normalizeOutboundMode(undefined), 'normal');
+  assert.equal(normalizeOutboundMode(' NEVER '), 'never');
+  assert.equal(normalizeOutboundMode('typo'), 'never');
+  assert.equal(outboundRequestAllowed('never', 'POST'), false);
+  assert.equal(outboundRequestAllowed('never', 'GET'), true);
+  assert.equal(outboundRequestAllowed('normal', 'POST'), true);
+  console.log('  ✓ outbound policy blocks writes while preserving inbound reads');
+}
 
 // -- inbound read receipts ------------------------------------------------
 {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -13,6 +13,16 @@ export const MIME_MAP = {
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 };
 
+export function normalizeOutboundMode(value) {
+  const mode = String(value || 'normal').trim().toLowerCase();
+  return mode === 'normal' || mode === 'never' ? mode : 'never';
+}
+
+export function outboundRequestAllowed(mode, method) {
+  return normalizeOutboundMode(mode) !== 'never'
+    || String(method || '').toUpperCase() !== 'POST';
+}
+
 export function normalizeWhatsAppId(value) {
   if (!value) return '';
   return String(value).replace(':', '@');

--- a/tests/gateway/test_whatsapp_outbound_mode.py
+++ b/tests/gateway/test_whatsapp_outbound_mode.py
@@ -1,0 +1,116 @@
+"""Outbound send-policy tests for the WhatsApp Baileys adapter."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.whatsapp.adapter import (
+    WhatsAppAdapter,
+    _apply_yaml_config,
+    _normalize_outbound_mode,
+    _standalone_send,
+)
+
+
+@pytest.fixture
+def read_only_adapter(tmp_path):
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "outbound_mode": "never",
+                "session_path": str(tmp_path / "session"),
+            },
+        )
+    )
+    adapter._running = True
+    adapter._http_session = MagicMock()
+    adapter._send_read_receipts = True
+    return adapter
+
+
+def test_outbound_mode_defaults_normal_and_fails_closed():
+    assert _normalize_outbound_mode(None) == "normal"
+    assert _normalize_outbound_mode(" NORMAL ") == "normal"
+    assert _normalize_outbound_mode("never") == "never"
+    assert _normalize_outbound_mode("typo") == "never"
+
+
+def test_yaml_config_seeds_outbound_mode_without_process_env():
+    assert _apply_yaml_config({}, {"outbound_mode": "never"}) == {
+        "outbound_mode": "never"
+    }
+    assert _apply_yaml_config({}, {"outbound_mode": "typo"}) == {
+        "outbound_mode": "never"
+    }
+
+
+@pytest.mark.asyncio
+async def test_never_mode_refuses_every_adapter_outbound_primitive(
+    read_only_adapter, tmp_path
+):
+    media = tmp_path / "photo.png"
+    media.write_bytes(b"png")
+
+    results = [
+        await read_only_adapter.send("15551234567", "hello"),
+        await read_only_adapter.edit_message("15551234567", "m1", "edited"),
+        await read_only_adapter._send_media_to_bridge(
+            "15551234567", str(media), "image"
+        ),
+        await read_only_adapter.send_poll(
+            "15551234567", "Proceed?", ["Yes", "No"]
+        ),
+        await read_only_adapter.send_location("15551234567", 1.0, 2.0),
+    ]
+    await read_only_adapter.send_typing("15551234567")
+    await read_only_adapter._send_read_receipt(
+        {"readReceiptKey": {"id": "incoming-1"}}
+    )
+
+    assert all(result.success is False for result in results)
+    assert all("outbound_mode=never" in result.error for result in results)
+    read_only_adapter._http_session.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_never_mode_refuses_standalone_delivery_before_http():
+    config = SimpleNamespace(extra={"outbound_mode": "never", "bridge_port": 3000})
+    with patch("aiohttp.ClientSession", new_callable=MagicMock) as client:
+        result = await _standalone_send(config, "15551234567", "hello")
+
+    assert "outbound_mode=never" in result["error"]
+    client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_normal_mode_preserves_adapter_send_path(tmp_path):
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "outbound_mode": "normal",
+                "session_path": str(tmp_path / "session"),
+            },
+        )
+    )
+    adapter._running = True
+    adapter._check_managed_bridge_exit = AsyncMock(return_value=None)
+
+    response = AsyncMock()
+    response.status = 200
+    response.json = AsyncMock(return_value={"messageId": "sent-1"})
+    response_context = MagicMock()
+    response_context.__aenter__ = AsyncMock(return_value=response)
+    response_context.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.post.return_value = response_context
+    adapter._http_session = session
+
+    result = await adapter.send("15551234567", "hello")
+
+    assert result.success is True
+    assert result.message_id == "sent-1"
+    session.post.assert_called_once()

--- a/tests/gateway/test_whatsapp_outbound_mode.py
+++ b/tests/gateway/test_whatsapp_outbound_mode.py
@@ -5,10 +5,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig, load_gateway_config
 from plugins.platforms.whatsapp.adapter import (
     WhatsAppAdapter,
-    _apply_yaml_config,
     _normalize_outbound_mode,
     _standalone_send,
 )
@@ -38,13 +37,20 @@ def test_outbound_mode_defaults_normal_and_fails_closed():
     assert _normalize_outbound_mode("typo") == "never"
 
 
-def test_yaml_config_seeds_outbound_mode_without_process_env():
-    assert _apply_yaml_config({}, {"outbound_mode": "never"}) == {
-        "outbound_mode": "never"
-    }
-    assert _apply_yaml_config({}, {"outbound_mode": "typo"}) == {
-        "outbound_mode": "never"
-    }
+def test_yaml_config_seeds_outbound_mode_through_gateway_loader(
+    tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "whatsapp:\n  enabled: true\n  outbound_mode: never\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+
+    assert config.platforms[Platform.WHATSAPP].extra["outbound_mode"] == "never"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -54,6 +54,7 @@ def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
     adapter._bridge_process = None
     adapter._reply_prefix = None
     adapter._send_read_receipts = False
+    adapter._outbound_mode = "normal"
     adapter._running = False
     adapter._message_handler = None
     adapter._fatal_error_code = None
@@ -134,6 +135,7 @@ class TestStaleBridgeHandshake:
                 "status": "connected",
                 "scriptHash": disk_hash,
                 "sendReadReceipts": False,
+                "outboundMode": "normal",
             }
         )
         mock_proc = MagicMock()
@@ -211,3 +213,4 @@ class TestCacheDirEnvPassthrough:
         assert env["HERMES_AUDIO_CACHE_DIR"] == str(get_audio_cache_dir())
         assert env["HERMES_DOCUMENT_CACHE_DIR"] == str(get_document_cache_dir())
         assert env["WHATSAPP_SEND_READ_RECEIPTS"] == "true"
+        assert env["WHATSAPP_OUTBOUND_MODE"] == "normal"

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -181,9 +181,12 @@ whatsapp:
   reply_prefix: ""                          # Empty string disables the header
   # reply_prefix: "🤖 *My Bot*\n──────\n"  # Custom prefix (supports \n for newlines)
   send_read_receipts: false                 # Mark accepted inbound messages as read (blue ticks)
+  outbound_mode: normal                     # "normal" or structural read-only "never"
 ```
 
 When `send_read_receipts` is `true`, the adapter marks policy-accepted inbound messages as read after DM/group/mention filtering passes. Rejected messages (e.g., from non-allowlisted senders) are not marked read. Disabled by default for privacy. Changing this setting automatically restarts the bridge subprocess on the next connection.
+
+Set `outbound_mode: never` when WhatsApp should be an observation-only data source. Hermes continues to ingest allowed inbound messages, but rejects text, edits, media, polls, locations, typing indicators, and read receipts at both the Python adapter and the local bridge. The bridge exposes the active value as `outboundMode` from `GET /health`. The default, `normal`, preserves existing delivery behavior. Invalid values fail closed as `never`.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds a structural read-only mode for the WhatsApp Baileys integration. Operators can set `whatsapp.outbound_mode: never` to continue ingesting allowed inbound traffic while preventing Hermes or direct local bridge callers from sending messages, edits, media, polls, locations, typing state, or read receipts.

### Motivation

Prompt-level instructions cannot enforce an observation-only boundary for a personal WhatsApp account. A transport-level policy is needed because outbound actions can enter through the live adapter, standalone cron delivery, and direct bridge HTTP routes.

### Behavior

- `outbound_mode: normal` remains the default and preserves current delivery behavior.
- `outbound_mode: never` rejects every adapter send primitive and every bridge POST request while leaving inbound GET routes available.
- Invalid values fail closed as `never`.
- `GET /health` reports `outboundMode`, and a running bridge is restarted when its mode differs from the active config.
- This implements the issue's recommended structural read-only stage. Approval-gated queuing remains a separate delivery stage because it requires owner-only routing and pending-send lifecycle semantics above the transport.

### Implementation

The plugin seeds the behavioral setting directly into `PlatformConfig.extra`, applies one policy gate to live and standalone adapter paths, and passes the normalized mode to the Node bridge. The bridge uses an early middleware guard for all POST requests, with pure helper coverage proving that GET-based inbound ingestion remains available.

## Related Issue

Implements the structural read-only first stage of #92098.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/whatsapp/adapter.py` - normalize and enforce the outbound mode across live, native, receipt, typing, and standalone paths; include it in bridge process configuration and reuse checks.
- `scripts/whatsapp-bridge/bridge.js` - reject bridge writes in read-only mode and report the active mode from health.
- `scripts/whatsapp-bridge/bridge_helpers.js` - add pure fail-closed policy helpers.
- `tests/gateway/test_whatsapp_outbound_mode.py` - cover normal compatibility, invalid-value fail-closed behavior, all adapter primitives, YAML propagation, and standalone delivery.
- `tests/gateway/test_whatsapp_stale_bridge.py` - cover bridge env propagation and health compatibility.
- `scripts/whatsapp-bridge/bridge.native.test.mjs` - cover write refusal and preserved reads.
- `website/docs/user-guide/messaging/whatsapp.md` - document configuration, behavior, and health observability.

## How to Test

1. Configure `whatsapp.outbound_mode: never`, restart the gateway, and verify `GET /health` reports `"outboundMode":"never"`.
2. Confirm `GET /messages` remains available while bridge POST routes return HTTP 403.
3. Run the focused automated checks:

```bash
scripts/run_tests.sh tests/gateway/test_whatsapp_outbound_mode.py tests/gateway/test_whatsapp_stale_bridge.py tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_native_delivery.py tests/gateway/test_whatsapp_reply_prefix.py tests/tools/test_whatsapp_send_message_media.py -q
node scripts/whatsapp-bridge/bridge.native.test.mjs
node --check scripts/whatsapp-bridge/bridge.js
```

Focused Python result: 46 passed, 1 platform-specific skip. Node helper and syntax checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because this plugin-owned platform setting is documented in the WhatsApp guide
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no project architecture or workflow changed
- [x] I've considered cross-platform impact; policy logic is platform-independent and tests use the repository's Windows test runner
- [x] Tool descriptions and schemas are N/A because no model tool changed

## Screenshots / Logs

N/A - this is a transport policy and configuration change covered by focused automated checks.
