### PR TITLE
fix(agent): keep large streamed tool calls responsive

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3886,6 +3886,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _conn_cap = min(_base_timeout, 60.0) if _provider_timeout_cfg is not None else 30.0
         content_parts: list = []
         tool_calls_acc: dict = {}
+        tool_argument_parts: dict[int, list[str]] = {}
         tool_gen_notified: set = set()
         # Ollama-compatible endpoints reuse index 0 for every tool call
         # in a parallel batch, distinguishing them only by id.  Track
@@ -3969,7 +3970,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             last_chunk_time["t"] = time.time()
             return True
 
+        def _materialize_tool_arguments() -> None:
+            for index, parts in tool_argument_parts.items():
+                tool_calls_acc[index]["function"]["arguments"] = "".join(parts)
+
         def _relay_final_response() -> dict[str, Any]:
+            _materialize_tool_arguments()
             tool_calls = [tool_calls_acc[index] for index in sorted(tool_calls_acc)]
             return {
                 "model": model_name,
@@ -4211,6 +4217,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             "function": {"name": "", "arguments": ""},
                             "extra_content": None,
                         }
+                        tool_argument_parts[idx] = []
                     entry = tool_calls_acc[idx]
                     tc_id = getattr(tc_delta, "id", None)
                     if tc_id is not None:
@@ -4234,7 +4241,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             entry["function"]["name"] = function_name
                         function_arguments = getattr(tc_function, "arguments", None)
                         if function_arguments:
-                            entry["function"]["arguments"] += function_arguments
+                            tool_argument_parts[idx].append(function_arguments)
                     extra = getattr(tc_delta, "extra_content", None)
                     if extra is None and hasattr(tc_delta, "model_extra"):
                         extra = (tc_delta.model_extra if isinstance(tc_delta.model_extra, dict) else {}).get("extra_content")
@@ -4313,6 +4320,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         mock_tool_calls = None
         has_truncated_tool_args = False
         if tool_calls_acc:
+            _materialize_tool_arguments()
             mock_tool_calls = []
             for idx in sorted(tool_calls_acc):
                 tc = tool_calls_acc[idx]

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -356,8 +356,120 @@ class TestStreamingAccumulator:
             '{"path":"out.txt","content":"hello"}'
         )
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    @patch("agent.relay_llm.stream")
+    def test_relay_finalizer_emits_joined_tool_arguments(
+        self, mock_relay_stream, mock_close, mock_create
+    ):
+        """Relay receives the public string shape, not buffered fragments."""
+        from run_agent import AIAgent
 
+        captured = {}
+        fake_stream = MagicMock()
+        fake_stream.final_response = None
+        fake_stream.__iter__.return_value = iter([
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_123",
+                    name="search",
+                    arguments='{"q":',
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='"hello"}')
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ])
 
+        def relay_stream_impl(*args, **kwargs):
+            captured["finalizer"] = kwargs["finalizer"]
+            return fake_stream
+
+        mock_relay_stream.side_effect = relay_stream_impl
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter([])
+        mock_create.return_value = mock_client
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        agent._interruptible_streaming_api_call({})
+
+        payload = captured["finalizer"]()
+        tool_calls = payload["choices"][0]["message"]["tool_calls"]
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["function"] == {
+            "name": "search",
+            "arguments": '{"q":"hello"}',
+        }
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_argument_assembly_is_chunk_boundary_invariant(
+        self, mock_close, mock_create
+    ):
+        """Argument bytes are identical across ASCII and Unicode fragment sizes."""
+        import json
+
+        from run_agent import AIAgent
+
+        payload = json.dumps(
+            {"path": "/tmp/x", "content": "héllo wörld 日本語 " * 50},
+            ensure_ascii=False,
+        )
+
+        def assemble(fragment_size):
+            fragments = [
+                payload[i : i + fragment_size]
+                for i in range(0, len(payload), fragment_size)
+            ]
+            chunks = [
+                _make_stream_chunk(tool_calls=[
+                    _make_tool_call_delta(
+                        index=0,
+                        tc_id="call_123",
+                        name="write_file",
+                        arguments=fragments[0],
+                    )
+                ])
+            ]
+            chunks.extend(
+                _make_stream_chunk(tool_calls=[
+                    _make_tool_call_delta(index=0, arguments=fragment)
+                ])
+                for fragment in fragments[1:]
+            )
+            chunks.append(_make_stream_chunk(finish_reason="tool_calls"))
+
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = iter(chunks)
+            mock_create.return_value = mock_client
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.api_mode = "chat_completions"
+            agent._interrupt_requested = False
+
+            response = agent._interruptible_streaming_api_call({})
+            return response.choices[0].message.tool_calls[0].function.arguments
+
+        for fragment_size in (len(payload), 64, 7, 3, 1):
+            arguments = assemble(fragment_size)
+            assert arguments.encode("utf-8") == payload.encode("utf-8")
 
 
 # ── Test: Streaming Callbacks ────────────────────────────────────────────

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -305,6 +305,57 @@ class TestStreamingAccumulator:
         assert tc[0].function.name == "terminal"
         assert tc[0].function.arguments == '{"command": "ls"}'
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_argument_deltas_are_collected_without_concatenating_each_chunk(
+        self, mock_close, mock_create
+    ):
+        """Large tool arguments must not rebuild the accumulated string per delta."""
+        from run_agent import AIAgent
+
+        class AppendOnlyChunk(str):
+            def __radd__(self, other):
+                raise AssertionError("tool argument delta was concatenated eagerly")
+
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0, tc_id="call_123", name="write_file"
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0, arguments=AppendOnlyChunk('{"path":"out.txt",')
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0, arguments=AppendOnlyChunk('"content":"hello"}')
+                )
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        tool_call = response.choices[0].message.tool_calls[0]
+        assert tool_call.function.arguments == (
+            '{"path":"out.txt","content":"hello"}'
+        )
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Large streamed tool calls, especially `write_file` calls with substantial content, no longer rebuild all previously received arguments for every provider delta. Tool argument chunks are now collected append-only and joined only when Relay or the final response consumes them, keeping accumulation linear while preserving the exact final JSON.

### Symptom

The time spent processing each streamed tool-argument chunk grows with the amount of argument text already received. Large file-writing calls can therefore spend disproportionate CPU time in the agent before the tool executes.

### Impact

Any Chat Completions provider that streams large tool arguments is affected. The total argument accumulation work grows quadratically with payload size instead of linearly.

### Bug Cause

**Trigger:** `agent/chat_completion_helpers.py:4242` in `interruptible_streaming_api_call`

**Causal chain:**
1. A provider emits a tool call's JSON arguments across many small deltas.
2. Each delta is concatenated into a string stored inside `tool_calls_acc`, forcing the accumulated prefix to be copied again.
3. Per-delta work grows with the prior payload, so large tool calls become progressively more expensive to assemble.

**Why it is wrong:** The accumulator performs repeated immutable string rebuilding on the streaming hot path instead of append-only collection.

**Working sibling / contrast:** Assistant content already accumulates into `content_parts` and joins once after streaming.

**Ruled out:** Provider chunk size is not the root cause. Regardless of chunk boundaries, storing each concatenated result back into the dictionary repeatedly copies the prior argument prefix.

### Fix

Keep argument chunks in a list for each tool-call slot. Materialize the joined argument string only at the two terminal readers: the Relay finalizer and the final mock response builder. The materialization assignment is idempotent, so repeated finalization cannot duplicate arguments.

## Related Issue

Closes #92207

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` - collect streamed tool arguments append-only and materialize them at terminal read sites.
- `tests/run_agent/test_streaming.py` - verify the real streaming path does not concatenate each delta and still returns byte-identical JSON.

## How to Test

1. Run the streaming accumulator tests.
2. Run the related partial-stream and retry tests.

```bash
scripts/run_tests.sh tests/run_agent/test_streaming.py -k TestStreamingAccumulator -q
scripts/run_tests.sh tests/run_agent/test_partial_stream_finish_reason.py tests/run_agent/test_stream_interrupt_retry.py tests/run_agent/test_70773_shared_client_fd_corruption.py -q
```

Result: 34 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test entry points and all related tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: the accumulator is platform-independent
- [x] Tool descriptions/schemas update: N/A
