### PR TITLE
fix(terminal-env): block dashboard basic-auth/OIDC/drain secrets from subprocess env

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -231,6 +231,45 @@ class TestProviderEnvBlocklist:
         for var in leaked_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
 
+    def test_dashboard_basic_auth_vars_are_stripped(self):
+        """dashboard_auth/basic provider credentials must not leak into
+        subprocess env.
+
+        Regression: HERMES_DASHBOARD_SESSION_TOKEN (the opaque per-session
+        token) was blocked, but the four env vars the ``basic`` dashboard
+        auth provider itself reads (plugins/dashboard_auth/basic/__init__.py)
+        were not: HERMES_DASHBOARD_BASIC_AUTH_SECRET, _PASSWORD_HASH,
+        _PASSWORD, and _USERNAME. SECRET is the HMAC key that signs every
+        dashboard session token (_sign()/_unsign()) — a terminal command
+        that can read it can forge an arbitrary admin session offline and
+        bypass dashboard login entirely, confirmed exploitable against a
+        live dashboard (not theoretical). PASSWORD_HASH/PASSWORD are the
+        stored/plaintext-fallback login credential itself.
+        """
+        leaked_vars = {
+            "HERMES_DASHBOARD_BASIC_AUTH_SECRET": "hmac-signing-secret",
+            "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH": "scrypt$16384$8$1$salt$hash",
+            "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD": "plaintext-fallback-password",
+            "HERMES_DASHBOARD_BASIC_AUTH_USERNAME": "admin",
+        }
+        result_env = _run_with_env(extra_os_env=leaked_vars)
+
+        for var in leaked_vars:
+            assert var not in result_env, f"{var} leaked into subprocess env"
+
+    def test_dashboard_oidc_and_drain_secrets_are_stripped(self):
+        """dashboard_auth/self_hosted (OIDC) and dashboard_auth/drain
+        secrets must not leak into subprocess env — same class of gap as
+        the basic-auth vars above, closed in the same pass."""
+        leaked_vars = {
+            "HERMES_DASHBOARD_OIDC_CLIENT_SECRET": "oidc-confidential-secret",
+            "HERMES_DASHBOARD_DRAIN_SECRET": "drain-bearer-secret",
+        }
+        result_env = _run_with_env(extra_os_env=leaked_vars)
+
+        for var in leaked_vars:
+            assert var not in result_env, f"{var} leaked into subprocess env"
+
     def test_safe_vars_are_preserved(self):
         """Standard env vars (PATH, HOME, USER) must still be passed through."""
         result_env = _run_with_env()

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -306,6 +306,29 @@ def _build_provider_env_blocklist() -> frozenset:
         "EMAIL_HOME_ADDRESS",
         "EMAIL_HOME_ADDRESS_NAME",
         "HERMES_DASHBOARD_SESSION_TOKEN",
+        # dashboard_auth/basic provider (plugins/dashboard_auth/basic) —
+        # HERMES_DASHBOARD_BASIC_AUTH_SECRET is the HMAC key that SIGNS every
+        # dashboard session token (see _sign()/_unsign() in that plugin). A
+        # model-authored shell command that can read this value can forge an
+        # arbitrary admin session offline and bypass dashboard login entirely
+        # — confirmed exploitable in practice, not theoretical (a terminal
+        # session with this var present minted a token accepted by a live
+        # dashboard on protected endpoints). PASSWORD_HASH is a scrypt hash
+        # of the login password (offline-crackable if leaked) and PASSWORD is
+        # the plaintext fallback; both are credential material the same as
+        # any other provider's stored password. USERNAME is included too —
+        # it halves the credential-guessing search space and mirrors the
+        # EMAIL_ADDRESS precedent above (identifier alongside its secret is
+        # blocked as a pair, not just the secret half).
+        "HERMES_DASHBOARD_BASIC_AUTH_SECRET",
+        "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH",
+        "HERMES_DASHBOARD_BASIC_AUTH_PASSWORD",
+        "HERMES_DASHBOARD_BASIC_AUTH_USERNAME",
+        # dashboard_auth/self_hosted (OIDC) — confidential-client secret.
+        "HERMES_DASHBOARD_OIDC_CLIENT_SECRET",
+        # dashboard_auth/drain — shared bearer secret for the gateway
+        # drain-control endpoint (NAS-provisioned, >=256-bit).
+        "HERMES_DASHBOARD_DRAIN_SECRET",
         "GATEWAY_ALLOWED_USERS",
         "GH_TOKEN",
         "GITHUB_APP_ID",


### PR DESCRIPTION
## Summary

`HERMES_DASHBOARD_BASIC_AUTH_SECRET` — the HMAC key that signs every dashboard
session token (`plugins/dashboard_auth/basic/__init__.py`, `_sign`/`_unsign`)
— was missing from the terminal-subprocess env blocklist in
`tools/environments/local.py`. Only the *derived* token
(`HERMES_DASHBOARD_SESSION_TOKEN`) was blocked, not the credential that mints
it, along with three siblings from the same provider and two from other
dashboard-auth providers.

**This is not theoretical.** On a self-hosted deployment running the
`basic` dashboard auth provider, a terminal session inherited
`HERMES_DASHBOARD_BASIC_AUTH_SECRET` from the gateway process environment.
Using the exact HMAC scheme from the plugin's own source, a forged admin
session token was minted offline and submitted as the `hermes_session_at`
cookie against the live dashboard — accepted (`200`, not redirected to
`/login`), and verified against real protected endpoints:

| Endpoint | Without cookie | With forged cookie |
|---|---|---|
| `/api/sessions` | 401 | **200** |
| `/api/profiles` | 401 | **200** |
| `/api/skills` | 401 | **200** |

Any terminal command run by the agent — on any Hermes install using
`dashboard.basic_auth` with terminal/execute_code tools enabled — can read
this var from its own environment and self-escalate to full dashboard admin
access, bypassing login entirely.

## What's added to the blocklist

- `HERMES_DASHBOARD_BASIC_AUTH_SECRET` — HMAC signing key (the exploit above)
- `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH` — stored scrypt hash of the login password
- `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD` — plaintext-fallback login password
- `HERMES_DASHBOARD_BASIC_AUTH_USERNAME` — paired with the above per the existing `EMAIL_ADDRESS`-alongside-`EMAIL_PASSWORD` precedent in the same list
- `HERMES_DASHBOARD_OIDC_CLIENT_SECRET` — `dashboard_auth/self_hosted` confidential-client secret (same class of gap, found auditing this)
- `HERMES_DASHBOARD_DRAIN_SECRET` — `dashboard_auth/drain` shared bearer secret for the gateway drain-control endpoint

## Test plan

- [x] Two new regression tests added to `tests/tools/test_local_env_blocklist.py`, mirroring the existing Bedrock (#32314) and Vertex regression-test style in the same file
- [x] Full file: `78 passed, 3 skipped` (skips are pre-existing Windows-only tests)
- [x] Live-verified: after applying the corresponding config-side fix (moving these values from `.env` to `config.yaml`, which this blocklist doesn't affect either way) the old leaked secret was confirmed dead against a running dashboard (`401` where it previously returned `200`)

## Remediation on the affected install

Independent of this code fix, the affected device rotated its
`dashboard.basic_auth.secret` and moved credentials from `.env` to
`config.yaml` (the plugin's documented config-file path, which never enters
process environment variables) — that's an operational fix, not a substitute
for closing this gap in the shared codebase.
