### PR TITLE
fix(cli): bind credential pool when /model switches before first turn

### DIFF
--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -595,6 +595,30 @@ class CLIModelSwitchMixin:
                     f"  ⚠ Model switch to {result.new_model} failed ({exc}); "
                     f"staying on {old_model}.")
                 return False
+        else:
+            # The agent is not constructed yet (switch before the first turn):
+            # agent.switch_model() — which reloads the credential pool on the
+            # agent — never runs. Re-resolve the CLI's runtime provider so
+            # the pool is bound for THIS provider before lazy `_init_agent`
+            # snapshots it; otherwise the new provider runs with no pool and
+            # 429/billing/401 never rotate to the next key (#92250).
+            from cli import logger
+            try:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+
+                resolved = resolve_runtime_provider(requested=self.provider)
+                # Bind whatever pool the resolved runtime carries for THIS
+                # provider (None when it has none) — same value the resume
+                # path binds and lazy `_init_agent` will snapshot.
+                self._credential_pool = resolved.get("credential_pool")
+            except Exception as exc:
+                # Fail-loud: a pool-less rotation is a support-visible symptom
+                # (auth/billing 401s won't rotate), so log at WARNING, not DEBUG.
+                logger.warning(
+                    "Credential pool re-resolution for switched provider "
+                    "%s failed; no rotation this session (%s)",
+                    self.provider, exc,
+                )
         return True
 
     def _apply_model_switch_result(

--- a/tests/hermes_cli/test_apply_model_switch_result_context.py
+++ b/tests/hermes_cli/test_apply_model_switch_result_context.py
@@ -45,6 +45,7 @@ class _StubCLI:
     base_url = ""
     _explicit_base_url = ""
     api_mode = ""
+    _credential_pool = None
     _pending_model_switch_note = ""
 
 
@@ -174,3 +175,112 @@ def test_global_switch_clears_context_pin_owned_by_previous_route(monkeypatch):
         cli_mod.HermesCLI._apply_model_switch_result(cli, result, True)
 
     assert ("model.context_length", None) in writes
+
+
+def test_switch_before_first_turn_binds_credential_pool(monkeypatch):
+    """A `/model` switch before the agent is constructed (lazy `_init_agent`)
+    must still re-bind the CLI credential pool to the NEW provider, so the
+    first 429/billing/401 can rotate to the next key. Regression #92250.
+    """
+    import cli as cli_mod
+
+    fake_pool = object()
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *_a, **_k: None)
+    monkeypatch.setattr(cli_mod, "save_config_value", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None: {
+            "provider": "new-provider",
+            "api_mode": "chat_completions",
+            "base_url": "",
+            "api_key": "new-key",
+            "credential_pool": fake_pool,
+            "requested_provider": requested,
+        },
+    )
+
+    cli = _StubCLI()
+    # Simulate a session that started on provider A with an old pool.
+    cli.provider = "old-provider"
+    cli.model = "old-model"
+    cli.api_key = "old-key"
+    cli._explicit_api_key = ""
+    cli.base_url = "https://old.example/v1"
+    cli.api_mode = "chat_completions"
+    cli._credential_pool = "stale-pool"
+
+    result = ModelSwitchResult(
+        success=True,
+        new_model="new-model",
+        target_provider="new-provider",
+        provider_changed=True,
+        api_key="new-key",
+        base_url="",
+        api_mode="chat_completions",
+        warning_message="",
+        provider_label="New Provider",
+        resolved_via_alias=False,
+        capabilities=None,
+        model_info=_FakeModelInfo(),
+        is_global=False,
+    )
+
+    cli_mod.HermesCLI._apply_model_switch_result(cli, result, False)
+
+    assert cli._credential_pool is fake_pool, (
+        "switch-before-agent must re-bind the pool for the new provider, "
+        f"got {cli._credential_pool!r}"
+    )
+
+
+def test_switch_before_first_turn_no_pool_leaves_none(monkeypatch):
+    """When the resolved runtime carries no pool (provider with a single key),
+    the rebind must land on None — not silently keep the stale old-provider pool,
+    which would be rejected as mismatched later. Regression #92250.
+    """
+    import cli as cli_mod
+
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *_a, **_k: None)
+    monkeypatch.setattr(cli_mod, "save_config_value", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda requested=None: {
+            "provider": "solo-provider",
+            "api_mode": "chat_completions",
+            "base_url": "",
+            "api_key": "solo-key",
+            "credential_pool": None,
+            "requested_provider": requested,
+        },
+    )
+
+    cli = _StubCLI()
+    cli.provider = "old-provider"
+    cli.model = "old-model"
+    cli.api_key = "old-key"
+    cli.base_url = "https://old.example/v1"
+    cli.api_mode = "chat_completions"
+    cli._credential_pool = "stale-pool"
+
+    result = ModelSwitchResult(
+        success=True,
+        new_model="solo-model",
+        target_provider="solo-provider",
+        provider_changed=True,
+        api_key="solo-key",
+        base_url="",
+        api_mode="chat_completions",
+        warning_message="",
+        provider_label="Solo Provider",
+        resolved_via_alias=False,
+        capabilities=None,
+        model_info=_FakeModelInfo(),
+        is_global=False,
+    )
+
+    cli_mod.HermesCLI._apply_model_switch_result(cli, result, False)
+
+    assert cli._credential_pool is None, (
+        "no-pool provider must clear the stale pool, "
+        f"got {cli._credential_pool!r}"
+    )


### PR DESCRIPTION
Fixes #92250

### Problem
A `/model` provider switch **before the first turn** leaves the CLI credential pool unbound, so the first 429/billing/401 on the new provider never rotates to the next key. `_apply_model_switch_result` rebinds `model`/`provider`/`api_key`/`base_url`/`api_mode` but **not** `self._credential_pool`. Because the agent is lazily `_init`'d on the first message, `agent.switch_model()` (which reloads the pool on the agent) never runs before that snapshot — lazy init picks up the stale old-provider pool (or `None`), `credential_pool_matches_provider()` rejects it, and the new provider runs pool-less for the whole session.

### Fix
In the `self.agent is None` branch of `_apply_model_switch_result`, re-resolve the CLI runtime provider for the switched provider and bind its `credential_pool` — the same mechanism the session-resume path uses. `None` when the provider has no pool (clears the stale one rather than carrying it).

### What this PR does
- `cli.py`: re-resolve + bind `self._credential_pool` when the agent isn't constructed yet.
- 2 regression tests in `tests/hermes_cli/test_apply_model_switch_result_context.py` (agent=None path): pool bound to the new provider's pool; pool cleared to `None` when the new provider has none. Both reproduce the bug on current main (fail without the fix, pass with it).

### How did I verify
- `.venv/bin/python -m pytest tests/hermes_cli/test_apply_model_switch_result_context.py` → 5 passed (3 existing + 2 new).
- Confirmed the 2 new tests **fail on current main** (pool stays `'stale-pool'`) and pass with the fix — proving they capture #92250.