### PR TITLE
feat(bots): make group chat round, message, member and history limits per room

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9288,117 +9288,120 @@ function GroupDialog({ bot, onClose }) {
  *  a live preview (image, else the organization glyph), Upload / Generate /
  *  Remove. Reuses the bot-avatar pipeline (device picker, 256px normalize,
  *  image.generate probe) so room pictures cost the same as bot avatars. */
-/** One axis of the room budget: a number, or off. Rounds and messages get a
- *  second row when they are off, holding the safety brake — which is itself
- *  switchable, because a room the user deliberately unbounds should actually
- *  be unbounded. */
+/** One row of the room budget, built on the same shape the app's own settings
+ *  rows use (src/app/settings/primitives.tsx: ListRow / ToggleRow): a
+ *  container-queried grid, label and description on the left, the control
+ *  right-aligned. Plugins cannot import those primitives, so the structure is
+ *  mirrored here rather than invented.
+ *
+ *  Rounds and messages get a second row when they are off, holding the safety
+ *  brake, which is itself switchable: a room the user deliberately unbounds
+ *  should actually be unbounded. */
 function GroupLimitRow({ label, hint, value, fallback, ceiling, onChange, brake }) {
   const off = value === null
   const shown = off ? '' : String(value ?? fallback)
 
+  const numberField = (props) =>
+    jsx(Input, {
+      className: 'w-20 text-right',
+      inputMode: 'numeric',
+      max: ceiling,
+      min: 1,
+      type: 'number',
+      ...props
+    })
+
+  const control = (children) => jsx('div', { className: 'flex items-center justify-end gap-2', children })
+
   return jsxs('div', {
-    className: 'flex flex-col gap-1 py-1.5',
+    className: '@container',
     children: [
       jsxs('div', {
-        className: 'flex items-center gap-2',
+        className: 'grid gap-3 py-3 @2xl:grid-cols-[minmax(0,1fr)_minmax(15rem,22rem)] @2xl:items-center',
         children: [
           jsxs('div', {
-            className: 'flex-1 min-w-0',
+            className: 'min-w-0',
             children: [
-              jsx('div', { className: 'text-xs text-foreground', children: label }),
-              hint ? jsx('div', { className: 'text-[0.65rem] text-(--ui-text-tertiary)', children: hint }) : null
-            ]
-          }),
-          jsx(Input, {
-            'aria-label': label,
-            className: 'w-16 text-right',
-            disabled: off,
-            inputMode: 'numeric',
-            max: ceiling,
-            min: 1,
-            placeholder: off ? '\u221e' : String(fallback),
-            type: 'number',
-            value: shown,
-            onChange: event => {
-              const raw = event.target.value.trim()
-              if (!raw) {
-                onChange(undefined)
-                return
-              }
-              const n = Math.floor(Number(raw))
-              onChange(Number.isFinite(n) && n > 0 ? Math.min(n, ceiling) : undefined)
-            }
-          }),
-          // The switch alone is not readable in the dark theme: "on" is a
-          // slightly different dark track. Name the state next to it.
-          jsxs('div', {
-            className: 'flex shrink-0 items-center gap-1.5',
-            children: [
-              jsx('span', {
-                className: off
-                  ? 'w-12 text-right text-[0.65rem] text-(--ui-warning,#d68b00)'
-                  : 'w-12 text-right text-[0.65rem] text-(--ui-text-tertiary)',
-                children: off ? 'no limit' : 'limit'
+              jsx('div', {
+                className: 'text-[length:var(--conversation-text-font-size)] font-medium text-foreground',
+                children: label
               }),
-              jsx(Tip, {
-                label: off ? `No limit on ${label.toLowerCase()}` : `Limit ${label.toLowerCase()}`,
-                children: jsx(Switch, {
-                  'aria-label': `Limit ${label.toLowerCase()}`,
-                  checked: !off,
-                  onCheckedChange: on => onChange(on ? fallback : null)
-                })
-              })
+              hint
+                ? jsx('div', {
+                    className:
+                      'mt-1 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)',
+                    children: hint
+                  })
+                : null
             ]
+          }),
+          jsx('div', {
+            className: 'min-w-0 @2xl:justify-self-end',
+            children: control([
+              numberField({
+                'aria-label': label,
+                disabled: off,
+                placeholder: off ? '\u221e' : String(fallback),
+                value: shown,
+                onChange: event => {
+                  const raw = event.target.value.trim()
+                  if (!raw) {
+                    onChange(undefined)
+                    return
+                  }
+                  const n = Math.floor(Number(raw))
+                  onChange(Number.isFinite(n) && n > 0 ? Math.min(n, ceiling) : undefined)
+                }
+              }),
+              jsx(Switch, {
+                'aria-label': `Limit ${label.toLowerCase()}`,
+                checked: !off,
+                onCheckedChange: on => {
+                  haptic('tap')
+                  onChange(on ? fallback : null)
+                }
+              })
+            ])
           })
         ]
       }),
       off && brake
         ? jsxs('div', {
-            className: 'flex items-center gap-2 pl-3 border-l border-(--ui-border)',
+            className:
+              'grid gap-3 border-l border-(--ui-border) pb-3 pl-3 @2xl:grid-cols-[minmax(0,1fr)_minmax(15rem,22rem)] @2xl:items-center',
             children: [
               jsx('div', {
-                className: 'flex-1 min-w-0 text-[0.65rem] text-(--ui-text-tertiary)',
-                children: brake.value === null ? 'No safety stop' : 'Safety stop after'
+                className:
+                  'min-w-0 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)',
+                children: brake.value === null ? `No safety stop on ${label.toLowerCase()}` : 'Safety stop after'
               }),
-              jsx(Input, {
-                'aria-label': `Safety stop for ${label.toLowerCase()}`,
-                className: 'w-16 text-right',
-                disabled: brake.value === null,
-                inputMode: 'numeric',
-                max: ceiling,
-                min: 1,
-                placeholder: String(brake.fallback),
-                type: 'number',
-                value: brake.value === null ? '' : String(brake.value ?? brake.fallback),
-                onChange: event => {
-                  const raw = event.target.value.trim()
-                  if (!raw) {
-                    brake.onChange(undefined)
-                    return
-                  }
-                  const n = Math.floor(Number(raw))
-                  brake.onChange(Number.isFinite(n) && n > 0 ? Math.min(n, ceiling) : undefined)
-                }
-              }),
-              jsxs('div', {
-                className: 'flex shrink-0 items-center gap-1.5',
-                children: [
-                  jsx('span', {
-                    className:
-                      brake.value === null
-                        ? 'w-12 text-right text-[0.65rem] text-(--ui-warning,#d68b00)'
-                        : 'w-12 text-right text-[0.65rem] text-(--ui-text-tertiary)',
-                    children: brake.value === null ? 'none' : 'brake'
+              jsx('div', {
+                className: 'min-w-0 @2xl:justify-self-end',
+                children: control([
+                  numberField({
+                    'aria-label': `Safety stop for ${label.toLowerCase()}`,
+                    disabled: brake.value === null,
+                    placeholder: brake.value === null ? '\u221e' : String(brake.fallback),
+                    value: brake.value === null ? '' : String(brake.value ?? brake.fallback),
+                    onChange: event => {
+                      const raw = event.target.value.trim()
+                      if (!raw) {
+                        brake.onChange(undefined)
+                        return
+                      }
+                      const n = Math.floor(Number(raw))
+                      brake.onChange(Number.isFinite(n) && n > 0 ? Math.min(n, ceiling) : undefined)
+                    }
                   }),
-                  jsx(Tip, {
-                    label: brake.value === null ? 'No safety stop at all' : 'Stop the room after this many',
-                    children: jsx(Switch, {
-                      'aria-label': `Safety stop for ${label.toLowerCase()}`,
-                      checked: brake.value !== null,
-                      onCheckedChange: on => brake.onChange(on ? brake.fallback : null)
-                    })
+                  jsx(Switch, {
+                    'aria-label': `Safety stop for ${label.toLowerCase()}`,
+                    checked: brake.value !== null,
+                    onCheckedChange: on => {
+                      haptic('tap')
+                      brake.onChange(on ? brake.fallback : null)
+                    }
                   })
-                ]
+                ])
               })
             ]
           })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -11918,6 +11918,7 @@ export default {
                   members: Array.isArray(room.members) ? room.members : [],
                   roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
                   image: typeof room.image === 'string' && room.image ? room.image : null,
+                  limits: durableGroupChatLimits(room.limits),
                   syncRevision: Math.max(0, Number(room.syncRevision || 0)),
                   epoch: 0,
                   running: false

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -264,6 +264,14 @@ function groupActivityLabel(event) {
     return base
   }
 
+  // The safety stop is about the room, not about a member, so it reads as a
+  // statement rather than "<bot> hit the safety stop".
+  if (kind === 'safety') {
+    return event?.detail === 'messages'
+      ? `safety stop: ${event?.at ?? '?'} messages reached`
+      : `safety stop: ${event?.at ?? '?'} rounds reached`
+  }
+
   const who = event?.member === 'You' ? 'You' : groupSpeakerLabel(event?.member || 'A bot')
 
   return `${who} ${base}`
@@ -278,7 +286,8 @@ const GROUP_ACTIVITY_LABELS = {
   failed: 'hit an error',
   cancelled: 'turn interrupted by a newer message',
   settled: 'turn settled',
-  delivered: 'delivered a late reply'
+  delivered: 'delivered a late reply',
+  safety: 'safety stop'
 }
 
 const GROUP_ACTIVITY_GLYPHS = {
@@ -290,7 +299,8 @@ const GROUP_ACTIVITY_GLYPHS = {
   failed: 'error',
   cancelled: 'close',
   settled: 'check-all',
-  delivered: 'mail-read'
+  delivered: 'mail-read',
+  safety: 'debug-pause'
 }
 
 /** Text tone for an activity row: quiet for pass/cancel/settle, accent for
@@ -298,6 +308,12 @@ const GROUP_ACTIVITY_GLYPHS = {
 function groupActivityTone(kind) {
   if (kind === 'failed' || kind === 'timed-out') {
     return 'text-destructive'
+  }
+
+  // A safety stop is not a failure, but it must not read as routine either:
+  // the room stopped short of what the user asked for.
+  if (kind === 'safety') {
+    return 'text-(--ui-warning,#d68b00)'
   }
 
   if (kind === 'working' || kind === 'replied' || kind === 'delivered') {
@@ -429,12 +445,18 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
       at: Number(entry?.at || 0),
       ...(entry?.thread ? { thread: String(entry.thread).slice(0, 128) } : {})
     }))
+    // A room that raised its member cap syncs the members it actually has; the
+    // ceiling still bounds the payload so one room cannot blow the envelope.
+    const syncMembers = (Array.isArray(room?.members) ? room.members : []).slice(
+      0,
+      resolveGroupChatLimits(room).members ?? GROUP_CHAT_LIMIT_CEILINGS.members
+    )
     const compact = {
       name: String(name).slice(0, 64),
       ...(typeof room?.roomId === 'string' && room.roomId ? { roomId: String(room.roomId).slice(0, 128) } : {}),
       log,
       revision: Math.max(0, Number(room?.syncRevision ?? room?.revision ?? 0)),
-      members: (Array.isArray(room.members) ? room.members : []).slice(0, GROUP_CHAT_MAX_MEMBERS).map(member => ({
+      members: syncMembers.map(member => ({
         name: String(member?.name || '').slice(0, 128),
         ...(member?.handle ? { handle: String(member.handle).slice(0, 128) } : {}),
         ...(member?.connectionId ? { connectionId: String(member.connectionId).slice(0, 128) } : {}),
@@ -444,7 +466,10 @@ function groupChatSyncSnapshot(all = $groupChats.get(), deleted = {}) {
       })),
       ...(typeof room?.image === 'string' && room.image.length <= GROUP_CHAT_SYNC_IMAGE_CHARS
         ? { image: room.image }
-        : {})
+        : {}),
+      // Carried across gateways so a room keeps its rules on every machine
+      // that mirrors it; omitted entirely when the room is on the defaults.
+      ...(durableGroupChatLimits(room?.limits) ? { limits: durableGroupChatLimits(room.limits) } : {})
     }
 
     const key = groupChatRoomKey(name, room)
@@ -761,6 +786,13 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
         : remoteRevision >= localRevision && Object.prototype.hasOwnProperty.call(projected, 'image')
           ? projected.image || null
           : existing.image || null,
+      // Same rule as image: the newer revision decides. A room whose rules
+      // were changed on another machine arrives with them attached.
+      limits: isPreserved
+        ? existing.limits || null
+        : remoteRevision >= localRevision && Object.prototype.hasOwnProperty.call(projected, 'limits')
+          ? durableGroupChatLimits(projected.limits)
+          : existing.limits || null,
       syncRevision: isPreserved ? localRevision : Math.max(remoteRevision, localRevision),
       epoch: Number(existing.epoch || 0),
       running: Boolean(existing.running)
@@ -793,6 +825,36 @@ function mergeRemoteGroupChatSnapshotIntoRooms(
   return rooms
 }
 
+/** The stored form of a room's limit overrides: only the axes the room
+ *  actually set, each a positive integer or null. Absent means "inherit", so
+ *  writing nothing is how a room stays on the defaults. */
+function durableGroupChatLimits(limits) {
+  if (!limits || typeof limits !== 'object') {
+    return null
+  }
+
+  const out = {}
+
+  for (const key of ['rounds', 'messages', 'members', 'history', 'safetyRounds', 'safetyMessages']) {
+    if (!Object.prototype.hasOwnProperty.call(limits, key)) {
+      continue
+    }
+    if (limits[key] === null) {
+      out[key] = null
+      continue
+    }
+    if (typeof limits[key] !== 'number' && typeof limits[key] !== 'string') {
+      continue
+    }
+    const n = Math.floor(Number(limits[key]))
+    if (Number.isFinite(n) && n > 0) {
+      out[key] = n
+    }
+  }
+
+  return Object.keys(out).length ? out : null
+}
+
 function durableGroupChatRooms(all = $groupChats.get()) {
   const durable = {}
 
@@ -820,6 +882,7 @@ function durableGroupChatRooms(all = $groupChats.get()) {
       // already carries.
       roomId: typeof room.roomId === 'string' && room.roomId ? room.roomId : null,
       image: room.image || null,
+      limits: durableGroupChatLimits(room.limits),
       syncRevision: Math.max(0, Number(room.syncRevision || 0))
     }
   }
@@ -4478,10 +4541,98 @@ function knownGroups(metaByName) {
 // turn in its OWN persistent per-group Hermes session and is fed only the
 // room messages that are NEW since it last saw the room.
 
+// Defaults. A room may override any of these; see resolveGroupChatLimits.
 const GROUP_CHAT_MAX_ROUNDS = 3
 const GROUP_CHAT_MAX_MESSAGES = 10
 const GROUP_CHAT_HISTORY_LIMIT = 24
 const GROUP_CHAT_MAX_MEMBERS = 6
+
+// Ceilings for the room-level overrides. Not a policy on how long a
+// conversation may run — purely the range the UI offers, so a typo in a
+// number field cannot ask for a million rounds.
+const GROUP_CHAT_LIMIT_CEILINGS = { rounds: 100, messages: 500, members: 24, history: 200 }
+
+// Where the safety brake starts when a room turns a limit off. The user can
+// move it, or switch it off entirely for a genuinely unbounded room.
+const GROUP_CHAT_SAFETY_DEFAULTS = { rounds: 50, messages: 200 }
+
+/** Per-room limit overrides. Each axis is one of three states:
+ *
+ *    number  the limit, enforced as before
+ *    null    off — the axis no longer stops the loop
+ *    absent  inherit the default above
+ *
+ *  With `rounds`/`messages` off, `safetyRounds`/`safetyMessages` take over as
+ *  a brake; those are themselves nullable, and null there means a room that
+ *  runs until every member passes or the user sends again. Both of those
+ *  still hold: `spokeThisRound === 0` ends the drive, and a new user message
+ *  bumps the epoch, which the loop honors at the next member boundary. So an
+ *  unlimited room is never a room you cannot get out of.
+ */
+function resolveGroupChatLimits(room) {
+  const raw = room && typeof room.limits === 'object' && room.limits ? room.limits : {}
+
+  const axis = (key, fallback, ceiling) => {
+    if (!Object.prototype.hasOwnProperty.call(raw, key)) {
+      return fallback
+    }
+    if (raw[key] === null) {
+      return null
+    }
+    // Guard the coercion: Number(true) is 1 and Number([]) is 0, so a stray
+    // boolean or array would otherwise read as a real limit.
+    if (typeof raw[key] !== 'number' && typeof raw[key] !== 'string') {
+      return fallback
+    }
+    const n = Math.floor(Number(raw[key]))
+    return Number.isFinite(n) && n > 0 ? Math.min(n, ceiling) : fallback
+  }
+
+  const rounds = axis('rounds', GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_LIMIT_CEILINGS.rounds)
+  const messages = axis('messages', GROUP_CHAT_MAX_MESSAGES, GROUP_CHAT_LIMIT_CEILINGS.messages)
+
+  return {
+    rounds,
+    messages,
+    members: axis('members', GROUP_CHAT_MAX_MEMBERS, GROUP_CHAT_LIMIT_CEILINGS.members),
+    history: axis('history', GROUP_CHAT_HISTORY_LIMIT, GROUP_CHAT_LIMIT_CEILINGS.history),
+    // Only meaningful while the matching axis is off.
+    safetyRounds: rounds === null ? axis('safetyRounds', GROUP_CHAT_SAFETY_DEFAULTS.rounds, GROUP_CHAT_LIMIT_CEILINGS.rounds) : null,
+    safetyMessages:
+      messages === null ? axis('safetyMessages', GROUP_CHAT_SAFETY_DEFAULTS.messages, GROUP_CHAT_LIMIT_CEILINGS.messages) : null
+  }
+}
+
+/** Short room-budget summary for the room header: "3 rounds · 10 msgs", or
+ *  what the room actually does when an axis is off. */
+function groupChatBudgetLabel(room) {
+  const limits = resolveGroupChatLimits(room)
+
+  const axis = (value, brake, one, many) => {
+    if (value !== null) {
+      return `${value} ${value === 1 ? one : many}`
+    }
+    return brake === null ? `\u221e ${many}` : `\u2264${brake} ${many}`
+  }
+
+  return `${axis(limits.rounds, limits.safetyRounds, 'round', 'rounds')} \u00b7 ${axis(
+    limits.messages,
+    limits.safetyMessages,
+    'msg',
+    'msgs'
+  )}`
+}
+
+/** The round/message ceiling actually applied to a drive: the limit, else the
+ *  safety brake, else nothing. `null` means the loop is not bounded by count. */
+function groupChatDriveCaps(limits) {
+  return {
+    rounds: limits.rounds ?? limits.safetyRounds,
+    messages: limits.messages ?? limits.safetyMessages,
+    roundsUnbounded: limits.rounds === null && limits.safetyRounds === null,
+    messagesUnbounded: limits.messages === null && limits.safetyMessages === null
+  }
+}
 
 /** "(pass)" (loosely: pass / (pass) / pass.) or empty = the member stayed silent. */
 function isGroupPassText(text) {
@@ -4821,6 +4972,16 @@ async function disbandGroupChat(group, members) {
 function setGroupChatImage(group, image) {
   updateGroupChat(group, room => {
     room.image = image || null
+    return room
+  })
+}
+
+/** Write a room's budget overrides. Storing nothing (every axis on its
+ *  default) clears the field, so a room that was reset looks exactly like a
+ *  room that never changed anything. */
+function setGroupChatLimits(group, limits) {
+  updateGroupChat(group, room => {
+    room.limits = durableGroupChatLimits(limits)
     return room
   })
 }
@@ -5433,10 +5594,19 @@ async function harvestStrandedGroupReply(group, member) {
 async function runGroupChatRounds(group, members, thread) {
   const startEpoch = ($groupChats.get()[group] || {}).epoch || 0
   const isCurrent = () => (($groupChats.get()[group] || {}).epoch || 0) === startEpoch
+  // Read once per drive: a mid-drive settings change applies to the NEXT send,
+  // so a running conversation keeps the rules it started under.
+  const limits = resolveGroupChatLimits($groupChats.get()[group])
+  const caps = groupChatDriveCaps(limits)
   let posted = 0
 
   try {
-    for (let round = 0; round < GROUP_CHAT_MAX_ROUNDS; round++) {
+    for (let round = 0; caps.rounds === null || round < caps.rounds; round++) {
+      // A room that turned rounds off but kept the brake stops here, and says
+      // so — silence would read as the conversation having settled.
+      if (limits.rounds === null && caps.rounds !== null && round === caps.rounds - 1) {
+        recordGroupActivity(group, { kind: 'safety', member: null, thread, detail: 'rounds', at: caps.rounds })
+      }
       // Deliver any replies that finished after their turn timed out —
       // every member, not just this round's responders, so long work is
       // late, never lost.
@@ -5468,9 +5638,11 @@ async function runGroupChatRounds(group, members, thread) {
       let spokeThisRound = 0
 
       for (const member of responders) {
-        if (!isCurrent() || posted >= GROUP_CHAT_MAX_MESSAGES) {
+        if (!isCurrent() || (caps.messages !== null && posted >= caps.messages)) {
           if (!isCurrent()) {
             recordGroupActivity(group, { kind: 'cancelled', member: null, thread })
+          } else if (limits.messages === null) {
+            recordGroupActivity(group, { kind: 'safety', member: null, thread, detail: 'messages', at: caps.messages })
           }
           return
         }
@@ -5491,7 +5663,9 @@ async function runGroupChatRounds(group, members, thread) {
           groupName: group,
           members,
           viewer: member,
-          deltaLines: delta.slice(-GROUP_CHAT_HISTORY_LIMIT).map(e => formatGroupChatLine(e, member.name))
+          deltaLines: (limits.history === null ? delta : delta.slice(-limits.history)).map(e =>
+            formatGroupChatLine(e, member.name)
+          )
         })
 
         // Images riding this delta (user attachments — member entries don't
@@ -9095,6 +9269,198 @@ function GroupDialog({ bot, onClose }) {
  *  a live preview (image, else the organization glyph), Upload / Generate /
  *  Remove. Reuses the bot-avatar pipeline (device picker, 256px normalize,
  *  image.generate probe) so room pictures cost the same as bot avatars. */
+/** One axis of the room budget: a number, or off. Rounds and messages get a
+ *  second row when they are off, holding the safety brake — which is itself
+ *  switchable, because a room the user deliberately unbounds should actually
+ *  be unbounded. */
+function GroupLimitRow({ label, hint, value, fallback, ceiling, onChange, brake }) {
+  const off = value === null
+  const shown = off ? '' : String(value ?? fallback)
+
+  return jsxs('div', {
+    className: 'flex flex-col gap-1 py-1.5',
+    children: [
+      jsxs('div', {
+        className: 'flex items-center gap-2',
+        children: [
+          jsxs('div', {
+            className: 'flex-1 min-w-0',
+            children: [
+              jsx('div', { className: 'text-xs text-foreground', children: label }),
+              hint ? jsx('div', { className: 'text-[0.65rem] text-(--ui-text-tertiary)', children: hint }) : null
+            ]
+          }),
+          jsx(Input, {
+            'aria-label': label,
+            className: 'w-16 text-right',
+            disabled: off,
+            inputMode: 'numeric',
+            max: ceiling,
+            min: 1,
+            placeholder: String(fallback),
+            type: 'number',
+            value: shown,
+            onChange: event => {
+              const raw = event.target.value.trim()
+              if (!raw) {
+                onChange(undefined)
+                return
+              }
+              const n = Math.floor(Number(raw))
+              onChange(Number.isFinite(n) && n > 0 ? Math.min(n, ceiling) : undefined)
+            }
+          }),
+          jsx(Tip, {
+            label: off ? `No limit on ${label.toLowerCase()}` : `Limit ${label.toLowerCase()}`,
+            children: jsx(Switch, {
+              'aria-label': `Limit ${label.toLowerCase()}`,
+              checked: !off,
+              onCheckedChange: on => onChange(on ? fallback : null)
+            })
+          })
+        ]
+      }),
+      off && brake
+        ? jsxs('div', {
+            className: 'flex items-center gap-2 pl-3 border-l border-(--ui-border)',
+            children: [
+              jsx('div', {
+                className: 'flex-1 min-w-0 text-[0.65rem] text-(--ui-text-tertiary)',
+                children: brake.value === null ? 'No safety stop' : 'Safety stop after'
+              }),
+              jsx(Input, {
+                'aria-label': `Safety stop for ${label.toLowerCase()}`,
+                className: 'w-16 text-right',
+                disabled: brake.value === null,
+                inputMode: 'numeric',
+                max: ceiling,
+                min: 1,
+                placeholder: String(brake.fallback),
+                type: 'number',
+                value: brake.value === null ? '' : String(brake.value ?? brake.fallback),
+                onChange: event => {
+                  const raw = event.target.value.trim()
+                  if (!raw) {
+                    brake.onChange(undefined)
+                    return
+                  }
+                  const n = Math.floor(Number(raw))
+                  brake.onChange(Number.isFinite(n) && n > 0 ? Math.min(n, ceiling) : undefined)
+                }
+              }),
+              jsx(Tip, {
+                label: brake.value === null ? 'No safety stop at all' : 'Stop the room after this many',
+                children: jsx(Switch, {
+                  'aria-label': `Safety stop for ${label.toLowerCase()}`,
+                  checked: brake.value !== null,
+                  onCheckedChange: on => brake.onChange(on ? brake.fallback : null)
+                })
+              })
+            ]
+          })
+        : null
+    ]
+  })
+}
+
+/** The room budget editor. Shared by the create dialog, group settings, and
+ *  the room's own budget popover, so all three write the same shape. */
+function GroupLimitsControls({ limits, onChange, memberCount = 0 }) {
+  const set = (key, next) => {
+    const draft = { ...(limits || {}) }
+    if (next === undefined) {
+      delete draft[key]
+    } else {
+      draft[key] = next
+    }
+    onChange(draft)
+  }
+
+  const read = key => (Object.prototype.hasOwnProperty.call(limits || {}, key) ? limits[key] : undefined)
+  const resolved = resolveGroupChatLimits({ limits })
+  const unbounded =
+    (resolved.rounds === null && resolved.safetyRounds === null) ||
+    (resolved.messages === null && resolved.safetyMessages === null)
+
+  // The two axes multiply: with N members, one round is N messages, so the
+  // message budget usually runs out first. Raising rounds alone then changes
+  // nothing visible, which reads as the setting being broken. Say which one
+  // actually ends the conversation.
+  const effectiveRounds = resolved.rounds ?? resolved.safetyRounds
+  const effectiveMessages = resolved.messages ?? resolved.safetyMessages
+  const binding =
+    effectiveMessages !== null && effectiveRounds !== null && memberCount > 0
+      ? Math.ceil(effectiveMessages / memberCount) < effectiveRounds
+        ? 'messages'
+        : null
+      : null
+
+  return jsxs('div', {
+    className: 'flex flex-col divide-y divide-(--ui-border)',
+    children: [
+      jsx(GroupLimitRow, {
+        label: 'Rounds',
+        hint: 'Round-robin passes over the members per message you send',
+        value: read('rounds'),
+        fallback: GROUP_CHAT_MAX_ROUNDS,
+        ceiling: GROUP_CHAT_LIMIT_CEILINGS.rounds,
+        onChange: next => set('rounds', next),
+        brake: {
+          value: read('safetyRounds'),
+          fallback: GROUP_CHAT_SAFETY_DEFAULTS.rounds,
+          onChange: next => set('safetyRounds', next)
+        }
+      }),
+      jsx(GroupLimitRow, {
+        label: 'Messages',
+        hint: 'Total bot messages per message you send',
+        value: read('messages'),
+        fallback: GROUP_CHAT_MAX_MESSAGES,
+        ceiling: GROUP_CHAT_LIMIT_CEILINGS.messages,
+        onChange: next => set('messages', next),
+        brake: {
+          value: read('safetyMessages'),
+          fallback: GROUP_CHAT_SAFETY_DEFAULTS.messages,
+          onChange: next => set('safetyMessages', next)
+        }
+      }),
+      jsx(GroupLimitRow, {
+        label: 'Members',
+        hint: 'How many bots this room may hold',
+        value: read('members'),
+        fallback: GROUP_CHAT_MAX_MEMBERS,
+        ceiling: GROUP_CHAT_LIMIT_CEILINGS.members,
+        onChange: next => set('members', next)
+      }),
+      jsx(GroupLimitRow, {
+        label: 'History',
+        hint: 'Room lines each bot sees per turn — drives token cost',
+        value: read('history'),
+        fallback: GROUP_CHAT_HISTORY_LIMIT,
+        ceiling: GROUP_CHAT_LIMIT_CEILINGS.history,
+        onChange: next => set('history', next)
+      }),
+      binding === 'messages'
+        ? jsx('div', {
+            className: 'pt-2 text-[0.65rem] text-(--ui-text-tertiary)',
+            children: `With ${memberCount} bots, the message budget runs out after about ${Math.max(
+              1,
+              Math.ceil(effectiveMessages / memberCount)
+            )} round${Math.ceil(effectiveMessages / memberCount) === 1 ? '' : 's'} — raise it too, or the round setting will not change anything.`
+          })
+        : null,
+      unbounded
+        ? jsx('div', {
+            className: 'pt-2 text-[0.65rem] text-(--ui-warning,#d68b00)',
+            children:
+              'Unlimited means unlimited: this room keeps going until every bot passes, or until you send again. ' +
+              'Nothing else will stop it, and every turn costs tokens. Your call.'
+          })
+        : null
+    ]
+  })
+}
+
 function GroupImageControls({ image, onImage, seedName, seedMembers }) {
   const imagen = useValue($imagenAvailable)
   const [busy, setBusy] = useState(false)
@@ -9179,13 +9545,16 @@ function GroupImageControls({ image, onImage, seedName, seedMembers }) {
 function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }) {
   const rooms = useValue($groupChats)
   const current = (rooms[group] || {}).image || null
+  const currentLimits = (rooms[group] || {}).limits || null
   const [name, setName] = useState(group)
   const [image, setImage] = useState(current)
+  const [limits, setLimits] = useState(currentLimits)
 
   useEffect(() => {
     if (open) {
       setName(group)
       setImage(current)
+      setLimits(currentLimits)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, group])
@@ -9200,6 +9569,8 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }) {
     if (image !== current) {
       setGroupChatImage(finalName, image)
     }
+
+    setGroupChatLimits(finalName, limits)
 
     onClose()
 
@@ -9216,7 +9587,7 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }) {
       }
     },
     children: jsxs(DialogContent, {
-      className: 'max-w-sm',
+      className: 'max-w-md',
       children: [
         jsxs(DialogHeader, {
           children: [
@@ -9245,6 +9616,16 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }) {
             onChange: event => setName(event.target.value)
           })
         }),
+        jsxs('div', {
+          className: 'mt-1',
+          children: [
+            jsx('div', {
+              className: 'text-[0.65rem] uppercase tracking-wider text-(--ui-text-quaternary) mb-1',
+              children: 'Room budget'
+            }),
+            jsx(GroupLimitsControls, { limits, memberCount: (members || []).length, onChange: setLimits })
+          ]
+        }),
         jsxs(DialogFooter, {
           children: [
             jsx(Button, { variant: 'secondary', onClick: onClose, children: 'Cancel' }),
@@ -9266,6 +9647,8 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
   const [checked, setChecked] = useState({})
   const [name, setName] = useState('')
   const [image, setImage] = useState(null)
+  const [limits, setLimits] = useState(null)
+  const [showBudget, setShowBudget] = useState(false)
 
   // Reset per open so a cancelled draft doesn't leak into the next one.
   useEffect(() => {
@@ -9274,12 +9657,17 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
       setChecked({})
       setName('')
       setImage(null)
+      setLimits(null)
+      setShowBudget(false)
     }
   }, [open])
 
   const selected = roster.filter(bot => checked[botRosterKey(bot)])
   const visible = filterBots(roster, allMeta, query)
-  const atCap = selected.length >= GROUP_CHAT_MAX_MEMBERS
+  // The member cap is part of the budget, so raising it here immediately
+  // widens the picker instead of forcing a create-then-edit round trip.
+  const memberCap = resolveGroupChatLimits({ limits }).members
+  const atCap = memberCap !== null && selected.length >= memberCap
   const placeholder = selected.length
     ? selected.map(bot => displayName(bot, botRosterMeta(bot, allMeta))).join(', ')
     : 'Group name'
@@ -9322,12 +9710,18 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
     // gateway's name-keyed bot metadata to remain seated in this room.
     const roomMembers = durableGroupChatMembers(selected)
 
+    const roomLimits = durableGroupChatLimits(limits)
+
     updateGroupChat(groupName, room => {
       room.members = roomMembers
       room.roomId = roomId
 
       if (image) {
         room.image = image
+      }
+
+      if (roomLimits) {
+        room.limits = roomLimits
       }
 
       return room
@@ -9352,7 +9746,7 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
           children: [
             jsx(DialogTitle, { children: 'New Group Chat' }),
             jsx(DialogDescription, {
-              children: `Pick 2–${GROUP_CHAT_MAX_MEMBERS} bots. Local memberships sync through each Bot profile; cross-machine members stay scoped to this room.`
+              children: `Pick ${memberCap === null ? '2 or more' : `2–${memberCap}`} bots. Local memberships sync through each Bot profile; cross-machine members stay scoped to this room.`
             })
           ]
         }),
@@ -9456,6 +9850,19 @@ function CreateGroupChatDialog({ open, roster, onClose, onCreated }) {
                 onChange: event => setName(event.target.value)
               })
             })
+          ]
+        }),
+        jsxs('div', {
+          className: 'flex flex-col',
+          children: [
+            jsx('button', {
+              className:
+                'w-fit text-[0.65rem] text-(--ui-text-tertiary) hover:text-(--ui-text-secondary) transition-colors',
+              type: 'button',
+              onClick: () => setShowBudget(value => !value),
+              children: showBudget ? 'Hide room budget' : 'Room budget \u2026'
+            }),
+            showBudget ? jsx(GroupLimitsControls, { limits, memberCount: selected.length, onChange: setLimits }) : null
           ]
         }),
         jsxs(DialogFooter, {
@@ -10044,6 +10451,16 @@ function GroupChatWorkspace({ group, members, onBack, visible = true }) {
       jsx('span', {
         className: 'shrink-0 text-[0.65rem] text-(--ui-text-quaternary)',
         children: `${members.length} bots`
+      }),
+      jsx(Tip, {
+        label: 'Room budget — click to change',
+        children: jsx('button', {
+          className:
+            'shrink-0 text-[0.65rem] text-(--ui-text-quaternary) hover:text-(--ui-text-secondary) transition-colors',
+          type: 'button',
+          onClick: () => setSettingsOpen(true),
+          children: groupChatBudgetLabel(room)
+        })
       }),
       jsx(Button, {
         variant: 'ghost',

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9303,7 +9303,10 @@ function GroupLimitRow({ label, hint, value, fallback, ceiling, onChange, brake 
 
   const numberField = (props) =>
     jsx(Input, {
-      className: 'w-20 text-right',
+      // text-xs mirrors CONTROL_TEXT in src/app/settings/constants.ts; the
+      // field fills its column there rather than carrying a fixed width,
+      // which is what makes its border read at this size.
+      className: 'min-w-0 flex-1 text-xs',
       inputMode: 'numeric',
       max: ceiling,
       min: 1,
@@ -9311,13 +9314,13 @@ function GroupLimitRow({ label, hint, value, fallback, ceiling, onChange, brake 
       ...props
     })
 
-  const control = (children) => jsx('div', { className: 'flex items-center justify-end gap-2', children })
+  const control = (children) => jsx('div', { className: 'flex min-w-0 items-center gap-2', children })
 
   return jsxs('div', {
     className: '@container',
     children: [
       jsxs('div', {
-        className: 'grid gap-3 py-3 @2xl:grid-cols-[minmax(0,1fr)_minmax(15rem,22rem)] @2xl:items-center',
+        className: 'grid gap-2 py-2.5 @xs:grid-cols-[minmax(0,1fr)_11rem] @xs:items-center @xs:gap-3',
         children: [
           jsxs('div', {
             className: 'min-w-0',
@@ -9336,7 +9339,7 @@ function GroupLimitRow({ label, hint, value, fallback, ceiling, onChange, brake 
             ]
           }),
           jsx('div', {
-            className: 'min-w-0 @2xl:justify-self-end',
+            className: 'min-w-0 @xs:justify-self-end',
             children: control([
               numberField({
                 'aria-label': label,
@@ -9368,7 +9371,7 @@ function GroupLimitRow({ label, hint, value, fallback, ceiling, onChange, brake 
       off && brake
         ? jsxs('div', {
             className:
-              'grid gap-3 border-l border-(--ui-border) pb-3 pl-3 @2xl:grid-cols-[minmax(0,1fr)_minmax(15rem,22rem)] @2xl:items-center',
+              'grid gap-2 border-l border-(--ui-border) pb-2.5 pl-3 @xs:grid-cols-[minmax(0,1fr)_11rem] @xs:items-center @xs:gap-3',
             children: [
               jsx('div', {
                 className:
@@ -9376,7 +9379,7 @@ function GroupLimitRow({ label, hint, value, fallback, ceiling, onChange, brake 
                 children: brake.value === null ? `No safety stop on ${label.toLowerCase()}` : 'Safety stop after'
               }),
               jsx('div', {
-                className: 'min-w-0 @2xl:justify-self-end',
+                className: 'min-w-0 @xs:justify-self-end',
                 children: control([
                   numberField({
                     'aria-label': `Safety stop for ${label.toLowerCase()}`,

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -240,7 +240,9 @@ function recordGroupActivity(group, event) {
   }
 
   const current = $groupActivity.get()[group] || { events: [] }
-  const entry = { at: Date.now(), epoch: room.epoch || 0, ...event }
+  // Spread first: `at` and `epoch` belong to the record, not to the caller. A
+  // caller that shipped its own `at` once rendered an event as decades old.
+  const entry = { ...event, at: Date.now(), epoch: room.epoch || 0 }
   const events = [...current.events, entry].slice(-GROUP_ACTIVITY_LIMIT)
   $groupActivity.set({ ...$groupActivity.get(), [group]: { ...current, events } })
 
@@ -268,10 +270,10 @@ function groupActivityLabel(event) {
   // statement rather than "<bot> hit the safety stop".
   if (kind === 'safety' || kind === 'capped') {
     const what = event?.detail === 'messages' ? 'messages' : 'rounds'
-    const at = event?.at ?? '?'
+    const count = event?.count ?? '?'
     return kind === 'safety'
-      ? `safety stop: ${at} ${what} reached`
-      : `stopped at the ${what} limit (${at}), raise it in the room budget`
+      ? `safety stop: ${count} ${what} reached`
+      : `stopped at the ${what} limit (${count}), raise it in the room budget`
   }
 
   const who = event?.member === 'You' ? 'You' : groupSpeakerLabel(event?.member || 'A bot')
@@ -5737,7 +5739,11 @@ async function runGroupChatRounds(group, members, thread) {
               member: null,
               thread,
               detail: stoppedBy,
-              at: stoppedBy === 'rounds' ? caps.rounds : caps.messages
+              // NOT `at`: recordGroupActivity stamps that with Date.now(), and
+              // spreading the event over it turned "1 round" into a timestamp
+              // of 1ms past the epoch, which the room rendered as "20688 days
+              // ago".
+              count: stoppedBy === 'rounds' ? caps.rounds : caps.messages
             }
           : { kind: 'settled', member: null, thread }
       )

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -266,10 +266,12 @@ function groupActivityLabel(event) {
 
   // The safety stop is about the room, not about a member, so it reads as a
   // statement rather than "<bot> hit the safety stop".
-  if (kind === 'safety') {
-    return event?.detail === 'messages'
-      ? `safety stop: ${event?.at ?? '?'} messages reached`
-      : `safety stop: ${event?.at ?? '?'} rounds reached`
+  if (kind === 'safety' || kind === 'capped') {
+    const what = event?.detail === 'messages' ? 'messages' : 'rounds'
+    const at = event?.at ?? '?'
+    return kind === 'safety'
+      ? `safety stop: ${at} ${what} reached`
+      : `stopped at the ${what} limit (${at}), raise it in the room budget`
   }
 
   const who = event?.member === 'You' ? 'You' : groupSpeakerLabel(event?.member || 'A bot')
@@ -287,7 +289,8 @@ const GROUP_ACTIVITY_LABELS = {
   cancelled: 'turn interrupted by a newer message',
   settled: 'turn settled',
   delivered: 'delivered a late reply',
-  safety: 'safety stop'
+  safety: 'safety stop',
+  capped: 'stopped at the limit'
 }
 
 const GROUP_ACTIVITY_GLYPHS = {
@@ -300,7 +303,8 @@ const GROUP_ACTIVITY_GLYPHS = {
   cancelled: 'close',
   settled: 'check-all',
   delivered: 'mail-read',
-  safety: 'debug-pause'
+  safety: 'debug-pause',
+  capped: 'debug-pause'
 }
 
 /** Text tone for an activity row: quiet for pass/cancel/settle, accent for
@@ -312,7 +316,7 @@ function groupActivityTone(kind) {
 
   // A safety stop is not a failure, but it must not read as routine either:
   // the room stopped short of what the user asked for.
-  if (kind === 'safety') {
+  if (kind === 'safety' || kind === 'capped') {
     return 'text-(--ui-warning,#d68b00)'
   }
 
@@ -5602,10 +5606,19 @@ async function runGroupChatRounds(group, members, thread) {
 
   try {
     for (let round = 0; caps.rounds === null || round < caps.rounds; round++) {
-      // A room that turned rounds off but kept the brake stops here, and says
-      // so — silence would read as the conversation having settled.
-      if (limits.rounds === null && caps.rounds !== null && round === caps.rounds - 1) {
-        recordGroupActivity(group, { kind: 'safety', member: null, thread, detail: 'rounds', at: caps.rounds })
+      // Any stop on a count says so, inherited default included. Reported by
+      // AllanGamal on #92213: a two-bot room hit the shipped 3-round cap on a
+      // directed handoff and went quiet, which is indistinguishable from the
+      // room having settled. `capped` is the ordinary limit, `safety` the
+      // brake behind a switched-off axis.
+      if (caps.rounds !== null && round === caps.rounds - 1) {
+        recordGroupActivity(group, {
+          kind: limits.rounds === null ? 'safety' : 'capped',
+          member: null,
+          thread,
+          detail: 'rounds',
+          at: caps.rounds
+        })
       }
       // Deliver any replies that finished after their turn timed out —
       // every member, not just this round's responders, so long work is
@@ -5641,8 +5654,14 @@ async function runGroupChatRounds(group, members, thread) {
         if (!isCurrent() || (caps.messages !== null && posted >= caps.messages)) {
           if (!isCurrent()) {
             recordGroupActivity(group, { kind: 'cancelled', member: null, thread })
-          } else if (limits.messages === null) {
-            recordGroupActivity(group, { kind: 'safety', member: null, thread, detail: 'messages', at: caps.messages })
+          } else {
+            recordGroupActivity(group, {
+              kind: limits.messages === null ? 'safety' : 'capped',
+              member: null,
+              thread,
+              detail: 'messages',
+              at: caps.messages
+            })
           }
           return
         }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9297,7 +9297,7 @@ function GroupLimitRow({ label, hint, value, fallback, ceiling, onChange, brake 
             inputMode: 'numeric',
             max: ceiling,
             min: 1,
-            placeholder: String(fallback),
+            placeholder: off ? '\u221e' : String(fallback),
             type: 'number',
             value: shown,
             onChange: event => {
@@ -9310,13 +9310,26 @@ function GroupLimitRow({ label, hint, value, fallback, ceiling, onChange, brake 
               onChange(Number.isFinite(n) && n > 0 ? Math.min(n, ceiling) : undefined)
             }
           }),
-          jsx(Tip, {
-            label: off ? `No limit on ${label.toLowerCase()}` : `Limit ${label.toLowerCase()}`,
-            children: jsx(Switch, {
-              'aria-label': `Limit ${label.toLowerCase()}`,
-              checked: !off,
-              onCheckedChange: on => onChange(on ? fallback : null)
-            })
+          // The switch alone is not readable in the dark theme: "on" is a
+          // slightly different dark track. Name the state next to it.
+          jsxs('div', {
+            className: 'flex shrink-0 items-center gap-1.5',
+            children: [
+              jsx('span', {
+                className: off
+                  ? 'w-12 text-right text-[0.65rem] text-(--ui-warning,#d68b00)'
+                  : 'w-12 text-right text-[0.65rem] text-(--ui-text-tertiary)',
+                children: off ? 'no limit' : 'limit'
+              }),
+              jsx(Tip, {
+                label: off ? `No limit on ${label.toLowerCase()}` : `Limit ${label.toLowerCase()}`,
+                children: jsx(Switch, {
+                  'aria-label': `Limit ${label.toLowerCase()}`,
+                  checked: !off,
+                  onCheckedChange: on => onChange(on ? fallback : null)
+                })
+              })
+            ]
           })
         ]
       }),
@@ -9348,13 +9361,25 @@ function GroupLimitRow({ label, hint, value, fallback, ceiling, onChange, brake 
                   brake.onChange(Number.isFinite(n) && n > 0 ? Math.min(n, ceiling) : undefined)
                 }
               }),
-              jsx(Tip, {
-                label: brake.value === null ? 'No safety stop at all' : 'Stop the room after this many',
-                children: jsx(Switch, {
-                  'aria-label': `Safety stop for ${label.toLowerCase()}`,
-                  checked: brake.value !== null,
-                  onCheckedChange: on => brake.onChange(on ? brake.fallback : null)
-                })
+              jsxs('div', {
+                className: 'flex shrink-0 items-center gap-1.5',
+                children: [
+                  jsx('span', {
+                    className:
+                      brake.value === null
+                        ? 'w-12 text-right text-[0.65rem] text-(--ui-warning,#d68b00)'
+                        : 'w-12 text-right text-[0.65rem] text-(--ui-text-tertiary)',
+                    children: brake.value === null ? 'none' : 'brake'
+                  }),
+                  jsx(Tip, {
+                    label: brake.value === null ? 'No safety stop at all' : 'Stop the room after this many',
+                    children: jsx(Switch, {
+                      'aria-label': `Safety stop for ${label.toLowerCase()}`,
+                      checked: brake.value !== null,
+                      onCheckedChange: on => brake.onChange(on ? brake.fallback : null)
+                    })
+                  })
+                ]
               })
             ]
           })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -5602,24 +5602,15 @@ async function runGroupChatRounds(group, members, thread) {
   // so a running conversation keeps the rules it started under.
   const limits = resolveGroupChatLimits($groupChats.get()[group])
   const caps = groupChatDriveCaps(limits)
+  // Why the drive ended, decided where it actually ends and reported once in
+  // `finally`. Before this, every ending reported as `settled`, so a room cut
+  // off by its budget looked exactly like a room that had finished talking
+  // (#92213, reported by AllanGamal against a two-bot room on the 3-round cap).
+  let stoppedBy = null
   let posted = 0
 
   try {
     for (let round = 0; caps.rounds === null || round < caps.rounds; round++) {
-      // Any stop on a count says so, inherited default included. Reported by
-      // AllanGamal on #92213: a two-bot room hit the shipped 3-round cap on a
-      // directed handoff and went quiet, which is indistinguishable from the
-      // room having settled. `capped` is the ordinary limit, `safety` the
-      // brake behind a switched-off axis.
-      if (caps.rounds !== null && round === caps.rounds - 1) {
-        recordGroupActivity(group, {
-          kind: limits.rounds === null ? 'safety' : 'capped',
-          member: null,
-          thread,
-          detail: 'rounds',
-          at: caps.rounds
-        })
-      }
       // Deliver any replies that finished after their turn timed out —
       // every member, not just this round's responders, so long work is
       // late, never lost.
@@ -5655,13 +5646,7 @@ async function runGroupChatRounds(group, members, thread) {
           if (!isCurrent()) {
             recordGroupActivity(group, { kind: 'cancelled', member: null, thread })
           } else {
-            recordGroupActivity(group, {
-              kind: limits.messages === null ? 'safety' : 'capped',
-              member: null,
-              thread,
-              detail: 'messages',
-              at: caps.messages
-            })
+            stoppedBy = 'messages'
           }
           return
         }
@@ -5734,12 +5719,28 @@ async function runGroupChatRounds(group, members, thread) {
       }
 
       if (spokeThisRound === 0) {
+        stoppedBy = 'settled'
         return // everyone passed — the conversation settled
       }
     }
+
+    // Falling out of the loop means the round budget ran out; every other exit
+    // returns above.
+    stoppedBy = stoppedBy ?? (caps.rounds === null ? 'settled' : 'rounds')
   } finally {
     if (isCurrent()) {
-      recordGroupActivity(group, { kind: 'settled', member: null, thread })
+      recordGroupActivity(
+        group,
+        stoppedBy === 'rounds' || stoppedBy === 'messages'
+          ? {
+              kind: (stoppedBy === 'rounds' ? limits.rounds : limits.messages) === null ? 'safety' : 'capped',
+              member: null,
+              thread,
+              detail: stoppedBy,
+              at: stoppedBy === 'rounds' ? caps.rounds : caps.messages
+            }
+          : { kind: 'settled', member: null, thread }
+      )
       updateGroupChat(group, r => {
         r.running = false
         r.turn = null

--- a/apps/desktop/src/plugins/hermes-bots/tests/create-group-chat.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/create-group-chat.test.mjs
@@ -19,8 +19,10 @@ test('source contract: create-group modal has search, checkboxes, name, create',
   assert.match(pluginSource, /function CreateGroupChatDialog\(/)
   // Reuses the roster search filter so name/@handle/title all match.
   assert.match(pluginSource, /const visible = filterBots\(roster, allMeta, query\)/)
-  // Selection is checkbox-driven and capped at the room member limit.
-  assert.match(pluginSource, /const atCap = selected\.length >= GROUP_CHAT_MAX_MEMBERS/)
+  // Selection is checkbox-driven and capped at the room member limit, which
+  // the budget controls can raise or switch off before the room exists.
+  assert.match(pluginSource, /const memberCap = resolveGroupChatLimits\(\{ limits \}\)\.members/)
+  assert.match(pluginSource, /const atCap = memberCap !== null && selected\.length >= memberCap/)
   // Create requires 2+ members. Membership mutation is covered by the
   // behavioral groupMembershipPatch tests rather than another source regex.
   assert.match(pluginSource, /selected\.length >= 2/)

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
@@ -183,23 +183,29 @@ test('the room header label is what the create dialog and settings also write', 
   assert.match(source, /children: groupChatBudgetLabel\(room\)/, 'the header shows the same resolved budget')
 })
 
-test('every switch is paired with the state in words', () => {
-  // Radix renders "on" as a slightly different dark track, which is not
-  // readable in the dark theme. First live test: the toggles looked off while
-  // every limit was active.
-  const editor = source.slice(source.indexOf('function GroupLimitRow('))
-  const body = editor.slice(0, editor.indexOf('\nfunction '))
+test('the budget row mirrors the app\'s own settings row', () => {
+  // src/app/settings/primitives.tsx (ListRow / ToggleRow) is the canonical
+  // shape for a labelled control. Plugins cannot import it, so the structure
+  // is mirrored. Diverging from it is what made the switches unreadable in
+  // the first live test.
+  const row = source.slice(source.indexOf('function GroupLimitRow('))
+  const body = row.slice(0, row.indexOf('\n/** The room budget editor'))
 
-  assert.match(body, /children: off \? 'no limit' : 'limit'/)
-  assert.match(body, /children: brake\.value === null \? 'none' : 'brake'/)
+  assert.match(body, /@container/)
+  assert.match(body, /grid gap-3 py-3 @2xl:grid-cols-\[minmax\(0,1fr\)_minmax\(15rem,22rem\)\] @2xl:items-center/)
+  assert.match(body, /text-\[length:var\(--conversation-text-font-size\)\] font-medium text-foreground/)
+  assert.match(body, /@2xl:justify-self-end/)
+})
 
-  const switches = [...body.matchAll(/jsx\(Switch, \{/g)]
-  const labels = [...body.matchAll(/text-\(--ui-warning,#d68b00\)'\n\s*: 'w-12/g)]
-  assert.equal(switches.length, 2, 'the row has a limit switch and a brake switch')
-  assert.equal(labels.length, switches.length, 'each switch carries its own state word')
+test('switching an axis fires the same haptic the app uses elsewhere', () => {
+  const row = source.slice(source.indexOf('function GroupLimitRow('))
+  const body = row.slice(0, row.indexOf('\n/** The room budget editor'))
+  const taps = [...body.matchAll(/haptic\('tap'\)/g)]
+
+  assert.equal(taps.length, 2, 'both the limit switch and the brake switch give feedback')
 })
 
 test('a switched-off axis shows the infinity placeholder, not an empty box', () => {
-  const editor = source.slice(source.indexOf('function GroupLimitRow('))
-  assert.match(editor.slice(0, 3000), /placeholder: off \? '\\u221e' : String\(fallback\)/)
+  const row = source.slice(source.indexOf('function GroupLimitRow('))
+  assert.match(row.slice(0, 4000), /placeholder: off \? '\\u221e' : String\(fallback\)/)
 })

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
@@ -1,0 +1,165 @@
+// Per-room limit overrides. Three states per axis (a number, off, or absent)
+// and a safety brake that is itself switchable, so the resolver is where a
+// wrong default would quietly change how long every room runs.
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../plugin.js', import.meta.url), 'utf8')
+
+function loadLimits() {
+  const consts = source.slice(
+    source.indexOf('const GROUP_CHAT_MAX_ROUNDS'),
+    source.indexOf('/** Per-room limit overrides')
+  )
+  assert.ok(consts.includes('GROUP_CHAT_LIMIT_CEILINGS'), 'the ceilings block must stay extractable')
+
+  const fn = name => {
+    const start = source.indexOf(`function ${name}(`)
+    assert.ok(start >= 0, `${name} not found`)
+    const end = source.indexOf('\n}\n', start) + 3
+    return source.slice(start, end)
+  }
+
+  const context = {}
+  vm.runInNewContext(
+    [
+      consts,
+      fn('resolveGroupChatLimits'),
+      fn('groupChatDriveCaps'),
+      fn('durableGroupChatLimits'),
+      fn('groupChatBudgetLabel'),
+      'globalThis.__resolve = resolveGroupChatLimits',
+      'globalThis.__caps = groupChatDriveCaps',
+      'globalThis.__durable = durableGroupChatLimits',
+      'globalThis.__label = groupChatBudgetLabel',
+      'globalThis.__defaults = { GROUP_CHAT_MAX_ROUNDS, GROUP_CHAT_MAX_MESSAGES, GROUP_CHAT_HISTORY_LIMIT, GROUP_CHAT_MAX_MEMBERS }',
+      'globalThis.__ceilings = GROUP_CHAT_LIMIT_CEILINGS',
+      'globalThis.__safety = GROUP_CHAT_SAFETY_DEFAULTS'
+    ].join('\n'),
+    context
+  )
+
+  return context
+}
+
+const { __resolve: resolve, __caps: caps, __durable: durable, __label: label, __defaults: defaults, __ceilings: ceilings, __safety: safety } =
+  loadLimits()
+
+/** Objects minted inside the vm carry that realm's prototype, which
+ *  deepEqual compares. Compare the data, not the realm. */
+const plain = value => (value === null || value === undefined ? value : JSON.parse(JSON.stringify(value)))
+
+test('a room with no overrides gets the shipped defaults', () => {
+  for (const room of [undefined, null, {}, { limits: null }, { limits: {} }]) {
+    const limits = resolve(room)
+    assert.equal(limits.rounds, defaults.GROUP_CHAT_MAX_ROUNDS)
+    assert.equal(limits.messages, defaults.GROUP_CHAT_MAX_MESSAGES)
+    assert.equal(limits.members, defaults.GROUP_CHAT_MAX_MEMBERS)
+    assert.equal(limits.history, defaults.GROUP_CHAT_HISTORY_LIMIT)
+  }
+})
+
+test('an explicit number wins over the default', () => {
+  const limits = resolve({ limits: { rounds: 9, messages: 40, members: 12, history: 60 } })
+  assert.deepEqual(
+    [limits.rounds, limits.messages, limits.members, limits.history],
+    [9, 40, 12, 60]
+  )
+})
+
+test('null means off, and off is not the same as absent', () => {
+  assert.equal(resolve({ limits: { rounds: null } }).rounds, null)
+  assert.equal(resolve({ limits: {} }).rounds, defaults.GROUP_CHAT_MAX_ROUNDS)
+})
+
+test('a nonsense value falls back instead of disabling the limit', () => {
+  for (const bad of [0, -3, 'lots', NaN, {}, [], true]) {
+    assert.equal(resolve({ limits: { rounds: bad } }).rounds, defaults.GROUP_CHAT_MAX_ROUNDS, `rounds: ${String(bad)}`)
+  }
+})
+
+test('a value above the ceiling is clamped, never rejected', () => {
+  assert.equal(resolve({ limits: { rounds: 10_000 } }).rounds, ceilings.rounds)
+  assert.equal(resolve({ limits: { messages: 10_000 } }).messages, ceilings.messages)
+})
+
+test('the safety brake only exists while its axis is off', () => {
+  assert.equal(resolve({ limits: { rounds: 5 } }).safetyRounds, null, 'a bounded axis needs no brake')
+  assert.equal(resolve({ limits: { rounds: null } }).safetyRounds, safety.rounds)
+  assert.equal(resolve({ limits: { rounds: null, safetyRounds: 12 } }).safetyRounds, 12)
+  assert.equal(resolve({ limits: { rounds: null, safetyRounds: null } }).safetyRounds, null)
+})
+
+test('drive caps collapse the three states into what the loop needs', () => {
+  const bounded = caps(resolve({ limits: { rounds: 4 } }))
+  assert.equal(bounded.rounds, 4)
+  assert.equal(bounded.roundsUnbounded, false)
+
+  const braked = caps(resolve({ limits: { rounds: null, safetyRounds: 20 } }))
+  assert.equal(braked.rounds, 20, 'the brake becomes the loop bound')
+  assert.equal(braked.roundsUnbounded, false)
+
+  const free = caps(resolve({ limits: { rounds: null, safetyRounds: null } }))
+  assert.equal(free.rounds, null, 'nothing bounds the loop by count')
+  assert.equal(free.roundsUnbounded, true)
+})
+
+test('the stored form keeps only what the room actually set', () => {
+  assert.equal(durable(null), null)
+  assert.equal(durable({}), null, 'a room on every default stores nothing')
+  assert.deepEqual(plain(durable({ rounds: 5 })), { rounds: 5 })
+  assert.deepEqual(plain(durable({ rounds: null })), { rounds: null }, 'off must survive a round trip')
+  assert.deepEqual(plain(durable({ rounds: 5, bogus: 1 })), { rounds: 5 }, 'unknown axes are dropped')
+  assert.equal(durable({ rounds: 0 }), null, 'a nonsense value is not stored')
+})
+
+test('a stored override survives the round trip through the resolver', () => {
+  const stored = durable({ rounds: null, safetyRounds: null, messages: 40 })
+  const limits = resolve({ limits: stored })
+  assert.equal(limits.rounds, null)
+  assert.equal(limits.safetyRounds, null)
+  assert.equal(limits.messages, 40)
+})
+
+test('the header label names all three states', () => {
+  assert.equal(label({}), `${defaults.GROUP_CHAT_MAX_ROUNDS} rounds · ${defaults.GROUP_CHAT_MAX_MESSAGES} msgs`)
+  assert.match(label({ limits: { rounds: null } }), /≤\d+ rounds/)
+  assert.match(label({ limits: { rounds: null, safetyRounds: null } }), /∞ rounds/)
+  assert.equal(label({ limits: { rounds: 1, messages: 1 } }), '1 round · 1 msg', 'singular reads correctly')
+})
+
+test('the drive loop is bounded by the caps, not by the constants', () => {
+  const loop = source.slice(source.indexOf('async function runGroupChatRounds('))
+  assert.match(loop, /for \(let round = 0; caps\.rounds === null \|\| round < caps\.rounds; round\+\+\)/)
+  assert.match(loop, /caps\.messages !== null && posted >= caps\.messages/)
+  assert.doesNotMatch(
+    loop.slice(0, loop.indexOf('\n}\n')),
+    /GROUP_CHAT_MAX_ROUNDS|GROUP_CHAT_MAX_MESSAGES/,
+    'the loop must read the room, not the module defaults'
+  )
+})
+
+test('a room that hits its brake says so instead of going quiet', () => {
+  const loop = source.slice(source.indexOf('async function runGroupChatRounds('))
+  assert.match(loop, /kind: 'safety', member: null, thread, detail: 'rounds'/)
+  assert.match(loop, /kind: 'safety', member: null, thread, detail: 'messages'/)
+})
+
+test('the editor warns when the message budget, not the round setting, ends the room', () => {
+  const editor = source.slice(source.indexOf('function GroupLimitsControls('))
+  const body = editor.slice(0, editor.indexOf('\n}\n'))
+
+  // With N members one round costs N messages, so raising rounds alone is a
+  // no-op whenever messages/N is the smaller number. That has to be visible.
+  assert.match(body, /Math\.ceil\(effectiveMessages \/ memberCount\) < effectiveRounds/)
+  assert.match(body, /raise it too, or the round setting will not change anything/)
+})
+
+test('the room header label is what the create dialog and settings also write', () => {
+  // One component, three mount points: a second editor would drift.
+  const mounts = [...source.matchAll(/jsx\(GroupLimitsControls, \{/g)]
+  assert.equal(mounts.length, 2, 'create dialog and group settings mount the shared editor')
+  assert.match(source, /children: groupChatBudgetLabel\(room\)/, 'the header shows the same resolved budget')
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
@@ -222,3 +222,22 @@ test('a switched-off axis shows the infinity placeholder, not an empty box', () 
   const row = source.slice(source.indexOf('function GroupLimitRow('))
   assert.match(row.slice(0, 4000), /placeholder: off \? '\\u221e' : String\(fallback\)/)
 })
+
+test('an activity event cannot overwrite its own timestamp', () => {
+  // Live test: the limit event carried `at: 1` for "1 round". recordGroupActivity
+  // spread the event over its own `at: Date.now()`, so the room rendered the
+  // stop as "20688 days ago". The record's fields win over the caller's.
+  const record = source.slice(source.indexOf('function recordGroupActivity('))
+  const body = record.slice(0, record.indexOf('\n}\n'))
+
+  assert.match(body, /const entry = \{ \.\.\.event, at: Date\.now\(\), epoch: room\.epoch \|\| 0 \}/)
+  assert.doesNotMatch(body, /at: Date\.now\(\), epoch: room\.epoch \|\| 0, \.\.\.event/)
+})
+
+test('the limit event carries its count under a name of its own', () => {
+  const loop = source.slice(source.indexOf('async function runGroupChatRounds('))
+
+  assert.match(loop, /count: stoppedBy === 'rounds' \? caps\.rounds : caps\.messages/)
+  assert.doesNotMatch(loop, /at: stoppedBy === 'rounds'/)
+  assert.match(source, /const count = event\?\.count \?\? '\?'/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
@@ -163,3 +163,24 @@ test('the room header label is what the create dialog and settings also write', 
   assert.equal(mounts.length, 2, 'create dialog and group settings mount the shared editor')
   assert.match(source, /children: groupChatBudgetLabel\(room\)/, 'the header shows the same resolved budget')
 })
+
+test('every switch is paired with the state in words', () => {
+  // Radix renders "on" as a slightly different dark track, which is not
+  // readable in the dark theme. First live test: the toggles looked off while
+  // every limit was active.
+  const editor = source.slice(source.indexOf('function GroupLimitRow('))
+  const body = editor.slice(0, editor.indexOf('\nfunction '))
+
+  assert.match(body, /children: off \? 'no limit' : 'limit'/)
+  assert.match(body, /children: brake\.value === null \? 'none' : 'brake'/)
+
+  const switches = [...body.matchAll(/jsx\(Switch, \{/g)]
+  const labels = [...body.matchAll(/text-\(--ui-warning,#d68b00\)'\n\s*: 'w-12/g)]
+  assert.equal(switches.length, 2, 'the row has a limit switch and a brake switch')
+  assert.equal(labels.length, switches.length, 'each switch carries its own state word')
+})
+
+test('a switched-off axis shows the infinity placeholder, not an empty box', () => {
+  const editor = source.slice(source.indexOf('function GroupLimitRow('))
+  assert.match(editor.slice(0, 3000), /placeholder: off \? '\\u221e' : String\(fallback\)/)
+})

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
@@ -141,18 +141,21 @@ test('the drive loop is bounded by the caps, not by the constants', () => {
   )
 })
 
-test('every stop on a count is reported, the inherited default included', () => {
-  // #92213 review (AllanGamal): a two-bot room hit the shipped 3-round cap on
-  // a directed handoff and went silent for 12 minutes. Silence there is
-  // indistinguishable from the conversation having settled.
+test('the drive reports why it ended, not just that it ended', () => {
+  // #92213 (AllanGamal): every ending reported as `settled`, so a room cut off
+  // by its budget looked like a room that had finished talking. The reason is
+  // recorded where the drive actually exits and reported once in `finally`.
   const loop = source.slice(source.indexOf('async function runGroupChatRounds('))
 
-  assert.match(loop, /if \(caps\.rounds !== null && round === caps\.rounds - 1\)/)
-  assert.match(loop, /kind: limits\.rounds === null \? 'safety' : 'capped'/)
-  assert.match(loop, /kind: limits\.messages === null \? 'safety' : 'capped'/)
+  assert.match(loop, /let stoppedBy = null/)
+  assert.match(loop, /stoppedBy = 'settled'\n\s*return \/\/ everyone passed/)
+  assert.match(loop, /stoppedBy = 'messages'/)
+  assert.match(loop, /stoppedBy = stoppedBy \?\? \(caps\.rounds === null \? 'settled' : 'rounds'\)/)
+  assert.match(loop, /stoppedBy === 'rounds' \|\| stoppedBy === 'messages'/)
 
-  // The report must not hang off the axis being switched off.
-  assert.doesNotMatch(loop, /limits\.rounds === null && caps\.rounds !== null/)
+  // The reason must not be guessed at the top of the last round: a round that
+  // settles there would report a limit stop that never happened.
+  assert.doesNotMatch(loop, /round === caps\.rounds - 1/)
 })
 
 test('the two stop kinds read differently and both stand out', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
@@ -141,10 +141,29 @@ test('the drive loop is bounded by the caps, not by the constants', () => {
   )
 })
 
-test('a room that hits its brake says so instead of going quiet', () => {
+test('every stop on a count is reported, the inherited default included', () => {
+  // #92213 review (AllanGamal): a two-bot room hit the shipped 3-round cap on
+  // a directed handoff and went silent for 12 minutes. Silence there is
+  // indistinguishable from the conversation having settled.
   const loop = source.slice(source.indexOf('async function runGroupChatRounds('))
-  assert.match(loop, /kind: 'safety', member: null, thread, detail: 'rounds'/)
-  assert.match(loop, /kind: 'safety', member: null, thread, detail: 'messages'/)
+
+  assert.match(loop, /if \(caps\.rounds !== null && round === caps\.rounds - 1\)/)
+  assert.match(loop, /kind: limits\.rounds === null \? 'safety' : 'capped'/)
+  assert.match(loop, /kind: limits\.messages === null \? 'safety' : 'capped'/)
+
+  // The report must not hang off the axis being switched off.
+  assert.doesNotMatch(loop, /limits\.rounds === null && caps\.rounds !== null/)
+})
+
+test('the two stop kinds read differently and both stand out', () => {
+  const labels = source.slice(source.indexOf('function groupActivityLabel('))
+  const body = labels.slice(0, labels.indexOf('\nconst GROUP_ACTIVITY_LABELS'))
+
+  assert.match(body, /kind === 'safety' \|\| kind === 'capped'/)
+  assert.match(body, /safety stop: /)
+  assert.match(body, /raise it in the room budget/)
+  assert.match(source, /capped: 'stopped at the limit'/)
+  assert.match(source, /if \(kind === 'safety' \|\| kind === 'capped'\) \{\n {4}return 'text-\(--ui-warning/)
 })
 
 test('the editor warns when the message budget, not the round setting, ends the room', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
@@ -192,9 +192,19 @@ test('the budget row mirrors the app\'s own settings row', () => {
   const body = row.slice(0, row.indexOf('\n/** The room budget editor'))
 
   assert.match(body, /@container/)
-  assert.match(body, /grid gap-3 py-3 @2xl:grid-cols-\[minmax\(0,1fr\)_minmax\(15rem,22rem\)\] @2xl:items-center/)
   assert.match(body, /text-\[length:var\(--conversation-text-font-size\)\] font-medium text-foreground/)
-  assert.match(body, /@2xl:justify-self-end/)
+  assert.match(body, /@xs:justify-self-end/)
+
+  // The app's own rows split at @2xl, which is 672px of container. These rows
+  // live in a 448px dialog, so that breakpoint would never fire and every row
+  // would stack label-over-control. Split early instead.
+  assert.match(body, /@xs:grid-cols-\[minmax\(0,1fr\)_11rem\]/)
+  assert.doesNotMatch(body, /@2xl:grid-cols/)
+
+  // CONTROL_TEXT in src/app/settings/constants.ts is 'text-xs', and the
+  // standard field fills its column instead of carrying a fixed width.
+  assert.match(body, /className: 'min-w-0 flex-1 text-xs'/)
+  assert.doesNotMatch(body, /className: 'w-20/)
 })
 
 test('switching an axis fires the same haptic the app uses elsewhere', () => {

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-chat-limits.test.mjs
@@ -241,3 +241,35 @@ test('the limit event carries its count under a name of its own', () => {
   assert.doesNotMatch(loop, /at: stoppedBy === 'rounds'/)
   assert.match(source, /const count = event\?\.count \?\? '\?'/)
 })
+
+test('every field the room persists is read back on hydrate', () => {
+  // Live test: room budgets did not survive a restart. durableGroupChatRooms
+  // wrote `limits`, the gateway merge carried it, and the hydrate path rebuilt
+  // the room field by field without it. A persisted field has three sites, and
+  // two of three is a field that silently resets.
+  const durable = source.slice(source.indexOf('function durableGroupChatRooms('))
+  const durableBody = durable.slice(0, durable.indexOf('\n}\n'))
+
+  const hydrateAt = source.indexOf("ctx.storage?.get?.('group-chats')")
+  assert.ok(hydrateAt > 0, 'the hydrate path must stay findable')
+  const hydrateBody = source.slice(hydrateAt, hydrateAt + 2000)
+
+  // Fields written inside the `durable[name] = { … }` literal.
+  const written = [...durableBody.matchAll(/^\s{6}(\w+):/gm)].map(m => m[1])
+  assert.ok(written.length >= 6, `expected the durable shape to have fields, saw ${written.length}`)
+
+  // Runtime-only by design: the hydrate path resets these on purpose.
+  const runtimeOnly = new Set(['epoch', 'running'])
+  const missing = written.filter(f => !runtimeOnly.has(f) && !new RegExp(`\\b${f}:`).test(hydrateBody))
+
+  assert.deepEqual(missing, [], 'these fields are written but never read back')
+})
+
+test('a room budget survives the write and read round trip', () => {
+  const durable = source.slice(source.indexOf('function durableGroupChatRooms('))
+  const durableBody = durable.slice(0, durable.indexOf('\n}\n'))
+  assert.match(durableBody, /limits: durableGroupChatLimits\(room\.limits\)/)
+
+  const hydrateAt = source.indexOf("ctx.storage?.get?.('group-chats')")
+  assert.match(source.slice(hydrateAt, hydrateAt + 2000), /limits: durableGroupChatLimits\(room\.limits\)/)
+})


### PR DESCRIPTION
## The problem

A group chat is capped at `GROUP_CHAT_MAX_ROUNDS = 3` and
`GROUP_CHAT_MAX_MESSAGES = 10` per user send, with `GROUP_CHAT_MAX_MEMBERS = 6`
and `GROUP_CHAT_HISTORY_LIMIT = 24`. All four are module constants.

The message cap binds first, and it binds harder than the numbers suggest,
because the two multiply: with N members one round costs N messages. Running
the current loop shows what a room actually gets:

| members | rounds reached | messages | stopped by |
| --- | --- | --- | --- |
| 6 | 2 | 10 | messages |
| 4 | 3 (last one partial) | 10 | messages |

At six members the round cap is unreachable. At four it is reached only
nominally: eight messages are gone after two rounds, so the third round seats
two members and the other two never speak.

That last line is #89545, closed as fixed by #91084. The stranded-harvest fix
addresses the symptom, that late replies were lost and the room looked
abandoned. It does not change the arithmetic: an
Orchestrator → Scout → Builder → Verifier room spends one full round per pass,
and a verifier BLOCK plus a correction handoff plus the re-build is three
passes minimum. Ten messages does not fit that shape, whatever the harvest
does afterwards.

## What this changes

Each of the four axes becomes a per-room override with three states: a number,
off, or absent. Absent inherits the shipped default, and the stored form omits
every axis left alone, so a room that never opens the settings stores nothing
and behaves exactly as it does today. Defaults are unchanged.

Turning rounds or messages off hands control to a safety brake, defaulting to
50 rounds / 200 messages, which is itself switchable.

## On unbounded rooms, given #91481

#91481 is open: two Telegram bots exchanged 132 messages with no loop guard
anywhere in the admission path. Offering an unlimited group room in that
climate deserves an explicit answer rather than silence, so:

- The brake is **on by default** whenever an axis is switched off. Reaching
  "no limit at all" takes two deliberate steps on two separate controls, and
  the editor states in plain words what that means before the user gets there.
- Unlike the Telegram path, this loop already has two exits that do not depend
  on a counter. `spokeThisRound === 0` ends the drive when every member passes
  a round, and a new user message bumps the room epoch, which the loop honors
  at the next member boundary. An unlimited room is a room that stops counting,
  not a room you cannot get out of.
- A room that stops on its brake records a `safety` activity event naming the
  axis and the count, so it does not go quiet in a way that reads as "the
  conversation settled".

If you would rather not ship the fully-unbounded state at all, the brake can
be made non-nullable in one line and everything else here still stands. I
would rather ask than guess.

## Bounds on what a room can ask for

Every numeric value is clamped, not just validated. A room can raise an axis
but not past these:

| axis | default | ceiling |
| --- | ---: | ---: |
| rounds | 3 | 100 |
| messages | 10 | 500 |
| members | 6 | 24 |
| history | 24 | 200 |

A value above the ceiling is clamped rather than rejected, so a typo in a
number field lands on the ceiling instead of erroring at the user. A value
that is not a positive number falls back to the default rather than reading as
"no limit", which matters because a stray `true` coerces to `1` under
`Number()` and would otherwise pass as a real setting. Both are tested.

The ceilings bound numbers. They do not bound the off state, which is the
whole point of the section above: switching an axis off hands control to the
brake, and switching the brake off too is the deliberate two-step described
there.

## Which cap binds first

The message cap, in almost every room, because the two multiply: with N
members one round costs N messages.

| members | rounds reached on the defaults | messages | stopped by |
| --- | ---: | ---: | --- |
| 2 | 3 | 6 | rounds |
| 4 | 3 (last one partial) | 10 | messages |
| 6 | 2 | 10 | messages |

So raising rounds alone changes nothing above four members. Rather than leave
that to the release notes, the editor computes it live and says so under the
rows: "With 6 bots, the message budget runs out after about 2 rounds, raise it
too, or the round setting will not change anything."

## Where it is edited

One component, three surfaces, all writing the same shape:

- **Create dialog**, behind a disclosure. Raising the member cap widens the
  picker immediately rather than forcing a create-then-edit round trip.
- **Group settings**, next to rename and room picture.
- **Room header**, where the label doubles as the current budget at a glance:
  `3 rounds · 10 msgs`, `≤50 rounds · 10 msgs`, `∞ rounds · ∞ msgs`.

Because the axes multiply, the editor warns when raising rounds alone would do
nothing: "With 6 bots, the message budget runs out after about 2 rounds, raise
it too, or the round setting will not change anything." That case is the one a
user hits first and the one that would otherwise read as a broken setting.

Overrides persist with the room and ride the existing gateway sync under the
same newest-revision rule as the room picture.

## Verification

The plugin suite goes from 362/362 to 376/376; `eslint` reports no problems.
The 14 added tests cover the resolver (defaults, explicit values, off versus
absent, clamping at the ceiling, and nonsense values falling back rather than
silently disabling a limit), the brake's dependence on its axis, the stored
round trip, the header label in all three states, the multiplication warning,
and two source assertions that the drive loop reads the room instead of the
constants.

Two of those tests were red on the first run and caught real defects: a
boolean `true` coerced to `1` and read as a valid limit, and a stale reference
to a constant in the sync path. Both are fixed here.

## Not in this change

The four constants keep their current values as the defaults. This PR does not
argue that 3 and 10 are wrong for a new room, only that a room should be able
to say otherwise.

