### PR TITLE
fix(memory): prevent silent loss of external provider writes

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1875,7 +1875,18 @@ def init_agent(
             if _mem_provider_name and _mem_provider_name.strip():
                 from agent.memory_manager import MemoryManager as _MemoryManager
                 from plugins.memory import load_memory_provider as _load_mem
-                agent._memory_manager = _MemoryManager()
+                agent._memory_manager = _MemoryManager(
+                    external_write_alerts=bool(
+                        mem_config.get("alert_on_provider_write_failure", False)
+                    ),
+                    warning_callback=agent._emit_warning,
+                    outbox_max_entries=int(
+                        mem_config.get("provider_write_outbox_max_entries", 1000)
+                    ),
+                    alert_cooldown_seconds=float(
+                        mem_config.get("provider_write_alert_cooldown_seconds", 3600)
+                    ),
+                )
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
                     agent._memory_manager.add_provider(_mp)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3201,7 +3201,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             # All gating/op-expansion lives behind the manager interface
             # (MemoryManager.notify_memory_tool_write).
             if agent._memory_manager:
-                agent._memory_manager.notify_memory_tool_write(
+                mirror_result = agent._memory_manager.notify_memory_tool_write(
                     result,
                     next_args,
                     build_metadata=lambda: agent._build_memory_write_metadata(
@@ -3209,6 +3209,8 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                         tool_call_id=tool_call_id,
                     ),
                 )
+                if mirror_result is not None:
+                    result = mirror_result
             return _finish_agent_tool(result, next_args)
     elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
         def _execute(next_args: dict) -> Any:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -1097,7 +1097,20 @@ class MemoryManager:
         for provider in self._providers:
             if provider.name == "builtin":
                 continue
-            self._replay_provider_writes(provider)
+            replay = self._replay_provider_writes(provider)
+            if replay["remaining"]:
+                error = replay["error"] or "provider write replay is already in progress"
+                queued = self._queue_provider_write(
+                    provider.name, action, target, content, dict(metadata or {})
+                )
+                failures.append({
+                    "provider": provider.name,
+                    "success": False,
+                    "queued": queued,
+                    "error": error[:500],
+                })
+                self._alert_external_write_failure(provider.name, error, queued)
+                continue
             try:
                 self._deliver_memory_write(
                     provider, action, target, content, dict(metadata or {})
@@ -1109,30 +1122,9 @@ class MemoryManager:
                     "Memory provider '%s' on_memory_write failed: %s",
                     provider.name, e,
                 )
-                queued = False
-                try:
-                    if self._write_outbox is not None:
-                        enqueue_result = self._write_outbox.enqueue(
-                            provider.name,
-                            action,
-                            target,
-                            content,
-                            dict(metadata or {}),
-                        )
-                        queued = bool(enqueue_result["queued"])
-                        if enqueue_result["dropped"]:
-                            logger.warning(
-                                "Memory provider '%s' outbox reached its %d-entry bound; "
-                                "dropped %d oldest write(s)",
-                                provider.name,
-                                self._outbox_max_entries,
-                                enqueue_result["dropped"],
-                            )
-                except Exception:
-                    logger.exception(
-                        "Failed to persist memory write for provider '%s'",
-                        provider.name,
-                    )
+                queued = self._queue_provider_write(
+                    provider.name, action, target, content, dict(metadata or {})
+                )
                 failures.append({
                     "provider": provider.name,
                     "success": False,
@@ -1141,6 +1133,33 @@ class MemoryManager:
                 })
                 self._alert_external_write_failure(provider.name, str(e), queued)
         return failures
+
+    def _queue_provider_write(
+        self,
+        provider: str,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Dict[str, Any],
+    ) -> bool:
+        try:
+            if self._write_outbox is None:
+                return False
+            enqueue_result = self._write_outbox.enqueue(
+                provider, action, target, content, metadata
+            )
+            if enqueue_result["dropped"]:
+                logger.warning(
+                    "Memory provider '%s' outbox reached its %d-entry bound; "
+                    "dropped %d oldest write(s)",
+                    provider,
+                    self._outbox_max_entries,
+                    enqueue_result["dropped"],
+                )
+            return bool(enqueue_result["queued"])
+        except Exception:
+            logger.exception("Failed to persist memory write for provider '%s'", provider)
+            return False
 
     def _deliver_memory_write(
         self,
@@ -1158,9 +1177,9 @@ class MemoryManager:
         else:
             provider.on_memory_write(action, target, content)
 
-    def _replay_provider_writes(self, provider: MemoryProvider) -> None:
+    def _replay_provider_writes(self, provider: MemoryProvider) -> Dict[str, Any]:
         if self._write_outbox is None or provider.name == "builtin":
-            return
+            return {"replayed": 0, "remaining": 0, "error": "", "blocked": False}
         result = self._write_outbox.replay(
             provider.name,
             lambda action, target, content, metadata: self._deliver_memory_write(
@@ -1180,6 +1199,7 @@ class MemoryManager:
                 result["remaining"],
                 result["error"],
             )
+        return result
 
     def _alert_external_write_failure(self, provider: str, error: str, queued: bool) -> None:
         if (

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -1148,13 +1148,14 @@ class MemoryManager:
             enqueue_result = self._write_outbox.enqueue(
                 provider, action, target, content, metadata
             )
-            if enqueue_result["dropped"]:
+            if enqueue_result["dropped"] or enqueue_result.get("overflow"):
                 logger.warning(
                     "Memory provider '%s' outbox reached its %d-entry bound; "
-                    "dropped %d oldest write(s)",
+                    "discarded %d unclaimed write(s), with %d entry(s) still over bound",
                     provider,
                     self._outbox_max_entries,
                     enqueue_result["dropped"],
+                    enqueue_result.get("overflow", 0),
                 )
             return bool(enqueue_result["queued"])
         except Exception:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -34,6 +34,7 @@ from concurrent.futures import Future, ThreadPoolExecutor, wait
 from typing import Any, Callable, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
+from agent.memory_write_outbox import MemoryWriteOutbox
 from agent.skill_commands import extract_user_instruction_from_skill_message
 from tools.registry import tool_error
 
@@ -368,7 +369,15 @@ class MemoryManager:
     provider is allowed.  Failures in one provider never block the other.
     """
 
-    def __init__(self, *, external_prefetch_timeout: Optional[float] = None) -> None:
+    def __init__(
+        self,
+        *,
+        external_prefetch_timeout: Optional[float] = None,
+        external_write_alerts: bool = False,
+        warning_callback: Optional[Callable[[str], None]] = None,
+        outbox_max_entries: int = 1000,
+        alert_cooldown_seconds: float = 3600.0,
+    ) -> None:
         self._providers: List[MemoryProvider] = []
         self._tool_to_provider: Dict[str, MemoryProvider] = {}
         self._has_external: bool = False  # True once a non-builtin provider is added
@@ -398,6 +407,11 @@ class MemoryManager:
             "abandoned_prefetches": 0,
             "active_tasks": 0,
         }
+        self._external_write_alerts = bool(external_write_alerts)
+        self._warning_callback = warning_callback
+        self._outbox_max_entries = max(1, int(outbox_max_entries))
+        self._alert_cooldown_seconds = max(0.0, float(alert_cooldown_seconds))
+        self._write_outbox: Optional[MemoryWriteOutbox] = None
 
     # -- Registration --------------------------------------------------------
 
@@ -1072,29 +1086,117 @@ class MemoryManager:
         target: str,
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
-    ) -> None:
+    ) -> List[Dict[str, Any]]:
         """Notify external providers when the built-in memory tool writes.
 
         Skips the builtin provider itself (it's the source of the write).
+        Failed mirrors are persisted and returned so the tool result can make
+        the degraded external write visible without undoing the built-in write.
         """
+        failures: List[Dict[str, Any]] = []
         for provider in self._providers:
             if provider.name == "builtin":
                 continue
+            self._replay_provider_writes(provider)
             try:
-                metadata_mode = self._provider_memory_write_metadata_mode(provider)
-                if metadata_mode == "keyword":
-                    provider.on_memory_write(
-                        action, target, content, metadata=dict(metadata or {})
-                    )
-                elif metadata_mode == "positional":
-                    provider.on_memory_write(action, target, content, dict(metadata or {}))
-                else:
-                    provider.on_memory_write(action, target, content)
+                self._deliver_memory_write(
+                    provider, action, target, content, dict(metadata or {})
+                )
+                if self._write_outbox and self._write_outbox.pending_count(provider.name) == 0:
+                    self._write_outbox.clear_alert(provider.name)
             except Exception as e:
-                logger.debug(
+                logger.warning(
                     "Memory provider '%s' on_memory_write failed: %s",
                     provider.name, e,
                 )
+                queued = False
+                try:
+                    if self._write_outbox is not None:
+                        enqueue_result = self._write_outbox.enqueue(
+                            provider.name,
+                            action,
+                            target,
+                            content,
+                            dict(metadata or {}),
+                        )
+                        queued = bool(enqueue_result["queued"])
+                        if enqueue_result["dropped"]:
+                            logger.warning(
+                                "Memory provider '%s' outbox reached its %d-entry bound; "
+                                "dropped %d oldest write(s)",
+                                provider.name,
+                                self._outbox_max_entries,
+                                enqueue_result["dropped"],
+                            )
+                except Exception:
+                    logger.exception(
+                        "Failed to persist memory write for provider '%s'",
+                        provider.name,
+                    )
+                failures.append({
+                    "provider": provider.name,
+                    "success": False,
+                    "queued": queued,
+                    "error": str(e)[:500],
+                })
+                self._alert_external_write_failure(provider.name, str(e), queued)
+        return failures
+
+    def _deliver_memory_write(
+        self,
+        provider: MemoryProvider,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Dict[str, Any],
+    ) -> None:
+        metadata_mode = self._provider_memory_write_metadata_mode(provider)
+        if metadata_mode == "keyword":
+            provider.on_memory_write(action, target, content, metadata=dict(metadata))
+        elif metadata_mode == "positional":
+            provider.on_memory_write(action, target, content, dict(metadata))
+        else:
+            provider.on_memory_write(action, target, content)
+
+    def _replay_provider_writes(self, provider: MemoryProvider) -> None:
+        if self._write_outbox is None or provider.name == "builtin":
+            return
+        result = self._write_outbox.replay(
+            provider.name,
+            lambda action, target, content, metadata: self._deliver_memory_write(
+                provider, action, target, content, metadata
+            ),
+        )
+        if result["replayed"]:
+            logger.info(
+                "Replayed %d queued memory write(s) to provider '%s'",
+                result["replayed"],
+                provider.name,
+            )
+        if result["error"]:
+            logger.warning(
+                "Memory provider '%s' outbox replay paused with %d write(s) pending: %s",
+                provider.name,
+                result["remaining"],
+                result["error"],
+            )
+
+    def _alert_external_write_failure(self, provider: str, error: str, queued: bool) -> None:
+        if (
+            not self._external_write_alerts
+            or self._warning_callback is None
+            or self._write_outbox is None
+            or not self._write_outbox.should_alert(provider, self._alert_cooldown_seconds)
+        ):
+            return
+        recovery = "queued for replay" if queued else "could not be queued"
+        try:
+            self._warning_callback(
+                f"⚠ External memory provider '{provider}' write failed and was {recovery}: "
+                f"{error[:300]}"
+            )
+        except Exception:
+            logger.debug("Memory provider write warning callback failed", exc_info=True)
 
     # Actions the bridge mirrors to external providers. The built-in memory
     # tool can also return non-mutating shapes (errors, staged-for-approval
@@ -1126,7 +1228,7 @@ class MemoryManager:
         tool_args: Dict[str, Any],
         *,
         build_metadata: Optional[Callable[[], Dict[str, Any]]] = None,
-    ) -> None:
+    ) -> Any:
         """Mirror a built-in memory tool call to external providers.
 
         This is the single entry point the agent loop calls after running the
@@ -1144,7 +1246,7 @@ class MemoryManager:
         mirrored op.
         """
         if not self._memory_tool_result_succeeded(tool_result):
-            return
+            return tool_result
 
         target = str(tool_args.get("target") or "memory")
         operations = tool_args.get("operations")
@@ -1157,6 +1259,7 @@ class MemoryManager:
                 "old_text": tool_args.get("old_text"),
             }]
 
+        failures: List[Dict[str, Any]] = []
         for op in raw_operations:
             if not isinstance(op, dict):
                 continue
@@ -1168,14 +1271,29 @@ class MemoryManager:
                 old_text = op.get("old_text")
                 if old_text:
                     metadata["old_text"] = str(old_text)
-                self.on_memory_write(
+                failures.extend(self.on_memory_write(
                     action,
                     target,
                     str(op.get("content") or ""),
                     metadata=metadata,
-                )
+                ))
             except Exception as e:
-                logger.debug("notify_memory_tool_write failed for op %s: %s", action, e)
+                logger.warning("notify_memory_tool_write failed for op %s: %s", action, e)
+
+        if not failures:
+            return tool_result
+        parsed = tool_result
+        was_json = isinstance(tool_result, str)
+        if was_json:
+            try:
+                parsed = json.loads(tool_result)
+            except Exception:
+                return tool_result
+        if not isinstance(parsed, dict):
+            return tool_result
+        parsed = dict(parsed)
+        parsed["external_provider_writes"] = failures
+        return json.dumps(parsed, ensure_ascii=False) if was_json else parsed
 
     def on_delegation(self, task: str, result: str, *,
                       child_session_id: str = "", **kwargs) -> None:
@@ -1281,9 +1399,14 @@ class MemoryManager:
         if "hermes_home" not in kwargs:
             from hermes_constants import get_hermes_home
             kwargs["hermes_home"] = str(get_hermes_home())
+        self._write_outbox = MemoryWriteOutbox(
+            kwargs["hermes_home"],
+            max_entries_per_provider=self._outbox_max_entries,
+        )
         for provider in self._providers:
             try:
                 provider.initialize(session_id=session_id, **kwargs)
+                self._replay_provider_writes(provider)
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' initialize failed: %s",

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -383,6 +383,13 @@ class MemoryProvider(ABC):
           ``parent_session_id``, ``platform``, and ``tool_name``.
 
         Use to mirror built-in memory writes to your backend.
+
+        Raise an exception when the write does not reach durable provider
+        storage. MemoryManager logs the failure, exposes it in the memory tool
+        result, and queues the intent locally for bounded replay. Providers
+        that move work to a background thread must propagate asynchronous
+        failures to their own durable retry mechanism; returning successfully
+        declares that the provider accepted durable responsibility for it.
         """
 
     def backup_paths(self) -> List[str]:

--- a/agent/memory_write_outbox.py
+++ b/agent/memory_write_outbox.py
@@ -1,0 +1,195 @@
+"""Profile-scoped durable outbox for external memory-provider mirrors."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict
+
+
+class MemoryWriteOutbox:
+    """Persist failed provider writes and replay them in FIFO order."""
+
+    def __init__(self, hermes_home: str | Path, *, max_entries_per_provider: int = 1000) -> None:
+        self._path = Path(hermes_home) / "memories" / "provider_write_outbox.sqlite3"
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._max_entries = max(1, int(max_entries_per_provider))
+        self._lock = threading.RLock()
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._path), timeout=10)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _initialize(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS pending_writes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    provider TEXT NOT NULL,
+                    fingerprint TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    target TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    last_error TEXT NOT NULL DEFAULT '',
+                    UNIQUE(provider, fingerprint)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS provider_alerts (
+                    provider TEXT PRIMARY KEY,
+                    last_alert_at REAL NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pending_provider_fifo "
+                "ON pending_writes(provider, id)"
+            )
+
+    @staticmethod
+    def _fingerprint(
+        action: str,
+        target: str,
+        content: str,
+        metadata: Dict[str, Any],
+    ) -> str:
+        # Provenance (session/tool-call ids) changes when the agent retries the
+        # same intent. Only old_text affects replace/remove write semantics.
+        payload = json.dumps(
+            [action, target, content, metadata.get("old_text", "")],
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            default=str,
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def enqueue(
+        self,
+        provider: str,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Insert one write intent, deduplicate it, and enforce the bound."""
+        metadata = dict(metadata or {})
+        metadata_json = json.dumps(metadata, sort_keys=True, ensure_ascii=False, default=str)
+        fingerprint = self._fingerprint(action, target, content, metadata)
+        with self._lock, self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            cursor = conn.execute(
+                """
+                INSERT OR IGNORE INTO pending_writes
+                    (provider, fingerprint, action, target, content, metadata_json, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (provider, fingerprint, action, target, content, metadata_json, time.time()),
+            )
+            inserted = cursor.rowcount == 1
+            before = conn.execute(
+                "SELECT COUNT(*) FROM pending_writes WHERE provider = ?", (provider,)
+            ).fetchone()[0]
+            conn.execute(
+                """
+                DELETE FROM pending_writes
+                WHERE provider = ? AND id NOT IN (
+                    SELECT id FROM pending_writes
+                    WHERE provider = ? ORDER BY id DESC LIMIT ?
+                )
+                """,
+                (provider, provider, self._max_entries),
+            )
+            after = conn.execute(
+                "SELECT COUNT(*) FROM pending_writes WHERE provider = ?", (provider,)
+            ).fetchone()[0]
+        return {
+            "queued": True,
+            "deduplicated": not inserted,
+            "dropped": max(0, before - after),
+        }
+
+    def pending_count(self, provider: str) -> int:
+        with self._lock, self._connect() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM pending_writes WHERE provider = ?", (provider,)
+            ).fetchone()
+        return int(row[0])
+
+    def replay(
+        self,
+        provider: str,
+        deliver: Callable[[str, str, str, Dict[str, Any]], None],
+    ) -> Dict[str, Any]:
+        """Replay queued writes until the provider fails, preserving FIFO order."""
+        replayed = 0
+        with self._lock:
+            while True:
+                with self._connect() as conn:
+                    row = conn.execute(
+                        """
+                        SELECT id, action, target, content, metadata_json
+                        FROM pending_writes WHERE provider = ? ORDER BY id LIMIT 1
+                        """,
+                        (provider,),
+                    ).fetchone()
+                if row is None:
+                    self.clear_alert(provider)
+                    return {"replayed": replayed, "remaining": 0, "error": ""}
+                try:
+                    metadata = json.loads(row["metadata_json"])
+                    deliver(row["action"], row["target"], row["content"], metadata)
+                except Exception as exc:
+                    error = str(exc)
+                    with self._connect() as conn:
+                        conn.execute(
+                            """
+                            UPDATE pending_writes
+                            SET attempts = attempts + 1, last_error = ? WHERE id = ?
+                            """,
+                            (error, row["id"]),
+                        )
+                    return {
+                        "replayed": replayed,
+                        "remaining": self.pending_count(provider),
+                        "error": error,
+                    }
+                with self._connect() as conn:
+                    conn.execute("DELETE FROM pending_writes WHERE id = ?", (row["id"],))
+                replayed += 1
+
+    def should_alert(self, provider: str, cooldown_seconds: float) -> bool:
+        """Persistently rate-limit alerts across short-lived agent instances."""
+        now = time.time()
+        cooldown = max(0.0, float(cooldown_seconds))
+        with self._lock, self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT last_alert_at FROM provider_alerts WHERE provider = ?", (provider,)
+            ).fetchone()
+            if row is not None and now - float(row[0]) < cooldown:
+                return False
+            conn.execute(
+                """
+                INSERT INTO provider_alerts(provider, last_alert_at) VALUES (?, ?)
+                ON CONFLICT(provider) DO UPDATE SET last_alert_at = excluded.last_alert_at
+                """,
+                (provider, now),
+            )
+        return True
+
+    def clear_alert(self, provider: str) -> None:
+        with self._lock, self._connect() as conn:
+            conn.execute("DELETE FROM provider_alerts WHERE provider = ?", (provider,))

--- a/agent/memory_write_outbox.py
+++ b/agent/memory_write_outbox.py
@@ -125,23 +125,40 @@ class MemoryWriteOutbox:
             before = conn.execute(
                 "SELECT COUNT(*) FROM pending_writes WHERE provider = ?", (provider,)
             ).fetchone()[0]
-            conn.execute(
-                """
-                DELETE FROM pending_writes
-                WHERE provider = ? AND id NOT IN (
+            overflow = max(0, before - self._max_entries)
+            dropped = 0
+            if overflow:
+                # A leased row may still be inside a provider callback. Never
+                # evict it: doing so makes a later callback failure impossible
+                # to release/replay. Prefer the oldest unclaimed rows, which
+                # also causes a newly inserted row to be rejected when every
+                # older row is in flight.
+                eligible = conn.execute(
+                    """
                     SELECT id FROM pending_writes
-                    WHERE provider = ? ORDER BY id DESC LIMIT ?
-                )
-                """,
-                (provider, provider, self._max_entries),
-            )
+                    WHERE provider = ? AND claim_token = ''
+                    ORDER BY id LIMIT ?
+                    """,
+                    (provider, overflow),
+                ).fetchall()
+                if eligible:
+                    placeholders = ",".join("?" for _ in eligible)
+                    dropped = conn.execute(
+                        f"DELETE FROM pending_writes WHERE id IN ({placeholders})",
+                        tuple(row["id"] for row in eligible),
+                    ).rowcount
             after = conn.execute(
                 "SELECT COUNT(*) FROM pending_writes WHERE provider = ?", (provider,)
             ).fetchone()[0]
+            queued = conn.execute(
+                "SELECT 1 FROM pending_writes WHERE provider = ? AND fingerprint = ?",
+                (provider, fingerprint),
+            ).fetchone() is not None
         return {
-            "queued": True,
+            "queued": queued,
             "deduplicated": not inserted,
-            "dropped": max(0, before - after),
+            "dropped": dropped,
+            "overflow": max(0, after - self._max_entries),
         }
 
     def pending_count(self, provider: str) -> int:
@@ -207,13 +224,49 @@ class MemoryWriteOutbox:
                         "error": "",
                         "blocked": True,
                     }
+                stop_renewal = threading.Event()
+                ownership_lost = threading.Event()
+                renewal_interval = min(5.0, max(0.05, self._claim_lease_seconds / 3.0))
+
+                def _renew_claim() -> None:
+                    while not stop_renewal.wait(renewal_interval):
+                        try:
+                            with self._connect() as renewal_conn:
+                                renewed = renewal_conn.execute(
+                                    """
+                                    UPDATE pending_writes SET claim_until = ?
+                                    WHERE id = ? AND claim_token = ?
+                                    """,
+                                    (
+                                        time.time() + self._claim_lease_seconds,
+                                        row["id"],
+                                        claim_token,
+                                    ),
+                                ).rowcount
+                            if renewed != 1:
+                                ownership_lost.set()
+                                return
+                        except sqlite3.Error:
+                            # A transient SQLite writer can consume one renewal
+                            # interval. Keep trying; the guarded final mutation
+                            # below is the authority on ownership.
+                            continue
+
+                renewer = threading.Thread(
+                    target=_renew_claim,
+                    daemon=True,
+                    name=f"memory-outbox-lease-{provider}",
+                )
+                renewer.start()
                 try:
                     metadata = json.loads(row["metadata_json"])
                     deliver(row["action"], row["target"], row["content"], metadata)
                 except Exception as exc:
+                    stop_renewal.set()
+                    renewer.join()
                     error = str(exc)
                     with self._connect() as conn:
-                        conn.execute(
+                        released = conn.execute(
                             """
                             UPDATE pending_writes
                             SET attempts = attempts + 1, last_error = ?,
@@ -221,18 +274,27 @@ class MemoryWriteOutbox:
                             WHERE id = ? AND claim_token = ?
                             """,
                             (error, row["id"], claim_token),
-                        )
+                        ).rowcount
                     return {
                         "replayed": replayed,
                         "remaining": self.pending_count(provider),
                         "error": error,
-                        "blocked": False,
+                        "blocked": released != 1 or ownership_lost.is_set(),
                     }
+                stop_renewal.set()
+                renewer.join()
                 with self._connect() as conn:
-                    conn.execute(
+                    deleted = conn.execute(
                         "DELETE FROM pending_writes WHERE id = ? AND claim_token = ?",
                         (row["id"], claim_token),
-                    )
+                    ).rowcount
+                if deleted != 1 or ownership_lost.is_set():
+                    return {
+                        "replayed": replayed,
+                        "remaining": self.pending_count(provider),
+                        "error": "provider write claim ownership was lost during delivery",
+                        "blocked": True,
+                    }
                 replayed += 1
 
     def should_alert(self, provider: str, cooldown_seconds: float) -> bool:

--- a/agent/memory_write_outbox.py
+++ b/agent/memory_write_outbox.py
@@ -7,6 +7,7 @@ import json
 import sqlite3
 import threading
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict
 
@@ -14,10 +15,17 @@ from typing import Any, Callable, Dict
 class MemoryWriteOutbox:
     """Persist failed provider writes and replay them in FIFO order."""
 
-    def __init__(self, hermes_home: str | Path, *, max_entries_per_provider: int = 1000) -> None:
+    def __init__(
+        self,
+        hermes_home: str | Path,
+        *,
+        max_entries_per_provider: int = 1000,
+        claim_lease_seconds: float = 300.0,
+    ) -> None:
         self._path = Path(hermes_home) / "memories" / "provider_write_outbox.sqlite3"
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._max_entries = max(1, int(max_entries_per_provider))
+        self._claim_lease_seconds = max(1.0, float(claim_lease_seconds))
         self._lock = threading.RLock()
         self._initialize()
 
@@ -41,6 +49,8 @@ class MemoryWriteOutbox:
                     created_at REAL NOT NULL,
                     attempts INTEGER NOT NULL DEFAULT 0,
                     last_error TEXT NOT NULL DEFAULT '',
+                    claim_token TEXT NOT NULL DEFAULT '',
+                    claim_until REAL NOT NULL DEFAULT 0,
                     UNIQUE(provider, fingerprint)
                 )
                 """
@@ -57,6 +67,19 @@ class MemoryWriteOutbox:
                 "CREATE INDEX IF NOT EXISTS idx_pending_provider_fifo "
                 "ON pending_writes(provider, id)"
             )
+            columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(pending_writes)")
+            }
+            if "claim_token" not in columns:
+                conn.execute(
+                    "ALTER TABLE pending_writes "
+                    "ADD COLUMN claim_token TEXT NOT NULL DEFAULT ''"
+                )
+            if "claim_until" not in columns:
+                conn.execute(
+                    "ALTER TABLE pending_writes "
+                    "ADD COLUMN claim_until REAL NOT NULL DEFAULT 0"
+                )
 
     @staticmethod
     def _fingerprint(
@@ -137,17 +160,53 @@ class MemoryWriteOutbox:
         replayed = 0
         with self._lock:
             while True:
+                claim_token = uuid.uuid4().hex
+                now = time.time()
+                blocked = False
                 with self._connect() as conn:
+                    conn.execute("BEGIN IMMEDIATE")
                     row = conn.execute(
                         """
-                        SELECT id, action, target, content, metadata_json
+                        SELECT id, action, target, content, metadata_json,
+                               claim_token, claim_until
                         FROM pending_writes WHERE provider = ? ORDER BY id LIMIT 1
                         """,
                         (provider,),
                     ).fetchone()
+                    if row is not None:
+                        blocked = bool(
+                            row["claim_token"] and float(row["claim_until"]) > now
+                        )
+                        if not blocked:
+                            claimed = conn.execute(
+                                """
+                                UPDATE pending_writes
+                                SET claim_token = ?, claim_until = ?
+                                WHERE id = ? AND (claim_token = '' OR claim_until <= ?)
+                                """,
+                                (
+                                    claim_token,
+                                    now + self._claim_lease_seconds,
+                                    row["id"],
+                                    now,
+                                ),
+                            ).rowcount
+                            blocked = claimed != 1
                 if row is None:
                     self.clear_alert(provider)
-                    return {"replayed": replayed, "remaining": 0, "error": ""}
+                    return {
+                        "replayed": replayed,
+                        "remaining": 0,
+                        "error": "",
+                        "blocked": False,
+                    }
+                if blocked:
+                    return {
+                        "replayed": replayed,
+                        "remaining": self.pending_count(provider),
+                        "error": "",
+                        "blocked": True,
+                    }
                 try:
                     metadata = json.loads(row["metadata_json"])
                     deliver(row["action"], row["target"], row["content"], metadata)
@@ -157,17 +216,23 @@ class MemoryWriteOutbox:
                         conn.execute(
                             """
                             UPDATE pending_writes
-                            SET attempts = attempts + 1, last_error = ? WHERE id = ?
+                            SET attempts = attempts + 1, last_error = ?,
+                                claim_token = '', claim_until = 0
+                            WHERE id = ? AND claim_token = ?
                             """,
-                            (error, row["id"]),
+                            (error, row["id"], claim_token),
                         )
                     return {
                         "replayed": replayed,
                         "remaining": self.pending_count(provider),
                         "error": error,
+                        "blocked": False,
                     }
                 with self._connect() as conn:
-                    conn.execute("DELETE FROM pending_writes WHERE id = ?", (row["id"],))
+                    conn.execute(
+                        "DELETE FROM pending_writes WHERE id = ? AND claim_token = ?",
+                        (row["id"], claim_token),
+                    )
                 replayed += 1
 
     def should_alert(self, provider: str, cooldown_seconds: float) -> bool:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2140,7 +2140,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 # providers. All gating/op-expansion lives behind the manager
                 # interface (MemoryManager.notify_memory_tool_write).
                 if agent._memory_manager:
-                    agent._memory_manager.notify_memory_tool_write(
+                    mirror_result = agent._memory_manager.notify_memory_tool_write(
                         result,
                         next_args,
                         build_metadata=lambda: agent._build_memory_write_metadata(
@@ -2148,6 +2148,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_call_id=getattr(tool_call, "id", None),
                         ),
                     )
+                    if mirror_result is not None:
+                        result = mirror_result
                 return result
             function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
                 agent,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -838,6 +838,16 @@ memory:
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.
   nudge_interval: 10        # Nudge every 10 user turns (0 = disabled)
 
+  # Optional external memory provider. Failed explicit-write mirrors are kept
+  # in a profile-local durable outbox and replayed after provider recovery.
+  provider: ""
+  provider_write_outbox_max_entries: 1000
+
+  # User-visible provider write alerts are opt-in. Warning-level logs and the
+  # memory tool's degraded-write details remain enabled regardless.
+  alert_on_provider_write_failure: false
+  provider_write_alert_cooldown_seconds: 3600
+
 # =============================================================================
 # Session Reset Policy (Messaging Platforms)
 # =============================================================================

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1896,6 +1896,13 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # Failed explicit-write mirrors are always queued locally for replay.
+        # This caps the durable backlog independently for each provider.
+        "provider_write_outbox_max_entries": 1000,
+        # User-visible first-failure warnings are opt-in and rate-limited across
+        # short-lived gateway agent instances. Warning-level logs remain on.
+        "alert_on_provider_write_failure": False,
+        "provider_write_alert_cooldown_seconds": 3600,
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/plugins/memory/byterover/__init__.py
+++ b/plugins/memory/byterover/__init__.py
@@ -329,18 +329,11 @@ class ByteRoverMemoryProvider(MemoryProvider):
         if action not in {"add", "replace"} or not content:
             return
 
-        def _write():
-            try:
-                label = "User profile" if target == "user" else "Agent memory"
-                _run_brv(
-                    ["curate", "--", f"[{label}] {content}"],
-                    timeout=_CURATE_TIMEOUT, cwd=self._cwd,
-                )
-            except Exception as e:
-                logger.debug("ByteRover memory mirror failed: %s", e)
-
-        t = threading.Thread(target=_write, daemon=True, name="brv-memwrite")
-        t.start()
+        label = "User profile" if target == "user" else "Agent memory"
+        _run_brv(
+            ["curate", "--", f"[{label}] {content}"],
+            timeout=_CURATE_TIMEOUT, cwd=self._cwd,
+        )
 
     def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
         """Extract insights before context compression discards turns."""

--- a/plugins/memory/byterover/__init__.py
+++ b/plugins/memory/byterover/__init__.py
@@ -330,10 +330,12 @@ class ByteRoverMemoryProvider(MemoryProvider):
             return
 
         label = "User profile" if target == "user" else "Agent memory"
-        _run_brv(
+        result = _run_brv(
             ["curate", "--", f"[{label}] {content}"],
             timeout=_CURATE_TIMEOUT, cwd=self._cwd,
         )
+        if result.get("success") is not True:
+            raise RuntimeError(result.get("error") or "ByteRover memory write failed")
 
     def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
         """Extract insights before context compression discards turns."""

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -244,12 +244,12 @@ class HolographicMemoryProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes as facts."""
-        if action == "add" and self._store and content:
-            try:
-                category = "user_pref" if target == "user" else "general"
-                self._store.add_fact(content, category=category)
-            except Exception as e:
-                logger.debug("Holographic memory_write mirror failed: %s", e)
+        if action != "add" or not content:
+            return
+        if not self._store:
+            raise RuntimeError("Holographic memory store is not initialized")
+        category = "user_pref" if target == "user" else "general"
+        self._store.add_fact(content, category=category)
 
     def shutdown(self) -> None:
         # Release the shared SQLite connection deterministically on the

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1485,19 +1485,12 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._config and not getattr(self._config, "save_messages", True):
             return
         if self._recall_mode == "tools" and not self._session_ready():
-            return
+            raise RuntimeError("Honcho session is not ready for memory writes")
         if not self._session_ready():
             self._start_session_init_background()
-            return
+            raise RuntimeError("Honcho session is not ready for memory writes")
 
-        def _write():
-            try:
-                self._manager.create_conclusion(self._session_key, content)
-            except Exception as e:
-                logger.debug("Honcho memory mirror failed: %s", e)
-
-        self._memwrite_thread = spawn_context_thread(_write, name="honcho-memwrite")
-        self._memwrite_thread.start()
+        self._manager.create_conclusion(self._session_key, content)
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -4789,36 +4789,22 @@ class OpenVikingMemoryProvider(MemoryProvider):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Mirror successful built-in memory additions to OpenViking."""
-        if action != "add" or not content or not self._ensure_client():
+        if action != "add" or not content:
             return
+        if not self._ensure_client():
+            raise RuntimeError("OpenViking server not connected")
+        if self._shutting_down:
+            raise RuntimeError("OpenViking provider is shutting down")
 
         subdir = _MEMORY_WRITE_TARGET_SUBDIR_MAP.get(target, _DEFAULT_MEMORY_SUBDIR)
         uri = self._build_memory_uri(subdir)
 
-        def _write():
-            try:
-                client = self._new_client()
-                client.post("/api/v1/content/write", {
-                    "uri": uri,
-                    "content": content,
-                    "mode": "create",
-                })
-            except Exception as e:
-                logger.debug("OpenViking memory mirror failed: %s", e)
-            finally:
-                with self._memory_write_lock:
-                    self._memory_write_threads.discard(threading.current_thread())
-
-        t = threading.Thread(target=_write, daemon=True, name="openviking-memwrite")
-        with self._memory_write_lock:
-            if self._shutting_down:
-                return
-            self._memory_write_threads.add(t)
-            try:
-                t.start()
-            except Exception as e:
-                self._memory_write_threads.discard(t)
-                logger.debug("OpenViking memory mirror worker failed to start: %s", e)
+        client = self._new_client()
+        client.post("/api/v1/content/write", {
+            "uri": uri,
+            "content": content,
+            "mode": "create",
+        })
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -836,13 +836,12 @@ class RetainDBMemoryProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes to RetainDB."""
-        if action != "add" or not content or not self._client:
+        if action != "add" or not content:
             return
-        try:
-            memory_type = "preference" if target == "user" else "factual"
-            self._client.add_memory(self._user_id, self._session_id, content, memory_type=memory_type)
-        except Exception as exc:
-            logger.debug("RetainDB memory mirror failed: %s", exc)
+        if not self._client:
+            raise RuntimeError("RetainDB client is not initialized")
+        memory_type = "preference" if target == "user" else "factual"
+        self._client.add_memory(self._user_id, self._session_id, content, memory_type=memory_type)
 
     def shutdown(self) -> None:
         for t in self._prefetch_threads:

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -828,26 +828,18 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._turn_count = 0
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
-        if not self._active or not self._write_enabled or not self._client:
+        if not self._active or not self._write_enabled:
             return
         if action != "add" or not (content or "").strip():
             return
+        if not self._client:
+            raise RuntimeError("Supermemory client is not initialized")
 
-        def _run():
-            try:
-                self._client.add_memory(
-                    content.strip(),
-                    metadata={"target": target, "type": "explicit_memory"},
-                    entity_context=self._entity_context,
-                )
-            except Exception:
-                logger.debug("Supermemory on_memory_write failed", exc_info=True)
-
-        if self._write_thread and self._write_thread.is_alive():
-            self._write_thread.join(timeout=2.0)
-        self._write_thread = None
-        self._write_thread = threading.Thread(target=_run, daemon=False, name="supermemory-memory-write")
-        self._write_thread.start()
+        self._client.add_memory(
+            content.strip(),
+            metadata={"target": target, "type": "explicit_memory"},
+            entity_context=self._entity_context,
+        )
 
     def shutdown(self) -> None:
         # Emergency fallback (crashes only). Buffer is cleared on normal on_session_end().

--- a/tests/agent/test_memory_write_outbox.py
+++ b/tests/agent/test_memory_write_outbox.py
@@ -1,6 +1,7 @@
 """Behavior tests for durable external-provider memory write recovery."""
 
 import json
+import threading
 
 from agent.memory_manager import MemoryManager
 from agent.memory_provider import MemoryProvider
@@ -32,6 +33,18 @@ class _Provider(MemoryProvider):
         if self.fail:
             raise RuntimeError("gateway unavailable")
         self.calls.append((action, target, content, dict(metadata or {})))
+
+
+class _FailingThenOrderedProvider(_Provider):
+    def __init__(self, failures: int) -> None:
+        super().__init__(fail=False)
+        self.failures = failures
+
+    def on_memory_write(self, action, target, content, metadata=None):
+        if self.failures:
+            self.failures -= 1
+            raise RuntimeError("gateway unavailable")
+        super().on_memory_write(action, target, content, metadata)
 
 
 def test_outbox_deduplicates_and_bounds_pending_writes(tmp_path):
@@ -98,3 +111,60 @@ def test_failed_write_is_visible_and_replayed_after_restart(tmp_path, caplog):
         ("add", "user", "likes coffee", {}),
     ]
     assert MemoryWriteOutbox(tmp_path).pending_count("external-test") == 0
+
+
+def test_new_write_queues_behind_failed_fifo_head(tmp_path):
+    failing = _FailingThenOrderedProvider(failures=2)
+    manager = MemoryManager()
+    manager.add_provider(failing)
+    manager.initialize_all("session-1", hermes_home=str(tmp_path))
+
+    manager.notify_memory_tool_write(
+        json.dumps({"success": True}),
+        {"action": "remove", "target": "user", "old_text": "old"},
+    )
+    result = manager.notify_memory_tool_write(
+        json.dumps({"success": True}),
+        {"action": "add", "target": "user", "content": "new"},
+    )
+
+    assert failing.calls == []
+    assert json.loads(result)["external_provider_writes"][0]["queued"] is True
+
+    failing.failures = 0
+    restarted = MemoryManager()
+    restarted.add_provider(failing)
+    restarted.initialize_all("session-2", hermes_home=str(tmp_path))
+
+    assert [call[:3] for call in failing.calls] == [
+        ("remove", "user", ""),
+        ("add", "user", "new"),
+    ]
+
+
+def test_concurrent_replay_claims_each_row_once(tmp_path):
+    first = MemoryWriteOutbox(tmp_path)
+    second = MemoryWriteOutbox(tmp_path)
+    first.enqueue("provider", "add", "memory", "one", {})
+    delivery_started = threading.Barrier(2)
+    release_delivery = threading.Event()
+    calls = []
+
+    def deliver(action, target, content, metadata):
+        calls.append((action, target, content, metadata))
+        delivery_started.wait(timeout=5)
+        assert release_delivery.wait(timeout=5)
+
+    worker = threading.Thread(target=lambda: first.replay("provider", deliver))
+    worker.start()
+    delivery_started.wait(timeout=5)
+
+    blocked = second.replay("provider", deliver)
+    release_delivery.set()
+    worker.join(timeout=5)
+
+    assert worker.is_alive() is False
+    assert blocked["blocked"] is True
+    assert blocked["remaining"] == 1
+    assert len(calls) == 1
+    assert first.pending_count("provider") == 0

--- a/tests/agent/test_memory_write_outbox.py
+++ b/tests/agent/test_memory_write_outbox.py
@@ -2,6 +2,7 @@
 
 import json
 import threading
+import time
 
 from agent.memory_manager import MemoryManager
 from agent.memory_provider import MemoryProvider
@@ -167,4 +168,74 @@ def test_concurrent_replay_claims_each_row_once(tmp_path):
     assert blocked["blocked"] is True
     assert blocked["remaining"] == 1
     assert len(calls) == 1
+    assert first.pending_count("provider") == 0
+
+
+def test_bound_never_evicts_claimed_head(tmp_path):
+    first = MemoryWriteOutbox(tmp_path, max_entries_per_provider=1)
+    second = MemoryWriteOutbox(tmp_path, max_entries_per_provider=1)
+    first.enqueue("provider", "add", "memory", "old", {})
+    started = threading.Event()
+    release = threading.Event()
+
+    def fail_after_release(action, target, content, metadata):
+        started.set()
+        assert release.wait(timeout=5)
+        raise RuntimeError("still unavailable")
+
+    result = {}
+    worker = threading.Thread(
+        target=lambda: result.update(first.replay("provider", fail_after_release))
+    )
+    worker.start()
+    assert started.wait(timeout=5)
+
+    overflow = second.enqueue("provider", "add", "memory", "new", {})
+    assert overflow["queued"] is False
+    assert overflow["dropped"] == 1
+
+    release.set()
+    worker.join(timeout=5)
+    assert worker.is_alive() is False
+    assert result["error"] == "still unavailable"
+    assert first.pending_count("provider") == 1
+
+    delivered = []
+    replayed = second.replay(
+        "provider",
+        lambda action, target, content, metadata: delivered.append(content),
+    )
+    assert replayed["replayed"] == 1
+    assert delivered == ["old"]
+
+
+def test_claim_is_renewed_while_delivery_exceeds_lease(tmp_path):
+    first = MemoryWriteOutbox(tmp_path, claim_lease_seconds=1)
+    second = MemoryWriteOutbox(tmp_path, claim_lease_seconds=1)
+    first.enqueue("provider", "add", "memory", "one", {})
+    started = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    def slow_deliver(action, target, content, metadata):
+        calls.append(content)
+        started.set()
+        assert release.wait(timeout=5)
+
+    first_result = {}
+    worker = threading.Thread(
+        target=lambda: first_result.update(first.replay("provider", slow_deliver))
+    )
+    worker.start()
+    assert started.wait(timeout=5)
+    time.sleep(1.25)
+
+    blocked = second.replay("provider", slow_deliver)
+    assert blocked["blocked"] is True
+    assert calls == ["one"]
+
+    release.set()
+    worker.join(timeout=5)
+    assert worker.is_alive() is False
+    assert first_result["replayed"] == 1
     assert first.pending_count("provider") == 0

--- a/tests/agent/test_memory_write_outbox.py
+++ b/tests/agent/test_memory_write_outbox.py
@@ -1,0 +1,100 @@
+"""Behavior tests for durable external-provider memory write recovery."""
+
+import json
+
+from agent.memory_manager import MemoryManager
+from agent.memory_provider import MemoryProvider
+from agent.memory_write_outbox import MemoryWriteOutbox
+
+
+class _Provider(MemoryProvider):
+    def __init__(self, *, fail: bool) -> None:
+        self.fail = fail
+        self.calls = []
+
+    @property
+    def name(self) -> str:
+        return "external-test"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        pass
+
+    def get_tool_schemas(self):
+        return []
+
+    def shutdown(self) -> None:
+        pass
+
+    def on_memory_write(self, action, target, content, metadata=None):
+        if self.fail:
+            raise RuntimeError("gateway unavailable")
+        self.calls.append((action, target, content, dict(metadata or {})))
+
+
+def test_outbox_deduplicates_and_bounds_pending_writes(tmp_path):
+    outbox = MemoryWriteOutbox(tmp_path, max_entries_per_provider=2)
+
+    first = outbox.enqueue("provider", "add", "memory", "one", {"session_id": "s1"})
+    duplicate = outbox.enqueue(
+        "provider",
+        "add",
+        "memory",
+        "one",
+        {"session_id": "s2", "tool_call_id": "retry"},
+    )
+    outbox.enqueue("provider", "add", "memory", "two", {})
+    bounded = outbox.enqueue("provider", "add", "memory", "three", {})
+
+    assert first["queued"] is True
+    assert duplicate["deduplicated"] is True
+    assert bounded["dropped"] == 1
+    assert outbox.pending_count("provider") == 2
+
+
+def test_failed_write_is_visible_and_replayed_after_restart(tmp_path, caplog):
+    warnings = []
+    failing = _Provider(fail=True)
+    manager = MemoryManager(
+        external_write_alerts=True,
+        warning_callback=warnings.append,
+        alert_cooldown_seconds=3600,
+    )
+    manager.add_provider(failing)
+    manager.initialize_all("session-1", hermes_home=str(tmp_path))
+
+    result = manager.notify_memory_tool_write(
+        json.dumps({"success": True}),
+        {"action": "add", "target": "user", "content": "likes tea"},
+        build_metadata=lambda: {"session_id": "session-1"},
+    )
+    visible = json.loads(result)
+
+    assert visible["success"] is True
+    assert visible["external_provider_writes"] == [{
+        "provider": "external-test",
+        "success": False,
+        "queued": True,
+        "error": "gateway unavailable",
+    }]
+    assert "on_memory_write failed" in caplog.text
+    assert len(warnings) == 1
+
+    manager.notify_memory_tool_write(
+        json.dumps({"success": True}),
+        {"action": "add", "target": "user", "content": "likes coffee"},
+    )
+    assert len(warnings) == 1, "persistent cooldown must suppress repeated outage alerts"
+
+    recovered = _Provider(fail=False)
+    restarted = MemoryManager()
+    restarted.add_provider(recovered)
+    restarted.initialize_all("session-2", hermes_home=str(tmp_path))
+
+    assert recovered.calls == [
+        ("add", "user", "likes tea", {"session_id": "session-1"}),
+        ("add", "user", "likes coffee", {}),
+    ]
+    assert MemoryWriteOutbox(tmp_path).pending_count("external-test") == 0

--- a/tests/honcho_plugin/test_save_messages.py
+++ b/tests/honcho_plugin/test_save_messages.py
@@ -52,13 +52,8 @@ class TestOnMemoryWrite:
         p._manager.create_conclusion.assert_not_called()
 
     def test_enabled_mirrors(self):
-        import time
-
         p = _provider(save_messages=True)
         p.on_memory_write('add', 'user', 'user likes coffee')
-        deadline = time.time() + 5
-        while time.time() < deadline and not p._manager.create_conclusion.called:
-            time.sleep(0.05)
         p._manager.create_conclusion.assert_called_once()
 
 

--- a/tests/plugins/memory/test_byterover_provider.py
+++ b/tests/plugins/memory/test_byterover_provider.py
@@ -31,3 +31,16 @@ def test_memory_write_propagates_backend_failure(monkeypatch):
         provider.on_memory_write("add", "memory", "remember this")
 
 
+def test_memory_write_propagates_unsuccessful_cli_result(monkeypatch):
+    provider = ByteRoverMemoryProvider({"auto_extract": True})
+    provider._auto_extract = True
+
+    monkeypatch.setattr(
+        "plugins.memory.byterover._run_brv",
+        lambda *args, **kwargs: {"success": False, "error": "backend rejected"},
+    )
+
+    with pytest.raises(RuntimeError, match="backend rejected"):
+        provider.on_memory_write("add", "memory", "remember this")
+
+

--- a/tests/plugins/memory/test_byterover_provider.py
+++ b/tests/plugins/memory/test_byterover_provider.py
@@ -1,5 +1,7 @@
 """Tests for the ByteRover memory provider config gates."""
 
+import pytest
+
 from plugins.memory.byterover import ByteRoverMemoryProvider
 
 
@@ -14,5 +16,18 @@ def test_auto_extract_false_skips_sync_turn(monkeypatch):
 
     assert calls == []
     assert provider._sync_thread is None
+
+
+def test_memory_write_propagates_backend_failure(monkeypatch):
+    provider = ByteRoverMemoryProvider({"auto_extract": True})
+    provider._auto_extract = True
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("byterover unavailable")
+
+    monkeypatch.setattr("plugins.memory.byterover._run_brv", fail)
+
+    with pytest.raises(RuntimeError, match="byterover unavailable"):
+        provider.on_memory_write("add", "memory", "remember this")
 
 

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1265,7 +1265,7 @@ def test_concurrent_providers_claim_unlocked_pending_owner_once(
 # ---------------------------------------------------------------------------
 
 
-def test_shutdown_waits_for_memory_write_worker(monkeypatch):
+def test_memory_write_waits_for_backend_acceptance(monkeypatch):
     import threading
 
     provider = OpenVikingMemoryProvider()
@@ -1278,8 +1278,7 @@ def test_shutdown_waits_for_memory_write_worker(monkeypatch):
 
     worker_started = threading.Event()
     release_worker = threading.Event()
-    worker_finished = threading.Event()
-    shutdown_returned = threading.Event()
+    write_returned = threading.Event()
 
     class StubClient:
         def __init__(self, *a, **kw):
@@ -1289,27 +1288,23 @@ def test_shutdown_waits_for_memory_write_worker(monkeypatch):
             assert path == "/api/v1/content/write"
             worker_started.set()
             release_worker.wait(timeout=2.0)
-            worker_finished.set()
             return {}
 
     monkeypatch.setattr(openviking_module, "_VikingClient", StubClient)
 
-    provider.on_memory_write("add", "user", "remember this")
-    assert worker_started.wait(timeout=2.0), "worker never entered post()"
-
-    shutdown_thread = threading.Thread(
-        target=lambda: (provider.shutdown(), shutdown_returned.set()),
+    write_thread = threading.Thread(
+        target=lambda: (
+            provider.on_memory_write("add", "user", "remember this"),
+            write_returned.set(),
+        ),
         daemon=True,
     )
-    shutdown_thread.start()
-
-    returned_before_worker_finished = shutdown_returned.wait(timeout=0.1)
+    write_thread.start()
+    assert worker_started.wait(timeout=2.0), "worker never entered post()"
+    assert write_returned.wait(timeout=0.1) is False
     release_worker.set()
-    assert shutdown_returned.wait(timeout=2.0), "shutdown did not return after worker finished"
-    shutdown_thread.join(timeout=2.0)
-
-    assert not returned_before_worker_finished
-    assert worker_finished.is_set()
+    assert write_returned.wait(timeout=2.0)
+    write_thread.join(timeout=2.0)
     assert provider._memory_write_threads == set()
 
 

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -159,13 +159,8 @@ def test_merge_metadata_stamps_sm_source():
 
 
 def test_shutdown_joins_threads_and_flushes_buffer(provider, monkeypatch):
-    started = threading.Event()
-    release = threading.Event()
-
     def slow_add_memory(content, metadata=None, *, entity_context="",
                         container_tag=None, custom_id=None):
-        started.set()
-        release.wait(timeout=1)
         provider._client.add_calls.append({
             "content": content,
             "metadata": metadata,
@@ -184,12 +179,9 @@ def test_shutdown_joins_threads_and_flushes_buffer(provider, monkeypatch):
     assert provider._sync_thread is None
     assert len(provider._session_turns) == 1
 
-    # on_memory_write still runs on a background thread.
+    # Explicit writes synchronously establish durable provider responsibility.
     provider.on_memory_write("add", "memory", "Jordan likes concise docs")
-    assert started.wait(timeout=1)
-    assert provider._write_thread is not None
-
-    release.set()
+    assert provider._write_thread is None
     provider.shutdown()
 
     # All tracked threads joined and cleared.

--- a/tests/plugins/test_retaindb_plugin.py
+++ b/tests/plugins/test_retaindb_plugin.py
@@ -411,6 +411,21 @@ class TestOnMemoryWrite:
             mock_add.assert_not_called()
         p.shutdown()
 
+    def test_backend_failure_propagates(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("RETAINDB_API_KEY", "rdb-test-key")
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(exist_ok=True)
+        p = RetainDBMemoryProvider()
+        p.initialize("test-session", hermes_home=str(hermes_home))
+        with patch.object(
+            p._client,
+            "add_memory",
+            side_effect=RuntimeError("retaindb unavailable"),
+        ):
+            with pytest.raises(RuntimeError, match="retaindb unavailable"):
+                p.on_memory_write("add", "user", "User prefers dark mode")
+        p.shutdown()
+
 
     def test_memory_target_maps_to_type(self, tmp_path, monkeypatch):
         monkeypatch.setenv("RETAINDB_API_KEY", "rdb-test-key")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1714,6 +1714,33 @@ class TestExecuteToolCalls:
         assert metadata["tool_call_id"] == "mem-1"
         assert messages[-1]["tool_call_id"] == "mem-1"
 
+    def test_sequential_memory_write_emits_provider_degradation(self, agent):
+        tc = _mock_tool_call(
+            name="memory",
+            arguments=json.dumps({
+                "action": "add",
+                "target": "memory",
+                "content": "remember this",
+            }),
+            call_id="mem-1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        degraded = {
+            "success": True,
+            "external_provider_writes": [
+                {"provider": "external", "queued": True, "error": "unavailable"}
+            ],
+        }
+        agent._memory_manager = MagicMock()
+        agent._memory_manager.notify_memory_tool_write.return_value = json.dumps(degraded)
+        agent._memory_store = object()
+
+        with patch("tools.memory_tool.memory_tool", return_value=json.dumps({"success": True})):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert json.loads(messages[-1]["content"]) == degraded
+
     def test_keyboard_interrupt_emits_cancelled_post_tool_hook(self, agent, monkeypatch):
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -130,6 +130,26 @@ class MyMemoryProvider(MemoryProvider):
 | `on_memory_write(action, target, content)` | Built-in memory writes | Mirror to your backend |
 | `shutdown()` | Process exit | Clean up connections |
 
+### Memory Write Error Contract
+
+`on_memory_write()` must raise when the explicit memory mirror was not accepted
+into durable provider storage. Hermes logs the provider failure at warning
+level, marks the otherwise-successful built-in memory tool result as degraded,
+and stores the intent in a bounded profile-local outbox for FIFO replay after
+the provider recovers. Duplicate failed intents are coalesced.
+
+If a provider hands the write to a background worker, returning successfully
+means that worker has accepted durable responsibility for retrying it. Do not
+swallow an asynchronous write error at debug level: either keep a provider-owned
+durable queue or arrange for the hook to raise before it returns.
+
+The outbox bound is configured with
+`memory.provider_write_outbox_max_entries` (default `1000` per provider).
+Set `memory.alert_on_provider_write_failure: true` to emit a user-visible
+first-failure warning; `memory.provider_write_alert_cooldown_seconds` controls
+the persistent rate limit. Warning-level logs and in-tool degradation details
+do not require the alert flag.
+
 ## Config Schema
 
 `get_config_schema()` returns a list of field descriptors used by `hermes memory setup`:


### PR DESCRIPTION
## What does this PR do?

External memory provider write failures no longer disappear while the built-in memory tool reports an unqualified success. Failed mirrors are warning-logged, included in the tool result, persisted in a bounded profile-local SQLite outbox, and replayed in FIFO order after provider recovery.

### Symptom

When an external provider raises from `on_memory_write()`, the built-in memory tool returns success while the mirror failure is only debug-logged and the payload is discarded.

### Impact

Users can lose explicit memories in their configured external backend without any normal log, session-visible degradation, or recovery path. The built-in file-backed memory remains committed, but the external provider silently diverges.

### Bug Cause

**Trigger:** `agent/memory_manager.py:1086` / `MemoryManager.on_memory_write()` catches an external provider exception.

**Causal chain:**
1. A successful built-in `memory` tool mutation is mirrored to the configured external provider.
2. `MemoryManager.on_memory_write()` catches the provider exception, records it only at debug level, and returns no outcome to the caller.
3. `agent_runtime_helpers.py` returns the original successful tool result, while the failed external payload is discarded.

**Why it is wrong:** The fail-open mirror path protected the built-in write, but it also erased the only failure signal and retained no recoverable write intent.

**Working sibling / contrast:** Built-in memory writes already use checked local persistence. This change preserves that successful result while explicitly reporting and durably queuing only the failed external mirror.

**Ruled out:** Provider initialization was not the missing path. Initialization failures already log warnings; the data loss occurs after successful activation when a later explicit provider write raises.

### Fix

- Add a profile-scoped SQLite outbox with per-provider bounds, intent deduplication, persistent alert cooldowns, and FIFO replay.
- Promote provider write failures to warning level and include degraded external write details in the memory tool result.
- Replay pending writes after provider initialization and before later explicit writes.
- Add opt-in user-visible alerts through existing status plumbing, without a new core tool or environment variable.
- Document the provider error contract and the new `config.yaml` settings.

## Related Issue

Fixes #92219

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/memory_write_outbox.py` - persist, deduplicate, bound, rate-limit, and replay failed provider write intents.
- `agent/memory_manager.py` - surface provider failures, queue them, and replay recovered writes.
- `agent/agent_runtime_helpers.py` - return mirror degradation details to the agent.
- `agent/agent_init.py` and `hermes_cli/config_defaults.py` - wire profile configuration and alert callbacks.
- `tests/agent/test_memory_write_outbox.py` - cover bounds, deduplication, visibility, alert throttling, restart persistence, and replay.
- `agent/memory_provider.py`, `cli-config.yaml.example`, and provider documentation - define and document the write error contract and settings.

## How to Test

1. Run the focused memory provider and bridge tests:

```bash
scripts/run_tests.sh tests/agent/test_memory_write_outbox.py tests/agent/test_memory_write_bridge.py tests/agent/test_memory_provider.py -q
```

2. Run the agent-loop memory path and config loader tests:

```bash
scripts/run_tests.sh tests/run_agent/test_run_agent.py -k memory -q
scripts/run_tests.sh tests/hermes_cli/test_config_loader_e2e.py -q
```

3. Configure a provider whose `on_memory_write()` raises, invoke the built-in memory tool, and verify the response contains `external_provider_writes`, the warning log names the provider, and the queued writes replay after the provider recovers.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on all relevant tests
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation and docstrings
- [x] I've updated `cli-config.yaml.example` for the new config keys
- [x] `CONTRIBUTING.md` and `AGENTS.md` do not require changes
- [x] I've considered cross-platform impact; the outbox uses stdlib `pathlib` and `sqlite3`
- [x] No tool schema change is required
