### PR TITLE
fix(desktop): don't follow venv python symlink in Linux .desktop Exec

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -67,6 +67,7 @@ def resolve_exec_command() -> str:
     from hermes_cli.relaunch import resolve_hermes_bin
 
     bin_path = resolve_hermes_bin()
+    interpreter = _running_interpreter()
     if bin_path:
         resolved = Path(bin_path).resolve()
         if _needs_interpreter(resolved):
@@ -76,14 +77,27 @@ def resolve_exec_command() -> str:
             # installer's bash wrapper). Launched from the .desktop entry that
             # shebang resolves to the SYSTEM python and dies on the first
             # third-party import (#90292) — silently, since Terminal=false.
-            # sys.executable is the interpreter actually running Hermes (the
-            # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            # Prefix the interpreter that is actually running Hermes (the
+            # venv one). Do not follow a venv/bin/python → /usr/bin/python
+            # symlink or the prefix is the system interpreter again.
+            argv = [str(interpreter), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(interpreter), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
+
+
+def _running_interpreter() -> Path:
+    """Interpreter that can see Hermes' site-packages.
+
+    Do not ``Path.resolve()`` this. A venv's ``bin/python`` is often a
+    symlink to the system interpreter (``/usr/bin/python3.11``). Following
+    that symlink writes an ``Exec=`` that imports from the system
+    site-packages and dies with ``ModuleNotFoundError: hermes_cli`` —
+    silent under ``Terminal=false``.
+    """
+    return Path(sys.executable)
 
 
 def _needs_interpreter(bin_path: Path) -> bool:
@@ -103,10 +117,28 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
+    shebang_interp = shebang[2:].strip().split()[0] if shebang.startswith("#!") else ""
+    # ``#!/usr/bin/env python3`` always escapes to the DE's PATH python.
+    # Do not treat this as "inside the venv" just because exe_dir is
+    # ``/usr/bin`` (a substring of ``/usr/bin/env``).
+    if shebang_interp in {"/usr/bin/env", "env"}:
+        return True
+    # Console script next to its own interpreter (venv/bin/hermes shebang
+    # venv/bin/python3) is already self-sufficient, even when
+    # sys.executable.resolve() would point at /usr/bin/python3.11.
+    if shebang_interp:
+        interp_path = Path(shebang_interp)
+        try:
+            if interp_path.is_file() and interp_path.parent == bin_path.parent:
+                return False
+        except OSError:
+            pass
     # A python shebang pointing INSIDE the running interpreter's environment
-    # already resolves correctly; anything else (``/usr/bin/env python3``,
-    # a system path) would escape the venv when spawned by the DE.
-    exe_dir = str(Path(sys.executable).resolve().parent)
+    # already resolves correctly; anything else (a system path) would
+    # escape the venv when spawned by the DE. Compare against the
+    # unresolved interpreter so a venv symlink does not look like a
+    # foreign /usr/bin python.
+    exe_dir = str(_running_interpreter().parent)
     return exe_dir not in shebang
 
 

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -107,7 +107,7 @@ def test_exec_prefixes_interpreter_for_env_shebang_python_script(tmp_path, xdg_h
     entry = lde.install_desktop_entry(root)
     exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
 
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(Path(sys.executable))
     assert exec_line.split(" ")[0].strip('"') == interpreter
     assert str(hermes_bin) in exec_line
     assert exec_line.endswith("desktop")
@@ -135,7 +135,7 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     root = _make_project(tmp_path)
     hermes_bin = tmp_path / "bin" / "hermes"
     hermes_bin.parent.mkdir()
-    interpreter = str(Path(sys.executable).resolve())
+    interpreter = str(Path(sys.executable))
     hermes_bin.write_text(f"#!{interpreter}\nimport hermes_cli\n", encoding="utf-8")
     hermes_bin.chmod(0o755)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
@@ -147,6 +147,36 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     # Console-script with the venv's own interpreter in the shebang: correct
     # as-is, prefixing would only add noise.
     assert exec_line == f"{hermes_bin} desktop"
+
+
+def test_exec_does_not_follow_venv_python_symlink(tmp_path, xdg_home, monkeypatch):
+    """venv/bin/python is usually a symlink to /usr/bin/python3.X.
+
+    Following that symlink wrote Exec=/usr/bin/python3.11 …/venv/bin/hermes
+    desktop, which imports from the system site-packages and dies with
+    ModuleNotFoundError: hermes_cli (silent, Terminal=false).
+    """
+    root = _make_project(tmp_path)
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    system_py = tmp_path / "usr" / "bin" / "python3.11"
+    system_py.parent.mkdir(parents=True)
+    system_py.write_text("#!/bin/sh\n", encoding="utf-8")
+    system_py.chmod(0o755)
+    venv_py = venv_bin / "python3"
+    venv_py.symlink_to(system_py)
+    hermes_bin = venv_bin / "hermes"
+    hermes_bin.write_text(f"#!{venv_py}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+    monkeypatch.setattr(lde.sys, "executable", str(venv_py))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    assert exec_line == f"{hermes_bin} desktop"
+    assert str(system_py) not in exec_line
 
 
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):


### PR DESCRIPTION
## Bug Description

After `hermes desktop` rebuilds the Linux menu entry, launching Hermes from the app menu does nothing. A TTY `hermes desktop` works (including after the chrome-sandbox sudo).

The generated `~/.local/share/applications/hermes.desktop` contained:

```
Exec=/usr/bin/python3.11 /home/…/.hermes/hermes-agent/venv/bin/hermes desktop
```

That command exits 1 with `ModuleNotFoundError: hermes_cli`. `Terminal=false`, so there is no window and no error.

Follow-up to #90292 (still open). That fix prefixed `sys.executable`, but `.resolve()` followed the venv `python` symlink back out to the system interpreter.

## Root Cause

A venv's `bin/python3` is typically a symlink to `/usr/bin/python3.11`. Invoking the system path does **not** activate the venv — `sys.prefix` stays `/usr`, so `hermes_cli` is missing.

`resolve_exec_command()` wrote `Path(sys.executable).resolve()` into `Exec=`. After a successful TTY launch (which *does* use the venv shebang), the rewritten menu entry pointed at system Python.

A second hole in the same helper: `_needs_interpreter` used `exe_dir not in shebang`. When the running interpreter lives under `/usr/bin`, that substring matches `#!/usr/bin/env python3` and skips the #90292 prefix.

## Fix

- `_running_interpreter()` returns `Path(sys.executable)` **without** following the venv→system symlink, and that path is what gets written into `Exec=` when a prefix is needed.
- Console scripts whose shebang already names a python next to themselves (`venv/bin/hermes` → `venv/bin/python3`) are left alone.
- `#!/usr/bin/env python3` always gets the prefix (no more `/usr/bin` ⊂ `/usr/bin/env` false negative).

## How to Verify

1. On Linux with a venv whose `bin/python3` is a symlink to `/usr/bin/python3.X`, run `hermes desktop` once from a TTY.
2. `awk -F= '/^Exec=/{print substr($0,6)}' ~/.local/share/applications/hermes.desktop`
   - bad: starts with `/usr/bin/python3.11`
   - good: `~/.local/bin/hermes desktop` or `…/venv/bin/hermes desktop` (or `…/venv/bin/python3 …` if prefixed)
3. Click the menu icon — window should open.
4. Reproduce the silent fail of the old line:
   `/usr/bin/python3.11 ~/.hermes/hermes-agent/venv/bin/hermes --version` → `ModuleNotFoundError: hermes_cli`

## Test Plan

- [x] Added regression test (`test_exec_does_not_follow_venv_python_symlink`)
- [x] Existing `tests/hermes_cli/test_linux_desktop_entry.py` still pass (16 passed, 2 skipped)
- [x] Manual verification: rewrote the live `.desktop` Exec and confirmed `--version` works; the old Exec line fails as above

## Risk Assessment

Low — Linux `.desktop` writer only. macOS/Windows installers are no-ops here. Worst case a prefixed Exec uses the unresolved venv interpreter (correct) instead of the resolved system one (broken).