### PR TITLE
chore: map contributor email for watchdog-wave salvages

### DIFF
--- a/contributors/emails/rodrigo.smscom@gmail.com
+++ b/contributors/emails/rodrigo.smscom@gmail.com
@@ -1,0 +1,2 @@
+rodrigogs
+# P1 gateway watchdog wave salvage


### PR DESCRIPTION
AUTHOR_MAP entry for rodrigo.smscom@gmail.com → rodrigogs, needed before the #90502 salvage merges (contributor-audit gate). devops@sycamore.group was already mapped.