### PR TITLE
fix(acp): heal bare 'custom' provider identity on session save and restore

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -442,6 +442,29 @@ class SessionManager:
             session_meta["base_url"] = base_url.strip()
         if isinstance(api_mode, str) and api_mode.strip():
             session_meta["api_mode"] = api_mode.strip()
+        # The agent's resolved provider for a named ``providers:`` entry is the
+        # bare billing class ``"custom"``, which is not routable on restore
+        # (resolve_runtime_provider falls through to the OpenRouter default
+        # with no api_key -> "No LLM provider configured"). Persist the durable
+        # ``custom:<name>`` identity instead, recovered from the endpoint URL /
+        # model — same contract as the TUI/desktop heal (runtime_provider.
+        # canonical_custom_identity docstring: every persist/restore path must
+        # run bare "custom" through this helper).
+        if str(session_meta.get("provider") or "").strip().lower() == "custom":
+            try:
+                from hermes_cli.runtime_provider import canonical_custom_identity
+
+                healed = canonical_custom_identity(
+                    base_url=session_meta.get("base_url") or None,
+                    model=model_str or None,
+                )
+                if healed:
+                    session_meta["provider"] = healed
+            except Exception:
+                logger.debug(
+                    "ACP save: custom provider identity recovery failed",
+                    exc_info=True,
+                )
         cwd_json = json.dumps(session_meta)
 
         try:
@@ -545,6 +568,31 @@ class SessionManager:
                 pass
 
         model = row.get("model") or None
+
+        # Heal rows persisted before the save-side fix above (and rows written
+        # by other writers): a bare ``"custom"`` provider cannot be routed by
+        # resolve_runtime_provider — recover the ``custom:<name>`` identity
+        # from the persisted endpoint URL / session model before rebuilding
+        # the agent, mirroring the TUI/desktop restore heal.
+        if str(requested_provider or "").strip().lower() == "custom":
+            try:
+                from hermes_cli.runtime_provider import canonical_custom_identity
+
+                healed = canonical_custom_identity(
+                    base_url=restored_base_url or None,
+                    model=model,
+                )
+                if healed:
+                    logger.info(
+                        "ACP restore: healed bare 'custom' provider for %s -> %s",
+                        session_id, healed,
+                    )
+                    requested_provider = healed
+            except Exception:
+                logger.debug(
+                    "ACP restore: custom provider identity recovery failed",
+                    exc_info=True,
+                )
 
         # Load conversation history. repair_alternation: this restore feeds
         # LIVE REPLAY — the loaded list becomes the resumed agent's working

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -280,6 +280,57 @@ class TestPersistence:
 
 
 
+    def test_save_persists_routable_custom_identity(self, manager):
+        """save_session must not persist the bare 'custom' billing class —
+        it is not routable on restore (resolve_runtime_provider falls through
+        to OpenRouter with no key -> "No LLM provider configured")."""
+        state = manager.create_session(cwd="/work")
+        state.model = "qwen3.5:9b-mlx"
+        state.agent.provider = "custom"
+        state.agent.base_url = "http://127.0.0.1:11434/v1"
+        state.agent.api_mode = "chat_completions"
+        with patch(
+            "hermes_cli.runtime_provider.canonical_custom_identity",
+            return_value="custom:ollama-local",
+        ):
+            manager.save_session(state.session_id)
+        row = manager._get_db().get_session(state.session_id)
+        meta = json.loads(row["model_config"])
+        assert meta["provider"] == "custom:ollama-local"
+        assert meta["base_url"] == "http://127.0.0.1:11434/v1"
+
+    def test_restore_heals_bare_custom_provider(self, manager):
+        """Rows persisted with a bare 'custom' provider (pre-fix writers)
+        must be healed to their custom:<name> identity before agent rebuild."""
+        state = manager.create_session(cwd="/work")
+        sid = state.session_id
+        state.model = "qwen3.5:9b-mlx"
+        state.agent.provider = "custom"
+        state.agent.base_url = "http://127.0.0.1:11434/v1"
+        # Persist a PRE-FIX row: bypass the save-side heal.
+        with patch(
+            "hermes_cli.runtime_provider.canonical_custom_identity",
+            return_value=None,
+        ):
+            manager.save_session(sid)
+        meta = json.loads(manager._get_db().get_session(sid)["model_config"])
+        assert meta["provider"] == "custom"
+        with manager._lock:
+            del manager._sessions[sid]
+        captured = {}
+
+        def _capture_make_agent(**kwargs):
+            captured.update(kwargs)
+            return _mock_agent()
+
+        with patch(
+            "hermes_cli.runtime_provider.canonical_custom_identity",
+            return_value="custom:ollama-local",
+        ), patch.object(manager, "_make_agent", side_effect=_capture_make_agent):
+            restored = manager.get_session(sid)
+        assert restored is not None
+        assert captured.get("requested_provider") == "custom:ollama-local"
+        assert captured.get("base_url") == "http://127.0.0.1:11434/v1"
 
     def test_only_restores_acp_sessions(self, manager):
         """get_session should not restore non-ACP sessions from DB."""


### PR DESCRIPTION
## What does this PR do?

Sessions on **named custom providers** (`providers:` entries — local ollama/vllm endpoints etc.) cannot survive an ACP daemon restart: `save_session` persists the agent's *resolved billing class* — the bare string `"custom"` — as the session's provider. On restore, `resolve_runtime_provider("custom")` falls through to the OpenRouter default URL with no api_key, and every subsequent turn of the session dies with **"No LLM provider configured"** (or, worse, the session silently stops responding, since the restore failure itself is swallowed — see companion PR #92252 for that).

This is precisely the failure class `hermes_cli/runtime_provider.py::canonical_custom_identity` was built for. Its docstring says:

> Any code path that persists or restores a session's provider override must run the resolved provider through this helper so a bare `"custom"` is upgraded back to its durable `custom:<name>` menu key.

The TUI gateway, desktop, and CLI already do this (e.g. `tui_gateway/server.py` — "the origin of the recurring 'No LLM provider configured' rows"), but the ACP adapter was missed.

The fix applies the same heal in both directions:

- **save** (`SessionManager.save_session`): a bare `"custom"` provider is healed to its routable `custom:<name>` identity (recovered from the endpoint URL / model) *before* persisting, so new rows are durable from the start.
- **restore** (`SessionManager._restore`): rows persisted by pre-fix writers are healed from the persisted `base_url` / session model before the agent is rebuilt.

## Related Issue

Companion PR: #92252 — makes the restore failure loud when healing is impossible (this PR heals the identity; that one screams when it can't). Best reviewed together.

No exact open issue found for the save/restore path. Possibly related (same "No LLM provider configured" family on the `session/set_model` path, not addressed here): #91090, #59089.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/session.py`: heal bare `"custom"` in `save_session` (before `session_meta` is serialized) and in `_restore` (before `_make_agent`), both via `canonical_custom_identity` with debug-logged failure fallback (behavior unchanged when healing finds nothing).
- `tests/acp/test_session.py`: `test_save_persists_routable_custom_identity`, `test_restore_heals_bare_custom_provider` (covers the pre-fix-row case).

## How to Test

1. Configure a named custom provider and make it the default, e.g. in `config.yaml`: `providers: {ollama-local: {api: http://127.0.0.1:11434/v1, ...}}`, `model: {default: <some-local-model>, provider: ollama-local}`.
2. Start the ACP daemon (`python -m acp_adapter`), `initialize` → `session/new` → one `session/prompt` (works).
3. Kill the daemon, start a fresh one, `session/load` the same session, then `session/prompt`.
4. **Before:** the sessions row holds `provider: "custom"`; the turn fails with "No LLM provider configured". **After:** the row holds `provider: "custom:ollama-local"`, and pre-fix rows are healed on restore; the turn streams normally with full history replay. Verified live against a real daemon for both new and pre-fix rows.
5. `pytest tests/acp/ -q` → 137 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (tests/acp fully; full suite spot-checked)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Apple Silicon), Python 3.13.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config/API change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

