### PR TITLE
Add MindsHub as a model provider

### DIFF
--- a/plugins/model-providers/mindshub/__init__.py
+++ b/plugins/model-providers/mindshub/__init__.py
@@ -1,0 +1,78 @@
+"""MindsHub provider profile.
+
+MindsHub (https://mindshub.ai) is a fully OpenAI/Anthropic-compatible LLM
+inference gateway: one API key and one bill for Claude, GPT, Gemini, Kimi,
+DeepSeek, Qwen, GLM, Grok, and more, addressed through short catalog
+aliases (``sonnet``, ``opus``, ``kimi``, ``deepseek``, ``gpt``, ...) that
+stay stable across upstream model upgrades. See
+https://docs.mindshub.ai/inference/.
+
+This profile targets the Chat Completions endpoint
+(``https://api.mindshub.ai/v1/chat/completions``) — standard OpenAI wire
+format, so no new adapter or ``api_mode`` is needed; streaming, tool /
+function calling, and image inputs (``image_url`` parts, accepted on every
+catalog chat model) all flow through Hermes' existing chat_completions
+transport unmodified. MindsHub also exposes an OpenAI Responses endpoint
+and an Anthropic Messages endpoint (see /responses and
+/anthropic-compatibility in the docs), but neither is required here.
+
+MindsHub forwards ``reasoning_effort`` as a plain top-level Chat
+Completions field and degrades gracefully server-side — a level a model
+doesn't support is clamped or dropped rather than failing the request (see
+/models#reasoning-effort) — so this profile passes the caller's effort
+straight through with no per-model gating.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class MindsHubProfile(ProviderProfile):
+    """MindsHub gateway — top-level ``reasoning_effort`` passthrough."""
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, **context: Any
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        top_level: dict[str, Any] = {}
+        if isinstance(reasoning_config, dict) and reasoning_config.get("enabled") is not False:
+            effort = str(reasoning_config.get("effort") or "").strip().lower()
+            if effort and effort != "none":
+                top_level["reasoning_effort"] = effort
+        return {}, top_level
+
+
+mindshub = MindsHubProfile(
+    name="mindshub",
+    aliases=("mindshub-ai",),
+    display_name="MindsHub",
+    description="MindsHub — one API key for Claude, GPT, Gemini, Kimi, DeepSeek, and more",
+    signup_url="https://console.mindshub.ai",
+    env_vars=("MINDSHUB_API_KEY", "MINDSHUB_BASE_URL"),
+    base_url="https://api.mindshub.ai/v1",
+    auth_type="api_key",
+    default_aux_model="haiku",
+    # Chat-capable catalog aliases only (embed-small is an embeddings-only
+    # model and is intentionally excluded — see providers/base.py).
+    fallback_models=(
+        "sonnet",
+        "opus",
+        "fable",
+        "haiku",
+        "gpt",
+        "gpt-codex",
+        "gpt-mini",
+        "gemini",
+        "gemini-flash",
+        "kimi",
+        "deepseek",
+        "qwen",
+        "glm",
+        "grok",
+    ),
+)
+
+register_provider(mindshub)

--- a/plugins/model-providers/mindshub/__init__.py
+++ b/plugins/model-providers/mindshub/__init__.py
@@ -7,20 +7,17 @@ aliases (``sonnet``, ``opus``, ``kimi``, ``deepseek``, ``gpt``, ...) that
 stay stable across upstream model upgrades. See
 https://docs.mindshub.ai/inference/.
 
-This profile targets the Chat Completions endpoint
+This profile only relies on the Chat Completions endpoint
 (``https://api.mindshub.ai/v1/chat/completions``) — standard OpenAI wire
 format, so no new adapter or ``api_mode`` is needed; streaming, tool /
 function calling, and image inputs (``image_url`` parts, accepted on every
 catalog chat model) all flow through Hermes' existing chat_completions
-transport unmodified. MindsHub also exposes an OpenAI Responses endpoint
-and an Anthropic Messages endpoint (see /responses and
-/anthropic-compatibility in the docs), but neither is required here.
+transport unmodified.
 
 MindsHub forwards ``reasoning_effort`` as a plain top-level Chat
-Completions field and degrades gracefully server-side — a level a model
-doesn't support is clamped or dropped rather than failing the request (see
-/models#reasoning-effort) — so this profile passes the caller's effort
-straight through with no per-model gating.
+Completions field, so this profile passes the caller's effort straight
+through with no per-model gating; unsupported levels are MindsHub's own
+concern to handle, not something this integration needs to track.
 """
 
 from __future__ import annotations
@@ -54,7 +51,15 @@ mindshub = MindsHubProfile(
     env_vars=("MINDSHUB_API_KEY", "MINDSHUB_BASE_URL"),
     base_url="https://api.mindshub.ai/v1",
     auth_type="api_key",
-    default_aux_model="haiku",
+    # gpt-mini over haiku: aux calls (naming, routing, summarization) are
+    # high-frequency and latency-insensitive, so price wins over ceiling
+    # quality. gpt-mini is ~25-33% cheaper than haiku per MTok on MindsHub's
+    # current price list and is a well-exercised general-purpose pick in
+    # MindsHub's own docs; the even-cheaper gpt-nano/mindshub_air aliases
+    # are undocumented outside the price list (mindshub_air is also a
+    # shifting billing-bucket alias, not a fixed model), so they're too
+    # unproven to default to.
+    default_aux_model="gpt-mini",
     # Chat-capable catalog aliases only (embed-small is an embeddings-only
     # model and is intentionally excluded — see providers/base.py).
     fallback_models=(

--- a/plugins/model-providers/mindshub/plugin.yaml
+++ b/plugins/model-providers/mindshub/plugin.yaml
@@ -1,0 +1,5 @@
+name: mindshub-provider
+kind: model-provider
+version: 1.0.0
+description: MindsHub — unified OpenAI/Anthropic-compatible inference gateway
+author: Jorge Torres

--- a/tests/plugins/model_providers/test_mindshub_profile.py
+++ b/tests/plugins/model_providers/test_mindshub_profile.py
@@ -1,0 +1,251 @@
+"""Unit tests for the MindsHub provider profile.
+
+MindsHub (https://mindshub.ai) is a fully OpenAI-compatible inference
+gateway addressed via short catalog aliases (``sonnet``, ``kimi``,
+``deepseek``, ...). These tests pin:
+
+- registration / identity (name, aliases, base URL, auth)
+- the model catalog exposed as ``fallback_models``
+- the ``reasoning_effort`` top-level passthrough contract in
+  ``build_api_kwargs_extras``
+- end-to-end kwargs shape through the shared chat_completions transport
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def mindshub_profile():
+    """Resolve the registered MindsHub profile.
+
+    Going through ``providers.get_provider_profile`` (rather than importing
+    the plugin module directly) keeps the test honest about discovery too.
+    """
+    import model_tools  # noqa: F401  (triggers plugin discovery on import)
+    import providers
+
+    profile = providers.get_provider_profile("mindshub")
+    assert profile is not None, "mindshub provider profile must be registered"
+    return profile
+
+
+class TestMindsHubIdentity:
+    def test_name(self, mindshub_profile):
+        assert mindshub_profile.name == "mindshub"
+
+    def test_alias_resolves(self):
+        import providers
+
+        assert providers.get_provider_profile("mindshub-ai").name == "mindshub"
+
+    def test_base_url(self, mindshub_profile):
+        assert mindshub_profile.base_url == "https://api.mindshub.ai/v1"
+
+    def test_auth_type(self, mindshub_profile):
+        assert mindshub_profile.auth_type == "api_key"
+
+    def test_env_vars(self, mindshub_profile):
+        assert mindshub_profile.env_vars == ("MINDSHUB_API_KEY", "MINDSHUB_BASE_URL")
+
+    def test_no_fixed_temperature(self, mindshub_profile):
+        assert mindshub_profile.fixed_temperature is None
+
+    def test_default_aux_model_set(self, mindshub_profile):
+        assert mindshub_profile.default_aux_model == "haiku"
+
+    def test_signup_url(self, mindshub_profile):
+        assert mindshub_profile.signup_url == "https://console.mindshub.ai"
+
+
+class TestMindsHubCatalog:
+    def test_fallback_models_are_catalog_aliases(self, mindshub_profile):
+        expected = {
+            "sonnet",
+            "opus",
+            "fable",
+            "haiku",
+            "gpt",
+            "gpt-codex",
+            "gpt-mini",
+            "gemini",
+            "gemini-flash",
+            "kimi",
+            "deepseek",
+            "qwen",
+            "glm",
+            "grok",
+        }
+        assert set(mindshub_profile.fallback_models) == expected
+
+    def test_embedding_only_alias_excluded(self, mindshub_profile):
+        """embed-small is embeddings-only and must never appear in a chat
+        model picker fallback list."""
+        assert "embed-small" not in mindshub_profile.fallback_models
+
+    def test_raw_provider_model_ids_not_used(self, mindshub_profile):
+        """MindsHub only accepts catalog aliases on chat completions — raw
+        upstream model IDs like claude-sonnet-5 404. Guard against ever
+        listing one by accident."""
+        for model in mindshub_profile.fallback_models:
+            assert "claude-" not in model
+            assert "gpt-5" not in model
+
+
+class TestMindsHubAuxModel:
+    def test_consumer_api_returns_haiku(self):
+        from agent.auxiliary_client import _get_aux_model_for_provider
+
+        assert _get_aux_model_for_provider("mindshub") == "haiku"
+
+    def test_consumer_api_returns_non_empty(self):
+        from agent.auxiliary_client import _get_aux_model_for_provider
+
+        assert _get_aux_model_for_provider("mindshub") != ""
+
+
+class TestMindsHubReasoningEffortPassthrough:
+    """``build_api_kwargs_extras`` forwards ``reasoning_effort`` verbatim.
+
+    MindsHub's own API applies the graceful degrade documented in
+    /models#reasoning-effort (clamp or drop server-side, never a hard
+    failure), so the profile does no per-model gating — it just forwards
+    whatever effort level the caller has.
+    """
+
+    def test_no_reasoning_config_emits_nothing(self, mindshub_profile):
+        eb, tl = mindshub_profile.build_api_kwargs_extras(reasoning_config=None)
+        assert eb == {}
+        assert tl == {}
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high", "max", "xhigh"])
+    def test_effort_passes_through_top_level(self, mindshub_profile, effort):
+        eb, tl = mindshub_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort}
+        )
+        assert tl == {"reasoning_effort": effort}
+        assert eb == {}
+
+    def test_effort_is_lowercased(self, mindshub_profile):
+        _, tl = mindshub_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "  HIGH  "}
+        )
+        assert tl == {"reasoning_effort": "high"}
+
+    def test_explicitly_disabled_emits_nothing(self, mindshub_profile):
+        eb, tl = mindshub_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "high"}
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_none_effort_omitted(self, mindshub_profile):
+        _, tl = mindshub_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "none"}
+        )
+        assert tl == {}
+
+    def test_empty_effort_omitted(self, mindshub_profile):
+        _, tl = mindshub_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": ""}
+        )
+        assert tl == {}
+
+    def test_effort_without_explicit_enabled_key_passes_through(self, mindshub_profile):
+        """``enabled`` defaults to True when absent."""
+        _, tl = mindshub_profile.build_api_kwargs_extras(
+            reasoning_config={"effort": "medium"}
+        )
+        assert tl == {"reasoning_effort": "medium"}
+
+
+class TestMindsHubFullKwargsIntegration:
+    """End-to-end: the transport produces MindsHub's plain Chat Completions
+    wire shape — a top-level ``reasoning_effort`` string, no extra_body."""
+
+    def test_full_kwargs_include_reasoning_effort(self, mindshub_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="sonnet",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=mindshub_profile,
+            reasoning_config={"enabled": True, "effort": "high"},
+            base_url="https://api.mindshub.ai/v1",
+            provider_name="mindshub",
+        )
+        assert kwargs["model"] == "sonnet"
+        assert kwargs["reasoning_effort"] == "high"
+        assert "extra_body" not in kwargs
+
+    def test_full_kwargs_omit_reasoning_effort_when_disabled(self, mindshub_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="sonnet",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=mindshub_profile,
+            reasoning_config={"enabled": False},
+            base_url="https://api.mindshub.ai/v1",
+            provider_name="mindshub",
+        )
+        assert "reasoning_effort" not in kwargs
+
+    def test_tools_pass_through_unmodified(self, mindshub_profile):
+        """MindsHub's chat/completions is standard OpenAI tool-calling
+        shape — tools should pass through the transport untouched."""
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "description": "Read a file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"],
+                    },
+                },
+            }
+        ]
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="kimi",
+            messages=[{"role": "user", "content": "read foo.txt"}],
+            tools=tools,
+            provider_profile=mindshub_profile,
+            base_url="https://api.mindshub.ai/v1",
+            provider_name="mindshub",
+        )
+        assert kwargs["tools"] == tools
+
+    def test_image_content_parts_pass_through_unmodified(self, mindshub_profile):
+        """Images are accepted on every MindsHub chat model as standard
+        OpenAI ``image_url`` content parts — no per-provider conversion."""
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What's in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,iVBOR..."},
+                    },
+                ],
+            }
+        ]
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="sonnet",
+            messages=messages,
+            tools=None,
+            provider_profile=mindshub_profile,
+            base_url="https://api.mindshub.ai/v1",
+            provider_name="mindshub",
+        )
+        assert kwargs["messages"] == messages

--- a/tests/plugins/model_providers/test_mindshub_profile.py
+++ b/tests/plugins/model_providers/test_mindshub_profile.py
@@ -53,7 +53,7 @@ class TestMindsHubIdentity:
         assert mindshub_profile.fixed_temperature is None
 
     def test_default_aux_model_set(self, mindshub_profile):
-        assert mindshub_profile.default_aux_model == "haiku"
+        assert mindshub_profile.default_aux_model == "gpt-mini"
 
     def test_signup_url(self, mindshub_profile):
         assert mindshub_profile.signup_url == "https://console.mindshub.ai"
@@ -94,10 +94,10 @@ class TestMindsHubCatalog:
 
 
 class TestMindsHubAuxModel:
-    def test_consumer_api_returns_haiku(self):
+    def test_consumer_api_returns_gpt_mini(self):
         from agent.auxiliary_client import _get_aux_model_for_provider
 
-        assert _get_aux_model_for_provider("mindshub") == "haiku"
+        assert _get_aux_model_for_provider("mindshub") == "gpt-mini"
 
     def test_consumer_api_returns_non_empty(self):
         from agent.auxiliary_client import _get_aux_model_for_provider

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -150,6 +150,26 @@ class TestOpenRouterProfile:
         assert tl == {"verbosity": "high"}
 
 
+class TestMindsHubProfile:
+    def test_discovery(self):
+        p = get_provider_profile("mindshub")
+        assert p is not None
+        assert p.name == "mindshub"
+
+    def test_base_url(self):
+        p = get_provider_profile("mindshub")
+        assert p.base_url == "https://api.mindshub.ai/v1"
+
+    def test_no_special_temperature(self):
+        p = get_provider_profile("mindshub")
+        assert p.fixed_temperature is None
+
+    def test_reasoning_effort_passthrough(self):
+        p = get_provider_profile("mindshub")
+        _, tl = p.build_api_kwargs_extras(reasoning_config={"enabled": True, "effort": "high"})
+        assert tl == {"reasoning_effort": "high"}
+
+
 class TestNousProfile:
     def test_tags(self):
         from agent.portal_tags import nous_portal_tags

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -120,6 +120,7 @@ Good defaults:
 | **Arcee AI** | Trinity models | Set `ARCEEAI_API_KEY` |
 | **GMI Cloud** | Multi-model direct API | Set `GMI_API_KEY` |
 | **Actual Computer** | Your own hardware as a private inference cluster — hosted relay or local daemon | Set `ACTUAL_API_KEY` (relay) or `ACTUAL_BASE_URL=http://127.0.0.1:8080` (local, no key) |
+| **MindsHub** | One API key for Claude, GPT, Gemini, Kimi, DeepSeek, and more | Set `MINDSHUB_API_KEY` |
 | **MiniMax (OAuth)** | MiniMax frontier model via browser OAuth — no API key needed (model name in `hermes_cli/models.py` may change between releases) | `hermes model` → MiniMax (OAuth) |
 | **MiniMax** | International MiniMax endpoint | Set `MINIMAX_API_KEY` |
 | **MiniMax China** | China-region MiniMax endpoint | Set `MINIMAX_CN_API_KEY` |

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -29,6 +29,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
 | **Actual Computer** | `ACTUAL_API_KEY` in `~/.hermes/.env` for the hosted relay, or `ACTUAL_BASE_URL=http://127.0.0.1:8080` for the local daemon — no key needed on loopback (provider: `actual`; aliases: `actual-computer`, `actualcomputer`, `aci`) |
+| **MindsHub** | `MINDSHUB_API_KEY` in `~/.hermes/.env` (provider: `mindshub`; alias: `mindshub-ai`; one key for Claude, GPT, Gemini, Kimi, DeepSeek, and more) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
@@ -297,6 +298,10 @@ hermes chat --provider meta-ai --model muse-spark-1.2
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# MindsHub — one API key for Claude, GPT, Gemini, Kimi, DeepSeek, and more
+hermes chat --provider mindshub --model sonnet
+# Requires: MINDSHUB_API_KEY in ~/.hermes/.env
 ```
 
 Fireworks uses its native slash-form catalog IDs, such as `accounts/fireworks/models/kimi-k2p6`. Run `hermes model`, choose **Fireworks AI**, and select from the live catalog or enter another Fireworks model ID. The default endpoint is `https://api.fireworks.ai/inference/v1`; configure a different endpoint through `model.base_url` in `config.yaml`, not `.env`.
@@ -308,7 +313,7 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `META_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `META_BASE_URL`, `TOKENHUB_BASE_URL`, or `MINDSHUB_BASE_URL` environment variables.
 
 :::note Meta contributor tier
 `muse-spark-1.2-contributor` is Meta's discounted tier — Meta may train on your prompts and completions, so [interactive model selection asks for confirmation](../user-guide/configuring-models.md) before using it. Use `muse-spark-1.2` (standard pricing, no training) for confidential work.
@@ -586,6 +591,33 @@ Notes:
 - Reasoning effort is clamped to Actual's supported range (`none/low/medium/high/max`) — a global `xhigh`/`ultra` setting will not 400 requests.
 - Small local models: Hermes' full default toolset plus the system prompt can exceed a 32k context window, producing an empty-stream error from llama.cpp-family servers. Restrict the toolset (`-t file,web`) or load the model with a larger context. The optional `actual-setup` skill (`hermes skills install official/devops/actual-setup`) covers setup and troubleshooting in detail.
 - Aliases: `actual-computer`, `actualcomputer`, `aci`.
+
+### MindsHub
+
+[MindsHub](https://mindshub.ai) is a fully OpenAI/Anthropic-compatible inference gateway: one API key and one bill for every model in its catalog — Claude, GPT, Gemini, Kimi, DeepSeek, Qwen, GLM, Grok, and more — addressed through short, stable aliases (`sonnet`, `opus`, `kimi`, `deepseek`, `gpt`, `gpt-codex`, ...) instead of raw provider model IDs. See the [MindsHub docs](https://docs.mindshub.ai/inference/) for the full catalog and pricing.
+
+```bash
+# MindsHub
+hermes chat --provider mindshub --model sonnet
+# Requires: MINDSHUB_API_KEY in ~/.hermes/.env
+
+# Switch models by alias — no provider change needed
+hermes chat --provider mindshub --model kimi
+hermes chat --provider mindshub --model deepseek
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "mindshub"
+  default: "sonnet"
+```
+
+Get your API key from the [MindsHub console](https://console.mindshub.ai). The base URL can be overridden with `MINDSHUB_BASE_URL` (default: `https://api.mindshub.ai/v1`).
+
+:::tip Use catalog aliases, not raw model IDs
+MindsHub's OpenAI-compatible endpoints only accept catalog aliases in the `model` field (`sonnet`, not `claude-sonnet-5`) — a raw upstream provider model ID returns `404 model_not_found`. Run `hermes model` or `curl https://api.mindshub.ai/v1/models -H "Authorization: Bearer $MINDSHUB_API_KEY"` to see the current alias list; the catalog changes over time.
+:::
 
 ### StepFun
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -47,6 +47,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `GMI_BASE_URL` | Override GMI Cloud base URL (default: `https://api.gmi-serving.com/v1`) |
 | `ACTUAL_API_KEY` | Actual Computer inference key (`ac_...`, [actual.inc/user/keys](https://actual.inc/user/keys)). Not needed for the local daemon. |
 | `ACTUAL_BASE_URL` | Override Actual Computer base URL (default: `https://api.actual.inc/v1`). Set to `http://127.0.0.1:8080` for the local offline daemon — loopback hosts need no API key. |
+| `MINDSHUB_API_KEY` | MindsHub API key — one key for Claude, GPT, Gemini, Kimi, DeepSeek, and more ([console.mindshub.ai](https://console.mindshub.ai)) |
+| `MINDSHUB_BASE_URL` | Override MindsHub base URL (default: `https://api.mindshub.ai/v1`) |
 | `MINIMAX_API_KEY` | MiniMax API key — global endpoint ([minimax.io](https://www.minimax.io)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |
 | `MINIMAX_BASE_URL` | Override MiniMax base URL (default: `https://api.minimax.io/anthropic` — Hermes uses MiniMax's Anthropic Messages-compatible endpoint). **Not used by `minimax-oauth`**. |
 | `MINIMAX_CN_API_KEY` | MiniMax API key — China endpoint ([minimaxi.com](https://www.minimaxi.com)). **Not used by `minimax-oauth`** (OAuth path uses browser login instead). |


### PR DESCRIPTION
## What is MindsHub

[MindsHub](https://mindshub.ai) is a fully OpenAI/Anthropic-compatible LLM inference gateway: one API key and one bill for every model in its catalog — Claude, GPT, Gemini, Kimi, DeepSeek, Qwen, GLM, Grok, and more — addressed through short, stable catalog aliases (`sonnet`, `opus`, `kimi`, `deepseek`, `gpt`, `gpt-codex`, ...) instead of raw upstream provider model IDs. Docs: https://docs.mindshub.ai/inference/.

Its primary inference surface (`https://api.mindshub.ai/v1/chat/completions`) is standard OpenAI Chat Completions wire format, so this lands through the documented "fast path" for OpenAI-compatible providers (`plugins/model-providers/<name>/` + `ProviderProfile`) rather than a new adapter or `api_mode` — streaming, tool/function calling, and image inputs all flow through the existing `chat_completions` transport unmodified.

## What was added

- **Provider plugin** — `plugins/model-providers/mindshub/__init__.py` + `plugin.yaml`
  - `base_url = https://api.mindshub.ai/v1`, `auth_type = api_key`, env vars `MINDSHUB_API_KEY` / `MINDSHUB_BASE_URL`
  - Model catalog (`fallback_models`) pulled from MindsHub's published alias list (`sonnet`, `opus`, `fable`, `haiku`, `gpt`, `gpt-codex`, `gpt-mini`, `gemini`, `gemini-flash`, `kimi`, `deepseek`, `qwen`, `glm`, `grok`) — embeddings-only aliases intentionally excluded
  - `default_aux_model = gpt-mini` for cheap auxiliary tasks (compression, vision, summarization) — switched from an earlier `haiku` default per review feedback: on MindsHub's current price list `gpt-mini` runs ~25-33% cheaper than `haiku` per MTok and is a documented, well-exercised general-purpose pick elsewhere in MindsHub's own docs, which matters given aux calls are high-frequency and cost-sensitive; the even-cheaper `gpt-nano`/`mindshub_air` aliases have no track record outside the raw price list (and `mindshub_air` is a shifting billing-bucket alias rather than a fixed model), so they're too unproven to default to
  - Overrides `build_api_kwargs_extras()` to forward `reasoning_effort` as a plain top-level Chat Completions field, with no per-model gating — the profile docstring was trimmed to just this + the chat_completions wire format, dropping factual claims about MindsHub's other endpoints and clamping specifics that could rot silently as the vendor changes
  - Registering the profile is the only change needed — credential resolution (`hermes_cli/auth.py`), the `--provider` flag, the `hermes model` picker, `hermes doctor` health checks, and runtime resolution all auto-wire from the plugin registry with zero other repo edits, per `website/docs/developer-guide/adding-providers.md`
- **Docs** — `website/docs/integrations/providers.md` (new "MindsHub" section + table/CLI-example entries), `website/docs/reference/environment-variables.md`, `website/docs/getting-started/quickstart.md`
- **Tests**
  - `tests/plugins/model_providers/test_mindshub_profile.py` — registration/identity, catalog contents, aux-model wiring, `reasoning_effort` passthrough contract, and an end-to-end check through `ChatCompletionsTransport` (tools + image content parts pass through unmodified)
  - `tests/providers/test_provider_profiles.py` — registry/alias resolution entries alongside the existing per-provider test classes

## How it was tested

- `ruff check .` — clean, no new issues
- `scripts/check-windows-footguns.py` on the new/changed files — clean
- `tests/providers/` + `tests/plugins/` (1,452 tests) — all pass
- The provider-wiring suite `adding-providers.md` recommends for new providers (`test_runtime_provider_resolution.py`, `test_cli_provider_resolution.py`, `test_setup_model_provider.py`, `test_provider_parity.py` — 254 tests) — all pass
- `tests/test_packaging_metadata.py` — confirms `plugin.yaml` is already covered by the existing `**/plugin.yaml` package-data glob, no `pyproject.toml` change needed
- Full suite via `scripts/run_tests.sh tests/` (the repo's canonical per-file-isolated runner) — the only failures are pre-existing and unrelated to this change (confirmed identical on the parent commit before this diff): OAuth/credential-file tests in `test_anthropic_adapter.py` that pick up real local credential files, an AWS-credentials-on-this-machine artifact in `test_resolve_provider_openrouter_pool.py`, macOS `/tmp` vs `/private/tmp` symlink mocking in `test_file_tools.py`, and a few gateway/WSL/browser-detection tests tied to this local machine's environment
- Manually verified the fast-path auto-wiring end-to-end: `providers.get_provider_profile("mindshub")` and the `mindshub-ai` alias resolve correctly, `hermes_cli.auth.PROVIDER_REGISTRY["mindshub"]` is populated automatically, and `hermes_cli.models.CANONICAL_PROVIDERS` picks up the provider with zero code changes beyond the plugin directory
