### PR TITLE
fix(slack): serialize assistant status writes per thread

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1045,6 +1045,11 @@ class SlackAdapter(BasePlatformAdapter):
         # eviction (key[2] is the thread ts).
         self._active_status_threads: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
         self._ACTIVE_STATUS_THREADS_MAX = 1000
+        # Serialize Slack Assistant API status writes per workspace thread.
+        # A delayed "is thinking" request must never land after a completion
+        # clear: the pause flag alone cannot reach a send_typing call that is
+        # already awaiting the Slack API.
+        self._status_thread_locks: Dict[Tuple[str, str, str], asyncio.Lock] = {}
         # Native progress streams share Slack's workspace/thread isolation.
         # Each stream owns a lock so concurrent start/append/stop calls cannot
         # race into duplicate streams or append after finalization.
@@ -3439,15 +3444,51 @@ class SlackAdapter(BasePlatformAdapter):
                     _status = f"still working… ({_human})"
                 else:
                     _status = "is thinking..."
-            await self._get_client(chat_id, team_id=team_id).assistant_threads_setStatus(
-                channel_id=chat_id,
-                thread_ts=thread_ts,
-                status=_status,
-            )
+            if status_key:
+                async with self._status_thread_lock(status_key):
+                    # A completion can clear the thread while this refresh
+                    # waits for its turn. Do not resurrect its status
+                    # afterward — the final clear must be the last status
+                    # write Slack observes.
+                    if status_key not in self._active_status_threads:
+                        return
+                    await self._get_client(
+                        chat_id, team_id=team_id
+                    ).assistant_threads_setStatus(
+                        channel_id=chat_id,
+                        thread_ts=thread_ts,
+                        status=_status,
+                    )
+            else:
+                await self._get_client(
+                    chat_id, team_id=team_id
+                ).assistant_threads_setStatus(
+                    channel_id=chat_id,
+                    thread_ts=thread_ts,
+                    status=_status,
+                )
         except Exception as e:
             # Silently ignore — may lack assistant:write scope or not be
             # in an assistant-enabled context. Falls back to reactions.
             logger.debug("[Slack] assistant.threads.setStatus failed: %s", e)
+
+    def _status_thread_lock(self, key: Tuple[str, str, str]) -> asyncio.Lock:
+        """Return the lock that orders Assistant API writes for one thread."""
+        lock = self._status_thread_locks.get(key)
+        if lock is None:
+            if len(self._status_thread_locks) > self._ACTIVE_STATUS_THREADS_MAX:
+                # Never evict a lock for a thread that still tracks a status:
+                # a waiter in the release-to-wake handoff window reads as
+                # unlocked, but its thread is still registered, so this
+                # filter keeps the handoff race out of the sweep.
+                for old_key in [
+                    k
+                    for k, v in self._status_thread_locks.items()
+                    if not v.locked() and k not in self._active_status_threads
+                ][: self._ACTIVE_STATUS_THREADS_MAX // 2]:
+                    self._status_thread_locks.pop(old_key, None)
+            lock = self._status_thread_locks[key] = asyncio.Lock()
+        return lock
 
     async def stop_typing(self, chat_id: str, metadata=None) -> None:
         """Clear the assistant thread status indicator."""
@@ -3464,14 +3505,20 @@ class SlackAdapter(BasePlatformAdapter):
             )
         requested_team_id = self._metadata_team_id(metadata)
         active = None
+        resolved_key = None
         ambiguous_tracked = False
+        # Resolution only PEEKS at the tracked entry; the pop happens inside
+        # the per-thread lock below. Popping here would let a send_typing that
+        # re-registered its entry while this clear was mid-flight pass its
+        # in-lock re-check and resurrect the status right after the clear.
         if requested_thread_ts:
             if requested_team_id:
                 active_key = self._workspace_thread_key(
                     requested_team_id, chat_id, requested_thread_ts
                 )
-                if active_key:
-                    active = self._active_status_threads.pop(active_key, None)
+                if active_key and active_key in self._active_status_threads:
+                    resolved_key = active_key
+                    active = self._active_status_threads.get(active_key)
             else:
                 # Do not trust the mutable channel-only workspace fallback for
                 # a thread-specific cleanup: Slack Connect workspaces can share
@@ -3483,7 +3530,8 @@ class SlackAdapter(BasePlatformAdapter):
                     if key[1] == str(chat_id) and key[2] == requested_thread_ts
                 ]
                 if len(matching_keys) == 1:
-                    active = self._active_status_threads.pop(matching_keys[0], None)
+                    resolved_key = matching_keys[0]
+                    active = self._active_status_threads.get(matching_keys[0])
                 ambiguous_tracked = len(matching_keys) > 1
         else:
             # Metadata-free cleanup is safe only if exactly one status exists
@@ -3495,7 +3543,8 @@ class SlackAdapter(BasePlatformAdapter):
                 if key[1] == str(chat_id)
             ]
             if len(matching_keys) == 1:
-                active = self._active_status_threads.pop(matching_keys[0], None)
+                resolved_key = matching_keys[0]
+                active = self._active_status_threads.get(matching_keys[0])
         if isinstance(active, str):
             thread_ts = active
             team_id = ""
@@ -3519,12 +3568,37 @@ class SlackAdapter(BasePlatformAdapter):
             team_id = requested_team_id or team_id
         if not thread_ts:
             return
+        lock_key = self._workspace_thread_key(team_id, chat_id, str(thread_ts))
         try:
-            await self._get_client(chat_id, team_id=team_id).assistant_threads_setStatus(
-                channel_id=chat_id,
-                thread_ts=thread_ts,
-                status="",
-            )
+            # send_typing may already be in a slow Assistant API call.
+            # Serialize the clear behind it so the final clear is always the
+            # last status write Slack observes. The tracked entry is popped
+            # INSIDE the lock, after a successful clear: any send_typing
+            # queued behind this clear then fails its in-lock re-check and
+            # skips its write instead of resurrecting the status (a genuinely
+            # new turn is re-set by the next typing refresh tick), and a
+            # failed clear stays retryable.
+            if lock_key:
+                async with self._status_thread_lock(lock_key):
+                    await self._get_client(
+                        chat_id, team_id=team_id
+                    ).assistant_threads_setStatus(
+                        channel_id=chat_id,
+                        thread_ts=thread_ts,
+                        status="",
+                    )
+                    if resolved_key:
+                        self._active_status_threads.pop(resolved_key, None)
+            else:
+                await self._get_client(
+                    chat_id, team_id=team_id
+                ).assistant_threads_setStatus(
+                    channel_id=chat_id,
+                    thread_ts=thread_ts,
+                    status="",
+                )
+                if resolved_key:
+                    self._active_status_threads.pop(resolved_key, None)
         except Exception as e:
             logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -3473,7 +3473,14 @@ class SlackAdapter(BasePlatformAdapter):
             logger.debug("[Slack] assistant.threads.setStatus failed: %s", e)
 
     def _status_thread_lock(self, key: Tuple[str, str, str]) -> asyncio.Lock:
-        """Return the lock that orders Assistant API writes for one thread."""
+        """Return the lock that orders Assistant API writes for one thread.
+
+        This only orders when each write is *initiated* against Slack, not
+        the order Slack applies them in; an internal retry on the earlier
+        request could still in principle land it after the later one. If a
+        "status still stuck" report ever recurs with this lock in place,
+        that residual reordering is where to look next.
+        """
         lock = self._status_thread_locks.get(key)
         if lock is None:
             if len(self._status_thread_locks) > self._ACTIVE_STATUS_THREADS_MAX:

--- a/tests/gateway/test_slack_status_serialization.py
+++ b/tests/gateway/test_slack_status_serialization.py
@@ -1,0 +1,113 @@
+"""Ordering tests for Slack assistant status set/clear serialization.
+
+A delayed "is thinking" write must never land after a completion clear:
+the per-thread lock orders the writes, and a queued set skips itself when
+the tracked entry was cleared while it waited.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+class RecordingClient:
+    def __init__(self):
+        self.calls = []
+        self.release = asyncio.Event()
+        self.entered = asyncio.Event()
+        self.block_next_set = False
+        self.block_next_clear = False
+
+    async def assistant_threads_setStatus(self, channel_id, thread_ts, status):
+        if status and self.block_next_set:
+            self.block_next_set = False
+            self.entered.set()
+            await self.release.wait()
+        if not status and self.block_next_clear:
+            self.block_next_clear = False
+            self.entered.set()
+            await self.release.wait()
+        self.calls.append((thread_ts, status))
+
+
+def make_adapter(client):
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="test"))
+    adapter._app = MagicMock()
+    adapter._get_client = lambda chat_id, team_id=None: client
+    adapter._channel_team = {"C123": "T1"}
+    return adapter
+
+
+META = {"thread_id": "100.000", "team_id": "T1"}
+
+
+@pytest.mark.asyncio
+async def test_clear_lands_after_in_flight_set():
+    client = RecordingClient()
+    adapter = make_adapter(client)
+
+    client.block_next_set = True
+    set_task = asyncio.create_task(adapter.send_typing("C123", dict(META)))
+    await client.entered.wait()  # the set is mid-flight at the Slack API
+
+    stop_task = asyncio.create_task(adapter.stop_typing("C123", dict(META)))
+    await asyncio.sleep(0.01)
+    assert client.calls == []  # the clear is queued behind the lock
+
+    client.release.set()
+    await set_task
+    await stop_task
+
+    assert [s for _, s in client.calls] == ["is thinking...", ""]
+
+
+@pytest.mark.asyncio
+async def test_set_queued_behind_in_flight_clear_is_dropped():
+    """A send_typing that starts while stop_typing is mid-clear re-registers
+    its entry, but the clear pops it inside the lock, so the queued set must
+    drop itself instead of landing after the clear."""
+    client = RecordingClient()
+    adapter = make_adapter(client)
+
+    # A tracked status exists, then the clear starts and blocks mid-API-call.
+    await adapter.send_typing("C123", dict(META))
+    client.block_next_clear = True
+    stop_task = asyncio.create_task(adapter.stop_typing("C123", dict(META)))
+    await client.entered.wait()
+
+    # A refresh tick arrives while the clear is in flight.
+    set_task = asyncio.create_task(adapter.send_typing("C123", dict(META)))
+    await asyncio.sleep(0.01)
+
+    client.release.set()
+    await stop_task
+    await set_task
+
+    statuses = [s for _, s in client.calls]
+    assert statuses == ["is thinking...", ""]  # no set after the final clear
+
+
+@pytest.mark.asyncio
+async def test_queued_set_skips_after_clear():
+    client = RecordingClient()
+    adapter = make_adapter(client)
+
+    key = ("T1", "C123", "100.000")
+    lock = adapter._status_thread_lock(key)
+    await lock.acquire()  # simulate a clear already holding the lock
+    try:
+        set_task = asyncio.create_task(adapter.send_typing("C123", dict(META)))
+        await asyncio.sleep(0.01)
+        assert key in adapter._active_status_threads  # registered, waiting
+
+        # The completion clears the tracked entry while the set waits.
+        adapter._active_status_threads.pop(key)
+    finally:
+        lock.release()
+    await set_task
+
+    assert client.calls == []  # the stale set never reached Slack


### PR DESCRIPTION
## What does this PR do?

Fixes a race where a delayed `assistant_threads_setStatus('is thinking...')` write lands after the completion clear for the same thread and sticks, disabling the thread's compose box. `send_typing` registers its tracked entry and then awaits the Slack API; nothing orders that in-flight write against a concurrent `stop_typing` clear, and the pause flag cannot reach a call already awaiting the API.

The fix adds a per-workspace-thread `asyncio.Lock` that orders both writes, with the invariant: the final clear is the last status write Slack observes.

- `send_typing` takes the lock and re-checks the tracked entry inside it, so a set queued behind a clear finds its entry gone and drops itself (a genuinely new turn is re-set by the next refresh tick).
- `stop_typing` resolution only peeks at the tracked entry; the pop moves inside the lock, after a successful clear - so a set that re-registered while the clear was mid-flight still skips, and a failed clear stays retryable.
- Lock eviction skips threads that still track a status, keeping the release-to-wake handoff window out of the sweep.

The tracked-entry maps remain single-loop mutations; the lock only orders the awaited API writes, so no other call path changes.

## Related Issue

Fixes #92201

Related: #92202 / its PR covers the exec-approval flow's missing client-side clear, which this lock then serializes against.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py`: `_status_thread_locks` state, `_status_thread_lock()` helper with tracked-status-aware eviction, in-lock re-check in `send_typing`, peek-then-pop-inside-lock in `stop_typing`.
- `tests/gateway/test_slack_status_serialization.py`: three ordering regressions - clear queues behind an in-flight set and lands last; a set queued behind an in-flight clear drops itself; a set waiting on the lock skips when the entry was cleared meanwhile.

## How to Test

1. `pytest tests/gateway/test_slack_status_serialization.py -q` - the new tests drive the real `send_typing`/`stop_typing` with a client double that blocks mid-API-call to force each interleaving.
2. Without the adapter change, test 1 records `['', 'is thinking...']` (set after clear) and test 2 records a trailing set - both now assert the clear is final.
3. `pytest tests/gateway/test_slack.py tests/gateway/test_slack_status_update.py tests/test_slack_thread_require_mention.py -q` - 175 passed locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass - ran the Slack gateway suites listed above (175 passed); the full suite on this machine has pre-existing environment failures (optional media/voice deps) unrelated to this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon), Python 3.11, Socket Mode gateway running this patch live

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal race fix; behavior comments added in code)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — asyncio-only change, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A