### PR TITLE
feat(i18n): localize gateway busy-input acknowledgements

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -2,7 +2,8 @@
 
 Scope (thin slice, by design): only the highest-impact static strings shown
 to the user by Hermes itself -- approval prompts, a handful of gateway slash
-command replies, restart-drain notices.  Agent-generated output, log lines,
+command replies, restart-drain notices, and gateway busy-input acknowledgements
+(steer / queue / interrupt).  Agent-generated output, log lines,
 error tracebacks, tool outputs, and slash-command descriptions all stay in
 English.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10499,48 +10499,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if start_ts:
                     elapsed_min = int((now - start_ts) / 60)
                     if elapsed_min > 0:
-                        status_parts.append(f"{elapsed_min} min elapsed")
+                        status_parts.append(
+                            t("gateway.busy_ack.status_elapsed", minutes=elapsed_min)
+                        )
                 if max_iter:
-                    status_parts.append(f"iteration {iteration}/{max_iter}")
+                    status_parts.append(
+                        t(
+                            "gateway.busy_ack.status_iteration",
+                            iteration=iteration,
+                            max_iter=max_iter,
+                        )
+                    )
                 if current_tool:
-                    status_parts.append(f"running: {current_tool}")
+                    status_parts.append(
+                        t("gateway.busy_ack.status_running", tool=current_tool)
+                    )
             except Exception:
                 pass
 
         status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
         if is_steer_mode:
-            message = (
-                f"⏩ Steered into current run{status_detail}. "
-                f"Your message arrives after the next tool call."
-            )
+            message = t("gateway.busy_ack.steer", status_detail=status_detail)
         elif is_redirect_mode:
-            message = (
-                f"↪ Redirected current run{status_detail}. "
-                f"I'll adjust using your correction."
-            )
+            message = t("gateway.busy_ack.redirect", status_detail=status_detail)
         elif is_queue_mode and demoted_for_subagents:
             # #30170 — explain the demotion so the user knows their
             # follow-up didn't accidentally kill the subagent and
             # discovers `/stop` as the explicit escape hatch.
-            message = (
-                f"⏳ Subagent working{status_detail} — your message is queued for "
-                f"when it finishes (use /stop to cancel everything)."
-            )
+            message = t("gateway.busy_ack.queue_subagent", status_detail=status_detail)
         elif is_queue_mode and demoted_for_compression:
-            message = (
-                f"⏳ Compressing context{status_detail} — your message is queued for "
-                f"when it finishes (use /stop to cancel everything)."
+            message = t(
+                "gateway.busy_ack.queue_compression", status_detail=status_detail
             )
         elif is_queue_mode:
-            message = (
-                f"⏳ Queued for the next turn{status_detail}. "
-                f"I'll respond once the current task finishes."
-            )
+            message = t("gateway.busy_ack.queue", status_detail=status_detail)
         else:
-            message = (
-                f"⚡ Interrupting current task{status_detail}. "
-                f"I'll respond to your message shortly."
-            )
+            message = t("gateway.busy_ack.interrupt", status_detail=status_detail)
 
         # First-touch onboarding: the very first time a user sends a message
         # while the agent is busy, append a one-time hint explaining the

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ Kon nie config.yaml lees nie: {error}"
   config_save_failed: "⚠️ Kon nie konfigurasie stoor nie: {error}"
 
+  busy_ack:
+    steer: "⏩ In die huidige lopie ingevoeg{status_detail}. Jou boodskap kom ná die volgende nutoproep."
+    redirect: "↪ Huidige lopie herlei{status_detail}. Ek pas aan volgens jou korreksie."
+    queue_subagent: "⏳ Subagent werk{status_detail} — jou boodskap wag tot dit klaar is (gebruik /stop om alles te kanselleer)."
+    queue_compression: "⏳ Konteks word saamgepers{status_detail} — jou boodskap wag tot dit klaar is (gebruik /stop om alles te kanselleer)."
+    queue: "⏳ In die ry vir die volgende beurt{status_detail}. Ek antwoord wanneer die huidige taak klaar is."
+    interrupt: "⚡ Onderbreek die huidige taak{status_detail}. Ek antwoord binnekort."
+    status_elapsed: "{minutes} min verloop"
+    status_iteration: "iterasie {iteration}/{max_iter}"
+    status_running: "besig: {tool}"
+
   model:
     error_prefix:           "Fout: {error}"
     switched:               "Model verander na `{model}`"

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -50,6 +50,17 @@ gateway:
   config_read_failed: "⚠️ تعذّر قراءة config.yaml: {error}"
   config_save_failed: "⚠️ تعذّر حفظ الإعدادات: {error}"
 
+  busy_ack:
+    steer: "⏩ أُدرج في التشغيل الحالي{status_detail}. تصل رسالتك بعد استدعاء الأداة التالي."
+    redirect: "↪ أُعيد توجيه التشغيل الحالي{status_detail}. سأعدّل وفق تصحيحك."
+    queue_subagent: "⏳ الوكيل الفرعي يعمل{status_detail} — رسالتك في الانتظار حتى ينتهي (استخدم /stop لإلغاء الكل)."
+    queue_compression: "⏳ جارٍ ضغط السياق{status_detail} — رسالتك في الانتظار حتى ينتهي (استخدم /stop لإلغاء الكل)."
+    queue: "⏳ وُضعت في الانتظار للجولة التالية{status_detail}. سأرد عندما تنتهي المهمة الحالية."
+    interrupt: "⚡ أقاطع المهمة الحالية{status_detail}. سأرد قريبًا."
+    status_elapsed: "مرّت {minutes} دقائق"
+    status_iteration: "تكرار {iteration}/{max_iter}"
+    status_running: "يعمل: {tool}"
+
   model:
     error_prefix:           "خطأ: {error}"
     switched:               "تم التبديل إلى النموذج `{model}`"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ config.yaml konnte nicht gelesen werden: {error}"
   config_save_failed: "⚠️ Konfiguration konnte nicht gespeichert werden: {error}"
 
+  busy_ack:
+    steer: "⏩ In den laufenden Durchlauf eingefügt{status_detail}. Deine Nachricht kommt nach dem nächsten Tool-Aufruf."
+    redirect: "↪ Laufenden Durchlauf umgeleitet{status_detail}. Ich passe anhand deiner Korrektur an."
+    queue_subagent: "⏳ Unteragent arbeitet{status_detail} — deine Nachricht wartet bis zum Ende (mit /stop alles abbrechen)."
+    queue_compression: "⏳ Kontext wird komprimiert{status_detail} — deine Nachricht wartet bis zum Ende (mit /stop alles abbrechen)."
+    queue: "⏳ Für den nächsten Zug vorgemerkt{status_detail}. Ich antworte, wenn die aktuelle Aufgabe fertig ist."
+    interrupt: "⚡ Unterbreche die aktuelle Aufgabe{status_detail}. Ich antworte gleich."
+    status_elapsed: "{minutes} Min. vergangen"
+    status_iteration: "Iteration {iteration}/{max_iter}"
+    status_running: "läuft: {tool}"
+
   model:
     error_prefix:           "Fehler: {error}"
     switched:               "Modell gewechselt zu `{model}`"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -1,9 +1,10 @@
 # Hermes static-message catalog -- English (baseline / source of truth)
 #
-# Only user-facing static messages from the CLI approval prompt and a handful
-# of gateway slash-command replies live here.  Agent-generated output, log
-# lines, error tracebacks, tool outputs, and slash-command descriptions stay
-# in English and are NOT translated -- see agent/i18n.py for scope rationale.
+# Only user-facing static messages from the CLI approval prompt, a handful
+# of gateway slash-command replies, and gateway busy-input acknowledgements
+# live here.  Agent-generated output, log lines, error tracebacks, tool
+# outputs, and slash-command descriptions stay in English and are NOT
+# translated -- see agent/i18n.py for scope rationale.
 #
 # Keys are dotted paths; nesting below is purely for readability.  Values may
 # contain {placeholder} tokens for str.format substitution.  When adding a
@@ -37,6 +38,18 @@ gateway:
   no_active_goal:   "No active goal."
   config_read_failed: "⚠️ Could not read config.yaml: {error}"
   config_save_failed: "⚠️ Could not save config: {error}"
+
+  # Busy-input acknowledgements — shown when a user messages a running turn.
+  busy_ack:
+    steer: "⏩ Steered into current run{status_detail}. Your message arrives after the next tool call."
+    redirect: "↪ Redirected current run{status_detail}. I'll adjust using your correction."
+    queue_subagent: "⏳ Subagent working{status_detail} — your message is queued for when it finishes (use /stop to cancel everything)."
+    queue_compression: "⏳ Compressing context{status_detail} — your message is queued for when it finishes (use /stop to cancel everything)."
+    queue: "⏳ Queued for the next turn{status_detail}. I'll respond once the current task finishes."
+    interrupt: "⚡ Interrupting current task{status_detail}. I'll respond to your message shortly."
+    status_elapsed: "{minutes} min elapsed"
+    status_iteration: "iteration {iteration}/{max_iter}"
+    status_running: "running: {tool}"
 
   # /model command output -- shown after a model switch or when listing models.
   # Provider names, model IDs, capability strings, and cost figures are NOT

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ No se pudo leer config.yaml: {error}"
   config_save_failed: "⚠️ No se pudo guardar la configuración: {error}"
 
+  busy_ack:
+    steer: "⏩ Insertado en la ejecución actual{status_detail}. Tu mensaje llega después de la siguiente llamada a herramienta."
+    redirect: "↪ Ejecución actual redirigida{status_detail}. Ajustaré con tu corrección."
+    queue_subagent: "⏳ Subagente trabajando{status_detail} — tu mensaje queda en cola hasta que termine (usa /stop para cancelarlo todo)."
+    queue_compression: "⏳ Comprimiendo contexto{status_detail} — tu mensaje queda en cola hasta que termine (usa /stop para cancelarlo todo)."
+    queue: "⏳ En cola para el siguiente turno{status_detail}. Responderé cuando termine la tarea actual."
+    interrupt: "⚡ Interrumpiendo la tarea actual{status_detail}. Responderé enseguida."
+    status_elapsed: "{minutes} min transcurridos"
+    status_iteration: "iteración {iteration}/{max_iter}"
+    status_running: "ejecutando: {tool}"
+
   model:
     error_prefix:           "Error: {error}"
     switched:               "Modelo cambiado a `{model}`"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ Impossible de lire config.yaml : {error}"
   config_save_failed: "⚠️ Impossible de sauvegarder la configuration : {error}"
 
+  busy_ack:
+    steer: "⏩ Inséré dans l'exécution en cours{status_detail}. Votre message arrive après le prochain appel d'outil."
+    redirect: "↪ Exécution en cours redirigée{status_detail}. J'ajuste avec votre correction."
+    queue_subagent: "⏳ Sous-agent au travail{status_detail} — votre message est mis en file jusqu'à la fin (utilisez /stop pour tout annuler)."
+    queue_compression: "⏳ Compression du contexte{status_detail} — votre message est mis en file jusqu'à la fin (utilisez /stop pour tout annuler)."
+    queue: "⏳ Mis en file pour le prochain tour{status_detail}. Je répondrai une fois la tâche actuelle terminée."
+    interrupt: "⚡ Interruption de la tâche actuelle{status_detail}. Je répondrai sous peu."
+    status_elapsed: "{minutes} min écoulées"
+    status_iteration: "itération {iteration}/{max_iter}"
+    status_running: "en cours : {tool}"
+
   model:
     error_prefix:           "Erreur : {error}"
     switched:               "Modèle changé pour `{model}`"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -31,6 +31,17 @@ gateway:
   config_read_failed: "⚠️ Níorbh fhéidir config.yaml a léamh: {error}"
   config_save_failed: "⚠️ Níorbh fhéidir an chumraíocht a shábháil: {error}"
 
+  busy_ack:
+    steer: "⏩ Curtha isteach sa rith reatha{status_detail}. Tagann do theachtaireacht i ndiaidh an chéad ghlao uirlise eile."
+    redirect: "↪ Rith reatha atreoraithe{status_detail}. Déanfaidh mé coigeartú de réir do cheartúcháin."
+    queue_subagent: "⏳ Fo-ghníomhaire ag obair{status_detail} — tá do theachtaireacht i scuaine go dtí go gcríochnaíonn sé (úsáid /stop chun gach rud a chealú)."
+    queue_compression: "⏳ Comhthéacs á chomhbhrú{status_detail} — tá do theachtaireacht i scuaine go dtí go gcríochnaíonn sé (úsáid /stop chun gach rud a chealú)."
+    queue: "⏳ Curtha i scuaine don chéad bhabhta eile{status_detail}. Freagróidh mé nuair a chríochnaíonn an tasc reatha."
+    interrupt: "⚡ Ag cur isteach ar an tasc reatha{status_detail}. Freagróidh mé go luath."
+    status_elapsed: "{minutes} nóim imithe"
+    status_iteration: "aiteráil {iteration}/{max_iter}"
+    status_running: "ar siúl: {tool}"
+
   model:
     error_prefix:           "Earráid: {error}"
     switched:               "Athraíodh an tsamhail go `{model}`"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ Nem sikerült olvasni a config.yaml fájlt: {error}"
   config_save_failed: "⚠️ Nem sikerült menteni a konfigurációt: {error}"
 
+  busy_ack:
+    steer: "⏩ Beillesztve a jelenlegi futásba{status_detail}. Az üzeneted a következő eszközhívás után érkezik."
+    redirect: "↪ Jelenlegi futás átirányítva{status_detail}. A javításod alapján igazítom."
+    queue_subagent: "⏳ Az alügynök dolgozik{status_detail} — az üzeneted a végéig várakozik (mindent töröl: /stop)."
+    queue_compression: "⏳ Kontextus tömörítése{status_detail} — az üzeneted a végéig várakozik (mindent töröl: /stop)."
+    queue: "⏳ Sorban a következő körre{status_detail}. Akkor válaszolok, ha a jelenlegi feladat kész."
+    interrupt: "⚡ Megszakítom a jelenlegi feladatot{status_detail}. Hamarosan válaszolok."
+    status_elapsed: "{minutes} perc telt el"
+    status_iteration: "iteráció {iteration}/{max_iter}"
+    status_running: "fut: {tool}"
+
   model:
     error_prefix:           "Hiba: {error}"
     switched:               "Modell átváltva: `{model}`"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ Impossibile leggere config.yaml: {error}"
   config_save_failed: "⚠️ Impossibile salvare la configurazione: {error}"
 
+  busy_ack:
+    steer: "⏩ Inserito nell'esecuzione corrente{status_detail}. Il messaggio arriva dopo la prossima chiamata allo strumento."
+    redirect: "↪ Esecuzione corrente reindirizzata{status_detail}. Mi adatto con la tua correzione."
+    queue_subagent: "⏳ Sotto-agente al lavoro{status_detail} — il messaggio è in coda fino alla fine (usa /stop per annullare tutto)."
+    queue_compression: "⏳ Compressione del contesto{status_detail} — il messaggio è in coda fino alla fine (usa /stop per annullare tutto)."
+    queue: "⏳ In coda per il turno successivo{status_detail}. Rispondo quando l'attività corrente finisce."
+    interrupt: "⚡ Interrompo l'attività corrente{status_detail}. Rispondo a breve."
+    status_elapsed: "{minutes} min trascorsi"
+    status_iteration: "iterazione {iteration}/{max_iter}"
+    status_running: "in esecuzione: {tool}"
+
   model:
     error_prefix:           "Errore: {error}"
     switched:               "Modello cambiato a `{model}`"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ config.yaml を読み込めませんでした: {error}"
   config_save_failed: "⚠️ 設定を保存できませんでした: {error}"
 
+  busy_ack:
+    steer: "⏩ 実行中の処理に差し込みました{status_detail}。次のツール呼び出しの後に反映されます。"
+    redirect: "↪ 実行中の処理を修正します{status_detail}。いまの指示で方向を変えます。"
+    queue_subagent: "⏳ サブエージェント作業中{status_detail} — 終了後にメッセージを処理します（全部キャンセルは /stop）。"
+    queue_compression: "⏳ コンテキストを圧縮中{status_detail} — 終了後にメッセージを処理します（全部キャンセルは /stop）。"
+    queue: "⏳ 次のターンにキューしました{status_detail}。今の作業が終わってから返信します。"
+    interrupt: "⚡ 今の作業を中断します{status_detail}。すぐ返信します。"
+    status_elapsed: "{minutes}分経過"
+    status_iteration: "反復 {iteration}/{max_iter}"
+    status_running: "実行中: {tool}"
+
   model:
     error_prefix:           "エラー: {error}"
     switched:               "モデルを `{model}` に切り替えました"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ config.yaml을 읽을 수 없습니다: {error}"
   config_save_failed: "⚠️ 설정을 저장할 수 없습니다: {error}"
 
+  busy_ack:
+    steer: "⏩ 지금 실행 중인 작업에 넣었습니다{status_detail}. 다음 도구 호출 뒤에 반영됩니다."
+    redirect: "↪ 지금 실행 중인 작업을 고칩니다{status_detail}. 방금 말로 방향을 바꿉니다."
+    queue_subagent: "⏳ 하위 에이전트가 작업 중입니다{status_detail} — 끝나면 대기 중인 메시지를 처리합니다 (/stop으로 전부 취소)."
+    queue_compression: "⏳ 맥락을 압축하는 중입니다{status_detail} — 끝나면 대기 중인 메시지를 처리합니다 (/stop으로 전부 취소)."
+    queue: "⏳ 다음 턴에 대기시켰습니다{status_detail}. 현재 작업이 끝나면 답합니다."
+    interrupt: "⚡ 현재 작업을 중단합니다{status_detail}. 곧 답합니다."
+    status_elapsed: "{minutes}분 경과"
+    status_iteration: "반복 {iteration}/{max_iter}"
+    status_running: "실행 중: {tool}"
+
   model:
     error_prefix:           "오류: {error}"
     switched:               "모델이 `{model}`(으)로 전환되었습니다"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ Não foi possível ler config.yaml: {error}"
   config_save_failed: "⚠️ Não foi possível guardar a configuração: {error}"
 
+  busy_ack:
+    steer: "⏩ Inserido na execução atual{status_detail}. A tua mensagem chega depois da próxima chamada de ferramenta."
+    redirect: "↪ Execução atual redirecionada{status_detail}. Vou ajustar com a tua correção."
+    queue_subagent: "⏳ Subagente a trabalhar{status_detail} — a tua mensagem fica em fila até terminar (usa /stop para cancelar tudo)."
+    queue_compression: "⏳ A comprimir o contexto{status_detail} — a tua mensagem fica em fila até terminar (usa /stop para cancelar tudo)."
+    queue: "⏳ Em fila para o próximo turno{status_detail}. Respondo quando a tarefa atual terminar."
+    interrupt: "⚡ A interromper a tarefa atual{status_detail}. Respondo em breve."
+    status_elapsed: "{minutes} min decorridos"
+    status_iteration: "iteração {iteration}/{max_iter}"
+    status_running: "a executar: {tool}"
+
   model:
     error_prefix:           "Erro: {error}"
     switched:               "Modelo alterado para `{model}`"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ Не удалось прочитать config.yaml: {error}"
   config_save_failed: "⚠️ Не удалось сохранить конфигурацию: {error}"
 
+  busy_ack:
+    steer: "⏩ Добавлено в текущий запуск{status_detail}. Сообщение придёт после следующего вызова инструмента."
+    redirect: "↪ Текущий запуск перенаправлен{status_detail}. Подстроюсь под вашу правку."
+    queue_subagent: "⏳ Работает подагент{status_detail} — сообщение в очереди до завершения (отменить всё: /stop)."
+    queue_compression: "⏳ Сжимается контекст{status_detail} — сообщение в очереди до завершения (отменить всё: /stop)."
+    queue: "⏳ В очереди на следующий ход{status_detail}. Отвечу, когда текущая задача закончится."
+    interrupt: "⚡ Прерываю текущую задачу{status_detail}. Отвечу скоро."
+    status_elapsed: "прошло {minutes} мин"
+    status_iteration: "итерация {iteration}/{max_iter}"
+    status_running: "выполняется: {tool}"
+
   model:
     error_prefix:           "Ошибка: {error}"
     switched:               "Модель изменена на `{model}`"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ config.yaml okunamadı: {error}"
   config_save_failed: "⚠️ Yapılandırma kaydedilemedi: {error}"
 
+  busy_ack:
+    steer: "⏩ Geçerli çalışmaya eklendi{status_detail}. Mesajın bir sonraki araç çağrısından sonra gelir."
+    redirect: "↪ Geçerli çalışma yönlendirildi{status_detail}. Düzeltmene göre ayarlayacağım."
+    queue_subagent: "⏳ Alt ajan çalışıyor{status_detail} — mesajın bitince kuyruğa alındı (hepsini iptal için /stop)."
+    queue_compression: "⏳ Bağlam sıkıştırılıyor{status_detail} — mesajın bitince kuyruğa alındı (hepsini iptal için /stop)."
+    queue: "⏳ Sonraki tur için kuyruğa alındı{status_detail}. Geçerli iş bitince yanıtlarım."
+    interrupt: "⚡ Geçerli iş kesiliyor{status_detail}. Kısa süre içinde yanıtlarım."
+    status_elapsed: "{minutes} dk geçti"
+    status_iteration: "yineleme {iteration}/{max_iter}"
+    status_running: "çalışıyor: {tool}"
+
   model:
     error_prefix:           "Hata: {error}"
     switched:               "Model `{model}` olarak değiştirildi"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ Не вдалося прочитати config.yaml: {error}"
   config_save_failed: "⚠️ Не вдалося зберегти конфігурацію: {error}"
 
+  busy_ack:
+    steer: "⏩ Додано до поточного запуску{status_detail}. Повідомлення надійде після наступного виклику інструмента."
+    redirect: "↪ Поточний запуск перенаправлено{status_detail}. Підлаштуюсь за вашим виправленням."
+    queue_subagent: "⏳ Працює підагент{status_detail} — повідомлення в черзі до завершення (скасувати все: /stop)."
+    queue_compression: "⏳ Стискається контекст{status_detail} — повідомлення в черзі до завершення (скасувати все: /stop)."
+    queue: "⏳ У черзі на наступний хід{status_detail}. Відповім, коли поточне завдання завершиться."
+    interrupt: "⚡ Перериваю поточне завдання{status_detail}. Відповім незабаром."
+    status_elapsed: "минуло {minutes} хв"
+    status_iteration: "ітерація {iteration}/{max_iter}"
+    status_running: "виконується: {tool}"
+
   model:
     error_prefix:           "Помилка: {error}"
     switched:               "Модель змінено на `{model}`"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ 無法讀取 config.yaml：{error}"
   config_save_failed: "⚠️ 無法儲存設定：{error}"
 
+  busy_ack:
+    steer: "⏩ 已插入目前執行中的工作{status_detail}。下次工具呼叫後生效。"
+    redirect: "↪ 已依你的更正調整目前執行中的工作{status_detail}。"
+    queue_subagent: "⏳ 子代理作業中{status_detail} — 結束後處理你的訊息（用 /stop 取消全部）。"
+    queue_compression: "⏳ 正在壓縮上下文{status_detail} — 結束後處理你的訊息（用 /stop 取消全部）。"
+    queue: "⏳ 已排到下一輪{status_detail}。目前任務結束後回覆。"
+    interrupt: "⚡ 正在中斷目前任務{status_detail}。稍後回覆。"
+    status_elapsed: "已過 {minutes} 分鐘"
+    status_iteration: "迭代 {iteration}/{max_iter}"
+    status_running: "執行中: {tool}"
+
   model:
     error_prefix:           "錯誤：{error}"
     switched:               "已切換模型為 `{model}`"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -27,6 +27,17 @@ gateway:
   config_read_failed: "⚠️ 无法读取 config.yaml：{error}"
   config_save_failed: "⚠️ 无法保存配置：{error}"
 
+  busy_ack:
+    steer: "⏩ 已插入当前运行{status_detail}。下一次工具调用后生效。"
+    redirect: "↪ 已根据你的更正调整当前运行{status_detail}。"
+    queue_subagent: "⏳ 子代理工作中{status_detail} — 结束后处理你的消息（用 /stop 取消全部）。"
+    queue_compression: "⏳ 正在压缩上下文{status_detail} — 结束后处理你的消息（用 /stop 取消全部）。"
+    queue: "⏳ 已排队到下一轮{status_detail}。当前任务结束后回复。"
+    interrupt: "⚡ 正在中断当前任务{status_detail}。稍后回复。"
+    status_elapsed: "已过 {minutes} 分钟"
+    status_iteration: "迭代 {iteration}/{max_iter}"
+    status_running: "正在运行: {tool}"
+
   model:
     error_prefix:           "错误：{error}"
     switched:               "已切换模型为 `{model}`"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -122,6 +122,19 @@ def test_t_missing_key_in_non_english_falls_back_to_english(tmp_path, monkeypatc
 
 
 
+def test_busy_ack_keys_render_korean():
+    """Gateway busy-ack strings are in the catalog and format cleanly in Korean."""
+    i18n.reset_language_cache()
+    try:
+        text = i18n.t("gateway.busy_ack.steer", lang="ko", status_detail="")
+        assert "지금 실행 중인 작업에 넣었습니다" in text
+        assert "{status_detail}" not in text
+        elapsed = i18n.t("gateway.busy_ack.status_elapsed", lang="ko", minutes=10)
+        assert "10" in elapsed
+    finally:
+        i18n.reset_language_cache()
+
+
 # ---------------------------------------------------------------------------
 # _locales_dir resolution ladder -- regression for #23943 / #27632 / #35374.
 # Sealed installs (Nix store venv, pip wheel) have no source tree next to

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -226,6 +226,38 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
+    async def test_steer_ack_follows_display_language(self, monkeypatch):
+        """Busy-ack copy comes from the i18n catalog, not a hardcoded English string."""
+        import gateway.run as _gr
+        from agent import i18n
+
+        monkeypatch.delenv("HERMES_GATEWAY_BUSY_STEER_ACK_ENABLED", raising=False)
+        monkeypatch.setenv("HERMES_LANGUAGE", "ko")
+        i18n.reset_language_cache()
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+        try:
+            runner, _sentinel = _make_runner()
+            runner._busy_input_mode = "steer"
+            adapter = _make_adapter()
+
+            event = _make_event(text="한글화 확인")
+            sk = build_session_key(event.source)
+            runner.adapters[event.source.platform] = adapter
+
+            agent = MagicMock()
+            agent.steer = MagicMock(return_value=True)
+            runner._running_agents[sk] = agent
+
+            await runner._handle_active_session_busy_message(event, sk)
+
+            content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+            assert "지금 실행 중인 작업에 넣었습니다" in content
+            assert "Steered into current run" not in content
+        finally:
+            monkeypatch.delenv("HERMES_LANGUAGE", raising=False)
+            i18n.reset_language_cache()
+
+    @pytest.mark.asyncio
     async def test_steer_mode_transcribes_voice_before_injection(self, monkeypatch):
         """A busy voice follow-up is transcribed and steered, never queued."""
         import gateway.run as _gr

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1894,7 +1894,7 @@ If writes to Hermes state (cron jobs, skills, scripts under `~/.hermes/`) are fa
 
 ### UI language for static messages
 
-The `display.language` setting translates a small set of static user-facing messages — the CLI approval prompt, a handful of gateway slash-command replies (e.g. restart-drain notices, "approval expired", "goal cleared"). It does **not** translate agent responses, log lines, tool output, error tracebacks, or slash-command descriptions — those stay in English. If you want the agent itself to reply in another language, just tell it in your prompt or system message.
+The `display.language` setting translates a small set of static user-facing messages — the CLI approval prompt, a handful of gateway slash-command replies (e.g. restart-drain notices, "approval expired", "goal cleared"), and gateway busy-input acknowledgements (steer / queue / interrupt). It does **not** translate agent responses, log lines, tool output, error tracebacks, or slash-command descriptions — those stay in English. If you want the agent itself to reply in another language, just tell it in your prompt or system message.
 
 Supported values: `en` (default), `zh` (Simplified Chinese), `zh-hant` (Traditional Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `tr` (Turkish), `uk` (Ukrainian), `af` (Afrikaans), `ko` (Korean), `it` (Italian), `ga` (Irish), `pt` (Portuguese), `ru` (Russian), `hu` (Hungarian). Unknown values fall back to English.
 


### PR DESCRIPTION
## Summary

`display.language` already translates approval prompts and a handful of gateway slash replies. Busy-input acknowledgements (`⏩ Steered into current run…`, queue, interrupt, redirect) were still hardcoded English in `gateway/run.py`, so a `ko` (or any non-English) install kept posting English bubbles.

This wires those strings through `t()` and adds `gateway.busy_ack.*` keys to every locale catalog.

## What changed

- `gateway/run.py` — steer / redirect / queue / subagent-queue / compression-queue / interrupt copy, plus the optional status fragments (`N min elapsed`, `iteration a/b`, `running: tool`)
- `locales/*.yaml` — catalog parity for all `SUPPORTED_LANGUAGES`
- docs + `agent/i18n.py` scope note
- tests: catalog render in Korean, and a live steer-ack path with `HERMES_LANGUAGE=ko`

English wording is unchanged when `display.language` is `en`.

## Related

Complementary to #26024 / #26150 (`display.busy_ack_templates`). Templates would let an install rewrite the copy; this is the official i18n path so `display.language: ko` just works.

## Test plan

- [x] `./scripts/run_tests.sh tests/agent/test_i18n.py tests/gateway/test_busy_session_ack.py tests/gateway/test_subagent_protection_30170.py` (54 passed)
- [ ] Set `display.language: ko`, message a busy Slack/Telegram session in steer mode, confirm the Korean bubble
- [ ] Repeat with unset / `en` and confirm the existing English string