### PR TITLE
fix(memory): require batch operation fields

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -334,6 +334,20 @@ class TestMemoryToolDispatcher:
 class TestMemoryBatch:
     """The 'operations' batch shape: atomic, all-or-nothing, final-budget."""
 
+    def test_batch_missing_old_text_returns_specific_error(self, store):
+        store.add("memory", "old entry")
+        result = json.loads(memory_tool(
+            target="memory",
+            operations=[{"action": "replace", "content": "updated entry"}],
+            store=store,
+        ))
+        assert result["success"] is False
+        assert result["error"] == (
+            "Operation 1 (replace): old_text is required. "
+            "No operations were applied (batch is all-or-nothing)."
+        )
+        assert store.memory_entries == ["old entry"]
+
     def test_batch_add_and_remove_atomic(self, store):
         store.add("memory", "stale one")
         store.add("memory", "stale two")

--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -18,6 +18,7 @@ backends reject.
 """
 
 import json
+from typing import Any, cast
 
 from tools.memory_tool import MEMORY_SCHEMA
 
@@ -38,3 +39,10 @@ def test_memory_schema_has_no_forbidden_top_level_combinators():
 
 def test_memory_schema_is_json_serializable():
     json.dumps(MEMORY_SCHEMA)
+
+
+def test_memory_batch_schema_requires_runtime_fields():
+    """Structured-output backends must emit fields the batch handler needs."""
+    parameters = cast(dict[str, Any], MEMORY_SCHEMA["parameters"])
+    operation = cast(dict[str, Any], parameters["properties"]["operations"]["items"])
+    assert {"action", "content", "old_text"} <= set(operation["required"])

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1097,7 +1097,7 @@ def memory_tool(
 
     Two shapes:
       - Single op: action + (content / old_text).
-      - Batch:     operations=[{action, content?, old_text?}, ...] applied
+      - Batch:     operations=[{action, content, old_text}, ...] applied
                    atomically against the final char budget in ONE call.
 
     ``new_text`` is accepted as an alias for ``content`` on both shapes. The
@@ -1129,7 +1129,7 @@ def memory_tool(
     # --- Batch path -------------------------------------------------------
     if operations:
         if not isinstance(operations, list):
-            return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
+            return tool_error("operations must be a list of {action, content, old_text} objects.", success=False)
         gate_result = _apply_batch_write_gate(target, operations)
         if gate_result is not None:
             return gate_result
@@ -1265,7 +1265,8 @@ MEMORY_SCHEMA = {
         "Save durable facts to persistent memory that survive across sessions. Memory is "
         "injected into every future turn, so keep entries compact and high-signal.\n\n"
         "HOW: make ALL your changes in ONE call via an 'operations' array (each item: "
-        "{action, content?, old_text?}). The batch applies atomically and the char limit is "
+        "{action, content, old_text}; use an empty string when a field does not apply). The "
+        "batch applies atomically and the char limit is "
         "checked only on the FINAL result — so a single call can remove/replace stale entries "
         "to free room AND add new ones, even when an add alone would overflow. The response "
         "reports current/limit chars and confirms completion; one batch call finishes the "
@@ -1313,17 +1314,18 @@ MEMORY_SCHEMA = {
                 "description": (
                     "Batch shape: a list of operations applied atomically in one call "
                     "against the final char budget. Preferred when making multiple changes "
-                    "or consolidating to make room. Each item is {action, content?, old_text?}."
+                    "or consolidating to make room. Every item must include action, content, "
+                    "and old_text; use an empty string when content or old_text does not apply."
                 ),
                 "items": {
                     "type": "object",
                     "properties": {
                         "action": {"type": "string", "enum": ["add", "replace", "remove"]},
-                        "content": {"type": "string", "description": "Entry content for add/replace. Alias: 'new_text'."},
+                        "content": {"type": "string", "description": "Entry content for add/replace. Use an empty string for remove. Alias: 'new_text'."},
                         "new_text": {"type": "string", "description": "Alias for 'content' in a batch op."},
-                        "old_text": {"type": "string", "description": "Substring identifying the entry for replace/remove."},
+                        "old_text": {"type": "string", "description": "Substring identifying the entry for replace/remove. Use an empty string for add."},
                     },
-                    "required": ["action"],
+                    "required": ["action", "content", "old_text"],
                 },
             },
         },
@@ -1388,7 +1390,6 @@ registry.register(
     emoji="🧠",
     dynamic_schema_overrides=_build_memory_schema_overrides,
 )
-
 
 
 


### PR DESCRIPTION
## What does this PR do?

The `memory` batch schema currently requires only `action`, so structured-output backends may omit `content` or `old_text` from nested operations. Valid multi-operation requests can therefore reach the runtime incomplete and fail.

This PR requires `action`, `content`, and `old_text` in every batch item, with an empty string when a field does not apply. It avoids conditional schema combinators that are incompatible with some supported providers and preserves the existing runtime behavior and `new_text` alias.

**Compatibility note:** Integrators that construct batch operations manually must include both `content` and `old_text`; use an empty string for the field that does not apply.

## Related Issue

Fixes #90255

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/memory_tool.py` so every batch operation requires the fields consumed by the runtime.
- Documented empty-string placeholders for fields that do not apply to an action.
- Added schema and runtime regression tests for the strengthened batch contract.

## How to Test

1. Run `scripts/run_tests.sh tests/tools/test_memory_tool_schema.py tests/tools/test_memory_tool.py`.
2. Send a structured batch request containing two `replace` operations and one `add` operation through an OpenAI-compatible structured-output backend.
3. Confirm every generated operation includes `action`, `content`, and `old_text`, and that the batch succeeds.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 26.5.2, with an Unsloth OpenAI-compatible backend running on Windows

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I have updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

- Targeted suite: 45 passed, 0 failed.
- Live Unsloth validation at temperature 0: before the schema change, all 3 generated calls omitted a nested field, including `content` on both `replace` operations; after the change, all 3 generated calls contained complete operations with the expected values.
- Full repository runner: 36,489 passed, 83 failed, 335 skipped. All failures are outside the changed files; examples include unavailable optional integrations and host-specific assumptions in this macOS environment.
