### PR TITLE
fix(web): readable Chat unavailable banner when the chat TUI fails to start

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16374,6 +16374,39 @@ async def console_ws(ws: WebSocket) -> None:
                 pass
 
 
+def _chat_unavailable_message(exc: BaseException) -> str:
+    """Human-readable detail for the dashboard's red 'Chat unavailable' banner.
+
+    The embedded ``/chat`` terminal is a Node-based TUI spawned by the
+    dashboard. Several startup failures reach these handlers as opaque values
+    -- most notably ``SystemExit(1)``, raised by ``_make_tui_argv`` when
+    ``node``/``npm`` are missing, whose only signal is the bare exit code.
+    Surfacing that code verbatim (``Chat unavailable: 1``) tells the user
+    nothing; translate the known cases into actionable text and fall back to
+    the exception's own message for the rest.
+    """
+    if isinstance(exc, SystemExit):
+        # _make_tui_argv prints a readable "node not found" line then
+        # sys.exit(1); that stdout never reaches this handler, so reconstruct
+        # the guidance here. Code 1 is the documented missing-Node case; any
+        # other non-zero exit gets a generic but still readable note.
+        code = getattr(exc, "code", None)
+        if code in (None, 0, 1):
+            return (
+                "the embedded chat terminal could not start because Node.js "
+                "was not found. The dashboard spawns a Node-based TUI, so "
+                "install Node.js 18+ and ensure `node` is on the dashboard "
+                "process's PATH (or point HERMES_NODE at the binary), then "
+                "reload the page."
+            )
+        return f"the chat terminal exited during startup (exit code {code})."
+    if isinstance(exc, HTTPException):
+        detail = exc.detail
+        return str(detail) if detail is not None else "unknown profile or request error."
+    text = str(exc).strip()
+    return text or f"{exc.__class__.__name__} during chat startup."
+
+
 @app.websocket("/api/pty")
 async def pty_ws(ws: WebSocket) -> None:
     peer = ws.client.host if ws.client else "?"
@@ -16460,12 +16493,13 @@ async def pty_ws(ws: WebSocket) -> None:
         argv, cwd, env = await _resolve_chat_argv_async(**resolve_kwargs)
     except HTTPException as exc:
         # Unknown/invalid profile from _resolve_profile_dir.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc.detail}\x1b[0m\r\n")
+        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {_chat_unavailable_message(exc)}\x1b[0m\r\n")
         await ws.close(code=1011)
         return
     except SystemExit as exc:
-        # _make_tui_argv calls sys.exit(1) when node/npm is missing.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+        # _make_tui_argv calls sys.exit(1) when node/npm is missing; the
+        # readable reason it prints never reaches here, so render guidance.
+        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {_chat_unavailable_message(exc)}\x1b[0m\r\n")
         await ws.close(code=1011)
         return
 
@@ -16486,11 +16520,11 @@ async def pty_ws(ws: WebSocket) -> None:
         try:
             bridge = _spawn()
         except PtyUnavailableError as exc:
-            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {_chat_unavailable_message(exc)}\x1b[0m\r\n")
             await ws.close(code=1011)
             return
         except (FileNotFoundError, OSError) as exc:
-            await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
+            await ws.send_text(f"\r\n\x1b[31mChat failed to start: {_chat_unavailable_message(exc)}\x1b[0m\r\n")
             await ws.close(code=1011)
             return
         await _legacy_pump(ws, bridge)
@@ -16502,11 +16536,11 @@ async def pty_ws(ws: WebSocket) -> None:
             attach_token, spawn=_spawn
         )
     except PtyUnavailableError as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {_chat_unavailable_message(exc)}\x1b[0m\r\n")
         await ws.close(code=1011)
         return
     except (FileNotFoundError, OSError, RegistryFull) as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {_chat_unavailable_message(exc)}\x1b[0m\r\n")
         await ws.close(code=1011)
         return
 

--- a/tests/hermes_cli/test_web_server_chat_unavailable.py
+++ b/tests/hermes_cli/test_web_server_chat_unavailable.py
@@ -1,0 +1,53 @@
+"""Readable-error rendering for the dashboard's embedded-chat spawn failures.
+
+Regression guard for the cryptic ``Chat unavailable: 1`` banner: when the
+embedded TUI fails to start (most commonly ``SystemExit(1)`` because Node.js
+is missing), the dashboard must surface actionable text, not a bare exit code.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from hermes_cli.web_server import _chat_unavailable_message
+
+
+def test_system_exit_one_is_not_a_bare_code_and_mentions_node():
+    msg = _chat_unavailable_message(SystemExit(1))
+    # The whole point: never leak the raw "1" as the message.
+    assert msg != "1"
+    assert "Node.js" in msg
+
+
+@pytest.mark.parametrize("code", [None, 0])
+def test_system_exit_none_or_zero_mentions_node(code):
+    assert "Node.js" in _chat_unavailable_message(SystemExit(code))
+
+
+def test_system_exit_other_code_reports_the_code():
+    assert "exit code 2" in _chat_unavailable_message(SystemExit(2))
+
+
+def test_http_exception_uses_its_detail():
+    exc = HTTPException(status_code=404, detail="unknown profile 'foo'")
+    assert _chat_unavailable_message(exc) == "unknown profile 'foo'"
+
+
+def test_http_exception_without_detail_falls_back():
+    msg = _chat_unavailable_message(HTTPException(status_code=500))
+    assert msg  # non-empty, readable
+    assert "1" != msg
+
+
+def test_generic_exception_falls_back_to_str():
+    class _Boom(Exception):
+        pass
+
+    assert "disk full" in _chat_unavailable_message(_Boom("disk full"))
+
+
+def test_empty_exception_uses_class_name():
+    class _Quiet(Exception):
+        def __str__(self) -> str:
+            return ""
+
+    assert "_Quiet" in _chat_unavailable_message(_Quiet())


### PR DESCRIPTION
## What

The dashboard's embedded `/chat` terminal is a Node-based TUI (`hermes --tui`). When it fails to start, the PTY-spawn handlers in `pty_ws` sent the raw exception to the browser, which rendered as an opaque banner — most famously **`Chat unavailable: 1`**.

## Why this happens

`_make_tui_argv` calls `sys.exit(1)` when `node`/`npm` aren't found. It does print a readable `"node not found — install Node.js"` line first, but that goes to the child's stdout, which isn't connected yet — so the only signal that reaches the WebSocket handler is the bare `SystemExit` code `1`. The handler did `f"Chat unavailable: {exc}"`, leaking the code verbatim. I hit this exact case after restarting the dashboard without Node on its PATH; decoding "1" required reading the source.

## The fix

Route every PTY-spawn failure through a small `_chat_unavailable_message(exc)` helper (`hermes_cli/web_server.py`) that:

- translates the known `SystemExit(1)` (and `None`/`0`) case into actionable Node.js guidance,
- reports other non-zero exit codes readably,
- uses `HTTPException.detail` for profile/request errors,
- falls back to the exception's own message (or its class name if empty) for `PtyUnavailableError`, `FileNotFoundError`/`OSError`, and `RegistryFull`.

This covers all six dynamic `Chat unavailable` / `Chat failed to start` sites in `pty_ws`, not just the one I tripped over. The static POSIX-PTY (Windows) message is already readable and left untouched.

## Testing

Added `tests/hermes_cli/test_web_server_chat_unavailable.py` asserting the invariants — `SystemExit(1)` mentions Node.js and is never the bare `"1"`, other codes are reported, HTTP detail passes through, generic/empty exceptions fall back sensibly — rather than freezing exact strings.

## Scope

One helper + six call sites in `web_server.py`, plus the test. No behavior change for the non-`SystemExit` paths beyond guaranteeing a non-empty, readable message.
