### PR TITLE
fix(cron): decode Bot Chat subprocess output as UTF-8

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2497,6 +2497,8 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_get_bot_chat_delivery_timeout(),
             env=env,
             creationflags=windows_hide_flags(),

--- a/tests/cron/test_cron_bot_chat_delivery.py
+++ b/tests/cron/test_cron_bot_chat_delivery.py
@@ -140,6 +140,8 @@ def test_deliver_runs_canonical_bot_chat_lane():
     assert "--create-if-missing" in argv
     assert "-Q" in argv
     assert "--query-file" in argv
+    assert calls["kwargs"]["encoding"] == "utf-8"
+    assert calls["kwargs"]["errors"] == "replace"
     # Message rides a temp file, never inline argv (quote/expansion safety).
     assert not any("the output" in str(a) for a in argv)
 


### PR DESCRIPTION
## Summary
- decode cron-to-Bot-Chat subprocess output as UTF-8 on every platform
- replace unexpected bytes instead of letting Windows locale decoding crash a reader thread
- cover the subprocess contract in the existing Bot Chat delivery test

This fixes manual cron runs on Windows where `text=True` inherited cp1252 and raised `UnicodeDecodeError` while reading UTF-8 Bot Chat output.

## Test plan
- `scripts/run_tests.sh tests/cron/test_cron_bot_chat_delivery.py -q` (17 passed)
- `ruff check cron/scheduler.py tests/cron/test_cron_bot_chat_delivery.py`