### PR TITLE
fix(web): repaint dashboard terminal immediately after tab-return blank

### DIFF
--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -70,14 +70,21 @@ class FakeTerminal {
     return { dispose() {} };
   }
 
-  onScroll() {
+  onScrollHandler: (() => void) | null = null;
+
+  onScroll(handler: () => void) {
+    this.onScrollHandler = handler;
     return { dispose() {} };
   }
 
+  scrollPos = { baseY: 0, viewportY: 0 };
+
   get buffer() {
-    // Minimal active-buffer surface for the resume follow-scroll pin
-    // (isViewportPinnedToBottom reads viewportY/baseY).
-    return { active: { baseY: 0, viewportY: 0 } };
+    // Minimal active-buffer surface for the resume follow-scroll pin and
+    // the stick-to-bottom re-anchor gate (isViewportPinnedToBottom reads
+    // viewportY/baseY); tests mutate scrollPos before invoking the
+    // captured onScroll handler to simulate the user scrolling up.
+    return { active: { ...this.scrollPos } };
   }
 
   scrollToBottom = vi.fn();
@@ -350,6 +357,64 @@ describe("ChatPage", () => {
     );
 
     expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a mid-scrollback reader's position on Chat return", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+    const page = (isActive: boolean) => (
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive={isActive} />
+      </MemoryRouter>
+    );
+
+    await render(page(true));
+    await vi.waitFor(() => expect(FakeTerminal.instances).toHaveLength(1));
+    const terminal = FakeTerminal.instances[0];
+    // Simulate the user scrolling up into the backlog: the captured onScroll
+    // handler releases the stick-to-bottom pin (viewportY < baseY).
+    terminal.scrollPos = { baseY: 120, viewportY: 40 };
+    terminal.onScrollHandler?.();
+    terminal.scrollToBottom.mockClear();
+
+    await act(async () => root.render(page(false)));
+    await act(async () => root.render(page(true)));
+
+    // The WebGL retry still runs, but the viewport is NOT yanked to the tail.
+    expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+  });
+
+  it("keeps a mid-scrollback reader's position when the browser tab returns", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+    await vi.waitFor(() => expect(FakeTerminal.instances).toHaveLength(1));
+    const terminal = FakeTerminal.instances[0];
+    terminal.scrollPos = { baseY: 120, viewportY: 40 };
+    terminal.onScrollHandler?.();
+    terminal.scrollToBottom.mockClear();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    await act(async () =>
+      document.dispatchEvent(new Event("visibilitychange")),
+    );
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    await act(async () =>
+      document.dispatchEvent(new Event("visibilitychange")),
+    );
+
+    // The fallback repaint still happens; the re-anchor does not.
+    expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+    expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
   });
 
   it("treats loopback 4401 closes as stale-token reload candidates", async () => {

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -11,12 +11,24 @@ class FakeFitAddon {
 }
 
 class FakeWebglAddon {
-  onContextLoss() {
+  static instances: FakeWebglAddon[] = [];
+
+  contextLossHandler: (() => void) | null = null;
+  dispose = vi.fn();
+
+  constructor() {
+    FakeWebglAddon.instances.push(this);
+  }
+
+  onContextLoss(handler: () => void) {
+    this.contextLossHandler = handler;
     return { dispose() {} };
   }
 }
 
 class FakeTerminal {
+  static instances: FakeTerminal[] = [];
+
   options: Record<string, unknown>;
   rows = 24;
   cols = 80;
@@ -27,6 +39,7 @@ class FakeTerminal {
 
   constructor(options: Record<string, unknown>) {
     this.options = options;
+    FakeTerminal.instances.push(this);
   }
 
   attachCustomKeyEventHandler() {
@@ -67,13 +80,12 @@ class FakeTerminal {
     return { active: { baseY: 0, viewportY: 0 } };
   }
 
-  scrollToBottom() {}
+  scrollToBottom = vi.fn();
 
   open() {}
-
   paste() {}
 
-  refresh() {}
+  refresh = vi.fn();
 
   write() {}
 }
@@ -190,6 +202,8 @@ async function render(ui: ReactNode) {
 }
 
 beforeEach(() => {
+  FakeTerminal.instances = [];
+  FakeWebglAddon.instances = [];
   FakeWebSocket.instances = [];
   maybeReloadForLoopbackWsAuthFailure.mockClear();
   apiMocks.buildWsUrl.mockReset();
@@ -222,6 +236,10 @@ beforeEach(() => {
     randomUUID: () => "chat-test-id",
   });
 
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: "visible",
+  });
   Object.defineProperty(window, "visualViewport", {
     configurable: true,
     value: { addEventListener() {}, removeEventListener() {}, width: 1280 },
@@ -255,6 +273,85 @@ afterEach(async () => {
 });
 
 describe("ChatPage", () => {
+  it("repaints with the fallback renderer immediately on WebGL context loss", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+    await vi.waitFor(() => expect(FakeWebglAddon.instances).toHaveLength(1));
+    const webgl = FakeWebglAddon.instances[0];
+    const host = container.querySelector(".hermes-chat-xterm-host");
+    expect(host).not.toBeNull();
+
+    // The capture-phase listener on the terminal host must fire before the
+    // addon's own 3000ms grace timer, disposing the WebGL renderer and
+    // repainting the viewport at once.
+    await act(async () => {
+      host!.dispatchEvent(new Event("webglcontextlost"));
+    });
+
+    expect(webgl.dispose).toHaveBeenCalledTimes(1);
+    expect(FakeTerminal.instances[0].refresh).toHaveBeenCalledWith(
+      0,
+      FakeTerminal.instances[0].rows - 1,
+    );
+  });
+
+  it("restores the live terminal viewport when returning to Chat", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+    const page = (isActive: boolean) => (
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive={isActive} />
+      </MemoryRouter>
+    );
+
+    await render(page(true));
+    await vi.waitFor(() => expect(FakeTerminal.instances).toHaveLength(1));
+    const terminal = FakeTerminal.instances[0];
+    terminal.scrollToBottom.mockClear();
+
+    await act(async () => root.render(page(false)));
+    expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+
+    await act(async () => root.render(page(true)));
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores the live terminal viewport when the browser tab becomes visible", async () => {
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+    await vi.waitFor(() => expect(FakeTerminal.instances).toHaveLength(1));
+    const terminal = FakeTerminal.instances[0];
+    terminal.scrollToBottom.mockClear();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    await act(async () =>
+      document.dispatchEvent(new Event("visibilitychange")),
+    );
+    expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    await act(async () =>
+      document.dispatchEvent(new Event("visibilitychange")),
+    );
+
+    expect(terminal.scrollToBottom).toHaveBeenCalledTimes(1);
+  });
+
   it("treats loopback 4401 closes as stale-token reload candidates", async () => {
     const { default: ChatPage } = await import("./ChatPage");
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -20,7 +20,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
-import { Terminal } from "@xterm/xterm";
+import { Terminal, type IDisposable } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@nous-research/ui/ui/components/typography/index";
@@ -184,6 +184,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // the moment `isActive` flips back to true (display:none → display:flex
   // collapses the host's box, so ResizeObserver never fires on return).
   const syncMetricsRef = useRef<(() => void) | null>(null);
+  // Retry the WebGL renderer install when the chat tab or browser tab
+  // becomes active again after a context loss (see the WebGL block below).
+  const webglRecoverRef = useRef<(() => void) | null>(null);
   // NS-434 follow-up: the keyboard-inset sync + reset closures from the main
   // PTY effect, exposed to the visibility-gated listener effect below.
   // ChatPage stays mounted (hidden) on every dashboard route, so the
@@ -886,19 +889,117 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // than `fontSize` suggests — users see "huge" text even at 7–9px settings.
     // The canvas/DOM renderer tracks `fontSize` faithfully; use it for narrow
     // hosts.  Wide layouts still get WebGL for crisp box-drawing.
-    const useWebgl = terminalTierWidthPx(host) >= 768;
-    if (useWebgl) {
+    //
+    // Consolidated WebGL context-loss recovery (family: #78973, #64259, #28008):
+    //
+    // 1. Immediate fallback. The WebglAddon reacts to the DOM
+    //    `webglcontextlost` event by starting a 3000ms restoration grace
+    //    timer and only fires its own `onContextLoss` if the context is not
+    //    restored by then. When the context is lost because the tab went
+    //    hidden (GPU resources reclaimed — the normal switch-away-and-back
+    //    case), it never restores, so waiting leaves the viewport blank for
+    //    ~3s after every tab return, looking like a crash. We listen for the
+    //    DOM event ourselves (capture phase, so we run before the addon's
+    //    own canvas listener starts the timer) and dispose the addon
+    //    immediately: the terminal falls back to the canvas renderer and
+    //    repaints at once. The addon's later onContextLoss (if its grace
+    //    timer still fires) is a no-op on an already-disposed addon.
+    //
+    // 2. Full repaint after fallback. Disposing alone leaves xterm's DOM
+    //    fallback unrendered until the next dirty region; force a viewport
+    //    refresh so a suspended tab or GPU reset cannot leave a black pane.
+    //
+    // 3. Reinstall on return. After a context loss the WebGL renderer is
+    //    re-attempted (via webglRecoverRef) when the chat tab or browser tab
+    //    becomes active again, so wide layouts get crisp WebGL back instead
+    //    of staying on the canvas fallback for the rest of the session.
+    let webglAddon: WebglAddon | null = null;
+    let webglContextLossDisposable: IDisposable | null = null;
+    let webglContextLostListener: (() => void) | null = null;
+    let webglRecoverRaf = 0;
+
+    const disposeWebglAddon = () => {
+      webglContextLossDisposable?.dispose();
+      webglContextLossDisposable = null;
+      if (webglContextLostListener) {
+        host.removeEventListener(
+          "webglcontextlost",
+          webglContextLostListener,
+          true,
+        );
+        webglContextLostListener = null;
+      }
+      webglAddon?.dispose();
+      webglAddon = null;
+    };
+
+    const installWebglAddon = () => {
+      if (webglAddon || terminalTierWidthPx(host) < 768) {
+        return;
+      }
+      let nextWebgl: WebglAddon | null = null;
       try {
-        const webgl = new WebglAddon();
-        webgl.onContextLoss(() => webgl.dispose());
-        term.loadAddon(webgl);
+        nextWebgl = new WebglAddon();
+        webglContextLossDisposable = nextWebgl.onContextLoss(() => {
+          if (webglAddon !== nextWebgl) {
+            return;
+          }
+          recoverFromWebglContextLoss();
+        });
+        // Capture phase: fires before the addon's own canvas listener (set
+        // up in its constructor) starts the 3000ms restoration grace timer.
+        const onWebglContextLost = () => {
+          if (webglAddon !== nextWebgl) {
+            return;
+          }
+          recoverFromWebglContextLoss();
+        };
+        host.addEventListener("webglcontextlost", onWebglContextLost, true);
+        webglContextLostListener = onWebglContextLost;
+        term.loadAddon(nextWebgl);
+        webglAddon = nextWebgl;
       } catch (err) {
+        webglContextLossDisposable?.dispose();
+        webglContextLossDisposable = null;
+        if (webglContextLostListener) {
+          host.removeEventListener(
+            "webglcontextlost",
+            webglContextLostListener,
+            true,
+          );
+          webglContextLostListener = null;
+        }
+        nextWebgl?.dispose();
         console.warn(
           "[hermes-chat] WebGL renderer unavailable; falling back to default",
           err,
         );
       }
-    }
+    };
+
+    const recoverFromWebglContextLoss = () => {
+      disposeWebglAddon();
+      try {
+        term.refresh(0, term.rows - 1);
+      } catch {
+        /* terminal teardown raced the context-loss callback */
+      }
+      // Re-attempt WebGL once the tab is interactable again (rAF is paused
+      // while hidden, so this naturally defers to the next visible frame).
+      if (host.isConnected && !webglRecoverRaf) {
+        webglRecoverRaf = requestAnimationFrame(() => {
+          webglRecoverRaf = 0;
+          installWebglAddon();
+          syncMetricsRef.current?.();
+        });
+      }
+    };
+
+    installWebglAddon();
+    webglRecoverRef.current = () => {
+      installWebglAddon();
+      syncMetricsRef.current?.();
+    };
 
     // Initial fit + resize observer.  fit.fit() reads the container's
     // current bounding box and resizes the terminal grid to match.
@@ -1478,6 +1579,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       host.removeEventListener("paste", handleBrowserPaste, true);
       host.removeEventListener("dragover", handleBrowserDragOver, true);
       host.removeEventListener("drop", handleBrowserDrop, true);
+      webglRecoverRef.current = null;
+      if (webglRecoverRaf) cancelAnimationFrame(webglRecoverRaf);
+      disposeWebglAddon();
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
       keyboardInsetSyncRef.current = null;
@@ -1575,7 +1679,15 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       raf1 = 0;
       raf2 = requestAnimationFrame(() => {
         raf2 = 0;
-        syncMetricsRef.current?.();
+        // Retry the WebGL renderer after a context loss and re-sync metrics;
+        // then re-anchor to the live tail. Inline-mode output lives in
+        // xterm's primary-buffer scrollback — after Chat was display:none,
+        // xterm can resume with the viewport parked above the live tail,
+        // presenting an entirely black pane even though the PTY is fine.
+        // Re-anchor only on the explicit inactive → active path so ordinary
+        // resizes preserve a user's intentional history position.
+        webglRecoverRef.current?.();
+        termRef.current?.scrollToBottom();
         const host = hostRef.current;
         const active = typeof document !== "undefined"
           ? document.activeElement
@@ -1645,6 +1757,42 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       window.removeEventListener("online", onResume);
     };
   }, [isActive, maybeReconnectOnPageResume]);
+
+  // Safety net for the blank-viewport-on-tab-return case: force a full
+  // viewport repaint whenever the document becomes visible again. rAF is
+  // suspended while the tab is hidden, and a hidden tab's GPU resources can
+  // be reclaimed, leaving the canvas stale or blank on return even when the
+  // WebSocket never dropped. The webglcontextlost handler above covers the
+  // WebGL path; this covers every renderer for the remaining cases. The
+  // refresh is cheap (xterm only repaints the viewport rows).
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    const onVisible = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      // Retry WebGL if a context loss left us on the canvas fallback, and
+      // re-anchor to the live tail (tab suspension can park the viewport
+      // above it, presenting a black pane even with a live PTY).
+      webglRecoverRef.current?.();
+      const term = termRef.current;
+      if (!term) return;
+      try {
+        term.refresh(0, term.rows - 1);
+      } catch {
+        /* ignore */
+      }
+      try {
+        term.scrollToBottom();
+      } catch {
+        /* ignore */
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, []);
 
   // Keep the live xterm theme in sync when the active theme's terminal
   // colors change (e.g. user switches to a custom YAML theme mid-session).

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -977,6 +977,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       }
     };
 
+    // Declared after installWebglAddon, which references it — safe because
+    // both consts initialize before any call site runs (the first call is
+    // installWebglAddon() below). The two are mutually recursive (the rAF
+    // below calls installWebglAddon), so a declaration-order swap would
+    // only move the forward reference; the comment makes it explicit.
     const recoverFromWebglContextLoss = () => {
       disposeWebglAddon();
       try {
@@ -1684,10 +1689,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         // xterm's primary-buffer scrollback — after Chat was display:none,
         // xterm can resume with the viewport parked above the live tail,
         // presenting an entirely black pane even though the PTY is fine.
-        // Re-anchor only on the explicit inactive → active path so ordinary
-        // resizes preserve a user's intentional history position.
+        // Re-anchor only on the explicit inactive → active path AND only
+        // while the user was already pinned to the bottom (stickToBottomRef,
+        // maintained by onScroll): a reader parked mid-scrollback keeps
+        // their history position across tab switches.
         webglRecoverRef.current?.();
-        termRef.current?.scrollToBottom();
+        if (stickToBottomRef.current) {
+          termRef.current?.scrollToBottom();
+        }
         const host = hostRef.current;
         const active = typeof document !== "undefined"
           ? document.activeElement
@@ -1775,7 +1784,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       }
       // Retry WebGL if a context loss left us on the canvas fallback, and
       // re-anchor to the live tail (tab suspension can park the viewport
-      // above it, presenting a black pane even with a live PTY).
+      // above it, presenting a black pane even with a live PTY). The
+      // re-anchor is gated on stick-to-bottom state so a reader parked
+      // mid-scrollback keeps their position on tab return; the repaint
+      // below is unconditional (renderer-level, not navigation).
       webglRecoverRef.current?.();
       const term = termRef.current;
       if (!term) return;
@@ -1784,10 +1796,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       } catch {
         /* ignore */
       }
-      try {
-        term.scrollToBottom();
-      } catch {
-        /* ignore */
+      if (stickToBottomRef.current) {
+        try {
+          term.scrollToBottom();
+        } catch {
+          /* ignore */
+        }
       }
     };
     document.addEventListener("visibilitychange", onVisible);


### PR DESCRIPTION
## Symptom

On the web dashboard, the Chat terminal goes **blank for ~3 seconds** every time the user switches to another application and back, giving the appearance that the terminal crashed.

## Root cause

The Chat tab renders xterm with the WebGL addon (`WebglAddon`). When the browser tab is hidden, the GPU reclaims the WebGL context and the canvas fires `webglcontextlost`. The WebglAddon's own listener responds with a **3000ms restoration grace timer** and only fires its public `onContextLoss` if the context is not restored by then — which it never is for a tab-hide eviction (the tab must be visible for the context to restore). The old handler (`webgl.onContextLoss(() => webgl.dispose())`) therefore only fell back to the canvas renderer **after the full 3s grace period**, leaving the viewport blank in between. Verified against the installed addon source (`@xterm/addon-webgl` 0.19.0): the `webglcontextlost` listener starts a `setTimeout(..., 3e3)` before firing `onContextLoss`.

## Consolidated fix (family: #78973, #64259, #28008)

1. **Immediate fallback** — listen for `webglcontextlost` on the terminal host in the **capture phase**, before the addon's own canvas listener starts the grace timer, and dispose the WebglAddon immediately. The terminal falls back to the canvas renderer and repaints at once, so content reappears the moment the user returns. The addon's later `onContextLoss` (if its timer still fires) is a guarded no-op on an already-disposed addon.
2. **Full repaint after fallback** — disposing alone leaves xterm's DOM fallback unrendered until the next dirty region; force `term.refresh(0, rows-1)` so a suspended tab or GPU reset cannot leave a black pane.
3. **Reinstall + re-anchor on return** — after a context loss, the WebGL renderer is re-attempted (`webglRecoverRef`) when the chat tab or browser tab becomes active again, so wide layouts get crisp WebGL back instead of staying on the canvas fallback for the rest of the session. On the same return paths, `scrollToBottom` re-anchors the viewport to the live tail — tab suspension can park xterm's primary-buffer viewport above the live tail, presenting a black pane even with a live PTY.

**Behavior note (scroll re-anchor):** the re-anchor is a deliberate behavior change beyond the WebGL fix — on every chat-tab/browser-tab return, the viewport is moved back to the live tail. It is **gated on the existing stick-to-bottom pin** (`stickToBottomRef`, released by `term.onScroll` when the user scrolls up into the backlog, the same pin the resume replay uses per #59591): only the tail-following default posture is re-anchored, so a reader parked mid-scrollback keeps their history position across tab switches. The renderer-level repaint on tab-visible return is unconditional (renderer-level, not navigation).

Mechanism 1 subsumes #64259/#78973's `onContextLoss`-based disposal (same dispose+repaint, triggered 3s earlier — the only fix in the family that removes the visible blank window). Mechanisms 2–3 incorporate #78973's repaint/scroll recovery and #28008's tracked-addon reinstall. If the maintainers prefer a different structure from one of the sibling PRs, happy to rebase onto it.

## Tests

Five ChatPage tests: WebGL context loss → dispose + full repaint; route return (inactive → active) → viewport re-anchored (tail posture); tab-visible return → viewport re-anchored (tail posture); route return → mid-scrollback reader's position preserved (re-anchor skipped, WebGL retry still runs); tab-visible return → mid-scrollback reader's position preserved (repaint still runs). All 11 ChatPage tests pass; full suite 280/280; `npm run build` (tsc + vite) clean.
