### PR TITLE
fix(kanban): let orchestrator_profile mutate other cards as a worker

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -716,6 +716,296 @@ def test_orchestrator_complete_any_task_allowed(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# kanban.orchestrator_profile board-health exemption (t_d2335f3c)
+# ---------------------------------------------------------------------------
+#
+# The profile named by kanban.orchestrator_profile may mutate ANY task while
+# running as a dispatcher-spawned worker on its own card. Every other profile
+# keeps today's single-task scope. Every cross-card mutation must write a
+# cross_card_mutation task_event naming the acting profile and source task.
+
+
+@pytest.fixture
+def board_health_orchestrator_env(monkeypatch, tmp_path):
+    """A dispatcher-spawned worker whose profile IS the configured
+    kanban.orchestrator_profile, with its own task id in HERMES_KANBAN_TASK."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: orchestrator\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        own = kb.create_task(conn, title="orchestrator's own card", assignee="orchestrator")
+        kb.claim_task(conn, own)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", own)
+    return own
+
+
+def test_ordinary_worker_still_cannot_mutate_other_card(worker_env):
+    """A normal (non-orchestrator) worker profile keeps today's behaviour:
+    it still cannot complete a foreign task."""
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        other = kb.create_task(conn, title="sibling", assignee="peer")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (other,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"task_id": other, "summary": "should be refused"})
+    d = json.loads(out)
+    assert d.get("ok") is not True
+    assert "refusing to mutate" in d.get("error", "")
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, other).status == "ready"
+        events = kb.list_events(conn, other)
+        assert not [e for e in events if e.kind == "cross_card_mutation"]
+    finally:
+        conn.close()
+
+
+def test_orchestrator_profile_can_mutate_foreign_card_as_worker(
+    board_health_orchestrator_env,
+):
+    """The configured kanban.orchestrator_profile, even while dispatched as a
+    worker on its own card, may complete a DIFFERENT card (D1/D3)."""
+    own = board_health_orchestrator_env
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        other = kb.create_task(conn, title="someone else's card", assignee="peer")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (other,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"task_id": other, "summary": "board-health close"})
+    d = json.loads(out)
+    assert d.get("ok") is True, f"orchestrator profile must be allowed: {d}"
+    assert d.get("task_id") == other
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, other).status == "done"
+    finally:
+        conn.close()
+
+    # Own card, meanwhile, is untouched by this call.
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, own).status != "done"
+    finally:
+        conn.close()
+
+
+def test_cross_card_mutation_records_acting_profile_event(
+    board_health_orchestrator_env,
+):
+    """D4: every cross-card mutation writes a task_event naming the acting
+    profile and the source task id, so the audit trail never shows the
+    foreign task's own worker having done the work."""
+    own = board_health_orchestrator_env
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        other = kb.create_task(conn, title="audited card", assignee="peer")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (other,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"task_id": other, "summary": "board-health close"})
+    d = json.loads(out)
+    assert d.get("ok") is True
+
+    conn = kb.connect()
+    try:
+        events = kb.list_events(conn, other)
+    finally:
+        conn.close()
+    audit = [e for e in events if e.kind == "cross_card_mutation"]
+    assert len(audit) == 1, f"expected exactly one audit event, got {events}"
+    payload = audit[0].payload
+    assert payload["actor_profile"] == "orchestrator"
+    assert payload["source_task_id"] == own
+    assert payload["tool"] == "kanban_complete"
+
+
+def test_exemption_follows_configured_profile_name_not_hardcoded_orchestrator(
+    monkeypatch, tmp_path,
+):
+    """D1: the exemption is the configured kanban.orchestrator_profile value,
+    not the string 'orchestrator'. A worker named techlead with that config
+    may mutate; a worker named orchestrator with a different config must not."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: techlead\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "techlead")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        own = kb.create_task(conn, title="techlead own", assignee="techlead")
+        kb.claim_task(conn, own)
+        other = kb.create_task(conn, title="foreign", assignee="peer")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (other,))
+        conn.commit()
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", own)
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"task_id": other, "summary": "techlead close"})
+    d = json.loads(out)
+    assert d.get("ok") is True, f"configured profile must be allowed: {d}"
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, other).status == "done"
+        events = kb.list_events(conn, other)
+    finally:
+        conn.close()
+    audit = [e for e in events if e.kind == "cross_card_mutation"]
+    assert len(audit) == 1
+    assert audit[0].payload["actor_profile"] == "techlead"
+    assert audit[0].payload["source_task_id"] == own
+
+
+def test_hardcoded_orchestrator_name_does_not_grant_exemption(
+    monkeypatch, tmp_path,
+):
+    """D1: a worker whose profile happens to be named 'orchestrator' still
+    cannot mutate another card when kanban.orchestrator_profile is unset
+    (or set to someone else)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "kanban:\n  orchestrator_profile: techlead\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "orchestrator")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        own = kb.create_task(conn, title="named-orchestrator own", assignee="orchestrator")
+        kb.claim_task(conn, own)
+        other = kb.create_task(conn, title="foreign", assignee="peer")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (other,))
+        conn.commit()
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", own)
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"task_id": other, "summary": "should be refused"})
+    d = json.loads(out)
+    assert d.get("ok") is not True
+    assert "refusing to mutate" in d.get("error", "")
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, other).status == "ready"
+        events = kb.list_events(conn, other)
+        assert not [e for e in events if e.kind == "cross_card_mutation"]
+    finally:
+        conn.close()
+
+
+def test_failed_cross_card_complete_does_not_write_audit(
+    board_health_orchestrator_env,
+):
+    """D4 audit is post-success: a refused complete must not leave a
+    cross_card_mutation row claiming work that did not happen."""
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        other = kb.create_task(conn, title="todo card", assignee="peer")
+        # 'todo' is not a completable status — complete_task returns False.
+        conn.execute("UPDATE tasks SET status='todo' WHERE id=?", (other,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_complete({"task_id": other, "summary": "will fail"})
+    d = json.loads(out)
+    assert d.get("ok") is not True
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, other).status == "todo"
+        events = kb.list_events(conn, other)
+        assert not [e for e in events if e.kind == "cross_card_mutation"]
+    finally:
+        conn.close()
+
+
+def test_orchestrator_worker_can_unblock_foreign_card(
+    board_health_orchestrator_env,
+):
+    """D2: status mutations used for board health (unblock) are in the
+    exemption. Sibling PR 92206 unhides the tool; this pins the ownership
+    check plus the D4 audit event."""
+    own = board_health_orchestrator_env
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        other = kb.create_task(conn, title="blocked sibling", assignee="peer")
+        kb.block_task(conn, other, reason="false trip")
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_unblock({"task_id": other})
+    d = json.loads(out)
+    assert d.get("ok") is True, f"orchestrator worker must unblock: {d}"
+
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, other).status in {"ready", "todo"}
+        events = kb.list_events(conn, other)
+    finally:
+        conn.close()
+    audit = [e for e in events if e.kind == "cross_card_mutation"]
+    assert len(audit) == 1
+    assert audit[0].payload["actor_profile"] == "orchestrator"
+    assert audit[0].payload["source_task_id"] == own
+    assert audit[0].payload["tool"] == "kanban_unblock"
+
+
+# ---------------------------------------------------------------------------
 # Optional ``board`` parameter — per-call DB override
 # ---------------------------------------------------------------------------
 #

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -127,11 +127,17 @@ def _check_kanban_orchestrator_mode() -> bool:
     lifecycle tools (complete/block/heartbeat), not enumerate or unblock
     board state. Profiles that explicitly opt into the kanban toolset
     and are NOT scoped to a single task are the orchestrator surface.
+
+    The one exception is a dispatched worker run of the configured
+    ``kanban.orchestrator_profile``: that profile IS the board-routing
+    surface, so it keeps ``kanban_list`` / ``kanban_unblock`` even while
+    ``HERMES_KANBAN_TASK`` is set. Any other worker stays scoped to its
+    own card.
     """
     if _is_delegated_child_context():
         return False
     if os.environ.get("HERMES_KANBAN_TASK") and _is_dispatcher_owned_worker():
-        return False
+        return _is_orchestrator_worker()
     return _profile_has_kanban_toolset()
 
 
@@ -180,7 +186,112 @@ def _stamp_worker_session_metadata(
     return stamped
 
 
-def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
+def _acting_profile() -> str:
+    """Best-effort name of the profile this process is running as.
+
+    The dispatcher exports ``HERMES_PROFILE`` for every worker it spawns.
+    Interactive/CLI runs may not have it, so fall back to inferring the
+    profile from ``HERMES_HOME``. Preserves the original casing for audit
+    events; matching against ``kanban.orchestrator_profile`` is case-insensitive
+    in :func:`_is_orchestrator_worker`.
+    """
+    env_profile = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if env_profile:
+        return env_profile
+    try:
+        from hermes_cli import profiles as profiles_mod
+
+        return (profiles_mod.get_active_profile_name() or "").strip()
+    except Exception:
+        return ""
+
+
+def _configured_orchestrator_profile() -> str:
+    """``kanban.orchestrator_profile`` as a normalized name, or "".
+
+    Deliberately does NOT apply ``kanban_decompose``'s
+    "fall back to the active default profile" rule: that fallback exists so a
+    root card is never stranded without an owner, and reusing it here would
+    silently hand every ``default`` worker cross-card mutation rights. The
+    board-health exemption is opt-in and only ever applies to an explicitly
+    configured profile name.
+    """
+    try:
+        cfg = load_config()
+        kcfg = cfg.get("kanban") or {}
+        if not isinstance(kcfg, dict):
+            return ""
+        return (kcfg.get("orchestrator_profile") or "").strip().lower()
+    except Exception:
+        return ""
+
+
+def _is_orchestrator_worker() -> bool:
+    """True when THIS dispatched worker run is the board's orchestrator.
+
+    The dispatcher exports ``HERMES_PROFILE`` for the assignee it spawns
+    (see kanban_db._worker_env). A worker run of
+    ``kanban.orchestrator_profile`` is the board-health agent: it may
+    enumerate the board and mutate other cards. Any OTHER profile's
+    worker stays scoped to its own card.
+
+    A delegate_task child never qualifies even if it inherits the
+    parent's ``HERMES_PROFILE``: it shares the process, so the name is
+    not proof of dispatcher ownership.
+    """
+    if _is_delegated_child_context():
+        return False
+    orchestrator = _configured_orchestrator_profile()
+    if not orchestrator:
+        return False
+    profile = (os.environ.get("HERMES_PROFILE") or "").strip().lower()
+    if not profile or profile != orchestrator:
+        return False
+    return bool(os.environ.get("HERMES_KANBAN_TASK")) and _is_dispatcher_owned_worker()
+
+
+def _record_cross_card_mutation(
+    tid: str, tool_name: str, *, board: Optional[str] = None
+) -> None:
+    """Audit a board-health mutation the orchestrator made on someone else's card.
+
+    Non-negotiable per the card's D4/D3: the event names the acting profile and
+    the source task id, so the trail never reads as the assigned worker having
+    completed work it did not do. Best-effort — an audit write must never be
+    the reason a legitimate board fix fails.
+    """
+    try:
+        kb, conn = _connect(board=board)
+    except Exception:
+        logger.warning("cross-card audit event skipped: cannot open board", exc_info=True)
+        return
+    try:
+        kb._append_event(
+            conn,
+            tid,
+            "cross_card_mutation",
+            {
+                "actor_profile": _acting_profile(),
+                "source_task_id": os.environ.get("HERMES_KANBAN_TASK"),
+                "tool": tool_name,
+            },
+        )
+        conn.commit()
+    except Exception:
+        logger.warning("cross-card audit event failed for %s", tid, exc_info=True)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def _enforce_worker_task_ownership(
+    tid: str,
+    tool_name: str = "this tool",
+    *,
+    board: Optional[str] = None,
+) -> Optional[str]:
     """Reject worker-driven destructive calls on foreign task IDs.
 
     A process spawned by the dispatcher has ``HERMES_KANBAN_TASK`` set
@@ -195,6 +306,12 @@ def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
     tasks or reopen blocked ones. Workers are narrowly scoped to their
     one task.
 
+    The profile named by ``kanban.orchestrator_profile`` owns board health, so
+    it keeps that cross-card freedom even when the dispatcher spawned it as a
+    worker on its own card (``HERMES_KANBAN_TASK`` set). Callers MUST then
+    invoke :func:`_maybe_record_cross_card_mutation` *after* the mutation
+    actually lands, so a refused complete does not leave a fake audit row.
+
     Returns ``None`` when the call is allowed, or a tool-error string
     when it must be rejected. Callers should ``return`` the error
     verbatim.
@@ -204,12 +321,31 @@ def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
         # Orchestrator or CLI context — no task-scope restriction.
         return None
     if tid != env_tid:
+        if _is_orchestrator_worker():
+            return None
         return tool_error(
             f"worker is scoped to task {env_tid}; refusing to mutate "
             f"{tid}. Use kanban_comment to hand off information to other "
             f"tasks, or kanban_create to spawn follow-up work."
         )
     return None
+
+
+def _maybe_record_cross_card_mutation(
+    tid: str, tool_name: str, *, board: Optional[str] = None
+) -> None:
+    """Write the D4 audit event for a successful foreign-card mutation.
+
+    No-op unless this process is a dispatched orchestrator worker acting
+    on a task other than ``HERMES_KANBAN_TASK``. Call after the kernel
+    write succeeded, never before.
+    """
+    env_tid = os.environ.get("HERMES_KANBAN_TASK")
+    if not env_tid or tid == env_tid:
+        return
+    if not _is_orchestrator_worker():
+        return
+    _record_cross_card_mutation(tid, tool_name, board=board)
 
 
 def _connect(board: Optional[str] = None):
@@ -473,7 +609,7 @@ def _require_orchestrator_tool(tool_name: str) -> Optional[str]:
     structured tool_error so the model gets a clear refusal instead of
     silently mutating board state from a worker context.
     """
-    if os.environ.get("HERMES_KANBAN_TASK"):
+    if os.environ.get("HERMES_KANBAN_TASK") and not _is_orchestrator_worker():
         return tool_error(
             f"{tool_name} is orchestrator-only; dispatcher-spawned workers "
             "must use kanban_complete, kanban_block, kanban_heartbeat, or "
@@ -662,7 +798,9 @@ def _handle_complete(args: dict, **kw) -> str:
         return tool_error(
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
-    ownership_err = _enforce_worker_task_ownership(tid)
+    ownership_err = _enforce_worker_task_ownership(
+        tid, "kanban_complete", board=args.get("board")
+    )
     if ownership_err:
         return ownership_err
     summary = args.get("summary")
@@ -803,6 +941,9 @@ def _handle_complete(args: dict, **kw) -> str:
                 return tool_error(
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
+            _maybe_record_cross_card_mutation(
+                tid, "kanban_complete", board=board
+            )
             run = kb.latest_run(conn, tid)
             return _ok(task_id=tid, run_id=run.id if run else None)
         finally:
@@ -824,7 +965,9 @@ def _handle_block(args: dict, **kw) -> str:
         return tool_error(
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
-    ownership_err = _enforce_worker_task_ownership(tid)
+    ownership_err = _enforce_worker_task_ownership(
+        tid, "kanban_block", board=args.get("board")
+    )
     if ownership_err:
         return ownership_err
     reason = args.get("reason")
@@ -876,6 +1019,7 @@ def _handle_block(args: dict, **kw) -> str:
                     f"could not block {tid} (unknown id or not in "
                     f"running/ready)"
                 )
+            _maybe_record_cross_card_mutation(tid, "kanban_block", board=board)
             run = kb.latest_run(conn, tid)
             # Tell the worker where the task actually landed so it doesn't
             # assume it's sitting in 'blocked' when routing sent it elsewhere.
@@ -905,7 +1049,9 @@ def _handle_request_review(args: dict, **kw) -> str:
         return tool_error(
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
-    ownership_err = _enforce_worker_task_ownership(tid)
+    ownership_err = _enforce_worker_task_ownership(
+        tid, "kanban_request_review", board=args.get("board")
+    )
     if ownership_err:
         return ownership_err
     summary = args.get("summary")
@@ -957,6 +1103,9 @@ def _handle_request_review(args: dict, **kw) -> str:
                 return tool_error(
                     f"could not request review for {tid}: {detail}"
                 )
+            _maybe_record_cross_card_mutation(
+                tid, "kanban_request_review", board=board
+            )
             run = kb.latest_run(conn, tid)
             landed = kb.get_task(conn, tid)
             return _ok(
@@ -983,7 +1132,9 @@ def _handle_request_changes(args: dict, **kw) -> str:
         return tool_error(
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
-    ownership_err = _enforce_worker_task_ownership(tid)
+    ownership_err = _enforce_worker_task_ownership(
+        tid, "kanban_request_changes", board=args.get("board")
+    )
     if ownership_err:
         return ownership_err
     reason = args.get("reason")
@@ -1004,6 +1155,9 @@ def _handle_request_changes(args: dict, **kw) -> str:
                 return tool_error(
                     f"could not request changes for {tid}: {detail or 'invalid review state'}"
                 )
+            _maybe_record_cross_card_mutation(
+                tid, "kanban_request_changes", board=board
+            )
             landed = kb.get_task(conn, tid)
             run = kb.latest_run(conn, tid)
             return _ok(
@@ -1039,7 +1193,9 @@ def _handle_heartbeat(args: dict, **kw) -> str:
         return tool_error(
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
-    ownership_err = _enforce_worker_task_ownership(tid)
+    ownership_err = _enforce_worker_task_ownership(
+        tid, "kanban_heartbeat", board=args.get("board")
+    )
     if ownership_err:
         return ownership_err
     note = args.get("note")
@@ -1065,6 +1221,9 @@ def _handle_heartbeat(args: dict, **kw) -> str:
                 return tool_error(
                     f"could not heartbeat {tid} (unknown id or not running)"
                 )
+            _maybe_record_cross_card_mutation(
+                tid, "kanban_heartbeat", board=board
+            )
             return _ok(task_id=tid)
         finally:
             conn.close()
@@ -1133,7 +1292,9 @@ def _handle_attach(args: dict, **kw) -> str:
         return tool_error(
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
-    ownership_err = _enforce_worker_task_ownership(tid)
+    ownership_err = _enforce_worker_task_ownership(
+        tid, "kanban_attach", board=args.get("board")
+    )
     if ownership_err:
         return ownership_err
     filename = args.get("filename")
@@ -1161,6 +1322,9 @@ def _handle_attach(args: dict, **kw) -> str:
                 content_type=content_type,
                 uploaded_by="agent",
                 board=board,
+            )
+            _maybe_record_cross_card_mutation(
+                tid, "kanban_attach", board=board
             )
             return _ok(task_id=tid, attachment_id=att_id, size=len(data))
         finally:
@@ -1255,7 +1419,9 @@ def _handle_attach_url(args: dict, **kw) -> str:
         return tool_error(
             "task_id is required (or set HERMES_KANBAN_TASK in the env)"
         )
-    ownership_err = _enforce_worker_task_ownership(tid)
+    ownership_err = _enforce_worker_task_ownership(
+        tid, "kanban_attach_url", board=args.get("board")
+    )
     if ownership_err:
         return ownership_err
     url = args.get("url")
@@ -1288,6 +1454,9 @@ def _handle_attach_url(args: dict, **kw) -> str:
                 content_type=content_type or fetched_ct,
                 uploaded_by="agent",
                 board=board,
+            )
+            _maybe_record_cross_card_mutation(
+                tid, "kanban_attach_url", board=board
             )
             return _ok(task_id=tid, attachment_id=att_id, size=len(data))
         finally:
@@ -1620,7 +1789,9 @@ def _handle_unblock(args: dict, **kw) -> str:
     tid = args.get("task_id")
     if not tid:
         return tool_error("task_id is required")
-    ownership_err = _enforce_worker_task_ownership(str(tid))
+    ownership_err = _enforce_worker_task_ownership(
+        str(tid), "kanban_unblock", board=args.get("board")
+    )
     if ownership_err:
         return ownership_err
     board = args.get("board")
@@ -1630,6 +1801,9 @@ def _handle_unblock(args: dict, **kw) -> str:
             ok = kb.unblock_task(conn, str(tid))
             if not ok:
                 return tool_error(f"could not unblock {tid} (not blocked or unknown)")
+            _maybe_record_cross_card_mutation(
+                str(tid), "kanban_unblock", board=board
+            )
             task = kb.get_task(conn, str(tid))
             return _ok(task_id=str(tid), status=task.status if task else None)
         finally:


### PR DESCRIPTION
## What does this PR do?

The profile named by `kanban.orchestrator_profile` owns board health, but once the dispatcher spawns it as a worker (`HERMES_KANBAN_TASK` set) every lifecycle tool is hard-scoped to that one card. Routine board fixes (re-park a human-gated card, unblock a false circuit-breaker trip, close a superseded card) currently require minting a proxy CLI card for another profile.

This PR exempts the **configured** orchestrator profile from that ownership gate while it is running as a dispatcher-owned worker. Everyone else keeps today's single-task scope. No new CLI surface.

Decisions encoded here (do not re-litigate in review):

- D1. Exemption is `kanban.orchestrator_profile`, not the hardcoded string `orchestrator`, and not `default`. Empty config = no exemption (does not reuse decompose's fallback-to-active-profile rule).
- D2. Tools in scope: status/lifecycle mutations used for board health (`complete`, `block`, `unblock`, `request_review`, `request_changes`, `heartbeat`, attach). `kanban_comment` was already cross-card.
- D3. `kanban_complete` on someone else's card is allowed under the exemption.
- D4. Every successful cross-card mutation writes a `cross_card_mutation` task_event naming `actor_profile`, `source_task_id`, and `tool`. Failed mutations do not write one.
- D5. MCP tool-scope change only.

Also unhides `kanban_list` / `kanban_unblock` for that same worker (same helper as #92206). Merge order with #92206 will conflict on `_configured_orchestrator_profile` / `_is_orchestrator_worker` — the two PRs implement the same helpers; take either copy.

## Related Issue

N/A (operator-requested board-health gap)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/kanban_tools.py`: `_configured_orchestrator_profile`, `_is_orchestrator_worker`, post-success `_maybe_record_cross_card_mutation`
- `tests/tools/test_kanban_tools.py`: ordinary worker still refused; configured profile can mutate; D4 audit event; D1 follows config not the name `orchestrator`; failed complete writes no audit; orchestrator worker can unblock

## How to Test

```
pytest tests/tools/test_kanban_tools.py tests/tools/test_delegate_kanban_isolation.py tests/cron/test_cron_kanban_env_isolation.py -q
```

63 passed locally (macOS).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate (related: #92206, overlapping helpers only)
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (focused kanban tool suite, 63 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0 arm64

### Documentation & Housekeeping

- [x] N/A — no new config keys; existing `kanban.orchestrator_profile` is reused
- [x] Tool descriptions/schemas unchanged (behavior of existing tools only)