### PR TITLE
fix(desktop): let the transcript hear the power-resume wake signal

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -15,6 +15,7 @@ import {
 
 afterEach(() => {
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe('subscribeToThreadForeground', () => {
@@ -82,6 +83,80 @@ describe('subscribeToThreadForeground', () => {
 
     expect(cancel).toHaveBeenCalledWith(9)
     expect(reanchor).not.toHaveBeenCalled()
+  })
+
+  // A macOS lock/unlock can produce neither `visibilitychange` nor `focus`:
+  // the window is not occluded and never loses focus, so both listeners above
+  // stay silent while rAF and ResizeObserver were frozen the whole time
+  // (#92180). The main process signal is the only edge left.
+  it('reanchors when the main process reports a power resume', () => {
+    const reanchor = vi.fn()
+    let fire: (() => void) | undefined
+
+    vi.stubGlobal('hermesDesktop', {
+      onPowerResume: (callback: () => void) => {
+        fire = callback
+
+        return () => {
+          fire = undefined
+        }
+      }
+    })
+
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      callback(0)
+
+      return 1
+    })
+
+    const unsubscribe = subscribeToThreadForeground(() => true, reanchor)
+
+    expect(fire).toBeTypeOf('function')
+    fire?.()
+
+    expect(raf).toHaveBeenCalledOnce()
+    expect(reanchor).toHaveBeenCalledOnce()
+    unsubscribe()
+  })
+
+  it('leaves a scrolled-up reader in place on a power resume', () => {
+    const reanchor = vi.fn()
+    let fire: (() => void) | undefined
+
+    vi.stubGlobal('hermesDesktop', {
+      onPowerResume: (callback: () => void) => {
+        fire = callback
+
+        return () => undefined
+      }
+    })
+    const raf = vi.spyOn(window, 'requestAnimationFrame')
+
+    const unsubscribe = subscribeToThreadForeground(() => false, reanchor)
+
+    fire?.()
+
+    expect(raf).not.toHaveBeenCalled()
+    expect(reanchor).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it('drops the power-resume subscription when its thread unmounts', () => {
+    const off = vi.fn()
+
+    vi.stubGlobal('hermesDesktop', { onPowerResume: () => off })
+
+    subscribeToThreadForeground(() => true, vi.fn())()
+
+    expect(off).toHaveBeenCalledOnce()
+  })
+
+  it('subscribes to nothing outside the desktop shell', () => {
+    // The web build and every unit test render without a preload bridge; an
+    // optional hop must stay optional rather than throwing on mount.
+    const reanchor = vi.fn()
+
+    expect(() => subscribeToThreadForeground(() => true, reanchor)()).not.toThrow()
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -151,6 +151,69 @@ describe('subscribeToThreadForeground', () => {
     expect(off).toHaveBeenCalledOnce()
   })
 
+  // powerMonitor fires on wake regardless of what the window is doing, so a
+  // resume can arrive at a MINIMIZED window. Re-anchoring one is worse than
+  // doing nothing: a hidden surface has no layout to measure, so the
+  // virtualizer would re-record exactly the zeroed geometry this subscription
+  // exists to replace, and the later visibilitychange would then find nothing
+  // to correct. The visibility guard predates this edge; these two pin that
+  // the new edge still routes through it, because "powerMonitor already
+  // proves we are awake" is a plausible reason for someone to skip it later.
+  it('does not reanchor a minimized window on a power resume', () => {
+    const reanchor = vi.fn()
+    let fire: (() => void) | undefined
+
+    vi.stubGlobal('hermesDesktop', {
+      onPowerResume: (callback: () => void) => {
+        fire = callback
+
+        return () => undefined
+      }
+    })
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+
+    const raf = vi.spyOn(window, 'requestAnimationFrame')
+    const unsubscribe = subscribeToThreadForeground(() => true, reanchor)
+
+    fire?.()
+
+    expect(raf).not.toHaveBeenCalled()
+    expect(reanchor).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
+  it('does not reanchor when the window is minimized between the resume and the frame', () => {
+    const reanchor = vi.fn()
+    let fire: (() => void) | undefined
+    let visibility: DocumentVisibilityState = 'visible'
+
+    vi.stubGlobal('hermesDesktop', {
+      onPowerResume: (callback: () => void) => {
+        fire = callback
+
+        return () => undefined
+      }
+    })
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => visibility)
+
+    const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      // The user minimizes while the frame is queued: the entry guard passed,
+      // the one inside the callback is the only thing left.
+      visibility = 'hidden'
+      callback(0)
+
+      return 1
+    })
+
+    const unsubscribe = subscribeToThreadForeground(() => true, reanchor)
+
+    fire?.()
+
+    expect(raf).toHaveBeenCalledOnce()
+    expect(reanchor).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
   it('subscribes to nothing outside the desktop shell', () => {
     // The web build and every unit test render without a preload bridge; an
     // optional hop must stay optional rather than throwing on mount.

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -153,10 +153,22 @@ export function subscribeToThreadForeground(shouldReanchor: () => boolean, onRea
 
   document.addEventListener('visibilitychange', onForeground)
   window.addEventListener('focus', onForeground)
+  // Third edge, because the two above can BOTH miss a wake. A macOS screen
+  // lock or display sleep freezes rAF and ResizeObserver, but an Electron
+  // window that is never occluded and never loses focus stays
+  // `visibilityState: 'visible'` and fires no `focus`, so nothing re-anchors
+  // and the transcript is left holding measurements taken before the freeze
+  // (#92180). The main process already publishes the signal that does fire:
+  // powerMonitor `resume` / `unlock-screen` -> `hermes:power-resume`.
+  // use-gateway-boot subscribes to it as a peer of focus/visibility for
+  // exactly this reason; this view documents the same need and was listening
+  // to only two of the three.
+  const offPowerResume = window.hermesDesktop?.onPowerResume?.(onForeground)
 
   return () => {
     document.removeEventListener('visibilitychange', onForeground)
     window.removeEventListener('focus', onForeground)
+    offPowerResume?.()
 
     if (frameId !== null) {
       cancelAnimationFrame(frameId)


### PR DESCRIPTION
## What does this PR do?

Gives the desktop transcript the one wake signal it was missing.

`subscribeToThreadForeground`
(`apps/desktop/src/components/assistant-ui/thread/list.tsx:127`) is the thread
list's wake handler. Its own comment states the problem it solves: after the
window comes back, "rAF and ResizeObserver may have been frozen, so the
virtualizer's measurements, and scrollTop itself, are stale". It subscribes to
two edges:

```ts
document.addEventListener('visibilitychange', onForeground)
window.addEventListener('focus', onForeground)
```

A macOS screen lock or display sleep can fire neither. The window is never
occluded (the display is off, nothing covers the window), so `visibilityState`
stays `visible`; and an app that still holds focus through the lock gets no
`focus` on unlock. The handler already documents half of this, noting that an
active turn disables Chromium's background throttling and "window focus is then
the only foreground edge". It does not cover the case where focus is absent too,
and then there is no edge left at all: the freeze happens, and nothing tells this
view about it.

The signal that does fire is already plumbed end to end, and this view is simply
not on it:

- `apps/desktop/electron/main.ts:6205` registers
  `powerMonitor.on('resume', sendPowerResume)` and
  `powerMonitor.on('unlock-screen', sendPowerResume)`, which sends
  `hermes:power-resume`.
- `apps/desktop/electron/preload.ts:404` exposes it as `onPowerResume`.
- Its only renderer subscriber today is `use-gateway-boot.ts:555`, under the
  comment "Wake signals: power resume (macOS/Windows), network coming back, and
  the window regaining focus/visibility".

That hook treats power-resume as a peer of focus and visibility. The transcript
view was listening to two of the three.

## Related Issue

Refs #92180

`Refs`, not `Fixes`, and I want to be exact about why, because that issue is
labelled `needs-repro` and I am on Windows and cannot reproduce it.

What I can show from the source is above: the view documents a need for a wake
edge, macOS lock/unlock can supply neither of the two it listens to, and the
signal it should have been using was already available. That stands on its own.

What I cannot show is that it fixes the blank chat. I posted the full analysis on
the issue, including a proof that the render budget is *not* what blanks the view
(`firstVisibleGroupIndex` assigns `firstVisible = i` on its first iteration at
`i = groups.length - 1`, before the budget is tested, and the trailing `Math.min`
only lowers it, so at least one turn survives for any non-empty transcript and
any budget). That leaves two live possibilities: the turns are mounted but not
painted, which this patch's re-anchor plausibly recovers, or `groups` is empty,
which is a session-store problem this patch does not touch. I asked the reporter
for the one measurement that separates them (whether
`div[data-slot="aui_thread-content"]` has turn children while blank). If the
answer is "no children", this PR is still correct on its own terms but should not
be credited with the fix, and I will go look at the store.

One further limit, stated rather than papered over: the handler deliberately
leaves a scrolled-up reader exactly where they were, and I have not changed that.
If the reporter was reading back through history when they locked, this does
nothing for them.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`apps/desktop/src/components/assistant-ui/thread/list.tsx`**

- `subscribeToThreadForeground` subscribes to `window.hermesDesktop?.onPowerResume`
  as a third foreground edge, routed into the same `onForeground` handler as the
  other two, and unsubscribes it in the returned cleanup.
- No new predicate and no new behaviour on the existing edges: the power-resume
  path runs the same `shouldReanchor()` gate, the same single-frame coalescing,
  and the same `visibilityState === 'visible'` recheck inside the frame.
- Optional-chained twice (`?.onPowerResume?.()`), so the web build, jsdom and
  anything without the preload bridge get exactly today's behaviour.

**`apps/desktop/src/components/assistant-ui/thread/list.test.ts`**

- Four tests in the existing `subscribeToThreadForeground` describe block, plus
  `vi.unstubAllGlobals()` in the shared `afterEach` so the stubbed bridge cannot
  leak into the rest of the file.

## How to Test

1. `npx vitest run src/components/assistant-ui/thread/list.test.ts` from
   `apps/desktop`: 29 passed (25 pre-existing, 4 new).

2. Mutation proof. Replace the subscription with nothing:

   ```ts
   const offPowerResume: (() => void) | undefined = undefined
   ```

   2 of the 4 fail, and they are the two that assert the wiring:
   `reanchors when the main process reports a power resume` and
   `drops the power-resume subscription when its thread unmounts`. The other two
   are guardrails that must pass either way, and do: the scrolled-up reader is
   still left alone on a power resume, and a renderer with no bridge still
   subscribes to nothing without throwing.

3. Whole renderer project, run on this branch and on its base `261a4efb90`:

   ```
   npx vitest run --project ui
   ```

   Branch: 24 failed / 5401 passed. Base: 24 failed / 5397 passed. `diff` of the
   sorted FAIL lists is **empty**: same 24 node ids, byte for byte, in
   `skills/index.test.tsx`, `messaging/index.test.tsx`, `settings/*`,
   `chat/sidebar/*` and `store/*`, none of which this PR touches. The +4 is
   exactly the 4 tests added here. (I ran these against a borrowed `node_modules`
   from another worktree rather than a fresh install, which may itself account for
   those 24; either way both sides saw the identical tree.)

4. `npx tsc -p . --noEmit` clean; `npx eslint src/components/assistant-ui/thread/`
   clean.

5. On a Mac, manually: open a session, scroll to the bottom, lock the screen for
   long enough for the display to sleep, unlock. Before this, the thread gets no
   foreground callback at all (log inside `onForeground` to see it); after, it
   gets one from `hermes:power-resume` and re-anchors.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass: N/A, this is renderer-only
  and touches no Python. What I ran instead is in "How to Test": the touched file
  at 29/29 and the whole `--project ui` run compared against this branch's base,
  with an empty diff between the two failure sets.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11. The reported symptom is macOS only
  and I have not reproduced it; see "Related Issue" for exactly what is and is not
  demonstrated here.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A:
  the comment block above the listeners is the documentation for this path and it
  now names the third edge and why the first two can both miss a lock/unlock.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A: N/A.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A: N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility):
  `powerMonitor`'s `resume` fires on Windows and Linux as well as macOS, and
  `unlock-screen` on Windows and macOS, so this is an extra wake edge everywhere
  rather than a macOS special case. Where the bridge is absent (web build, tests)
  the optional chain makes it a no-op. It never replaces the existing edges, so no
  platform loses a signal it has today.
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A: N/A.

## Screenshots / Logs

Nothing visual. The observable difference is a callback that did not previously
happen: with a `console.log` inside `onForeground`, a macOS lock/unlock cycle
currently prints nothing, and prints once after this change.

## Note for a maintainer, not fixed here

`sendPowerResume` (`main.ts:6156`) sends only to `mainWindow`, while its sibling
`broadcastBatteryState` twenty lines below loops `BrowserWindow.getAllWindows()`.
A secondary window therefore gets no wake signal at all, including the gateway
reconnect that function's docstring says it exists for. I left it alone because I
do not know whether the asymmetry is deliberate, but this PR's subscription
inherits it: a transcript in a secondary window still gets nothing. Happy to send
that as a separate one-liner if it is simply an oversight.
