### PR TITLE
fix(desktop): memoize statusbar render-contributions so state survives re-renders

### DIFF
--- a/apps/desktop/src/app/contrib/panes.test.tsx
+++ b/apps/desktop/src/app/contrib/panes.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ContribRender } from '@/contrib/react/boundary'
+import { registry } from '@/contrib/registry'
+
+import { useStatusbarContributions } from './panes'
+
+// Registrations are global (module-level registry); each test captures its
+// own disposer and this undoes it, so tests don't bleed into each other.
+let dispose: (() => void) | undefined
+
+afterEach(() => {
+  cleanup()
+  dispose?.()
+  dispose = undefined
+})
+
+// A stateful contribution — a chip that opens a dialog-like panel and holds
+// that open/closed state itself, the same shape a real plugin uses.
+function StatefulChip() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div>
+      <button onClick={() => setOpen(true)} type="button">
+        open
+      </button>
+      {open && <div data-testid="panel">panel open</div>}
+    </div>
+  )
+}
+
+// Hosts the contributed items and carries UNRELATED state of its own, so
+// clicking "bump" re-renders the host (and re-invokes useStatusbarContributions)
+// without touching the registry — exactly what a streaming message or a
+// session-timer tick does to the real statusbar.
+function Host() {
+  const [, setTick] = useState(0)
+  const items = useStatusbarContributions('right')
+
+  return (
+    <div>
+      <button onClick={() => setTick(t => t + 1)} type="button">
+        bump
+      </button>
+      {items.map(item =>
+        // Mirror the real consumer exactly (statusbar-controls.tsx): `item.render`
+        // is passed as a PROP and mounted via `createElement(render)` inside
+        // ContribRender — not invoked inline. Calling it directly here would
+        // dodge the bug entirely (the wrapper's own identity never gets used
+        // as a component type, so no remount could ever be observed).
+        item.render ? <ContribRender key={item.id} render={item.render} /> : null
+      )}
+    </div>
+  )
+}
+
+describe('useStatusbarContributions', () => {
+  it('keeps a render-contribution mounted (state intact) across an unrelated host re-render', () => {
+    dispose = registry.register({ area: 'statusBar.right', id: 'stateful-chip', render: () => <StatefulChip /> })
+
+    render(<Host />)
+
+    // Open the panel — this is the state that must survive.
+    fireEvent.click(screen.getByRole('button', { name: 'open' }))
+    expect(screen.getByTestId('panel')).toBeTruthy()
+
+    // Re-render the host for a reason that has nothing to do with the
+    // registry (a streaming tick, a session switch elsewhere in the tree).
+    fireEvent.click(screen.getByRole('button', { name: 'bump' }))
+
+    // #91603: before the fix, useStatusbarContributions handed back a new
+    // `render` closure identity every call, so ContribRender's
+    // createElement(render) read it as a different component type and
+    // remounted StatefulChip — dropping `open` back to false.
+    expect(screen.getByTestId('panel')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/contrib/panes.tsx
+++ b/apps/desktop/src/app/contrib/panes.tsx
@@ -11,6 +11,7 @@
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import { atom } from 'nanostores'
+import { useMemo } from 'react'
 
 import { RightSidebarPane } from '@/app/right-sidebar'
 import { ReviewPane } from '@/app/right-sidebar/review'
@@ -118,24 +119,35 @@ export function ReviewPaneContent() {
 
 /** Collect statusbar contributions for one side. A `render()` contribution
  *  becomes a render-item (arbitrary stateful node); otherwise the declarative
- *  `data` payload is the StatusbarItem. */
+ *  `data` payload is the StatusbarItem.
+ *
+ *  Memoized on `items` (a stable reference from `useContributions` until the
+ *  area actually changes — see `registry.getArea`'s snapshot cache): without
+ *  this, every render-item's `render` wrapper was a brand-new arrow function,
+ *  so `ContribRender`'s `createElement(render)` saw a different component
+ *  TYPE on every statusbar re-render and remounted the whole contributed
+ *  subtree — dropping any state it held (e.g. an open Dialog). See #91603. */
 export function useStatusbarContributions(side: 'left' | 'right'): StatusbarItem[] {
   const items = useContributions(`statusBar.${side}`)
 
-  return items
-    .map(c =>
-      c.render
-        ? ({
-            id: c.id,
-            render: () => (
-              <ContribBoundary id={c.id} variant="chip">
-                <ContribRender render={c.render!} />
-              </ContribBoundary>
-            )
-          } satisfies StatusbarItem)
-        : (c.data as StatusbarItem)
-    )
-    .filter(Boolean)
+  return useMemo(
+    () =>
+      items
+        .map(c =>
+          c.render
+            ? ({
+                id: c.id,
+                render: () => (
+                  <ContribBoundary id={c.id} variant="chip">
+                    <ContribRender render={c.render!} />
+                  </ContribBoundary>
+                )
+              } satisfies StatusbarItem)
+            : (c.data as StatusbarItem)
+        )
+        .filter(Boolean),
+    [items]
+  )
 }
 
 /** Collect TitlebarTool data contributions for one side of the titlebar. */

--- a/apps/desktop/src/contrib/registry.test.ts
+++ b/apps/desktop/src/contrib/registry.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { registry } from './registry'
+
+// Registrations are global (module-level registry); each test captures its
+// own disposer and this undoes it, so tests don't bleed into each other.
+let dispose: (() => void) | undefined
+
+afterEach(() => {
+  dispose?.()
+  dispose = undefined
+})
+
+describe('registry.getArea', () => {
+  it('returns the same array reference across repeated calls until the area mutates', () => {
+    dispose = registry.register({ area: 'test.stability', id: 'a' })
+
+    const first = registry.getArea('test.stability')
+    const second = registry.getArea('test.stability')
+
+    // Consumers (useContributions, and anything memoized on its result — see
+    // useStatusbarContributions in panes.tsx) depend on this snapshot cache
+    // for referential stability. If getArea ever started returning a fresh
+    // array per call, every memo keyed on it would recompute every render,
+    // silently reintroducing bugs like #91603 with no failing test to catch it.
+    expect(second).toBe(first)
+
+    dispose()
+    dispose = registry.register({ area: 'test.stability', id: 'b' })
+
+    // A real mutation of the area IS expected to invalidate the snapshot.
+    expect(registry.getArea('test.stability')).not.toBe(first)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

`useStatusbarContributions` (`apps/desktop/src/app/contrib/panes.tsx`) rebuilds a fresh `render()` closure for every render-item on every call. `ContribRender` mounts that closure via `createElement(render)`, so a new closure identity reads as a different component **type** — React tears down and remounts the whole contributed subtree on any unrelated statusbar re-render, dropping any state it held (e.g. an open Dialog).

The fix wraps the mapping in `useMemo` keyed on `items`, which `useContributions` already returns as a stable reference (`registry.getArea` caches per area) until the area actually mutates — confirmed by reading `registry.ts`, not assumed.

## Important caveat — please read before reviewing

This repo enables the React Compiler for files matching the JSX/react-import filter in `vite.config.ts`, and `panes.tsx` matches it. **With the compiler on (the shipped build config), it already auto-memoizes this exact pattern**, so I could not reproduce user-visible state loss against a compiler-enabled build. I verified this by toggling the compiler filter off/on against both the pre-fix and fixed source, running the same test each time:

| | compiler ON (current config) | compiler OFF |
|---|---|---|
| pre-fix source | test **passes** (no repro) | test **fails** (remounts, state lost) |
| fixed source | test passes | test passes |

So this isn't "fixes a live bug users are hitting right now" — it's "stops a correctness property (contribution state survives unrelated re-renders) from silently depending on the compiler's memoization heuristics staying happy for this function forever." If the compiler ever bails out here (a Rules-of-React violation added elsewhere in the function later, a filter change, compiler disabled for debugging), the state-loss bug returns with nothing to catch it. The added test guards that regardless of compiler state.

I'm flagging this plainly rather than claiming more than I can back up. Happy to close if maintainers consider compiler-masked issues out of scope — but the underlying fragility seemed worth a small, targeted fix either way, and the root-cause analysis in #91603 is correct about the mechanism even if its current real-world impact is uncertain.

## Related Issue

Closes #91603

## Changes Made

- `apps/desktop/src/app/contrib/panes.tsx`: memoize `useStatusbarContributions`'s return value on `items`
- `apps/desktop/src/app/contrib/panes.test.tsx`: new regression test mirroring the real consumer (`statusbar-controls.tsx`'s `<ContribRender render={item.render} />` pattern exactly, not a simplified stand-in) — a stateful contribution opens a panel, an unrelated host re-render fires, panel state must survive

## How to Test

Automated: `npx vitest run src/app/contrib/panes.test.tsx` — passes with the fix, fails without it (with the compiler disabled; see caveat above for why it can't distinguish the two with the compiler on).

Manual (if you want to see the compiler-masked version): register a `statusBar.right` render-contribution holding `useState`, trigger any statusbar re-render, watch whether its state survives — should always survive with this fix regardless of compiler state.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs referencing #91603 — none found at time of submission
- [x] My PR contains **only** changes related to this fix
- [x] I've run `npx vitest run` for the touched test file (passes), plus `npx eslint` and `npx tsc -p . --noEmit` on changed files — clean
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10 22H2 (build 19045) — pure React/jsdom logic, not OS-specific

### Documentation & Housekeeping

- [x] N/A — no docs, config keys, or tool schemas affected
- [x] Cross-platform impact considered — renderer-only React logic, not OS-specific

## Screenshots / Logs

Not included — see the caveat above: I could not get this to visibly reproduce against the compiler-enabled build this repo ships, so there's no "before" screenshot to show. The vitest pass/fail table above is the actual evidence.
