### PR TITLE
feat(platform/google_chat): add options to force threading in DMs

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1893,15 +1893,22 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # (Telegram forum / Discord thread parity); always isolate AND
         # always reply in-thread.
         if chat_type == "dm":
+            always_thread = os.getenv("GOOGLE_CHAT_ALWAYS_THREAD_DMS", "").lower() in ("true", "1", "yes") or self.config.extra.get("always_thread_dms", False)
+            isolate_all = os.getenv("GOOGLE_CHAT_ISOLATE_ALL_THREADS", "").lower() in ("true", "1", "yes") or self.config.extra.get("isolate_all_threads", False)
             is_side_thread = prev_thread_count > 0
-            session_thread_id = thread_name if is_side_thread else None
-            # Outbound thread cache: populated only when side-thread, so
-            # _resolve_thread_id falls through to "no thread" on main
-            # flow and the bot reply lands as a top-level sibling.
-            if thread_name and space_name and is_side_thread:
-                self._last_inbound_thread[space_name] = thread_name
-            elif space_name:
-                self._last_inbound_thread.pop(space_name, None)
+            if always_thread:
+                session_thread_id = thread_name if (is_side_thread or isolate_all) else None
+                if thread_name and space_name:
+                    self._last_inbound_thread[space_name] = thread_name
+            else:
+                session_thread_id = thread_name if is_side_thread else None
+                # Outbound thread cache: populated only when side-thread, so
+                # _resolve_thread_id falls through to "no thread" on main
+                # flow and the bot reply lands as a top-level sibling.
+                if thread_name and space_name and is_side_thread:
+                    self._last_inbound_thread[space_name] = thread_name
+                elif space_name:
+                    self._last_inbound_thread.pop(space_name, None)
         else:
             session_thread_id = thread_name
             # Groups always reply in-thread.

--- a/plugins/platforms/google_chat/plugin.yaml
+++ b/plugins/platforms/google_chat/plugin.yaml
@@ -48,3 +48,11 @@ optional_env:
     description: "Default space for cron / notification delivery (e.g. spaces/AAAA...)."
     prompt: "Home space ID (or empty)"
     password: false
+  - name: GOOGLE_CHAT_ALWAYS_THREAD_DMS
+    description: "If true, Hermes will always reply to top-level DM messages inside their auto-created Google Chat thread, rather than as adjacent top-level cards."
+    prompt: "Always reply inside DM threads? (true/false)"
+    password: false
+  - name: GOOGLE_CHAT_ISOLATE_ALL_THREADS
+    description: "If true (and GOOGLE_CHAT_ALWAYS_THREAD_DMS is enabled), each DM thread will be treated as an independent conversation session with isolated history. If false (default), they share the main DM session."
+    prompt: "Isolate session history per DM thread? (true/false)"
+    password: false


### PR DESCRIPTION
### Description
In Google Chat DMs, every top-level message sent by a user is technically treated as a new thread at the API level. By default, the Google Chat platform adapter uses a heuristic to reply as a top-level adjacent card (avoiding visual threads) to preserve a continuous chat-like appearance. 

However, some users prefer to have the bot reply nested directly inside the thread automatically created by their top-level message in Google Chat.

This PR introduces two optional environment variables / configuration settings to give users full control over this behavior:
1. `GOOGLE_CHAT_ALWAYS_THREAD_DMS` (boolean): If set to `true`, the bot's replies will always land inside the message's thread in the UI (creating an expandable/collapsible thread under the user's message).
2. `GOOGLE_CHAT_ISOLATE_ALL_THREADS` (boolean): If `GOOGLE_CHAT_ALWAYS_THREAD_DMS` is enabled, this setting controls session continuity:
   - If `false` (default): All top-level threads in the DM continue to share the same continuous session history (context is preserved across threads).
   - If `true`: Each top-level message starts its own completely isolated conversation session.

### Changes
- Updated `plugin.yaml` to document and register `GOOGLE_CHAT_ALWAYS_THREAD_DMS` and `GOOGLE_CHAT_ISOLATE_ALL_THREADS`.
- Patched `adapter.py` to support these settings when routing inbound events and outbound replies.
