### PR TITLE
fix(agent): isolate output-cap retry budget

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8307,17 +8307,17 @@ def _effective_aux_timeout(task: str, timeout: Optional[float]) -> float:
     return effective
 
 
-def _get_task_extra_body(task: str) -> Dict[str, Any]:
-    """Read auxiliary.<task>.extra_body and return a shallow copy when valid.
+def _get_task_request_config(
+    task: str,
+) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Return task extra-body fields and Hermes reasoning configuration.
 
-    Also folds in ``auxiliary.<task>.reasoning_effort`` as an
-    ``extra_body.reasoning`` config dict ({"enabled": ..., "effort": ...})
-    when set. An explicit ``extra_body.reasoning`` in config wins over the
-    ``reasoning_effort`` shorthand (it is the more specific wire control).
-    Downstream, each wire already translates ``extra_body.reasoning``:
-    chat.completions passes it through, the Codex Responses adapter maps it
-    to top-level ``reasoning``/``include``, and the Anthropic auxiliary
-    client maps it to ``build_anthropic_kwargs(reasoning_config=...)``.
+    ``auxiliary.<task>.reasoning_effort`` is a provider-neutral Hermes knob.
+    Preserve the legacy ``extra_body.reasoning`` projection for compatible
+    callers, and also return the parsed config separately so provider profiles
+    can translate it to the active endpoint's wire shape. An explicit
+    ``extra_body.reasoning`` wins and suppresses profile projection because it
+    is the more specific wire control.
 
     MoA tasks are excluded by design: reasoning depth for MoA is a per-slot
     setting in the MoA preset (``moa.presets.<name>.reference_models[].
@@ -8328,29 +8328,41 @@ def _get_task_extra_body(task: str) -> Dict[str, Any]:
     task_config = _get_auxiliary_task_config(task)
     raw = task_config.get("extra_body")
     result = dict(raw) if isinstance(raw, dict) else {}
-    if "reasoning" not in result:
-        effort = task_config.get("reasoning_effort")
-        if effort is not None and effort != "":
-            if task in ("moa_reference", "moa_aggregator"):
-                logger.warning(
-                    "auxiliary.%s.reasoning_effort is not supported — MoA "
-                    "reasoning depth is per-slot: set reasoning_effort on the "
-                    "preset's reference_models entries / aggregator instead "
-                    "(moa.presets.<name>...). Ignoring.",
-                    task,
-                )
-                return result
-            from hermes_constants import parse_reasoning_effort
-            parsed = parse_reasoning_effort(effort)
-            if parsed is not None:
-                result["reasoning"] = parsed
-            else:
-                logger.warning(
-                    "auxiliary.%s.reasoning_effort %r is not a valid level "
-                    "(none, minimal, low, medium, high, xhigh, max, ultra) — ignoring",
-                    task, effort,
-                )
-    return result
+    if "reasoning" in result:
+        return result, None
+
+    effort = task_config.get("reasoning_effort")
+    if effort is None or effort == "":
+        return result, None
+    if task in ("moa_reference", "moa_aggregator"):
+        logger.warning(
+            "auxiliary.%s.reasoning_effort is not supported — MoA "
+            "reasoning depth is per-slot: set reasoning_effort on the "
+            "preset's reference_models entries / aggregator instead "
+            "(moa.presets.<name>...). Ignoring.",
+            task,
+        )
+        return result, None
+
+    from hermes_constants import parse_reasoning_effort
+
+    parsed = parse_reasoning_effort(effort)
+    if parsed is not None:
+        result["reasoning"] = parsed
+        return result, parsed
+
+    logger.warning(
+        "auxiliary.%s.reasoning_effort %r is not a valid level "
+        "(none, minimal, low, medium, high, xhigh, max, ultra) — ignoring",
+        task, effort,
+    )
+    return result, None
+
+
+def _get_task_extra_body(task: str) -> Dict[str, Any]:
+    """Return the legacy extra-body projection for a configured task."""
+    extra_body, _reasoning_config = _get_task_request_config(task)
+    return extra_body
 
 
 # ---------------------------------------------------------------------------
@@ -9416,8 +9428,12 @@ def _call_llm_impl(
         task, provider, model, base_url, api_key)
     if api_mode:
         resolved_api_mode = api_mode
-    effective_extra_body = _get_task_extra_body(task)
+    effective_extra_body, task_reasoning_config = _get_task_request_config(task)
     effective_extra_body.update(extra_body or {})
+    if isinstance(extra_body, dict) and "reasoning" in extra_body:
+        task_reasoning_config = None
+    if reasoning_config is None:
+        reasoning_config = task_reasoning_config
     effective_provider = resolved_provider
 
     if task == "vision":
@@ -10239,8 +10255,12 @@ async def _async_call_llm_impl(
     main_runtime = _normalize_main_runtime(main_runtime)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
-    effective_extra_body = _get_task_extra_body(task)
+    effective_extra_body, task_reasoning_config = _get_task_request_config(task)
     effective_extra_body.update(extra_body or {})
+    if isinstance(extra_body, dict) and "reasoning" in extra_body:
+        task_reasoning_config = None
+    if reasoning_config is None:
+        reasoning_config = task_reasoning_config
     effective_provider = resolved_provider
 
     if task == "vision":

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1899,6 +1899,7 @@ def run_conversation(
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
+    output_cap_retry_attempts = 0
     # One resolved per-turn compression attempt cap, shared by every site that
     # consumes ``compression_attempts``: the pre-API pressure gate, the
     # overflow/413 retry handlers, and the post-tool compaction gate. The
@@ -3455,6 +3456,18 @@ def run_conversation(
                     continue  # Retry the API call
 
                 agent._turn_received_provider_response = True
+
+                # Output-cap recovery has its own consecutive-failure budget.
+                # A valid provider response proves the most recent clamp was
+                # effective and rearms later tool iterations in this turn.
+                if output_cap_retry_attempts:
+                    logger.info(
+                        "Output-cap retry budget rearmed after successful "
+                        "provider response (attempts were %s/%s)",
+                        output_cap_retry_attempts,
+                        max_compression_attempts,
+                    )
+                    output_cap_retry_attempts = 0
 
                 # Check finish_reason before proceeding
                 if agent.api_mode == "codex_responses":
@@ -5086,6 +5099,7 @@ def run_conversation(
                     agent._client_log_context(),
                     _error_summary,
                 )
+                logger.debug("API call failed full error: %s", api_error)
 
                 _provider = getattr(agent, "provider", "unknown")
                 _base = getattr(agent, "base_url", "unknown")
@@ -5678,24 +5692,37 @@ def run_conversation(
                             # budget, which is authoritative for the failed
                             # request.
                             safe_out = max(1, available_out - 64)
-                        agent._ephemeral_max_output_tokens = safe_out
-                        agent._buffer_vprint(
-                            f"⚠️  Output cap too large for current prompt — "
-                            f"retrying with max_tokens={safe_out:,} "
-                            f"(provider_available={available_out:,}, "
-                            f"estimated_request_tokens={request_input_estimate:,}; "
-                            f"context_length unchanged at {old_ctx:,})"
-                        )
-                        # Still count against compression_attempts so we don't
-                        # loop forever if the error keeps recurring.
-                        compression_attempts += 1
-                        if compression_attempts > max_compression_attempts:
+                        # Output-cap clamps and context compactions are separate
+                        # recovery mechanisms. Preflight/post-tool compression
+                        # can legitimately consume its whole budget before the
+                        # provider reveals that this request's output cap is too
+                        # large. Charging the clamp to that shared counter made
+                        # the first output-cap error terminate without ever
+                        # sending the reduced request. Keep a dedicated bounded
+                        # counter, rearmed by the next valid provider response.
+                        output_cap_retry_attempts += 1
+                        if output_cap_retry_attempts > max_compression_attempts:
                             agent._flush_status_buffer()
-                            agent._vprint(f"{agent.log_prefix}❌ Max compression attempts ({max_compression_attempts}) reached.", force=True)
-                            agent._vprint(f"{agent.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
-                            logger.error("%sContext compression failed after %d attempts.", agent.log_prefix, max_compression_attempts)
+                            agent._vprint(
+                                f"{agent.log_prefix}❌ Max output-cap recovery "
+                                f"attempts ({max_compression_attempts}) reached.",
+                                force=True,
+                            )
+                            agent._vprint(
+                                f"{agent.log_prefix}   💡 Lower model.max_tokens, "
+                                "run /compress, or start a fresh conversation with /new.",
+                                force=True,
+                            )
+                            logger.error(
+                                "%sOutput-cap recovery failed after %d attempts.",
+                                agent.log_prefix,
+                                max_compression_attempts,
+                            )
                             agent._persist_session(messages, conversation_history)
-                            _final_response = f"Context length exceeded: max compression attempts ({max_compression_attempts}) reached."
+                            _final_response = (
+                                "Context length exceeded: max output-cap recovery "
+                                f"attempts ({max_compression_attempts}) reached."
+                            )
                             return {
                                 "final_response": _final_response,
                                 "messages": messages,
@@ -5705,7 +5732,29 @@ def run_conversation(
                                 "partial": True,
                                 "failed": True,
                                 "compression_exhausted": True,
+                                "output_cap_recovery_exhausted": True,
                             }
+                        agent._ephemeral_max_output_tokens = safe_out
+                        agent._buffer_vprint(
+                            f"⚠️  Output cap too large for current prompt — "
+                            f"retrying with max_tokens={safe_out:,} "
+                            f"(provider_available={available_out:,}, "
+                            f"estimated_request_tokens={request_input_estimate:,}; "
+                            f"context_length unchanged at {old_ctx:,})"
+                        )
+                        logger.info(
+                            "%sOutput cap too large for current prompt; retrying "
+                            "with max_tokens=%s (attempt %s/%s, "
+                            "provider_available=%s, estimated_request_tokens=%s, "
+                            "context_length=%s)",
+                            agent.log_prefix,
+                            safe_out,
+                            output_cap_retry_attempts,
+                            max_compression_attempts,
+                            available_out,
+                            request_input_estimate,
+                            old_ctx,
+                        )
                         # Also compress the message history so the output-cap
                         # retry does not just spin on max_tokens alone.  The
                         # compressor drops the middle window, freeing enough

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2244,6 +2244,103 @@ class TestStaleBaseUrlWarning:
 
 
 class TestAuxiliaryTaskExtraBody:
+    def test_task_reasoning_effort_uses_custom_provider_profile(self):
+        """The generic task knob reaches custom OpenAI-compatible wires."""
+        client = MagicMock()
+        client.base_url = "http://127.0.0.1:8000/v1"
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+
+        config = {
+            "auxiliary": {
+                "compression": {
+                    "provider": "custom",
+                    "model": "local-reasoning-model",
+                    "reasoning_effort": "low",
+                }
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config), patch(
+            "hermes_cli.config.load_config_readonly", return_value=config
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "local-reasoning-model"),
+        ):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["reasoning_effort"] == "low"
+
+    @pytest.mark.asyncio
+    async def test_async_task_reasoning_effort_uses_custom_provider_profile(self):
+        client = MagicMock()
+        client.base_url = "http://127.0.0.1:8000/v1"
+        response = MagicMock()
+        client.chat.completions.create = AsyncMock(return_value=response)
+        config = {
+            "auxiliary": {
+                "web_extract": {
+                    "provider": "custom",
+                    "model": "local-reasoning-model",
+                    "reasoning_effort": "none",
+                }
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config), patch(
+            "hermes_cli.config.load_config_readonly", return_value=config
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "local-reasoning-model"),
+        ):
+            result = await async_call_llm(
+                task="web_extract",
+                messages=[{"role": "user", "content": "extract"}],
+            )
+
+        assert result is response
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["reasoning_effort"] == "none"
+        assert kwargs["extra_body"]["think"] is False
+
+    def test_explicit_reasoning_extra_body_suppresses_profile_projection(self):
+        """A task's explicit wire control still wins over the shorthand."""
+        client = MagicMock()
+        client.base_url = "http://127.0.0.1:8000/v1"
+        response = MagicMock()
+        client.chat.completions.create.return_value = response
+        explicit_reasoning = {"enabled": False, "vendor": "custom"}
+        config = {
+            "auxiliary": {
+                "compression": {
+                    "provider": "custom",
+                    "model": "local-reasoning-model",
+                    "reasoning_effort": "low",
+                    "extra_body": {"reasoning": explicit_reasoning},
+                }
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config), patch(
+            "hermes_cli.config.load_config_readonly", return_value=config
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "local-reasoning-model"),
+        ):
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarize"}],
+            )
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert "reasoning_effort" not in kwargs
+        assert kwargs["extra_body"]["reasoning"] == explicit_reasoning
+
     def test_sync_call_merges_task_extra_body_from_config(self):
         client = MagicMock()
         client.base_url = "https://api.example.com/v1"

--- a/tests/run_agent/test_output_cap_recovery_e2e.py
+++ b/tests/run_agent/test_output_cap_recovery_e2e.py
@@ -1,0 +1,383 @@
+"""End-to-end recovery tests for OpenAI-compatible output-cap overflows."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+
+CONTEXT_LENGTH = 131_072
+DEFAULT_OUTPUT_CAP = 65_536
+
+
+def _content_chars(value: object) -> int:
+    if isinstance(value, str):
+        return len(value)
+    if isinstance(value, list):
+        return sum(_content_chars(item) for item in value)
+    if isinstance(value, dict):
+        return sum(_content_chars(item) for item in value.values())
+    return 0
+
+
+class _OpenAICompatibleHandler(BaseHTTPRequestHandler):
+    requests: list[dict] = []
+    tool_responses_remaining = 0
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        size = int(self.headers.get("Content-Length", "0"))
+        request = json.loads(self.rfile.read(size))
+        if self.path != "/v1/chat/completions":
+            self._send_json(404, {"error": {"message": "not found"}})
+            return
+
+        type(self).requests.append(request)
+        input_tokens = max(
+            1,
+            sum(_content_chars(message.get("content")) for message in request["messages"])
+            // 4,
+        )
+        output_cap = request.get("max_tokens", DEFAULT_OUTPUT_CAP)
+        if input_tokens + output_cap > CONTEXT_LENGTH:
+            # This reproduces vLLM's derived lower bound exactly. The reported
+            # input is computed from the rejected cap, not measured.
+            reported_input = CONTEXT_LENGTH + 1 - output_cap
+            message = (
+                "This model's maximum context length is 131072 tokens. However, "
+                f"you requested {output_cap} output tokens and your prompt contains "
+                f"at least {reported_input} input tokens, for a total of at least "
+                "131073 tokens. Please reduce the length of the input prompt or "
+                "the number of requested output tokens. (parameter=input_tokens, "
+                f"value={reported_input})"
+            )
+            self._send_json(400, {"error": {"message": message}})
+            return
+
+        tool_call = type(self).tool_responses_remaining > 0
+        if tool_call:
+            type(self).tool_responses_remaining -= 1
+
+        if request.get("stream") is True:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            for chunk in self._stream_chunks(tool_call):
+                self.wfile.write(f"data: {json.dumps(chunk)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+            return
+
+        message: dict = {"role": "assistant", "content": "Recovered"}
+        finish_reason = "stop"
+        if tool_call:
+            message = {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [self._tool_call()],
+            }
+            finish_reason = "tool_calls"
+        self._send_json(
+            200,
+            {
+                "id": "output-cap-recovery",
+                "object": "chat.completion",
+                "model": request["model"],
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": message,
+                        "finish_reason": finish_reason,
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": input_tokens,
+                    "completion_tokens": 1,
+                    "total_tokens": input_tokens + 1,
+                },
+            },
+        )
+
+    @classmethod
+    def _tool_call(cls) -> dict:
+        index = len(cls.requests)
+        return {
+            "id": f"call-large-result-{index}",
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "arguments": f'{{"query":"large-{index}"}}',
+            },
+        }
+
+    @classmethod
+    def _stream_chunks(cls, tool_call: bool) -> list[dict]:
+        deltas = [{"role": "assistant", "content": ""}]
+        if tool_call:
+            call = cls._tool_call()
+            call["index"] = 0
+            deltas.append({"tool_calls": [call]})
+            finish_reason = "tool_calls"
+        else:
+            deltas.append({"content": "Recovered"})
+            finish_reason = "stop"
+        return [
+            {
+                "id": "output-cap-recovery",
+                "object": "chat.completion.chunk",
+                "choices": [
+                    {"index": 0, "delta": delta, "finish_reason": None}
+                ],
+            }
+            for delta in deltas
+        ] + [
+            {
+                "id": "output-cap-recovery",
+                "object": "chat.completion.chunk",
+                "choices": [
+                    {"index": 0, "delta": {}, "finish_reason": finish_reason}
+                ],
+            }
+        ]
+
+    def _send_json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args: object) -> None:
+        pass
+
+
+@pytest.fixture
+def openai_compatible_server():
+    _OpenAICompatibleHandler.requests = []
+    _OpenAICompatibleHandler.tool_responses_remaining = 0
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _OpenAICompatibleHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}/v1"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _make_agent(tmp_path, monkeypatch, base_url, *, max_iterations=3):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url=base_url,
+        provider="custom",
+        model="local-model",
+        max_iterations=max_iterations,
+        disabled_toolsets=["*"],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        skip_background_review=True,
+        save_trajectories=False,
+        session_db=None,
+    )
+    agent.context_compressor.context_length = CONTEXT_LENGTH
+    assert agent.max_tokens is None
+    return agent
+
+
+@pytest.mark.parametrize("streaming", [True, False])
+def test_output_cap_overflow_recovers_through_real_turn_path(
+    tmp_path, monkeypatch, openai_compatible_server, streaming, caplog
+):
+    """A near-full custom-provider session clamps and completes the turn."""
+    agent = _make_agent(tmp_path, monkeypatch, openai_compatible_server)
+    agent.context_compressor.threshold_tokens = 98_304
+    agent._disable_streaming = not streaming
+    monkeypatch.setattr(
+        agent,
+        "_compress_context",
+        lambda messages, system_message, **_kwargs: (messages, system_message),
+    )
+    caplog.set_level(logging.DEBUG, logger="agent.conversation_loop")
+
+    history = [
+        {"role": "user", "content": "x" * 262_144},
+        {"role": "assistant", "content": "ack"},
+    ]
+    result = agent.run_conversation(
+        "continue",
+        conversation_history=history,
+        stream_callback=(lambda _delta: None) if streaming else None,
+    )
+
+    requests = _OpenAICompatibleHandler.requests
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered"
+    assert result.get("compression_exhausted") is not True
+    assert len(requests) == 2
+    assert (requests[0].get("stream") is True) is streaming
+    assert requests[0]["max_tokens"] == DEFAULT_OUTPUT_CAP
+    assert requests[1]["max_tokens"] < requests[0]["max_tokens"] // 2 + 1
+    assert (requests[1].get("stream") is True) is streaming
+    assert any(
+        "API call failed full error" in record.getMessage()
+        and "value=65537" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_output_cap_retry_is_independent_of_compression_budget(
+    tmp_path, monkeypatch, openai_compatible_server
+):
+    """Prior compactions cannot cancel the first reduced-cap request."""
+    _OpenAICompatibleHandler.tool_responses_remaining = 3
+    agent = _make_agent(
+        tmp_path, monkeypatch, openai_compatible_server, max_iterations=4
+    )
+    agent.context_compressor.threshold_tokens = 20_000
+    agent.tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Return a test payload",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    agent.valid_tool_names = {"web_search"}
+
+    monkeypatch.setattr(
+        agent,
+        "_compress_context",
+        lambda messages, system_message, **_kwargs: (messages, system_message),
+    )
+    monkeypatch.setattr(
+        "run_agent.handle_function_call",
+        lambda *_args, **_kwargs: "x" * 90_000,
+    )
+    monkeypatch.setattr(
+        "agent.tool_executor.maybe_persist_tool_result",
+        lambda content, *_args, **_kwargs: content,
+    )
+    monkeypatch.setattr(
+        "agent.tool_executor.enforce_turn_budget",
+        lambda *_args, **_kwargs: None,
+    )
+
+    result = agent.run_conversation("fetch several large results")
+
+    requests = _OpenAICompatibleHandler.requests
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered"
+    assert result.get("compression_exhausted") is not True
+    assert [request["max_tokens"] for request in requests] == [
+        DEFAULT_OUTPUT_CAP,
+        DEFAULT_OUTPUT_CAP,
+        DEFAULT_OUTPUT_CAP,
+        DEFAULT_OUTPUT_CAP,
+        32_704,
+    ]
+
+
+def test_output_cap_retry_preserves_later_compression_budget(
+    tmp_path, monkeypatch, openai_compatible_server
+):
+    """An output-cap retry cannot spend a later compression attempt."""
+    _OpenAICompatibleHandler.tool_responses_remaining = 1
+    agent = _make_agent(
+        tmp_path, monkeypatch, openai_compatible_server, max_iterations=2
+    )
+    agent.max_compression_attempts = 1
+    agent.context_compressor.threshold_tokens = 98_304
+    agent.tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Return a test payload",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    agent.valid_tool_names = {"web_search"}
+
+    compression_request_counts = []
+    tool_response_request_counts = []
+
+    def compress(messages, system_message, **_kwargs):
+        compression_request_counts.append(len(_OpenAICompatibleHandler.requests))
+        return messages, system_message
+
+    def large_tool_result(*_args, **_kwargs):
+        tool_response_request_counts.append(len(_OpenAICompatibleHandler.requests))
+        agent.context_compressor.last_prompt_tokens = 0
+        return "x" * 200_000
+
+    monkeypatch.setattr(agent, "_compress_context", compress)
+    monkeypatch.setattr("run_agent.handle_function_call", large_tool_result)
+    monkeypatch.setattr(
+        "agent.tool_executor.maybe_persist_tool_result",
+        lambda content, *_args, **_kwargs: content,
+    )
+    monkeypatch.setattr(
+        "agent.tool_executor.enforce_turn_budget",
+        lambda *_args, **_kwargs: None,
+    )
+
+    history = [
+        {"role": "user", "content": "x" * 262_144},
+        {"role": "assistant", "content": "ack"},
+    ]
+    result = agent.run_conversation("continue", conversation_history=history)
+
+    assert result["completed"] is True
+    assert len(tool_response_request_counts) == 1
+    assert tool_response_request_counts[0] in compression_request_counts
+
+
+def test_successful_provider_response_rearms_output_cap_budget(
+    tmp_path, monkeypatch, openai_compatible_server
+):
+    """Later tool iterations receive a fresh bounded clamp opportunity."""
+    _OpenAICompatibleHandler.tool_responses_remaining = 1
+    agent = _make_agent(
+        tmp_path, monkeypatch, openai_compatible_server, max_iterations=2
+    )
+    agent.max_compression_attempts = 1
+    agent.context_compressor.threshold_tokens = 98_304
+    agent.tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Return a test payload",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    agent.valid_tool_names = {"web_search"}
+    monkeypatch.setattr(
+        agent,
+        "_compress_context",
+        lambda messages, system_message, **_kwargs: (messages, system_message),
+    )
+    monkeypatch.setattr("run_agent.handle_function_call", lambda *_a, **_k: "ok")
+
+    history = [
+        {"role": "user", "content": "x" * 262_144},
+        {"role": "assistant", "content": "ack"},
+    ]
+    result = agent.run_conversation("continue", conversation_history=history)
+
+    assert result["completed"] is True
+    caps = [request["max_tokens"] for request in _OpenAICompatibleHandler.requests]
+    assert caps == [DEFAULT_OUTPUT_CAP, 32_704, DEFAULT_OUTPUT_CAP, 32_704]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4851,6 +4851,7 @@ class TestRunConversation:
 
         assert result["completed"] is False
         assert result.get("compression_exhausted") is True
+        assert result.get("output_cap_recovery_exhausted") is True
         # Terminated in a bounded number of API calls (default max attempts=3
         # => ~4 create calls), NOT an unbounded retry loop.
         assert agent.client.chat.completions.create.call_count <= 6


### PR DESCRIPTION
## What does this PR do?

Fixes a context-compression death loop observed on a production custom
OpenAI-compatible backend.

A turn can consume the shared `compression_attempts` budget through pre-API or
post-tool compaction before the provider reports that the requested output cap
is too large. The first output-cap error then increments that already exhausted
counter and terminates immediately. Hermes never sends the reduced-cap request,
so later turns can repeatedly hit the same failure.

This PR gives output-cap recovery its own bounded retry budget. A valid provider
response rearms that budget for later tool iterations in the same turn. The
existing compression behavior remains intact, and the solution does not depend
on vLLM, Qwen, LM Studio, or llama.cpp detection.

It also retains the full provider exception at DEBUG level and routes generic
auxiliary `reasoning_effort` configuration through the existing provider
profile abstraction.

## Related Issue

Related to #61761 and #78405. Those issues cover adjacent output-cap failure
classes. This PR fixes the remaining case where prior context compaction has
already consumed the shared budget before the first reduced-cap retry.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py`
  - Separate output-cap retry accounting from context-compression accounting.
  - Rearm output-cap recovery after a valid provider response.
  - Log successful cap reductions at INFO and full provider errors at DEBUG.
  - Distinguish terminal output-cap recovery exhaustion in logs and results.
- `agent/auxiliary_client.py`
  - Project task-level `reasoning_effort` through provider profiles instead of
    treating the OpenRouter-shaped nested body as the only wire format.
  - Preserve explicit `extra_body.reasoning` as the higher-priority control.
- `tests/run_agent/test_output_cap_recovery_e2e.py`
  - Add a local OpenAI-compatible HTTP server supporting streaming and
    non-streaming chat completions.
  - Reproduce the exact 131,072-token overflow response.
  - Verify recovery after the compression budget is already exhausted.
  - Verify successful responses rearm the output-cap retry budget.
- Extend existing auxiliary and bounded-exhaustion tests.

## How to Test

1. Run the focused regression and related suites:

   ```bash
   pytest -q \
     tests/run_agent/test_run_agent.py \
     tests/run_agent/test_output_cap_recovery_e2e.py \
     tests/test_output_cap_parsing.py \
     tests/test_ctx_halving_fix.py \
     tests/run_agent/test_compression_budget_refund.py \
     tests/run_agent/test_compression_budget_rearm.py \
     tests/run_agent/test_compression_lock_defer.py \
     tests/agent/test_auxiliary_client.py
   ```

2. Run static checks:

   ```bash
   ruff check agent/conversation_loop.py agent/auxiliary_client.py \
     tests/run_agent/test_output_cap_recovery_e2e.py \
     tests/run_agent/test_run_agent.py tests/agent/test_auxiliary_client.py
   git diff --check
   ```

Expected result: 515 tests pass, with all static checks clean.

Tested on Linux 7.0.0-30-generic x86_64 with Python 3.12.13.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64, Python 3.12.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Screenshots / Logs

<details>
<summary>Sanitized production log excerpt</summary>

```text
# hermes-agent context-compression failure - relevant log excerpts
# Source: ~/.hermes/profiles/<profile>/logs/errors.log
# Profile: <redacted>, local vLLM backend (qwen3.8:27b-nvfp4), provider=custom, base_url=http://localhost:<port>/v1
# Config in effect at time of these entries: model.context_length varied across the two failure
# clusters below (131072, then lowered to 130048 - did not change the outcome, see PR notes).

# ============================================================================
# Failure mode 1: compaction-timeout skip (pre-crash symptom)
# compression.context_timeout_seconds / context_total_ceiling_seconds were unset
# and fell back to defaults (120s / 600s), too short for this model/hardware.
# ============================================================================
2026-08-20 18:33:42,629 WARNING [<session-id>] run_agent: Context compression made no progress for 120.3s (total wait 120.4s, ceiling 600.0s); continuing without compression
2026-08-20 18:36:14,511 WARNING [<session-id>] run_agent: Context compression made no progress for 120.0s (total wait 120.1s, ceiling 600.0s); continuing without compression

# ============================================================================
# Failure mode 2: hard crash - "maximum context length exceeded" on the MAIN
# model turn (not the compression/summarization call), full traceback capture
# ============================================================================
2026-08-20 19:26:34,414 ERROR agent.chat_completion_helpers: Streaming failed before delivery: Error code: 400 - {'error': {'message': "This model's maximum context length is 131072 tokens. However, you requested 65536 output tokens and your prompt contains at least 65537 input tokens, for a total of at least 131073 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=65537)", 'type': 'BadRequestError', 'param': 'input_tokens', 'code': 400}}
Traceback (most recent call last):
  File "/home/<user>/.hermes/hermes-agent/agent/chat_completion_helpers.py", line 4709, in _call
    result["response"] = _call_chat_completions(stream_attempt_id)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/<user>/.hermes/hermes-agent/agent/chat_completion_helpers.py", line 3989, in _call_chat_completions
    relay_llm.stream(
  File "/home/<user>/.hermes/hermes-agent/agent/relay_llm.py", line 395, in stream
    return ManagedLlmStream(
           ^^^^^^^^^^^^^^^^^
  File "/home/<user>/.hermes/hermes-agent/agent/relay_llm.py", line 477, in __init__
    raw_stream = stream_factory(request)
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/<user>/.hermes/hermes-agent/agent/chat_completion_helpers.py", line 3926, in _open_stream
    return request_client.chat.completions.create(**stream_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/<user>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/openai/_utils/_utils.py", line 286, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/<user>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/openai/resources/chat/completions/completions.py", line 1204, in create
    return self._post(
           ^^^^^^^^^^^
  File "/home/<user>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/openai/_base_client.py", line 1297, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/<user>/.hermes/hermes-agent/venv/lib/python3.11/site-packages/openai/_base_client.py", line 1070, in request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'message': "This model's maximum context length is 131072 tokens. However, you requested 65536 output tokens and your prompt contains at least 65537 input tokens, for a total of at least 131073 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens, value=65537)", 'type': 'BadRequestError', 'param': 'input_tokens', 'code': 400}}
2026-08-20 19:26:34,430 WARNING [<session-id>] agent.conversation_loop: API call failed (attempt 1/3) error_type=BadRequestError thread=hermes-gateway_0:<thread-id> provider=custom base_url=http://localhost:<port>/v1 model=qwen3.8:27b-nvfp4 summary=HTTP 400: This model's maximum context length is 131072 tokens. However, you requested 65536 output tokens and your prompt contains at least 65537 input tokens, for a total of at least 131073 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens

# ============================================================================
# Same error recurring after lowering model.context_length 131072 -> 130048
# and restarting hermes-gateway-<profile>.service (config-only change - proves the
# fix was ineffective, since context_length only affects Hermes' internal
# compaction-trigger math, not the actual outgoing max_tokens sent to vLLM).
# All entries below are from a single session, spaced ~6-8 minutes apart -
# i.e. one occurrence per turn, not a tight retry loop.
# ============================================================================
2026-08-21 21:12:06,904 WARNING [<session-id>] agent.conversation_loop: API call failed (attempt 1/3) error_type=BadRequestError thread=hermes-gateway_0:<thread-id> provider=custom base_url=http://localhost:<port>/v1 model=qwen3.8:27b-nvfp4 summary=HTTP 400: This model's maximum context length is 131072 tokens. However, you requested 65536 output tokens and your prompt contains at least 65537 input tokens, for a total of at least 131073 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens
2026-08-21 21:18:37,363 WARNING [<session-id>] agent.conversation_loop: API call failed (attempt 1/3) error_type=BadRequestError thread=hermes-gateway_0:<thread-id> provider=custom base_url=http://localhost:<port>/v1 model=qwen3.8:27b-nvfp4 summary=HTTP 400: This model's maximum context length is 131072 tokens. However, you requested 65536 output tokens and your prompt contains at least 65537 input tokens, for a total of at least 131073 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens
2026-08-21 21:26:06,061 WARNING [<session-id>] agent.conversation_loop: API call failed (attempt 1/3) error_type=BadRequestError thread=hermes-gateway_0:<thread-id> provider=custom base_url=http://localhost:<port>/v1 model=qwen3.8:27b-nvfp4 summary=HTTP 400: This model's maximum context length is 131072 tokens. However, you requested 65536 output tokens and your prompt contains at least 65537 input tokens, for a total of at least 131073 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens
2026-08-21 21:30:13,956 WARNING [<session-id>] agent.conversation_loop: API call failed (attempt 1/3) error_type=BadRequestError thread=hermes-gateway_0:<thread-id> provider=custom base_url=http://localhost:<port>/v1 model=qwen3.8:27b-nvfp4 summary=HTTP 400: This model's maximum context length is 131072 tokens. However, you requested 65536 output tokens and your prompt contains at least 65537 input tokens, for a total of at least 131073 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens
2026-08-21 21:34:12,715 WARNING [<session-id>] agent.conversation_loop: API call failed (attempt 1/3) error_type=BadRequestError thread=hermes-gateway_0:<thread-id> provider=custom base_url=http://localhost:<port>/v1 model=qwen3.8:27b-nvfp4 summary=HTTP 400: This model's maximum context length is 131072 tokens. However, you requested 65536 output tokens and your prompt contains at least 65537 input tokens, for a total of at least 131073 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens

# ============================================================================
# Final occurrence in this session: shows the terminal crash. Note the ~2ms
# gap between the "API call failed (attempt 1/3)" WARNING and the "Context
# compression failed after 3 attempts" ERROR - this is NOT three real retry
# attempts with backoff/shrink; it fails almost instantly. This is the key
# evidence that Hermes' own smart-retry/shrink logic
# (parse_available_output_tokens_from_error + the shrink branch in
# conversation_loop.py) does not result in a reduced-cap request on this error path.
# ============================================================================
2026-08-21 21:38:05,854 WARNING [<session-id>] agent.conversation_loop: API call failed (attempt 1/3) error_type=BadRequestError thread=hermes-gateway_0:<thread-id> provider=custom base_url=http://localhost:<port>/v1 model=qwen3.8:27b-nvfp4 summary=HTTP 400: This model's maximum context length is 131072 tokens. However, you requested 65536 output tokens and your prompt contains at least 65537 input tokens, for a total of at least 131073 tokens. Please reduce the length of the input prompt or the number of requested output tokens. (parameter=input_tokens
2026-08-21 21:38:05,856 ERROR [<session-id>] agent.conversation_loop: Context compression failed after 3 attempts.
```

</details>

Redactions cover the local profile name, username, session IDs, thread IDs,
and endpoint port. The model name and token counts are retained because they
are relevant to the failure.

The key terminal sequence is a single attempt warning followed 2 ms later by
compression exhaustion. No reduced-cap HTTP request occurs between them.

The local HTTP regression records the recovered request sequence:

```text
65536, 65536, 65536, 65536, 32704
```

The first four requests use the provider default. The fifth is the reduced-cap
retry that was previously skipped. It succeeds and completes the turn.
