### PR TITLE
fix(terminal): scope environment cache by session key to prevent cross-profile SSH leakage

### DIFF
--- a/tests/tools/test_shared_container_task_id.py
+++ b/tests/tools/test_shared_container_task_id.py
@@ -67,3 +67,51 @@ def test_env_type_override_keeps_own_id():
         )
     finally:
         terminal_tool.clear_task_env_overrides("bench-env")
+
+
+# --- Cross-profile SSH-leak isolation (commit e00f940a9, re-applied) ---------
+#
+# When a session key is present (WebUI/gateway), each session must own its own
+# slot in _active_environments so switching from profile A (ssh_host=10.0.0.1)
+# to profile B (ssh_host=10.0.0.2) cannot reuse A's SSHEnvironment. Without this
+# the shared "default" slot silently runs commands on the wrong remote host.
+
+
+def test_session_key_scopes_to_its_own_slot(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_KEY", "sess-A")
+    assert terminal_tool._resolve_container_task_id(None) == "session:sess-A"
+
+
+def test_distinct_session_keys_get_distinct_slots(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_KEY", "sess-A")
+    a = terminal_tool._resolve_container_task_id(None)
+    monkeypatch.setenv("HERMES_SESSION_KEY", "sess-B")
+    b = terminal_tool._resolve_container_task_id(None)
+    assert a == "session:sess-A"
+    assert b == "session:sess-B"
+    assert a != b
+
+
+def test_subagent_collapses_onto_parent_session(monkeypatch):
+    # Subagents inherit the parent's session key, so they share the parent's
+    # container (the #16177 intent) rather than a global "default".
+    monkeypatch.setenv("HERMES_SESSION_KEY", "sess-A")
+    assert (
+        terminal_tool._resolve_container_task_id("subagent-3-cafef00d")
+        == "session:sess-A"
+    )
+
+
+def test_rl_override_wins_over_session_key(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_KEY", "sess-A")
+    terminal_tool.register_task_env_overrides("tb2-z", {"docker_image": "z:1"})
+    try:
+        assert terminal_tool._resolve_container_task_id("tb2-z") == "tb2-z"
+    finally:
+        terminal_tool.clear_task_env_overrides("tb2-z")
+
+
+def test_no_session_key_still_defaults(monkeypatch):
+    # CLI mode: no session key -> unchanged "default" behaviour.
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    assert terminal_tool._resolve_container_task_id(None) == "default"

--- a/tests/tools/test_shared_container_task_id.py
+++ b/tests/tools/test_shared_container_task_id.py
@@ -115,3 +115,51 @@ def test_no_session_key_still_defaults(monkeypatch):
     # CLI mode: no session key -> unchanged "default" behaviour.
     monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
     assert terminal_tool._resolve_container_task_id(None) == "default"
+
+
+# --- Production gateway path: session key bound via ContextVars ---------------
+#
+# The tests above set HERMES_SESSION_KEY through os.environ, which only
+# exercises the os.getenv() *fallback* branch of the scoping logic. Real
+# gateway turns never write this process-global env var — they bind the
+# identity through gateway.session_context.set_session_vars(), which stores it
+# in a ContextVar, and _resolve_container_task_id reads it back via
+# get_session_env(). These companion tests cover that production path with
+# HERMES_SESSION_KEY absent from os.environ.
+
+
+def test_session_key_from_contextvar_without_environ(monkeypatch):
+    # Prove the fix works on the gateway path: HERMES_SESSION_KEY is NOT in
+    # os.environ; the key lives only in the ContextVar bound by the gateway.
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    tokens = set_session_vars(session_key="sess-ctx")
+    try:
+        assert (
+            terminal_tool._resolve_container_task_id(None) == "session:sess-ctx"
+        )
+        # Subagents inherit the same ContextVar and collapse onto the parent.
+        assert (
+            terminal_tool._resolve_container_task_id("subagent-1-cafe")
+            == "session:sess-ctx"
+        )
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_contextvar_session_key_wins_over_environ(monkeypatch):
+    # Two concurrent gateway sessions in one process must not cross-contaminate:
+    # the ContextVar is authoritative even when a *different* value lingers in
+    # os.environ (e.g. a CLI-set or previously-leaked global). The container
+    # slot must follow the ContextVar-bound session, not the process global.
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    monkeypatch.setenv("HERMES_SESSION_KEY", "sess-ENV")
+    tokens = set_session_vars(session_key="sess-CTX")
+    try:
+        assert (
+            terminal_tool._resolve_container_task_id(None) == "session:sess-CTX"
+        )
+    finally:
+        clear_session_vars(tokens)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -272,6 +272,19 @@ def _get_sudo_password_callback():
     return getattr(_callback_tls, "sudo_password", None)
 
 
+def _current_session_key() -> str:
+    """Return the active gateway/WebUI session key, or "" outside sessions.
+
+    Single lookup point for the ``HERMES_SESSION_KEY`` ContextVar with the
+    os.environ fallback that ``get_session_env()`` applies for CLI, cron, and
+    test processes. Callers scope per-session caches by prefixing the value
+    with ``"session:"`` so two sessions never share a cache slot.
+    """
+    from gateway.session_context import get_session_env
+
+    return get_session_env("HERMES_SESSION_KEY", "")
+
+
 def _get_approval_callback():
     return getattr(_callback_tls, "approval", None)
 
@@ -297,12 +310,7 @@ def set_approval_callback(cb):
 
 def _get_sudo_password_cache_scope() -> str:
     """Return the cache scope for interactive sudo passwords."""
-    try:
-        from gateway.session_context import get_session_env
-
-        session_key = get_session_env("HERMES_SESSION_KEY", "")
-    except Exception:
-        session_key = os.getenv("HERMES_SESSION_KEY", "")
+    session_key = _current_session_key()
     if session_key:
         return f"session:{session_key}"
 
@@ -1398,12 +1406,7 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     # branches above: those paths already key containers per task_id, so they
     # stay authoritative where they apply and this only covers the cases that
     # would otherwise collapse to the shared "default" key (notably SSH).
-    try:
-        from gateway.session_context import get_session_env
-
-        session_key = get_session_env("HERMES_SESSION_KEY", "")
-    except Exception:
-        session_key = os.getenv("HERMES_SESSION_KEY", "")
+    session_key = _current_session_key()
     if session_key:
         return f"session:{session_key}"
     return "default"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1386,6 +1386,26 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
         return task_id
     if task_id and _docker_session_isolation_enabled():
         return _resolve_container_alias(task_id)
+    # Per-session isolation: when a session key is present (the WebUI streaming
+    # layer sets it per-session, the gateway per-message via contextvars), scope
+    # the container to it so switching profiles can't reuse a previous profile's
+    # SSHEnvironment and silently run commands on the wrong remote host. Subagents
+    # inherit the same session key, so they still collapse onto the parent's
+    # container (the #16177 shared-container intent). CLI mode has no session key
+    # and falls through to "default", behaviour unchanged. See commit e00f940a9.
+    #
+    # This runs *after* the isolation-override and docker/container_persistent
+    # branches above: those paths already key containers per task_id, so they
+    # stay authoritative where they apply and this only covers the cases that
+    # would otherwise collapse to the shared "default" key (notably SSH).
+    try:
+        from gateway.session_context import get_session_env
+
+        session_key = get_session_env("HERMES_SESSION_KEY", "")
+    except Exception:
+        session_key = os.getenv("HERMES_SESSION_KEY", "")
+    if session_key:
+        return f"session:{session_key}"
     return "default"
 
 


### PR DESCRIPTION
## Summary

Terminal environments are now cached per session (`session:<key>`), so switching WebUI/gateway profiles can no longer reuse the previous profile's cached `SSHEnvironment` and silently run commands on the wrong remote host.

Salvage of #30861 (@Carry00), rebased onto current `main` with authorship preserved.

## Root cause

`_active_environments` in `tools/terminal_tool.py` is keyed by `_resolve_container_task_id()`, which collapsed every WebUI/gateway session onto the shared `"default"` key. With profile A (`ssh_host=10.0.0.1`) and profile B (`ssh_host=10.0.0.2`) in the same process, whichever connected first owned the `"default"` slot — profile B then executed on A's host even though `TERMINAL_SSH_HOST` had switched.

## Changes

- `tools/terminal_tool.py` — `_resolve_container_task_id()`: when a session key is present (WebUI streaming layer per-session env, gateway per-message via ContextVars), return `"session:<key>"` instead of `"default"`. Ordered *after* the RL/benchmark isolation-override and docker-session-isolation branches, which stay authoritative where they apply. CLI mode (no session key) is unchanged.
- `tests/tools/test_shared_container_task_id.py` — 7 new regressions: session scoping, distinct slots per session, subagent collapse onto the parent session, RL override precedence, CLI no-op, gateway ContextVar path (env var absent), and ContextVar-beats-stale-env.
- Follow-up `refactor(terminal)`: the session-key lookup duplicated a byte-identical block in `_get_sudo_password_cache_scope()`; both now share one `_current_session_key()` helper (bare-import convention, matching `tools/approval.py`).

## Validation

| | Before | After |
|---|---|---|
| `test_shared_container_task_id.py` + `test_docker_session_isolation.py` | — | 38 passed |
| Mutation check (session scoping reverted → tests red) | — | 5 fail pre-fix, green restored |
| E2E, real imports (9 scenarios: CLI no-op, env path, ContextVar precedence, subagent collapse, RL override, empty key, docker branch, cross-profile slots differ) | cross-profile leak reproduces | all pass |
| ruff / lint diff vs origin/main | — | 🆕 New issues: none |

## Provenance

- Commits `22da7c16d1` + `dfcede5a73` cherry-picked from #30861 (@Carry00, authorship preserved via rebase-style cherry-pick).
- Follow-up refactor commit by @kshitijk4poor.
- Closes #30861
