### PR TITLE
fix(acp): reject duplicate session MCP server names

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1123,6 +1123,17 @@ class HermesACPAgent(acp.Agent):
         loop = asyncio.get_running_loop()
         loop.call_soon(asyncio.create_task, self._send_usage_update(state))
 
+    @staticmethod
+    def _validate_session_mcp_server_names(
+        mcp_servers: list[McpServerStdio | McpServerHttp | McpServerSse] | None,
+    ) -> None:
+        """Reject duplicate ACP MCP server names before mutating session state."""
+        server_names: set[str] = set()
+        for server in mcp_servers or []:
+            if server.name in server_names:
+                raise ValueError(f"duplicate ACP MCP server name: {server.name}")
+            server_names.add(server.name)
+
     async def _register_session_mcp_servers(
         self,
         state: SessionState,
@@ -1131,6 +1142,8 @@ class HermesACPAgent(acp.Agent):
         """Register ACP-provided MCP servers and refresh the agent tool surface."""
         if not mcp_servers:
             return
+
+        self._validate_session_mcp_server_names(mcp_servers)
 
         try:
             from tools.mcp_tool import register_mcp_servers
@@ -1594,6 +1607,7 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
+        self._validate_session_mcp_server_names(mcp_servers)
         state = self.session_manager.create_session(cwd=cwd)
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
@@ -1616,6 +1630,7 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> LoadSessionResponse | None:
+        self._validate_session_mcp_server_names(mcp_servers)
         state = self.session_manager.update_cwd(session_id, cwd)
         if state is None:
             logger.warning("load_session: session %s not found", session_id)
@@ -1664,6 +1679,7 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> ResumeSessionResponse:
+        self._validate_session_mcp_server_names(mcp_servers)
         state = self.session_manager.update_cwd(session_id, cwd)
         if state is None:
             logger.warning("resume_session: session %s not found, creating new", session_id)
@@ -1721,6 +1737,7 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> ForkSessionResponse:
+        self._validate_session_mcp_server_names(mcp_servers)
         state = self.session_manager.fork_session(session_id, cwd=cwd)
         new_id = state.session_id if state else ""
         if state is not None:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -16,6 +16,7 @@ from typing import Any, Deque, Optional
 from urllib.parse import unquote, urlparse
 
 import acp
+from acp.exceptions import RequestError
 from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
@@ -1131,7 +1132,7 @@ class HermesACPAgent(acp.Agent):
         server_names: set[str] = set()
         for server in mcp_servers or []:
             if server.name in server_names:
-                raise ValueError(f"duplicate ACP MCP server name: {server.name}")
+                raise RequestError.invalid_params({"serverName": server.name})
             server_names.add(server.name)
 
     async def _register_session_mcp_servers(

--- a/tests/acp/test_mcp_duplicate_validation_wire.py
+++ b/tests/acp/test_mcp_duplicate_validation_wire.py
@@ -1,0 +1,158 @@
+"""Wire-level regression tests for request-local ACP MCP validation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import acp
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+
+
+class _DrainProtocol(asyncio.Protocol):
+    async def _drain_helper(self) -> None:
+        return None
+
+    def _get_close_waiter(self, _stream: asyncio.StreamWriter) -> asyncio.Future[None]:
+        waiter = asyncio.get_running_loop().create_future()
+        waiter.set_result(None)
+        return waiter
+
+
+class _CapturingTransport(asyncio.WriteTransport):
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+        self.response_ready = asyncio.Event()
+        self._closing = False
+
+    def write(self, data: bytes | bytearray | memoryview[Any]) -> None:
+        self.buffer.extend(data)
+        if b"\n" in data:
+            self.response_ready.set()
+
+    def is_closing(self) -> bool:
+        return self._closing
+
+    def close(self) -> None:
+        self._closing = True
+
+    def abort(self) -> None:
+        self.close()
+
+    def get_extra_info(self, name: str, default: Any = None) -> Any:
+        return default
+
+
+async def _send_wire_request(agent: HermesACPAgent, request: dict) -> bytes:
+    """Send one JSON-RPC request through the real ACP connection and serializer."""
+    loop = asyncio.get_running_loop()
+    request_reader = asyncio.StreamReader()
+    response_transport = _CapturingTransport()
+    response_writer = asyncio.StreamWriter(
+        response_transport,
+        _DrainProtocol(),
+        request_reader,
+        loop,
+    )
+    agent_task = asyncio.create_task(
+        acp.run_agent(
+            agent,
+            input_stream=response_writer,
+            output_stream=request_reader,
+            use_unstable_protocol=True,
+        )
+    )
+
+    request_reader.feed_data((json.dumps(request) + "\n").encode())
+    try:
+        await asyncio.wait_for(response_transport.response_ready.wait(), timeout=5.0)
+        return bytes(response_transport.buffer)
+    finally:
+        request_reader.feed_eof()
+        await asyncio.wait_for(agent_task, timeout=2.0)
+        response_writer.close()
+        await response_writer.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "extra_params"),
+    [
+        pytest.param("session/new", {}, id="new"),
+        pytest.param("session/load", {"sessionId": "existing"}, id="load"),
+        pytest.param("session/resume", {"sessionId": "existing"}, id="resume"),
+        pytest.param("session/fork", {"sessionId": "existing"}, id="fork"),
+    ],
+)
+async def test_duplicate_mcp_names_are_invalid_params_without_side_effects(
+    tmp_path, method, extra_params
+):
+    manager = SessionManager(agent_factory=lambda: MagicMock(name="MockAIAgent"))
+    agent = HermesACPAgent(session_manager=manager)
+    mcp_servers = [
+        {
+            "name": "duplicate",
+            "command": "/private/mcp-command",
+            "args": ["--token", "private-argument"],
+            "env": [{"name": "PRIVATE_CONFIG", "value": "private-config-value"}],
+        },
+        {
+            "type": "http",
+            "name": "duplicate",
+            "url": "https://credential.example/mcp?token=private-url-value",
+            "headers": [
+                {"name": "Authorization", "value": "Bearer private-header-value"}
+            ],
+        },
+    ]
+    request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": {
+            "cwd": str(tmp_path),
+            "mcpServers": mcp_servers,
+            **extra_params,
+        },
+    }
+
+    with (
+        patch.object(manager, "create_session", wraps=manager.create_session) as create,
+        patch.object(manager, "update_cwd", wraps=manager.update_cwd) as update_cwd,
+        patch.object(manager, "fork_session", wraps=manager.fork_session) as fork,
+        patch.object(
+            agent, "_register_session_mcp_servers", new_callable=AsyncMock
+        ) as register,
+    ):
+        raw_response = await _send_wire_request(agent, request)
+
+    assert json.loads(raw_response) == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {
+            "code": -32602,
+            "message": "Invalid params",
+            "data": {"serverName": "duplicate"},
+        },
+    }
+    for private_value in (
+        "/private/mcp-command",
+        "private-argument",
+        "PRIVATE_CONFIG",
+        "private-config-value",
+        "credential.example",
+        "private-url-value",
+        "Authorization",
+        "private-header-value",
+    ):
+        assert private_value.encode() not in raw_response
+    create.assert_not_called()
+    update_cwd.assert_not_called()
+    fork.assert_not_called()
+    register.assert_not_awaited()
+    assert manager._sessions == {}

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -9,6 +9,7 @@ import pytest
 
 import acp
 from acp.agent.router import build_agent_router
+from acp.exceptions import RequestError
 from acp.schema import (
     AgentCapabilities,
     AgentMessageChunk,
@@ -618,20 +619,26 @@ class TestRegisterSessionMcpServers:
         await agent._register_session_mcp_servers(state, [])
 
     @pytest.mark.asyncio
-    async def test_rejects_duplicate_server_names_without_registering(self, agent, mock_manager):
+    @pytest.mark.parametrize("second_command", ["/first", "/second"])
+    async def test_rejects_duplicate_server_names_without_registering(
+        self, agent, mock_manager, second_command
+    ):
         """Duplicate ACP server names fail instead of silently replacing one config."""
         from acp.schema import McpServerStdio
 
         state = mock_manager.create_session(cwd="/tmp")
         servers = [
             McpServerStdio(name="duplicate", command="/first", args=[], env=[]),
-            McpServerStdio(name="duplicate", command="/second", args=[], env=[]),
+            McpServerStdio(name="duplicate", command=second_command, args=[], env=[]),
         ]
 
         with patch("tools.mcp_tool.register_mcp_servers") as register:
-            with pytest.raises(ValueError, match="duplicate ACP MCP server name: duplicate"):
+            with pytest.raises(RequestError) as exc_info:
                 await agent._register_session_mcp_servers(state, servers)
 
+        assert exc_info.value.code == -32602
+        assert str(exc_info.value) == "Invalid params"
+        assert exc_info.value.data == {"serverName": "duplicate"}
         register.assert_not_called()
 
     @pytest.mark.asyncio
@@ -647,9 +654,12 @@ class TestRegisterSessionMcpServers:
         ]
 
         with patch.object(agent.session_manager, "create_session") as create_session:
-            with pytest.raises(ValueError, match="duplicate ACP MCP server name: duplicate"):
+            with pytest.raises(RequestError) as exc_info:
                 await agent.new_session(cwd="/tmp", mcp_servers=servers)
 
+        assert exc_info.value.code == -32602
+        assert str(exc_info.value) == "Invalid params"
+        assert exc_info.value.data == {"serverName": "duplicate"}
         create_session.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -618,6 +618,41 @@ class TestRegisterSessionMcpServers:
         await agent._register_session_mcp_servers(state, [])
 
     @pytest.mark.asyncio
+    async def test_rejects_duplicate_server_names_without_registering(self, agent, mock_manager):
+        """Duplicate ACP server names fail instead of silently replacing one config."""
+        from acp.schema import McpServerStdio
+
+        state = mock_manager.create_session(cwd="/tmp")
+        servers = [
+            McpServerStdio(name="duplicate", command="/first", args=[], env=[]),
+            McpServerStdio(name="duplicate", command="/second", args=[], env=[]),
+        ]
+
+        with patch("tools.mcp_tool.register_mcp_servers") as register:
+            with pytest.raises(ValueError, match="duplicate ACP MCP server name: duplicate"):
+                await agent._register_session_mcp_servers(state, servers)
+
+        register.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_new_session_rejects_duplicate_server_names_before_creating_session(
+        self, agent
+    ):
+        """Invalid duplicate input does not leave an unreachable new ACP session behind."""
+        from acp.schema import McpServerStdio
+
+        servers = [
+            McpServerStdio(name="duplicate", command="/first", args=[], env=[]),
+            McpServerStdio(name="duplicate", command="/second", args=[], env=[]),
+        ]
+
+        with patch.object(agent.session_manager, "create_session") as create_session:
+            with pytest.raises(ValueError, match="duplicate ACP MCP server name: duplicate"):
+                await agent.new_session(cwd="/tmp", mcp_servers=servers)
+
+        create_session.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_registers_stdio_servers(self, agent, mock_manager):
         """McpServerStdio servers are converted and passed to register_mcp_servers."""
         from acp.schema import McpServerStdio, EnvVariable


### PR DESCRIPTION
## Summary
- Reject duplicate names in client-provided ACP MCP server lists before registration can overwrite one server config.
- Validate before new/load/resume/fork session mutations; errors name only the duplicate server and do not include transport commands, URLs, or headers.
- Add regression coverage for no registration and no orphaned new session.

## Test plan
- [x] `scripts/run_tests.sh tests/acp/test_server.py -k "test_rejects_duplicate_server_names_without_registering or test_new_session_rejects_duplicate_server_names_before_creating_session" -q`
- [x] `scripts/run_tests.sh tests/acp -q` (137 passed)
- [x] `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check acp_adapter/server.py tests/acp/test_server.py`
- [x] `git diff --check`
- [x] `python3 scripts/check-windows-footguns.py --diff upstream/main`

## Related issue
No existing issue; this fixes ACP request-local MCP input that silently overwrote an earlier server with the same name.