### PR TITLE
fix: reject empty tool args missing required fields

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1257,6 +1257,122 @@ def _canonicalize_tool_call_arguments(arg_str: str) -> str:
     return canonical
 
 
+def _tool_parameters_schema(agent, tool_name: str) -> Optional[dict]:
+    """Return the model-facing parameter schema for ``tool_name``.
+
+    Hermes exposes OpenAI-style function definitions in ``agent.tools``. A
+    few dynamically supplied tools use the bare function shape, so accept
+    both forms here. This lookup deliberately does not consult the global
+    registry: the active agent's tool list is the schema the provider saw for
+    this turn, and MCP/deferred tools may not be present in the registry.
+    """
+    for raw_tool in getattr(agent, "tools", None) or []:
+        if not isinstance(raw_tool, dict):
+            continue
+        function = raw_tool.get("function")
+        if not isinstance(function, dict):
+            function = raw_tool
+        if function.get("name") != tool_name:
+            continue
+        parameters = function.get("parameters")
+        return parameters if isinstance(parameters, dict) else None
+    return None
+
+
+def _missing_top_level_required_arguments(
+    agent,
+    tool_name: str,
+    arguments: dict,
+) -> list[str]:
+    """Return missing top-level ``required`` keys from a tool schema.
+
+    This is intentionally the narrow validation available at this boundary:
+    it checks only the parameter object's top-level ``required`` list. A
+    nested property's own ``required`` list is not interpreted as a
+    top-level requirement, so the check cannot reject a valid parent object
+    merely because the same word appears deeper in a JSON Schema.
+    """
+    parameters = _tool_parameters_schema(agent, tool_name)
+    required = parameters.get("required") if parameters else None
+    if not isinstance(required, list):
+        return []
+    return [name for name in required if isinstance(name, str) and name not in arguments]
+
+
+def _validate_tool_call_arguments(
+    agent,
+    tool_calls,
+    mixed_invalid_batch: bool = False,
+) -> list[tuple[str, str]]:
+    """Normalize empty optional calls and reject missing required fields.
+
+    Empty arguments are a compatibility case only for tools whose active
+    schema has no top-level required fields. For required tools, both an
+    empty wire string and a parsed ``{}`` remain invalid and are returned to
+    the caller for the existing bounded recovery path. Non-empty malformed
+    JSON is left untouched so its existing repair/retry behavior remains the
+    authority for that failure class.
+    """
+    invalid: list[tuple[str, str]] = []
+    valid_tool_names = getattr(agent, "valid_tool_names", set()) or set()
+
+    for tool_call in tool_calls:
+        function = getattr(tool_call, "function", None)
+        if function is None:
+            continue
+        name = getattr(function, "name", "") or ""
+
+        # Keep the existing SDK compatibility normalization for structured
+        # arguments. The schema check below then sees the same object that
+        # the executor will parse from the resulting JSON string.
+        arguments = getattr(function, "arguments", None)
+        if isinstance(arguments, (dict, list)):
+            function.arguments = json.dumps(arguments)
+            arguments = function.arguments
+        elif arguments is not None and not isinstance(arguments, str):
+            function.arguments = str(arguments)
+            arguments = function.arguments
+
+        if not arguments or not arguments.strip():
+            missing = _missing_top_level_required_arguments(agent, name, {})
+            if missing:
+                invalid.append((
+                    name,
+                    "Tool call arguments missing required fields for "
+                    f"'{name}': {', '.join(missing)}. The tool was not "
+                    "executed; retry with arguments matching the schema.",
+                ))
+            else:
+                function.arguments = "{}"
+            continue
+
+        try:
+            parsed = json.loads(arguments)
+        except json.JSONDecodeError:
+            # The existing malformed/truncated JSON recovery below owns this
+            # class. Do not replace the raw string here.
+            continue
+
+        if not isinstance(parsed, dict):
+            # The executor's existing JSON-object guard handles scalar/list
+            # payloads. This patch is only the required-key boundary.
+            continue
+
+        if mixed_invalid_batch and name not in valid_tool_names:
+            continue
+
+        missing = _missing_top_level_required_arguments(agent, name, parsed)
+        if missing:
+            invalid.append((
+                name,
+                "Tool call arguments missing required fields for "
+                f"'{name}': {', '.join(missing)}. The tool was not "
+                "executed; retry with arguments matching the schema.",
+            ))
+
+    return invalid
+
+
 def _clone_message_for_send(msg):
     """Structural clone of a history message for the per-call API copy.
 
@@ -7021,20 +7137,22 @@ def run_conversation(
                 # Reset retry counter on successful tool call validation
                 agent._invalid_tool_retries = 0
                 
-                # Validate tool call arguments are valid JSON
-                # Handle empty strings as empty objects (common model quirk)
+                # Validate tool call arguments are valid JSON and satisfy the
+                # active tool's top-level required fields. Empty strings are
+                # normalized only for tools with no required parameters.
+                invalid_required_args = _validate_tool_call_arguments(
+                    agent,
+                    assistant_message.tool_calls,
+                    mixed_invalid_batch=_mixed_invalid_batch,
+                )
                 invalid_json_args = []
                 for tc in assistant_message.tool_calls:
                     args = tc.function.arguments
-                    if isinstance(args, (dict, list)):
-                        tc.function.arguments = json.dumps(args)
-                        continue
-                    if args is not None and not isinstance(args, str):
-                        tc.function.arguments = str(args)
-                        args = tc.function.arguments
-                    # Treat empty/whitespace strings as empty object
+                    # Required-empty calls are recorded above and remain raw
+                    # so the recovery result does not turn them into a
+                    # successful-looking ``{}`` transcript entry. Optional
+                    # empty calls were normalized by the helper.
                     if not args or not args.strip():
-                        tc.function.arguments = "{}"
                         continue
                     try:
                         json.loads(args)
@@ -7049,7 +7167,8 @@ def run_conversation(
                             continue
                         invalid_json_args.append((tc.function.name, str(e)))
                 
-                if invalid_json_args:
+                invalid_argument_errors = invalid_json_args + invalid_required_args
+                if invalid_argument_errors:
                     # Check if the invalid JSON is due to truncation rather
                     # than a model formatting mistake.  Routers sometimes
                     # rewrite finish_reason from "length" to "tool_calls",
@@ -7086,7 +7205,7 @@ def run_conversation(
                     # Track retries for invalid JSON arguments
                     agent._invalid_json_retries += 1
 
-                    tool_name, error_msg = invalid_json_args[0]
+                    tool_name, error_msg = invalid_argument_errors[0]
                     agent._buffer_vprint(f"⚠️  Invalid JSON in tool call arguments for '{tool_name}': {error_msg}")
 
                     if agent._invalid_json_retries < 3:
@@ -7104,15 +7223,27 @@ def run_conversation(
                         append_message(messages, recovery_assistant)
                         
                         # Respond with tool error results for each tool call
-                        invalid_names = {name for name, _ in invalid_json_args}
+                        invalid_names = {name for name, _ in invalid_argument_errors}
+                        required_errors = {
+                            name: error for name, error in invalid_required_args
+                        }
+                        json_errors = {
+                            name: error for name, error in invalid_json_args
+                        }
                         for tc in assistant_message.tool_calls:
                             if tc.function.name in invalid_names:
-                                err = next(e for n, e in invalid_json_args if n == tc.function.name)
-                                tool_result = (
-                                    f"Error: Invalid JSON arguments. {err}. "
-                                    f"For tools with no required parameters, use an empty object: {{}}. "
-                                    f"Please retry with valid JSON."
-                                )
+                                if tc.function.name in required_errors:
+                                    tool_result = (
+                                        f"Error: {required_errors[tc.function.name]} "
+                                        "Please retry with complete arguments."
+                                    )
+                                else:
+                                    err = json_errors[tc.function.name]
+                                    tool_result = (
+                                        f"Error: Invalid JSON arguments. {err}. "
+                                        f"For tools with no required parameters, use an empty object: {{}}. "
+                                        f"Please retry with valid JSON."
+                                    )
                             else:
                                 tool_result = "Skipped: other tool call in this response had invalid JSON."
                             append_message(messages, {

--- a/tests/run_agent/test_schema_required_tool_arguments.py
+++ b/tests/run_agent/test_schema_required_tool_arguments.py
@@ -1,0 +1,238 @@
+"""Regression coverage for schema-required tool arguments at dispatch."""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _tool_call(arguments: str):
+    return SimpleNamespace(
+        id="call-required",
+        type="function",
+        function=SimpleNamespace(name="read_file", arguments=arguments),
+    )
+
+
+def _response_with_tool_call(arguments: str):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None,
+                    reasoning=None,
+                    tool_calls=[_tool_call(arguments)],
+                ),
+                finish_reason="tool_calls",
+            )
+        ],
+        usage=None,
+    )
+
+
+class _FakeChatCompletions:
+    def __init__(self):
+        self.calls = 0
+
+    def create(self, **kwargs):
+        self.calls += 1
+        if self.calls <= 3:
+            return _response_with_tool_call("{}")
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="done", reasoning=None, tool_calls=[]
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=None,
+        )
+
+
+class _FakeClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=_FakeChatCompletions())
+
+
+def _validation_agent(parameters: dict):
+    return SimpleNamespace(
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "parameters": parameters,
+                },
+            }
+        ],
+        valid_tool_names={"read_file"},
+    )
+
+
+def _validation_call(arguments):
+    return SimpleNamespace(
+        function=SimpleNamespace(name="read_file", arguments=arguments)
+    )
+
+
+@pytest.mark.parametrize("arguments", ["", "{}"])
+def test_required_schema_rejects_empty_arguments(arguments):
+    from agent.conversation_loop import _validate_tool_call_arguments
+
+    invalid = _validate_tool_call_arguments(
+        _validation_agent({
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        }),
+        [_validation_call(arguments)],
+    )
+
+    assert len(invalid) == 1
+    assert "path" in invalid[0][1]
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {"type": "object", "properties": {}, "required": []},
+        {
+            "type": "object",
+            "properties": {"mode": {"type": "string"}},
+        },
+    ],
+)
+def test_empty_object_is_allowed_without_top_level_required_fields(parameters):
+    from agent.conversation_loop import _validate_tool_call_arguments
+
+    call = _validation_call("{}")
+    assert _validate_tool_call_arguments(_validation_agent(parameters), [call]) == []
+    assert call.function.arguments == "{}"
+
+
+def test_valid_required_arguments_are_allowed():
+    from agent.conversation_loop import _validate_tool_call_arguments
+
+    assert (
+        _validate_tool_call_arguments(
+            _validation_agent({
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            }),
+            [_validation_call('{"path":"README.md"}')],
+        )
+        == []
+    )
+
+
+def test_missing_one_of_multiple_required_fields_is_rejected():
+    from agent.conversation_loop import _validate_tool_call_arguments
+
+    invalid = _validate_tool_call_arguments(
+        _validation_agent({
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "mode": {"type": "string"},
+            },
+            "required": ["path", "mode"],
+        }),
+        [_validation_call('{"path":"README.md"}')],
+    )
+
+    assert len(invalid) == 1
+    assert "mode" in invalid[0][1]
+    assert "path" not in invalid[0][1]
+
+
+def test_nested_required_is_outside_this_top_level_boundary():
+    from agent.conversation_loop import _validate_tool_call_arguments
+
+    parameters = {
+        "type": "object",
+        "properties": {
+            "options": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            }
+        },
+        "required": [],
+    }
+
+    assert (
+        _validate_tool_call_arguments(
+            _validation_agent(parameters), [_validation_call("{}")]
+        )
+        == []
+    )
+
+
+def test_malformed_non_empty_arguments_remain_on_existing_recovery_path():
+    from agent.conversation_loop import _validate_tool_call_arguments
+
+    call = _validation_call('{"path":')
+    assert (
+        _validate_tool_call_arguments(
+            _validation_agent({
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            }),
+            [call],
+        )
+        == []
+    )
+    assert call.function.arguments == '{"path":'
+
+
+def test_required_schema_empty_object_never_reaches_handler(monkeypatch):
+    from run_agent import AIAgent
+
+    tool_defs = [
+        {
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "read a file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                },
+            },
+        }
+    ]
+    executed = []
+
+    def fake_dispatch(name, args, task_id=None, **kwargs):
+        executed.append((name, args))
+        return "unexpected handler execution"
+
+    monkeypatch.setattr("run_agent.OpenAI", lambda **kwargs: _FakeClient())
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda *a, **k: tool_defs)
+    monkeypatch.setattr("run_agent.handle_function_call", fake_dispatch)
+
+    agent = AIAgent(
+        model="test-model",
+        api_key="test-key",
+        base_url="http://localhost:8080/v1",
+        platform="cli",
+        max_iterations=6,
+        quiet_mode=True,
+        skip_memory=True,
+        skip_context_files=True,
+    )
+    setattr(agent, "_disable_streaming", True)
+
+    result = agent.run_conversation("invoke the file tool")
+
+    assert executed == []
+    assert result["final_response"].startswith("done")
+    tool_results = [
+        message for message in result["messages"] if message.get("role") == "tool"
+    ]
+    assert len(tool_results) == 1
+    assert "missing required fields" in tool_results[0]["content"]


### PR DESCRIPTION
## Summary

Tool calls whose argument object is empty can currently pass the conversation-loop JSON check even when the selected tool schema declares required top-level fields. That allows an invalid no-argument invocation to reach the tool handler.

This adds a schema-aware fail-closed check against the active tool definitions before dispatch and recovery. Missing top-level required fields are rejected, while no-argument tools and optional-only schemas continue to work.

## Scope

The check intentionally covers only the selected parameter object's top-level `required` list. Nested JSON Schema requirements and full type validation remain outside this dispatch-boundary fix.

## Behavior

- `""` or `{}` with required fields: existing bounded invalid-argument recovery; no handler invocation.
- `{}` with no required fields or optional-only properties: allowed.
- Valid required arguments: allowed.
- Malformed non-empty arguments: existing repair/retry path is unchanged.

## Tests

- Added deterministic coverage for empty/required, optional-only, valid required, multiple required, nested scope, and malformed non-empty arguments.
- The baseline commit fails the handler-count repro; this branch passes with zero handler invocations and recovery followed by a normal final response.
- Targeted argument, dispatch, sanitization, repair, streaming, and tool-search suites pass.

## Related

Complements #89246, which addresses malformed/truncated argument repair failure provenance.
