### PR TITLE
fix(tools): preserve search regexes on Windows

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -278,7 +278,9 @@ class TestSearchContextParsing:
             )
 
         cmd_arg = mock_exec.call_args[0][0]
-        assert cmd_arg.startswith("set -o pipefail; grep -rnHE ")
+        assert cmd_arg.startswith("set -o pipefail; { grep -rnHE ")
+        assert " -f - " in cmd_arg
+        assert mock_exec.call_args.kwargs["stdin_data"] == "foo|bar"
         assert result.error is None
         assert result.total_count == 2
         assert [match.content for match in result.matches] == ["foo", "bar"]

--- a/tests/tools/test_macos_protected_search.py
+++ b/tests/tools/test_macos_protected_search.py
@@ -97,12 +97,15 @@ def test_broad_content_search_passes_protected_globs_to_ripgrep(tmp_path, monkey
     home.mkdir(parents=True)
     env = RecordingEnvironment(home)
     ops = ShellFileOperations(env)
-    monkeypatch.setattr(file_operations, "_HOME", str(home))
-    monkeypatch.setattr(file_operations.sys, "platform", "darwin")
+    monkeypatch.setattr(
+        ops, "_macos_search_exclusions",
+        lambda path: _macos_protected_search_exclusions(
+            path, cwd=str(home), home=str(home), platform="darwin"),
+    )
 
     ops.search("needle", path=str(home), target="content")
 
-    rg_command = next(command for command in env.commands if command.startswith("set -o pipefail; rg"))
+    rg_command = next(command for command in env.commands if "--line-number" in command)
     for dirname in PROTECTED_NAMES:
         assert f"!{dirname}/**" in rg_command
 

--- a/tests/tools/test_search_giant_line_containment.py
+++ b/tests/tools/test_search_giant_line_containment.py
@@ -37,6 +37,7 @@ class RecordingEnv:
     def execute(self, command, timeout=60, **kwargs):
         proc = subprocess.run(
             ["bash", "-c", command],
+            input=kwargs.get("stdin_data"),
             capture_output=True, text=True, errors="replace",
             timeout=timeout + 30,
         )

--- a/tests/tools/test_search_windows_regex_quoting.py
+++ b/tests/tools/test_search_windows_regex_quoting.py
@@ -1,0 +1,134 @@
+"""Regression tests for Windows ripgrep regex argument quoting."""
+
+import shutil
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.environments.base import BaseEnvironment
+from tools.environments.local import LocalEnvironment
+from tools.file_operations import ShellFileOperations
+
+
+def test_search_regex_bypasses_path_normalization(monkeypatch):
+    """Regex escapes must never pass through path normalization."""
+    import tools.environments.local as local_mod
+
+    calls = []
+    env = MagicMock()
+    env.cwd = "/tmp/test"
+
+    def execute(command, **kwargs):
+        calls.append((command, kwargs))
+        if command.startswith("command -v rg"):
+            return {"output": "yes", "returncode": 0}
+        return {"output": "", "returncode": 0}
+
+    env.execute.side_effect = execute
+    monkeypatch.setattr(
+        local_mod,
+        "_bash_safe_path",
+        lambda value: value.replace("\\", "/"),
+    )
+
+    result = ShellFileOperations(env).search(
+        r'AddDataFilePath\("Digital',
+        path="/tmp/test",
+    )
+
+    assert result.error is None
+    rg_calls = [
+        (command, kwargs)
+        for command, kwargs in calls
+        if command.startswith(("{ rg ", "set -o pipefail; { rg "))
+    ]
+    assert rg_calls
+    assert all(
+        kwargs.get("stdin_data") == 'AddDataFilePath\\("Digital'
+        for _, kwargs in rg_calls
+    )
+
+
+def test_search_pattern_reaches_rg_via_heredoc_transport(tmp_path):
+    """SDK backends that embed stdin as a heredoc must feed rg, not head."""
+    bash = shutil.which("bash")
+    if bash is None or shutil.which("rg") is None:
+        pytest.skip("bash and ripgrep are required")
+
+    source = tmp_path / "sample.cs"
+    source.write_text(
+        'unrelated line\nAddDataFilePath("Digital")\n',
+        encoding="utf-8",
+    )
+    env = MagicMock()
+    env.cwd = str(tmp_path)
+
+    def execute(command, **kwargs):
+        stdin_data = kwargs.get("stdin_data")
+        if stdin_data is not None:
+            command = BaseEnvironment._embed_stdin_heredoc(command, stdin_data)
+        completed = subprocess.run(
+            [bash, "-c", command],
+            cwd=str(tmp_path),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=kwargs.get("timeout", 60),
+        )
+        return {"output": completed.stdout, "returncode": completed.returncode}
+
+    env.execute.side_effect = execute
+
+    result = ShellFileOperations(env).search(
+        r'AddDataFilePath\("Digital',
+        path=str(tmp_path),
+        file_glob="*.cs",
+    )
+
+    assert result.error is None
+    assert result.total_count == 1
+
+
+def test_grep_fallback_does_not_reinterpret_newline_escape(tmp_path, monkeypatch):
+    """A real newline must not become a grep regex that matches letter n."""
+    if shutil.which("grep") is None:
+        pytest.skip("grep is required")
+
+    source = tmp_path / "sample.txt"
+    source.write_text("anb\n", encoding="utf-8")
+    ops = ShellFileOperations(LocalEnvironment(cwd=str(tmp_path)))
+    monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
+
+    result = ops.search("a\nb", path=str(tmp_path), file_glob="*.txt")
+
+    assert result.error is None
+    assert result.total_count == 0
+    assert result.warning is not None
+    assert "line-oriented" in result.warning
+
+
+@pytest.mark.windows_only
+@pytest.mark.parametrize(
+    ("content", "pattern"),
+    [
+        ('Form1.AddDataFilePath("Digital\\\\Setting")\n', r'AddDataFilePath\("Digital'),
+        (r"value = a\nb" + "\n", r"a\\nb"),
+        ('value = x"y\n', r'x\"y'),
+    ],
+    ids=("escaped-metacharacter", "literal-backslash", "escaped-quote"),
+)
+def test_native_windows_rg_receives_regex_backslashes(tmp_path, content, pattern):
+    """Native rg must receive both single and doubled regex backslashes intact."""
+    if shutil.which("rg") is None:
+        pytest.skip("native Windows ripgrep is not installed")
+
+    source = tmp_path / "sample.cs"
+    source.write_text(content, encoding="utf-8")
+    ops = ShellFileOperations(LocalEnvironment(cwd=str(tmp_path)))
+
+    result = ops.search(pattern, path=str(tmp_path), file_glob="*.cs")
+
+    assert result.error is None
+    assert result.total_count == 1
+    assert result.matches[0].path.endswith("sample.cs")

--- a/tests/tools/test_search_windows_regex_quoting.py
+++ b/tests/tools/test_search_windows_regex_quoting.py
@@ -50,6 +50,37 @@ def test_search_regex_bypasses_path_normalization(monkeypatch):
     )
 
 
+def test_search_glob_bypasses_path_normalization(monkeypatch):
+    """Glob syntax is shell data, not a filesystem path to rewrite."""
+    import tools.environments.local as local_mod
+
+    commands = []
+    env = MagicMock()
+    env.cwd = "/tmp/test"
+
+    def execute(command, **kwargs):
+        commands.append(command)
+        if command.startswith("command -v rg"):
+            return {"output": "yes", "returncode": 0}
+        return {"output": "", "returncode": 0}
+
+    env.execute.side_effect = execute
+    monkeypatch.setattr(
+        local_mod,
+        "_bash_safe_path",
+        lambda value: value.replace("\\", "/"),
+    )
+
+    result = ShellFileOperations(env).search(
+        "needle",
+        path="/tmp/test",
+        file_glob=r"dir\*.cs",
+    )
+
+    assert result.error is None
+    assert any("'dir\\*.cs'" in command for command in commands)
+
+
 def test_search_pattern_reaches_rg_via_heredoc_transport(tmp_path):
     """SDK backends that embed stdin as a heredoc must feed rg, not head."""
     bash = shutil.which("bash")
@@ -90,22 +121,40 @@ def test_search_pattern_reaches_rg_via_heredoc_transport(tmp_path):
     assert result.total_count == 1
 
 
-def test_grep_fallback_does_not_reinterpret_newline_escape(tmp_path, monkeypatch):
-    """A real newline must not become a grep regex that matches letter n."""
+@pytest.mark.parametrize(
+    ("pattern", "content", "expected_count", "expects_warning"),
+    [
+        ("a\nb", "anb\n", 0, True),
+        ("a\rb", "arb\n", 0, False),
+    ],
+    ids=("newline", "carriage-return-no-false-match"),
+)
+def test_grep_fallback_preserves_control_characters(
+    tmp_path,
+    monkeypatch,
+    pattern,
+    content,
+    expected_count,
+    expects_warning,
+):
+    """grep must not reinterpret CR/LF controls as letters r/n."""
     if shutil.which("grep") is None:
         pytest.skip("grep is required")
 
     source = tmp_path / "sample.txt"
-    source.write_text("anb\n", encoding="utf-8")
+    source.write_text(content, encoding="utf-8")
     ops = ShellFileOperations(LocalEnvironment(cwd=str(tmp_path)))
     monkeypatch.setattr(ops, "_has_command", lambda command: command == "grep")
 
-    result = ops.search("a\nb", path=str(tmp_path), file_glob="*.txt")
+    result = ops.search(pattern, path=str(tmp_path), file_glob="*.txt")
 
     assert result.error is None
-    assert result.total_count == 0
-    assert result.warning is not None
-    assert "line-oriented" in result.warning
+    assert result.total_count == expected_count
+    if expects_warning:
+        assert result.warning is not None
+        assert "line-oriented" in result.warning
+    else:
+        assert result.warning is None
 
 
 @pytest.mark.windows_only

--- a/tests/tools/test_search_windows_regex_quoting.py
+++ b/tests/tools/test_search_windows_regex_quoting.py
@@ -21,6 +21,8 @@ def test_search_regex_bypasses_path_normalization(monkeypatch):
 
     def execute(command, **kwargs):
         calls.append((command, kwargs))
+        if command.startswith("test -e "):
+            return {"output": "exists", "returncode": 0}
         if command.startswith("command -v rg"):
             return {"output": "yes", "returncode": 0}
         return {"output": "", "returncode": 0}
@@ -60,6 +62,8 @@ def test_search_glob_bypasses_path_normalization(monkeypatch):
 
     def execute(command, **kwargs):
         commands.append(command)
+        if command.startswith("test -e "):
+            return {"output": "exists", "returncode": 0}
         if command.startswith("command -v rg"):
             return {"output": "yes", "returncode": 0}
         return {"output": "", "returncode": 0}
@@ -181,3 +185,87 @@ def test_native_windows_rg_receives_regex_backslashes(tmp_path, content, pattern
     assert result.error is None
     assert result.total_count == 1
     assert result.matches[0].path.endswith("sample.cs")
+
+
+@pytest.mark.parametrize("transport", ["payload", "heredoc", "local"])
+@pytest.mark.parametrize(
+    ("pattern", "expected_count", "expected_error"),
+    [
+        ("(?x)alpha\n/beta", 1, False),
+        ("(?x)alpha # comment\n/beta", 1, False),
+        ("one\ntwo", 2, False),
+        ("(?x)absent\n/match", 0, False),
+        ("(?x)(alpha\n/beta", 0, True),
+        ("(?x)alpha\r/beta", 1, False),
+        ("(?x)alpha # comment\r\n/beta", 1, False),
+        ("one\ntwo\n", 2, False),
+        ("one\ntwo\n\n", 0, False),
+        ('(?x)x\\"y\n', 1, False),
+        (r"(?x)foo\\bar" + "\n", 1, False),
+        ("(?x)alpha # $(touch injected); `touch injected`; '\"\n/beta", 1, False),
+    ],
+    ids=["extended-mode", "extended-comment", "literal-newline", "no-match", "invalid-regex",
+         "carriage-return", "comment-crlf", "trailing-newline", "trailing-newlines-no-match",
+         "escaped-quote", "literal-backslash", "shell-metacharacters"],
+)
+def test_shell_multiline_pattern_preserves_regex_semantics(
+    tmp_path, transport, pattern, expected_count, expected_error,
+):
+    """Line breaks may be regex whitespace/comments, not only matchable characters."""
+    bash = shutil.which("bash")
+    if bash is None or shutil.which("rg") is None:
+        pytest.skip("bash and ripgrep are required")
+    source = tmp_path / "sample.txt"
+    source.write_text('alpha/beta\nx"y\nfoo\\bar\none\ntwo\n', encoding="utf-8", newline="\n")
+    env = MagicMock()
+    env.cwd = str(tmp_path)
+
+    def execute(command, **kwargs):
+        stdin_data = kwargs.get("stdin_data")
+        if transport == "heredoc" and stdin_data is not None:
+            command = BaseEnvironment._embed_stdin_heredoc(command, stdin_data)
+            stdin_data = None
+        completed = subprocess.run(
+            [bash, "-c", command], cwd=str(tmp_path), input=stdin_data,
+            text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            timeout=kwargs.get("timeout", 60),
+        )
+        return {"output": completed.stdout, "returncode": completed.returncode}
+
+    env.execute.side_effect = execute
+    if transport == "local":
+        env = LocalEnvironment(cwd=str(tmp_path))
+    result = ShellFileOperations(env).search(pattern, path=str(source))
+
+    assert bool(result.error) is expected_error
+    assert result.total_count == expected_count
+    assert not (tmp_path / "injected").exists()
+
+
+@pytest.mark.parametrize(
+    ("pattern", "content", "hint"),
+    [
+        ("(?x)ALPHA\n/BETA", "alpha/beta\n", "case-insensitive"),
+        ("lookup[key+1]\r", "lookup[key+1]\r\n", "literal match"),
+        ("lookup[key+1]\r", "lookup[key+1]\\r\n", None),
+        ("lookup[key+1]\nneedle", "lookup[key+1]\\nneedle\n", None),
+    ],
+    ids=["extended-mode", "fixed-carriage-return", "not-literal-backslash-r", "not-literal-backslash-n"],
+)
+def test_shell_zero_match_probes_preserve_control_characters(
+    tmp_path, monkeypatch, pattern, content, hint,
+):
+    """Probe patterns must retain the same meaning even when rg uses -F."""
+    if shutil.which("bash") is None or shutil.which("rg") is None:
+        pytest.skip("bash and ripgrep are required")
+    monkeypatch.setenv("HERMES_NATIVE_FILE_READ", "0")
+    (tmp_path / "sample.txt").write_bytes(content.encode("utf-8"))
+    ops = ShellFileOperations(LocalEnvironment(cwd=str(tmp_path)))
+
+    warning = ops._zero_match_probe(pattern, str(tmp_path), "*.txt")
+
+    if hint is None:
+        assert warning is None
+    else:
+        assert hint in warning
+        assert "sample.txt" in warning

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -339,13 +339,18 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
                     return expand_result.stdout.strip() + path[1 + len(username):]
         return path
 
+    @staticmethod
+    def _quote_shell_arg(arg: str) -> str:
+        """Quote arbitrary shell data without rewriting it as a path."""
+        return "'" + arg.replace("'", "'\"'\"'") + "'"
+
     def _escape_shell_arg(self, arg: str) -> str:
         """Single-quote ``arg`` for the shell. On Windows, native drive paths and
         mixed MSYS leftovers are first rewritten to the Git Bash ``/c/Users/x``
         form via the env-layer ``_bash_safe_path`` (bash eats backslashes; MSYS
         mangles drive paths), so shell file ops and the terminal ``cd`` agree."""
         from tools.environments.local import _bash_safe_path
-        return "'" + _bash_safe_path(arg).replace("'", "'\"'\"'") + "'"
+        return self._quote_shell_arg(_bash_safe_path(arg))
 
     def _escape_native_tool_arg(self, arg: str) -> str:
         """Quote a path for a NATIVE Windows binary (rg, node, git ...): those don't
@@ -355,7 +360,7 @@ class ShellFileOperations(LintMixin, SearchMixin, FileOperations):
         from tools.environments.local import _IS_WINDOWS, _msys_to_windows_path
         if _IS_WINDOWS and arg:
             arg = _msys_to_windows_path(arg).replace("\\", "/")
-        return "'" + arg.replace("'", "'\"'\"'") + "'"
+        return self._quote_shell_arg(arg)
 
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
         """Write ``content`` atomically: stdin → temp file in the SAME directory →

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -168,6 +168,17 @@ def _pattern_has_regex_newline(pattern: str) -> bool:
     return "\n" in pattern or bool(_REGEX_NEWLINE_ESCAPE_RE.search(pattern))
 
 
+def _rg_pattern_stdin(pattern: str) -> str:
+    """Encode one ripgrep pattern for stdin pattern-file transport."""
+    pattern = pattern.replace("\r", r"\r").replace("\n", r"\n")
+    return pattern or "\n"
+
+
+def _grep_pattern_stdin(pattern: str) -> str:
+    """Encode one grep pattern without reinterpreting backslash escapes."""
+    return pattern or "\n"
+
+
 def _is_line_oriented_newline_error(error: Optional[str]) -> bool:
     """Return True for rg's hard error when multiline mode is required."""
     return bool(error) and "literal \"\\n\" is not allowed" in error and "--multiline" in error
@@ -255,6 +266,7 @@ def _posix_roots(roots: List[str]) -> bool:
 class SearchMixin:
     """File-name and content search via rg with find/grep fallbacks. Requires
     ``_exec``, ``_has_command``, ``_expand_path``, ``_escape_shell_arg``,
+    ``_quote_shell_arg``,
     ``_escape_native_tool_arg``, ``env``, ``cwd``, ``_command_cache``,
     ``_rg_resolution_cache`` and ``_rg_modified_capability`` from the host class."""
 
@@ -468,7 +480,7 @@ class SearchMixin:
         """``--glob '!<dir>/**'`` pairs excluding protected dirs from an rg run."""
         out: List[str] = []
         for item in self._macos_search_exclusions(path):
-            out.extend(["--glob", self._escape_shell_arg(f"!{item}/**")])
+            out.extend(["--glob", self._quote_shell_arg(f"!{item}/**")])
         return out
 
     def _path_exists_probe(self, path: str) -> str:
@@ -560,7 +572,7 @@ class SearchMixin:
         globs = []
         for dirname in sorted(SEARCH_PRUNE_DIR_NAMES):
             for prefix in ("", "**/"):
-                globs.extend(("--glob", self._escape_shell_arg(f"!{prefix}{dirname}/**")))
+                globs.extend(("--glob", self._quote_shell_arg(f"!{prefix}{dirname}/**")))
         return " ".join(globs)
 
     # (rg flags, message template) probes for a 0-match content search, in order.
@@ -585,7 +597,7 @@ class SearchMixin:
             return None
         rg = self._quote_executable(rg_executable)
         has_meta = bool(re.search(r"[.\[\](){}?*+^$\\|]", pattern))
-        glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        glob_expr = f" --glob {self._quote_shell_arg(file_glob)}" if file_glob else ""
         for flags, template in self._ZERO_MATCH_PROBES:
             if flags == "-F" and not has_meta:
                 continue
@@ -595,9 +607,17 @@ class SearchMixin:
                 glob_expr_probe = f"{glob_expr} {self._search_prune_glob_args()}"
             else:
                 glob_expr_probe = glob_expr
-            probe_words = [rg, flags, "--count-matches", glob_expr_probe,
-                           self._escape_shell_arg(pattern), self._escape_native_tool_arg(path)]
-            probe = self._run_rg_bounded(probe_words, 50, timeout=30)
+            if self._native_read_enabled():
+                probe_words = [rg, flags, "--count-matches", glob_expr_probe,
+                               "-e", self._quote_shell_arg(pattern), self._escape_native_tool_arg(path)]
+                probe = self._run_rg_bounded(probe_words, 50, timeout=30)
+            else:
+                probe = self._exec(
+                    f"set -o pipefail; {{ {rg} {flags} --count-matches{glob_expr_probe} "
+                    f"-f - {self._escape_native_tool_arg(path)} 2>/dev/null | head -50; }}",
+                    timeout=30,
+                    stdin_data=_rg_pattern_stdin(pattern),
+                )
             total, per_file = 0, []
             for line in (probe.stdout or "").strip().splitlines():
                 p, _sep, n = line.rpartition(":")
@@ -691,7 +711,7 @@ class SearchMixin:
         protected_prune = f" {self._prune_expr(protected_paths)} -o" if protected_paths else ""
         fetch_limit = offset + limit + 1
         base = (f"find {' '.join(q_roots)}{protected_prune}{hidden_prune} -type f "
-                f"! -name '.*' -name {self._escape_shell_arg(search_pattern)}")
+                f"! -name '.*' -name {self._quote_shell_arg(search_pattern)}")
         if order == "modified":
             cmd = "set -o pipefail; " + base + f" -printf '%T@ %p\\n' 2>/dev/null | sort -rn | head -n {fetch_limit}"
         else:
@@ -755,11 +775,11 @@ class SearchMixin:
             scoped_common = posixpath.commonpath(absolute_roots)
             command_roots = [posixpath.relpath(root, scoped_common) for root in absolute_roots]
             exclusion_terms = [
-                f"--glob {self._escape_shell_arg(f'!{posixpath.relpath(absolute, scoped_common)}/**')}"
+                f"--glob {self._quote_shell_arg(f'!{posixpath.relpath(absolute, scoped_common)}/**')}"
                 for _r, _rel, absolute in effective_exclusions]
         else:
             exclusion_terms = [
-                f"--glob {self._escape_shell_arg(f'!{relative}/**')}"
+                f"--glob {self._quote_shell_arg(f'!{relative}/**')}"
                 for _r, relative, _abs in effective_exclusions]
         exclusion_globs = " ".join(dict.fromkeys(exclusion_terms))
         exclusion_args = f" {exclusion_globs}" if exclusion_globs else ""
@@ -775,7 +795,7 @@ class SearchMixin:
         root_args = " ".join(self._escape_native_tool_arg(root) for root in command_roots)
         cd_prefix = f"cd {self._escape_shell_arg(scoped_common)} && " if scoped_common else ""
         # ``--`` terminates options so a dash-prefixed root is never parsed as a flag.
-        rg_cmd = (f"{rg} --files{sort_arg} -g {self._escape_shell_arg(glob_pattern)}"
+        rg_cmd = (f"{rg} --files{sort_arg} -g {self._quote_shell_arg(glob_pattern)}"
                   f"{exclusion_args} -- {root_args}")
         result = self._run_rg_bounded([rg_cmd], fetch_limit, timeout=60, native_ok=not scoped_common,
                                       shell_prefix=f"set -o pipefail; {cd_prefix}")
@@ -825,7 +845,8 @@ class SearchMixin:
 
     def _run_search_pipeline(self, cmd_parts: List[str], output_mode: str, limit: int,
                              offset: int, context: int, warning: Optional[str] = None,
-                             line_cap: bool = False) -> SearchResult:
+                             line_cap: bool = False,
+                             stdin_data: Optional[str] = None) -> SearchResult:
         """Run ``cmd_parts | head -n <fetch_limit>`` under pipefail and parse. Extra
         rows report the true total (context mode also emits "--" separators, so
         grab 200 more). pipefail keeps the engine's exit 2 alive across ``| head``
@@ -834,11 +855,15 @@ class SearchMixin:
         (grep): bounds giant single-line matches at the pipe layer; skipped for
         files_only/count where lines are paths/counts."""
         fetch_limit = limit + offset + (200 if context > 0 else 0)
-        if line_cap:  # grep/find pipelines: shell only, with the column cap
+        if line_cap or stdin_data is not None:
             parts = cmd_parts + ["|", "head", "-n", str(fetch_limit)]
-            if output_mode not in ("files_only", "count"):
+            if line_cap and output_mode not in ("files_only", "count"):
                 parts += ["|", "cut", "-c1-2000"]
-            result = self._exec("set -o pipefail; " + " ".join(parts), timeout=60)
+            command = " ".join(parts)
+            if stdin_data is not None:
+                # Heredoc backends must attach stdin to the whole pipeline, not head.
+                command = "{ " + command + "; }"
+            result = self._exec("set -o pipefail; " + command, timeout=60, stdin_data=stdin_data)
         else:
             result = self._run_rg_bounded(cmd_parts, fetch_limit, timeout=60, merge_stderr=True,
                                           shell_prefix="set -o pipefail; ")
@@ -867,34 +892,57 @@ class SearchMixin:
             cmd_parts.extend(["-C", str(context)])
         cmd_parts.extend(self._rg_exclusion_globs(path))
         if file_glob:
-            cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--glob", self._quote_shell_arg(file_glob)])
         if output_mode in _OUTPUT_MODE_FLAGS:
             cmd_parts.append(_OUTPUT_MODE_FLAGS[output_mode])
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        stdin_data = None
+        if self._native_read_enabled():
+            # Direct POSIX argv has no shell/Win32 rewriting; preserve the fast path.
+            cmd_parts.extend(["-e", self._quote_shell_arg(pattern)])
+        else:
+            cmd_parts.extend(["-f", "-"])
+            stdin_data = _rg_pattern_stdin(pattern)
         # rg is a native Windows binary (winget/cargo/choco): needs C:/... not MSYS /c/...
         cmd_parts.append(self._escape_native_tool_arg(path))
         ml_note = (
             "Pattern contains \\n — multiline mode (-U) was enabled automatically "
             "so the regex can match across line boundaries."
         ) if multiline else None
-        return self._run_search_pipeline(cmd_parts, output_mode, limit, offset, context, warning=ml_note)
+        return self._run_search_pipeline(
+            cmd_parts,
+            output_mode,
+            limit,
+            offset,
+            context,
+            warning=ml_note,
+            stdin_data=stdin_data,
+        )
 
     def _grep_cmd(self, head: List[str], pattern: str, output_mode: str, context: int,
-                  file_glob: Optional[str] = None) -> List[str]:
+                  file_glob: Optional[str] = None,
+                  pattern_stdin: bool = False) -> List[str]:
         """``head`` + context/include/mode flags + quoted pattern (argument order is fixed)."""
         parts = list(head)
         if context > 0:
             parts.extend(["-C", str(context)])
         if file_glob:
-            parts.extend(["--include", self._escape_shell_arg(file_glob)])
+            parts.extend(["--include", self._quote_shell_arg(file_glob)])
         if output_mode in _OUTPUT_MODE_FLAGS:
             parts.append(_OUTPUT_MODE_FLAGS[output_mode])
-        parts.append(self._escape_shell_arg(pattern))
+        if pattern_stdin:
+            parts.extend(["-f", "-"])
+        else:
+            parts.append(self._quote_shell_arg(pattern))
         return parts
 
     def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],
                           limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Fallback search using grep."""
+        # grep pattern files cannot represent one cross-line regex. Returning
+        # a clean zero lets the existing line-oriented warning explain the
+        # limitation instead of treating each line as an OR'd pattern.
+        if _pattern_has_regex_newline(pattern):
+            return SearchResult(total_count=0)
         # grep's --exclude-dir matches BASENAMES anywhere, so it can't express "only
         # the home-level Downloads"; route pruning through find's path-scoped -prune.
         protected_paths = self._protected_prune_paths(path)
@@ -903,7 +951,14 @@ class SearchMixin:
                 pattern, path, file_glob, limit, offset, output_mode, context, protected_paths)
         # -H forces filenames; -E matches rg regex behavior; --exclude-dir='.*'
         # mirrors rg's hidden-dir default (.git/, .hub/index-cache/, ...).
-        cmd_parts = self._grep_cmd(["grep", "-rnHE", "--exclude-dir='.*'"], pattern, output_mode, context, file_glob)
+        cmd_parts = self._grep_cmd(
+            ["grep", "-rnHE", "--exclude-dir='.*'"],
+            pattern,
+            output_mode,
+            context,
+            file_glob,
+            pattern_stdin=True,
+        )
         # --exclude-dir applies to the root too, so "." would be excluded by '.*';
         # anchor relative paths at the shell's live $PWD.
         is_absolute = path.startswith(("/", "\\\\")) or bool(re.match(r"^[A-Za-z]:[\\/]", path))
@@ -915,7 +970,15 @@ class SearchMixin:
             if relative_path not in {"", "."}:
                 search_root += f"/{self._escape_shell_arg(relative_path)}"
         cmd_parts.append(search_root)
-        return self._run_search_pipeline(cmd_parts, output_mode, limit, offset, context, line_cap=True)
+        return self._run_search_pipeline(
+            cmd_parts,
+            output_mode,
+            limit,
+            offset,
+            context,
+            line_cap=True,
+            stdin_data=_grep_pattern_stdin(pattern),
+        )
 
     def _search_with_grep_pruned(self, pattern: str, path: str, file_glob: Optional[str],
                                  limit: int, offset: int, output_mode: str, context: int,
@@ -933,6 +996,6 @@ class SearchMixin:
             "-type f",
         ]
         if file_glob:
-            find_parts.extend(["-name", self._escape_shell_arg(file_glob)])
+            find_parts.extend(["-name", self._quote_shell_arg(file_glob)])
         find_parts.extend(["-exec", *grep_parts, "{}", "+", "2>/dev/null"])
         return self._run_search_pipeline(find_parts, output_mode, limit, offset, context, line_cap=True)

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -4,6 +4,7 @@
 (no I/O).
 """
 
+import base64
 import os
 import posixpath
 import re
@@ -168,12 +169,6 @@ def _pattern_has_regex_newline(pattern: str) -> bool:
     return "\n" in pattern or bool(_REGEX_NEWLINE_ESCAPE_RE.search(pattern))
 
 
-def _rg_pattern_stdin(pattern: str) -> str:
-    """Encode one ripgrep pattern for stdin pattern-file transport."""
-    pattern = pattern.replace("\r", r"\r").replace("\n", r"\n")
-    return pattern or "\n"
-
-
 def _grep_pattern_stdin(pattern: str) -> str:
     """Encode one grep pattern without reinterpreting backslash escapes."""
     return pattern or "\n"
@@ -215,7 +210,12 @@ def _parse_search_output(result, output_mode: str, limit: int, offset: int,
     usable payload remains. ``warning`` is attached to files_only/content results."""
     stdout, limit_reason = _search_stdout_and_limit(result)
     diagnostics, payload = _split_tool_diagnostics(stdout)
-    if result.exit_code == 2 and not payload.strip():
+    # A multiline regex diagnostic contains whitespace-free '~' rulers, which
+    # look like filenames to the shared splitter. Compilation errors are fatal
+    # regardless: rg cannot have produced partial matches before compiling.
+    if result.exit_code == 2 and (
+        not payload.strip() or "rg: regex parse error:" in diagnostics.splitlines()
+    ):
         error_msg = diagnostics.strip() or result.stdout.strip() or "Search error"
         return SearchResult(error=f"Search failed: {error_msg}", total_count=0)
     lines = [ln for ln in payload.strip().split('\n') if ln]
@@ -398,15 +398,40 @@ class SearchMixin:
 
     def _run_rg_bounded(self, words: List[str], fetch_limit: int, timeout: int, *,
                         merge_stderr: bool = False, native_ok: bool = True,
-                        shell_prefix: str = "") -> ExecuteResult:
+                        shell_prefix: str = "", pattern: Optional[str] = None) -> ExecuteResult:
         """Run an rg command (shell-quoted words) and keep the first ``fetch_limit``
         lines: natively on a local POSIX host, else through the backend shell as
         ``<prefix><words> | head -n N``. ``native_ok=False`` keeps a form the native
- lane cannot express (the multi-root ``cd`` prefix); ``shell_prefix`` is shell-only."""
+        lane cannot express (the multi-root ``cd`` prefix); ``shell_prefix`` is
+        shell-only. ``pattern`` is data, not a shell word: native argv or stdin
+        transport preserves it without regex rewriting."""
         if native_ok and self._native_read_enabled():
+            if pattern is not None:
+                words = words + ["-e", self._quote_shell_arg(pattern)]
             return self._run_rg_native(words, fetch_limit, timeout, merge_stderr=merge_stderr)
         stderr = "" if merge_stderr else " 2>/dev/null"
-        return self._exec(f"{shell_prefix}{' '.join(words)}{stderr} | head -n {fetch_limit}", timeout=timeout)
+        command = " ".join(words)
+        stdin_data = None
+        if pattern is not None:
+            if "\r" in pattern or "\n" in pattern:
+                # Pattern files split on LF and strip CRLF. Rewriting controls as
+                # regex escapes changes (?x) whitespace/comments and -F semantics.
+                # Decode only after command preprocessing. Quoted expansion does
+                # not interpret regex data as shell syntax. The trailing sentinel
+                # prevents command substitution from stripping pattern newlines.
+                if "\0" in pattern:
+                    return ExecuteResult(stdout="rg: CR/LF patterns cannot contain NUL bytes", exit_code=2)
+                stdin_data = base64.b64encode(pattern.encode("utf-8")).decode("ascii")
+                command = ('( pattern=$(base64 -d && printf .) || exit 2; '
+                           + command + ' -e "${pattern%.}"; )')
+            else:
+                stdin_data = pattern or "\n"
+                command += " -f -"
+        command = f"{command}{stderr} | head -n {fetch_limit}"
+        if stdin_data is not None:
+            # Heredoc redirection must feed the producer, not head.
+            command = "{ " + command + "; }"
+        return self._exec(shell_prefix + command, timeout=timeout, stdin_data=stdin_data)
 
     def _quote_executable(self, executable: str) -> str:
         """Quote an executable without leaking controller path semantics."""
@@ -607,17 +632,10 @@ class SearchMixin:
                 glob_expr_probe = f"{glob_expr} {self._search_prune_glob_args()}"
             else:
                 glob_expr_probe = glob_expr
-            if self._native_read_enabled():
-                probe_words = [rg, flags, "--count-matches", glob_expr_probe,
-                               "-e", self._quote_shell_arg(pattern), self._escape_native_tool_arg(path)]
-                probe = self._run_rg_bounded(probe_words, 50, timeout=30)
-            else:
-                probe = self._exec(
-                    f"set -o pipefail; {{ {rg} {flags} --count-matches{glob_expr_probe} "
-                    f"-f - {self._escape_native_tool_arg(path)} 2>/dev/null | head -50; }}",
-                    timeout=30,
-                    stdin_data=_rg_pattern_stdin(pattern),
-                )
+            probe_words = [rg, flags, "--count-matches", glob_expr_probe,
+                           self._escape_native_tool_arg(path)]
+            probe = self._run_rg_bounded(
+                probe_words, 50, timeout=30, shell_prefix="set -o pipefail; ", pattern=pattern)
             total, per_file = 0, []
             for line in (probe.stdout or "").strip().splitlines():
                 p, _sep, n = line.rpartition(":")
@@ -846,7 +864,8 @@ class SearchMixin:
     def _run_search_pipeline(self, cmd_parts: List[str], output_mode: str, limit: int,
                              offset: int, context: int, warning: Optional[str] = None,
                              line_cap: bool = False,
-                             stdin_data: Optional[str] = None) -> SearchResult:
+                             stdin_data: Optional[str] = None,
+                             rg_pattern: Optional[str] = None) -> SearchResult:
         """Run ``cmd_parts | head -n <fetch_limit>`` under pipefail and parse. Extra
         rows report the true total (context mode also emits "--" separators, so
         grab 200 more). pipefail keeps the engine's exit 2 alive across ``| head``
@@ -866,7 +885,7 @@ class SearchMixin:
             result = self._exec("set -o pipefail; " + command, timeout=60, stdin_data=stdin_data)
         else:
             result = self._run_rg_bounded(cmd_parts, fetch_limit, timeout=60, merge_stderr=True,
-                                          shell_prefix="set -o pipefail; ")
+                                          shell_prefix="set -o pipefail; ", pattern=rg_pattern)
         return _parse_search_output(result, output_mode, limit, offset, context, warning=warning)
 
     def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
@@ -895,13 +914,6 @@ class SearchMixin:
             cmd_parts.extend(["--glob", self._quote_shell_arg(file_glob)])
         if output_mode in _OUTPUT_MODE_FLAGS:
             cmd_parts.append(_OUTPUT_MODE_FLAGS[output_mode])
-        stdin_data = None
-        if self._native_read_enabled():
-            # Direct POSIX argv has no shell/Win32 rewriting; preserve the fast path.
-            cmd_parts.extend(["-e", self._quote_shell_arg(pattern)])
-        else:
-            cmd_parts.extend(["-f", "-"])
-            stdin_data = _rg_pattern_stdin(pattern)
         # rg is a native Windows binary (winget/cargo/choco): needs C:/... not MSYS /c/...
         cmd_parts.append(self._escape_native_tool_arg(path))
         ml_note = (
@@ -915,7 +927,7 @@ class SearchMixin:
             offset,
             context,
             warning=ml_note,
-            stdin_data=stdin_data,
+            rg_pattern=pattern,
         )
 
     def _grep_cmd(self, head: List[str], pattern: str, output_mode: str, context: int,


### PR DESCRIPTION
## What does this PR do?

Fixes `search_files` regex arguments being rewritten as Windows paths before they reach `rg` or the `grep` fallback.

On native Windows, `_escape_shell_arg()` sends every value through `_bash_safe_path()`. That is correct for filesystem paths, but `_bash_safe_path()` also replaces backslashes with `/`. Regexes such as `AddDataFilePath\("Digital` therefore reached ripgrep as `AddDataFilePath/("Digital` and failed with an unclosed-group parse error.

### Fix

- Separate arbitrary shell quoting from filesystem path normalization, including globs and filename patterns.
- Preserve upstream's bounded native POSIX ripgrep fast path, passing patterns directly as argv without rewriting.
- On shell backends, pass single-line patterns through `stdin_data` to `rg -f -` / `grep -f -`, avoiding shell/path rewriting and Windows argv encoding.
- Preserve actual CR/LF in ripgrep patterns without converting them to regex escapes: send base64 data through stdin, decode after command preprocessing, and expand one quoted argument. A trailing sentinel prevents command substitution from stripping final newlines. This preserves `(?x)` whitespace/comment semantics and fixed-string zero-match probes. CR/LF patterns containing NUL are rejected explicitly; normal OS argument-size limits apply to this multiline path.
- Keep the grep fallback line-oriented rather than turning control characters into false matches.
- Group stdin-consuming pipelines so SDK heredoc redirection feeds the search engine rather than the trailing `head` process. Avoid an accidental blank second pattern.
- Distinguish multiline regex compilation errors from zero matches while retaining usable partial results for ordinary I/O errors.
- Keep the existing MSYS/native handling for actual filesystem paths.

## Related work

This is distinct from #80314, which addressed the search-root path passed to native `rg.exe`. This follow-up addresses regex/glob values accidentally passing through the path normalizer.

## Type of change

- [x] Bug fix (non-breaking change that fixes incorrect behavior)

## Verification

Rebased onto upstream `main` at `0d08cd295` and tested on Windows 11 with native WinGet ripgrep 15.2.0 using the canonical `scripts/run_tests.sh` runner and isolated temporary Hermes homes.

- `tests/tools/test_search_windows_regex_quoting.py`: **48 passed**. Covers escaped metacharacters, backslashes/quotes, payload and UUID-heredoc transport, real `LocalEnvironment`, grep control-character handling, `(?x)` newlines/comments, CRLF, trailing newlines, invalid regexes, zero-match probes, and shell metacharacters remaining data.
- Broader targeted run across 13 search/file-operation test files: **270 passed, 9 failed, 3 skipped**. All nine failures were reproduced on a clean upstream worktree at the rebase base: two CRLF fixture assumptions, four POSIX permission assertions, two missing Windows symlink-privilege cases, and one existing fake-macOS integration test reaching `os.getpgid` on Windows. No new failures in this targeted comparison.
- The three native POSIX runner tests are skipped on Windows; that fast path was reviewed but was not executed on a POSIX host locally.
- `git diff --check` and `scripts/check_compat_pointers.py` pass.
- Independent review of the complete rebased diff found no remaining actionable security or logic issues.

This is targeted local verification, not a claim that the full suite or GitHub CI is green.

## Checklist

- [x] Read `CONTRIBUTING.md`
- [x] Searched open/closed issues and PRs for duplicates
- [x] Added behavior-level regression coverage
- [x] Tested with the repository's canonical test runner
- [x] Tested the real native Windows `rg.exe` execution path
- [x] Tested payload and heredoc-mode stdin transport
- [x] No config, dependency, schema, or documentation changes required
