### PR TITLE
fix(kanban): auto-decomposed subtrees are dispatchable and the orchestrator worker can see the board

### DIFF
--- a/hermes_cli/kanban_db_graph.py
+++ b/hermes_cli/kanban_db_graph.py
@@ -115,7 +115,7 @@ def decompose_triage_task(
     now = int(time.time())
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "SELECT id, status, tenant, priority, workspace_kind, workspace_path "
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if root_row is None or root_row["status"] != "triage":
@@ -196,14 +196,31 @@ def _insert_decomposed_child(
         child_ws_path = None
     new_id = _new_task_id()
     body = child.get("body")
+    # Children inherit the ROOT's priority. Dispatch is strictly
+    # highest-priority-first with a per-profile in-flight cap, so a child
+    # emitted at the column default (0) queues behind every hand-created
+    # card on a board whose live band sits in the 90s and never visibly
+    # moves. That is not starvation of one card: every auto-decomposed
+    # subtree lands below the floor, which is what makes autonomous
+    # orchestration look like it never fires. A child dict may still
+    # override with its own 'priority'.
+    child_priority = child.get("priority")
+    try:
+        child_priority = (
+            int(child_priority) if child_priority is not None
+            else (root_row["priority"] or 0)
+        )
+    except (TypeError, ValueError):
+        child_priority = root_row["priority"] or 0
     conn.execute(
         "INSERT INTO tasks "
-        "(id, title, body, assignee, status, workspace_kind, "
+        "(id, title, body, assignee, status, priority, workspace_kind, "
         " workspace_path, tenant, created_at, created_by) "
-        "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+        "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, ?)",
         (
             new_id, child["title"].strip(), body if isinstance(body, str) else None,
-            _canonical_assignee(child.get("assignee")), child_ws_kind, child_ws_path,
+            _canonical_assignee(child.get("assignee")), child_priority,
+            child_ws_kind, child_ws_path,
             root_row["tenant"], now, (author or "decomposer"),
         ),
     )

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -90,5 +90,74 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decomposed_children_inherit_root_priority(kanban_home):
+    """Regression: children were inserted without a priority column, so
+    they landed at the SQL default 0 and queued behind every card on a
+    board whose live band sits far above 0. Dispatch is strictly
+    highest-priority-first, so every auto-decomposed subtree was starved
+    and autonomous orchestration looked like it never fired.
+    """
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="high-band root", triage=True, priority=97)
+        child_ids = decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "child A", "assignee": "researcher"},
+                {"title": "child B", "assignee": "engineer", "parents": [0]},
+            ],
+            author="decomposer",
+        )
+    assert child_ids is not None
+
+    with kbc.connect() as conn:
+        root = kb.get_task(conn, tid)
+        priorities = [kb.get_task(conn, cid).priority for cid in child_ids]
+
+    assert root.priority == 97
+    assert priorities == [97, 97], (
+        "auto-decomposed children must inherit the root's priority so the "
+        f"subtree dispatches in the same band; got {priorities}"
+    )
 
 
+def test_decomposed_child_can_override_priority(kanban_home):
+    """Inheritance is the default, not a ceiling: an explicit per-child
+    priority still wins so a decomposer can deprioritize one leaf."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="root", triage=True, priority=90)
+        child_ids = decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "inherits"},
+                {"title": "explicit", "priority": 12},
+            ],
+            author="decomposer",
+        )
+    assert child_ids is not None
+
+    with kbc.connect() as conn:
+        priorities = [kb.get_task(conn, cid).priority for cid in child_ids]
+
+    assert priorities == [90, 12]
+
+
+def test_decomposed_children_inherit_zero_priority_root(kanban_home):
+    """A root genuinely at 0 still yields children at 0 - the fix is
+    inheritance, not a hardcoded floor."""
+    with kbc.connect() as conn:
+        tid = kb.create_task(conn, title="root", triage=True, priority=0)
+        child_ids = decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[{"title": "child A"}],
+            author="decomposer",
+        )
+    assert child_ids is not None
+
+    with kbc.connect() as conn:
+        assert kb.get_task(conn, child_ids[0]).priority == 0

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -41,6 +41,133 @@ def test_kanban_tools_hidden_without_env_var(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Orchestrator worker gate (kanban_list on a dispatched orchestrator run)
+# ---------------------------------------------------------------------------
+
+def _orchestrator_gate_env(monkeypatch, tmp_path, *, profile, orchestrator):
+    """Write a config pinning kanban.orchestrator_profile and simulate a
+    dispatcher-spawned worker run of ``profile``."""
+    home = tmp_path / ".hermes"
+    home.mkdir(exist_ok=True)
+    (home / "config.yaml").write_text(
+        f"kanban:\n  orchestrator_profile: {orchestrator}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", profile)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_gate_probe")
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+
+    from tools import kanban_tools as kt
+
+    monkeypatch.setattr(kt, "_is_delegated_child_context", lambda: False)
+    monkeypatch.setattr(kt, "_is_dispatcher_owned_worker", lambda: True)
+    return kt
+
+
+def test_orchestrator_worker_run_keeps_board_routing_tools(monkeypatch, tmp_path):
+    """Regression: a dispatched worker run of kanban.orchestrator_profile
+    got a NARROWER toolset than the same profile's interactive session -
+    no kanban_list - so the card meant to sweep the board could only read
+    the ids handed to it and had to route a read-only inventory card to
+    another profile just to enumerate the board.
+    """
+    kt = _orchestrator_gate_env(
+        monkeypatch, tmp_path, profile="orchestrator", orchestrator="orchestrator"
+    )
+    assert kt._check_kanban_orchestrator_mode() is True
+    # The belt-and-suspenders runtime guard must agree with the schema
+    # gate, or the tool is registered and then refuses at call time.
+    assert kt._require_orchestrator_tool("kanban_list") is None
+
+
+def test_non_orchestrator_worker_run_stays_task_scoped(monkeypatch, tmp_path):
+    """Every OTHER profile's worker keeps the original narrow surface:
+    close your own card, do not enumerate or unblock the board."""
+    kt = _orchestrator_gate_env(
+        monkeypatch, tmp_path, profile="builder", orchestrator="orchestrator"
+    )
+    assert kt._check_kanban_orchestrator_mode() is False
+    with pytest.raises(kt._Reject) as excinfo:
+        kt._require_orchestrator_tool("kanban_list")
+    assert "orchestrator-only" in str(excinfo.value)
+
+
+def test_worker_run_stays_task_scoped_when_no_orchestrator_configured(
+    monkeypatch, tmp_path
+):
+    """With kanban.orchestrator_profile unset, no worker is the board
+    agent - the gate must not fall open for everyone."""
+    kt = _orchestrator_gate_env(
+        monkeypatch, tmp_path, profile="orchestrator", orchestrator=""
+    )
+    assert kt._check_kanban_orchestrator_mode() is False
+    with pytest.raises(kt._Reject):
+        kt._require_orchestrator_tool("kanban_list")
+
+
+def test_delegated_child_never_gets_board_tools(monkeypatch, tmp_path):
+    """A delegate_task child runs in its parent's process, so inherited
+    HERMES_* env is not proof of ownership - it stays denied even when
+    the parent IS the orchestrator."""
+    kt = _orchestrator_gate_env(
+        monkeypatch, tmp_path, profile="orchestrator", orchestrator="orchestrator"
+    )
+    monkeypatch.setattr(kt, "_is_delegated_child_context", lambda: True)
+    assert kt._check_kanban_orchestrator_mode() is False
+    with pytest.raises(kt._Reject):
+        kt._require_orchestrator_tool("kanban_unblock")
+
+
+def test_orchestrator_elevation_fails_closed_when_ownership_unprovable(
+    monkeypatch, tmp_path
+):
+    """Regression for the fail-open authority hole.
+
+    ``_is_dispatcher_owned_worker()`` defaults PERMISSIVE (True) when
+    ``agent.delegation_context`` cannot be imported or raises. The
+    orchestrator elevation is the ONLY path that hands a dispatched
+    worker board-WIDE mutation authority (kanban_unblock), so it must
+    consult the canonical predicate itself and refuse when no verdict is
+    available - process env (HERMES_PROFILE + HERMES_KANBAN_TASK) is not
+    an authority proof (#79657).
+
+    Production path: the helper is NOT monkeypatched here; the real
+    import target is made to raise.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(exist_ok=True)
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: orchestrator\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_gate_probe")
+
+    from tools import kanban_tools as kt
+
+    monkeypatch.setattr(kt, "_is_delegated_child_context", lambda: False)
+
+    from agent import delegation_context
+
+    def _boom():
+        raise RuntimeError("delegation context probe unavailable")
+
+    monkeypatch.setattr(
+        delegation_context, "is_dispatcher_owned_worker_context", _boom
+    )
+
+    # The legacy wrapper still fails open by design (broad compatibility).
+    assert kt._is_dispatcher_owned_worker() is True
+    # The elevation does NOT inherit that permissiveness.
+    assert kt._is_orchestrator_worker() is False
+    assert kt._check_kanban_orchestrator_mode() is False
+    with pytest.raises(kt._Reject) as excinfo:
+        kt._require_orchestrator_tool("kanban_unblock")
+    assert "orchestrator-only" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
 # Handler happy paths
 # ---------------------------------------------------------------------------
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -76,8 +76,62 @@ def _check_kanban_mode() -> bool:
     return _visible(to_env_worker=True)
 
 
+def _configured_orchestrator_profile() -> str:
+    """``kanban.orchestrator_profile`` as a normalized name, or ""."""
+    try:
+        cfg = load_config()
+        kcfg = cfg.get("kanban") or {}
+        if not isinstance(kcfg, dict):
+            return ""
+        return (kcfg.get("orchestrator_profile") or "").strip().lower()
+    except Exception:
+        return ""
+
+
+def _is_orchestrator_worker() -> bool:
+    """True when THIS dispatched worker run is the board's orchestrator.
+
+    The dispatcher exports ``HERMES_PROFILE`` for the assignee it spawns
+    (see kanban_db._worker_env). A worker run of
+    ``kanban.orchestrator_profile`` is the board-health agent: its whole
+    job is to sweep the board, so denying it ``kanban_list`` leaves it
+    able to read only the ids handed to it and forces it to route a
+    read-only inventory card to another profile just to see the board.
+    That is the autonomy gap. Any OTHER profile's worker stays scoped to
+    its own card, which is the behavior this gate was written for.
+
+    This elevation is the ONLY path that hands a dispatched worker
+    board-wide mutation authority (``kanban_unblock``), so it must fail
+    CLOSED: when the canonical dispatcher-ownership verdict from
+    ``agent.delegation_context`` cannot be obtained, we refuse rather than
+    fall back to "HERMES_PROFILE + HERMES_KANBAN_TASK is enough". Process
+    env is not an authority proof (#79657); only the ContextVar is.
+    """
+    orchestrator = _configured_orchestrator_profile()
+    if not orchestrator:
+        return False
+    profile = (os.environ.get("HERMES_PROFILE") or "").strip().lower()
+    if not profile or profile != orchestrator:
+        return False
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return False
+    # Fail closed, unlike _is_dispatcher_owned_worker()'s permissive default.
+    return _delegation_ctx("is_dispatcher_owned_worker_context", False)
+
+
 def _check_kanban_orchestrator_mode() -> bool:
-    """Board-routing tools (kanban_list, kanban_unblock): hidden from task workers."""
+    """Board-routing tools (kanban_list, kanban_unblock): hidden from task workers.
+
+    The one exception is a dispatched worker run of the configured
+    ``kanban.orchestrator_profile``: that profile IS the board-routing
+    surface, and it must carry the same kanban_* tools as its interactive
+    session or autonomous board sweeps cannot enumerate the board at all.
+    That elevation is fail-closed (see ``_is_orchestrator_worker``).
+    """
+    if _is_delegated_child_context():
+        return False
+    if _is_orchestrator_worker():
+        return True
     return _visible(to_env_worker=False)
 
 
@@ -188,8 +242,15 @@ def _worker_guard(tool_name: str, args: dict) -> str:
 
 def _require_orchestrator_tool(tool_name: str) -> None:
     """The check_fn already hides orchestrator tools from workers; this catches
-    a stale registration or test harness routing a worker here anyway."""
-    if os.environ.get("HERMES_KANBAN_TASK"):
+    a stale registration or test harness routing a worker here anyway.
+
+    Mirrors ``_check_kanban_orchestrator_mode``: a worker run of the
+    configured ``kanban.orchestrator_profile`` is the board-routing surface
+    and is allowed through, otherwise the schema fix would be defeated at
+    call time. That exception is fail-closed (``_is_orchestrator_worker``)."""
+    if os.environ.get("HERMES_KANBAN_TASK") and (
+        _is_delegated_child_context() or not _is_orchestrator_worker()
+    ):
         raise _Reject(
             f"{tool_name} is orchestrator-only; dispatcher-spawned workers must use "
             "kanban_complete, kanban_block, kanban_heartbeat, or kanban_comment for their "


### PR DESCRIPTION
Auto-decompose fires correctly — the engine works. Two defects make every
decomposed subtree invisible and leave the board-sweeping card unable to see
the board.

## Defect 1 — decomposed children are emitted at priority 0

`kanban_db.decompose_triage_task()` inserts children with an INSERT that omits
the `priority` column entirely, so every child gets the SQL default `0`,
regardless of the root's priority.

Dispatch is strictly `ORDER BY priority DESC, created_at ASC` with
`kanban.max_in_progress_per_profile`, so on any board whose live band is above
0 an auto-decomposed subtree queues behind every hand-created card and never
runs. This is not one starved card: the decomposer systematically emits below
the floor, which is exactly what makes autonomous orchestration look like it
never fires.

Observed on a live board: root at priority 1, its five children all at 0, while
the board's live band was 94-99.

**Fix:** children inherit the ROOT's priority. A child dict may still set its
own `priority` to deprioritize one leaf, and a root genuinely at 0 still yields
children at 0 — this is inheritance, not a hardcoded floor.

## Defect 2 — an orchestrator WORKER run has no `kanban_list`

`_check_kanban_orchestrator_mode()` returned `False` for **any**
dispatcher-spawned worker:

```python
if os.environ.get("HERMES_KANBAN_TASK") and _is_dispatcher_owned_worker():
    return False
```

That is right for ordinary workers — close your own card, do not enumerate or
unblock the board — but it also strips the board-routing tools from a worker run
of `kanban.orchestrator_profile`, the profile whose entire job is sweeping the
board. The same profile has `kanban_list` in an interactive session, so a
dispatched orchestrator gets a strictly narrower toolset than its own chat.

Consequence, quoted verbatim from a real orchestrator card's completion
metadata:

> no kanban_list tool registered for orchestrator this run - board enumeration
> impossible from this profile

It could read only the handful of ids handed to it and had to route a read-only
inventory card to another profile just to see the board.

**Fix:** a dispatched worker run of the configured
`kanban.orchestrator_profile` keeps the board-routing surface. Every other
profile's worker stays scoped to its own card, unchanged. The dispatcher already
exports `HERMES_PROFILE` for the assignee it spawns (`kanban_db._worker_env`),
so the check needs no new state.

`_require_orchestrator_tool()`, the belt-and-suspenders runtime guard, mirrors
the same condition. Without that half the tool would be registered in the
schema and then refuse at call time.

With `kanban.orchestrator_profile` unset, nothing changes for anyone: no worker
is treated as the board agent. A `delegate_task` child stays denied even when
its parent is the orchestrator, since it shares the parent's process and its
inherited `HERMES_*` env is not proof of ownership.

## Tests

`tests/hermes_cli/test_kanban_decompose_db.py`
- children inherit the root's priority
- an explicit per-child `priority` still wins
- a root at 0 yields children at 0 (no hardcoded floor)

`tests/tools/test_kanban_tools.py`
- orchestrator worker run keeps the board-routing tools, and the runtime guard
  agrees with the schema gate
- another profile's worker stays task-scoped
- unset `orchestrator_profile` does not fall open
- `delegate_task` child stays denied

Both headline tests are proven to fail on the unpatched tree:

```
FAILED tests/hermes_cli/test_kanban_decompose_db.py::test_decomposed_children_inherit_root_priority
FAILED tests/hermes_cli/test_kanban_decompose_db.py::test_decomposed_child_can_override_priority
FAILED tests/tools/test_kanban_tools.py::test_orchestrator_worker_run_keeps_board_routing_tools
```

and pass with it: `41 passed` across both files.

`tests/hermes_cli -k kanban` shows 15 failures both with and without this
change (identical set, byte for byte) — pre-existing suite-order pollution,
untouched here. `tests/hermes_cli/test_kanban_decompose.py` passes in isolation.
