### PR TITLE
fix(update): name the stale gateway pids the update already recorded

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4899,6 +4899,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_npm_manifests_digest",
         "_orphaned_desktop_backend_pids",
         "_pause_windows_gateways_for_update",
+        "_pids_still_running",
         "_print_curator_first_run_notice",
         "_print_curator_recent_run_notice",
         "_print_fts_optimize_available_notice",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -5044,7 +5044,36 @@ def _surviving_gateway_pids_after_failed_restart():
         logger.debug("Could not probe for surviving gateways after update: %s", exc)
         return None
 
-def _warn_gateway_restart_phase_aborted(exc: BaseException, pids) -> None:
+def _pids_still_running(pids):
+    """Filter ``pids`` to those that still exist, or ``None`` if unprobeable.
+
+    Delegates to :func:`gateway.status._pid_exists`, the project's no-kill
+    probe, for the reason spelled out in :func:`hermes_cli.update_lock._pid_alive`:
+    on Windows ``os.kill(pid, 0)`` is not a no-op -- CPython routes ``sig=0``
+    to ``GenerateConsoleCtrlEvent`` and Ctrl+C's the target's whole console
+    process group (bpo-14484). A liveness check must never be able to kill the
+    gateway it is asking about.
+
+    ``None`` means "could not determine", and is returned rather than ``[]``
+    because this runs on the aborted-restart path, where an unimportable
+    checkout is the norm rather than the exception. The caller must be able to
+    tell "nothing is left running" from "we could not look" -- the same
+    distinction :func:`_surviving_gateway_pids_after_failed_restart` draws.
+    """
+    if not pids:
+        return []
+    try:
+        from gateway.status import _pid_exists
+
+        return [pid for pid in pids if _pid_exists(pid)]
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Could not probe pre-restart gateway pids: %s", exc)
+        return None
+
+
+def _warn_gateway_restart_phase_aborted(
+    exc: BaseException, pids, pre_restart_pids=None
+) -> None:
     """Print a recovery warning when the whole restart phase raised.
 
     Issue #78574: the gateway auto-restart phase was wrapped in a blanket
@@ -5054,12 +5083,43 @@ def _warn_gateway_restart_phase_aborted(exc: BaseException, pids) -> None:
     printed "Update complete!" and exited 0 while the running gateway kept
     serving pre-update modules against replaced source files — the next turn
     died with an ImportError.
+
+    Issue #92145 is the follow-on: the warning fires, but with no PIDs in it.
+    ``pids`` comes from :func:`_surviving_gateway_pids_after_failed_restart`,
+    which re-imports ``hermes_cli.gateway`` from the checkout that just broke,
+    so on exactly the runs this warning exists for it answers ``None``. The
+    operator is then told that some gateway somewhere is stale and left to find
+    it, even though the update recorded the running PIDs at
+    ``_pre_restart_gateway_pids`` before it touched anything. Fall back to that
+    snapshot, liveness-filtered so a gateway that DID exit is not named as a
+    survivor.
+
+    Deliberately NOT done here: killing what we name. Whether the update may
+    SIGKILL a surviving gateway depends on whether anything will bring it back
+    (systemd ``Restart=``, launchd ``KeepAlive``, the detached profile watcher)
+    and killing an unsupervised ``hermes gateway run`` trades a stale gateway
+    for no gateway. That is a blast-radius policy decision, and it is separable
+    from making this message actionable.
     """
     print()
     print(f"⚠ Update incomplete — gateway auto-restart failed: {exc}")
-    if pids:
-        listed = ", ".join(str(pid) for pid in pids)
+    listed_pids = list(pids) if pids else []
+    from_snapshot = False
+
+    if not listed_pids and pre_restart_pids:
+        still_running = _pids_still_running(pre_restart_pids)
+        if still_running:
+            listed_pids = still_running
+            from_snapshot = True
+
+    if listed_pids:
+        listed = ", ".join(str(pid) for pid in listed_pids)
         print(f"  Gateway process(es) still running pre-update code: {listed}")
+        if from_snapshot:
+            # Say where the list came from. It is a pre-restart snapshot that
+            # is still alive now, not a fresh enumeration, and an operator
+            # reading it should know the difference before acting on it.
+            print("  (seen before the restart phase, still running now)")
     else:
         print("  Any gateway still running is serving pre-update code")
         print("  (mixed sys.modules) against the updated checkout.")
@@ -7883,7 +7943,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _surviving, _pre_restart_gateway_pids
             ):
                 gateway_fleet_restart_incomplete = True
-                _warn_gateway_restart_phase_aborted(e, _surviving)
+                _warn_gateway_restart_phase_aborted(
+                    e, _surviving, _pre_restart_gateway_pids
+                )
                 if gateway_mode:
                     _exit_code_path = get_hermes_home() / ".update_exit_code"
                     try:

--- a/tests/hermes_cli/test_update_gateway_restart_aborted.py
+++ b/tests/hermes_cli/test_update_gateway_restart_aborted.py
@@ -16,6 +16,7 @@ import sys
 import types
 
 from hermes_cli.main import (
+    _pids_still_running,
     _restart_phase_failure_is_incomplete,
     _surviving_gateway_pids_after_failed_restart,
     _warn_gateway_restart_phase_aborted,
@@ -103,3 +104,167 @@ class TestAbortedRestartWarning:
         assert "Update incomplete" in out
         assert "systemctl exploded" in out
         assert "hermes gateway restart" in out
+
+
+class TestPreRestartSnapshotFallback:
+    """Regression for #92145 -- the warning that knows nothing it already knew.
+
+    The #78574 fix above made the aborted restart phase speak up. What it says
+    on the runs that matter, though, is "any gateway still running is serving
+    pre-update code", with no pid attached, because ``pids`` comes from
+    :func:`_surviving_gateway_pids_after_failed_restart`, which re-imports
+    ``hermes_cli.gateway`` from the checkout that just broke. The reporter's own
+    log is the proof: it shows the no-pid branch, so the probe answered ``None``
+    or ``[]`` on a box where a stale gateway was demonstrably alive (their next
+    turn died importing ``opencode_provider_family`` from stale
+    ``sys.modules``).
+
+    The update was not actually ignorant. ``_pre_restart_gateway_pids``, taken
+    before the phase touched anything, is a local at the abort site. These tests
+    pin that the snapshot reaches the operator, and that it is liveness-filtered
+    so a gateway that really did exit is never named as a survivor.
+    """
+
+    @staticmethod
+    def _pid_exists_module(alive):
+        """A stand-in ``gateway.status`` whose ``_pid_exists`` answers ``alive``."""
+        fake = types.ModuleType("gateway.status")
+        fake._pid_exists = lambda pid: pid in alive
+
+        return fake
+
+    def test_snapshot_pids_are_named_when_the_probe_cannot_answer(
+        self, monkeypatch, capsys
+    ):
+        """The reporter's exact shape: probe undeterminable, gateway alive."""
+        monkeypatch.setitem(
+            sys.modules, "gateway.status", self._pid_exists_module({991, 992})
+        )
+
+        _warn_gateway_restart_phase_aborted(
+            ImportError("cannot import name 'line_input' from 'hermes_cli.cli_output'"),
+            None,
+            [991, 992],
+        )
+        out = capsys.readouterr().out
+
+        assert "991, 992" in out, (
+            "the update recorded these pids before the restart phase; naming "
+            "them is the difference between an actionable warning and a riddle"
+        )
+        assert "seen before the restart phase" in out, (
+            "an operator must be able to tell a pre-restart snapshot from a "
+            "fresh enumeration before acting on it"
+        )
+        assert "hermes gateway restart" in out
+
+    def test_a_snapshot_pid_that_has_since_exited_is_not_named(
+        self, monkeypatch, capsys
+    ):
+        """Liveness-filtered, not replayed.
+
+        The snapshot is a list of pids that WERE running. Printing it back
+        unfiltered would accuse a process that the restart phase successfully
+        stopped, which is worse than the silence it replaces.
+        """
+        monkeypatch.setitem(
+            sys.modules, "gateway.status", self._pid_exists_module({991})
+        )
+
+        _warn_gateway_restart_phase_aborted(RuntimeError("boom"), None, [991, 992])
+        out = capsys.readouterr().out
+
+        assert "991" in out
+        assert "992" not in out
+
+    def test_no_survivors_falls_back_to_the_original_message(
+        self, monkeypatch, capsys
+    ):
+        """Every snapshot pid is gone: say nothing new, and still fail closed.
+
+        The caller has already decided this run is incomplete (an empty
+        survivor set with a non-empty pre-state is the #78574 case). The
+        warning must not invent a pid list it cannot stand behind.
+        """
+        monkeypatch.setitem(sys.modules, "gateway.status", self._pid_exists_module(set()))
+
+        _warn_gateway_restart_phase_aborted(RuntimeError("boom"), None, [991])
+        out = capsys.readouterr().out
+
+        assert "991" not in out
+        assert "Any gateway still running is serving pre-update code" in out
+        assert "hermes gateway restart" in out
+
+    def test_a_live_survivor_probe_still_wins(self, monkeypatch, capsys):
+        """The fresh answer beats the snapshot when there is one.
+
+        The snapshot is a fallback, not a replacement: it is older, and it
+        cannot see a gateway that started during the phase.
+        """
+        monkeypatch.setitem(
+            sys.modules, "gateway.status", self._pid_exists_module({991})
+        )
+
+        _warn_gateway_restart_phase_aborted(RuntimeError("boom"), [4321], [991])
+        out = capsys.readouterr().out
+
+        assert "4321" in out
+        assert "991" not in out
+        assert "seen before the restart phase" not in out
+
+    def test_no_snapshot_is_the_pre_fix_behaviour(self, capsys):
+        """Guardrail for the callers that pass two arguments.
+
+        ``pre_restart_pids`` defaults to ``None`` precisely so the existing
+        call shape keeps working; this pins that it does.
+        """
+        _warn_gateway_restart_phase_aborted(RuntimeError("boom"), None)
+        out = capsys.readouterr().out
+
+        assert "Any gateway still running is serving pre-update code" in out
+
+
+class TestPidsStillRunning:
+    """The liveness helper itself.
+
+    It must never hand-roll ``os.kill(pid, 0)``: on Windows CPython routes
+    ``sig=0`` to ``GenerateConsoleCtrlEvent``, which Ctrl+C's the target's whole
+    console process group (bpo-14484). ``update_lock._pid_alive`` documents this
+    and delegates to ``gateway.status._pid_exists``; so does this.
+    """
+
+    def test_filters_to_the_living(self, monkeypatch):
+        fake = types.ModuleType("gateway.status")
+        fake._pid_exists = lambda pid: pid == 7
+        monkeypatch.setitem(sys.modules, "gateway.status", fake)
+
+        assert _pids_still_running([7, 8, 9]) == [7]
+
+    def test_empty_input_is_empty_output_without_importing_anything(self, monkeypatch):
+        """No pids means no probe -- and on this path an import can raise."""
+        broken = types.ModuleType("gateway.status")
+
+        def _boom(_pid):
+            raise ImportError("checkout is mid-rewrite")
+
+        broken._pid_exists = _boom
+        monkeypatch.setitem(sys.modules, "gateway.status", broken)
+
+        assert _pids_still_running([]) == []
+
+    def test_unprobeable_is_none_not_empty(self, monkeypatch):
+        """"We could not look" must stay distinguishable from "nothing is left".
+
+        Same contract as ``_surviving_gateway_pids_after_failed_restart``. If
+        this returned ``[]`` on a failed probe the caller would silently drop
+        back to the vague message with no way to know why.
+        """
+        broken = types.ModuleType("gateway.status")
+
+        def _boom(_pid):
+            raise ImportError("checkout is mid-rewrite")
+
+        broken._pid_exists = _boom
+        monkeypatch.setitem(sys.modules, "gateway.status", broken)
+
+        assert _pids_still_running([7]) is None


### PR DESCRIPTION
## What does this PR do?

`hermes update`'s gateway auto-restart phase is wrapped in a blanket
`except Exception`. When it raises, `_warn_gateway_restart_phase_aborted`
(`update_cmd.py:5047`) tells the operator that a gateway is still running
pre-update code. #78574 added that warning, and it was the right fix.

The problem is what the warning says on the runs it exists for. Its pid list
comes from `_surviving_gateway_pids_after_failed_restart()`, which re-imports
`hermes_cli.gateway` from the checkout that just broke. Its own docstring says
so:

> Returns `None` when the answer cannot be determined, most importantly when
> `hermes_cli.gateway` itself no longer imports, which is one of the ways the
> restart phase aborts in the first place.

So on the aborted-restart path the probe routinely answers `None`, and the
operator gets the no-pid branch:

```
  Any gateway still running is serving pre-update code
  (mixed sys.modules) against the updated checkout.
```

That is the exact text the reporter of #92145 pasted, from a Raspberry Pi OS
box where the stale gateway was demonstrably alive: their next chat turn died
with `cannot import name 'opencode_provider_family' from 'hermes_cli.models'`
for a symbol that imports fine in a fresh interpreter. They recovered with
`systemctl --user restart`, after going and finding the process themselves.

**The update was not ignorant of that pid.** `_pre_restart_gateway_pids` is
captured at `update_cmd.py:7328`, before the restart phase touches anything,
and it is a live local at the abort site: two lines above the warning it is
passed to `_restart_phase_failure_is_incomplete`. It just never reached the
message.

This PR routes it there.

### Why this approach rather than the one the issue suggests

The issue proposes force-killing the survivors, starting from
"re-read the list of surviving gateway PIDs
(`_surviving_gateway_pids_after_failed_restart` already exists)".

That step iterates over nothing in the reporter's own incident, for the reason
above: their pasted log is the falsy-`pids` branch, so the probe had already
failed. A kill loop over its result kills nothing. Whatever the eventual
policy, the pid list has to come from somewhere that does not depend on the
broken checkout first.

And on the kill itself I have deliberately stopped short, rather than quietly
dropping it. Whether the update may SIGKILL a surviving gateway depends on
whether anything will bring it back: true for the reporter's systemd user
units and for launchd `KeepAlive`, false for a manually-run
`hermes gateway run`, where killing it trades a stale gateway for no gateway
at all. That is a blast-radius decision a maintainer owns, not something to
smuggle into a message fix. It is also a strictly separable change: it needs
the pid list this PR produces, and nothing else here would have to move. If a
maintainer names the policy I will send it.

## Related Issue

Refs #92145

Not `Fixes`, because this makes the failure findable rather than
self-healing. The stale process still has to be restarted; the update now
tells you which one.

Related but distinct, so it does not get read as a duplicate: #88654 / #88703
covers the branch where a restart *could not be armed*
(`_prepare_profile_gateway_update_restart` returning `None`). This is the
branch where the restart phase *raised*. Different trigger, different code
path, no overlapping lines; the two cherry-pick cleanly onto fresh main in
either order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`hermes_cli/update_cmd.py`**

- New `_pids_still_running(pids)`. Filters a pid list to those that still
  exist, delegating to `gateway.status._pid_exists`, the project's existing
  no-kill probe. It does **not** hand-roll `os.kill(pid, 0)`, for the reason
  `update_lock._pid_alive` already documents: on Windows CPython routes
  `sig=0` to `GenerateConsoleCtrlEvent`, which Ctrl+C's the target's whole
  console process group (bpo-14484). Returns `None`, not `[]`, when it cannot
  probe, so "we could not look" stays distinct from "nothing is left running".
  That is the same distinction `_surviving_gateway_pids_after_failed_restart`
  draws, and on this path an unimportable checkout is the norm.
- `_warn_gateway_restart_phase_aborted` takes an optional third argument,
  `pre_restart_pids`. A live probe result still wins when there is one; the
  snapshot is only consulted when `pids` is falsy, and only its still-running
  members are named. The line reads
  `(seen before the restart phase, still running now)` so an operator can tell
  a snapshot from a fresh enumeration before acting on it.
- The abort site now passes `_pre_restart_gateway_pids`.

**`hermes_cli/main.py`**

- Re-export `_pids_still_running` alongside the other update internals the
  test module imports.

**`tests/hermes_cli/test_update_gateway_restart_aborted.py`**

- `TestPreRestartSnapshotFallback` (5) and `TestPidsStillRunning` (3).

## How to Test

1. `pytest tests/hermes_cli/test_update_gateway_restart_aborted.py -q`
   (18 passed: 10 pre-existing, 8 new).
2. Mutation proof. Delete only the fallback block from
   `_warn_gateway_restart_phase_aborted`:

   ```python
   if not listed_pids and pre_restart_pids:
       still_running = _pids_still_running(pre_restart_pids)
       if still_running:
           listed_pids = still_running
           from_snapshot = True
   ```

   Two tests fail, and they are the two that encode the reporter's shape:
   `test_snapshot_pids_are_named_when_the_probe_cannot_answer` and
   `test_a_snapshot_pid_that_has_since_exited_is_not_named`. The other six
   still pass, so they are pinning the surrounding contract rather than the
   shape of the code.
3. End to end, without needing a broken checkout: the abort path is reachable
   by making the restart phase raise. With a gateway running, the warning now
   names its pid instead of describing it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass: the touched file is
  18/18, and the wider `tests/hermes_cli -k update` slice is unchanged
  against this branch's base (same failures on both sides, all
  pre-existing Windows-local reds; the exact comparison is in the first
  comment).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A: the behaviour and the omitted kill are both documented in the function docstrings, which is where the next reader of this path will be.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A: N/A, no config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A: N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): this is the cross-platform crux of the change. The liveness check goes through `gateway.status._pid_exists` rather than `os.kill(pid, 0)` specifically because the latter is not a no-op on Windows. The reported incident is Linux/systemd; the code path is platform-neutral and the tests stub the probe, so they run identically everywhere.
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A: N/A.

## Screenshots / Logs

Before, on an abort where the survivor probe cannot answer:

```
⚠ Update incomplete — gateway auto-restart failed: cannot import name 'line_input' from 'hermes_cli.cli_output'
  Any gateway still running is serving pre-update code
  (mixed sys.modules) against the updated checkout.
  Restart it manually, then verify:
    hermes gateway restart
    hermes gateway status
```

After:

```
⚠ Update incomplete — gateway auto-restart failed: cannot import name 'line_input' from 'hermes_cli.cli_output'
  Gateway process(es) still running pre-update code: 991, 992
  (seen before the restart phase, still running now)
  Restart it manually, then verify:
    hermes gateway restart
    hermes gateway status
```
