### PR TITLE
fix(peer): find a hidden canonical Bot Chat instead of colliding with it

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4203,11 +4203,13 @@ class APIServerAdapter(BasePlatformAdapter):
         offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
         source = request.query.get("source") or None
         include_children = _coerce_request_bool(request.query.get("include_children"), default=False)
+        include_hidden = _coerce_request_bool(request.query.get("include_hidden"), default=False)
         sessions = await asyncio.to_thread(db.list_sessions_rich,
             source=source,
             limit=limit,
             offset=offset,
             include_children=include_children,
+            include_hidden=include_hidden,
             order_by_last_active=True,
             # A pin means "always reachable", so a pinned conversation that has
             # aged past the recency window is back-filled rather than dropped.

--- a/hermes_cli/subcommands/peer.py
+++ b/hermes_cli/subcommands/peer.py
@@ -108,8 +108,15 @@ def _base_url(peer: dict, profile: str | None) -> str:
 
 
 def _find_bot_chat(base: str, key: str) -> str | None:
-    """The remote canonical Bot Chat's session id, or None."""
-    listing = _request(f"{base}/api/sessions?limit=200", key)
+    """The remote canonical Bot Chat's session id, or None.
+
+    ``include_hidden`` is required, not cosmetic: a canonical Bot Chat is
+    hidden once Bot Mode has taken it over, while the create path's title
+    uniqueness check spans hidden rows too. Without it this lookup misses the
+    existing chat and the caller's create fails with "Title already in use",
+    permanently, for every agent that has one.
+    """
+    listing = _request(f"{base}/api/sessions?limit=200&include_hidden=1", key)
     for session in listing.get("data") or []:
         if isinstance(session, dict) and (session.get("title") or "").strip() == BOT_CHAT_TITLE:
             return str(session.get("id") or "") or None

--- a/hermes_cli/subcommands/peer.py
+++ b/hermes_cli/subcommands/peer.py
@@ -116,6 +116,11 @@ def _find_bot_chat(base: str, key: str) -> str | None:
     existing chat and the caller's create fails with "Title already in use",
     permanently, for every agent that has one.
     """
+    # limit=200 with the API's most-recently-active ordering: an agent with
+    # more sessions than that could in principle page its Bot Chat out, but a
+    # Bot Chat that matters is by definition recently active, so it ranks in
+    # the first page. Revisit only if a fleet agent ever legitimately idles a
+    # canonical chat past 200 newer sessions.
     listing = _request(f"{base}/api/sessions?limit=200&include_hidden=1", key)
     for session in listing.get("data") or []:
         if isinstance(session, dict) and (session.get("title") or "").strip() == BOT_CHAT_TITLE:

--- a/tests/gateway/test_api_server_session_list_hidden.py
+++ b/tests/gateway/test_api_server_session_list_hidden.py
@@ -1,0 +1,83 @@
+"""``GET /api/sessions`` must be able to include hidden sessions.
+
+``list_sessions_rich`` has always taken ``include_hidden``, but the HTTP
+handler never read it from the query string, so every API client saw only the
+visible rows. That is not merely a missing filter: session creation enforces
+title uniqueness across hidden rows too (raw ``SELECT id FROM sessions WHERE
+title = ?``), so anything that looks a session up by title over HTTP and
+creates it when absent hits a permanent, unrecoverable collision once that
+title belongs to a hidden row.
+
+``hermes peer dm`` is exactly that pattern — it resolves the peer agent's
+canonical "Bot Chat" by title — and Bot Mode hides a canonical chat once it
+owns it. Observed Aug 2026 on 4 of 4 agents: every peer DM failed with
+``Title already in use by session <id>`` naming a session the listing refused
+to return.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+AUTH = {"Authorization": "Bearer sk-secret"}
+
+
+class _RecordingDB:
+    """Captures the kwargs the handler forwards to ``list_sessions_rich``."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def list_sessions_rich(self, **kwargs):
+        self.calls.append(kwargs)
+        return []
+
+
+@pytest.fixture()
+def adapter_and_db():
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-secret"}))
+    db = _RecordingDB()
+    adapter._session_db = db
+
+    return adapter, db
+
+
+def _app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/sessions", adapter._handle_list_sessions)
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_hides_hidden_rows_by_default(adapter_and_db):
+    """The default stays unchanged — hidden rows are still out of the listing."""
+    adapter, db = adapter_and_db
+
+    async with TestClient(TestServer(_app(adapter))) as cli:
+        resp = await cli.get("/api/sessions", headers=AUTH)
+
+        assert resp.status == 200
+
+    assert db.calls[0]["include_hidden"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raw", ["1", "true", "yes"])
+async def test_list_sessions_includes_hidden_when_asked(adapter_and_db, raw):
+    """``include_hidden`` must reach the DB, in the same truthy spellings the
+    sibling ``include_children`` flag already accepts."""
+    adapter, db = adapter_and_db
+
+    async with TestClient(TestServer(_app(adapter))) as cli:
+        resp = await cli.get(f"/api/sessions?include_hidden={raw}", headers=AUTH)
+
+        assert resp.status == 200
+
+    assert db.calls[0]["include_hidden"] is True

--- a/tests/hermes_cli/test_peer_cmd.py
+++ b/tests/hermes_cli/test_peer_cmd.py
@@ -2,6 +2,7 @@
 
 import json
 import threading
+import urllib.parse
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from types import SimpleNamespace
 
@@ -91,8 +92,14 @@ def test_dm_unknown_peer_and_missing_key(monkeypatch):
 
 class _FakePeer(BaseHTTPRequestHandler):
     sessions: list = []
+    # Sessions the listing withholds unless ``include_hidden`` is requested.
+    # Bot Mode hides a canonical Bot Chat once it owns it, and the real
+    # api_server's title-uniqueness check still sees those rows — so a fake
+    # that always lists everything cannot reproduce the collision.
+    hidden_sessions: list = []
     chats: list = []
     auth_seen: list = []
+    list_queries: list = []
 
     def _json(self, payload, status=200):
         body = json.dumps(payload).encode()
@@ -105,7 +112,13 @@ class _FakePeer(BaseHTTPRequestHandler):
     def do_GET(self):
         type(self).auth_seen.append(self.headers.get("Authorization", ""))
         if self.path.startswith("/api/sessions"):
-            data = [{"id": s, "title": "Bot Chat"} for s in type(self).sessions]
+            type(self).list_queries.append(self.path)
+            query = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            include_hidden = (query.get("include_hidden") or ["0"])[0] in ("1", "true", "yes")
+            listed = list(type(self).sessions)
+            if include_hidden:
+                listed += list(type(self).hidden_sessions)
+            data = [{"id": s, "title": "Bot Chat"} for s in listed]
             return self._json({"object": "list", "data": data})
         return self._json({"error": {"message": "not found"}}, 404)
 
@@ -115,6 +128,14 @@ class _FakePeer(BaseHTTPRequestHandler):
         body = json.loads(self.rfile.read(length) or b"{}")
 
         if self.path == "/api/sessions":
+            # Title uniqueness spans hidden rows, exactly like the real
+            # api_server's ``SELECT id FROM sessions WHERE title = ?``.
+            clash = list(type(self).sessions) + list(type(self).hidden_sessions)
+            if body.get("title") == "Bot Chat" and clash:
+                return self._json(
+                    {"error": {"message": f"Title already in use by session {clash[0]}"}},
+                    400,
+                )
             type(self).sessions.append("bc_1")
             # REAL api_server create shape: the row is wrapped under "session"
             # (verified live Aug 2026 — a flat fake hid a parser bug).
@@ -122,10 +143,13 @@ class _FakePeer(BaseHTTPRequestHandler):
 
         if self.path.startswith("/api/sessions/") and self.path.endswith("/chat"):
             type(self).chats.append(body.get("message"))
+            # Echo the session the turn actually ran on, like the real
+            # api_server — a hardcoded id cannot show WHICH chat was targeted.
+            target = self.path[len("/api/sessions/"):-len("/chat")]
             return self._json(
                 {
                     "object": "hermes.session.chat.completion",
-                    "session_id": "bc_1",
+                    "session_id": target,
                     "message": {"role": "assistant", "content": "reply from the other machine"},
                 }
             )
@@ -139,8 +163,10 @@ class _FakePeer(BaseHTTPRequestHandler):
 @pytest.fixture()
 def fake_peer_server():
     _FakePeer.sessions = []
+    _FakePeer.hidden_sessions = []
     _FakePeer.chats = []
     _FakePeer.auth_seen = []
+    _FakePeer.list_queries = []
     server = HTTPServer(("127.0.0.1", 0), _FakePeer)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -186,3 +212,28 @@ def test_dm_reuses_existing_bot_chat(monkeypatch, capsys, fake_peer_server):
     assert payload["reply"] == "reply from the other machine"
     # No new session was created — the existing canonical chat was reused.
     assert _FakePeer.sessions == ["bc_existing"]
+
+
+def test_dm_reuses_hidden_bot_chat(monkeypatch, capsys, fake_peer_server):
+    """A HIDDEN canonical Bot Chat must still be found and reused.
+
+    Bot Mode hides a canonical chat once it owns it, so this is the normal
+    state of any agent that has ever been DM'd — not an edge case. Because
+    title uniqueness spans hidden rows, a lookup that cannot see them leaves
+    peer dm permanently broken: the find misses, the create collides, and the
+    caller gets "Title already in use by session <id>" forever.
+    """
+    _FakePeer.hidden_sessions = ["bc_hidden"]
+    monkeypatch.setattr(peer_cmd, "_load_peers", lambda: {"spark": {"url": fake_peer_server}})
+    monkeypatch.setattr(peer_cmd, "_peer_secret", lambda name: "secret-key-123456")
+
+    rc = peer_cmd.cmd_peer(SimpleNamespace(peer_action="dm", target="spark", message="ping", json=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["reply"] == "reply from the other machine"
+    assert payload["session_id"] == "bc_hidden"
+    # Nothing was created: the hidden chat was located, not collided with.
+    assert _FakePeer.sessions == []
+    # And the lookup asked for hidden rows rather than relying on luck.
+    assert any("include_hidden=1" in q for q in _FakePeer.list_queries)

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -536,7 +536,7 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/sessions` | List sessions (paginated — `limit`, `offset`, `source`, `include_children`, `include_hidden`) |
+| `GET` | `/api/sessions` | List sessions (paginated — `limit`, `offset`, `source`, `include_children`, `include_hidden`). `include_hidden=1` also returns Bot-Mode-hidden sessions (canonical Bot Chats), which the default listing withholds |
 | `POST` | `/api/sessions` | Create an empty session |
 | `GET` | `/api/sessions/{id}` | Read session metadata |
 | `PATCH` | `/api/sessions/{id}` | Update title or `end_reason` |

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -536,7 +536,7 @@ External UIs can manage Hermes sessions over REST without standing up the dashbo
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/sessions` | List sessions (paginated — `limit`, `offset`, `source`, `include_children`) |
+| `GET` | `/api/sessions` | List sessions (paginated — `limit`, `offset`, `source`, `include_children`, `include_hidden`) |
 | `POST` | `/api/sessions` | Create an empty session |
 | `GET` | `/api/sessions/{id}` | Read session metadata |
 | `PATCH` | `/api/sessions/{id}` | Update title or `end_reason` |


### PR DESCRIPTION
## Problem

`hermes peer dm` is unusable against any agent whose canonical `Bot Chat` is hidden — which is
every agent that has ever had one, because Bot Mode hides that chat once it owns it.

```
Peer 'mini-researcher' rejected the request (HTTP 400):
Title already in use by session 20260821_194434_9793b5
```

The failure is permanent, it names a session the listing refuses to return, and the error gives
no path forward. Observed on **4 of 4 agents across two machines** — the peer transport added in
#91802 does not work in the Bot-Mode fleet it was built for.

The cause is an asymmetry between two halves of `_ensure_bot_chat`:

1. **Find** — `GET /api/sessions`, scanning for `title == "Bot Chat"`. The listing goes through
   `list_sessions_rich`, which **omits hidden rows**.
2. **Create when absent** — `POST /api/sessions`. Its uniqueness check is a bare
   `SELECT id FROM sessions WHERE title = ? AND id != ?` (`api_server.py`), which **sees hidden
   rows**.

So the find always misses, the create always collides, and there is no state a caller can reach
where the DM succeeds.

## Changes

`list_sessions_rich` has always accepted `include_hidden`; the HTTP handler simply never read it,
so no API client could ask for those rows.

- **`gateway/platforms/api_server.py`** — parse `include_hidden` from the query string and forward
  it, directly alongside the `include_children` flag the handler already parses this way.
- **`hermes_cli/subcommands/peer.py`** — `_find_bot_chat` requests it, so the lookup can see the
  chat the create path is about to collide with.
- Docs: the endpoint table enumerates its query params, so `include_hidden` joins them.

**No behaviour change for existing callers.** The flag defaults to `false`, so a listing that
doesn't pass it is identical to before — this only adds a capability that was already present one
layer down.

Fixing it on the read side rather than teaching the create path to recover from its own 400 keeps
the fix off the error-message-parsing path and leaves session creation untouched.

## Testing

- **`tests/gateway/test_api_server_session_list_hidden.py`** (new) — the flag reaches the DB in the
  truthy spellings its sibling already accepts, and the default still withholds hidden rows.
- **`tests/hermes_cli/test_peer_cmd.py`** — a hidden canonical Bot Chat must be found and reused:
  no session created, and the turn runs on the hidden chat.

  The fake peer needed the two halves of the real contract it was missing — hidden rows withheld
  from listings, title uniqueness spanning them — because without both, nothing in this file can
  reproduce the collision. Its chat reply also now echoes the session the turn ran on, matching
  the real api_server; the previous hardcoded id meant a test could not tell *which* chat was
  targeted.

- **All 5 of the new/affected tests fail when the fix is reverted**, so they pin the behaviour
  rather than merely passing alongside it.
- 188 passed across every suite touching session listing (`test_api_server.py`,
  `test_session_api.py`, `test_session_list_allowed_sources.py`, `test_sessions_pin.py`,
  `test_session_search.py`); 588 passed in `tests/test_tui_gateway_server.py`, which holds the
  fixed-signature `list_sessions_rich` stubs — that handler is a separate call site and is
  untouched. `ruff check` clean.
- One unrelated pre-existing failure, `TestHealthDetailedEndpoint::test_health_detailed_returns_ok`,
  reproduces identically on an unmodified checkout.
