### PR TITLE
fix(providers): keep Go-native free slugs on the Go relay

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -5356,6 +5356,21 @@ _OPENCODE_ZEN_FREE_BASE_URL = "https://opencode.ai/zen/v1"
 # (big-pickle is OpenCode's rotating free stealth slot.)
 _OPENCODE_KEYLESS_EXTRA_SLUGS = frozenset({"big-pickle"})
 
+# Slugs that actually exist on the Zen relay's free tier (live GET
+# /zen/v1/models, 2026-08-22). Go now publishes its own free slugs
+# (notably ox-alpha-free) that are NOT on Zen. Remapping those to
+# /zen/v1 yields 401 "Model … is not supported".
+_OPENCODE_ZEN_LIVE_FREE_SLUGS = frozenset({
+    "x-preview-f-free",
+    "deepseek-v4-flash-free",
+    "muse-spark-1.2-contributor-free",
+    "mimo-v2.5-free",
+    "hy3-free",
+    "nemotron-3-ultra-free",
+    "nemotron-3.5-lightning-free",
+    "laguna-s-2.1-free",
+}) | _OPENCODE_KEYLESS_EXTRA_SLUGS
+
 
 def is_opencode_zen_free_model(model_id: Optional[str]) -> bool:
     """True when ``model_id`` is an OpenCode Zen free-tier slug.
@@ -5409,6 +5424,13 @@ def opencode_zen_free_runtime(provider_id: Optional[str], model_id: Optional[str
         return None
     if family != "opencode-free" and not is_opencode_zen_free_model(model_id):
         return None
+    # Go-native free slugs must stay on the Go relay. Healing every *-free
+    # selection onto Zen was correct when Go served no free models; it is
+    # now wrong for ox-alpha-free (in the live Go catalog, absent from Zen).
+    if family == "opencode-go":
+        bare = str(model_id or "").strip().rsplit("/", 1)[-1].lower()
+        if bare not in _OPENCODE_ZEN_LIVE_FREE_SLUGS:
+            return None
     normalized = normalize_opencode_model_id(provider_id, model_id)
     api_mode = opencode_model_api_mode("opencode-zen", normalized)
     base_url = normalize_opencode_base_url(

--- a/tests/hermes_cli/test_opencode_zen_free_keyless.py
+++ b/tests/hermes_cli/test_opencode_zen_free_keyless.py
@@ -72,11 +72,15 @@ class TestFreeRuntime:
         assert rt["default_headers"]["Authorization"] == ""
 
     def test_go_provider_heals_to_zen(self):
-        # Free slugs only exist on the Zen relay; a Go selection must be
-        # routed to Zen (the Go relay rejects the model outright).
+        # Known Zen-only free slugs picked under Go still heal to Zen.
         rt = opencode_zen_free_runtime("opencode-go", "x-preview-f-free")
         assert rt is not None
         assert rt["base_url"] == "https://opencode.ai/zen/v1"
+
+    def test_go_native_free_slug_stays_on_go(self):
+        # ox-alpha-free is in the live Go catalog and not on Zen. Remapping
+        # it to /zen/v1 401s "Model ox-alpha-free is not supported".
+        assert opencode_zen_free_runtime("opencode-go", "ox-alpha-free") is None
 
     def test_paid_model_returns_none(self):
         assert opencode_zen_free_runtime("opencode-zen", "claude-sonnet-5") is None


### PR DESCRIPTION
## Problem

Selecting `ox-alpha-free` on `opencode-go` fails with `401 Model ox-alpha-free is not supported` and silently falls back.

## Root cause

The Zen free-tier keyless routing (`opencode_zen_free_runtime`) heals **any** `*-free` slug onto `https://opencode.ai/zen/v1`. That was correct when Go served no free models, but the live Go catalog now publishes `ox-alpha-free` (verified via `GET /zen/go/v1/models`, 2026-08-22) while Zen's Ox Alpha is `x-preview-f-free`. The blanket remap sends the Go-native id to Zen, which rejects it. Live receipt from a real session:

```
provider=opencode-go base_url=https://opencode.ai/zen/v1 model=ox-alpha-free
HTTP 401: Model ox-alpha-free is not supported
Fallback activated: ox-alpha-free → hy3-free (opencode-zen)
```

## Fix

Pin the healing set to slugs actually served by Zen's free tier (live `GET /zen/v1/models`) and let Go-native free slugs stay on Go with their subscription credential:

- `_OPENCODE_ZEN_LIVE_FREE_SLUGS`: the eight Zen free slugs + `big-pickle`
- `opencode_zen_free_runtime("opencode-go", <slug>)` returns `None` for slugs not in that set, so resolution falls through to the normal Go path (correct base URL `/zen/go/v1`, Go key)
- Known Zen-only free slugs selected under Go still heal to Zen keylessly, unchanged

## Tests

- Updated `test_go_provider_heals_to_zen` comment to reflect intent
- New `test_go_native_free_slug_stays_on_go`
- `pytest tests/hermes_cli/test_opencode_zen_free_keyless.py`: **15 passed**

## Verification

Live end-to-end after the patch (fresh CLI session):

```
OpenAI client created ... provider=opencode-go base_url=https://opencode.ai/zen/go/v1 model=ox-alpha-free
API call #1: model=ox-alpha-free provider=opencode-go in=23256 out=10 latency=19.4s
Turn ended: reason=text_response(finish_reason=stop) model=ox-alpha-free
```

No fallback fired.