### PR TITLE
fix(file-tools): stop active-profile instruction persistence from bypassing approval

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -581,6 +581,26 @@ class TestProtectedInstructionFiles:
         assert not res.get("error"), res
         assert approvals["calls"] == []
 
+    def test_relative_regular_file_in_real_hermes_home_not_gated(
+        self, tmp_path, approvals, monkeypatch
+    ):
+        import tools.file_tools as ft
+        fake_home = tmp_path / ".hermes"
+        fake_home.mkdir()
+        monkeypatch.setattr(
+            ft, "_get_real_hermes_home", lambda: str(fake_home.resolve())
+        )
+        monkeypatch.setattr(
+            ft,
+            "_resolve_base_dir",
+            lambda task_id, container_paths=None: tmp_path,
+        )
+
+        res = self._write(".hermes/scratch.txt", "ok")
+
+        assert not res.get("error"), res
+        assert approvals["calls"] == []
+
     def test_protected_basename_in_real_hermes_home_is_gated(
         self, tmp_path, approvals, monkeypatch
     ):

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -534,6 +534,28 @@ class TestProtectedInstructionFiles:
         res = self._write(proj / "config.yaml")
         assert res.get("error") and "BLOCKED" in res["error"]
 
+    def test_project_local_hermes_symlink_into_real_home_is_gated(
+        self, tmp_path, approvals, monkeypatch
+    ):
+        import tools.file_tools as ft
+        fake_home = tmp_path / "active" / ".hermes"
+        target = fake_home / "notes" / "config.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text("original", encoding="utf-8")
+        project_home = tmp_path / "project" / ".hermes"
+        project_home.mkdir(parents=True)
+        link = project_home / "config.yaml"
+        link.symlink_to(target)
+        monkeypatch.setattr(
+            ft, "_get_real_hermes_home", lambda: str(fake_home.resolve())
+        )
+        approvals["answer"] = "deny"
+
+        res = self._write(link, "injected")
+
+        assert res.get("error") and "BLOCKED" in res["error"]
+        assert target.read_text(encoding="utf-8") == "original"
+
     def test_checkout_nested_under_hermes_dir_not_gated(self, tmp_path, approvals):
         """A repo living UNDER a .hermes dir (e.g. ~/.hermes/hermes-agent)
         must not have every write gated — only files directly inside a

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -3,6 +3,7 @@
 Based on PR #1085 by ismoilh (salvaged).
 """
 
+import json
 import os
 from pathlib import Path
 
@@ -595,7 +596,9 @@ class TestProtectedInstructionFiles:
 
         assert res.get("error") and "BLOCKED" in res["error"]
         assert not (fake_home / "SOUL.md").exists()
-        assert str((fake_home / "SOUL.md").resolve()) in approvals["calls"][0]["command"]
+        assert json.dumps(
+            str((fake_home / "SOUL.md").resolve()), ensure_ascii=False
+        ) in approvals["calls"][0]["command"]
 
     def test_active_home_symlink_approval_names_alias_and_resolved_target(
         self, tmp_path, approvals, monkeypatch
@@ -616,8 +619,10 @@ class TestProtectedInstructionFiles:
 
         assert res.get("error") and "BLOCKED" in res["error"]
         command = approvals["calls"][0]["command"]
-        assert str(alias) in command
-        assert str(target.resolve()) in command
+        displayed = json.dumps(
+            f"{alias} -> {target.resolve()}", ensure_ascii=False
+        )
+        assert displayed in command
         assert target.read_text(encoding="utf-8") == "original"
 
     def test_extra_pattern_in_real_hermes_home_is_gated(
@@ -737,8 +742,8 @@ class TestProtectedInstructionFiles:
 
         assert res.get("error") and "BLOCKED" in res["error"]
         command = approvals["calls"][0]["command"]
-        assert str(project_agents.resolve()) in command
-        assert str(home_agents.resolve()) in command
+        assert json.dumps(str(project_agents.resolve()), ensure_ascii=False) in command
+        assert json.dumps(str(home_agents.resolve()), ensure_ascii=False) in command
         assert command.count("AGENTS.md") == 2
 
     # ---- gateway round-trip ----------------------------------------------

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -595,6 +595,30 @@ class TestProtectedInstructionFiles:
 
         assert res.get("error") and "BLOCKED" in res["error"]
         assert not (fake_home / "SOUL.md").exists()
+        assert str((fake_home / "SOUL.md").resolve()) in approvals["calls"][0]["command"]
+
+    def test_active_home_symlink_approval_names_alias_and_resolved_target(
+        self, tmp_path, approvals, monkeypatch
+    ):
+        import tools.file_tools as ft
+        fake_home = tmp_path / ".hermes"
+        fake_home.mkdir()
+        target = fake_home / "SOUL.md"
+        target.write_text("original", encoding="utf-8")
+        alias = tmp_path / "innocent.txt"
+        alias.symlink_to(target)
+        monkeypatch.setattr(
+            ft, "_get_real_hermes_home", lambda: str(fake_home.resolve())
+        )
+        approvals["answer"] = "deny"
+
+        res = self._write(alias, "injected")
+
+        assert res.get("error") and "BLOCKED" in res["error"]
+        command = approvals["calls"][0]["command"]
+        assert str(alias) in command
+        assert str(target.resolve()) in command
+        assert target.read_text(encoding="utf-8") == "original"
 
     def test_extra_pattern_in_real_hermes_home_is_gated(
         self, tmp_path, approvals, monkeypatch
@@ -678,6 +702,44 @@ class TestProtectedInstructionFiles:
         res = json.loads(patch_tool(mode="patch", patch=patch))
         assert not res.get("error"), res
         assert agents.read_text(encoding="utf-8") == "updated rules\n"
+
+    def test_patch_v4a_names_project_and_active_home_targets(
+        self, tmp_path, approvals, monkeypatch
+    ):
+        import json
+        import tools.file_tools as ft
+        from tools.file_tools import patch_tool
+        project_agents = tmp_path / "project" / "AGENTS.md"
+        project_agents.parent.mkdir()
+        project_agents.write_text("project rules\n", encoding="utf-8")
+        fake_home = tmp_path / ".hermes"
+        fake_home.mkdir()
+        home_agents = fake_home / "AGENTS.md"
+        home_agents.write_text("home rules\n", encoding="utf-8")
+        monkeypatch.setattr(
+            ft, "_get_real_hermes_home", lambda: str(fake_home.resolve())
+        )
+        patch = (
+            "*** Begin Patch\n"
+            f"*** Update File: {project_agents}\n"
+            "@@\n"
+            "-project rules\n"
+            "+changed project rules\n"
+            f"*** Update File: {home_agents}\n"
+            "@@\n"
+            "-home rules\n"
+            "+changed home rules\n"
+            "*** End Patch"
+        )
+        approvals["answer"] = "deny"
+
+        res = json.loads(patch_tool(mode="patch", patch=patch))
+
+        assert res.get("error") and "BLOCKED" in res["error"]
+        command = approvals["calls"][0]["command"]
+        assert str(project_agents.resolve()) in command
+        assert str(home_agents.resolve()) in command
+        assert command.count("AGENTS.md") == 2
 
     # ---- gateway round-trip ----------------------------------------------
 

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -544,10 +544,10 @@ class TestProtectedInstructionFiles:
         assert not res.get("error"), res
         assert approvals["calls"] == []
 
-    def test_real_hermes_home_not_gated_by_this_check(
+    def test_regular_file_in_real_hermes_home_not_gated_by_this_check(
         self, tmp_path, approvals, monkeypatch
     ):
-        """~/.hermes itself is governed by existing guards, not this gate."""
+        """Ordinary ~/.hermes files remain governed by the existing guards."""
         import tools.file_tools as ft
         fake_home = tmp_path / ".hermes"
         (fake_home / "notes").mkdir(parents=True)
@@ -557,6 +557,42 @@ class TestProtectedInstructionFiles:
         res = self._write(fake_home / "notes" / "scratch.txt", "ok")
         assert not res.get("error"), res
         assert approvals["calls"] == []
+
+    def test_protected_basename_in_real_hermes_home_is_gated(
+        self, tmp_path, approvals, monkeypatch
+    ):
+        import tools.file_tools as ft
+        fake_home = tmp_path / ".hermes"
+        fake_home.mkdir()
+        monkeypatch.setattr(
+            ft, "_get_real_hermes_home", lambda: str(fake_home.resolve())
+        )
+        approvals["answer"] = "deny"
+
+        res = self._write(fake_home / "SOUL.md")
+
+        assert res.get("error") and "BLOCKED" in res["error"]
+        assert not (fake_home / "SOUL.md").exists()
+
+    def test_extra_pattern_in_real_hermes_home_is_gated(
+        self, tmp_path, approvals, monkeypatch
+    ):
+        import tools.file_tools as ft
+        fake_home = tmp_path / ".hermes"
+        scripts = fake_home / "scripts"
+        scripts.mkdir(parents=True)
+        monkeypatch.setattr(
+            ft, "_get_real_hermes_home", lambda: str(fake_home.resolve())
+        )
+        monkeypatch.setattr(
+            ft, "_protected_instruction_config", lambda: (True, ["*_prerun.py"])
+        )
+        approvals["answer"] = "deny"
+
+        res = self._write(scripts / "nightly_prerun.py")
+
+        assert res.get("error") and "BLOCKED" in res["error"]
+        assert not (scripts / "nightly_prerun.py").exists()
 
     # ---- patch tool -----------------------------------------------------
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -805,15 +805,16 @@ def _protected_instruction_reason(filepath: str, task_id: str = "default",
     except (OSError, ValueError, RuntimeError):
         resolved = os.path.realpath(normalized)
 
-    # The authoritative ~/.hermes home is governed by its own guards
-    # (config.yaml hard-block, cross-profile guard, write_approval); this
-    # gate targets PROJECT-LOCAL instruction files only. Checked before the
-    # ``.hermes`` component rule below, which would otherwise match the
-    # home directory itself.
+    # The authoritative ~/.hermes home is governed by its own guards for
+    # ordinary files. Only exempt it from the broad ``.hermes`` parent rule
+    # below; protected basenames and configured patterns must still apply to
+    # live instruction files and pre-run scripts inside the active home.
     real_home = _get_real_hermes_home()
-    if real_home and (resolved == real_home
-                      or resolved.startswith(real_home + os.sep)):
-        return None
+    in_real_home = bool(
+        real_home
+        and (resolved == real_home
+             or resolved.startswith(real_home + os.sep))
+    )
 
     import fnmatch
     for candidate in (normalized, resolved):
@@ -824,6 +825,8 @@ def _protected_instruction_reason(filepath: str, task_id: str = "default",
         for pattern in extra_patterns:
             if fnmatch.fnmatch(base_lower, pattern.lower()):
                 return base
+        if in_real_home:
+            continue
         # Project-local .hermes config dirs (e.g. <repo>/.hermes/config.yaml)
         # are loaded as project context and steer behavior the same way.
         # Scope: the file's IMMEDIATE parent must be ``.hermes`` — matching

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -783,6 +783,36 @@ def _protected_instruction_config() -> tuple[bool, list[str]]:
     return enabled, [str(p) for p in extra if p]
 
 
+def _qualified_lexical_path(filepath: str, task_id: str = "default") -> str:
+    """Qualify a task path without dereferencing its final symlink."""
+    container_paths = _uses_container_paths(task_id)
+    expanded = _expand_tilde(filepath)
+    if container_paths:
+        return str(_normalize_without_host_deref(
+            expanded if posixpath.isabs(expanded)
+            else posixpath.join(
+                str(_resolve_base_dir(task_id, container_paths=True)), expanded
+            )
+        ))
+    if sys.platform == "win32":
+        from tools.environments.local import _msys_to_windows_path
+        import ntpath
+
+        expanded = _expand_tilde(_msys_to_windows_path(filepath))
+        return ntpath.normpath(
+            expanded if ntpath.isabs(expanded)
+            else ntpath.join(
+                str(_resolve_base_dir(task_id, container_paths=False)), expanded
+            )
+        )
+    return os.path.normpath(
+        expanded if os.path.isabs(expanded)
+        else os.path.join(
+            str(_resolve_base_dir(task_id, container_paths=False)), expanded
+        )
+    )
+
+
 def _protected_instruction_reason(filepath: str, task_id: str = "default",
                                   *, enabled: bool | None = None,
                                   extra_patterns: list[str] | None = None) -> str | None:
@@ -799,7 +829,10 @@ def _protected_instruction_reason(filepath: str, task_id: str = "default",
     if not enabled:
         return None
 
-    normalized = os.path.normpath(_expand_tilde(filepath))
+    try:
+        normalized = _qualified_lexical_path(filepath, task_id)
+    except (OSError, ValueError, RuntimeError):
+        normalized = os.path.abspath(os.path.normpath(_expand_tilde(filepath)))
     try:
         resolved = os.path.realpath(str(_resolve_path_for_task(filepath, task_id)))
     except (OSError, ValueError, RuntimeError):
@@ -842,43 +875,20 @@ def _protected_instruction_reason(filepath: str, task_id: str = "default",
 
 
 def _protected_instruction_approval_target(
-        filepath: str, task_id: str = "default") -> tuple[str, str]:
-    """Return the canonical identity and qualified display for an approved write."""
+        filepath: str, task_id: str = "default") -> tuple[str, str, bool]:
+    """Return canonical identity, qualified display, and alias status."""
     try:
-        container_paths = _uses_container_paths(task_id)
-        expanded = _expand_tilde(filepath)
-        if container_paths:
-            requested = _normalize_without_host_deref(
-                expanded if posixpath.isabs(expanded)
-                else posixpath.join(
-                    str(_resolve_base_dir(task_id, container_paths=True)), expanded
-                )
-            )
-        elif sys.platform == "win32":
-            from tools.environments.local import _msys_to_windows_path
-            import ntpath
-
-            expanded = _expand_tilde(_msys_to_windows_path(filepath))
-            requested = ntpath.normpath(
-                expanded if ntpath.isabs(expanded)
-                else ntpath.join(
-                    str(_resolve_base_dir(task_id, container_paths=False)), expanded
-                )
-            )
-        else:
-            requested = os.path.normpath(
-                expanded if os.path.isabs(expanded)
-                else os.path.join(
-                    str(_resolve_base_dir(task_id, container_paths=False)), expanded
-                )
-            )
+        requested = _qualified_lexical_path(filepath, task_id)
     except (OSError, ValueError, RuntimeError):
         requested = os.path.abspath(os.path.normpath(_expand_tilde(filepath)))
     canonical = os.path.realpath(requested)
-    display = requested
-    if os.path.normcase(requested) != os.path.normcase(canonical):
-        display = f"{requested} -> {canonical}"
-    return os.path.normcase(canonical), json.dumps(display, ensure_ascii=False)
+    is_alias = os.path.normcase(requested) != os.path.normcase(canonical)
+    display = f"{requested} -> {canonical}" if is_alias else requested
+    return (
+        os.path.normcase(canonical),
+        json.dumps(display, ensure_ascii=False),
+        is_alias,
+    )
 
 
 def _request_protected_instruction_approval(
@@ -993,18 +1003,22 @@ def _check_protected_instruction_write(paths: list[str],
     enabled, extra = _protected_instruction_config()
     if not enabled:
         return None
-    targets: dict[str, str] = {}
+    targets: dict[str, tuple[str, bool]] = {}
     for p in paths:
         reason = _protected_instruction_reason(
             p, task_id, enabled=enabled, extra_patterns=extra)
         if reason:
-            identity, display = _protected_instruction_approval_target(p, task_id)
+            identity, display, is_alias = _protected_instruction_approval_target(
+                p, task_id
+            )
             previous = targets.get(identity)
-            if previous is None or (" -> " in display and " -> " not in previous):
-                targets[identity] = display
+            if previous is None or (is_alias and not previous[1]):
+                targets[identity] = (display, is_alias)
     if not targets:
         return None
-    return _request_protected_instruction_approval(list(targets.values()), task_id)
+    return _request_protected_instruction_approval(
+        [display for display, _is_alias in targets.values()], task_id
+    )
 
 
 def _check_approval_required_write(paths: list[str],

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -841,8 +841,22 @@ def _protected_instruction_reason(filepath: str, task_id: str = "default",
     return None
 
 
+def _protected_instruction_approval_target(
+        filepath: str, task_id: str = "default") -> tuple[str, str]:
+    """Return the canonical identity and qualified display for an approved write."""
+    try:
+        requested = os.path.normpath(str(_resolve_path_for_task(filepath, task_id)))
+    except (OSError, ValueError, RuntimeError):
+        requested = os.path.abspath(os.path.normpath(_expand_tilde(filepath)))
+    canonical = os.path.realpath(requested)
+    display = requested
+    if os.path.normcase(requested) != os.path.normcase(canonical):
+        display = f"{requested} -> {canonical}"
+    return os.path.normcase(canonical), display
+
+
 def _request_protected_instruction_approval(
-        reasons: list[str], task_id: str = "default") -> str | None:
+        targets: list[str], task_id: str = "default") -> str | None:
     """Ask the human to approve a write to protected instruction file(s).
 
     Returns ``None`` when approved, or a BLOCKED error string. This gate
@@ -851,15 +865,15 @@ def _request_protected_instruction_approval(
     here is one-operation approval EVERY time, with no persistent scope
     and no yolo bypass. Fail-closed when no human channel exists.
     """
-    targets = ", ".join(dict.fromkeys(reasons))
+    target_list = ", ".join(targets)
     description = (
-        f"Write to protected agent-instruction file(s): {targets}. "
+        f"Write to protected agent-instruction file(s): {target_list}. "
         "These files steer future agent behavior; approval is always "
         "required (not bypassed by auto-approve)."
     )
-    display = f"<write to {targets}>"
+    display = f"<write to {target_list}>"
     blocked = (
-        f"BLOCKED: write to protected agent-instruction file(s) ({targets}) "
+        f"BLOCKED: write to protected agent-instruction file(s) ({target_list}) "
         "{why} The user has NOT consented to this write. Do NOT retry it or "
         "attempt the same edit via another path (terminal, execute_code, "
         "etc.)."
@@ -953,15 +967,16 @@ def _check_protected_instruction_write(paths: list[str],
     enabled, extra = _protected_instruction_config()
     if not enabled:
         return None
-    reasons: list[str] = []
+    targets: dict[str, str] = {}
     for p in paths:
         reason = _protected_instruction_reason(
             p, task_id, enabled=enabled, extra_patterns=extra)
         if reason:
-            reasons.append(reason)
-    if not reasons:
+            identity, display = _protected_instruction_approval_target(p, task_id)
+            targets.setdefault(identity, display)
+    if not targets:
         return None
-    return _request_protected_instruction_approval(reasons, task_id)
+    return _request_protected_instruction_approval(list(targets.values()), task_id)
 
 
 def _check_approval_required_write(paths: list[str],

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -845,14 +845,40 @@ def _protected_instruction_approval_target(
         filepath: str, task_id: str = "default") -> tuple[str, str]:
     """Return the canonical identity and qualified display for an approved write."""
     try:
-        requested = os.path.normpath(str(_resolve_path_for_task(filepath, task_id)))
+        container_paths = _uses_container_paths(task_id)
+        expanded = _expand_tilde(filepath)
+        if container_paths:
+            requested = _normalize_without_host_deref(
+                expanded if posixpath.isabs(expanded)
+                else posixpath.join(
+                    str(_resolve_base_dir(task_id, container_paths=True)), expanded
+                )
+            )
+        elif sys.platform == "win32":
+            from tools.environments.local import _msys_to_windows_path
+            import ntpath
+
+            expanded = _expand_tilde(_msys_to_windows_path(filepath))
+            requested = ntpath.normpath(
+                expanded if ntpath.isabs(expanded)
+                else ntpath.join(
+                    str(_resolve_base_dir(task_id, container_paths=False)), expanded
+                )
+            )
+        else:
+            requested = os.path.normpath(
+                expanded if os.path.isabs(expanded)
+                else os.path.join(
+                    str(_resolve_base_dir(task_id, container_paths=False)), expanded
+                )
+            )
     except (OSError, ValueError, RuntimeError):
         requested = os.path.abspath(os.path.normpath(_expand_tilde(filepath)))
     canonical = os.path.realpath(requested)
     display = requested
     if os.path.normcase(requested) != os.path.normcase(canonical):
         display = f"{requested} -> {canonical}"
-    return os.path.normcase(canonical), display
+    return os.path.normcase(canonical), json.dumps(display, ensure_ascii=False)
 
 
 def _request_protected_instruction_approval(
@@ -973,7 +999,9 @@ def _check_protected_instruction_write(paths: list[str],
             p, task_id, enabled=enabled, extra_patterns=extra)
         if reason:
             identity, display = _protected_instruction_approval_target(p, task_id)
-            targets.setdefault(identity, display)
+            previous = targets.get(identity)
+            if previous is None or (" -> " in display and " -> " not in previous):
+                targets[identity] = display
     if not targets:
         return None
     return _request_protected_instruction_approval(list(targets.values()), task_id)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -810,11 +810,7 @@ def _protected_instruction_reason(filepath: str, task_id: str = "default",
     # below; protected basenames and configured patterns must still apply to
     # live instruction files and pre-run scripts inside the active home.
     real_home = _get_real_hermes_home()
-    in_real_home = bool(
-        real_home
-        and (resolved == real_home
-             or resolved.startswith(real_home + os.sep))
-    )
+    real_home_key = os.path.normcase(real_home) if real_home else None
 
     import fnmatch
     for candidate in (normalized, resolved):
@@ -825,7 +821,13 @@ def _protected_instruction_reason(filepath: str, task_id: str = "default",
         for pattern in extra_patterns:
             if fnmatch.fnmatch(base_lower, pattern.lower()):
                 return base
-        if in_real_home:
+        candidate_key = os.path.normcase(os.path.abspath(candidate))
+        candidate_in_real_home = bool(
+            real_home_key
+            and (candidate_key == real_home_key
+                 or candidate_key.startswith(real_home_key + os.sep))
+        )
+        if candidate_in_real_home:
             continue
         # Project-local .hermes config dirs (e.g. <repo>/.hermes/config.yaml)
         # are loaded as project context and steer behavior the same way.


### PR DESCRIPTION
## What does this PR do?

Writes to live active-profile instruction files could bypass the protected-instruction approval gate, allowing persistent agent behavior changes without the mandatory one-operation confirmation. Configured extra patterns were also ineffective for files under `HERMES_HOME`, including matched cron pre-run scripts. This change narrows the home exemption to the broad `.hermes` parent-directory rule while keeping ordinary profile files writable.

### Symptom

`_protected_instruction_reason()` returned no protection reason for `HERMES_HOME/SOUL.md`, `HERMES_HOME/AGENTS.md`, and any active-home file matched by `security.protected_instruction_extra_patterns`, even though equivalent files outside the active home were gated.

### Impact

A prompt-injected file-tool write could persist instructions in the active profile or modify a configured protected cron pre-run script without the mandatory approval prompt. The affected scope is the shared file tools; the measured blast radius beyond those write paths is unknown.

### Bug Cause

**Trigger:** `tools/file_tools_write_guards.py:_protected_instruction_reason()` when the resolved target is the active `HERMES_HOME` or one of its descendants.

**Causal chain:**
1. A file-tool write resolves a target inside the active profile home.
2. The active-home exemption returns `None` before protected basenames and configured extra patterns are evaluated.
3. The write proceeds without the protected-instruction approval gate.

**Why it is wrong:** The exemption is only needed to stop the broad immediate-parent `.hermes` rule from gating every ordinary file at the profile root. Applying it before location-independent basename and configured-pattern checks disables protections that users explicitly enabled.

**Working sibling / contrast:** The same protected basename or configured pattern outside `HERMES_HOME` reaches the approval gate because it does not take the early return.

**Ruled out:** The existing active-home guards do not cover this class. The sensitive-path guard is limited to specific files such as `config.yaml`, and the cross-profile guard only protects other profiles.

### Fix

Compute whether the resolved path is inside the active home, evaluate protected basenames and configured patterns for both normalized and resolved paths, and use the home exemption only to skip the broad `.hermes` immediate-parent rule. This intentionally applies the one-operation approval gate to the active profile's own `SOUL.md`; self-editing remains supported after explicit approval. Regression tests cover live `SOUL.md`, a configured cron-script pattern, and an ordinary active-home file that must remain ungated.

## Related Issue

Closes #92146

## Type of Change

- [x] Security fix

## Changes Made

- `tools/file_tools_write_guards.py` - apply basename and configured-pattern protections before the active-home location exemption and identify exact approval targets.
- `tests/tools/test_file_write_safety.py` - cover protected and ordinary writes inside the active profile home, exact target disclosure, and container path identity.

## How to Test

1. Run the protected-instruction behavior tests.
2. Confirm all 31 selected tests pass.

```bash
scripts/run_tests.sh tests/tools/test_file_write_safety.py -k TestProtectedInstructionFiles
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are not applicable
- [x] Config example updates are not applicable because no config keys changed
- [x] Architecture and workflow documentation updates are not applicable
- [x] I've considered cross-platform path behavior
- [x] Tool schema updates are not applicable because the existing documented protection behavior is restored
