### PR TITLE
feat(desktop): syntax-highlight .tex/.sty/.bib in file previews and diffs

### DIFF
--- a/apps/desktop/src/lib/markdown-code.test.ts
+++ b/apps/desktop/src/lib/markdown-code.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { isLikelyProseCodeBlock, isLikelyProseFence, isLikelyStructuredText } from './markdown-code'
+import {
+  isLikelyProseCodeBlock,
+  isLikelyProseFence,
+  isLikelyStructuredText,
+  shikiLanguageForFilename
+} from './markdown-code'
 
 describe('isLikelyProseCodeBlock', () => {
   it('detects prose that Streamdown mislabels as an unknown language', () => {
@@ -91,5 +96,26 @@ describe('isLikelyProseFence', () => {
         ].join('\n')
       )
     ).toBe(true)
+  })
+})
+
+describe('shikiLanguageForFilename', () => {
+  it('maps LaTeX sources to the bundled latex grammar', () => {
+    expect(shikiLanguageForFilename('manuscript.tex')).toBe('latex')
+    expect(shikiLanguageForFilename('/papers/ch1/methods.tex')).toBe('latex')
+    expect(shikiLanguageForFilename('journal.sty')).toBe('latex')
+  })
+
+  it('maps BibTeX bibliographies to the bibtex grammar', () => {
+    expect(shikiLanguageForFilename('references.bib')).toBe('bibtex')
+  })
+
+  it('is case-insensitive, like every other extension', () => {
+    expect(shikiLanguageForFilename('MANUSCRIPT.TEX')).toBe('latex')
+  })
+
+  it('still returns an empty string for unknown extensions', () => {
+    expect(shikiLanguageForFilename('notes.unknownext')).toBe('')
+    expect(shikiLanguageForFilename(undefined)).toBe('')
   })
 })

--- a/apps/desktop/src/lib/markdown-code.ts
+++ b/apps/desktop/src/lib/markdown-code.ts
@@ -168,6 +168,7 @@ function filenameExtToken(path: string | undefined): string {
 const SHIKI_LANGUAGE_BY_EXTENSION: Record<string, string> = {
   astro: 'astro',
   bash: 'bash',
+  bib: 'bibtex',
   c: 'c',
   cc: 'cpp',
   cjs: 'javascript',
@@ -223,8 +224,10 @@ const SHIKI_LANGUAGE_BY_EXTENSION: Record<string, string> = {
   scss: 'scss',
   sh: 'bash',
   sql: 'sql',
+  sty: 'latex',
   svelte: 'svelte',
   swift: 'swift',
+  tex: 'latex',
   tf: 'terraform',
   toml: 'toml',
   ts: 'typescript',


### PR DESCRIPTION
## What does this PR do?

Adds `.tex`, `.sty` and `.bib` to `SHIKI_LANGUAGE_BY_EXTENSION`, so LaTeX sources and BibTeX bibliographies get syntax highlighting in the right-rail file preview and in diffs, instead of rendering as flat plain text.

`shikiLanguageForFilename()` currently returns `''` for these extensions, so `preview-file.tsx` falls back to `language: 'text'`:

```ts
language={shikiLanguageForFilename(filePath) || state.language || 'text'}
```

A `.tex` file is not markdown, so the preview correctly picks `SourceView` — the view that carries the clickable line gutter and the ⌘/Ctrl+L "add selection to chat" path. That all works today. What doesn't work is reading the file: a 400-line manuscript renders as one undifferentiated grey block, which makes picking the line range you want to discuss needlessly hard.

`latex`, `bibtex` and `tex` are all in Shiki's `bundledLanguages`, and `shiki-highlighter.tsx` already loads the full bundle:

> loads the `react-shiki` full bundle so all `bundledLanguages` work

so no grammar registration or bundle change is needed — this is purely a missing entry in the lookup table.

For context on who this affects: academic and research users keep their whole working corpus in `.tex` and `.bib`. The table already covers `r`, `jl`, `py`, `nix`, `zig`, `astro` and 50 others; LaTeX is a conspicuous gap for a tool that markets itself for research workflows.

### Extension choices

| Extension | Grammar | Why |
|---|---|---|
| `.tex` | `latex` | LaTeX documents. |
| `.sty` | `latex` | Style/package files are LaTeX source; journals ship these with submission templates. |
| `.bib` | `bibtex` | BibTeX has its own bundled grammar; `latex` would mis-highlight it. |

I deliberately left out `.cls`. It is a LaTeX class file, but `.cls` is also Apex and Visual Basic, and a wrong guess is worse than no highlighting. Happy to add it if maintainers prefer LaTeX as the default reading.

## Related Issue

No existing issue — I searched open and merged PRs and issues for `shiki` / `latex` / `SHIKI_LANGUAGE_BY_EXTENSION` and found no prior art. Filing the PR directly since the change is three lines of data.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/lib/markdown-code.ts` — three entries added to `SHIKI_LANGUAGE_BY_EXTENSION`, in the table's existing alphabetical order (`bib` after `bash`, `sty` after `sql`, `tex` after `swift`).
- `apps/desktop/src/lib/markdown-code.test.ts` — new `describe('shikiLanguageForFilename')` block. The function had no test coverage before; this covers the new mappings, path-qualified filenames, the case-insensitivity that `normalize()` provides, and the unknown-extension/`undefined` fallbacks that callers depend on.

Net: +3 / -0 in the source file.

## How to Test

1. Open a session whose cwd holds a `.tex` file (a `.bib` works too).
2. Click it in the right-rail file tree to preview it.
3. Before this change: plain grey text. After: LaTeX highlighting — commands, math, environments, comments.
4. `cd apps/desktop && npx vitest run src/lib/markdown-code.test.ts`

## Verification I actually ran

Being straightforward about this, since it matters for review: I did **not** run the repo's test suite or build. This change was authored against the GitHub API rather than a local checkout, so I have not executed `vitest`, `tsc`, or the linter.

What I did verify: I extracted the patched `SHIKI_LANGUAGE_BY_EXTENSION` table and re-implemented `filenameExtToken`/`shikiLanguageForFilename` faithfully in a standalone Node script, then ran every assertion from the new test block through it. All nine pass, including the pre-existing `main.py → python` and `a.md → markdown` mappings as regression controls.

That validates the lookup logic and my test expectations. It does not validate formatting against the repo's Prettier/ESLint config, so please flag anything the linter objects to and I will fix it — or push a formatting commit yourself if that is faster.

The runtime risk is low regardless: the change adds keys to a lookup table whose miss path already returns `''`, so any grammar problem degrades to exactly today's behaviour.
