### PR TITLE
fix(acp): fail loud on restore failure, silent load success, and non-retryable turn errors

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1618,6 +1618,25 @@ class HermesACPAgent(acp.Agent):
     ) -> LoadSessionResponse | None:
         state = self.session_manager.update_cwd(session_id, cwd)
         if state is None:
+            reason = self.session_manager.last_restore_error(session_id)
+            if reason:
+                # Fail loud: the session exists in the DB but its agent could
+                # not be rebuilt (e.g. its provider/model was removed). A bare
+                # ``return None`` is normalized to a silent ``{}`` SUCCESS on
+                # the wire (acp normalize_result), so the client believes the
+                # load worked and only discovers the problem on its next
+                # prompt. Surface the real reason as a JSON-RPC error instead.
+                logger.warning(
+                    "load_session: session %s could not be restored: %s",
+                    session_id, reason,
+                )
+                from acp.exceptions import RequestError
+
+                raise RequestError(
+                    -32603,
+                    f"Session {session_id} could not be restored: {reason}",
+                    {"sessionId": session_id},
+                )
             logger.warning("load_session: session %s not found", session_id)
             return None
         await self._register_session_mcp_servers(state, mcp_servers)
@@ -1796,7 +1815,22 @@ class HermesACPAgent(acp.Agent):
         """Run Hermes on the user's prompt and stream events back to the editor."""
         state = self.session_manager.get_session(session_id)
         if state is None:
-            logger.error("prompt: session %s not found", session_id)
+            # Fail loud (robustness): if the session exists in the DB but its
+            # agent could not be rebuilt, tell the client the real reason rather
+            # than a bare "not found" (e.g. its provider/model was removed).
+            reason = self.session_manager.last_restore_error(session_id)
+            if reason:
+                logger.error("prompt: session %s could not be restored: %s", session_id, reason)
+                if self._conn:
+                    await self._conn.session_update(
+                        session_id,
+                        acp.update_agent_message_text(
+                            f"⚠️ This session can't run: {reason}. Its model or provider may "
+                            "have been removed — start a new session, or restore that provider."
+                        ),
+                    )
+            else:
+                logger.error("prompt: session %s not found", session_id)
             return PromptResponse(stop_reason="refusal")
 
         user_text = _extract_text(prompt).strip()
@@ -2180,6 +2214,26 @@ class HermesACPAgent(acp.Agent):
             # rewritten text never reaches the client.
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
+
+        # Fail loud (robustness — ACP fail-silent fix): a non-retryable provider
+        # error (e.g. 401 token_expired, billing exhausted) returns the
+        # conversation loop result with final_response=None + failed=True and the
+        # reason in `error` (agent/conversation_loop.py). Previously the adapter
+        # sent nothing and the client saw an EMPTY "completed" turn with no
+        # explanation. Surface the reason as a visible message (only when nothing
+        # was already streamed) so the user knows to act — re-authenticate,
+        # switch model, etc.
+        if (
+            result.get("failed")
+            and not final_response
+            and not streamed_message
+            and conn
+        ):
+            reason = (result.get("error") or "the model provider returned an error").strip()
+            await conn.session_update(
+                session_id,
+                acp.update_agent_message_text(f"⚠️ Turn failed: {reason}"),
+            )
 
         # Mark this turn idle before draining queued work so recursive prompt()
         # calls can acquire the session. Queued turns are intentionally run as

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -204,6 +204,10 @@ class SessionManager:
         self._lock = Lock()
         self._agent_factory = agent_factory
         self._db_instance = db  # None → lazy-init on first use
+        # Fail-loud (robustness): records WHY a recent `_restore` of a session
+        # failed (e.g. "No LLM provider configured"), so the server can surface
+        # the real reason to the client instead of a generic "session not found".
+        self._restore_errors: Dict[str, str] = {}
 
     # ---- public API ---------------------------------------------------------
 
@@ -241,8 +245,18 @@ class SessionManager:
         # Attempt to restore from database.
         return self._restore(session_id)
 
+    def last_restore_error(self, session_id: str) -> Optional[str]:
+        """The reason a recent `_restore` of *session_id* failed, if any.
+
+        Set by `_restore` when the agent could not be rebuilt; consulted by the
+        server so a failed restore surfaces the real cause instead of a generic
+        "session not found". Cleared on a successful restore or removal.
+        """
+        return self._restore_errors.get(session_id)
+
     def remove_session(self, session_id: str) -> bool:
         """Remove a session from memory and database. Returns True if it existed."""
+        self._restore_errors.pop(session_id, None)
         with self._lock:
             existed = self._sessions.pop(session_id, None) is not None
         db_existed = self._delete_persisted(session_id)
@@ -568,9 +582,19 @@ class SessionManager:
                 base_url=restored_base_url,
                 api_mode=restored_api_mode,
             )
-        except Exception:
-            logger.warning("Failed to recreate agent for ACP session %s", session_id, exc_info=True)
+        except Exception as exc:
+            # Fail loud (robustness): record the real reason so the server can
+            # tell the client why the session can't run, instead of returning a
+            # bare None that surfaces as a generic "session not found".
+            reason = str(exc).strip() or exc.__class__.__name__
+            self._restore_errors[session_id] = reason
+            logger.warning(
+                "Failed to recreate agent for ACP session %s: %s",
+                session_id, reason, exc_info=True,
+            )
             return None
+        # Successful restore — clear any stale failure record.
+        self._restore_errors.pop(session_id, None)
 
         state = SessionState(
             session_id=session_id,

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -191,6 +191,11 @@ class SessionManager:
     via ``session_search``.
     """
 
+    # Cap on the failed-restore reason registry (see __init__); ~2× the
+    # largest plausible live-session population, far above what any one
+    # editor connection can hold open.
+    _RESTORE_ERRORS_MAX = 128
+
     def __init__(self, agent_factory=None, db=None):
         """
         Args:
@@ -207,6 +212,10 @@ class SessionManager:
         # Fail-loud (robustness): records WHY a recent `_restore` of a session
         # failed (e.g. "No LLM provider configured"), so the server can surface
         # the real reason to the client instead of a generic "session not found".
+        # Bounded (oldest evicted beyond _RESTORE_ERRORS_MAX): entries are
+        # cleared on successful restore or removal, but a session that keeps
+        # failing and is never removed would otherwise pin one string per
+        # session id for process lifetime.
         self._restore_errors: Dict[str, str] = {}
 
     # ---- public API ---------------------------------------------------------
@@ -253,6 +262,14 @@ class SessionManager:
         "session not found". Cleared on a successful restore or removal.
         """
         return self._restore_errors.get(session_id)
+
+    def _record_restore_error(self, session_id: str, reason: str) -> None:
+        """Record *reason* for *session_id*, evicting oldest beyond the cap."""
+        # Re-insert so a repeatedly failing session counts as newest.
+        self._restore_errors.pop(session_id, None)
+        self._restore_errors[session_id] = reason
+        while len(self._restore_errors) > self._RESTORE_ERRORS_MAX:
+            self._restore_errors.pop(next(iter(self._restore_errors)))
 
     def remove_session(self, session_id: str) -> bool:
         """Remove a session from memory and database. Returns True if it existed."""
@@ -587,7 +604,7 @@ class SessionManager:
             # tell the client why the session can't run, instead of returning a
             # bare None that surfaces as a generic "session not found".
             reason = str(exc).strip() or exc.__class__.__name__
-            self._restore_errors[session_id] = reason
+            self._record_restore_error(session_id, reason)
             logger.warning(
                 "Failed to recreate agent for ACP session %s: %s",
                 session_id, reason, exc_info=True,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -178,6 +178,69 @@ class TestAuthenticate:
 class TestSessionOps:
 
     @pytest.mark.asyncio
+    async def test_failed_turn_surfaces_error_not_empty(self, tmp_path):
+        """Robustness (ACP fail-silent fix): a non-retryable provider error
+        returns final_response=None + failed=True; the adapter must surface the
+        reason to the client instead of an empty 'completed' turn."""
+        def _failing_agent():
+            a = MagicMock(name="FailingAgent")
+            a.model = "gpt-5.5"
+            a.provider = "openai-codex"
+            a.run_conversation.return_value = {
+                "final_response": None,
+                "messages": [],
+                "failed": True,
+                "error": "HTTP 401 token_expired",
+            }
+            return a
+
+        manager = SessionManager(
+            agent_factory=_failing_agent, db=SessionDB(tmp_path / "state.db")
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        acp_agent._conn = mock_conn
+
+        resp = await acp_agent.new_session(cwd="/tmp")
+        await acp_agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hi")],
+            session_id=resp.session_id,
+        )
+
+        blob = " ".join(str(c) for c in mock_conn.session_update.await_args_list)
+        assert "Turn failed" in blob
+        assert "401" in blob
+
+    @pytest.mark.asyncio
+    async def test_load_session_surfaces_restore_failure(self, tmp_path):
+        """Robustness (ACP fail-silent fix): a failed agent rebuild during
+        session/load must produce a JSON-RPC error carrying the real reason —
+        a bare ``return None`` is normalized to a silent ``{}`` success on the
+        wire and the client believes the load worked."""
+        from unittest.mock import patch
+        from acp.exceptions import RequestError
+
+        manager = SessionManager(
+            agent_factory=lambda: MagicMock(name="MockAIAgent"),
+            db=SessionDB(tmp_path / "state.db"),
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/work")
+        sid = state.session_id
+        manager.save_session(sid)
+        with manager._lock:
+            del manager._sessions[sid]
+
+        with patch.object(
+            manager, "_make_agent",
+            side_effect=RuntimeError("No LLM provider configured"),
+        ):
+            with pytest.raises(RequestError) as exc_info:
+                await acp_agent.load_session(cwd="/work", session_id=sid)
+        assert "No LLM provider configured" in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_new_session_returns_authenticated_cross_provider_model_state(self):
         manager = SessionManager(
             agent_factory=lambda: SimpleNamespace(

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -307,6 +307,21 @@ class TestPersistence:
         assert restored is not None
         assert manager.last_restore_error(sid) is None
 
+    def test_restore_error_registry_is_bounded(self, manager):
+        """The failure registry evicts oldest entries beyond the cap, so
+        long-lived processes with many failed session ids can't grow it
+        without bound; a repeated failure re-ranks that id as newest."""
+        cap = manager._RESTORE_ERRORS_MAX
+        for i in range(cap + 10):
+            manager._record_restore_error(f"sid-{i}", "boom")
+        assert len(manager._restore_errors) == cap
+        assert manager.last_restore_error("sid-9") is None  # oldest evicted
+        assert manager.last_restore_error(f"sid-{cap + 9}") == "boom"
+        # A repeat failure refreshes recency instead of duplicating the entry.
+        manager._record_restore_error("sid-10", "boom again")
+        assert len(manager._restore_errors) == cap
+        assert next(reversed(manager._restore_errors)) == "sid-10"
+
 
     def test_only_restores_acp_sessions(self, manager):
         """get_session should not restore non-ACP sessions from DB."""

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -279,6 +279,33 @@ class TestPersistence:
 
 
 
+    def test_restore_failure_records_and_exposes_reason(self, manager):
+        """Robustness: a rebuild failure during restore records the real reason
+        (so the server can surface it) instead of a bare None → 'not found'."""
+        state = manager.create_session(cwd="/work")
+        sid = state.session_id
+        manager.save_session(sid)
+        with manager._lock:
+            del manager._sessions[sid]
+        with patch.object(
+            manager, "_make_agent",
+            side_effect=RuntimeError("No LLM provider configured"),
+        ):
+            restored = manager.get_session(sid)
+        assert restored is None
+        assert "No LLM provider configured" in (manager.last_restore_error(sid) or "")
+
+    def test_successful_restore_clears_prior_reason(self, manager):
+        """A clean restore clears any stale recorded failure reason."""
+        state = manager.create_session(cwd="/work")
+        sid = state.session_id
+        manager.save_session(sid)
+        manager._restore_errors[sid] = "stale failure"
+        with manager._lock:
+            del manager._sessions[sid]
+        restored = manager.get_session(sid)
+        assert restored is not None
+        assert manager.last_restore_error(sid) is None
 
 
     def test_only_restores_acp_sessions(self, manager):


### PR DESCRIPTION
## What does this PR do?

The ACP adapter swallows three failure modes, all of which surface to the editor/client as *silence* instead of an actionable error:

1. **Restore failure is masked.** `SessionManager._restore()` catches the agent-rebuild exception and returns `None`, so the server can only say "session not found" — hiding the real cause (e.g. a removed provider: "No LLM provider configured").
2. **`session/load` reports silent success for a failed restore.** The handler returns `None`, which `normalize_result` turns into a bare `{}` **success** on the wire — the client believes the load worked and only discovers the problem when its next prompt comes back empty.
3. **A failed turn looks like an empty completed turn.** A non-retryable provider error (e.g. `401 token_expired`, billing exhausted) returns `final_response=None + failed=True` from the conversation loop, and the adapter sent nothing — the client saw an empty "completed" turn with no explanation.

Fix: `_restore` records the real reason (`SessionManager.last_restore_error`, cleared on a later successful restore); `session/load` raises a JSON-RPC error carrying that reason (**unknown** session ids keep the existing `None`/`{}` behavior, so there is no compat change for clients probing nonexistent sessions); `prompt()` on an unloadable session streams a visible "⚠️ This session can't run: <reason>…" message; and a failed turn's reason is surfaced as a visible "⚠️ Turn failed: <reason>" message (only when nothing was already streamed). No core conversation-loop changes.

## Related Issue

No existing issue found for these symptoms (searched open + closed).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/session.py`: `_restore` records the rebuild-failure reason; `last_restore_error()` accessor; reason cleared on successful restore/removal.
- `acp_adapter/server.py`: `session/load` raises `RequestError(-32603, "Session <id> could not be restored: <reason>")` when a recorded restore failure exists; `prompt()` surfaces the recorded reason; failed-turn reason streamed as a visible message.
- `tests/acp/test_session.py`: restore-reason recorded/exposed/cleared.
- `tests/acp/test_server.py`: `session/load` raises with the real reason; a failed turn surfaces its error instead of an empty completed turn.

## How to Test

1. Create an ACP session on any provider, run one turn, kill the daemon.
2. Make the session unrestorable (e.g. remove its provider from `config.yaml`, or simulate a rebuild failure).
3. Start a fresh daemon, `session/load` the session: **before** — `{}` success with zero replay, then an empty turn; **after** — a JSON-RPC error naming the real reason (and `session/prompt` explains it in-stream if attempted).
4. For the failed-turn path: force a non-retryable provider error (e.g. expired credentials); the turn now streams "⚠️ Turn failed: <reason>" instead of completing empty.
5. `pytest tests/acp/ -q` → 139 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (tests/acp fully; full suite spot-checked)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Apple Silicon), Python 3.13.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (error-surfacing only, no config/API change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
