### PR TITLE
fix(gateway): isolate supervised watcher contexts — keep Kanban dispatch running after delegate_task (salvage of #91971)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -15,6 +15,7 @@ import logging
 import os
 import sqlite3
 import time
+from contextvars import Context
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -71,6 +72,23 @@ def _kanban_dispatch_allowed() -> bool:
     except ImportError:
         return True
     return not check_paused("kanban", logger)
+
+
+def _run_in_fresh_context(func: Callable[..., Any], /, *args: Any) -> Any:
+    """Run *func* in an empty ``Context`` so request-local ContextVars stay behind.
+
+    ``asyncio.to_thread`` copies the calling task's context onto the worker
+    thread. Supervised Kanban ticks are process-owned writers; if that copy
+    still carries a ``delegate_task`` child marker (spawn-time snapshot or a
+    later polluted task), ``write_txn`` false-trips. An empty Context keeps
+    the DB guard intact for real children without exempting dispatcher writes.
+    """
+    return Context().run(func, *args)
+
+
+async def _to_thread_process_service(func: Callable[..., Any], /, *args: Any) -> Any:
+    """Offload blocking dispatcher work without inheriting request-local ContextVars."""
+    return await asyncio.to_thread(_run_in_fresh_context, func, *args)
 
 
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
@@ -1681,7 +1699,7 @@ class GatewayKanbanWatchersMixin:
             try:
                 # Reap zombie children before per-board work so a board DB
                 # failure cannot block cleanup of unrelated workers.
-                pids = await asyncio.to_thread(_kb.reap_worker_zombies)
+                pids = await _to_thread_process_service(_kb.reap_worker_zombies)
                 if pids:
                     logger.info(
                         "kanban dispatcher: reaped %d zombie worker(s), pids=%s",
@@ -1704,8 +1722,8 @@ class GatewayKanbanWatchersMixin:
                     # takes effect on the next tick, not on gateway restart (#49638).
                     _ad_enabled, _ad_per_tick = _read_auto_decompose_settings()
                     if _ad_enabled:
-                        await asyncio.to_thread(_auto_decompose_tick, _ad_per_tick)
-                    results = await asyncio.to_thread(_tick_once)
+                        await _to_thread_process_service(_auto_decompose_tick, _ad_per_tick)
+                    results = await _to_thread_process_service(_tick_once)
                     any_spawned = False
                     for slug, res in (results or []):
                         if res is not None and getattr(res, "spawned", None):
@@ -1724,7 +1742,7 @@ class GatewayKanbanWatchersMixin:
                                 len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                             )
                     # Health telemetry (aggregate across boards)
-                    ready_pending = await asyncio.to_thread(_ready_nonempty)
+                    ready_pending = await _to_thread_process_service(_ready_nonempty)
                     if ready_pending and not any_spawned:
                         bad_ticks += 1
                     else:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,7 @@ import threading
 import time
 import traceback
 from collections import OrderedDict
-from contextvars import copy_context
+from contextvars import Context, copy_context
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
@@ -13388,6 +13388,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ``_SUPERVISED_HEALTHY_SECS`` — so a long-lived daemon that crashes
         occasionally over days is never permanently abandoned.
 
+        Each watcher starts in a fresh ``Context``. These are process-level
+        services, not continuations of whichever message turn happened to
+        spawn them; inheriting a delegated-child marker would make the Kanban
+        dispatcher reject its own writes when ``asyncio.to_thread`` copies the
+        watcher's context.
+
         ``on_spawn`` (optional) is invoked with the freshly-created task on
         every spawn, INCLUDING internal backoff respawns. Callers that also
         track the live handle elsewhere (e.g. ``self._reconnect_watcher_task``
@@ -13403,9 +13409,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # uses it to distinguish a rapid crash-loop from a healthy-run-then-crash.
         _started = time.monotonic()
 
-        # Deliberately do NOT pass name= to create_task — some test doubles mock
-        # create_task with a signature that rejects the name kwarg.
-        task = asyncio.create_task(coro_factory())
+        # Deliberately do NOT pass kwargs to create_task — some test doubles
+        # mock it with a narrow signature. Calling it from a fresh Context has
+        # the same isolation semantics as create_task(..., context=Context())
+        # while preserving that compatibility.
+        task = Context().run(lambda: asyncio.create_task(coro_factory()))
         # Mark this as a PERMANENT supervised watcher, not transient background
         # WORK. The scale-to-zero idle check must ignore these: supervised
         # watchers (session-expiry, kanban, reconnect, the scale-to-zero watcher
@@ -13467,7 +13475,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             on_spawn=on_spawn,
                         )
 
-                respawn_task = asyncio.create_task(_respawn())
+                # The done callback retains the context in which it was
+                # registered, so isolate the backoff task too; otherwise a
+                # restart could reintroduce the original caller's turn scope.
+                respawn_task = Context().run(lambda: asyncio.create_task(_respawn()))
                 self._background_tasks.add(respawn_task)
                 respawn_task.add_done_callback(self._background_tasks.discard)
 

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -446,6 +446,28 @@ class TestSpawnSupervised:
     """Verify the task-level supervision wrapper around watcher launches."""
 
     @pytest.mark.asyncio
+    async def test_watcher_does_not_inherit_delegated_child_context(self):
+        """Long-lived gateway services must not inherit one turn's child scope."""
+        from agent.delegation_context import (
+            delegated_child_context,
+            is_delegated_child_context,
+        )
+
+        runner = _make_runner()
+        observed = []
+
+        async def _watcher():
+            observed.append(is_delegated_child_context())
+
+        with delegated_child_context():
+            assert is_delegated_child_context() is True
+            task = runner._spawn_supervised(_watcher, "isolated_watcher")
+            await task
+            assert is_delegated_child_context() is True
+
+        assert observed == [False]
+
+    @pytest.mark.asyncio
     async def test_clean_synchronous_return_is_not_respawned(self):
         # A supervised coro that returns immediately (clean exit) must be
         # invoked EXACTLY ONCE — a clean return means deliberate shutdown or a

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -468,6 +468,30 @@ class TestSpawnSupervised:
         assert observed == [False]
 
     @pytest.mark.asyncio
+    async def test_dispatcher_to_thread_does_not_trip_kanban_guard(self):
+        """Already-running ticks copy the caller task context into to_thread.
+
+        Issue #91958 is a dispatcher that was spawned at boot, then a later
+        ``delegate_task`` leaves the worker copy marked as a child. Spawn
+        isolation does not rewrite that frozen task context; the offload
+        helper must scrub it at the tick boundary. The in-task child guard
+        stays closed.
+        """
+        from agent.delegation_context import (
+            delegated_child_context,
+            is_delegated_child_context,
+        )
+        from gateway.kanban_watchers import _to_thread_process_service
+        from hermes_cli.kanban_db import _assert_not_delegated_child_mutation
+
+        with delegated_child_context():
+            assert is_delegated_child_context() is True
+            with pytest.raises(PermissionError, match="delegate_task child"):
+                _assert_not_delegated_child_mutation()
+            await _to_thread_process_service(_assert_not_delegated_child_mutation)
+            assert is_delegated_child_context() is True
+
+    @pytest.mark.asyncio
     async def test_clean_synchronous_return_is_not_respawned(self):
         # A supervised coro that returns immediately (clean exit) must be
         # invoked EXACTLY ONCE — a clean return means deliberate shutdown or a


### PR DESCRIPTION
## Summary
Salvage of #91971 by @fangliquanflq — supervised gateway watchers now start (and respawn) in a fresh `contextvars.Context`, so a message turn's delegated-child marker can never leak into process-level services; the Kanban dispatcher stops false-tripping `PermissionError: delegate_task child contexts cannot mutate Kanban tasks or boards` (#91958).

## What was wrong
`_spawn_supervised` used bare `asyncio.create_task`, snapshotting the spawner's ContextVars; `asyncio.to_thread` then copied that context into dispatcher DB writes, tripping `_assert_not_delegated_child_mutation`.

## Changes
- gateway/run.py: watcher tasks and backoff respawn tasks created via `Context().run(...)` — fixes all 12 supervised watchers (incl. the kanban notifier's ~10 guarded offloads), not just the dispatcher.
- gateway/kanban_watchers.py: `_to_thread_process_service` belt-and-braces on the 4 dispatcher offloads.
- tests: spawn-boundary isolation + guard-stays-closed-for-real-children.

Chosen over competing #91968 (wrapped only the 4 dispatcher offloads and introduced a public force-override of the child marker — wrong boundary, missed sibling sites, weakened the guard).

## Validation
| | |
|---|---|
| tests/gateway/test_platform_reconnect.py (incl. new) | 23 passed |
| live smoke | thread copy scrubbed, caller guard intact, spawn isolation confirmed |
| ContextVar audit | all agent/gateway ContextVars per-turn scoped; watchers use self/closures — nothing legitimate dropped |
| ruff | clean |

Authorship preserved: both commits by @fangliquanflq. Fixes #91958. Closes #91971. Supersedes #91968 (@1052326311 credited for the independent diagnosis).