### PR TITLE
fix(slack): clear assistant status after posting the exec approval prompt

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6965,6 +6965,18 @@ class SlackAdapter(BasePlatformAdapter):
                     self._approval_resolved, self._APPROVAL_RESOLVED_MAX
                 )
 
+            if msg_ts and thread_ts:
+                # The threaded approval post auto-clears the assistant status
+                # on Slack's side, but the tracked entry survives, so a
+                # delayed send_typing (e.g. a refresh already in flight when
+                # the pause flag was set) re-creates "is thinking..." and
+                # disables the composer exactly while the user needs to type
+                # /approve. Run the client-side clear so the tracked entry is
+                # dropped and a late set has nothing to resurrect.
+                await self._clear_thread_status_quietly(
+                    chat_id, {**(metadata or {}), "thread_id": thread_ts}
+                )
+
             return SendResult(success=True, message_id=msg_ts, raw_response=result)
         except Exception as e:
             logger.error("[Slack] send_exec_approval failed: %s", e, exc_info=True)

--- a/tests/gateway/test_slack_approval_status_clear.py
+++ b/tests/gateway/test_slack_approval_status_clear.py
@@ -1,0 +1,75 @@
+"""The Block Kit approval prompt must leave the composer usable.
+
+Slack auto-clears the assistant status server-side when the approval
+message posts into the thread, but the adapter's tracked entry survived,
+so a delayed "is thinking" write re-created the status and disabled the
+compose box for the whole approval wait. The approval send now runs the
+client-side clear, dropping the tracked entry.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+class RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    async def assistant_threads_setStatus(self, channel_id, thread_ts, status):
+        self.calls.append((thread_ts, status))
+
+    async def chat_postMessage(self, **kwargs):
+        self.calls.append((kwargs.get("thread_ts"), "post"))
+        return {"ts": "999.000"}
+
+
+def make_adapter(client):
+    adapter = SlackAdapter(PlatformConfig(enabled=True, token="test"))
+    adapter._app = MagicMock()
+    adapter._get_client = lambda chat_id, team_id=None: client
+    adapter._channel_team = {"C123": "T1"}
+    return adapter
+
+
+META = {"thread_id": "100.000", "team_id": "T1"}
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_clears_tracked_status_after_posting():
+    client = RecordingClient()
+    adapter = make_adapter(client)
+
+    await adapter.send_typing("C123", dict(META))
+    assert ("T1", "C123", "100.000") in adapter._active_status_threads
+
+    result = await adapter.send_exec_approval(
+        "C123",
+        command="rm -rf /tmp/x",
+        session_key="s1",
+        metadata=dict(META),
+    )
+
+    assert result.success
+    assert client.calls[-1] == ("100.000", "")  # explicit client-side clear
+    assert ("T1", "C123", "100.000") not in adapter._active_status_threads
+
+
+@pytest.mark.asyncio
+async def test_exec_approval_without_thread_context_skips_clear():
+    client = RecordingClient()
+    adapter = make_adapter(client)
+
+    result = await adapter.send_exec_approval(
+        "C123",
+        command="ls",
+        session_key="s1",
+        metadata=None,
+    )
+
+    assert result.success
+    assert [s for _, s in client.calls if s == ""] == []  # nothing to clear


### PR DESCRIPTION
## What does this PR do?

Fixes a stuck 'is thinking...' status during the exec-approval wait. `send_exec_approval` posts the Block Kit prompt with a raw `chat_postMessage`; Slack auto-clears the assistant status server-side on that threaded post, but the adapter's tracked `_active_status_threads` entry survives and no client-side clear participates in the flow. A `send_typing` refresh already in flight when `pause_typing_for_chat` flipped the flag lands after the auto-clear and re-creates the status - which disables the compose box exactly while the user needs to type `/approve`, and nothing clears it again until the blocked turn ends.

The fix runs the existing `_clear_thread_status_quietly` after a successful approval post: the tracked entry is dropped so a late set has nothing to resurrect, the explicit clear is a harmless no-op when Slack already cleared, and a cleanup failure can never mask the approval `SendResult`.

## Related Issue

Fixes #92202

Related: #92201 / PR #92203 adds per-thread write serialization, which additionally orders this clear against an in-flight set. The two fixes are independent and compose.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py`: client-side status clear in `send_exec_approval` after a successful post (thread-scoped metadata, only when a thread context exists).
- `tests/gateway/test_slack_approval_status_clear.py`: the approval post drops the tracked entry and issues the clear as the last status write; a thread-less approval skips the clear.

## How to Test

1. `pytest tests/gateway/test_slack_approval_status_clear.py -q` - drives the real `send_exec_approval` with a recording client double.
2. Without the adapter change, the tracked entry survives the approval post and no clear is issued - the first test fails on both assertions.
3. `pytest tests/gateway/test_slack_approval_buttons.py tests/gateway/test_slack.py -q` - 187 passed locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass - ran the Slack gateway suites listed above (187 passed); the full suite on this machine has pre-existing environment failures (optional media/voice deps) unrelated to this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon), Python 3.11, Socket Mode gateway running this patch live

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal fix; rationale comment added at the call site)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-independent adapter logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A