### PR TITLE
fix(tests): isolate platform-specific assumptions

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -107,7 +107,11 @@ class TestCamofoxNavigate:
         assert result["url"] == "https://example.com"
 
 
-    def test_connection_error_returns_helpful_message(self, monkeypatch):
+    @patch("tools.browser_camofox.requests.post")
+    def test_connection_error_returns_helpful_message(self, mock_post, monkeypatch):
+        from requests import ConnectionError as RequestsConnectionError
+
+        mock_post.side_effect = RequestsConnectionError("camofox unavailable")
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:19999")
         result = json.loads(camofox_navigate("https://example.com", task_id="t_err"))
         assert result["success"] is False
@@ -360,5 +364,4 @@ class TestBrowserToolRouting:
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
         from tools.browser_tool import check_browser_requirements
         assert check_browser_requirements() is True
-
 

--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -112,7 +112,7 @@ class TestCamofoxNavigate:
         from requests import ConnectionError as RequestsConnectionError
 
         mock_post.side_effect = RequestsConnectionError("camofox unavailable")
-        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:19999")
+        monkeypatch.setenv("CAMOFOX_URL", "http://camofox.test")
         result = json.loads(camofox_navigate("https://example.com", task_id="t_err"))
         assert result["success"] is False
         assert "Cannot connect" in result["error"]

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -220,6 +220,7 @@ def test_openwakeword_ensures_base_models_for_custom_path(monkeypatch):
     # so a fresh install crashed at load time on a missing melspectrogram.onnx.
     # The base feature models must be ensured for a custom path too.
     calls = _install_fake_openwakeword(monkeypatch)
+    monkeypatch.setattr(ww, "_is_macos_arm64", lambda: False)
     eng = ww._OpenWakeWordEngine(
         {"provider": "openwakeword", "openwakeword": {"model": "/models/hey_hermes.onnx"}}
     )


### PR DESCRIPTION
## Summary

Isolates two platform-specific test assumptions so they are deterministic on macOS. Both tests were deterministically failing on this Mac — each assumed a platform branch it never selected.

## Changes

- **Camofox** (`test_connection_error_returns_helpful_message`): mock `requests.post` instead of relying on TCP port 19999 being unused. Any local service already bound to that port made the test return an unrelated HTTP response instead of the connection error it intends to exercise.
- **Wake word** (`test_openwakeword_ensures_base_models_for_custom_path`): mock `_is_macos_arm64` so the test isolates the custom-model download behavior instead of falling into the real Apple Silicon tflite requirement.

## Scope note

This PR is intentionally limited to the two files that #82023 does not cover. The remaining macOS portability fixes (systemd abstract socket, service_manager permissions, GNOME helper filter, file-tool temp paths, WSL playback) already live in Jind0la's open #82023, so those are left there to avoid duplicating the work.

## Validation

On macOS, the affected two-file suite passes: 47 passed, 2 skipped.

Fixes #83095