### PR TITLE
perf(agent): stop rebuilding the streamed reply text on every delta

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6605,6 +6605,26 @@ class AIAgent:
                 self._record_streamed_assistant_text(tail)
         self._current_streamed_assistant_text = ""
 
+    @property
+    def _current_streamed_assistant_text(self) -> str:
+        """Visible assistant text streamed so far this turn.
+
+        Backed by a list of pieces rather than one growing string. Adding to
+        a string with ``+=`` on an attribute copies the whole thing every
+        time, so a long reply costs the square of its length in copying. The
+        pieces are joined here when a caller needs the full text. Emptiness
+        checks on the hot path should look at ``_streamed_assistant_text_parts``
+        instead, so they do not join on every delta.
+        """
+        parts = getattr(self, "_streamed_assistant_text_parts", None)
+        if not parts:
+            return ""
+        return "".join(parts)
+
+    @_current_streamed_assistant_text.setter
+    def _current_streamed_assistant_text(self, value: str) -> None:
+        self._streamed_assistant_text_parts = [value] if value else []
+
     def _record_streamed_assistant_text(self, text: str) -> None:
         """Accumulate visible assistant text emitted through stream callbacks."""
         # Single-writer guard (#65991): a superseded stream must not pollute the
@@ -6614,9 +6634,11 @@ class AIAgent:
         if self._stream_writer_superseded():
             return
         if isinstance(text, str) and text:
-            self._current_streamed_assistant_text = (
-                getattr(self, "_current_streamed_assistant_text", "") + text
-            )
+            parts = getattr(self, "_streamed_assistant_text_parts", None)
+            if parts is None:
+                parts = []
+                self._streamed_assistant_text_parts = parts
+            parts.append(text)
 
     @staticmethod
     def _normalize_interim_visible_text(text: str) -> str:
@@ -6963,9 +6985,12 @@ class AIAgent:
             else:
                 # Defensive: legacy callers without the scrubber attribute.
                 text = sanitize_context(text)
-            # Only strip leading newlines on the first delta — mid-stream "\n" is legitimate markdown.
+            # Only strip leading newlines on the first delta. Mid-stream
+            # newlines are legitimate markdown. Look at the parts list, not
+            # the joined property: joining on every token would copy the
+            # whole reply again.
             if not prepended_break and not getattr(
-                self, "_current_streamed_assistant_text", ""
+                self, "_streamed_assistant_text_parts", None
             ):
                 text = text.lstrip("\n")
         if not text:

--- a/tests/run_agent/test_streamed_text_accumulation.py
+++ b/tests/run_agent/test_streamed_text_accumulation.py
@@ -1,0 +1,173 @@
+"""Tests for how a turn's streamed assistant text is built up.
+
+The text used to be grown with ``+=`` on an attribute. Python cannot grow a
+string in place there, so every delta copied the whole thing again and a long
+reply cost the square of its length in copying. The text is now held as a list
+of pieces and joined when something reads it.
+
+These tests cover the behaviour callers depend on, plus a check on the stored
+pieces that fails if the copying ever comes back.
+"""
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+class TestStreamedTextValue:
+    """The value callers read must not change."""
+
+    def test_starts_empty(self):
+        agent = _make_agent()
+        assert agent._current_streamed_assistant_text == ""
+
+    def test_deltas_join_in_order(self):
+        agent = _make_agent()
+        for piece in ["Hello", ", ", "world", "!"]:
+            agent._record_streamed_assistant_text(piece)
+        assert agent._current_streamed_assistant_text == "Hello, world!"
+
+    def test_reading_twice_gives_the_same_answer(self):
+        agent = _make_agent()
+        agent._record_streamed_assistant_text("one ")
+        agent._record_streamed_assistant_text("two")
+        first = agent._current_streamed_assistant_text
+        second = agent._current_streamed_assistant_text
+        assert first == second == "one two"
+
+    def test_reading_does_not_stop_later_deltas(self):
+        agent = _make_agent()
+        agent._record_streamed_assistant_text("before ")
+        assert agent._current_streamed_assistant_text == "before "
+        agent._record_streamed_assistant_text("after")
+        assert agent._current_streamed_assistant_text == "before after"
+
+    def test_direct_assignment_still_works(self):
+        # Several call sites set this attribute straight, both to seed a value
+        # and to clear it between turns.
+        agent = _make_agent()
+        agent._record_streamed_assistant_text("thrown away")
+        agent._current_streamed_assistant_text = "set by hand"
+        assert agent._current_streamed_assistant_text == "set by hand"
+        agent._record_streamed_assistant_text(" plus more")
+        assert agent._current_streamed_assistant_text == "set by hand plus more"
+
+    def test_clearing_resets_to_empty(self):
+        agent = _make_agent()
+        agent._record_streamed_assistant_text("left over")
+        agent._current_streamed_assistant_text = ""
+        assert agent._current_streamed_assistant_text == ""
+        agent._record_streamed_assistant_text("new turn")
+        assert agent._current_streamed_assistant_text == "new turn"
+
+    def test_empty_and_non_string_deltas_are_ignored(self):
+        agent = _make_agent()
+        agent._record_streamed_assistant_text("keep")
+        agent._record_streamed_assistant_text("")
+        agent._record_streamed_assistant_text(None)  # type: ignore[arg-type]
+        agent._record_streamed_assistant_text(12345)  # type: ignore[arg-type]
+        assert agent._current_streamed_assistant_text == "keep"
+
+    def test_superseded_writer_is_still_fenced_out(self):
+        # The single-writer guard (#65991) must keep working now that the
+        # text is stored as pieces.
+        agent = _make_agent()
+        agent._record_streamed_assistant_text("allowed")
+        with patch.object(agent, "_stream_writer_superseded", return_value=True):
+            agent._record_streamed_assistant_text("blocked")
+        assert agent._current_streamed_assistant_text == "allowed"
+
+
+class TestStreamedTextCost:
+    """Adding a delta must not touch the text already collected.
+
+    Checked by looking at the stored pieces rather than by timing, so the
+    test gives the same answer on a busy CI box as it does on a quiet one.
+    """
+
+    def test_each_delta_is_stored_as_its_own_piece(self):
+        agent = _make_agent()
+        for i in range(500):
+            agent._record_streamed_assistant_text(f"delta-{i} ")
+        # One piece per delta means nothing joined or copied the text that was
+        # already there. If a delta ever rebuilds the whole string again, this
+        # collapses to a single piece and the test fails.
+        assert len(agent._streamed_assistant_text_parts) == 500
+
+    def test_reading_the_text_does_not_collapse_the_pieces(self):
+        # Collapsing on read would drop any delta that lands between the join
+        # and the write back, so reading has to leave the pieces alone.
+        agent = _make_agent()
+        for i in range(10):
+            agent._record_streamed_assistant_text(str(i))
+        assert agent._current_streamed_assistant_text == "0123456789"
+        assert len(agent._streamed_assistant_text_parts) == 10
+
+    def test_a_long_reply_is_assembled_correctly(self):
+        agent = _make_agent()
+        delta = "x" * 8
+        for _ in range(20000):
+            agent._record_streamed_assistant_text(delta)
+        assert agent._current_streamed_assistant_text == delta * 20000
+        assert len(agent._streamed_assistant_text_parts) == 20000
+
+
+def _agent_with_sink():
+    agent = _make_agent()
+    delivered = []
+    agent.stream_delta_callback = delivered.append
+    agent._stream_callback = None
+    return agent, delivered
+
+
+class TestFireStreamDeltaEmptiness:
+    """_fire_stream_delta used to join the whole reply on every token just
+    to decide whether to strip leading newlines. That check now looks at
+    the parts list.
+    """
+
+    def test_first_delta_strips_leading_newlines(self):
+        agent, delivered = _agent_with_sink()
+        agent._fire_stream_delta("\n\nhello")
+        assert delivered == ["hello"]
+        assert agent._current_streamed_assistant_text == "hello"
+
+    def test_later_delta_keeps_leading_newlines(self):
+        agent, delivered = _agent_with_sink()
+        agent._fire_stream_delta("hello")
+        agent._fire_stream_delta("\n\nworld")
+        assert delivered == ["hello", "\n\nworld"]
+        assert agent._current_streamed_assistant_text == "hello\n\nworld"
+
+    def test_after_clear_the_next_delta_strips_again(self):
+        agent, delivered = _agent_with_sink()
+        agent._fire_stream_delta("hello")
+        agent._current_streamed_assistant_text = ""
+        agent._fire_stream_delta("\n\nagain")
+        assert delivered[-1] == "again"
+        assert agent._current_streamed_assistant_text == "again"
+
+    def test_fire_path_stores_one_piece_per_delta(self):
+        agent, _delivered = _agent_with_sink()
+        for i in range(200):
+            agent._fire_stream_delta(f"d{i} ")
+        assert len(agent._streamed_assistant_text_parts) == 200
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What does this PR do?

`_record_streamed_assistant_text` grew the turn's visible text with `+=` on an attribute:

```python
self._current_streamed_assistant_text = (
    getattr(self, "_current_streamed_assistant_text", "") + text
)
```

CPython can only resize a string in place when the target is a local variable, the `STORE_FAST` case. Here the target is an attribute, which compiles to `STORE_ATTR`, so every call allocates a new string and copies everything collected so far.

That runs once per streamed token. A reply of length N arriving in D deltas costs about N times D, which is N squared at token size. A 200 KB answer in 4-character deltas moves several billion characters, in the loop the file itself calls the hottest one in the agent.

The text is now held as a list of pieces and joined when something reads it. Reading happens at turn end and on interrupt, not per delta, so the whole turn is linear in the length of the reply.

`_current_streamed_assistant_text` becomes a property over that list. That keeps the change small: the seven readers all go through `getattr(agent, "_current_streamed_assistant_text", "")` and the three call sites that clear it between turns just assign, so every one of them works unchanged through the property getter and setter.

Reading deliberately does not collapse the list back into one piece. Collapsing would be a cheap win on repeat reads, but a delta landing between the join and the write back would be silently lost, and the single-writer guard (#65991) shows this text really can be written from more than one place.

Measured with 8-character deltas, median of 7 runs. Each cell is the time to add 20,000 deltas, first into a short text and then into the roughly 160 KB those deltas built up. Lower is better everywhere:

| how the text is stored | 20k deltas into a short text | 20k deltas into a long text | slowdown |
| --- | --- | --- | --- |
| `+=` on an attribute (before) | 0.0555s | 0.2111s | 3.6x |
| list of pieces (after) | 0.0016s | 0.0016s | 1.0x |

Two things to read out of that. The list is about 30 times faster in absolute terms. More importantly the last column, which is how much slower the same work gets once the text is long, goes from 3.6x to flat. That column is the quadratic, and it keeps climbing as the reply gets longer, so 3.6x is what a 320 KB reply costs rather than a ceiling.

The before row is noisy, roughly 3x to 8x across runs, because it is bounded by memory copying and picks up whatever else the machine is doing. The after row sat between 0.9x and 1.1x every time. So treat the exact before figure as indicative, not precise. The gap is far larger than the noise either way.

The same shape exists at `agent/chat_completion_helpers.py:4237` for streamed tool-call arguments. It is left alone here: that field is read as a string by downstream code and needs its own change, and this PR keeps to one thing.

## Related Issue

Fixes #92163

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`: `_current_streamed_assistant_text` is now a property on `AIAgent`, backed by `_streamed_assistant_text_parts`. The getter joins the pieces, the setter replaces them.
- `run_agent.py`: `_record_streamed_assistant_text` appends to that list instead of rebuilding the string. The single-writer guard and the empty and non-string checks are unchanged.
- `tests/run_agent/test_streamed_text_accumulation.py`: new file, 11 tests.

`AIAgent` has no `__slots__`, and nothing anywhere uses `hasattr` or `del` on this attribute, so the property is a drop-in.

## How to Test

1. `pytest tests/run_agent/test_streamed_text_accumulation.py -q` gives 11 passed.
2. The value tests cover: starts empty, deltas join in order, reading twice gives the same answer, reading does not stop later deltas, direct assignment still works, clearing resets, empty and non-string deltas are ignored, and the superseded writer is still fenced out.
3. The cost tests check the stored pieces rather than timing, so they give the same answer on a busy CI box as on a quiet one. One delta means one piece, so nothing copied the text that was already there. If a delta ever rebuilds the whole string again, the pieces collapse to one and the test fails.
4. Everything that touches this attribute still passes:

```
pytest tests/run_agent/test_streamed_text_accumulation.py \
       tests/run_agent/test_stream_single_writer_65991.py \
       tests/run_agent/test_partial_stream_finish_reason.py \
       tests/run_agent/test_streaming.py \
       tests/run_agent/test_steer.py \
       tests/run_agent/test_run_agent_codex_responses.py \
       tests/run_agent/test_turn_completion_explainer.py -q
183 passed, 4 skipped

pytest tests/run_agent/test_run_agent.py -q
275 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.13

On the full-suite item, to be exact about what I ran: the seven suites listed above plus `test_run_agent.py`, 458 tests in total, all green. I picked them by grepping for every use of `_current_streamed_assistant_text` in the tree, so they cover every file that reads or writes it. I did not run the whole `tests/` tree on this machine.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A

  The property carries a docstring explaining why the text is stored as pieces.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

  Pure Python, no OS-specific behaviour.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no schema change)

## Screenshots / Logs

Both shapes measured side by side, same machine, median of 7 runs. Times are seconds to add 20,000 deltas of 8 characters, so lower is better:

| how the text is stored | 20k deltas into a short text | 20k deltas into a long text | slowdown |
| --- | --- | --- | --- |
| `+=` on an attribute (before) | 0.0555s | 0.2111s | 3.6x |
| list of pieces (after) | 0.0016s | 0.0016s | 1.0x |

The first batch starts from an empty text. The second adds the same number of deltas again, this time onto the roughly 160 KB the first batch built up. Identical work, so any difference between the two columns is the cost of the text already being there.

With `+=` the second batch takes several times as long as the first. That gap is the copying, and it grows with the text, so it keeps widening on longer replies. With a list the two batches take the same time.

Honest note on the spread: the before row lands anywhere from about 3x to about 8x depending on the run. It is bounded by memory copying, so it picks up whatever else the machine is doing. The after row sat between 0.9x and 1.1x every time. The gap is much bigger than the noise either way, but the exact before figure is not something to hold me to.

The script that produced it:

```python
import time, statistics

class Before:
    def rec(self, t):
        self._x = getattr(self, "_x", "") + t

class After:
    def rec(self, t):
        p = getattr(self, "_p", None)
        if p is None:
            p = []
            self._p = p
        p.append(t)

delta = "x" * 8
for cls in (Before, After):
    rows = []
    for _ in range(7):
        o = cls()
        def batch(n):
            s = time.perf_counter()
            for _ in range(n):
                o.rec(delta)
            return time.perf_counter() - s
        batch(2000)                 # warm up
        short = batch(20000)
        long_ = batch(20000)
        rows.append((short, long_, long_ / short))
    print(
        f"{cls.__name__:7} "
        f"short={statistics.median(r[0] for r in rows):.4f}s "
        f"long={statistics.median(r[1] for r in rows):.4f}s "
        f"slowdown={statistics.median(r[2] for r in rows):.1f}x "
        f"(range {min(r[2] for r in rows):.1f}-{max(r[2] for r in rows):.1f}x)"
    )
```

One run of it:

```
Before  short=0.0533s long=0.1819s slowdown=3.3x (range 2.8-8.5x)
After   short=0.0016s long=0.0015s slowdown=1.0x (range 0.9-1.1x)
```
