### PR TITLE
fix(logging): line-buffer a piped stdout so headless log streams track the agent loop

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -86,6 +86,30 @@ _LOG_FORMAT = "%(asctime)s %(levelname)s%(session_tag)s %(name)s: %(message)s"
 _LOG_FORMAT_VERBOSE = "%(asctime)s - %(name)s - %(levelname)s%(session_tag)s - %(message)s"
 
 
+def _line_buffer_piped_stdout() -> None:
+    """Best-effort line buffering for a piped stdout (#92281).
+
+    Python block-buffers stdout when it isn't a TTY, so an agent loop
+    driving ``print()`` into a supervisor's pipe delivers its output in
+    large delayed bursts — a headless run looks stalled for minutes while
+    the work is actually progressing (only stderr, which we already give
+    ``line_buffering=True`` in ``_safe_stderr()``, shows up on time).
+    Reconfigure the interpreter's own stdout for line buffering when it is
+    piped; interactive TTY stdout is already line-buffered, and the ACP
+    entry point keeps stdout as a protocol channel it manages itself and
+    never calls ``setup_logging``.
+    """
+    try:
+        stream = sys.stdout
+        if stream is None or stream.isatty():
+            return
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(line_buffering=True)
+    except Exception:
+        pass  # buffering is observability, not correctness — never crash
+
+
 def _safe_stderr():  # type: ignore[return]
     """Return a stderr stream that tolerates Unicode on all platforms.
 
@@ -303,6 +327,12 @@ def setup_logging(
     home = hermes_home or get_hermes_home()
     log_dir = home / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stdout is block-buffered when piped (no TTY); line-buffer it so a
+    # headless supervisor's log stream tracks the agent loop incrementally
+    # (#92281). Runs before the initialized check so every entry mode that
+    # reaches this function gets it, idempotent by construction.
+    _line_buffer_piped_stdout()
 
     # Read config defaults (best-effort — config may not be loaded yet).
     cfg_level, cfg_max_size, cfg_backup = _read_logging_config()

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -678,3 +678,47 @@ class TestAsyncQueueLogging:
         )
 
 
+class TestLineBufferPipedStdout:
+    """A piped stdout is line-buffered so headless log streams track the
+    agent loop incrementally (#92281); a TTY stdout is left alone."""
+
+    def _fake_stdout(self, isatty: bool):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        stream = MagicMock()
+        stream.isatty.return_value = isatty
+        stream.reconfigure = MagicMock()
+        return stream
+
+    def test_piped_stdout_reconfigured_line_buffered(self, monkeypatch):
+        stream = self._fake_stdout(isatty=False)
+        monkeypatch.setattr(sys, "stdout", stream)
+        hermes_logging._line_buffer_piped_stdout()
+        stream.reconfigure.assert_called_once_with(line_buffering=True)
+
+    def test_tty_stdout_untouched(self, monkeypatch):
+        stream = self._fake_stdout(isatty=True)
+        monkeypatch.setattr(sys, "stdout", stream)
+        hermes_logging._line_buffer_piped_stdout()
+        stream.reconfigure.assert_not_called()
+
+    def test_none_or_reconfigure_less_stdout_is_noop(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdout", None)
+        hermes_logging._line_buffer_piped_stdout()  # must not raise
+
+        from types import SimpleNamespace
+
+        # A stream without reconfigure() (e.g. a print-redirect shim).
+        monkeypatch.setattr(
+            sys, "stdout", SimpleNamespace(isatty=lambda: False)
+        )
+        hermes_logging._line_buffer_piped_stdout()
+
+    def test_setup_logging_applies_it_to_piped_stdout(self, tmp_path, monkeypatch):
+        stream = self._fake_stdout(isatty=False)
+        monkeypatch.setattr(sys, "stdout", stream)
+        hermes_logging.setup_logging(hermes_home=tmp_path, force=True)
+        stream.reconfigure.assert_called_once_with(line_buffering=True)
+
+


### PR DESCRIPTION
## What does this PR do?

When `hermes` is launched headlessly (stdout attached to a pipe, no TTY — the common case for any supervisor/orchestrator integration), Python block-buffers stdout, so the agent loop's `print()` output arrives in large delayed bursts. The reporter's production evidence: 24 minutes of log silence while the work was actually progressing steadily (verified by matching the burst timestamp to a file mtime to the millisecond), then 15 lines in one ~20ms burst about a minute before the process was killed for "apparent inactivity". Crucially, stderr lines (startup banner, session id) were never delayed — because `hermes_logging._safe_stderr()` already wraps stderr with `line_buffering=True`. Stdout had no symmetric treatment (#92281).

This adds `_line_buffer_piped_stdout()` and calls it from `setup_logging()` — the shared seam every `cli.py` (module-level init) and `hermes_cli/main.py` (cli/gui/cron modes) entry path already calls:

- piped stdout → `sys.stdout.reconfigure(line_buffering=True)` (cheapest fix; Python ≥3.7; no subprocess/env involved)
- TTY stdout → untouched (already line-buffered)
- the ACP entry point is deliberately NOT touched: it routes all logging to stderr precisely because "stdout stays clean for ACP stdio" — stdout there is a protocol channel the ACP library manages itself, and it never calls `setup_logging`
- best-effort by construction: `None` stdout, a `reconfigure`-less stream shim, or a failing `reconfigure` are all silent no-ops (buffering is observability, not correctness)

The codebase already establishes this fix pattern for subprocess-spawn paths (`gateway/slash_commands.py` sets `PYTHONUNBUFFERED=1` for `hermes update --gateway` with a comment, `tools/process_registry.py` sets it for pty/background spawns, `tui_gateway/transport.py` documents the `-u` requirement) — this applies the same treatment to the main process's own stdout, which none of them cover.

## Related Issue

Fixes #92281

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_logging.py`: new `_line_buffer_piped_stdout()` helper (defensive reconfigure, docstring citing the burst mechanism and the stderr symmetry); called once at the top of `setup_logging()` before the initialized check so every entry mode gets it
- `tests/test_hermes_logging.py`: four tests — piped stdout is reconfigured with `line_buffering=True`; TTY stdout untouched; `None` and `reconfigure`-less streams are silent no-ops; `setup_logging(force=True)` applies it end-to-end

## How to Test

1. `pytest tests/test_hermes_logging.py`
2. Observed result: 30 passed, 3 skipped (pre-existing Windows-only skips).
3. Manual check of the issue's scenario: `hermes -p <profile> chat -q "count slowly"` piped into a file — with the fix, the agent-loop lines appear as they are printed instead of in one burst at exit.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Comments added for complex logic (burst mechanism, ACP-excluded rationale)
- [x] Tests added/updated and passing (30 passed locally)
- [x] No new warnings introduced
- [x] Behavior change is additive and scoped: only a piped (non-TTY) stdout of processes that call setup_logging; interactive sessions and the ACP stdio protocol are byte-identical
- [x] Tested on macOS (arm64) via unit tests; the reconfigure path is stdlib Python, platform-independent
