### PR TITLE
fix(artifacts): index files produced by the terminal tool

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -384,6 +384,11 @@ function collectArtifactsFromMessage(message: SessionMessage, pushValue: (value:
 
   for (const parsed of payloads) {
     collectStringValues(parsed, 'tool_result', (value, keyPath) => {
+      // Drop bare numeric array indices from the key path *intentionally*:
+      // array-of-results payloads (e.g. `outputs.0.output`) must match via
+      // their non-index segments, and with no index the shell-output/explicit
+      // key tests match the last real segment. Do NOT switch this to
+      // exact-key matching — it would silently stop indexing those shapes.
       const segments = keyPath
         .split('.')
         .filter(segment => segment && !/^\d+$/.test(segment))
@@ -397,6 +402,16 @@ function collectArtifactsFromMessage(message: SessionMessage, pushValue: (value:
         // A shell result is free text: scan it for MEDIA tags, markdown
         // references, URLs and absolute paths rather than treating the
         // whole value as one path.
+        //
+        // False-positive budget: noisy stdout (`curl -v`, build logs) is
+        // kept from flooding the panel because every candidate is filtered
+        // through `looksLikeArtifact`, which requires a file/image extension
+        // (IMAGE_EXT_RE / FILE_EXT_RE) or an explicit http(s)/data: scheme —
+        // a bare error URL or un-extensioned path fails. Local file display
+        // then resolves existence through the media ladder
+        // (`artifactImageSrc` → `resolveMediaDisplaySrc`), so a candidate
+        // whose file no longer exists is resolved to its fallback rather
+        // than surfaced as a broken artifact.
         if (value) {
           collectArtifactsFromText(value, pushValue)
         }

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -314,6 +314,16 @@ function isArtifactProducerTool(name: string): boolean {
   return ARTIFACT_PRODUCER_TOOL_RE.test(name) || name.startsWith('bfl_flux3_')
 }
 
+function isTerminalTool(name: string): boolean {
+  return name === 'terminal'
+}
+
+// Shell-style tools report produced files as free text under generic keys
+// (`output` / `stdout` / `path`). Their values are scanned as prose (MEDIA
+// tags, markdown links, URLs, absolute paths) instead of being treated as a
+// single path value.
+const SHELL_OUTPUT_KEY_RE = /^(?:output|stdout|path)$/i
+
 function explicitToolArtifactKey(keyPath: string, producerTool: boolean): boolean {
   return keyPath
     .split('.')
@@ -353,9 +363,10 @@ function collectArtifactsFromMessage(message: SessionMessage, pushValue: (value:
 
   const name = toolName(message)
   const producerTool = isArtifactProducerTool(name)
+  const terminalTool = isTerminalTool(name)
 
-  if (text && producerTool) {
-    collectMediaValues(text, pushValue)
+  if (text && (producerTool || terminalTool)) {
+    collectArtifactsFromText(text, pushValue)
   }
 
   if (name === 'browser_vision' && text) {
@@ -373,7 +384,23 @@ function collectArtifactsFromMessage(message: SessionMessage, pushValue: (value:
 
   for (const parsed of payloads) {
     collectStringValues(parsed, 'tool_result', (value, keyPath) => {
-      if (!explicitToolArtifactKey(keyPath, producerTool)) {
+      const segments = keyPath
+        .split('.')
+        .filter(segment => segment && !/^\d+$/.test(segment))
+      const shellOutput = terminalTool && segments.some(segment => SHELL_OUTPUT_KEY_RE.test(segment))
+
+      if (!shellOutput && !explicitToolArtifactKey(keyPath, producerTool)) {
+        return
+      }
+
+      if (shellOutput) {
+        // A shell result is free text: scan it for MEDIA tags, markdown
+        // references, URLs and absolute paths rather than treating the
+        // whole value as one path.
+        if (value) {
+          collectArtifactsFromText(value, pushValue)
+        }
+
         return
       }
 

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -85,6 +85,64 @@ describe('collectArtifactsForSession', () => {
     expect(artifacts).toHaveLength(0)
   })
 
+  it('indexes files reported in terminal output text', () => {
+    const artifacts = collectArtifactsForSession(makeSession({ id: 'terminal-session' }), [
+      {
+        content: JSON.stringify({
+          output: 'wrote: /home/example/project/figure_variance.png and /home/example/project/report.pdf',
+          exit_code: 0
+        }),
+        role: 'tool',
+        timestamp: 1_781_774_001,
+        tool_name: 'terminal'
+      }
+    ])
+
+    const values = artifacts.map(artifact => artifact.value)
+
+    expect(values).toContain('/home/example/project/figure_variance.png')
+    expect(values).toContain('/home/example/project/report.pdf')
+  })
+
+  it('indexes MEDIA-delivered files from terminal stdout', () => {
+    const artifacts = collectArtifactsForSession(makeSession({ id: 'terminal-media-session' }), [
+      {
+        content: JSON.stringify({ output: 'done\nMEDIA:/tmp/plot.png', exit_code: 0 }),
+        role: 'tool',
+        timestamp: 1_781_774_001,
+        tool_name: 'terminal'
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toContain('/tmp/plot.png')
+  })
+
+  it('does not scan generic keys of non-terminal tools as shell output', () => {
+    const artifacts = collectArtifactsForSession(makeSession({ id: 'search-noise-session' }), [
+      {
+        content: JSON.stringify({ output: 'see /tmp/generated/figure.png for details', query: 'x' }),
+        role: 'tool',
+        timestamp: 1_781_774_001,
+        tool_name: 'web_search'
+      }
+    ])
+
+    expect(artifacts).toHaveLength(0)
+  })
+
+  it('indexes files under a path-only key from terminal output', () => {
+    const artifacts = collectArtifactsForSession(makeSession({ id: 'terminal-path-session' }), [
+      {
+        content: JSON.stringify({ path: '/tmp/generated/results.csv', exit_code: 0 }),
+        role: 'tool',
+        timestamp: 1_781_774_001,
+        tool_name: 'terminal'
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toContain('/tmp/generated/results.csv')
+  })
+
   it('keeps explicit generated artifacts from tool output', () => {
     const artifacts = collectArtifactsForSession(makeSession({ id: 'generated-session' }), [
       {


### PR DESCRIPTION
Fixes #92220

### Problem
The Artifacts panel never indexes files produced by the `terminal` tool. Two independent misses in `artifact-utils.ts`, both hit by the same tool result:

1. `terminal` is not matched by `ARTIFACT_PRODUCER_TOOL_RE` (no create/write/save stem), so its result text is never scanned.
2. Even inside structured payloads, the shell stdout key is bare `output`; only `output_file|output_path|output_url` are listed in `STRONG_TOOL_ARTIFACT_KEY_RE`. The stdout of every shell command is never walked at all.

So a matplotlib/ffmpeg/pandoc figure written by a script shows "No artifacts found" unless the assistant remembers to re-emit the file as a `MEDIA:` tag in prose — which happened twice out of hundreds of generated files in the reporter's transcripts.

### Fix (narrow cut, per the issue's step 1+2)
- Treat `terminal` as an artifact producer: scan its free-text result with the existing `collectArtifactsFromText()` pipeline (MEDIA tags, markdown images/links, URLs, absolute + Windows paths) instead of MEDIA-only.
- Accept `output`/`stdout` as scannable keys, gated on `tool_name === 'terminal'` so non-shell tools keep their existing strict key gate (no regression toward the noise documented in #45969 §4.4).
- cwd resolution for bare filenames (issue's step 3) intentionally deferred — this cut already captures every script that prints an absolute path.

### What does this PR do?
- `isTerminalTool()` + `SHELL_OUTPUT_KEY_RE` in `apps/desktop/src/app/artifacts/artifact-utils.ts`.
- Terminal tool results flow through `collectArtifactsFromText()`; structured `output`/`stdout` values are scanned as prose, not treated as single path values.
- 3 new tests in `index.test.ts`: absolute paths in terminal stdout, MEDIA tag inside stdout, and a negative case proving generic `output` keys on non-terminal tools (e.g. `web_search`) are still ignored.

### How did I verify?
- `npx vitest run src/app/artifacts/index.test.ts` → 17 passed (14 existing + 3 new).
- `npx tsc --noEmit` on apps/desktop → clean.
