### PR TITLE
docs: add MnemoStack to the memory providers page

### DIFF
--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -652,6 +652,30 @@ hermes config set memory.provider memori
 hermes memory setup
 ```
 
+### MnemoStack
+
+Self-hosted hybrid memory: vector, lexical, temporal and graph retrieval over your own Qdrant, either as a shared service or as a local library. Turns are captured verbatim with their event time, so temporal recall ("what did we discuss last week") and freshness ranking both work on ordinary conversation rather than only on documents indexed by hand.
+
+| | |
+|---|---|
+| **Best for** | Self-hosted memory with hybrid retrieval and a real tenant boundary |
+| **Requires** | `pip install hermes-mnemostack` + a [mnemostack](https://github.com/udjin-labs/mnemostack) service or local Qdrant |
+| **Data storage** | Self-hosted — your Qdrant, optionally behind your own `mnemostack serve` deployment |
+| **Cost** | Free (self-hosted, no vendor) |
+
+**Tools (3):** `mnemostack_search` (hybrid recall), `mnemostack_remember` (store an explicit fact), `mnemostack_forget` (soft retraction — irreversible deletion is deliberately operator-only)
+
+**Two transports:** `remote` talks to a `mnemostack serve --auth` deployment, where the tenant is resolved from the service key and is therefore a real authorization boundary. `local` uses mnemostack as a library against your own Qdrant, where profile scoping is isolation but **not** an authorization boundary (same machine, same trust domain).
+
+**Setup:**
+```bash
+pip install hermes-mnemostack
+hermes-mnemostack install   # hermes-agent 0.19 only; 0.20+ finds it by entry point
+hermes memory setup mnemostack
+```
+
+`hermes-mnemostack doctor` reports what configuration is in effect, whether Hermes would activate the provider, and whether the service on the other end is reachable and healthy. It is read-only and never prints the API key.
+
 ---
 
 ## Provider Comparison
@@ -667,6 +691,7 @@ hermes memory setup
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud/Self-hosted | Free/Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
 | **Memori** | Cloud | Free/Paid | 5 | `hermes-memori` | Tool-aware memory + structured recall |
+| **MnemoStack** | Self-hosted | Free | 3 | `hermes-mnemostack` + Qdrant | Hybrid vector/lexical/temporal/graph + event-time capture |
 
 ## Profile Isolation
 
@@ -676,6 +701,7 @@ Each provider's data is isolated per [profile](/user-guide/profiles):
 - **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file
+- **Self-hosted service providers** (MnemoStack in `remote` mode) resolve the tenant from the service key, so isolation is enforced by the service rather than asserted by the client
 
 ## Building a Memory Provider
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -670,11 +670,11 @@ Self-hosted hybrid memory: vector, lexical, temporal and graph retrieval over yo
 **Setup:**
 ```bash
 pip install hermes-mnemostack
-hermes-mnemostack install   # hermes-agent 0.19 only; 0.20+ finds it by entry point
+hermes-mnemostack install   # only on Hermes releases without entry-point discovery
 hermes memory setup mnemostack
 ```
 
-`hermes-mnemostack doctor` reports what configuration is in effect, whether Hermes would activate the provider, and whether the service on the other end is reachable and healthy. It is read-only and never prints the API key.
+`hermes-mnemostack doctor` reports what configuration is in effect, whether Hermes would activate the provider, and whether the service on the other end is reachable and healthy — including whether the extra `install` step is needed here, which it answers by running Hermes's own discovery rather than by comparing version numbers. It is read-only and never prints the API key.
 
 ---
 
@@ -691,7 +691,7 @@ hermes memory setup mnemostack
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud/Self-hosted | Free/Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
 | **Memori** | Cloud | Free/Paid | 5 | `hermes-memori` | Tool-aware memory + structured recall |
-| **MnemoStack** | Self-hosted | Free | 3 | `hermes-mnemostack` + Qdrant | Hybrid vector/lexical/temporal/graph + event-time capture |
+| **MnemoStack** | Self-hosted | Free | 3 | `hermes-mnemostack` + mnemostack service or Qdrant | Hybrid vector/lexical/temporal/graph + event-time capture |
 
 ## Profile Isolation
 


### PR DESCRIPTION
Adds a documentation section for **MnemoStack**, a self-hosted memory provider published as a standalone package.

**No code changes.** The provider lives in its own repository and installs from PyPI, following the pattern the existing **Memori** section documents — so this is one file, one new section, one comparison row, and one line in the profile-isolation list.

- GitHub: https://github.com/udjin-labs/hermes-mnemostack
- PyPI: https://pypi.org/project/hermes-mnemostack/

### What it is

Hybrid recall — vector, lexical, temporal and graph — over the operator's own Qdrant, with no vendor in the path. Two transports: `remote` against a `mnemostack serve --auth` deployment, where the tenant comes from the service key and is a real authorization boundary; `local` as a library against your own Qdrant, where profile scoping is isolation but not an authorization boundary. The section says that distinction plainly rather than implying the stronger one.

### Verified before submitting

Both discovery paths, against real hosts rather than a test harness:

- **0.19** — the compatibility shim is loaded by hermes's own `plugins.memory` loader.
- **0.20.4** — the provider is discovered through its `hermes_agent.memory_providers` entry point in a running install.

Driven through a live session against a running mnemostack service: a turn was captured, recall returned it, duplicate detection held, soft retraction and reactivation behaved, and the provider's `doctor` reported clean on every check.

186 tests across Python 3.11–3.13 on Linux, macOS and Windows, plus a clean-install job that builds the wheel and exercises it from an empty environment.

### Noticed but deliberately not changed

Three counts in this repo have drifted, and they are yours to decide on rather than mine to quietly edit in a PR about something else:

- the intro to `memory-providers.md` says *"ships with 8 external memory provider plugins"* — there are now ten sections, and Memori and MnemoStack are not shipped;
- the frontmatter `description` on the same page lists eight providers and omits Memori;
- `integrations/index.md` says *"Eight providers are supported"* and likewise omits Memori.

Happy to fold any of those into this PR if you would like them fixed here.
