### PR TITLE
fix(gateway): close the boot-send TOCTOU replay window + P1-batch simplify follow-ups

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -79,15 +79,19 @@ def _run_in_fresh_context(func: Callable[..., Any], /, *args: Any) -> Any:
 
     ``asyncio.to_thread`` copies the calling task's context onto the worker
     thread. Supervised Kanban ticks are process-owned writers; if that copy
-    still carries a ``delegate_task`` child marker (spawn-time snapshot or a
-    later polluted task), ``write_txn`` false-trips. An empty Context keeps
-    the DB guard intact for real children without exempting dispatcher writes.
+    still carries a ``delegate_task`` child marker, ``write_txn``
+    false-trips. Since watchers spawn from a fresh ``Context``
+    (``_spawn_supervised``), this offload-boundary scrub is defense in
+    depth: it covers non-supervised spawn paths and any task context frozen
+    before spawn isolation shipped. An empty Context keeps the DB guard
+    intact for real children without exempting dispatcher writes.
     """
     return Context().run(func, *args)
 
 
 async def _to_thread_process_service(func: Callable[..., Any], /, *args: Any) -> Any:
-    """Offload blocking dispatcher work without inheriting request-local ContextVars."""
+    """Offload blocking process-service work (dispatcher + notifier writers)
+    without inheriting request-local ContextVars."""
     return await asyncio.to_thread(_run_in_fresh_context, func, *args)
 
 
@@ -496,7 +500,7 @@ class GatewayKanbanWatchersMixin:
                     except ValueError:
                         # Unknown platform string; skip and advance cursor so
                         # we don't replay forever.
-                        await asyncio.to_thread(
+                        await _to_thread_process_service(
                             self._kanban_advance, sub, d["cursor"], board_slug,
                         )
                         continue
@@ -516,7 +520,7 @@ class GatewayKanbanWatchersMixin:
                             "kanban notifier: adapter %s disconnected before delivery for %s; rewinding claim",
                             platform_str, sub["task_id"],
                         )
-                        await asyncio.to_thread(
+                        await _to_thread_process_service(
                             self._kanban_rewind,
                             sub,
                             d["cursor"],
@@ -745,10 +749,10 @@ class GatewayKanbanWatchersMixin:
                                     "%s on %s after %d consecutive send failures",
                                     sub["task_id"], platform_str, fails,
                                 )
-                                await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
+                                await _to_thread_process_service(self._kanban_unsub, sub, board_slug)
                                 sub_fail_counts.pop(sub_key, None)
                             else:
-                                await asyncio.to_thread(
+                                await _to_thread_process_service(
                                     self._kanban_rewind,
                                     sub,
                                     d["cursor"],
@@ -868,13 +872,13 @@ class GatewayKanbanWatchersMixin:
                                         "%s on %s after %d consecutive wake failures",
                                         sub["task_id"], platform_str, fails,
                                     )
-                                    await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
+                                    await _to_thread_process_service(self._kanban_unsub, sub, board_slug)
                                     sub_fail_counts.pop(sub_key, None)
                                 else:
                                     # Rewind the pre-send claim so the next
                                     # tick retries the self-post — the event
                                     # is NOT lost.
-                                    await asyncio.to_thread(
+                                    await _to_thread_process_service(
                                         self._kanban_rewind,
                                         sub,
                                         d["cursor"],
@@ -968,13 +972,13 @@ class GatewayKanbanWatchersMixin:
                                         "%s on %s after %d consecutive wake failures",
                                         sub["task_id"], platform_str, fails,
                                     )
-                                    await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
+                                    await _to_thread_process_service(self._kanban_unsub, sub, board_slug)
                                     sub_fail_counts.pop(sub_key, None)
                                 else:
                                     # Rewind the pre-send claim so the next
                                     # tick retries the wake — the event is
                                     # NOT lost.
-                                    await asyncio.to_thread(
+                                    await _to_thread_process_service(
                                         self._kanban_rewind,
                                         sub,
                                         d["cursor"],
@@ -988,7 +992,7 @@ class GatewayKanbanWatchersMixin:
                         # push subs): advance cursor. The cursor is the dedup
                         # mechanism — it prevents re-delivery of the same
                         # event on subsequent ticks.
-                        await asyncio.to_thread(
+                        await _to_thread_process_service(
                             self._kanban_advance, sub, d["cursor"], board_slug,
                         )
                         if not _is_push_adapter:
@@ -1018,7 +1022,7 @@ class GatewayKanbanWatchersMixin:
                                     sub["task_id"], _wk_err, exc_info=True,
                                 )
                         if task_terminal:
-                            await asyncio.to_thread(
+                            await _to_thread_process_service(
                                 self._kanban_unsub, sub, board_slug,
                             )
             except Exception as exc:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11920,12 +11920,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         startup-restore gate.  Logs a late failure that would otherwise be
         swallowed once the task is discarded from ``_background_tasks``.
         Cancellation is expected (shutdown) and is not an error."""
+        GatewayRunner._log_late_background_failure(
+            task,
+            "background startup auto-resume task failed after gate release",
+            level=logging.DEBUG,
+        )
+
+    @staticmethod
+    def _log_late_background_failure(
+        task: "asyncio.Task", message: str, *, level: int = logging.WARNING
+    ) -> None:
+        """Shared done-callback body for boot-path tasks that outlive the
+        startup-restore gate: surface a late failure that would otherwise be
+        swallowed once the task is discarded from ``_background_tasks``.
+        Cancellation is expected (shutdown) and is not an error."""
         if task.cancelled():
             return
         exc = task.exception()
         if exc is not None:
-            logger.debug(
-                "background startup auto-resume task failed after gate release",
+            logger.log(
+                level,
+                message,
                 exc_info=(type(exc), exc, exc.__traceback__),
             )
 
@@ -11945,7 +11960,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         This uses the same bounded ``asyncio.wait`` the resume gate already
         uses: on timeout we return and let the sends finish in the
         background. Tasks are not cancelled.
+
+        The ledger claim + ``resume_pending`` clear happen INLINE here,
+        before the send task exists: they are pure DB work (no network,
+        bounded by claimed-row count), and deferring them into the send
+        task left a window where a hung restart notification ahead of the
+        redelivery step let the gate expire with zero rows claimed — the
+        resume scheduler then replayed turns whose answers were already in
+        the ledger, and the background task later redelivered them too
+        (duplicate delivery + re-paid turn).
         """
+        claimed = await self._claim_pending_obligations()
+
         async def _boot_sends() -> None:
             await self._send_restart_notification()
             if planned_restart_notification_pending:
@@ -11955,7 +11981,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
                 finally:
                     _clear_planned_restart_notification()
-            await self._redeliver_pending_obligations()
+            await self._redeliver_claimed_obligations(claimed)
 
         boot_task = asyncio.create_task(_boot_sends())
         timeout = _startup_restore_drain_timeout_secs()
@@ -11982,43 +12008,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     @staticmethod
     def _log_background_boot_send_result(task: "asyncio.Task") -> None:
         """Done-callback for boot-path sends that outlived the restore gate."""
-        if task.cancelled():
-            return
-        exc = task.exception()
-        if exc is not None:
-            logger.warning(
-                "background boot-path send failed after gate release: %s",
-                exc,
-                exc_info=(type(exc), exc, exc.__traceback__),
-            )
+        GatewayRunner._log_late_background_failure(
+            task, "background boot-path send failed after gate release: see traceback"
+        )
 
-    async def _redeliver_pending_obligations(self) -> int:
-        """Redeliver final responses recorded in the delivery ledger by a
-        previous (now dead) gateway process.
+    async def _claim_pending_obligations(self) -> list:
+        """Claim recoverable delivery-ledger rows and clear their
+        ``resume_pending`` flags. Pure DB work — no network sends.
 
-        Runs at startup BEFORE ``_schedule_resume_pending_sessions``. A
+        Runs INLINE at startup BEFORE ``_schedule_resume_pending_sessions``
+        and before the (bounded, abandonable) boot-send task exists. A
         session with a recoverable obligation already produced its answer —
-        the turn completed and only delivery is owed — so this method sends
-        the stored text and clears ``resume_pending`` for that session,
-        preventing the resume path from re-running (and re-paying for) a
-        turn whose output we hold.
+        the turn completed and only delivery is owed — so clearing
+        ``resume_pending`` here prevents the resume path from re-running
+        (and re-paying for) a turn whose output we hold, regardless of how
+        long the sends ahead of redelivery take (#91969).
 
         Crash-ambiguity contract (see gateway/delivery_ledger.py):
         rows that were mid-send or previously rejected carry a visible
         recovered-reply marker so a possible duplicate is labeled, never
-        silent. Returns the number of redeliveries attempted.
+        silent. Returns the claimed rows for redelivery.
         """
         try:
             from gateway.delivery_ledger import (
-                RECOVERED_MARKER,
                 ledger_enabled,
-                mark_delivered,
-                mark_failed,
                 sweep_recoverable,
             )
 
             if not await asyncio.to_thread(ledger_enabled):
-                return 0
+                return []
             # Only claim rows we can actually send this boot: self.adapters
             # holds a platform only after its connect() succeeded, and each
             # claim spends one of the row's three redelivery attempts.
@@ -12030,17 +12048,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         except Exception:
             logger.debug("delivery ledger sweep failed", exc_info=True)
-            return 0
+            return []
         if not claimed:
-            return 0
+            return []
 
         # Clear resume_pending for EVERY claimed row up front, before any
         # send. Claiming already spent one of the row's redelivery attempts —
         # the answer is in the ledger, so the resume path must never re-run
-        # these turns. Doing this per-row as the loop reaches each send left
-        # a window: when a slow/flood-limited send held the loop past the
-        # inbound-gate timeout, _schedule_resume_pending_sessions could
-        # replay turns for rows the loop had not reached yet (#91969).
+        # these turns (#91969).
         for row in claimed:
             session_key = row.get("session_key") or ""
             if not session_key:
@@ -12052,6 +12067,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "clear_resume_pending failed for %s", session_key,
                     exc_info=True,
                 )
+        return claimed
+
+    async def _redeliver_claimed_obligations(self, claimed: list) -> int:
+        """Redeliver final responses for rows already claimed (and
+        resume-cleared) by :meth:`_claim_pending_obligations`.
+
+        Network half of the split — runs inside the bounded boot-send task,
+        so a flood-limited send can be abandoned by the restore gate without
+        reopening the turn-replay window. Returns redeliveries attempted.
+        """
+        if not claimed:
+            return 0
+        try:
+            from gateway.delivery_ledger import (
+                RECOVERED_MARKER,
+                mark_delivered,
+                mark_failed,
+            )
+        except Exception:
+            logger.debug("delivery ledger import failed", exc_info=True)
+            return 0
 
         redelivered = 0
         for row in claimed:
@@ -12106,6 +12142,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 logger.debug("delivery ledger update failed", exc_info=True)
         return redelivered
+
+    async def _redeliver_pending_obligations(self) -> int:
+        """Claim + redeliver in one call — composition of
+        :meth:`_claim_pending_obligations` and
+        :meth:`_redeliver_claimed_obligations`.
+
+        Kept as the stable public shape (tests and any external callers
+        drive this name); the startup path calls the two halves separately
+        so the DB half can run inline before the abandonable send task.
+        """
+        return await self._redeliver_claimed_obligations(
+            await self._claim_pending_obligations()
+        )
 
     def _schedule_resume_pending_sessions(self, platform=None) -> int:
         """Auto-continue fresh restart-interrupted sessions after startup.

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -382,7 +382,7 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
                 if value.isdigit():
                     timeout_us = int(value)
                 else:
-                    timeout_us = _parse_systemd_duration_to_us(value)
+                    timeout_us = parse_systemd_duration_to_us(value)
                 if timeout_us is not None:
                     break
         if timeout_us is not None:
@@ -406,11 +406,13 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     }
 
 
-def _parse_systemd_duration_to_us(raw: str) -> Optional[int]:
+def parse_systemd_duration_to_us(raw: str) -> Optional[int]:
     """Parse 'TimeoutStopUSec=1min 30s' / '90s' style values to microseconds.
 
     systemd accepts a wide grammar; we cover the common cases (s, ms, min,
     h) and return None on anything unexpected.  Never raises.
+
+    Public: also consumed by hermes_cli.gateway's restart-wait sizing.
     """
     if not raw:
         return None
@@ -460,3 +462,7 @@ def _parse_systemd_duration_to_us(raw: str) -> Optional[int]:
                 return None
             digits = ""
     return total_us if total_us > 0 else None
+
+
+# Backward-compat private alias (pre-promotion name).
+_parse_systemd_duration_to_us = parse_systemd_duration_to_us

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1330,7 +1330,7 @@ def _wait_for_systemd_service_restart(
 
 def _systemd_restart_wait_timeout(system: bool = False) -> float:
     """Cover systemd's relaunch delays before applying the runtime wait floor."""
-    from gateway.shutdown_forensics import _parse_systemd_duration_to_us
+    from gateway.shutdown_forensics import parse_systemd_duration_to_us
 
     props = _read_systemd_unit_properties(
         system=system,
@@ -1340,7 +1340,7 @@ def _systemd_restart_wait_timeout(system: bool = False) -> float:
     for name in ("RestartUSec", "TimeoutStartUSec"):
         raw = props.get(name, "")
         duration_us = (
-            int(raw) if raw.isdigit() else _parse_systemd_duration_to_us(raw)
+            int(raw) if raw.isdigit() else parse_systemd_duration_to_us(raw)
         )
         if duration_us is not None:
             supervisor_budget += duration_us / 1_000_000

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -311,6 +311,25 @@ from plugins.platforms.telegram.telegram_network import (
 from utils import atomic_replace, env_float, env_int
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+
+# Max seconds a send/edit coroutine may sleep inline on a Telegram
+# flood-control RetryAfter. Longer server penalties fail closed with a
+# ``flood_control:{wait}`` SendResult so the caller's retry machinery
+# (delivery ledger, streaming fallback) owns the wait instead of the
+# coroutine pinning its worker — a 97-minute penalty on the boot path
+# froze inbound on every platform (#91969).
+_FLOOD_INLINE_WAIT_CAP_SECS = 5.0
+
+
+def _flood_cap_result(wait: float) -> "SendResult":
+    """The shared fail-closed SendResult for an over-cap flood wait."""
+    return SendResult(
+        success=False,
+        error=f"flood_control:{wait}",
+        retry_after=float(wait),
+    )
+
+
 _TELEGRAM_IMAGE_MIME_TO_EXT = {
     "image/png": ".png",
     "image/jpeg": ".jpg",
@@ -5449,20 +5468,17 @@ class TelegramAdapter(BasePlatformAdapter):
                             # pinned send() for 97 minutes in production and
                             # froze inbound on every platform when it ran on
                             # the gateway boot path (#91969).
-                            if wait > 5.0:
+                            if wait > _FLOOD_INLINE_WAIT_CAP_SECS:
                                 logger.warning(
                                     "[%s] Telegram flood control on send "
-                                    "(retry_after=%.1fs > 5s); failing closed "
+                                    "(retry_after=%.1fs > %.0fs); failing closed "
                                     "instead of sleeping: %s",
                                     self.name,
                                     wait,
+                                    _FLOOD_INLINE_WAIT_CAP_SECS,
                                     safe_send_error,
                                 )
-                                return SendResult(
-                                    success=False,
-                                    error=f"flood_control:{wait}",
-                                    retry_after=float(wait),
-                                )
+                                return _flood_cap_result(wait)
                             if _send_attempt < 2:
                                 logger.warning(
                                     "[%s] Telegram flood control on send (attempt %d/3), retrying in %.1fs: %s",
@@ -5714,12 +5730,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] Telegram flood control, waiting %.1fs",
                     self.name, wait,
                 )
-                if wait > 5.0:
-                    return SendResult(
-                        success=False,
-                        error=f"flood_control:{wait}",
-                        retry_after=float(wait),
-                    )
+                if wait > _FLOOD_INLINE_WAIT_CAP_SECS:
+                    return _flood_cap_result(wait)
                 await asyncio.sleep(wait)
                 try:
                     await self._bot.edit_message_text(

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -1102,7 +1102,8 @@ async def test_startup_restore_gate_releases_when_boot_path_send_hangs(
         return None
 
     runner._send_restart_notification = never_returns
-    runner._redeliver_pending_obligations = AsyncMock(return_value=0)
+    runner._claim_pending_obligations = AsyncMock(return_value=[])
+    runner._redeliver_claimed_obligations = AsyncMock(return_value=0)
 
     seen: list[str] = []
 
@@ -1133,7 +1134,11 @@ async def test_startup_restore_gate_releases_when_boot_path_send_hangs(
     )
     assert runner._startup_restore_queue == []
     assert runner._startup_restore_in_progress is False
-    runner._redeliver_pending_obligations.assert_not_awaited()
+    # The DB half (claim + resume clear) runs inline BEFORE the abandonable
+    # send task, so it must have completed even though the boot send hung;
+    # the network half never ran because the hung notification precedes it.
+    runner._claim_pending_obligations.assert_awaited_once()
+    runner._redeliver_claimed_obligations.assert_not_awaited()
 
     hung.set()
     leftover = [t for t in list(runner._background_tasks) if not t.done()]
@@ -1149,13 +1154,15 @@ async def test_startup_boot_sends_still_run_when_they_finish_quickly(monkeypatch
     runner, _adapter = make_restart_runner()
     runner._background_tasks = set()
     runner._send_restart_notification = AsyncMock(return_value=None)
-    runner._redeliver_pending_obligations = AsyncMock(return_value=0)
+    runner._claim_pending_obligations = AsyncMock(return_value=[])
+    runner._redeliver_claimed_obligations = AsyncMock(return_value=0)
 
     await runner._await_startup_boot_sends(
         planned_restart_notification_pending=False,
     )
 
     runner._send_restart_notification.assert_awaited_once()
-    runner._redeliver_pending_obligations.assert_awaited_once()
+    runner._claim_pending_obligations.assert_awaited_once()
+    runner._redeliver_claimed_obligations.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary
/simplify-code follow-ups on the just-merged P1 gateway batch (#92171–#92175): closes the one verdict-relevant residue — a TOCTOU window in #92173's boot-send bounding that could still replay + double-deliver ledger-answered turns — plus three verified cleanup findings.

## Changes
- **gateway/run.py** (fix): `_redeliver_pending_obligations` split into `_claim_pending_obligations` (pure DB: ledger sweep + `resume_pending` clear, awaited **inline before** the abandonable boot-send task exists) and `_redeliver_claimed_obligations` (network half, stays inside the bounded task). Previously the claim+clear ran inside the task AFTER `_send_restart_notification` — itself a flood-controllable send — so a hung notification let the restore gate expire with zero rows claimed: the resume scheduler replayed turns whose answers were already in the ledger, and the background task later redelivered them too. Original method name retained as a composition wrapper (stable test/caller seam). Also dedupes the late-failure done-callback (`_log_late_background_failure`).
- **gateway/kanban_watchers.py** (refactor): the notifier watcher's 10 guarded writer offloads (`_kanban_advance`/`_kanban_rewind`/`_kanban_unsub`) now use `_to_thread_process_service`, same as the dispatcher ticks #92172 wrapped — uniform defense-in-depth; docstrings reworded to state the relationship to spawn isolation accurately.
- **plugins/platforms/telegram/adapter.py** (refactor): `_FLOOD_INLINE_WAIT_CAP_SECS` + `_flood_cap_result` shared by the edit path and #92173's send path — cap value and `flood_control:` error contract can no longer drift.
- **gateway/shutdown_forensics.py + hermes_cli/gateway.py** (refactor): `parse_systemd_duration_to_us` promoted to public (private alias retained) — removes the tree's only cross-module underscore-private import of that module.

## Validation
| | |
|---|---|
| test_restart_resume_pending + test_delivery_ledger | 54 passed |
| kanban notifier suites + gateway_service + telegram_send_path_health | 106 passed, 1 skipped |
| mutation check | both updated gate tests FAIL on pre-split run.py, pass on the stack |
| ruff (all touched files) | clean |

Findings dropped as false positives: the discord-adapter "magic 25" finding (stale-base diff artifact — the merged #92171 commits touch only run.py + tests); the `replacement_observed` out-param finding (deferred — churns 14 test call sites for a cosmetic shape change on a just-merged internal).


## Infographic

![p1-gateway-defense-wave](https://v3b.fal.media/files/b/0aa759c6/RgoeKlHS1k7JkaMc3iAhA_15OxRMKS.png)

*Covers the full P1 gateway batch: #92171 #92172 #92173 #92174 #92175 + this follow-up.*
