### PR TITLE
fix(agent): retry streams that end with finish_reason network_error (Ox Alpha / GLM)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -50,7 +50,7 @@ from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
 _OPENROUTER_PROVIDER_SORT_VALUES = {"throughput", "latency", "price"}
-_PROVIDER_STREAM_ERROR_FINISH_REASONS = {"error", "error_finish"}
+_PROVIDER_STREAM_ERROR_FINISH_REASONS = {"error", "error_finish", "network_error", "network-error"}
 _PROVIDER_STREAM_SSE_FIELDS = {"event", "data", "id", "retry"}
 _PROVIDER_STREAM_ERROR_TEXT_LIMIT = 4096
 
@@ -4371,6 +4371,24 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             raise EmptyStreamError(
                 "Provider returned an empty stream with no finish_reason "
                 "(possible upstream error or malformed SSE response)."
+            )
+        # finish_reason="network_error"/"network-error" (observed on OpenCode Zen
+        # x-preview-f-free; OpenCode fixed the same bug in v1.18.20/21): the
+        # stream terminates cleanly with an error finish reason and often ZERO
+        # content. Treating it as a successful empty turn leaves the agent with
+        # nothing to do - surfacing as a hang until a follow-up message. Raise
+        # so the bounded stream-retry machinery handles it like any transient
+        # provider drop.
+        _fr_text = str(finish_reason or "").strip().lower()
+        if (
+            _fr_text in ("network_error", "network-error")
+            and not content_parts
+            and not reasoning_parts
+            and not tool_calls_acc
+        ):
+            raise EmptyStreamError(
+                f"Provider stream ended with finish_reason={_fr_text} and no "
+                "content (transient upstream network failure)."
             )
 
         # A stream that delivered a tool call but only partial/unparseable


### PR DESCRIPTION
## Problem

OpenCode Zen (`x-preview-f-free`) can terminate a chat-completions stream **cleanly** with `finish_reason: network_error` and zero content. OpenCode fixed the identical bug on their side in v1.18.20/21 ("Retry provider responses that end with finish_reason: network_error", "Retry more network error variants, including network-error and network_error").

On Hermes, this shape falls through every existing guard:

1. The zero-chunk guard only fires when `finish_reason is None` — here it is set.
2. `_provider_stream_error_from_text` only treats `{"error", "error_finish"}` as error finish reasons — `network_error` isn't in the set.

The result is a "successful" assistant turn with empty content: the agent has nothing to do and the session appears to hang until a follow-up message (reproduced on a fleet running ~20 concurrent agents against Zen; OpenCode's changelog confirms the provider-side behavior).

## Fix

- Add `"network_error"` / `"network-error"` to `_PROVIDER_STREAM_ERROR_FINISH_REASONS`.
- Raise `EmptyStreamError` when a stream ends with one of those finish reasons and no content, so it rides the existing bounded stream-retry machinery (fresh connection, up to `HERMES_STREAM_RETRIES`) instead of fabricating an empty turn.

Non-empty content with those finish reasons keeps flowing through the existing partial-stream-stub paths unchanged.

## Testing

- Existing targeted suites pass: `tests/run_agent/test_streaming.py` + `tests/run_agent/test_partial_stream_finish_reason.py` (55 passed).
- Verified against the live provider during an incident window: streams that previously returned an empty successful turn now raise and retry.
