### PR TITLE
fix(files): allow agents to edit gettext pot templates

### DIFF
--- a/tests/tools/test_binary_document_write_guard.py
+++ b/tests/tools/test_binary_document_write_guard.py
@@ -226,9 +226,58 @@ def test_remote_pot_guard_uses_backend_for_both_write_paths(
         )
 
     assert bool(result.get("error")) is should_reject
-    assert file_ops.prefix_reads == [("/workspace/slides.pot", 8)]
+    expected_reads = 1 if should_reject else 2
+    assert file_ops.prefix_reads == [
+        ("/workspace/slides.pot", 8)
+    ] * expected_reads
     assert file_ops.write_calls == (1 if tool_name == "write" and not should_reject else 0)
     assert file_ops.patch_calls == (1 if tool_name == "patch" and not should_reject else 0)
+
+
+@pytest.mark.parametrize("tool_name", ["write", "patch"])
+def test_pot_guard_reinspects_after_acquiring_mutation_lock(
+    monkeypatch, tmp_path: Path, tool_name: str
+):
+    import tools.file_tools as file_tools
+
+    target = tmp_path / "messages.pot"
+    target.write_text('msgid "hello"\nmsgstr ""\n', encoding="utf-8")
+    ole_content = bytes.fromhex("D0CF11E0A1B11AE1") + b"legacy powerpoint"
+    real_lock_path = file_tools.file_state.lock_path
+
+    class SwapToOleOnEnter:
+        def __init__(self, resolved: str):
+            self._lock = real_lock_path(resolved)
+
+        def __enter__(self):
+            self._lock.__enter__()
+            target.write_bytes(ole_content)
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return self._lock.__exit__(exc_type, exc, traceback)
+
+    monkeypatch.setattr(
+        file_tools.file_state,
+        "lock_path",
+        lambda resolved: SwapToOleOnEnter(resolved),
+    )
+
+    if tool_name == "write":
+        result = json.loads(write_file_tool(str(target), 'msgid "replacement"\n'))
+    else:
+        result = json.loads(
+            patch_tool(
+                mode="replace",
+                path=str(target),
+                old_string="hello",
+                new_string="replacement",
+            )
+        )
+
+    assert result.get("error")
+    assert "PowerPoint" in result["error"]
+    assert target.read_bytes() == ole_content
 
 
 class TestWriteFileToolGuard:

--- a/tests/tools/test_binary_document_write_guard.py
+++ b/tests/tools/test_binary_document_write_guard.py
@@ -160,6 +160,15 @@ class TestCheckBinaryDocumentWrite:
         assert err is not None
         assert "PowerPoint" in err
 
+    def test_existing_non_regular_pot_rejected(self, tmp_path: Path):
+        pot = tmp_path / "messages.pot"
+        pot.mkdir()
+
+        err = _check_binary_document_write(str(pot))
+
+        assert err is not None
+        assert "not a regular file" in err
+
     def test_remote_inspection_failure_rejected(self, monkeypatch):
         file_ops = _install_remote_file_ops(
             monkeypatch, FilePrefixResult(error="permission denied")
@@ -170,6 +179,20 @@ class TestCheckBinaryDocumentWrite:
         assert err is not None
         assert "could not be inspected safely" in err
         assert file_ops.prefix_reads == [("/workspace/slides.pot", 8)]
+
+    def test_remote_inspection_exception_rejected(self, monkeypatch):
+        file_ops = _install_remote_file_ops(monkeypatch, FilePrefixResult())
+
+        def raise_transport_error(path: str, length: int) -> FilePrefixResult:
+            raise RuntimeError("transport unavailable")
+
+        monkeypatch.setattr(file_ops, "read_file_prefix", raise_transport_error)
+
+        err = _check_binary_document_write("slides.pot", task_id="remote")
+
+        assert err is not None
+        assert "could not be inspected safely" in err
+        assert "transport unavailable" in err
 
 
 @pytest.mark.parametrize("tool_name", ["write", "patch"])

--- a/tests/tools/test_binary_document_write_guard.py
+++ b/tests/tools/test_binary_document_write_guard.py
@@ -42,11 +42,11 @@ class TestExtensionHelpers:
     def test_opaque_document_extensions(self):
         for p in ("a.docx", "b.XLSX", "c.pptx", "d.doc", "e.odt", "f.ods", "g.odp",
                   "h.docm", "i.xlsm", "j.xlsb", "k.pptm", "l.ppsx", "m.ppsm",
-                  "n.pps", "o.pot", "p.rtf", "q.epub"):
+                  "n.pps", "p.rtf", "q.epub"):
             assert has_opaque_document_extension(p) is True, f"{p} should be opaque"
 
     def test_non_opaque_paths(self):
-        for p in ("a.txt", "b.py", "c.pdf", "d.md", "noext", "e.csv"):
+        for p in ("a.txt", "b.py", "c.pdf", "d.md", "noext", "e.csv", "messages.pot"):
             assert has_opaque_document_extension(p) is False
 
     def test_is_pdf_path(self):
@@ -74,6 +74,21 @@ class TestCheckBinaryDocumentWrite:
 
     def test_plain_text_allowed(self, tmp_path: Path):
         assert _check_binary_document_write(str(tmp_path / "notes.txt")) is None
+
+    def test_new_gettext_pot_allowed(self, tmp_path: Path):
+        assert _check_binary_document_write(str(tmp_path / "messages.pot")) is None
+
+    def test_existing_gettext_pot_allowed(self, tmp_path: Path):
+        pot = tmp_path / "messages.pot"
+        pot.write_text('msgid "hello"\nmsgstr ""\n', encoding="utf-8")
+        assert _check_binary_document_write(str(pot)) is None
+
+    def test_existing_ole_powerpoint_pot_rejected(self, tmp_path: Path):
+        pot = tmp_path / "slides.pot"
+        pot.write_bytes(bytes.fromhex("D0CF11E0A1B11AE1") + b"legacy powerpoint")
+        err = _check_binary_document_write(str(pot))
+        assert err is not None
+        assert "PowerPoint" in err
 
 
 class TestWriteFileToolGuard:
@@ -128,6 +143,21 @@ class TestWriteFileToolGuard:
         result = json.loads(write_file_tool(str(target), "hello world"))
         assert not result.get("error")
         assert target.read_text() == "hello world"
+
+    def test_write_file_allows_gettext_pot(self, tmp_path: Path):
+        target = tmp_path / "messages.pot"
+        content = 'msgid "hello"\nmsgstr ""\n'
+        result = json.loads(write_file_tool(str(target), content))
+        assert not result.get("error")
+        assert target.read_text() == content
+
+    def test_write_file_rejects_ole_powerpoint_pot(self, tmp_path: Path):
+        target = tmp_path / "slides.pot"
+        original = bytes.fromhex("D0CF11E0A1B11AE1") + b"legacy powerpoint"
+        target.write_bytes(original)
+        result = json.loads(write_file_tool(str(target), "replacement text"))
+        assert result.get("error")
+        assert target.read_bytes() == original
 
 
 class TestPatchToolGuard:
@@ -186,3 +216,13 @@ class TestPatchToolGuard:
         )
         assert not result.get("error")
         assert target.read_text() == "hello there"
+
+    def test_patch_replace_allows_gettext_pot(self, tmp_path: Path):
+        target = tmp_path / "messages.pot"
+        target.write_text('msgid "hello"\nmsgstr ""\n', encoding="utf-8")
+        result = json.loads(
+            patch_tool(mode="replace", path=str(target),
+                       old_string='msgid "hello"', new_string='msgid "goodbye"')
+        )
+        assert not result.get("error")
+        assert target.read_text(encoding="utf-8").startswith('msgid "goodbye"')

--- a/tests/tools/test_binary_document_write_guard.py
+++ b/tests/tools/test_binary_document_write_guard.py
@@ -8,7 +8,9 @@ allowing new-.pdf creation (raw PDF syntax is text-authorable).
 
 import json
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+
+import pytest
 
 from tools.binary_extensions import (
     has_opaque_document_extension,
@@ -19,6 +21,52 @@ from tools.file_tools import (
     patch_tool,
     write_file_tool,
 )
+from tools.file_operations import (
+    FilePrefixResult,
+    PatchResult,
+    ShellFileOperations,
+    WriteResult,
+)
+from tools.environments.local import LocalEnvironment
+
+
+class _RemoteEnvironment:
+    cwd = "/workspace"
+
+
+class _FakeRemoteFileOps:
+    def __init__(self, prefix: FilePrefixResult):
+        self.env = _RemoteEnvironment()
+        self.prefix = prefix
+        self.prefix_reads = []
+        self.write_calls = 0
+        self.patch_calls = 0
+
+    def read_file_prefix(self, path: str, length: int) -> FilePrefixResult:
+        self.prefix_reads.append((path, length))
+        return self.prefix
+
+    def write_file(self, path: str, content: str) -> WriteResult:
+        self.write_calls += 1
+        return WriteResult(bytes_written=len(content), verified=True)
+
+    def patch_replace(self, path: str, old_string: str, new_string: str,
+                      replace_all: bool = False) -> PatchResult:
+        self.patch_calls += 1
+        return PatchResult(success=True, files_modified=[path])
+
+
+def _install_remote_file_ops(monkeypatch, prefix: FilePrefixResult) -> _FakeRemoteFileOps:
+    import tools.file_tools as file_tools
+
+    file_ops = _FakeRemoteFileOps(prefix)
+    monkeypatch.setattr(
+        file_tools,
+        "_resolve_path_for_task",
+        lambda path, task_id="default": PurePosixPath("/workspace") / path,
+    )
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda task_id="default": file_ops)
+    return file_ops
 
 
 def _make_minimal_docx(path: Path) -> None:
@@ -36,6 +84,28 @@ def _make_minimal_docx(path: Path) -> None:
             "<w:t>Quarterly numbers look good.</w:t></w:r></w:p></w:body>"
             "</w:document>",
         )
+
+
+class TestFilePrefixRead:
+    def test_reads_only_requested_binary_prefix(self, tmp_path: Path):
+        target = tmp_path / "large.pot"
+        target.write_bytes(bytes.fromhex("D0CF11E0A1B11AE1") + b"x" * 100_000)
+        file_ops = ShellFileOperations(LocalEnvironment(cwd=str(tmp_path)))
+
+        result = file_ops.read_file_prefix(str(target), 8)
+
+        assert result.error is None
+        assert result.missing is False
+        assert result.content == bytes.fromhex("D0CF11E0A1B11AE1")
+
+    def test_distinguishes_missing_file(self, tmp_path: Path):
+        file_ops = ShellFileOperations(LocalEnvironment(cwd=str(tmp_path)))
+
+        result = file_ops.read_file_prefix(str(tmp_path / "missing.pot"), 8)
+
+        assert result.error is None
+        assert result.missing is True
+        assert result.content == b""
 
 
 class TestExtensionHelpers:
@@ -89,6 +159,53 @@ class TestCheckBinaryDocumentWrite:
         err = _check_binary_document_write(str(pot))
         assert err is not None
         assert "PowerPoint" in err
+
+    def test_remote_inspection_failure_rejected(self, monkeypatch):
+        file_ops = _install_remote_file_ops(
+            monkeypatch, FilePrefixResult(error="permission denied")
+        )
+
+        err = _check_binary_document_write("slides.pot", task_id="remote")
+
+        assert err is not None
+        assert "could not be inspected safely" in err
+        assert file_ops.prefix_reads == [("/workspace/slides.pot", 8)]
+
+
+@pytest.mark.parametrize("tool_name", ["write", "patch"])
+@pytest.mark.parametrize(
+    ("prefix", "should_reject"),
+    [
+        (FilePrefixResult(content=bytes.fromhex("D0CF11E0A1B11AE1")), True),
+        (FilePrefixResult(content=b'msgid "'), False),
+        (FilePrefixResult(missing=True), False),
+    ],
+    ids=["ole-powerpoint", "gettext", "missing"],
+)
+def test_remote_pot_guard_uses_backend_for_both_write_paths(
+    monkeypatch, tool_name, prefix, should_reject
+):
+    file_ops = _install_remote_file_ops(monkeypatch, prefix)
+
+    if tool_name == "write":
+        result = json.loads(
+            write_file_tool("slides.pot", 'msgid "hello"\n', task_id="remote")
+        )
+    else:
+        result = json.loads(
+            patch_tool(
+                mode="replace",
+                path="slides.pot",
+                old_string="hello",
+                new_string="goodbye",
+                task_id="remote",
+            )
+        )
+
+    assert bool(result.get("error")) is should_reject
+    assert file_ops.prefix_reads == [("/workspace/slides.pot", 8)]
+    assert file_ops.write_calls == (1 if tool_name == "write" and not should_reject else 0)
+    assert file_ops.patch_calls == (1 if tool_name == "patch" and not should_reject else 0)
 
 
 class TestWriteFileToolGuard:

--- a/tools/binary_extensions.py
+++ b/tools/binary_extensions.py
@@ -53,7 +53,7 @@ def has_binary_extension(path: str) -> bool:
 OPAQUE_DOCUMENT_EXTENSIONS = frozenset({
     ".doc", ".docx", ".docm",
     ".xls", ".xlsx", ".xlsm", ".xlsb",
-    ".ppt", ".pps", ".pot", ".pptx", ".pptm", ".ppsx", ".ppsm",
+    ".ppt", ".pps", ".pptx", ".pptm", ".ppsx", ".ppsm",
     ".odt", ".ods", ".odp",
     ".rtf", ".epub",
 })
@@ -73,3 +73,8 @@ def has_opaque_document_extension(path: str) -> bool:
 def is_pdf_path(path: str) -> bool:
     """True when the path has a .pdf extension. Pure string check, no I/O."""
     return path.lower().endswith(".pdf")
+
+
+def is_pot_path(path: str) -> bool:
+    """True for the ambiguous gettext/PowerPoint .pot extension."""
+    return path.lower().endswith(".pot")

--- a/tools/binary_extensions.py
+++ b/tools/binary_extensions.py
@@ -34,6 +34,12 @@ BINARY_EXTENSIONS = frozenset({
 })
 
 
+# Legacy PowerPoint .pot templates use the OLE compound document container.
+# The extension is shared with plain-text gettext templates, so callers must
+# inspect this signature before deciding whether a .pot file is safe to edit.
+OLE_COMPOUND_MAGIC = bytes.fromhex("D0CF11E0A1B11AE1")
+
+
 def has_binary_extension(path: str) -> bool:
     """Check if a file path has a binary extension. Pure string check, no I/O."""
     dot = path.rfind(".")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -179,6 +179,15 @@ class ReadResult:
 
 
 @dataclass
+class FilePrefixResult:
+    """Internal binary-safe prefix read across a file backend boundary."""
+
+    content: bytes = b""
+    missing: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
 class WriteResult:
     """Result from writing a file."""
     bytes_written: int = 0
@@ -535,6 +544,10 @@ class FileOperations(ABC):
     def read_file_bytes(self, path: str, max_bytes: Optional[int] = None) -> ReadResult:
         """Read complete binary content as base64 across the backend boundary."""
         return ReadResult(error="Binary reads are not implemented for this backend")
+
+    def read_file_prefix(self, path: str, length: int) -> FilePrefixResult:
+        """Read at most ``length`` bytes without decoding or reading to EOF."""
+        return FilePrefixResult(error="Prefix reads are not implemented for this backend")
 
     @abstractmethod
     def write_file(self, path: str, content: str,
@@ -1831,6 +1844,47 @@ class ShellFileOperations(FileOperations):
             file_size=file_size,
             is_binary=True,
         )
+
+    def read_file_prefix(self, path: str, length: int) -> FilePrefixResult:
+        """Read a bounded binary prefix from any shell-backed environment."""
+        if length < 0:
+            return FilePrefixResult(error="Prefix length must be non-negative")
+
+        path = self._expand_path(path)
+        arg = self._escape_shell_arg(path)
+        missing_marker = "__HERMES_PREFIX_MISSING__"
+        not_regular_marker = "__HERMES_PREFIX_NOT_REGULAR__"
+        # Capture ``head`` into a temporary file before base64 encoding so its
+        # exit status cannot be hidden by a successful downstream pipeline.
+        command = (
+            f"if [ ! -e {arg} ]; then printf '{missing_marker}'; "
+            f"elif [ ! -f {arg} ]; then printf '{not_regular_marker}'; "
+            "else "
+            "t=$(mktemp \"${TMPDIR:-/tmp}/.hermes-prefix.XXXXXX\") || exit 1; "
+            "trap 'rm -f \"$t\"' EXIT; "
+            f"head -c {int(length)} {arg} > \"$t\" 2>/dev/null || exit 1; "
+            "base64 < \"$t\"; "
+            "fi"
+        )
+        result = self._exec(command)
+        output = _strip_terminal_fence_leaks(result.stdout).strip()
+        if result.exit_code != 0:
+            return FilePrefixResult(
+                error=f"Failed to inspect file prefix: {path}: {output or 'backend read failed'}"
+            )
+        if output == missing_marker:
+            return FilePrefixResult(missing=True)
+        if output == not_regular_marker:
+            return FilePrefixResult(error=f"Cannot inspect '{path}': not a regular file")
+
+        compact = "".join(output.split())
+        try:
+            content = base64.b64decode(compact, validate=True) if compact else b""
+        except (ValueError, binascii.Error):
+            return FilePrefixResult(error=f"Backend returned invalid file prefix for: {path}")
+        if len(content) > length:
+            return FilePrefixResult(error=f"Backend returned an oversized file prefix for: {path}")
+        return FilePrefixResult(content=content)
 
     def delete_file(self, path: str) -> WriteResult:
         """Delete a single file.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -16,6 +16,7 @@ from tools.binary_extensions import (
     has_binary_extension,
     has_opaque_document_extension,
     is_pdf_path,
+    is_pot_path,
 )
 from tools.file_operations import (
     ShellFileOperations,
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
+_OLE_COMPOUND_MAGIC = bytes.fromhex("D0CF11E0A1B11AE1")
 
 
 def _expand_tilde(path: str) -> str:
@@ -2187,6 +2189,9 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
     - Opaque container formats (.doc/.docx/.xls/.xlsx/.ppt/.pptx/.odt/.ods/
       .odp): always rejected — text bytes are never a valid document, whether
       creating or overwriting.
+    - .pot: rejected only when an existing file has the OLE compound signature
+      used by legacy PowerPoint templates. The extension also belongs to
+      plain-text gettext templates, which text tools must be able to author.
     - .pdf: rejected only when OVERWRITING an existing regular file. Raw PDF
       syntax is text-authorable, so new-file creation stays allowed.
     """
@@ -2200,6 +2205,26 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
             "python-docx/openpyxl/python-pptx via the terminal to create or edit "
             "this document."
         )
+    if is_pot_path(filepath):
+        try:
+            resolved = Path(_resolve_path_for_task(filepath, task_id))
+        except Exception:
+            resolved = Path(_expand_tilde(filepath))
+        try:
+            is_ole_template = False
+            if resolved.is_file():
+                with resolved.open("rb") as existing:
+                    is_ole_template = existing.read(8) == _OLE_COMPOUND_MAGIC
+            if is_ole_template:
+                return (
+                    f"Refusing to overwrite legacy PowerPoint template '{filepath}' "
+                    "with plain text. The existing .pot file is an OLE compound "
+                    "document; use the powerpoint skill or a compatible library via "
+                    "the terminal to modify it. Plain-text gettext .pot files remain "
+                    "writable."
+                )
+        except OSError:
+            pass
     if is_pdf_path(filepath):
         try:
             resolved = Path(_resolve_path_for_task(filepath, task_id))

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -13,6 +13,7 @@ from pathlib import Path, PurePosixPath
 
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import (
+    OLE_COMPOUND_MAGIC,
     has_binary_extension,
     has_opaque_document_extension,
     is_pdf_path,
@@ -30,7 +31,6 @@ logger = logging.getLogger(__name__)
 
 
 _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
-_OLE_COMPOUND_MAGIC = bytes.fromhex("D0CF11E0A1B11AE1")
 
 
 def _expand_tilde(path: str) -> str:
@@ -2223,7 +2223,7 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
                 host_path = Path(resolved)
                 if host_path.is_file():
                     with host_path.open("rb") as existing:
-                        prefix = existing.read(len(_OLE_COMPOUND_MAGIC))
+                        prefix = existing.read(len(OLE_COMPOUND_MAGIC))
             except OSError as exc:
                 return (
                     f"Refusing to write '{filepath}' because its existing .pot file "
@@ -2231,7 +2231,7 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
                 )
         else:
             inspected = file_ops.read_file_prefix(
-                str(resolved), len(_OLE_COMPOUND_MAGIC)
+                str(resolved), len(OLE_COMPOUND_MAGIC)
             )
             if inspected.error:
                 return (
@@ -2240,7 +2240,7 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
                 )
             prefix = b"" if inspected.missing else inspected.content
 
-        if prefix == _OLE_COMPOUND_MAGIC:
+        if prefix == OLE_COMPOUND_MAGIC:
             return (
                 f"Refusing to overwrite legacy PowerPoint template '{filepath}' "
                 "with plain text. The existing .pot file is an OLE compound "

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2207,24 +2207,47 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
         )
     if is_pot_path(filepath):
         try:
-            resolved = Path(_resolve_path_for_task(filepath, task_id))
+            resolved = _resolve_path_for_task(filepath, task_id)
         except Exception:
             resolved = Path(_expand_tilde(filepath))
         try:
-            is_ole_template = False
-            if resolved.is_file():
-                with resolved.open("rb") as existing:
-                    is_ole_template = existing.read(8) == _OLE_COMPOUND_MAGIC
-            if is_ole_template:
+            file_ops = _get_file_ops(task_id)
+        except Exception as exc:
+            return (
+                f"Refusing to write '{filepath}' because its .pot file could not "
+                f"be inspected through the active file backend: {exc}"
+            )
+        if _file_ops_uses_host_paths(file_ops):
+            try:
+                prefix = b""
+                host_path = Path(resolved)
+                if host_path.is_file():
+                    with host_path.open("rb") as existing:
+                        prefix = existing.read(len(_OLE_COMPOUND_MAGIC))
+            except OSError as exc:
                 return (
-                    f"Refusing to overwrite legacy PowerPoint template '{filepath}' "
-                    "with plain text. The existing .pot file is an OLE compound "
-                    "document; use the powerpoint skill or a compatible library via "
-                    "the terminal to modify it. Plain-text gettext .pot files remain "
-                    "writable."
+                    f"Refusing to write '{filepath}' because its existing .pot file "
+                    f"could not be inspected safely: {exc}"
                 )
-        except OSError:
-            pass
+        else:
+            inspected = file_ops.read_file_prefix(
+                str(resolved), len(_OLE_COMPOUND_MAGIC)
+            )
+            if inspected.error:
+                return (
+                    f"Refusing to write '{filepath}' because its existing .pot file "
+                    f"could not be inspected safely: {inspected.error}"
+                )
+            prefix = b"" if inspected.missing else inspected.content
+
+        if prefix == _OLE_COMPOUND_MAGIC:
+            return (
+                f"Refusing to overwrite legacy PowerPoint template '{filepath}' "
+                "with plain text. The existing .pot file is an OLE compound "
+                "document; use the powerpoint skill or a compatible library via "
+                "the terminal to modify it. Plain-text gettext .pot files remain "
+                "writable."
+            )
     if is_pdf_path(filepath):
         try:
             resolved = Path(_resolve_path_for_task(filepath, task_id))

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2221,6 +2221,11 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
             try:
                 prefix = b""
                 host_path = Path(resolved)
+                if host_path.exists() and not host_path.is_file():
+                    return (
+                        f"Refusing to write '{filepath}' because its existing .pot file "
+                        "could not be inspected safely: not a regular file"
+                    )
                 if host_path.is_file():
                     with host_path.open("rb") as existing:
                         prefix = existing.read(len(OLE_COMPOUND_MAGIC))
@@ -2230,9 +2235,15 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
                     f"could not be inspected safely: {exc}"
                 )
         else:
-            inspected = file_ops.read_file_prefix(
-                str(resolved), len(OLE_COMPOUND_MAGIC)
-            )
+            try:
+                inspected = file_ops.read_file_prefix(
+                    str(resolved), len(OLE_COMPOUND_MAGIC)
+                )
+            except Exception as exc:
+                return (
+                    f"Refusing to write '{filepath}' because its existing .pot file "
+                    f"could not be inspected safely: {exc}"
+                )
             if inspected.error:
                 return (
                     f"Refusing to write '{filepath}' because its existing .pot file "

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2322,6 +2322,10 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
 
         if _resolved is None:
             stale_warning = _check_file_staleness(path, task_id)
+            if is_pot_path(path):
+                binary_doc_err = _check_binary_document_write(path, task_id)
+                if binary_doc_err:
+                    return tool_error(binary_doc_err)
             file_ops = _get_file_ops(task_id)
             result = file_ops.write_file(path, content)
             result_dict = result.to_dict()
@@ -2336,6 +2340,13 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         # subagents can't interleave on the same file.  Different paths
         # remain fully parallel.
         with file_state.lock_path(_resolved):
+            # Reinspect ambiguous .pot files under the mutation lock. Another
+            # in-process writer may have replaced the file after the initial
+            # preflight check while this operation waited for the lock.
+            if is_pot_path(path):
+                binary_doc_err = _check_binary_document_write(path, task_id)
+                if binary_doc_err:
+                    return tool_error(binary_doc_err)
             # Cross-agent staleness wins over per-task warning when both
             # fire — its message names the sibling subagent.
             cross_warning = file_state.check_stale(task_id, _resolved)
@@ -2475,6 +2486,14 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         with ExitStack() as _locks:
             for _r in _resolved_paths:
                 _locks.enter_context(file_state.lock_path(_r))
+
+            # Reinspect ambiguous .pot files only after every target lock is
+            # held, closing the gap between preflight validation and mutation.
+            for _p in _content_write_paths:
+                if is_pot_path(_p):
+                    binary_doc_err = _check_binary_document_write(_p, task_id)
+                    if binary_doc_err:
+                        return tool_error(binary_doc_err)
 
             # Collect warnings — cross-agent registry first (names sibling),
             # then per-task tracker as a fallback.


### PR DESCRIPTION
## What does this PR do?

Hermes file tools can now create and update plain-text gettext `.pot` templates instead of rejecting them as PowerPoint containers. Existing legacy PowerPoint `.pot` files remain protected by checking their OLE compound signature before a text write.

### Symptom

`write_file` and `patch` returned "Refusing to write plain text to binary document" for every `.pot` path, including normal gettext catalogs.

### Impact

Agents could not create or maintain gettext message templates through either supported text-write path on any platform.

### Bug Cause

**Trigger:** `tools/file_tools.py` in `_check_binary_document_write()` classified every `.pot` path through `has_opaque_document_extension()`.

**Causal chain:**
1. A localization workflow asks `write_file` or `patch` to write a gettext `.pot` template.
2. `OPAQUE_DOCUMENT_EXTENSIONS` identifies the path as a binary PowerPoint template using only its suffix.
3. The shared pre-write guard rejects the operation before the text content can be written.

**Why it is wrong:** `.pot` is an ambiguous extension. Gettext templates are plain text, while legacy PowerPoint templates are OLE compound documents.

**Working sibling / contrast:** Existing PDFs already use content-aware overwrite handling rather than unconditional extension-only rejection.

**Ruled out:** The failure is not specific to one write implementation; both `write_file` and V4A/replace patch operations call the same shared guard.

### Fix

Remove `.pot` from the always-opaque extension set and inspect existing `.pot` files for the OLE compound magic bytes. New files and existing gettext text templates are writable, while existing legacy PowerPoint templates remain protected.

### Backend coverage

All shipped file backends—local, Docker, SSH, Singularity, Modal, Daytona, and Vercel Sandbox—use `ShellFileOperations.read_file_prefix()` for the bounded signature inspection. The `FileOperations` base implementation deliberately fails closed, so a future custom implementation must provide `read_file_prefix()` before it can write `.pot` files.

## Related Issue

Closes #92131

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/binary_extensions.py` - classify `.pot` as an ambiguous extension instead of an always-opaque container and keep its OLE signature metadata beside the extension helper.
- `tools/file_tools.py` - reject OLE `.pot` overwrites, fail closed on backend inspection errors, and recheck signatures under mutation locks.
- `tests/tools/test_binary_document_write_guard.py` - cover gettext creation/update, legacy PowerPoint protection, backend failures, and concurrent replacement through both write paths.

## How to Test

1. Run the focused binary-document write guard suite.
2. Confirm all 36 tests pass, including gettext `.pot` writes and OLE PowerPoint `.pot` rejection.

```bash
scripts/run_tests.sh tests/tools/test_binary_document_write_guard.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the focused regression suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - docstrings updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-independent path and byte handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A; no schema change

## Screenshots / Logs

Focused regression suite: 36 passed.
