### PR TITLE
feat(plugins): add turn-clock plugin for per-turn time and elapsed awareness

### DIFF
--- a/plugins/turn_clock/__init__.py
+++ b/plugins/turn_clock/__init__.py
@@ -1,0 +1,98 @@
+"""turn-clock: give the model a sense of "now" — and of elapsed time.
+
+Injects a compact wall-clock stamp (plus elapsed time since the previous
+message in this session) into the API copy of the current turn's user
+message via the ``pre_llm_call`` hook. The hook returns
+``{"context": "[Current time ...; last message ... ago]"}`` which
+``agent/turn_context.py`` merges into the ephemeral user-content block
+(see ``plugin_user_context``).
+
+Properties:
+- Ephemeral only: the stored transcript stays clean and the cached system
+  prompt is untouched, so the provider prompt-cache prefix stays byte-stable.
+- Per-turn fresh: the stamp is recomputed on every API call, so the model no
+  longer has to guess whether something happened "this morning" or "3 days
+  ago" — it can read the elapsed time right in the turn it is answering.
+- TZ-aware: prefers ``hermes_time`` (Hermes' configured timezone), falls
+  back to the system-local timezone.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+try:
+    from hermes_time import now as _hermes_now
+except Exception:  # pragma: no cover - hermes_time is always present in-process
+    _hermes_now = None
+
+
+# session_id -> tz-aware timestamp of the previous turn
+_last_ts: Dict[str, datetime] = {}
+_lock = threading.Lock()
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Human-readable English elapsed-time string, >= 60s granularity."""
+    if seconds < 60:
+        return "just now"
+    m = int(seconds // 60)
+    if m < 60:
+        return f"{m} minute{'s' if m != 1 else ''} ago"
+    h, rem = divmod(m, 60)
+    if h < 24:
+        return f"{h} hour{'s' if h != 1 else ''} {rem} minute{'s' if rem != 1 else ''} ago"
+    d, rem = divmod(h, 24)
+    return f"{d} day{'s' if d != 1 else ''} {rem} hour{'s' if rem != 1 else ''} ago"
+
+
+def _now() -> datetime:
+    if _hermes_now is not None:
+        try:
+            return _hermes_now()
+        except Exception:
+            pass
+    return datetime.now().astimezone()
+
+
+def _prev_turn_ts(conversation_history: Optional[List[Dict[str, Any]]]) -> Optional[datetime]:
+    """Timestamp of the previous message in this session.
+
+    The prologue appends the current message to ``conversation_history``
+    before hooks fire (turn_context appends first, then invokes hooks), so
+    ``[-1]`` is the current message and ``[-2]`` is the previous one. Message
+    timestamps are restored from the store (``hermes_state._rows_to_conversation``),
+    so they stay accurate across processes/restarts.
+    """
+    try:
+        hist = conversation_history or []
+        if len(hist) >= 2:
+            ts = hist[-2].get("timestamp")
+            if isinstance(ts, (int, float)) and ts > 0:
+                return datetime.fromtimestamp(ts).astimezone()
+    except (IndexError, TypeError, ValueError):
+        pass
+    return None
+
+
+def _pre_llm_call(session_id: str = "", conversation_history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> Dict[str, str]:
+    key = session_id or "default"
+    now = _now()
+    prev = _prev_turn_ts(conversation_history or [])
+    if prev is None:
+        prev = _last_ts.get(key)  # fallback: in-process record of the previous turn
+    elapsed = ""
+    if prev is not None:
+        delta = now - prev
+        if delta.total_seconds() >= 60:
+            elapsed = f"; last message {_format_elapsed(delta.total_seconds())} ago"
+    with _lock:
+        _last_ts[key] = now
+    stamp = now.strftime("%Y-%m-%d %H:%M %Z")
+    return {"context": f"[Current time {stamp}{elapsed}]"}
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("pre_llm_call", _pre_llm_call)

--- a/plugins/turn_clock/plugin.yaml
+++ b/plugins/turn_clock/plugin.yaml
@@ -1,0 +1,7 @@
+name: turn-clock
+version: 1.0.0
+description: "Per-turn wall-clock time + elapsed-since-last-message, injected into the API copy of the user message (ephemeral, prompt-cache safe)."
+author: zkangping-glitch
+kind: standalone
+provides_hooks:
+  - pre_llm_call

--- a/tests/plugins/test_turn_clock.py
+++ b/tests/plugins/test_turn_clock.py
@@ -1,0 +1,115 @@
+"""Tests for the turn-clock plugin: per-turn time + elapsed injection.
+
+Covers the ``pre_llm_call`` hook contract (returns ``{"context": ...}``
+merged by ``agent/turn_context.py``), the elapsed-time formatting, and the
+elapsed sources: conversation-history timestamps first, in-process previous-
+turn record as fallback.
+"""
+
+import re
+
+from plugins.turn_clock import _format_elapsed, _pre_llm_call, register
+
+
+# ---------------------------------------------------------------------------
+# _format_elapsed
+# ---------------------------------------------------------------------------
+
+
+class TestFormatElapsed:
+    def test_under_a_minute_is_just_now(self):
+        assert _format_elapsed(30) == "just now"
+        assert _format_elapsed(59.9) == "just now"
+
+    def test_minutes(self):
+        assert _format_elapsed(60) == "1 minute ago"
+        assert _format_elapsed(125) == "2 minutes ago"
+
+    def test_hours_with_minute_remainder(self):
+        assert _format_elapsed(3600) == "1 hour 0 minutes ago"
+        assert _format_elapsed(3725) == "1 hour 2 minutes ago"
+
+    def test_days_with_hour_remainder(self):
+        assert _format_elapsed(86400) == "1 day 0 hours ago"
+        assert _format_elapsed(90000) == "1 day 1 hour ago"
+
+
+# ---------------------------------------------------------------------------
+# _pre_llm_call
+# ---------------------------------------------------------------------------
+
+
+class TestPreLlmCall:
+    def test_returns_context_dict(self):
+        result = _pre_llm_call(session_id="s1")
+        assert isinstance(result, dict)
+        assert "context" in result
+        assert result["context"].startswith("[Current time ")
+
+    def test_stamp_is_iso_like_with_timezone(self):
+        result = _pre_llm_call(session_id="s2")
+        assert re.match(r"^\[Current time \d{4}-\d{2}-\d{2} \d{2}:\d{2} [A-Z]+", result["context"])
+
+    def test_elapsed_from_conversation_history(self):
+        # [-1] is the current message, [-2] the previous one (prologue appends first)
+        hist = [
+            {"timestamp": 1_700_000_000.0},  # previous message (old)
+            {"timestamp": 1_700_000_100.0},  # current message
+        ]
+        result = _pre_llm_call(session_id="s3", conversation_history=hist)
+        assert "last message" in result["context"]
+
+    def test_no_elapsed_when_previous_message_is_fresh(self):
+        import time
+
+        now = time.time()
+        hist = [
+            {"timestamp": now - 10},  # 10 seconds ago -> under 60s threshold
+            {"timestamp": now},
+        ]
+        result = _pre_llm_call(session_id="s4", conversation_history=hist)
+        assert "last message" not in result["context"]
+
+    def test_no_elapsed_without_history(self):
+        result = _pre_llm_call(session_id="s5", conversation_history=[])
+        assert "last message" not in result["context"]
+
+    def test_in_process_fallback_record(self):
+        # With no usable history, the in-process record of the previous turn
+        # serves as the elapsed source.
+        from datetime import datetime, timedelta
+
+        from plugins.turn_clock import _last_ts, _lock
+
+        with _lock:
+            _last_ts["s6"] = datetime.now().astimezone() - timedelta(minutes=5)
+        result = _pre_llm_call(session_id="s6", conversation_history=[])
+        assert "last message" in result["context"]
+        assert "5 minutes ago" in result["context"]
+
+    def test_session_isolation(self):
+        from plugins.turn_clock import _last_ts, _lock
+
+        with _lock:
+            _last_ts.pop("s7", None)
+        result = _pre_llm_call(session_id="s7", conversation_history=[])
+        assert "last message" not in result["context"]
+
+
+# ---------------------------------------------------------------------------
+# register
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    def test_registers_pre_llm_call_hook(self):
+        class FakeCtx:
+            def __init__(self):
+                self.hooks = []
+
+            def register_hook(self, hook_name, callback):
+                self.hooks.append((hook_name, callback))
+
+        ctx = FakeCtx()
+        register(ctx)
+        assert ("pre_llm_call", _pre_llm_call) in ctx.hooks


### PR DESCRIPTION
## Summary

Adds **turn-clock**, a small standalone plugin that gives the model a sense of "now" **and of elapsed time** — injecting a compact wall-clock stamp plus the time since the previous message into the API copy of the current turn's user message, via the `pre_llm_call` hook.

```
[Current time 2026-08-22 19:16 CST; last message 2 hours 5 minutes ago]
```

This is the "elapsed-since-last-message" dimension called out as missing in [#17476](https://github.com/NousResearch/hermes-agent/issues/17476): every live-time proposal there injects absolute "now", but none tells the model *how much time passed since the last exchange* — which is what actually matters in long-lived / cross-day / 24-7 sessions ("user replied 3 minutes later" vs "user came back after 3 days").

## Design

- **Ephemeral only**: returns `{"context": ...}` from the `pre_llm_call` hook, merged by `agent/turn_context.py` (`plugin_user_context`) into the user-message API copy. The stored transcript stays clean and the cached system prompt is untouched → prompt-cache prefix stays byte-stable.
- **Elapsed source**: `conversation_history[-2].timestamp` — the prologue appends the current message before hooks fire, so `[-1]` is current and `[-2]` is the previous one; message timestamps come from the store, so they stay accurate across processes/restarts. An in-process per-session record (`_last_ts`) serves as fallback.
- **TZ-aware**: prefers `hermes_time.now()` (Hermes' configured timezone), falls back to system-local.
- **Zero dependencies**: stdlib only (`datetime`, `threading`); `hermes_time` import is guarded.
- **60s floor**: no elapsed stamp for sub-minute gaps, avoiding noise.

## Tests

`tests/plugins/test_turn_clock.py` — 12 tests: formatting (minutes/hours/days, singular/plural, just-now), the `{"context": ...}` contract, history-based vs in-process elapsed sources, fresh-message threshold, session isolation, and hook registration.

All 12 pass via `scripts/run_tests.sh`.

## Notes

- Plugin manifest uses `kind: standalone`, `provides_hooks: [pre_llm_call]`.
- The plugin has been running locally (author's deployment) with this exact hook contract; the bundled copy is a cleaned-up English version of that.
