### PR TITLE
fix(desktop): check ancestry before trusting the bundle skew count

### DIFF
--- a/apps/desktop/electron/bundle-skew.test.ts
+++ b/apps/desktop/electron/bundle-skew.test.ts
@@ -9,6 +9,27 @@ function gitReturning(stdout: string, code = 0): RunGit {
   return async () => ({ code, stderr: '', stdout })
 }
 
+/**
+ * A git fake that answers per subcommand, so a test can say "ancestry fails,
+ * but the count would have claimed skew" — which is the shape of #92233.
+ */
+function gitAnswering(answers: Record<string, { code?: number; stdout?: string }>): {
+  calls: string[][]
+  git: RunGit
+} {
+  const calls: string[][] = []
+
+  const git: RunGit = async args => {
+    calls.push(args)
+
+    const answer = answers[args[0]] ?? {}
+
+    return { code: answer.code ?? 0, stderr: '', stdout: answer.stdout ?? '' }
+  }
+
+  return { calls, git }
+}
+
 describe('isFallbackCommit', () => {
   it('matches the all-zero placeholder at any stamp length', () => {
     expect(isFallbackCommit('0'.repeat(40))).toBe(true)
@@ -80,6 +101,59 @@ describe('detectBundleSkew', () => {
 
   it('is quiet on unparsable rev-list output', async () => {
     expect(await detectBundleSkew(STAMP, gitReturning('fatal: bad object'), REPO)).toEqual({
+      desktopCommitsBehind: null,
+      outOfSync: false
+    })
+  })
+
+  // #92233: a ZIP-fallback update rewrites the tree into a synthetic root, so
+  // the stamp commit still RESOLVES but is unreachable from HEAD. `A..HEAD`
+  // then counts HEAD's own history instead of measuring skew, and reports a
+  // permanent 1 even though apps/desktop is byte-identical. The user gets an
+  // "App build out of date" warning that cannot go off, so no remedy clears it.
+  it('is quiet when the stamp is not an ancestor of HEAD', async () => {
+    const { git } = gitAnswering({
+      'merge-base': { code: 1 },
+      'rev-list': { stdout: '1\n' }
+    })
+
+    expect(await detectBundleSkew(STAMP, git, REPO)).toEqual({
+      desktopCommitsBehind: null,
+      outOfSync: false
+    })
+  })
+
+  it('does not consult the commit count once ancestry is refused', async () => {
+    const { calls, git } = gitAnswering({
+      'merge-base': { code: 1 },
+      'rev-list': { stdout: '9999\n' }
+    })
+
+    await detectBundleSkew(STAMP, git, REPO)
+
+    expect(calls.map(args => args[0])).toEqual(['merge-base'])
+  })
+
+  it('asks about ancestry before counting, against the same stamp', async () => {
+    const { calls, git } = gitAnswering({
+      'merge-base': { code: 0 },
+      'rev-list': { stdout: '2\n' }
+    })
+
+    const result = await detectBundleSkew(STAMP, git, REPO)
+
+    expect(calls[0]).toEqual(['merge-base', '--is-ancestor', STAMP.commit, 'HEAD'])
+    expect(calls[1]?.[0]).toBe('rev-list')
+    expect(result).toEqual({ desktopCommitsBehind: 2, outOfSync: true })
+  })
+
+  it('is quiet when git cannot answer the ancestry question at all', async () => {
+    const { git } = gitAnswering({
+      'merge-base': { code: 128 },
+      'rev-list': { stdout: '4\n' }
+    })
+
+    expect(await detectBundleSkew(STAMP, git, REPO)).toEqual({
       desktopCommitsBehind: null,
       outOfSync: false
     })

--- a/apps/desktop/electron/bundle-skew.test.ts
+++ b/apps/desktop/electron/bundle-skew.test.ts
@@ -13,7 +13,9 @@ function gitReturning(stdout: string, code = 0): RunGit {
  * A git fake that answers per subcommand, so a test can say "ancestry fails,
  * but the count would have claimed skew" — which is the shape of #92233.
  */
-function gitAnswering(answers: Record<string, { code?: number; stdout?: string }>): {
+function gitAnswering(
+  answers: Record<string, { code?: number; stderr?: string; stdout?: string }>
+): {
   calls: string[][]
   git: RunGit
 } {
@@ -24,7 +26,11 @@ function gitAnswering(answers: Record<string, { code?: number; stdout?: string }
 
     const answer = answers[args[0]] ?? {}
 
-    return { code: answer.code ?? 0, stderr: '', stdout: answer.stdout ?? '' }
+    return {
+      code: answer.code ?? 0,
+      stderr: answer.stderr ?? '',
+      stdout: answer.stdout ?? ''
+    }
   }
 
   return { calls, git }
@@ -156,6 +162,41 @@ describe('detectBundleSkew', () => {
     expect(await detectBundleSkew(STAMP, git, REPO)).toEqual({
       desktopCommitsBehind: null,
       outOfSync: false
+    })
+  })
+
+  // Shallow clones, measured against git 2.55 rather than assumed. A stamp
+  // commit from BEFORE the graft boundary is not an object the clone has, so
+  // `--is-ancestor` exits 128 with "Not a valid object name" — the same
+  // unknowable bucket as any other missing commit, not a shallow-specific
+  // failure. A stamp INSIDE the shallow graph is answered normally, so
+  // `--fetch-depth`-limited CI checkouts do not lose skew detection wholesale;
+  // only builds stamped deeper than the checkout goes do.
+  it('is quiet on a shallow clone whose stamp predates the graft boundary', async () => {
+    const { calls, git } = gitAnswering({
+      'merge-base': {
+        code: 128,
+        stderr: `fatal: Not a valid object name ${STAMP.commit}`
+      },
+      'rev-list': { stdout: '7\n' }
+    })
+
+    expect(await detectBundleSkew(STAMP, git, REPO)).toEqual({
+      desktopCommitsBehind: null,
+      outOfSync: false
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  it('still detects skew on a shallow clone when the stamp is in the graph', async () => {
+    const { git } = gitAnswering({
+      'merge-base': { code: 0 },
+      'rev-list': { stdout: '2\n' }
+    })
+
+    expect(await detectBundleSkew(STAMP, git, REPO)).toEqual({
+      desktopCommitsBehind: 2,
+      outOfSync: true
     })
   })
 })

--- a/apps/desktop/electron/bundle-skew.ts
+++ b/apps/desktop/electron/bundle-skew.ts
@@ -14,7 +14,17 @@
  * tree AFTER that stamp commit, the running renderer is provably missing
  * desktop changes the installed runtime has:
  *
+ *   git merge-base --is-ancestor <stampCommit> HEAD
  *   git rev-list --count <stampCommit>..HEAD -- apps/desktop
+ *
+ * The ancestry check has to come first, because `A..HEAD` only means "how far
+ * HEAD is ahead of A" when A is an ancestor of HEAD. When it is not, the range
+ * degenerates to HEAD's own history and the count stops describing skew at
+ * all: an update that rewrote the tree into a synthetic root leaves a stamp
+ * commit that still resolves but sits on a disconnected graph, so the count is
+ * a permanent >= 1 even when apps/desktop is byte-identical (#92233). Resolving
+ * the stamp is not enough — an unknown commit already exits non-zero below, but
+ * a merely *unrelated* one exits 0 with a positive count.
  *
  * Scoping to `apps/desktop/` keeps this quiet for the common case where the
  * repo advances with agent-only changes — a shell built before those is not
@@ -22,8 +32,9 @@
  *
  * Fail-quiet by design: no stamp (dev runs), a fallback all-zero stamp
  * (non-git build), an unknown commit (stamp predates a shallow clone's
- * history), or any git failure all report "not stale". This warning must
- * never false-positive — it tells users their install is torn.
+ * history), a stamp that is not an ancestor of HEAD, or any git failure all
+ * report "not stale". This warning must never false-positive — it tells users
+ * their install is torn.
  *
  * Pure + injectable so it is testable without booting Electron or git.
  */
@@ -63,6 +74,25 @@ export async function detectBundleSkew(
   }
 
   try {
+    // Exit 0 = ancestor, 1 = unrelated or diverged, anything else = git could
+    // not answer (unknown object, shallow clone, not a repo). Only the first
+    // makes the commit count below a statement about skew, and the other two
+    // are the same "unknowable" the branches above already answer quietly.
+    //
+    // Deliberately not falling back to comparing apps/desktop CONTENT here.
+    // Differing content would prove the build and the tree disagree, but not
+    // which way round: a user sitting on an older checkout than their build
+    // would be told "app build out of date" backwards. Ancestry is what makes
+    // this a proof that the renderer PREDATES the tree, which is the claim the
+    // warning actually makes.
+    const ancestry = await runGit(['merge-base', '--is-ancestor', stamp.commit, 'HEAD'], {
+      cwd: repoRoot
+    })
+
+    if (ancestry.code !== 0) {
+      return NOT_STALE
+    }
+
     const result = await runGit(['rev-list', '--count', `${stamp.commit}..HEAD`, '--', 'apps/desktop'], {
       cwd: repoRoot
     })


### PR DESCRIPTION
## What does this PR do?

`detectBundleSkew` (`apps/desktop/electron/bundle-skew.ts`) decides whether the packaged
renderer is behind the source tree with one command:

```
git rev-list --count <stampCommit>..HEAD -- apps/desktop
```

`A..HEAD` counts commits reachable from HEAD but not from A. That measures how far HEAD is
ahead of A **only when A is an ancestor of HEAD**. When it is not, the range degenerates into
HEAD's own history and the number stops describing skew at all.

An update that takes the ZIP fallback rewrites the tree into a synthetic root commit, which
leaves the build stamp resolvable but unreachable from HEAD. The count is then a permanent 1
even when `apps/desktop` is byte-identical, so About shows `App build out of date` forever.
The warning cannot go off in that state, so it carries no information, and neither the in-app
Update button nor a reinstall from the latest installer can clear it. #92233 reports exactly
that dead end.

### Why the existing guards miss it

The file documents itself as fail-quiet ("This warning must never false-positive, it tells
users their install is torn") and has five branches that decline to warn when the answer is
unknowable. The fourth is a near miss:

```
$ git rev-list --count deadbeef..deadbeef..HEAD -- apps/desktop ; echo $?
fatal: Invalid revision range ...
128                                  <- caught today, returns NOT_STALE
```

A stamp git cannot **resolve** exits non-zero and goes quiet. A stamp that resolves onto an
**unrelated** graph exits 0 with a positive count and walks straight through into
`outOfSync: true`. Unknown was handled, unrelated was not.

### Witness

Scratch repo reproducing the reporter's exact numbers. One commit containing
`apps/desktop/f.txt`, then `git checkout --orphan` and re-commit identical content, which is
the shape the ZIP fallback leaves behind:

```
$ git diff --quiet $STAMP HEAD -- apps/desktop ; echo $?
0                          <- content byte-identical
$ git rev-list --count $STAMP..HEAD -- apps/desktop
1                          <- exit code 0, so no existing guard fires
$ git merge-base --is-ancestor $STAMP HEAD ; echo $?
1                          <- not an ancestor
```

Count 1 with an empty content diff matches the reporter's `install-stamp.json` observation
(`rev-list` = 1, `git diff --stat` empty).

### The fix

Gate the count on `git merge-base --is-ancestor <stamp> HEAD`. An ancestor stamp keeps
today's behaviour exactly, commit count included, so **no healthy install changes at all**.
Anything else (unrelated, diverged, or git unable to answer) joins the existing quiet
branches.

### One thing deliberately left out, and its cost

I am not falling back to comparing `apps/desktop` **content** when ancestry fails, even
though the reporter's own evidence line shows it would have answered correctly here.
Differing content proves the build and the tree disagree, but not the direction: a user
sitting on an older checkout than their build would be told "app build out of date"
backwards. Ancestry is what makes this a proof that the renderer *predates* the tree, which
is the claim the warning makes.

The honest cost: after a ZIP-fallback update this warning goes quiet even if the bundle
really is stale. I think that is a strict improvement over a warning pinned on regardless of
truth, but it is a real reduction in coverage and should be a maintainer's call with the
trade visible rather than buried. Detecting skew across a rewritten history needs a
different primitive (hashing the built renderer assets against the tree, not counting
commits), which is its own change.

### Scope

#92233 proposes three fixes. This PR takes only the false-positive one and leaves the issue
open. Not taken, with reasons in the issue thread:

- **The locked `Hermes.exe` / bundle swap.** Real and the root cause of the reported state,
  but "finish the swap on next launch via a helper that outlives the app" is a new Windows
  updater lifecycle, not something to staple to a detector correction.
- **The About guidance text.** When a freshly installed release build is genuinely behind
  `main`, the warning is *correct* and only the advice is wrong. Choosing what to say
  instead is a support-policy decision across five locale files.
- **`hermes update` prompting `Restore local changes now? [Y/n]` under the desktop updater.**
  A separate bug worth its own issue, unrelated to skew detection.

## Related Issue

Refs #92233

<!-- Refs, not Fixes: this closes one of the issue's three legs. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/bundle-skew.ts`: run `git merge-base --is-ancestor <stamp> HEAD`
  before the commit count and return the existing `NOT_STALE` result on any non-zero exit.
  The module docstring now names ancestry as part of the detection and lists the
  non-ancestor stamp among the fail-quiet cases; an inline comment records why a content
  comparison is not used as a fallback.
- `apps/desktop/electron/bundle-skew.test.ts`: four regression tests plus a `gitAnswering`
  helper that answers per subcommand, so a test can say "ancestry fails, but the count would
  have claimed skew".

## How to Test

1. Reproduce the false positive without the patch:

   ```
   git init repo && cd repo
   mkdir -p apps/desktop && echo v1 > apps/desktop/f.txt
   git add -A && git commit -m c1
   STAMP=$(git rev-parse HEAD)
   git checkout --orphan synth && git add -A && git commit -m "synthetic root"
   git diff --quiet $STAMP HEAD -- apps/desktop ; echo "content identical: $?"
   git rev-list --count $STAMP..HEAD -- apps/desktop   # prints 1, exit 0
   ```

2. Regression tests, from `apps/desktop/`:

   ```
   npx vitest run electron/bundle-skew.test.ts
   ```

   13 passed (9 pre-existing, 4 new).

3. Sabotage proof. Revert only the source file, keep the tests:

   ```
   git stash push apps/desktop/electron/bundle-skew.ts
   npx vitest run electron/bundle-skew.test.ts
   git stash pop
   ```

   All four new tests fail, the headline one with the reporter's exact number:

   ```
   × is quiet when the stamp is not an ancestor of HEAD
     AssertionError: expected { desktopCommitsBehind: 1, ... } to deeply equal
                              { desktopCommitsBehind: null, ... }
   × does not consult the commit count once ancestry is refused
     AssertionError: expected [ 'rev-list' ] to deeply equal [ 'merge-base' ]
   × asks about ancestry before counting, against the same stamp
   × is quiet when git cannot answer the ancestry question at all
     AssertionError: expected { desktopCommitsBehind: 4, ... } to deeply equal
                              { desktopCommitsBehind: null, ... }

   Tests  4 failed | 9 passed (13)
   ```

   The nine existing tests pass in both directions, which is the evidence that healthy
   installs are untouched.

4. `npx tsc -p . --noEmit` and `npx eslint electron/bundle-skew.ts electron/bundle-skew.test.ts`
   both exit 0.

5. Whole electron project, same tree, before and after: identical FAIL sets. The 28 to 29
   pre-existing failures are POSIX-dependent suites that do not pass on this Windows box at
   all (`hardening.test.ts` chmod/symlink, `ssh-config`, `ssh-connection`,
   `git-worktree-ops`, `connection-registry`, `desktop-installation`,
   `windows-hermes-path`, `stage-native-deps`), and one of them is flaky across runs. Test
   count moves 1593 to 1597, which is the four new tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, this is TypeScript only; the
      equivalent (`npx vitest run --project electron`, `tsc`, `eslint`) is in How to Test
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 Pro (10.0.26200)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the module
      docstring is updated; no user-facing docs describe this detector
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the
      change is one extra `git` invocation through the existing injected `runGit`, with no
      shell, no path handling and no platform branch. The reported symptom is Windows-only
      because the ZIP fallback is what Windows falls back to, but the defect and the fix are
      platform-neutral.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The user-visible state, from the issue:

```
install-stamp.json commit: a4f16e3f...   HEAD: 4a6b3621...
git rev-list --count <stamp>..HEAD -- apps/desktop   ->  1
git diff --stat <stamp> HEAD -- apps/desktop         ->  (empty)
```

One commit "behind" with zero content difference, because the two commits are disconnected
roots. After this change that stamp is recognised as unrelated rather than ahead, and About
stops claiming the build is out of date.
