### PR TITLE
fix(session): avoid rewriting resumed transcript on turn flush

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -11168,6 +11168,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
             msg = {"role": row["role"], "content": content}
+            # Live replay hands these dictionaries to the agent's next turn.
+            # Mark rows restored from SQLite as already durable so a later
+            # flush does not append the entire resumed transcript again when
+            # the live history has been reconstructed into fresh dicts.
+            # Display and inspection projections intentionally omit this
+            # internal marker.
+            if repair_alternation:
+                msg["_db_persisted"] = True
             # Durable per-message identity for surfaces that need to address a
             # specific row later (desktop reactions). OPT-IN: only the gateway
             # asks for it — every other consumer (ACP restore, export,

--- a/tests/run_agent/test_identity_flush.py
+++ b/tests/run_agent/test_identity_flush.py
@@ -89,6 +89,47 @@ class TestIdentityFlush:
             finally:
                 db.close()
 
+    def test_resumed_history_is_not_rewritten_after_reconstruction(self):
+        """A live resume marks durable rows before the next flush.
+
+        Gateway/session restore can reconstruct the history dictionaries before
+        the next turn.  Object identity is then no longer enough to distinguish
+        old rows from the new user/assistant pair, so the restored rows must
+        carry the intrinsic persistence marker.
+        """
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "t.db")
+            try:
+                agent = _make_agent(db)
+                for role, content in (("user", "old question"), ("assistant", "old answer")):
+                    db.append_message(
+                        session_id=SESSION_ID,
+                        role=role,
+                        content=content,
+                    )
+
+                restored = db.get_messages_as_conversation(
+                    SESSION_ID, repair_alternation=True
+                )
+                assert all(message.get("_db_persisted") is True for message in restored)
+
+                # Reconstruct the live list to model a resume path that loses
+                # object identity while preserving the durable marker.
+                messages = [dict(message) for message in restored]
+                messages.extend([
+                    {"role": "user", "content": "new question"},
+                    {"role": "assistant", "content": "new answer"},
+                ])
+                agent._flush_messages_to_session_db(messages, restored)
+
+                assert _contents(db) == [
+                    "old question", "old answer", "new question", "new answer"
+                ]
+            finally:
+                db.close()
+
     def test_cursor_reset_starts_new_turn_identity_window(self):
         """Gateway resets _last_flushed_db_idx=0 before a cached-agent turn."""
         from hermes_state import SessionDB


### PR DESCRIPTION
## Summary

Fixes #92231. Live session restores now mark messages loaded from SQLite as already persisted before the next turn flush. This prevents a reconstructed history list from appending the entire prior transcript again.

The marker is applied only to live replay projections (`repair_alternation=True`); display and inspection projections remain unchanged. New messages are still flushed normally.

## Tests

- `python -m pytest tests/run_agent/test_identity_flush.py tests/hermes_state/test_restore_alternation_repair.py -q`
- `python -m pytest tests/run_agent/test_compression_persistence.py tests/run_agent/test_tool_call_incremental_persistence.py -q`
- `python -m ruff check hermes_state.py tests/run_agent/test_identity_flush.py`

All checks pass.