### PR TITLE
feat(agent): let backend plugins resolve exact live prompts

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -1523,13 +1523,16 @@ def spawn_background_review_thread(
         )
 
     def _target() -> None:
-        _run_review_in_thread(
-            agent,
-            messages_snapshot,
-            prompt,
-            task_cfg=task_cfg,
-            review_run=review_run,
-        )
+        from agent.pending_interactions import pending_interaction_source
+
+        with pending_interaction_source("background_review"):
+            _run_review_in_thread(
+                agent,
+                messages_snapshot,
+                prompt,
+                task_cfg=task_cfg,
+                review_run=review_run,
+            )
 
     return _target, prompt
 

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1967,9 +1967,12 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # terminal. The background-thread runner also hides it; this
         # belt-and-suspenders path matters when a caller invokes
         # run_curator_review(synchronous=True) from the CLI.
+        from agent.pending_interactions import pending_interaction_source
+
         with open(os.devnull, "w", encoding="utf-8") as _devnull, \
              contextlib.redirect_stdout(_devnull), \
-             contextlib.redirect_stderr(_devnull):
+             contextlib.redirect_stderr(_devnull), \
+             pending_interaction_source("curator"):
             conv_result = review_agent.run_conversation(user_message=prompt)
 
         final = ""

--- a/agent/pending_interactions.py
+++ b/agent/pending_interactions.py
@@ -1,0 +1,374 @@
+"""Process-bound pending interaction service for trusted backend plugins.
+
+The service is deliberately transport-neutral: native approval and clarify
+registries remain authoritative, while plugins receive immutable identities and
+may request an exact, policy-checked resolution without owning a UI transport.
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextvars
+import logging
+import os
+import threading
+import time
+import uuid
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Callable, Mapping
+
+logger = logging.getLogger(__name__)
+
+PUBLIC_CONTRACT_VERSION = 1
+PROCESS_INSTANCE_ID = uuid.uuid4().hex
+_TERMINAL_STATUSES = frozenset(
+    {"resolved", "denied", "expired", "cancelled", "interrupted", "process_stopping"}
+)
+_INTERACTION_SOURCE: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "pending_interaction_source", default=""
+)
+
+
+@contextmanager
+def pending_interaction_source(kind: str):
+    """Mark an internal fork so observer metadata cannot mimic a primary turn."""
+    token = _INTERACTION_SOURCE.set(str(kind or "internal")[:64])
+    try:
+        yield
+    finally:
+        _INTERACTION_SOURCE.reset(token)
+
+
+@dataclass(frozen=True)
+class PendingInteractionTarget:
+    """Exact process-local identity of one pending interaction."""
+
+    contract_version: int
+    process_instance_id: str
+    profile_id: str
+    runtime_session_id: str
+    request_id: str
+    interaction_type: str
+    question_id: str | None = None
+    registration_id: str = ""
+
+
+@dataclass(frozen=True)
+class PendingInteractionEvent:
+    """Immutable lifecycle snapshot delivered to subscribers."""
+
+    contract_version: int
+    event: str
+    target: PendingInteractionTarget
+    occurred_at: float
+    metadata: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    status: str | None = None
+    resolved_by: str | None = None
+
+
+@dataclass(frozen=True)
+class PendingInteractionResponse:
+    """A resolver's explicit response to a pending interaction."""
+
+    kind: str
+    value: Any = None
+    resolved_by: str = "plugin"
+
+
+@dataclass(frozen=True)
+class PendingInteractionResolveResult:
+    """Stable result of an exact resolution attempt."""
+
+    status: str
+
+
+@dataclass
+class _Record:
+    target: PendingInteractionTarget
+    resolver: Callable[[PendingInteractionResponse], bool]
+    validator: Callable[[PendingInteractionResponse], bool]
+    metadata: Mapping[str, Any]
+
+
+def _active_profile_id() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return str(get_active_profile_name() or "default")
+    except Exception:
+        return str(os.environ.get("HERMES_PROFILE") or "default")
+
+
+def current_interaction_metadata(*, surface: str = "") -> dict[str, Any]:
+    """Return bounded, authoritative metadata for the current execution context."""
+    try:
+        from gateway.session_context import get_session_env
+
+        platform = str(get_session_env("HERMES_SESSION_PLATFORM", "") or "")
+        session_id = str(get_session_env("HERMES_SESSION_ID", "") or "")
+        source = str(get_session_env("HERMES_SESSION_SOURCE", "") or "")
+    except Exception:
+        platform = session_id = source = ""
+    fork_kind = _INTERACTION_SOURCE.get()
+    try:
+        from agent.delegation_context import is_delegated_child_context
+
+        delegated = bool(is_delegated_child_context())
+    except Exception:
+        delegated = False
+    if not fork_kind and delegated:
+        fork_kind = "subagent"
+    internal = bool(fork_kind)
+    return {
+        "surface": str(surface or platform or "unknown")[:64],
+        "platform": platform[:64],
+        "session_id": session_id[:256],
+        "source": source[:64],
+        "primary_user_turn": not internal,
+        "internal": internal,
+        "fork_kind": fork_kind,
+    }
+
+
+class PendingInteractionService:
+    """Versioned, profile-scoped observer and exact resolver service."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._records: dict[PendingInteractionTarget, _Record] = {}
+        self._terminal_targets: set[PendingInteractionTarget] = set()
+        self._terminal_order: deque[PendingInteractionTarget] = deque()
+        self._subscribers: dict[str, Callable[[PendingInteractionEvent], None]] = {}
+        self._executor = ThreadPoolExecutor(
+            max_workers=4, thread_name_prefix="hermes-pending-interaction"
+        )
+        self._dispatch_slots = threading.BoundedSemaphore(128)
+        self._stopping = False
+
+    def subscribe(
+        self, callback: Callable[[PendingInteractionEvent], None]
+    ) -> Callable[[], None]:
+        """Subscribe without attaching to, replacing, or retaining any transport."""
+        if not callable(callback):
+            raise TypeError("pending interaction subscriber must be callable")
+        subscription_id = uuid.uuid4().hex
+        with self._lock:
+            if self._stopping:
+                raise RuntimeError("pending interaction service is stopping")
+            self._subscribers[subscription_id] = callback
+
+        def unsubscribe() -> None:
+            with self._lock:
+                self._subscribers.pop(subscription_id, None)
+
+        return unsubscribe
+
+    def register(
+        self,
+        *,
+        runtime_session_id: str,
+        request_id: str,
+        interaction_type: str,
+        resolver: Callable[[PendingInteractionResponse], bool],
+        validator: Callable[[PendingInteractionResponse], bool],
+        question_id: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> PendingInteractionTarget:
+        """Register only after the native request identity is authoritative."""
+        target = PendingInteractionTarget(
+            PUBLIC_CONTRACT_VERSION,
+            PROCESS_INSTANCE_ID,
+            _active_profile_id(),
+            str(runtime_session_id),
+            str(request_id),
+            str(interaction_type),
+            str(question_id) if question_id is not None else None,
+            uuid.uuid4().hex,
+        )
+        frozen_metadata = MappingProxyType(dict(metadata or {}))
+        with self._lock:
+            if self._stopping:
+                raise RuntimeError("pending interaction service is stopping")
+            if target in self._records:
+                raise ValueError("pending interaction target is already registered")
+            self._records[target] = _Record(target, resolver, validator, frozen_metadata)
+        self._emit("pending_interaction.registered", target, frozen_metadata)
+        return target
+
+    def resolve(
+        self,
+        target: PendingInteractionTarget,
+        response: PendingInteractionResponse,
+    ) -> PendingInteractionResolveResult:
+        """Atomically resolve one exact native request, never a heuristic fallback."""
+        if not isinstance(target, PendingInteractionTarget):
+            return PendingInteractionResolveResult("not_found")
+        if target.contract_version != PUBLIC_CONTRACT_VERSION:
+            return PendingInteractionResolveResult("unsupported_source")
+        if target.process_instance_id != PROCESS_INSTANCE_ID:
+            return PendingInteractionResolveResult("process_mismatch")
+        if target.profile_id != _active_profile_id():
+            return PendingInteractionResolveResult("policy_denied")
+        if not isinstance(response, PendingInteractionResponse):
+            return PendingInteractionResolveResult("invalid_response")
+        with self._lock:
+            record = self._records.get(target)
+            if record is None:
+                status = (
+                    "already_resolved"
+                    if target in self._terminal_targets
+                    else "not_found"
+                )
+                return PendingInteractionResolveResult(status)
+            if not record.validator(response):
+                return PendingInteractionResolveResult("invalid_response")
+            try:
+                accepted = bool(record.resolver(response))
+            except Exception:
+                logger.exception("Pending interaction native resolver failed")
+                return PendingInteractionResolveResult("unsupported_source")
+            if not accepted:
+                return PendingInteractionResolveResult("already_resolved")
+            self._records.pop(target, None)
+            self._remember_terminal_locked(target)
+        status = "denied" if response.kind == "deny" else "resolved"
+        self._emit_terminal(record, status, response.resolved_by)
+        return PendingInteractionResolveResult("accepted")
+
+    def terminal(
+        self,
+        target: PendingInteractionTarget,
+        status: str,
+        *,
+        resolved_by: str | None = None,
+    ) -> bool:
+        """Close a natively terminated request without exposing answer content."""
+        if status not in _TERMINAL_STATUSES:
+            raise ValueError(f"unsupported pending interaction terminal status: {status}")
+        with self._lock:
+            record = self._records.pop(target, None)
+            if record is not None:
+                self._remember_terminal_locked(target)
+        if record is None:
+            return False
+        self._emit_terminal(record, status, resolved_by)
+        return True
+
+    def _remember_terminal_locked(self, target: PendingInteractionTarget) -> None:
+        self._terminal_targets.add(target)
+        self._terminal_order.append(target)
+        while len(self._terminal_order) > 4096:
+            expired = self._terminal_order.popleft()
+            self._terminal_targets.discard(expired)
+
+    def _emit_terminal(
+        self, record: _Record, status: str, resolved_by: str | None
+    ) -> None:
+        self._emit(
+            "pending_interaction.terminal",
+            record.target,
+            record.metadata,
+            status=status,
+            resolved_by=(str(resolved_by)[:64] if resolved_by else None),
+        )
+
+    def _emit(
+        self,
+        event_name: str,
+        target: PendingInteractionTarget,
+        metadata: Mapping[str, Any],
+        *,
+        status: str | None = None,
+        resolved_by: str | None = None,
+    ) -> None:
+        event = PendingInteractionEvent(
+            PUBLIC_CONTRACT_VERSION,
+            event_name,
+            target,
+            time.time(),
+            metadata,
+            status,
+            resolved_by,
+        )
+        with self._lock:
+            callbacks = tuple(self._subscribers.values())
+        for callback in callbacks:
+            if not self._dispatch_slots.acquire(blocking=False):
+                logger.warning("Dropping pending interaction event: subscriber queue full")
+                continue
+            try:
+                self._executor.submit(self._deliver_with_slot, callback, event)
+            except RuntimeError:
+                self._dispatch_slots.release()
+                break
+
+    def _deliver_with_slot(
+        self,
+        callback: Callable[[PendingInteractionEvent], None],
+        event: PendingInteractionEvent,
+    ) -> None:
+        try:
+            self._deliver(callback, event)
+        finally:
+            self._dispatch_slots.release()
+
+    @staticmethod
+    def _deliver(
+        callback: Callable[[PendingInteractionEvent], None],
+        event: PendingInteractionEvent,
+    ) -> None:
+        try:
+            callback(event)
+        except Exception:
+            logger.exception("Pending interaction subscriber failed")
+
+    def shutdown(self) -> None:
+        with self._lock:
+            if self._stopping:
+                return
+            self._stopping = True
+            records = tuple(self._records.values())
+            self._records.clear()
+        for record in records:
+            self._emit_terminal(record, "process_stopping", None)
+        with self._lock:
+            self._subscribers.clear()
+        self._executor.shutdown(wait=False, cancel_futures=False)
+
+
+class PluginPendingInteractionService:
+    """Plugin-owned view that removes subscriptions during plugin unload."""
+
+    def __init__(
+        self,
+        service: PendingInteractionService,
+        track_unsubscribe: Callable[[Callable[[], None]], None],
+    ) -> None:
+        self._service = service
+        self._track_unsubscribe = track_unsubscribe
+
+    def subscribe(
+        self, callback: Callable[[PendingInteractionEvent], None]
+    ) -> Callable[[], None]:
+        unsubscribe = self._service.subscribe(callback)
+        self._track_unsubscribe(unsubscribe)
+        return unsubscribe
+
+    def resolve(
+        self,
+        target: PendingInteractionTarget,
+        response: PendingInteractionResponse,
+    ) -> PendingInteractionResolveResult:
+        return self._service.resolve(target, response)
+
+
+_SERVICE = PendingInteractionService()
+atexit.register(_SERVICE.shutdown)
+
+
+def get_pending_interaction_service() -> PendingInteractionService:
+    return _SERVICE

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1399,6 +1399,7 @@ class PluginContext:
         # Lazy-built host-owned LLM facade — see ctx.llm property below.
         self._llm: Any = None
         self._subagent_lifecycle: Any = None
+        self._pending_interactions: Any = None
         self._state: PluginState | None = None
         # Lazy-built capability-gated platform action facade (#64176).
         self._platform_actions: Any = None
@@ -1600,6 +1601,28 @@ class PluginContext:
                 get_active_subagent_parent
             )
         return self._subagent_lifecycle
+
+    @property
+    def pending_interactions(self) -> Any:
+        """Return the process-bound observer/resolver for live user prompts.
+
+        Subscriptions receive immutable approval and clarification lifecycle
+        snapshots without attaching a UI transport. They are automatically
+        removed when this plugin unloads.
+        """
+        if self._pending_interactions is None:
+            from agent.pending_interactions import (
+                PluginPendingInteractionService,
+                get_pending_interaction_service,
+            )
+
+            def _track(unsubscribe: Callable[[], None]) -> None:
+                self._track("pending_interaction_subscription", "subscription", unsubscribe)
+
+            self._pending_interactions = PluginPendingInteractionService(
+                get_pending_interaction_service(), _track
+            )
+        return self._pending_interactions
 
     # -- profile awareness --------------------------------------------------
 

--- a/tests/agent/test_pending_interactions.py
+++ b/tests/agent/test_pending_interactions.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import threading
+from dataclasses import FrozenInstanceError, replace
+
+import pytest
+
+from agent.pending_interactions import (
+    PROCESS_INSTANCE_ID,
+    PendingInteractionResponse,
+    PendingInteractionService,
+    current_interaction_metadata,
+    pending_interaction_source,
+)
+
+
+def _register(service, resolver, validator=lambda response: True, **kwargs):
+    return service.register(
+        runtime_session_id=kwargs.get("runtime_session_id", "session-1"),
+        request_id=kwargs.get("request_id", "request-1"),
+        interaction_type=kwargs.get("interaction_type", "clarify"),
+        question_id=kwargs.get("question_id"),
+        resolver=resolver,
+        validator=validator,
+        metadata={"surface": "test"},
+    )
+
+
+def test_registered_event_has_exact_immutable_target_and_no_transport_side_effect():
+    service = PendingInteractionService()
+    received = []
+    delivered = threading.Event()
+
+    def subscriber(event):
+        received.append(event)
+        delivered.set()
+
+    unsubscribe = service.subscribe(subscriber)
+    target = _register(service, lambda _response: True)
+
+    assert delivered.wait(2)
+    event = received[0]
+    assert event.event == "pending_interaction.registered"
+    assert event.target == target
+    assert target.process_instance_id == PROCESS_INSTANCE_ID
+    assert target.runtime_session_id == "session-1"
+    assert target.request_id == "request-1"
+    assert event.metadata == {"surface": "test"}
+    with pytest.raises(TypeError):
+        event.metadata["surface"] = "mutated"
+    with pytest.raises(FrozenInstanceError):
+        event.status = "resolved"
+
+    unsubscribe()
+    service.terminal(target, "cancelled")
+    service.shutdown()
+
+
+def test_resolution_is_exact_validated_and_at_most_once_under_race():
+    service = PendingInteractionService()
+    native_calls = []
+    target = _register(
+        service,
+        lambda response: native_calls.append(response.value) or True,
+        validator=lambda response: response.kind == "answer" and response.value == "yes",
+    )
+
+    assert service.resolve(target, PendingInteractionResponse("answer", "no")).status == "invalid_response"
+
+    barrier = threading.Barrier(3)
+    statuses = []
+
+    def resolve():
+        barrier.wait()
+        statuses.append(
+            service.resolve(target, PendingInteractionResponse("answer", "yes")).status
+        )
+
+    threads = [threading.Thread(target=resolve) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+
+    assert sorted(statuses) == ["accepted", "already_resolved"]
+    assert native_calls == ["yes"]
+    service.shutdown()
+
+
+def test_process_and_profile_identity_fail_closed(monkeypatch):
+    service = PendingInteractionService()
+    target = _register(service, lambda _response: True)
+
+    stale = replace(target, process_instance_id="previous-process")
+    assert service.resolve(stale, PendingInteractionResponse("answer", "x")).status == "process_mismatch"
+
+    other_profile = replace(target, profile_id="other-profile")
+    assert service.resolve(other_profile, PendingInteractionResponse("answer", "x")).status == "policy_denied"
+
+    assert service.terminal(target, "cancelled") is True
+    service.shutdown()
+
+
+def test_subscriber_failure_isolated_from_registration_and_resolution():
+    service = PendingInteractionService()
+    delivered = threading.Event()
+
+    def broken(_event):
+        delivered.set()
+        raise RuntimeError("subscriber failed")
+
+    service.subscribe(broken)
+    target = _register(service, lambda _response: True)
+    assert delivered.wait(2)
+    assert service.resolve(target, PendingInteractionResponse("answer", "ok")).status == "accepted"
+    service.shutdown()
+
+
+def test_batch_question_targets_share_parent_but_resolve_independently():
+    service = PendingInteractionService()
+    answers = {}
+    targets = []
+    for question_id in ("deployment", "region"):
+        targets.append(
+            _register(
+                service,
+                lambda response, qid=question_id: answers.setdefault(qid, response.value) is not None,
+                request_id="batch-request",
+                question_id=question_id,
+            )
+        )
+
+    assert targets[0].request_id == targets[1].request_id == "batch-request"
+    assert targets[0].question_id != targets[1].question_id
+    assert service.resolve(targets[0], PendingInteractionResponse("answer", "staging")).status == "accepted"
+    assert service.resolve(targets[1], PendingInteractionResponse("answer", "us-east")).status == "accepted"
+    assert answers == {"deployment": "staging", "region": "us-east"}
+    service.shutdown()
+
+
+@pytest.mark.parametrize("kind", ["background_review", "curator"])
+def test_internal_fork_metadata_is_authoritative(kind):
+    with pending_interaction_source(kind):
+        metadata = current_interaction_metadata(surface="internal-test")
+
+    assert metadata["primary_user_turn"] is False
+    assert metadata["internal"] is True
+    assert metadata["fork_kind"] == kind
+    assert metadata["surface"] == "internal-test"

--- a/tests/tools/test_pending_interaction_integration.py
+++ b/tests/tools/test_pending_interaction_integration.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import threading
+
+from agent.pending_interactions import (
+    PendingInteractionResponse,
+    get_pending_interaction_service,
+)
+
+
+def _registered_for(request_id: str):
+    service = get_pending_interaction_service()
+    ready = threading.Event()
+    events = []
+
+    def subscriber(event):
+        if (
+            event.event == "pending_interaction.registered"
+            and event.target.request_id == request_id
+        ):
+            events.append(event)
+            ready.set()
+
+    return service, service.subscribe(subscriber), ready, events
+
+
+def test_gateway_approval_exposes_exact_id_and_rejects_missing_choice():
+    from tools import approval
+
+    session_key = "pending-service-approval-session"
+    entry = approval._ApprovalEntry(
+        {
+            "request_id": "pending-service-approval",
+            "command": "secret command must not escape",
+            "allow_permanent": False,
+        }
+    )
+    service, unsubscribe, ready, events = _registered_for(entry.data["request_id"])
+    try:
+        with approval._lock:
+            approval._gateway_queues[session_key] = [entry]
+        approval._register_pending_approval(session_key, entry, "desktop")
+
+        assert ready.wait(2)
+        target = events[0].target
+        assert target.runtime_session_id == session_key
+        assert events[0].metadata["choices"] == ("once", "session", "deny")
+        assert "command" not in events[0].metadata
+
+        assert service.resolve(
+            target, PendingInteractionResponse("answer", "once")
+        ).status == "invalid_response"
+        assert service.resolve(
+            target, PendingInteractionResponse("always")
+        ).status == "invalid_response"
+        assert service.resolve(
+            target, PendingInteractionResponse("once", resolved_by="test-plugin")
+        ).status == "accepted"
+        assert entry.event.is_set()
+        assert entry.result == "once"
+        assert approval.resolve_gateway_approval(
+            session_key, "deny", request_id=entry.data["request_id"]
+        ) == 0
+    finally:
+        unsubscribe()
+        with approval._lock:
+            approval._gateway_queues.pop(session_key, None)
+
+
+def test_gateway_clarify_plugin_and_native_race_has_one_winner():
+    from tools import clarify_gateway
+
+    request_id = "pending-service-clarify"
+    service, unsubscribe, ready, events = _registered_for(request_id)
+    entry = clarify_gateway.register(
+        request_id,
+        "pending-service-clarify-session",
+        "Deploy where?",
+        ["staging", "production"],
+    )
+    try:
+        assert ready.wait(2)
+        target = events[0].target
+        barrier = threading.Barrier(3)
+        outcomes = []
+
+        def plugin_resolve():
+            barrier.wait()
+            outcomes.append(
+                service.resolve(
+                    target,
+                    PendingInteractionResponse(
+                        "answer", "staging", resolved_by="test-plugin"
+                    ),
+                ).status
+            )
+
+        def native_resolve():
+            barrier.wait()
+            outcomes.append(
+                "accepted"
+                if clarify_gateway.resolve_gateway_clarify(request_id, "production")
+                else "already_resolved"
+            )
+
+        threads = [threading.Thread(target=plugin_resolve), threading.Thread(target=native_resolve)]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join()
+
+        assert sorted(outcomes) == ["accepted", "already_resolved"]
+        assert clarify_gateway.wait_for_response(request_id, 0.1) in {
+            "staging",
+            "production",
+        }
+    finally:
+        unsubscribe()
+        clarify_gateway.clear_session(entry.session_key)

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -243,15 +243,17 @@ def test_clarify_block_registers_exact_target_without_replacing_transport(
     )
 
     emitted = []
+    emitted_ready = threading.Event()
     registered = []
     ready = threading.Event()
     transport = object()
     server._sessions["observer-session"] = {"transport": transport}
-    monkeypatch.setattr(
-        server,
-        "_emit",
-        lambda event, sid, payload: emitted.append((event, sid, dict(payload))),
-    )
+
+    def capture_emit(event, sid, payload):
+        emitted.append((event, sid, dict(payload)))
+        emitted_ready.set()
+
+    monkeypatch.setattr(server, "_emit", capture_emit)
     service = get_pending_interaction_service()
 
     def observe(event):
@@ -277,6 +279,7 @@ def test_clarify_block_registers_exact_target_without_replacing_transport(
     try:
         thread.start()
         assert ready.wait(2)
+        assert emitted_ready.wait(2)
         target = registered[0].target
         assert emitted[0][2]["request_id"] == target.request_id
         assert server._sessions["observer-session"]["transport"] is transport

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -216,6 +216,135 @@ def test_live_session_payload_replays_pending_approval(server, monkeypatch):
     assert replayed == first
 
 
+def test_approval_respond_requires_explicit_choice(server, monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_sess",
+        lambda _params, _rid: ({"session_key": "stored-session"}, None),
+    )
+    response = server.handle_request(
+        {
+            "id": "missing-choice",
+            "method": "approval.respond",
+            "params": {"session_id": "ui-1", "request_id": "req-1"},
+        }
+    )
+
+    assert response["error"]["code"] == 4002
+    assert response["error"]["message"] == "explicit approval choice required"
+
+
+def test_clarify_block_registers_exact_target_without_replacing_transport(
+    server, monkeypatch
+):
+    from agent.pending_interactions import (
+        PendingInteractionResponse,
+        get_pending_interaction_service,
+    )
+
+    emitted = []
+    registered = []
+    ready = threading.Event()
+    transport = object()
+    server._sessions["observer-session"] = {"transport": transport}
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload: emitted.append((event, sid, dict(payload))),
+    )
+    service = get_pending_interaction_service()
+
+    def observe(event):
+        if (
+            event.event == "pending_interaction.registered"
+            and event.target.runtime_session_id == "observer-session"
+        ):
+            registered.append(event)
+            ready.set()
+
+    unsubscribe = service.subscribe(observe)
+    result = []
+    thread = threading.Thread(
+        target=lambda: result.append(
+            server._block(
+                "clarify.request",
+                "observer-session",
+                {"question": "Deploy?"},
+                timeout=2,
+            )
+        )
+    )
+    try:
+        thread.start()
+        assert ready.wait(2)
+        target = registered[0].target
+        assert emitted[0][2]["request_id"] == target.request_id
+        assert server._sessions["observer-session"]["transport"] is transport
+        assert service.resolve(
+            target,
+            PendingInteractionResponse("answer", "staging", resolved_by="test-plugin"),
+        ).status == "accepted"
+        thread.join(2)
+        assert result == ["staging"]
+    finally:
+        unsubscribe()
+        server._sessions.pop("observer-session", None)
+        thread.join(2)
+
+
+def test_batch_clarify_registers_one_target_per_question(server, monkeypatch):
+    from agent.pending_interactions import (
+        PendingInteractionResponse,
+        get_pending_interaction_service,
+    )
+
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+    service = get_pending_interaction_service()
+    targets = []
+    ready = threading.Event()
+
+    def observe(event):
+        if (
+            event.event == "pending_interaction.registered"
+            and event.target.runtime_session_id == "batch-observer-session"
+        ):
+            targets.append(event.target)
+            if len(targets) == 2:
+                ready.set()
+
+    unsubscribe = service.subscribe(observe)
+    result = []
+    thread = threading.Thread(
+        target=lambda: result.append(
+            server._block(
+                "clarify.request",
+                "batch-observer-session",
+                {"questions": []},
+                timeout=2,
+                batch_qids=["environment", "region"],
+            )
+        )
+    )
+    try:
+        thread.start()
+        assert ready.wait(2)
+        assert {target.question_id for target in targets} == {"environment", "region"}
+        assert len({target.request_id for target in targets}) == 1
+        for target in targets:
+            value = "staging" if target.question_id == "environment" else "us-east"
+            assert service.resolve(
+                target, PendingInteractionResponse("answer", value)
+            ).status == "accepted"
+        thread.join(2)
+        payload = json.loads(result[0])
+        assert payload == {
+            "answers": {"environment": "staging", "region": "us-east"}
+        }
+    finally:
+        unsubscribe()
+        thread.join(2)
+
+
 def test_live_session_payload_replays_pending_clarify(server):
     """A reattached client also receives a clarify question emitted while detached."""
     session = {

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2588,7 +2588,10 @@ def _denial_breaker_addendum(session_key: str) -> str:
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason", "acknowledged")
+    __slots__ = (
+        "event", "data", "result", "reason", "acknowledged",
+        "pending_interaction_target",
+    )
 
     def __init__(self, data: dict):
         self.event = threading.Event()
@@ -2596,6 +2599,7 @@ class _ApprovalEntry:
         self.data.setdefault("request_id", uuid.uuid4().hex)
         self.acknowledged = False
         self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
+        self.pending_interaction_target = None
         # Optional free-text reason supplied with an explicit deny
         # (``/deny <reason>``) so the agent can adapt instead of only
         # hearing "denied". Ported from qwibitai/nanoclaw#2832.
@@ -2629,6 +2633,65 @@ def unregister_gateway_notify(session_key: str) -> None:
         entries = _gateway_queues.pop(session_key, [])
     for entry in entries:
         entry.event.set()
+        if entry.pending_interaction_target is not None:
+            from agent.pending_interactions import get_pending_interaction_service
+
+            get_pending_interaction_service().terminal(
+                entry.pending_interaction_target, "cancelled"
+            )
+
+
+def _native_approval_choices(data: dict) -> tuple[str, ...]:
+    choices = data.get("choices")
+    if isinstance(choices, (list, tuple)):
+        return tuple(str(choice) for choice in choices)
+    if data.get("smart_denied"):
+        return ("once", "deny")
+    if data.get("allow_permanent") is False:
+        return ("once", "session", "deny")
+    return ("once", "session", "always", "deny")
+
+
+def _register_pending_approval(session_key: str, entry: _ApprovalEntry, surface: str) -> None:
+    from agent.pending_interactions import (
+        PendingInteractionResponse,
+        current_interaction_metadata,
+        get_pending_interaction_service,
+    )
+
+    choices = _native_approval_choices(entry.data)
+
+    def _resolve(response: PendingInteractionResponse) -> bool:
+        with _lock:
+            queue = _gateway_queues.get(session_key, [])
+            if entry not in queue or entry.event.is_set():
+                return False
+            queue.remove(entry)
+            if not queue:
+                _gateway_queues.pop(session_key, None)
+            entry.result = response.kind
+            if response.kind == "deny" and response.value:
+                entry.reason = str(response.value)[:500]
+            entry.event.set()
+            return True
+
+    entry.pending_interaction_target = get_pending_interaction_service().register(
+        runtime_session_id=session_key,
+        request_id=str(entry.data["request_id"]),
+        interaction_type="approval",
+        resolver=_resolve,
+        validator=lambda response: (
+            response.kind in choices
+            and (
+                response.value in (None, "")
+                or (response.kind == "deny" and isinstance(response.value, str))
+            )
+        ),
+        metadata={
+            **current_interaction_metadata(surface=surface),
+            "choices": choices,
+        },
+    )
 
 
 def resolve_gateway_approval(session_key: str, choice: str,
@@ -2656,21 +2719,42 @@ def resolve_gateway_approval(session_key: str, choice: str,
             targets = [entry for entry in queue if entry.data.get("request_id") == request_id]
             if not targets:
                 return 0
-            queue[:] = [entry for entry in queue if entry not in targets]
         elif resolve_all:
             targets = list(queue)
-            queue.clear()
         else:
-            targets = [queue.pop(0)]
-        if not queue:
-            _gateway_queues.pop(session_key, None)
+            targets = [queue[0]]
 
+    resolved = 0
     for entry in targets:
-        entry.result = choice
-        if reason:
-            entry.reason = reason
-        entry.event.set()
-    return len(targets)
+        target = entry.pending_interaction_target
+        if target is None:  # Backward-compatible synthetic entries in integrations/tests.
+            with _lock:
+                queue = _gateway_queues.get(session_key, [])
+                if entry not in queue:
+                    continue
+                queue.remove(entry)
+                if not queue:
+                    _gateway_queues.pop(session_key, None)
+                entry.result = choice
+                entry.reason = reason
+                entry.event.set()
+            resolved += 1
+            continue
+        from agent.pending_interactions import (
+            PendingInteractionResponse,
+            get_pending_interaction_service,
+        )
+
+        result = get_pending_interaction_service().resolve(
+            target,
+            PendingInteractionResponse(
+                kind=choice,
+                value=reason if choice == "deny" else None,
+                resolved_by="native_ui",
+            ),
+        )
+        resolved += result.status == "accepted"
+    return resolved
 
 
 def list_gateway_approvals(session_key: str) -> list[dict]:
@@ -4232,14 +4316,23 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     entry = _ApprovalEntry(approval_data)
     with _lock:
         _gateway_queues.setdefault(session_key, []).append(entry)
+    _register_pending_approval(session_key, entry, surface)
 
-    def _drop_entry() -> None:
+    def _drop_entry(status: str = "expired") -> None:
+        removed = False
         with _lock:
             queue = _gateway_queues.get(session_key, [])
             if entry in queue:
                 queue.remove(entry)
+                removed = True
             if not queue:
                 _gateway_queues.pop(session_key, None)
+        if removed and entry.pending_interaction_target is not None:
+            from agent.pending_interactions import get_pending_interaction_service
+
+            get_pending_interaction_service().terminal(
+                entry.pending_interaction_target, status
+            )
 
     # Notify plugins that an approval is being requested. Fires before the
     # gateway notify callback so observers get the event in real time.
@@ -4251,6 +4344,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         pattern_keys=list(all_keys),
         session_key=session_key,
         surface=surface,
+        request_id=entry.data["request_id"],
     )
 
     # Notify the user (bridges sync agent thread → async gateway)
@@ -4258,7 +4352,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         notify_cb(dict(entry.data))
     except Exception as exc:
         logger.warning("Gateway approval notify failed: %s", exc)
-        _drop_entry()
+        _drop_entry("cancelled")
         _fire_approval_hook(
             "post_approval_response",
             command=command,
@@ -4306,9 +4400,12 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
                     "returning deny for session %s",
                     session_key,
                 )
-                entry.result = "deny"
-                entry.event.set()
-                resolved = True
+                result = resolve_gateway_approval(
+                    session_key,
+                    "deny",
+                    request_id=str(entry.data["request_id"]),
+                )
+                resolved = result == 1
                 break
             _remaining = _deadline - time.monotonic()
             if _remaining <= 0:

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -55,6 +55,7 @@ class _ClarifyEntry:
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
+    pending_interaction_target: object = None
 
     def signature(self) -> Dict[str, object]:
         return {
@@ -99,8 +100,50 @@ def register(
         awaiting_text=not bool(choices),
     )
     with _lock:
+        previous = _entries.get(clarify_id)
         _entries[clarify_id] = entry
         _session_index.setdefault(session_key, []).append(clarify_id)
+    if previous is not None and previous.pending_interaction_target is not None:
+        from agent.pending_interactions import get_pending_interaction_service
+
+        get_pending_interaction_service().terminal(
+            previous.pending_interaction_target, "cancelled"
+        )
+    from agent.pending_interactions import (
+        PendingInteractionResponse,
+        current_interaction_metadata,
+        get_pending_interaction_service,
+    )
+
+    def _resolve(response: PendingInteractionResponse) -> bool:
+        with _lock:
+            current = _entries.get(clarify_id)
+            if current is not entry or entry.event.is_set():
+                return False
+            entry.response = str(response.value) if response.value is not None else ""
+            entry.event.set()
+            return True
+
+    def _valid(response: PendingInteractionResponse) -> bool:
+        if response.kind == "cancel":
+            return response.value in (None, "")
+        if response.kind != "answer" or not isinstance(response.value, str):
+            return False
+        if not entry.choices or entry.awaiting_text:
+            return True
+        return _coerce_text_response(entry, response.value) is not None
+
+    entry.pending_interaction_target = get_pending_interaction_service().register(
+        runtime_session_id=session_key,
+        request_id=clarify_id,
+        interaction_type="clarify",
+        resolver=_resolve,
+        validator=_valid,
+        metadata={
+            **current_interaction_metadata(surface="gateway"),
+            "multi_select": entry.multi_select,
+        },
+    )
     return entry
 
 
@@ -154,6 +197,14 @@ def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
             if not ids:
                 _session_index.pop(entry.session_key, None)
 
+    if entry.pending_interaction_target is not None:
+        from agent.pending_interactions import get_pending_interaction_service
+
+        get_pending_interaction_service().terminal(
+            entry.pending_interaction_target,
+            "resolved" if entry.event.is_set() else "expired",
+        )
+
     return entry.response
 
 
@@ -171,9 +222,26 @@ def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
         entry = _entries.get(clarify_id)
         if entry is None or entry.event.is_set():
             return False
-        entry.response = str(response) if response is not None else ""
-        entry.event.set()
-        return True
+        target = entry.pending_interaction_target
+    if target is None:
+        with _lock:
+            entry.response = str(response) if response is not None else ""
+            entry.event.set()
+            return True
+    from agent.pending_interactions import (
+        PendingInteractionResponse,
+        get_pending_interaction_service,
+    )
+
+    result = get_pending_interaction_service().resolve(
+        target,
+        PendingInteractionResponse(
+            kind="cancel" if response in (None, "") else "answer",
+            value=response,
+            resolved_by="native_ui",
+        ),
+    )
+    return result.status == "accepted"
 
 
 def get_pending_for_session(
@@ -521,6 +589,13 @@ def clear_session(session_key: str) -> int:
             entry.response = ""
             entry.event.set()
             cancelled += 1
+    from agent.pending_interactions import get_pending_interaction_service
+
+    for entry in entries:
+        if entry is not None and entry.pending_interaction_target is not None:
+            get_pending_interaction_service().terminal(
+                entry.pending_interaction_target, "cancelled"
+            )
     return cancelled
 
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1523,6 +1523,9 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
+    choice = params.get("choice")
+    if not isinstance(choice, str) or not choice:
+        return _err(rid, 4002, "explicit approval choice required")
     try:
         from tools.approval import resolve_gateway_approval
 
@@ -1531,7 +1534,7 @@ def _(rid, params: dict) -> dict:
             {
                 "resolved": resolve_gateway_approval(
                     session["session_key"],
-                    params.get("choice", "deny"),
+                    choice,
                     resolve_all=params.get("all", False),
                     request_id=params.get("request_id"),
                 )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -146,6 +146,7 @@ _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
 _answers: dict[str, str] = {}
+_pending_interaction_targets: dict[tuple[str, str], object] = {}
 # Batch clarify accumulators: rid → {"qids": [...], "answers": {qid: answer}}.
 # Written by clarify.respond (per-question lock, update-in-place), read out by
 # _block on resolution/timeout so locked answers survive the deadline.
@@ -3527,6 +3528,51 @@ def _block(
             # (update-in-place until every qid is locked). Locked answers
             # survive a timeout — see the batch read-out below.
             _batch_clarify[rid] = {"qids": list(batch_qids), "answers": {}}
+    if event == "clarify.request":
+        from agent.pending_interactions import (
+            PendingInteractionResponse,
+            current_interaction_metadata,
+            get_pending_interaction_service,
+        )
+
+        def _register_target(question_id: str | None) -> None:
+            key = (rid, question_id or "")
+
+            def _resolve(response: PendingInteractionResponse) -> bool:
+                with _prompt_lock:
+                    entry = _pending.get(rid)
+                    if entry is None:
+                        return False
+                    _, pending_event = entry
+                    batch = _batch_clarify.get(rid)
+                    if question_id is not None:
+                        if batch is None or question_id not in batch["qids"]:
+                            return False
+                        batch["answers"][question_id] = response.value
+                        if all(qid in batch["answers"] for qid in batch["qids"]):
+                            pending_event.set()
+                    else:
+                        _answers[rid] = response.value if response.value is not None else ""
+                        pending_event.set()
+                    return True
+
+            target = get_pending_interaction_service().register(
+                runtime_session_id=sid,
+                request_id=rid,
+                interaction_type="clarify",
+                question_id=question_id,
+                resolver=_resolve,
+                validator=lambda response: (
+                    response.kind in {"answer", "cancel"}
+                    and (response.kind != "cancel" or response.value in (None, ""))
+                ),
+                metadata=current_interaction_metadata(surface="desktop"),
+            )
+            with _prompt_lock:
+                _pending_interaction_targets[key] = target
+
+        for qid in batch_qids or [None]:
+            _register_target(qid)
     answered = False
     answer = ""
     answer_present = False
@@ -3538,6 +3584,7 @@ def _block(
         # session.interrupt), 0 → return immediately, > 0 → bounded wait.
         answered = ev.wait(timeout)
     finally:
+        terminal_status = "resolved" if answered else "expired"
         with _prompt_lock:
             _pending.pop(rid, None)
             _pending_prompt_payloads.pop(rid, None)
@@ -3546,6 +3593,15 @@ def _block(
             batch_state = _batch_clarify.pop(rid, None)
             if batch_state is not None:
                 batch_answers = dict(batch_state["answers"])
+            targets = [
+                _pending_interaction_targets.pop((rid, qid or ""), None)
+                for qid in (batch_qids or [None])
+            ]
+        from agent.pending_interactions import get_pending_interaction_service
+
+        for target in targets:
+            if target is not None:
+                get_pending_interaction_service().terminal(target, terminal_status)
 
     if batch_qids is not None:
         # Cancel-all (respond with no question_id) resolves via _answers with
@@ -11985,6 +12041,39 @@ def _stage_session_file_attachment(
 def _respond(rid, params, key, *, allow_expired=False):
     r = params.get("request_id", "")
     question_id = str(params.get("question_id") or "")
+    if key == "answer":
+        with _prompt_lock:
+            target = _pending_interaction_targets.get((r, question_id))
+        if target is not None:
+            from agent.pending_interactions import (
+                PendingInteractionResponse,
+                get_pending_interaction_service,
+            )
+
+            value = params.get(key, "")
+            result = get_pending_interaction_service().resolve(
+                target,
+                PendingInteractionResponse(
+                    kind="cancel" if value in (None, "") else "answer",
+                    value=value,
+                    resolved_by="native_ui",
+                ),
+            )
+            if result.status != "accepted":
+                if allow_expired and result.status == "already_resolved":
+                    return _ok(rid, {"status": "expired"})
+                return _err(rid, 4009, f"pending {key} request already resolved")
+            with _prompt_lock:
+                batch = _batch_clarify.get(r)
+                remaining = (
+                    [qid for qid in batch["qids"] if qid not in batch["answers"]]
+                    if batch is not None
+                    else []
+                )
+            result_payload = {"status": "ok"}
+            if question_id:
+                result_payload["remaining"] = remaining
+            return _ok(rid, result_payload)
     with _prompt_lock:
         entry = _pending.get(r)
         if not entry:

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -162,6 +162,46 @@ from an isolated `HERMES_HOME`. Those tests load and invoke the plugin through
 `PluginManager`; they assert real registration and callback outcomes rather
 than internal symbol lists or source-code shape.
 
+### Observe and resolve live user interactions
+
+Trusted backend plugins can use `ctx.pending_interactions` to observe an exact
+approval or clarification after Hermes has registered its native request:
+
+```python
+from agent.pending_interactions import PendingInteractionResponse
+
+def register(ctx):
+    def on_interaction(event):
+        if event.event != "pending_interaction.registered":
+            return
+        # Store event.target in process memory and present the bounded metadata.
+
+    unsubscribe = ctx.pending_interactions.subscribe(on_interaction)
+    # Hermes also removes this subscription automatically when the plugin unloads.
+```
+
+To answer the same request, pass its immutable target back unchanged:
+
+```python
+result = ctx.pending_interactions.resolve(
+    target,
+    PendingInteractionResponse(kind="answer", value="staging"),
+)
+```
+
+Approvals use one of the explicit choices carried in event metadata (`once`,
+`session`, `always`, or `deny` as permitted by that request); omitting or
+inventing a choice returns `invalid_response`. Clarification uses `answer` or
+`cancel`. Resolution results include `accepted`, `already_resolved`,
+`process_mismatch`, `policy_denied`, `invalid_response`, and `not_found`.
+
+Targets are profile- and process-bound and include the runtime session, native
+request id, interaction type, and optional batch question id. Events never
+contain answer text, secrets, or raw approval commands. Subscription does not
+attach or replace a TUI/Desktop transport, resume a session, receive transcript
+streams, or keep the session alive. Subscriber exceptions are isolated from the
+agent, and no chat-completion event is emitted by this service.
+
 ## What you're building
 
 A **calculator** plugin with two tools:


### PR DESCRIPTION
## What does this PR do?

Adds a documented, process-bound pending interaction service for trusted backend plugins. Plugins can passively observe exact live approval and clarification identities and request an atomic native resolution without attaching to Desktop/TUI transports, reading transcripts, or selecting sessions heuristically.

The service exposes immutable, versioned targets, profile/process/session/request validation, explicit response validation, registered/terminal lifecycle events, bounded failure-isolated subscribers, and authoritative internal-fork metadata.

## Related Issue

Closes #92245

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/pending_interactions.py` - adds the public target, event, response, result, subscription, exact resolution, lifecycle, and internal-source contracts.
- `hermes_cli/plugins.py` - exposes `ctx.pending_interactions` with automatic subscription cleanup on plugin unload.
- `tools/approval.py` and `tools/clarify_gateway.py` - register exact native requests, route native and plugin responders through one atomic winner, validate choices, and emit terminal lifecycle.
- `tui_gateway/server.py` and `tui_gateway/methods_prompt.py` - expose single/batch clarification identities and reject approval responses without an explicit choice while preserving transport ownership.
- `agent/background_review.py` and `agent/curator.py` - mark internal fork provenance authoritatively.
- `website/docs/developer-guide/plugins/index.md` - documents subscription and resolution for plugin authors.
- `tests/` - covers exact identity, single/batch registration, race resolution, response validation, transport non-interference, metadata, immutability, and subscriber failure isolation.

## How to Test

1. Run the focused service, gateway, TUI, and approval regression suites:

```bash
scripts/run_tests.sh tests/agent/test_pending_interactions.py tests/tools/test_pending_interaction_integration.py tests/tools/test_clarify_gateway.py tests/tui_gateway/test_protocol.py tests/gateway/test_approve_deny_commands.py -q
```

2. Verify approval regressions excluding two pre-existing Windows path-assumption cases:

```bash
scripts/run_tests.sh tests/tui_gateway/test_protocol.py tests/tools/test_approval.py -k 'not nonrecursive_verification_artifact_cleanup_is_not_dangerous and not symlinked_temp_dir_only_exempts_canonical_target' -q
```

3. Verify internal background-review and curator provenance paths:

```bash
scripts/run_tests.sh tests/agent/test_pending_interactions.py tests/run_agent/test_background_review.py tests/agent/test_curator.py -q
```

Local results: 120 passed, 166 passed, and 49 passed respectively on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the relevant test suites and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/developer-guide/plugins/index.md`)
- [x] Config example updates are N/A because this adds no configuration keys
- [x] Architecture guide updates are N/A; the developer plugin guide documents the public contract
- [x] I've considered cross-platform impact; the service uses stdlib threading/contextvars and profile-aware runtime identity
- [x] Tool description/schema updates are N/A because this adds no model tool

## Screenshots / Logs

N/A - this is a backend plugin API with behavior-based automated coverage.
