### PR TITLE
fix(vertex): keep Vertex visible in pickers and list Gemini 3.7 Flash

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1885,7 +1885,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
 
     Checks:
       1. active_provider in auth.json matches
-      2. model.provider in config.yaml matches
+      2. model.provider or a provider-specific section in config.yaml matches
       3. Provider-specific env vars are set (e.g. ANTHROPIC_API_KEY)
 
     This is used to gate auto-discovery of external credentials (e.g.
@@ -1912,6 +1912,26 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
         if isinstance(model_cfg, dict):
             cfg_provider = (model_cfg.get("provider") or "").strip().lower()
             if cfg_provider == normalized:
+                return True
+
+        # Vertex has no static API key or credential-pool entry. Its setup flow
+        # instead writes a dedicated ``vertex:`` section, which is still an
+        # explicit provider choice even after the user switches their primary
+        # model elsewhere. Read the raw config so DEFAULT_CONFIG cannot make
+        # Vertex appear explicitly configured for every installation.
+        if normalized == "vertex":
+            from hermes_cli.config import get_env_value, read_raw_config
+
+            vertex_cfg = read_raw_config().get("vertex")
+            if isinstance(vertex_cfg, dict) and any(
+                str(value).strip()
+                for value in vertex_cfg.values()
+                if value is not None
+            ):
+                return True
+            # This variable is specific to Hermes' documented Vertex setup,
+            # unlike ambient GOOGLE_APPLICATION_CREDENTIALS or ADC state.
+            if str(get_env_value("VERTEX_CREDENTIALS_PATH") or "").strip():
                 return True
 
         # MoA presets are explicit model selections too.  A user who configured

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -696,6 +696,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "vertex": [
         "google/gemini-3.1-pro-preview",
         "google/gemini-3-pro-preview",
+        "google/gemini-3.7-flash",
         "google/gemini-3.6-flash",
         "google/gemini-3.5-flash",
         "google/gemini-3.5-flash-lite",

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -75,6 +75,62 @@ def test_returns_true_when_moa_reference_slot_uses_provider(tmp_path, monkeypatc
     assert is_provider_explicitly_configured("anthropic") is True
 
 
+def test_vertex_section_counts_as_explicit_configuration(tmp_path, monkeypatch):
+    """The Vertex setup flow persists its explicit choice under ``vertex:``."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("VERTEX_CREDENTIALS_PATH", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    _write_config(tmp_path, {
+        "model": {"provider": "openrouter", "default": "openai/gpt-5.5"},
+        "vertex": {
+            "project_id": "example-project",
+            "region": "global",
+        },
+    })
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "providers": {},
+        "active_provider": None,
+    })
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("vertex") is True
+
+
+def test_vertex_credentials_path_counts_as_explicit_configuration(tmp_path, monkeypatch):
+    """Hermes' Vertex-specific credential path is an explicit opt-in."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("VERTEX_CREDENTIALS_PATH", "/tmp/example-service-account.json")
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    _write_config(tmp_path, {
+        "model": {"provider": "openrouter", "default": "openai/gpt-5.5"},
+    })
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "providers": {},
+        "active_provider": None,
+    })
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("vertex") is True
+
+
+def test_default_vertex_config_does_not_count_as_explicit(tmp_path, monkeypatch):
+    """Merged defaults alone must not make Vertex visible in every picker."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_config(tmp_path, {
+        "model": {"provider": "openrouter", "default": "openai/gpt-5.5"},
+    })
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "providers": {},
+        "active_provider": None,
+    })
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("vertex") is False
+
+
 def test_stale_env_pool_entry_does_not_count_when_var_unset(tmp_path, monkeypatch):
     """An env-seeded pool entry left in auth.json after the env var was removed
     must not mark the provider configured (#55790): the picker showed removed

--- a/tests/hermes_cli/test_vertex_model_picker.py
+++ b/tests/hermes_cli/test_vertex_model_picker.py
@@ -38,6 +38,7 @@ def test_vertex_appears_when_credentials_configured():
     assert vertex is not None, "vertex should appear when credentials are configured"
     assert vertex["models"], "vertex row must carry the curated model list"
     assert "google/gemini-3-pro-preview" in vertex["models"]
+    assert "google/gemini-3.7-flash" in vertex["models"]
 
 
 def test_vertex_hidden_without_credentials():


### PR DESCRIPTION
## Summary

Two related picker bugs for Google Vertex AI users:

### 1. `is_provider_explicitly_configured("vertex")` always returned False

The gate only recognized:
- `active_provider` in auth.json,
- `model.provider` in config.yaml, or
- provider API-key env vars.

Vertex has **none of these**: its setup flow writes a dedicated `vertex:` config section (project/region — non-secret) and optionally `VERTEX_CREDENTIALS_PATH` in `.env`. Auth is OAuth2 via ADC/service-account, so there is no static key env var either.

Downstream, this gate drives auto-discovery of external credentials, so a fully-configured Vertex install was treated as unconfigured and the provider could vanish from the desktop/`/model` pickers as soon as the user's primary model pointed elsewhere.

**Fix:** treat a non-empty raw `vertex:` config section or a set `VERTEX_CREDENTIALS_PATH` as explicit configuration. Reads the *raw* config so `DEFAULT_CONFIG` cannot make every installation look explicitly configured.

### 2. Gemini 3.7 Flash missing from the Vertex curated catalog

Adds `google/gemini-3.7-flash` to `_PROVIDER_MODELS["vertex"]`. GA on the Gemini API and Vertex AI since 2026-08-13; validated live against a GCP project (`global` region) with both the raw OpenAI-compatible endpoint and Hermes' Vertex runtime path.

## Test Plan

- [x] New regression test: `test_vertex_section_counts_as_explicit_configuration` (+ VERTEX_CREDENTIALS_PATH variant) in `tests/hermes_cli/test_auth_provider_gate.py`
- [x] Extended `tests/hermes_cli/test_vertex_model_picker.py` to assert the curated row carries `google/gemini-3.7-flash`
- [x] Both files pass locally against current `main`: 9/9 targeted, 295 passed across `tests/hermes_cli -k "vertex or provider_gate or model_picker or models"`

## Notes

Observed in practice: `hermes update` autostashes local working-tree changes and resets to origin/main, which silently reverted an identical local patch three times before it was upstreamed here.