### PR TITLE
fix(gateway): keep named sessions discoverable in resume pickers

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4805,6 +4805,7 @@ class GatewaySlashCommandsMixin:
                 source=user_source,
                 session_key=None if widen else session_key,
                 limit=10,
+                titled_only=True,
             )
             return [s for s in sessions if s.get("title")][:10]
 

--- a/hermes_cli/session_listing.py
+++ b/hermes_cli/session_listing.py
@@ -66,8 +66,9 @@ def query_session_listing(
     unnamed sessions stay visible since an id match may be the only handle.
     """
     query_source = None if include_all_sources else source
-    fetch_limit = max(limit * 4, limit)
     search = (search_query or "").strip()
+    titled_only = not include_unnamed and not search
+    fetch_limit = max(limit * 4, limit)
     rows = session_db.list_sessions_rich(
         source=query_source,
         session_key=session_key,
@@ -75,6 +76,7 @@ def query_session_listing(
         limit=fetch_limit,
         search_query=search or None,
         order_by_last_active=bool(search),
+        titled_only=titled_only,
     )
     result: list[dict[str, Any]] = []
     for row in rows:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -8947,6 +8947,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         include_pinned: bool = False,
         session_key: str = None,
         include_hidden: bool = False,
+        titled_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -9001,6 +9002,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Pass ``session_key`` to restrict results to one stable gateway
         conversation scope (DM, group, channel, or thread, including the
         configured per-user isolation policy).
+
+        Pass ``titled_only=True`` to exclude null, empty, and whitespace-only
+        titles before LIMIT/OFFSET are applied. Picker callers use this so
+        recent unnamed sessions cannot displace older named conversations.
         """
         # Rows carry token/cost totals — drain queued deltas first so
         # listings (sidebar, /resume, dashboards) show exact counters.
@@ -9051,6 +9056,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             where_clauses.append("s.archived = 0")
         if not include_hidden:
             where_clauses.append("s.hidden = 0")
+        if titled_only:
+            where_clauses.append("NULLIF(TRIM(s.title), '') IS NOT NULL")
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
         # Snapshot the filter params before the query builders below extend

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9004,8 +9004,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         configured per-user isolation policy).
 
         Pass ``titled_only=True`` to exclude null, empty, and whitespace-only
-        titles before LIMIT/OFFSET are applied. Picker callers use this so
-        recent unnamed sessions cannot displace older named conversations.
+        effective titles before LIMIT/OFFSET are applied. For compression
+        lineages the effective title is the surfaced continuation tip's title,
+        not the hidden root's. Picker callers use this so recent unnamed
+        sessions cannot displace older named conversations.
         """
         # Rows carry token/cost totals — drain queued deltas first so
         # listings (sidebar, /resume, dashboards) show exact counters.
@@ -9057,7 +9059,49 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not include_hidden:
             where_clauses.append("s.hidden = 0")
         if titled_only:
-            where_clauses.append("NULLIF(TRIM(s.title), '') IS NOT NULL")
+            # The row admitted here may later project from a compression root
+            # to its live tip. Filter on that same surfaced tip's title before
+            # LIMIT/OFFSET, including the child-selection precedence used by
+            # get_compression_tip(), so a lineage title transferred off the
+            # hidden root remains discoverable without letting unnamed rows
+            # consume the picker window.
+            where_clauses.append(
+                f"""
+                NULLIF(TRIM((
+                    WITH RECURSIVE effective_tip(id, title, depth) AS (
+                        SELECT s.id, s.title, 0
+                        UNION ALL
+                        SELECT child.id, child.title, et.depth + 1
+                        FROM effective_tip et
+                        JOIN sessions parent ON parent.id = et.id
+                        JOIN sessions child ON child.id = (
+                            SELECT candidate.id
+                            FROM sessions candidate
+                            WHERE candidate.parent_session_id = parent.id
+                              AND json_extract(COALESCE(candidate.model_config, '{{}}'), '$._branched_from') IS NULL
+                              AND json_extract(COALESCE(candidate.model_config, '{{}}'), '$._delegate_from') IS NULL
+                              AND COALESCE(candidate.source, '') != 'tool'
+                            ORDER BY
+                              CASE
+                                WHEN candidate.end_reason = 'compression' THEN 0
+                                WHEN candidate.ended_at IS NULL THEN 1
+                                ELSE 2
+                              END,
+                              {_sql_session_last_active("candidate")} DESC,
+                              candidate.started_at DESC,
+                              candidate.id DESC
+                            LIMIT 1
+                        )
+                        WHERE parent.end_reason = 'compression'
+                          AND et.depth < 100
+                    )
+                    SELECT title
+                    FROM effective_tip
+                    ORDER BY depth DESC
+                    LIMIT 1
+                )), '') IS NOT NULL
+                """
+            )
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
         # Snapshot the filter params before the query builders below extend

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -268,6 +268,34 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_bare_resume_unnamed_rows_do_not_hide_named_sessions(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(text="/resume")
+        lane_key = _session_key_for_event(event)
+        for i in range(3):
+            sid = f"named_{i}"
+            db.create_session(
+                sid, "telegram", session_key=lane_key,
+                user_id="12345", chat_id="67890",
+            )
+            db.set_session_title(sid, f"Named Work {i}")
+        for i in range(12):
+            db.create_session(
+                f"unnamed_{i}", "telegram", session_key=lane_key,
+                user_id="12345", chat_id="67890",
+            )
+
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Named Work 0" in result
+        assert "Named Work 1" in result
+        assert "Named Work 2" in result
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_bare_resume_admin_all_preserves_same_platform_widening(self, tmp_path):
         from hermes_state import SessionDB
 

--- a/tests/hermes_cli/test_session_listing.py
+++ b/tests/hermes_cli/test_session_listing.py
@@ -159,3 +159,36 @@ class TestQuerySessionListingLaneScope:
             assert [row["id"] for row in rows] == ["named_2", "named_1"]
         finally:
             db.close()
+
+    def test_titled_compression_tip_survives_named_listing_filter(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "named-compression-tip.db")
+        lane_key = "agent:main:telegram:dm:lane"
+        try:
+            db.create_session("root", "telegram", session_key=lane_key)
+            db.set_session_title("root", "Old Chat")
+            db.end_session("root", end_reason="compression")
+            db.create_session(
+                "tip",
+                "telegram",
+                session_key=lane_key,
+                parent_session_id="root",
+            )
+            # Reusing the lineage title transfers it from the hidden root to
+            # the surfaced continuation tip.
+            db.set_session_title("tip", "Old Chat")
+            assert db.get_session("root")["title"] is None
+
+            rows = query_session_listing(
+                db,
+                source="telegram",
+                session_key=lane_key,
+                limit=10,
+            )
+
+            assert [(row["id"], row["title"]) for row in rows] == [
+                ("tip", "Old Chat")
+            ]
+        finally:
+            db.close()

--- a/tests/hermes_cli/test_session_listing.py
+++ b/tests/hermes_cli/test_session_listing.py
@@ -135,3 +135,27 @@ class TestQuerySessionListingLaneScope:
         )
 
         assert [row["id"] for row in rows] == ["foreign_59"]
+
+    def test_unnamed_rows_do_not_consume_named_listing_limit(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "named-window.db")
+        lane_key = "agent:main:telegram:dm:lane"
+        try:
+            for i in range(3):
+                sid = f"named_{i}"
+                db.create_session(sid, "telegram", session_key=lane_key)
+                db.set_session_title(sid, f"Named {i}")
+            for i in range(50):
+                db.create_session(f"unnamed_{i}", "telegram", session_key=lane_key)
+
+            rows = query_session_listing(
+                db,
+                source="telegram",
+                session_key=lane_key,
+                limit=2,
+            )
+
+            assert [row["id"] for row in rows] == ["named_2", "named_1"]
+        finally:
+            db.close()


### PR DESCRIPTION
## What does this PR do?

Gateway `/resume` and the default `/sessions` browser now return the requested window of named conversations even when newer unnamed sessions exist. The database applies a titled-only predicate before LIMIT/OFFSET, so unnamed desktop or gateway rows no longer make older named sessions undiscoverable.

### Symptom

When recent unnamed sessions fill the database result window, `/resume` and `/sessions` list only a few named sessions or report that none exist, even though older named conversations remain directly resumable.

### Impact

Users cannot discover older named conversations from gateway pickers and must already know an exact title or session ID to resume them.

### Bug Cause

**Trigger:** `gateway/slash_commands.py` in `_list_titled_sessions` and `hermes_cli/session_listing.py` in `query_session_listing` when unnamed rows sort ahead of named rows.

**Causal chain:**
1. A user accumulates more recent unnamed sessions than the listing fetch window.
2. `SessionDB.list_sessions_rich` applies LIMIT before callers discard rows without titles.
3. Older named conversations fall outside the fetched window and disappear from `/resume` and `/sessions` browsing.

**Why it is wrong:** pagination must apply to the user-visible named result set, not to an intermediate set containing rows the picker will discard.

**Working sibling / contrast:** direct `/resume <Title>` resolution does not use the paginated listing and continues to resolve older named sessions.

**Ruled out:** session ownership and source scoping are not the cause; regression coverage uses the same source and exact gateway lane while varying only whether recent rows have titles.

### Fix

Add a `titled_only` database-listing option that excludes null, empty, and whitespace-only titles in SQL before pagination. Use it for bare `/resume` and default shared session listings while preserving `/sessions full` and search behavior.

## Related Issue

Closes #92134

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` - add SQL-level titled-only filtering before LIMIT/OFFSET.
- `hermes_cli/session_listing.py` - request titled-only rows for default named browsing.
- `gateway/slash_commands.py` - request titled-only rows for `/resume` picker and numeric selection.
- `tests/hermes_cli/test_session_listing.py` - cover named pagination behind a large unnamed window.
- `tests/gateway/test_resume_command.py` - cover the gateway `/resume` symptom through the real session database facade.

## How to Test

1. Create several named sessions in one gateway lane.
2. Create more recent unnamed sessions than the picker window.
3. Run `/resume` or `/sessions` and verify the older named sessions remain listed.
4. Run:

```bash
scripts/run_tests.sh tests/hermes_cli/test_session_listing.py tests/gateway/test_resume_command.py -q
```

Result: 35 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A beyond the public method docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
