### PR TITLE
fix(compression): restore the prune runway when a would-grow refusal keeps the transcript

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3471,8 +3471,7 @@ def compress_context(
                     # The durable copy was never cleared (that clear only rides
                     # the archive_and_compact / child-row commit that never
                     # ran), so restoring the snapshot re-aligns memory with
-                    # disk. When compress() aborted before its tail, snapshot
-                    # and current value are identical and this is a no-op.
+                    # disk.
                     if "_proactive_prune_rearm_tokens" in _compressor_attempt_snapshot:
                         agent.context_compressor._proactive_prune_rearm_tokens = (
                             _compressor_attempt_snapshot[

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3460,6 +3460,25 @@ def compress_context(
                             "could not record rejected-compaction strike",
                             exc_info=True,
                         )
+                    # Restore ONLY the prune runway (same rationale as the
+                    # rotation-failure rollback below): compress()'s successful
+                    # tail already zeroed _proactive_prune_rearm_tokens in
+                    # memory, but this refusal keeps the ORIGINAL transcript —
+                    # whose cached prefix is intact. Leaving the runway at 0
+                    # disarms the #79640 throttle, so the very next iteration's
+                    # proactive prune rewrites history and breaks the prompt
+                    # cache without the required regrowth interval (#91830).
+                    # The durable copy was never cleared (that clear only rides
+                    # the archive_and_compact / child-row commit that never
+                    # ran), so restoring the snapshot re-aligns memory with
+                    # disk. When compress() aborted before its tail, snapshot
+                    # and current value are identical and this is a no-op.
+                    if "_proactive_prune_rearm_tokens" in _compressor_attempt_snapshot:
+                        agent.context_compressor._proactive_prune_rearm_tokens = (
+                            _compressor_attempt_snapshot[
+                                "_proactive_prune_rearm_tokens"
+                            ]
+                        )
                     _release_lock()
                     return messages, _existing_sp
 

--- a/tests/agent/test_would_grow_refusal_runway.py
+++ b/tests/agent/test_would_grow_refusal_runway.py
@@ -1,0 +1,82 @@
+"""Regression: a would-grow refusal must not disarm the proactive-prune runway.
+
+#91830 follow-up. ``ContextCompressor.compress()`` zeroes
+``_proactive_prune_rearm_tokens`` on its successful tail — correct for a
+COMMITTED compaction (the boundary already broke the prompt-cache prefix, so
+the throttle restarts from the new baseline). But ``compress_context``'s
+anti-growth guard can then REFUSE the result and keep the original
+transcript, whose cached prefix is intact. Before the fix, that refusal
+returned with the in-memory runway still at 0 while the durable
+``model_config`` copy kept the old value:
+
+- the very next eligible iteration's proactive prune fired without the
+  regrowth interval #79640 introduced — an immediate, unthrottled
+  cache-breaking rewrite of history that was still byte-identical to what
+  the provider had cached, and
+- memory and disk disagreed until the next restart silently re-armed the
+  throttle from the stale durable row.
+
+The refusal branch now restores the runway from the attempt snapshot, the
+same targeted restore the rotation-failure rollback already performed.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_state import SessionDB
+
+
+def _build_agent(db: SessionDB, session_id: str):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    # Skip the one-time aux-model feasibility probe (may hit the network).
+    agent._compression_feasibility_checked = True
+    return agent
+
+
+def test_would_grow_refusal_restores_prune_runway(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "WOULD_GROW_RUNWAY"
+    db.create_session(session_id, source="test")
+
+    agent = _build_agent(db, session_id)
+    compressor = agent.context_compressor
+    armed_runway = 250_000
+    compressor._proactive_prune_rearm_tokens = armed_runway
+
+    messages = [{"role": "user", "content": f"m{i} " + "x" * 200} for i in range(10)]
+
+    def _growing_compress(msgs, **_kw):
+        # Mirror the real compress() tail: it zeroes the in-memory runway
+        # before returning — then return a transcript LARGER than the input
+        # so the caller's anti-growth guard refuses the commit.
+        compressor._proactive_prune_rearm_tokens = 0
+        return list(msgs) + [
+            {"role": "assistant", "content": "GROWN " * 20_000},
+        ]
+
+    with patch.object(type(compressor), "compress", side_effect=_growing_compress):
+        returned, _sp = agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    # Refusal contract: original transcript kept, refusal flagged.
+    assert returned == messages
+    assert compressor._last_compress_refused_would_grow is True
+    # The runway must survive the refusal — memory re-aligned with the
+    # (never-cleared) durable copy, keeping the #79640 throttle armed.
+    assert compressor._proactive_prune_rearm_tokens == armed_runway
+    # And the compression lock must not leak.
+    assert db.get_compression_lock_holder(session_id) is None

--- a/tests/agent/test_would_grow_refusal_runway.py
+++ b/tests/agent/test_would_grow_refusal_runway.py
@@ -57,6 +57,12 @@ def test_would_grow_refusal_restores_prune_runway(tmp_path: Path) -> None:
     compressor = agent.context_compressor
     armed_runway = 250_000
     compressor._proactive_prune_rearm_tokens = armed_runway
+    # Arm the durable copy too, exactly as a committed prune would have
+    # (prune_tool_results_only persists it via archive_and_compact's
+    # model_config_patch) — the refusal must leave it untouched.
+    db.patch_session_model_config(
+        session_id, {"_proactive_prune_rearm_tokens": armed_runway}
+    )
 
     messages = [{"role": "user", "content": f"m{i} " + "x" * 200} for i in range(10)]
 
@@ -78,5 +84,11 @@ def test_would_grow_refusal_restores_prune_runway(tmp_path: Path) -> None:
     # The runway must survive the refusal — memory re-aligned with the
     # (never-cleared) durable copy, keeping the #79640 throttle armed.
     assert compressor._proactive_prune_rearm_tokens == armed_runway
+    assert (
+        db.get_session_model_config_value(
+            session_id, "_proactive_prune_rearm_tokens", 0
+        )
+        == armed_runway
+    )
     # And the compression lock must not leak.
     assert db.get_compression_lock_holder(session_id) is None


### PR DESCRIPTION
## Summary

A would-grow compression refusal no longer disarms the proactive-prune throttle: the refusal branch restores `_proactive_prune_rearm_tokens` from the attempt snapshot, so the next prune still waits for the full regrowth runway instead of immediately re-breaking the prompt-cache prefix.

Root cause: `ContextCompressor.compress()` zeroes the in-memory runway on its success tail (correct for a committed compaction — that boundary already broke the cache prefix). When `compress_context`'s anti-growth guard then refuses the result and keeps the original transcript, the cached prefix is intact but the runway stayed at 0 in memory while the durable `model_config` copy kept the old value. The #79640 throttle was disarmed until the next restart.

Found while verifying the structural asymmetry flagged in #91830 (jackulau's comment): `compress()`'s runway void has no per-site durable companion, unlike the model-switch path. Tracing every non-commit exit showed the would-grow refusal is the one reachable branch where memory ends up zeroed against an unchanged transcript + un-cleared durable row.

## Changes

- `agent/conversation_compression.py`: would_grow refusal branch restores the runway from `_compressor_attempt_snapshot` — the identical targeted restore the rotation-failure rollback already performs (deliberately inline, matching that sibling; both sites cross-reference each other).
- `tests/agent/test_would_grow_refusal_runway.py`: regression test (real `AIAgent` + real `SessionDB`; only `compress` is stubbed, mirroring the real tail's zeroing). Red without the fix, green with it.

## Sibling-branch audit (all other non-commit exits after compress())

| Branch | Verdict |
|---|---|
| `_last_compress_aborted` | aborts return before the tail zero — runway untouched |
| no-progress (`compressed == before`) | built-in tail zero only runs after a real boundary rewrite; a no-progress result never executed it |
| empty transcript | built-in compress() never returns `[]`; only a plugin engine could, and plugin engines don't run the built-in tail |
| commit-fence denied | `_restore_compressor_attempt_state` restores the full snapshot, runway included |
| rotation publication failure | already has this exact restore (the pattern this PR mirrors) |
| in-place `archive_and_compact` failure | in-memory transcript keeps the compacted form, so a zeroed runway is consistent with the state actually in use |

## Validation

| Check | Result |
|---|---|
| New regression test without fix | FAILS (runway stays 0) |
| New regression test with fix | passes |
| Targeted suites (prune restart-safety, refusal feedback, anti-thrash, salvage-grown, concurrent-fork, context_compressor: 699 total) | all pass, 0 new failures |
| E2E (real SessionDB + AIAgent, durable copy armed, would-grow refusal driven) | in-memory == durable == 250000 after refusal; prune re-throttled; lock released |
| ruff + ty on touched files | clean |

Refs #91830.


## Infographic

![prune-runway-survives-refusal](https://v3b.fal.media/files/b/0aa75959/MMn3H0HJvohx6evTKR86w_ic70htPp.png)
