### PR TITLE
fix(bedrock): add claude-opus-5 to context length table

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1614,6 +1614,7 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     "anthropic.claude-fable-5":      1_000_000,
     "anthropic.claude-fable":        1_000_000,
     "anthropic.claude-sonnet-5":     1_000_000,
+    "anthropic.claude-opus-5":       1_000_000,
     "anthropic.claude-opus-4-8":     1_000_000,
     "anthropic.claude-opus-4-7":     1_000_000,
     "anthropic.claude-opus-4-6":     1_000_000,

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -750,6 +750,16 @@ class TestBedrockContextLength:
         from agent.bedrock_adapter import get_bedrock_context_length, BEDROCK_DEFAULT_CONTEXT_LENGTH
         assert get_bedrock_context_length("unknown.model-v1:0") == BEDROCK_DEFAULT_CONTEXT_LENGTH
 
+    def test_claude_opus_5_resolves_1m(self):
+        # Regression: claude-opus-5 was missing from the table and fell
+        # through to the 128K default, halving the compression threshold
+        # for Opus 5 Bedrock users. Regional inference-profile prefixes
+        # must resolve via substring matching too.
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("anthropic.claude-opus-5") == 1_000_000
+        assert get_bedrock_context_length("eu.anthropic.claude-opus-5") == 1_000_000
+        assert get_bedrock_context_length("us.anthropic.claude-opus-5-v1:0") == 1_000_000
+
 
 
     def test_no_region_skips_probe_uses_table(self):


### PR DESCRIPTION
## Problem

`claude-opus-5` is missing from `BEDROCK_CONTEXT_LENGTHS` in `agent/bedrock_adapter.py`, so `get_bedrock_context_length()` falls through to `BEDROCK_DEFAULT_CONTEXT_LENGTH` (128K) instead of the model's actual 1M window.

Because the context compressor's threshold defaults to 50% of the resolved context length, any Bedrock user running Opus 5 (`anthropic.claude-opus-5`, or regional profiles like `eu.anthropic.claude-opus-5`) gets compaction triggering at just **64K tokens**. In practice an agentic session with a few file reads and tool calls hits "🗜️ Compacting context" every few minutes, and long sessions degrade through repeated re-summarization ("Session compressed 9 times — accuracy may degrade").

The rest of the Claude 5 family (`claude-fable-5`, `claude-sonnet-5`) is already in the table at 1M — Opus 5 just missed the update.

## Fix

One table entry:

```python
"anthropic.claude-opus-5":       1_000_000,
```

Substring matching handles the regional inference-profile prefixes (`eu.`/`us.`/`global.`) and versioned IDs, same as the existing entries. The `anthropic.claude-opus-4` fallback entry is unaffected (longest-key-wins).

## Testing

Added a regression test asserting 1M for the bare ID and `eu.`/`us.` profile variants. `tests/agent/test_bedrock_adapter.py`: 67 passed.

Found in the wild: my gateway on Bedrock eu Sonnet 5/Opus 5 was compacting constantly until I traced it to this lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)