### PR TITLE
fix(aux): honor per-provider extra_headers on auxiliary calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6680,6 +6680,18 @@ def resolve_provider_client(
                 _headers2 = _apply_user_default_headers(_extra2.get("default_headers"))
                 if _headers2:
                     _extra2["default_headers"] = _headers2
+                # Per-provider extra_headers (providers.<name>.extra_headers /
+                # custom_providers[].extra_headers) — mirrors the main agent
+                # client so headers are identical for auxiliary calls too.
+                try:
+                    from hermes_cli.config import (
+                        apply_custom_provider_extra_headers_to_client_kwargs,
+                    )
+                    apply_custom_provider_extra_headers_to_client_kwargs(
+                        _extra2, _clean_base2,
+                    )
+                except Exception:
+                    logger.debug("custom-provider extra_headers skipped", exc_info=True)
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
                     provider, final_model, entry_api_mode or "chat_completions")
@@ -6705,6 +6717,16 @@ def resolve_provider_client(
                         _fb_headers = _apply_user_default_headers(_fb_extra.get("default_headers"))
                         if _fb_headers:
                             _fb_extra["default_headers"] = _fb_headers
+                        # Per-provider extra_headers on the fallback path too.
+                        try:
+                            from hermes_cli.config import (
+                                apply_custom_provider_extra_headers_to_client_kwargs,
+                            )
+                            apply_custom_provider_extra_headers_to_client_kwargs(
+                                _fb_extra, _fb_clean,
+                            )
+                        except Exception:
+                            logger.debug("custom-provider extra_headers skipped", exc_info=True)
                         client = _create_openai_client(api_key=custom_key, base_url=_fb_clean, **_fb_extra)
                         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                                 else (client, final_model))


### PR DESCRIPTION
## What does this PR do?

Fixes a behavioral inconsistency between the main agent client and the auxiliary client (context compression, title generation, vision routing, session search, etc.).

The main agent path (`run_agent.py` / `agent/agent_init.py`) applies per-provider `extra_headers` from `providers.<name>.extra_headers` / `custom_providers[].extra_headers` onto the OpenAI client's `default_headers` via `apply_custom_provider_extra_headers_to_client_kwargs`. The auxiliary client's "named custom provider" branch in `agent/auxiliary_client.py` only honored `model.default_headers` / `model.extra_headers` and never read the per-provider `extra_headers`.

For a custom OpenAI-compatible endpoint that relies on per-provider headers for auth or WAF/gateway identification (e.g. `x-client-type`, Cloudflare Access service tokens), the main turn succeeds while auxiliary calls to the same endpoint are sent without those headers.

This change mirrors the main agent's existing pattern in both auxiliary client construction sites (the named custom provider branch and the OpenAI-wire fallback when the anthropic SDK is missing), reusing the same `apply_custom_provider_extra_headers_to_client_kwargs` helper so precedence (provider-level > model-level) stays identical.

## Related Issue

No open issue found for this behavior. Related prior work: #40033 established the "main and auxiliary must never drift" convention for `model.default_headers`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py` — in `resolve_provider_client()`'s named custom provider branch: after merging `model.default_headers`, call `apply_custom_provider_extra_headers_to_client_kwargs(_extra2, _clean_base2)` so per-provider `extra_headers` are merged as well (provider-level wins over model-level, matching the main agent).
- `agent/auxiliary_client.py` — same merge in the OpenAI-wire fallback branch (used when `api_mode: anthropic_messages` but the anthropic SDK is unavailable), using `_fb_extra` / `_fb_clean`.

## How to Test

1. Configure a custom provider with `extra_headers` and `auxiliary.compression.provider: auto` (resolves to the main provider).
2. Main turn sends the header; compression/title calls do not → before this fix.
3. After this fix, the auxiliary client's `default_headers` include the per-provider `extra_headers` (verified locally by capturing client kwargs via mock).
4. `pytest tests/agent/test_auxiliary_client.py -k "custom or named or header" -q` passes (10 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (full suite requires sandbox; targeted `tests/agent/test_auxiliary_client.py` passes)
- [ ] I've added tests for my changes (existing tests already exercise the named custom provider path)
- [x] I've tested on my platform: macOS 15.7.8

### Documentation & Housekeeping

- [x] N/A — no docs or config keys added

## Screenshots / Logs

N/A