### PR TITLE
perf(process): poll sandbox job logs for new bytes only

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -781,7 +781,7 @@ class TestSpawnEnvSanitization:
             def __init__(self):
                 self.commands = []
                 self._responses = iter([
-                    {"output": "hello\n"},
+                    {"output": "6 0\nhello\n"},
                     {"output": "1\n"},
                     {"output": "0\n"},
                 ])
@@ -802,9 +802,151 @@ class TestSpawnEnvSanitization:
                 "/path with spaces/hermes_bg.exit",
             )
 
-        assert env.commands[0][0] == "cat '/path with spaces/hermes_bg.log' 2>/dev/null"
+        assert "'/path with spaces/hermes_bg.log'" in env.commands[0][0]
+        assert "cat '/path with spaces/hermes_bg.log'" not in env.commands[0][0]
         assert env.commands[1][0] == "kill -0 \"$(cat '/path with spaces/hermes_bg.pid' 2>/dev/null)\" 2>/dev/null; echo $?"
         assert env.commands[2][0] == "cat '/path with spaces/hermes_bg.exit' 2>/dev/null"
+
+
+class TestEnvPollerIncrementalRead:
+    """The sandbox log poller must read only new bytes, not the whole file.
+
+    Reading the whole file every poll made one poll cost grow with the total
+    output so far, so a long noisy job re-sent all of its output over the
+    docker or SSH channel every two seconds.
+    """
+
+    @staticmethod
+    def _run_poller(registry, session, responses):
+        """Drive one poll cycle and hand back the commands the env saw."""
+
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+                self._responses = iter(responses)
+
+            def execute(self, command, **kwargs):
+                self.commands.append(command)
+                return next(self._responses)
+
+        env = FakeEnv()
+        with patch("tools.process_registry.time.sleep", return_value=None), \
+            patch.object(registry, "_move_to_finished"):
+            registry._env_poller_loop(
+                session, env, "/tmp/bg.log", "/tmp/bg.pid", "/tmp/bg.exit"
+            )
+        return env.commands
+
+    def test_read_command_asks_only_for_new_bytes(self):
+        cmd = ProcessRegistry._log_delta_command("'/tmp/bg.log'", 4096)
+        # The offset is carried into the command, and the file is opened with
+        # tail rather than cat.
+        assert "O=4096" in cmd
+        assert "tail -c +$((O+1)) '/tmp/bg.log'" in cmd
+        assert "cat '/tmp/bg.log'" not in cmd
+
+    def test_read_command_starts_from_zero_on_first_poll(self):
+        cmd = ProcessRegistry._log_delta_command("'/tmp/bg.log'", 0)
+        assert "O=0" in cmd
+
+    def test_first_poll_reads_from_the_start(self, registry):
+        session = _make_session(sid="proc_delta")
+        session.exited = False
+        commands = self._run_poller(
+            registry,
+            session,
+            [
+                {"output": "11 0\nfirst chunk"},
+                {"output": "1\n"},
+                {"output": "0\n"},
+            ],
+        )
+        assert "O=0" in commands[0]
+        assert session.output_buffer == "first chunk"
+
+    def test_delta_is_appended_not_replaced(self, registry):
+        session = _make_session(sid="proc_append", output="already here ")
+        session.exited = False
+        self._run_poller(
+            registry,
+            session,
+            [
+                {"output": "8 0\nand new"},
+                {"output": "1\n"},
+                {"output": "0\n"},
+            ],
+        )
+        assert session.output_buffer == "already here and new"
+
+    def test_second_poll_asks_from_where_the_first_one_stopped(self, registry):
+        session = _make_session(sid="proc_two_polls")
+        session.exited = False
+        commands = self._run_poller(
+            registry,
+            session,
+            [
+                {"output": "11 0\nfirst chunk"},
+                {"output": "0\n"},          # still running, poll again
+                {"output": "17 11\n and more"},
+                {"output": "1\n"},          # gone now
+                {"output": "0\n"},
+            ],
+        )
+        assert "O=0" in commands[0]
+        # The second read starts at byte 11, so the first chunk is not sent
+        # a second time.
+        assert "O=11" in commands[2]
+        assert session.output_buffer == "first chunk and more"
+
+    def test_truncated_log_drops_the_stale_buffer(self, registry):
+        session = _make_session(sid="proc_rotate")
+        session.exited = False
+        # The second read reports offset 0 even though the first one left off
+        # at byte 11. The file no longer reaches that byte, so it was rotated
+        # or truncated and the buffer we hold no longer matches it.
+        self._run_poller(
+            registry,
+            session,
+            [
+                {"output": "11 0\nfirst chunk"},
+                {"output": "0\n"},          # still running, poll again
+                {"output": "5 0\nfresh"},
+                {"output": "1\n"},
+                {"output": "0\n"},
+            ],
+        )
+        assert session.output_buffer == "fresh"
+
+    def test_unreadable_header_leaves_the_buffer_alone(self, registry):
+        session = _make_session(sid="proc_bad", output="keep me")
+        session.exited = False
+        # No header at all, for example when the shell is missing one of the
+        # tools the command needs.
+        self._run_poller(
+            registry,
+            session,
+            [
+                {"output": ""},
+                {"output": "1\n"},
+                {"output": "0\n"},
+            ],
+        )
+        assert session.output_buffer == "keep me"
+
+    def test_buffer_stays_within_the_cap(self, registry):
+        session = _make_session(sid="proc_cap")
+        session.exited = False
+        session.max_output_chars = 10
+        self._run_poller(
+            registry,
+            session,
+            [
+                {"output": "20 0\n" + "x" * 20},
+                {"output": "1\n"},
+                {"output": "0\n"},
+            ],
+        )
+        assert session.output_buffer == "x" * 10
 
 
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1443,6 +1443,32 @@ class ProcessRegistry:
                 session.completion_reason = "exited"
             self._move_to_finished(session)
 
+    @staticmethod
+    def _log_delta_command(quoted_log_path: str, offset: int) -> str:
+        """Build the shell command that reads only new bytes from a log file.
+
+        The old version ran ``cat`` on the whole file every poll, so a job
+        that keeps writing pays for its entire output again and again. Over a
+        long run that turns into a lot of wasted traffic on the docker/SSH
+        channel, since only the new part is ever used.
+
+        The command prints one header line, ``"<size> <offset>"``, then the
+        bytes between ``offset`` and ``size``. Reading the size first and
+        cutting the tail at that same size keeps the two numbers in step, so
+        a file that grows while the command runs never sends a byte twice.
+        A file that shrank was rotated or truncated, so the offset drops back
+        to 0 and the reader starts over.
+        """
+        return (
+            f"O={offset}; "
+            f"S=$({{ wc -c < {quoted_log_path}; }} 2>/dev/null | tr -dc '0-9'); "
+            f"S=${{S:-0}}; "
+            f'if [ "$S" -lt "$O" ]; then O=0; fi; '
+            f'echo "$S $O"; '
+            f'if [ "$S" -gt "$O" ]; then '
+            f"tail -c +$((O+1)) {quoted_log_path} 2>/dev/null | head -c $((S-O)); fi"
+        )
+
     def _env_poller_loop(
         self, session: ProcessSession, env: Any, log_path: str, pid_path: str, exit_path: str
     ):
@@ -1450,24 +1476,44 @@ class ProcessRegistry:
         quoted_log_path = shlex.quote(log_path)
         quoted_pid_path = shlex.quote(pid_path)
         quoted_exit_path = shlex.quote(exit_path)
-        prev_output_len = 0  # track delta for watch pattern scanning
+        # Byte offset already read from the log. Bytes, not characters: the
+        # shell counts bytes, and a log with non-ASCII text has more bytes
+        # than characters.
+        prev_output_bytes = 0
         while not session.exited:
             time.sleep(2)  # Poll every 2 seconds
             try:
-                # Read new output from the log file
-                result = env.execute(f"cat {quoted_log_path} 2>/dev/null", timeout=10)
-                new_output = result.get("output", "")
-                if new_output:
-                    # Compute delta for watch pattern scanning
-                    delta = new_output[prev_output_len:] if len(new_output) > prev_output_len else ""
-                    prev_output_len = len(new_output)
+                # Read only the bytes written since the last poll.
+                result = env.execute(
+                    self._log_delta_command(quoted_log_path, prev_output_bytes),
+                    timeout=10,
+                )
+                raw = result.get("output", "")
+                header, _, delta = raw.partition("\n")
+                try:
+                    size_str, offset_str = header.split()
+                    new_size = int(size_str)
+                    used_offset = int(offset_str)
+                except ValueError:
+                    # No usable header (command failed, shell missing a tool).
+                    # Skip this poll rather than act on a half-read value.
+                    new_size = None
+                    used_offset = None
+                    delta = ""
+                if new_size is not None:
+                    if used_offset < prev_output_bytes:
+                        # The log was rotated or truncated, so what we hold no
+                        # longer lines up with the file. Drop it and restart.
+                        with session._lock:
+                            session.output_buffer = ""
+                    prev_output_bytes = new_size
+                if delta:
                     with session._lock:
-                        session.output_buffer = new_output
+                        session.output_buffer += delta
                         if len(session.output_buffer) > session.max_output_chars:
                             session.output_buffer = session.output_buffer[-session.max_output_chars:]
-                    if delta:
-                        self._check_watch_patterns(session, delta)
-                        self._emit_output(session, delta)
+                    self._check_watch_patterns(session, delta)
+                    self._emit_output(session, delta)
 
                 # Check if process is still running
                 check = env.execute(


### PR DESCRIPTION
## What does this PR do?

The background-process poller for non-local backends ran `cat` on the whole sandbox log every 2 seconds, then threw away everything except the part it had not seen yet. The offset it needed was already tracked on the line right below the read, so the full read was pure waste.

The cost of one poll grew with the total output so far, which makes a whole run cost the square of how long it runs, and every byte of it crossed the docker exec or SSH channel. A job writing 10 MB over an hour did about 1800 polls averaging 5 MB each, so roughly 9 GB of traffic to deliver 10 MB of output.

The poller now asks the shell for the file size and for the bytes after the offset in one command:

```sh
O=<offset>
S=$({ wc -c < LOG; } 2>/dev/null | tr -dc '0-9'); S=${S:-0}
if [ "$S" -lt "$O" ]; then O=0; fi
echo "$S $O"
if [ "$S" -gt "$O" ]; then tail -c +$((O+1)) LOG 2>/dev/null | head -c $((S-O)); fi
```

Why this shape:

- Reading the size first and cutting the tail at that same size keeps the two numbers in step. A file that grows while the command is running cannot send a byte twice, and cannot leave a gap.
- The header line carries back both the new size and the offset actually used, so the reader knows whether a reset happened without a second round trip.
- A file that shrank below the offset was rotated or truncated, so the offset drops to 0 and the stale buffer is dropped.
- The size probe is wrapped in `{ ...; } 2>/dev/null` so a missing log file does not leak a shell error into the captured output.

Two related things had to change with it:

- The offset is counted in bytes, not characters. The shell counts bytes, and a log with non-ASCII text has more bytes than characters.
- `session.output_buffer` is appended to instead of replaced, matching what the local reader loops already do, since the read now returns only new bytes.

## Related Issue

Fixes #92162

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/process_registry.py`: new `_log_delta_command` static method that builds the incremental read command.
- `tools/process_registry.py`: `_env_poller_loop` now calls it with a byte offset, parses the `"<size> <offset>"` header, appends the delta to the buffer, and drops the buffer when the log was rotated or truncated. An unreadable header skips that poll instead of acting on a half-read value.
- `tests/tools/test_process_registry.py`: updated `test_env_poller_quotes_temp_paths_with_spaces`, which asserted on the old `cat` command, to assert the path is still quoted and that `cat` is no longer used on the log.
- `tests/tools/test_process_registry.py`: new `TestEnvPollerIncrementalRead` with 8 tests.

## How to Test

1. `pytest tests/tools/test_process_registry.py -q`
2. The new `TestEnvPollerIncrementalRead` class covers: the command carries the offset and uses `tail` not `cat`, a second poll starts where the first stopped, the delta is appended rather than replacing the buffer, a truncated log drops the stale buffer, an unreadable header leaves the buffer alone, and the buffer stays inside `max_output_chars`.
3. The generated shell command was also run against a real shell to confirm each case end to end:

```
poll 1, offset 0, 12-byte file   -> "12 0\nhello world\n"
poll 2, offset 12, no new writes -> "12 12\n"           (no body)
poll 3, offset 12, after append  -> "24 12\nsecond line\n"
missing file                     -> "0 0\n"             (no stderr leak)
truncated file, stale offset 24  -> "8 0\nnew run\n"    (offset reset to 0)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.13

On the full-suite item, to be exact about what I ran: `tests/tools/test_process_registry.py` goes from 53 passed to 61 passed. The same 9 tests fail before and after my change, all of them POSIX-only tests that do not run correctly on Windows (`TestTerminateHostPidPosix`, `TestSpawnRewriteCompoundBackground`, and similar). None of them touch the poller. The shell command itself was exercised against a real shell as shown above, since the poller only runs against a non-local backend.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A

  The new method carries a docstring explaining why the command is shaped this way, and the offset comment in the loop says why it counts bytes.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

  This path only runs against non-local backends, which are Linux sandboxes reached over docker exec or SSH, so the command runs in a Linux shell regardless of the host OS. `wc`, `tr`, `tail -c` and `head -c` are all in coreutils and in busybox. `tail -c` is POSIX. `head -c` is not in POSIX but is present in both coreutils and busybox, so every realistic sandbox image has it.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no schema change)

## Screenshots / Logs

Behaviour of the generated command against a real shell, byte for byte:

```
== poll 1 (offset 0)
0000000   1   2       0  \n   h   e   l   l   o       w   o   r   l   d
0000020  \n

== poll 2 (offset 12), file unchanged
0000000   1   2       1   2  \n

== poll 3 (offset 12), after appending "second line"
0000000   2   4       1   2  \n   s   e   c   o   n   d       l   i   n
0000020   e  \n

== missing file
0000000   0       0  \n

== rotated file, polled with stale offset 24
0000000   8       0  \n   n   e   w       r   u   n  \n
```
