### PR TITLE
Fix remote gateway fallback caused by auth-less liveness and registry drift

### DIFF
--- a/apps/desktop/electron/connection-config-apply.test.ts
+++ b/apps/desktop/electron/connection-config-apply.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { applyConnectionConfigAtomically } from './connection-config-apply'
+
+describe('applyConnectionConfigAtomically', () => {
+  it('commits legacy and registry state before activation', async () => {
+    const events: string[] = []
+
+    await applyConnectionConfigAtomically({
+      previousConfig: 'old-config',
+      previousRegistry: 'old-registry',
+      nextConfig: 'remote-config',
+      nextRegistry: 'remote-registry',
+      writeConfig: value => events.push(`config:${value}`),
+      writeRegistry: value => events.push(`registry:${value}`),
+      apply: async () => {
+        events.push('activate')
+      }
+    })
+
+    expect(events).toEqual(['config:remote-config', 'registry:remote-registry', 'activate'])
+  })
+
+  it('rolls both stores back when activation fails', async () => {
+    const writeConfig = vi.fn()
+    const writeRegistry = vi.fn()
+
+    await expect(
+      applyConnectionConfigAtomically({
+        previousConfig: 'local-config',
+        previousRegistry: 'local-registry',
+        nextConfig: 'remote-config',
+        nextRegistry: 'remote-registry',
+        writeConfig,
+        writeRegistry,
+        apply: async () => {
+          throw new Error('activation failed')
+        }
+      })
+    ).rejects.toThrow('activation failed')
+
+    expect(writeConfig.mock.calls).toEqual([['remote-config'], ['local-config']])
+    expect(writeRegistry.mock.calls).toEqual([['remote-registry'], ['local-registry']])
+  })
+
+  it('rolls legacy state back when the registry write fails', async () => {
+    const writes: string[] = []
+    let registryWrites = 0
+
+    await expect(
+      applyConnectionConfigAtomically({
+        previousConfig: 'local-config',
+        previousRegistry: 'local-registry',
+        nextConfig: 'remote-config',
+        nextRegistry: 'remote-registry',
+        writeConfig: value => writes.push(`config:${value}`),
+        writeRegistry: value => {
+          registryWrites += 1
+
+          if (registryWrites === 1) {
+            throw new Error('disk full')
+          }
+
+          writes.push(`registry:${value}`)
+        },
+        apply: vi.fn()
+      })
+    ).rejects.toThrow('disk full')
+
+    expect(writes).toEqual(['config:remote-config', 'config:local-config', 'registry:local-registry'])
+  })
+})

--- a/apps/desktop/electron/connection-config-apply.ts
+++ b/apps/desktop/electron/connection-config-apply.ts
@@ -1,0 +1,41 @@
+interface ApplyConnectionConfigAtomicallyOptions<TConfig, TRegistry> {
+  apply: () => Promise<void>
+  nextConfig: TConfig
+  nextRegistry: TRegistry
+  previousConfig: TConfig
+  previousRegistry: TRegistry
+  writeConfig: (config: TConfig) => void
+  writeRegistry: (registry: TRegistry) => void
+}
+
+/**
+ * Commit the legacy config and v2 registry as one recoverable Apply boundary.
+ * File replacement itself is atomic per file; this wrapper restores both
+ * previous snapshots when the second write or synchronous re-home fails.
+ */
+export async function applyConnectionConfigAtomically<TConfig, TRegistry>({
+  apply,
+  nextConfig,
+  nextRegistry,
+  previousConfig,
+  previousRegistry,
+  writeConfig,
+  writeRegistry
+}: ApplyConnectionConfigAtomicallyOptions<TConfig, TRegistry>): Promise<void> {
+  try {
+    writeConfig(nextConfig)
+    writeRegistry(nextRegistry)
+    await apply()
+  } catch (error) {
+    try {
+      writeConfig(previousConfig)
+      writeRegistry(previousRegistry)
+    } catch {
+      // Preserve the original activation/write failure. Both storage writers
+      // are atomic replacements, so a rollback failure cannot be repaired by
+      // retrying one side blindly here.
+    }
+
+    throw error
+  }
+}

--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -25,6 +25,7 @@ import {
   normalizeConnectionInput,
   normalizeRegistry,
   parseRemoteProfileListing,
+  reconcileAppliedGlobalConnection,
   REGISTRY_VERSION,
   rememberSshEnumeration,
   removeConnection,
@@ -927,6 +928,90 @@ test('upsertConnection replaces by id and appends new ids', () => {
 
   assert.equal(registry.connections.filter(c => c.id === a.id).length, 1)
   assert.equal(registry.connections.find(c => c.id === a.id)?.url, 'http://a:2')
+})
+
+test('Apply remote inserts into an existing local-only registry and becomes primary/current', () => {
+  const registry = reconcileAppliedGlobalConnection(emptyRegistry(), {
+    mode: 'remote',
+    remote: { url: 'https://gateway.example.com/', authMode: 'oauth' }
+  })
+
+  const remote = registry.connections.find(connection => connection.kind === 'remote')
+
+  assert.ok(remote)
+  assert.equal(registry.primary, remote.id)
+  assert.equal(registry.lastUsed, remote.id)
+  assert.equal(
+    resolvedConnectionId(registry, {
+      baseUrl: 'https://gateway.example.com',
+      mode: 'remote',
+      remoteKind: 'url'
+    }),
+    remote.id
+  )
+})
+
+test('Apply remote preserves an existing URL identity and label without duplicates', () => {
+  let registry = emptyRegistry()
+
+  registry = upsertConnection(registry, {
+    id: 'hermes-alex',
+    kind: 'remote',
+    label: 'Existing gateway',
+    url: 'https://gateway.example.com',
+    authMode: 'token',
+    token: { old: true }
+  })
+
+  const applied = reconcileAppliedGlobalConnection(registry, {
+    mode: 'remote',
+    remote: { url: 'https://GATEWAY.example.com/', authMode: 'oauth' }
+  })
+
+  const matches = applied.connections.filter(connection => connection.url === 'https://gateway.example.com')
+
+  assert.equal(matches.length, 1)
+  assert.equal(matches[0].id, 'hermes-alex')
+  assert.equal(matches[0].label, 'Existing gateway')
+  assert.equal(matches[0].authMode, 'oauth')
+  assert.equal(applied.primary, 'hermes-alex')
+  assert.equal(applied.lastUsed, 'hermes-alex')
+})
+
+test('Apply local moves primary/current to This device without deleting registered remotes', () => {
+  const remoteRegistry = reconcileAppliedGlobalConnection(emptyRegistry(), {
+    mode: 'remote',
+    remote: { url: 'https://one.example.com', authMode: 'oauth' }
+  })
+
+  const localRegistry = reconcileAppliedGlobalConnection(remoteRegistry, { mode: 'local', remote: {} })
+
+  assert.equal(localRegistry.primary, LOCAL_CONNECTION_ID)
+  assert.equal(localRegistry.lastUsed, LOCAL_CONNECTION_ID)
+  assert.equal(localRegistry.connections.filter(connection => connection.kind === 'remote').length, 1)
+  assert.equal(resolvedConnectionId(localRegistry, { mode: 'local' }), LOCAL_CONNECTION_ID)
+})
+
+test('Apply between two remotes keeps each real registration once and activates the latest', () => {
+  const first = reconcileAppliedGlobalConnection(emptyRegistry(), {
+    mode: 'remote',
+    remote: { url: 'https://one.example.com', authMode: 'oauth' }
+  })
+
+  const second = reconcileAppliedGlobalConnection(first, {
+    mode: 'remote',
+    remote: { url: 'https://two.example.com/', authMode: 'oauth' }
+  })
+
+  const remotes = second.connections.filter(connection => connection.kind === 'remote')
+
+  assert.deepEqual(
+    remotes.map(connection => connection.url).sort(),
+    ['https://one.example.com', 'https://two.example.com']
+  )
+  assert.equal(new Set(remotes.map(connection => connection.id)).size, 2)
+  assert.equal(second.primary, remotes.find(connection => connection.url === 'https://two.example.com')?.id)
+  assert.equal(second.lastUsed, second.primary)
 })
 
 // --- connectionDialFieldsChanged (edit → recycle decision) ---

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -1109,6 +1109,79 @@ export function setLastUsedConnection(registry: ConnectionRegistry, id: string):
   return { ...registry, lastUsed: id }
 }
 
+/**
+ * Reconcile a successfully-coerced global v1 connection config into the v2
+ * registry. Settings still writes connection.json for compatibility, but an
+ * Apply must publish the same primary identity to connections.json in the
+ * same transaction or the live remote descriptor has no connectionId.
+ *
+ * Remote-shaped entries are matched by normalized URL across remote/cloud so
+ * changing provenance never duplicates a gateway. Existing identity and
+ * user-chosen label win; a new entry derives both from the host. Switching to
+ * local keeps registered remotes available while moving primary/last-used
+ * back to This device.
+ */
+export function reconcileAppliedGlobalConnection(
+  registry: ConnectionRegistry,
+  config: Record<string, any>
+): ConnectionRegistry {
+  const mode = config?.mode
+
+  if (!modeIsRemoteLike(mode)) {
+    if (mode === 'local') {
+      return { ...registry, primary: LOCAL_CONNECTION_ID, lastUsed: LOCAL_CONNECTION_ID }
+    }
+
+    // SSH registry identity is managed by its existing registry editor and
+    // migration path. Do not reinterpret or delete it here.
+    return registry
+  }
+
+  const block = config.remote && typeof config.remote === 'object' ? config.remote : {}
+  const url = normalizeRemoteBaseUrl(block.url)
+
+  const existing = registry.connections.find(connection => {
+    if (connection.kind !== 'remote' && connection.kind !== 'cloud') {
+      return false
+    }
+
+    try {
+      return normalizeRemoteBaseUrl(connection.url) === url
+    } catch {
+      return false
+    }
+  })
+
+  const kind: ConnectionKind = mode === 'cloud' ? 'cloud' : 'remote'
+
+  const label =
+    existing?.label ||
+    uniqueLabel(
+      hostLabelFromBaseUrl(url) || (kind === 'cloud' ? 'Hermes Cloud' : 'Remote gateway'),
+      registry.connections.map(connection => connection.label)
+    )
+
+  const entry = normalizeConnectionInput(
+    {
+      id: existing?.id,
+      kind,
+      label,
+      url,
+      authMode: block.authMode,
+      token: block.token,
+      headers: block.headers,
+      org: block.org
+    },
+    registry
+  )
+
+  return {
+    ...upsertConnection(registry, entry),
+    primary: entry.id,
+    lastUsed: entry.id
+  }
+}
+
 /** Choose whether launch restores the explicit primary or the last-used source. */
 export function setConnectionLaunchMode(registry: ConnectionRegistry, launchMode: string): ConnectionRegistry {
   if (launchMode !== 'last-used' && launchMode !== 'primary') {

--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -938,6 +938,30 @@ test('registry JSON helpers retain native OAuth bearer authentication', () => {
   assert.doesNotMatch(helpers, /fetchJsonViaOauthSession/)
 })
 
+test('connection tests authenticate protected OAuth status probes', () => {
+  const source = readMain()
+  const helperStart = source.indexOf('async function fetchConnectionStatus(')
+  const helperEnd = source.indexOf('\nfunction ', helperStart + 1)
+  const helper = source.slice(helperStart, helperEnd === -1 ? undefined : helperEnd)
+
+  assert.notEqual(helperStart, -1)
+  assert.match(helper, /ensureNativeAccessToken\(baseUrl\)/)
+  assert.match(helper, /fetchJsonViaOauthSession\(url/)
+  assert.match(helper, /bearer: nativeAt/)
+})
+
+test('global remote Apply preflights before the atomic persistence boundary', () => {
+  const source = readMain()
+  const handlerStart = source.indexOf("ipcMain.handle('hermes:connection-config:apply'")
+  const handlerEnd = source.indexOf("ipcMain.handle('hermes:profile:get'", handlerStart)
+  const handler = source.slice(handlerStart, handlerEnd)
+  const preflight = handler.indexOf('await testDesktopConnectionConfig(payload)')
+  const commit = handler.indexOf('await applyConnectionConfigAtomically({')
+
+  assert.notEqual(handlerStart, -1)
+  assert.ok(preflight >= 0 && preflight < commit, 'remote REST+WS validation must happen before either config is committed')
+})
+
 test('coerceDesktopConnectionConfig routes token persistence through resolvePersistedRemoteToken', () => {
   const source = readMain()
   const fnStart = source.indexOf('function coerceDesktopConnectionConfig(')
@@ -974,7 +998,7 @@ test('connection-config save and apply IPC handlers route payloads through coerc
     const handlerBody = source.slice(handlerStart, handlerStart + 400)
     assert.match(
       handlerBody,
-      /coerceDesktopConnectionConfig\(payload\)/,
+      /coerceDesktopConnectionConfig\(payload(?:, previousConfig)?\)/,
       `${channel} must coerce its payload (the propagation seam) before persisting`
     )
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -96,6 +96,7 @@ import {
   tokenPreview,
   translateSelfProfileQuery
 } from './connection-config'
+import { applyConnectionConfigAtomically } from './connection-config-apply'
 import {
   backendScopeKey,
   backendScopePrefix,
@@ -105,6 +106,7 @@ import {
   migrateV1ToRegistry,
   normalizeConnectionInput,
   normalizeRegistry,
+  reconcileAppliedGlobalConnection,
   rememberSshEnumeration,
   removeConnection,
   resolvedConnectionId,
@@ -9676,10 +9678,11 @@ async function testDesktopConnectionConfig(input: any = {}) {
   const wantRemote =
     modeIsRemoteLike(block?.mode) || (!key && modeIsRemoteLike(config.mode)) || (modeIsRemoteLike(input.mode) && block)
 
-  // ``/api/status`` is public on every gateway (no creds needed), so a
-  // reachability test works for local, token, and oauth modes alike — we only
-  // need a base URL. For a remote config we normalize the URL from the input;
-  // for local we fall back to the resolved/started backend.
+  // Test ``/api/status`` through the connection's real auth path. Self-hosted
+  // gateways may protect it, and an anonymous success/failure would not prove
+  // that the OAuth cookie/native bearer or configured token is reusable. For
+  // a remote config we normalize the URL from the input; for local we fall
+  // back to the resolved/started backend.
   let baseUrl
   let token = null
   let authMode = 'token'
@@ -9701,7 +9704,7 @@ async function testDesktopConnectionConfig(input: any = {}) {
     testHeaders = remote.headers || {}
   }
 
-  const status = (await fetchJson(`${baseUrl}/api/status`, token, { timeoutMs: 8_000, headers: testHeaders })) as any
+  const status = (await fetchConnectionStatus(baseUrl, authMode, token, testHeaders)) as any
 
   // The HTTP status check above proves the backend is reachable, but the chat
   // surface only works once the renderer's live WebSocket to ``/api/ws``
@@ -9733,6 +9736,22 @@ async function testDesktopConnectionConfig(input: any = {}) {
     baseUrl,
     version: status?.version || null
   }
+}
+
+async function fetchConnectionStatus(baseUrl, authMode, token, headers = {}) {
+  const url = `${baseUrl}/api/status`
+
+  if (authMode === 'oauth') {
+    const nativeAt = await ensureNativeAccessToken(baseUrl).catch(() => null)
+
+    if (nativeAt) {
+      return fetchJson(url, null, { timeoutMs: 8_000, bearer: nativeAt, headers })
+    }
+
+    return fetchJsonViaOauthSession(url, { timeoutMs: 8_000, headers })
+  }
+
+  return fetchJson(url, token, { timeoutMs: 8_000, headers })
 }
 
 function resetBootProgressForReconnect() {
@@ -12768,7 +12787,7 @@ ipcMain.handle('hermes:connections:test', async (_event, id) => {
     }
   }
 
-  const status = (await fetchJson(`${baseUrl}/api/status`, token, { timeoutMs: 8_000, headers: testHeaders })) as any
+  const status = (await fetchConnectionStatus(baseUrl, authMode, token, testHeaders)) as any
 
   // The Test button is the cheapest moment to (re)learn this backend's stable
   // identity for the same-backend roster collapse + Settings hint.
@@ -13281,32 +13300,50 @@ ipcMain.handle('hermes:connection-config:save', async (_event, payload) => {
   return sanitizeDesktopConnectionConfig(config, payload?.profile)
 })
 ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
-  const config = coerceDesktopConnectionConfig(payload)
-  writeDesktopConnectionConfig(config)
+  const previousConfig = readDesktopConnectionConfig()
+  const previousRegistry = readDesktopConnectionsRegistry()
+  const config = coerceDesktopConnectionConfig(payload, previousConfig)
 
   const key = connectionScopeKey(payload?.profile)
   const scope = key || ''
+  const nextRegistry = key ? previousRegistry : reconcileAppliedGlobalConnection(previousRegistry, config)
 
-  await applyConnectionChange({
-    cancelAndWait: value => sshBootstrapCoordinator.cancelAndWait(value),
-    isPrimary: !key || key === primaryProfileKey(),
-    rehomePrimary: () =>
-      rehomePrimaryConnection({
-        clearLocalBootstrapFailure: () => {
-          // A remote connection bypasses local runtime/bootstrap failures. Clear
-          // the local-install latch so unsupported/failure escape paths can re-home.
-          bootstrapFailure = null
-        },
-        mode: config.mode,
-        notifyConnectionApplied: sendConnectionApplied,
-        resumeFirstRunRemote: abandonFirstRunSetupChoiceForRemoteApply,
-        teardownPrimaryBackend: teardownPrimaryBackendAndWait
-      }),
-    scope,
-    sendApplied: sendConnectionApplied,
-    stopPool: stopPoolBackend,
-    teardownPrimary: () => teardownPrimaryBackendAndWait({ soft: true }),
-    teardownSsh: value => teardownSshConnection(value || null)
+  // Exercise the same authenticated REST + real WebSocket legs before either
+  // config file changes. A rejected OAuth session or blocked /api/ws leaves
+  // the previous primary/current connection intact.
+  if (!key && modeIsRemoteLike(config.mode)) {
+    await testDesktopConnectionConfig(payload)
+  }
+
+  await applyConnectionConfigAtomically({
+    previousConfig,
+    previousRegistry,
+    nextConfig: config,
+    nextRegistry,
+    writeConfig: writeDesktopConnectionConfig,
+    writeRegistry: writeDesktopConnectionsRegistry,
+    apply: () =>
+      applyConnectionChange({
+        cancelAndWait: value => sshBootstrapCoordinator.cancelAndWait(value),
+        isPrimary: !key || key === primaryProfileKey(),
+        rehomePrimary: () =>
+          rehomePrimaryConnection({
+            clearLocalBootstrapFailure: () => {
+              // A remote connection bypasses local runtime/bootstrap failures. Clear
+              // the local-install latch so unsupported/failure escape paths can re-home.
+              bootstrapFailure = null
+            },
+            mode: config.mode,
+            notifyConnectionApplied: sendConnectionApplied,
+            resumeFirstRunRemote: abandonFirstRunSetupChoiceForRemoteApply,
+            teardownPrimaryBackend: teardownPrimaryBackendAndWait
+          }),
+        scope,
+        sendApplied: sendConnectionApplied,
+        stopPool: stopPoolBackend,
+        teardownPrimary: () => teardownPrimaryBackendAndWait({ soft: true }),
+        teardownSsh: value => teardownSshConnection(value || null)
+      })
   })
 
   return sanitizeDesktopConnectionConfig(config, payload?.profile)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12294,7 +12294,7 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
         connectionPromise,
         currentConnectionPromise: () => backendConnectionState.getPromise(),
         log: rememberLog,
-        probe: fetchPublicJson,
+        probe: (connection, path, options) => fetchJsonForBackend(connection, path, options),
         resetConnection: resetHermesConnection,
         tracker: remoteLiveness
       }),
@@ -12325,7 +12325,7 @@ function revalidatePool() {
   return revalidatePooledRemoteBackends({
     entries: backendPool.entries(),
     log: rememberLog,
-    probe: fetchPublicJson,
+    probe: (connection, path, options) => fetchJsonForBackend(connection, path, options),
     stopBackend: stopPoolBackend,
     tracker: remoteLiveness
   })

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -179,9 +179,13 @@ describe('revalidateRemoteConnection', () => {
     const test = harness()
 
     await expect(revalidateRemoteConnection(test.options)).resolves.toEqual({ ok: true, rebuilt: false })
-    expect(test.probe).toHaveBeenCalledWith('https://gateway.example.com/api/status', {
-      timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS
-    })
+    expect(test.probe).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: 'https://gateway.example.com/' }),
+      '/api/status',
+      {
+        timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS
+      }
+    )
     expect(test.resetConnection).not.toHaveBeenCalled()
   })
 
@@ -254,13 +258,34 @@ describe('revalidateRemoteConnection', () => {
 })
 
 describe('revalidatePooledRemoteBackends', () => {
-  const harness = (entries: Array<[string, { process?: unknown; remoteBaseUrl?: null | string }]>) => {
+  interface TestRemoteConnection {
+    authMode?: string
+    baseUrl: string
+    process?: unknown
+    remoteBaseUrl?: null | string
+  }
+
+  const harness = (
+    rawEntries: Array<[string, { process?: unknown; remoteBaseUrl?: null | string; authMode?: string }]>
+  ) => {
+    const entries: Array<[
+      string,
+      TestRemoteConnection & { connectionPromise: Promise<TestRemoteConnection> }
+    ]> = rawEntries.map(([profile, entry]) => {
+      const connection = { ...entry, baseUrl: String(entry.remoteBaseUrl || '') }
+
+      return [
+        profile,
+        { ...connection, connectionPromise: Promise.resolve(connection) }
+      ]
+    })
+
     const unreachable = new Set<string>()
     const log = vi.fn()
     const stopBackend = vi.fn()
 
-    const probe = vi.fn(async (url: string) => {
-      if ([...unreachable].some(base => url.startsWith(base))) {
+    const probe = vi.fn(async (connection: TestRemoteConnection) => {
+      if ([...unreachable].some(base => connection.remoteBaseUrl?.startsWith(base))) {
         throw new Error('unreachable')
       }
 
@@ -291,7 +316,26 @@ describe('revalidatePooledRemoteBackends', () => {
     await pool.run(new RemoteLivenessTracker())
 
     expect(pool.probe).toHaveBeenCalledTimes(1)
-    expect(pool.probe).toHaveBeenCalledWith('https://remote.example.com/api/status', {
+    expect(pool.probe).toHaveBeenCalledWith(
+      expect.objectContaining({ remoteBaseUrl: 'https://remote.example.com' }),
+      '/api/status',
+      { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS }
+    )
+    expect(pool.stopBackend).not.toHaveBeenCalled()
+  })
+
+  it('passes the authenticated OAuth descriptor to the liveness probe', async () => {
+    const remote = {
+      process: null,
+      remoteBaseUrl: 'https://remote.example.com',
+      authMode: 'oauth'
+    }
+
+    const pool = harness([['oauth', remote]])
+
+    await pool.run(new RemoteLivenessTracker())
+
+    expect(pool.probe).toHaveBeenCalledWith(expect.objectContaining({ authMode: 'oauth' }), '/api/status', {
       timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS
     })
     expect(pool.stopBackend).not.toHaveBeenCalled()

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -19,7 +19,7 @@ export interface RevalidateRemoteConnectionOptions<TConnection extends RemoteCon
   connectionPromise: Promise<TConnection>
   currentConnectionPromise: () => null | Promise<TConnection>
   log: (message: string) => void
-  probe: (url: string, options: { timeoutMs: number }) => Promise<unknown>
+  probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
   resetConnection: () => void
   tracker: RemoteLivenessTracker
 }
@@ -117,15 +117,16 @@ export class RemoteLivenessTracker {
   }
 }
 
-export interface PooledRemoteEntry {
+export interface PooledRemoteEntry<TConnection extends RemoteConnectionDescriptor = RemoteConnectionDescriptor> {
+  connectionPromise?: null | Promise<TConnection>
   process?: unknown
   remoteBaseUrl?: null | string
 }
 
-export interface RevalidatePooledRemoteBackendsOptions {
-  entries: Iterable<[string, PooledRemoteEntry]>
+export interface RevalidatePooledRemoteBackendsOptions<TConnection extends RemoteConnectionDescriptor> {
+  entries: Iterable<[string, PooledRemoteEntry<TConnection>]>
   log: (message: string) => void
-  probe: (url: string, options: { timeoutMs: number }) => Promise<unknown>
+  probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
   stopBackend: (profile: string) => void
   tracker: RemoteLivenessTracker
 }
@@ -141,13 +142,13 @@ export interface RevalidatePooledRemoteBackendsOptions {
  * Entries share the primary's failure policy, keyed per base URL, so a profile
  * pointing at the same host as another does not burn the streak twice as fast.
  */
-export async function revalidatePooledRemoteBackends({
+export async function revalidatePooledRemoteBackends<TConnection extends RemoteConnectionDescriptor>({
   entries,
   log,
   probe,
   stopBackend,
   tracker
-}: RevalidatePooledRemoteBackendsOptions): Promise<{ dropped: string[] }> {
+}: RevalidatePooledRemoteBackendsOptions<TConnection>): Promise<{ dropped: string[] }> {
   const remotes = [...entries].filter(([, entry]) => !entry.process && entry.remoteBaseUrl)
   const dropped: string[] = []
 
@@ -156,7 +157,12 @@ export async function revalidatePooledRemoteBackends({
       const baseUrl = String(entry.remoteBaseUrl).replace(/\/+$/, '')
 
       try {
-        await probe(`${baseUrl}/api/status`, { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
+        if (!entry.connectionPromise) {
+          throw new Error('Remote backend descriptor is unavailable.')
+        }
+
+        const connection = await entry.connectionPromise
+        await probe(connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
         tracker.recordSuccess(baseUrl)
       } catch {
         const failure = tracker.recordFailure(baseUrl)
@@ -212,7 +218,7 @@ export async function revalidateRemoteConnection<TConnection extends RemoteConne
   const baseUrl = connection.baseUrl.replace(/\/+$/, '')
 
   try {
-    await probe(`${baseUrl}/api/status`, { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
+    await probe(connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
 
     if (currentConnectionPromise() !== connectionPromise) {
       return { ok: true, rebuilt: false }


### PR DESCRIPTION
## Problem

Hermes Desktop could initially connect to an authenticated remote gateway and load its sessions, then later drop the connection and fall back to `This device`.

A separate issue affected `Save and reconnect`: the remote backend could become reachable without the corresponding registered gateway becoming `Current` or `Primary`.

## Root cause

Two independent issues contributed to the behavior.

### 1. Remote liveness probes dropped authentication

Primary and pooled remote liveness checks queried the status endpoint through an anonymous fetch path.

For authenticated self-hosted gateways, this could return an authorization failure even though the active OAuth session, native bearer token, or static token was valid.

Those failures accumulated in the liveness tracker until the cached remote connection was treated as stale and replaced.

### 2. `Save and reconnect` updated only the legacy connection config

The apply path wrote `connection.json`, while the Connections UI and active connection identity are resolved through the v2 `connections.json` registry.

Migration only runs when the registry does not yet exist. If the registry already contained only the local connection, applying a remote gateway left the two stores divergent.

The backend could therefore connect successfully without having a matching registry `connectionId`, preventing the remote connection from becoming `Current` or `Primary`.

## Solution

- Pass the resolved connection descriptor into primary and pooled liveness probes.
- Run remote liveness probes through the existing authenticated backend fetch path, preserving OAuth cookies, native bearer tokens, static tokens, and configured headers.
- Authenticate protected status checks used by connection testing.
- Reconcile successfully applied global connections into the v2 registry.
- Match remote gateways by normalized URL to preserve existing IDs and labels without creating duplicates.
- Set the applied connection as `Primary` and last-used/current.
- Keep local, remote, cloud, SSH, and profile-scoped behavior isolated.
- Treat legacy config and registry persistence as one recoverable apply boundary, restoring both snapshots if persistence or activation fails.
- Preflight authenticated REST and WebSocket connectivity before committing a global remote apply.

## Tests

Added regression coverage for:

- authenticated primary and pooled remote liveness probes;
- applying a remote gateway to a local-only registry;
- preserving an existing remote ID and label;
- avoiding duplicate normalized URLs;
- switching remote → local;
- switching between two remotes;
- rolling back both stores after activation or registry-write failure;
- authenticated OAuth connection status checks;
- preflight ordering before persistence.

Focused tests, ESLint, and TypeScript typechecking pass.

The full Desktop suite was also run on Windows. Remaining failures were unrelated existing platform/environment issues involving POSIX permission and SSH assumptions, locale-dependent formatting, jsdom canvas support, and UI timing.

## Manual verification

A Windows x64 unpacked build was tested end-to-end against a real self-hosted Hermes Agent v0.20.5 exposed over public HTTPS with OAuth authentication.

Verified behavior:

- `Save and reconnect` registers the remote gateway;
- the remote becomes `Current` and `Primary`;
- remote sessions load;
- chat works;
- the remote connection remains active;
- Desktop no longer falls back automatically to `This device`.

No server-side changes are required, and no changes are required to Tailscale, Funnel, DNS, reverse proxy configuration, or other network infrastructure.