### PR TITLE
class DiscordAdapter.__init__() reads from platforms.discord

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4333,6 +4333,7 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             from hermes_cli.config import read_raw_config
             cfg = read_raw_config() or {}
+            cfg = cfg.get("platforms") or cfg
             raw = (cfg.get("discord") or {}).get(key, default)
             value = int(raw)
             return max(minimum, value)


### PR DESCRIPTION
Allows class DiscordAdapter.__init__() reads some configuration parameters (inactivity_timeout, playback_timeout and fx_voice) from platforms.discord section or discord section (legacy)

## Related Issue
Root cause of Issue https://github.com/NousResearch/hermes-agent/issues/91877

## Type of Change

<!-- Check the one that applies. -->

- [ X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Light improvement  _load_discord_int_config

## How to Test
1.  set platforms.discord.voice_channel_inactivity_timeout_seconds
2. or verify discord.voice_channel_inactivity_timeout_seconds (legacy) works

### Code

- [X ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
