### PR TITLE
fix(bot-mode): the canonical Bot Chat is titled at birth, closing the untitled-registry window (salvage #90957)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4149,6 +4149,24 @@ function createCanonicalChat(name) {
     const sid = res?.stored_session_id
     const runtime = res?.session_id
 
+    // session.create is intentionally lazy: its stored row does not exist until
+    // the first prompt. Mounting `sid` immediately therefore emits a noisy REST
+    // 404 ("Session not found"), and the turn-start auto-titler can win the race
+    // against the deferred `title: 'Bot Chat'` — under name-identity that is an
+    // identity outage: until the row is titled, the registry has no "Bot Chat"
+    // entry, so a second click during the intro turn mints a duplicate.
+    // session.title materializes the row now and records a user-authority title
+    // before either the open or kickoff, closing both the 404 race and the
+    // untitled window. Older gateways may not support the eager write; retain
+    // the kickoff-and-retry fallback below.
+    if (runtime) {
+      try {
+        await host.request('session.title', { session_id: runtime, title: CANONICAL_CHAT_TITLE })
+      } catch {
+        /* compatibility fallback: prompt.submit will persist the lazy row */
+      }
+    }
+
     // Mount the session view FIRST, then send the kickoff — submitting into
     // an unmounted session left the intro reply invisible until reopen.
     let opened = false

--- a/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/canonical-chat-creation.test.mjs
@@ -22,7 +22,31 @@ function loadCanonicalCreation({ openSession, request }) {
   return { ...context.__canonical }
 }
 
-test('regression: navigation retries after the kickoff persists a new canonical chat', async () => {
+test('regression: creation materializes and titles the lazy row before opening it', async () => {
+  const events = []
+  const runtime = loadCanonicalCreation({
+    openSession: async id => events.push(`open:${id}`),
+    request: async (method, params) => {
+      events.push(method)
+      if (method === 'session.create') return { stored_session_id: 'stored-1', session_id: 'runtime-1' }
+      if (method === 'session.title') {
+        assert.deepEqual(params, { session_id: 'runtime-1', title: 'Bot Chat' })
+      }
+      return {}
+    }
+  })
+
+  assert.equal(await runtime.createCanonicalChat('ops'), 'stored-1')
+  assert.deepEqual(events, [
+    'session.list',
+    'session.create',
+    'session.title',
+    'open:stored-1',
+    'prompt.submit'
+  ])
+})
+
+test('compatibility: navigation retries after kickoff when eager title persistence is unavailable', async () => {
   const events = []
   let attempts = 0
   const runtime = loadCanonicalCreation({
@@ -33,6 +57,7 @@ test('regression: navigation retries after the kickoff persists a new canonical 
     },
     request: async method => {
       if (method === 'session.create') return { stored_session_id: 'stored-1', session_id: 'runtime-1' }
+      if (method === 'session.title') throw new Error('unknown method')
       if (method === 'prompt.submit') events.push('kickoff:persisted')
       return {}
     }

--- a/contributors/emails/switchstatement@gmail.com
+++ b/contributors/emails/switchstatement@gmail.com
@@ -1,0 +1,1 @@
+krunkosaurus


### PR DESCRIPTION
## Summary

The canonical Bot Chat is now titled "Bot Chat" the moment it's created, instead of after its first turn completes — closing the window where the registry had no row for a chat that already existed. Salvage of #90957 by @krunkosaurus onto the name-identity architecture (#92129).

Root cause: `session.create` is intentionally lazy — the stored row doesn't materialize until the first prompt, and the requested title rides as `pending_title`, written only when the intro turn completes. Two consequences: mounting the stored id immediately emits a REST 404 ("Session not found"), and under name-identity the untitled window is an identity outage — `session.list {title: 'Bot Chat'}` finds nothing while the intro runs, so a second bot-row click mints a duplicate, and the turn-start auto-titler can win the race and name the row something else entirely.

## Changes

- `plugin.js` (`createCanonicalChat`): after `session.create`, eagerly call `session.title {session_id: runtime, title: CANONICAL_CHAT_TITLE}` — materializes the row and records the title at user authority before the open and the kickoff. Older gateways without eager title persistence fall back to the existing kickoff-and-retry path, unchanged.
- Tests: new ordering regression (list → create → title → open → kickoff) plus a compatibility test pinning the fallback when `session.title` is unavailable.

## Validation

| | Result |
|---|---|
| Plugin suite | 362/362 pass |
| E2E (real gateway handlers, temp HERMES_HOME) | `session.create` → `session.title` → registry lookup finds the titled row immediately, before any turn |
| Contributor attribution | @krunkosaurus commit cherry-picked, email mapped |

## Infographic

![Named at birth — eager canonical title](https://v3b.fal.media/files/b/0aa75651/dDcxQZaub0vp95xpPvbAv_jAk2T7Ov.png)
