### PR TITLE
feat(gateway): add structured per-session runtime options

### DIFF
--- a/contributors/emails/mattyford@protonmail.com
+++ b/contributors/emails/mattyford@protonmail.com
@@ -1,0 +1,2 @@
+ocuclaw
+# PR #92187 (gateway: structured per-session runtime options)

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -547,7 +547,7 @@ The `_session_expiry_watcher` task runs in the gateway event loop every 300 seco
    - Invoke `on_session_finalize` plugin hooks (cleanup, notifications).
    - Clean up cached AIAgent resources (close tool resources, shut down memory provider).
    - Evict the cached agent entry.
-   - Clear per-session overrides (`_session_model_overrides`, reasoning overrides, etc.).
+   - Clear per-session runtime options (live `SessionState.conversation` model / reasoning / service-tier overrides and the persisted `SessionEntry` snapshot, see `gateway/session_options.py`).
    - Mark `expiry_finalized=True` and persist (sessions.json + state.db).
    - Promote the state.db session row to `end_reason='session_reset'` via
      `promote_to_session_reset()` — conditional: only live rows or rows ended with a

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7496,7 +7496,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Sync helpers keep using ``session_store`` directly; async gateway
         # handlers call this facade and await every operation.
         self._async_session_store = AsyncSessionStore(self.session_store)
-        # Serializes structured host-UI option changes per messaging session.
+        # Per-session admission lock: shared by the runtime-options write-through
+        # (gateway/session_options.py) and _handle_message's idle->running claim.
         # Locks are process-local; accepted values are persisted by SessionStore.
         self._session_options_locks: Dict[str, asyncio.Lock] = {}
         self.delivery_router = DeliveryRouter(self.config)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10192,6 +10192,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             None if reasoning_config is None else dict(reasoning_config)
         )
 
+    def _rehydrate_session_reasoning_override(self, session_entry) -> None:
+        """Copy a durable override from an already-loaded routing entry."""
+        session_key = str(getattr(session_entry, "session_key", "") or "")
+        persisted = getattr(session_entry, "reasoning_override", None)
+        if not session_key or persisted is None:
+            return
+        state = self._session_state(session_key)
+        if state.conversation.reasoning_override is None:
+            state.conversation.reasoning_override = dict(persisted)
+
     def _resolve_session_service_tier(
         self,
         source=None,
@@ -20521,6 +20531,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 touch_activity=not bool(getattr(event, "internal", False)),
             )
         session_key = session_entry.session_key
+        self._rehydrate_session_reasoning_override(session_entry)
         if not strict_session and pinned_session_id:
             resolved_entry = await self._resolve_async_delegation_session(
                 session_entry,
@@ -20529,6 +20540,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if resolved_entry is None:
                 return
             session_entry = resolved_entry
+            session_key = session_entry.session_key
+            self._rehydrate_session_reasoning_override(session_entry)
         self._cache_session_source(session_key, source)
         if await asyncio.to_thread(self._is_telegram_topic_lane, source):
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -45,7 +45,7 @@ from collections import OrderedDict
 from contextvars import Context, copy_context
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
-from typing import Awaitable, Callable, Dict, Optional, Any, List, Tuple, Union, cast
+from typing import Awaitable, Callable, Dict, Mapping, Optional, Any, List, Tuple, Union, cast
 
 from agent.async_utils import consume_detached_task_result, safe_schedule_threadsafe
 from agent.conversation_compression import (
@@ -7489,6 +7489,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Sync helpers keep using ``session_store`` directly; async gateway
         # handlers call this facade and await every operation.
         self._async_session_store = AsyncSessionStore(self.session_store)
+        # Serializes structured host-UI option changes per messaging session.
+        # Locks are process-local; accepted values are persisted by SessionStore.
+        self._session_options_locks: Dict[str, asyncio.Lock] = {}
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False
         self._gateway_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -8678,7 +8681,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         model = _resolve_gateway_model(user_config)
         if resolved_session_key:
-            self._rehydrate_session_model_override(resolved_session_key)
+            self._rehydrate_session_runtime_options(resolved_session_key)
         _override_state = (
             self._peek_session_state(resolved_session_key)
             if resolved_session_key
@@ -10172,6 +10175,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 resolved_session_key = None
 
         if resolved_session_key:
+            self._rehydrate_session_runtime_options(resolved_session_key)
             _r_state = self._peek_session_state(resolved_session_key)
             if _r_state is not None and _r_state.conversation.reasoning_override is not None:
                 return _r_state.conversation.reasoning_override
@@ -10185,12 +10189,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Set or clear the session-scoped reasoning override."""
         if not session_key:
             return
+        self._rehydrate_session_runtime_options(session_key)
         # Per-session field write — the old lazy ``self._session_reasoning_overrides
         # = {}`` init replaced the WHOLE dict, racing concurrent sessions'
         # overrides; a SessionState field reset cannot cross sessions.
         self._session_state(session_key).conversation.reasoning_override = (
             None if reasoning_config is None else dict(reasoning_config)
         )
+        self._persist_session_runtime_options(session_key)
 
     def _rehydrate_session_reasoning_override(self, session_entry) -> None:
         """Copy a durable override from an already-loaded routing entry."""
@@ -10221,6 +10227,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 resolved_session_key = None
 
         if resolved_session_key:
+            self._rehydrate_session_runtime_options(resolved_session_key)
             _t_state = self._peek_session_state(resolved_session_key)
             if (
                 _t_state is not None
@@ -10243,6 +10250,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if not session_key:
             return
+        self._rehydrate_session_runtime_options(session_key)
         # Presence-sensitive: "priority" or None (explicit normal) both count
         # as an override; the sentinel means "no override".  Old code
         # wholesale-replaced the dict on lazy init (cross-session race) —
@@ -10250,6 +10258,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._session_state(session_key).conversation.service_tier_override = (
             _SERVICE_TIER_UNSET if clear else service_tier
         )
+        self._persist_session_runtime_options(session_key)
 
     @staticmethod
     def _load_service_tier() -> str | None:
@@ -28334,45 +28343,52 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         return hashlib.sha256(blob.encode()).hexdigest()[:16]
 
-    def _rehydrate_session_model_override(self, session_key: str) -> None:
-        """Lazily restore a persisted /model override after a gateway restart.
+    async def apply_session_options(
+        self,
+        source: SessionSource,
+        options: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        """Apply silent, structured runtime options to a messaging session.
 
-        ``_session_model_overrides`` is in-memory only, so before persistence
-        a restart silently reverted every session to the global default model.
-        The non-secret parts (model/provider/base_url) are written through to
-        the session store when /model runs (and cleared on /new); here we read
-        them back on first use and re-resolve credentials via the normal
-        runtime provider resolution — api_key is never persisted to disk.
-
-        No-op when an in-memory override already exists (live state wins) or
-        when the store has nothing persisted (e.g. the user ran /new, which
-        clears both the in-memory dict and the persisted field).
+        Messaging adapters and host UIs should use this public boundary instead
+        of injecting visible slash-command turns. Values are validated before
+        any state is created or changed, then persisted atomically per session.
         """
-        _rehydrate_state = self._peek_session_state(session_key)
-        if (
-            _rehydrate_state is not None
-            and _rehydrate_state.conversation.model_override is not None
-        ):
+        from gateway.session_options import apply_gateway_session_options
+
+        return await apply_gateway_session_options(self, source, options)
+
+    def _rehydrate_session_runtime_options(self, session_key: str) -> None:
+        """Lazily restore persisted runtime options after a gateway restart.
+
+        The model, reasoning effort, and fast tier belong to the existing
+        messaging session. Model credentials are re-resolved from live config;
+        they are never stored in sessions.json.
+        """
+        state = self._session_state(session_key)
+        if state.persistent.runtime_options_rehydrated:
             return
         store = getattr(self, "session_store", None)
         if store is None:
             return
         try:
-            persisted = store.get_model_override(session_key)
+            persisted = store.get_runtime_options(session_key)
         except Exception:
             logger.debug(
-                "Failed to read persisted session model override", exc_info=True
+                "Failed to read persisted session runtime options", exc_info=True
             )
             return
+        state.persistent.runtime_options_rehydrated = True
         if not persisted:
             return
-        override: Dict[str, Any] = {
-            "model": persisted.get("model"),
-            "provider": persisted.get("provider"),
-            "base_url": persisted.get("base_url"),
-        }
-        provider = persisted.get("provider")
-        if provider:
+        model_persisted = persisted.get("model_override")
+        if model_persisted:
+            override: Dict[str, Any] = {
+                "model": model_persisted.get("model"),
+                "provider": model_persisted.get("provider"),
+                "base_url": model_persisted.get("base_url"),
+            }
+            provider = model_persisted.get("provider")
             # Re-resolve credentials for the persisted provider. On failure
             # (e.g. credentials were removed since the switch) keep the
             # credential-less override — _resolve_session_agent_runtime falls
@@ -28401,6 +28417,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "Rehydrated persisted /model override for session=%s: model=%s provider=%s",
             session_key, override.get("model"), provider or "",
         )
+
+        reasoning = persisted.get("reasoning_override")
+        state.conversation.reasoning_override = (
+            dict(reasoning) if isinstance(reasoning, dict) else None
+        )
+        tier = persisted.get("service_tier_override")
+        if tier == "priority":
+            state.conversation.service_tier_override = "priority"
+        elif tier == "normal":
+            state.conversation.service_tier_override = None
+        else:
+            state.conversation.service_tier_override = _SERVICE_TIER_UNSET
+
+    def _rehydrate_session_model_override(self, session_key: str) -> None:
+        """Compatibility alias for callers that predate structured options."""
+        self._rehydrate_session_runtime_options(session_key)
+
+    def _persist_session_runtime_options(self, session_key: str) -> None:
+        """Keep durable host defaults aligned with later slash-command edits."""
+        store = getattr(self, "session_store", None)
+        state = self._peek_session_state(session_key)
+        if store is None or state is None:
+            return
+        tier = state.conversation.service_tier_override
+        durable_tier = (
+            None
+            if tier is _SERVICE_TIER_UNSET
+            else ("priority" if tier == "priority" else "normal")
+        )
+        try:
+            store.set_runtime_options(
+                session_key,
+                model_override=state.conversation.model_override,
+                reasoning_override=state.conversation.reasoning_override,
+                service_tier_override=durable_tier,
+            )
+        except Exception:
+            logger.debug(
+                "Failed to persist session runtime options for %s",
+                session_key,
+                exc_info=True,
+            )
 
     def _apply_session_model_override(
         self, session_key: str, model: str, runtime_kwargs: dict

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3005,6 +3005,10 @@ from gateway.session_state import (
     legacy_dict_property,
     legacy_lease_token_property,
 )
+from gateway.session_options import (
+    session_admission_lock as _session_admission_lock,
+    session_admission_lock_held as _session_admission_lock_held,
+)
 from gateway.authz_mixin import GatewayAuthorizationMixin
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
@@ -3102,7 +3106,10 @@ def _own_policy_open_startup_violation(config) -> Optional[str]:
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
-# between the guard check and actual agent creation.
+# between the guard check and actual agent creation.  The claim itself runs
+# under gateway.session_options.session_admission_lock, shared with the
+# runtime-options write-through, so an options commit cannot slip in between
+# a host observing "idle" and this sentinel being placed.
 _AGENT_PENDING_SENTINEL = object()
 
 # Conversation-scoped per-session state registry (legacy contract).
@@ -10181,32 +10188,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return _r_state.conversation.reasoning_override
         return self._load_reasoning_config(model)
 
-    def _set_session_reasoning_override(
+    async def _set_session_reasoning_override(
         self,
         session_key: str,
         reasoning_config: Optional[dict],
     ) -> None:
-        """Set or clear the session-scoped reasoning override."""
+        """Set or clear the session-scoped reasoning override (durable-first)."""
         if not session_key:
             return
-        self._rehydrate_session_runtime_options(session_key)
         # Per-session field write — the old lazy ``self._session_reasoning_overrides
         # = {}`` init replaced the WHOLE dict, racing concurrent sessions'
         # overrides; a SessionState field reset cannot cross sessions.
-        self._session_state(session_key).conversation.reasoning_override = (
-            None if reasoning_config is None else dict(reasoning_config)
+        await self._commit_session_runtime_options(
+            session_key,
+            reasoning_override=(
+                None if reasoning_config is None else dict(reasoning_config)
+            ),
         )
-        self._persist_session_runtime_options(session_key)
-
-    def _rehydrate_session_reasoning_override(self, session_entry) -> None:
-        """Copy a durable override from an already-loaded routing entry."""
-        session_key = str(getattr(session_entry, "session_key", "") or "")
-        persisted = getattr(session_entry, "reasoning_override", None)
-        if not session_key or persisted is None:
-            return
-        state = self._session_state(session_key)
-        if state.conversation.reasoning_override is None:
-            state.conversation.reasoning_override = dict(persisted)
 
     def _resolve_session_service_tier(
         self,
@@ -10237,28 +10235,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return _t_state.conversation.service_tier_override
         return self._load_service_tier()
 
-    def _set_session_service_tier_override(
+    async def _set_session_service_tier_override(
         self,
         session_key: str,
         service_tier,
         clear: bool = False,
     ) -> None:
-        """Set or clear the session-scoped /fast override.
+        """Set or clear the session-scoped /fast override (durable-first).
 
         ``service_tier`` is "priority" or None (explicit normal). Pass
         ``clear=True`` to remove the override entirely (fall back to config).
         """
         if not session_key:
             return
-        self._rehydrate_session_runtime_options(session_key)
         # Presence-sensitive: "priority" or None (explicit normal) both count
         # as an override; the sentinel means "no override".  Old code
         # wholesale-replaced the dict on lazy init (cross-session race) —
         # per-session field writes eliminate that class of bug.
-        self._session_state(session_key).conversation.service_tier_override = (
-            _SERVICE_TIER_UNSET if clear else service_tier
+        await self._commit_session_runtime_options(
+            session_key,
+            service_tier_override=_SERVICE_TIER_UNSET if clear else service_tier,
         )
-        self._persist_session_runtime_options(session_key)
 
     @staticmethod
     def _load_service_tier() -> str | None:
@@ -13170,6 +13167,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Already being resumed (e.g. scheduled at startup and still
             # in-flight) — don't synthesize a second continuation turn.
             if self._is_session_running(entry.session_key):
+                continue
+            # A runtime-options commit owns this session's admission lock
+            # (gateway/session_options.py). This pre-claim cannot await it, so
+            # leave the session resume_pending for this pass; the next real
+            # user message (whose claim does await the lock) resumes it.
+            if _session_admission_lock_held(self, entry.session_key):
                 continue
 
             source = entry.origin
@@ -19348,6 +19351,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             preset = moa_cfg["default_preset"]
             try:
                 event.text = moa_payload
+                # Rehydrate first so the post-turn restore puts back the
+                # persisted override, not a pre-rehydrate None.
+                self._rehydrate_session_runtime_options(_quick_key)
                 _moa_state = self._session_state(_quick_key)
                 event._moa_restore_override = _moa_state.conversation.model_override
                 _moa_state.conversation.model_override = {
@@ -19635,23 +19641,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # message arriving during any of those yields would pass the
         # "already running" guard and spin up a duplicate agent for the
         # same session — corrupting the transcript.
-        _active_session_lease, _limit_message = self._claim_active_session_slot(
-            _quick_key,
-            source,
-        )
-        if _limit_message is not None:
-            logger.info(
-                "Rejecting new active session %s: max_concurrent_sessions reached",
+        #
+        # The claim shares one per-session lock with the runtime-options
+        # write-through (gateway/session_options.py), so a host UI cannot
+        # observe "idle", yield, and commit new options under a turn admitted
+        # in between. Uncontended acquire never yields, so the discipline
+        # above still holds; the only wait is for an in-flight commit on this
+        # exact session, after which this turn resolves the committed values.
+        async with _session_admission_lock(self, _quick_key):
+            _active_session_lease, _limit_message = self._claim_active_session_slot(
                 _quick_key,
+                source,
             )
-            return _limit_message
-        _claim_state = self._session_state(_quick_key)
-        if _active_session_lease is not None:
-            _claim_state.turn.lease = _active_session_lease
-        _claim_state.turn.agent = _AGENT_PENDING_SENTINEL
-        _claim_state.turn.started_ts = time.time()
-        self._persist_active_agents()
-        _run_generation = self._begin_session_run_generation(_quick_key)
+            if _limit_message is not None:
+                logger.info(
+                    "Rejecting new active session %s: max_concurrent_sessions reached",
+                    _quick_key,
+                )
+                return _limit_message
+            _claim_state = self._session_state(_quick_key)
+            if _active_session_lease is not None:
+                _claim_state.turn.lease = _active_session_lease
+            _claim_state.turn.agent = _AGENT_PENDING_SENTINEL
+            _claim_state.turn.started_ts = time.time()
+            self._persist_active_agents()
+            _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
             try:
@@ -20540,7 +20554,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 touch_activity=not bool(getattr(event, "internal", False)),
             )
         session_key = session_entry.session_key
-        self._rehydrate_session_reasoning_override(session_entry)
         if not strict_session and pinned_session_id:
             resolved_entry = await self._resolve_async_delegation_session(
                 session_entry,
@@ -20550,7 +20563,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return
             session_entry = resolved_entry
             session_key = session_entry.session_key
-            self._rehydrate_session_reasoning_override(session_entry)
         self._cache_session_source(session_key, source)
         if await asyncio.to_thread(self._is_telegram_topic_lane, source):
             try:
@@ -28381,8 +28393,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         state.persistent.runtime_options_rehydrated = True
         if not persisted:
             return
+        # Live state wins per field: a one-turn override already installed in
+        # this process (/model --once, /moa) must not be clobbered by the
+        # first rehydrate touch; only fields still at their default are filled.
         model_persisted = persisted.get("model_override")
-        if model_persisted:
+        if model_persisted and state.conversation.model_override is None:
             override: Dict[str, Any] = {
                 "model": model_persisted.get("model"),
                 "provider": model_persisted.get("provider"),
@@ -28412,53 +28427,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "(provider=%s); using credential-less override",
                     provider, exc_info=True,
                 )
-        self._session_state(session_key).conversation.model_override = override
-        logger.info(
-            "Rehydrated persisted /model override for session=%s: model=%s provider=%s",
-            session_key, override.get("model"), provider or "",
-        )
+            state.conversation.model_override = override
+            logger.info(
+                "Rehydrated persisted /model override for session=%s: "
+                "model=%s provider=%s",
+                session_key,
+                override.get("model"),
+                provider or "",
+            )
 
         reasoning = persisted.get("reasoning_override")
-        state.conversation.reasoning_override = (
-            dict(reasoning) if isinstance(reasoning, dict) else None
-        )
+        if state.conversation.reasoning_override is None and isinstance(reasoning, dict):
+            state.conversation.reasoning_override = dict(reasoning)
         tier = persisted.get("service_tier_override")
-        if tier == "priority":
-            state.conversation.service_tier_override = "priority"
-        elif tier == "normal":
-            state.conversation.service_tier_override = None
-        else:
-            state.conversation.service_tier_override = _SERVICE_TIER_UNSET
+        if state.conversation.service_tier_override is _SERVICE_TIER_UNSET:
+            if tier == "priority":
+                state.conversation.service_tier_override = "priority"
+            elif tier == "normal":
+                state.conversation.service_tier_override = None
 
     def _rehydrate_session_model_override(self, session_key: str) -> None:
         """Compatibility alias for callers that predate structured options."""
         self._rehydrate_session_runtime_options(session_key)
 
-    def _persist_session_runtime_options(self, session_key: str) -> None:
-        """Keep durable host defaults aligned with later slash-command edits."""
-        store = getattr(self, "session_store", None)
-        state = self._peek_session_state(session_key)
-        if store is None or state is None:
-            return
-        tier = state.conversation.service_tier_override
-        durable_tier = (
-            None
-            if tier is _SERVICE_TIER_UNSET
-            else ("priority" if tier == "priority" else "normal")
-        )
-        try:
-            store.set_runtime_options(
-                session_key,
-                model_override=state.conversation.model_override,
-                reasoning_override=state.conversation.reasoning_override,
-                service_tier_override=durable_tier,
-            )
-        except Exception:
-            logger.debug(
-                "Failed to persist session runtime options for %s",
-                session_key,
-                exc_info=True,
-            )
+    async def _commit_session_runtime_options(self, session_key: str, **options) -> bool:
+        """Single durable-first write-through for per-session runtime options.
+
+        Shared by ``/model``, ``/reasoning``, ``/fast`` and the structured host
+        API: persist the complete snapshot first, then move live state; a
+        failed durable write raises with live state untouched. Runs under the
+        per-session admission lock. See
+        ``gateway.session_options.commit_session_runtime_options``.
+        """
+        from gateway.session_options import commit_session_runtime_options
+
+        return await commit_session_runtime_options(self, session_key, **options)
 
     def _apply_session_model_override(
         self, session_key: str, model: str, runtime_kwargs: dict

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19349,24 +19349,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 moa_cfg = normalize_moa_config({})
             preset = moa_cfg["default_preset"]
-            try:
-                event.text = moa_payload
-                # Rehydrate first so the post-turn restore puts back the
-                # persisted override, not a pre-rehydrate None.
-                self._rehydrate_session_runtime_options(_quick_key)
-                _moa_state = self._session_state(_quick_key)
-                event._moa_restore_override = _moa_state.conversation.model_override
-                _moa_state.conversation.model_override = {
-                    "provider": "moa",
-                    "model": preset,
-                    "base_url": "moa://local",
-                    "api_key": "moa-virtual-provider",
-                    "api_mode": "chat_completions",
-                }
-                self._evict_cached_agent(_quick_key)
-                event._moa_disable_after_turn = True
-            except Exception:
-                return "Failed to prepare MoA turn."
+            event.text = moa_payload
+            # Only stage the preset here. The live model_override is installed
+            # by _install_moa_one_shot AFTER this turn's idle->running claim
+            # below, so a host apply_session_options() (which persists the
+            # live model) cannot land between the install and the claim and
+            # write provider "moa" to disk.
+            event._moa_pending_preset = preset
 
         if canonical == "voice":
             return await self._handle_voice_command(event)
@@ -19668,6 +19657,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
+            # The session is claimed (turn.agent sentinel set, no await since),
+            # so apply_session_options() now sees it busy. Returning from here
+            # still runs the finally below, which unwinds the claim.
+            if getattr(event, "_moa_pending_preset", None) is not None:
+                if not self._install_moa_one_shot(event, _quick_key):
+                    return "Failed to prepare MoA turn."
             try:
                 _agent_result = await self._handle_message_with_agent(
                     event, source, _quick_key, _run_generation
@@ -19699,15 +19694,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("post-turn hook failed: %s", _goal_exc)
             return _agent_result
         finally:
-            # MoA one-shot restore must run on EVERY exit path, not just
-            # success. The restore data lives on the per-turn event object
-            # (_moa_restore_override), which is discarded once the event goes
-            # out of scope — so if _handle_message_with_agent raises, a restore
-            # in the try block would be skipped and the MoA override would leak
-            # permanently (every later message silently fans out through MoA).
-            # Putting it in finally guarantees the revert on success, exception,
-            # and interrupt alike.
-            self._restore_moa_one_shot(event, _quick_key)
+            # One-turn model restore (/model --once and the /moa one-shot share
+            # conversation.one_turn_restore) must run on EVERY exit path, not
+            # just success: if _handle_message_with_agent raises, a restore in
+            # the try block would be skipped and the one-turn override would
+            # leak permanently (every later message silently fanning out
+            # through MoA). Putting it in finally guarantees the revert on
+            # success, exception, and interrupt alike.
             self._restore_pending_one_turn_model_override(_quick_key)
             # Normal completion/exception/interrupt owns and clears this exact
             # durable marker.  SIGKILL/OOM skips finally, leaving the marker for
@@ -19726,26 +19719,64 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # the lease its own turn acquired, never a newer turn's.
             self._release_turn_lease(_quick_key, _run_generation)
 
-    def _restore_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> None:
-        """Revert a ``/moa <prompt>`` one-shot model override after its turn.
+    def _install_moa_one_shot(self, event: "MessageEvent", quick_key: str) -> bool:
+        """Install the ``/moa <prompt>`` one-shot model override for this turn.
 
-        Called from the ``finally`` of the message-handling path so the revert
-        fires whether the turn succeeded, raised, or was interrupted. A no-op
-        unless ``event._moa_disable_after_turn`` is set. ``_moa_restore_override``
-        carries the prior per-session override (``None`` means the user had no
-        override, so the MoA override is cleared outright).
+        Must be called after the idle->running claim in ``_handle_message`` and
+        before ``_handle_message_with_agent``, so the MoA turn itself always
+        runs on MoA and a ``/moa`` refused before the claim never leaves the
+        override live. The virtual ``moa`` provider is live-only: the prior
+        override is parked in ``conversation.one_turn_restore`` (the slot
+        ``/model --once`` uses) BEFORE the live swap, so a durable commit that
+        lands while the override is live -- the post-turn window after
+        ``_run_agent_inner`` releases the running slot included -- persists
+        the parked snapshot, never provider ``moa``, and the ``finally`` in
+        ``_handle_message`` (``_restore_pending_one_turn_model_override``)
+        reverts even a partially applied install. Returns ``False`` when the
+        install failed.
         """
-        if not getattr(event, "_moa_disable_after_turn", False):
-            return
+        preset = getattr(event, "_moa_pending_preset", None)
+        event._moa_pending_preset = None
         try:
-            _restore = getattr(event, "_moa_restore_override", None)
-            self._session_state(quick_key).conversation.model_override = _restore
+            # Rehydrate first so the post-turn restore puts back the
+            # persisted override, not a pre-rehydrate None.
+            self._rehydrate_session_runtime_options(quick_key)
+            _moa_state = self._session_state(quick_key)
+            # Park the prior override in the same slot /model --once uses so
+            # the durable-first primitive persists the pre-MoA model (never
+            # provider "moa") for any commit that lands while the virtual
+            # override is live -- including the post-turn window after
+            # _run_agent_inner releases the running slot and before this
+            # turn's finally restores. An older pending /model --once
+            # snapshot wins. _restore_pending_one_turn_model_override in the
+            # finally puts it back; a durable model commit in between clears
+            # the slot and supersedes the restore.
+            if _moa_state.conversation.one_turn_restore is None:
+                _moa_state.conversation.one_turn_restore = (
+                    self._snapshot_session_model_override(quick_key)
+                )
+            _moa_state.conversation.model_override = {
+                "provider": "moa",
+                "model": preset,
+                "base_url": "moa://local",
+                "api_key": "moa-virtual-provider",
+                "api_mode": "chat_completions",
+            }
             self._evict_cached_agent(quick_key)
+            return True
         except Exception:
-            pass
+            logger.debug("Failed to install MoA one-shot override", exc_info=True)
+            return False
 
     def _restore_pending_one_turn_model_override(self, session_key: str) -> None:
-        """Restore a per-session model override after ``/model --once`` runs."""
+        """Restore a per-session model override after a one-turn switch.
+
+        Both ``/model --once`` and the ``/moa <prompt>`` one-shot park the prior
+        override in ``conversation.one_turn_restore``; the message-handling
+        ``finally`` calls this on every exit path. A durable model commit made
+        while the one-turn override was live has already cleared the slot, so
+        this is then a no-op and live stays equal to disk.
+        """
         if not session_key:
             return
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28396,6 +28396,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Messaging adapters and host UIs should use this public boundary instead
         of injecting visible slash-command turns. Values are validated before
         any state is created or changed, then persisted atomically per session.
+        Returns a structured result; an I/O failure on the durable write is
+        ``rejected``/``durable_write_failed``. Persist and live assignment are
+        one unit under the session lock, completed even if the caller is
+        cancelled.
         """
         from gateway.session_options import apply_gateway_session_options
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass, field, replace
 from typing import Dict, List, Optional, Any
 
+from hermes_constants import VALID_REASONING_EFFORTS
+
 logger = logging.getLogger(__name__)
 
 
@@ -754,6 +756,7 @@ def build_session_context_prompt(
 # written to sessions.json.  On rehydration after a gateway restart the
 # runner re-resolves credentials via the normal runtime provider resolution.
 PERSISTABLE_MODEL_OVERRIDE_KEYS = ("model", "provider", "base_url")
+PERSISTABLE_REASONING_OVERRIDE_KEYS = ("enabled", "effort")
 
 
 def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:
@@ -771,6 +774,28 @@ def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict
         if k in PERSISTABLE_MODEL_OVERRIDE_KEYS and v not in (None, "")
     }
     return cleaned or None
+
+
+def sanitize_reasoning_override(
+    override: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Return the credential-free canonical shape for a /reasoning override."""
+    if not isinstance(override, dict):
+        return None
+    enabled = override.get("enabled")
+    if not isinstance(enabled, bool):
+        return None
+    cleaned: Dict[str, Any] = {"enabled": enabled}
+    if enabled:
+        effort = override.get("effort")
+        if effort not in VALID_REASONING_EFFORTS:
+            return None
+        cleaned["effort"] = str(effort)
+    return {
+        key: cleaned[key]
+        for key in PERSISTABLE_REASONING_OVERRIDE_KEYS
+        if key in cleaned
+    }
 
 
 @dataclass
@@ -870,6 +895,9 @@ class SessionEntry:
     # override is rehydrated after a restart and are never written to disk
     # (see sanitize_model_override / SessionStore.set_model_override).
     model_override: Optional[Dict[str, str]] = None
+    # Session-scoped /reasoning override. Only ``enabled`` and a canonical
+    # effort are persisted; arbitrary runtime/provider fields are discarded.
+    reasoning_override: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -914,6 +942,10 @@ class SessionEntry:
             # Defence-in-depth: strip credentials even if a caller stored an
             # unsanitized dict directly on the entry.
             result["model_override"] = sanitize_model_override(self.model_override)
+        if self.reasoning_override is not None:
+            result["reasoning_override"] = sanitize_reasoning_override(
+                self.reasoning_override
+            )
         if self.origin:
             result["origin"] = self.origin.to_dict()
         return result
@@ -1003,6 +1035,9 @@ class SessionEntry:
             reset_had_activity=data.get("reset_had_activity", False),
             prev_session_id=data.get("prev_session_id"),
             model_override=sanitize_model_override(data.get("model_override")),
+            reasoning_override=sanitize_reasoning_override(
+                data.get("reasoning_override")
+            ),
         )
 
 
@@ -2573,10 +2608,11 @@ class SessionStore:
         with self._lock:
             entry.expiry_finalized = True
             if clear_model_override:
-                # Session finalization is a conversation boundary — drop the
-                # persisted /model override too so a later message doesn't
-                # rehydrate it after the in-memory override was popped.
+                # Session finalization is a conversation boundary — drop both
+                # persisted runtime overrides so a later message cannot
+                # rehydrate state already cleared from SessionState.
                 entry.model_override = None
+                entry.reasoning_override = None
             self._save()
         # The expiry watcher calls this from a background task that never
         # entered ``_profile_runtime_scope``, so resolve the store from the
@@ -3339,6 +3375,30 @@ class SessionStore:
             if entry is None:
                 return None
             return dict(entry.model_override) if entry.model_override else None
+
+    def set_reasoning_override(
+        self, session_key: str, override: Optional[Dict[str, Any]]
+    ) -> None:
+        """Persist or clear the sanitized session-scoped /reasoning override."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return
+            cleaned = sanitize_reasoning_override(override)
+            if entry.reasoning_override == cleaned:
+                return
+            entry.reasoning_override = cleaned
+            self._save()
+
+    def get_reasoning_override(self, session_key: str) -> Optional[Dict[str, Any]]:
+        """Return the persisted /reasoning override for *session_key*."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None or entry.reasoning_override is None:
+                return None
+            return dict(entry.reasoning_override)
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -899,6 +899,13 @@ class SessionEntry:
     # effort are persisted; arbitrary runtime/provider fields are discarded.
     reasoning_override: Optional[Dict[str, Any]] = None
 
+    # Structured session controls set by a host UI. Unlike the process-local
+    # conversation fields on GatewayRunner, these survive a gateway restart.
+    # ``service_tier_override`` uses "priority" / "normal" so explicit normal
+    # remains distinguishable from an omitted (inherit-profile) value.
+    reasoning_override: Optional[Dict[str, Any]] = None
+    service_tier_override: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "session_key": self.session_key,
@@ -946,6 +953,8 @@ class SessionEntry:
             result["reasoning_override"] = sanitize_reasoning_override(
                 self.reasoning_override
             )
+        if self.service_tier_override in {"priority", "normal"}:
+            result["service_tier_override"] = self.service_tier_override
         if self.origin:
             result["origin"] = self.origin.to_dict()
         return result
@@ -1037,6 +1046,11 @@ class SessionEntry:
             model_override=sanitize_model_override(data.get("model_override")),
             reasoning_override=sanitize_reasoning_override(
                 data.get("reasoning_override")
+            ),
+            service_tier_override=(
+                data.get("service_tier_override")
+                if data.get("service_tier_override") in {"priority", "normal"}
+                else None
             ),
         )
 
@@ -2613,6 +2627,7 @@ class SessionStore:
                 # rehydrate state already cleared from SessionState.
                 entry.model_override = None
                 entry.reasoning_override = None
+                entry.service_tier_override = None
             self._save()
         # The expiry watcher calls this from a background task that never
         # entered ``_profile_runtime_scope``, so resolve the store from the
@@ -3399,6 +3414,73 @@ class SessionStore:
             if entry is None or entry.reasoning_override is None:
                 return None
             return dict(entry.reasoning_override)
+
+    def set_runtime_options(
+        self,
+        session_key: str,
+        *,
+        model_override: Optional[Dict[str, Any]],
+        reasoning_override: Optional[Dict[str, Any]],
+        service_tier_override: Optional[str],
+    ) -> bool:
+        """Atomically persist host-selected per-session runtime options.
+
+        All three values are complete snapshots. ``None`` clears/inherits;
+        service tier additionally accepts ``"normal"`` for explicit normal.
+        Credentials are stripped from the model override before persistence.
+        """
+        if service_tier_override not in {None, "priority", "normal"}:
+            raise ValueError("service_tier_override must be priority|normal|None")
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return False
+            cleaned_model = sanitize_model_override(model_override)
+            cleaned_reasoning = sanitize_reasoning_override(reasoning_override)
+            changed = (
+                entry.model_override != cleaned_model
+                or entry.reasoning_override != cleaned_reasoning
+                or entry.service_tier_override != service_tier_override
+            )
+            if not changed:
+                return True
+            previous_model = entry.model_override
+            previous_reasoning = entry.reasoning_override
+            previous_tier = entry.service_tier_override
+            entry.model_override = cleaned_model
+            entry.reasoning_override = cleaned_reasoning
+            entry.service_tier_override = service_tier_override
+            try:
+                self._save()
+            except Exception:
+                # Keep the in-memory store transactional with the durable
+                # write. A failed save must not leave this process using a
+                # configuration that a restart would silently discard.
+                entry.model_override = previous_model
+                entry.reasoning_override = previous_reasoning
+                entry.service_tier_override = previous_tier
+                raise
+            return True
+
+    def get_runtime_options(self, session_key: str) -> Optional[Dict[str, Any]]:
+        """Return the durable host-selected options for ``session_key``."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            return {
+                "model_override": (
+                    dict(entry.model_override) if entry.model_override else None
+                ),
+                "reasoning_override": (
+                    dict(entry.reasoning_override)
+                    if entry.reasoning_override is not None
+                    else None
+                ),
+                "service_tier_override": entry.service_tier_override,
+            }
 
     def suspend_session(self, session_key: str) -> bool:
         """Mark a session as suspended so it auto-resets on next access.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2832,7 +2832,7 @@ class SessionStore:
 
     def _heal_compression_tip_locked(
         self,
-        entry: "SessionEntry",
+        entry: SessionEntry,
         original_session_id: Optional[str],
         canonical_session_id: Optional[str],
     ) -> bool:
@@ -3394,17 +3394,23 @@ class SessionStore:
     def set_reasoning_override(
         self, session_key: str, override: Optional[Dict[str, Any]]
     ) -> None:
-        """Persist or clear the sanitized session-scoped /reasoning override."""
+        """Persist or clear the sanitized session-scoped /reasoning override.
+
+        Single-field convenience over :meth:`set_runtime_options`: the model
+        and service-tier snapshot are carried through unchanged and the
+        write gets the same rollback-on-failed-save guarantee.
+        """
         with self._lock:
             self._ensure_loaded_locked()
             entry = self._entries.get(session_key)
             if entry is None:
                 return
-            cleaned = sanitize_reasoning_override(override)
-            if entry.reasoning_override == cleaned:
-                return
-            entry.reasoning_override = cleaned
-            self._save()
+            self._set_runtime_options_locked(
+                entry,
+                model_override=entry.model_override,
+                reasoning_override=override,
+                service_tier_override=entry.service_tier_override,
+            )
 
     def get_reasoning_override(self, session_key: str) -> Optional[Dict[str, Any]]:
         """Return the persisted /reasoning override for *session_key*."""
@@ -3436,32 +3442,48 @@ class SessionStore:
             entry = self._entries.get(session_key)
             if entry is None:
                 return False
-            cleaned_model = sanitize_model_override(model_override)
-            cleaned_reasoning = sanitize_reasoning_override(reasoning_override)
-            changed = (
-                entry.model_override != cleaned_model
-                or entry.reasoning_override != cleaned_reasoning
-                or entry.service_tier_override != service_tier_override
+            self._set_runtime_options_locked(
+                entry,
+                model_override=model_override,
+                reasoning_override=reasoning_override,
+                service_tier_override=service_tier_override,
             )
-            if not changed:
-                return True
-            previous_model = entry.model_override
-            previous_reasoning = entry.reasoning_override
-            previous_tier = entry.service_tier_override
-            entry.model_override = cleaned_model
-            entry.reasoning_override = cleaned_reasoning
-            entry.service_tier_override = service_tier_override
-            try:
-                self._save()
-            except Exception:
-                # Keep the in-memory store transactional with the durable
-                # write. A failed save must not leave this process using a
-                # configuration that a restart would silently discard.
-                entry.model_override = previous_model
-                entry.reasoning_override = previous_reasoning
-                entry.service_tier_override = previous_tier
-                raise
             return True
+
+    def _set_runtime_options_locked(
+        self,
+        entry: SessionEntry,
+        *,
+        model_override: Optional[Dict[str, Any]],
+        reasoning_override: Optional[Dict[str, Any]],
+        service_tier_override: Optional[str],
+    ) -> None:
+        """Write the sanitized triple onto *entry* and save; caller holds the lock."""
+        cleaned_model = sanitize_model_override(model_override)
+        cleaned_reasoning = sanitize_reasoning_override(reasoning_override)
+        changed = (
+            entry.model_override != cleaned_model
+            or entry.reasoning_override != cleaned_reasoning
+            or entry.service_tier_override != service_tier_override
+        )
+        if not changed:
+            return
+        previous_model = entry.model_override
+        previous_reasoning = entry.reasoning_override
+        previous_tier = entry.service_tier_override
+        entry.model_override = cleaned_model
+        entry.reasoning_override = cleaned_reasoning
+        entry.service_tier_override = service_tier_override
+        try:
+            self._save()
+        except Exception:
+            # Keep the in-memory store transactional with the durable
+            # write. A failed save must not leave this process using a
+            # configuration that a restart would silently discard.
+            entry.model_override = previous_model
+            entry.reasoning_override = previous_reasoning
+            entry.service_tier_override = previous_tier
+            raise
 
     def get_runtime_options(self, session_key: str) -> Optional[Dict[str, Any]]:
         """Return the durable host-selected options for ``session_key``."""

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -9,6 +9,8 @@ Handles:
 """
 
 import asyncio
+import contextvars
+import functools
 import hashlib
 import logging
 import os
@@ -1281,6 +1283,18 @@ class AsyncSessionStore:
             return await asyncio.to_thread(attr, *args, **kwargs)
 
         return _offloaded
+
+    def submit(self, name: str, *args, **kwargs) -> "asyncio.Future[Any]":
+        """Offload ``store.<name>`` like attribute access, but return the loop
+        Future for the worker instead of a coroutine.
+
+        The Future is not a Task, so no task cancellation -- including
+        ``asyncio.run`` teardown's cancel-all-tasks -- can detach a
+        done-callback from the worker's completion.
+        """
+        call = functools.partial(getattr(self._store, name), *args, **kwargs)
+        ctx = contextvars.copy_context()  # same propagation as to_thread
+        return asyncio.get_running_loop().run_in_executor(None, ctx.run, call)
 
 
 # Sentinel for "no explicit SessionDB has been pinned on this store", so the

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -903,7 +903,6 @@ class SessionEntry:
     # conversation fields on GatewayRunner, these survive a gateway restart.
     # ``service_tier_override`` uses "priority" / "normal" so explicit normal
     # remains distinguishable from an omitted (inherit-profile) value.
-    reasoning_override: Optional[Dict[str, Any]] = None
     service_tier_override: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
@@ -2832,7 +2831,7 @@ class SessionStore:
 
     def _heal_compression_tip_locked(
         self,
-        entry: SessionEntry,
+        entry: "SessionEntry",
         original_session_id: Optional[str],
         canonical_session_id: Optional[str],
     ) -> bool:

--- a/gateway/session_options.py
+++ b/gateway/session_options.py
@@ -1,0 +1,316 @@
+"""Structured, silent runtime options for messaging-gateway sessions.
+
+Host UIs use this instead of injecting human-facing slash commands. The
+gateway remains the single owner of provider resolution, capability checks,
+session state, and restart persistence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import Any, Mapping
+
+from gateway.session_state import SERVICE_TIER_UNSET
+
+logger = logging.getLogger(__name__)
+
+
+def _reasoning_label(value: dict | None) -> str | None:
+    if value is None:
+        return None
+    if value.get("enabled") is False:
+        return "none"
+    return str(value.get("effort") or "medium")
+
+
+async def apply_gateway_session_options(
+    runner: Any,
+    source: Any,
+    options: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate and atomically apply per-session model/reasoning/fast state."""
+    allowed = {
+        "model",
+        "provider",
+        "reasoning_effort",
+        "fast",
+        "confirm_model_selection",
+        "initial",
+    }
+    unknown = sorted(set(options) - allowed)
+    if unknown:
+        return {
+            "status": "rejected",
+            "code": "invalid_options",
+            "error": f"unknown session option(s): {', '.join(unknown)}",
+        }
+
+    normalized_source = await asyncio.to_thread(
+        runner._normalize_source_for_session_key, source
+    )
+    session_key = runner._session_key_for_source(normalized_source)
+    if not session_key:
+        return {
+            "status": "rejected",
+            "code": "invalid_session",
+            "error": "session source did not resolve to a session key",
+        }
+    if runner._is_session_running(session_key):
+        return {
+            "status": "rejected",
+            "code": "session_busy",
+            "error": "session options can only change while the session is idle",
+        }
+
+    locks = getattr(runner, "_session_options_locks", None)
+    if locks is None:
+        locks = {}
+        runner._session_options_locks = locks
+    lock = locks.setdefault(session_key, asyncio.Lock())
+    async with lock:
+        profile_scope = contextlib.nullcontext()
+        if getattr(getattr(runner, "config", None), "multiplex_profiles", False):
+            from gateway.run import _profile_runtime_scope
+
+            profile_scope = _profile_runtime_scope(
+                runner._resolve_profile_home_for_source(normalized_source)
+            )
+        with profile_scope:
+            return await _apply_scoped(
+                runner, normalized_source, session_key, options
+            )
+
+
+async def _apply_scoped(
+    runner: Any,
+    source: Any,
+    session_key: str,
+    options: Mapping[str, Any],
+) -> dict[str, Any]:
+    from gateway.run import _load_gateway_config, _resolve_gateway_model
+    from hermes_cli.model_selection_guards import combined_selection_warning
+    from hermes_cli.model_switch import switch_model
+    from hermes_cli.models import resolve_fast_mode_overrides
+    from hermes_constants import parse_reasoning_effort
+
+    runner._rehydrate_session_runtime_options(session_key)
+    state = runner._session_state(session_key)
+    current_model, current_runtime = runner._resolve_session_agent_runtime(
+        source=source,
+        session_key=session_key,
+    )
+    current_provider = str(current_runtime.get("provider") or "openrouter")
+    current_base_url = str(current_runtime.get("base_url") or "")
+    current_api_key = str(current_runtime.get("api_key") or "")
+
+    model_override = state.conversation.model_override
+    reasoning_override = state.conversation.reasoning_override
+    current_tier = state.conversation.service_tier_override
+    service_tier_override = (
+        None
+        if current_tier is SERVICE_TIER_UNSET
+        else ("priority" if current_tier == "priority" else "normal")
+    )
+    effective_model = current_model
+    effective_provider = current_provider
+    model_warning = ""
+    changed_fields: list[str] = []
+
+    if "provider" in options and "model" not in options:
+        return {
+            "status": "rejected",
+            "code": "invalid_options",
+            "error": "provider requires model",
+        }
+
+    if "model" in options:
+        requested_model = str(options.get("model") or "").strip()
+        requested_provider = str(options.get("provider") or "").strip()
+        if not requested_model:
+            model_override = None
+            user_config = _load_gateway_config()
+            effective_model = _resolve_gateway_model(user_config)
+            effective_provider = str(
+                ((user_config.get("model") or {}).get("provider")
+                 if isinstance(user_config.get("model"), dict) else "")
+                or current_provider
+            )
+        else:
+            user_config = _load_gateway_config()
+            user_providers = user_config.get("providers")
+            try:
+                from hermes_cli.config import get_compatible_custom_providers
+
+                custom_providers = get_compatible_custom_providers(user_config)
+            except Exception:
+                custom_providers = user_config.get("custom_providers")
+            result = await asyncio.to_thread(
+                switch_model,
+                raw_input=requested_model,
+                current_provider=current_provider,
+                current_model=current_model,
+                current_base_url=current_base_url,
+                current_api_key=current_api_key,
+                is_global=False,
+                explicit_provider=requested_provider or None,
+                user_providers=user_providers,
+                custom_providers=custom_providers,
+            )
+            if not result.success:
+                return {
+                    "status": "rejected",
+                    "code": "model_rejected",
+                    "error": result.error_message or "model switch failed",
+                }
+            selection_warning = await asyncio.to_thread(
+                combined_selection_warning,
+                result.new_model,
+                provider=result.target_provider,
+                base_url=result.base_url or current_base_url,
+                api_key=result.api_key or current_api_key,
+                model_info=result.model_info,
+            )
+            if selection_warning is not None and not bool(
+                options.get("confirm_model_selection")
+            ):
+                return {
+                    "status": "confirmation_required",
+                    "code": "model_confirmation_required",
+                    "title": selection_warning.title,
+                    "message": selection_warning.message,
+                }
+            model_override = {
+                "model": result.new_model,
+                "provider": result.target_provider,
+                "api_key": result.api_key,
+                "base_url": result.base_url,
+                "api_mode": result.api_mode,
+            }
+            effective_model = result.new_model
+            effective_provider = result.target_provider
+            model_warning = str(result.warning_message or "")
+        changed_fields.append("model")
+
+    if "reasoning_effort" in options:
+        effort = str(options.get("reasoning_effort") or "").strip().lower()
+        if not effort:
+            reasoning_override = None
+        else:
+            try:
+                reasoning_override = parse_reasoning_effort(effort)
+            except Exception as exc:
+                return {
+                    "status": "rejected",
+                    "code": "reasoning_rejected",
+                    "error": str(exc),
+                }
+            if reasoning_override is None:
+                return {
+                    "status": "rejected",
+                    "code": "reasoning_rejected",
+                    "error": f"unsupported reasoning effort: {effort}",
+                }
+        changed_fields.append("reasoning_effort")
+
+    if "fast" in options:
+        requested_fast = options.get("fast")
+        if not isinstance(requested_fast, bool):
+            return {
+                "status": "rejected",
+                "code": "fast_rejected",
+                "error": "fast must be a boolean",
+            }
+        if requested_fast:
+            overrides = resolve_fast_mode_overrides(effective_model)
+            if overrides is None:
+                return {
+                    "status": "rejected",
+                    "code": "fast_unsupported",
+                    "error": "fast mode is not available for this model",
+                }
+            service_tier_override = "priority"
+        else:
+            service_tier_override = "normal"
+        changed_fields.append("fast")
+
+    if not changed_fields:
+        return {
+            "status": "accepted",
+            "session_key": session_key,
+            "applied": [],
+            "effective": {
+                "model": effective_model,
+                "provider": effective_provider,
+                "reasoning_effort": _reasoning_label(reasoning_override),
+                "fast": service_tier_override == "priority",
+            },
+        }
+
+    # Create/resolve the routing entry only after every requested value has
+    # passed validation. Persistence happens before process-local mutation so
+    # a disk failure cannot leave a half-applied runtime.
+    await runner.async_session_store.get_or_create_session(source)
+    persisted = await runner.async_session_store.set_runtime_options(
+        session_key,
+        model_override=model_override,
+        reasoning_override=reasoning_override,
+        service_tier_override=service_tier_override,
+    )
+    if not persisted:
+        return {
+            "status": "rejected",
+            "code": "session_missing",
+            "error": "session disappeared while applying runtime options",
+        }
+
+    state.conversation.model_override = (
+        dict(model_override) if model_override is not None else None
+    )
+    state.conversation.reasoning_override = (
+        dict(reasoning_override) if reasoning_override is not None else None
+    )
+    state.conversation.service_tier_override = (
+        "priority" if service_tier_override == "priority" else None
+    ) if service_tier_override is not None else SERVICE_TIER_UNSET
+    state.persistent.runtime_options_rehydrated = True
+    runner._evict_cached_agent(session_key)
+
+    if "model" in changed_fields and not bool(options.get("initial")):
+        from hermes_cli.model_switch import format_model_for_display
+
+        if not hasattr(runner, "_pending_model_notes"):
+            runner._pending_model_notes = {}
+        runner._pending_model_notes[session_key] = (
+            f"[Note: model was just switched from "
+            f"{format_model_for_display(current_model)} to "
+            f"{format_model_for_display(effective_model)} via "
+            f"{effective_provider}. Adjust your self-identification accordingly.]"
+        )
+
+    session_db = getattr(runner, "_session_db", None)
+    if session_db is not None and model_override is not None:
+        try:
+            entry = await runner.async_session_store.lookup_by_session_key(session_key)
+            if entry is not None:
+                await session_db.update_session_model(
+                    entry.session_id,
+                    effective_model,
+                    provider=effective_provider,
+                )
+        except Exception:
+            logger.debug("Failed to mirror structured model option", exc_info=True)
+
+    return {
+        "status": "accepted",
+        "session_key": session_key,
+        "applied": changed_fields,
+        "effective": {
+            "model": effective_model,
+            "provider": effective_provider,
+            "reasoning_effort": _reasoning_label(reasoning_override),
+            "fast": service_tier_override == "priority",
+        },
+        **({"warning": model_warning} if model_warning else {}),
+    }

--- a/gateway/session_options.py
+++ b/gateway/session_options.py
@@ -250,6 +250,28 @@ async def apply_gateway_session_options(
             "invalid_options", f"unknown session option(s): {', '.join(unknown)}"
         )
 
+    # Same fail-closed profile-routing gate as the inbound message path
+    # (GatewayRunner._handle_message): a source that was not stamped by
+    # adapter.build_source() is routed here, and one whose explicit route
+    # targets an unserved profile is refused rather than silently falling
+    # back to the active profile's session namespace.
+    if (
+        getattr(getattr(runner, "config", None), "multiplex_profiles", False)
+        and not getattr(source, "profile", None)
+        and getattr(source, "profile_route_rejected", False) is not True
+    ):
+        from gateway.profile_routing import ProfileRouteRejected
+
+        try:
+            source.profile = runner._profile_name_for_source(source)
+        except ProfileRouteRejected:
+            source.profile_route_rejected = True
+    if getattr(source, "profile_route_rejected", False) is True:
+        return _rejected(
+            "invalid_session",
+            "session source's profile route targets an unserved profile",
+        )
+
     normalized_source = await asyncio.to_thread(
         runner._normalize_source_for_session_key, source
     )

--- a/gateway/session_options.py
+++ b/gateway/session_options.py
@@ -50,6 +50,14 @@ def _rejected(code: str, error: str) -> dict[str, Any]:
     return {"status": "rejected", "code": code, "error": error}
 
 
+def _durable_write_failed(exc: BaseException) -> dict[str, Any]:
+    logger.warning("session runtime options durable write failed: %s", exc)
+    return _rejected(
+        "durable_write_failed",
+        f"could not persist session runtime options: {exc}",
+    )
+
+
 def _busy_result() -> dict[str, Any]:
     return _rejected(
         "session_busy",
@@ -203,9 +211,22 @@ async def _commit_session_runtime_options_locked(
             else None
         )
 
-    persisted = True
+    def _assign_live() -> None:
+        conversation.model_override = new_model
+        conversation.reasoning_override = new_reasoning
+        conversation.service_tier_override = new_tier
+        if durable and model_override is not UNSET:
+            # A durable model commit supersedes any pending one-turn restore;
+            # the old snapshot would otherwise revert this model after the
+            # next turn.
+            conversation.one_turn_restore = None
+
     store = getattr(runner, "session_store", None)
-    if durable and callable(getattr(store, "set_runtime_options", None)):
+    if not (durable and callable(getattr(store, "set_runtime_options", None))):
+        _assign_live()
+        return True
+
+    async def _persist_then_assign() -> bool:
         # Off-loop via the async facade. Raises on a failed save (the store
         # rolls its own entry back); False when no routing entry exists yet.
         persisted = bool(
@@ -218,15 +239,23 @@ async def _commit_session_runtime_options_locked(
         )
         if not persisted and require_routing_entry:
             return False
+        _assign_live()
+        return persisted
 
-    conversation.model_override = new_model
-    conversation.reasoning_override = new_reasoning
-    conversation.service_tier_override = new_tier
-    if durable and model_override is not UNSET:
-        # A durable model commit supersedes any pending one-turn restore; the
-        # old snapshot would otherwise revert this model after the next turn.
-        conversation.one_turn_restore = None
-    return persisted
+    # Persist + live assignment are one unit: the worker-thread write cannot
+    # be un-done by cancelling the awaiting task, so a cancelled caller must
+    # still see live state follow whatever landed on disk. The unit runs
+    # shielded and, on cancellation, is awaited to completion under the lock
+    # before the cancellation propagates. Known residual: a second
+    # cancellation delivered during that wait still exits the lock with the
+    # unit in flight -- that one case is not covered.
+    unit = asyncio.ensure_future(_persist_then_assign())
+    try:
+        return await asyncio.shield(unit)
+    except asyncio.CancelledError:
+        if not unit.done():
+            await asyncio.wait({unit})
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -459,7 +488,10 @@ async def _apply_scoped(
             return _busy_result()
         # Create/resolve the routing entry only after every requested value
         # has passed validation.
-        entry = await runner.async_session_store.get_or_create_session(source)
+        try:
+            entry = await runner.async_session_store.get_or_create_session(source)
+        except OSError as exc:
+            return _durable_write_failed(exc)
         conversation = state.conversation
         if getattr(entry, "was_auto_reset", False):
             # The session crossed an idle/daily boundary: consume the flag so
@@ -528,12 +560,20 @@ async def _apply_scoped(
                 [], new["reasoning_override"], new["service_tier_override"]
             )
 
-        persisted = await _commit_session_runtime_options_locked(
-            runner,
-            session_key,
-            require_routing_entry=True,
-            **{name: new[name] for name in changed},
-        )
+        try:
+            persisted = await _commit_session_runtime_options_locked(
+                runner,
+                session_key,
+                require_routing_entry=True,
+                **{name: new[name] for name in changed},
+            )
+        except OSError as exc:
+            # The store rolled its entry back and live state never moved
+            # (durable-first). The host API contract is a structured result,
+            # not an exception, so map the I/O failure to a rejection code;
+            # the slash paths keep raising (the adapter's generic handler
+            # turns that into a visible "Sorry, I encountered an error").
+            return _durable_write_failed(exc)
         if not persisted:
             return _rejected(
                 "session_missing",

--- a/gateway/session_options.py
+++ b/gateway/session_options.py
@@ -145,9 +145,12 @@ async def commit_session_runtime_options(
     which creates the entry first) leaves live state untouched instead.
 
     ``durable=False`` is reserved for ``/model --once``: the one-turn override
-    is live-only by contract (#29923). While such an override is live, any
-    durable write made by a sibling path (e.g. ``/reasoning``) persists the
-    PRE-once model from the restore snapshot, never the one-turn model.
+    is live-only by contract (#29923). While a one-turn override is live
+    (``conversation.one_turn_restore`` is set -- ``/model --once`` and the
+    ``/moa`` one-shot both park their restore snapshot there), any durable
+    write made by a sibling path (e.g. ``/reasoning``, the host API) persists
+    the PRE-switch model from the snapshot, never the one-turn model or the
+    virtual ``moa`` provider.
     """
     async with session_admission_lock(runner, session_key):
         return await _commit_session_runtime_options_locked(
@@ -190,8 +193,9 @@ async def _commit_session_runtime_options_locked(
 
     durable_model = new_model
     if durable and model_override is UNSET and conversation.one_turn_restore:
-        # A /model --once override is live: persist what the post-turn restore
-        # will put back, never the one-turn model.
+        # A one-turn override (/model --once or the /moa one-shot) is live:
+        # persist what the post-turn restore will put back, never the
+        # one-turn model.
         snapshot = conversation.one_turn_restore
         durable_model = (
             dict(snapshot.get("override") or {})

--- a/gateway/session_options.py
+++ b/gateway/session_options.py
@@ -29,7 +29,7 @@ import contextlib
 import logging
 from typing import Any, Mapping
 
-from gateway.session import sanitize_model_override
+from gateway.session import AsyncSessionStore, sanitize_model_override
 from gateway.session_state import SERVICE_TIER_UNSET
 
 logger = logging.getLogger(__name__)
@@ -226,44 +226,62 @@ async def _commit_session_runtime_options_locked(
         _assign_live()
         return True
 
-    async def _persist_then_assign() -> bool:
-        # Off-loop via the async facade. Raises on a failed save (the store
-        # rolls its own entry back); False when no routing entry exists yet.
-        persisted = bool(
-            await runner.async_session_store.set_runtime_options(
-                session_key,
-                model_override=durable_model,
-                reasoning_override=new_reasoning,
-                service_tier_override=_durable_tier(new_tier),
-            )
-        )
-        if not persisted and require_routing_entry:
-            return False
-        _assign_live()
-        return persisted
-
     # Persist + live assignment are one unit: the worker-thread write cannot
     # be un-done by cancelling the awaiting task, so a cancelled caller must
-    # still see live state follow whatever landed on disk. The unit runs as
-    # its own task and is settled here, under the admission lock, before the
-    # caller's cancellation propagates -- across arbitrarily repeated
-    # cancellation, so a second Task.cancel() during settlement cannot
-    # release the lock with the unit still in flight. Nothing else holds a
-    # reference to the unit, so it can only be cancelled by event-loop
-    # teardown, when no admission can run.
-    unit = asyncio.ensure_future(_persist_then_assign())
-    cancelled: asyncio.CancelledError | None = None
-    while not unit.done():
+    # still see live state follow whatever landed on disk. Live assignment is
+    # a done-callback on the write's executor Future -- not a task -- so
+    # nothing that cancels tasks (a caller's owner, event-loop teardown) can
+    # separate the two. The caller waits for that callback (``settled``) here,
+    # under the admission lock, before its own cancellation propagates --
+    # across arbitrarily repeated cancellation, so a second Task.cancel()
+    # during settlement cannot release the lock with the unit in flight.
+    write = dict(
+        model_override=durable_model,
+        reasoning_override=new_reasoning,
+        service_tier_override=_durable_tier(new_tier),
+    )
+    facade = runner.async_session_store
+    if isinstance(facade, AsyncSessionStore):
+        unit: asyncio.Future[Any] = facade.submit("set_runtime_options", session_key, **write)
+    else:  # test doubles that replace the facade with an async fake
+        unit = asyncio.ensure_future(facade.set_runtime_options(session_key, **write))
+    settled: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+
+    def _assign_then_settle(done: asyncio.Future[Any]) -> None:
+        # Mirror the write's terminal state onto ``settled`` after assigning
+        # live. The store raises on a failed save (it rolls its own entry
+        # back) and returns False when no routing entry exists yet. Whatever
+        # happens here, ``settled`` must resolve: the caller is parked on it
+        # under the admission lock.
         try:
-            await asyncio.shield(unit)
+            if done.cancelled():
+                settled.cancel()
+                return
+            failure = done.exception()
+            if failure is not None:
+                settled.set_exception(failure)
+                return
+            persisted = bool(done.result())
+            if persisted or not require_routing_entry:
+                _assign_live()
+            settled.set_result(persisted)
+        except BaseException as exc:  # noqa: BLE001 - never leave the caller parked
+            if not settled.done():
+                settled.set_exception(exc)
+
+    unit.add_done_callback(_assign_then_settle)
+    cancelled: asyncio.CancelledError | None = None
+    while not settled.done():
+        try:
+            await asyncio.shield(settled)
         except asyncio.CancelledError as exc:
             cancelled = exc
-        except Exception:  # noqa: BLE001 - unit is terminal; retrieved below
+        except Exception:  # noqa: BLE001 - settled is terminal; retrieved below
             break
     if cancelled is not None:
         # Retrieve the terminal result so a durable-write failure is never
         # left as an unobserved task exception behind the cancellation.
-        failure = None if unit.cancelled() else unit.exception()
+        failure = None if settled.cancelled() else settled.exception()
         if failure is not None:
             logger.warning(
                 "Durable runtime-options write for %s failed while the caller "
@@ -275,7 +293,7 @@ async def _commit_session_runtime_options_locked(
         # task's cancelling() count is left alone: this loop did not request
         # any of those cancellations, so it must not uncancel() them either.
         raise cancelled
-    return unit.result()
+    return settled.result()
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/session_options.py
+++ b/gateway/session_options.py
@@ -244,18 +244,38 @@ async def _commit_session_runtime_options_locked(
 
     # Persist + live assignment are one unit: the worker-thread write cannot
     # be un-done by cancelling the awaiting task, so a cancelled caller must
-    # still see live state follow whatever landed on disk. The unit runs
-    # shielded and, on cancellation, is awaited to completion under the lock
-    # before the cancellation propagates. Known residual: a second
-    # cancellation delivered during that wait still exits the lock with the
-    # unit in flight -- that one case is not covered.
+    # still see live state follow whatever landed on disk. The unit runs as
+    # its own task and is settled here, under the admission lock, before the
+    # caller's cancellation propagates -- across arbitrarily repeated
+    # cancellation, so a second Task.cancel() during settlement cannot
+    # release the lock with the unit still in flight. Nothing else holds a
+    # reference to the unit, so it can only be cancelled by event-loop
+    # teardown, when no admission can run.
     unit = asyncio.ensure_future(_persist_then_assign())
-    try:
-        return await asyncio.shield(unit)
-    except asyncio.CancelledError:
-        if not unit.done():
-            await asyncio.wait({unit})
-        raise
+    cancelled: asyncio.CancelledError | None = None
+    while not unit.done():
+        try:
+            await asyncio.shield(unit)
+        except asyncio.CancelledError as exc:
+            cancelled = exc
+        except Exception:  # noqa: BLE001 - unit is terminal; retrieved below
+            break
+    if cancelled is not None:
+        # Retrieve the terminal result so a durable-write failure is never
+        # left as an unobserved task exception behind the cancellation.
+        failure = None if unit.cancelled() else unit.exception()
+        if failure is not None:
+            logger.warning(
+                "Durable runtime-options write for %s failed while the caller "
+                "was cancelled",
+                session_key,
+                exc_info=failure,
+            )
+        # Re-raise the last cancellation we absorbed (keeps its message). The
+        # task's cancelling() count is left alone: this loop did not request
+        # any of those cancellations, so it must not uncancel() them either.
+        raise cancelled
+    return unit.result()
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/session_options.py
+++ b/gateway/session_options.py
@@ -3,6 +3,23 @@
 Host UIs use this instead of injecting human-facing slash commands. The
 gateway remains the single owner of provider resolution, capability checks,
 session state, and restart persistence.
+
+Two primitives defined here are shared with the user-facing slash commands
+(``/model``, ``/reasoning``, ``/fast``) so the host API and the user never
+disagree about a session's runtime options:
+
+* :func:`session_admission_lock` — one ``asyncio.Lock`` per session key.
+  ``GatewayRunner._handle_message`` holds it across its idle->running claim
+  (no await inside, so the uncontended hot path never yields), the slash
+  write-through holds it across persist + live mutation, and
+  :func:`apply_gateway_session_options` holds it across busy check + durable
+  commit + live mutation. A turn therefore cannot be admitted *between* the
+  API observing "idle" and the API committing, and two writers cannot
+  interleave their persist/mutate steps.
+* :func:`commit_session_runtime_options` — the single durable-first
+  write-through: persist the complete snapshot via the async session store,
+  then (and only then) move live ``SessionState``. A failed durable write
+  raises with live state untouched.
 """
 
 from __future__ import annotations
@@ -12,9 +29,13 @@ import contextlib
 import logging
 from typing import Any, Mapping
 
+from gateway.session import sanitize_model_override
 from gateway.session_state import SERVICE_TIER_UNSET
 
 logger = logging.getLogger(__name__)
+
+# "caller did not pass this field" for the partial-patch primitive below.
+UNSET = object()
 
 
 def _reasoning_label(value: dict | None) -> str | None:
@@ -23,6 +44,190 @@ def _reasoning_label(value: dict | None) -> str | None:
     if value.get("enabled") is False:
         return "none"
     return str(value.get("effort") or "medium")
+
+
+def _rejected(code: str, error: str) -> dict[str, Any]:
+    return {"status": "rejected", "code": code, "error": error}
+
+
+def _busy_result() -> dict[str, Any]:
+    return _rejected(
+        "session_busy",
+        "session options can only change while the session is idle",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-session admission exclusion
+# ---------------------------------------------------------------------------
+
+
+def session_admission_lock(runner: Any, session_key: str) -> asyncio.Lock:
+    """Return the per-session lock shared by turn admission and option writes.
+
+    One lock per session key, created lazily and never evicted (same lifetime
+    as ``GatewayRunner._sessions``). ``__dict__`` access keeps bare
+    ``object.__new__`` test runners working.
+    """
+    locks = runner.__dict__.get("_session_options_locks")
+    if locks is None:
+        locks = {}
+        runner._session_options_locks = locks
+    lock = locks.get(session_key)
+    if lock is None:
+        lock = locks[session_key] = asyncio.Lock()
+    return lock
+
+
+def session_admission_lock_held(runner: Any, session_key: str) -> bool:
+    """True while a runtime-options write or a turn claim owns ``session_key``.
+
+    Synchronous probe for the one idle->running claimer that cannot await the
+    lock (the boot-resume pre-claim); it must skip the session for that pass
+    instead of claiming underneath an in-flight commit.
+    """
+    locks = runner.__dict__.get("_session_options_locks") or {}
+    lock = locks.get(session_key)
+    return lock is not None and lock.locked()
+
+
+# ---------------------------------------------------------------------------
+# Single durable-first write-through
+# ---------------------------------------------------------------------------
+
+
+def _durable_tier(live_tier: Any) -> str | None:
+    """Map the live tri-state (UNSET / None / "priority") to the durable one."""
+    if live_tier is SERVICE_TIER_UNSET:
+        return None
+    return "priority" if live_tier == "priority" else "normal"
+
+
+def _runtime_options_signature(conversation: Any) -> tuple:
+    """Comparable snapshot of the live triple (credentials stripped)."""
+    reasoning = conversation.reasoning_override
+    return (
+        sanitize_model_override(conversation.model_override),
+        dict(reasoning) if isinstance(reasoning, dict) else None,
+        conversation.service_tier_override,
+    )
+
+
+async def commit_session_runtime_options(
+    runner: Any,
+    session_key: str,
+    *,
+    model_override: Any = UNSET,
+    reasoning_override: Any = UNSET,
+    service_tier_override: Any = UNSET,
+    durable: bool = True,
+    require_routing_entry: bool = False,
+) -> bool:
+    """Durable-first write-through for per-session runtime options.
+
+    Every session-runtime mutation — the structured host API and the
+    ``/model``, ``/reasoning`` and ``/fast`` slash commands — funnels through
+    here under :func:`session_admission_lock`, so memory and disk cannot
+    disagree: the complete snapshot is persisted FIRST and live
+    ``SessionState`` only moves once the store commit succeeded. A failed
+    durable write propagates to the caller with live state untouched, so a
+    command fails loudly instead of leaving this process on a configuration a
+    restart would silently discard.
+
+    Omitted keyword arguments keep their current live value (partial patch).
+    ``service_tier_override`` uses the live encoding (``"priority"``,
+    ``None`` = explicit normal, ``SERVICE_TIER_UNSET`` = inherit).
+
+    Returns ``False`` when the store has no routing entry for ``session_key``
+    yet. Slash commands can run before the entry exists (first message of a
+    chat), so by default the override then stays process-local exactly as it
+    did before persistence existed; ``require_routing_entry=True`` (host API,
+    which creates the entry first) leaves live state untouched instead.
+
+    ``durable=False`` is reserved for ``/model --once``: the one-turn override
+    is live-only by contract (#29923). While such an override is live, any
+    durable write made by a sibling path (e.g. ``/reasoning``) persists the
+    PRE-once model from the restore snapshot, never the one-turn model.
+    """
+    async with session_admission_lock(runner, session_key):
+        return await _commit_session_runtime_options_locked(
+            runner,
+            session_key,
+            model_override=model_override,
+            reasoning_override=reasoning_override,
+            service_tier_override=service_tier_override,
+            durable=durable,
+            require_routing_entry=require_routing_entry,
+        )
+
+
+async def _commit_session_runtime_options_locked(
+    runner: Any,
+    session_key: str,
+    *,
+    model_override: Any = UNSET,
+    reasoning_override: Any = UNSET,
+    service_tier_override: Any = UNSET,
+    durable: bool = True,
+    require_routing_entry: bool = False,
+) -> bool:
+    """Body of :func:`commit_session_runtime_options`; caller holds the lock."""
+    runner._rehydrate_session_runtime_options(session_key)
+    conversation = runner._session_state(session_key).conversation
+    new_model = (
+        conversation.model_override if model_override is UNSET else model_override
+    )
+    new_reasoning = (
+        conversation.reasoning_override
+        if reasoning_override is UNSET
+        else reasoning_override
+    )
+    new_tier = (
+        conversation.service_tier_override
+        if service_tier_override is UNSET
+        else service_tier_override
+    )
+
+    durable_model = new_model
+    if durable and model_override is UNSET and conversation.one_turn_restore:
+        # A /model --once override is live: persist what the post-turn restore
+        # will put back, never the one-turn model.
+        snapshot = conversation.one_turn_restore
+        durable_model = (
+            dict(snapshot.get("override") or {})
+            if snapshot.get("had_override")
+            else None
+        )
+
+    persisted = True
+    store = getattr(runner, "session_store", None)
+    if durable and callable(getattr(store, "set_runtime_options", None)):
+        # Off-loop via the async facade. Raises on a failed save (the store
+        # rolls its own entry back); False when no routing entry exists yet.
+        persisted = bool(
+            await runner.async_session_store.set_runtime_options(
+                session_key,
+                model_override=durable_model,
+                reasoning_override=new_reasoning,
+                service_tier_override=_durable_tier(new_tier),
+            )
+        )
+        if not persisted and require_routing_entry:
+            return False
+
+    conversation.model_override = new_model
+    conversation.reasoning_override = new_reasoning
+    conversation.service_tier_override = new_tier
+    if durable and model_override is not UNSET:
+        # A durable model commit supersedes any pending one-turn restore; the
+        # old snapshot would otherwise revert this model after the next turn.
+        conversation.one_turn_restore = None
+    return persisted
+
+
+# ---------------------------------------------------------------------------
+# Structured host API
+# ---------------------------------------------------------------------------
 
 
 async def apply_gateway_session_options(
@@ -41,46 +246,32 @@ async def apply_gateway_session_options(
     }
     unknown = sorted(set(options) - allowed)
     if unknown:
-        return {
-            "status": "rejected",
-            "code": "invalid_options",
-            "error": f"unknown session option(s): {', '.join(unknown)}",
-        }
+        return _rejected(
+            "invalid_options", f"unknown session option(s): {', '.join(unknown)}"
+        )
 
     normalized_source = await asyncio.to_thread(
         runner._normalize_source_for_session_key, source
     )
     session_key = runner._session_key_for_source(normalized_source)
     if not session_key:
-        return {
-            "status": "rejected",
-            "code": "invalid_session",
-            "error": "session source did not resolve to a session key",
-        }
+        return _rejected(
+            "invalid_session", "session source did not resolve to a session key"
+        )
+    # Cheap early-out only; the authoritative busy check runs under the
+    # admission lock in _apply_scoped, right before the durable commit.
     if runner._is_session_running(session_key):
-        return {
-            "status": "rejected",
-            "code": "session_busy",
-            "error": "session options can only change while the session is idle",
-        }
+        return _busy_result()
 
-    locks = getattr(runner, "_session_options_locks", None)
-    if locks is None:
-        locks = {}
-        runner._session_options_locks = locks
-    lock = locks.setdefault(session_key, asyncio.Lock())
-    async with lock:
-        profile_scope = contextlib.nullcontext()
-        if getattr(getattr(runner, "config", None), "multiplex_profiles", False):
-            from gateway.run import _profile_runtime_scope
+    profile_scope = contextlib.nullcontext()
+    if getattr(getattr(runner, "config", None), "multiplex_profiles", False):
+        from gateway.run import _profile_runtime_scope
 
-            profile_scope = _profile_runtime_scope(
-                runner._resolve_profile_home_for_source(normalized_source)
-            )
-        with profile_scope:
-            return await _apply_scoped(
-                runner, normalized_source, session_key, options
-            )
+        profile_scope = _profile_runtime_scope(
+            runner._resolve_profile_home_for_source(normalized_source)
+        )
+    with profile_scope:
+        return await _apply_scoped(runner, normalized_source, session_key, options)
 
 
 async def _apply_scoped(
@@ -95,8 +286,16 @@ async def _apply_scoped(
     from hermes_cli.models import resolve_fast_mode_overrides
     from hermes_constants import parse_reasoning_effort
 
+    if "provider" in options and "model" not in options:
+        return _rejected("invalid_options", "provider requires model")
+
     runner._rehydrate_session_runtime_options(session_key)
     state = runner._session_state(session_key)
+    # Validation below runs OUTSIDE the admission lock (model resolution can
+    # hit the network) against this snapshot of the live triple; the commit
+    # re-reads live state under the lock and refuses to overwrite anything
+    # that moved in between (a user slash command stays authoritative).
+    expected = _runtime_options_signature(state.conversation)
     current_model, current_runtime = runner._resolve_session_agent_runtime(
         source=source,
         session_key=session_key,
@@ -105,31 +304,19 @@ async def _apply_scoped(
     current_base_url = str(current_runtime.get("base_url") or "")
     current_api_key = str(current_runtime.get("api_key") or "")
 
-    model_override = state.conversation.model_override
-    reasoning_override = state.conversation.reasoning_override
-    current_tier = state.conversation.service_tier_override
-    service_tier_override = (
-        None
-        if current_tier is SERVICE_TIER_UNSET
-        else ("priority" if current_tier == "priority" else "normal")
-    )
     effective_model = current_model
     effective_provider = current_provider
     model_warning = ""
-    changed_fields: list[str] = []
-
-    if "provider" in options and "model" not in options:
-        return {
-            "status": "rejected",
-            "code": "invalid_options",
-            "error": "provider requires model",
-        }
+    # Requested values in the LIVE encoding, only for fields named in options.
+    patch: dict[str, Any] = {}
 
     if "model" in options:
         requested_model = str(options.get("model") or "").strip()
         requested_provider = str(options.get("provider") or "").strip()
         if not requested_model:
-            model_override = None
+            if requested_provider:
+                return _rejected("invalid_options", "provider requires model")
+            patch["model_override"] = None
             user_config = _load_gateway_config()
             effective_model = _resolve_gateway_model(user_config)
             effective_provider = str(
@@ -140,6 +327,8 @@ async def _apply_scoped(
         else:
             user_config = _load_gateway_config()
             user_providers = user_config.get("providers")
+            if not isinstance(user_providers, dict):
+                user_providers = {}
             try:
                 from hermes_cli.config import get_compatible_custom_providers
 
@@ -154,16 +343,14 @@ async def _apply_scoped(
                 current_base_url=current_base_url,
                 current_api_key=current_api_key,
                 is_global=False,
-                explicit_provider=requested_provider or None,
+                explicit_provider=requested_provider,
                 user_providers=user_providers,
                 custom_providers=custom_providers,
             )
             if not result.success:
-                return {
-                    "status": "rejected",
-                    "code": "model_rejected",
-                    "error": result.error_message or "model switch failed",
-                }
+                return _rejected(
+                    "model_rejected", result.error_message or "model switch failed"
+                )
             selection_warning = await asyncio.to_thread(
                 combined_selection_warning,
                 result.new_model,
@@ -181,7 +368,7 @@ async def _apply_scoped(
                     "title": selection_warning.title,
                     "message": selection_warning.message,
                 }
-            model_override = {
+            patch["model_override"] = {
                 "model": result.new_model,
                 "provider": result.target_provider,
                 "api_key": result.api_key,
@@ -191,106 +378,162 @@ async def _apply_scoped(
             effective_model = result.new_model
             effective_provider = result.target_provider
             model_warning = str(result.warning_message or "")
-        changed_fields.append("model")
 
     if "reasoning_effort" in options:
         effort = str(options.get("reasoning_effort") or "").strip().lower()
         if not effort:
-            reasoning_override = None
+            patch["reasoning_override"] = None
         else:
-            try:
-                reasoning_override = parse_reasoning_effort(effort)
-            except Exception as exc:
-                return {
-                    "status": "rejected",
-                    "code": "reasoning_rejected",
-                    "error": str(exc),
-                }
+            reasoning_override = parse_reasoning_effort(effort)
             if reasoning_override is None:
-                return {
-                    "status": "rejected",
-                    "code": "reasoning_rejected",
-                    "error": f"unsupported reasoning effort: {effort}",
-                }
-        changed_fields.append("reasoning_effort")
+                return _rejected(
+                    "reasoning_rejected", f"unsupported reasoning effort: {effort}"
+                )
+            patch["reasoning_override"] = reasoning_override
 
     if "fast" in options:
         requested_fast = options.get("fast")
         if not isinstance(requested_fast, bool):
-            return {
-                "status": "rejected",
-                "code": "fast_rejected",
-                "error": "fast must be a boolean",
-            }
+            return _rejected("fast_rejected", "fast must be a boolean")
         if requested_fast:
-            overrides = resolve_fast_mode_overrides(effective_model)
-            if overrides is None:
-                return {
-                    "status": "rejected",
-                    "code": "fast_unsupported",
-                    "error": "fast mode is not available for this model",
-                }
-            service_tier_override = "priority"
+            if resolve_fast_mode_overrides(effective_model) is None:
+                return _rejected(
+                    "fast_unsupported", "fast mode is not available for this model"
+                )
+            patch["service_tier_override"] = "priority"
         else:
-            service_tier_override = "normal"
-        changed_fields.append("fast")
+            patch["service_tier_override"] = None  # explicit normal
 
-    if not changed_fields:
+    def _accepted(applied: list[str], reasoning: Any, tier: Any) -> dict[str, Any]:
         return {
             "status": "accepted",
             "session_key": session_key,
-            "applied": [],
+            "applied": applied,
             "effective": {
                 "model": effective_model,
                 "provider": effective_provider,
-                "reasoning_effort": _reasoning_label(reasoning_override),
-                "fast": service_tier_override == "priority",
+                "reasoning_effort": _reasoning_label(reasoning),
+                "fast": tier == "priority",
             },
+            **({"warning": model_warning} if model_warning else {}),
         }
 
-    # Create/resolve the routing entry only after every requested value has
-    # passed validation. Persistence happens before process-local mutation so
-    # a disk failure cannot leave a half-applied runtime.
-    await runner.async_session_store.get_or_create_session(source)
-    persisted = await runner.async_session_store.set_runtime_options(
-        session_key,
-        model_override=model_override,
-        reasoning_override=reasoning_override,
-        service_tier_override=service_tier_override,
-    )
-    if not persisted:
-        return {
-            "status": "rejected",
-            "code": "session_missing",
-            "error": "session disappeared while applying runtime options",
-        }
-
-    state.conversation.model_override = (
-        dict(model_override) if model_override is not None else None
-    )
-    state.conversation.reasoning_override = (
-        dict(reasoning_override) if reasoning_override is not None else None
-    )
-    state.conversation.service_tier_override = (
-        "priority" if service_tier_override == "priority" else None
-    ) if service_tier_override is not None else SERVICE_TIER_UNSET
-    state.persistent.runtime_options_rehydrated = True
-    runner._evict_cached_agent(session_key)
-
-    if "model" in changed_fields and not bool(options.get("initial")):
-        from hermes_cli.model_switch import format_model_for_display
-
-        if not hasattr(runner, "_pending_model_notes"):
-            runner._pending_model_notes = {}
-        runner._pending_model_notes[session_key] = (
-            f"[Note: model was just switched from "
-            f"{format_model_for_display(current_model)} to "
-            f"{format_model_for_display(effective_model)} via "
-            f"{effective_provider}. Adjust your self-identification accordingly.]"
+    if not patch:
+        return _accepted(
+            [], state.conversation.reasoning_override,
+            state.conversation.service_tier_override,
         )
 
+    # Commit. Everything from the busy check to the live mutation runs under
+    # the per-session admission lock that _handle_message also takes around
+    # its idle->running claim, so no turn can be admitted in between and no
+    # other writer can interleave its persist/mutate steps with ours.
+    async with session_admission_lock(runner, session_key):
+        if runner._is_session_running(session_key):
+            return _busy_result()
+        # Create/resolve the routing entry only after every requested value
+        # has passed validation.
+        entry = await runner.async_session_store.get_or_create_session(source)
+        conversation = state.conversation
+        if getattr(entry, "was_auto_reset", False):
+            # The session crossed an idle/daily boundary: consume the flag so
+            # the next message's cleanup does not wipe what we are about to
+            # store (#48031), and clear the previous conversation's scope NOW
+            # so it cannot leak into the fresh session either (#58403).
+            # Note: a rejection below (fast_unsupported) still consumes this
+            # boundary -- the next inbound message would have cleared the same
+            # scope anyway, so nothing the caller could observe is lost.
+            entry.was_auto_reset = False
+            runner._clear_conversation_scope(session_key, reason="auto_reset")
+            runner._evict_cached_agent(session_key)
+            if "model_override" not in patch:
+                # The previous override is gone: re-derive what the fresh
+                # session will actually run so the fast check and the reply
+                # describe that model, not the one we validated against.
+                effective_model, runtime = runner._resolve_session_agent_runtime(
+                    source=source, session_key=session_key
+                )
+                effective_provider = str(runtime.get("provider") or "openrouter")
+                if (
+                    patch.get("service_tier_override") == "priority"
+                    and resolve_fast_mode_overrides(effective_model) is None
+                ):
+                    return _rejected(
+                        "fast_unsupported",
+                        "fast mode is not available for this model",
+                    )
+        elif _runtime_options_signature(conversation) != expected:
+            return _rejected(
+                "conflict",
+                "session runtime options changed while the request was "
+                "being validated; re-read and retry",
+            )
+        # Every idle->running claim that can await takes this lock. The one
+        # claimer that cannot (the synchronous boot-resume pre-claim in
+        # GatewayRunner._schedule_resume_pending_sessions) probes the lock and skips
+        # the session instead; this in-lock re-read is defence-in-depth for
+        # that single site, not a substitute for the lock.
+        if runner._is_session_running(session_key):
+            return _busy_result()
+
+        # Patch onto the (possibly just cleared) live triple; only fields whose
+        # value actually changes are applied, so re-asserting the current
+        # options is a no-op (no durable write, no agent eviction, no note).
+        base = {
+            "model_override": conversation.model_override,
+            "reasoning_override": conversation.reasoning_override,
+            "service_tier_override": conversation.service_tier_override,
+        }
+        new = {**base, **patch}
+        changed = {
+            name for name, value in patch.items() if base[name] != value
+        }
+        changed_fields = [
+            label
+            for label, name in (
+                ("model", "model_override"),
+                ("reasoning_effort", "reasoning_override"),
+                ("fast", "service_tier_override"),
+            )
+            if name in changed
+        ]
+        if not changed:
+            return _accepted(
+                [], new["reasoning_override"], new["service_tier_override"]
+            )
+
+        persisted = await _commit_session_runtime_options_locked(
+            runner,
+            session_key,
+            require_routing_entry=True,
+            **{name: new[name] for name in changed},
+        )
+        if not persisted:
+            return _rejected(
+                "session_missing",
+                "session disappeared while applying runtime options",
+            )
+        state.persistent.runtime_options_rehydrated = True
+        runner._evict_cached_agent(session_key)
+
+        model_switched = "model_override" in changed and (
+            effective_model != current_model
+            or effective_provider != current_provider
+        )
+        if model_switched and not bool(options.get("initial")):
+            from hermes_cli.model_switch import format_model_for_display
+
+            if not hasattr(runner, "_pending_model_notes"):
+                runner._pending_model_notes = {}
+            runner._pending_model_notes[session_key] = (
+                f"[Note: model was just switched from "
+                f"{format_model_for_display(current_model)} to "
+                f"{format_model_for_display(effective_model)} via "
+                f"{effective_provider}. Adjust your self-identification accordingly.]"
+            )
+
     session_db = getattr(runner, "_session_db", None)
-    if session_db is not None and model_override is not None:
+    if session_db is not None and new["model_override"] is not None:
         try:
             entry = await runner.async_session_store.lookup_by_session_key(session_key)
             if entry is not None:
@@ -302,15 +545,6 @@ async def _apply_scoped(
         except Exception:
             logger.debug("Failed to mirror structured model option", exc_info=True)
 
-    return {
-        "status": "accepted",
-        "session_key": session_key,
-        "applied": changed_fields,
-        "effective": {
-            "model": effective_model,
-            "provider": effective_provider,
-            "reasoning_effort": _reasoning_label(reasoning_override),
-            "fast": service_tier_override == "priority",
-        },
-        **({"warning": model_warning} if model_warning else {}),
-    }
+    return _accepted(
+        changed_fields, new["reasoning_override"], new["service_tier_override"]
+    )

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -166,6 +166,10 @@ class PersistentState:
     # not). gateway.run mirrors this value to the DB keyed by session_key so
     # the same semantics also survive gateway restarts.
     hygiene_failure_streak: int = 0
+    # Durable runtime options have been loaded from SessionStore for this
+    # process. Conversation boundaries clear both stores explicitly; gateway
+    # restart constructs fresh SessionState objects and rehydrates once.
+    runtime_options_rehydrated: bool = False
 
 
 @dataclass

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3771,7 +3771,23 @@ class GatewaySlashCommandsMixin:
             logger.error("Failed to save config key %s: %s", key_path, e)
             return False
 
-    def _apply_reasoning_selection(
+    async def _persist_session_reasoning_override(
+        self, session_key: str, reasoning_config: Optional[dict]
+    ) -> None:
+        """Write through via AsyncSessionStore when the runner owns a store."""
+        if getattr(self, "session_store", None) is None:
+            return
+        try:
+            await self.async_session_store.set_reasoning_override(
+                session_key, reasoning_config
+            )
+        except Exception:
+            logger.debug(
+                "Failed to persist session reasoning override",
+                exc_info=True,
+            )
+
+    async def _apply_reasoning_selection(
         self,
         session_key: str,
         platform_key: str,
@@ -3806,6 +3822,7 @@ class GatewaySlashCommandsMixin:
             if persist_global:
                 return t("gateway.reasoning.reset_global_unsupported")
             self._set_session_reasoning_override(session_key, None)
+            await self._persist_session_reasoning_override(session_key, None)
             self._reasoning_config = self._load_reasoning_config()
             self._evict_cached_agent(session_key)
             return t("gateway.reasoning.reset_done")
@@ -3818,13 +3835,20 @@ class GatewaySlashCommandsMixin:
         if persist_global:
             if self._save_gateway_config_key("agent.reasoning_effort", value):
                 self._set_session_reasoning_override(session_key, None)
+                await self._persist_session_reasoning_override(
+                    session_key, None
+                )
                 self._evict_cached_agent(session_key)
                 return t("gateway.reasoning.set_global", effort=value)
             self._set_session_reasoning_override(session_key, parsed)
+            await self._persist_session_reasoning_override(
+                session_key, parsed
+            )
             self._evict_cached_agent(session_key)
             return t("gateway.reasoning.set_global_save_failed", effort=value)
 
         self._set_session_reasoning_override(session_key, parsed)
+        await self._persist_session_reasoning_override(session_key, parsed)
         self._evict_cached_agent(session_key)
         return t("gateway.reasoning.set_session", effort=value)
 
@@ -3955,7 +3979,7 @@ class GatewaySlashCommandsMixin:
             _picker_platform_key = _platform_config_key(event.source.platform)
 
             async def _on_reasoning_choice(_chat_id: str, value: str) -> str:
-                return self._apply_reasoning_selection(
+                return await self._apply_reasoning_selection(
                     session_key, _picker_platform_key, value
                 )
 
@@ -3983,7 +4007,7 @@ class GatewaySlashCommandsMixin:
 
         # Typed argument path — same applier the picker uses.
         platform_key = _platform_config_key(event.source.platform)
-        return self._apply_reasoning_selection(
+        return await self._apply_reasoning_selection(
             session_key, platform_key, args, persist_global=persist_global
         )
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1840,6 +1840,9 @@ class GatewaySlashCommandsMixin:
         # (#30479).
         source = await asyncio.to_thread(self._normalize_source_for_session_key, source)
         session_key = self._session_key_for_source(source)
+        # Rehydrate first so "switched from X" and the --once restore snapshot
+        # reflect the persisted override after a gateway restart.
+        self._rehydrate_session_runtime_options(session_key)
         override = self._session_model_overrides.get(session_key, {})
         restore_snapshot = (
             self._snapshot_session_model_override(session_key) if one_turn else None
@@ -1975,6 +1978,30 @@ class GatewaySlashCommandsMixin:
                                     ),
                                 )
 
+                        # Session override through the single durable-first
+                        # write-through (persist first, then live; a failed
+                        # save propagates with live state untouched).
+                        try:
+                            await _self._commit_session_runtime_options(
+                                _session_key,
+                                model_override={
+                                    "model": result.new_model,
+                                    "provider": result.target_provider,
+                                    "api_key": result.api_key,
+                                    "base_url": result.base_url,
+                                    "api_mode": result.api_mode,
+                                    "request_overrides": dict(
+                                        result.request_overrides or {}
+                                    ),
+                                    "capabilities": dict(
+                                        result.runtime_capabilities or {}
+                                    ),
+                                },
+                            )
+                        except Exception:
+                            _self._evict_cached_agent(_session_key)
+                            raise
+
                         # Persist the new model to the session DB so the
                         # dashboard shows the updated model (#34850).
                         _sess_db = getattr(_self, "_session_db", None)
@@ -2006,30 +2033,6 @@ class GatewaySlashCommandsMixin:
                             f"via {result.provider_label or result.target_provider}. "
                             f"Adjust your self-identification accordingly.]"
                         )
-                        _self._session_model_overrides[_session_key] = {
-                            "model": result.new_model,
-                            "provider": result.target_provider,
-                            "api_key": result.api_key,
-                            "base_url": result.base_url,
-                            "api_mode": result.api_mode,
-                            "request_overrides": dict(result.request_overrides or {}),
-                            "capabilities": dict(result.runtime_capabilities or {}),
-                        }
-
-                        # Write-through the non-secret parts to the session
-                        # store so the picked model survives a gateway restart
-                        # (api_key is never persisted).
-                        try:
-                            await _self.async_session_store.set_model_override(
-                                _session_key,
-                                _self._session_model_overrides[_session_key],
-                            )
-                        except Exception:
-                            logger.debug(
-                                "Failed to persist session model override",
-                                exc_info=True,
-                            )
-
                         # Evict cached agent so the next turn creates a fresh
                         # agent from the override rather than relying on the
                         # stale cache signature to trigger a rebuild.
@@ -2286,6 +2289,43 @@ class GatewaySlashCommandsMixin:
                         ),
                     )
 
+            # Session override for the next agent build, through the single
+            # durable-first write-through shared with /reasoning, /fast and the
+            # structured host API: the non-secret parts (model/provider/
+            # base_url) are persisted FIRST, then live state moves, so the
+            # reply below is never sent for a switch a restart would discard.
+            # A failed durable write propagates with live state untouched.
+            #
+            # /model --once is live-only by contract (#29923): a one-turn
+            # override must never survive a restart, and while it is live any
+            # sibling durable write persists the pre-once snapshot instead.
+            new_override = {
+                "model": result.new_model,
+                "provider": result.target_provider,
+                "api_key": result.api_key,
+                "base_url": result.base_url,
+                "api_mode": result.api_mode,
+                "request_overrides": dict(result.request_overrides or {}),
+                "capabilities": dict(result.runtime_capabilities or {}),
+            }
+            if one_turn:
+                if not hasattr(self, "_pending_one_turn_model_restores"):
+                    self._pending_one_turn_model_restores = {}
+                self._pending_one_turn_model_restores[session_key] = (
+                    restore_snapshot or {"had_override": False, "override": None}
+                )
+            try:
+                await self._commit_session_runtime_options(
+                    session_key,
+                    model_override=new_override,
+                    durable=not one_turn,
+                )
+            except Exception:
+                # The cached agent may already have switched in place above;
+                # drop it so the next turn rebuilds from the unchanged override.
+                self._evict_cached_agent(session_key)
+                raise
+
             # Persist the new model to the session DB so the dashboard
             # shows the updated model (#34850).
             _sess_db = getattr(self, "_session_db", None)
@@ -2319,48 +2359,6 @@ class GatewaySlashCommandsMixin:
                 f"{'This override applies to the next turn only. ' if one_turn else ''}"
                 f"Adjust your self-identification accordingly.]"
             )
-
-            # Store session override so next agent creation uses the new model
-            self._session_model_overrides[session_key] = {
-                "model": result.new_model,
-                "provider": result.target_provider,
-                "api_key": result.api_key,
-                "base_url": result.base_url,
-                "api_mode": result.api_mode,
-                "request_overrides": dict(result.request_overrides or {}),
-                "capabilities": dict(result.runtime_capabilities or {}),
-            }
-            if one_turn:
-                if not hasattr(self, "_pending_one_turn_model_restores"):
-                    self._pending_one_turn_model_restores = {}
-                self._pending_one_turn_model_restores[session_key] = (
-                    restore_snapshot or {"had_override": False, "override": None}
-                )
-            elif hasattr(self, "_pending_one_turn_model_restores"):
-                self._pending_one_turn_model_restores.pop(session_key, None)
-
-            # Write-through the non-secret parts (model/provider/base_url) to
-            # the session store so the override survives a gateway restart.
-            # api_key/api_mode are never persisted — they are re-resolved via
-            # runtime provider resolution on rehydration.
-            #
-            # /model --once is intentionally EXCLUDED from the write-through:
-            # a one-turn override must never survive a restart. The persisted
-            # value stays at the pre-once state (the prior session override,
-            # or nothing), which is exactly what the finally-restore reverts
-            # the in-memory dict to. (#29923 review defect: the original
-            # implementation wrote through, so a crash before the restore
-            # rehydrated the once-model permanently.)
-            if not one_turn:
-                try:
-                    await self.async_session_store.set_model_override(
-                        session_key,
-                        self._session_model_overrides[session_key],
-                    )
-                except Exception:
-                    logger.debug(
-                        "Failed to persist session model override", exc_info=True
-                    )
 
             # Evict cached agent so the next turn creates a fresh agent from the
             # override rather than relying on cache signature mismatch detection.
@@ -3771,22 +3769,6 @@ class GatewaySlashCommandsMixin:
             logger.error("Failed to save config key %s: %s", key_path, e)
             return False
 
-    async def _persist_session_reasoning_override(
-        self, session_key: str, reasoning_config: Optional[dict]
-    ) -> None:
-        """Write through via AsyncSessionStore when the runner owns a store."""
-        if getattr(self, "session_store", None) is None:
-            return
-        try:
-            await self.async_session_store.set_reasoning_override(
-                session_key, reasoning_config
-            )
-        except Exception:
-            logger.debug(
-                "Failed to persist session reasoning override",
-                exc_info=True,
-            )
-
     async def _apply_reasoning_selection(
         self,
         session_key: str,
@@ -3821,8 +3803,7 @@ class GatewaySlashCommandsMixin:
         if value == "reset":
             if persist_global:
                 return t("gateway.reasoning.reset_global_unsupported")
-            self._set_session_reasoning_override(session_key, None)
-            await self._persist_session_reasoning_override(session_key, None)
+            await self._set_session_reasoning_override(session_key, None)
             self._reasoning_config = self._load_reasoning_config()
             self._evict_cached_agent(session_key)
             return t("gateway.reasoning.reset_done")
@@ -3834,21 +3815,14 @@ class GatewaySlashCommandsMixin:
         self._reasoning_config = parsed
         if persist_global:
             if self._save_gateway_config_key("agent.reasoning_effort", value):
-                self._set_session_reasoning_override(session_key, None)
-                await self._persist_session_reasoning_override(
-                    session_key, None
-                )
+                await self._set_session_reasoning_override(session_key, None)
                 self._evict_cached_agent(session_key)
                 return t("gateway.reasoning.set_global", effort=value)
-            self._set_session_reasoning_override(session_key, parsed)
-            await self._persist_session_reasoning_override(
-                session_key, parsed
-            )
+            await self._set_session_reasoning_override(session_key, parsed)
             self._evict_cached_agent(session_key)
             return t("gateway.reasoning.set_global_save_failed", effort=value)
 
-        self._set_session_reasoning_override(session_key, parsed)
-        await self._persist_session_reasoning_override(session_key, parsed)
+        await self._set_session_reasoning_override(session_key, parsed)
         self._evict_cached_agent(session_key)
         return t("gateway.reasoning.set_session", effort=value)
 
@@ -4136,7 +4110,7 @@ class GatewaySlashCommandsMixin:
         if not model_supports_fast_mode(model):
             return t("gateway.fast.not_supported")
 
-        def _apply_fast_selection(value: str, persist: bool = False) -> str:
+        async def _apply_fast_selection(value: str, persist: bool = False) -> str:
             """Apply a /fast argument (typed or picked) and return the reply."""
             if value in {"fast", "on"}:
                 tier = "priority"
@@ -4152,17 +4126,17 @@ class GatewaySlashCommandsMixin:
             if persist:
                 if self._save_gateway_config_key("agent.service_tier", saved_value):
                     # Global write supersedes any session override.
-                    self._set_session_service_tier_override(
+                    await self._set_session_service_tier_override(
                         session_key, None, clear=True
                     )
                     self._evict_cached_agent(session_key)
                     return t("gateway.fast.saved", label=label)
                 # Config write failed — fall back to a session override so the
                 # user's choice still applies (mirrors /reasoning --global).
-                self._set_session_service_tier_override(session_key, tier)
+                await self._set_session_service_tier_override(session_key, tier)
                 self._evict_cached_agent(session_key)
                 return t("gateway.fast.session_only", label=label)
-            self._set_session_service_tier_override(session_key, tier)
+            await self._set_session_service_tier_override(session_key, tier)
             self._evict_cached_agent(session_key)
             return t("gateway.fast.session_only", label=label)
 
@@ -4171,7 +4145,7 @@ class GatewaySlashCommandsMixin:
             status = t("gateway.fast.status_fast") if is_fast else t("gateway.fast.status_normal")
 
             async def _on_fast_choice(_chat_id: str, value: str) -> str:
-                return _apply_fast_selection(value, persist=persist_global)
+                return await _apply_fast_selection(value, persist=persist_global)
 
             picker_sent = await self._try_send_choice_picker(
                 event,
@@ -4196,7 +4170,7 @@ class GatewaySlashCommandsMixin:
 
             return t("gateway.fast.status", mode=status)
 
-        return _apply_fast_selection(args, persist=persist_global)
+        return await _apply_fast_selection(args, persist=persist_global)
 
     async def _handle_approvals_command(self, event: MessageEvent) -> str:
         """Show or persist the profile-wide dangerous-command approval mode."""

--- a/tests/gateway/test_moa_one_shot_commit_windows.py
+++ b/tests/gateway/test_moa_one_shot_commit_windows.py
@@ -1,0 +1,280 @@
+"""``/moa`` must never let a runtime-options commit persist its virtual provider.
+
+``/moa <prompt>`` installs a live-only ``model_override`` whose provider is
+the virtual ``moa`` provider. Two windows exist in which a durable commit
+(host ``apply_session_options()``, or a ``/reasoning``/``/fast`` slash) can
+observe the session as idle while that override is live:
+
+* pre-claim: between the ``/moa`` slash branch and the idle->running claim in
+  ``_handle_message`` there is a real ``asyncio.to_thread`` yield (the Telegram
+  lobby probe). The install therefore runs only after the claim
+  (``_install_moa_one_shot``), so nothing is live in this window.
+* post-turn: ``_run_agent_inner``'s ``finally`` releases the running slot,
+  then ``_handle_message_with_agent`` keeps awaiting before
+  ``_handle_message``'s ``finally`` restores. The install parks the prior
+  override in ``conversation.one_turn_restore`` (the ``/model --once`` slot),
+  so the durable-first primitive persists that snapshot, never ``moa``.
+
+These tests drive the real ``_handle_message`` and park it at each seam while
+a commit lands, then require that nothing durable ever says ``moa``, that the
+turn itself still ran through MoA, and that live and durable state agree once
+the turn has restored the prior override.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionStore
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch) -> SessionStore:
+    def _raise():
+        raise RuntimeError("SQLite disabled in test")
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _raise)
+    built = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    assert built._db is None
+    return built
+
+
+def _wire_runner(store, monkeypatch, chat_id):
+    """Real ``_handle_message`` over a real store; the agent turn is stubbed."""
+    runner, adapter = make_restart_runner()
+    runner.session_store = store
+    runner._session_db = None
+    runner._session_options_locks = {}
+    source = make_restart_source(chat_id=chat_id)
+    session_key = runner._session_key_for_source(source)
+
+    runner._handle_message = GatewayRunner._handle_message.__get__(runner, GatewayRunner)
+    runner._release_running_agent_state = (
+        GatewayRunner._release_running_agent_state.__get__(runner, GatewayRunner)
+    )
+    runner._check_slash_access = lambda *a, **k: None
+    runner._begin_session_run_generation = lambda session_key: 1
+    runner._is_session_run_current = lambda session_key, generation: True
+    runner._invalidate_session_run_generation = lambda *a, **k: 0
+    runner._claim_active_session_slot = lambda session_key, source: (object(), None)
+    runner._active_session_leases = {}
+    runner._busy_ack_ts = {}
+    runner._post_turn_goal_continuation = AsyncMock()
+    runner._is_user_authorized = lambda _source: True
+    runner.evictions = []
+    runner._evict_cached_agent = lambda key: runner.evictions.append(key)
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "old-model",
+        {"provider": "openrouter", "base_url": "", "api_key": ""},
+    )
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+
+    adapter.set_message_handler(runner._handle_message)
+    adapter.send = AsyncMock()
+    adapter._keep_typing = AsyncMock()
+    adapter._stop_typing_refresh = AsyncMock()
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+    adapter._run_processing_hook = AsyncMock()
+    store.get_or_create_session(source)  # routing entry exists, as for a live chat
+    return runner, source, session_key
+
+
+def _moa_event(source):
+    return MessageEvent(text="/moa summarise this", message_type=MessageType.TEXT, source=source)
+
+
+@pytest.mark.asyncio
+async def test_host_commit_in_moa_pre_claim_window_never_persists_moa(store, monkeypatch):
+    runner, source, session_key = _wire_runner(store, monkeypatch, "moa-chat")
+
+    # Park the turn at the one real yield between the /moa branch and the
+    # idle->running claim: the lobby probe runs via asyncio.to_thread.
+    reached_seam = asyncio.Event()
+    release_seam = threading.Event()
+    loop = asyncio.get_running_loop()
+
+    def _lobby_probe(_source):
+        loop.call_soon_threadsafe(reached_seam.set)
+        release_seam.wait(timeout=5)
+        return False
+
+    runner._is_telegram_topic_root_lobby = _lobby_probe
+
+    seen_models: list = []
+
+    async def _fake_run(event, source, _quick_key, run_generation):
+        # What the agent turn would resolve: the live override at run time.
+        seen_models.append(runner._session_state(_quick_key).conversation.model_override)
+        return "OK"
+
+    runner._handle_message_with_agent = _fake_run
+
+    turn = asyncio.create_task(runner._handle_message(_moa_event(source)))
+    await asyncio.wait_for(reached_seam.wait(), timeout=5)
+    assert runner._is_session_running(session_key) is False  # pre-claim window
+    assert runner._session_state(session_key).conversation.model_override is None
+
+    # A host commit lands in the window. It must not see the MoA override.
+    result = await runner.apply_session_options(source, {"reasoning_effort": "high"})
+    assert result["status"] == "accepted", result
+    durable = store.get_runtime_options(session_key)
+    assert durable["model_override"] is None, durable
+    assert durable["reasoning_override"] == {"enabled": True, "effort": "high"}
+
+    release_seam.set()
+    assert await asyncio.wait_for(turn, timeout=5) == "OK"
+
+    # The turn itself still ran through MoA, and restored the prior override.
+    assert seen_models and seen_models[0]["provider"] == "moa"
+    conv = runner._session_state(session_key).conversation
+    assert conv.model_override is None
+    assert conv.one_turn_restore is None
+    assert conv.reasoning_override == {"enabled": True, "effort": "high"}
+    assert store.get_runtime_options(session_key)["model_override"] is None
+    assert runner._is_session_running(session_key) is False
+    # Every /moa install is paired with its restore eviction.
+    assert runner.evictions.count(session_key) >= 2
+
+
+@pytest.mark.asyncio
+async def test_host_commit_after_claim_is_rejected_busy_while_moa_turn_runs(store, monkeypatch):
+    """Once the turn is claimed and MoA installed, a host commit is busy-rejected
+    rather than persisting the live MoA override."""
+    runner, source, session_key = _wire_runner(store, monkeypatch, "moa-chat-2")
+
+    in_turn = asyncio.Event()
+    finish_turn = asyncio.Event()
+
+    async def _fake_run(event, source, _quick_key, run_generation):
+        assert runner._session_state(_quick_key).conversation.model_override["provider"] == "moa"
+        in_turn.set()
+        await finish_turn.wait()
+        return "OK"
+
+    runner._handle_message_with_agent = _fake_run
+
+    turn = asyncio.create_task(runner._handle_message(_moa_event(source)))
+    await asyncio.wait_for(in_turn.wait(), timeout=5)
+
+    result = await runner.apply_session_options(source, {"reasoning_effort": "high"})
+    assert result["status"] == "rejected" and result["code"] == "session_busy", result
+    durable = store.get_runtime_options(session_key)
+    assert (durable or {}).get("model_override") is None, durable
+
+    finish_turn.set()
+    assert await asyncio.wait_for(turn, timeout=5) == "OK"
+    assert runner._session_state(session_key).conversation.model_override is None
+
+
+async def _park_in_post_turn_window(runner, source):
+    """Start a /moa turn and park it after the running slot is released but
+    before ``_handle_message``'s ``finally`` restores the override."""
+    agent_done = asyncio.Event()
+    release_post = asyncio.Event()
+    seen_models: list = []
+
+    async def _fake_run(event, source, _quick_key, run_generation):
+        seen_models.append(runner._session_state(_quick_key).conversation.model_override)
+        # Mimic _run_agent_inner's finally: the running slot is released here,
+        # then _handle_message_with_agent keeps awaiting (transcript appends,
+        # update_session, sends) before returning to _handle_message's finally.
+        runner._release_running_agent_state(_quick_key, run_generation=run_generation)
+        agent_done.set()
+        await release_post.wait()
+        return "OK"
+
+    runner._handle_message_with_agent = _fake_run
+    turn = asyncio.create_task(runner._handle_message(_moa_event(source)))
+    await asyncio.wait_for(agent_done.wait(), timeout=5)
+    assert seen_models and seen_models[0]["provider"] == "moa"
+    return turn, release_post
+
+
+@pytest.mark.asyncio
+async def test_host_commit_in_moa_post_turn_window_persists_prior_model(store, monkeypatch):
+    """Slot released, override still live: a commit that does not name a model
+    persists the parked pre-MoA snapshot, and the restore leaves live == disk."""
+    runner, source, session_key = _wire_runner(store, monkeypatch, "moa-chat-3")
+    turn, release_post = await _park_in_post_turn_window(runner, source)
+    assert runner._is_session_running(session_key) is False  # post-turn, pre-restore
+    assert runner._session_state(session_key).conversation.model_override["provider"] == "moa"
+
+    result = await runner.apply_session_options(source, {"reasoning_effort": "high"})
+    assert result["status"] == "accepted", result
+    durable = store.get_runtime_options(session_key)
+    assert durable["model_override"] is None, durable
+    assert durable["reasoning_override"] == {"enabled": True, "effort": "high"}
+
+    release_post.set()
+    assert await asyncio.wait_for(turn, timeout=5) == "OK"
+    conv = runner._session_state(session_key).conversation
+    assert conv.model_override is None
+    assert conv.one_turn_restore is None
+    assert store.get_runtime_options(session_key)["model_override"] is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_model_commit_in_moa_post_turn_window_is_not_reverted(store, monkeypatch):
+    """A commit that names a model in the post-turn window wins: it clears the
+    parked snapshot, so the turn's restore does not revert it and live == disk."""
+    runner, source, session_key = _wire_runner(store, monkeypatch, "moa-chat-4")
+    turn, release_post = await _park_in_post_turn_window(runner, source)
+
+    from gateway.session_options import commit_session_runtime_options
+
+    new_override = {"provider": "openrouter", "model": "gpt-4", "base_url": "", "api_key": ""}
+    assert await commit_session_runtime_options(
+        runner, session_key, model_override=new_override, require_routing_entry=True
+    )
+    assert store.get_runtime_options(session_key)["model_override"] == {
+        "provider": "openrouter", "model": "gpt-4",
+    }
+
+    release_post.set()
+    assert await asyncio.wait_for(turn, timeout=5) == "OK"
+    conv = runner._session_state(session_key).conversation
+    assert conv.model_override == new_override
+    assert conv.one_turn_restore is None
+    assert store.get_runtime_options(session_key)["model_override"] == {
+        "provider": "openrouter", "model": "gpt-4",
+    }
+
+
+@pytest.mark.asyncio
+async def test_moa_refused_by_drain_gate_leaves_no_live_override(store, monkeypatch):
+    """``/moa`` that is turned away between dispatch and the claim (here: the
+    gateway is draining) must not leave the MoA override live: the install
+    only happens once the turn is actually admitted."""
+    runner, adapter = make_restart_runner()
+    runner.session_store = store
+    runner._session_db = None
+    runner._session_options_locks = {}
+    source = make_restart_source(chat_id="moa-chat-5")
+    session_key = runner._session_key_for_source(source)
+
+    runner._handle_message = GatewayRunner._handle_message.__get__(runner, GatewayRunner)
+    runner._check_slash_access = lambda *a, **k: None
+    runner._is_user_authorized = lambda _source: True
+    runner.evictions = []
+    runner._evict_cached_agent = lambda key: runner.evictions.append(key)
+    runner._handle_message_with_agent = AsyncMock(return_value="OK")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    adapter.set_message_handler(runner._handle_message)
+    adapter._run_processing_hook = AsyncMock()
+    runner._draining = True
+
+    reply = await runner._handle_message(_moa_event(source))
+    assert reply and "not accepting new work" in reply
+    runner._handle_message_with_agent.assert_not_awaited()
+    assert runner._session_state(session_key).conversation.model_override is None
+    assert runner._session_state(session_key).conversation.one_turn_restore is None

--- a/tests/gateway/test_moa_one_shot_restore.py
+++ b/tests/gateway/test_moa_one_shot_restore.py
@@ -1,10 +1,14 @@
 """MoA one-shot model override must be restored on both success and failure.
 
-These exercise the real ``GatewayRunner._restore_moa_one_shot`` helper that the
+These exercise the real ``GatewayRunner._install_moa_one_shot`` helper (which
+parks the prior per-session override in the same ``conversation.one_turn_restore``
+slot that ``/model --once`` uses) and the real
+``GatewayRunner._restore_pending_one_turn_model_override`` helper that the
 message-handling ``finally`` block calls, so they prove the production logic —
-not a re-implementation of it. The bug being guarded: the restore used to live
-in the ``try`` block, so a turn that raised skipped it and the MoA override
-leaked permanently (every later message silently fanned out through MoA).
+not a re-implementation of it. The bug
+being guarded: the restore used to live in the ``try`` block, so a turn that
+raised skipped it and the MoA override leaked permanently (every later message
+silently fanned out through MoA).
 """
 
 from types import SimpleNamespace
@@ -14,19 +18,27 @@ from gateway.run import GatewayRunner
 
 
 def _make_runner():
-    """Minimal GatewayRunner with only the fields _restore_moa_one_shot reads."""
+    """Minimal GatewayRunner with only the fields the restore helper reads."""
     runner = object.__new__(GatewayRunner)
     runner._session_model_overrides = {}
     runner._evict_cached_agent = MagicMock()
+    runner._rehydrate_session_runtime_options = lambda key: None
     return runner
 
 
-def _make_event(moa_disable=False, moa_restore=None):
-    event = SimpleNamespace()
-    if moa_disable:
-        event._moa_disable_after_turn = True
-        event._moa_restore_override = moa_restore
-    return event
+def _install_moa(runner, key, prior_override):
+    """Run the real post-claim install: snapshot into the slot, then swap."""
+    runner._session_state(key).conversation.model_override = prior_override
+    event = SimpleNamespace(_moa_pending_preset="default")
+    assert runner._install_moa_one_shot(event, key) is True
+    assert event._moa_pending_preset is None
+    runner._evict_cached_agent.reset_mock()
+    conv = runner._session_state(key).conversation
+    assert conv.model_override["provider"] == "moa"
+    assert conv.one_turn_restore == {
+        "had_override": prior_override is not None,
+        "override": prior_override,
+    }
 
 
 def test_restore_runs_from_finally_even_when_turn_raises():
@@ -37,19 +49,29 @@ def test_restore_runs_from_finally_even_when_turn_raises():
     """
     runner = _make_runner()
     key = "agent:main:telegram:dm:999"
-    runner._session_model_overrides[key] = {"provider": "moa", "model": "default"}
-    event = _make_event(
-        moa_disable=True,
-        moa_restore={"provider": "openrouter", "model": "gpt-4"},
-    )
+    _install_moa(runner, key, {"provider": "openrouter", "model": "gpt-4"})
 
     with __import__("pytest").raises(RuntimeError):
         try:
             raise RuntimeError("provider error mid-turn")
         finally:
-            runner._restore_moa_one_shot(event, key)
+            runner._restore_pending_one_turn_model_override(key)
 
     assert runner._session_model_overrides[key] == {
         "provider": "openrouter",
         "model": "gpt-4",
     }
+    assert runner._session_state(key).conversation.one_turn_restore is None
+    runner._evict_cached_agent.assert_called_once_with(key)
+
+
+def test_restore_clears_override_when_user_had_none():
+    """No prior override: the MoA override is cleared outright, not kept."""
+    runner = _make_runner()
+    key = "agent:main:telegram:dm:1000"
+    _install_moa(runner, key, None)
+    assert runner._session_model_overrides[key]["provider"] == "moa"
+
+    runner._restore_pending_one_turn_model_override(key)
+
+    assert runner._session_model_overrides.get(key) is None

--- a/tests/gateway/test_model_switch_persistence.py
+++ b/tests/gateway/test_model_switch_persistence.py
@@ -222,11 +222,16 @@ class TestOneTurnNeverPersisted:
         runner._pending_one_turn_model_restores = {}
         runner._running_agents = {}
         # async_session_store is a property over session_store; install the
-        # mock behind the private cache attribute it reads.
+        # mock behind the private cache attribute it reads. The sync store
+        # must expose the write-through primitive so the once-path's refusal
+        # to call it is observable (not merely skipped for lack of a store).
+        _sync_store = MagicMock()
+        _sync_store.get_runtime_options.return_value = None
         _store = MagicMock()
         _store.set_model_override = AsyncMock()
-        _store._store = None
-        runner.session_store = None
+        _store.set_runtime_options = AsyncMock(return_value=True)
+        _store._store = _sync_store
+        runner.session_store = _sync_store
         runner._async_session_store = _store
         return runner
 
@@ -260,4 +265,5 @@ class TestOneTurnNeverPersisted:
         assert sk in runner._pending_one_turn_model_restores
         # ...but NEVER written through to the persistent session store.
         runner.async_session_store.set_model_override.assert_not_awaited()
+        runner.async_session_store.set_runtime_options.assert_not_awaited()
 

--- a/tests/gateway/test_reasoning_persistence.py
+++ b/tests/gateway/test_reasoning_persistence.py
@@ -1,0 +1,89 @@
+"""Durable, async-safe persistence for session-scoped /reasoning overrides."""
+from unittest.mock import AsyncMock
+import pytest
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore, sanitize_reasoning_override
+
+def _source():
+    return SessionSource(platform=Platform.TELEGRAM, user_id="u1", chat_id="c1", chat_type="dm")
+
+@pytest.fixture
+def store_factory(tmp_path, monkeypatch):
+    import hermes_state
+    def _disabled(): raise RuntimeError("SQLite disabled in test")
+    monkeypatch.setattr(hermes_state, "SessionDB", _disabled)
+    return lambda: SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+def test_round_trips_full_effort_ladder(store_factory):
+    from hermes_constants import VALID_REASONING_EFFORTS
+    store = store_factory(); entry = store.get_or_create_session(_source())
+    for effort in VALID_REASONING_EFFORTS:
+        store.set_reasoning_override(entry.session_key, {"enabled": True, "effort": effort, "unexpected": "discard"})
+        assert store_factory().get_reasoning_override(entry.session_key) == {"enabled": True, "effort": effort}
+
+def test_clear_and_expiry_survive_restart(store_factory):
+    store = store_factory(); entry = store.get_or_create_session(_source())
+    store.set_reasoning_override(entry.session_key, {"enabled": True, "effort": "ultra"})
+    store.set_reasoning_override(entry.session_key, None)
+    assert store_factory().get_reasoning_override(entry.session_key) is None
+    store.set_reasoning_override(entry.session_key, {"enabled": True, "effort": "max"})
+    store.set_expiry_finalized(entry)
+    assert store_factory().get_reasoning_override(entry.session_key) is None
+
+def test_state_db_round_trip_without_json_mirror(tmp_path, monkeypatch):
+    import hermes_state
+
+    real_session_db = hermes_state.SessionDB
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(
+        hermes_state,
+        "SessionDB",
+        lambda: real_session_db(db_path=db_path),
+    )
+    config = GatewayConfig()
+    config.write_sessions_json = False
+    sessions_dir = tmp_path / "sessions"
+
+    store = SessionStore(sessions_dir=sessions_dir, config=config)
+    entry = store.get_or_create_session(_source())
+    store.set_reasoning_override(
+        entry.session_key, {"enabled": True, "effort": "ultra"}
+    )
+    store._db.close()
+
+    restored = SessionStore(sessions_dir=sessions_dir, config=config)
+    try:
+        assert restored.get_reasoning_override(entry.session_key) == {
+            "enabled": True,
+            "effort": "ultra",
+        }
+    finally:
+        restored._db.close()
+
+
+def test_sanitizer_rejects_malformed_shape():
+    assert sanitize_reasoning_override(None) is None
+    assert sanitize_reasoning_override({"enabled": "false", "effort": "max"}) is None
+    assert sanitize_reasoning_override({"enabled": True, "effort": "unknown"}) is None
+    assert sanitize_reasoning_override({"enabled": False, "effort": "ultra"}) == {"enabled": False}
+
+@pytest.mark.asyncio
+async def test_command_persists_through_async_store():
+    import gateway.run as gateway_run
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._session_reasoning_overrides = {}; runner._reasoning_config = None
+    runner._show_reasoning = False; runner._running_agents = {}
+    runner.session_store = object()
+    runner._async_session_store = AsyncMock()
+    runner._async_session_store._store = runner.session_store
+    runner._evict_cached_agent = lambda _key: None
+    runner._save_gateway_config_key = lambda *_args: True
+    assert await runner._apply_reasoning_selection("agent:main:telegram:dm:u1", "telegram", "ultra")
+    runner._async_session_store.set_reasoning_override.assert_awaited_once_with("agent:main:telegram:dm:u1", {"enabled": True, "effort": "ultra"})
+
+def test_rehydrate_copies_durable_override():
+    import gateway.run as gateway_run
+    runner = object.__new__(gateway_run.GatewayRunner); runner._session_reasoning_overrides = {}
+    entry = type("Entry", (), {"session_key": "agent:main:telegram:dm:u1", "reasoning_override": {"enabled": True, "effort": "max"}})()
+    runner._rehydrate_session_reasoning_override(entry)
+    assert runner._resolve_session_reasoning_config(session_key=entry.session_key) == {"enabled": True, "effort": "max"}

--- a/tests/gateway/test_reasoning_persistence.py
+++ b/tests/gateway/test_reasoning_persistence.py
@@ -68,22 +68,27 @@ def test_sanitizer_rejects_malformed_shape():
     assert sanitize_reasoning_override({"enabled": False, "effort": "ultra"}) == {"enabled": False}
 
 @pytest.mark.asyncio
-async def test_command_persists_through_async_store():
+async def test_command_persists_through_async_store(store_factory):
+    """/reasoning writes through the unified durable-first primitive."""
     import gateway.run as gateway_run
+    store = store_factory()
+    entry = store.get_or_create_session(_source())
     runner = object.__new__(gateway_run.GatewayRunner)
-    runner._session_reasoning_overrides = {}; runner._reasoning_config = None
-    runner._show_reasoning = False; runner._running_agents = {}
-    runner.session_store = object()
-    runner._async_session_store = AsyncMock()
-    runner._async_session_store._store = runner.session_store
+    runner._sessions = {}; runner._session_options_locks = {}
+    runner._reasoning_config = None; runner._show_reasoning = False
+    runner.session_store = store
+    runner._async_session_store = gateway_run.AsyncSessionStore(store)
     runner._evict_cached_agent = lambda _key: None
     runner._save_gateway_config_key = lambda *_args: True
-    assert await runner._apply_reasoning_selection("agent:main:telegram:dm:u1", "telegram", "ultra")
-    runner._async_session_store.set_reasoning_override.assert_awaited_once_with("agent:main:telegram:dm:u1", {"enabled": True, "effort": "ultra"})
+    assert await runner._apply_reasoning_selection(entry.session_key, "telegram", "ultra")
+    assert store_factory().get_reasoning_override(entry.session_key) == {"enabled": True, "effort": "ultra"}
 
-def test_rehydrate_copies_durable_override():
+def test_rehydrate_copies_durable_override(store_factory):
     import gateway.run as gateway_run
-    runner = object.__new__(gateway_run.GatewayRunner); runner._session_reasoning_overrides = {}
-    entry = type("Entry", (), {"session_key": "agent:main:telegram:dm:u1", "reasoning_override": {"enabled": True, "effort": "max"}})()
-    runner._rehydrate_session_reasoning_override(entry)
+    store = store_factory()
+    entry = store.get_or_create_session(_source())
+    store.set_reasoning_override(entry.session_key, {"enabled": True, "effort": "max"})
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._sessions = {}; runner.session_store = store_factory()
+    runner._rehydrate_session_runtime_options(entry.session_key)
     assert runner._resolve_session_reasoning_config(session_key=entry.session_key) == {"enabled": True, "effort": "max"}

--- a/tests/gateway/test_session_admission_lock.py
+++ b/tests/gateway/test_session_admission_lock.py
@@ -1,0 +1,275 @@
+"""Per-session admission exclusion shared by turn start and runtime options.
+
+Contract (#92185 / review finding 2 on #92187):
+
+* ``gateway.session_options.session_admission_lock(runner, key)`` is the ONE
+  exclusion a session crosses when it flips idle->running. ``_handle_message`` awaits it around
+  its claim block; ``apply_session_options`` holds it across check + persist +
+  mutate; the boot-resume pre-claim (which cannot await) skips a session whose
+  lock is held.
+* Taking the uncontended lock never yields, so the gateway's "claim before
+  any await" discipline is unchanged on the hot path.
+
+Plus the /model half of review finding 1: every session-runtime mutation goes
+through one durable-first primitive, so a failed durable write makes the slash
+command fail loudly with live state untouched, and ``/model --once`` stays
+live-only while sibling durable writes persist the pre-once model.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session_options import session_admission_lock, session_admission_lock_held
+from gateway.session import SessionEntry, SessionSource, SessionStore
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=_make_source())
+
+
+@pytest.fixture
+def store_factory(tmp_path, monkeypatch):
+    """SessionStores over one shared sessions dir, without SQLite."""
+
+    def _raise():
+        raise RuntimeError("SQLite disabled in test")
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _raise)
+
+    def _make() -> SessionStore:
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+        assert store._db is None
+        return store
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# The exclusion itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_uncontended_admission_lock_never_yields():
+    """The claim block in ``_handle_message`` runs under the shared lock. For
+    the "claim before any await" discipline to survive, taking the lock when
+    nobody holds it must not give the loop a chance to run anything else."""
+    runner = object.__new__(GatewayRunner)
+    key = "agent:main:telegram:dm:c1"
+    sibling_ran = asyncio.Event()
+
+    async def _sibling():
+        sibling_ran.set()
+
+    sibling = asyncio.create_task(_sibling())
+    async with session_admission_lock(runner, key):
+        assert not sibling_ran.is_set(), "uncontended acquire yielded to the loop"
+    await sibling
+    assert session_admission_lock(runner, key) is session_admission_lock(runner, key)
+    assert session_admission_lock(runner, key) is not session_admission_lock(runner, key + "x")
+
+
+@pytest.mark.asyncio
+async def test_lock_held_probe_tracks_in_flight_transaction():
+    runner = object.__new__(GatewayRunner)
+    key = "agent:main:telegram:dm:c1"
+    assert session_admission_lock_held(runner, key) is False  # never created
+    async with session_admission_lock(runner, key):
+        assert session_admission_lock_held(runner, key) is True
+    assert session_admission_lock_held(runner, key) is False
+
+
+@pytest.mark.asyncio
+async def test_boot_resume_pre_claim_skips_session_under_options_transaction():
+    """The startup auto-resume pre-claims ``turn.agent`` synchronously (it
+    cannot await the lock). While an options transaction owns the session it
+    must leave the session resume_pending instead of claiming underneath the
+    in-flight commit; once the lock is free the same pass resumes it."""
+    runner, adapter = make_restart_runner()
+    runner._is_user_authorized = lambda _source: True
+    runner._restart_loop_guard_config = lambda: (0, 0, 0)
+    runner._run_startup_resume_event = AsyncMock()
+    adapter.handle_message = AsyncMock()
+    source = make_restart_source(chat_id="held-chat")
+    key = "agent:main:telegram:dm:held-chat"
+    entry = SessionEntry(
+        session_key=key,
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {key: entry}
+
+    async with session_admission_lock(runner, key):
+        assert runner._schedule_resume_pending_sessions() == 0
+        assert runner._is_session_running(key) is False
+
+    assert runner._schedule_resume_pending_sessions() == 1
+    assert runner._is_session_running(key) is True
+
+
+# ---------------------------------------------------------------------------
+# /model through the shared durable-first primitive
+# ---------------------------------------------------------------------------
+
+
+def _model_runner(store: SessionStore, tmp_path, monkeypatch) -> GatewayRunner:
+    import yaml as _yaml
+
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        _yaml.safe_dump({"model": {"default": "old-model", "provider": "openrouter"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: ModelSwitchResult(
+            success=True,
+            new_model="gpt-5.5",
+            target_provider="openrouter",
+            provider_changed=False,
+            api_key="sk-test",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            provider_label="OpenRouter",
+        ),
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.config = GatewayConfig()
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._show_reasoning = False
+    runner.session_store = store
+    runner._session_options_locks = {}
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "old-model",
+        {"provider": "openrouter", "base_url": "", "api_key": ""},
+    )
+    return runner
+
+
+def _live_model(runner: GatewayRunner, key: str):
+    override = runner._session_state(key).conversation.model_override
+    return override.get("model") if override else None
+
+
+def _durable_model(store: SessionStore, key: str):
+    opts = store.get_runtime_options(key) or {}
+    override = opts.get("model_override")
+    return override.get("model") if override else None
+
+
+@pytest.mark.asyncio
+async def test_model_slash_fails_loudly_and_leaves_state_untouched_when_save_fails(
+    store_factory, tmp_path, monkeypatch
+):
+    store = store_factory()
+    store.get_or_create_session(_make_source())
+    runner = _model_runner(store, tmp_path, monkeypatch)
+    key = runner._session_key_for_source(_make_source())
+    notes_before = dict(getattr(runner, "_pending_model_notes", {}) or {})
+
+    def _fail(_data):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(store, "_save_sessions_json", _fail)
+
+    with pytest.raises(OSError):
+        await runner._handle_model_command(_event("/model gpt-5.5"))
+
+    assert _live_model(runner, key) is None
+    assert _durable_model(store, key) is None
+    assert dict(getattr(runner, "_pending_model_notes", {}) or {}) == notes_before
+    fresh = _model_runner(store_factory(), tmp_path, monkeypatch)
+    fresh._rehydrate_session_runtime_options(key)
+    assert _live_model(fresh, key) is None
+
+
+@pytest.mark.asyncio
+async def test_model_slash_is_durable_on_healthy_store(store_factory, tmp_path, monkeypatch):
+    store = store_factory()
+    store.get_or_create_session(_make_source())
+    runner = _model_runner(store, tmp_path, monkeypatch)
+    key = runner._session_key_for_source(_make_source())
+
+    reply = await runner._handle_model_command(_event("/model gpt-5.5"))
+
+    assert reply and "gpt-5.5" in reply
+    assert _live_model(runner, key) == "gpt-5.5"
+    assert _durable_model(store, key) == "gpt-5.5"
+    fresh = _model_runner(store_factory(), tmp_path, monkeypatch)
+    fresh._rehydrate_session_runtime_options(key)
+    assert _live_model(fresh, key) == "gpt-5.5"
+
+
+@pytest.mark.asyncio
+async def test_sibling_durable_write_during_model_once_persists_pre_once_model(
+    store_factory, tmp_path, monkeypatch
+):
+    """``/model --once`` is live-only (#29923). A ``/reasoning`` issued while
+    the one-turn override is live must persist the PRE-once model, and the
+    post-turn restore must leave live == durable."""
+    store = store_factory()
+    store.get_or_create_session(_make_source())
+    runner = _model_runner(store, tmp_path, monkeypatch)
+    key = runner._session_key_for_source(_make_source())
+
+    await runner._handle_model_command(_event("/model gpt-5.5 --once"))
+    assert _live_model(runner, key) == "gpt-5.5"
+    assert _durable_model(store, key) is None
+
+    await runner._handle_reasoning_command(_event("/reasoning high"))
+    assert _live_model(runner, key) == "gpt-5.5"  # one-turn override still live
+    assert _durable_model(store, key) is None  # but never persisted
+    assert store.get_runtime_options(key)["reasoning_override"] == {
+        "enabled": True,
+        "effort": "high",
+    }
+
+    runner._restore_pending_one_turn_model_override(key)
+    assert _live_model(runner, key) is None
+    fresh = _model_runner(store_factory(), tmp_path, monkeypatch)
+    fresh._rehydrate_session_runtime_options(key)
+    assert _live_model(fresh, key) is None
+    assert fresh._session_state(key).conversation.reasoning_override == {
+        "enabled": True,
+        "effort": "high",
+    }

--- a/tests/gateway/test_session_admission_lock.py
+++ b/tests/gateway/test_session_admission_lock.py
@@ -129,6 +129,7 @@ async def test_boot_resume_pre_claim_skips_session_under_options_transaction():
 
     async with session_admission_lock(runner, key):
         assert runner._schedule_resume_pending_sessions() == 0
+        assert entry.resume_pending is True  # left for the next pass
         assert runner._is_session_running(key) is False
 
     assert runner._schedule_resume_pending_sessions() == 1

--- a/tests/gateway/test_session_model_override_persistence.py
+++ b/tests/gateway/test_session_model_override_persistence.py
@@ -15,6 +15,7 @@ Covers:
   - api_key is NEVER serialized to sessions.json
 """
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -149,4 +150,182 @@ def test_sanitize_model_override():
         "model": "gpt-5o",
         "provider": "openai",
         "base_url": "https://api.openai.example/v1",
+    }
+
+
+def test_structured_runtime_options_persist_atomically_and_reset(store_factory, tmp_path):
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+
+    assert store.set_runtime_options(
+        session_key,
+        model_override=OVERRIDE,
+        reasoning_override={"enabled": True, "effort": "high"},
+        service_tier_override="normal",
+    )
+
+    restarted = store_factory()
+    assert restarted.get_runtime_options(session_key) == {
+        "model_override": {
+            "model": "gpt-5o",
+            "provider": "openai",
+            "base_url": "https://api.openai.example/v1",
+        },
+        "reasoning_override": {"enabled": True, "effort": "high"},
+        "service_tier_override": "normal",
+    }
+    assert "sk-SUPER-SECRET" not in _sessions_json(tmp_path)
+
+    restarted.reset_session(session_key)
+    assert restarted.get_runtime_options(session_key) == {
+        "model_override": None,
+        "reasoning_override": None,
+        "service_tier_override": None,
+    }
+
+
+def test_structured_runtime_options_roll_back_memory_when_save_fails(
+    store_factory, monkeypatch
+):
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    assert store.set_runtime_options(
+        session_key,
+        model_override=OVERRIDE,
+        reasoning_override={"enabled": True, "effort": "high"},
+        service_tier_override="priority",
+    )
+    before = store.get_runtime_options(session_key)
+
+    def _fail_save():
+        raise OSError("disk full")
+
+    monkeypatch.setattr(store, "_save", _fail_save)
+    with pytest.raises(OSError, match="disk full"):
+        store.set_runtime_options(
+            session_key,
+            model_override=None,
+            reasoning_override={"enabled": False},
+            service_tier_override="normal",
+        )
+
+    assert store.get_runtime_options(session_key) == before
+
+
+def test_runner_rehydrates_all_structured_runtime_options(store_factory):
+    store = store_factory()
+    entry = store.get_or_create_session(_make_source())
+    session_key = entry.session_key
+    store.set_runtime_options(
+        session_key,
+        model_override=OVERRIDE,
+        reasoning_override={"enabled": False},
+        service_tier_override="normal",
+    )
+
+    runner = _make_runner(store_factory())
+    with patch(
+        "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+        return_value={"api_key": "sk-live", "provider": "openai"},
+    ):
+        runner._rehydrate_session_runtime_options(session_key)
+
+    state = runner._session_state(session_key)
+    assert state.conversation.model_override["api_key"] == "sk-live"
+    assert state.conversation.reasoning_override == {"enabled": False}
+    assert state.conversation.service_tier_override is None
+    assert state.persistent.runtime_options_rehydrated is True
+
+
+@pytest.mark.asyncio
+async def test_public_session_options_api_applies_without_a_message_turn(store_factory):
+    from gateway.run import GatewayRunner
+
+    source = _make_source()
+    store = store_factory()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.session_store = store
+    runner._session_options_locks = {}
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "anthropic/claude-sonnet-4",
+        {"provider": "openrouter", "base_url": "", "api_key": ""},
+    )
+    runner._evict_cached_agent = lambda _session_key: None
+    runner._session_db = None
+
+    result = await runner.apply_session_options(
+        source,
+        {"reasoning_effort": "high", "fast": False, "initial": True},
+    )
+
+    assert result["status"] == "accepted"
+    assert result["applied"] == ["reasoning_effort", "fast"]
+    session_key = result["session_key"]
+    assert store.get_runtime_options(session_key) == {
+        "model_override": None,
+        "reasoning_override": {"enabled": True, "effort": "high"},
+        "service_tier_override": "normal",
+    }
+    assert runner._session_reasoning_overrides[session_key] == {
+        "enabled": True,
+        "effort": "high",
+    }
+    assert runner._session_service_tier_overrides[session_key] is None
+
+
+@pytest.mark.asyncio
+async def test_public_session_options_api_uses_native_model_validation(store_factory):
+    from gateway.run import GatewayRunner
+
+    source = _make_source()
+    store = store_factory()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.session_store = store
+    runner._session_options_locks = {}
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "old-model",
+        {"provider": "openrouter", "base_url": "", "api_key": ""},
+    )
+    runner._evict_cached_agent = lambda _session_key: None
+    runner._session_db = None
+    selected = SimpleNamespace(
+        success=True,
+        new_model="gpt-5",
+        target_provider="openai",
+        api_key="sk-live-only",
+        base_url="https://api.openai.com/v1",
+        api_mode="responses",
+        model_info=None,
+        warning_message="",
+    )
+
+    with (
+        patch("gateway.run._load_gateway_config", return_value={}),
+        patch("hermes_cli.model_switch.switch_model", return_value=selected),
+        patch(
+            "hermes_cli.model_selection_guards.combined_selection_warning",
+            return_value=None,
+        ),
+    ):
+        result = await runner.apply_session_options(
+            source,
+            {
+                "model": "gpt-5",
+                "provider": "openai",
+                "confirm_model_selection": True,
+                "initial": True,
+            },
+        )
+
+    assert result["status"] == "accepted"
+    assert result["effective"]["model"] == "gpt-5"
+    persisted = store.get_runtime_options(result["session_key"])
+    assert persisted["model_override"] == {
+        "model": "gpt-5",
+        "provider": "openai",
+        "base_url": "https://api.openai.com/v1",
     }

--- a/tests/gateway/test_session_options_busy_barrier.py
+++ b/tests/gateway/test_session_options_busy_barrier.py
@@ -1,0 +1,235 @@
+"""apply_session_options() must rendezvous with turn admission (#92185).
+
+Reviewer finding 2 on #92187: ``apply_gateway_session_options`` reads
+``_is_session_running`` once, *before* it yields to the event loop, and never
+re-checks. A turn admitted during any of its awaits is therefore invisible to
+it and the call returns ``accepted`` while the session is busy.
+
+These tests are the deterministic barrier the review asked for: pause the
+options coroutine after its idle observation (at a real await seam), admit a
+turn the same way ``_handle_message`` does, resume, and require a
+``session_busy`` rejection with no durable write and no live mutation.
+"""
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import _AGENT_PENDING_SENTINEL, GatewayRunner
+from gateway.session import AsyncSessionStore, SessionSource, SessionStore
+from gateway.session_state import SERVICE_TIER_UNSET
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch) -> SessionStore:
+    def _raise():
+        raise RuntimeError("SQLite disabled in test")
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _raise)
+    built = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    assert built._db is None
+    return built
+
+
+def _make_runner(store: SessionStore) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.session_store = store
+    runner._session_options_locks = {}
+    runner._session_db = None
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "old-model",
+        {"provider": "openrouter", "base_url": "", "api_key": ""},
+    )
+    runner.evictions = []
+    runner._evict_cached_agent = lambda session_key: runner.evictions.append(session_key)
+    return runner
+
+
+def _admit_turn(runner: GatewayRunner, session_key: str) -> int:
+    """Mirror the synchronous claim block in ``_handle_message``.
+
+    gateway/run.py:18176-18182 — claim the slot (sentinel + started_ts) and
+    bump the run generation before any await. ``_claim_active_session_slot``
+    returns ``(None, None)`` when ``max_concurrent_sessions`` is unset, so the
+    lease assignment is a no-op in the default configuration.
+    """
+    state = runner._session_state(session_key)
+    state.turn.agent = _AGENT_PENDING_SENTINEL
+    state.turn.started_ts = 0.0
+    return runner._begin_session_run_generation(session_key)
+
+
+class _PausingStore(AsyncSessionStore):
+    """AsyncSessionStore whose first get_or_create_session parks on a gate."""
+
+    def __init__(self, inner: SessionStore, reached: asyncio.Event, gate: asyncio.Event):
+        super().__init__(inner)
+        self._reached = reached
+        self._gate = gate
+
+    async def get_or_create_session(self, *args, **kwargs):
+        self._reached.set()
+        await self._gate.wait()
+        return await asyncio.to_thread(self._store.get_or_create_session, *args, **kwargs)
+
+
+def _assert_untouched(runner: GatewayRunner, store: SessionStore, session_key: str) -> None:
+    durable = store.get_runtime_options(session_key)
+    assert durable in (
+        None,
+        {"model_override": None, "reasoning_override": None, "service_tier_override": None},
+    ), durable
+    state = runner._session_state(session_key)
+    assert state.conversation.model_override is None
+    assert state.conversation.reasoning_override is None
+    assert state.conversation.service_tier_override is SERVICE_TIER_UNSET
+    assert runner.evictions == []
+    assert not getattr(runner, "_pending_model_notes", {})
+
+
+@pytest.mark.asyncio
+async def test_turn_admitted_during_persist_await_is_rejected(store):
+    """Reasoning-only patch: the only awaits after the idle check are the two
+    store calls (session_options.py:254-255). Pause inside the first one."""
+    runner = _make_runner(store)
+    source = _make_source()
+    session_key = runner._session_key_for_source(
+        runner._normalize_source_for_session_key(source)
+    )
+    reached, gate = asyncio.Event(), asyncio.Event()
+    runner._async_session_store = _PausingStore(store, reached, gate)
+
+    options_task = asyncio.create_task(
+        runner.apply_session_options(source, {"reasoning_effort": "high"})
+    )
+    await asyncio.wait_for(reached.wait(), timeout=2.0)
+    assert runner._is_session_running(session_key) is False  # idle was observed
+
+    _admit_turn(runner, session_key)
+    assert runner._is_session_running(session_key) is True
+
+    gate.set()
+    result = await asyncio.wait_for(options_task, timeout=2.0)
+
+    assert result["status"] == "rejected", result
+    assert result["code"] == "session_busy", result
+    _assert_untouched(runner, store, session_key)
+
+
+@pytest.mark.asyncio
+async def test_turn_admitted_during_model_resolution_is_rejected(store):
+    """Model patch: ``switch_model`` runs on a worker thread
+    (session_options.py:149). Park the worker, admit a turn on the loop."""
+    runner = _make_runner(store)
+    runner._async_session_store = AsyncSessionStore(store)
+    source = _make_source()
+    session_key = runner._session_key_for_source(
+        runner._normalize_source_for_session_key(source)
+    )
+    loop = asyncio.get_running_loop()
+    reached = asyncio.Event()
+    release = threading.Event()
+
+    def _blocking_switch_model(**_kwargs):
+        loop.call_soon_threadsafe(reached.set)
+        assert release.wait(timeout=5.0), "test did not release switch_model"
+        return SimpleNamespace(
+            success=True,
+            new_model="gpt-5",
+            target_provider="openai",
+            api_key="sk-live-only",
+            base_url="https://api.openai.com/v1",
+            api_mode="responses",
+            model_info=None,
+            warning_message="",
+        )
+
+    with (
+        patch("gateway.run._load_gateway_config", return_value={}),
+        patch("hermes_cli.model_switch.switch_model", _blocking_switch_model),
+        patch(
+            "hermes_cli.model_selection_guards.combined_selection_warning",
+            return_value=None,
+        ),
+    ):
+        options_task = asyncio.create_task(
+            runner.apply_session_options(
+                source,
+                {"model": "gpt-5", "provider": "openai", "confirm_model_selection": True},
+            )
+        )
+        await asyncio.wait_for(reached.wait(), timeout=2.0)
+        assert runner._is_session_running(session_key) is False
+
+        _admit_turn(runner, session_key)
+
+        release.set()
+        result = await asyncio.wait_for(options_task, timeout=5.0)
+
+    assert result["status"] == "rejected", result
+    assert result["code"] == "session_busy", result
+    _assert_untouched(runner, store, session_key)
+
+
+@pytest.mark.asyncio
+async def test_turn_arriving_mid_transaction_waits_for_commit(store):
+    """Shared-exclusion direction: a turn whose claim block runs while an
+    options transaction is in flight must wait for the commit, then admit
+    and see the committed values (it must not be rejected or race)."""
+    runner = _make_runner(store)
+    source = _make_source()
+    session_key = runner._session_key_for_source(
+        runner._normalize_source_for_session_key(source)
+    )
+    reached, gate = asyncio.Event(), asyncio.Event()
+    runner._async_session_store = _PausingStore(store, reached, gate)
+
+    options_task = asyncio.create_task(
+        runner.apply_session_options(source, {"reasoning_effort": "high"})
+    )
+    await asyncio.wait_for(reached.wait(), timeout=2.0)
+
+    async def _admission():
+        # Same shape as the claim block in _handle_message: take the shared
+        # per-session lock, then claim synchronously.
+        from gateway.session_options import session_admission_lock
+
+        async with session_admission_lock(runner, session_key):
+            return _admit_turn(runner, session_key)
+
+    admit_task = asyncio.create_task(_admission())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert not admit_task.done()  # parked behind the in-flight transaction
+    assert runner._is_session_running(session_key) is False
+
+    gate.set()
+    result = await asyncio.wait_for(options_task, timeout=2.0)
+    await asyncio.wait_for(admit_task, timeout=2.0)
+
+    assert result["status"] == "accepted", result
+    assert runner._is_session_running(session_key) is True
+    assert store.get_runtime_options(session_key)["reasoning_override"] == {
+        "enabled": True,
+        "effort": "high",
+    }
+    assert runner._session_state(session_key).conversation.reasoning_override == {
+        "enabled": True,
+        "effort": "high",
+    }

--- a/tests/gateway/test_session_options_cancel_mid_persist.py
+++ b/tests/gateway/test_session_options_cancel_mid_persist.py
@@ -2,14 +2,22 @@
 
 The durable write runs in a worker thread (AsyncSessionStore -> to_thread);
 cancelling the awaiting task does not un-write the file. The primitive must
-therefore finish the persist+assign unit before propagating the cancellation,
-so live SessionState always matches what landed on disk.
+therefore settle the persist+assign unit -- under the admission lock, across
+arbitrarily repeated cancellation -- before propagating the cancellation, so
+live SessionState always matches what landed on disk and no competing
+admission can enter while the two are divergent.
 """
 import asyncio
+import logging
 import threading
+from unittest.mock import AsyncMock
 
 import pytest
 
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+from gateway.session_options import session_admission_lock
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
 from tests.gateway.test_session_options_rejections import (
     _make_runner,
     _make_source,
@@ -17,13 +25,12 @@ from tests.gateway.test_session_options_rejections import (
 )
 
 
-@pytest.mark.asyncio
-async def test_cancel_during_persist_still_assigns_live_to_match_disk(store, monkeypatch):
-    runner = _make_runner(store)
-    source = _make_source()
-    key = runner._session_key_for_source(runner._normalize_source_for_session_key(source))
-    store.get_or_create_session(source)
+def _key(runner, source):
+    return runner._session_key_for_source(runner._normalize_source_for_session_key(source))
 
+
+def _park_runtime_options_save(store, monkeypatch):
+    """Block the save that carries a runtime-options write until released."""
     entered = threading.Event()
     release = threading.Event()
     real_save = store._save_sessions_json
@@ -31,14 +38,27 @@ async def test_cancel_during_persist_still_assigns_live_to_match_disk(store, mon
     def _slow_save(data):
         # get_or_create_session also saves (last_active); only park the save
         # that carries the runtime-options write.
-        if any(
-            (entry or {}).get("reasoning_override") for entry in data.values()
-        ):
+        if any((entry or {}).get("reasoning_override") for entry in data.values()):
             entered.set()
             assert release.wait(5), "test never released the write"
         return real_save(data)
 
     monkeypatch.setattr(store, "_save_sessions_json", _slow_save)
+    return entered, release
+
+
+async def _settle_loop(n: int = 5) -> None:
+    for _ in range(n):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_persist_still_assigns_live_to_match_disk(store, monkeypatch):
+    runner = _make_runner(store)
+    source = _make_source()
+    key = _key(runner, source)
+    store.get_or_create_session(source)
+    entered, release = _park_runtime_options_save(store, monkeypatch)
 
     task = asyncio.create_task(
         runner.apply_session_options(source, {"reasoning_effort": "high"})
@@ -57,3 +77,266 @@ async def test_cancel_during_persist_still_assigns_live_to_match_disk(store, mon
     # The lock was released on the way out: a follow-up call is not wedged.
     again = await runner.apply_session_options(source, {"reasoning_effort": "low"})
     assert again["status"] == "accepted"
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_keeps_admission_lock_until_unit_settles(
+    store, monkeypatch
+):
+    """Cancel once, cancel again while settling (and again), admit a competitor:
+    the lock stays held and live stays untouched until persist+assign finish."""
+    runner = _make_runner(store)
+    source = _make_source()
+    key = _key(runner, source)
+    store.get_or_create_session(source)
+    entered, release = _park_runtime_options_save(store, monkeypatch)
+    lock = session_admission_lock(runner, key)
+
+    apply = asyncio.create_task(
+        runner.apply_session_options(source, {"reasoning_effort": "high"})
+    )
+    await asyncio.to_thread(entered.wait, 5)
+    assert lock.locked()
+
+    # Cancel #1 (shielded await), then #2 and #3 while the caller is settling.
+    for _ in range(3):
+        apply.cancel()
+        await _settle_loop()
+        assert not apply.done(), "caller surfaced cancellation before settlement"
+        assert lock.locked(), "admission lock released with the unit in flight"
+
+    # A competing admission arrives while the write is still blocked: it must
+    # park on the lock, not enter.
+    competitor = asyncio.create_task(
+        runner.apply_session_options(source, {"reasoning_effort": "low"})
+    )
+    await _settle_loop()
+    assert not competitor.done(), "competing admission entered under an unsettled commit"
+    # (No sync store read here: the parked writer holds the store lock.)
+    assert runner._session_state(key).conversation.reasoning_override is None
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await apply
+    assert apply.cancelled()
+
+    # The competitor validated against the pre-commit live triple and entered
+    # only after persist+assign were terminal, so its in-lock CAS sees the
+    # settled change and rejects with `conflict` -- never a commit on top of a
+    # half-applied unit. A re-read retry then lands on the settled state.
+    result = await competitor
+    assert (result["status"], result["code"]) == ("rejected", "conflict")
+    durable = (store.get_runtime_options(key) or {}).get("reasoning_override")
+    live = runner._session_state(key).conversation.reasoning_override
+    assert durable == live == {"enabled": True, "effort": "high"}
+    retry = await runner.apply_session_options(source, {"reasoning_effort": "low"})
+    assert retry["status"] == "accepted"
+    durable = (store.get_runtime_options(key) or {}).get("reasoning_override")
+    live = runner._session_state(key).conversation.reasoning_override
+    assert durable == live == {"enabled": True, "effort": "low"}
+    assert not lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_durable_write_failure_behind_cancellation_is_observed(
+    store, monkeypatch, caplog
+):
+    """Cancelled caller + failing write: live untouched, failure logged (not an
+    unobserved task exception), caller still ends cancelled, lock released."""
+    runner = _make_runner(store)
+    source = _make_source()
+    key = _key(runner, source)
+    store.get_or_create_session(source)
+    entered = threading.Event()
+    release = threading.Event()
+
+    def _failing_save(data):
+        if any((entry or {}).get("reasoning_override") for entry in data.values()):
+            entered.set()
+            assert release.wait(5)
+            raise OSError(28, "No space left on device")
+        return None
+
+    monkeypatch.setattr(store, "_save_sessions_json", _failing_save)
+
+    apply = asyncio.create_task(
+        runner.apply_session_options(source, {"reasoning_effort": "high"})
+    )
+    await asyncio.to_thread(entered.wait, 5)
+    apply.cancel()
+    await _settle_loop()
+    apply.cancel()
+    release.set()
+    with caplog.at_level(logging.WARNING, logger="gateway.session_options"):
+        with pytest.raises(asyncio.CancelledError):
+            await apply
+    assert apply.cancelled()
+    assert any("failed while the caller was cancelled" in r.getMessage() for r in caplog.records)
+
+    assert runner._session_state(key).conversation.reasoning_override is None
+    assert (store.get_runtime_options(key) or {}).get("reasoning_override") is None
+    assert not session_admission_lock(runner, key).locked()
+
+
+@pytest.mark.asyncio
+async def test_external_cancel_during_settlement_survives_enclosing_asyncio_timeout(
+    store, monkeypatch
+):
+    """apply_session_options under asyncio.timeout: the timeout fires (cancel #1,
+    absorbed by the settle loop), then an external cancel #2 arrives while the
+    write is still parked. The settle loop must NOT uncancel(): the task's
+    cancelling() count stays 2, so timeout.__aexit__ sees a cancel it did not
+    initiate and lets CancelledError propagate. The caller ends cancelled,
+    never resumes with TimeoutError."""
+    runner = _make_runner(store)
+    source = _make_source()
+    store.get_or_create_session(source)
+    entered, release = _park_runtime_options_save(store, monkeypatch)
+    loop = asyncio.get_running_loop()
+    resumed = asyncio.Event()
+    tm = asyncio.timeout(60)
+
+    async def caller():
+        try:
+            async with tm:
+                await runner.apply_session_options(source, {"reasoning_effort": "high"})
+        except TimeoutError:
+            pass
+        resumed.set()
+        return "resumed"
+
+    task = asyncio.create_task(caller())
+    await asyncio.to_thread(entered.wait, 5)
+    tm.reschedule(loop.time())  # timeout -> cancel #1 (absorbed, still settling)
+    await _settle_loop()
+    assert not task.done()
+    assert task.cancelling() == 1
+    task.cancel()  # external cancel #2 during settlement
+    assert task.cancelling() == 2
+    await _settle_loop()
+    assert not task.done()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+    assert not resumed.is_set()
+
+
+# ---------------------------------------------------------------------------
+# (e) competing REAL inbound turn (_handle_message) parks behind settlement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_parks_real_inbound_turn_until_unit_settles(
+    store, monkeypatch
+):
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="park-chat")
+    session_key = runner._session_key_for_source(source)
+
+    # Real store + the commit machinery on top of the restart harness.
+    runner.session_store = store
+    runner._session_options_locks = {}
+    runner._session_db = None
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "old-model",
+        {"provider": "openrouter", "base_url": "", "api_key": ""},
+    )
+    runner._evict_cached_agent = lambda _session_key: None
+
+    runner._handle_message = GatewayRunner._handle_message.__get__(runner, GatewayRunner)
+    runner._release_running_agent_state = (
+        GatewayRunner._release_running_agent_state.__get__(runner, GatewayRunner)
+    )
+    runner._check_slash_access = lambda *a, **k: None
+    runner._begin_session_run_generation = lambda session_key: 1
+    runner._is_session_run_current = lambda session_key, generation: True
+    runner._invalidate_session_run_generation = lambda *a, **k: 0
+    runner._claim_active_session_slot = lambda session_key, source: (object(), None)
+    runner._active_session_leases = {}
+    runner._busy_ack_ts = {}
+    runner._post_turn_goal_continuation = AsyncMock()
+    runner._is_user_authorized = lambda _source: True
+    agent_runs: list[str] = []
+
+    async def _fake_run(event, source, _quick_key, run_generation):
+        agent_runs.append(_quick_key)
+        return "OK"
+
+    runner._handle_message_with_agent = _fake_run
+    adapter.set_message_handler(runner._handle_message)
+    adapter.send = AsyncMock()
+    adapter._keep_typing = AsyncMock()
+    adapter._stop_typing_refresh = AsyncMock()
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+    adapter._run_processing_hook = AsyncMock()
+
+    store.get_or_create_session(source)
+    entered, release = _park_runtime_options_save(store, monkeypatch)
+    lock = session_admission_lock(runner, session_key)
+
+    apply = asyncio.create_task(
+        runner.apply_session_options(source, {"reasoning_effort": "high"})
+    )
+    await asyncio.to_thread(entered.wait, 5)
+    assert lock.locked()
+
+    for _ in range(2):
+        apply.cancel()
+        await _settle_loop()
+        assert not apply.done()
+        assert lock.locked()
+
+    inbound = MessageEvent(text="hello", message_type=MessageType.TEXT, source=source)
+    turn = asyncio.create_task(runner._handle_message(inbound))
+    await _settle_loop()
+    assert not turn.done(), "real inbound turn admitted under an unsettled commit"
+    assert agent_runs == []
+    assert runner._is_session_running(session_key) is False
+    assert runner._session_state(session_key).conversation.reasoning_override is None
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await apply
+    assert apply.cancelled()
+    assert await asyncio.wait_for(turn, timeout=2.0) == "OK"
+    assert agent_runs == [session_key]
+    durable = (store.get_runtime_options(session_key) or {}).get("reasoning_override")
+    live = runner._session_state(session_key).conversation.reasoning_override
+    assert durable == live == {"enabled": True, "effort": "high"}
+    assert not lock.locked()
+
+
+# ---------------------------------------------------------------------------
+# (a) cancel landing in the same iteration the unit completes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_in_the_iteration_the_unit_completes(store, monkeypatch):
+    """Release the write, then cancel on the very next loop step so the cancel
+    races the shield's inner-done callback; live must equal disk and the lock
+    must be free afterwards."""
+    runner = _make_runner(store)
+    source = _make_source()
+    key = _key(runner, source)
+    store.get_or_create_session(source)
+    entered, release = _park_runtime_options_save(store, monkeypatch)
+    lock = session_admission_lock(runner, key)
+    apply = asyncio.create_task(
+        runner.apply_session_options(source, {"reasoning_effort": "high"})
+    )
+    await asyncio.to_thread(entered.wait, 5)
+
+    release.set()
+    # Cancel on EVERY loop step until the caller is terminal, so one cancel
+    # lands in the very iteration the unit completes.
+    while not apply.done():
+        apply.cancel()
+        await asyncio.sleep(0)
+    assert apply.cancelled()
+    durable = (store.get_runtime_options(key) or {}).get("reasoning_override")
+    live = runner._session_state(key).conversation.reasoning_override
+    assert durable == live == {"enabled": True, "effort": "high"}
+    assert not lock.locked()

--- a/tests/gateway/test_session_options_cancel_mid_persist.py
+++ b/tests/gateway/test_session_options_cancel_mid_persist.py
@@ -1,0 +1,59 @@
+"""A cancelled apply_session_options() task cannot leave disk ahead of live.
+
+The durable write runs in a worker thread (AsyncSessionStore -> to_thread);
+cancelling the awaiting task does not un-write the file. The primitive must
+therefore finish the persist+assign unit before propagating the cancellation,
+so live SessionState always matches what landed on disk.
+"""
+import asyncio
+import threading
+
+import pytest
+
+from tests.gateway.test_session_options_rejections import (
+    _make_runner,
+    _make_source,
+    store,  # noqa: F401  (fixture re-export)
+)
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_persist_still_assigns_live_to_match_disk(store, monkeypatch):
+    runner = _make_runner(store)
+    source = _make_source()
+    key = runner._session_key_for_source(runner._normalize_source_for_session_key(source))
+    store.get_or_create_session(source)
+
+    entered = threading.Event()
+    release = threading.Event()
+    real_save = store._save_sessions_json
+
+    def _slow_save(data):
+        # get_or_create_session also saves (last_active); only park the save
+        # that carries the runtime-options write.
+        if any(
+            (entry or {}).get("reasoning_override") for entry in data.values()
+        ):
+            entered.set()
+            assert release.wait(5), "test never released the write"
+        return real_save(data)
+
+    monkeypatch.setattr(store, "_save_sessions_json", _slow_save)
+
+    task = asyncio.create_task(
+        runner.apply_session_options(source, {"reasoning_effort": "high"})
+    )
+    # Park the task inside the worker-thread write, then cancel it.
+    await asyncio.to_thread(entered.wait, 5)
+    task.cancel()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    durable = (store.get_runtime_options(key) or {}).get("reasoning_override")
+    live = runner._session_state(key).conversation.reasoning_override
+    assert durable == live, f"disk {durable!r} != live {live!r}"
+    assert durable == {"enabled": True, "effort": "high"}
+    # The lock was released on the way out: a follow-up call is not wedged.
+    again = await runner.apply_session_options(source, {"reasoning_effort": "low"})
+    assert again["status"] == "accepted"

--- a/tests/gateway/test_session_options_cancel_mid_persist.py
+++ b/tests/gateway/test_session_options_cancel_mid_persist.py
@@ -1,6 +1,6 @@
 """A cancelled apply_session_options() task cannot leave disk ahead of live.
 
-The durable write runs in a worker thread (AsyncSessionStore -> to_thread);
+The durable write runs in a worker thread (AsyncSessionStore -> executor);
 cancelling the awaiting task does not un-write the file. The primitive must
 therefore settle the persist+assign unit -- under the admission lock, across
 arbitrarily repeated cancellation -- before propagating the cancellation, so

--- a/tests/gateway/test_session_options_commit_contract.py
+++ b/tests/gateway/test_session_options_commit_contract.py
@@ -1,0 +1,584 @@
+"""Contract of the shared runtime-options commit (#92185, review on #92187).
+
+Every per-session runtime mutation — the structured host API and the
+``/model``, ``/reasoning``, ``/fast`` slash commands — goes through one
+durable-first primitive under one per-session admission lock. These tests pin
+the behaviours that fall out of that single seam:
+
+* a user slash command that lands while the host API is still validating
+  stays authoritative (the API is refused with ``conflict``);
+* an inbound turn whose claim runs during an in-flight API commit parks
+  behind it and then runs exactly once (real ``_handle_message`` path);
+* first-touch rehydration after a restart never clobbers a live one-shot
+  override, and the one-shot restore puts the persisted override back;
+* an API write on an idle-expired session consumes the auto-reset boundary
+  and never resurrects the previous conversation's overrides;
+* re-asserting the current options is a no-op (no durable write, no agent
+  eviction, no "switched from X to X" note);
+* a durable model commit supersedes a pending ``/model --once`` restore.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, SessionResetPolicy
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
+from gateway.run import _AGENT_PENDING_SENTINEL, GatewayRunner
+from gateway.session import SessionEntry, SessionSource, SessionStore
+from gateway.session_options import session_admission_lock
+from gateway.session_state import SERVICE_TIER_UNSET
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+def _src() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=_src())
+
+
+@pytest.fixture
+def store_factory(tmp_path, monkeypatch):
+    """SessionStores over one shared sessions dir, without SQLite."""
+
+    def _raise():
+        raise RuntimeError("SQLite disabled in test")
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _raise)
+
+    def _make(cfg: GatewayConfig | None = None) -> SessionStore:
+        store = SessionStore(sessions_dir=tmp_path / "sessions", config=cfg or GatewayConfig())
+        assert store._db is None
+        return store
+
+    return _make
+
+
+def _runner(store: SessionStore, cfg: GatewayConfig | None = None) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.config = cfg or GatewayConfig()
+    runner.session_store = store
+    runner._session_db = None
+    runner._session_options_locks = {}
+    runner.evictions = []
+    runner._evict_cached_agent = lambda key: runner.evictions.append(key)
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "old-model",
+        {"provider": "openrouter", "base_url": "", "api_key": ""},
+    )
+    return runner
+
+
+def _switch_result(model: str = "gpt-5") -> SimpleNamespace:
+    return SimpleNamespace(
+        success=True,
+        new_model=model,
+        target_provider="openai",
+        api_key="sk-live-only",
+        base_url="https://api.openai.com/v1",
+        api_mode="responses",
+        model_info=None,
+        warning_message="",
+        error_message="",
+    )
+
+
+def _durable(store: SessionStore, key: str) -> dict:
+    return store.get_runtime_options(key) or {}
+
+
+# ---------------------------------------------------------------------------
+# Slash vs API: later user-issued slash commands stay authoritative
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_slash_during_api_validation_stays_authoritative(store_factory):
+    """Slash dispatch runs before the turn claim, so a ``/reasoning`` on an
+    idle session never flips the busy gate. The API validated against a
+    snapshot that the user has since moved: it must refuse, not overwrite."""
+    store = store_factory()
+    key = store.get_or_create_session(_src()).session_key
+    runner = _runner(store)
+    loop = asyncio.get_running_loop()
+    reached, release = asyncio.Event(), threading.Event()
+
+    def _slow_switch(**_kwargs):
+        loop.call_soon_threadsafe(reached.set)
+        assert release.wait(timeout=5.0), "test did not release switch_model"
+        return _switch_result()
+
+    with (
+        patch("gateway.run._load_gateway_config", return_value={}),
+        patch("hermes_cli.model_switch.switch_model", _slow_switch),
+        patch(
+            "hermes_cli.model_selection_guards.combined_selection_warning",
+            return_value=None,
+        ),
+    ):
+        api_task = asyncio.create_task(
+            runner.apply_session_options(_src(), {"model": "gpt-5"})
+        )
+        await asyncio.wait_for(reached.wait(), timeout=2.0)
+        # The user's slash write lands while the API is in its worker hop.
+        await runner._set_session_reasoning_override(
+            key, {"enabled": True, "effort": "low"}
+        )
+        release.set()
+        result = await asyncio.wait_for(api_task, timeout=5.0)
+
+    assert (result["status"], result["code"]) == ("rejected", "conflict"), result
+    low = {"enabled": True, "effort": "low"}
+    assert runner._session_state(key).conversation.reasoning_override == low
+    assert _durable(store, key)["reasoning_override"] == low
+    assert runner._session_state(key).conversation.model_override is None
+    assert _durable(store, key)["model_override"] is None
+    assert runner.evictions == []
+
+
+@pytest.mark.asyncio
+async def test_api_commit_and_slash_commit_serialise_on_the_same_lock(store_factory):
+    """Both writers hold the admission lock across persist + live mutation, so
+    their steps cannot interleave: the later writer sees the earlier commit."""
+    store = store_factory()
+    key = store.get_or_create_session(_src()).session_key
+    runner = _runner(store)
+    entered = asyncio.Event()
+    gate = asyncio.Event()
+    real_store_set = store.set_runtime_options
+    calls: list[str] = []
+
+    def _slow_set(*args, **kwargs):
+        calls.append("set")
+        return real_store_set(*args, **kwargs)
+
+    class _GatedStore:
+        """Async facade that parks the API's get_or_create inside the lock."""
+
+        def __init__(self, inner):
+            self._store = inner
+
+        async def get_or_create_session(self, *a, **k):
+            entered.set()
+            await gate.wait()
+            return await asyncio.to_thread(self._store.get_or_create_session, *a, **k)
+
+        def __getattr__(self, name):
+            attr = getattr(self._store, name)
+
+            async def _offloaded(*a, **k):
+                return await asyncio.to_thread(attr, *a, **k)
+
+            return _offloaded
+
+    runner._async_session_store = _GatedStore(store)
+    store.set_runtime_options = _slow_set  # type: ignore[method-assign]
+
+    api_task = asyncio.create_task(
+        runner.apply_session_options(_src(), {"reasoning_effort": "high"})
+    )
+    await asyncio.wait_for(entered.wait(), timeout=2.0)
+    slash_task = asyncio.create_task(
+        runner._set_session_service_tier_override(key, "priority")
+    )
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert not slash_task.done()  # parked behind the API's lock
+    assert calls == []
+
+    gate.set()
+    result = await asyncio.wait_for(api_task, timeout=2.0)
+    await asyncio.wait_for(slash_task, timeout=2.0)
+
+    assert result["status"] == "accepted", result
+    assert calls == ["set", "set"]
+    conv = runner._session_state(key).conversation
+    assert conv.reasoning_override == {"enabled": True, "effort": "high"}
+    assert conv.service_tier_override == "priority"
+    assert _durable(store, key) == {
+        "model_override": None,
+        "reasoning_override": {"enabled": True, "effort": "high"},
+        "service_tier_override": "priority",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Real _handle_message claim parks behind an in-flight commit, runs once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbound_turn_parks_behind_in_flight_commit_then_runs_once():
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="park-chat")
+    session_key = runner._session_key_for_source(source)
+
+    runner._handle_message = GatewayRunner._handle_message.__get__(runner, GatewayRunner)
+    runner._release_running_agent_state = (
+        GatewayRunner._release_running_agent_state.__get__(runner, GatewayRunner)
+    )
+    runner._check_slash_access = lambda *a, **k: None
+    runner._begin_session_run_generation = lambda session_key: 1
+    runner._is_session_run_current = lambda session_key, generation: True
+    runner._invalidate_session_run_generation = lambda *a, **k: 0
+    runner._claim_active_session_slot = lambda session_key, source: (object(), None)
+    runner._active_session_leases = {}
+    runner._busy_ack_ts = {}
+    runner._post_turn_goal_continuation = AsyncMock()
+    runner._is_user_authorized = lambda _source: True
+    runner.session_store.get_or_create_session.return_value = None
+    agent_runs: list[str] = []
+
+    async def _fake_run(event, source, _quick_key, run_generation):
+        agent_runs.append(_quick_key)
+        return "OK"
+
+    runner._handle_message_with_agent = _fake_run
+    adapter.set_message_handler(runner._handle_message)
+    adapter.send = AsyncMock()
+    adapter._keep_typing = AsyncMock()
+    adapter._stop_typing_refresh = AsyncMock()
+    adapter._send_with_retry = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+    adapter._run_processing_hook = AsyncMock()
+
+    inbound = MessageEvent(text="hello", message_type=MessageType.TEXT, source=source)
+
+    # Hold the session's admission lock as an in-flight options commit would.
+    lock = session_admission_lock(runner, session_key)
+    await lock.acquire()
+    try:
+        turn = asyncio.create_task(runner._handle_message(inbound))
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert not turn.done()
+        assert agent_runs == []
+        assert runner._is_session_running(session_key) is False
+    finally:
+        lock.release()
+
+    assert await asyncio.wait_for(turn, timeout=2.0) == "OK"
+    assert agent_runs == [session_key]
+    assert runner._is_session_running(session_key) is False
+
+
+# ---------------------------------------------------------------------------
+# Boot-resume pre-claim skip: the skipped session is resumed by the next pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_boot_resume_skipped_session_resumes_once_lock_is_free():
+    runner, adapter = make_restart_runner()
+    runner._is_user_authorized = lambda _source: True
+    runner._restart_loop_guard_config = lambda: (0, 0, 0)
+    runner._run_startup_resume_event = AsyncMock()
+    adapter.handle_message = AsyncMock()
+    source = make_restart_source(chat_id="held-chat")
+    key = runner._session_key_for_source(source)
+    entry = SessionEntry(
+        session_key=key,
+        session_id="sid",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        resume_pending=True,
+        resume_reason="restart_timeout",
+        last_resume_marked_at=datetime.now(),
+    )
+    runner.session_store._entries = {key: entry}
+
+    async with session_admission_lock(runner, key):
+        assert runner._schedule_resume_pending_sessions() == 0
+        assert entry.resume_pending is True  # left for the next pass
+        assert runner._is_session_running(key) is False
+
+    assert runner._schedule_resume_pending_sessions() == 1
+    assert runner._is_session_running(key) is True
+
+
+# ---------------------------------------------------------------------------
+# Rehydrate never clobbers a live one-shot override
+# ---------------------------------------------------------------------------
+
+
+def _model_runner(store: SessionStore, tmp_path, monkeypatch, switched_to: str) -> GatewayRunner:
+    import yaml as _yaml
+
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        _yaml.safe_dump({"model": {"default": "old-model", "provider": "openrouter"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: ModelSwitchResult(
+            success=True,
+            new_model=switched_to,
+            target_provider="openrouter",
+            provider_changed=False,
+            api_key="sk-test",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            provider_label="OpenRouter",
+        ),
+    )
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
+
+    runner = _runner(store)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._show_reasoning = False
+    return runner
+
+
+def _live_model(runner: GatewayRunner, key: str):
+    override = runner._session_state(key).conversation.model_override
+    return override.get("model") if override else None
+
+
+@pytest.mark.asyncio
+async def test_rehydrate_never_clobbers_a_live_one_shot_override(
+    store_factory, tmp_path, monkeypatch
+):
+    """Restart with a persisted /model Y; the first action is ``/model X --once``.
+    The turn must run X (not be swapped back to Y by the first-touch
+    rehydrate) and the post-turn restore must put Y back, live AND durable."""
+    store = store_factory()
+    key = store.get_or_create_session(_src()).session_key
+    store.set_runtime_options(
+        key,
+        model_override={"model": "persisted-y", "provider": "openrouter"},
+        reasoning_override=None,
+        service_tier_override=None,
+    )
+    runner = _model_runner(store, tmp_path, monkeypatch, switched_to="once-x")
+    assert runner._session_state(key).persistent.runtime_options_rehydrated is False
+
+    await runner._handle_model_command(_event("/model once-x --once"))
+    assert _live_model(runner, key) == "once-x"
+
+    # Every first-touch reader of the runtime rehydrates; it must not clobber.
+    runner._rehydrate_session_runtime_options(key)
+    assert _live_model(runner, key) == "once-x"
+    assert _durable(store, key)["model_override"]["model"] == "persisted-y"
+
+    runner._restore_pending_one_turn_model_override(key)
+    assert _live_model(runner, key) == "persisted-y"
+    assert _durable(store, key)["model_override"]["model"] == "persisted-y"
+
+
+def test_rehydrate_fills_only_fields_still_at_default(store_factory):
+    store = store_factory()
+    key = store.get_or_create_session(_src()).session_key
+    store.set_runtime_options(
+        key,
+        model_override={"model": "persisted-y", "provider": "openrouter"},
+        reasoning_override={"enabled": True, "effort": "high"},
+        service_tier_override="priority",
+    )
+    runner = _runner(store)
+    conv = runner._session_state(key).conversation
+    # A /moa-style live override installed before the first rehydrate touch.
+    conv.model_override = {"provider": "moa", "model": "preset-a", "base_url": "moa://local"}
+
+    runner._rehydrate_session_runtime_options(key)
+
+    assert conv.model_override["provider"] == "moa"  # live wins
+    assert conv.reasoning_override == {"enabled": True, "effort": "high"}  # filled
+    assert conv.service_tier_override == "priority"  # filled
+
+
+# ---------------------------------------------------------------------------
+# Auto-reset boundary consumed by the API
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_on_idle_expired_session_consumes_boundary_and_drops_old_scope(
+    store_factory,
+):
+    cfg = GatewayConfig()
+    cfg.default_reset_policy = SessionResetPolicy(mode="idle", idle_minutes=1)
+    store = store_factory(cfg)
+    entry = store.get_or_create_session(_src())
+    key = entry.session_key
+    runner = _runner(store, cfg)
+
+    # Previous conversation: model + tier overrides, live and durable.
+    await runner._commit_session_runtime_options(
+        key,
+        model_override={"model": "pre-reset-model", "provider": "openrouter"},
+        service_tier_override="priority",
+    )
+    runner._pending_model_notes = {key: "[Note: stale note from the old conversation]"}
+    store.lookup_by_session_key(key).updated_at -= timedelta(minutes=5)
+
+    result = await runner.apply_session_options(_src(), {"reasoning_effort": "low"})
+
+    assert result["status"] == "accepted", result
+    assert result["applied"] == ["reasoning_effort"]
+    fresh = store.lookup_by_session_key(key)
+    assert fresh.session_id != entry.session_id
+    assert fresh.was_auto_reset is False  # consumed: the next turn won't wipe us
+    low = {"enabled": True, "effort": "low"}
+    conv = runner._session_state(key).conversation
+    assert conv.reasoning_override == low
+    assert conv.model_override is None  # the old conversation's model is gone
+    assert conv.service_tier_override is SERVICE_TIER_UNSET
+    assert _durable(store, key) == {
+        "model_override": None,
+        "reasoning_override": low,
+        "service_tier_override": None,
+    }
+    assert key not in runner._pending_model_notes
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identical_patch_is_a_noop(store_factory, monkeypatch):
+    store = store_factory()
+    runner = _runner(store)
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "gpt-5",  # a model with a fast tier
+        {"provider": "openai", "base_url": "", "api_key": ""},
+    )
+    first = await runner.apply_session_options(_src(), {"reasoning_effort": "high", "fast": True})
+    assert first["status"] == "accepted" and first["applied"] == ["reasoning_effort", "fast"]
+    assert runner.evictions == [first["session_key"]]
+
+    saves: list[int] = []
+    real_save = store._save
+
+    def _counting_save():
+        saves.append(1)
+        return real_save()
+
+    monkeypatch.setattr(store, "_save", _counting_save)
+
+    again = await runner.apply_session_options(_src(), {"reasoning_effort": "high", "fast": True})
+
+    assert again["status"] == "accepted", again
+    assert again["applied"] == []
+    assert again["effective"]["reasoning_effort"] == "high"
+    assert again["effective"]["fast"] is True
+    assert saves == []
+    assert runner.evictions == [first["session_key"]]  # no second eviction
+
+
+@pytest.mark.asyncio
+async def test_same_model_reassert_does_not_stage_a_switch_note(store_factory):
+    store = store_factory()
+    runner = _runner(store)
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "gpt-5",
+        {"provider": "openai", "base_url": "https://api.openai.com/v1", "api_key": "k"},
+    )
+    with (
+        patch("gateway.run._load_gateway_config", return_value={}),
+        patch("hermes_cli.model_switch.switch_model", lambda **_k: _switch_result("gpt-5")),
+        patch(
+            "hermes_cli.model_selection_guards.combined_selection_warning",
+            return_value=None,
+        ),
+    ):
+        result = await runner.apply_session_options(_src(), {"model": "gpt-5"})
+
+    assert result["status"] == "accepted", result
+    assert not getattr(runner, "_pending_model_notes", {})
+
+
+# ---------------------------------------------------------------------------
+# Durable model commit supersedes a pending /model --once restore
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_model_commit_clears_pending_once_restore(
+    store_factory, tmp_path, monkeypatch
+):
+    store = store_factory()
+    key = store.get_or_create_session(_src()).session_key
+    runner = _model_runner(store, tmp_path, monkeypatch, switched_to="once-x")
+
+    await runner._handle_model_command(_event("/model once-x --once"))
+    assert runner._session_state(key).conversation.one_turn_restore is not None
+
+    with (
+        patch("gateway.run._load_gateway_config", return_value={}),
+        patch("hermes_cli.model_switch.switch_model", lambda **_k: _switch_result("gpt-5")),
+        patch(
+            "hermes_cli.model_selection_guards.combined_selection_warning",
+            return_value=None,
+        ),
+    ):
+        result = await runner.apply_session_options(_src(), {"model": "gpt-5"})
+
+    assert result["status"] == "accepted", result
+    assert runner._session_state(key).conversation.one_turn_restore is None
+    runner._restore_pending_one_turn_model_override(key)  # must be a no-op now
+    assert _live_model(runner, key) == "gpt-5"
+    assert _durable(store, key)["model_override"]["model"] == "gpt-5"
+
+
+@pytest.mark.asyncio
+async def test_busy_rejection_is_authoritative_under_the_lock(store_factory):
+    """A turn that claims the slot while the API is validating (outside the
+    lock) is seen by the locked busy check: nothing is written."""
+    store = store_factory()
+    runner = _runner(store)
+    key = runner._session_key_for_source(runner._normalize_source_for_session_key(_src()))
+    loop = asyncio.get_running_loop()
+    reached, release = asyncio.Event(), threading.Event()
+
+    def _slow_switch(**_kwargs):
+        loop.call_soon_threadsafe(reached.set)
+        assert release.wait(timeout=5.0)
+        return _switch_result()
+
+    with (
+        patch("gateway.run._load_gateway_config", return_value={}),
+        patch("hermes_cli.model_switch.switch_model", _slow_switch),
+        patch(
+            "hermes_cli.model_selection_guards.combined_selection_warning",
+            return_value=None,
+        ),
+    ):
+        api_task = asyncio.create_task(runner.apply_session_options(_src(), {"model": "gpt-5"}))
+        await asyncio.wait_for(reached.wait(), timeout=2.0)
+        runner._session_state(key).turn.agent = _AGENT_PENDING_SENTINEL
+        release.set()
+        result = await asyncio.wait_for(api_task, timeout=5.0)
+
+    assert (result["status"], result["code"]) == ("rejected", "session_busy"), result
+    assert store.lookup_by_session_key(key) is None
+    assert runner._session_state(key).conversation.model_override is None

--- a/tests/gateway/test_session_options_commit_contract.py
+++ b/tests/gateway/test_session_options_commit_contract.py
@@ -278,43 +278,6 @@ async def test_inbound_turn_parks_behind_in_flight_commit_then_runs_once():
 
 
 # ---------------------------------------------------------------------------
-# Boot-resume pre-claim skip: the skipped session is resumed by the next pass
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_boot_resume_skipped_session_resumes_once_lock_is_free():
-    runner, adapter = make_restart_runner()
-    runner._is_user_authorized = lambda _source: True
-    runner._restart_loop_guard_config = lambda: (0, 0, 0)
-    runner._run_startup_resume_event = AsyncMock()
-    adapter.handle_message = AsyncMock()
-    source = make_restart_source(chat_id="held-chat")
-    key = runner._session_key_for_source(source)
-    entry = SessionEntry(
-        session_key=key,
-        session_id="sid",
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        origin=source,
-        platform=Platform.TELEGRAM,
-        chat_type="dm",
-        resume_pending=True,
-        resume_reason="restart_timeout",
-        last_resume_marked_at=datetime.now(),
-    )
-    runner.session_store._entries = {key: entry}
-
-    async with session_admission_lock(runner, key):
-        assert runner._schedule_resume_pending_sessions() == 0
-        assert entry.resume_pending is True  # left for the next pass
-        assert runner._is_session_running(key) is False
-
-    assert runner._schedule_resume_pending_sessions() == 1
-    assert runner._is_session_running(key) is True
-
-
-# ---------------------------------------------------------------------------
 # Rehydrate never clobbers a live one-shot override
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_session_options_rejections.py
+++ b/tests/gateway/test_session_options_rejections.py
@@ -159,3 +159,35 @@ async def test_session_missing_when_entry_vanishes_between_create_and_persist(
     result = await runner.apply_session_options(source, {"reasoning_effort": "high"})
     assert (result["status"], result["code"]) == ("rejected", "session_missing")
     assert runner._session_state(key).conversation.reasoning_override is None
+
+
+# --- multiplex: the API runs the same fail-closed profile-routing gate -------
+# as the inbound message path (#92185 "normal routing path").
+
+
+@pytest.mark.asyncio
+async def test_explicitly_rejected_profile_route_is_refused(store):
+    runner = _make_runner(store)
+    source = _make_source()
+    source.profile_route_rejected = True
+    result = await runner.apply_session_options(source, {"reasoning_effort": "high"})
+    assert (result["status"], result["code"]) == ("rejected", "invalid_session")
+    assert store.list_sessions() == []
+
+
+@pytest.mark.asyncio
+async def test_unstamped_source_is_routed_and_refused_when_route_targets_unserved_profile(store):
+    from gateway.profile_routing import ProfileRouteRejected
+
+    runner = _make_runner(store)
+    runner.config = SimpleNamespace(multiplex_profiles=True)
+
+    def _route(_source):
+        raise ProfileRouteRejected("unserved")
+
+    runner._profile_name_for_source = _route
+    source = _make_source()
+    result = await runner.apply_session_options(source, {"reasoning_effort": "high"})
+    assert (result["status"], result["code"]) == ("rejected", "invalid_session")
+    assert source.profile_route_rejected is True
+    assert store.list_sessions() == []

--- a/tests/gateway/test_session_options_rejections.py
+++ b/tests/gateway/test_session_options_rejections.py
@@ -191,3 +191,33 @@ async def test_unstamped_source_is_routed_and_refused_when_route_targets_unserve
     assert (result["status"], result["code"]) == ("rejected", "invalid_session")
     assert source.profile_route_rejected is True
     assert store.list_sessions() == []
+
+
+# --- durable write failure: structured rejection, live state untouched ------
+
+
+@pytest.mark.asyncio
+async def test_durable_write_failure_is_a_rejection_not_an_exception(
+    store, monkeypatch
+):
+    runner = _make_runner(store)
+    source = _make_source()
+    key = runner._session_key_for_source(runner._normalize_source_for_session_key(source))
+    # Routing entry exists and is healthy; only the later options write fails.
+    store.get_or_create_session(source)
+
+    def _fail(_data):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(store, "_save_sessions_json", _fail)
+
+    result = await runner.apply_session_options(source, {"reasoning_effort": "high"})
+
+    assert (result["status"], result["code"]) == ("rejected", "durable_write_failed")
+    assert runner._session_state(key).conversation.reasoning_override is None
+    assert (store.get_runtime_options(key) or {}).get("reasoning_override") is None
+    # Nothing is stuck: once the disk is healthy again the same patch lands.
+    monkeypatch.undo()
+    retry = await runner.apply_session_options(source, {"reasoning_effort": "high"})
+    assert retry["status"] == "accepted"
+    assert retry["applied"] == ["reasoning_effort"]

--- a/tests/gateway/test_session_options_rejections.py
+++ b/tests/gateway/test_session_options_rejections.py
@@ -1,0 +1,161 @@
+"""Rejection paths of apply_session_options (AI review point 1 on #92187).
+
+Each test asserts only ``status`` + ``code`` (the API contract), never the
+human-readable ``error`` text, so none of these are change-detector tests.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    def _raise():
+        raise RuntimeError("SQLite disabled in test")
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _raise)
+    s = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    assert s._db is None
+    return s
+
+
+def _make_runner(store, model="anthropic/claude-sonnet-4"):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner.session_store = store
+    runner._session_options_locks = {}
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        model,
+        {"provider": "openrouter", "base_url": "", "api_key": ""},
+    )
+    runner._evict_cached_agent = lambda _session_key: None
+    runner._session_db = None
+    return runner
+
+
+# --- cheap: no store, no runner scaffolding beyond object.__new__ -----------
+
+
+@pytest.mark.asyncio
+async def test_unknown_option_key_is_rejected_before_any_state_is_touched(store):
+    runner = _make_runner(store)
+    result = await runner.apply_session_options(_make_source(), {"temperature": 1})
+    assert (result["status"], result["code"]) == ("rejected", "invalid_options")
+    # Nothing created: no routing entry, no SessionState, no lock.
+    assert store.lookup_by_session_key(
+        runner._session_key_for_source(_make_source())
+    ) is None
+    assert runner._session_options_locks == {}
+
+
+# --- cheap: same scaffold as the existing happy-path tests ------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_without_model_is_rejected(store):
+    runner = _make_runner(store)
+    result = await runner.apply_session_options(_make_source(), {"provider": "openai"})
+    assert (result["status"], result["code"]) == ("rejected", "invalid_options")
+    assert store.lookup_by_session_key(result.get("session_key", "")) is None
+
+
+@pytest.mark.asyncio
+async def test_reasoning_effort_unknown_value_is_rejected(store):
+    runner = _make_runner(store)
+    result = await runner.apply_session_options(
+        _make_source(), {"reasoning_effort": "galactic"}
+    )
+    assert (result["status"], result["code"]) == ("rejected", "reasoning_rejected")
+
+
+@pytest.mark.asyncio
+async def test_fast_non_bool_is_rejected(store):
+    runner = _make_runner(store)
+    result = await runner.apply_session_options(_make_source(), {"fast": "yes"})
+    assert (result["status"], result["code"]) == ("rejected", "fast_rejected")
+
+
+@pytest.mark.asyncio
+async def test_fast_unsupported_for_model_is_rejected(store):
+    # A model that resolve_fast_mode_overrides does not know.
+    runner = _make_runner(store, model="someorg/no-fast-tier-model")
+    result = await runner.apply_session_options(_make_source(), {"fast": True})
+    assert (result["status"], result["code"]) == ("rejected", "fast_unsupported")
+
+
+@pytest.mark.asyncio
+async def test_rejected_patch_persists_nothing_even_when_one_field_was_valid(store):
+    """Atomicity: a valid reasoning value + invalid fast value writes nothing."""
+    runner = _make_runner(store)
+    source = _make_source()
+    result = await runner.apply_session_options(
+        source, {"reasoning_effort": "high", "fast": "yes"}
+    )
+    assert result["status"] == "rejected"
+    key = runner._session_key_for_source(source)
+    assert store.lookup_by_session_key(key) is None
+    assert runner._peek_session_state(key) is None or (
+        runner._peek_session_state(key).conversation.reasoning_override is None
+    )
+
+
+# --- cheap-ish: needs the admission sentinel -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_busy_is_rejected_and_persists_nothing(store):
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner = _make_runner(store)
+    source = _make_source()
+    key = runner._session_key_for_source(runner._normalize_source_for_session_key(source))
+    runner._session_state(key).turn.agent = _AGENT_PENDING_SENTINEL
+
+    result = await runner.apply_session_options(source, {"reasoning_effort": "high"})
+    assert (result["status"], result["code"]) == ("rejected", "session_busy")
+    assert store.lookup_by_session_key(key) is None
+    assert runner._session_state(key).conversation.reasoning_override is None
+
+
+# --- awkward: session_missing requires faking the store's False return ------
+
+
+@pytest.mark.asyncio
+async def test_session_missing_when_entry_vanishes_between_create_and_persist(
+    store, monkeypatch
+):
+    runner = _make_runner(store)
+    source = _make_source()
+    key = runner._session_key_for_source(runner._normalize_source_for_session_key(source))
+
+    real_create = store.get_or_create_session
+
+    def _create_then_vanish(src):
+        entry = real_create(src)
+        # Simulate /new or expiry removing the routing entry mid-flight.
+        with store._lock:
+            store._entries.pop(key, None)
+        return entry
+
+    monkeypatch.setattr(store, "get_or_create_session", _create_then_vanish)
+    result = await runner.apply_session_options(source, {"reasoning_effort": "high"})
+    assert (result["status"], result["code"]) == ("rejected", "session_missing")
+    assert runner._session_state(key).conversation.reasoning_override is None

--- a/tests/gateway/test_session_options_teardown_unit.py
+++ b/tests/gateway/test_session_options_teardown_unit.py
@@ -1,0 +1,46 @@
+"""Event-loop teardown cannot separate the durable write from live assignment.
+
+``asyncio.run`` teardown cancels every task (``_cancel_all_tasks``). Live
+assignment is a done-callback on the write's executor Future -- not a task --
+so the caller, absorbing that cancel under the lock, still observes live
+state follow whatever landed on disk before the loop closes.
+"""
+
+import asyncio
+import threading
+
+from tests.gateway.test_session_options_cancel_mid_persist import (
+    _key,
+    _park_runtime_options_save,
+)
+from tests.gateway.test_session_options_rejections import (
+    _make_runner,
+    _make_source,
+    store,  # noqa: F401  (fixture re-export)
+)
+
+
+def test_loop_teardown_cannot_separate_write_from_live_assignment(store, monkeypatch):
+    runner = _make_runner(store)
+    source = _make_source()
+    key = _key(runner, source)
+    store.get_or_create_session(source)
+    entered, release = _park_runtime_options_save(store, monkeypatch)
+
+    async def main() -> asyncio.Task:
+        task = asyncio.create_task(
+            runner.apply_session_options(source, {"reasoning_effort": "high"})
+        )
+        await asyncio.to_thread(entered.wait, 5)
+        # Return with the write still parked in the worker: asyncio.run now
+        # cancels every task, then joins the default executor.
+        threading.Timer(0.2, release.set).start()
+        return task
+
+    task = asyncio.run(main())
+
+    assert task.cancelled()
+    durable = (store.get_runtime_options(key) or {}).get("reasoning_override")
+    live = runner._session_state(key).conversation.reasoning_override
+    assert durable == {"enabled": True, "effort": "high"}
+    assert durable == live, f"disk {durable!r} != live {live!r}"

--- a/tests/gateway/test_session_runtime_options_slash_write_through.py
+++ b/tests/gateway/test_session_runtime_options_slash_write_through.py
@@ -1,0 +1,222 @@
+"""Later user-issued slash commands must stay durable/authoritative (#92185).
+
+Regression for review finding #1 on PR #92187. On 1ddc941c
+``apply_session_options()`` persisted *before* mutating live state, but the
+sibling ``/reasoning`` and ``/fast`` seams mutated live state first and then
+called a ``_persist_session_runtime_options()`` helper that swallowed every
+store failure. Both seams now go through ``commit_session_runtime_options``.
+
+Contract under test (both halves):
+  * after a slash change whose durable write fails, live state and durable
+    state agree (either the command did not advance live state, or it failed
+    explicitly) -- never "live low / durable high"; and a success reply is
+    only acceptable if the value actually advanced (no "replied OK, changed
+    nothing");
+  * a simulated restart rehydrates the same value the live gateway was using.
+
+The save failure is injected at ``SessionStore._save_sessions_json`` so the
+exception travels through the real ``_persist_routing_data`` raise path
+(no state.db in this fixture => the sessions.json failure is fatal).
+"""
+from __future__ import annotations
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source())
+
+
+@pytest.fixture
+def store_factory(tmp_path, monkeypatch):
+    """SessionStores over one shared sessions dir, without SQLite."""
+
+    def _raise():
+        raise RuntimeError("SQLite disabled in test")
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _raise)
+
+    def _make() -> SessionStore:
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        assert store._db is None
+        return store
+
+    return _make
+
+
+def _make_runner(store: SessionStore) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner.config = GatewayConfig()
+    runner.session_store = store
+    runner._session_options_locks = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._show_reasoning = False
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "gpt-5.4",
+        {"provider": "openai", "base_url": "", "api_key": ""},
+    )
+    runner._evict_cached_agent = lambda _session_key: None
+    return runner
+
+
+@pytest.fixture
+def env(monkeypatch, tmp_path):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path / "home")
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4"
+    )
+
+
+def _live(runner: GatewayRunner, session_key: str) -> dict:
+    state = runner._session_state(session_key)
+    tier = state.conversation.service_tier_override
+    return {
+        "reasoning_override": state.conversation.reasoning_override,
+        "service_tier_override": (
+            None
+            if tier is gateway_run._SERVICE_TIER_UNSET
+            else ("priority" if tier == "priority" else "normal")
+        ),
+    }
+
+
+def _durable(store: SessionStore, session_key: str) -> dict:
+    opts = store.get_runtime_options(session_key) or {}
+    return {
+        "reasoning_override": opts.get("reasoning_override"),
+        "service_tier_override": opts.get("service_tier_override"),
+    }
+
+
+async def _seed_host_defaults(runner: GatewayRunner, store: SessionStore) -> str:
+    result = await runner.apply_session_options(
+        _make_source(),
+        {"reasoning_effort": "high", "fast": True, "initial": True},
+    )
+    assert result["status"] == "accepted", result
+    session_key = result["session_key"]
+    assert _durable(store, session_key) == {
+        "reasoning_override": {"enabled": True, "effort": "high"},
+        "service_tier_override": "priority",
+    }
+    assert _live(runner, session_key) == _durable(store, session_key)
+    return session_key
+
+
+def _arm_save_failure(monkeypatch, store: SessionStore) -> list:
+    attempts: list = []
+
+    def _fail(_data):
+        attempts.append(1)
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(store, "_save_sessions_json", _fail)
+    return attempts
+
+
+def _restart(store_factory, session_key: str) -> dict:
+    """Fresh store + fresh runner over the same sessions dir."""
+    runner = _make_runner(store_factory())
+    runner._rehydrate_session_runtime_options(session_key)
+    return _live(runner, session_key)
+
+
+@pytest.mark.asyncio
+async def test_reasoning_slash_stays_consistent_when_durable_write_fails(
+    store_factory, monkeypatch, env
+):
+    store = store_factory()
+    runner = _make_runner(store)
+    session_key = await _seed_host_defaults(runner, store)
+
+    attempts = _arm_save_failure(monkeypatch, store)
+
+    seeded = _live(runner, session_key)
+    try:
+        reply = await runner._handle_reasoning_command(_make_event("/reasoning low"))
+    except OSError:
+        reply = None  # explicit failure is an acceptable outcome
+
+    assert attempts, "slash change never attempted a durable write"
+    live = _live(runner, session_key)
+    durable = _durable(store, session_key)
+    assert live == durable, (
+        f"live state diverged from durable state after a failed save: "
+        f"live={live!r} durable={durable!r} reply={reply!r}"
+    )
+    if reply is not None:
+        assert live != seeded, f"replied {reply!r} but changed nothing"
+
+    # Restart must resurrect exactly what the live gateway was using.
+    assert _restart(store_factory, session_key) == live
+
+
+@pytest.mark.asyncio
+async def test_fast_slash_stays_consistent_when_durable_write_fails(
+    store_factory, monkeypatch, env
+):
+    store = store_factory()
+    runner = _make_runner(store)
+    session_key = await _seed_host_defaults(runner, store)
+
+    attempts = _arm_save_failure(monkeypatch, store)
+
+    seeded = _live(runner, session_key)
+    try:
+        reply = await runner._handle_fast_command(_make_event("/fast normal"))
+    except OSError:
+        reply = None
+
+    assert attempts, "slash change never attempted a durable write"
+    live = _live(runner, session_key)
+    durable = _durable(store, session_key)
+    assert live == durable, (
+        f"live state diverged from durable state after a failed save: "
+        f"live={live!r} durable={durable!r} reply={reply!r}"
+    )
+    if reply is not None:
+        assert live != seeded, f"replied {reply!r} but changed nothing"
+    assert _restart(store_factory, session_key) == live
+
+
+@pytest.mark.asyncio
+async def test_slash_write_through_succeeds_on_healthy_store(
+    store_factory, monkeypatch, env
+):
+    """Control: with a healthy store the slash edit is durable and authoritative."""
+    store = store_factory()
+    runner = _make_runner(store)
+    session_key = await _seed_host_defaults(runner, store)
+
+    await runner._handle_reasoning_command(_make_event("/reasoning low"))
+    await runner._handle_fast_command(_make_event("/fast normal"))
+
+    expected = {
+        "reasoning_override": {"enabled": True, "effort": "low"},
+        "service_tier_override": "normal",
+    }
+    assert _live(runner, session_key) == expected
+    assert _durable(store, session_key) == expected
+    assert _restart(store_factory, session_key) == expected

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -131,6 +131,32 @@ if _quick_key in self._running_agents:
 
 Bypass commands (`/stop`, `/new`, `/approve`, `/deny`, `/queue`, `/status`) have special handling.
 
+### Per-Session Runtime Options
+
+`/model`, `/reasoning`, `/fast` and the structured host API
+`GatewayRunner.apply_session_options(source, options)` (`gateway/session_options.py`)
+all change the same per-session triple — model override, reasoning override,
+service tier — and share two primitives:
+
+- **`commit_session_runtime_options()`** — the single durable-first write-through.
+  The complete snapshot is persisted via `AsyncSessionStore.set_runtime_options`
+  first; live `SessionState` is assigned only after the save succeeds; a failed
+  save raises with live state untouched, so a slash command fails explicitly
+  instead of replying "set" while disk disagrees. Persisted: model override
+  (credentials stripped — the API key is re-resolved from live config on
+  rehydrate), reasoning override, service tier. Never persisted: `/model --once`
+  and the `/moa` one-shot (live-only by contract).
+- **`session_admission_lock(runner, key)`** — one `asyncio.Lock` per session key.
+  `_handle_message` holds it across its synchronous idle→running claim (uncontended
+  acquire never yields, so the "claim before any await" rule still holds); every
+  slash write-through and the API's commit section hold it across busy-check →
+  persist → live mutation. A turn therefore cannot be admitted between the API
+  observing "idle" and its commit landing. The lock is not re-entrant.
+
+The API validates (model resolution may hit the network) outside the lock and
+re-reads the live triple under it; if a user slash command changed the triple in
+between it returns `rejected` / `conflict` — later user commands stay authoritative.
+
 ## Config Sources
 
 The gateway reads configuration from multiple sources:

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -150,9 +150,11 @@ service tier — and share two primitives:
   live persists that snapshot, never the one-turn model or the virtual `moa`
   provider). An I/O failure on the durable write reaches `apply_session_options()`
   callers as `rejected`/`durable_write_failed`; slash commands surface it as the
-  adapter's error reply. Persist and live assignment run as one shielded unit
-  under the lock: a caller cancelled mid-commit still observes live state equal
-  to disk (a second cancellation during that wait is the one case not covered).
+  adapter's error reply. Persist and live assignment run as one unit that is
+  settled under the lock before the caller's cancellation propagates, across
+  repeated cancellation: a caller cancelled mid-commit (however many times)
+  still observes live state equal to disk, and a durable-write failure behind
+  the cancellation is logged rather than left as an unobserved task exception.
 - **`session_admission_lock(runner, key)`** — one `asyncio.Lock` per session key.
   `_handle_message` holds it across its synchronous idle→running claim (uncontended
   acquire never yields, so the "claim before any await" rule still holds); every

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -145,7 +145,14 @@ service tier — and share two primitives:
   instead of replying "set" while disk disagrees. Persisted: model override
   (credentials stripped — the API key is re-resolved from live config on
   rehydrate), reasoning override, service tier. Never persisted: `/model --once`
-  and the `/moa` one-shot (live-only by contract).
+  and the `/moa` one-shot (live-only by contract; both park the prior override in
+  `conversation.one_turn_restore`, so a durable commit landing while either is
+  live persists that snapshot, never the one-turn model or the virtual `moa`
+  provider). An I/O failure on the durable write reaches `apply_session_options()`
+  callers as `rejected`/`durable_write_failed`; slash commands surface it as the
+  adapter's error reply. Persist and live assignment run as one shielded unit
+  under the lock: a caller cancelled mid-commit still observes live state equal
+  to disk (a second cancellation during that wait is the one case not covered).
 - **`session_admission_lock(runner, key)`** — one `asyncio.Lock` per session key.
   `_handle_message` holds it across its synchronous idle→running claim (uncontended
   acquire never yields, so the "claim before any await" rule still holds); every

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -150,11 +150,14 @@ service tier — and share two primitives:
   live persists that snapshot, never the one-turn model or the virtual `moa`
   provider). An I/O failure on the durable write reaches `apply_session_options()`
   callers as `rejected`/`durable_write_failed`; slash commands surface it as the
-  adapter's error reply. Persist and live assignment run as one unit that is
-  settled under the lock before the caller's cancellation propagates, across
-  repeated cancellation: a caller cancelled mid-commit (however many times)
-  still observes live state equal to disk, and a durable-write failure behind
-  the cancellation is logged rather than left as an unobserved task exception.
+  adapter's error reply. Persist and live assignment run as one unit: live
+  assignment is a done-callback on the durable write's executor Future (not a
+  task, so no task cancellation -- including event-loop teardown -- can
+  separate the two), and the caller waits for that callback under the lock
+  before its own cancellation propagates, across repeated cancellation. A
+  caller cancelled mid-commit (however many times) still observes live state
+  equal to disk, and a durable-write failure behind the cancellation is logged
+  rather than left as an unobserved task exception.
 - **`session_admission_lock(runner, key)`** — one `asyncio.Lock` per session key.
   `_handle_message` holds it across its synchronous idle→running claim (uncontended
   acquire never yields, so the "claim before any await" rule still holds); every


### PR DESCRIPTION
Salvages and supersedes #27504 (by @Qwinty / Maxim Esipov). Original PR by @Qwinty. His durable `/reasoning` commit is cherry-picked onto this branch with authorship preserved; this PR generalises it to one atomic model + reasoning + service-tier snapshot behind a public `apply_session_options()` boundary and keeps his `sanitize_reasoning_override()` as the store-level validator.

## What does this PR do?

Adds a public structured session-options boundary for messaging adapters and host UIs. They can set a session's model, provider, reasoning effort, and fast mode without injecting visible slash-command turns or mutating global config.

The implementation reuses Hermes' native model guards and parsers, persists only non-secret per-session values, rehydrates them after gateway restart, and clears them at conversation boundaries. Every session-runtime mutation — `/model`, `/reasoning`, `/fast` and the host API — goes through one durable-first write-through primitive, so live state and restart state cannot disagree.

## Related Issue

Closes #92185. Supersedes #27504 (to be closed by its author/a maintainer at merge — closing keywords do not close PRs).

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Security fix
- [x] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Add `GatewayRunner.apply_session_options(source, options)`.
- Validate model/provider, reasoning effort, and fast mode with existing native helpers.
- Persist model/reasoning/tier snapshots atomically in `SessionStore` without credentials.
- Every session-runtime mutation (`/model`, `/reasoning`, `/fast`, host API) goes through one durable-first write-through primitive, `commit_session_runtime_options()`: persist first, assign live state only on success, fail explicitly otherwise.
- Turn admission and option commits share one per-session `asyncio.Lock` (non-reentrant; in-lock callers use `_commit_session_runtime_options_locked`). New rejection code `conflict` when a user slash write lands during API validation, so later user commands stay authoritative.
- An I/O failure on the durable write in the API path is returned as `rejected`/`durable_write_failed` (slash commands keep failing explicitly through the adapter's error reply).
- Persist + live assignment are one unit under the session lock: live assignment is a done-callback on the durable write's executor `Future`, and the caller settles on it under the admission lock across arbitrarily repeated cancellation before its own cancellation surfaces, so no task cancellation — a cancelled host task, a second `Task.cancel()` during settlement, or event-loop teardown — can leave disk ahead of live or admit a turn while the two diverge; a durable-write failure behind a cancellation is logged, never an unobserved task exception.
- `AsyncSessionStore.submit(name, ...)` — offload a store method and return the executor `Future` (same contextvars propagation as `to_thread`).
- The `/moa` one-shot installs its live override only after the turn's idle→running claim and parks the prior override in the `/model --once` restore slot, so a durable commit landing while the virtual provider is live (before the claim or after the running slot is released) persists the prior model, never `moa`; a `/moa` refused by the drain gate no longer leaves the override live.
- The API runs the same fail-closed inbound profile-routing gate as `_handle_message`.
- `/reasoning --global` and `/fast --global` now also issue a durable per-session clear (global supersedes session).
- Rehydrate options after restart (per-field, live wins) and clear them on `/new`/reset boundaries.
- Commit 1 is @Qwinty's #27504 cherry-picked (`-x`).

## Salvaged from #27504 — what is preserved and what changed

Preserved: `SessionEntry.reasoning_override`, `sanitize_reasoning_override()` sourced from `VALID_REASONING_EFFORTS`, the `set_expiry_finalized` clear, the async `_apply_reasoning_selection`, and his store/sanitizer tests byte-identical.

Changed: `set_reasoning_override` is now a wrapper over the shared locked write body (gains rollback on a failed save); his swallowing `_persist_session_reasoning_override` is replaced by the shared primitive that fails loudly; rehydration is the per-field live-wins `_rehydrate_session_runtime_options`; the MoA one-shot restore helper (`_restore_moa_one_shot`) is replaced by the existing one-turn restore slot, and `test_moa_one_shot_restore.py` exercises the real install/restore helpers.

## Not persisted by design

`/model --once` and the `/moa` one-shot are live-only; both park the prior override in `conversation.one_turn_restore`, and a durable commit landing while either is live persists that snapshot, never the one-turn model or the virtual `moa` provider. Credentials are never persisted (`api_key` is re-resolved on rehydrate).

## How to Test

Ubuntu Linux, Python 3.12:

```
scripts/run_tests.sh tests/gateway/test_session_runtime_options_slash_write_through.py tests/gateway/test_session_options_busy_barrier.py tests/gateway/test_session_admission_lock.py tests/gateway/test_session_options_commit_contract.py tests/gateway/test_session_options_rejections.py tests/gateway/test_session_model_override_persistence.py tests/gateway/test_reasoning_persistence.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_reasoning_command.py tests/gateway/test_fast_command.py tests/gateway/test_moa_one_shot_restore.py tests/gateway/test_moa_one_shot_commit_windows.py tests/gateway/test_session_options_cancel_mid_persist.py tests/gateway/test_session_options_teardown_unit.py tests/cli/test_moa_command.py -q
# 15 files, 84 passed, 0 failed
scripts/run_tests.sh tests/gateway/test_multiplex_*.py -q
# 13 files, 109 passed, 0 failed
scripts/run_tests.sh tests/gateway/ -q
# 694 files: 6177 passed, 1 failed, 38 skipped — the 1 (`test_session_hygiene::test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown`) is a wall-clock timeout test, load-sensitive under 16 workers, passes in isolation on this head
.venv/bin/ruff check gateway/run.py gateway/session.py gateway/session_options.py gateway/slash_commands.py tests/gateway/test_session_*.py tests/gateway/test_reasoning_persistence.py tests/gateway/test_moa_one_shot_*.py   # clean
.venv/bin/ty check gateway/session_options.py                                                   # clean
python3 scripts/check-windows-footguns.py gateway/run.py gateway/session.py gateway/session_options.py gateway/slash_commands.py   # clean
```

## Downstream consumer

OcuClaw (Even G2 glasses host UI for the Hermes gateway) is the consumer. Today it ships a fallback that edits Hermes' profile-wide defaults and labels them "global", because that is the only non-slash-command surface public Hermes exposes. That fallback is the wrong UX for the product: a model/reasoning/fast choice made for one chat leaks into every other session on the profile. OcuClaw's per-session controls will be built against `apply_session_options()` and are gated on this API appearing in a Hermes release; until then they stay behind the global fallback.

No OcuClaw-specific behaviour is in this PR; the API is the generic structured boundary #92185 describes, usable by any messaging adapter or host UI.

## Known adjacent PRs

#89122 (stale-override notice) composes; mechanical `run.py` hunks only. #60359 (per-channel reasoning config): both edit `_resolve_session_reasoning_config`; compatible precedence rungs, method not renamed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs for duplicates.
- [x] This PR contains only related changes.
- [x] I added tests for the change.
- [x] Tested on Ubuntu Linux with Python 3.12.

### Documentation & Housekeeping

- [x] Relevant docstrings are updated.
- [x] `cli-config.yaml.example` is N/A; no global config key was added.
- [x] Contributor workflow docs are N/A.
- [x] Cross-platform impact considered; persistence uses the existing `SessionStore` path; `check-windows-footguns.py` clean.
- [x] Tool schemas are N/A.

