### PR TITLE
perf(constants): remember the resolved Hermes home key

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -139,16 +139,51 @@ def get_hermes_home() -> Path:
     return _hermes_home_from_env()
 
 
+# Resolved keys, keyed by the path string that was handed in. Path.resolve()
+# is a filesystem call, and this function sits under every ToolRegistry
+# lookup through current_scope_key(), so without this the registry pays a
+# syscall per lookup. A process only ever sees a handful of home paths, so
+# the dict stays tiny. Only paths that really exist are stored, see below.
+_HOME_KEY_CACHE: dict[str, str] = {}
+
+
 def hermes_home_key(path: str | Path | None = None) -> str:
     """Return a stable key for a Hermes home/profile directory.
 
     Runtime registries use this key to isolate plugin-owned entries while
     keeping built-in registrations process-global.  ``strict=False`` preserves
     useful behavior for profiles whose directories have not been created yet.
+
+    The resolved value is remembered per input path. A directory that does
+    not exist yet is resolved without touching the cache, because the answer
+    can change once it is created, for example when part of the path turns
+    out to be a symlink.
     """
     candidate = Path(path) if path is not None else get_hermes_home()
-    resolved = candidate.expanduser().resolve(strict=False)
-    return os.path.normcase(str(resolved))
+    raw = str(candidate)
+    cached = _HOME_KEY_CACHE.get(raw)
+    if cached is not None:
+        return cached
+    expanded = candidate.expanduser()
+    try:
+        resolved = expanded.resolve(strict=True)
+    except OSError:
+        # Not on disk yet. Fall back to the lenient resolve and do not store
+        # it, so the real answer is picked up once the directory appears.
+        return os.path.normcase(str(expanded.resolve(strict=False)))
+    key = os.path.normcase(str(resolved))
+    _HOME_KEY_CACHE[raw] = key
+    return key
+
+
+def reset_hermes_home_key_cache() -> None:
+    """Forget every remembered home key.
+
+    For tests that move a home directory around on disk under one path.
+    Normal callers never need this: a different home path is a different
+    cache key already.
+    """
+    _HOME_KEY_CACHE.clear()
 
 
 def get_process_hermes_home() -> Path:

--- a/tests/test_hermes_home_key_cache.py
+++ b/tests/test_hermes_home_key_cache.py
@@ -1,0 +1,164 @@
+"""Tests for the remembered results in `hermes_home_key`.
+
+`Path.resolve()` is a filesystem call. `hermes_home_key` sits under
+`ToolRegistry.current_scope_key()`, which runs on every registry lookup, so
+before the results were remembered the registry paid a syscall per lookup.
+
+The value this returns must not change, so most of these tests compare
+against the plain uncached calculation.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+import hermes_constants as hc
+
+
+def _uncached(path=None) -> str:
+    """The calculation as it was before results were remembered."""
+    candidate = Path(path) if path is not None else hc.get_hermes_home()
+    return os.path.normcase(str(candidate.expanduser().resolve(strict=False)))
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    hc.reset_hermes_home_key_cache()
+    yield
+    hc.reset_hermes_home_key_cache()
+
+
+class TestSameAnswerAsBefore:
+    """Remembering a result must not change what comes back."""
+
+    @pytest.mark.parametrize("case", ["real", "missing", "trailing_sep", "dot_dot"])
+    def test_matches_the_uncached_calculation(self, tmp_path, case):
+        (tmp_path / "real").mkdir()
+        target = {
+            "real": str(tmp_path / "real"),
+            "missing": str(tmp_path / "not_there"),
+            "trailing_sep": str(tmp_path / "real") + os.sep,
+            "dot_dot": str(tmp_path / "real" / ".." / "real"),
+        }[case]
+        assert hc.hermes_home_key(target) == _uncached(target)
+
+    def test_matches_for_the_default_home(self):
+        assert hc.hermes_home_key() == _uncached()
+
+    def test_matches_for_a_tilde_path(self):
+        assert hc.hermes_home_key("~") == _uncached("~")
+
+    def test_accepts_a_path_object(self, tmp_path):
+        (tmp_path / "real").mkdir()
+        assert hc.hermes_home_key(tmp_path / "real") == _uncached(tmp_path / "real")
+
+    def test_second_call_returns_the_same_string(self, tmp_path):
+        (tmp_path / "real").mkdir()
+        first = hc.hermes_home_key(str(tmp_path / "real"))
+        second = hc.hermes_home_key(str(tmp_path / "real"))
+        assert first == second == _uncached(str(tmp_path / "real"))
+
+
+class TestWhatGetsRemembered:
+    def test_an_existing_path_is_remembered(self, tmp_path):
+        (tmp_path / "real").mkdir()
+        hc.hermes_home_key(str(tmp_path / "real"))
+        assert len(hc._HOME_KEY_CACHE) == 1
+
+    def test_a_missing_path_is_not_remembered(self, tmp_path):
+        # The answer can change once the directory is created, for example
+        # when part of the path turns out to be a link, so it must not stick.
+        hc.hermes_home_key(str(tmp_path / "not_there"))
+        assert hc._HOME_KEY_CACHE == {}
+
+    def test_a_path_created_later_picks_up_the_real_answer(self, tmp_path):
+        later = tmp_path / "later"
+        before = hc.hermes_home_key(str(later))
+        later.mkdir()
+        after = hc.hermes_home_key(str(later))
+        assert after == _uncached(str(later))
+        assert hc._HOME_KEY_CACHE == {str(later): after}
+        # On a plain directory both answers agree anyway. The point is that
+        # the first one was never stored.
+        assert before == after
+
+    def test_different_paths_get_their_own_entries(self, tmp_path):
+        for name in ("a", "b", "c"):
+            (tmp_path / name).mkdir()
+            hc.hermes_home_key(str(tmp_path / name))
+        assert len(hc._HOME_KEY_CACHE) == 3
+
+    def test_reset_clears_everything(self, tmp_path):
+        (tmp_path / "real").mkdir()
+        hc.hermes_home_key(str(tmp_path / "real"))
+        assert hc._HOME_KEY_CACHE
+        hc.reset_hermes_home_key_cache()
+        assert hc._HOME_KEY_CACHE == {}
+
+
+class TestHomeChanges:
+    def test_pointing_hermes_home_somewhere_else_gives_a_new_key(
+        self, tmp_path, monkeypatch,
+    ):
+        # A different home is a different input path, so it lands on its own
+        # entry rather than reusing the first one.
+        first = tmp_path / "home_one"
+        second = tmp_path / "home_two"
+        first.mkdir()
+        second.mkdir()
+
+        monkeypatch.setenv("HERMES_HOME", str(first))
+        key_one = hc.hermes_home_key()
+        monkeypatch.setenv("HERMES_HOME", str(second))
+        key_two = hc.hermes_home_key()
+
+        assert key_one != key_two
+        assert key_one == _uncached(str(first))
+        assert key_two == _uncached(str(second))
+
+
+class TestSymlinks:
+    def test_a_link_resolves_to_its_target(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        link = tmp_path / "link"
+        try:
+            link.symlink_to(target, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("this platform or account cannot create symlinks")
+        assert hc.hermes_home_key(str(link)) == _uncached(str(link))
+        assert hc.hermes_home_key(str(link)) == hc.hermes_home_key(str(target))
+
+
+class TestRegistryLookupsDoNotHitTheDisk:
+    def test_scope_key_resolves_the_path_once(self, monkeypatch):
+        # The reason this cache exists. ToolRegistry.current_scope_key() runs
+        # on every registry lookup, so it must not resolve the home path on
+        # the filesystem every time.
+        from tools.registry import registry
+
+        calls = {"n": 0}
+        real_resolve = Path.resolve
+
+        def counting_resolve(self, *a, **kw):
+            calls["n"] += 1
+            return real_resolve(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "resolve", counting_resolve)
+
+        registry.current_scope_key()
+        after_first = calls["n"]
+        for _ in range(50):
+            registry.current_scope_key()
+
+        assert calls["n"] == after_first, (
+            f"current_scope_key resolved the path on the filesystem "
+            f"{calls['n'] - after_first} extra times across 50 calls"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What does this PR do?

`hermes_home_key` called `Path.resolve()` on every call, and that is a filesystem call, not string work.

`ToolRegistry.current_scope_key()` calls it, `_merged_tools()` calls that, so every registry lookup went to the disk: `get_entry`, `get_toolset_for_tool`, `get_emoji`, and everything built on them.

Anything that looks up many tools in a row paid for it. Building the deferred-tool catalog for `tool_search` calls `get_entry` once per tool, so with 400 deferrable tools one search did 800 path resolutions.

Profiled on Windows with 400 deferrable tools:

```
build_catalog total   148.0ms
  _classify_source    139.8ms   <- 800 nt._getfinalpathname calls
  tokenizing            3.8ms
```

The path resolving is 94% of it. The BM25 tokenizing that looks like the costly part is under 4ms. It also barely moves with registry size, 130.8ms at 0 entries against 139.8ms at 1500, which rules out the dict copy inside `_merged_tools` as the cause.

The resolved value is now remembered per input path. A process only ever sees a handful of home paths, so the dict stays tiny. On that same catalog build the lookups drop from 132ms to 3.1ms, with one entry cached.

Two things the change is careful about:

- A path that does not exist yet is resolved but not remembered. The answer can change once it is created, for example when part of the path turns out to be a link. So the lenient resolve still runs and the result is handed back without being stored.
- A different home path is a different key. Switching profiles or `HERMES_HOME` gets its own entry rather than reusing a stale one, because the cache is keyed on the path that was handed in.

There is also a `reset_hermes_home_key_cache()` for tests that move a directory around under one path. Normal callers never need it.

## Related Issue

Fixes #92225

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_constants.py`: `hermes_home_key` remembers the resolved value per input path, in a module-level `_HOME_KEY_CACHE`. A path that cannot be resolved strictly falls back to the lenient resolve and is not stored.
- `hermes_constants.py`: new `reset_hermes_home_key_cache()` for tests.
- `tests/test_hermes_home_key_cache.py`: new file, 16 tests.

## How to Test

1. `pytest tests/test_hermes_home_key_cache.py -q` gives 16 passed.
2. Most of the tests compare against the old calculation inlined in the test file, so the returned value is checked to be unchanged rather than just self-consistent. Covered: an existing directory, a missing one, a trailing separator, a `..` segment, the default home, a `~` path, a `Path` object, and a symlink (skipped where the platform or account cannot make one).
3. Behaviour of the cache itself: an existing path is stored, a missing path is not, a path created later picks up the real answer, different paths get their own entries, and reset clears it.
4. Pointing `HERMES_HOME` at a second directory gives a different key, so profile switching does not reuse a stale entry.
5. The test that pins the actual point of this PR counts filesystem calls:

```python
monkeypatch.setattr(Path, "resolve", counting_resolve)
registry.current_scope_key()
after_first = calls["n"]
for _ in range(50):
    registry.current_scope_key()
assert calls["n"] == after_first
```

On `main` that same loop makes 50 extra `Path.resolve` calls. On this branch it makes zero.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.13

I have left the full-suite box unticked rather than tick it loosely. What I have run so far is the new file (16 passed) and a direct comparison of the returned value against the old calculation across the path shapes listed above. This function sits under a lot of the codebase, so a broad `tests/agent` and `tests/tools` comparison against unmodified `main` is running now and I will post the numbers as a comment on this PR. Happy to hold merge until that lands.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A

  The docstring now says what is remembered and why a missing path is not, and the cache has a comment explaining what sits above it.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (no architecture change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

  The syscall is there on every platform, so every platform gains. Windows gains most, because `nt._getfinalpathname` is dearer than `realpath`. Nothing in the change is OS-specific, and `os.path.normcase` still does the same job it did before.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no schema change)

## Screenshots / Logs

Where the time actually went, 400 deferrable tools, before the change:

```
build_catalog total   148.0ms
  _classify_source    139.8ms
  tokenizing            3.8ms
```

`_classify_source` against registry size, showing it is not the dict copy:

```
registry entries      0   ->  classify 130.8ms
registry entries    500   ->  classify 134.5ms
registry entries   1500   ->  classify 139.8ms
```

Same 400-tool classify pass, before and after:

```
before (resolve per call)    132.2ms
after  (remembered)            3.1ms
cache entries: 1
```
