### PR TITLE
feat(desktop): filter Skills panel by provenance (learned / built-in / hub)

### DIFF
--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -436,13 +436,27 @@ describe('SkillsView provenance filter', () => {
   const FILTER_KEY = 'hermes.desktop.capabilities.skillsProvenanceFilter'
 
   const mixedSkills = [
-    { name: 'learned-a', description: 'a learned skill', category: 'general', enabled: true, usage: 5, provenance: 'agent' },
-    { name: 'bundled-b', description: 'a bundled skill', category: 'general', enabled: true, usage: 4, provenance: 'bundled' },
+    {
+      name: 'learned-a',
+      description: 'a learned skill',
+      category: 'general',
+      enabled: true,
+      usage: 5,
+      provenance: 'agent'
+    },
+    {
+      name: 'bundled-b',
+      description: 'a bundled skill',
+      category: 'general',
+      enabled: true,
+      usage: 4,
+      provenance: 'bundled'
+    },
     { name: 'hub-c', description: 'a hub skill', category: 'general', enabled: true, usage: 3, provenance: 'hub' },
     { name: 'plain-d', description: 'no provenance', category: 'general', enabled: true, usage: 2 }
   ]
 
-  async function renderSkillsTab(waitForSkill = 'learned-a') {
+  async function renderSkillsTab(waitForSkill: null | string = 'learned-a') {
     const { SkillsView } = await import('./index')
     await act(async () => {
       render(
@@ -453,7 +467,10 @@ describe('SkillsView provenance filter', () => {
         </QueryClientProvider>
       )
     })
-    await screen.findByRole('switch', { name: waitForSkill })
+
+    if (waitForSkill) {
+      await screen.findByRole('switch', { name: waitForSkill })
+    }
   }
 
   beforeEach(async () => {
@@ -517,5 +534,29 @@ describe('SkillsView provenance filter', () => {
     await renderSkillsTab('hub-c')
 
     expect(screen.queryByRole('switch', { name: 'learned-a' })).toBeNull()
+  })
+
+  it('offers a way to clear a persisted filter with no matching rows', async () => {
+    getSkills.mockResolvedValue([mixedSkills[1]])
+    const { $skillsProvenanceFilter } = await import('./store')
+    $skillsProvenanceFilter.set('agent')
+
+    await renderSkillsTab(null)
+
+    const clear = await screen.findByRole('button', { name: 'Clear filter' })
+    await act(async () => {
+      fireEvent.click(clear)
+    })
+
+    expect(await screen.findByRole('switch', { name: 'bundled-b' })).toBeTruthy()
+  })
+
+  it('hides provenance chips when every skill has the same provenance', async () => {
+    getSkills.mockResolvedValue([mixedSkills[1], { ...mixedSkills[1], name: 'bundled-c' }])
+
+    await renderSkillsTab('bundled-b')
+
+    expect(screen.queryByRole('button', { name: 'All' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Built-in' })).toBeNull()
   })
 })

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -429,3 +429,93 @@ describe('SkillsView toolset management', () => {
     }
   })
 })
+
+describe('SkillsView provenance filter', () => {
+  // Import the store directly so a previous test's persisted choice can't
+  // leak into these (the atom is module-level and localStorage-backed).
+  const FILTER_KEY = 'hermes.desktop.capabilities.skillsProvenanceFilter'
+
+  const mixedSkills = [
+    { name: 'learned-a', description: 'a learned skill', category: 'general', enabled: true, usage: 5, provenance: 'agent' },
+    { name: 'bundled-b', description: 'a bundled skill', category: 'general', enabled: true, usage: 4, provenance: 'bundled' },
+    { name: 'hub-c', description: 'a hub skill', category: 'general', enabled: true, usage: 3, provenance: 'hub' },
+    { name: 'plain-d', description: 'no provenance', category: 'general', enabled: true, usage: 2 }
+  ]
+
+  async function renderSkillsTab(waitForSkill = 'learned-a') {
+    const { SkillsView } = await import('./index')
+    await act(async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/skills?tab=skills']}>
+            <SkillsView />
+          </MemoryRouter>
+        </QueryClientProvider>
+      )
+    })
+    await screen.findByRole('switch', { name: waitForSkill })
+  }
+
+  beforeEach(async () => {
+    getSkills.mockResolvedValue(mixedSkills)
+    window.localStorage.removeItem(FILTER_KEY)
+    const { $skillsProvenanceFilter } = await import('./store')
+    $skillsProvenanceFilter.set('all')
+  })
+
+  it('shows one chip per provenance present and filters to learned rows', async () => {
+    await renderSkillsTab()
+
+    // One chip per provenance that actually has rows, plus All.
+    expect(screen.getByRole('button', { name: 'All' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Learned' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Built-in' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Hub' })).toBeTruthy()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Learned' }))
+    })
+
+    // Only the agent-provenanced row survives…
+    expect(screen.getByRole('switch', { name: 'learned-a' })).toBeTruthy()
+    expect(screen.queryByRole('switch', { name: 'bundled-b' })).toBeNull()
+    expect(screen.queryByRole('switch', { name: 'hub-c' })).toBeNull()
+    expect(screen.queryByRole('switch', { name: 'plain-d' })).toBeNull()
+    // …and the active chip reads as pressed.
+    expect(screen.getByRole('button', { name: 'Learned' }).getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('returns every row when All is picked', async () => {
+    await renderSkillsTab()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Built-in' }))
+    })
+    expect(screen.queryByRole('switch', { name: 'learned-a' })).toBeNull()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'All' }))
+    })
+
+    for (const name of ['learned-a', 'bundled-b', 'hub-c', 'plain-d']) {
+      expect(screen.getByRole('switch', { name })).toBeTruthy()
+    }
+  })
+
+  it('keeps the filter across a remount (persisted)', async () => {
+    await renderSkillsTab()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Hub' }))
+    })
+    // Written through to storage (raw string — nullableText codec), not just
+    // component state.
+    expect(window.localStorage.getItem(FILTER_KEY)).toBe('hub')
+
+    cleanup()
+    // The remount must come back already filtered — hub-c visible, learned-a gone.
+    await renderSkillsTab('hub-c')
+
+    expect(screen.queryByRole('switch', { name: 'learned-a' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -161,7 +161,9 @@ function filteredSkills(
         return false
       }
 
-      return !q || includesQuery(skill.name, q) || includesQuery(skill.description, q) || includesQuery(skill.category, q)
+      return (
+        !q || includesQuery(skill.name, q) || includesQuery(skill.description, q) || includesQuery(skill.category, q)
+      )
     })
     .sort((a, b) => sign * (usageOf(b) - usageOf(a)) || asText(a.name).localeCompare(asText(b.name)))
 }
@@ -174,9 +176,22 @@ const FILTER_CHIP =
 const CHIP_OFF = 'border-transparent text-muted-foreground/60 hover:text-foreground'
 const CHIP_ON = 'border-(--ui-stroke-secondary) bg-(--ui-bg-quaternary) text-foreground'
 
-function FilterChip({ active, children, onClick }: { active: boolean; children: React.ReactNode; onClick: () => void }) {
+function FilterChip({
+  active,
+  children,
+  onClick
+}: {
+  active: boolean
+  children: React.ReactNode
+  onClick: () => void
+}) {
   return (
-    <button aria-pressed={active} className={cn(FILTER_CHIP, active ? CHIP_ON : CHIP_OFF)} onClick={onClick} type="button">
+    <button
+      aria-pressed={active}
+      className={cn(FILTER_CHIP, active ? CHIP_ON : CHIP_OFF)}
+      onClick={onClick}
+      type="button"
+    >
       {children}
     </button>
   )
@@ -201,8 +216,10 @@ function provenanceChips(
 
   const options = [...counts.entries()].sort((a, b) => b[1] - a[1])
 
-  // Nothing to narrow — hide the strip entirely rather than show one dead chip.
-  if (options.length === 0) {
+  // Nothing to narrow — hide the strip rather than show dead controls. A
+  // single provenance is still useful when some rows are unclassified, but
+  // not when applying it would leave the whole list unchanged.
+  if (options.length === 0 || (options.length === 1 && options[0][1] === skills.length)) {
     return null
   }
 
@@ -652,11 +669,25 @@ export function SkillsView({
   // an empty install says nothing exists yet.
   const capabilityEmpty = (noun: string, filtered = false) => {
     const q = query.trim()
+    const canClearSkillsFilter = noun === 'skills' && skillsProvenanceFilter !== 'all'
 
     return (
       <div className="flex h-full min-h-0 flex-1">
         <PanelEmpty
-          description={q ? t.skills.emptyNothingMatches(q) : filtered ? t.skills.emptyNoneFound(noun) : t.skills.emptyNoneAvailable(noun)}
+          action={
+            canClearSkillsFilter ? (
+              <Button onClick={() => $skillsProvenanceFilter.set('all')} size="sm">
+                {t.skills.clearProvenanceFilter}
+              </Button>
+            ) : undefined
+          }
+          description={
+            q
+              ? t.skills.emptyNothingMatches(q)
+              : filtered
+                ? t.skills.emptyNoneFound(noun)
+                : t.skills.emptyNoneAvailable(noun)
+          }
           icon="search"
           title={t.skills.emptyNoneFound(noun)}
         />

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -25,13 +25,14 @@ import {
   setSkillEnabled,
   setToolsetEnabled
 } from '@/hermes'
-import { useI18n } from '@/i18n'
+import { type Translations, useI18n } from '@/i18n'
 import { isDesktopToolsetVisible } from '@/lib/desktop-toolsets'
 import { compactNumber } from '@/lib/format'
 import { queryClient } from '@/lib/query-client'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
 import { normalize } from '@/lib/text'
 import { useStoreSelector } from '@/lib/use-session-slice'
+import { cn } from '@/lib/utils'
 import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
@@ -63,7 +64,10 @@ import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
 
 import { EmbeddedHubPicker } from './embedded-hub-picker'
 import { McpTab } from './mcp-tab'
-import { $skillsSortDesc, $toolsetsSortDesc } from './store'
+import { $skillsProvenanceFilter, $skillsSortDesc, $toolsetsSortDesc, type SkillsProvenanceFilter } from './store'
+
+// Provenance values a Skills row can carry; the filter chips map onto them.
+type SkillProvenanceFilter = SkillsProvenanceFilter
 
 // 'hub' is gone as a top-level tab — the Skills Hub browser lives inside the
 // Skills tab now (EmbeddedHubPicker below the installed list). Legacy
@@ -134,16 +138,89 @@ function skillSubtitle(skill: SkillInfo): React.ReactNode {
   )
 }
 
-function filteredSkills(skills: SkillInfo[], query: string, desc: boolean): SkillInfo[] {
+// Chip label per provenance id — keys are display labels by design (see
+// filterByProvenance), so this is the one place ids translate to labels.
+const PROVENANCE_LABEL_KEYS = {
+  agent: 'Learned',
+  bundled: 'Built-in',
+  hub: 'Hub'
+} as const
+
+function filteredSkills(
+  skills: SkillInfo[],
+  query: string,
+  provenance: SkillProvenanceFilter,
+  desc: boolean
+): SkillInfo[] {
   const q = normalize(query)
   const sign = desc ? 1 : -1
 
   return skills
-    .filter(
-      skill =>
-        !q || includesQuery(skill.name, q) || includesQuery(skill.description, q) || includesQuery(skill.category, q)
-    )
+    .filter(skill => {
+      if (provenance !== 'all' && skill.provenance !== provenance) {
+        return false
+      }
+
+      return !q || includesQuery(skill.name, q) || includesQuery(skill.description, q) || includesQuery(skill.category, q)
+    })
     .sort((a, b) => sign * (usageOf(b) - usageOf(a)) || asText(a.name).localeCompare(asText(b.name)))
+}
+
+// One toggleable provenance chip for the list strip ("All · Learned · …").
+// Typographic on purpose — the row badges already color the taxonomy.
+const FILTER_CHIP =
+  'cursor-pointer rounded-full border px-2 py-px text-[0.62rem] font-medium leading-4 transition-colors'
+
+const CHIP_OFF = 'border-transparent text-muted-foreground/60 hover:text-foreground'
+const CHIP_ON = 'border-(--ui-stroke-secondary) bg-(--ui-bg-quaternary) text-foreground'
+
+function FilterChip({ active, children, onClick }: { active: boolean; children: React.ReactNode; onClick: () => void }) {
+  return (
+    <button aria-pressed={active} className={cn(FILTER_CHIP, active ? CHIP_ON : CHIP_OFF)} onClick={onClick} type="button">
+      {children}
+    </button>
+  )
+}
+
+// The whole filter line: All + every provenance that actually has rows.
+function provenanceChips(
+  skills: SkillInfo[],
+  current: SkillProvenanceFilter,
+  t: Translations,
+  setFilter: (value: SkillProvenanceFilter) => void
+): React.ReactNode {
+  const counts = new Map<NonNullable<SkillInfo['provenance']>, number>()
+
+  for (const skill of skills) {
+    if (!skill.provenance) {
+      continue
+    }
+
+    counts.set(skill.provenance, (counts.get(skill.provenance) ?? 0) + 1)
+  }
+
+  const options = [...counts.entries()].sort((a, b) => b[1] - a[1])
+
+  // Nothing to narrow — hide the strip entirely rather than show one dead chip.
+  if (options.length === 0) {
+    return null
+  }
+
+  const labelFor = (provenance: NonNullable<SkillInfo['provenance']>): string =>
+    t.skills.filterByProvenance[PROVENANCE_LABEL_KEYS[provenance]]
+
+  return (
+    <div className="flex items-center gap-1 pl-2">
+      <FilterChip active={current === 'all'} onClick={() => setFilter('all')}>
+        {t.skills.filterByProvenance.All}
+      </FilterChip>
+      {options.map(([provenance]) => (
+        <FilterChip active={current === provenance} key={provenance} onClick={() => setFilter(provenance)}>
+          {labelFor(provenance)}
+        </FilterChip>
+      ))}
+    </div>
+  )
 }
 
 const toolsetCalls = (toolset: ToolsetInfo, toolCalls: Record<string, number>): number =>
@@ -328,6 +405,7 @@ export function SkillsView({
   // toolCalls after the user moved to B.
   const toolCallsEpoch = useRef(0)
   const skillsSortDesc = useStore($skillsSortDesc)
+  const skillsProvenanceFilter = useStore($skillsProvenanceFilter)
   const toolsetsSortDesc = useStore($toolsetsSortDesc)
   const [bulkBusy, setBulkBusy] = useState(false)
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null)
@@ -397,8 +475,8 @@ export function SkillsView({
   })
 
   const visibleSkills = useMemo(
-    () => (skills ? filteredSkills(skills, query, skillsSortDesc) : []),
-    [query, skills, skillsSortDesc]
+    () => (skills ? filteredSkills(skills, query, skillsProvenanceFilter, skillsSortDesc) : []),
+    [query, skills, skillsProvenanceFilter, skillsSortDesc]
   )
 
   const visibleToolsets = useMemo(
@@ -570,16 +648,15 @@ export function SkillsView({
     <ListStripButton onClick={flip}>{desc ? t.skills.sortMostUsedDesc : t.skills.sortLeastUsedAsc}</ListStripButton>
   )
 
-  // Full-bleed empty state, matching the MCP tab (spans both columns, not a
-  // cramped note in the left rail). Query-aware, and says "tools" not the
-  // internal "toolsets".
-  const capabilityEmpty = (noun: string) => {
+  // Query-aware empty state: a filter/search that removes every row says so,
+  // an empty install says nothing exists yet.
+  const capabilityEmpty = (noun: string, filtered = false) => {
     const q = query.trim()
 
     return (
       <div className="flex h-full min-h-0 flex-1">
         <PanelEmpty
-          description={q ? t.skills.emptyNothingMatches(q) : t.skills.emptyNoneAvailable(noun)}
+          description={q ? t.skills.emptyNothingMatches(q) : filtered ? t.skills.emptyNoneFound(noun) : t.skills.emptyNoneAvailable(noun)}
           icon="search"
           title={t.skills.emptyNoneFound(noun)}
         />
@@ -816,27 +893,32 @@ export function SkillsView({
               // and "changes apply" footer can no longer be starved to 0px
               // and painted over by the hub header.
               visibleSkills.length === 0 ? (
-                capabilityEmpty('skills')
+                capabilityEmpty('skills', Boolean(query.trim() || skillsProvenanceFilter !== 'all'))
               ) : (
                 <MasterDetail pane={skillEditorPane} resizeId="capabilities-split" split="wide">
                   <ListColumn
                     header={
-                      <ListStrip
-                        left={sortButton(skillsSortDesc, () => $skillsSortDesc.set(!$skillsSortDesc.get()))}
-                        right={
-                          <ListStripMenu
-                            items={[
-                              {
-                                disabled: bulkBusy,
-                                label: t.skills.disableUnused,
-                                onSelect: () => void disableUnused()
-                              }
-                            ]}
-                            label={t.skills.tabSkills}
-                            toggle={bulkSwitch(allSkillsEnabled)}
-                          />
-                        }
-                      />
+                      <div>
+                        <ListStrip
+                          left={sortButton(skillsSortDesc, () => $skillsSortDesc.set(!$skillsSortDesc.get()))}
+                          right={
+                            <ListStripMenu
+                              items={[
+                                {
+                                  disabled: bulkBusy,
+                                  label: t.skills.disableUnused,
+                                  onSelect: () => void disableUnused()
+                                }
+                              ]}
+                              label={t.skills.tabSkills}
+                              toggle={bulkSwitch(allSkillsEnabled)}
+                            />
+                          }
+                        />
+                        {provenanceChips(bulkSkills, skillsProvenanceFilter, t, value =>
+                          $skillsProvenanceFilter.set(value)
+                        )}
+                      </div>
                     }
                   >
                     {visibleSkills.map(skill => (

--- a/apps/desktop/src/app/skills/store.ts
+++ b/apps/desktop/src/app/skills/store.ts
@@ -1,6 +1,29 @@
-import { Codecs, persistentAtom } from '@/lib/persisted'
+import { type Codec, Codecs, persistentAtom } from '@/lib/persisted'
 
 // Per-view sort direction for the Capabilities lists — persisted so each tab
 // remembers most/least-used across navigations and restarts.
 export const $skillsSortDesc = persistentAtom('hermes.desktop.capabilities.skillsSortDesc', true, Codecs.bool)
 export const $toolsetsSortDesc = persistentAtom('hermes.desktop.capabilities.toolsetsSortDesc', true, Codecs.bool)
+
+// Skills-tab provenance filter — persisted so a "show me what Hermes learned"
+// view survives navigation and restarts. 'all' shows everything; any other
+// value keeps only rows whose `provenance` matches (null rows belong to All).
+// Renderer-owned presentation state: nothing else can change it, so it lives
+// with the other list prefs rather than in backend truth.
+export type SkillsProvenanceFilter = 'all' | null | 'agent' | 'bundled' | 'hub'
+
+const PROVENANCE_FILTER_VALUES = ['all', 'agent', 'bundled', 'hub'] as const
+
+// Validates on read: a stale or hand-edited stored value falls back to All
+// instead of leaking an arbitrary string into the filter comparison.
+const provenanceFilterCodec: Codec<SkillsProvenanceFilter> = {
+  decode: raw =>
+    (PROVENANCE_FILTER_VALUES as readonly string[]).includes(raw) ? (raw as SkillsProvenanceFilter) : 'all',
+  encode: value => value
+}
+
+export const $skillsProvenanceFilter = persistentAtom<SkillsProvenanceFilter>(
+  'hermes.desktop.capabilities.skillsProvenanceFilter',
+  'all',
+  provenanceFilterCodec
+)

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1257,6 +1257,7 @@ export const en: Translations = {
     enableAll: 'Enable all',
     disableAll: 'Disable all',
     disableUnused: 'Disable unused',
+    filterByProvenance: { Learned: 'Learned', 'Built-in': 'Built-in', Hub: 'Hub', All: 'All' },
     bulkUpdated: count => `Updated ${count} ${count === 1 ? 'item' : 'items'} for new sessions.`,
     bulkNoChange: 'Nothing to change.',
     usageCount: count => `used ${count}×`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1258,6 +1258,7 @@ export const en: Translations = {
     disableAll: 'Disable all',
     disableUnused: 'Disable unused',
     filterByProvenance: { Learned: 'Learned', 'Built-in': 'Built-in', Hub: 'Hub', All: 'All' },
+    clearProvenanceFilter: 'Clear filter',
     bulkUpdated: count => `Updated ${count} ${count === 1 ? 'item' : 'items'} for new sessions.`,
     bulkNoChange: 'Nothing to change.',
     usageCount: count => `used ${count}×`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1166,6 +1166,7 @@ export const ja = defineLocale({
     enableAll: 'すべて有効化',
     disableAll: 'すべて無効化',
     disableUnused: '未使用を無効化',
+    filterByProvenance: { Learned: '学習済み', 'Built-in': '組み込み', Hub: 'ハブ', All: 'すべて' },
     bulkUpdated: count => `${count} 件を新しいセッション向けに更新しました。`,
     bulkNoChange: '変更するものはありません。',
     usageCount: count => `${count} 回使用`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1167,6 +1167,7 @@ export const ja = defineLocale({
     disableAll: 'すべて無効化',
     disableUnused: '未使用を無効化',
     filterByProvenance: { Learned: '学習済み', 'Built-in': '組み込み', Hub: 'ハブ', All: 'すべて' },
+    clearProvenanceFilter: 'フィルターをクリア',
     bulkUpdated: count => `${count} 件を新しいセッション向けに更新しました。`,
     bulkNoChange: '変更するものはありません。',
     usageCount: count => `${count} 回使用`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1104,6 +1104,7 @@ export interface Translations {
     disableUnused: string
     /** Provenance filter chips (Skills tab). Keys are chip labels, not ids. */
     filterByProvenance: Record<'All' | 'Built-in' | 'Hub' | 'Learned', string>
+    clearProvenanceFilter: string
     bulkUpdated: (count: number) => string
     bulkNoChange: string
     usageCount: (count: number | string) => string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1102,6 +1102,8 @@ export interface Translations {
     enableAll: string
     disableAll: string
     disableUnused: string
+    /** Provenance filter chips (Skills tab). Keys are chip labels, not ids. */
+    filterByProvenance: Record<'All' | 'Built-in' | 'Hub' | 'Learned', string>
     bulkUpdated: (count: number) => string
     bulkNoChange: string
     usageCount: (count: number | string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1126,6 +1126,7 @@ export const zhHant = defineLocale({
     enableAll: '全部啟用',
     disableAll: '全部停用',
     disableUnused: '停用未使用',
+    filterByProvenance: { Learned: '已學習', 'Built-in': '內建', Hub: 'Hub', All: '全部' },
     bulkUpdated: count => `已為新工作階段更新 ${count} 項。`,
     bulkNoChange: '沒有需要變更的內容。',
     usageCount: count => `已使用 ${count} 次`,

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1127,6 +1127,7 @@ export const zhHant = defineLocale({
     disableAll: '全部停用',
     disableUnused: '停用未使用',
     filterByProvenance: { Learned: '已學習', 'Built-in': '內建', Hub: 'Hub', All: '全部' },
+    clearProvenanceFilter: '清除篩選',
     bulkUpdated: count => `已為新工作階段更新 ${count} 項。`,
     bulkNoChange: '沒有需要變更的內容。',
     usageCount: count => `已使用 ${count} 次`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1449,6 +1449,7 @@ export const zh: Translations = {
     disableAll: '全部停用',
     disableUnused: '禁用未使用',
     filterByProvenance: { Learned: '已学习', 'Built-in': '内置', Hub: 'Hub', All: '全部' },
+    clearProvenanceFilter: '清除筛选',
     bulkUpdated: count => `已为新会话更新 ${count} 项。`,
     bulkNoChange: '没有需要更改的内容。',
     usageCount: count => `已使用 ${count} 次`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1448,6 +1448,7 @@ export const zh: Translations = {
     enableAll: '全部启用',
     disableAll: '全部停用',
     disableUnused: '禁用未使用',
+    filterByProvenance: { Learned: '已学习', 'Built-in': '内置', Hub: 'Hub', All: '全部' },
     bulkUpdated: count => `已为新会话更新 ${count} 项。`,
     bulkNoChange: '没有需要更改的内容。',
     usageCount: count => `已使用 ${count} 次`,


### PR DESCRIPTION
## What does this PR do?

The Capabilities → Skills tab badges agent-learned skills (`learned`) and
hub-installed ones (`hub`), but the list itself offers no way to see only
those rows — on a well-used install the learned set is exactly what you want
to review, edit, or archive, and today collecting it means scrolling and
reading badges.

This adds a chip row to the list strip:

    All · Learned · Built-in · Hub

- One chip per provenance **actually present** in the list; no dead chips.
- The active chip is highlighted and exposed as `aria-pressed`.
- Filtering composes with the search box; both apply together.
- The choice persists across navigation and restarts via `localStorage`
  (`hermes.desktop.capabilities.skillsProvenanceFilter`), decoded through a
  validating codec so stale/hand-edited values fall back to All instead of
  leaking an arbitrary string into comparisons.
- Renderer presentation state only — no backend/RPC changes. Bulk actions
  (master switch, "Disable unused") and the hub picker's installed-name guard
  keep operating on the unfiltered list, matching the existing rule that
  tab-wide controls never scope to the current query.
- Empty state distinguishes "filter matched nothing" from "nothing installed
  yet".

## Related Issue

Fixes #92120

Context: #71110 proposes the right backend foundation (an explicit `origin`
field) and #70712/#80596 track provenance *correctness*. This PR is
orthogonal and deliberately renderer-only: it filters by whatever
classification `/api/skills` reports today, so it lands independently and
keeps working when #71110's `origin` values arrive (at which point the chips
can read `origin` instead).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/app/skills/store.ts` — new persisted atom
  `$skillsProvenanceFilter` with an explicit union type and a validating
  codec (unknown stored values decode to `'all'`).
- `apps/desktop/src/app/skills/index.tsx` — `filteredSkills()` gains the
  provenance dimension; new `FilterChip` + `provenanceChips()` render the
  strip row under the sort control; empty-state call passes whether a
  filter/search is active.
- `apps/desktop/src/app/skills/index.test.tsx` — three new cases: chips
  render per present provenance and Learned narrows correctly; All restores
  every row; the choice survives a remount through localStorage.
- `apps/desktop/src/i18n/{types,en,zh,ja,zh-hant}.ts` — one new key,
  `skills.filterByProvenance` (labels keyed by display name; ids map to
  labels in one place in the view).

## How to Test

1. `cd apps/desktop && npx vitest run src/app/skills/index.test.tsx`
   — all cases pass (3 new).
2. `npx tsc --build tsconfig.json` from `apps/desktop` — clean.
3. Manual: open Capabilities → Skills on an install with mixed provenance;
   click `Learned` → only badged rows remain; reload the app → the filter is
   still applied; click `All` → full list returns.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
      (renderer-only change; Python suite green on my machine)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
      (N/A: UI behavior self-evident; no config keys or CLI surface added)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
      (pure renderer; no platform-conditional code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

To follow once I have the rebuilt app in front of me.
