### PR TITLE
fix(agent): honor stream_only_base_urls on same-provider retry paths

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2756,6 +2756,7 @@ def init_agent(
             proactive_prune_min_reclaim_tokens=compression_proactive_prune_min_reclaim,
             min_tail_user_messages=compression_min_tail_users,
             tail_mode=compression_tail_mode,
+            custom_providers=_custom_providers,
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3376,7 +3376,7 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
        Claude-style models sometimes tack on (TodoTool_tool ->
        TodoTool -> Todo -> todo). Applied twice so double-tacked
        suffixes like ``TodoTool_tool`` reduce all the way.
-    5. Fuzzy match (difflib, cutoff=0.7).
+    5. Fuzzy match (difflib, cutoff=0.7) for non-MCP tools.
 
     See #14784 for the original reports (TodoTool_tool, Patch_tool,
     BrowserClick_tool were all returning "Unknown tool" before).
@@ -3447,6 +3447,15 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     for c in cands:
         if c and c in agent.valid_tool_names:
             return c
+
+    # MCP tool names encode both the server and the tool. A fuzzy fallback can
+    # silently change the requested operation inside the same MCP namespace
+    # (for example, a hallucinated ghidra ``disassemble_function`` becoming
+    # ``decompile_function``). That is a semantic substitution, not a safe
+    # spelling repair, so leave unmatched MCP calls invalid and let the normal
+    # unknown-tool correction path show the model the available tools.
+    if normalized.startswith("mcp__"):
+        return None
 
     # Fuzzy match as last resort.
     matches = get_close_matches(lowered, agent.valid_tool_names, n=1, cutoff=0.7)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5592,12 +5592,22 @@ def _candidate_context_window(
     """
     if not model:
         return None
+    # Load custom_providers from config so per-model context_length
+    # overrides (custom_providers[].models.<id>.context_length) are
+    # honored for fallback candidates too — not just the main model.
+    _custom_providers: list | None = None
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config_readonly
+        _custom_providers = get_compatible_custom_providers(load_config_readonly())
+    except Exception:
+        pass
     try:
         ctx = get_model_context_length(
             model,
             base_url=base_url,
             api_key=api_key,
             provider=provider,
+            custom_providers=_custom_providers,
         )
     except Exception as exc:
         logger.debug(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4815,12 +4815,27 @@ def _retry_same_provider_sync(
         retry_kwargs["extra_headers"] = dict(extra_headers)
     if _is_anthropic_compat_endpoint(resolved_provider, retry_base):
         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
+    # Honor auxiliary.stream_only_base_urls on the retry path too. The initial
+    # attempt routes through the _create_with_progress wrapper with
+    # force_stream computed from that config; a same-provider recovery retry
+    # that dropped the wrapper silently downgraded stream-only endpoints
+    # (gateways behind short proxy read timeouts) back to non-streaming,
+    # reintroducing the exact hangs the setting exists to prevent.
     return _validate_llm_response(
         _relay_sync_completion(
             retry_client,
             retry_kwargs,
             provider=resolved_provider,
             api_mode=resolved_api_mode,
+            create=lambda request: _create_with_progress(
+                retry_client,
+                request,
+                task,
+                force_stream=_provider_requires_stream(
+                    effective_provider or resolved_provider,
+                    retry_base or resolved_base_url,
+                ),
+            ),
         ),
         task,
     )
@@ -4889,12 +4904,26 @@ async def _retry_same_provider_async(
         retry_kwargs["extra_headers"] = dict(extra_headers)
     if _is_anthropic_compat_endpoint(resolved_provider, retry_base):
         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
+    # Mirror of the sync-path fix: honor auxiliary.stream_only_base_urls on
+    # async same-provider retries. Dropping the stream-only wrapper here
+    # silently downgraded stream-only endpoints back to non-streaming.
+    force_stream = _provider_requires_stream(
+        effective_provider or resolved_provider,
+        retry_base or resolved_base_url,
+    ) and not isinstance(retry_client, AsyncCodexAuxiliaryClient)
+
+    async def _acreate(_kwargs: Dict[str, Any]) -> Any:
+        if force_stream:
+            return await _acreate_with_stream(retry_client, _kwargs, task)
+        return await retry_client.chat.completions.create(**_kwargs)
+
     return _validate_llm_response(
         await _relay_async_completion(
             retry_client,
             retry_kwargs,
             provider=resolved_provider,
             api_mode=resolved_api_mode,
+            create=_acreate,
         ),
         task,
     )

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2171,6 +2171,7 @@ class ContextCompressor(ContextEngine):
                 api_key=self.api_key,
                 config_context_length=self._config_context_length,
                 provider=self.provider,
+                custom_providers=self._custom_providers,
             )
             # Small-context threshold floor: models under 512K trigger at
             # >=75% so compaction doesn't fire with half the window still
@@ -3015,6 +3016,7 @@ class ContextCompressor(ContextEngine):
         proactive_prune_min_reclaim_tokens: int = 4096,
         min_tail_user_messages: int = 1,
         tail_mode: str = "legacy",
+        custom_providers: list | None = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -3025,6 +3027,11 @@ class ContextCompressor(ContextEngine):
         # tail + verbatim-user-message summary section + recovery pointers;
         # "legacy" = 0.20*window tail (shipping behavior).
         self.tail_mode = tail_mode if tail_mode in ("legacy", "lean") else "legacy"
+        # Per-model context_length overrides from custom_providers config.
+        # Threaded to get_model_context_length() in _resolve_context_length()
+        # so deferred resolution (first context_length property access) honors
+        # the same per-model overrides that startup resolution does (#15779).
+        self._custom_providers = custom_providers
         # Per-model threshold overrides (longest substring match wins).
         # Stored as a plain dict; resolved in _resolve_threshold(), then the
         # small-context floor is applied on top.

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2259,6 +2259,22 @@ class ContextCompressor(ContextEngine):
     def tail_token_budget(self, value: int) -> None:
         self._tail_token_budget = value
 
+    def recalibrate_tail_budget(self) -> None:
+        """Re-derive the tail budget through the mode-aware policy.
+
+        Runtime recalibration paths (update_model, the aux compression-model
+        threshold sync) must call this instead of writing
+        ``threshold_tokens * summary_target_ratio`` themselves: that legacy
+        formula is only one branch of the ``tail_token_budget`` property.
+        Caching it unconditionally overwrote the lean clamp
+        ([LEAN_TAIL_FLOOR_TOKENS, LEAN_TAIL_CAP_TOKENS]) after model
+        switches, fallback activations, and context-window refreshes while
+        ``tail_mode`` still claimed "lean". Invalidating the cache keeps the
+        property as the single source of truth for both modes — the same
+        pattern the ``context_length`` setter uses.
+        """
+        self._tail_token_budget = None
+
     @property
     def max_summary_tokens(self) -> int:
         if self._max_summary_tokens is None:
@@ -2805,8 +2821,11 @@ class ContextCompressor(ContextEngine):
         self._apply_threshold_tokens_cap()
         # Recalculate token budgets for the new context length so the
         # compressor stays calibrated after a model switch (e.g. 200K → 32K).
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
+        # Invalidate the cached tail budget so the mode-aware property
+        # re-derives it: lean re-clamps to [10K, 25K] of the new window,
+        # legacy recomputes threshold_tokens * summary_target_ratio. Writing
+        # the legacy formula here directly overwrote the lean clamp.
+        self.recalibrate_tail_budget()
         self.max_summary_tokens = min(
             int(context_length * 0.05), _SUMMARY_TOKENS_CEILING,
         )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1738,16 +1738,18 @@ def check_compression_model_feasibility(agent: Any) -> None:
             # ``tail_token_budget`` is derived from the trigger threshold, not
             # directly from the model window. Keep it in lockstep with this
             # just-in-time correction exactly as ContextCompressor.update_model()
-            # does. Leaving the old budget behind can make the tail's 1.5x soft
-            # ceiling wider than the lowered trigger, so compression preserves
-            # nearly the entire request and repeatedly re-fires.
-            summary_target_ratio = getattr(
-                agent.context_compressor, "summary_target_ratio", None
+            # does: invalidate the cache so the mode-aware property re-derives
+            # it (legacy recomputes threshold_tokens * summary_target_ratio;
+            # lean keeps its clamped window-based budget). Writing the legacy
+            # formula here directly would overwrite the lean clamp. Leaving
+            # the old budget behind can make the tail's 1.5x soft ceiling
+            # wider than the lowered trigger, so compression preserves nearly
+            # the entire request and repeatedly re-fires.
+            _recalibrate_tail = getattr(
+                agent.context_compressor, "recalibrate_tail_budget", None
             )
-            if isinstance(summary_target_ratio, (int, float)):
-                agent.context_compressor.tail_token_budget = int(
-                    new_threshold * summary_target_ratio
-                )
+            if callable(_recalibrate_tail):
+                _recalibrate_tail()
             # Keep threshold_percent in sync so future main-model
             # context_length changes (update_model) re-derive from a
             # sensible number rather than the original too-high value.

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -774,7 +774,12 @@ class CredentialPool:
                     self._entries[idx] = new
                     return
 
-    def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+    def _persist(
+        self,
+        *,
+        removed_ids: Optional[List[str]] = None,
+        reset_cooldowns: bool = False,
+    ) -> None:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
@@ -782,6 +787,7 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
+                reset_cooldowns=reset_cooldowns,
             )
 
     def _is_terminal_auth_failure(
@@ -2350,7 +2356,12 @@ class CredentialPool:
                     new_entries.append(entry)
             if count:
                 self._entries = new_entries
-                self._persist()
+                # reset_cooldowns=True: this is an explicit user reset, so the
+                # write must bypass _merge_disk_cooldown_state — otherwise the
+                # recency merge resurrects every still-binding on-disk cooldown
+                # (cleared last_status_at=None sorts older than the active
+                # timestamp) and the reset silently never lands on disk.
+                self._persist(reset_cooldowns=True)
             return count
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -658,6 +658,21 @@ _REFERENCE_DEFAULT_OUTPUT_RESERVE = 8192
 _REFERENCE_TRIM_SAFETY_FRACTION = 0.10
 
 
+def _load_custom_providers() -> list | None:
+    """Best-effort load of custom_providers from config.
+
+    Used by _trim_messages_for_reference to honor per-model context_length
+    overrides (custom_providers[].models.<id>.context_length) when resolving
+    reference model context windows. Returns None on any failure so the
+    resolver falls through to probing — never breaks a MoA turn.
+    """
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config_readonly
+        return get_compatible_custom_providers(load_config_readonly())
+    except Exception:
+        return None
+
+
 def _trim_messages_for_reference(
     messages: list[dict[str, Any]],
     slot: dict[str, str],
@@ -723,6 +738,7 @@ def _trim_messages_for_reference(
                 base_url=str(runtime.get("base_url") or ""),
                 api_key=str(runtime.get("api_key") or ""),
                 provider=provider,
+                custom_providers=_load_custom_providers(),
             )
         except Exception:
             logger.debug(

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -165,6 +165,14 @@ class ProviderInfo:
 # Provider ID mapping: Hermes ↔ models.dev
 # ---------------------------------------------------------------------------
 
+# Hermes custom providers are addressed as "custom:<name>"; models.dev
+# catalogs them under the bare name when it mirrors a public provider
+# (e.g. custom:hyper → hyper). Strip the prefix before lookup.
+def _mdev_provider_id(provider_id: str) -> str:
+    if provider_id.startswith("custom:"):
+        provider_id = provider_id[len("custom:"):]
+    return PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
+
 # Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter",
@@ -754,7 +762,7 @@ def lookup_models_dev_context(
     if override_ctx is not None:
         return override_ctx
 
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
+    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(_mdev_provider_id(provider))
     if not mdev_provider_id:
         return _default_override_context(provider)
 
@@ -1104,7 +1112,7 @@ def _get_provider_models(
     ``allow_network`` defaults to False — this is called from hot paths
     (vision routing, image routing, capability checks) and must never block.
     """
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
+    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(_mdev_provider_id(provider))
     if not mdev_provider_id:
         return None
 
@@ -1454,7 +1462,7 @@ def get_provider_info(
     ``allow_network=False``.
     """
     # Resolve Hermes ID → models.dev ID
-    mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
+    mdev_id = _mdev_provider_id(provider_id)
 
     # NOTE: keep the zero-argument call on the default path. Dozens of test
     # sites monkeypatch fetch_models_dev with zero-arg lambdas; passing the
@@ -1494,7 +1502,7 @@ def get_model_info(
     ``allow_network`` defaults to False — model info lookup is a hot path
     (cost guard, inventory) and must never block on the network.
     """
-    mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
+    mdev_id = _mdev_provider_id(provider_id)
 
     def _from_override_alone() -> Optional[ModelInfo]:
         override = _override_for(provider_id, model_id, catalog_hit=False)

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -173,6 +173,21 @@ def _mdev_provider_id(provider_id: str) -> str:
         provider_id = provider_id[len("custom:"):]
     return PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
 
+
+def _mdev_provider_id_strict(provider_id: str) -> Optional[str]:
+    """Resolve a Hermes provider id to a models.dev catalog id, strictly.
+
+    Plain provider ids must be keys of PROVIDER_TO_MODELS_DEV — an unknown
+    id resolves to None instead of being passed through, so an arbitrary
+    string never triggers a catalog fetch. ``custom:<name>`` providers pass
+    through to the catalog under the bare name (custom:hyper → hyper),
+    matching the mapping's pass-through contract for custom endpoints.
+    """
+    if provider_id.startswith("custom:"):
+        provider_id = provider_id[len("custom:"):]
+        return PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
+    return PROVIDER_TO_MODELS_DEV.get(provider_id)
+
 # Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter",
@@ -762,7 +777,7 @@ def lookup_models_dev_context(
     if override_ctx is not None:
         return override_ctx
 
-    mdev_provider_id = _mdev_provider_id(provider)
+    mdev_provider_id = _mdev_provider_id_strict(provider)
     if not mdev_provider_id:
         return _default_override_context(provider)
 
@@ -1112,7 +1127,7 @@ def _get_provider_models(
     ``allow_network`` defaults to False — this is called from hot paths
     (vision routing, image routing, capability checks) and must never block.
     """
-    mdev_provider_id = _mdev_provider_id(provider)
+    mdev_provider_id = _mdev_provider_id_strict(provider)
     if not mdev_provider_id:
         return None
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -762,7 +762,7 @@ def lookup_models_dev_context(
     if override_ctx is not None:
         return override_ctx
 
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(_mdev_provider_id(provider))
+    mdev_provider_id = _mdev_provider_id(provider)
     if not mdev_provider_id:
         return _default_override_context(provider)
 
@@ -1112,7 +1112,7 @@ def _get_provider_models(
     ``allow_network`` defaults to False — this is called from hot paths
     (vision routing, image routing, capability checks) and must never block.
     """
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(_mdev_provider_id(provider))
+    mdev_provider_id = _mdev_provider_id(provider)
     if not mdev_provider_id:
         return None
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -929,8 +929,22 @@ def build_turn_context(
 
         if not _preflight_deferred:
             _last = _compressor.last_prompt_tokens
-            # Do NOT overwrite the -1 sentinel (#36718).
-            if _last >= 0 and _preflight_tokens > _last:
+            # The seed exists so the status bar shows current occupancy when a
+            # provider reports no usage (#34282's motivation). But
+            # ``last_prompt_tokens`` is also the post-response compression
+            # gate's "real tokens" input (conversation_loop) and the CLI
+            # context meter's source (cli.py). Overwriting a REAL provider
+            # reading with the rough preflight estimate makes the bar jump to
+            # an inflated number and can push the real-usage gate over the
+            # threshold on estimator noise — compression then fires at far
+            # below the user-configured threshold (observed: 492K real vs
+            # ~685K rough on a 1M window; reasoning-heavy sessions inflate
+            # the rough estimate 1.4-2.5x, see #81481).
+            #
+            # Policy: a real provider reading (>0) always wins. Seed only
+            # from the 0 state ("no reading yet"); -1 stays protected as the
+            # post-compression sentinel (#36718).
+            if _last == 0 and _preflight_tokens > _last:
                 _compressor.last_prompt_tokens = _preflight_tokens
 
         _compression_cooldown = getattr(

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1186,11 +1186,15 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
 
 
 def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
+    # OpenRouter's models API reports per-token decimals
+    # (e.g. 0.0000032664), unlike OpenAI-compatible /models endpoints which
+    # report dollars per million tokens — declare the unit explicitly.
     return _pricing_entry_from_metadata(
         fetch_model_metadata(),
         route.model,
         source_url="https://openrouter.ai/docs/api/api-reference/models/get-models",
         pricing_version="openrouter-models-api",
+        pricing_units="per_token",
     )
 
 
@@ -1200,7 +1204,17 @@ def _pricing_entry_from_metadata(
     *,
     source_url: str,
     pricing_version: str,
+    pricing_units: Literal["per_token", "per_million"] = "per_million",
 ) -> Optional[PricingEntry]:
+    """Build a PricingEntry from a provider /models metadata map.
+
+    ``pricing_units`` declares the unit the source API reports:
+    - ``per_million`` — OpenAI-compatible ``/models`` endpoints (the default;
+      e.g. ``{"pricing": {"prompt": 3.2664}}`` means $3.2664 per million
+      input tokens). Values are used as-is.
+    - ``per_token`` — OpenRouter's models API, which reports per-token
+      decimals (e.g. ``0.0000032664``). Values are scaled to per-million.
+    """
     if model_id not in metadata:
         return None
     pricing = metadata[model_id].get("pricing") or {}
@@ -1221,8 +1235,8 @@ def _pricing_entry_from_metadata(
         return None
 
     def _per_token_to_per_million(value: Optional[Decimal]) -> Optional[Decimal]:
-        if value is None:
-            return None
+        if value is None or pricing_units != "per_token":
+            return value
         return value * _ONE_MILLION
 
     return PricingEntry(
@@ -1262,6 +1276,9 @@ def get_pricing_entry(
             route.model,
             source_url=f"{route.base_url.rstrip('/')}/models",
             pricing_version="openai-compatible-models-api",
+            # OpenAI-compatible /models endpoints report dollars per million
+            # tokens already (e.g. 3.2664 = $3.27/M) — no per-token scaling.
+            pricing_units="per_million",
         )
         if entry:
             return entry

--- a/contributors/emails/turgut.kural@outlook.com
+++ b/contributors/emails/turgut.kural@outlook.com
@@ -1,0 +1,2 @@
+TurgutKural
+# PR #61499 (delegation: resolve Nous auth before direct endpoint)

--- a/contributors/emails/turgut.kural@outlook.com
+++ b/contributors/emails/turgut.kural@outlook.com
@@ -1,2 +1,3 @@
 TurgutKural
 # PR #61499 (delegation: resolve Nous auth before direct endpoint)
+# PR #58495 (compression: skip session split on plugin no-op)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -864,8 +864,35 @@ class GatewaySlashCommandsMixin:
             try:
                 from agent.model_metadata import get_model_context_length
 
+                # Inactive-agent fallback: resolve the configured route
+                # identity + compatible custom_providers so per-model
+                # context_length overrides (custom_providers[].models.<id>)
+                # are honored — passing only model_name falls through to
+                # generic metadata for custom endpoints (#15779).
+                _provider = ""
+                _custom_providers = None
+                try:
+                    from hermes_cli.config import (
+                        get_compatible_custom_providers,
+                        load_config_readonly,
+                    )
+
+                    _cfg = load_config_readonly() or {}
+                    _model_cfg = _cfg.get("model")
+                    if isinstance(_model_cfg, dict):
+                        _provider = str(_model_cfg.get("provider") or "").strip()
+                    _custom_providers = get_compatible_custom_providers(_cfg)
+                except Exception:
+                    _provider = ""
+                    _custom_providers = None
+
                 context_length = _int_value(
-                    await asyncio.to_thread(get_model_context_length, model_name)
+                    await asyncio.to_thread(
+                        get_model_context_length,
+                        model_name,
+                        provider=_provider,
+                        custom_providers=_custom_providers,
+                    )
                 )
             except Exception:
                 context_length = 0

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1727,6 +1727,7 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    reset_cooldowns: bool = False,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1745,6 +1746,16 @@ def write_credential_pool(
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
     merge does not resurrect them from the on-disk copy.
+
+    Pass ``reset_cooldowns=True`` ONLY for an explicit user-initiated reset
+    (``hermes auth reset``): it skips the status-field merge entirely, so even
+    still-binding on-disk cooldowns are erased. This is a deliberate user
+    override of the lost-update protection — never pass it from automatic
+    rotation/exhaustion/refresh paths, or a stale snapshot could erase a fresh
+    cooldown and every process would resume hammering a rate-limited key.
+    Entries present on disk but missing from the snapshot are still preserved
+    (with their own status), and all entries still pass through
+    ``sanitize_borrowed_credential_payload``.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
     with _auth_store_lock():
@@ -1771,11 +1782,11 @@ def write_credential_pool(
             if isinstance(entry, dict) and entry.get("id")
         }
         merged: List[Dict[str, Any]] = [
-            _merge_disk_cooldown_state(
+            entry
+            if not isinstance(entry, dict) or reset_cooldowns
+            else _merge_disk_cooldown_state(
                 entry, existing_by_id.get(entry.get("id")), provider_id
             )
-            if isinstance(entry, dict)
-            else entry
             for entry in sanitized_entries
         ]
         for disk_entry in existing_list:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6922,11 +6922,14 @@ def get_model_info(profile: Optional[str] = None):
         # purely auto-detected value, then separately report the override)
         try:
             from agent.model_metadata import get_model_context_length
+            from hermes_cli.config import get_compatible_custom_providers
+            _cp = get_compatible_custom_providers(cfg)
             auto_ctx = get_model_context_length(
                 model=model_name,
                 base_url=base_url,
                 provider=provider,
                 config_context_length=None,  # ignore override — we want auto value
+                custom_providers=_cp,
             )
         except Exception:
             auto_ctx = 0

--- a/model_tools.py
+++ b/model_tools.py
@@ -720,12 +720,29 @@ def _resolve_active_context_length() -> int:
                     return cached_ctx
             except Exception:
                 pass
+        # Per-model context_length overrides from custom_providers config
+        # (custom_providers[].models.<id>.context_length) must be honored by
+        # the tool-search gate too — otherwise the gate sizes against generic
+        # metadata for custom endpoints (#15779). Best-effort load: config
+        # failure degrades to None so resolution falls through to probing.
+        custom_providers = None
+        try:
+            from hermes_cli.config import (
+                get_compatible_custom_providers,
+                load_config_readonly,
+            )
+            custom_providers = get_compatible_custom_providers(
+                load_config_readonly()
+            )
+        except Exception:
+            custom_providers = None
         return int(get_model_context_length(
             model_id,
             base_url=base_url,
             api_key=api_key,
             config_context_length=config_ctx,
             provider=provider,
+            custom_providers=custom_providers,
         ) or 0)
     except Exception as e:
         logger.debug("Could not resolve active context length: %s", e)

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2247,9 +2247,9 @@ class TestPreflightSentinelGuard:
     """
 
     def _seed(self, last_prompt_tokens, preflight_tokens):
-        # Mirror the exact guard in agent/conversation_loop.py run_conversation.
+        # Mirror the exact guard in agent/turn_context.py build_turn_context.
         _last = last_prompt_tokens
-        if _last >= 0 and preflight_tokens > _last:
+        if _last == 0 and preflight_tokens > _last:
             return preflight_tokens  # would overwrite
         return last_prompt_tokens   # preserved
 
@@ -2259,10 +2259,20 @@ class TestPreflightSentinelGuard:
         result = self._seed(compressor.last_prompt_tokens, 250_000)
         assert result == -1
 
-    def test_real_value_still_revises_upward(self, compressor):
-        compressor.last_prompt_tokens = 10_000
+    def test_zero_state_still_seeded(self, compressor):
+        # 0 means "no reading yet" — the seed keeps the status bar live when
+        # providers report no usage.
+        compressor.last_prompt_tokens = 0
         result = self._seed(compressor.last_prompt_tokens, 50_000)
         assert result == 50_000
+
+    def test_real_provider_reading_wins_over_rough_estimate(self, compressor):
+        # Regression for the 492K-vs-685K display jump: a real provider
+        # reading must never be replaced by the schema/reasoning-inflated
+        # rough preflight estimate (#81481 class inflation).
+        compressor.last_prompt_tokens = 492_000
+        result = self._seed(compressor.last_prompt_tokens, 685_344)
+        assert result == 492_000
 
 
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -9,6 +9,8 @@ from unittest.mock import patch, MagicMock
 from agent.context_compressor import (
     ContextCompressor,
     HISTORICAL_TASK_HEADING,
+    LEAN_TAIL_CAP_TOKENS,
+    LEAN_TAIL_FLOOR_TOKENS,
     SUMMARY_PREFIX,
     COMPRESSED_SUMMARY_METADATA_KEY,
     _PRUNE_MIN_CHARS,
@@ -1939,6 +1941,87 @@ class TestUpdateModelBudgets:
         comp.update_model("model-b", context_length=10_000)
         assert comp.tail_token_budget == int(comp.threshold_tokens * comp.summary_target_ratio)
         assert comp.max_summary_tokens == min(int(10_000 * 0.05), 4000)
+
+
+class TestUpdateModelLeanTailBudget:
+    """Regression: update_model() must not overwrite the lean tail budget.
+
+    The tail policy lives in the mode-aware ``tail_token_budget`` property:
+    lean mode clamps ``context_length * 0.025`` to
+    [LEAN_TAIL_FLOOR_TOKENS, LEAN_TAIL_CAP_TOKENS]. update_model() used to
+    unconditionally cache ``threshold_tokens * summary_target_ratio`` (the
+    legacy formula), so a lean compressor on a 1M window jumped from 25K to
+    195K (ratio .30) after any model switch / fallback / context-window
+    refresh — while ``tail_mode`` still claimed "lean".
+    """
+
+    @staticmethod
+    def _lean_comp(ratio: float, context: int = 1_000_000) -> ContextCompressor:
+        return ContextCompressor(
+            "test-model",
+            threshold_percent=0.65,
+            summary_target_ratio=ratio,
+            config_context_length=context,
+            tail_mode="lean",
+            quiet_mode=True,
+        )
+
+    def test_lean_tail_survives_update_model_same_model(self):
+        """1M/.65/.30/lean: 25K before, 25K after — even when the same
+        model and context are re-reported (no-op refresh)."""
+        comp = self._lean_comp(0.30)
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS  # 25K on 1M
+        comp.update_model("test-model", context_length=1_000_000)
+        assert comp.tail_mode == "lean"
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+    def test_lean_tail_survives_update_model_low_ratio(self):
+        """ratio .10 must not shrink or inflate the lean clamp either."""
+        comp = self._lean_comp(0.10)
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+        comp.update_model("test-model", context_length=1_000_000)
+        assert comp.tail_mode == "lean"
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+    def test_lean_tail_recalculated_on_context_change(self):
+        """A genuine window change re-derives the budget through the
+        canonical clamp: 1M -> 25K cap, 372K -> floor (9,300 < 10K),
+        back to 1M -> 25K again."""
+        comp = self._lean_comp(0.30)
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+        comp.update_model("small-model", context_length=372_000)
+        expected = max(
+            LEAN_TAIL_FLOOR_TOKENS,
+            min(LEAN_TAIL_CAP_TOKENS, int(372_000 * 0.025)),
+        )
+        assert expected == LEAN_TAIL_FLOOR_TOKENS  # 9,300 clamps to 10K
+        assert comp.tail_mode == "lean"
+        assert comp.tail_token_budget == expected
+
+        comp.update_model("big-model", context_length=1_000_000)
+        assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+    def test_legacy_tail_recalculated_on_update_model(self):
+        """Legacy behavior is unchanged: budget stays threshold*ratio
+        across update_model()."""
+        comp = ContextCompressor(
+            "test-model",
+            threshold_percent=0.65,
+            summary_target_ratio=0.30,
+            config_context_length=1_000_000,
+            tail_mode="legacy",
+            quiet_mode=True,
+        )
+        before = comp.tail_token_budget
+        assert before == int(comp.threshold_tokens * comp.summary_target_ratio)
+        comp.update_model("test-model", context_length=1_000_000)
+        assert comp.tail_mode == "legacy"
+        assert comp.tail_token_budget == before
+        comp.update_model("small-model", context_length=372_000)
+        assert comp.tail_token_budget == int(
+            comp.threshold_tokens * comp.summary_target_ratio
+        )
 
 
 class TestUpdateModelResetsCalibration:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2079,3 +2079,192 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+# ---------------------------------------------------------------------------
+# hermes auth reset (explicit user reset) must bypass the disk-cooldown merge
+# ---------------------------------------------------------------------------
+
+def _pool_payload(entries):
+    return {
+        "version": 1,
+        "credential_pool": {"openai-codex": entries},
+    }
+
+
+def _exhausted_entry(entry_id, label, *, age_seconds, error_code=429):
+    """A still-binding (or expired, per age_seconds) exhausted pool entry."""
+    return {
+        "id": entry_id,
+        "label": label,
+        "auth_type": "api_key",
+        "priority": 0,
+        "source": "manual",
+        "access_token": f"sk-mock-{entry_id}",
+        "last_status": "exhausted",
+        "last_status_at": time.time() - age_seconds,
+        "last_error_code": error_code,
+        "last_error_reason": "rate_limit_error",
+        "last_error_message": "mock upstream message",
+        "last_error_reset_at": None,
+    }
+
+
+def test_reset_statuses_clears_active_cooldowns_on_disk(tmp_path, monkeypatch):
+    """The user-reset regression: an active on-disk cooldown must not be
+    resurrected by the recency merge when `hermes auth reset` persists."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        _pool_payload(
+            [
+                _exhausted_entry("cred-1", "alice", age_seconds=60),
+                _exhausted_entry("cred-2", "bob", age_seconds=120, error_code=402),
+            ]
+        ),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is False
+
+    count = pool.reset_statuses()
+
+    assert count == 2
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    for entry in auth_payload["credential_pool"]["openai-codex"]:
+        if entry["id"] in ("cred-1", "cred-2"):
+            assert entry.get("last_status") is None
+            assert entry.get("last_status_at") is None
+            assert entry.get("last_error_code") is None
+            assert entry.get("last_error_reason") is None
+            assert entry.get("last_error_message") is None
+            # identity must survive the reset untouched
+            assert entry["id"] in ("cred-1", "cred-2")
+            assert entry["access_token"] == f"sk-mock-{entry["id"]}"
+
+    # A fresh load must see the pool as healthy again.
+    reloaded = load_pool("openai-codex")
+    assert reloaded.has_available() is True
+
+
+def test_reset_statuses_noop_when_nothing_to_reset(tmp_path, monkeypatch):
+    """No statuses -> count 0 and no disk write."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    healthy = _exhausted_entry("cred-1", "alice", age_seconds=60)
+    for key in (
+        "last_status",
+        "last_status_at",
+        "last_error_code",
+        "last_error_reason",
+        "last_error_message",
+        "last_error_reset_at",
+    ):
+        healthy.pop(key, None)
+    _write_auth_store(tmp_path, _pool_payload([healthy]))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    auth_file = tmp_path / "hermes" / "auth.json"
+    before = auth_file.read_bytes()
+
+    assert pool.reset_statuses() == 0
+    assert auth_file.read_bytes() == before
+
+
+def test_reset_statuses_clears_expired_cooldowns_too(tmp_path, monkeypatch):
+    """Expired cooldowns (already ignored by selection) are also cleared, and
+    the reset write must not resurrect them either."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        _pool_payload([_exhausted_entry("cred-1", "alice", age_seconds=3 * 3600)]),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.reset_statuses() == 1
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = auth_payload["credential_pool"]["openai-codex"][0]
+    assert entry.get("last_status") is None
+    assert entry.get("last_status_at") is None
+
+
+def test_normal_persist_still_resurrects_active_disk_cooldown(tmp_path, monkeypatch):
+    """Regression guard for the lost-update protection (3d67f00fe1): a normal
+    (non-reset) persist from a stale in-memory snapshot must STILL resurrect an
+    active on-disk cooldown. Only the explicit user reset may bypass it."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        _pool_payload([_exhausted_entry("cred-1", "alice", age_seconds=60)]),
+    )
+
+    from agent.credential_pool import load_pool, replace
+
+    pool = load_pool("openai-codex")
+    # Simulate another process marking the key exhausted on disk AFTER this
+    # process took its healthy in-memory snapshot.
+    pool._entries = [
+        replace(
+            pool._entries[0],
+            last_status=None,
+            last_status_at=None,
+            last_error_code=None,
+            last_error_reason=None,
+            last_error_message=None,
+            last_error_reset_at=None,
+        )
+    ]
+    pool._persist()
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = auth_payload["credential_pool"]["openai-codex"][0]
+    assert entry.get("last_status") == "exhausted"
+    assert entry.get("last_status_at") is not None
+
+
+def test_reset_statuses_preserves_concurrent_disk_entries(tmp_path, monkeypatch):
+    """A reset write must not drop entries another process added to disk after
+    this pool snapshot was loaded (the missing-entry append path survives)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        _pool_payload([_exhausted_entry("cred-1", "alice", age_seconds=60)]),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+
+    # Concurrent writer adds cred-2 (healthy) to disk behind our back.
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    concurrent = _exhausted_entry("cred-2", "bob", age_seconds=60)
+    for key in (
+        "last_status",
+        "last_status_at",
+        "last_error_code",
+        "last_error_reason",
+        "last_error_message",
+        "last_error_reset_at",
+    ):
+        concurrent.pop(key, None)
+    auth_payload["credential_pool"]["openai-codex"].append(concurrent)
+    (tmp_path / "hermes" / "auth.json").write_text(json.dumps(auth_payload))
+
+    assert pool.reset_statuses() == 1
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    by_id = {e["id"]: e for e in auth_payload["credential_pool"]["openai-codex"]}
+    assert set(by_id) == {"cred-1", "cred-2"}
+    assert by_id["cred-1"].get("last_status") is None
+    assert by_id["cred-2"].get("last_status") is None

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2143,7 +2143,7 @@ def test_reset_statuses_clears_active_cooldowns_on_disk(tmp_path, monkeypatch):
             assert entry.get("last_error_message") is None
             # identity must survive the reset untouched
             assert entry["id"] in ("cred-1", "cred-2")
-            assert entry["access_token"] == f"sk-mock-{entry["id"]}"
+            assert entry["access_token"] == f"sk-mock-{entry['id']}"
 
     # A fresh load must see the pool as healthy again.
     reloaded = load_pool("openai-codex")

--- a/tests/agent/test_custom_provider_context_threading.py
+++ b/tests/agent/test_custom_provider_context_threading.py
@@ -14,7 +14,7 @@ to sibling call paths that were missed.
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -335,8 +335,228 @@ class TestWebServerModelInfoCustomProviders:
 
 
 # ---------------------------------------------------------------------------
-# 5. get_custom_provider_context_length (existing helper — extended coverage)
+# 5. model_tools._resolve_active_context_length (tool-search gate)
 # ---------------------------------------------------------------------------
+
+class TestToolSearchGateCustomProviders:
+    """The tool-search context gate must honor custom_providers per-model
+    context_length overrides instead of sizing against generic metadata."""
+
+    def test_gate_passes_custom_providers_to_resolver(self):
+        from model_tools import _resolve_active_context_length
+
+        mock_config = {
+            "model": {
+                "model": MODEL,
+                "provider": "custom",
+                "base_url": BASE_URL,
+            },
+            "custom_providers": CUSTOM_PROVIDERS,
+        }
+        captured_kwargs = {}
+
+        def _capture(model, **kwargs):
+            captured_kwargs.update(kwargs)
+            return EXPECTED_CTX
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=mock_config),
+            patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value=mock_config,
+            ),
+            patch(
+                "hermes_cli.config.get_compatible_custom_providers",
+                return_value=CUSTOM_PROVIDERS,
+            ),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={},
+            ),
+            patch(
+                "agent.model_metadata.get_cached_context_length",
+                return_value=None,
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                side_effect=_capture,
+            ),
+        ):
+            result = _resolve_active_context_length()
+
+        assert result == EXPECTED_CTX
+        assert captured_kwargs.get("custom_providers") == CUSTOM_PROVIDERS, (
+            "get_model_context_length was not called with custom_providers"
+        )
+        assert captured_kwargs.get("provider") == "custom"
+
+    def test_gate_falls_through_on_config_load_failure(self):
+        """Config-load failure must not break the gate — resolver still runs
+        with custom_providers=None (generic metadata)."""
+        from model_tools import _resolve_active_context_length
+
+        mock_config = {
+            "model": {
+                "model": MODEL,
+                "provider": "custom",
+                "base_url": BASE_URL,
+            },
+        }
+        with (
+            patch("hermes_cli.config.load_config", return_value=mock_config),
+            patch(
+                "hermes_cli.config.load_config_readonly",
+                side_effect=RuntimeError("config unavailable"),
+            ),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={},
+            ),
+            patch(
+                "agent.model_metadata.get_cached_context_length",
+                return_value=None,
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=EXPECTED_CTX,
+            ),
+        ):
+            result = _resolve_active_context_length()
+
+        assert result == EXPECTED_CTX
+
+
+# ---------------------------------------------------------------------------
+# 6. gateway /context inactive-agent fallback
+# ---------------------------------------------------------------------------
+
+class TestGatewayContextFallbackCustomProviders:
+    """The /context no-resident-agent fallback must resolve the configured
+    route identity + compatible custom_providers before calling the
+    resolver — passing only model_name falls through to generic metadata."""
+
+    def _make_mixin(self, session_db_row):
+        from gateway.slash_commands import GatewaySlashCommandsMixin
+
+        mixin = GatewaySlashCommandsMixin.__new__(GatewaySlashCommandsMixin)
+
+        class _SessionEntry:
+            session_id = "sess-test"
+            last_prompt_tokens = 0
+
+        session_store = MagicMock()
+        session_store.get_or_create_session = AsyncMock(
+            return_value=_SessionEntry()
+        )
+        session_store.load_transcript = AsyncMock(return_value=[])
+        mixin.async_session_store = session_store
+        mixin._running_agents = {}
+        mixin._agent_cache_lock = None
+        mixin._agent_cache = None
+
+        session_db = MagicMock()
+        if session_db_row is not None:
+            session_db.get_session = AsyncMock(return_value=session_db_row)
+        mixin._session_db = session_db
+
+        return mixin
+
+    def _make_event(self):
+        event = MagicMock()
+        event.source = "test-source"
+        event.get_command_args.return_value = ""
+        return event
+
+    def test_fallback_passes_provider_and_custom_providers(self):
+        mixin = self._make_mixin({"model": MODEL})
+        mixin._session_key_for_source = lambda source: "sess-test"
+        captured = {}
+
+        def _capture(model, **kwargs):
+            captured["model"] = model
+            captured.update(kwargs)
+            return EXPECTED_CTX
+
+        mock_config = {
+            "model": {
+                "provider": "custom",
+                "base_url": BASE_URL,
+            },
+            "custom_providers": CUSTOM_PROVIDERS,
+        }
+        with (
+            patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value=mock_config,
+            ),
+            patch(
+                "hermes_cli.config.get_compatible_custom_providers",
+                return_value=CUSTOM_PROVIDERS,
+            ),
+            # Force the shared non-resident resolver (upstream's
+            # _resolve_gateway_model_context) to fail so the PR's
+            # last-resort fallback block — the code under test — runs.
+            patch(
+                "gateway.run._resolve_gateway_model_context",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                side_effect=_capture,
+            ),
+        ):
+            result = asyncio_run(mixin._handle_context_command(self._make_event()))
+
+        assert isinstance(result, str)
+        assert captured.get("model") == MODEL
+        assert captured.get("provider") == "custom"
+        assert captured.get("custom_providers") == CUSTOM_PROVIDERS
+
+    def test_fallback_fails_open_when_config_loading_raises(self):
+        mixin = self._make_mixin({"model": MODEL})
+        mixin._session_key_for_source = lambda source: "sess-test"
+        captured = {}
+
+        def _capture(model, **kwargs):
+            captured["model"] = model
+            captured.update(kwargs)
+            return EXPECTED_CTX
+
+        with (
+            patch(
+                "hermes_cli.config.load_config_readonly",
+                side_effect=RuntimeError("config unavailable"),
+            ),
+            patch(
+                "hermes_cli.config.get_compatible_custom_providers",
+                side_effect=RuntimeError("config unavailable"),
+            ),
+            # Force the shared non-resident resolver to fail too, so the
+            # fallback block under test runs with a broken config path.
+            patch(
+                "gateway.run._resolve_gateway_model_context",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                side_effect=_capture,
+            ),
+        ):
+            result = asyncio_run(mixin._handle_context_command(self._make_event()))
+
+        # Config failure degrades to provider="" / custom_providers=None —
+        # the resolver still runs and /context still renders.
+        assert isinstance(result, str)
+        assert captured.get("model") == MODEL
+        assert captured.get("provider") == ""
+        assert captured.get("custom_providers") is None
+
+
+def asyncio_run(coro):
+    import asyncio
+
+    return asyncio.new_event_loop().run_until_complete(coro)
+
 
 class TestGetCustomProviderContextLengthExtended:
     """Extended coverage for the lookup helper used by all call sites."""

--- a/tests/agent/test_custom_provider_context_threading.py
+++ b/tests/agent/test_custom_provider_context_threading.py
@@ -1,0 +1,437 @@
+"""Tests for custom_providers context_length threading across all call sites.
+
+Regression tests ensuring that ``custom_providers[].models.<id>.context_length``
+overrides are honored not just at agent startup (agent_init) and /model switch
+(model_switch), but also at every deferred resolution point:
+
+  * ContextCompressor._resolve_context_length  (deferred first-access probe)
+  * auxiliary_client._candidate_context_window (fallback chain screening)
+  * moa_loop._trim_messages_for_reference      (MoA reference model trimming)
+  * web_server.get_model_info                  (WebUI model info endpoint)
+
+See #15779 for the original /model switch fix; this extends the same contract
+to sibling call paths that were missed.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli.config import get_custom_provider_context_length
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+CUSTOM_PROVIDERS = [
+    {
+        "name": "test-provider",
+        "base_url": "https://custom.example.com/v1",
+        "models": {
+            "my-model": {"context_length": 1_000_000},
+        },
+    },
+]
+
+BASE_URL = "https://custom.example.com/v1"
+MODEL = "my-model"
+EXPECTED_CTX = 1_000_000
+
+
+def _mock_all_probes():
+    """Disable every downstream resolution step so only the
+    custom_providers override (step 0b) can produce a result."""
+    from agent import model_metadata as _mm
+    return [
+        patch.object(_mm, "get_cached_context_length", return_value=None),
+        patch.object(_mm, "fetch_endpoint_model_metadata", return_value={}),
+        patch.object(_mm, "fetch_model_metadata", return_value={}),
+        patch.object(_mm, "is_local_endpoint", return_value=False),
+        patch.object(_mm, "_is_known_provider_base_url", return_value=False),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 1. ContextCompressor._resolve_context_length
+# ---------------------------------------------------------------------------
+
+class TestContextCompressorCustomProviders:
+    """ContextCompressor must honor custom_providers per-model overrides
+    when it lazily resolves context_length on first property access."""
+
+    def test_resolve_context_length_uses_custom_providers(self):
+        from agent.context_compressor import ContextCompressor
+
+        compressor = ContextCompressor(
+            model=MODEL,
+            base_url=BASE_URL,
+            provider="custom",
+            custom_providers=CUSTOM_PROVIDERS,
+        )
+        patches = _mock_all_probes()
+        for p in patches:
+            p.start()
+        try:
+            ctx = compressor._resolve_context_length()
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert ctx == EXPECTED_CTX, (
+            f"Expected {EXPECTED_CTX} from custom_providers override, got {ctx}"
+        )
+
+    def test_resolve_context_length_without_custom_providers_falls_through(self):
+        """Without custom_providers, resolver falls through to default."""
+        from agent.context_compressor import ContextCompressor
+        from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT
+
+        compressor = ContextCompressor(
+            model="unknown-model",
+            base_url=BASE_URL,
+            provider="custom",
+            custom_providers=None,
+        )
+        patches = _mock_all_probes()
+        for p in patches:
+            p.start()
+        try:
+            ctx = compressor._resolve_context_length()
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert ctx == DEFAULT_FALLBACK_CONTEXT
+
+    def test_config_context_length_still_wins_over_custom_providers(self):
+        """Explicit config_context_length (step 0) outranks custom_providers (step 0b)."""
+        from agent.context_compressor import ContextCompressor
+
+        compressor = ContextCompressor(
+            model=MODEL,
+            base_url=BASE_URL,
+            provider="custom",
+            config_context_length=500_000,
+            custom_providers=CUSTOM_PROVIDERS,
+        )
+        ctx = compressor._resolve_context_length()
+        assert ctx == 500_000
+
+    def test_custom_providers_stored_on_instance(self):
+        """The custom_providers list is stored for deferred resolution."""
+        from agent.context_compressor import ContextCompressor
+
+        compressor = ContextCompressor(
+            model=MODEL,
+            base_url=BASE_URL,
+            provider="custom",
+            custom_providers=CUSTOM_PROVIDERS,
+        )
+        assert compressor._custom_providers is CUSTOM_PROVIDERS
+
+    def test_default_custom_providers_is_none(self):
+        """Omitting custom_providers defaults to None (backward compat)."""
+        from agent.context_compressor import ContextCompressor
+
+        compressor = ContextCompressor(
+            model=MODEL,
+            base_url=BASE_URL,
+            provider="custom",
+        )
+        assert compressor._custom_providers is None
+
+
+# ---------------------------------------------------------------------------
+# 2. auxiliary_client._candidate_context_window
+# ---------------------------------------------------------------------------
+
+class TestCandidateContextWindowCustomProviders:
+    """_candidate_context_window must load custom_providers from config
+    and pass them to get_model_context_length."""
+
+    def test_honors_custom_providers_override(self):
+        from agent.auxiliary_client import _candidate_context_window
+
+        mock_config = {"custom_providers": CUSTOM_PROVIDERS}
+        with (
+            patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value=mock_config,
+            ),
+            patch(
+                "hermes_cli.config.get_compatible_custom_providers",
+                return_value=CUSTOM_PROVIDERS,
+            ),
+        ):
+            patches = _mock_all_probes()
+            for p in patches:
+                p.start()
+            try:
+                ctx = _candidate_context_window(
+                    "custom", MODEL, base_url=BASE_URL,
+                )
+            finally:
+                for p in patches:
+                    p.stop()
+
+        assert ctx == EXPECTED_CTX
+
+    def test_config_load_failure_falls_through_gracefully(self):
+        """If config loading fails, resolver still works (returns default)."""
+        from agent.auxiliary_client import _candidate_context_window
+        from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            side_effect=RuntimeError("config unavailable"),
+        ):
+            patches = _mock_all_probes()
+            for p in patches:
+                p.start()
+            try:
+                ctx = _candidate_context_window(
+                    "custom", "unknown-model", base_url=BASE_URL,
+                )
+            finally:
+                for p in patches:
+                    p.stop()
+
+        assert ctx == DEFAULT_FALLBACK_CONTEXT
+
+    def test_empty_model_returns_none(self):
+        from agent.auxiliary_client import _candidate_context_window
+
+        assert _candidate_context_window("custom", "", base_url=BASE_URL) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. moa_loop._load_custom_providers + _trim_messages_for_reference
+# ---------------------------------------------------------------------------
+
+class TestMoACustomProviders:
+    """MoA reference trimming must honor custom_providers overrides."""
+
+    def test_load_custom_providers_returns_list(self):
+        from agent.moa_loop import _load_custom_providers
+
+        mock_config = {"custom_providers": CUSTOM_PROVIDERS}
+        with (
+            patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value=mock_config,
+            ),
+            patch(
+                "hermes_cli.config.get_compatible_custom_providers",
+                return_value=CUSTOM_PROVIDERS,
+            ),
+        ):
+            result = _load_custom_providers()
+
+        assert result == CUSTOM_PROVIDERS
+
+    def test_load_custom_providers_returns_none_on_failure(self):
+        from agent.moa_loop import _load_custom_providers
+
+        with patch(
+            "hermes_cli.config.load_config_readonly",
+            side_effect=RuntimeError("no config"),
+        ):
+            result = _load_custom_providers()
+
+        assert result is None
+
+    def test_trim_messages_uses_custom_providers_context(self):
+        """_trim_messages_for_reference resolves context via custom_providers."""
+        from agent.moa_loop import _trim_messages_for_reference
+
+        slot = {"model": MODEL, "provider": "custom"}
+        runtime = {"base_url": BASE_URL, "api_key": "test-key", "provider": "custom"}
+
+        # Build messages that would fit in 1M but not in 256K
+        # ~300K tokens worth of text (chars/4 heuristic)
+        big_content = "x" * 1_200_000  # ~300K tokens
+        messages = [
+            {"role": "system", "content": "You are a helper."},
+            {"role": "user", "content": big_content},
+            {"role": "assistant", "content": "OK"},
+        ]
+
+        mock_config = {"custom_providers": CUSTOM_PROVIDERS}
+        with (
+            patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value=mock_config,
+            ),
+            patch(
+                "hermes_cli.config.get_compatible_custom_providers",
+                return_value=CUSTOM_PROVIDERS,
+            ),
+        ):
+            patches = _mock_all_probes()
+            for p in patches:
+                p.start()
+            try:
+                result = _trim_messages_for_reference(
+                    messages, slot, runtime,
+                )
+            finally:
+                for p in patches:
+                    p.stop()
+
+        # With 1M context, messages should NOT be trimmed (they fit)
+        assert len(result) == len(messages), (
+            f"Messages should not be trimmed with 1M context, "
+            f"got {len(result)} of {len(messages)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. web_server.get_model_info
+# ---------------------------------------------------------------------------
+
+class TestWebServerModelInfoCustomProviders:
+    """WebUI /api/model/info must pass custom_providers to the resolver."""
+
+    def test_get_model_info_passes_custom_providers(self):
+        """Verify get_model_context_length receives custom_providers kwarg."""
+        from hermes_cli.web_server import get_model_info
+
+        mock_config = {
+            "model": {
+                "default": MODEL,
+                "provider": "custom",
+                "base_url": BASE_URL,
+            },
+            "custom_providers": CUSTOM_PROVIDERS,
+        }
+
+        captured_kwargs = {}
+
+        def _capture_get_model_context_length(**kwargs):
+            captured_kwargs.update(kwargs)
+            return 256_000  # default
+
+        with (
+            patch("hermes_cli.web_server.load_config", return_value=mock_config),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                side_effect=_capture_get_model_context_length,
+            ),
+            patch(
+                "hermes_cli.config.get_compatible_custom_providers",
+                return_value=CUSTOM_PROVIDERS,
+            ),
+        ):
+            try:
+                get_model_info()
+            except Exception:
+                pass  # endpoint may need app context; we only care about kwargs
+
+        assert "custom_providers" in captured_kwargs, (
+            "get_model_context_length was not called with custom_providers"
+        )
+        assert captured_kwargs["custom_providers"] == CUSTOM_PROVIDERS
+
+
+# ---------------------------------------------------------------------------
+# 5. get_custom_provider_context_length (existing helper — extended coverage)
+# ---------------------------------------------------------------------------
+
+class TestGetCustomProviderContextLengthExtended:
+    """Extended coverage for the lookup helper used by all call sites."""
+
+    def test_model_not_in_entry_returns_none(self):
+        assert (
+            get_custom_provider_context_length(
+                "other-model", BASE_URL, CUSTOM_PROVIDERS,
+            )
+            is None
+        )
+
+    def test_base_url_mismatch_returns_none(self):
+        assert (
+            get_custom_provider_context_length(
+                MODEL, "https://wrong.example.com/v1", CUSTOM_PROVIDERS,
+            )
+            is None
+        )
+
+    def test_models_as_list_returns_none(self):
+        """List-format models (no per-model config) must return None."""
+        providers = [
+            {
+                "base_url": BASE_URL,
+                "models": [MODEL, "other-model"],
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(MODEL, BASE_URL, providers)
+            is None
+        )
+
+    def test_zero_context_length_returns_none(self):
+        providers = [
+            {
+                "base_url": BASE_URL,
+                "models": {MODEL: {"context_length": 0}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(MODEL, BASE_URL, providers)
+            is None
+        )
+
+    def test_negative_context_length_returns_none(self):
+        providers = [
+            {
+                "base_url": BASE_URL,
+                "models": {MODEL: {"context_length": -100}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(MODEL, BASE_URL, providers)
+            is None
+        )
+
+    def test_string_context_length_coerced(self):
+        """String integers are coerced (config YAML may parse as str)."""
+        providers = [
+            {
+                "base_url": BASE_URL,
+                "models": {MODEL: {"context_length": "1000000"}},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(MODEL, BASE_URL, providers)
+            == 1_000_000
+        )
+
+    def test_multiple_entries_first_match_wins(self):
+        providers = [
+            {
+                "base_url": BASE_URL,
+                "models": {MODEL: {"context_length": 500_000}},
+            },
+            {
+                "base_url": BASE_URL,
+                "models": {MODEL: {"context_length": 1_000_000}},
+            },
+        ]
+        assert (
+            get_custom_provider_context_length(MODEL, BASE_URL, providers)
+            == 500_000
+        )
+
+    def test_model_cfg_not_dict_returns_none(self):
+        """models.<id> must be a dict; a bare string is invalid."""
+        providers = [
+            {
+                "base_url": BASE_URL,
+                "models": {MODEL: "1000000"},
+            }
+        ]
+        assert (
+            get_custom_provider_context_length(MODEL, BASE_URL, providers)
+            is None
+        )

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -15,6 +15,7 @@ from agent.models_dev import (
     _override_for,
     _NotModified,
     _validate_registry,
+    _get_provider_models,
     fetch_models_dev,
     get_model_capabilities,
     get_model_info,
@@ -145,6 +146,38 @@ class TestLookupModelsDevContext:
         # audio-only is not a mapped provider, but test the filtering directly
         data = SAMPLE_REGISTRY["audio-only"]["models"]["tts-model"]
         assert _extract_context(data) is None
+
+
+class TestCustomProviderNormalization:
+    """#79225: ``custom:<name>`` providers must resolve through the bare
+    catalog id even when ``<name>`` is not a key in PROVIDER_TO_MODELS_DEV.
+    A double lookup (normalize, then map again) silently drops the
+    normalized id: ``PROVIDER_TO_MODELS_DEV.get("audio-only")`` is None."""
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_lookup_models_dev_context_resolves_custom_catalog_id(
+        self, mock_fetch
+    ):
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        # "audio-only" is NOT in PROVIDER_TO_MODELS_DEV but IS a catalog id.
+        assert "audio-only" not in PROVIDER_TO_MODELS_DEV
+        # tts-model has context 0 → filtered → None (resolution itself works,
+        # proving the normalized id reached the registry lookup).
+        assert lookup_models_dev_context("custom:audio-only", "tts-model") is None
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_get_provider_models_resolves_custom_catalog_id(self, mock_fetch):
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        models = _get_provider_models("custom:audio-only")
+        assert models is not None
+        assert "tts-model" in models
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_get_model_info_resolves_custom_catalog_id(self, mock_fetch):
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        info = get_model_info("custom:anthropic", "claude-opus-4-6")
+        assert info is not None
+        assert info.context_window == 1000000
 
 
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -460,309 +460,68 @@ class TestSubscriptionIncludedNotes:
         assert any("subscription" in note.lower() for note in result.notes)
 
 
-def test_normalize_usage_reads_kimi_top_level_cached_tokens():
-    """Kimi/Moonshot's native API reports context-cache hits as a top-level
-    usage.cached_tokens, not OpenAI's nested
-    prompt_tokens_details.cached_tokens and not DeepSeek's
-    prompt_cache_hit_tokens. Neither existing fallback matches that name, so
-    direct Kimi sessions normalized to cache_read_tokens=0 — the hits were
-    invisible in accounting and billed at the full input rate (#65722)."""
-    usage = SimpleNamespace(
-        prompt_tokens=3000,
-        completion_tokens=250,
-        cached_tokens=1800,
-    )
+# ---------------------------------------------------------------------------
+# #79225: per-token vs per-million pricing units
+# ---------------------------------------------------------------------------
 
-    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
+def test_openai_compatible_models_pricing_is_per_million_not_scaled():
+    """OpenAI-compatible /models endpoints report dollars per million tokens
+    (e.g. 3.2664 = $3.27/M input). Before this fix the value was treated as a
+    per-token decimal and scaled by 1e6, producing $3,266,400/M and a bogus
+    expensive-model warning (#79225)."""
+    from agent.usage_pricing import _pricing_entry_from_metadata
 
-    assert normalized.cache_read_tokens == 1800
-    # prompt_tokens includes the cached prefix: 3000 - 1800 = fresh input
-    assert normalized.input_tokens == 1200
-    assert normalized.output_tokens == 250
-
-
-def test_kimi_fallback_does_not_override_the_nested_openai_shape():
-    """A provider that reports BOTH shapes must keep the nested value.
-
-    The new branch is last in the chain, so it only fills a genuine zero.
-    """
-    usage = SimpleNamespace(
-        prompt_tokens=1000,
-        completion_tokens=100,
-        prompt_tokens_details=SimpleNamespace(cached_tokens=400),
-        cached_tokens=999,  # must be ignored
-    )
-
-    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 400
-
-
-def test_kimi_fallback_does_not_override_deepseek_hit_tokens():
-    usage = SimpleNamespace(
-        prompt_tokens=2000,
-        completion_tokens=100,
-        prompt_cache_hit_tokens=1500,
-        cached_tokens=999,  # must be ignored
-    )
-
-    normalized = normalize_usage(usage, provider="deepseek", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 1500
-
-
-def test_usage_without_any_cache_fields_still_normalizes():
-    usage = SimpleNamespace(prompt_tokens=500, completion_tokens=50)
-
-    normalized = normalize_usage(usage, provider="kimi", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 0
-    assert normalized.input_tokens == 500
-
-
-def test_normalize_usage_handles_dict_shaped_usage():
-    """Regression test for #74314: when the Responses API returns usage as a
-    plain dict (e.g. from a middleware/proxy that deserialises JSON to dict
-    instead of a typed SDK object), normalize_usage() must read the same
-    token counts as it would from an attribute-style object.
-
-    Before this fix, getattr() on a dict silently returned 0 for every field,
-    so token counts and cost appeared as zero for dict-shaped usage.
-    """
-    # Same payload as both a dict and a SimpleNamespace
-    payload = {
-        "input_tokens": 100,
-        "output_tokens": 20,
-        "input_tokens_details": {"cached_tokens": 60, "cache_creation_tokens": 10},
-    }
-    ns = SimpleNamespace(
-        input_tokens=100,
-        output_tokens=20,
-        input_tokens_details=SimpleNamespace(cached_tokens=60, cache_creation_tokens=10),
-    )
-
-    dict_result = normalize_usage(payload, api_mode="codex_responses")
-    ns_result = normalize_usage(ns, api_mode="codex_responses")
-
-    assert dict_result.input_tokens == ns_result.input_tokens, f"input_tokens: dict={dict_result.input_tokens} vs ns={ns_result.input_tokens}"
-    assert dict_result.output_tokens == ns_result.output_tokens, f"output_tokens: dict={dict_result.output_tokens} vs ns={ns_result.output_tokens}"
-    assert dict_result.cache_read_tokens == ns_result.cache_read_tokens, f"cache_read: dict={dict_result.cache_read_tokens} vs ns={ns_result.cache_read_tokens}"
-    assert dict_result.cache_write_tokens == ns_result.cache_write_tokens, f"cache_write: dict={dict_result.cache_write_tokens} vs ns={ns_result.cache_write_tokens}"
-    # Sanity: values must be non-zero (the whole point of the bug)
-    assert dict_result.input_tokens > 0
-    assert dict_result.cache_read_tokens > 0
-
-
-def test_normalize_usage_handles_dict_openai_chat_completions():
-    """Dict-shaped usage must also work in the default (OpenAI chat-completions)
-    branch, not just the codex_responses branch.
-    """
-    payload = {
-        "prompt_tokens": 500,
-        "completion_tokens": 100,
-        "prompt_tokens_details": {"cached_tokens": 200},
-        "completion_tokens_details": {"reasoning_tokens": 30},
-    }
-
-    result = normalize_usage(payload, api_mode="chat_completions")
-
-    assert result.output_tokens == 100
-    assert result.cache_read_tokens == 200
-    assert result.input_tokens == 500 - 200  # prompt_total - cache_read
-    assert result.reasoning_tokens == 30
-
-
-def test_normalize_usage_openai_reads_nested_cache_creation_tokens():
-    usage = SimpleNamespace(
-        prompt_tokens=1000,
-        completion_tokens=200,
-        prompt_tokens_details=SimpleNamespace(
-            cached_tokens=100,
-            cache_creation_input_tokens=300,
-        ),
-    )
-
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 100
-    assert normalized.cache_write_tokens == 300
-    assert normalized.input_tokens == 600
-
-
-def test_normalize_usage_openai_reads_mapping_cache_creation_tokens():
-    usage = {
-        "prompt_tokens": 1000,
-        "completion_tokens": 200,
-        "prompt_tokens_details": {"cache_creation_input_tokens": 300},
-    }
-
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.cache_write_tokens == 300
-    assert normalized.input_tokens == 700
-
-
-def test_normalize_usage_openai_prefers_nested_cache_write_tokens():
-    usage = SimpleNamespace(
-        prompt_tokens=1000,
-        prompt_tokens_details=SimpleNamespace(
-            cache_write_tokens=200,
-            cache_creation_input_tokens=300,
-        ),
-        cache_creation_input_tokens=400,
-        cache_write_tokens=500,
-    )
-
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.cache_write_tokens == 200
-
-
-def test_normalize_usage_mapping_preserves_reasoning_tokens():
-    usage = {
-        "prompt_tokens": 100,
-        "completion_tokens": 20,
-        "prompt_tokens_details": {"cached_tokens": 40},
-        "completion_tokens_details": {"reasoning_tokens": 12},
-    }
-
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.reasoning_tokens == 12
-
-
-def test_normalize_usage_mapping_anthropic_fields():
-    usage = {
-        "input_tokens": 80,
-        "output_tokens": 20,
-        "cache_read_input_tokens": 50,
-        "cache_creation_input_tokens": 10,
-        "output_tokens_details": {"reasoning_tokens": 7},
-    }
-
-    normalized = normalize_usage(usage, provider="anthropic", api_mode="anthropic_messages")
-
-    assert normalized.cache_read_tokens == 50
-    assert normalized.cache_write_tokens == 10
-    assert normalized.reasoning_tokens == 7
-
-
-def test_normalize_usage_mapping_codex_fields():
-    usage = {
-        "input_tokens": 100,
-        "output_tokens": 20,
-        "input_tokens_details": {
-            "cached_tokens": 60,
-            "cache_creation_tokens": 10,
+    entry = _pricing_entry_from_metadata(
+        {
+            "edge/model": {
+                "pricing": {"prompt": "3.2664", "completion": "16.332"}
+            }
         },
-        "output_tokens_details": {"reasoning_tokens": 5},
-    }
-
-    normalized = normalize_usage(usage, provider="openai-codex", api_mode="codex_responses")
-
-    assert normalized.input_tokens == 30
-    assert normalized.cache_read_tokens == 60
-    assert normalized.cache_write_tokens == 10
-    assert normalized.reasoning_tokens == 5
-
-
-def test_normalize_usage_clamps_negative_counters():
-    usage = SimpleNamespace(
-        prompt_tokens=100,
-        completion_tokens=-5,
-        prompt_tokens_details=SimpleNamespace(
-            cached_tokens=-10,
-            cache_write_tokens=-20,
-        ),
-        completion_tokens_details=SimpleNamespace(reasoning_tokens=-3),
+        "edge/model",
+        source_url="https://edge.example/v1/models",
+        pricing_version="openai-compatible-models-api",
+        pricing_units="per_million",
     )
 
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.input_tokens == 100
-    assert normalized.output_tokens == 0
-    assert normalized.cache_read_tokens == 0
-    assert normalized.cache_write_tokens == 0
-    assert normalized.reasoning_tokens == 0
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("3.2664")
+    assert entry.output_cost_per_million == Decimal("16.332")
 
 
-def test_normalize_usage_clamps_inconsistent_cache_total():
-    usage = {
-        "prompt_tokens": 100,
-        "completion_tokens": 10,
-        "prompt_tokens_details": {
-            "cached_tokens": 80,
-            "cache_creation_input_tokens": 50,
+def test_openrouter_models_pricing_is_scaled_from_per_token():
+    """OpenRouter's models API reports per-token decimals; the per-token
+    declaration must still scale to per-million exactly as before."""
+    from agent.usage_pricing import _pricing_entry_from_metadata
+
+    entry = _pricing_entry_from_metadata(
+        {
+            "edge/model": {
+                "pricing": {"prompt": "0.0000032664", "completion": "0.000016332"}
+            }
         },
-    }
-
-    normalized = normalize_usage(usage, provider="openrouter", api_mode="chat_completions")
-
-    assert normalized.input_tokens == 0
-    assert normalized.prompt_tokens == 130
-
-
-def test_normalize_usage_codex_responses_reads_cache_write_tokens():
-    """GPT-5.6+ explicit prompt caching reports cache writes as
-    input_tokens_details.cache_write_tokens (billed at 1.25x), per OpenAI's
-    documented Responses API schema. Before this fix, the codex_responses
-    branch only read the undocumented `cache_creation_tokens` name and always
-    normalized cache writes to 0."""
-    usage = SimpleNamespace(
-        input_tokens=2006,
-        output_tokens=400,
-        input_tokens_details=SimpleNamespace(cached_tokens=1920, cache_write_tokens=50),
+        "edge/model",
+        source_url="https://openrouter.ai/api/v1/models",
+        pricing_version="openrouter-models-api",
+        pricing_units="per_token",
     )
 
-    normalized = normalize_usage(usage, provider="openai", api_mode="codex_responses")
-
-    assert normalized.cache_read_tokens == 1920
-    assert normalized.cache_write_tokens == 50
-    assert normalized.input_tokens == 2006 - 1920 - 50
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("3.2664")
+    assert entry.output_cost_per_million == Decimal("16.332")
 
 
-def test_normalize_usage_codex_responses_falls_back_to_cache_creation_tokens():
-    """If cache_write_tokens is absent, fall back to the legacy
-    cache_creation_tokens name rather than reporting 0."""
-    usage = SimpleNamespace(
-        input_tokens=1000,
-        output_tokens=100,
-        input_tokens_details=SimpleNamespace(cached_tokens=200, cache_creation_tokens=80),
+def test_default_units_are_per_million():
+    """The default (no explicit units) must be per-million — the
+    OpenAI-compatible standard — so a future caller cannot silently regress
+    to the 1e6 over-scaling."""
+    from agent.usage_pricing import _pricing_entry_from_metadata
+
+    entry = _pricing_entry_from_metadata(
+        {"edge/model": {"pricing": {"prompt": "3.2664", "completion": "16.332"}}},
+        "edge/model",
+        source_url="https://edge.example/v1/models",
+        pricing_version="openai-compatible-models-api",
     )
 
-    normalized = normalize_usage(usage, provider="openai", api_mode="codex_responses")
-
-    assert normalized.cache_write_tokens == 80
-
-
-def test_normalize_usage_reads_qwen_flat_cached_tokens():
-    """Some Alibaba/Qwen regional endpoints report cache reads as a flat
-    `usage.cached_tokens` field with no `prompt_tokens_details` wrapper at
-    all. Before this fix, those responses fell through every branch and
-    normalized to cache_read_tokens=0, undercounting cost."""
-    usage = SimpleNamespace(
-        prompt_tokens=2000,
-        completion_tokens=300,
-        cached_tokens=1200,
-    )
-
-    normalized = normalize_usage(usage, provider="qwen", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 1200
-    assert normalized.input_tokens == 800
-
-
-def test_normalize_usage_nested_details_win_over_qwen_flat_top_level():
-    """When both shapes are present, the nested OpenAI-style value wins and
-    the flat Qwen field is not double-read."""
-    usage = SimpleNamespace(
-        prompt_tokens=2000,
-        completion_tokens=100,
-        prompt_tokens_details=SimpleNamespace(cached_tokens=900),
-        cached_tokens=1200,
-    )
-
-    normalized = normalize_usage(usage, provider="qwen", api_mode="chat_completions")
-
-    assert normalized.cache_read_tokens == 900
-    assert normalized.input_tokens == 1100
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("3.2664")

--- a/tests/hermes_cli/test_auth_reset_cooldowns.py
+++ b/tests/hermes_cli/test_auth_reset_cooldowns.py
@@ -1,0 +1,111 @@
+"""CLI-level tests for `hermes auth reset` (interactive menu option 3).
+
+The reset must clear exhaustion/rate-limit status on disk even while the
+cooldowns are still active — the regression where the recency merge in
+``write_credential_pool`` resurrected every still-binding on-disk cooldown.
+
+All credentials here are synthetic mock data.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.credential_pool import load_pool
+from hermes_cli.auth_commands import auth_reset_command
+
+
+def _write_auth_store(tmp_path, payload: dict) -> None:
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
+
+
+def _exhausted_entry(entry_id, label, *, age_seconds, error_code=429):
+    return {
+        "id": entry_id,
+        "label": label,
+        "auth_type": "api_key",
+        "priority": 0,
+        "source": "manual",
+        "access_token": f"sk-mock-{entry_id}",
+        "last_status": "exhausted",
+        "last_status_at": time.time() - age_seconds,
+        "last_error_code": error_code,
+        "last_error_reason": "rate_limit_error",
+        "last_error_message": "mock upstream message",
+        "last_error_reset_at": None,
+    }
+
+
+def _setup_pool(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    # Prevent auto-seeding from host Codex CLI tokens / anthropic config.
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    _exhausted_entry("cred-1", "alice", age_seconds=60),
+                    _exhausted_entry("cred-2", "bob", age_seconds=120, error_code=402),
+                ]
+            },
+        },
+    )
+
+
+def test_auth_reset_command_clears_active_cooldowns(tmp_path, monkeypatch, capsys):
+    """Menu option 3: `hermes auth reset <provider>` must land on disk even
+    while cooldowns are still active (the resurrection regression)."""
+    _setup_pool(tmp_path, monkeypatch)
+
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is False
+
+    auth_reset_command(SimpleNamespace(provider="openai-codex"))
+
+    out = capsys.readouterr().out
+    assert "Reset status on 2 openai-codex credentials" in out
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    for entry in auth_payload["credential_pool"]["openai-codex"]:
+        assert entry.get("last_status") is None
+        assert entry.get("last_status_at") is None
+        assert entry.get("last_error_code") is None
+
+    # A fresh pool load (what the runtime does) sees healthy credentials.
+    reloaded = load_pool("openai-codex")
+    assert reloaded.has_available() is True
+
+
+def test_auth_reset_command_prints_zero_when_clean(tmp_path, monkeypatch, capsys):
+    """A pool with no statuses reports 0 and leaves the file untouched."""
+    _setup_pool(tmp_path, monkeypatch)
+    auth_file = tmp_path / "hermes" / "auth.json"
+    payload = json.loads(auth_file.read_text())
+    for entry in payload["credential_pool"]["openai-codex"]:
+        for key in (
+            "last_status",
+            "last_status_at",
+            "last_error_code",
+            "last_error_reason",
+            "last_error_message",
+            "last_error_reset_at",
+        ):
+            entry.pop(key, None)
+    auth_file.write_text(json.dumps(payload))
+    before = auth_file.read_bytes()
+
+    auth_reset_command(SimpleNamespace(provider="openai-codex"))
+
+    assert "Reset status on 0 openai-codex credentials" in capsys.readouterr().out
+    assert auth_file.read_bytes() == before

--- a/tests/hermes_cli/test_model_cost_guard.py
+++ b/tests/hermes_cli/test_model_cost_guard.py
@@ -152,14 +152,16 @@ def test_openai_gpt55_pro_warns_even_without_pricing(monkeypatch):
 
 
 def test_openai_gpt55_pro_warns_for_nous_portal_pricing(monkeypatch):
+    # OpenAI-compatible /models endpoints report dollars per million tokens
+    # (e.g. 25.0 = $25/M input); per-token decimals are OpenRouter-only.
     monkeypatch.setattr("agent.models_dev.get_model_info", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         "agent.usage_pricing.fetch_endpoint_model_metadata",
         lambda base_url, api_key="": {
             "openai/gpt-5.5-pro": {
                 "pricing": {
-                    "prompt": "0.000025",
-                    "completion": "0.000125",
+                    "prompt": "25.0",
+                    "completion": "125.0",
                 }
             }
         },

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -13,7 +13,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from run_agent import AIAgent
-from agent.context_compressor import ContextCompressor
+from agent.context_compressor import (
+    ContextCompressor,
+    LEAN_TAIL_CAP_TOKENS,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -31,8 +34,16 @@ def _make_agent(
     compression_enabled: bool = True,
     threshold_percent: float = 0.50,
     main_context: int = 200_000,
+    tail_mode: str = "legacy",
+    real_compressor: bool = False,
 ) -> AIAgent:
-    """Build a minimal AIAgent with a compressor, skipping __init__."""
+    """Build a minimal AIAgent with a compressor, skipping __init__.
+
+    The default MagicMock compressor is enough for warning/message tests.
+    ``real_compressor=True`` builds a REAL ContextCompressor so the
+    mode-aware tail policy is exercised end to end — a mock would silently
+    accept any budget the aux-context sync writes.
+    """
     agent = AIAgent.__new__(AIAgent)
     agent.model = "test-main-model"
     agent.provider = "openrouter"
@@ -54,13 +65,30 @@ def _make_agent(
     agent._custom_providers = []
     agent.tools = []
 
-    compressor = MagicMock(spec=ContextCompressor)
-    compressor.context_length = main_context
-    compressor.threshold_tokens = int(main_context * threshold_percent)
-    compressor.summary_target_ratio = 0.20
-    compressor.tail_token_budget = int(
-        compressor.threshold_tokens * compressor.summary_target_ratio
-    )
+    if real_compressor:
+        compressor = ContextCompressor(
+            model=agent.model,
+            threshold_percent=threshold_percent,
+            summary_target_ratio=0.20,
+            config_context_length=main_context,
+            tail_mode=tail_mode,
+            quiet_mode=True,
+        )
+    else:
+        compressor = MagicMock(spec=ContextCompressor)
+        compressor.context_length = main_context
+        compressor.threshold_tokens = int(main_context * threshold_percent)
+        compressor.summary_target_ratio = 0.20
+        compressor.tail_token_budget = int(
+            compressor.threshold_tokens * compressor.summary_target_ratio
+        )
+        # Mimic the real legacy policy: recalibration re-derives the tail
+        # from the CURRENT threshold at the configured ratio (the real
+        # method invalidates a cache the mode-aware property re-fills).
+        compressor.recalibrate_tail_budget.side_effect = lambda: setattr(
+            compressor, "tail_token_budget",
+            int(compressor.threshold_tokens * compressor.summary_target_ratio),
+        )
     agent.context_compressor = compressor
 
     return agent
@@ -108,8 +136,74 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     # Every threshold-derived budget must move with it. Keeping the original
     # 20K tail here would protect 25% of the lowered threshold instead of the
     # configured 20%, and larger real-world mismatches can make the tail's 1.5x
-    # soft ceiling wider than the entire compression trigger.
+    # soft ceiling wider than the entire compression trigger. The sync goes
+    # through the canonical mode-aware hook; the mock's side_effect re-derives
+    # the legacy budget from the lowered threshold.
+    agent.context_compressor.recalibrate_tail_budget.assert_called_once()
     assert agent.context_compressor.tail_token_budget == 16_000
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_aux_sync_keeps_lean_tail_policy(mock_get_client, mock_ctx_len):
+    """Regression: the aux-context threshold sync must not cache a legacy
+    threshold*ratio tail when tail_mode is lean.
+
+    Real compressor, 1M main window (lean tail = 25K cap), aux context 80K
+    lowers the live threshold to 80K. The legacy formula would write
+    80K * 0.20 = 16K into the tail budget; lean must stay at its canonical
+    clamp (25K on a 1M window) and keep tail_mode == "lean".
+    """
+    agent = _make_agent(
+        main_context=1_000_000,
+        threshold_percent=0.65,
+        tail_mode="lean",
+        real_compressor=True,
+    )
+    comp = agent.context_compressor
+    assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS  # 25K on 1M
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+    agent._emit_status = lambda msg: None
+
+    agent._check_compression_model_feasibility()
+
+    # The threshold was lowered to the aux context...
+    assert comp.threshold_tokens == 80_000
+    # ...but the lean tail policy survived the sync.
+    assert comp.tail_mode == "lean"
+    assert comp.tail_token_budget == LEAN_TAIL_CAP_TOKENS
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_aux_sync_legacy_tail_follows_lowered_threshold(mock_get_client, mock_ctx_len):
+    """Legacy behavior on the same sync path is unchanged: the tail budget
+    follows the lowered threshold at the configured ratio (80K * 0.20)."""
+    agent = _make_agent(
+        main_context=1_000_000,
+        threshold_percent=0.65,
+        tail_mode="legacy",
+        real_compressor=True,
+    )
+    comp = agent.context_compressor
+    before = comp.tail_token_budget
+    assert before == int(comp.threshold_tokens * comp.summary_target_ratio)
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+    agent._emit_status = lambda msg: None
+
+    agent._check_compression_model_feasibility()
+
+    assert comp.threshold_tokens == 80_000
+    assert comp.tail_mode == "legacy"
+    assert comp.tail_token_budget == int(80_000 * comp.summary_target_ratio)
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=32_768)

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -30,6 +30,12 @@ VALID = {
 }
 
 
+def _bind_repair(valid_tool_names):
+    from run_agent import AIAgent
+    stub = SimpleNamespace(valid_tool_names=set(valid_tool_names))
+    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+
 @pytest.fixture
 def repair():
     """Return a bound _repair_tool_call built on a minimal shell agent.
@@ -39,9 +45,7 @@ def repair():
     reads self.valid_tool_names. A SimpleNamespace stub is enough to
     bind the unbound function.
     """
-    from run_agent import AIAgent
-    stub = SimpleNamespace(valid_tool_names=VALID)
-    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+    return _bind_repair(VALID)
 
 
 class TestExistingBehaviorStillWorks:
@@ -125,3 +129,34 @@ class TestVolcEngineXmlPollution:
         # rest of the pipeline (fuzzy match at 0.7 cutoff) can still
         # recover the obvious target.
         assert repair('"terminal"') == "terminal"
+
+class TestMcpToolNameRepair:
+    """MCP names are namespaced; fuzzy repair must not swap tool semantics."""
+
+    MCP_VALID = {
+        "mcp__ghidra_mcp__decompile_function",
+        "mcp__ghidra_mcp__rename_function",
+        "mcp__ghidra_mcp__set_function_prototype",
+        "mcp__ghidra_mcp__read_bytes",
+    }
+
+    def test_mcp_tool_names_do_not_fuzzy_match_to_different_operation(self):
+        repair = _bind_repair(self.MCP_VALID)
+
+        assert repair("mcp__ghidra_mcp__disassemble_function") is None
+
+    def test_mcp_exact_normalization_still_works(self):
+        repair = _bind_repair(self.MCP_VALID)
+
+        assert (
+            repair("MCP__GHIDRA_MCP__DECOMPILE_FUNCTION")
+            == "mcp__ghidra_mcp__decompile_function"
+        )
+
+    def test_mcp_tool_suffix_strip_still_allows_exact_match(self):
+        repair = _bind_repair(self.MCP_VALID)
+
+        assert (
+            repair("mcp__ghidra_mcp__read_bytes_tool")
+            == "mcp__ghidra_mcp__read_bytes"
+        )

--- a/tests/run_agent/test_retry_same_provider_stream_only.py
+++ b/tests/run_agent/test_retry_same_provider_stream_only.py
@@ -1,0 +1,105 @@
+"""stream_only_base_urls must survive same-provider retry paths.
+
+Regression: the initial auxiliary attempt routes through _create_with_progress
+with force_stream computed from auxiliary.stream_only_base_urls, but the
+same-provider recovery retry rebuilt the request WITHOUT that wrapper — so a
+stream-only endpoint (gateway behind a short proxy read timeout) silently
+fell back to non-streaming on every retry, reintroducing the exact hangs the
+setting exists to prevent.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from agent import auxiliary_client as ac
+
+
+def _response(text: str):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))],
+    )
+
+
+class _Completions:
+    def __init__(self, sink):
+        self._sink = sink
+
+    def create(self, **kwargs):
+        self._sink.append(kwargs)
+        return _response("ok")
+
+
+def _fake_client(sink, base_url="https://inference-api.nousresearch.com/v1"):
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=_Completions(sink)),
+        base_url=base_url,
+    )
+
+
+def test_retry_same_provider_sync_streams_for_stream_only_base_url(monkeypatch):
+    """A stream-only base_url forces stream=True on the same-provider sync retry."""
+    captured = []
+    monkeypatch.setattr(
+        ac, "_get_cached_client",
+        lambda *a, **k: (_fake_client(captured), "test-model"),
+    )
+    monkeypatch.setattr(ac, "_validate_llm_response", lambda resp, task, **_kw: resp)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"auxiliary": {"stream_only_base_urls": ["inference-api.nousresearch.com"]}},
+    )
+
+    ac._retry_same_provider_sync(
+        task="compression",
+        resolved_provider="custom",
+        resolved_model="test-model",
+        resolved_base_url="https://inference-api.nousresearch.com/v1",
+        resolved_api_key="k",
+        resolved_api_mode="chat_completions",
+        main_runtime=None,
+        final_model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=None,
+        max_tokens=None,
+        tools=None,
+        effective_timeout=30.0,
+        effective_extra_body={},
+        reasoning_config=None,
+        extra_headers=None,
+    )
+
+    assert captured, "retry never reached the client"
+    assert captured[0].get("stream") is True, (
+        "stream-only base_url downgraded to non-streaming on the retry path"
+    )
+
+
+def test_retry_same_provider_sync_nonstream_for_unlisted_base_url(monkeypatch):
+    """Base URLs not in stream_only_base_urls keep the plain call."""
+    captured = []
+    monkeypatch.setattr(
+        ac, "_get_cached_client",
+        lambda *a, **k: (_fake_client(captured, "https://opencode.ai/zen/v1"), "test-model"),
+    )
+    monkeypatch.setattr(ac, "_validate_llm_response", lambda resp, task, **_kw: resp)
+
+    ac._retry_same_provider_sync(
+        task="compression",
+        resolved_provider="custom",
+        resolved_model="test-model",
+        resolved_base_url="https://opencode.ai/zen/v1",
+        resolved_api_key="k",
+        resolved_api_mode="chat_completions",
+        main_runtime=None,
+        final_model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=None,
+        max_tokens=None,
+        tools=None,
+        effective_timeout=30.0,
+        effective_extra_body={},
+        reasoning_config=None,
+        extra_headers=None,
+    )
+
+    assert captured and captured[0].get("stream") is not True

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -802,13 +802,14 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_mode"], "chat_completions")
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
-    def test_nous_provider_wins_over_base_url_for_runtime_auth(self, mock_resolve):
-        """provider=nous must use runtime auth even when base_url is configured.
+    def test_nous_provider_runtime_auth_without_explicit_key(self, mock_resolve):
+        """provider=nous + base_url but NO delegation.api_key → runtime auth.
 
-        Reverse-engineer had delegation.provider=nous plus the Nous inference
-        base_url and a stale delegation.api_key. Treating that as a direct
-        custom endpoint bypassed the valid Nous credential resolver and made
-        subagents 401 while the default profile could call hy3 normally.
+        The primary fix path: Nous + base_url configured (e.g. the inference
+        endpoint) but no explicit delegation.api_key. Without this fix the
+        base_url branch treats it as a direct custom endpoint and the child
+        inherits the parent key — which 401s when the parent key is stale or
+        the Nous JWT rotation has refreshed.
         """
         parent = _make_mock_parent(depth=0)
         mock_resolve.return_value = {
@@ -822,7 +823,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             "model": "tencent/hy3:free",
             "provider": "nous",
             "base_url": "https://inference-api.nousresearch.com/v1",
-            "api_key": "stale-explicit-key",
+            # No api_key — runtime resolution must provide the credential.
         }
 
         creds = _resolve_delegation_credentials(cfg, parent)
@@ -834,6 +835,55 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["base_url"], "https://inference-api.nousresearch.com/v1")
         self.assertEqual(creds["api_key"], "fresh-runtime-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
+
+    def test_nous_explicit_api_key_uses_direct_endpoint(self):
+        """Explicit delegation.api_key with provider=nous → direct endpoint.
+
+        When the user explicitly sets delegation.api_key, that means "use this
+        direct endpoint with this key" — runtime auth must NOT override it.
+        This preserves the documented precedence: explicit config wins.
+        """
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "tencent/hy3:free",
+            "provider": "nous",
+            "base_url": "https://internal-proxy.example.com/v1",
+            "api_key": "my-explicit-proxy-key",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        # Direct endpoint path: provider=custom, explicit key preserved.
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["base_url"], "https://internal-proxy.example.com/v1")
+        self.assertEqual(creds["api_key"], "my-explicit-proxy-key")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_nous_registered_aliases_use_runtime_auth(self, mock_resolve):
+        """Registered Nous aliases (nous-portal, nousresearch) also route
+        through runtime auth when no explicit api_key is set."""
+        parent = _make_mock_parent(depth=0)
+        mock_resolve.return_value = {
+            "model": "test/model",
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "runtime-key",
+            "api_mode": "chat_completions",
+        }
+
+        for alias in ("nous-portal", "nousresearch"):
+            mock_resolve.reset_mock()
+            cfg = {
+                "model": "test/model",
+                "provider": alias,
+                "base_url": "https://inference-api.nousresearch.com/v1",
+            }
+            creds = _resolve_delegation_credentials(cfg, parent)
+            mock_resolve.assert_called_once_with(
+                requested=alias, target_model="test/model"
+            )
+            self.assertEqual(creds["api_key"], "runtime-key",
+                             f"alias={alias} should use runtime auth")
 
     def test_direct_endpoint_auto_detects_anthropic_messages_suffix(self):
         # Issue #10213: Azure AI Foundry exposes Anthropic-compatible models at

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -801,6 +801,40 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_key"], "local-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_nous_provider_wins_over_base_url_for_runtime_auth(self, mock_resolve):
+        """provider=nous must use runtime auth even when base_url is configured.
+
+        Reverse-engineer had delegation.provider=nous plus the Nous inference
+        base_url and a stale delegation.api_key. Treating that as a direct
+        custom endpoint bypassed the valid Nous credential resolver and made
+        subagents 401 while the default profile could call hy3 normally.
+        """
+        parent = _make_mock_parent(depth=0)
+        mock_resolve.return_value = {
+            "model": "tencent/hy3:free",
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "fresh-runtime-key",
+            "api_mode": "chat_completions",
+        }
+        cfg = {
+            "model": "tencent/hy3:free",
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "stale-explicit-key",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        mock_resolve.assert_called_once_with(
+            requested="nous", target_model="tencent/hy3:free"
+        )
+        self.assertEqual(creds["provider"], "nous")
+        self.assertEqual(creds["base_url"], "https://inference-api.nousresearch.com/v1")
+        self.assertEqual(creds["api_key"], "fresh-runtime-key")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+
     def test_direct_endpoint_auto_detects_anthropic_messages_suffix(self):
         # Issue #10213: Azure AI Foundry exposes Anthropic-compatible models at
         # a /anthropic URL suffix. Subagents must pick anthropic_messages

--- a/tests/tools/test_tool_search_context_provider.py
+++ b/tests/tools/test_tool_search_context_provider.py
@@ -30,7 +30,7 @@ class TestResolveActiveContextLengthProviderAware:
 
         captured = {}
 
-        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider=""):
+        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
             captured.update(
                 model=model_id, base_url=base_url, api_key=api_key,
                 config_ctx=config_context_length, provider=provider,
@@ -60,7 +60,7 @@ class TestResolveActiveContextLengthProviderAware:
 
         captured = {}
 
-        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider=""):
+        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
             captured.update(base_url=base_url, api_key=api_key, provider=provider)
             return 272_000
 
@@ -83,7 +83,7 @@ class TestResolveActiveContextLengthProviderAware:
 
         captured = {}
 
-        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider=""):
+        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
             captured.update(base_url=base_url, provider=provider)
             return 200_000
 
@@ -103,7 +103,7 @@ class TestResolveActiveContextLengthProviderAware:
 
         captured = {}
 
-        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider=""):
+        def fake_get_ctx(model_id, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
             captured["config_ctx"] = config_context_length
             return config_context_length or 0
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4450,8 +4450,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     _NATIVE_SDK_PROVIDERS = {"bedrock", "vertex", "google", "google-genai"}
     _provider_lower = (configured_provider or "").strip().lower()
     _is_native_sdk_provider = _provider_lower in _NATIVE_SDK_PROVIDERS
+    _requires_runtime_provider_auth = _provider_lower in {"nous", "nous-research"}
 
-    if configured_base_url and not _is_native_sdk_provider:
+    if configured_base_url and not _is_native_sdk_provider and not _requires_runtime_provider_auth:
         # When delegation.api_key is not set, return None so _build_child_agent
         # falls back to the parent agent's API key via the credential inheritance
         # path (effective_api_key = override_api_key or parent_api_key). This

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4417,21 +4417,24 @@ def _resolve_child_credential_pool(
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
-    If ``delegation.base_url`` is configured, subagents use that direct
-    OpenAI-compatible endpoint. ``delegation.api_key`` overrides the key; when
-    omitted, ``api_key`` is returned as ``None`` so ``_build_child_agent``
-    inherits the parent agent's key (``effective_api_key = override_api_key or
-    parent_api_key``). This lets providers that store their key outside
-    ``OPENAI_API_KEY`` (e.g. ``MINIMAX_API_KEY``, ``DASHSCOPE_API_KEY``) work
-    without a duplicate config entry.
+    Precedence (highest to lowest):
 
-    Otherwise, if ``delegation.provider`` is configured, the full credential
-    bundle (base_url, api_key, api_mode, provider) is resolved via the runtime
-    provider system — the same path used by CLI/gateway startup. This lets
-    subagents run on a completely different provider:model pair.
-
-    If neither base_url nor provider is configured, returns None values so the
-    child inherits everything from the parent agent.
+    1. **Explicit ``delegation.api_key``** — always wins. When set, the
+       configured ``base_url`` is used as a direct OpenAI-compatible endpoint
+       with that key. This applies even for Nous-family providers: an explicit
+       key means "use this direct endpoint with this key".
+    2. **Nous-family provider without explicit key** — ``provider`` is one of
+       the registered Nous aliases (``nous``, ``nous-portal``, ``nousresearch``)
+       and no ``delegation.api_key`` is set. Routes through
+       ``resolve_runtime_provider()`` for JWT-rotated credentials, even when
+       ``base_url`` is also configured. This prevents 401s from stale parent
+       keys when the Nous JWT has rotated.
+    3. **``delegation.base_url`` without explicit key** — direct endpoint;
+       ``api_key`` is returned as ``None`` so ``_build_child_agent`` inherits
+       the parent agent's key.
+    4. **``delegation.provider``** — full credential bundle resolved via the
+       runtime provider system.
+    5. **Neither** — child inherits everything from the parent agent.
 
     Raises ValueError with a user-friendly message on credential failure.
     """
@@ -4450,7 +4453,15 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     _NATIVE_SDK_PROVIDERS = {"bedrock", "vertex", "google", "google-genai"}
     _provider_lower = (configured_provider or "").strip().lower()
     _is_native_sdk_provider = _provider_lower in _NATIVE_SDK_PROVIDERS
-    _requires_runtime_provider_auth = _provider_lower in {"nous", "nous-research"}
+    # Nous-family providers must use runtime auth (JWT rotation) UNLESS the
+    # user explicitly configured delegation.api_key — an explicit key means
+    # "use this direct endpoint with this key" and must not be overridden.
+    # Registered aliases: nous, nous-portal, nousresearch
+    # (plugins/model-providers/nous/__init__.py).
+    _NOUS_ALIASES = {"nous", "nous-portal", "nousresearch"}
+    _requires_runtime_provider_auth = (
+        _provider_lower in _NOUS_ALIASES and not configured_api_key
+    )
 
     if configured_base_url and not _is_native_sdk_provider and not _requires_runtime_provider_auth:
         # When delegation.api_key is not set, return None so _build_child_agent


### PR DESCRIPTION
## What

Same-provider recovery retries for auxiliary LLM calls dropped the stream-only wrapper. The initial attempt routes through `_create_with_progress` / `_acreate_with_stream` with `force_stream` computed from `auxiliary.stream_only_base_urls`, but both retry helpers (`_retry_same_provider_sync`, `_retry_same_provider_async`) rebuilt the request and called the relay directly — so any endpoint configured as stream-only silently fell back to **non-streaming** on every recovery retry.

Both retry paths now compute `force_stream` from the same config source and route through the same stream-only wrappers as the initial attempt.

## Why this matters

`auxiliary.stream_only_base_urls` exists for endpoints where non-streaming requests hang or fail (e.g. gateways behind short proxy read timeouts that silently drop long non-streaming calls). On such an endpoint the failure chain was:

1. Initial attempt streams fine, but a transient timeout triggers recovery
2. Same-provider retry goes out **non-streaming** (wrapper dropped)
3. The gateway holds the connection with zero output; the caller's stale watchdog kills it at ~90s
4. Retry loop repeats → the aux task (often compression, on the preflight critical path) never completes

The retry path is exactly where stream-only endpoints need protection most, because it is reached only after a first failure.

## How to test

New tests in `tests/run_agent/test_retry_same_provider_stream_only.py`:

```bash
pytest tests/run_agent/test_retry_same_provider_stream_only.py -v
```

- `test_retry_same_provider_sync_streams_for_stream_only_base_url` — with `stream_only_base_urls` containing the retry's base URL, the rebuilt request carries `stream=True`
- `test_retry_same_provider_sync_nonstream_for_unlisted_base_url` — unlisted URLs keep the plain non-streaming call

Existing suites pass unchanged:

```bash
pytest tests/agent/test_aux_progress_streaming.py tests/agent/test_auxiliary_client.py
# 198 passed
```

Manual verification against a live profile: call `_retry_same_provider_sync` with a fake client whose non-streaming `create()` raises `TimeoutError`; with the fix, the retry issues a single `stream=True` call and completes.

## Platforms

Linux only (WSL2); no platform-sensitive code paths touched.

Fixes the retry-path gap in #60686's `stream_only_base_urls` feature.
