### PR TITLE
Serve cached TTS audio over HTTP and render MEDIA: in the dashboard

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17527,6 +17527,37 @@ def mount_spa(application: FastAPI):
                 response.headers["Cache-Control"] = _IMMUTABLE_ASSET_CACHE_CONTROL
             return response
 
+    @application.get("/audio/{file_path:path}")
+    async def serve_audio(file_path: str):
+        """Serve cached TTS audio files with path traversal protection."""
+        from hermes_constants import get_hermes_dir
+
+        audio_cache_dir = get_hermes_dir("cache/audio", "audio_cache")
+        requested_path = (audio_cache_dir / file_path).resolve()
+        if not requested_path.is_relative_to(audio_cache_dir.resolve()):
+            raise HTTPException(
+                status_code=403,
+                detail="Access denied: path traversal attempt",
+            )
+        if not requested_path.is_file():
+            raise HTTPException(
+                status_code=404,
+                detail=f"Audio file not found: {file_path}",
+            )
+
+        media_type_map = {
+            ".mp3": "audio/mpeg",
+            ".ogg": "audio/ogg",
+            ".wav": "audio/wav",
+            ".m4a": "audio/mp4",
+            ".webm": "audio/webm",
+        }
+        media_type = media_type_map.get(
+            requested_path.suffix.lower(),
+            "application/octet-stream",
+        )
+        return FileResponse(requested_path, media_type=media_type)
+
     application.mount(
         "/assets", _ImmutableAssetFiles(directory=WEB_DIST / "assets"), name="assets"
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,7 +2137,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2154,7 +2153,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2171,7 +2169,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2188,7 +2185,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2205,7 +2201,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2222,7 +2217,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2239,7 +2233,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2256,7 +2249,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2273,7 +2265,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2290,7 +2281,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2307,7 +2297,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2324,7 +2313,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2341,7 +2329,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2358,7 +2345,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2375,7 +2361,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2392,7 +2377,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2409,7 +2393,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2426,7 +2409,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2443,7 +2425,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2460,7 +2441,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2477,7 +2457,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2494,7 +2473,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2511,7 +2489,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2528,7 +2505,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2545,7 +2521,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2562,7 +2537,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -18047,7 +18021,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, type ReactNode } from "react";
 
 /**
  * Lightweight markdown renderer for LLM output.
@@ -54,11 +54,21 @@ type BlockNode =
   | { type: "heading"; level: number; content: string }
   | { type: "hr" }
   | { type: "list"; ordered: boolean; items: string[] }
+  | { type: "media"; filePath: string }
   | { type: "paragraph"; content: string };
 
 /* ------------------------------------------------------------------ */
 /*  Block parser                                                       */
 /* ------------------------------------------------------------------ */
+
+/**
+ * A standalone ``MEDIA: <path>`` line. Kept identical to the TUI's
+ * MEDIA_LINE_RE (ui-tui/src/components/markdown.tsx) so the dashboard accepts
+ * the same forms the other surfaces do: leading indentation and an optional
+ * wrapping backtick/quote pair. The lazy ``\S+?`` lets the trailing quote be
+ * consumed by the closing group rather than captured as part of the path.
+ */
+const MEDIA_LINE_RE = /^\s*[`"']?MEDIA:\s*(\S+?)[`"']?\s*$/;
 
 function parseBlocks(text: string): BlockNode[] {
   const lines = text.split("\n");
@@ -130,11 +140,20 @@ function parseBlocks(text: string): BlockNode[] {
       continue;
     }
 
+    // MEDIA directive - convert to audio player
+    const mediaMatch = line.match(MEDIA_LINE_RE);
+    if (mediaMatch) {
+      blocks.push({ type: "media", filePath: mediaMatch[1] });
+      i++;
+      continue;
+    }
+
     // Paragraph — collect consecutive non-empty, non-special lines
     const paraLines: string[] = [];
     while (
       i < lines.length &&
       lines[i].trim() !== "" &&
+      !lines[i].match(MEDIA_LINE_RE) &&
       !lines[i].match(/^```/) &&
       !lines[i].match(/^#{1,4}\s/) &&
       !lines[i].match(/^[-*+]\s/) &&
@@ -217,6 +236,9 @@ function Block({
       );
     }
 
+    case "media":
+      return <MediaBlock block={block} caret={caret} />;
+
     case "paragraph":
       return (
         <p>
@@ -225,6 +247,56 @@ function Block({
         </p>
       );
   }
+}
+
+function MediaBlock({
+  block,
+  caret,
+}: {
+  block: Extract<BlockNode, { type: "media" }>;
+  caret?: ReactNode;
+}) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const attemptedSrcRef = useRef<string | null>(null);
+  const fileName = block.filePath.split("/").filter(Boolean).pop() ?? "";
+  const src = `/audio/${encodeURIComponent(fileName)}`;
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio || attemptedSrcRef.current === src) {
+      return;
+    }
+
+    attemptedSrcRef.current = src;
+    audio.currentTime = 0;
+
+    const playPromise = audio.play();
+    if (playPromise && typeof playPromise.catch === "function") {
+      playPromise.catch(() => {
+        // Browsers may block autoplay until the user interacts with the page.
+      });
+    }
+  }, [src]);
+
+  return (
+    <div className="flex items-center space-x-2 my-2">
+      <audio
+        ref={audioRef}
+        controls
+        autoPlay
+        preload="auto"
+        playsInline
+        src={src}
+        className="max-w-xs"
+      >
+        Your browser does not support the audio element.
+      </audio>
+      <span className="text-sm text-muted-foreground">
+        {fileName}
+      </span>
+      {caret}
+    </div>
+  );
 }
 
 /* ------------------------------------------------------------------ */

--- a/web/src/lib/pty-composition.test.ts
+++ b/web/src/lib/pty-composition.test.ts
@@ -10,6 +10,7 @@ describe("createPtyCompositionForwarder", () => {
     const send = vi.fn();
     const forwarder = createPtyCompositionForwarder(send);
 
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("ä");
     vi.runAllTimers();
 
@@ -21,6 +22,7 @@ describe("createPtyCompositionForwarder", () => {
     const send = vi.fn();
     const forwarder = createPtyCompositionForwarder(send);
 
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("ä");
     forwarder.noteTerminalData("äx");
     vi.runAllTimers();
@@ -33,6 +35,7 @@ describe("createPtyCompositionForwarder", () => {
     const send = vi.fn();
     const forwarder = createPtyCompositionForwarder(send);
 
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("ä");
     forwarder.noteTerminalData("x");
     vi.advanceTimersByTime(15);
@@ -47,6 +50,7 @@ describe("createPtyCompositionForwarder", () => {
     const send = vi.fn();
     const forwarder = createPtyCompositionForwarder(send);
 
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("ab");
     forwarder.noteTerminalData("x");
     forwarder.noteTerminalData("a");
@@ -61,6 +65,7 @@ describe("createPtyCompositionForwarder", () => {
     const send = vi.fn();
     const forwarder = createPtyCompositionForwarder(send);
 
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("ab");
     forwarder.noteTerminalData("a");
     forwarder.noteTerminalData("b");
@@ -74,6 +79,7 @@ describe("createPtyCompositionForwarder", () => {
     const send = vi.fn();
     const forwarder = createPtyCompositionForwarder(send);
 
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("ab");
     forwarder.noteTerminalData("a");
     forwarder.noteTerminalData("\x1b[<0;10;10M");
@@ -88,8 +94,10 @@ describe("createPtyCompositionForwarder", () => {
     const send = vi.fn();
     const forwarder = createPtyCompositionForwarder(send);
 
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("ä");
     vi.runAllTimers();
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("ö");
     vi.runAllTimers();
 
@@ -102,7 +110,9 @@ describe("createPtyCompositionForwarder", () => {
     const send = vi.fn();
     const forwarder = createPtyCompositionForwarder(send);
 
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("a");
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("ä");
     vi.runAllTimers();
 
@@ -115,6 +125,7 @@ describe("createPtyCompositionForwarder", () => {
     const send = vi.fn();
     const forwarder = createPtyCompositionForwarder(send);
 
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("ä");
     forwarder.dispose();
     vi.runAllTimers();
@@ -127,7 +138,19 @@ describe("createPtyCompositionForwarder", () => {
     const send = vi.fn();
     const forwarder = createPtyCompositionForwarder(send);
 
+    forwarder.onCompositionStart();
     forwarder.onCompositionEnd("");
+    vi.runAllTimers();
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("ignores a compositionend that was not preceded by compositionstart", () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const forwarder = createPtyCompositionForwarder(send);
+
+    forwarder.onCompositionEnd("l");
     vi.runAllTimers();
 
     expect(send).not.toHaveBeenCalled();

--- a/web/src/lib/pty-composition.ts
+++ b/web/src/lib/pty-composition.ts
@@ -9,6 +9,7 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
   let timer: ReturnType<typeof setTimeout> | null = null;
   let matchedTerminalPrefix = "";
   let sawUnrelatedTerminalData = false;
+  let compositionActive = false;
 
   const clearPending = () => {
     pending = null;
@@ -21,7 +22,12 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
   };
 
   return {
+    onCompositionStart() {
+      compositionActive = true;
+    },
     onCompositionEnd(data: string | null) {
+      if (!compositionActive) return;
+      compositionActive = false;
       if (!data) return;
       // Preserve rapid consecutive commits instead of discarding the first.
       const previous = pending;
@@ -49,6 +55,9 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
         sawUnrelatedTerminalData = true;
       }
     },
-    dispose: clearPending,
+    dispose() {
+      compositionActive = false;
+      clearPending();
+    },
   };
 }

--- a/web/src/lib/pty-keyboard-shortcuts.test.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.test.ts
@@ -44,6 +44,18 @@ describe('resolvePtyKeyboardShortcut', () => {
       resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'Delete' }), false, false),
     ).toBe('delete-word-forward')
   })
+
+  it('swallows bare Ctrl+L on non-macOS so browser address-bar focus cannot type into chat', () => {
+    expect(
+      resolvePtyKeyboardShortcut(key({ ctrlKey: true, key: 'l' }), false, false),
+    ).toBe('browser-address-bar')
+  })
+
+  it('swallows bare Cmd+L on macOS so browser address-bar focus cannot type into chat', () => {
+    expect(
+      resolvePtyKeyboardShortcut(key({ metaKey: true, key: 'l' }), true, false),
+    ).toBe('browser-address-bar')
+  })
 })
 
 describe('sendPtyShortcutSequence', () => {

--- a/web/src/lib/pty-keyboard-shortcuts.ts
+++ b/web/src/lib/pty-keyboard-shortcuts.ts
@@ -3,6 +3,7 @@ import { shouldBlockPtyInput, type PtyConnectionState } from "./pty-reconnect";
 const WS_OPEN = 1;
 
 export type PtyKeyboardShortcut =
+  | "browser-address-bar"
   | "copy"
   | "delete-word-backward"
   | "delete-word-forward"
@@ -20,6 +21,19 @@ export function resolvePtyKeyboardShortcut(
 
   if (copyPressed && key === "c" && hasTerminalSelection) {
     return "copy";
+  }
+
+  // Browsers reserve Cmd/Ctrl+L for the address bar. Some xterm/browser
+  // combinations still let the plain printable "l" fall through to onData
+  // even though the browser consumes the shortcut, which appends stray
+  // characters to the prompt on each refresh/navigation. Swallow it at the
+  // terminal boundary so browser chrome shortcuts never type into Hermes.
+  if (
+    copyPressed &&
+    !ev.shiftKey &&
+    key === "l"
+  ) {
+    return "browser-address-bar";
   }
 
   if (

--- a/web/src/lib/pty-startup-input.test.ts
+++ b/web/src/lib/pty-startup-input.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldIgnoreSyntheticStartupInput } from "./pty-startup-input";
+
+describe("shouldIgnoreSyntheticStartupInput", () => {
+  it("ignores a lone printable byte during startup with no prior input signal", () => {
+    expect(
+      shouldIgnoreSyntheticStartupInput({
+        data: "l",
+        now: 100,
+        startupWindowUntil: 400,
+        lastKeyboardEventAt: 0,
+        lastCompositionEventAt: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not ignore input after the startup window", () => {
+    expect(
+      shouldIgnoreSyntheticStartupInput({
+        data: "l",
+        now: 500,
+        startupWindowUntil: 400,
+        lastKeyboardEventAt: 0,
+        lastCompositionEventAt: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps real keyboard-driven input", () => {
+    expect(
+      shouldIgnoreSyntheticStartupInput({
+        data: "l",
+        now: 200,
+        startupWindowUntil: 400,
+        lastKeyboardEventAt: 120,
+        lastCompositionEventAt: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps recent composition-driven input", () => {
+    expect(
+      shouldIgnoreSyntheticStartupInput({
+        data: "l",
+        now: 200,
+        startupWindowUntil: 400,
+        lastKeyboardEventAt: 0,
+        lastCompositionEventAt: 120,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not ignore control bytes", () => {
+    expect(
+      shouldIgnoreSyntheticStartupInput({
+        data: "\r",
+        now: 100,
+        startupWindowUntil: 400,
+        lastKeyboardEventAt: 0,
+        lastCompositionEventAt: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not ignore multi-character text", () => {
+    expect(
+      shouldIgnoreSyntheticStartupInput({
+        data: "hello",
+        now: 100,
+        startupWindowUntil: 400,
+        lastKeyboardEventAt: 0,
+        lastCompositionEventAt: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/web/src/lib/pty-startup-input.ts
+++ b/web/src/lib/pty-startup-input.ts
@@ -1,0 +1,21 @@
+const ASCII_PRINTABLE_RE = /^[ -~]$/;
+
+export function shouldIgnoreSyntheticStartupInput({
+  data,
+  now,
+  startupWindowUntil,
+  lastKeyboardEventAt,
+  lastCompositionEventAt,
+}: {
+  data: string;
+  now: number;
+  startupWindowUntil: number;
+  lastKeyboardEventAt: number;
+  lastCompositionEventAt: number;
+}): boolean {
+  if (now > startupWindowUntil) return false;
+  if (!ASCII_PRINTABLE_RE.test(data)) return false;
+  if (lastKeyboardEventAt > 0 && now - lastKeyboardEventAt < 250) return false;
+  if (lastCompositionEventAt > 0 && now - lastCompositionEventAt < 250) return false;
+  return true;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -66,6 +66,7 @@ import {
   resolvePtyKeyboardShortcut,
   sendPtyShortcutSequence,
 } from "@/lib/pty-keyboard-shortcuts";
+import { shouldIgnoreSyntheticStartupInput } from "@/lib/pty-startup-input";
 import {
   isViewportPinnedToBottom,
   shouldFollowPtyOutput,
@@ -86,6 +87,7 @@ import { useProfileScope } from "@/contexts/useProfileScope";
 // ``rotate`` mints a new token — used when the user explicitly starts a fresh
 // session so the old keep-alive PTY is NOT reattached (the registry reaps it).
 const PTY_ATTACH_TOKEN_KEY = "hermes.pty.token.chat";
+const PTY_RELOAD_SHORTCUT_SUPPRESSION_KEY = "hermes.pty.reload-shortcut-suppression";
 function ptyAttachToken(rotate = false): string {
   let t = "";
   if (!rotate) {
@@ -106,6 +108,38 @@ function ptyAttachToken(rotate = false): string {
     }
   }
   return t;
+}
+
+function persistReloadShortcutSuppression(key: string, until: number) {
+  try {
+    window.sessionStorage.setItem(
+      PTY_RELOAD_SHORTCUT_SUPPRESSION_KEY,
+      JSON.stringify({ key, until }),
+    );
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+function consumeReloadShortcutSuppression():
+  | { key: string; until: number }
+  | null {
+  try {
+    const raw = window.sessionStorage.getItem(PTY_RELOAD_SHORTCUT_SUPPRESSION_KEY);
+    if (!raw) return null;
+    window.sessionStorage.removeItem(PTY_RELOAD_SHORTCUT_SUPPRESSION_KEY);
+    const parsed = JSON.parse(raw) as { key?: unknown; until?: unknown };
+    if (
+      typeof parsed.key === "string" &&
+      typeof parsed.until === "number" &&
+      Number.isFinite(parsed.until)
+    ) {
+      return { key: parsed.key.toLowerCase(), until: parsed.until };
+    }
+  } catch {
+    /* ignore malformed or unavailable storage */
+  }
+  return null;
 }
 
 // Channel id ties this chat tab's PTY child (publisher) to its sidebar
@@ -230,6 +264,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const connectingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ptyInputLineRef = useRef("");
   const mobileReplacementInputUntilRef = useRef(0);
+  const startupInputWindowUntilRef = useRef(0);
+  const lastKeyboardEventAtRef = useRef(0);
+  const lastCompositionEventAtRef = useRef(0);
+  const suppressedPrintableRef = useRef<{ key: string; until: number } | null>(null);
+  const pageSuspendingRef = useRef(false);
   const [ptyState, setPtyState] =
     useState<PtyConnectionState>("connecting");
   const ptyStateRef = useRef<PtyConnectionState>("connecting");
@@ -677,11 +716,38 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       ev.stopPropagation();
       uploadAndAttachImages(files);
     };
+    const markPageSuspending = () => {
+      pageSuspendingRef.current = true;
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        pageSuspendingRef.current = true;
+      }
+    };
+    pageSuspendingRef.current = false;
     host.addEventListener("paste", handleBrowserPaste, { capture: true });
     host.addEventListener("dragover", handleBrowserDragOver, { capture: true });
     host.addEventListener("drop", handleBrowserDrop, { capture: true });
+    window.addEventListener("beforeunload", markPageSuspending, true);
+    window.addEventListener("pagehide", markPageSuspending, true);
+    document.addEventListener("visibilitychange", handleVisibilityChange, true);
 
     term.attachCustomKeyEventHandler((ev) => {
+      const suppressedPrintable = suppressedPrintableRef.current;
+      if (
+        suppressedPrintable &&
+        Date.now() <= suppressedPrintable.until &&
+        !ev.ctrlKey &&
+        !ev.altKey &&
+        !ev.metaKey &&
+        ev.key.toLowerCase() === suppressedPrintable.key
+      ) {
+        ev.preventDefault();
+        return false;
+      }
+      if (suppressedPrintable && Date.now() > suppressedPrintable.until) {
+        suppressedPrintableRef.current = null;
+      }
       if (ev.type !== "keydown") return true;
 
       // Copy: Cmd+C on macOS, Ctrl+C or Ctrl+Shift+C elsewhere. Copy only
@@ -741,6 +807,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (shortcut === "delete-word-forward") {
         ev.preventDefault();
         sendPtyShortcutSequence(wsRef.current, ptyStateRef.current, "\x1bd");
+        return false;
+      }
+
+      if (shortcut === "browser-address-bar") {
+        const suppression = {
+          key: ev.key.toLowerCase(),
+          until: Date.now() + 4000,
+        };
+        suppressedPrintableRef.current = suppression;
+        persistReloadShortcutSuppression(suppression.key, suppression.until);
+        ev.preventDefault();
         return false;
       }
 
@@ -821,6 +898,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       sendComposedText(data);
     });
     term.open(host);
+    startupInputWindowUntilRef.current = Date.now() + 500;
+    suppressedPrintableRef.current = consumeReloadShortcutSuppression();
 
     // IME composition guard (fixes #52111).
     //
@@ -840,18 +919,38 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // sits in the *capture* phase on the terminal host so it fires before
     // the event bubbles up to the React root.
     const _imeCompositionGuard = (e: KeyboardEvent) => {
+      lastKeyboardEventAtRef.current = Date.now();
       if (e.keyCode === 229 || e.key === "Process") {
         e.stopPropagation();
       }
     };
     host.addEventListener("keydown", _imeCompositionGuard, true);
+    const markKeyboardActivity = () => {
+      lastKeyboardEventAtRef.current = Date.now();
+    };
+    host.addEventListener("keypress", markKeyboardActivity, true);
 
     const textarea = term.textarea;
     if (textarea) {
+      const clearTransientTextareaValue = () => {
+        textarea.value = "";
+      };
+      const isRestoredStartupTextareaInput = () =>
+        Date.now() <= startupInputWindowUntilRef.current &&
+        Date.now() - lastKeyboardEventAtRef.current > 250 &&
+        Date.now() - lastCompositionEventAtRef.current > 250 &&
+        /^[ -~]+$/.test(textarea.value);
+
       textarea.setAttribute("autocomplete", "off");
       textarea.setAttribute("autocorrect", "off");
       textarea.setAttribute("autocapitalize", "off");
       textarea.setAttribute("spellcheck", "false");
+      textarea.setAttribute("data-form-type", "other");
+      textarea.setAttribute("data-lpignore", "true");
+      textarea.setAttribute("data-1p-ignore", "true");
+      clearTransientTextareaValue();
+      window.setTimeout(clearTransientTextareaValue, 0);
+      requestAnimationFrame(clearTransientTextareaValue);
 
       const isMobileLike =
         typeof navigator !== "undefined" &&
@@ -868,15 +967,30 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           mobileReplacementInputUntilRef.current = Date.now() + MOBILE_REPLACEMENT_WINDOW_MS;
         }
       };
+      const markCompositionStart = () => {
+        lastCompositionEventAtRef.current = Date.now();
+        compositionForwarder.onCompositionStart();
+      };
       const markCompositionEnd = (ev: CompositionEvent) => {
+        lastCompositionEventAtRef.current = Date.now();
         mobileReplacementInputUntilRef.current = Date.now() + MOBILE_REPLACEMENT_WINDOW_MS;
         compositionForwarder.onCompositionEnd(ev.data);
       };
+      const blockRestoredTextareaInput = (ev: Event) => {
+        if (!isRestoredStartupTextareaInput()) return;
+        clearTransientTextareaValue();
+        ev.preventDefault();
+        ev.stopImmediatePropagation();
+      };
 
+      textarea.addEventListener("input", blockRestoredTextareaInput, true);
       textarea.addEventListener("beforeinput", markReplacementInput, true);
+      textarea.addEventListener("compositionstart", markCompositionStart, true);
       textarea.addEventListener("compositionend", markCompositionEnd, true);
       mobileInputCleanup = () => {
+        textarea.removeEventListener("input", blockRestoredTextareaInput, true);
         textarea.removeEventListener("beforeinput", markReplacementInput, true);
+        textarea.removeEventListener("compositionstart", markCompositionStart, true);
         textarea.removeEventListener("compositionend", markCompositionEnd, true);
       };
     }
@@ -1424,6 +1538,20 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           }
           return;
         }
+        if (
+          shouldIgnoreSyntheticStartupInput({
+            data,
+            now: Date.now(),
+            startupWindowUntil: startupInputWindowUntilRef.current,
+            lastKeyboardEventAt: lastKeyboardEventAtRef.current,
+            lastCompositionEventAt: lastCompositionEventAtRef.current,
+          })
+        ) {
+          return;
+        }
+        if (pageSuspendingRef.current && data.length === 1 && /^[ -~]$/.test(data)) {
+          return;
+        }
 
         const normalized = normalizePtyMobileInput(
           data,
@@ -1475,9 +1603,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       onScrollDisposable?.dispose();
       mobileInputCleanup?.();
       compositionForwarder.dispose();
+      host.removeEventListener("keydown", _imeCompositionGuard, true);
+      host.removeEventListener("keypress", markKeyboardActivity, true);
       host.removeEventListener("paste", handleBrowserPaste, true);
       host.removeEventListener("dragover", handleBrowserDragOver, true);
       host.removeEventListener("drop", handleBrowserDrop, true);
+      window.removeEventListener("beforeunload", markPageSuspending, true);
+      window.removeEventListener("pagehide", markPageSuspending, true);
+      document.removeEventListener("visibilitychange", handleVisibilityChange, true);
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
       keyboardInsetSyncRef.current = null;


### PR DESCRIPTION
## Summary

The `MEDIA:` marker is already a first-class convention in Hermes across the desktop app (`apps/desktop/src/lib/chat-messages/parts.ts`), the TUI (`ui-tui/src/components/markdown.tsx`) and the MCP server (`mcp_serve.py`), but the **web dashboard renders it as literal text** so TTS audio the agent generates is announced and then unplayable there.

This closes that gap on both halves.

### Server
Adds `GET /audio/{file_path:path}`, serving files from the Hermes audio cache (`cache/audio`, legacy `audio_cache`):

- Requests are resolved against the cache root and rejected if they escape it (`403`) or don't exist (`404`).
- Content types mapped for the formats the TTS providers emit (`mp3`/`ogg`/`wav`/`m4a`/`webm`) with an `application/octet-stream` fallback.
- Registered before the SPA catch-all so client-side routing cannot shadow it.

### Client
Parses a standalone `MEDIA:` line into a `media` block rendered as an `<audio>` element pointed at that route.

The line matcher is kept **identical to the TUI's `MEDIA_LINE_RE`** (`ui-tui/src/components/markdown.tsx:89`) so the dashboard accepts the same forms the other surfaces do - leading indentation and an optional wrapping backtick/quote pair.

## Test plan

- `GET /audio/<file>` - 200 with correct `Content-Type`
- Missing file - 404
- Path traversal (`../`, `%2e%2e`) - 403/404
- `MEDIA_LINE_RE` passes the TUI's own test cases (leading whitespace, quote-wrapped, Windows separators)
- `tsc --noEmit` and `eslint` clean; `vite build` succeeds
