### PR TITLE
fix(cli): guard IndexError on empty/whitespace user turns in foreign session import

### DIFF
--- a/contributors/emails/bot@blut-agent.dev
+++ b/contributors/emails/bot@blut-agent.dev
@@ -1,0 +1,1 @@
+blut-agent

--- a/contributors/emails/edrayoca+agent@gmail.com
+++ b/contributors/emails/edrayoca+agent@gmail.com
@@ -1,0 +1,2 @@
+edrayoca-agent
+# hermes-agent PR contributor

--- a/hermes_cli/foreign_sessions.py
+++ b/hermes_cli/foreign_sessions.py
@@ -305,7 +305,13 @@ def list_codex_sessions(root: Optional[Path] = None) -> List[ForeignSession]:
 def _first_user_line(turns: List[Tuple[str, str]]) -> Optional[str]:
     for role, text in turns:
         if role == "user":
-            line = text.strip().splitlines()[0].strip()
+            stripped = text.strip()
+            if not stripped:
+                continue
+            lines = stripped.splitlines()
+            if not lines:
+                continue
+            line = lines[0].strip()
             if line:
                 return line[:_TITLE_MAX * 2]
     return None


### PR DESCRIPTION
## Problem

`_first_user_line()` in `hermes_cli/foreign_sessions.py` calls `text.strip().splitlines()[0]` without checking whether `splitlines()` returns an empty list. When a user message is empty or whitespace-only (e.g. multimodal-only turns, reasoning-only turns), this raises `IndexError: list index out of range` and crashes the foreign session import flow (Claude Code / Codex CLI session imports).

## Fix

Split the chained indexing into safe steps:
1. Strip whitespace from text
2. Check if stripped text is empty → skip to next turn
3. Call `splitlines()`
4. Check if result is empty → skip to next turn
5. Safe to index `[0]`

This matches the same bug class fixed in `_display_resumed_history` (f5adeed3dc) and prevents a crash when importing foreign sessions with empty user turns.

## Test Plan

- [x] Empty string input returns `None` (was: `IndexError`)
- [x] Whitespace-only input returns `None` (was: `IndexError`)
- [x] Normal text returns first line correctly
- [x] Multiline text returns first line correctly
- [x] No user turns returns `None`
- [x] Mixed empty + non-empty user turns returns first non-empty line
- [x] All empty user turns returns `None`

Closes #59265 (same bug class)
