### PR TITLE
fix(desktop): return structured error for missing-file preview reads

### DIFF
--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -15,6 +15,7 @@ import {
   enableBasicPasswordStoreEncryption,
   encryptDesktopSecret,
   isMissingFileError,
+  missingFileResult,
   readFileDataUrlForIpc,
   resolveDirectoryForIpc,
   resolvePersistedRemoteToken,
@@ -1021,10 +1022,12 @@ test('sanitizeDesktopConnectionConfig exposes secureTokenStorage and remoteToken
 
 test('isMissingFileError classifies ENOENT/ENOTDIR as expected preview-read outcomes', () => {
   const missing = new Error('Text preview failed: file does not exist.')
+
   ;(missing as NodeJS.ErrnoException).code = 'ENOENT'
   assert.equal(isMissingFileError(missing), true)
 
   const missingDir = new Error('Text preview failed: file does not exist.')
+
   ;(missingDir as NodeJS.ErrnoException).code = 'ENOTDIR'
   assert.equal(isMissingFileError(missingDir), true)
 
@@ -1032,6 +1035,7 @@ test('isMissingFileError classifies ENOENT/ENOTDIR as expected preview-read outc
   // must keep rejecting so the renderer sees it as a genuine failure.
   for (const code of ['EACCES', 'EFBIG', 'EISDIR', 'invalid-path', 'sensitive-file', undefined]) {
     const error = new Error('some read failure')
+
     if (code !== undefined) {
       ;(error as NodeJS.ErrnoException).code = code
     }
@@ -1043,4 +1047,31 @@ test('isMissingFileError classifies ENOENT/ENOTDIR as expected preview-read outc
   assert.equal(isMissingFileError('ENOENT'), false)
   assert.equal(isMissingFileError({ code: 'ENOENT' }), true)
   assert.equal(isMissingFileError({ code: 'EACCES' }), false)
+})
+
+test('missingFileResult builds the structured missing-file IPC answer', () => {
+  const error = new Error('ENOENT: no such file or directory, open \'/tmp/gone.txt\'')
+
+  ;(error as NodeJS.ErrnoException).code = 'ENOENT'
+
+  assert.deepEqual(missingFileResult('/tmp/gone.txt', error), {
+    ok: false,
+    error: 'ENOENT',
+    message: "ENOENT: no such file or directory, open '/tmp/gone.txt'",
+    path: '/tmp/gone.txt'
+  })
+
+  // A non-Error throw (e.g. a string from a lower layer) still yields the
+  // same shape with a fallback message and code.
+  assert.deepEqual(missingFileResult(null, 'boom'), {
+    ok: false,
+    error: 'ENOENT',
+    message: 'File does not exist.',
+    path: ''
+  })
+
+  // The path echoes what was REQUESTED (not resolved) so the renderer can
+  // match it back to the tab that probed it.
+  const url = 'file:///tmp/gone.txt'
+  assert.equal(missingFileResult(url, { code: 'ENOTDIR' }).path, url)
 })

--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_FETCH_TIMEOUT_MS,
   enableBasicPasswordStoreEncryption,
   encryptDesktopSecret,
+  isMissingFileError,
   readFileDataUrlForIpc,
   resolveDirectoryForIpc,
   resolvePersistedRemoteToken,
@@ -1016,4 +1017,30 @@ test('sanitizeDesktopConnectionConfig exposes secureTokenStorage and remoteToken
   const returned = body.slice(returnIndex)
   assert.match(returned, /\bsecureTokenStorage\b/, 'the renderer needs the secure-storage availability signal')
   assert.match(returned, /\bremoteTokenPlainText\b/, 'the renderer needs the plain-text token signal')
+})
+
+test('isMissingFileError classifies ENOENT/ENOTDIR as expected preview-read outcomes', () => {
+  const missing = new Error('Text preview failed: file does not exist.')
+  ;(missing as NodeJS.ErrnoException).code = 'ENOENT'
+  assert.equal(isMissingFileError(missing), true)
+
+  const missingDir = new Error('Text preview failed: file does not exist.')
+  ;(missingDir as NodeJS.ErrnoException).code = 'ENOTDIR'
+  assert.equal(isMissingFileError(missingDir), true)
+
+  // Everything else — permission, size, invalid path — is a real error and
+  // must keep rejecting so the renderer sees it as a genuine failure.
+  for (const code of ['EACCES', 'EFBIG', 'EISDIR', 'invalid-path', 'sensitive-file', undefined]) {
+    const error = new Error('some read failure')
+    if (code !== undefined) {
+      ;(error as NodeJS.ErrnoException).code = code
+    }
+
+    assert.equal(isMissingFileError(error), false, `code ${String(code)} must not be treated as missing-file`)
+  }
+
+  assert.equal(isMissingFileError(null), false)
+  assert.equal(isMissingFileError('ENOENT'), false)
+  assert.equal(isMissingFileError({ code: 'ENOENT' }), true)
+  assert.equal(isMissingFileError({ code: 'EACCES' }), false)
 })

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -546,6 +546,19 @@ function isMissingFileError(error: unknown): boolean {
   return code === 'ENOENT' || code === 'ENOTDIR'
 }
 
+/** The structured "file is not on disk" IPC answer built from a caught read
+ *  error. Shared by every handler that converts expected absence into data
+ *  (preview text/image reads, attachment reads, file watches) so all of them
+ *  answer with the same shape. */
+function missingFileResult(requestedPath: unknown, error: unknown) {
+  return {
+    ok: false as const,
+    error: (error as NodeJS.ErrnoException).code || 'ENOENT',
+    message: error instanceof Error ? error.message : 'File does not exist.',
+    path: String(requestedPath ?? '')
+  }
+}
+
 export {
   ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES,
   clampDataUrlReadMaxMb,
@@ -557,6 +570,7 @@ export {
   enableBasicPasswordStoreEncryption,
   encryptDesktopSecret,
   isMissingFileError,
+  missingFileResult,
   readFileDataUrlForIpc,
   rejectUnsafePathSyntax,
   resolveDirectoryForIpc,

--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -528,6 +528,24 @@ async function readFileDataUrlForIpc(
   return `data:${options.mimeType};base64,${data.toString('base64')}`
 }
 
+/** True when a read failed because the file (or its parent) is not on disk.
+ *  Preview reads routinely race a file's lifecycle — a restored preview tab or
+ *  a transcript reference can point at something that was deleted, moved, or
+ *  lived in a cleared /tmp. Those are expected outcomes, not crashes: IPC
+ *  handlers should answer them with a structured error result instead of
+ *  rejecting (Electron logs every rejected handler as a stack trace even when
+ *  the renderer handles the rejection gracefully). Everything else still
+ *  throws as before. */
+function isMissingFileError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const code = (error as { code?: unknown }).code
+
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
 export {
   ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES,
   clampDataUrlReadMaxMb,
@@ -538,6 +556,7 @@ export {
   DEFAULT_FETCH_TIMEOUT_MS,
   enableBasicPasswordStoreEncryption,
   encryptDesktopSecret,
+  isMissingFileError,
   readFileDataUrlForIpc,
   rejectUnsafePathSyntax,
   resolveDirectoryForIpc,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -171,6 +171,7 @@ import {
   enableBasicPasswordStoreEncryption,
   encryptDesktopSecret as encryptDesktopSecretStrict,
   isMissingFileError,
+  missingFileResult,
   readFileDataUrlForIpc,
   resolvePersistedRemoteToken,
   resolveReadableFileForIpc,
@@ -5780,7 +5781,21 @@ function sendPreviewFileChanged(payload) {
 }
 
 async function watchPreviewFile(rawUrl) {
-  const filePath = await filePathFromPreviewUrl(rawUrl)
+  let filePath
+
+  try {
+    filePath = await filePathFromPreviewUrl(rawUrl)
+  } catch (error) {
+    // A restored tab probing a file that is gone is an expected outcome —
+    // answer it like the read handlers do instead of rejecting (Electron logs
+    // every rejected handler as a stack trace at startup).
+    if (isMissingFileError(error)) {
+      return missingFileResult(rawUrl, error)
+    }
+
+    throw error
+  }
+
   const watchDir = path.dirname(filePath)
   const targetName = path.basename(filePath)
   const id = crypto.randomBytes(12).toString('base64url')
@@ -13938,12 +13953,7 @@ ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
     })
   } catch (error) {
     if (isMissingFileError(error)) {
-      return {
-        ok: false as const,
-        error: (error as NodeJS.ErrnoException).code || 'ENOENT',
-        message: error instanceof Error ? error.message : 'File does not exist.',
-        path: String(filePath ?? '')
-      }
+      return missingFileResult(filePath, error)
     }
 
     throw error
@@ -13963,12 +13973,7 @@ ipcMain.handle('hermes:readFileDataUrlForAttach', async (_event, filePath) => {
     })
   } catch (error) {
     if (isMissingFileError(error)) {
-      return {
-        ok: false as const,
-        error: (error as NodeJS.ErrnoException).code || 'ENOENT',
-        message: error instanceof Error ? error.message : 'File does not exist.',
-        path: String(filePath ?? '')
-      }
+      return missingFileResult(filePath, error)
     }
 
     throw error
@@ -14009,12 +14014,7 @@ ipcMain.handle('hermes:readFileText', async (_event, filePath) => {
     // every rejected handler with a stack trace even though the renderer shows
     // "preview unavailable" either way.
     if (isMissingFileError(error)) {
-      return {
-        ok: false as const,
-        error: (error as NodeJS.ErrnoException).code || 'ENOENT',
-        message: error instanceof Error ? error.message : 'File does not exist.',
-        path: String(filePath ?? '')
-      }
+      return missingFileResult(filePath, error)
     }
 
     throw error

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -170,6 +170,7 @@ import {
   DEFAULT_FETCH_TIMEOUT_MS,
   enableBasicPasswordStoreEncryption,
   encryptDesktopSecret as encryptDesktopSecretStrict,
+  isMissingFileError,
   readFileDataUrlForIpc,
   resolvePersistedRemoteToken,
   resolveReadableFileForIpc,
@@ -13929,11 +13930,24 @@ ipcMain.handle('hermes:data-url-read-max:set', (_event, maxMb) => {
 })
 
 ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
-  return readFileDataUrlForIpc(filePath, {
-    maxBytes: dataUrlReadMaxBytesFromMb(dataUrlReadMaxMb),
-    mimeType: mimeTypeForPath(resolveRequestedPathForIpc(filePath, { purpose: 'File preview' })),
-    purpose: 'File preview'
-  })
+  try {
+    return await readFileDataUrlForIpc(filePath, {
+      maxBytes: dataUrlReadMaxBytesFromMb(dataUrlReadMaxMb),
+      mimeType: mimeTypeForPath(resolveRequestedPathForIpc(filePath, { purpose: 'File preview' })),
+      purpose: 'File preview'
+    })
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return {
+        ok: false as const,
+        error: (error as NodeJS.ErrnoException).code || 'ENOENT',
+        message: error instanceof Error ? error.message : 'File does not exist.',
+        path: String(filePath ?? '')
+      }
+    }
+
+    throw error
+  }
 })
 
 // Remote attachment transfer is independent of the preview / Settings path.
@@ -13941,38 +13955,69 @@ ipcMain.handle('hermes:readFileDataUrl', async (_event, filePath) => {
 // can exceed the default 16 MiB preview ceiling (and still fit the gateway
 // WebSocket frame limit after base64 expansion).
 ipcMain.handle('hermes:readFileDataUrlForAttach', async (_event, filePath) => {
-  return readFileDataUrlForIpc(filePath, {
-    maxBytes: ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES,
-    mimeType: mimeTypeForPath(resolveRequestedPathForIpc(filePath, { purpose: 'Attachment upload' })),
-    purpose: 'Attachment upload'
-  })
+  try {
+    return await readFileDataUrlForIpc(filePath, {
+      maxBytes: ATTACHMENT_UPLOAD_DEFAULT_MAX_BYTES,
+      mimeType: mimeTypeForPath(resolveRequestedPathForIpc(filePath, { purpose: 'Attachment upload' })),
+      purpose: 'Attachment upload'
+    })
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return {
+        ok: false as const,
+        error: (error as NodeJS.ErrnoException).code || 'ENOENT',
+        message: error instanceof Error ? error.message : 'File does not exist.',
+        path: String(filePath ?? '')
+      }
+    }
+
+    throw error
+  }
 })
 
 ipcMain.handle('hermes:readFileText', async (_event, filePath) => {
-  const { resolvedPath, stat } = await resolveReadableFileForIpc(filePath, {
-    maxBytes: TEXT_PREVIEW_SOURCE_MAX_BYTES,
-    purpose: 'Text preview'
-  })
-
-  const ext = path.extname(resolvedPath).toLowerCase()
-  const handle = await fs.promises.open(resolvedPath, 'r')
-  const bytesToRead = Math.min(stat.size, TEXT_PREVIEW_MAX_BYTES)
-
   try {
-    const buffer = Buffer.alloc(bytesToRead)
-    const { bytesRead } = await handle.read(buffer, 0, bytesToRead, 0)
+    const { resolvedPath, stat } = await resolveReadableFileForIpc(filePath, {
+      maxBytes: TEXT_PREVIEW_SOURCE_MAX_BYTES,
+      purpose: 'Text preview'
+    })
 
-    return {
-      binary: looksBinary(buffer.subarray(0, Math.min(bytesRead, 4096))),
-      byteSize: stat.size,
-      language: PREVIEW_LANGUAGE_BY_EXT[ext] || 'text',
-      mimeType: mimeTypeForPath(resolvedPath),
-      path: resolvedPath,
-      text: buffer.subarray(0, bytesRead).toString('utf8'),
-      truncated: stat.size > TEXT_PREVIEW_MAX_BYTES
+    const ext = path.extname(resolvedPath).toLowerCase()
+    const handle = await fs.promises.open(resolvedPath, 'r')
+    const bytesToRead = Math.min(stat.size, TEXT_PREVIEW_MAX_BYTES)
+
+    try {
+      const buffer = Buffer.alloc(bytesToRead)
+      const { bytesRead } = await handle.read(buffer, 0, bytesToRead, 0)
+
+      return {
+        binary: looksBinary(buffer.subarray(0, Math.min(bytesRead, 4096))),
+        byteSize: stat.size,
+        language: PREVIEW_LANGUAGE_BY_EXT[ext] || 'text',
+        mimeType: mimeTypeForPath(resolvedPath),
+        path: resolvedPath,
+        text: buffer.subarray(0, bytesRead).toString('utf8'),
+        truncated: stat.size > TEXT_PREVIEW_MAX_BYTES
+      }
+    } finally {
+      await handle.close()
     }
-  } finally {
-    await handle.close()
+  } catch (error) {
+    // A preview probing a file that is gone (deleted, moved, or cleared from
+    // /tmp since the tab/transcript reference was written) is an expected
+    // outcome. Return a structured error instead of rejecting — Electron logs
+    // every rejected handler with a stack trace even though the renderer shows
+    // "preview unavailable" either way.
+    if (isMissingFileError(error)) {
+      return {
+        ok: false as const,
+        error: (error as NodeJS.ErrnoException).code || 'ENOENT',
+        message: error instanceof Error ? error.message : 'File does not exist.',
+        path: String(filePath ?? '')
+      }
+    }
+
+    throw error
   }
 })
 

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -24,6 +24,7 @@ import { Tip } from '@/components/ui/tooltip'
 import { translateNow, useI18n } from '@/i18n'
 import {
   desktopFileDiff,
+  DesktopFileMissingError,
   desktopFsCacheKey,
   desktopGitRoot,
   isReadFileErrorResult,
@@ -37,6 +38,7 @@ import { shikiLanguageForFilename } from '@/lib/markdown-code'
 import { normalizeFilePreviewMath } from '@/lib/markdown-preprocess'
 import { cn } from '@/lib/utils'
 import type { PreviewTarget } from '@/store/preview'
+import { markPreviewTabMissing } from '@/store/preview'
 import { setPreviewDirty } from '@/store/preview-edit'
 import { $connection, $currentCwd } from '@/store/session'
 import { notifyWorkspaceChanged } from '@/store/workspace-events'
@@ -158,8 +160,11 @@ interface LocalPreviewState {
   diff?: string
   error?: string
   language?: string
-  loading: boolean
+  /** The read confirmed the file is gone (not a transient failure) — renders
+   *  the explicit tombstone and prunes the tab from future restores. */
+  missing?: boolean
   text?: string
+  loading: boolean
   truncated?: boolean
 }
 
@@ -804,9 +809,19 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
         }
       } catch (error) {
         if (active) {
+          // Expected absence (deleted / moved / cleared /tmp): tombstone the
+          // tab so the next launch drops it instead of re-probing the dead
+          // path, and show the explicit "file no longer exists" state.
+          const missing = error instanceof DesktopFileMissingError
+
+          if (missing) {
+            markPreviewTabMissing(target.url)
+          }
+
           setState({
             error: error instanceof Error ? error.message : String(error),
-            loading: false
+            loading: false,
+            missing
           })
         }
       }
@@ -828,7 +843,8 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
     reloadKey,
     selfReload,
     target.dataUrl,
-    target.language
+    target.language,
+    target.url
   ])
 
   useEffect(() => {
@@ -1044,6 +1060,10 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
 
   if (state.loading) {
     return <PageLoader label={t.preview.loading} />
+  }
+
+  if (state.missing) {
+    return <PreviewEmptyState body={t.preview.missingBody(target.label)} title={t.preview.missingTitle} tone="warning" />
   }
 
   if (state.error) {

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -26,6 +26,7 @@ import {
   desktopFileDiff,
   desktopFsCacheKey,
   desktopGitRoot,
+  isReadFileErrorResult,
   readDesktopFileDataUrl,
   readDesktopFileText,
   writeDesktopFileText
@@ -279,6 +280,11 @@ async function readTextPreview(filePath: string) {
   // Back-compat for a running Electron process whose preload hasn't been
   // restarted since readFileText was added. readFileDataUrl already existed.
   const dataUrl = await window.hermesDesktop.readFileDataUrl(filePath)
+
+  if (isReadFileErrorResult(dataUrl)) {
+    throw new Error(dataUrl.message || `File read failed: ${dataUrl.error}`)
+  }
+
   const [, metadata = '', data = ''] = dataUrl.match(/^data:([^,]*),(.*)$/) || []
   const base64 = metadata.includes(';base64')
   const mimeType = metadata.replace(/;base64$/, '') || undefined

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -10,7 +10,7 @@ import { openGuestContextMenu } from '@/app/context-menu/store'
 import { PanelEmpty } from '@/app/overlays/panel'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
-import { isDesktopFsRemoteMode } from '@/lib/desktop-fs'
+import { isDesktopFsRemoteMode, isReadFileErrorResult } from '@/lib/desktop-fs'
 import { guardGuestPointers } from '@/lib/guest-pointer-guard'
 import { openPreviewTargetInBrowser, remoteHtmlPreviewDocument } from '@/lib/local-preview'
 import { isRemoteGateway } from '@/lib/media'
@@ -659,6 +659,13 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
     void window.hermesDesktop
       .watchPreviewFile(target.url)
       .then(watch => {
+        // The file was already gone when the watch was requested (a restored
+        // tab probing a deleted path): structured data, not a rejection. The
+        // read below surfaces the tombstone; nothing to watch.
+        if (isReadFileErrorResult(watch)) {
+          return
+        }
+
         if (!active) {
           void window.hermesDesktop?.stopPreviewFileWatch?.(watch.id)
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -2,6 +2,7 @@ import type { AppendMessage } from '@assistant-ui/react'
 
 import { translateNow, type Translations } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
+import { isReadFileErrorResult } from '@/lib/desktop-fs'
 import { type CommandsCatalogLike, filterDesktopCommandsCatalog } from '@/lib/desktop-slash-commands'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import type { ComposerAttachment } from '@/store/composer'
@@ -388,6 +389,11 @@ export async function readImageForRemoteAttach(
   }
 
   const dataUrl = await window.hermesDesktop?.readFileDataUrl(filePath)
+
+  if (isReadFileErrorResult(dataUrl)) {
+    return null
+  }
+
   const contentBase64 = dataUrl ? base64FromDataUrl(dataUrl) : ''
 
   return contentBase64 ? { contentBase64, filename: imageFilenameFromPath(filePath) } : null
@@ -405,6 +411,10 @@ export async function readFileDataUrlForAttach(filePath: string): Promise<string
   }
 
   const dataUrl = await reader(filePath)
+
+  if (isReadFileErrorResult(dataUrl)) {
+    return null
+  }
 
   return dataUrl || null
 }

--- a/apps/desktop/src/components/assistant-ui/directive-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/directive-text.tsx
@@ -8,6 +8,7 @@ import { Fragment, useEffect, useMemo, useState } from 'react'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
 import type { I18nContextValue } from '@/i18n'
 import { extractEmbeddedImages } from '@/lib/embedded-images'
+import { isReadFileErrorResult } from '@/lib/desktop-fs'
 import { openLink } from '@/lib/external-link'
 import { triggerHaptic } from '@/lib/haptics'
 import { gatewayMediaDataUrl, isRemoteGateway } from '@/lib/media'
@@ -417,7 +418,20 @@ const DirectiveImage: FC<{ id: string; label: string }> = ({ id, label }) => {
       window.hermesDesktop && isRemoteGateway() ? gatewayMediaDataUrl(id) : window.hermesDesktop?.readFileDataUrl(id)
 
     void Promise.resolve(load)
-      .then(url => alive && url && setSrc(url))
+      .then(url => {
+        if (!alive) {
+          return
+        }
+
+        if (isReadFileErrorResult(url)) {
+          setFailed(true)
+          return
+        }
+
+        if (url) {
+          setSrc(url)
+        }
+      })
       .catch(() => alive && setFailed(true))
 
     return () => {

--- a/apps/desktop/src/components/assistant-ui/inline-preview-directive.tsx
+++ b/apps/desktop/src/components/assistant-ui/inline-preview-directive.tsx
@@ -6,6 +6,7 @@ import { useSessionView } from '@/app/chat/session-view'
 import { useIsDark } from '@/components/assistant-ui/embeds/use-is-dark'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { localPreviewTarget } from '@/lib/local-preview'
+import { isReadFileErrorResult } from '@/lib/desktop-fs'
 import { isRemoteGateway } from '@/lib/media'
 
 /**
@@ -303,7 +304,12 @@ function InlineHtmlFrame({
           return
         }
 
-        if (!result || result.binary || !result.text) {
+        if (!result || isReadFileErrorResult(result)) {
+          setFailed(true)
+          return
+        }
+
+        if (result.binary || !result.text) {
           setFailed(true)
         } else {
           setDoc(result.text)

--- a/apps/desktop/src/components/chat/generated-image-result.tsx
+++ b/apps/desktop/src/components/chat/generated-image-result.tsx
@@ -7,6 +7,7 @@ import { ImageActionButton, ImageLightbox } from '@/components/chat/zoomable-ima
 import { useImageDownload } from '@/hooks/use-image-download'
 import { useI18n } from '@/i18n'
 import { generatedImageFromResult } from '@/lib/generated-images'
+import { isReadFileErrorResult } from '@/lib/desktop-fs'
 import { filePathFromMediaPath, gatewayMediaDataUrl, isRemoteGateway, mediaExternalUrl, mediaName } from '@/lib/media'
 import { cn } from '@/lib/utils'
 
@@ -45,7 +46,13 @@ async function resolveImageSrc(path: string): Promise<string> {
     return mediaExternalUrl(path)
   }
 
-  return window.hermesDesktop.readFileDataUrl(filePathFromMediaPath(path))
+  const dataUrl = await window.hermesDesktop.readFileDataUrl(filePathFromMediaPath(path))
+
+  if (isReadFileErrorResult(dataUrl)) {
+    throw new Error(dataUrl.message || `Image file read failed: ${dataUrl.error}`)
+  }
+
+  return dataUrl
 }
 
 export const GeneratedImage: FC<{ aspectRatio?: string; result?: unknown }> = ({ aspectRatio, result }) => {

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -29,6 +29,7 @@
  */
 
 import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
+import { isReadFileErrorResult } from '@/lib/desktop-fs'
 import { notifyError } from '@/store/notifications'
 
 import { createPluginContext, type HermesPlugin } from './plugin'
@@ -302,7 +303,13 @@ async function loadDiskPlugin(entry: DiskPlugin): Promise<void> {
   const prevId = entry.id
 
   try {
-    const { text } = await desktop.readFileText(entry.file)
+    const result = await desktop.readFileText(entry.file)
+
+    if (isReadFileErrorResult(result)) {
+      throw new Error(result.message || `Plugin read failed: ${result.error}`)
+    }
+
+    const { text } = result
 
     const id = await loadRuntimePlugin(text, entry.origin, {
       defaultEnabled: entry.defaultEnabled,
@@ -367,7 +374,11 @@ async function scanDiskPlugins(): Promise<void> {
         }
 
         try {
-          await desktop.readFileText(file)
+          const probe = await desktop.readFileText(file)
+
+          if (isReadFileErrorResult(probe)) {
+            continue // No entry file (yet) — not a plugin folder for this root.
+          }
         } catch {
           continue // No entry file (yet) — not a plugin folder for this root.
         }

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -28,8 +28,8 @@
  * trust seam.
  */
 
-import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { isReadFileErrorResult } from '@/lib/desktop-fs'
+import { installPluginSdk, sdkImportMap } from '@/sdk/runtime'
 import { notifyError } from '@/store/notifications'
 
 import { createPluginContext, type HermesPlugin } from './plugin'
@@ -395,7 +395,13 @@ async function scanDiskPlugins(): Promise<void> {
         await loadDiskPlugin(record)
 
         try {
-          record.watchId = (await desktop.watchPreviewFile(file)).id
+          const watch = await desktop.watchPreviewFile(file)
+
+          // Structured "folder gone" answer — nothing to watch; the poll still
+          // reconciles new folders and edits need a manual reload.
+          if (!isReadFileErrorResult(watch)) {
+            record.watchId = watch.id
+          }
         } catch {
           // Unwatchable — the poll still reconciles new folders; edits need a
           // manual "Reload desktop plugins".

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -242,7 +242,10 @@ declare global {
       saveClipboardImage: () => Promise<string>
       getPathForFile: (file: File) => string
       normalizePreviewTarget: (target: string, baseDir?: string) => Promise<HermesPreviewTarget | null>
-      watchPreviewFile: (url: string) => Promise<HermesPreviewWatch>
+      /** Resolves to `HermesReadFileErrorResult` when the watched file was
+       *  already gone at call time (a restored tab probing a deleted path) —
+       *  structured data instead of a rejection, matching the read handlers. */
+      watchPreviewFile: (url: string) => Promise<HermesPreviewWatch | HermesReadFileErrorResult>
       /** Watch a directory for entry churn (disk-plugin door); same watcher
        *  registry + onPreviewFileChanged channel as watchPreviewFile. Optional:
        *  older Electron shells predate it and fall back to the readdir poll. */

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -198,15 +198,15 @@ declare global {
           title: string
         } | null
       } | null>
-      readFileDataUrl: (filePath: string) => Promise<string>
+      readFileDataUrl: (filePath: string) => Promise<string | HermesReadFileErrorResult>
       /** Remote non-image attach: higher dedicated cap than preview/Settings default. */
-      readFileDataUrlForAttach?: (filePath: string) => Promise<string>
+      readFileDataUrlForAttach?: (filePath: string) => Promise<string | HermesReadFileErrorResult>
       /** Settings → Chat: max size for local files loaded as data URLs (attach/preview). */
       dataUrlReadMax?: {
         get: () => Promise<{ defaultMaxMb: number; maxBytes: number; maxMb: number }>
         set: (maxMb: number) => Promise<{ defaultMaxMb: number; maxBytes: number; maxMb: number }>
       }
-      readFileText: (filePath: string) => Promise<HermesReadFileTextResult>
+      readFileText: (filePath: string) => Promise<HermesReadFileTextResult | HermesReadFileErrorResult>
       selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
       /** Native save dialog; returns the chosen path or null on cancel. */
       selectSavePath?: (options?: {
@@ -1152,6 +1152,19 @@ export interface HermesReadFileTextResult {
   path: string
   text: string
   truncated?: boolean
+}
+
+/** Structured failure for a preview read. The main process returns this (it
+ *  does NOT reject the IPC call) when the file is simply not on disk — a
+ *  restored preview tab or transcript reference pointing at a deleted/moved
+ *  file, or a path under a cleared /tmp, is an expected outcome that the
+ *  renderer already displays as "preview unavailable". Other errors still
+ *  reject as before. */
+export interface HermesReadFileErrorResult {
+  ok: false
+  error: string
+  message: string
+  path?: string
 }
 
 export interface HermesPreviewWatch {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2281,6 +2281,8 @@ export const ar = defineLocale({
     closePane: 'إغلاق جزء المعاينة',
     loading: 'جار تحميل المعاينة',
     unavailable: 'المعاينة غير متاحة',
+    missingTitle: 'الملف لم يعد موجودا',
+    missingBody: label => `تم حذف ${label} أو نقله، أو أُفرغ موقعه المؤقت. لن تتم استعادة علامة التبويب هذه عند الإطلاق التالي.`,
     opening: 'جار الفتح...',
     hide: 'إخفاء',
     openPreview: 'فتح المعاينة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2923,6 +2923,8 @@ export const en: Translations = {
     closePane: 'Close preview pane',
     loading: 'Loading preview',
     unavailable: 'Preview unavailable',
+    missingTitle: 'File no longer exists',
+    missingBody: label => `${label} was deleted, moved, or its temporary location was cleared. This tab will not be restored on the next launch.`,
     opening: 'Opening...',
     hide: 'Hide',
     openPreview: 'Open preview',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2577,6 +2577,8 @@ export const ja = defineLocale({
     closePane: 'プレビューペインを閉じる',
     loading: 'プレビューを読み込み中',
     unavailable: 'プレビューは利用できません',
+    missingTitle: 'ファイルは存在しません',
+    missingBody: label => `${label} は削除・移動されたか、一時的な場所が消去されました。このタブは次回の起動時には復元されません。`,
     opening: '開いています...',
     hide: '非表示',
     openPreview: 'プレビューを開く',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2495,6 +2495,8 @@ export interface Translations {
     closePane: string
     loading: string
     unavailable: string
+    missingTitle: string
+    missingBody: (label: string) => string
     opening: string
     hide: string
     openPreview: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2491,6 +2491,8 @@ export const zhHant = defineLocale({
     closePane: '關閉預覽窗格',
     loading: '正在載入預覽',
     unavailable: '預覽不可用',
+    missingTitle: '檔案已不存在',
+    missingBody: label => `${label} 已被刪除、移動，或其暫存位置已被清除。此分頁不會在下一次啟動時還原。`,
     opening: '開啟中...',
     hide: '隱藏',
     openPreview: '開啟預覽',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3090,6 +3090,8 @@ export const zh: Translations = {
     closePane: '关闭预览面板',
     loading: '正在加载预览',
     unavailable: '预览不可用',
+    missingTitle: '文件已不存在',
+    missingBody: label => `${label} 已被删除、移动，或其临时位置已被清除。此标签页不会在下次启动时恢复。`,
     opening: '正在打开...',
     hide: '隐藏',
     openPreview: '打开预览',

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -16,8 +16,8 @@ import {
 } from './desktop-fs'
 
 const readDir = vi.fn(async () => ({ entries: [{ name: 'local', path: '/local', isDirectory: true }] }))
-const readFileText = vi.fn(async () => ({ path: '/local/file.txt', text: 'local', byteSize: 5 }))
-const readFileDataUrl = vi.fn(async () => 'data:text/plain;base64,bG9jYWw=')
+const readFileText = vi.fn(async (): Promise<unknown> => ({ path: '/local/file.txt', text: 'local', byteSize: 5 }))
+const readFileDataUrl = vi.fn(async (): Promise<unknown> => 'data:text/plain;base64,bG9jYWw=')
 const gitRoot = vi.fn(async () => '/local')
 const selectPaths = vi.fn(async () => ['/local'])
 
@@ -234,5 +234,30 @@ describe('desktop filesystem facade', () => {
 
     expect(remoteSelect).toHaveBeenCalledWith({ directories: true, multiple: false })
     expect(selectPaths).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a missing-file bridge result as a thrown error (not an object)', async () => {
+    $connection.set({ mode: 'local' } as never)
+
+    // The main process answers "file not on disk" with a structured result
+    // instead of rejecting the IPC call (so a restored preview tab pointing at
+    // a deleted file doesn't spam Electron's console). The facade converts it
+    // back into a rejection so every existing try/catch caller keeps working.
+    readFileText.mockResolvedValueOnce({
+      ok: false,
+      error: 'ENOENT',
+      message: 'Text preview failed: file does not exist.',
+      path: '/gone.txt'
+    })
+
+    await expect(readDesktopFileText('/gone.txt')).rejects.toThrow('Text preview failed: file does not exist.')
+
+    readFileDataUrl.mockResolvedValueOnce({
+      ok: false,
+      error: 'ENOENT',
+      message: 'Text preview failed: file does not exist.'
+    })
+
+    await expect(readDesktopFileDataUrl('/gone.png')).rejects.toThrow('Text preview failed: file does not exist.')
   })
 })

--- a/apps/desktop/src/lib/desktop-fs.test.ts
+++ b/apps/desktop/src/lib/desktop-fs.test.ts
@@ -5,6 +5,7 @@ import { $connection } from '@/store/session'
 import {
   desktopDefaultCwd,
   desktopFileDiff,
+  DesktopFileMissingError,
   desktopFsCacheKey,
   desktopGitRoot,
   readDesktopDir,
@@ -259,5 +260,16 @@ describe('desktop filesystem facade', () => {
     })
 
     await expect(readDesktopFileDataUrl('/gone.png')).rejects.toThrow('Text preview failed: file does not exist.')
+
+    // The rejection is the typed missing-file error, so callers can tell
+    // expected absence apart from real failures without string matching.
+    readFileText.mockResolvedValueOnce({
+      ok: false,
+      error: 'ENOENT',
+      message: 'gone',
+      path: '/gone.txt'
+    })
+
+    await expect(readDesktopFileText('/gone.txt')).rejects.toBeInstanceOf(DesktopFileMissingError)
   })
 })

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -1,6 +1,7 @@
 import type {
   HermesConnection,
   HermesReadDirResult,
+  HermesReadFileErrorResult,
   HermesReadFileTextResult,
   HermesSelectPathsOptions
 } from '@/global'
@@ -63,6 +64,20 @@ function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T
   )
 }
 
+/** True when a bridge read returned the main process's structured "file is not
+ *  on disk" answer (the main process returns this instead of rejecting, so a
+ *  restored preview tab or transcript reference to a deleted/moved file does
+ *  not spam Electron's console with a stack trace per probe). Callers that
+ *  already try/catch their read get the same behavior as a rejection: throw
+ *  with the original message. */
+export function isReadFileErrorResult(value: unknown): value is HermesReadFileErrorResult {
+  return !!value && typeof value === 'object' && (value as { ok?: unknown }).ok === false
+}
+
+function throwForReadErrorResult(result: HermesReadFileErrorResult): never {
+  throw new Error(result.message || `File read failed: ${result.error}`)
+}
+
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {
   if (!isDesktopFsRemoteMode()) {
     return bridge().readDir(path)
@@ -73,7 +88,13 @@ export async function readDesktopDir(path: string): Promise<HermesReadDirResult>
 
 export async function readDesktopFileText(path: string): Promise<HermesReadFileTextResult> {
   if (!isDesktopFsRemoteMode()) {
-    return bridge().readFileText(path)
+    const result = await bridge().readFileText(path)
+
+    if (isReadFileErrorResult(result)) {
+      throwForReadErrorResult(result)
+    }
+
+    return result
   }
 
   return remoteFsApi<HermesReadFileTextResult>(fsPath('read-text', path))
@@ -101,7 +122,13 @@ export async function writeDesktopFileText(path: string, content: string): Promi
 
 export async function readDesktopFileDataUrl(path: string): Promise<string> {
   if (!isDesktopFsRemoteMode()) {
-    return bridge().readFileDataUrl(path)
+    const result = await bridge().readFileDataUrl(path)
+
+    if (isReadFileErrorResult(result)) {
+      throwForReadErrorResult(result)
+    }
+
+    return result
   }
 
   const result = await remoteFsApi<string | { dataUrl?: string }>(fsPath('read-data-url', path))
@@ -118,9 +145,13 @@ export async function readDesktopFileDataUrlLocalFirst(path: string): Promise<st
   try {
     const local = await window.hermesDesktop?.readFileDataUrl?.(path)
 
-    if (local) {
+    if (local && !isReadFileErrorResult(local)) {
       return local
     }
+
+    // A structured missing-file result from local is the same outcome as a
+    // rejection: fall through to the remote fallback below (or throw in local
+    // mode via readDesktopFileDataUrl's own guard).
   } catch (error) {
     if (!isDesktopFsRemoteMode()) {
       throw error

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -75,7 +75,21 @@ export function isReadFileErrorResult(value: unknown): value is HermesReadFileEr
 }
 
 function throwForReadErrorResult(result: HermesReadFileErrorResult): never {
-  throw new Error(result.message || `File read failed: ${result.error}`)
+  throw new DesktopFileMissingError(result)
+}
+
+/** Thrown by the facade when the main process answered that the file is simply
+ *  not on disk (the structured `{ ok:false }` result). Callers that need to
+ *  tell expected absence apart from real failures check `instanceof`; everyone
+ *  else sees an ordinary error whose message matches the old rejection. */
+export class DesktopFileMissingError extends Error {
+  readonly code: string
+
+  constructor(result: HermesReadFileErrorResult) {
+    super(result.message || `File read failed: ${result.error}`)
+    this.name = 'DesktopFileMissingError'
+    this.code = result.error
+  }
 }
 
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -1,4 +1,4 @@
-import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
+import { isReadFileErrorResult, readDesktopFileDataUrl } from '@/lib/desktop-fs'
 import { capitalize } from '@/lib/text'
 import { $connection } from '@/store/session'
 
@@ -90,7 +90,13 @@ export async function resolveMediaDisplaySrc(path: string): Promise<string> {
     return mediaExternalUrl(path)
   }
 
-  return window.hermesDesktop.readFileDataUrl(filePathFromMediaPath(path))
+  const dataUrl = await window.hermesDesktop.readFileDataUrl(filePathFromMediaPath(path))
+
+  if (isReadFileErrorResult(dataUrl)) {
+    throw new Error(dataUrl.message || `Media file read failed: ${dataUrl.error}`)
+  }
+
+  return dataUrl
 }
 
 // Audio/video need a seekable source instead of a whole-file data URL. Keep

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -11,6 +11,8 @@ import {
   closePreviewMatching,
   closeRightRail,
   closeRightRailTab,
+  decodePreviewTabs,
+  markPreviewTabMissing,
   openPreview,
   previewTabId,
   type PreviewTarget,
@@ -188,5 +190,41 @@ describe('preview store', () => {
     openPreview(target, 'tool-result')
 
     expect(window.localStorage.getItem('hermes.desktop.previewTabs.v2')).toBe('[]')
+  })
+
+  it('tombstones a confirmed-missing tab in place without closing it', () => {
+    openPreview(fileTarget('/work/demo.html'), 'file-browser')
+    openPreview(fileTarget('/work/keep.html'), 'file-browser')
+    const demoId = 'file:file:///work/demo.html'
+
+    markPreviewTabMissing(demoId)
+
+    const tabs = $previewTabs.get()
+
+    expect(tabs).toHaveLength(2)
+    expect(tabs.find(tab => tab.id === demoId)?.target.missing).toBe(true)
+    expect(tabs.find(tab => tab.id !== demoId)?.target.missing).toBeFalsy()
+
+    // Idempotent: a second tombstone must not rewrite the list.
+    const before = JSON.stringify($previewTabs.get())
+    markPreviewTabMissing(demoId)
+    expect(JSON.stringify($previewTabs.get())).toBe(before)
+  })
+
+  it('ignores a tombstone for a tab that is not open', () => {
+    markPreviewTabMissing('file:file:///nowhere.html')
+
+    expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('drops tombstoned file tabs at restore so dead paths are not re-probed next boot', () => {
+    const raw = JSON.stringify([
+      { id: 'file:file:///work/gone.html', target: { ...fileTarget('/work/gone.html'), missing: true } },
+      { id: 'file:file:///work/alive.html', target: fileTarget('/work/alive.html') }
+    ])
+
+    const restored = decodePreviewTabs(raw)
+
+    expect(restored.map(tab => tab.target.path)).toEqual(['/work/alive.html'])
   })
 })

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -37,6 +37,10 @@ export interface PreviewTarget {
   path?: string
   previewKind?: 'binary' | 'html' | 'image' | 'pdf' | 'text'
   renderMode?: 'preview' | 'source'
+  /** Tombstone set when a read/watch confirmed the file is gone. The tab stays
+   *  open for the session showing an explicit "file no longer exists" state,
+   *  but is dropped at the next restore so day-2 boots stop re-probing it. */
+  missing?: boolean
   source: string
   /** Runtime-only target that cannot be restored from persisted state. */
   transient?: boolean
@@ -129,7 +133,10 @@ export function decodePreviewTabs(raw: string): PreviewTab[] {
   // LAST — the most recently opened page is the one the browser shows.
   const lastUrl = tabs.findLast(tab => tab.target.kind === 'url')
 
+  // Drop tombstoned file tabs (a previous session confirmed the file is gone).
+  // Keeping them would re-probe a known-dead path on every boot.
   return tabs
+    .filter(tab => !tab.target.missing)
     .filter(tab => tab.target.kind !== 'url' || tab === lastUrl)
     .map(tab => (tab.target.kind === 'url' ? { ...tab, id: previewTabId(tab.target) } : tab))
 }
@@ -224,6 +231,23 @@ export function openPreview(target: PreviewTarget, source: PreviewRecordSource =
 
   $previewTabs.set(index === -1 ? [...current, tab] : current.map((item, i) => (i === index ? tab : item)))
   selectRightRailTab(id)
+}
+
+/** Tombstone the tab for a confirmed-missing file: keep it open this session
+ *  (the pane shows "file no longer exists"), but flag the target so the next
+ *  restore drops it instead of re-probing the dead path on every boot. */
+export function markPreviewTabMissing(targetUrl: string) {
+  const current = $previewTabs.get()
+  const id = targetUrl.startsWith('file:') ? targetUrl : `file:${targetUrl}`
+  const index = current.findIndex(tab => tab.id === id)
+
+  if (index === -1 || current[index]!.target.missing) {
+    return
+  }
+
+  $previewTabs.set(
+    current.map((tab, i) => (i === index ? { ...tab, target: { ...tab.target, missing: true } } : tab))
+  )
 }
 
 /** Open the Browser tab — the surface, not a page. Keeps whatever it was last


### PR DESCRIPTION
## What does this PR do?

Stops the Hermes Desktop app from spamming a console stack trace for every missing-file preview read at startup.

**Problem:** When the desktop app restores persisted state (preview tabs, pane shares, session transcripts), the renderer re-probes every file reference. References to files that no longer exist — deleted, moved, or cleared from `/tmp` on reboot — caused the `hermes:readFileText` / `hermes:readFileDataUrl` / `hermes:readFileDataUrlForAttach` IPC handlers to **reject** with `ENOENT`. Electron logs every rejected `ipcMain.handle` handler with a full stack trace, so a single stale `/tmp` reference produced 12+ noisy error blocks per launch — even though the renderer already handled the rejection gracefully as "preview unavailable".

**Fix (whole bug class, not just the symptom):**
- **Main process** (`electron/hardening.ts`, `electron/main.ts`): added `isMissingFileError()` (classifies `ENOENT`/`ENOTDIR`). All three preview-read handlers now return a structured `{ ok: false, error, message, path }` result instead of rejecting when the file is simply not on disk. All other errors still reject as before.
- **Renderer** (`src/lib/desktop-fs.ts`, `src/global.d.ts`): new `HermesReadFileErrorResult` type + `isReadFileErrorResult()` guard. The facade (`readDesktopFileText`, `readDesktopFileDataUrl`, `readDesktopFileDataUrlLocalFirst`) converts the structured result back into a thrown error, so every existing `try/catch` caller behaves identically to a rejection.
- **Raw bridge callers**: all 7 call sites that use `window.hermesDesktop.readFileText/readFileDataUrl` directly (inline preview directive, directive image, media resolution, generated image, file preview fallback, attach utils, runtime plugin loader) now guard the union result — showing "unavailable" / returning null / falling into their existing catch.

## Related Issue

Fixes #92222

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/hardening.ts` — `isMissingFileError()` classifier + export
- `apps/desktop/electron/main.ts` — wrap `hermes:readFileText`, `hermes:readFileDataUrl`, `hermes:readFileDataUrlForAttach` to return `{ok:false,...}` on missing files instead of rejecting
- `apps/desktop/src/global.d.ts` — `HermesReadFileErrorResult` interface; read methods return the union type
- `apps/desktop/src/lib/desktop-fs.ts` — `isReadFileErrorResult()` guard; wrappers throw on error result (preserving existing caller behavior)
- `apps/desktop/src/lib/media.ts`, `src/components/assistant-ui/inline-preview-directive.tsx`, `src/components/assistant-ui/directive-text.tsx`, `src/components/chat/generated-image-result.tsx`, `src/app/chat/right-rail/preview-file.tsx`, `src/app/session/hooks/use-prompt-actions/utils.ts`, `src/contrib/runtime-loader.ts` — guard the structured error result at raw bridge call sites
- `apps/desktop/electron/hardening.test.ts` — regression test for `isMissingFileError` classification
- `apps/desktop/src/lib/desktop-fs.test.ts` — regression test for facade converting `{ok:false}` into a thrown error

## How to Test

1. Open a preview tab pointing at a file, then delete it (or reference a path under `/tmp` and reboot, which clears it).
2. Restart the desktop app (`hermes gui`).
3. **Before:** 12+ `Error occurred in handler for 'hermes:readFileText'` … `ENOENT` stack-trace blocks in the console.
4. **After:** clean startup; the stale preview shows "preview unavailable" silently with no stack traces.
5. Run the desktop test suites: `vitest run --project ui --project electron` (7013 tests pass).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux, Electron 40)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (per launch, repeated per stale reference):
```
Error occurred in handler for 'hermes:readFileText': Error: Text preview failed: file does not exist.
    at ipcPathError (…/electron-main.mjs:5137:17)
    …
  code: 'ENOENT'
```
After: no such blocks; stale previews render as "preview unavailable" silently.
