### PR TITLE
fix(tools): never path-translate regex patterns in search shell commands

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -286,6 +286,37 @@ class TestShellFileOpsHelpers:
         assert file_ops._escape_shell_arg("hello") == "'hello'"
 
 
+    def test_escape_shell_pattern_never_translates_backslashes(self, file_ops):
+        """Patterns are not paths: no _bash_safe_path translation, ever.
+
+        On Windows the path translator rewrites every backslash to ``/``,
+        corrupting regex escapes before they reach rg/grep (#92260:
+        ``\\(`` → ``/(`` → "unclosed group"; ``\\.`` → ``/.`` → silent
+        zero-match). The pattern escaper must round-trip the backslashes
+        and only apply shell quoting — on every host, not just Windows,
+        so the invariant is pinned where CI can see it.
+        """
+        assert file_ops._escape_shell_pattern("syncBalance\\(") == "'syncBalance\\('"
+        assert file_ops._escape_shell_pattern("currency\\.") == "'currency\\.'"
+        # Single quotes still get shell-escaped.
+        assert file_ops._escape_shell_pattern("it's") == "'it'\"'\"'s'"
+
+
+    def test_escape_shell_pattern_ignores_path_translation(self, file_ops, monkeypatch):
+        """Even if _bash_safe_path WOULD rewrite the string (drive-path shape),
+        the pattern escaper must not call it."""
+        import tools.environments.local as local_mod
+
+        def _hostile_translate(path):
+            raise AssertionError(
+                "_bash_safe_path must never be called on a pattern argument"
+            )
+
+        monkeypatch.setattr(local_mod, "_bash_safe_path", _hostile_translate)
+        assert file_ops._escape_shell_pattern("C:\\dots\\d+") == "'C:\\dots\\d+'"
+
+
+
     @pytest.mark.windows_only
     def test_escape_shell_arg_rewrites_forward_slash_native_paths(self, file_ops):
         """Windows-only: ``_bash_safe_path`` only rewrites drive paths to the

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1138,12 +1138,29 @@ class ShellFileOperations(FileOperations):
         ``Directory \\drivers\\etc does not exist`` failure class. Reuses
         the env-layer translator so shell file ops and the terminal ``cd``
         agree on the path form. No-op off Windows and for plain POSIX paths.
+
+        Only use this for arguments that ARE paths: the translation is
+        positional (it rewrites every backslash), so a regex pattern like
+        ``syncBalance\\(`` would be corrupted into ``syncBalance/(``. Use
+        :meth:`_escape_shell_pattern` for pattern arguments.
         """
         from tools.environments.local import _bash_safe_path
 
         arg = _bash_safe_path(arg)
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
+
+    def _escape_shell_pattern(self, pattern: str) -> str:
+        """Escape a regex/glob PATTERN for shell use, untranslated.
+
+        ``_bash_safe_path`` is a *path* translator: on Windows it rewrites
+        every backslash to ``/``, which corrupts regex escapes before they
+        reach rg/grep (``\\(`` → ``/(`` → "unclosed group"; ``\\.`` → ``/.``
+        → silent zero-match false negatives). Patterns are never drive
+        paths, so they skip the translation entirely and only get shell
+        quoting (#92260).
+        """
+        return "'" + pattern.replace("'", "'\"'\"'") + "'"
 
     def _escape_native_tool_arg(self, arg: str) -> str:
         """Escape a path argument destined for a NATIVE Windows binary.
@@ -2910,10 +2927,10 @@ class ShellFileOperations(FileOperations):
             extra = len(per_file) - cap
             return shown + (f" (+{extra} more)" if extra > 0 else "")
 
-        glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        glob_expr = f" --glob {self._escape_shell_pattern(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_pattern(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2930,7 +2947,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_shell_pattern(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2944,7 +2961,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+                f"{self._escape_shell_pattern(pattern)} {self._escape_native_tool_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -2997,7 +3014,7 @@ class ShellFileOperations(FileOperations):
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
 
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_pattern(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
 
         result = self._exec(cmd, timeout=60)
@@ -3005,7 +3022,7 @@ class ShellFileOperations(FileOperations):
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_pattern(search_pattern)} " \
                         f"2>/dev/null | sort -rn{pagination_expr}"
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
@@ -3062,7 +3079,7 @@ class ShellFileOperations(FileOperations):
         fetch_limit = limit + offset
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
-            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
+            f"rg --files --sortr=modified -g {self._escape_shell_pattern(glob_pattern)} "
             f"{self._escape_native_tool_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
@@ -3073,7 +3090,7 @@ class ShellFileOperations(FileOperations):
         if not all_files and not limit_reason:
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
-                f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
+                f"rg --files -g {self._escape_shell_pattern(glob_pattern)} "
                 f"{self._escape_native_tool_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
@@ -3148,7 +3165,7 @@ class ShellFileOperations(FileOperations):
         
         # Add file glob filter (must be quoted to prevent shell expansion)
         if file_glob:
-            cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--glob", self._escape_shell_pattern(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -3157,7 +3174,7 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")  # Count per file
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_shell_pattern(pattern))
         # rg is a native Windows binary when installed via winget/cargo/choco:
         # it needs the C:/... path form, not the MSYS /c/... form (which
         # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
@@ -3287,7 +3304,7 @@ class ShellFileOperations(FileOperations):
         
         # Add file pattern filter (must be quoted to prevent shell expansion)
         if file_glob:
-            cmd_parts.extend(["--include", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--include", self._escape_shell_pattern(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -3300,7 +3317,7 @@ class ShellFileOperations(FileOperations):
         # ``.*`` to exclude the entire search. Anchor relative paths at the
         # shell's live cwd; quoting $PWD separately keeps user paths escaped
         # while working across local, container, and remote backends.
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_shell_pattern(pattern))
         is_absolute = path.startswith(("/", "\\\\")) or bool(
             re.match(r"^[A-Za-z]:[\\/]", path)
         )


### PR DESCRIPTION
## What does this PR do?

On Windows (Git Bash shell backend + ripgrep), `search_files` content patterns were corrupted before they reached the tool: `_escape_shell_arg` runs every argument through `_bash_safe_path`, a **positional path translator** that rewrites each backslash to `/`. Applied to a regex pattern that destroys escapes (#92260):

- `syncBalance\(` → rg receives `syncBalance/(` → loud `regex parse error: unclosed group`
- `currency\.` → rg receives `currency/.` → **silent zero-match false negative** (the reported dangerous variant: an agent concludes "the code doesn't exist" when it does; no error, no hint)

This splits the escapers: a new `_escape_shell_pattern` applies plain single-quote shell quoting with **no path translation**, and all twelve pattern-side call sites switch to it — the rg and grep main searches, all three zero-match probes (`rg -i`, `rg --hidden`, `rg -F` — the fixed-string fallback that should rescue a bad pattern was receiving the already-corrupted one), `find -name`, `rg --files -g`, and every `--glob`/`--include` value. Path arguments keep `_escape_shell_arg` (with the translation); `_escape_native_tool_arg` is untouched. The fix is a whole-class fix per the issue, not a single-site patch.

The pattern escaper never calls `_bash_safe_path` on any host (not just Windows), so the invariant is pinned by a test that monkeypatches the translator to raise if touched.

## Related Issue

Fixes #92260

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_operations.py`: new `_escape_shell_pattern()` (single-quote shell quoting only, docstring documenting why patterns must skip the path translator); `_escape_shell_arg()` docstring now says "only use for arguments that ARE paths" and points patterns at the new method; 12 pattern-side call sites migrated (`pattern` ×5, `search_pattern` ×2, `glob_pattern` ×2, `file_glob` ×3)
- `tests/tools/test_file_operations.py`: two regression tests — backslash round-trip (`syncBalance\(` / `currency\.` / single-quote escaping) and a hostile-translator monkeypatch proving `_bash_safe_path` is never consulted for patterns

## How to Test

1. `pytest tests/tools/test_file_operations.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_search_error_guard.py tests/tools/test_search_auto_multiline.py tests/tools/test_search_budget_truncation.py`
2. Observed result: 89 passed + 2 skipped, 20 passed — all green including the two new pattern-escaper tests; the two skips are the pre-existing `windows_only` markers.
3. The round-trip test fails on pre-fix code only on Windows (where the translator is active) — the hostile-translator test fails on every host, which is what makes the invariant CI-visible.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (pattern-vs-path rationale in both escaper docstrings)
- [x] Tests added/updated and passing (109 passed across the five files locally)
- [x] No new warnings introduced
- [x] Tested on macOS (arm64) via unit tests; the corrupted path is Windows Git Bash only, but the escaper invariant is host-independent and pinned by the hostile-translator test
