### PR TITLE
fix(vision): skip native DeepSeek chat endpoint in auto vision routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1024,11 +1024,16 @@ def _resolve_provider_vision_default(provider: str) -> Optional[str]:
 # it must skip straight to the aggregator chain instead of returning a client
 # that will 404 on every vision request.
 #
+# deepseek: the native DeepSeek chat endpoint is text-only. Vision models in
+# the broader DeepSeek ecosystem use separate model families/endpoints, so the
+# configured chat client cannot safely receive image content.
+#
 # kimi-coding / kimi-coding-cn: the Kimi Coding Plan routes through
 # api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
 # describe as having no image_in capability. Vision lives on the separate
 # Kimi Platform (api.moonshot.ai, OpenAI-wire, pay-as-you-go).  See #17076.
 _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
+    "deepseek",
     "kimi-coding",
     "kimi-coding-cn",
 })


### PR DESCRIPTION
## Summary

Prevents the auto vision router from returning the native DeepSeek chat client for image requests.

`resolve_vision_provider_client(provider="auto")` can currently return the user's native DeepSeek chat client even though that endpoint is text-only. The next image request then fails at the provider with a cryptic image-content error instead of falling through to a vision-capable aggregator.

## Why

`deepseek-v4-pro` has no usable capability record in the models.dev path, so the unknown result is treated permissively and the chat client is returned. `_PROVIDERS_WITHOUT_VISION` only listed Kimi Coding endpoints despite the native DeepSeek chat endpoint having the same invariant.

## Change

Add `deepseek` to `_PROVIDERS_WITHOUT_VISION`, so auto routing skips the native DeepSeek chat provider and continues through the configured vision aggregator chain. Explicit provider selection remains available for experimental endpoints.

## Validation

- `tests/agent/test_vision_routing_31179.py` passes, including the existing `test_text_only_main_skipped_when_no_aggregator` regression test
- Ruff and PLW1514 pass for `agent/auxiliary_client.py`
- `git diff --check` passes

Fixes #83097