### PR TITLE
fix(web): load web plugins before resolving extract_backend

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1121,15 +1121,21 @@ async def web_extract_tool(
         if not safe_urls:
             results = []
         else:
-            backend = _get_extract_backend()
-
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
+            # All providers now live as plugins. The dispatcher is a
             # registry lookup + delegation. Some providers' extract() is
             # async (parallel, firecrawl), others sync (exa, tavily) — we
             # detect coroutine functions and await; sync functions run
             # inline (the policy gate, SSRF re-check, etc. live inside the
             # provider itself for the firecrawl per-URL loop).
+            #
+            # Plugin discovery MUST happen before _get_extract_backend().
+            # Backends outside _LEGACY_WEB_BACKENDS resolve their
+            # availability through the registry, which is empty until the
+            # plugins are loaded. In cold-start contexts (cron subprocesses,
+            # delegate children — see _ensure_web_plugins_loaded's
+            # docstring) doing the backend lookup first makes a configured
+            # plugin-only extract_backend silently fall through to the
+            # shared web.backend default.
             _ensure_web_plugins_loaded()
             from agent.web_search_registry import (
                 get_active_extract_provider,
@@ -1137,6 +1143,7 @@ async def web_extract_tool(
                 _disabled_web_plugin_for,
             )
 
+            backend = _get_extract_backend()
             provider = _wsp_get_provider(backend) if backend else None
             if provider is None or not provider.supports_extract():
                 # When the configured name IS registered but doesn't support


### PR DESCRIPTION
## Problem

`web_extract_tool` resolves the extract backend *before* the web plugins are
discovered:

```python
backend = _get_extract_backend()
...
_ensure_web_plugins_loaded()
from agent.web_search_registry import (...)
provider = _wsp_get_provider(backend) if backend else None
```

Backends outside `_LEGACY_WEB_BACKENDS` resolve their availability through the
plugin registry, and that registry is empty until `_ensure_web_plugins_loaded()`
runs. So in any cold-start context — cron subprocesses and delegate children,
the exact cases `_ensure_web_plugins_loaded`'s own docstring calls out — a
configured plugin-only `web.extract_backend` is not yet visible when the lookup
happens, and the call silently falls through to the shared `web.backend`
default.

The failure mode is silent. No exception, no warning: extraction just runs on a
different backend than the one configured, and only the content quality changes.
On a machine driven mainly by cron jobs, every one of those jobs is affected and
nothing in the logs says so.

Interactive sessions do not hit this, because plugins are already loaded by the
time the tool is called. That is why it is easy to miss.

## Fix

Move `backend = _get_extract_backend()` to after `_ensure_web_plugins_loaded()`
and the registry import. No behavioural change for legacy backends; plugin-only
backends now resolve correctly on cold start.

The surrounding comment is updated to record the ordering requirement so the
lines do not get reordered again.

## Testing

Verified on macOS 26.6 with a cron-driven install (v0.20.5, `8e475ed`) using a
plugin-only extract backend:

- Before: cron-launched runs silently used the `web.backend` default.
- After: cron-launched runs use the configured `extract_backend`.
- Interactive runs are unchanged in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
