### PR TITLE
fix(gateway): add daily and idle reset policy

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -858,11 +858,12 @@ memory:
 #   "idle"  - Reset after N minutes of inactivity
 #   "daily" - Reset at a fixed hour each day
 #   "both"  - Reset on EITHER inactivity timeout or daily boundary
+#   "daily_and_idle" - Reset only after both the daily boundary and idle timeout
 #
 session_reset:
-  mode: none           # "none", "idle", "daily", or "both"
-  idle_minutes: 1440   # Inactivity timeout in minutes (used by "idle"/"both")
-  at_hour: 4           # Daily reset hour, 0-23 local time (used by "daily"/"both")
+  mode: none           # "none", "idle", "daily", "both", or "daily_and_idle"
+  idle_minutes: 1440   # Inactivity timeout (used by "idle"/"both"/"daily_and_idle")
+  at_hour: 4           # Daily boundary hour (used by "daily"/"both"/"daily_and_idle")
 
 # Maximum number of simultaneously active chat sessions across CLI, TUI,
 # dashboard chat, and messaging gateway. Set to null, 0, or omit to allow

--- a/cli.py
+++ b/cli.py
@@ -11750,6 +11750,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print(f"    Mode: {policy.mode}")
             print(f"    Daily reset at: {policy.at_hour}:00")
             print(f"    Idle timeout: {policy.idle_minutes} minutes")
+            if policy.mode == "daily_and_idle":
+                print("    (Daily reset fires only when also idle past the timeout)")
             
             print()
             print("  To start the gateway:")

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -302,7 +302,8 @@ Reset policies control when a session automatically loses context (gets a new `s
 | `"none"` | Never auto-reset. Context managed only by compression. | — |
 | `"idle"` | Reset after N minutes of inactivity from `updated_at`. | `idle_minutes: 1440` (24h) |
 | `"daily"` | Reset at a specific hour each day (local time). | `at_hour: 4` (4 AM) |
-| `"both"` | Whichever triggers first — daily boundary OR idle timeout. | **(default)** |
+| `"both"` | Whichever triggers first — daily boundary OR idle timeout. | — |
+| `"daily_and_idle"` | Reset only when the session predates the latest daily boundary AND its idle timeout has elapsed. | `at_hour: 4`, `idle_minutes: 1440` |
 
 ### Policy Evaluation
 
@@ -316,6 +317,13 @@ today_reset = now.replace(hour=policy.at_hour, minute=0, second=0, microsecond=0
 if now.hour < policy.at_hour:
     today_reset -= timedelta(days=1)  # Reset hasn't happened yet today
 if entry.updated_at < today_reset: return "daily"
+
+# Daily + idle check
+if (
+    entry.updated_at < today_reset
+    and now > entry.updated_at + timedelta(minutes=policy.idle_minutes)
+):
+    return "daily_and_idle"
 ```
 
 ### Per-Platform/Per-Type Policies
@@ -670,9 +678,9 @@ When a session expires:
 
 ```yaml
 session_reset:
-  mode: none            # none (default) | idle | daily | both
-  at_hour: 4            # daily reset hour (local time)
-  idle_minutes: 1440    # idle timeout (24h)
+  mode: none            # none (default) | idle | daily | both | daily_and_idle
+  at_hour: 4            # daily/daily_and_idle boundary hour (local time)
+  idle_minutes: 1440    # idle/both/daily_and_idle timeout (24h)
   notify: true          # notify user on auto-reset
 ```
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -156,6 +156,9 @@ def _coerce_int(value: Any, default: int) -> int:
         return default
 
 
+MAX_SESSION_IDLE_MINUTES = 525_600_000  # 1,000 years; safely below datetime limits.
+
+
 def _coerce_optional_positive_int(value: Any, key: str) -> Optional[int]:
     """Coerce an optional positive integer config value.
 
@@ -533,9 +536,11 @@ class SessionResetPolicy:
     Controls when sessions reset (lose context).
     
     Modes:
-    - "daily": Reset at a specific hour each day
+    - "daily": Reset at a specific hour each day (regardless of activity)
     - "idle": Reset after N minutes of inactivity
     - "both": Whichever triggers first (daily boundary OR idle timeout)
+    - "daily_and_idle": Reset only when the session predates the latest daily
+      boundary AND has been idle for `idle_minutes`.
     - "none": Never auto-reset (context managed only by compression)
 
     Default is "none" — sessions never auto-reset unless the user opts in
@@ -543,7 +548,7 @@ class SessionResetPolicy:
     overrides). Changed July 2026 from "both" (24h idle + daily 4am), which
     surprised users who expected their conversations to persist.
     """
-    mode: str = "none"  # "daily", "idle", "both", or "none"
+    mode: str = "none"  # "daily", "idle", "both", "daily_and_idle", or "none"
     at_hour: int = 4  # Hour for daily reset (0-23, local time)
     idle_minutes: int = 1440  # Minutes of inactivity before reset (24 hours)
     notify: bool = True  # Send a notification to the user when auto-reset occurs
@@ -575,6 +580,47 @@ class SessionResetPolicy:
         notify = data.get("notify")
         exclude = data.get("notify_exclude_platforms")
         bg_max_age = data.get("bg_process_max_age_hours")
+        # Defensive validation: an unrecognized mode would silently fall through
+        # every expiry check in SessionStore._is_session_expired and never reset
+        # (effectively "none" without telling the user). Warn + fall back instead.
+        _VALID_RESET_MODES = {"none", "idle", "daily", "both", "daily_and_idle"}
+        if isinstance(mode, str):
+            mode = mode.strip().lower()
+        if mode is not None and (not isinstance(mode, str) or mode not in _VALID_RESET_MODES):
+            logger.warning(
+                "Ignoring invalid session_reset mode %r (expected one of %s); "
+                "falling back to 'none'",
+                mode,
+                sorted(_VALID_RESET_MODES),
+            )
+            mode = "none"
+        # at_hour must be a valid hour; a YAML value outside [0,23] would raise a
+        # cryptic ValueError from datetime.replace() at session-check time.
+        if at_hour is not None:
+            try:
+                if isinstance(at_hour, bool) or isinstance(at_hour, float):
+                    raise ValueError(at_hour)
+                at_hour_int = int(at_hour.strip(), 10) if isinstance(at_hour, str) else int(at_hour)
+            except (AttributeError, TypeError, ValueError, OverflowError):
+                logger.warning("Ignoring invalid at_hour %r; falling back to 4", at_hour)
+                at_hour_int = 4
+            if not 0 <= at_hour_int <= 23:
+                logger.warning("Ignoring out-of-range at_hour %r; falling back to 4", at_hour)
+                at_hour_int = 4
+            at_hour = at_hour_int
+        if idle_minutes is not None:
+            try:
+                if isinstance(idle_minutes, bool) or isinstance(idle_minutes, float):
+                    raise ValueError(idle_minutes)
+                idle_minutes_int = int(idle_minutes.strip(), 10) if isinstance(idle_minutes, str) else int(idle_minutes)
+                if not 0 < idle_minutes_int <= MAX_SESSION_IDLE_MINUTES:
+                    raise ValueError(idle_minutes)
+            except (AttributeError, TypeError, ValueError, OverflowError):
+                logger.warning(
+                    "Ignoring invalid idle_minutes %r; falling back to 1440", idle_minutes
+                )
+                idle_minutes_int = 1440
+            idle_minutes = idle_minutes_int
         return cls(
             mode=mode if mode is not None else "none",
             at_hour=at_hour if at_hour is not None else 4,
@@ -1836,10 +1882,11 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
         )
         policy.at_hour = 4
 
-    if policy.idle_minutes is None or policy.idle_minutes <= 0:
+    if not isinstance(policy.idle_minutes, int) or not 0 < policy.idle_minutes <= MAX_SESSION_IDLE_MINUTES:
         logger.warning(
-            "Invalid idle_minutes=%s (must be positive). Using default 1440.",
+            "Invalid idle_minutes=%s (must be an integer from 1 to %s). Using default 1440.",
             policy.idle_minutes,
+            MAX_SESSION_IDLE_MINUTES,
         )
         policy.idle_minutes = 1440
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19158,6 +19158,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
             elif reset_reason == "daily":
                 context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
+            elif reset_reason == "daily_and_idle":
+                context_note = "[System note: The user's session was automatically reset after both the daily boundary and inactivity timeout passed. This is a fresh conversation with no prior context.]"
             elif reset_reason == "resume_pending_expired":
                 context_note = "[System note: The previous gateway session could not be recovered after a restart (API recovery timed out). This is a fresh conversation — use /resume to restore history if needed.]"
             else:
@@ -19204,6 +19206,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             reason_text = "gateway restart recovery timed out"
                         elif reset_reason == "daily":
                             reason_text = f"daily schedule at {policy.at_hour}:00"
+                        elif reset_reason == "daily_and_idle":
+                            reason_text = "daily boundary and inactivity timeout both passed"
                         else:
                             hours = policy.idle_minutes // 60
                             mins = policy.idle_minutes % 60

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2353,16 +2353,35 @@ class SessionStore:
                 return True
 
         if policy.mode in {"daily", "both"}:
-            today_reset = now.replace(
-                hour=policy.at_hour,
-                minute=0, second=0, microsecond=0,
-            )
-            if now.hour < policy.at_hour:
-                today_reset -= timedelta(days=1)
-            if entry.updated_at < today_reset:
+            if entry.updated_at < self._daily_reset_boundary(now, policy.at_hour):
+                return True
+
+        if policy.mode == "daily_and_idle":
+            if self._daily_and_idle_expired(entry, now, policy):
                 return True
 
         return False
+
+    @staticmethod
+    def _daily_reset_boundary(now: "datetime", at_hour: int) -> "datetime":
+        """Most recent daily-reset timestamp at or before ``now``.
+
+        With ``at_hour=4`` and ``now`` at 04:30, returns today's 04:00. With
+        ``now`` at 03:30, returns yesterday's 04:00. Shared by the ``daily``,
+        ``both`` and ``daily_and_idle`` reset modes so the boundary math lives
+        in exactly one place.
+        """
+        boundary = now.replace(hour=at_hour, minute=0, second=0, microsecond=0)
+        if now.hour < at_hour:
+            boundary -= timedelta(days=1)
+        return boundary
+
+    @staticmethod
+    def _daily_and_idle_expired(entry: SessionEntry, now: "datetime", policy) -> bool:
+        """Whether a session predates the daily boundary and idle deadline."""
+        if entry.updated_at >= SessionStore._daily_reset_boundary(now, policy.at_hour):
+            return False
+        return now > entry.updated_at + timedelta(minutes=policy.idle_minutes)
 
     def is_session_finalizable(self, entry: SessionEntry) -> bool:
         """Return True if the expiry watcher will *ever* finalize this session.
@@ -2454,18 +2473,13 @@ class SessionStore:
                 return "idle"
         
         if policy.mode in {"daily", "both"}:
-            today_reset = now.replace(
-                hour=policy.at_hour, 
-                minute=0, 
-                second=0, 
-                microsecond=0
-            )
-            if now.hour < policy.at_hour:
-                today_reset -= timedelta(days=1)
-            
-            if entry.updated_at < today_reset:
+            if entry.updated_at < self._daily_reset_boundary(now, policy.at_hour):
                 return "daily"
-        
+
+        if policy.mode == "daily_and_idle":
+            if self._daily_and_idle_expired(entry, now, policy):
+                return "daily_and_idle"
+
         return None
     
     def _compression_tip_for_session_id(self, session_id: Optional[str]) -> Optional[str]:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1690,6 +1690,7 @@ def _apply_default_agent_settings(config: dict):
 
 def setup_agent_settings(config: dict):
     """Configure agent behavior: iterations, progress display, compression, session reset."""
+    from gateway.config import MAX_SESSION_IDLE_MINUTES
 
     print_header("Agent Settings")
     print_info(f"   Guide: {_DOCS_BASE}/user-guide/configuration")
@@ -1790,6 +1791,7 @@ def setup_agent_settings(config: dict):
         "Inactivity + daily reset (reset whichever comes first)",
         "Inactivity only (reset after N minutes of no messages)",
         "Daily only (reset at a fixed hour each day)",
+        "Daily + inactivity (reset after the fixed hour once also idle)",
         "Never auto-reset (recommended - context lives until /reset or context compression)",
         "Keep current settings",
     ]
@@ -1799,7 +1801,7 @@ def setup_agent_settings(config: dict):
     current_idle = current_policy.get("idle_minutes", 1440)
     current_hour = current_policy.get("at_hour", 4)
 
-    default_reset = {"both": 0, "idle": 1, "daily": 2, "none": 3}.get(current_mode, 3)
+    default_reset = {"both": 0, "idle": 1, "daily": 2, "daily_and_idle": 3, "none": 4}.get(current_mode, 4)
 
     reset_idx = prompt_choice("Session reset mode:", reset_choices, default_reset)
 
@@ -1810,7 +1812,7 @@ def setup_agent_settings(config: dict):
         idle_str = prompt("  Inactivity timeout (minutes)", str(current_idle))
         try:
             idle_val = int(idle_str)
-            if idle_val > 0:
+            if 0 < idle_val <= MAX_SESSION_IDLE_MINUTES:
                 config["session_reset"]["idle_minutes"] = idle_val
         except ValueError:
             pass
@@ -1829,7 +1831,7 @@ def setup_agent_settings(config: dict):
         idle_str = prompt("  Inactivity timeout (minutes)", str(current_idle))
         try:
             idle_val = int(idle_str)
-            if idle_val > 0:
+            if 0 < idle_val <= MAX_SESSION_IDLE_MINUTES:
                 config["session_reset"]["idle_minutes"] = idle_val
         except ValueError:
             pass
@@ -1848,7 +1850,27 @@ def setup_agent_settings(config: dict):
         print_success(
             f"Sessions reset daily at {config['session_reset'].get('at_hour', 4)}:00"
         )
-    elif reset_idx == 3:  # None
+    elif reset_idx == 3:  # Daily + idle
+        config["session_reset"]["mode"] = "daily_and_idle"
+        idle_str = prompt("  Inactivity timeout before daily reset (minutes)", str(current_idle))
+        try:
+            idle_val = int(idle_str)
+            if 0 < idle_val <= MAX_SESSION_IDLE_MINUTES:
+                config["session_reset"]["idle_minutes"] = idle_val
+        except ValueError:
+            pass
+        hour_str = prompt("  Daily reset hour (0-23, local time)", str(current_hour))
+        try:
+            hour_val = int(hour_str)
+            if 0 <= hour_val <= 23:
+                config["session_reset"]["at_hour"] = hour_val
+        except ValueError:
+            pass
+        print_success(
+            f"Sessions reset at {config['session_reset'].get('at_hour', 4)}:00 "
+            f"only if also idle for {config['session_reset'].get('idle_minutes', 1440)} min"
+        )
+    elif reset_idx == 4:  # None
         config["session_reset"]["mode"] = "none"
         print_info(
             "Sessions will never auto-reset. Context is managed only by compression."
@@ -1856,7 +1878,7 @@ def setup_agent_settings(config: dict):
         print_warning(
             "Long conversations will grow in cost. Use /reset manually when needed."
         )
-    # else: keep current (idx == 4)
+    # else: keep current (idx == 5)
 
     save_config(config)
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6478,7 +6478,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         reopen must be promotable here.
 
         ``reason`` lets reset paths keep their auditable specific reasons
-        (``idle``, ``daily``, ``suspended``, ``resume_pending_expired``).
+        (``idle``, ``daily``, ``daily_and_idle``, ``suspended``,
+        ``resume_pending_expired``).
 
         Returns ``True`` when the row was promoted, ``False`` when skipped
         (already has a different explicit end_reason, or row not found).

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -195,6 +195,7 @@ _RESET_END_REASONS = (
     "session_switch",
     "idle",
     "daily",
+    "daily_and_idle",
     "suspended",
     "resume_pending_expired",
 )

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -22,6 +22,7 @@ from gateway.config import (
     SessionResetPolicy,
     StreamingConfig,
     _apply_env_overrides,
+    _validate_gateway_config,
     load_gateway_config,
     persist_home_channel,
 )
@@ -189,6 +190,15 @@ class TestSessionResetPolicy:
         assert restored.at_hour == 4
         assert restored.idle_minutes == 1440
         assert restored.bg_process_max_age_hours == 24
+
+    def test_environment_idle_timeout_is_bounded_after_overrides(self, monkeypatch):
+        monkeypatch.setenv("SESSION_IDLE_MINUTES", str(10**20))
+        config = GatewayConfig()
+
+        _apply_env_overrides(config)
+        _validate_gateway_config(config)
+
+        assert config.default_reset_policy.idle_minutes == 1440
 
 
 class TestStreamingConfig:

--- a/tests/gateway/test_session_reset_daily_and_idle.py
+++ b/tests/gateway/test_session_reset_daily_and_idle.py
@@ -1,0 +1,175 @@
+"""Tests for the ``daily_and_idle`` session reset mode.
+
+``daily_and_idle`` resets a session at the daily boundary (``at_hour``) ONLY
+when the session has ALSO been idle for ``idle_minutes``. A session touched
+after the previous daily boundary survives the rollover, so an active
+conversation that ran past midnight is not wiped at 4am.
+
+The existing ``both`` mode resets whenever EITHER trigger fires first, which
+is what wiped Discord threads at 4am even when they were used minutes earlier.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from gateway.config import SessionResetPolicy
+from gateway.session import SessionStore
+
+
+def _make_store(policy: SessionResetPolicy) -> SessionStore:
+    """Build a SessionStore whose reset policy resolves to ``policy``.
+
+    Avoids loading a full GatewayConfig; ``get_reset_policy`` is the only
+    policy accessor ``_is_session_expired`` uses.
+    """
+    store = object.__new__(SessionStore)
+    store._db = None
+    store._has_active_processes_fn = lambda *a, **k: False
+
+    class _Config:
+        def get_reset_policy(self, platform=None, session_type=None):
+            return policy
+
+    store.config = _Config()
+    return store
+
+
+def _entry(updated_at: datetime, platform="discord", chat_type="thread"):
+    from gateway.session import SessionEntry
+
+    return SessionEntry(
+        session_key="k",
+        session_id="s",
+        created_at=updated_at,
+        updated_at=updated_at,
+        platform=platform,
+        chat_type=chat_type,
+    )
+
+
+# Baseline: ``both`` resets at the daily boundary even if recently active.
+def test_both_resets_at_daily_boundary_regardless_of_recent_activity():
+    policy = SessionResetPolicy(mode="both", at_hour=4, idle_minutes=1440)
+    store = _make_store(policy)
+    # Now is 4:30am; last activity was 3:55am (35 min ago) — well within idle.
+    now = datetime(2026, 8, 23, 4, 30, 0)
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("gateway.session._now", lambda: now)
+        entry = _entry(datetime(2026, 8, 23, 3, 55, 0))
+        assert store._is_session_expired(entry) is True
+
+
+# The new mode: survives the daily boundary when recently active.
+def test_daily_and_idle_survives_daily_boundary_when_recently_active():
+    policy = SessionResetPolicy(mode="daily_and_idle", at_hour=4, idle_minutes=1440)
+    store = _make_store(policy)
+    now = datetime(2026, 8, 23, 4, 30, 0)
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("gateway.session._now", lambda: now)
+        # Active at 3:55am — less than idle_minutes ago AND after the 4am
+        # boundary of the prior day, so it must NOT reset.
+        entry = _entry(datetime(2026, 8, 23, 3, 55, 0))
+        assert store._is_session_expired(entry) is False
+
+
+# The new mode: resets at the daily boundary when ALSO idle past the threshold.
+def test_daily_and_idle_resets_at_daily_boundary_when_idle():
+    # Now 4:30am; last activity 1:00am. With idle_minutes=60 the session is
+    # idle past the window, and 1:00am is before the 4am boundary, so it resets.
+    policy = SessionResetPolicy(mode="daily_and_idle", at_hour=4, idle_minutes=60)
+    store = _make_store(policy)
+    now = datetime(2026, 8, 23, 4, 30, 0)
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("gateway.session._now", lambda: now)
+        entry = _entry(datetime(2026, 8, 23, 1, 0, 0))
+        assert store._is_session_expired(entry) is True
+
+
+# The new mode: idle but before the daily boundary does NOT reset.
+def test_daily_and_idle_idle_but_before_boundary_does_not_reset():
+    policy = SessionResetPolicy(mode="daily_and_idle", at_hour=4, idle_minutes=60)
+    store = _make_store(policy)
+    # Now is 3:00am (before the 4am boundary); last activity 1:00am (>60m ago).
+    # Daily gate fails (activity 01:00 Aug 23 is after the prior 4am boundary
+    # of Aug 22 04:00), so no reset even though idle_minutes is exceeded.
+    now = datetime(2026, 8, 23, 3, 0, 0)
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("gateway.session._now", lambda: now)
+        entry = _entry(datetime(2026, 8, 23, 1, 0, 0))
+        assert store._is_session_expired(entry) is False
+
+
+# Exact-boundary case: activity AT the boundary timestamp is NOT past it.
+def test_daily_and_idle_activity_exactly_at_boundary_survives():
+    policy = SessionResetPolicy(mode="daily_and_idle", at_hour=4, idle_minutes=10)
+    store = _make_store(policy)
+    # Now 4:30am; activity at exactly 4:00:00.000000 (the boundary). Although
+    # the idle deadline has passed, updated_at is NOT < boundary, so no reset.
+    now = datetime(2026, 8, 23, 4, 30, 0)
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("gateway.session._now", lambda: now)
+        entry = _entry(datetime(2026, 8, 23, 4, 0, 0, 0))
+        assert store._is_session_expired(entry) is False
+
+
+# The shared boundary helper behaves at the exact-hour edge.
+def test_daily_reset_boundary_helper_exact_hour():
+    from gateway.session import SessionStore as _S
+
+    # now == 4:00:00 -> today's boundary (not yesterday's)
+    assert _S._daily_reset_boundary(datetime(2026, 8, 23, 4, 0, 0), 4) == datetime(2026, 8, 23, 4, 0, 0)
+    # now == 3:59:59 -> yesterday's boundary
+    assert _S._daily_reset_boundary(datetime(2026, 8, 23, 3, 59, 59), 4) == datetime(2026, 8, 22, 4, 0, 0)
+    # now == 4:00:01 -> today's boundary
+    assert _S._daily_reset_boundary(datetime(2026, 8, 23, 4, 0, 1), 4) == datetime(2026, 8, 23, 4, 0, 0)
+    # at_hour == 0 (midnight)
+    assert _S._daily_reset_boundary(datetime(2026, 8, 23, 0, 30, 0), 0) == datetime(2026, 8, 23, 0, 0, 0)
+
+
+# Invalid mode / out-of-range at_hour are rejected by the policy loader.
+def test_session_reset_policy_rejects_invalid_mode_and_hour():
+    p = SessionResetPolicy.from_dict({"mode": "bogus", "at_hour": 99, "idle_minutes": 1440})
+    assert p.mode == "none"  # invalid mode falls back
+    assert p.at_hour == 4     # out-of-range hour falls back
+    p2 = SessionResetPolicy.from_dict({"mode": "daily_and_idle", "at_hour": "not-a-number", "idle_minutes": 60})
+    assert p2.mode == "daily_and_idle"
+    assert p2.at_hour == 4
+
+    for at_hour in (True, 4.0, float("inf")):
+        policy = SessionResetPolicy.from_dict({"mode": "daily", "at_hour": at_hour})
+        assert policy.at_hour == 4
+
+
+def test_session_reset_policy_sanitizes_non_scalar_mode_and_invalid_idle_timeout():
+    """Malformed YAML must not crash policy loading or make daily_and_idle daily-only."""
+    for mode in ([], {}):
+        policy = SessionResetPolicy.from_dict({"mode": mode, "idle_minutes": "not-a-number"})
+        assert policy.mode == "none"
+        assert policy.idle_minutes == 1440
+
+    for idle_minutes in (0, -1, True, 4.5, 10**20, "not-a-number"):
+        policy = SessionResetPolicy.from_dict(
+            {"mode": "daily_and_idle", "idle_minutes": idle_minutes}
+        )
+        assert policy.idle_minutes == 1440
+
+    assert SessionResetPolicy.from_dict({"idle_minutes": "1440"}).idle_minutes == 1440
+
+
+# Both exhausted: idle & past boundary.
+def test_daily_and_idle_expired_via_idle_window():
+    policy = SessionResetPolicy(mode="daily_and_idle", at_hour=4, idle_minutes=1440)
+    store = _make_store(policy)
+    # Now 4:30am; last activity 2 days ago (past boundary AND past idle).
+    now = datetime(2026, 8, 23, 4, 30, 0)
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("gateway.session._now", lambda: now)
+        entry = _entry(datetime(2026, 8, 21, 9, 0, 0))
+        assert store._is_session_expired(entry) is True
+
+
+def test_daily_and_idle_is_distinct_from_both_in_policy():
+    p = SessionResetPolicy.from_dict({"mode": "daily_and_idle", "at_hour": 4, "idle_minutes": 1440})
+    assert p.mode == "daily_and_idle"
+    assert p.to_dict()["mode"] == "daily_and_idle"

--- a/tests/gateway/test_session_reset_daily_and_idle.py
+++ b/tests/gateway/test_session_reset_daily_and_idle.py
@@ -100,6 +100,29 @@ def test_daily_and_idle_idle_but_before_boundary_does_not_reset():
         assert store._is_session_expired(entry) is False
 
 
+def test_daily_and_idle_resets_only_after_the_later_gate_crosses():
+    """The AND result is independent of whether daily or idle becomes true first."""
+    store = _make_store(SessionResetPolicy(mode="daily_and_idle", at_hour=4, idle_minutes=60))
+
+    # Idle is already true at 03:30, but the prior day's daily boundary still
+    # applies. Once 04:00 is crossed, both gates hold and the reset occurs.
+    entry_idle_first = _entry(datetime(2026, 8, 23, 2, 0, 0))
+    # The daily boundary is crossed at 04:00, but the idle deadline (04:30)
+    # has not. The reset waits until the idle gate is crossed too.
+    entry_daily_first = _entry(datetime(2026, 8, 23, 3, 30, 0))
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("gateway.session._now", lambda: datetime(2026, 8, 23, 3, 30, 0))
+        assert store._is_session_expired(entry_idle_first) is False
+
+        mp.setattr("gateway.session._now", lambda: datetime(2026, 8, 23, 4, 1, 0))
+        assert store._is_session_expired(entry_idle_first) is True
+        assert store._is_session_expired(entry_daily_first) is False
+
+        mp.setattr("gateway.session._now", lambda: datetime(2026, 8, 23, 4, 31, 0))
+        assert store._is_session_expired(entry_daily_first) is True
+
+
 # Exact-boundary case: activity AT the boundary timestamp is NOT past it.
 def test_daily_and_idle_activity_exactly_at_boundary_survives():
     policy = SessionResetPolicy(mode="daily_and_idle", at_hour=4, idle_minutes=10)

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -64,6 +64,47 @@ class TestShouldResetReason:
         source = _make_source()
         assert store._should_reset(entry, source) == "idle"
 
+    def test_returns_daily_when_daily_and_idle_conditions_are_both_met(self, tmp_path):
+        """Inbound routing must apply daily_and_idle, not only the watcher."""
+        store = _make_store(
+            SessionResetPolicy(mode="daily_and_idle", at_hour=4, idle_minutes=60),
+            tmp_path,
+        )
+        source = _make_source()
+        entry = SessionEntry(
+            session_key="test",
+            session_id="s1",
+            created_at=datetime(2026, 8, 22, 1, 0, 0),
+            updated_at=datetime(2026, 8, 23, 1, 0, 0),
+        )
+        with patch("gateway.session._now", return_value=datetime(2026, 8, 23, 4, 30, 0)):
+            assert store._should_reset(entry, source) == "daily_and_idle"
+
+    def test_daily_and_idle_requires_each_condition_in_routing_path(self, tmp_path):
+        store = _make_store(
+            SessionResetPolicy(mode="daily_and_idle", at_hour=4, idle_minutes=60),
+            tmp_path,
+        )
+        source = _make_source()
+        now = datetime(2026, 8, 23, 4, 30, 0)
+        entries = (
+            # Activity after today's boundary has not crossed the daily gate.
+            SessionEntry("test", "s1", datetime(2026, 8, 23, 4, 5), datetime(2026, 8, 23, 4, 5)),
+            # Before today's boundary, but not yet idle for the full timeout.
+            SessionEntry("test", "s2", datetime(2026, 8, 23, 3, 45), datetime(2026, 8, 23, 3, 45)),
+            # At the idle deadline: expiry is strictly greater than the deadline.
+            SessionEntry("test", "s3", datetime(2026, 8, 23, 3, 30), datetime(2026, 8, 23, 3, 30)),
+        )
+        with patch("gateway.session._now", return_value=now):
+            for entry in entries:
+                assert store._should_reset(entry, source) is None
+
+        # Before the next day's boundary, a session updated after the prior
+        # boundary must survive even when it is long past the idle timeout.
+        with patch("gateway.session._now", return_value=datetime(2026, 8, 23, 3, 0, 0)):
+            entry = SessionEntry("test", "s4", datetime(2026, 8, 22, 5), datetime(2026, 8, 22, 5))
+            assert store._should_reset(entry, source) is None
+
 
     def test_returns_none_when_active_process_check_raises(self, tmp_path):
         def _raise(_session_key):

--- a/tests/hermes_cli/test_setup_agent_settings.py
+++ b/tests/hermes_cli/test_setup_agent_settings.py
@@ -22,7 +22,7 @@ def test_setup_agent_settings_uses_displayed_max_iterations_value(tmp_path, monk
     prompt_answers = iter(["60", "all", "0.5"])
 
     monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_answers))
-    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 5)
     monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
     monkeypatch.setattr("hermes_cli.setup.remove_env_value", lambda *args, **kwargs: None)
     monkeypatch.setattr("hermes_cli.setup.save_config", lambda *args, **kwargs: None)
@@ -58,7 +58,7 @@ def test_setup_agent_settings_prefers_config_over_stale_env(tmp_path, monkeypatc
         lambda key: "60" if key == "HERMES_MAX_ITERATIONS" else "",
     )
     monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_answers))
-    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 5)
     monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
 
     removed_keys: list[str] = []
@@ -76,3 +76,45 @@ def test_setup_agent_settings_prefers_config_over_stale_env(tmp_path, monkeypatc
     assert "Press Enter to keep 60." not in out
     # And the stale .env entry gets cleaned up
     assert "HERMES_MAX_ITERATIONS" in removed_keys
+
+
+def test_setup_agent_settings_configures_daily_and_idle(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {
+        "agent": {"max_turns": 60},
+        "display": {"tool_progress": "all"},
+        "compression": {"threshold": 0.50},
+        "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
+    }
+    prompt_answers = iter(["60", "all", "0.5", "120", "5"])
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_answers))
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 3)
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.remove_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.save_config", lambda *args, **kwargs: None)
+
+    setup_agent_settings(config)
+
+    assert config["session_reset"] == {
+        "mode": "daily_and_idle", "idle_minutes": 120, "at_hour": 5
+    }
+
+
+def test_setup_agent_settings_rejects_oversized_idle_timeout(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = {
+        "agent": {"max_turns": 60},
+        "display": {"tool_progress": "all"},
+        "compression": {"threshold": 0.50},
+        "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
+    }
+    prompt_answers = iter(["60", "all", "0.5", str(10**20), "5"])
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_answers))
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 3)
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.remove_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.save_config", lambda *args, **kwargs: None)
+
+    setup_agent_settings(config)
+
+    assert config["session_reset"]["idle_minutes"] == 1440

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3920,8 +3920,9 @@ def test_gateway_session_peer_round_trip_and_recovery(db):
     ["agent:main:telegram:dm:chat-1", None],
     ids=["exact-key", "peer-fallback"],
 )
+@pytest.mark.parametrize("end_reason", ["session_reset", "daily_and_idle"])
 def test_gateway_session_recovery_does_not_cross_newer_reset_boundary(
-    db, persisted_session_key
+    db, persisted_session_key, end_reason
 ):
     """A newer session_reset row fences recovery for the peer (#68539).
 
@@ -3939,7 +3940,7 @@ def test_gateway_session_recovery_does_not_cross_newer_reset_boundary(
     db.append_message("gw-before-reset", "user", "old context")
     db.create_session("gw-reset", "telegram", **peer)
     db.append_message("gw-reset", "user", "/new")
-    db.end_session("gw-reset", "session_reset")
+    db.end_session("gw-reset", end_reason)
 
     assert db.find_latest_gateway_session_for_peer(
         source="telegram",

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -259,9 +259,9 @@ with the `session_reset` section in `~/.hermes/config.yaml`:
 
 ```yaml
 session_reset:
-  mode: idle        # "idle", "daily", "both", or "none" (default)
-  idle_minutes: 1440  # for idle/both: minutes of inactivity before reset
-  at_hour: 4          # for daily/both: hour of day (0-23, local time)
+  mode: idle        # "idle", "daily", "both", "daily_and_idle", or "none" (default)
+  idle_minutes: 1440  # for idle/both/daily_and_idle: minutes of inactivity before reset
+  at_hour: 4          # for daily/both/daily_and_idle: hour of day (0-23, local time)
 ```
 
 | Mode | Description |
@@ -270,6 +270,7 @@ session_reset:
 | `daily` | Reset at a specific hour each day |
 | `idle` | Reset after N minutes of inactivity |
 | `both` | Whichever triggers first |
+| `daily_and_idle` | Reset only when both the daily boundary and idle timeout have passed |
 
 A live background process (started with `terminal(background=true)`) normally
 protects its session from resetting so output isn't lost. To stop a forgotten

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -791,6 +791,7 @@ in to automatic resets via the `session_reset` section in `config.yaml`:
 - **idle** — reset after N minutes of inactivity
 - **daily** — reset at a specific hour each day
 - **both** — reset on whichever comes first (idle or daily)
+- **daily_and_idle** — reset only when a session predates the latest daily boundary and has also been idle for the configured timeout
 
 Before a session is auto-reset, the agent is given a turn to save any important memories or skills from the conversation.
 


### PR DESCRIPTION
## Summary

Adds `session_reset.mode: daily_and_idle`, a strict AND policy: a gateway session resets only after it predates the latest daily boundary **and** exceeds the configured idle timeout. This prevents active Discord threads from being discarded merely because they cross the daily reset hour.

- Applies the same shared predicate to expiry watching, inbound routing, and durable recovery.
- Preserves recovery fences for `daily_and_idle` reset boundaries.
- Sanitizes malformed reset configuration, including non-scalar modes, invalid hours, non-integer/oversized idle values, and environment overrides.
- Adds setup-wizard support, notifications, docs, config examples, and regression coverage.

## Verification

- `85 passed` in targeted policy, config, routing, recovery, and setup tests against the upstream-current worktree.
- `python -m compileall` passed for the modified Python modules.
- `git diff --check` passed.
- Final read-only review: GPT-5.6-Sol (high) approved with no findings.

Authorship: David Díaz Merino <david.diaz.merino@gmail.com>.
