### PR TITLE
fix(dashboard): survive vanished entries and dangling symlinks in Files listing

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2426,10 +2426,24 @@ def _managed_file_entry(policy: ManagedFilesPolicy, target: Path) -> Dict[str, A
     if policy.locked_root is not None and not _path_is_under(policy.locked_root, resolved):
         raise HTTPException(status_code=403, detail="Path outside managed files root")
 
+    # stat() follows symlinks, so two benign situations land here: a directory
+    # entry that vanished between scandir() and this stat (Steam's bootstrapper
+    # recreates such entries under ~/.steam on every launch), and dangling
+    # symlinks, which fail stat() forever. Both used to turn a routine listing
+    # into an HTTP 500 for the whole page. Report them as ghost rows instead;
+    # direct reads/downloads still return their proper 4xx because they check
+    # existence themselves before reaching this helper.
     try:
         st = resolved.stat()
-    except OSError as exc:
-        raise HTTPException(status_code=500, detail=f"Could not stat path: {exc}")
+    except OSError:
+        return {
+            "name": target.name or resolved.name or str(resolved),
+            "path": str(resolved),
+            "is_directory": False,
+            "size": None,
+            "mtime": None,
+            "mime_type": None,
+        }
 
     is_dir = resolved.is_dir()
     mime_type = None if is_dir else (mimetypes.guess_type(resolved.name)[0] or "application/octet-stream")
@@ -2561,11 +2575,19 @@ async def list_managed_files(request: Request, path: Optional[str] = None):
 
     try:
         with os.scandir(target) as scan:
-            entries = [
-                _managed_file_entry(policy, Path(entry.path))
-                for entry in scan
-                if not _is_sensitive_path(Path(entry.path))
-            ]
+            raw_entries = list(scan)
+        entries = []
+        for entry in raw_entries:
+            entry_path = Path(entry.path)
+            if _is_sensitive_path(entry_path):
+                continue
+            try:
+                entries.append(_managed_file_entry(policy, entry_path))
+            except HTTPException as exc:
+                # A single unreadable entry must not fail the whole listing.
+                if exc.status_code == 403:
+                    raise
+                continue
     except PermissionError:
         raise HTTPException(status_code=403, detail="Directory is not readable")
     except OSError as exc:

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -375,3 +375,85 @@ def test_credential_dir_trees_blocked_on_subdir_descent(forced_files_client):
     assert [e["name"] for e in mcp_listing.json()["entries"]] == []
 
 
+# ---------------------------------------------------------------------------
+# Ghost rows: entries that vanish mid-scan or dangle must not 500 the listing
+# ---------------------------------------------------------------------------
+
+
+def test_listing_survives_entry_vanishing_mid_scan(forced_files_client, monkeypatch):
+    """Regression: a directory entry that disappears between scandir() and its
+    stat() used to fail the whole listing with HTTP 500 ("Could not stat path").
+    Steam's bootstrapper recreates entries under ~/.steam on every launch, which
+    made the dashboard Files page intermittently unusable. The listing must
+    survive and report the vanished entry as a ghost row instead."""
+    import os
+
+    client, root = forced_files_client
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "real.txt").write_text("hello")
+
+    real_scandir = os.scandir
+
+    def _vanishing_scandir(path):
+        it = real_scandir(path)
+        try:
+            entries = list(it)
+        finally:
+            it.close()
+        ghost = SimpleNamespace(path=str(root / "vanished.tmp"), name="vanished.tmp")
+
+        class _FakeScan:
+            """os.scandir() stand-in: iterable *and* a context manager."""
+
+            def __init__(self, items):
+                self._it = iter(items)
+
+            def __iter__(self):
+                return self._it
+
+            def __enter__(self):
+                return self._it
+
+            def __exit__(self, *_exc):
+                return False
+
+        return _FakeScan([*entries, ghost])
+
+    monkeypatch.setattr(web_server.os, "scandir", _vanishing_scandir)
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert listing.status_code == 200
+    by_name = {e["name"]: e for e in listing.json()["entries"]}
+    assert by_name["real.txt"]["size"] == 5
+    assert by_name["real.txt"]["mtime"] is not None
+
+    ghost = by_name["vanished.tmp"]
+    assert ghost["is_directory"] is False
+    assert ghost["size"] is None
+    assert ghost["mtime"] is None
+    assert ghost["mime_type"] is None
+
+
+def test_listing_includes_dangling_symlink_as_ghost_row(forced_files_client):
+    """Dangling symlinks fail stat() permanently; they must appear as ghost rows
+    rather than turning the directory listing into an HTTP 500."""
+    client, root = forced_files_client
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "keep.txt").write_text("ok")
+    (root / "dangling").symlink_to(root / "never-existed")
+
+    listing = client.get("/api/files", params={"path": str(root)})
+    assert listing.status_code == 200
+    by_name = {e["name"]: e for e in listing.json()["entries"]}
+    assert by_name["keep.txt"]["mtime"] is not None
+
+    ghost = by_name["dangling"]
+    assert ghost["is_directory"] is False
+    assert ghost["mtime"] is None
+
+    # Direct reads of the dangling link keep their proper 4xx semantics.
+    assert client.get(
+        "/api/files/read", params={"path": str(root / "dangling")}
+    ).status_code == 404
+
+

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2068,7 +2068,8 @@ export interface ManagedFileEntry {
   path: string;
   is_directory: boolean;
   size: number | null;
-  mtime: number;
+  /** Null for ghost rows: entries that vanished or dangling symlinks that fail stat(). */
+  mtime: number | null;
   mime_type: string | null;
 }
 


### PR DESCRIPTION
## Summary

The dashboard Files page intermittently fails with:

```
Error: 500: {"detail":"Could not stat path: [Errno 2] No such file or directory: '/home/<user>/.steam/debian-installation/linux32/steam'"}
```

Root cause: `_managed_file_entry` calls `stat()` (which follows symlinks) on every scandir entry, and any `OSError` became an HTTP 500 for the **whole listing**. Two benign situations trigger this:

1. **Vanished entries** — Steam's bootstrapper recreates entries under `~/.steam/debian-installation/linux32/` on every launch, so a name visible during `scandir()` can be gone milliseconds later when the per-entry `stat()` runs.
2. **Dangling symlinks** — fail `stat()` permanently (Steam runtimes contain hundreds of them).

## Fix

- `_managed_file_entry`: on `stat()` failure return a **ghost row** (`is_directory: false`, `size/mtime/mime_type: null`) instead of raising. Direct read/download/upload endpoints keep their existing 4xx semantics — they check existence themselves before reaching this helper.
- `list_managed_files`: the entry loop now skips single-entry `HTTPException`s (403 still propagates), so one unreadable/broken entry can never fail a whole directory again.
- Frontend: `ManagedFileEntry.mtime` widens to `number | null`; the Files page already guards with `Number.isFinite()` and renders `"-"`, so no UI change is required.

## Testing

- Two new regression tests in `tests/hermes_cli/test_web_server_files.py`:
  - `test_listing_survives_entry_vanishing_mid_scan` — monkeypatches `os.scandir` to inject an entry that vanishes before stat; asserts the listing returns 200 with the real file intact and the ghost row nulled out.
  - `test_listing_includes_dangling_symlink_as_ghost_row` — real dangling symlink; asserts 200 + ghost row, and that direct read of the dangling link keeps its 404.
- Full file suite: **10 passed**.
- E2E against a live gateway process on the reporting machine: listing the previously-failing `linux32` directory now returns 200 with all three files; a directory containing a dangling symlink lists as 200 with a ghost row; direct read of the dangling link stays 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <[EMAIL]>