### PR TITLE
test(e2e): name the background-task crash behind a missing send

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -275,14 +275,57 @@ async def send_and_capture(adapter, text: str, platform: Platform, **event_kwarg
 
     Polls for the send rather than waiting a fixed delay: handler DB work now
     hops to worker threads (AsyncSessionDB), so completion latency varies.
+
+    ``handle_message`` returns as soon as it has spawned its background tasks,
+    so an exception raised in one of them belongs to that task and nothing
+    re-raises it. The caller then sees only ``send`` never being called, and
+    the assertion reads "Expected 'mock' to have been called once. Called 0
+    times." — the same message whether the handler decided not to reply, timed
+    out, or crashed. Every background exception raised inside this window is
+    captured and attached to the failure so the next occurrence names its own
+    cause.
     """
     event = make_event(platform, text, **event_kwargs)
     adapter.send.reset_mock()
-    await adapter.handle_message(event)
-    for _ in range(40):  # up to ~2s; returns as soon as the send lands
-        if adapter.send.called:
-            break
-        await asyncio.sleep(0.05)
+
+    loop = asyncio.get_running_loop()
+    before = asyncio.all_tasks(loop)
+    captured: list[BaseException] = []
+    previous_handler = loop.get_exception_handler()
+
+    def _capture(running_loop, context):
+        exc = context.get("exception")
+        if exc is not None:
+            captured.append(exc)
+        if previous_handler is not None:
+            previous_handler(running_loop, context)
+        else:
+            running_loop.default_exception_handler(context)
+
+    loop.set_exception_handler(_capture)
+    try:
+        await adapter.handle_message(event)
+        for _ in range(40):  # up to ~2s; returns as soon as the send lands
+            if adapter.send.called:
+                break
+            await asyncio.sleep(0.05)
+
+        if not adapter.send.called:
+            # Tasks that finished inside the window report their own
+            # exception; the loop handler only sees the ones nobody retrieved.
+            for task in asyncio.all_tasks(loop) - before:
+                if task.done() and not task.cancelled():
+                    exc = task.exception()
+                    if exc is not None and exc not in captured:
+                        captured.append(exc)
+            if captured:
+                raise AssertionError(
+                    "handler produced no send because a background task "
+                    f"raised {captured[0]!r}"
+                ) from captured[0]
+    finally:
+        loop.set_exception_handler(previous_handler)
+
     return adapter.send
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -10,6 +10,7 @@ No LLM, no real platform connections.
 """
 
 import asyncio
+import logging
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -313,16 +314,40 @@ async def send_and_capture(adapter, text: str, platform: Platform, **event_kwarg
         if not adapter.send.called:
             # Tasks that finished inside the window report their own
             # exception; the loop handler only sees the ones nobody retrieved.
-            for task in asyncio.all_tasks(loop) - before:
+            spawned = asyncio.all_tasks(loop) - before
+            for task in spawned:
                 if task.done() and not task.cancelled():
                     exc = task.exception()
                     if exc is not None and exc not in captured:
                         captured.append(exc)
+
+            # A task that is still running is neither done nor captured, so
+            # without this the third case — the handler simply did not finish
+            # in time — reads exactly like the handler declining to reply.
+            still_running = [task for task in spawned if not task.done()]
+            pending_note = ""
+            if still_running:
+                names = ", ".join(sorted(t.get_name() for t in still_running)[:5])
+                pending_note = (
+                    f" ({len(still_running)} background task(s) still running: "
+                    f"{names})"
+                )
+
             if captured:
                 raise AssertionError(
                     "handler produced no send because a background task "
-                    f"raised {captured[0]!r}"
+                    f"raised {captured[0]!r}{pending_note}"
                 ) from captured[0]
+            if still_running:
+                # Deliberately not an error: a handler may legitimately leave
+                # fire-and-forget work behind while correctly sending nothing,
+                # and the caller's own assertion stays the one that decides.
+                # pytest surfaces this with the report of a failing test,
+                # which is the only time it matters.
+                logging.getLogger(__name__).warning(
+                    "send_and_capture: poll window expired with no send;%s",
+                    pending_note,
+                )
     finally:
         loop.set_exception_handler(previous_handler)
 

--- a/tests/e2e/test_harness_diagnostics.py
+++ b/tests/e2e/test_harness_diagnostics.py
@@ -9,6 +9,7 @@ intermittent e2e failures have been so hard to place.
 """
 
 import asyncio
+import logging
 
 import pytest
 from unittest.mock import AsyncMock
@@ -62,6 +63,41 @@ async def test_a_successful_send_is_returned_untouched():
     adapter = _Adapter(_reply)
     send = await send_and_capture(adapter, "hi", Platform.TELEGRAM)
     send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_a_task_still_running_is_counted_in_the_crash_message():
+    """A crash and an unfinished task can happen together; name both."""
+    async def _boom(adapter):
+        asyncio.get_running_loop().create_task(asyncio.sleep(30))
+        raise RuntimeError("simulated background crash")
+
+    with pytest.raises(AssertionError) as excinfo:
+        await send_and_capture(_Adapter(_boom), "hi", Platform.TELEGRAM)
+
+    message = str(excinfo.value)
+    assert "simulated background crash" in message
+    assert "still running" in message, message
+
+
+@pytest.mark.asyncio
+async def test_a_hang_without_a_crash_is_reported_but_not_raised(caplog):
+    """The third case: nothing raised, nothing sent, work unfinished.
+
+    Left as a warning rather than an error — a handler may legitimately
+    leave fire-and-forget work behind while correctly sending nothing, so
+    the caller's own assertion stays the one that decides.
+    """
+    async def _hang(adapter):
+        await asyncio.sleep(30)
+
+    with caplog.at_level(logging.WARNING):
+        send = await send_and_capture(_Adapter(_hang), "hi", Platform.TELEGRAM)
+
+    assert not send.called
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("still running" in m for m in messages), messages
+    assert any("1 background task(s)" in m for m in messages), messages
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/test_harness_diagnostics.py
+++ b/tests/e2e/test_harness_diagnostics.py
@@ -1,0 +1,79 @@
+"""The e2e harness must name why a send never happened.
+
+``BasePlatformAdapter.handle_message`` returns as soon as it has spawned its
+background tasks, so an exception raised in one of them belongs to that task
+and nothing re-raises it. Without this, every such failure surfaced as
+``Expected 'mock' to have been called once. Called 0 times.`` — identical
+whether the handler declined to reply, ran long, or crashed, which is why
+intermittent e2e failures have been so hard to place.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform
+from tests.e2e.conftest import send_and_capture
+
+
+class _Adapter:
+    def __init__(self, worker=None):
+        self.send = AsyncMock()
+        self._worker = worker
+
+    async def handle_message(self, event):
+        if self._worker is not None:
+            asyncio.get_running_loop().create_task(self._worker(self))
+
+
+@pytest.mark.asyncio
+async def test_a_crashing_background_task_is_named():
+    async def _boom(_adapter):
+        raise RuntimeError("simulated background crash")
+
+    with pytest.raises(AssertionError) as excinfo:
+        await send_and_capture(_Adapter(_boom), "hi", Platform.TELEGRAM)
+
+    assert "simulated background crash" in str(excinfo.value)
+    assert isinstance(excinfo.value.__cause__, RuntimeError), (
+        "the original exception must stay chained so the traceback survives"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_handler_that_simply_declines_is_not_reported_as_a_crash():
+    """No send and no exception is a legitimate outcome for some commands.
+
+    The helper must stay silent here — the caller's own assertion decides
+    whether a missing send is a failure.
+    """
+    adapter = _Adapter()
+    send = await send_and_capture(adapter, "hi", Platform.TELEGRAM)
+    assert send is adapter.send
+    assert not send.called
+
+
+@pytest.mark.asyncio
+async def test_a_successful_send_is_returned_untouched():
+    async def _reply(adapter):
+        await adapter.send("chat", "hello")
+
+    adapter = _Adapter(_reply)
+    send = await send_and_capture(adapter, "hi", Platform.TELEGRAM)
+    send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_the_loop_exception_handler_is_restored():
+    """The helper installs one for the poll window only."""
+    loop = asyncio.get_running_loop()
+    sentinel = loop.get_exception_handler()
+
+    async def _boom(_adapter):
+        raise RuntimeError("x")
+
+    with pytest.raises(AssertionError):
+        await send_and_capture(_Adapter(_boom), "hi", Platform.TELEGRAM)
+
+    assert loop.get_exception_handler() is sentinel


### PR DESCRIPTION
## Why

`test_plaintext_restart_gateway_in_group_stays_plain_text[telegram]` is failing intermittently right now — on my #89118 and, with the identical assertion, on @-'s #92058, which touches only `tui_gateway/` and `ui-tui/`. Two unrelated PRs, same failure, so it is the test rather than either change.

Every occurrence reports exactly this:

```
AssertionError: Expected 'mock' to have been called once. Called 0 times.
```

That is all the information there is. `BasePlatformAdapter.handle_message` — by its own docstring — "returns quickly by spawning background tasks", so an exception raised in one of them belongs to that task and nothing re-raises it. `tests/e2e/conftest.py` has no exception surfacing at all, so the same message appears whether the handler declined to reply, ran past the 2s poll budget, or crashed outright.

## What this changes

`send_and_capture` now captures background exceptions raised inside the poll window — via a loop exception handler, plus a sweep of tasks that completed while it waited — and, **only when no send arrived**, attaches the first one to the failure with the original chained as `__cause__`:

```
handler produced no send because a background task raised
RuntimeError('simulated background crash')
```

Deliberately not a behavior change:

- a handler that legitimately sends nothing and raises nothing still returns quietly, so the caller's own assertion remains the one that decides;
- the previously installed loop exception handler is chained, not replaced, and restored in a `finally`.

## What this does **not** do

**It does not fix the flake.** I could not reproduce it locally: the single test ×5, the whole file ×3, the whole `tests/e2e/` directory ×4 including random ordering, and 8 runs under full CPU saturation — all green. Two hypotheses were investigated and disproven along the way (the planned-restart marker, and `_is_stale_restart_redelivery` — `make_event` leaves `platform_update_id` as `None`, so that gate cannot fire here).

One detail from the CI log worth recording for whoever picks this up: the failing run consumed the entire 2s poll budget without the 40 `asyncio.sleep(0.05)` iterations stretching, so the send did not arrive *late* — it did not happen at all. That is what pointed at a swallowed exception rather than latency, and it is what this change would have made visible.

## Tests

Four cases in `tests/e2e/test_harness_diagnostics.py` against a stub adapter: a crashing background task is named and stays chained, a handler that simply declines is not reported as a crash, a successful send is returned untouched, and the loop exception handler is restored afterwards. Reverting the conftest change fails two of them. The full `tests/e2e/` suite is green (64 passed, 8 skipped).