### PR TITLE
fix(worktree): archive pruned scratch in the active Hermes profile

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12533,6 +12533,8 @@ def main():
     # =========================================================================
     # worktree command — audit/reclaim accumulated git worktrees + branches
     # =========================================================================
+    from hermes_constants import display_hermes_home
+
     worktree_parser = subparsers.add_parser(
         "worktree",
         help="Audit and reclaim accumulated git worktrees and merged branches",
@@ -12540,7 +12542,8 @@ def main():
             "Attended reclaim for the .worktrees/ directory hermes -w sessions "
             "accumulate. Never deletes uncommitted tracked changes, unique "
             "unpushed commits, or in-use trees; untracked-only scratch is "
-            "archived to ~/.hermes/archive/worktree-prune/ before removal. See: "
+            f"archived to {display_hermes_home()}/archive/worktree-prune/ "
+            "before removal. See: "
             "https://hermes-agent.nousresearch.com/docs/user-guide/cli#worktree-cleanup"
         ),
     )

--- a/hermes_cli/worktree_gc.py
+++ b/hermes_cli/worktree_gc.py
@@ -25,8 +25,8 @@ safe. Invariants shared with the startup pruner (never violated here either):
 - live-locked trees (owning pid alive) are never touched;
 - a branch is deleted only after its worktree removal succeeded — a failed
   removal must not orphan reachable commits;
-- untracked-only dirt is ARCHIVED to ``~/.hermes/archive/worktree-prune/``
-  before its tree is reaped, never destroyed.
+- untracked-only dirt is ARCHIVED inside the active Hermes profile before its
+  tree is reaped, never destroyed.
 
 Classification primitives are imported from ``cli`` so the two paths can
 never drift apart on what "dirty", "unpushed", or "merged" means.
@@ -43,6 +43,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
+
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -146,10 +148,7 @@ def _archive_untracked(tree: Path, untracked: List[str]) -> Optional[Path]:
     something?" question.
     """
     stamp = time.strftime("%Y%m%d-%H%M%S")
-    dest = (
-        Path.home() / ".hermes" / "archive" / "worktree-prune"
-        / f"{tree.name}-{stamp}"
-    )
+    dest = get_hermes_home() / "archive" / "worktree-prune" / f"{tree.name}-{stamp}"
     try:
         for rel in untracked:
             src = tree / rel

--- a/tests/hermes_cli/test_worktree_gc.py
+++ b/tests/hermes_cli/test_worktree_gc.py
@@ -41,9 +41,13 @@ def _git(args, cwd, env=None):
 
 @pytest.fixture
 def repo(tmp_path, monkeypatch):
-    """origin (bare) + clone with .worktrees/, HOME redirected for archives."""
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    (tmp_path / "home").mkdir()
+    """origin + clone with distinct HOME and active Hermes profile roots."""
+    home = tmp_path / "home"
+    hermes_home = tmp_path / "active-hermes-home"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    home.mkdir()
+    hermes_home.mkdir()
 
     origin = tmp_path / "origin.git"
     origin.mkdir()
@@ -159,7 +163,13 @@ class TestReclaim:
         records = worktree_gc.audit_worktrees(str(repo), with_sizes=False)
         worktree_gc.reclaim_worktrees(str(repo), records=records)
         assert not tree.exists()
-        archive_root = Path.home() / ".hermes" / "archive" / "worktree-prune"
+        legacy_archive_root = (
+            Path(os.environ["HOME"]) / ".hermes" / "archive" / "worktree-prune"
+        )
+        assert not list(legacy_archive_root.rglob("NOTES.md")), (
+            "archive must not escape the active HERMES_HOME profile"
+        )
+        archive_root = Path(os.environ["HERMES_HOME"]) / "archive" / "worktree-prune"
         archived = list(archive_root.rglob("NOTES.md"))
         assert archived, "untracked file must be archived, not destroyed"
         assert archived[0].read_text() == "important scribbles\n"

--- a/tests/hermes_cli/test_worktree_gc.py
+++ b/tests/hermes_cli/test_worktree_gc.py
@@ -17,6 +17,7 @@ the entire value of these tests is exercising actual git verdicts):
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -200,6 +201,30 @@ class TestReclaim:
         assert _verdict(records, "hermes-zombie").verdict == "reap"
         worktree_gc.reclaim_worktrees(str(repo), records=records)
         assert not tree.exists()
+
+
+class TestWorktreeHelp:
+    def test_help_displays_active_profile_archive(self, tmp_path, monkeypatch, capsys):
+        """The displayed recovery location must follow the active profile."""
+        from hermes_cli import main as main_mod
+
+        home = tmp_path / "home"
+        profile_home = home / ".hermes" / "profiles" / "review"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(sys, "argv", ["hermes", "worktree", "--help"])
+        monkeypatch.setattr(main_mod, "_sweep_stale_bytecode_if_checkout_changed", lambda: None)
+        monkeypatch.setattr(main_mod, "_recover_from_interrupted_install", lambda: None)
+        monkeypatch.setattr(main_mod, "_plugin_cli_discovery_needed", lambda: False)
+
+        with pytest.raises(SystemExit) as exited:
+            main_mod.main()
+
+        assert exited.value.code == 0
+        output = capsys.readouterr().out
+        assert "~/.hermes/profiles/review/archive/worktree-prune/" in output
+        assert "~/.hermes/archive/worktree-prune/" not in output
 
 
 class TestBranchGC:

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -85,9 +85,9 @@ Safety guarantees (all modes, any age):
   patch-equivalence and count as merged, which is what lets the dominant
   "merged PR, tree preserved forever" leak finally reclaim.
 - Trees **in use by a running hermes session** are never touched.
-- **Untracked-only scratch** (PR body drafts, notes) is archived to
-  `~/.hermes/archive/worktree-prune/` before its tree is removed — never
-  destroyed.
+- **Untracked-only scratch** (PR body drafts, notes) is archived in the active
+  Hermes profile's `archive/worktree-prune/` directory before its tree is
+  removed — never destroyed.
 - Branch deletion is content-gated, not name-gated: any local branch whose
   commits are all on upstream is safe to delete; branches with unique work,
   checked-out branches, and `main`/`master`/`develop` are always kept.


### PR DESCRIPTION
## What does this PR do?

Fixes worktree-prune recovery so archived untracked scratch follows the active Hermes profile. `reclaim_worktrees()` still archives before force-removal and keeps its failure-safe behavior; only the archive root now resolves through `get_hermes_home()`.

## Related Issue

No linked issue — this is a targeted profile-scoping regression.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Resolve `hermes_cli/worktree_gc.py` archives from `get_hermes_home()` instead of `HOME/.hermes`.
- Extend the real-git worktree-reclaim fixture with distinct `HOME` and `HERMES_HOME` roots.
- Assert recovered scratch is absent from `HOME/.hermes` and present only in the active profile archive.

## How to Test

1. Run `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_worktree_gc.py -v`.
2. The real-git regression creates an untracked `NOTES.md`, reclaims its worktree, and verifies the worktree was removed only after archival.
3. With the regression applied to the base implementation, it fails after finding `NOTES.md` under `HOME/.hermes`; with this change, all 16 focused tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused real-git regression suite: `16 passed`.
