### PR TITLE
feat(usage): record per-API-call usage detail for accurate hourly/daily bucketing

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7740,6 +7740,38 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 now,
             ),
         )
+        # Per-API-call detail: one row per call with the exact timestamp, so
+        # analytics can bucket usage by hour/day without the last_seen drift of
+        # the aggregate row.  Same transaction, best-effort (never abort the
+        # aggregate accounting if this write fails).
+        try:
+            conn.execute(
+                """INSERT INTO api_call_usage (
+                       session_id, ts, model, billing_provider, billing_base_url,
+                       billing_mode, task, api_call_count, input_tokens, output_tokens,
+                       cache_read_tokens, cache_write_tokens, reasoning_tokens,
+                       estimated_cost_usd, actual_cost_usd
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    now,
+                    eff_model,
+                    eff_provider,
+                    eff_base_url,
+                    eff_billing_mode,
+                    task or "",
+                    api_call_count or 1,
+                    input_tokens or 0,
+                    output_tokens or 0,
+                    cache_read_tokens or 0,
+                    cache_write_tokens or 0,
+                    reasoning_tokens or 0,
+                    float(estimated_cost_usd or 0.0),
+                    float(actual_cost_usd or 0.0),
+                ),
+            )
+        except Exception:
+            pass  # best-effort — never let the detail write fail accounting
 
     def ensure_session(
         self,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7771,7 +7771,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 ),
             )
         except Exception:
-            pass  # best-effort — never let the detail write fail accounting
+            logger.debug("api_call_usage insert failed for session %s", session_id, exc_info=True)
 
     def ensure_session(
         self,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -365,6 +365,35 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
     PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
 );
 
+-- Per-API-call usage detail: one row per LLM call, carrying the precise
+-- timestamp so analytics can bucket by hour/day accurately.  The aggregate
+-- session_model_usage table only keeps per-(session,model,route,task)
+-- cumulative totals plus last_seen (the time of the MOST RECENT call in that
+-- bucket); a long-lived session spanning many hours would otherwise have its
+-- entire volume attributed to the final hour.  Written from the same
+-- chokepoint (_record_model_usage) in the same transaction as the aggregate.
+CREATE TABLE IF NOT EXISTS api_call_usage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    ts REAL NOT NULL,
+    model TEXT NOT NULL DEFAULT '',
+    billing_provider TEXT NOT NULL DEFAULT '',
+    billing_base_url TEXT NOT NULL DEFAULT '',
+    billing_mode TEXT NOT NULL DEFAULT '',
+    task TEXT NOT NULL DEFAULT '',
+    api_call_count INTEGER NOT NULL DEFAULT 1,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+    reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+    estimated_cost_usd REAL NOT NULL DEFAULT 0,
+    actual_cost_usd REAL NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_api_call_usage_ts ON api_call_usage(ts);
+CREATE INDEX IF NOT EXISTS idx_api_call_usage_model ON api_call_usage(model, ts);
+CREATE INDEX IF NOT EXISTS idx_api_call_usage_session ON api_call_usage(session_id, ts);
+
 CREATE TABLE IF NOT EXISTS state_meta (
     key TEXT PRIMARY KEY,
     value TEXT

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -372,6 +372,11 @@ CREATE TABLE IF NOT EXISTS session_model_usage (
 -- bucket); a long-lived session spanning many hours would otherwise have its
 -- entire volume attributed to the final hour.  Written from the same
 -- chokepoint (_record_model_usage) in the same transaction as the aggregate.
+--
+-- Growth note: one row per LLM call is unbounded.  A busy gateway profile
+-- can generate millions of rows/year (plus 3 index entries per insert).
+-- Operators should pair this with a retention rule (prune rows older than
+-- N days during startup/VACUUM maintenance) or monitor state.db size.
 CREATE TABLE IF NOT EXISTS api_call_usage (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
@@ -381,6 +386,9 @@ CREATE TABLE IF NOT EXISTS api_call_usage (
     billing_base_url TEXT NOT NULL DEFAULT '',
     billing_mode TEXT NOT NULL DEFAULT '',
     task TEXT NOT NULL DEFAULT '',
+    -- Normally 1 (one row = one LLM call).  Values > 1 indicate a batched
+    -- delta where multiple identical calls were collapsed into one insert;
+    -- analytics summing tokens should multiply by api_call_count.
     api_call_count INTEGER NOT NULL DEFAULT 1,
     input_tokens INTEGER NOT NULL DEFAULT 0,
     output_tokens INTEGER NOT NULL DEFAULT 0,

--- a/tests/state/test_api_call_usage_invariant.py
+++ b/tests/state/test_api_call_usage_invariant.py
@@ -1,0 +1,156 @@
+"""Invariant test: api_call_usage detail rows must reconcile with session_model_usage aggregate.
+
+Both tables are written from the same chokepoint (_record_model_usage) inside
+the same transaction.  This test asserts the fundamental consistency
+invariant:
+
+    sum(detail.tokens)  ==  aggregate.tokens
+
+for every (session, model, provider, base_url, billing_mode, task) bucket
+fully inside the recorded window.  Any future drift (e.g. a third write path
+that touches only one table) would break this invariant and fail the test.
+"""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+class TestApiCallUsageInvariant:
+    """Aggregate and detail tables must stay consistent by construction."""
+
+    def test_detail_sums_match_aggregate(self, tmp_path):
+        """sum(detail) == aggregate for each bucket after multiple calls."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session("s1", "cli", model="m1")
+            # Simulate three incremental API calls on the same route.
+            db.update_token_counts(
+                "s1", input_tokens=100, output_tokens=50,
+                model="m1", billing_provider="prov",
+                api_call_count=1,
+            )
+            db.update_token_counts(
+                "s1", input_tokens=200, output_tokens=80,
+                model="m1", billing_provider="prov",
+                api_call_count=1,
+            )
+            db.update_token_counts(
+                "s1", input_tokens=50, output_tokens=20,
+                model="m1", billing_provider="prov",
+                api_call_count=1,
+            )
+
+            agg = db._conn.execute(
+                "SELECT input_tokens, output_tokens, api_call_count "
+                "FROM session_model_usage "
+                "WHERE session_id=? AND model=?",
+                ("s1", "m1"),
+            ).fetchone()
+            assert agg is not None
+
+            detail = db._conn.execute(
+                "SELECT "
+                "  COALESCE(SUM(input_tokens), 0), "
+                "  COALESCE(SUM(output_tokens), 0), "
+                "  COALESCE(SUM(api_call_count), 0) "
+                "FROM api_call_usage "
+                "WHERE session_id=? AND model=?",
+                ("s1", "m1"),
+            ).fetchone()
+            assert detail is not None
+
+            assert detail[0] == agg["input_tokens"]
+            assert detail[1] == agg["output_tokens"]
+            assert detail[2] == agg["api_call_count"]
+        finally:
+            db.close()
+
+    def test_detail_rows_count_matches_calls(self, tmp_path):
+        """Each update_token_counts call produces exactly one detail row."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session("s2", "cli", model="m2")
+            for _ in range(5):
+                db.update_token_counts(
+                    "s2", input_tokens=10,
+                    model="m2", billing_provider="prov",
+                    api_call_count=1,
+                )
+            count = db._conn.execute(
+                "SELECT COUNT(*) FROM api_call_usage WHERE session_id=?",
+                ("s2",),
+            ).fetchone()[0]
+            assert count == 5
+        finally:
+            db.close()
+
+    def test_different_models_tracked_separately(self, tmp_path):
+        """Calls on different models produce separate detail and aggregate rows."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session("s3", "cli", model="m-a")
+            db.update_token_counts(
+                "s3", input_tokens=100,
+                model="m-a", billing_provider="prov",
+                api_call_count=1,
+            )
+            db.update_token_counts(
+                "s3", input_tokens=200,
+                model="m-b", billing_provider="prov",
+                api_call_count=1,
+            )
+
+            for model, expected_input in (("m-a", 100), ("m-b", 200)):
+                agg = db._conn.execute(
+                    "SELECT input_tokens FROM session_model_usage "
+                    "WHERE session_id=? AND model=?",
+                    ("s3", model),
+                ).fetchone()
+                detail_sum = db._conn.execute(
+                    "SELECT SUM(input_tokens) FROM api_call_usage "
+                    "WHERE session_id=? AND model=?",
+                    ("s3", model),
+                ).fetchone()[0]
+                assert agg["input_tokens"] == expected_input
+                assert detail_sum == expected_input
+        finally:
+            db.close()
+
+    def test_cost_reconciliation(self, tmp_path):
+        """Estimated and actual costs also reconcile between detail and aggregate."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session("s4", "cli", model="m4")
+            db.update_token_counts(
+                "s4", input_tokens=100,
+                model="m4", billing_provider="prov",
+                api_call_count=1,
+                estimated_cost_usd=0.05,
+                actual_cost_usd=0.04,
+            )
+            db.update_token_counts(
+                "s4", input_tokens=200,
+                model="m4", billing_provider="prov",
+                api_call_count=1,
+                estimated_cost_usd=0.10,
+                actual_cost_usd=0.08,
+            )
+            agg = db._conn.execute(
+                "SELECT estimated_cost_usd, actual_cost_usd "
+                "FROM session_model_usage "
+                "WHERE session_id=? AND model=?",
+                ("s4", "m4"),
+            ).fetchone()
+            detail = db._conn.execute(
+                "SELECT "
+                "  ROUND(SUM(estimated_cost_usd), 6), "
+                "  ROUND(SUM(actual_cost_usd), 6) "
+                "FROM api_call_usage "
+                "WHERE session_id=? AND model=?",
+                ("s4", "m4"),
+            ).fetchone()
+            assert detail[0] == pytest.approx(agg["estimated_cost_usd"])
+            assert detail[1] == pytest.approx(agg["actual_cost_usd"])
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary
`session_model_usage` aggregates per-(session, model, route, task) cumulative totals but only keeps `last_seen` — the time of the **most recent** call in that bucket. A long-lived session spanning many hours (measured: 18–44h, 94.7% of a day's tokens in 4 such rows) gets its **entire volume attributed to the final hour**, making hourly/daily token analytics drift badly.

This PR adds an `api_call_usage` detail table: **one row per LLM call** with the exact `ts`, written from the same chokepoint (`_record_model_usage`, where both the main loop's `update_token_counts` and auxiliary `record_auxiliary_usage` converge) in the **same transaction** as the aggregate. Consumers can now bucket usage by hour/day accurately, and still fall back to the aggregate for pre-upgrade history.

## Changes
- **`hermes_state_common.py`**: new `api_call_usage` table (id, session_id FK, ts, model, provider/base_url/mode, task, api_call_count, all token counters, cost) + 3 indexes (ts, model+ts, session+ts). Declarative `CREATE TABLE IF NOT EXISTS` in `SCHEMA_SQL`, so existing DBs self-heal on next open — no version-gated migration.
- **`hermes_state.py`**: `_record_model_usage` inserts one detail row per call alongside the aggregate upsert (best-effort; never aborts accounting on failure).

## Verification
- Tests: `tests/hermes_state/` + `test_aux_usage_accounting.py` + `test_session_model_usage_pk_heal.py` + `test_schema_read_probe.py` → **160 passed**; broader `tests/test_hermes_state.py` + `tests/state/` → **312 passed, 1 deselected** (pre-existing FTS5 env failure, reproduced on unmodified baseline).
- E2E: temp-DB schema + write + model-switch split verified; live call recorded detail tokens **exactly matching** the API `usage` response (in=20924/out=3), including an auxiliary `title_generation` row.

## Notes / boundaries
- Detail table only captures calls made **after** this code is live; older history remains in the aggregate (approximate, `last_seen`-bucketed). This is inherent — no backfill possible.
- During a mixed old/new process window, old processes still write the aggregate but not the detail table; the analytics layer blends detail (precise) + aggregate (fallback) and resolves once all processes restart.
- Per-call write cost is one extra INSERT with 3 indexed columns — negligible; the `ts` index keeps range queries fast.
