### PR TITLE
fix: resolve update toolset and Vite warnings

### DIFF
--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -4,7 +4,9 @@ Pure logic — the validity predicate is injected, so these tests need neither t
 tool registry nor a running Hermes.
 """
 
-import pytest
+from pathlib import Path
+
+import yaml
 
 from hermes_cli.toolset_validation import validate_platform_toolsets
 
@@ -34,6 +36,18 @@ def test_38798_corruption_warns_and_suggests_correct_name():
     assert "did you mean 'hermes-cli'?" in unknown[0]
     # And the zero-valid-toolsets safety net fires.
     assert any("zero valid toolsets" in w for w in warnings)
+
+
+def test_shipped_template_platform_toolsets_all_resolve():
+    """A fresh config seeded from the shipped template has no invalid presets."""
+    from toolsets import validate_toolset
+
+    template = Path(__file__).resolve().parents[2] / "cli-config.yaml.example"
+    config = yaml.safe_load(template.read_text(encoding="utf-8"))
+
+    assert validate_platform_toolsets(
+        config["platform_toolsets"], validate_toolset
+    ) == []
 
 
 def test_mixed_valid_and_invalid_flags_only_the_invalid():

--- a/toolsets.py
+++ b/toolsets.py
@@ -539,7 +539,19 @@ TOOLSETS = {
         "tools": _HERMES_CORE_TOOLS,
         "includes": []
     },
-    
+
+    "hermes-teams": {
+        "description": "Microsoft Teams bot toolset - full access for workspace use (terminal has safety checks)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
+    "hermes-google_chat": {
+        "description": "Google Chat bot toolset - full access for workspace use (terminal has safety checks)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-signal": {
         "description": "Signal bot toolset - encrypted messaging platform (full access)",
         "tools": _HERMES_CORE_TOOLS,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -77,8 +77,8 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@hermes/shared": path.resolve(__dirname, "../apps/shared/src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
+      "@hermes/shared": path.resolve(import.meta.dirname, "../apps/shared/src"),
     },
     // When @nous-research/ui is symlinked via `file:../../design-language`,
     // Node's module resolution would pick up shared deps from


### PR DESCRIPTION
## Summary
- add the missing Teams and Google Chat platform toolset presets referenced by the shipped config template
- validate every `platform_toolsets` entry in the shipped template resolves, preventing future template/registry drift
- replace Vite config `__dirname` aliases with `import.meta.dirname`, removing Vite 8 native-config-loader warning

## Verification
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_toolset_validation.py -q -o 'addopts='` (3 passed)\n- `cd web && npm run build` (passed; no native config-loader warning)\n- `git diff --check`\n\nNode support is `>=22.22.0`, so `import.meta.dirname` is supported.