### PR TITLE
fix(title): don't title a session after an @file: attachment path

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -149,7 +149,30 @@ def _summarize_user_message(user_message: str) -> str:
         described = describe_skill_invocation(user_message)
     except Exception:
         logger.debug("Skill-scaffolding summary failed; titling raw", exc_info=True)
-    return strip_control_wrappers(user_message if described is None else described)
+    text = described if described is not None else user_message
+    text = _strip_context_reference_tokens(text)
+    return strip_control_wrappers(text)
+
+
+# Matches an ``@file:``/``@folder:`` context reference the way the canonical
+# ``agent.context_references.REFERENCE_PATTERN`` does: an unquoted ``\S+``
+# value, or a backtick/double/single-quoted value. Kept local so the titler
+# doesn't import the context-reference machinery (circularity / startup cost)
+# just to drop the tokens from a title candidate (#92068).
+_CONTEXT_REFERENCE_TOKEN_RE = re.compile(
+    r"(?<![\w/])@(?:file|folder):(?P<value>(?:`[^`\n]+`|\"[^\"\n]+\"|'[^'\n]+')|\S+)",
+)
+
+
+def _strip_context_reference_tokens(text: str) -> str:
+    """Remove ``@file:``/``@folder:`` tokens so an attachment-only opener
+    titles as untitled rather than as the raw file path."""
+    if not text:
+        return ""
+    stripped = _CONTEXT_REFERENCE_TOKEN_RE.sub("", text)
+    # Collapse any whitespace left between removed tokens back to a single
+    # space so "look at  @file:x  please" reads "look at please".
+    return re.sub(r"[ \t]{2,}", " ", stripped).strip()
 
 
 def is_titleable_user_message(user_message: str) -> bool:

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -598,3 +598,40 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestAttachmentReferenceNotTitled:
+    """Regression for #92068: a session whose opening message is only an
+    attachment reference must not be titled after the raw @file: path."""
+
+    def test_attachment_only_opener_is_not_untitled_garbage(self):
+        from agent.title_generator import derive_title, is_titleable_user_message
+
+        msg = "@file:AppData/Local/hermes/profiles/name/attach-abc.png"
+        assert is_titleable_user_message(msg) is False
+        assert derive_title(msg) is None
+
+    def test_folder_only_opener_not_titleable(self):
+        from agent.title_generator import is_titleable_user_message
+
+        assert is_titleable_user_message("@folder:/some/dir") is False
+
+    def test_text_with_reference_keeps_the_text(self):
+        from agent.title_generator import derive_title, is_titleable_user_message
+
+        msg = "Review @file:notes.txt and fix the bug"
+        assert is_titleable_user_message(msg) is True
+        assert derive_title(msg) == "Review and fix the bug"
+
+    def test_quoted_reference_removed(self):
+        from agent.title_generator import derive_title
+
+        # Space-bearing path is written backtick-quoted; must still be dropped.
+        assert derive_title("summarize @file:`my file.txt` please") == "summarize please"
+
+    def test_strip_context_reference_tokens_single_char(self):
+        from agent.title_generator import _strip_context_reference_tokens
+
+        assert _strip_context_reference_tokens("") == ""
+        assert _strip_context_reference_tokens("plain text") == "plain text"
+        assert _strip_context_reference_tokens("a @file:x b") == "a b"


### PR DESCRIPTION
Fixes #92068

## Issue

When a session's first user message is only a context-reference attachment
(`@file:path` / `@folder:path`), the instant title deriver took the **raw
path** as the session title (`title_source='derived'`):

```
@file:AppData/Local/hermes/profiles/<name>/attach…
@file:AppData/Local/hermes/profiles/<name>/attach… #2
@file:AppData/Local/hermes/profiles/<name>/attach… #3
```

With the unique-title ` #2` / ` #3` suffix from the dedupe, several real
attachment-first conversations render as near-identical entries in the
sidebar — the user cannot tell them apart ("my chats disappeared").

## Fix

`_summarize_user_message` (the titler's reduction step) now strips
`@file:` / `@folder:` reference tokens before titling. The matcher mirrors
`agent.context_references.REFERENCE_PATTERN`'s value shapes: an unquoted
`\S+` token, or a backtick / double-quote / single-quote-quoted value
(space-bearing paths are written backtick-quoted).

Effect:
- Attachment-only opener → text reduces to empty → `is_titleable_user_message`
  returns `False` → session stays **untitled** until the model upgrade names
  it (the intended result — provenance `derived` can't clobber a title anyway).
- A real prompt alongside a reference keeps its words: `"Review @file:x and
  fix the bug"` → title `"Review and fix the bug"`.

## Validation

- `uv run pytest tests/agent/test_title_generator.py -q` → **41 passed**
  (36 pre-existing + 5 new), 0 failures.
- New `TestAttachmentReferenceNotTitled`: attachment-only (untitled),
  `@folder:`-only, text-with-reference, quoted-with-space path.
- Provenance + dedupe behavior untouched (`_set_session_title` unchanged).

### Type of change

- [x] 🐛 Bug fix

### Checklist

- [x] Bug verified on current `main` before the fix.
- [x] Regression test reproduces the failure pre-fix and passes post-fix.
- [x] Diff confined to `agent/title_generator.py` + its tests.