### PR TITLE
fix(cron): keep prefixed jobs out of each other run history

### DIFF
--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -87,9 +87,10 @@ class SessionPortabilityMixin:
         endpoint time out before it eventually populates).
 
         Instead this binds to one job with a ``[prefix, prefix_hi)`` range over
-        the id (an index range scan, not a ``%...%`` substring), filters
-        ``source='cron'``, and orders by ``started_at DESC``. Work scales with
-        the requested window, not the total cron history.
+        the id (an index range scan, not a ``%...%`` substring), then requires
+        the remainder to match the scheduler's exact timestamp shape. The
+        latter prevents an underscore-extended job id from sharing the range.
+        Work scales with the requested window, not the total cron history.
 
         Returns the same enriched row shape as ``list_sessions_rich`` (adds
         ``preview`` + ``last_active``) so callers can reuse it.
@@ -100,6 +101,7 @@ class SessionPortabilityMixin:
         # with ``prefix`` and nothing else. ``prefix`` always ends in '_', but
         # compute it generically rather than hardcoding the successor char.
         prefix_hi = prefix[:-1] + chr(ord(prefix[-1]) + 1)
+        timestamp_glob = "[0-9]" * 8 + "_" + "[0-9]" * 6
 
         query = f"""
             SELECT s.*,
@@ -116,11 +118,14 @@ class SessionPortabilityMixin:
             FROM sessions s
             LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash
             WHERE s.source = 'cron' AND s.id >= ? AND s.id < ?
+              AND substr(s.id, length(?) + 1) GLOB ?
             ORDER BY s.started_at DESC, s.id DESC
             LIMIT ? OFFSET ?
         """
         with self._lock:
-            cursor = self._conn.execute(query, (prefix, prefix_hi, limit, offset))
+            cursor = self._conn.execute(
+                query, (prefix, prefix_hi, prefix, timestamp_glob, limit, offset)
+            )
             rows = cursor.fetchall()
 
         runs: List[Dict[str, Any]] = []

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3838,7 +3838,7 @@ class TestListCronJobRuns:
     """
 
     def _seed_run(self, db, job_id: str, idx: int, started_at: float):
-        sid = f"cron_{job_id}_{idx:08d}"
+        sid = f"cron_{job_id}_20240101_{idx:06d}"
         db.create_session(session_id=sid, source="cron")
         db.append_message(sid, role="user", content=f"run {idx} for {job_id}")
         db.append_message(sid, role="assistant", content="done")
@@ -3868,6 +3868,16 @@ class TestListCronJobRuns:
         # Enriched like list_sessions_rich.
         assert runs[0]["preview"].startswith("run 4 for alpha")
         assert runs[0]["last_active"] >= runs[0]["started_at"]
+
+    def test_underscore_extended_job_id_does_not_leak_into_parent_history(self, db):
+        base = 1_700_000_000.0
+        own_run = self._seed_run(db, "backup", 1, base)
+        self._seed_run(db, "backup_weekly", 2, base + 60)
+
+        # The colliding job is newer, so filtering must happen before LIMIT.
+        runs = db.list_cron_job_runs("backup", limit=1)
+
+        assert [run["id"] for run in runs] == [own_run]
 
 
 


### PR DESCRIPTION
## What does this PR do?

Cron run history now returns only sessions owned by the requested job when another job id extends it with an underscore. Without this fix, jobs such as `backup` and `backup_weekly` share history entries, which corrupts counts, previews, ordering, and pagination.

### Symptom

Opening run history for `backup` also returns newer runs created by `backup_weekly`.

### Impact

Operators with underscore-prefix job ids see incorrect run histories in shared cron history consumers, including the desktop cron details view.

### Bug Cause

**Trigger:** `hermes_state_portability.py:72` / `SessionPortabilityMixin.list_cron_job_runs` / a job id is an underscore-prefix of another job id.

**Causal chain:**
1. The history query creates a lexicographic range for `cron_{job_id}_`.
2. A session id for an extended job, such as `cron_backup_weekly_20240101_000002`, falls inside the same range.
3. The query applies `LIMIT` and `OFFSET` before distinguishing ownership, so the parent job receives the extended job rows.

**Why it is wrong:** Prefix membership is not equivalent to job ownership because job ids may contain underscores.

**Working sibling / contrast:** Unrelated job ids such as `backup` and `report` occupy disjoint ranges and do not leak into each other.

**Ruled out:** The execution ledger is not involved; the affected endpoint reads session-backed history through `SessionDB.list_cron_job_runs`.

### Fix

Keep the index-friendly id range, then require the remaining id suffix to match the scheduler exact `YYYYMMDD_HHMMSS` shape in SQL before pagination. Regression fixtures now use production-shaped session ids and cover a newer underscore-extended job competing for a limited history page.

## Related Issue

Closes #92133

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_state_portability.py` - filter candidate run sessions by the exact scheduler timestamp suffix before ordering and pagination.
- `tests/test_hermes_state.py` - use production-shaped cron run ids and cover underscore-prefix isolation under `LIMIT`.

## How to Test

1. Seed cron sessions for jobs `backup` and `backup_weekly`, with the extended job run newer than the parent job run.
2. Request one run for `backup` and confirm only `cron_backup_YYYYMMDD_HHMMSS` is returned.
3. Run `scripts/run_tests.sh tests/test_hermes_state.py -q`.

Local result: 238 passed, 2 skipped.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the relevant tests and all tests pass
- [x] I added tests for my changes
- [x] I tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation and docstrings are updated or N/A
- [x] Configuration examples are updated or N/A
- [x] Architecture documentation is updated or N/A
- [x] Cross-platform impact was considered
- [x] Tool descriptions and schemas are updated or N/A

## Screenshots / Logs

```text
238 passed, 2 skipped
```