### PR TITLE
fix(models): skip redundant live validation for cached model

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -6715,7 +6715,31 @@ def validate_requested_model(
             ),
         }
 
-    # Probe the live API to check if the model actually exists
+    # A model chosen from an interactive picker is normally already present in
+    # the provider's disk-backed catalog. Avoid a second synchronous /models
+    # probe on that user-visible switch path; cache misses still follow the
+    # live validation path below so unknown IDs retain normal validation.
+    try:
+        cached_entry = _load_provider_models_cache().get(normalized)
+        cached_models = (
+            cached_entry.get("models", []) if isinstance(cached_entry, dict) else []
+        )
+        cached_ids = {
+            str(model_id).strip().lower()
+            for model_id in cached_models
+            if str(model_id).strip()
+        }
+        if requested_for_lookup.lower() in cached_ids:
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
+    except Exception:
+        pass
+
+    # Probe the live API to check if the model actually exists.
     api_models = fetch_api_models(api_key, base_url)
 
     if api_models is not None:

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -564,3 +564,30 @@ class TestProbeApiModelsUserAgent:
         assert req.get_header("Authorization") is None
 
 
+
+
+class TestCachedModelValidation:
+    def test_known_cached_model_skips_live_api_validation(self):
+        """Picker-selected cached models must not block on a redundant /models probe."""
+        cache = {"zai": {"models": ["glm-5.2"]}}
+
+        with patch(
+            "hermes_cli.models._load_provider_models_cache",
+            return_value=cache,
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            side_effect=AssertionError("live /models validation must be skipped"),
+        ):
+            result = validate_requested_model(
+                "glm-5.2",
+                "zai",
+                api_key="test-key",
+                base_url="https://api.z.ai/api/coding/paas/v4",
+            )
+
+        assert result == {
+            "accepted": True,
+            "persist": True,
+            "recognized": True,
+            "message": None,
+        }


### PR DESCRIPTION
## Summary

Fix the second half of the model-selection latency reported in #92244: selecting a model that was just shown in the picker synchronously re-fetched the provider's `/models` catalog before rebuilding the runtime.

- Accept a requested model immediately when it is present in the provider's disk-backed model catalog.
- Preserve existing live validation for cache misses and unknown IDs.
- Add a regression test proving a cached model does not initiate a live `/models` fetch.

## Evidence

On a real Raspberry Pi 5 using the interactive `hermes` CLI with Z.AI:

- Before: selecting cached `glm-5.2` took **10.54s**; cProfile attributed 10.01s to the validation `/models` socket connection.
- After: the same session-scoped selection resolved in **0.38s**.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_model_validation.py -k known_cached_model_skips_live_api_validation -q` — RED before implementation, GREEN after.
- Sabotage verification: removed the fast path temporarily; regression test failed because it reached the mocked live `/models` call; restored the implementation and re-ran green.
- `scripts/run_tests.sh tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_cached_fetch_api_models.py -q` — **53 passed**.
- `python -m py_compile hermes_cli/models.py tests/hermes_cli/test_model_validation.py`
- `git diff --check`

`tests/hermes_cli/test_model_switch_custom_providers.py` was also attempted but did not complete within a 300s run timeout; it is not claimed as passing.

Related to #92244; complements #92253, which addresses the separate cold-pricing picker stall.
