### PR TITLE
fix(doctor): stop flagging omniroute provider as vendor-prefixed

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1417,6 +1417,9 @@ def run_doctor(args):
                 # is exclusively ``vendor/model`` slugs (Qwen/Qwen3.5-…,
                 # meta-llama/Llama-3-…, anthropic/claude-opus-4-7, …).
                 "deepinfra",
+                # OmniRoute is a local aggregator proxy (routes to OpenRouter
+                # free tier); it legitimately accepts vendor/model slugs.
+                "omniroute",
             }
             provider_accepts_vendor_slug = (
                 provider_policy_id in providers_accepting_vendor_slugs

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -560,6 +560,9 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
         ("kimi-coding", "kimi-k2"),
         ("nvidia", "qwen/qwen3.5-122b-a10b"),
         ("moa", "anthropic/claude-sonnet-4.6"),
+        # OmniRoute: local aggregator proxy; auto/best-free is an auto-select
+        # routing mode, not a true vendor-slug — must NOT warn.
+        ("omniroute", "auto/best-free"),
     ],
 )
 def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
@@ -570,7 +573,15 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
     (home / "config.yaml").write_text(
         "model:\n"
         f"  provider: {provider}\n"
-        f"  default: {default_model}\n",
+        f"  default: {default_model}\n"
+        + (
+            "providers:\n"
+            "  omniroute:\n"
+            "    base_url: http://localhost:20128/v1\n"
+            "    api_key: test-key\n"
+            if provider == "omniroute"
+            else ""
+        ),
         encoding="utf-8",
     )
 
@@ -603,6 +614,13 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
     if provider in {"ai-gateway", "opencode-zen", "kilocode", "nvidia"}:
         assert (
             f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider}'"
+            not in out
+        )
+    # OmniRoute must be treated like the other aggregator providers in the
+    # whitelist: `auto/best-free` is an auto-select mode, not a vendor slug.
+    if provider == "omniroute":
+        assert (
+            f"model.default '{default_model}' is vendor-prefixed but model.provider is '{provider}'"
             not in out
         )
 


### PR DESCRIPTION
## Bug Description

`hermes doctor` meldet fälschlich einen Modell-Fehler für User, die einen lokalen Aggregator-Proxy `omniroute` mit `model.default: auto/best-free` verwenden:

```
model.default 'auto/best-free' is vendor-prefixed but model.provider is 'omniroute'.
Either set model.provider to 'openrouter', or drop the vendor prefix.
```

Dies ist ein False-Positive: `auto/best-free` ist ein Auto-Select-Routing-Modus, kein `vendor/model`-Slug. Die Konfiguration ist korrekt und funktioniert — der Doctor irrt.

## Root Cause

In `hermes_cli/doctor.py` prüft die Vendor-Slug-Erkennung naiv, ob `model.default` ein `/` enthält. `omniroute` (ein lokaler Aggregator-Proxy, der zu OpenRouter-Free-Tier routet) fehlt in der Whitelist `providers_accepting_vendor_slugs`, sodass die Slash-Form `auto/best-free` fälschlich als Vendor-Präfix klassifiziert wird.

## Fix

`omniroute` zur `providers_accepting_vendor_slugs`-Whitelist in `hermes_cli/doctor.py` hinzugefügt, analog zu den anderen Aggregator-Providern (`openrouter`, `deepinfra`, `ai-gateway`, …).

## How to Verify

1. Eine Config mit `model.provider: omniroute` und `model.default: auto/best-free` (plus `providers.omniroute`-Block) anlegen.
2. `hermes doctor` ausführen.
3. Vorher: `model.default 'auto/best-free' is vendor-prefixed...` erscheint als Issue.
4. Nachher: Kein Modell-`vendor-prefixed`-Issue mehr; nur noch unabhängige Issues (z.B. npm) gemeldet.

## Test Plan

- [x] Regressionstest: parametrisierter Fall `("omniroute", "auto/best-free")` in `test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases` hinzugefügt (inkl. `providers.omniroute`-Block im Test-Setup, damit auch die Recognised-Provider-Prüfung greift).
- [x] `pytest tests/hermes_cli/test_doctor.py -k "vendor_slugs or catalog_aliases"` → 8 passed.
- [x] Manuelle Verifikation: `hermes doctor` meldet das Modell-False-Positive nicht mehr.

## Risk Assessment

**Low** — Die Änderung fügt lediglich `omniroute` zu einer bestehenden Whitelist hinzu. Sie betrifft ausschließlich die Doctor-Warnung für User mit einem `omniroute`-Provider; keine Änderung an Laufzeit-Routing oder Modell-Auswahl. Andere Provider bleiben unverändert.