### PR TITLE
fix(telegram): close standalone Bot clients after sends

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -724,6 +724,7 @@ class TestSendTelegramHtmlDetection:
     def _make_bot(self):
         bot = MagicMock()
         bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        bot.shutdown = AsyncMock()
         bot.send_photo = AsyncMock()
         bot.send_video = AsyncMock()
         bot.send_voice = AsyncMock()
@@ -743,6 +744,7 @@ class TestSendTelegramHtmlDetection:
         kwargs = bot.send_message.await_args.kwargs
         assert kwargs["parse_mode"] == "HTML"
         assert kwargs["text"] == "<b>Hello</b> world"
+        bot.shutdown.assert_awaited_once()
 
 
     def test_transient_bad_gateway_retries_text_send(self, monkeypatch):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1339,6 +1339,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     already contains HTML tags, it is sent with ``parse_mode='HTML'``
     instead, bypassing MarkdownV2 conversion.
     """
+    bot = None
     try:
         from telegram import Bot
         from telegram.constants import ParseMode
@@ -1649,6 +1650,12 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return {"error": "python-telegram-bot not installed. Run: pip install python-telegram-bot"}
     except Exception as e:
         return _error(f"Telegram send failed: {e}")
+    finally:
+        if bot is not None:
+            try:
+                await bot.shutdown()
+            except Exception:
+                logger.debug("Telegram standalone bot shutdown failed", exc_info=True)
 
 
 # _send_slack moved to the slack plugin as _standalone_send


### PR DESCRIPTION
## Summary
- always shut down the one-shot Telegram Bot client after standalone sends
- run cleanup on success, delivery failure, and early-return paths
- keep cleanup best-effort so it cannot replace the real send result
- assert client shutdown in the existing Telegram send test

This prevents `Unclosed client session` warnings after manual cron and other standalone Telegram deliveries.

## Test plan
- `scripts/run_tests.sh tests/tools/test_send_message_tool.py -q` (48 passed)
- `ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py`