### PR TITLE
fix(desktop): mark the approval fallback as a glass-raised surface

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -165,6 +165,20 @@ describe('PendingToolApproval', () => {
     expect(within(fallback as HTMLElement).getByRole('button', { name: /Reject/ })).toBeTruthy()
   })
 
+  // #91026: under window glass, [data-hermes-glass] thins --ui-chat-surface-background
+  // to transparent everywhere except elements opted into the [data-glass-raised]
+  // near-opaque override (styles.css). The floating fallback paints with that same
+  // token, so without the attribute its text and Run/Reject controls wash out over
+  // whatever sits behind the window — the one prompt a user must read correctly
+  // before granting a command.
+  it('marks the floating fallback as a glass-raised surface so it stays legible over window glass', () => {
+    setRequest('rm /tmp/hermes_approval_test.txt')
+    const { container } = render(<PendingApprovalFallback />)
+    const fallback = container.querySelector('[data-slot="tool-approval-fallback"]')
+
+    expect(fallback?.querySelector('[data-glass-raised]')).not.toBeNull()
+  })
+
   it('hides the floating fallback once the inline approval bar is mounted', async () => {
     setRequest('rm /tmp/hermes_approval_test.txt')
 

--- a/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.test.tsx
@@ -171,6 +171,11 @@ describe('PendingToolApproval', () => {
   // token, so without the attribute its text and Run/Reject controls wash out over
   // whatever sits behind the window — the one prompt a user must read correctly
   // before granting a command.
+  //
+  // The inline approval bar (InlineApprovalBar in approval.tsx) doesn't need this
+  // attribute: it renders directly in the chat transcript flow with no background
+  // of its own, so it never floats independently over window glass the way this
+  // fallback card does.
   it('marks the floating fallback as a glass-raised surface so it stays legible over window glass', () => {
     setRequest('rm /tmp/hermes_approval_test.txt')
     const { container } = render(<PendingApprovalFallback />)

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -87,7 +87,16 @@ export const PendingApprovalFallback: FC = () => {
       data-slot="tool-approval-fallback"
       style={{ bottom: 'calc(var(--composer-measured-height) + 0.875rem)' }}
     >
-      <div className="pointer-events-auto rounded-xl border border-primary/30 bg-(--ui-chat-surface-background) px-3 py-2 shadow-lg backdrop-blur-xl [-webkit-backdrop-filter:blur(1rem)]">
+      <div
+        className="pointer-events-auto rounded-xl border border-primary/30 bg-(--ui-chat-surface-background) px-3 py-2 shadow-lg backdrop-blur-xl [-webkit-backdrop-filter:blur(1rem)]"
+        // Marks the card as a RAISED surface for window glass: while the field
+        // behind it thins to show the desktop, this card stays near-opaque
+        // (see the [data-glass-raised] rules in styles.css). Without it, the
+        // approval prompt — the one dialog a user must read correctly before
+        // granting a command — inherits the thinned field background and its
+        // text/controls wash out over whatever is behind the window.
+        data-glass-raised=""
+      >
         <div className="flex min-w-0 items-center gap-2 text-sm text-primary">
           <AlertCircle className="size-4 shrink-0" />
           <span className="shrink-0 font-medium">{t.assistant.approval.jumpToApproval}</span>


### PR DESCRIPTION
## What does this PR do?

Keeps the floating command-approval prompt (`PendingApprovalFallback`) legible when window glass is enabled. The card paints with `--ui-chat-surface-background`, which `[data-hermes-glass]` thins toward transparent for every surface **except** ones opted into the existing `[data-glass-raised]` near-opaque override (see `styles.css`). This card never opted in, so under glass its text and Run/Reject controls wash out over whatever is behind the window — the one prompt a user needs to read correctly before approving a command.

The fix adds `data-glass-raised=""`, the same attribute already used by `overlay-view.tsx` and `user-edit-composer.tsx` for exactly this class of surface (raised content that must stay legible over a thinned glass field). No new CSS, no new token — it reuses the mechanism the codebase already built for this problem.

## Related Issue

Fixes #91026

## Relation to #91041

#91041 is already open against this issue with a different approach (`bg-(--ui-chat-surface-background)` → `bg-popover/95`). Flagging this openly rather than leaving a silent duplicate:

- `--popover` resolves to `--dt-popover: color-mix(in srgb, var(--ui-bg-elevated) 96%, transparent)`. Layering Tailwind's `/95` on top compounds to ~91% opacity. Outside glass mode, this card was previously **100%** opaque (`--ui-chat-surface-background` → `--ui-bg-chrome` at full opacity), so #91041 introduces a small amount of unintended translucency for every user, not just those with glass enabled.
- It also switches the surface token from `--ui-bg-chrome` (the chat surface family used by sibling foreground UI) to `--ui-bg-elevated` (the popover family), which can read as a slightly different shade next to the rest of the approval UI.
- This PR instead reuses the codebase's own established `[data-glass-raised]` convention, which only engages under glass, tracks the user's translucency intensity via `--translucency-glass-keep`, and keeps the existing `--ui-chat-surface-background` token so the card matches its siblings in every mode.

Maintainers should feel free to close whichever direction they don't want — just wanted the tradeoff visible before review rather than discovered after.

## Changes Made

- `apps/desktop/src/components/assistant-ui/tool/approval.tsx`: add `data-glass-raised=""` to the fallback card
- `apps/desktop/src/components/assistant-ui/tool/approval.test.tsx`: regression test asserting the attribute is present

## How to Test

1. Enable window glass (macOS, or Windows 11 build 22621+ — `GLASS_SUPPORTED` gates this off on older Windows, see `apps/shared/src/translucency.ts`)
2. Trigger a command that requires approval with no session-window tool row mounted, so the floating fallback renders
3. Confirm the card stays legible against a busy desktop background

Automated: `npx vitest run src/components/assistant-ui/tool/approval.test.tsx` — 13/13 passing (1 new).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — found #91041 targeting the same issue; see the section above
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `npx vitest run` for the touched test file and all tests pass (13/13); also ran `npx eslint` and `npx tsc -p . --noEmit` on the changed files — clean
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10 22H2 (build 19045) — **note:** `GLASS_SUPPORTED` requires Windows 11 build 22621+ or macOS, so window glass cannot be enabled on this machine. Verification here is code-level (matching the existing `[data-glass-raised]` convention) plus the automated component test, not a manual on-screen check under live glass rendering.

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas affected
- [x] Cross-platform impact considered — see note above; the change is renderer-side CSS/attribute only, not OS-specific logic

## Screenshots / Logs

Not included — I can't render window glass on this machine (Windows 10, below the Windows 11 22H2+ glass-support floor). Happy to add a screenshot if a reviewer on macOS/Win11 can confirm, or if requested.
