### PR TITLE
fix(gateway): scope editable statuses to each turn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -712,6 +712,17 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     return await adapter.send(chat_id, content, metadata=metadata)
 
 
+def _turn_scoped_status_key(
+    event_type: str,
+    session_key: Optional[str],
+    run_generation: Optional[int],
+) -> str:
+    """Return a status cache key that is stable only within one gateway turn."""
+    if not session_key or run_generation is None:
+        return event_type
+    return f"{session_key}:run:{run_generation}:{event_type}"
+
+
 def _approval_send_outcome(future, timeout: float) -> str:
     """Classify an approval prompt send as ``sent`` / ``failed`` / ``ambiguous``.
 

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -760,7 +760,12 @@ class TurnRunner:
             logger.debug("Failed to attach session title callback", exc_info=True)
 
     def _status_callback_sync(self, event_type: str, message: str) -> None:
-        from gateway.run import _prepare_gateway_status_message, _redact_gateway_user_facing_secrets, _send_or_update_status_coro
+        from gateway.run import (
+            _prepare_gateway_status_message,
+            _redact_gateway_user_facing_secrets,
+            _send_or_update_status_coro,
+            _turn_scoped_status_key,
+        )
         ctx = self._ctx
         if not self._status_live():
             return
@@ -772,8 +777,19 @@ class TurnRunner:
                 _redact_gateway_user_facing_secrets(str(message or ""))[:160],
             )
             return
+        status_key = _turn_scoped_status_key(
+            event_type,
+            ctx.session_key,
+            ctx.run_generation,
+        )
         fut = self._schedule(
-            _send_or_update_status_coro(ctx._status_adapter, ctx._status_chat_id, event_type, prepared, ctx._status_thread_metadata),
+            _send_or_update_status_coro(
+                ctx._status_adapter,
+                ctx._status_chat_id,
+                status_key,
+                prepared,
+                ctx._status_thread_metadata,
+            ),
             f"status_callback ({event_type}) scheduling error",
         )
         if fut is not None and ctx._cleanup_progress:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -13,6 +13,8 @@ import time
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Set
+from weakref import WeakValueDictionary
+
 from hermes_cli import setup_platforms
 
 logger = logging.getLogger(__name__)
@@ -523,6 +525,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # bubbles owned by this adapter so subsequent calls with the same key edit the same message instead
         # of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        self._STATUS_MESSAGE_IDS_MAX = 2000
+        # Weak values keep per-key locks bounded after active callers release
+        # their last reference.
+        self._status_locks: WeakValueDictionary[tuple, asyncio.Lock] = (
+            WeakValueDictionary()
+        )
         # Last truncated mid-stream preview per (chat_id, message_id): past the 4096 cap every edit
         # truncates to the SAME text, and resending burns flood budget. Dropped on finalize.
         self._last_overflow_preview: Dict[tuple, str] = {}
@@ -3393,27 +3401,34 @@ class TelegramAdapter(BasePlatformAdapter):
                 error_kind=error_kind)
 
     async def send_or_update_status(
-        self, chat_id: str, status_key: str, content: str, *, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
-        """Send a status message, or edit the previous one with the same ``(chat_id, status_key)``; if the
-        edit fails (deleted, too old, …) the cached id is dropped and a fresh message is sent.
-
-        Issue #30045: progress/status callbacks (context-pressure, lifecycle, compression, etc.) used to
-        append a fresh bubble on every call. With this method, the first call sends and the message id is
-        remembered; subsequent calls with the same (chat_id, status_key) edit that same message in place.
-        """
+        self, chat_id: str, status_key: str, content: str, *, metadata: Optional[Dict[str, Any]] = None
+    ) -> SendResult:
+        """Send or edit the status bubble owned by ``(chat_id, status_key)``."""
         key = (str(chat_id), str(status_key))
-        cached_id = self._status_message_ids.get(key)
-        if cached_id is not None:
-            result = await self.edit_message(chat_id, cached_id, content, finalize=True, metadata=metadata)
-            if result.success:
-                if result.message_id:
-                    self._status_message_ids[key] = str(result.message_id)
-                return result
-            self._status_message_ids.pop(key, None)
-        result = await self.send(chat_id, content, metadata=metadata)
-        if result.success and result.message_id:
-            self._status_message_ids[key] = str(result.message_id)
-        return result
+        lock = self._status_locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._status_locks[key] = lock
+        async with lock:
+            cached_id = self._status_message_ids.get(key)
+            if cached_id is not None:
+                result = await self.edit_message(
+                    chat_id, cached_id, content, finalize=True, metadata=metadata
+                )
+                if result.success:
+                    if result.message_id:
+                        self._status_message_ids[key] = str(result.message_id)
+                    return result
+                self._status_message_ids.pop(key, None)
+            result = await self.send(chat_id, content, metadata=metadata)
+            if result.success and result.message_id:
+                if len(self._status_message_ids) >= self._STATUS_MESSAGE_IDS_MAX:
+                    for stale in list(self._status_message_ids)[
+                        : self._STATUS_MESSAGE_IDS_MAX // 2
+                    ]:
+                        self._status_message_ids.pop(stale, None)
+                self._status_message_ids[key] = str(result.message_id)
+            return result
 
     async def _edit_text(self, chat_id: str, message_id: str, text: str, parse_mode: Any = None) -> None:
         """``editMessageText`` with normalized ids; ``parse_mode=None`` sends plain text."""

--- a/tests/gateway/test_telegram_status_update.py
+++ b/tests/gateway/test_telegram_status_update.py
@@ -1,14 +1,18 @@
-"""Tests for TelegramAdapter.send_or_update_status (issue #30045).
+"""Tests for Telegram status updates (issues #30045 and #92210).
 
 The status-update path must:
   1. Send a fresh message on the first call for a (chat_id, status_key) pair.
   2. Edit that same message on subsequent calls with the same key.
   3. Fall back to sending fresh when the cached message edit fails.
   4. Keep distinct keys independent (no cross-talk).
+  5. Keep gateway keys stable within a turn and distinct across turns/topics.
+  6. Serialize overlapping updates for the same turn.
+  7. Bound cached turn-scoped status-message IDs.
 """
 
 from __future__ import annotations
 
+import asyncio
 import sys
 import types
 from types import SimpleNamespace
@@ -16,8 +20,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import SendResult
+from gateway.run_turn_runner import TurnRunner
+from gateway.turn_context import TurnContext
 
 
 def _install_fake_telegram(monkeypatch):
@@ -106,3 +112,108 @@ async def test_distinct_status_keys_do_not_collide(adapter):
     assert adapter._status_message_ids[("chat-1", "model-switch")] == "200"
 
 
+@pytest.mark.asyncio
+async def test_status_message_id_cache_is_bounded(adapter):
+    adapter._STATUS_MESSAGE_IDS_MAX = 4
+    adapter.send.side_effect = [
+        SendResult(success=True, message_id=str(index)) for index in range(5)
+    ]
+
+    for index in range(5):
+        await adapter.send_or_update_status(
+            "chat-1", f"turn-{index}:lifecycle", f"status {index}"
+        )
+
+    assert len(adapter._status_message_ids) <= adapter._STATUS_MESSAGE_IDS_MAX
+    assert adapter._status_message_ids[("chat-1", "turn-4:lifecycle")] == "4"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_turn_statuses_send_once_then_edit(adapter):
+    """Overlapping callbacks for one turn must not create duplicate bubbles."""
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def delayed_send(*args, **kwargs):
+        send_started.set()
+        await release_send.wait()
+        return SendResult(success=True, message_id="100")
+
+    adapter.send.side_effect = delayed_send
+    first = asyncio.create_task(
+        adapter.send_or_update_status("chat-1", "turn-1:lifecycle", "first")
+    )
+    await send_started.wait()
+    second = asyncio.create_task(
+        adapter.send_or_update_status("chat-1", "turn-1:lifecycle", "second")
+    )
+    await asyncio.sleep(0)
+
+    assert adapter.send.await_count == 1
+    release_send.set()
+    await asyncio.gather(first, second)
+
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_awaited_once()
+
+
+def _status_keys_for_turn(
+    monkeypatch,
+    *,
+    session_key: str,
+    run_generation: int,
+) -> list[str]:
+    captured: list[str] = []
+
+    monkeypatch.setattr(
+        "gateway.run._prepare_gateway_status_message",
+        lambda platform, event_type, message: message,
+    )
+    monkeypatch.setattr(
+        "gateway.run._send_or_update_status_coro",
+        lambda adapter, chat_id, status_key, content, metadata: captured.append(
+            status_key
+        ),
+    )
+    monkeypatch.setattr(
+        "gateway.run.safe_schedule_threadsafe",
+        lambda awaitable, loop, **kwargs: MagicMock(),
+    )
+
+    ctx = TurnContext(
+        source=SimpleNamespace(platform=Platform.TELEGRAM),
+        _run_still_current=lambda: True,
+        session_key=session_key,
+        run_generation=run_generation,
+        _status_adapter=object(),
+        _status_chat_id="chat-1",
+        _loop_for_step=object(),
+    )
+    runner = TurnRunner(MagicMock(), ctx)
+    runner._status_callback_sync("lifecycle", "first status")
+    runner._status_callback_sync("lifecycle", "updated status")
+    return captured
+
+
+def test_lifecycle_status_key_is_stable_within_turn_and_unique_across_turns(
+    monkeypatch,
+) -> None:
+    first_turn = _status_keys_for_turn(
+        monkeypatch,
+        session_key="agent:main:telegram:dm:chat-1:topic-a",
+        run_generation=1,
+    )
+    next_turn = _status_keys_for_turn(
+        monkeypatch,
+        session_key="agent:main:telegram:dm:chat-1:topic-a",
+        run_generation=2,
+    )
+    other_topic = _status_keys_for_turn(
+        monkeypatch,
+        session_key="agent:main:telegram:dm:chat-1:topic-b",
+        run_generation=1,
+    )
+
+    assert first_turn[0] == first_turn[1]
+    assert first_turn[0] != next_turn[0]
+    assert first_turn[0] != other_topic[0]


### PR DESCRIPTION
## What does this PR do?

Scopes editable gateway status-message keys to one session turn instead of reusing a bare event type such as `lifecycle` for the lifetime of the adapter.

The session key identifies the destination lane and the monotonic run generation identifies the turn. Repeated updates of one status type within the same turn still edit one bubble, while a later turn or another topic/session receives a fresh status bubble. Telegram serializes overlapping updates of one key, bounds the status-message cache, and uses weak lock values so turn-scoped bookkeeping does not grow indefinitely.

This restores the per-run behavior intended by #30045 and makes deterministic lifecycle notices such as memory-recall indicators visible in the current Telegram turn.

Related but not duplicate: #47791 adds Telegram topic fields to the adapter key, but does not scope status bubbles to individual turns.

## Related Issue

Fixes #92210

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [x] ♻️ Refactor adaptation (ports the fix to the current decomposed gateway modules)

## Changes Made

- `gateway/run.py`
  - Add the turn-scoped status-key helper.
- `gateway/run_turn_runner.py`
  - Use the session key and run generation when routing editable status updates from the current `TurnRunner` module.
  - Preserve the historical bare event type when no complete gateway turn identity is available.
- `plugins/platforms/telegram/adapter.py`
  - Serialize overlapping updates for one key so two cache misses cannot create duplicate bubbles.
  - Bound the status-message ID cache with a FIFO-half trim.
  - Keep the per-key lock table weakly referenced so completed turn keys are released.
- `tests/gateway/test_telegram_status_update.py`
  - Cover same-turn key stability, cross-turn/topic isolation, concurrent callback serialization, and cache bounds.

## How to Test

```shell
scripts/run_tests.sh \
  tests/gateway/test_telegram_status_update.py \
  tests/gateway/test_telegram_status_indicator.py \
  tests/gateway/test_status_phrases.py \
  tests/gateway/test_slack_status_update.py

uvx ruff==0.15.10 check \
  gateway/run.py \
  gateway/run_turn_runner.py \
  plugins/platforms/telegram/adapter.py \
  tests/gateway/test_telegram_status_update.py

git diff origin/main...HEAD --check
```

Verified after rebuilding on current `main` (`13e72fb205`): **14 passed, 0 failed**; Ruff and diff checks passed.

## Checklist

- [x] Read the contributing and repository instructions
- [x] Conventional commit
- [x] Narrowly scoped change
- [x] Regression tests added
- [x] Tested on Ubuntu 24.04 / Python 3.11.15
- [ ] Full repository suite run

## Screenshots / Logs

No private logs or credentials are required. The bug and fix are covered by deterministic gateway/adapter tests.
