### PR TITLE
fix(desktop): debounce zoom reassert on Linux/Wayland focus events

### DIFF
--- a/apps/desktop/electron/zoom.test.ts
+++ b/apps/desktop/electron/zoom.test.ts
@@ -13,6 +13,7 @@ import {
   clampZoomLevel,
   DEFAULT_ZOOM_LEVEL,
   installZoomReassertOnWindowEvents,
+  isDebouncedReassertEvent,
   percentToZoomLevel,
   ZOOM_RESIZE_REASSERT_DELAY_MS,
   ZOOM_STEP,
@@ -101,7 +102,7 @@ test('installZoomReassertOnWindowEvents wires show, restore, focus, resize, and 
   assert.equal(calls, 5)
 })
 
-test('focus event reasserts zoom immediately without debounce (Windows high-DPI alt-tab, #50837)', () => {
+test('focus event reasserts zoom immediately without debounce on Windows (high-DPI alt-tab, #50837)', () => {
   const handlers = new Map()
 
   const win = {
@@ -120,12 +121,22 @@ test('focus event reasserts zoom immediately without debounce (Windows high-DPI 
     'win32'
   )
 
-  // focus should trigger immediate reassert — no timer involved
+  // focus on Windows triggers immediate reassert — no timer involved
   handlers.get('focus')()
   assert.equal(calls, 1)
 })
 
-test('installZoomReassertOnWindowEvents debounces Linux resize and move events at the trailing edge', () => {
+test('isDebouncedReassertEvent debounces focus only on Linux, not Windows/macOS', () => {
+  assert.equal(isDebouncedReassertEvent('focus', 'linux'), true)
+  assert.equal(isDebouncedReassertEvent('focus', 'win32'), false)
+  assert.equal(isDebouncedReassertEvent('focus', 'darwin'), false)
+  assert.equal(isDebouncedReassertEvent('resize', 'linux'), true)
+  assert.equal(isDebouncedReassertEvent('resize', 'win32'), true)
+  assert.equal(isDebouncedReassertEvent('show', 'linux'), false)
+  assert.equal(isDebouncedReassertEvent('restore', 'linux'), false)
+})
+
+test('installZoomReassertOnWindowEvents debounces Linux resize, move, and focus events at the trailing edge', () => {
   vi.useFakeTimers()
 
   try {
@@ -158,10 +169,18 @@ test('installZoomReassertOnWindowEvents debounces Linux resize and move events a
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
     assert.equal(calls, 1)
 
+    // focus on Linux is also debounced — a session switch fires focus but
+    // the reassert must not jump the zoom mid-interaction.
+    handlers.get('focus')()
+    vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
+    assert.equal(calls, 1)
+    vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS / 2)
+    assert.equal(calls, 2)
+
     handlers.get('resize')()
     destroyed = true
     vi.advanceTimersByTime(ZOOM_RESIZE_REASSERT_DELAY_MS)
-    assert.equal(calls, 1)
+    assert.equal(calls, 2)
   } finally {
     vi.useRealTimers()
   }

--- a/apps/desktop/electron/zoom.ts
+++ b/apps/desktop/electron/zoom.ts
@@ -71,6 +71,21 @@ export function zoomReassertWindowEvents(platform = process.platform) {
     : ['show', 'restore', 'focus', 'resized', 'moved']
 }
 
+// Linux/Wayland fires `focus` on intra-app focus shifts (sidebar clicks,
+// Ctrl+Tab session switching, tile activation) — not just the cross-app
+// alt-tab the Windows high-DPI immediate-reassert guard (#50837) targets.
+// An undebounced reassert on every such focus event re-applies the persisted
+// zoom level mid-interaction, producing a visible zoom/DPI jump when the
+// session switch fires focus before Chromium has settled. Debounce `focus`
+// alongside `resize`/`move` on Linux so the reassert only fires after the
+// window has stabilized; the Windows alt-tab DPI case keeps its immediate
+// path because `platform` is `win32` there.
+const DEBOUNCED_REASSERT_EVENTS = new Set(['resize', 'move'])
+
+export function isDebouncedReassertEvent(event, platform = process.platform) {
+  return DEBOUNCED_REASSERT_EVENTS.has(event) || (platform === 'linux' && event === 'focus')
+}
+
 export function installZoomReassertOnWindowEvents(win, reassert, platform = process.platform) {
   if (!win?.on) {
     return
@@ -84,7 +99,7 @@ export function installZoomReassertOnWindowEvents(win, reassert, platform = proc
         return
       }
 
-      if (event !== 'resize' && event !== 'move') {
+      if (!isDebouncedReassertEvent(event, platform)) {
         reassert()
 
         return


### PR DESCRIPTION
## Summary

On Linux/Wayland, Electron fires a `focus` event on intra-app focus shifts — sidebar clicks, Ctrl+Tab session switching, tile activation — not just the cross-app alt-tab the Windows high-DPI immediate-reassert guard (#50837) targets. The undebounced reassert on every such focus event re-applies the persisted zoom level mid-interaction, producing a visible zoom/DPI jump when the session switch fires focus before Chromium has settled.

## Fix

Extract `isDebouncedReassertEvent(event, platform)` so Linux debounces `focus` alongside `resize`/`move` (100ms trailing edge), while Windows and macOS keep the immediate path for alt-tab DPI re-evaluation.

### Before
```js
if (event !== 'resize' && event !== 'move') {
  reassert()        // immediate — fires on every Linux focus event
  return
}
```

### After
```js
if (!isDebouncedReassertEvent(event, platform)) {
  reassert()        // immediate on Windows/macOS; debounced on Linux
  return
}
```

## Test Plan
- [x] All 19 existing zoom tests pass (`npx vitest run electron/zoom.test.ts`)
- [x] New `isDebouncedReassertEvent` unit test covers the platform split (Linux debounces focus, Windows/macOS do not)
- [x] Linux debounce test extended to assert `focus` is debounced
- [x] Windows immediate-`focus` test stays green (unchanged behavior)
- [ ] Manual: switch sessions on Linux/Wayland — no visible zoom/DPI jump