### PR TITLE
fix(tools): de-overlap fuzzy strategy matches before replace_all applies them

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -190,6 +190,58 @@ class TestReplaceAll:
         assert count == 0
         assert "2 matches" in err
 
+    def test_sliding_window_overlapping_matches_replace_all(self):
+        """Normalization strategies stride by one line, so their windows can
+        overlap when the pattern's normalized lines repeat.
+
+        Regression (#92132): line_trimmed matched "x)\\nx)" at BOTH window
+        offsets (lines 0-1 and 1-2) of "x)\\n x)\\n x)\\n"; _apply_replacements
+        applied the overlapping spans back-to-front on stale offsets and the
+        whole third line was silently deleted while reporting count=2.
+        De-overlapped spans must keep str.replace() semantics.
+        """
+        content = "x)\n x)\n x)\n"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, "x)\nx)", "y", replace_all=True
+        )
+        assert strategy == "line_trimmed"
+        assert err is None
+        assert count == 1
+        assert new == "y\n x)\n"
+
+    def test_sliding_window_overlapping_matches_unique_without_flag(self):
+        """After de-overlap the sliding window yields ONE match, so a plain
+        (replace_all=False) edit applies instead of erroring on a phantom
+        second match that shares lines with the first."""
+        content = "x)\n x)\n x)\n"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, "x)\nx)", "y", replace_all=False
+        )
+        assert err is None
+        assert count == 1
+        assert new == "y\n x)\n"
+
+    def test_sliding_window_disjoint_windows_all_replaced(self):
+        """Disjoint sliding-window matches still replace every window under
+        replace_all, and the content between the windows survives. The second
+        window's replacement carries the file region's one-space base indent
+        (the documented _reindent_replacement contract for fuzzy matches)."""
+        content = "x)\n x)\nMID\n x)\n x)\n"
+        new, count, strategy, err = fuzzy_find_and_replace(
+            content, "x)\nx)", "y", replace_all=True
+        )
+        assert strategy == "line_trimmed"
+        assert err is None
+        assert count == 2
+        assert new == "y\nMID\n y\n"
+
+        # without the flag the two disjoint windows are a genuine ambiguity
+        new, count, _, err = fuzzy_find_and_replace(
+            content, "x)\nx)", "y", replace_all=False
+        )
+        assert count == 0
+        assert "2 matches" in err
+
 
 class TestUnicodeNormalized:
     """Tests for the unicode_normalized strategy (Bug 5)."""

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -98,6 +98,30 @@ def is_already_applied(content: str, old_string: str, new_string: str) -> bool:
     return old_string not in content
 
 
+def _drop_overlapping(matches: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    """Collapse overlapping spans to ``str.replace``-style non-overlapping ones.
+
+    The sliding-window strategies (``_find_normalized_matches``,
+    ``_strategy_trimmed_boundary``, ``unicode_normalized`` via its
+    ``line_trimmed`` fallback) stride by one line and return a match for every
+    offset whose window compares equal after normalization — consecutive
+    windows can share lines, so their spans overlap. ``_apply_replacements``
+    substitutes back-to-front assuming disjoint spans; with overlapping ones
+    the second replacement slices at stale offsets into already-rewritten text
+    and silently deletes content. ``_strategy_exact`` advances past each match
+    for exactly this reason; this applies the same semantics to every strategy
+    (greedy left-to-right: keep a span only when it starts at or after the
+    previously kept span's end).
+    """
+    kept: List[Tuple[int, int]] = []
+    last_end = -1
+    for start, end in sorted(matches):
+        if start >= last_end:
+            kept.append((start, end))
+            last_end = end
+    return kept
+
+
 def _format_match_locations(content: str, matches: List[Tuple[int, int]],
                             cap: int = 5) -> str:
     """Render up to ``cap`` match positions as 'L<line>: <snippet>' rows.
@@ -174,6 +198,11 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
 
     for strategy_name, strategy_fn in strategies:
         matches = strategy_fn(content, old_string)
+        # Normalization strategies stride by one line, so their windows can
+        # overlap when the pattern's normalized lines repeat. De-overlap before
+        # counting/applying so replace_all semantics (and the descending
+        # substitution in _apply_replacements) stay correct for every strategy.
+        matches = _drop_overlapping(matches)
 
         if matches:
             # Found matches with this strategy


### PR DESCRIPTION
## What

Collapses overlapping match spans from the fuzzy matching strategies to `str.replace()`-style non-overlapping semantics before any replacement is applied.

## Why

Fixes #92132. The sliding-window strategies (`line_trimmed`, `indentation_flexible`, `trimmed_boundary`, and `unicode_normalized` via its `line_trimmed` fallback) stride their window by one line and return a match for **every** offset whose window compares equal after normalization. When the pattern's normalized lines repeat, consecutive windows share lines and their spans overlap. `_apply_replacements` (`tools/fuzzy_match.py`) substitutes back-to-front assuming disjoint spans — with overlapping spans, the second replacement slices at stale offsets into already-rewritten text and **silently deletes content while reporting success**:

```python
fuzzy_find_and_replace("x)\n x)\n x)\n", "x)\nx)", "y", replace_all=True)
# before: ('y', count=2)            ← third line silently destroyed
# after:  ('y\n x)\n', count=1)     ← str.replace semantics, nothing lost
```

`_strategy_exact` already advances its scan past each match for exactly this failure mode (see its comment about "overlapping matches that corrupt the file under replace_all=True"); the same protection was missing for the normalization strategies. The new `_drop_overlapping` applies it uniformly at the top of the strategy loop, before the ambiguity/similarity count checks — so it also fixes the reported match count for `replace_all=False` edits (a phantom overlapping second match no longer turns a unique window into a spurious "Found 2 matches" error).

Disjoint windows are unaffected: every genuine occurrence is still replaced, and the pre-existing `_reindent_replacement` contract (replacement inherits the file region's base indent) is preserved.

## How to test

```
.venv/bin/python -m pytest tests/tools/test_fuzzy_match.py tests/tools/test_patch_multimatch_locations.py tests/tools/test_patch_already_applied.py -q
# 79 passed
```

New regression tests in `TestReplaceAll` cover: overlapping windows under `replace_all=True` (no content loss), the de-overlapped unique-window case without the flag, and disjoint windows still all replaced.

## Platforms tested

macOS 15 (arm64), Python 3.12 (uv-managed venv). Logic is platform-independent.

Fixes #92132