### PR TITLE
fix: gateway restart guard misfires outside gateway; wait() swallows notify_on_complete

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7988,7 +7988,9 @@ def _gateway_command_inner(args):
     elif subcmd == "stop":
         # Defense: refuse self-targeting gateway stop from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
-        if os.getenv("_HERMES_GATEWAY") == "1":
+        from tools.process_registry import _is_supervised_gateway_process
+
+        if _is_supervised_gateway_process():
             print_error(
                 "Refusing to stop the gateway from inside the gateway process.\n"
                 "This command was blocked to prevent restart loops.\n"
@@ -8081,7 +8083,9 @@ def _gateway_command_inner(args):
     elif subcmd == "restart":
         # Defense: refuse self-targeting gateway restart from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
-        if os.getenv("_HERMES_GATEWAY") == "1":
+        from tools.process_registry import _is_supervised_gateway_process
+
+        if _is_supervised_gateway_process():
             print_error(
                 "Refusing to restart the gateway from inside the gateway process.\n"
                 "This command was blocked to prevent restart loops.\n"

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7988,6 +7988,10 @@ def _gateway_command_inner(args):
     elif subcmd == "stop":
         # Defense: refuse self-targeting gateway stop from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
+        # The supervised probe also PASSES a plain foreground `hermes gateway run`
+        # (env set, PID owned, but no supervisor): that is intentional and
+        # harmless — with no supervisor there is no KeepAlive, so a self-stop is
+        # a one-shot exit rather than a respawn loop.
         from tools.process_registry import _is_supervised_gateway_process
 
         if _is_supervised_gateway_process():
@@ -8083,6 +8087,10 @@ def _gateway_command_inner(args):
     elif subcmd == "restart":
         # Defense: refuse self-targeting gateway restart from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
+        # The supervised probe also PASSES a plain foreground `hermes gateway run`
+        # (env set, PID owned, but no supervisor): that is intentional and
+        # harmless — with no supervisor there is no KeepAlive, so a self-restart
+        # is a single relaunch rather than a respawn loop.
         from tools.process_registry import _is_supervised_gateway_process
 
         if _is_supervised_gateway_process():

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -204,8 +204,16 @@ class TestCodeExecutionBlocked:
 class TestCompletionConsumed:
     """Test that wait/log consume completion notifications while poll stays read-only."""
 
-    def test_wait_marks_completion_consumed(self, registry):
-        """wait() returning exited status marks session as consumed."""
+    def test_wait_preserves_notify_completion(self, registry):
+        """wait() on a notify_on_complete process must NOT mark it consumed.
+
+        The synchronous wait() result is the agent's own copy of the outcome.
+        Marking _completion_consumed here would also suppress the user-facing
+        autonomous delivery (the desktop/tui poller and gateway watcher both
+        gate on is_completion_consumed), so the user never learns the long
+        task finished. notify_on_complete is an explicit promise to surface a
+        notification on exit — wait() must not silently break it.
+        """
         s = _make_session(sid="proc_wait", notify_on_complete=True, output="done")
         s.exited = True
         s.exit_code = 0
@@ -221,8 +229,9 @@ class TestCompletionConsumed:
         result = registry.wait("proc_wait", timeout=1)
         assert result["status"] == "exited"
 
-        # Now the completion is marked as consumed
-        assert registry.is_completion_consumed("proc_wait")
+        # notify_on_complete survives wait(): the user-facing notification is
+        # still deliverable (the desktop/tui poller checks is_completion_consumed).
+        assert not registry.is_completion_consumed("proc_wait")
 
 
     def test_poll_observed_does_not_suppress_gateway_watcher(self, registry):
@@ -248,9 +257,10 @@ class TestCompletionConsumed:
         registry.poll("proc_run2")
         assert "proc_run2" not in registry._poll_observed
 
-    def test_wait_and_log_still_skip_cli_drain(self, registry):
-        """wait()/read_log() consume the output, so the CLI drain skips their
-        completions via _completion_consumed (the original #8228 contract)."""
+    def test_wait_and_log_preserve_notify_delivery(self, registry):
+        """wait()/read_log() consume the agent's own copy of the result, but a
+        notify_on_complete process keeps its user-facing completion queued so the
+        autonomous delivery (desktop/tui poller, gateway watcher) still fires."""
         for sid, action in (("proc_w", "wait"), ("proc_l", "log")):
             s = _make_session(sid=sid, notify_on_complete=True, output="done")
             s.exited = True
@@ -262,8 +272,9 @@ class TestCompletionConsumed:
                 registry.wait(sid, timeout=1)
             else:
                 registry.read_log(sid)
-            assert registry.is_completion_consumed(sid)
-        assert registry.drain_notifications() == []
+            assert not registry.is_completion_consumed(sid)
+        # The completion events remain deliverable — not drained as consumed.
+        assert len(registry.drain_notifications()) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1940,7 +1940,7 @@ class ProcessRegistry:
             "total_lines": total_lines,
             "showing": f"{len(selected)} lines",
         }
-        if session.exited and observed_completion_output:
+        if session.exited and observed_completion_output and not session.notify_on_complete:
             self._completion_consumed.add(session_id)
         return result
 
@@ -2002,7 +2002,17 @@ class ProcessRegistry:
             # child has already exited (issue #17327).
             self._reconcile_local_exit(session)
             if session.exited:
-                self._completion_consumed.add(session_id)
+                # A process started with notify_on_complete=True made an explicit
+                # promise to surface a completion notification on exit. The
+                # synchronous wait() result is the *agent's* copy of that outcome;
+                # marking it _completion_consumed here would ALSO suppress the
+                # autonomous user-facing delivery (the desktop/tui poller checks
+                # only is_completion_consumed, not _drain_should_skip), so the
+                # user never learns the long task finished. Honour the flag: only
+                # suppress the autonomous turn when the caller did NOT ask to be
+                # notified on completion.
+                if not session.notify_on_complete:
+                    self._completion_consumed.add(session_id)
                 result = {
                     "status": "exited",
                     "command": session.command,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1643,6 +1643,14 @@ class ProcessRegistry:
         duplicate (#8228).  The gateway/tui watchers do NOT use this — they
         check only ``is_completion_consumed`` so a read-only poll never
         suppresses their autonomous delivery turn (#10156).
+
+        Note: for a ``notify_on_complete`` task, ``wait()``/``read_log()``
+        deliberately do NOT mark the session consumed (see those methods), so a
+        pure-CLI caller that already obtained the result via ``wait()`` will
+        still drain the completion event on its next notification poll. That is
+        intentional — it is the user-facing delivery the flag promised — and a
+        deliberate reversal of #8228's suppression for the notify_on_complete
+        case only.
         """
         return session_id in self._completion_consumed or (
             skip_poll_observed and session_id in self._poll_observed

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2876,7 +2876,14 @@ def terminal_tool(
         # never restart. This mirrors the `hermes gateway restart` guard in
         # hermes_cli/gateway.py and the cron-path guard in hermes_cli/cron.py,
         # but applies unconditionally (force=True cannot help here).
-        if os.environ.get("_HERMES_GATEWAY") == "1":
+        # Gate on the SUPERVISED-gateway probe, not the raw _HERMES_GATEWAY
+        # marker: gateway.run sets it at import time, so it leaks into every
+        # process that merely imports gateway.run (hermes serve --isolated,
+        # CLI, web server) which are NOT the gateway and must be able to
+        # restart it.
+        from tools.process_registry import _is_supervised_gateway_process
+
+        if _is_supervised_gateway_process():
             from cron.lifecycle_guard import (
                 _MAX_REFERENCED_SCRIPT_BYTES,
                 contains_gateway_lifecycle_command_or_referenced_script,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2880,7 +2880,10 @@ def terminal_tool(
         # marker: gateway.run sets it at import time, so it leaks into every
         # process that merely imports gateway.run (hermes serve --isolated,
         # CLI, web server) which are NOT the gateway and must be able to
-        # restart it.
+        # restart it. A plain foreground `hermes gateway run` (env set, PID
+        # owned, no supervisor) now also PASSES this guard: intentional and
+        # harmless, since without a supervisor there is no KeepAlive to turn a
+        # self-restart into a respawn loop.
         from tools.process_registry import _is_supervised_gateway_process
 
         if _is_supervised_gateway_process():


### PR DESCRIPTION
Two small bug fixes found while operating Hermes from a desktop/CLI session.

## 1. `wait()`/`read_log()` swallow `notify_on_complete` notifications

`tools/process_registry.py` marks a session `_completion_consumed` when `wait()`/`read_log()` observe the exit. That flag is also the gate for the autonomous user-facing completion delivery (the desktop/tui poller and the gateway watcher both check `is_completion_consumed`). So a background task started with `notify_on_complete=True` — which promises to surface a completion notification — would have that notification silently suppressed if the agent *also* waited synchronously, and the user never learned the long task finished.

Fix: `wait()`/`read_log()` honour the `notify_on_complete` flag and leave the completion deliverable, so the autonomous turn still fires. Two tests that had pinned the buggy "wait marks consumed" behaviour are updated.

## 2. Gateway restart/stop guards misfire on non-gateway processes

`gateway/run.py` sets `_HERMES_GATEWAY=1` at *module import* time, so the marker leaks into every process that merely imports `gateway.run` — including `hermes serve --isolated` (the desktop SSH session), the interactive CLI, and the web server. The hard-block in `tools/terminal_tool.py` and the `stop`/`restart` guards in `hermes_cli/gateway.py` all tested the raw marker, which made it impossible to restart the gateway from a desktop/CLI session even though those processes are NOT the gateway and a restart would not SIGTERM them.

Fix: gate on `_is_supervised_gateway_process()` instead — only a process that owns the live gateway PID file under a supervisor is the real gateway. Desktop/CLI/web sessions can now restart the gateway; the real gateway still refuses to self-restart (double-guarded at both the tool and CLI layers).

## Tested

- `tests/tools/test_notify_on_complete.py` — 19 passed
- `tests/tools/test_process_registry.py` — 86 passed
- `tests/hermes_cli/test_gateway.py` — 115 passed
