### PR TITLE
fix(desktop): preserve venv symlink in .desktop Exec line

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -78,11 +78,11 @@ def resolve_exec_command() -> str:
             # third-party import (#90292) — silently, since Terminal=false.
             # sys.executable is the interpreter actually running Hermes (the
             # venv one), so prefix it explicitly.
-            argv = [str(Path(sys.executable).resolve()), str(resolved), "desktop"]
+            argv = [str(Path(sys.executable)), str(resolved), "desktop"]
         else:
             argv = [str(resolved), "desktop"]
     else:
-        argv = [str(Path(sys.executable).resolve()), "-m", "hermes_cli.main", "desktop"]
+        argv = [str(Path(sys.executable)), "-m", "hermes_cli.main", "desktop"]
     return " ".join(_quote_exec_arg(a) for a in argv)
 
 


### PR DESCRIPTION
## Problem

`Path(sys.executable).resolve()` in `linux_desktop_entry.py` follows the venv python symlink to the raw uv-managed interpreter, which lacks the venv site-packages.

When GNOME launches the `.desktop` entry with that resolved path, `hermes_cli` fails to import and the desktop app opens then silently dies on next launch.

Affects any uv-managed venv (symlink-based) on Linux.

## Fix

Drop `.resolve()` so the Exec line uses the `venv/bin/python` symlink directly. Python detects and activates the venv correctly through the symlink.

## Reproduction

1. Install hermes via the shell installer (uses uv, creates symlinked venv)
2. Run `hermes desktop` once (generates `.desktop` entry)
3. Close it, reopen from GNOME launcher — app fails silently

## Tested on

- Ubuntu 24.04, Wayland, uv-managed venv (cpython-3.11)