### PR TITLE
fix(goals): drop the hardcoded deepseek suggestion from the transport-failure pause

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -2032,11 +2032,9 @@ class GoalManager:
                 "message": (
                     f"⏸ Goal paused — judge API returned errors "
                     f"({state.consecutive_transport_failures} turns). "
-                    "Check the goal_judge provider/key in ~/.hermes/config.yaml:\n"
-                    "  auxiliary:\n"
-                    "    goal_judge:\n"
-                    "      provider: deepseek\n"
-                    "      model: deepseek-v4-flash\n"
+                    "Check the goal_judge provider/key via the dashboard "
+                    "Models page (http://127.0.0.1:9119/models) or in "
+                    "~/.hermes/config.yaml under auxiliary.goal_judge. "
                     "Then /goal resume to continue."
                 ),
             }

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -219,6 +219,34 @@ class TestJudgeParseFailureAutoPause:
             assert "config.yaml" in d3["message"]
 
 
+    def test_transport_pause_message_has_no_hardcoded_model(self, hermes_home):
+        """The transport-failure auto-pause must not suggest a specific
+        provider/model (#92195): the canned ``deepseek-v4-flash`` block read
+        as "the runtime secretly routes judge calls to DeepSeek" and sent
+        users debugging a config that wasn't the failure."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager, DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES
+
+        assert DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES == 5
+        mgr = GoalManager(session_id="transport-fail-sid-1", default_max_turns=20)
+        mgr.set("do a thing")
+
+        with patch.object(
+            goals, "judge_goal",
+            return_value=("continue", "judge transport unreachable", False, None, True),
+        ):
+            for i in range(DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES):
+                d = mgr.evaluate_after_turn(f"step {i + 1}")
+
+            assert d["should_continue"] is False
+            assert d["status"] == "paused"
+            # Points at the real config surface; no canned provider/model.
+            assert "goal_judge" in d["message"]
+            assert "config.yaml" in d["message"]
+            assert "deepseek" not in d["message"].lower()
+            assert "provider:" not in d["message"]
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

When the goal-judge transport fails 5 turns in a row, the auto-pause message printed a canned YAML block suggesting `provider: deepseek / model: deepseek-v4-flash`. Users (the reporter included, until they read the source) read that as "the runtime is secretly routing judge calls to DeepSeek" and debugged a config that had nothing to do with the failure — the actual cause is whatever the user's configured `auxiliary.goal_judge` resolution hit (auth, DNS, timeout; the reporter's was minimax-oauth failing auto-resolution) (#92195).

This removes the hardcoded suggestion from the transport-failure branch of `GoalManager.evaluate_after_turn` and points at the real config surface instead — the same defect and the same fix shape as the parse-failure branch of the module-level `evaluate_after_turn` (#22936, PR #22938): a neutral pointer to the dashboard Models page / `auxiliary.goal_judge` in config.yaml, naming no provider or model. That PR's diff covers only the parse branch; this branch (different function, different failure counter) is the mirror image.

## Related Issue

Fixes #92195

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/goals.py`: the transport-failure auto-pause message in `GoalManager.evaluate_after_turn` no longer embeds the `provider: deepseek / model: deepseek-v4-flash` YAML block; it now points at the dashboard Models page and `auxiliary.goal_judge` under config.yaml, mirroring the #22938 wording for the sibling branch
- `tests/hermes_cli/test_goals.py`: regression test driving 5 consecutive transport failures through `evaluate_after_turn` — asserts the pause fires, the message still names the real config surface (`goal_judge`, `config.yaml`), and contains neither `deepseek` nor a `provider:` key

## How to Test

1. `pytest tests/hermes_cli/test_goals.py`
2. Observed result: 34 passed, including the new transport-pause test; the 3 WaitBarrier failures (`test_parked_on_live_pid...`, `test_stop_waiting_clears_barrier`, `test_judge_wait_pid_parks_loop`) fail identically on a clean `main` checkout on this host (environment-dependent) — unrelated to this change.
3. The new test fails on pre-fix code: the old message contained `provider: deepseek`, tripping both the `deepseek` and `provider:` assertions.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (commit cites the mirror PR and the misreading mechanism)
- [x] Tests added/updated and passing (34 passed locally; 3 pre-existing env failures on clean main)
- [x] No new warnings introduced
- [x] Tested on macOS (arm64) via unit tests; the changed path is pure-Python message construction
