### PR TITLE
fix(telegram): preserve formatting around nested backticks

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8448,10 +8448,19 @@ class TelegramAdapter(BasePlatformAdapter):
             text,
         )
 
-        # 2) Protect inline code (`...`)
-        #    Escape \ inside inline code per MarkdownV2 spec.
+        # 2) Protect inline code (`...`).  Telegram only supports single-
+        #    backtick spans, so collapse GFM's double-backtick form when its
+        #    content does not itself contain backticks.
         text = re.sub(
-            r'(`[^`]+`)',
+            r'``([^`\r\n]+)``',
+            lambda m: _ph(f'`{m.group(1)}`'.replace('\\', '\\\\')),
+            text,
+        )
+        #    Do not start inside a longer backtick run or cross a line boundary.
+        #    This leaves the outer ticks in `` `code` `` as escaped literals
+        #    while preserving the inner span as Telegram inline code.
+        text = re.sub(
+            r'(?<!`)(`[^`\r\n]+`)',
             lambda m: _ph(m.group(0).replace('\\', '\\\\')),
             text,
         )
@@ -8536,7 +8545,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # 12) Safety net: escape unescaped ( ) { } that slipped through
         #     placeholder processing.  Split the text into code/non-code
         #     segments so we never touch content inside ``` or ` spans.
-        _code_split = re.split(r'(```[\s\S]*?```|`[^`]+`)', text)
+        _code_split = re.split(r'(```[\s\S]*?```|`[^`\r\n]+`)', text)
         _safe_parts = []
         for _idx, _seg in enumerate(_code_split):
             if _idx % 2 == 1:

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -25,6 +25,24 @@ from plugins.platforms.telegram.adapter import (  # noqa: E402
 )
 
 
+def _assert_balanced_mdv2_code_entities(text: str) -> None:
+    """Assert that every unescaped MarkdownV2 code delimiter is closed."""
+    delimiter = None
+    index = 0
+    while index < len(text):
+        if text[index] == "\\":
+            index += 2
+            continue
+        if text.startswith("```", index):
+            delimiter = None if delimiter == "```" else "```"
+            index += 3
+            continue
+        if text[index] == "`":
+            delimiter = None if delimiter == "`" else "`"
+        index += 1
+    assert delimiter is None, f"unclosed {delimiter} code entity in {text!r}"
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -119,6 +137,33 @@ class TestFormatMessageCodeBlocks:
         result = adapter.format_message(text)
         # \\ in input → \\\\ in output (each \ escaped once)
         assert r"`\\\\server\\share`" in result
+
+    def test_nested_backticks_preserve_markdownv2_formatting(self, adapter):
+        text = (
+            "**Раздел**\n"
+            "- `**жирный**`, `*курсив*`, `~~зачёркнутый~~`, `||спойлер||`\n"
+            "- `` `код` `` и ``` блоки кода ```\n"
+            "- `[ссылка](url)`, заголовки `##`\n"
+            "**Вывод**\n"
+            "5. Не мешай `**` и эмодзи внутри одной строки — каша."
+        )
+
+        result = adapter.format_message(text)
+
+        assert "*Раздел*" in result
+        assert r"\`\` `код` \`\`" in result
+        assert r"`**`" in result
+        _assert_balanced_mdv2_code_entities(result)
+
+    def test_double_backtick_span_collapses_to_telegram_inline_code(self, adapter):
+        result = adapter.format_message("Use ``value`` now")
+
+        assert result == "Use `value` now"
+
+    def test_inline_code_does_not_span_newlines(self, adapter):
+        result = adapter.format_message("`orphan\n(foo)`")
+
+        assert result == "\\`orphan\n\\(foo\\)\\`"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Telegram replies containing GFM nested or double-backtick code spans could produce an unclosed MarkdownV2 code entity. Telegram then rejected the formatted message and the adapter silently retried as plain text, stripping all formatting. This change keeps inline-code matching within one line and outside longer backtick runs, while converting supported double-backtick spans to Telegram inline code.

### Symptom

A reply containing nested backticks such as `` `code` `` could fail with `Can't parse entities: can't find end of code entity`. The reply still arrived, but all Markdown formatting was lost because delivery fell back to plain text.

### Impact

Telegram users receiving model output with nested backticks lost formatting for the entire message, not only the affected code span.

### Bug Cause

**Trigger:** `plugins/platforms/telegram/adapter.py:8451` / `TelegramAdapter.format_message` when inline-code protection processes nested or multiline backticks.

**Causal chain:**
1. The inline-code regex could begin on the second backtick of a longer run and could match across line boundaries.
2. Mis-paired spans left raw backticks that later escaping converted into an escaped closing delimiter.
3. Telegram rejected the resulting unclosed MarkdownV2 code entity, and the adapter resent the whole reply as plain text.

**Why it is wrong:** Telegram MarkdownV2 supports single-backtick inline code and requires every code delimiter to close. Matching across lines or from within a longer run violates that contract.

**Working sibling / contrast:** Fenced code blocks are protected before inline spans and already escape internal backticks correctly. The same no-newline boundary is now applied to the final code/non-code safety split.

**Ruled out:** The plain-text fallback itself was not the source of malformed MarkdownV2; direct `format_message` regression coverage reproduced the unclosed entity before any Telegram network call.

### Fix

- Collapse GFM double-backtick spans without inner backticks into Telegram single-backtick inline code.
- Prevent single-backtick matching from starting inside a longer run or crossing CR/LF boundaries.
- Apply the same line boundary to the safety-net code splitter.
- Cover the reported multilingual nested-backtick input, plain double-backtick spans, and multiline delimiters.

## Related Issue

Closes #92239

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/telegram/adapter.py` - make MarkdownV2 inline-code protection backtick-run and line aware.
- `tests/gateway/test_telegram_format.py` - add nested, double-backtick, multiline, and balanced-entity regressions.

## How to Test

1. Format the reproduction text from #92239 and confirm all unescaped MarkdownV2 code delimiters are balanced.
2. Confirm ``value`` becomes `value` in Telegram MarkdownV2 output.
3. Run:

```bash
scripts/run_tests.sh tests/gateway/test_telegram_format.py -q
```

Result: 45 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on all relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; this is an internal formatting correction
- [x] `cli-config.yaml.example` update is N/A; no configuration changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the change is platform-independent string processing
- [x] Tool descriptions and schemas are N/A; no tool interface changed

## Screenshots / Logs

N/A - covered by deterministic formatter regression tests.
