### PR TITLE
perf(agent): collect streamed tool-call arguments in a list

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3886,6 +3886,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _conn_cap = min(_base_timeout, 60.0) if _provider_timeout_cfg is not None else 30.0
         content_parts: list = []
         tool_calls_acc: dict = {}
+        # Argument chunks per slot, kept as a list and joined only when
+        # something reads them. Adding to the string on the accumulator dict
+        # instead would copy the whole argument blob on every chunk, so a
+        # large write_file call would cost the square of its own size.
+        tool_call_arg_parts: dict = {}  # slot -> list of argument chunks
         tool_gen_notified: set = set()
         # Ollama-compatible endpoints reuse index 0 for every tool call
         # in a parallel batch, distinguishing them only by id.  Track
@@ -3969,7 +3974,21 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             last_chunk_time["t"] = time.time()
             return True
 
+        def _materialize_tool_call_arguments() -> None:
+            """Write the collected argument chunks into the accumulator dicts.
+
+            Called wherever the arguments are about to be read. Always writes
+            the whole joined value rather than adding to what is there, so
+            calling it more than once is safe and chunks that arrive later
+            still end up in the right place.
+            """
+            for slot, parts in tool_call_arg_parts.items():
+                tc = tool_calls_acc.get(slot)
+                if tc is not None:
+                    tc["function"]["arguments"] = "".join(parts)
+
         def _relay_final_response() -> dict[str, Any]:
+            _materialize_tool_call_arguments()
             tool_calls = [tool_calls_acc[index] for index in sorted(tool_calls_acc)]
             return {
                 "model": model_name,
@@ -4234,7 +4253,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             entry["function"]["name"] = function_name
                         function_arguments = getattr(tc_function, "arguments", None)
                         if function_arguments:
-                            entry["function"]["arguments"] += function_arguments
+                            tool_call_arg_parts.setdefault(idx, []).append(
+                                function_arguments
+                            )
                     extra = getattr(tc_delta, "extra_content", None)
                     if extra is None and hasattr(tc_delta, "model_extra"):
                         extra = (tc_delta.model_extra if isinstance(tc_delta.model_extra, dict) else {}).get("extra_content")
@@ -4313,6 +4334,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         mock_tool_calls = None
         has_truncated_tool_args = False
         if tool_calls_acc:
+            _materialize_tool_call_arguments()
             mock_tool_calls = []
             for idx in sorted(tool_calls_acc):
                 tc = tool_calls_acc[idx]

--- a/tests/run_agent/test_tool_call_argument_accumulation.py
+++ b/tests/run_agent/test_tool_call_argument_accumulation.py
@@ -1,0 +1,218 @@
+"""Tests for how streamed tool-call arguments are collected.
+
+Arguments arrive in many small chunks. They used to be added onto a string
+held in the accumulator dict, which copies the whole blob on every chunk, so
+one big tool call cost the square of its own size. The chunks are now kept in
+a list per tool call and joined only where something reads them.
+
+These tests pin the behaviour that has to survive that change: chunks join in
+order, parallel tool calls stay separate, and a resent tool name still does
+not get doubled up.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_stream_chunk(content=None, tool_calls=None, finish_reason=None):
+    delta = SimpleNamespace(
+        content=content, tool_calls=tool_calls,
+        reasoning_content=None, reasoning=None,
+    )
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], model=None, usage=None)
+
+
+def _make_tool_call_delta(index=0, tc_id=None, name=None, arguments=None):
+    func = SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(index=index, id=tc_id, function=func)
+
+
+def _make_agent():
+    from run_agent import AIAgent
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://example.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+def _run_stream(chunks):
+    """Feed the chunks through the streaming call and hand back the response."""
+    with patch("run_agent.AIAgent._create_request_openai_client") as mock_create, \
+         patch("run_agent.AIAgent._close_request_openai_client"):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+        return agent._interruptible_streaming_api_call({})
+
+
+def _tool_calls(response):
+    return response.choices[0].message.tool_calls or []
+
+
+class TestArgumentChunksJoin:
+    def test_chunks_join_in_order(self):
+        pieces = ['{"pa', 'th": "a.txt", ', '"content": "hi"}']
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="write_file"),
+            ]),
+        ]
+        for piece in pieces:
+            chunks.append(_make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments=piece),
+            ]))
+        chunks.append(_make_stream_chunk(finish_reason="tool_calls"))
+
+        calls = _tool_calls(_run_stream(chunks))
+        assert len(calls) == 1
+        assert calls[0].function.name == "write_file"
+        assert calls[0].function.arguments == "".join(pieces)
+        assert json.loads(calls[0].function.arguments) == {
+            "path": "a.txt", "content": "hi",
+        }
+
+    def test_one_chunk_per_character_still_joins(self):
+        body = '{"q": "who wrote the sound and the fury"}'
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="web_search"),
+            ]),
+        ]
+        for ch in body:
+            chunks.append(_make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments=ch),
+            ]))
+        chunks.append(_make_stream_chunk(finish_reason="tool_calls"))
+
+        calls = _tool_calls(_run_stream(chunks))
+        assert calls[0].function.arguments == body
+
+    def test_a_large_argument_blob_is_assembled_correctly(self):
+        # The case the change is about. A big write_file body arriving in
+        # small pieces used to copy the whole blob on every piece.
+        body = json.dumps({"path": "big.txt", "content": "x" * 200_000})
+        step = 8
+        pieces = [body[i:i + step] for i in range(0, len(body), step)]
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="write_file"),
+            ]),
+        ]
+        for piece in pieces:
+            chunks.append(_make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments=piece),
+            ]))
+        chunks.append(_make_stream_chunk(finish_reason="tool_calls"))
+
+        calls = _tool_calls(_run_stream(chunks))
+        assert calls[0].function.arguments == body
+        assert json.loads(calls[0].function.arguments)["content"] == "x" * 200_000
+
+    def test_no_argument_chunks_leaves_arguments_empty(self):
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="get_time"),
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments="{}"),
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+        calls = _tool_calls(_run_stream(chunks))
+        assert calls[0].function.arguments == "{}"
+
+
+class TestParallelToolCalls:
+    def test_each_call_keeps_its_own_arguments(self):
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_a", name="read_file"),
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=1, tc_id="call_b", name="read_file"),
+            ]),
+            # Interleaved, the way a provider streams a parallel batch.
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"path": "'),
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=1, arguments='{"path": "'),
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='first.txt"}'),
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=1, arguments='second.txt"}'),
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+        calls = _tool_calls(_run_stream(chunks))
+        assert len(calls) == 2
+        by_id = {c.id: c.function.arguments for c in calls}
+        assert by_id["call_a"] == '{"path": "first.txt"}'
+        assert by_id["call_b"] == '{"path": "second.txt"}'
+
+    def test_reused_index_with_a_new_id_starts_a_fresh_call(self):
+        # Ollama-compatible endpoints reuse index 0 for a whole parallel
+        # batch and tell the calls apart only by id.
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_a", name="read_file"),
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"path": "first.txt"}'),
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_b", name="read_file"),
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"path": "second.txt"}'),
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+        calls = _tool_calls(_run_stream(chunks))
+        assert len(calls) == 2
+        by_id = {c.id: c.function.arguments for c in calls}
+        assert by_id["call_a"] == '{"path": "first.txt"}'
+        assert by_id["call_b"] == '{"path": "second.txt"}'
+
+
+class TestResentToolName:
+    def test_a_resent_name_is_not_doubled(self):
+        # MiniMax M2.7 through NVIDIA NIM resends the full tool name on every
+        # chunk. The name is assigned rather than added to, and that has to
+        # keep working now that the arguments are collected separately.
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, tc_id="call_1", name="read_file",
+                                      arguments='{"path"'),
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, name="read_file",
+                                      arguments=': "a.txt"}'),
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+        calls = _tool_calls(_run_stream(chunks))
+        assert calls[0].function.name == "read_file"
+        assert calls[0].function.arguments == '{"path": "a.txt"}'
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What does this PR do?

Streamed tool-call arguments were collected by adding onto a string held in the accumulator dict, once per chunk:

```python
entry["function"]["arguments"] += function_arguments
```

The target is a dict item, which compiles to `STORE_SUBSCR`, so CPython cannot grow the string in place. Every chunk allocates a new string and copies the whole blob collected so far, and one tool call ends up costing the square of its own argument size. It bites hardest on the calls with the biggest arguments, which is where you least want it: a model writing a large file through `write_file` streams the entire body through this line in small pieces.

The chunks now go into a list per tool call, and are joined only where something reads them.

There are exactly two places that read the accumulated arguments, and both run once at the end of a turn rather than per chunk:

- `_relay_final_response`, which hands the accumulator dicts to the relay
- the mock response builder at the end of the stream

I checked every other use of `tool_calls_acc`. The rest only look at keys, at the tool name, or at whether the dict is empty, so nothing else needs the joined value.

The join always writes the whole value instead of adding to what is already there. That makes it safe to call more than once, and it means chunks arriving after one read still land correctly on the next.

This is the second half of #92163, which fixed the same shape for the assistant reply text and named this site as needing its own change. The visible content path in this very same function already did it the cheap way with `"".join(content_parts)`.

## Related Issue

Fixes #92207

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`: new `tool_call_arg_parts` dict holding the argument chunks per slot, alongside the existing `tool_calls_acc`.
- `agent/chat_completion_helpers.py`: new `_materialize_tool_call_arguments` helper that joins the chunks into the accumulator dicts, called from the two read points.
- `agent/chat_completion_helpers.py`: the per-chunk line appends to the list instead of rebuilding the string.
- `tests/run_agent/test_tool_call_argument_accumulation.py`: new file, 7 tests.

## How to Test

1. `pytest tests/run_agent/test_tool_call_argument_accumulation.py -q` gives 7 passed.
2. The tests cover: chunks join in order, one chunk per character still joins, a 200 KB argument blob is assembled correctly, a call with a single `{}` chunk is unchanged, parallel tool calls keep their own arguments when interleaved, a reused index with a new id starts a fresh call (the Ollama shape), and a resent tool name is still not doubled (the MiniMax through NVIDIA NIM shape).
3. I checked the tests actually bite. Changing the join to keep only the last chunk turns 5 of the 7 red, so they are not passing by accident.
4. Wider suites that touch this code path:

```
pytest tests/run_agent/test_tool_call_argument_accumulation.py \
       tests/run_agent/test_partial_stream_finish_reason.py \
       tests/run_agent/test_streaming.py \
       tests/run_agent/test_anthropic_mid_tool_call_drop.py \
       tests/run_agent/test_plugin_stream_hooks.py \
       tests/agent/test_canon_args_memo_parity.py -q
86 passed, 4 skipped

pytest tests/run_agent/test_run_agent.py tests/run_agent/test_run_agent_codex_responses.py -q
333 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.13

To be exact about that full-suite line, since I would rather say what I actually ran. On top of the suites above I ran the whole `tests/agent` package twice, once on this branch and once on unmodified `main` in a separate worktree, same flags both times:

```
main                          199 failed, 4922 passed, 39 skipped
perf/tool-call-arguments-join 199 failed, 4922 passed, 39 skipped
```

Same totals. The failures are Windows and optional-dependency ones that fail the same way on `main`, so none of them are mine.

Comparing the two failure lists test by test, they differ by exactly one entry in each direction, and neither is related to this change. Both pass on their own on this branch, three runs each. Running the two files they live in gives an identical result on both branches, one failure in `test_outbound_webhooks.py` either way, and it is a third test again each time. That file has a flaky delivery test, which is a pre-existing problem and not something this PR touches.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A

  The new helper carries a docstring saying why it always writes the whole value, and the new dict has a comment saying why the chunks are kept in a list.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

  Pure Python, no OS-specific behaviour.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no schema change)

## Screenshots / Logs

Note on measurement, so nobody has to take the shape on trust. I did not put a timing test in the suite for this one. The accumulator lives inside the streaming function as a local, so a test cannot reach it to count copies the way the sibling PR does, and a wall-clock assertion would be flaky on CI. What the tests pin instead is that the arguments come out correct, including for a 200 KB blob arriving in 8-character pieces.

The cost argument itself is the same one measured in #92163 for the identical string shape:

| how the text is stored | 20k chunks into a short string | 20k chunks into a long string | slowdown |
| --- | --- | --- | --- |
| `+=` on an attribute or dict item | 0.0555s | 0.2111s | 3.6x |
| list of pieces | 0.0016s | 0.0016s | 1.0x |

Lower is better in every column. The last one is how much slower identical work gets once the string is long, which is the quadratic showing up.
