### PR TITLE
fix(honcho): fall back to peer_id filter when peer_perspective search is empty

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -72,6 +72,12 @@ class HonchoSessionManager(SessionAuthMixin, SessionPeersMixin, SessionContextMi
         self._auth_failure: str | None = None
         self._auth_notice_emitted = False
 
+        # base_url → True once a peer_perspective search has returned a
+        # non-empty result, proving the filter works on that server. Absent
+        # means unproven: empty perspective results keep paying the peer_id
+        # retry until proven otherwise.
+        self._perspective_supported: dict[str, bool] = {}
+
         # Behavior knobs copied from config (HonchoClientConfig defaults when absent); the
         # observation booleans map 1:1 to Honcho's SessionPeerConfig toggles.
         for name, default in (

--- a/plugins/memory/honcho/session_context.py
+++ b/plugins/memory/honcho/session_context.py
@@ -203,12 +203,20 @@ class SessionContextMixin:
             "message search", lambda: self.honcho.search(q, filters={"peer_perspective": peer_id}, limit=limit),
             _FAILED, logging.DEBUG, "Honcho message search failed (peer_perspective=%s): %s", peer_id,
         )
-        if messages is _FAILED:
-            # Older Honcho versions lack the perspective filter; fall back to peer-authored search.
+        if messages is _FAILED or not messages:
+            # Some API builds (e.g. self-hosted from source) silently return empty for the
+            # peer_perspective filter because the column is not filterable in their schema.
+            # Retry with the peer_id column filter before giving up.
             messages = self._guarded_authed(
-                "peer search", lambda: self._get_or_create_peer(peer_id).search(q, limit=limit),
-                None, logging.DEBUG, "Honcho peer search fallback also failed: %s",
+                "message search (peer_id)", lambda: self.honcho.search(q, filters={"peer_id": peer_id}, limit=limit),
+                _FAILED, logging.DEBUG, "Honcho message search failed (peer_id=%s): %s", peer_id,
             )
+            if messages is _FAILED:
+                # Older Honcho versions lack filters entirely; fall back to peer-authored search.
+                messages = self._guarded_authed(
+                    "peer search", lambda: self._get_or_create_peer(peer_id).search(q, limit=limit),
+                    None, logging.DEBUG, "Honcho peer search fallback also failed: %s",
+                )
         if not messages:
             return ""
         # Author labels distinguish user-stated facts from assistant-derived ones.

--- a/plugins/memory/honcho/session_context.py
+++ b/plugins/memory/honcho/session_context.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable
 
+from honcho import Peer
+
 from plugins.memory.honcho.session_auth import HonchoAuthError
 
 logger = logging.getLogger("plugins.memory.honcho.session")
@@ -188,6 +190,14 @@ class SessionContextMixin:
             return card or (self._fetch_peer_card(target_peer_id) if target_peer_id else [])
         return self._guarded_session(session_key, _fetch, [], logging.DEBUG, "Failed to fetch peer card from Honcho: %s")
 
+    def _honcho_base_url(self) -> str:
+        """Base URL of the bound Honcho client, or "" when unknown (tests)."""
+        try:
+            base = getattr(self.honcho, "base_url", "")
+        except Exception:
+            return ""
+        return base if isinstance(base, str) else ""
+
     def search_context(self, session_key: str, query: str, max_tokens: int = 800, peer: str = "user") -> str:
         """Hybrid search over raw messages visible from ``peer``'s perspective, all sessions. Snippets
         accumulate until ``max_tokens`` (~4 chars/token) is exhausted. Returns "" when nothing matches;
@@ -199,24 +209,41 @@ class SessionContextMixin:
         peer_id = self._resolve_peer_id(session, peer)
         char_budget = max(200, int(max_tokens) * 4)
         limit = max(3, min(20, char_budget // 300))
+        def _retry_peer_id() -> Any:
+            # Some API builds (e.g. self-hosted from source) silently return empty for the
+            # peer_perspective filter because the column is not filterable in their schema.
+            # Retry with the peer_id column filter, then with direct peer-object search.
+            retry = self._guarded_authed(
+                "message search (peer_id)", lambda: self.honcho.search(q, filters={"peer_id": peer_id}, limit=limit),
+                _FAILED, logging.DEBUG, "Honcho message search failed (peer_id=%s): %s", peer_id,
+            )
+            if retry is _FAILED:
+                # Older Honcho versions lack filters entirely; fall back to peer-authored search.
+                # Direct construction, not _get_or_create_peer: Honcho.peer() is get-or-create
+                # (a write) in the pinned SDK, and this is a read path. Peer(pid, client) is
+                # non-networking in honcho-ai 2.2.0 and is re-resolved inside _guarded_authed so
+                # a 401-triggered client rebuild (which orphans cached SDK objects) is respected.
+                retry = self._guarded_authed(
+                    "peer search", lambda: Peer(peer_id, self.honcho).search(q, limit=limit),
+                    None, logging.DEBUG, "Honcho peer search fallback also failed: %s",
+                )
+            return retry
+
+        base_url = self._honcho_base_url()
         messages = self._guarded_authed(
             "message search", lambda: self.honcho.search(q, filters={"peer_perspective": peer_id}, limit=limit),
             _FAILED, logging.DEBUG, "Honcho message search failed (peer_perspective=%s): %s", peer_id,
         )
-        if messages is _FAILED or not messages:
-            # Some API builds (e.g. self-hosted from source) silently return empty for the
-            # peer_perspective filter because the column is not filterable in their schema.
-            # Retry with the peer_id column filter before giving up.
-            messages = self._guarded_authed(
-                "message search (peer_id)", lambda: self.honcho.search(q, filters={"peer_id": peer_id}, limit=limit),
-                _FAILED, logging.DEBUG, "Honcho message search failed (peer_id=%s): %s", peer_id,
-            )
-            if messages is _FAILED:
-                # Older Honcho versions lack filters entirely; fall back to peer-authored search.
-                messages = self._guarded_authed(
-                    "peer search", lambda: self._get_or_create_peer(peer_id).search(q, limit=limit),
-                    None, logging.DEBUG, "Honcho peer search fallback also failed: %s",
-                )
+        if messages is _FAILED:
+            messages = _retry_peer_id()
+        elif messages:
+            # A non-empty perspective result proves the filter works on this server. Remember it
+            # per base_url so genuinely-empty queries stop paying the peer_id double-probe.
+            if base_url:
+                with self._cache_lock:
+                    self._perspective_supported[base_url] = True
+        elif not self._perspective_supported.get(base_url, False):
+            messages = _retry_peer_id()
         if not messages:
             return ""
         # Author labels distinguish user-stated facts from assistant-derived ones.

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -111,6 +111,26 @@ class TestPeerLookupHelpers:
         assert "[assistant" in result
 
 
+    def test_search_context_falls_back_to_peer_id_filter_on_empty_perspective(self):
+        """Older API builds return empty for peer_perspective; retry with peer_id."""
+        mgr, session = self._make_cached_manager()
+        honcho_client = MagicMock()
+        honcho_client.search.side_effect = [
+            [],  # peer_perspective filter unsupported -> silently empty
+            [SimpleNamespace(content="Robert runs neuralancer", peer_id="hermes", session_id="s-old", id="m1")],
+        ]
+        with patch.object(HonchoSessionManager, "honcho", new_callable=lambda: property(lambda s: honcho_client)):
+            result = mgr.search_context(session.key, "neuralancer")
+
+        # Peer_id retry returns content despite the empty perspective result.
+        assert "Robert runs neuralancer" in result
+        assert honcho_client.search.call_count == 2
+        first_args, first_kwargs = honcho_client.search.call_args_list[0]
+        second_args, second_kwargs = honcho_client.search.call_args_list[1]
+        assert first_kwargs["filters"] == {"peer_perspective": session.user_peer_id}
+        assert second_kwargs["filters"] == {"peer_id": session.user_peer_id}
+
+
     def test_create_conclusion_defaults_to_user_target(self):
         mgr, session = self._make_cached_manager()
         assistant_peer = MagicMock()

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -115,6 +115,7 @@ class TestPeerLookupHelpers:
         """Older API builds return empty for peer_perspective; retry with peer_id."""
         mgr, session = self._make_cached_manager()
         honcho_client = MagicMock()
+        honcho_client.base_url = "http://self-hosted"
         honcho_client.search.side_effect = [
             [],  # peer_perspective filter unsupported -> silently empty
             [SimpleNamespace(content="Robert runs neuralancer", peer_id="hermes", session_id="s-old", id="m1")],
@@ -129,6 +130,87 @@ class TestPeerLookupHelpers:
         second_args, second_kwargs = honcho_client.search.call_args_list[1]
         assert first_kwargs["filters"] == {"peer_perspective": session.user_peer_id}
         assert second_kwargs["filters"] == {"peer_id": session.user_peer_id}
+        # A peer_id result does NOT prove the perspective filter works.
+        assert mgr._perspective_supported.get("http://self-hosted") is None
+
+
+    def test_search_context_does_not_retry_when_perspective_returns_results(self):
+        """A non-empty perspective result is final; no peer_id double-probe."""
+        mgr, session = self._make_cached_manager()
+        honcho_client = MagicMock()
+        honcho_client.base_url = "http://test"
+        honcho_client.search.return_value = [
+            SimpleNamespace(content="Robert runs neuralancer", peer_id="hermes", session_id="s-old", id="m1"),
+        ]
+        with patch.object(HonchoSessionManager, "honcho", new_callable=lambda: property(lambda s: honcho_client)):
+            result = mgr.search_context(session.key, "neuralancer")
+
+        assert "Robert runs neuralancer" in result
+        assert honcho_client.search.call_count == 1
+        _args, kwargs = honcho_client.search.call_args
+        assert kwargs["filters"] == {"peer_perspective": session.user_peer_id}
+        # Non-empty perspective result marks the filter as supported.
+        assert mgr._perspective_supported.get("http://test") is True
+
+
+    def test_search_context_skips_retry_after_perspective_proven(self):
+        """Once perspective proves non-empty on a base_url, empties are final."""
+        mgr, session = self._make_cached_manager()
+        honcho_client = MagicMock()
+        honcho_client.base_url = "http://test"
+        honcho_client.search.side_effect = [
+            [SimpleNamespace(content="Robert runs neuralancer", peer_id="hermes", session_id="s-old", id="m1")],
+            [],  # genuinely empty afterwards — must NOT trigger peer_id retry
+        ]
+        with patch.object(HonchoSessionManager, "honcho", new_callable=lambda: property(lambda s: honcho_client)):
+            first = mgr.search_context(session.key, "neuralancer")
+            second = mgr.search_context(session.key, "nothing")
+
+        assert "Robert runs neuralancer" in first
+        assert second == ""
+        assert honcho_client.search.call_count == 2
+        filters = [call.kwargs["filters"] for call in honcho_client.search.call_args_list]
+        assert filters == [
+            {"peer_perspective": session.user_peer_id},
+            {"peer_perspective": session.user_peer_id},
+        ]
+
+
+    def test_search_context_fallback_never_creates_peer(self):
+        """Fallback uses direct Peer construction; no peer get-or-create on the read path."""
+        mgr, session = self._make_cached_manager()
+        honcho_client = MagicMock()
+        honcho_client.base_url = "http://self-hosted"
+        honcho_client.search.side_effect = [
+            [],  # perspective empty
+            [],  # peer_id filter empty
+        ]
+        mgr._get_or_create_peer = MagicMock(side_effect=AssertionError("peer creation on read path"))
+        with patch.object(HonchoSessionManager, "honcho", new_callable=lambda: property(lambda s: honcho_client)), \
+             patch("plugins.memory.honcho.session_context.Peer") as peer_cls:
+            result = mgr.search_context(session.key, "neuralancer")
+
+        # Empty read stays empty; neither the empty yet the error path touches peer creation.
+        assert result == ""
+        peer_cls.assert_not_called()
+
+
+    def test_search_context_error_fallback_uses_direct_peer(self):
+        """When both filter searches raise, the fallback builds Peer directly."""
+        mgr, session = self._make_cached_manager()
+        honcho_client = MagicMock()
+        honcho_client.base_url = "http://self-hosted"
+        honcho_client.search.side_effect = [RuntimeError("boom"), RuntimeError("boom")]
+        hit = [SimpleNamespace(content="Robert runs neuralancer", peer_id="hermes", session_id="s-old", id="m1")]
+        mgr._get_or_create_peer = MagicMock(side_effect=AssertionError("peer creation on read path"))
+        with patch.object(HonchoSessionManager, "honcho", new_callable=lambda: property(lambda s: honcho_client)), \
+             patch("plugins.memory.honcho.session_context.Peer") as peer_cls:
+            peer_cls.return_value.search.return_value = hit
+            result = mgr.search_context(session.key, "neuralancer")
+
+        assert "Robert runs neuralancer" in result
+        peer_cls.assert_called_once_with(session.user_peer_id, honcho_client)
+        peer_cls.return_value.search.assert_called_once_with("neuralancer", limit=10)
 
 
     def test_create_conclusion_defaults_to_user_target(self):


### PR DESCRIPTION
## Problem

On self-hosted Honcho (built from source), a message search with the `peer_perspective` filter returns an empty 200 instead of raising. The existing fallback only fires on an exception, so an empty 200 silently yields nothing. `honcho_search` reports "No relevant context found" even when memories exist. Verified live against a self-hosted Honcho instance: the same query returns **0 results** with `peer_perspective` and **5 results** with the `peer_id` column filter.

Fixes #88012.

## Fix

`search_context` now retries an empty `peer_perspective` result with the `peer_id` column filter, then with the raw peer-object search if that fails. A raised perspective search keeps the pre-existing peer-object fallback.

## Review follow-ups

 1. **No permanent capability cache.** An earlier revision cached "perspective works" per `base_url` after one non-empty result. Review noted that a reset `joined_at` visibility window can empty a later query that the `peer_id` filter still reaches, so a prior hit cannot make later empties definitive. The cache is removed; every empty perspective result retries.
 2. **No peer creation on the read path.** The fallback constructs `Peer(peer_id, self.honcho)` directly instead of `_get_or_create_peer(peer_id)`: `Honcho.peer()` is get-or-create (a write) in the pinned `honcho-ai==2.2.0`, and `search_context` is a read path. Direct construction is non-networking in 2.2.0 and is re-resolved inside `_guarded_authed`, so a 401-triggered client rebuild is respected.
 3. **Regression tests pin every branch.** Empty-200 triggers the `peer_id` retry; a non-empty perspective result never retries; an empty result after an earlier hit still retries; and both fallback tests assert `_get_or_create_peer` was never called (`_guarded` swallows an `AssertionError` side effect, so the assertion is explicit). The auth-recovery timeout test now patches the direct `Peer` path.

`tests/honcho_plugin/test_session.py` passes at 53 and `tests/honcho_plugin/test_auth_recovery.py` at 65.