### PR TITLE
fix(display): don't flag a JSON result with an explicit null error

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1375,6 +1375,12 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     # treat them as successes since failures would be JSON-encoded strings.
     if not isinstance(result, str):
         return False, ""
+    # A parseable JSON object was already evaluated above (structured error
+    # branch). Don't re-scan its raw text: an explicit ``"error": null`` on a
+    # successful result (e.g. web_extract) would otherwise match the literal
+    # ``"error"`` marker below and be mis-flagged as a failure (#91166).
+    if isinstance(data, dict):
+        return False, ""
     lower = result[:500].lower()
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
         return True, " [error]"

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -96,6 +96,30 @@ class TestDetectToolFailureStructured:
         result = json.dumps({"success": True, "data": "hello"})
         assert _detect_tool_failure("web_search", result) == (False, "")
 
+    def test_explicit_null_error_not_flagged(self):
+        """A successful result with an explicit ``"error": null`` field must
+        not trip the string heuristic — web_extract returns this on success
+        (#91166). The structured dict branch already evaluates the field, so
+        the 500-char literal scan must be skipped for JSON dicts.
+        """
+        result = json.dumps({
+            "success": True,
+            "error": None,
+            "data": "extracted page content here",
+        })
+        assert _detect_tool_failure("web_extract", result) == (False, "")
+
+    def test_short_json_with_error_null_and_failure_marker_still_flags(self):
+        """A genuinely failing short JSON result with a real error string is
+        still flagged — only the null-error case is exempted."""
+        result = json.dumps({
+            "success": False,
+            "error": "rate limited",
+        })
+        is_failure, suffix = _detect_tool_failure("web_extract", result)
+        assert is_failure is True
+        assert suffix == " [rate limited]"
+
 
 
 class TestGetCuteToolMessageFailureSuffix:


### PR DESCRIPTION
## Summary

Fixes #91166: `_detect_tool_failure`'s string heuristic scanned the first 500 chars for the literal `"error"` — a successful result carrying an explicit `"error": null` field (e.g. `web_extract`) was mis-flagged as a failure whenever the whole result was short enough to fit that field in the window.

## Approach

- The structured JSON-dict branch (`safe_json_loads` → `data.get("error")`) already evaluates the error field correctly — `null` is falsy so it returns cleanly.
- The bug was the fallthrough: the raw-text heuristic re-scanned the same string and matched the literal `"error"`.
- Fix: when the result parsed to a dict, skip the raw-text scan (the heuristic now applies only to genuinely unstructured strings).

## Test Plan

- 2 new tests: a short `web_extract`-style success with `"error": null` is not flagged; a genuinely failing short JSON result with a real error string is still flagged with the correct suffix.
- Verified the new test fails on the pre-fix logic (via stash) and passes after.
- Full file: 13/13 pass. `ruff check` clean.

## Risk / Exclusions

- Only the fallthrough heuristic changes for JSON-dict results; unstructured string behavior is untouched.
- Structured-error detection (real `"error": "..."` with `success: false`) is unaffected.

References #91166