### PR TITLE
fix(desktop): keep closed secondary gateways inactive

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -4220,6 +4220,40 @@ async function openBotCanonicalChat(name) {
   return createCanonicalChat(name)
 }
 
+function normalizeBotActivationValue(value) {
+  return String(value ?? '').trim()
+}
+
+/**
+ * Return a user-facing activation error when Bot Mode did not land on the
+ * requested source/profile and an open gateway.
+ */
+function botSourceActivationError(input) {
+  const targetConnectionId = normalizeBotActivationValue(input.targetConnectionId)
+  const activeConnectionId = normalizeBotActivationValue(input.activeConnectionId)
+
+  if (
+    (input.sourceScoped || input.remoteSource) &&
+    targetConnectionId &&
+    targetConnectionId !== 'local' &&
+    activeConnectionId !== targetConnectionId
+  ) {
+    return `Still on ${activeConnectionId || 'this device'}, not ${normalizeBotActivationValue(input.targetConnectionLabel) || targetConnectionId}`
+  }
+
+  const targetProfile = normalizeBotActivationValue(input.targetProfile) || 'default'
+
+  if (input.activeProfile != null && normalizeBotActivationValue(input.activeProfile) !== targetProfile) {
+    return `Still on ${normalizeBotActivationValue(input.activeProfile) || 'default'} profile, not ${targetProfile}`
+  }
+
+  if (input.gatewayState != null && input.gatewayState !== 'open') {
+    return 'Hermes gateway is not connected'
+  }
+
+  return null
+}
+
 async function prepareBotSource(bot) {
   if (!bot.sourceScoped) {
     return
@@ -4231,15 +4265,19 @@ async function prepareBotSource(bot) {
 
   await host.ensureAgent(bot.connectionId, bot.name)
 
-  if (!bot.remoteSource) {
-    return
-  }
+  const activationError = botSourceActivationError({
+    activeConnectionId: typeof host.activeConnectionId === 'function' ? host.activeConnectionId() : undefined,
+    activeProfile: host.state?.profile?.get?.(),
+    gatewayState: host.state?.gateway?.get?.(),
+    remoteSource: Boolean(bot.remoteSource),
+    sourceScoped: Boolean(bot.sourceScoped),
+    targetConnectionLabel: bot.connectionLabel,
+    targetConnectionId: bot.connectionId,
+    targetProfile: bot.name
+  })
 
-  const liveId = String(typeof host.activeConnectionId === 'function' ? host.activeConnectionId() || '' : '').trim()
-  const targetId = String(bot.connectionId || '').trim()
-
-  if (targetId && targetId !== 'local' && liveId !== targetId) {
-    throw new Error(`Still on ${liveId || 'this device'}, not ${bot.connectionLabel || targetId}`)
+  if (activationError) {
+    throw new Error(activationError)
   }
 
   // The canonical chat is found by NAME on the now-active owner source —

--- a/apps/desktop/src/store/gateway-agent-scope.test.ts
+++ b/apps/desktop/src/store/gateway-agent-scope.test.ts
@@ -82,6 +82,8 @@ function installAgentDesktop(): DesktopStub {
 }
 
 beforeEach(() => {
+  gatewayMocks.connect.mockReset()
+  gatewayMocks.connect.mockResolvedValue(undefined)
   configureGatewayRegistry({ onEvent: vi.fn() })
 })
 
@@ -103,6 +105,48 @@ describe('registry-agent scope eviction (activeGateway must never silently hit t
     expect(activeGateway()).not.toBe(primary)
     expect($gateway.get()).not.toBe(primary)
     expect(gatewayMocks.connect).toHaveBeenCalledWith(agentConn.wsUrl)
+  })
+
+  it('retries a transient cold-start websocket failure before publishing', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    installAgentDesktop()
+    gatewayMocks.connect.mockRejectedValueOnce(new Error('ECONNRESET'))
+
+    await expect(ensureGatewayForAgent('homelab', 'research')).resolves.toBe(true)
+
+    expect(gatewayMocks.connect).toHaveBeenCalledTimes(2)
+    expect(isActivePrimary()).toBe(false)
+    expect(activeGateway()?.connectionState).toBe('open')
+  })
+
+  it('keeps the previous route when both bounded activation attempts fail', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    await ensureGatewayForProfile('default')
+    installAgentDesktop()
+    gatewayMocks.connect.mockRejectedValue(new Error('ECONNRESET'))
+
+    await expect(ensureGatewayForAgent('homelab', 'research')).resolves.toBe(false)
+
+    expect(gatewayMocks.connect).toHaveBeenCalledTimes(2)
+    expect(isActivePrimary()).toBe(true)
+    expect(activeGateway()).toBe(primary)
+    expect($gateway.get()).toBe(primary)
+  })
+
+  it('does not publish a closed profile secondary after activation fails', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+    await ensureGatewayForProfile('default')
+    installAgentDesktop()
+    gatewayMocks.connect.mockRejectedValue(new Error('ECONNRESET'))
+
+    await expect(ensureGatewayForProfile('research')).resolves.toBe(false)
+
+    expect(isActivePrimary()).toBe(true)
+    expect(activeGateway()).toBe(primary)
+    expect($gateway.get()).toBe(primary)
   })
 
   it('keeps the primary active when a fresh registry activation cannot resolve', async () => {

--- a/apps/desktop/src/store/gateway-shared-remote.test.ts
+++ b/apps/desktop/src/store/gateway-shared-remote.test.ts
@@ -132,12 +132,13 @@ describe('ensureGatewayForProfile under a shared global remote', () => {
 
     await ensureGatewayForProfile('worker')
 
+    expect(gatewayMocks.connect).toHaveBeenCalledTimes(2)
     expect(gatewayMocks.setConnection).toHaveBeenCalledOnce()
     expect(gatewayMocks.setConnection).toHaveBeenLastCalledWith(connection)
 
     await ensureActiveGatewayOpen()
 
-    expect(gatewayMocks.setConnection).toHaveBeenCalledTimes(2)
+    expect(gatewayMocks.setConnection).toHaveBeenCalledOnce()
     expect(gatewayMocks.setConnection).toHaveBeenLastCalledWith(connection)
   })
 })

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -75,6 +75,7 @@ interface Secondary {
 // backend spawn + socket connect with margin, while still letting a leaked
 // lease expire quickly enough for the reaper to reclaim the entry.
 const ACTIVATION_LEASE_MS = 30_000
+const ACTIVATION_ATTEMPTS = 2
 
 // ── HMR-stable module state ─────────────────────────────────────────────────
 // All mutable singletons (live sockets, active-profile routing, the event
@@ -354,6 +355,49 @@ async function openSecondary(entry: Secondary): Promise<void> {
       entry.connectPromise = null
     }
   }
+}
+
+// A cold-started backend can have a listening port before its first websocket
+// handshake is ready. Give a foreground activation one immediate retry for
+// that narrow transport race; any longer recovery remains owned by the normal
+// exponential reconnect loop.
+async function openSecondaryForActivation(entry: Secondary): Promise<boolean> {
+  if (isOpen(entry.gateway)) {
+    return true
+  }
+
+  if (!window.hermesDesktop) {
+    return false
+  }
+
+  for (let attempt = 0; attempt < ACTIVATION_ATTEMPTS; attempt += 1) {
+    if (!entry.wantOpen) {
+      return false
+    }
+
+    clearTimer(entry)
+
+    try {
+      await openSecondary(entry)
+    } catch (error) {
+      // These are permanent registry/profile conditions, not a transient
+      // websocket race. Let the normal reconnect path apply its existing
+      // fail-stop handling instead of issuing a duplicate spawn request.
+      if ((entry.connectionId && isMissingConnectionError(error)) || isMissingProfileError(error)) {
+        break
+      }
+    }
+
+    if (isOpen(entry.gateway)) {
+      return true
+    }
+  }
+
+  if (entry.wantOpen && !isOpen(entry.gateway)) {
+    scheduleReconnect(entry)
+  }
+
+  return false
 }
 
 function scheduleReconnect(entry: Secondary): void {
@@ -709,9 +753,7 @@ export async function ensureGatewayForAgent(connectionId: null | string, profile
   const scope = registryBackendScopeKey(connectionId, profile)
 
   if (scope === normKey(profile)) {
-    await ensureGatewayForProfile(profile)
-
-    return true
+    return ensureGatewayForProfile(profile)
   }
 
   if (!window.hermesDesktop?.getConnectionFor) {
@@ -737,12 +779,7 @@ export async function ensureGatewayForAgent(connectionId: null | string, profile
   if (!isOpen(entry.gateway)) {
     clearTimer(entry)
     entry.reconnectAttempt = 0
-
-    try {
-      await openSecondary(entry)
-    } catch {
-      scheduleReconnect(entry)
-    }
+    await openSecondaryForActivation(entry)
   }
 
   // The activation is settling either way — release the prune lease.
@@ -753,6 +790,7 @@ export async function ensureGatewayForAgent(connectionId: null | string, profile
   const activated =
     entry.wantOpen &&
     g.secondaries.get(scope) === entry &&
+    isOpen(entry.gateway) &&
     Boolean(entry.connection) &&
     applyActive(scope, activationEpoch)
 
@@ -765,14 +803,12 @@ export async function ensureGatewayForAgent(connectionId: null | string, profile
 
 // Make `profile` the active gateway, lazily opening its socket if needed. The
 // primary is a no-op fast path. Background sockets are never closed here.
-export async function ensureGatewayForProfile(profile: string): Promise<void> {
+export async function ensureGatewayForProfile(profile: string): Promise<boolean> {
   const key = normKey(profile)
   const activationEpoch = beginGatewayActivation()
 
   if (key === g.primaryProfile) {
-    applyActive(key, activationEpoch)
-
-    return
+    return applyActive(key, activationEpoch)
   }
 
   // Global-remote share (routing case 3): one remote host serves every
@@ -781,9 +817,7 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
   // descriptor — $activeGatewayProfile still moves to `key`, so request
   // scoping and profile-aware surfaces behave identically.
   if (await sharedPrimaryRoute(key)) {
-    applyActive(g.primaryProfile, activationEpoch)
-
-    return
+    return applyActive(g.primaryProfile, activationEpoch)
   }
 
   let entry = g.secondaries.get(key)
@@ -801,20 +835,24 @@ export async function ensureGatewayForProfile(profile: string): Promise<void> {
   if (!isOpen(entry.gateway)) {
     clearTimer(entry)
     entry.reconnectAttempt = 0
-
-    try {
-      await openSecondary(entry)
-    } catch {
-      scheduleReconnect(entry)
-    }
+    await openSecondaryForActivation(entry)
   }
 
   // The activation is settling either way — release the prune lease.
   entry.activationLeaseUntil = 0
 
-  if (entry.wantOpen && g.secondaries.get(key) === entry && applyActive(key, activationEpoch) && entry.connection) {
+  const activated =
+    entry.wantOpen &&
+    g.secondaries.get(key) === entry &&
+    isOpen(entry.gateway) &&
+    Boolean(entry.connection) &&
+    applyActive(key, activationEpoch)
+
+  if (activated && entry.connection) {
     publishActiveConnection(entry.connection)
   }
+
+  return activated
 }
 
 // Reconnect the active gateway after a transient request failure. Primary

--- a/apps/desktop/src/store/profile-agent-activation.test.ts
+++ b/apps/desktop/src/store/profile-agent-activation.test.ts
@@ -17,7 +17,7 @@ import { deferred } from '../test/deferred'
 //     EARLIER setActive() landed last.
 
 const ensureGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => true)
-const ensureGatewayForProfile = vi.fn(async (_profile: string) => undefined)
+const ensureGatewayForProfile = vi.fn(async (_profile: string) => true)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
@@ -104,6 +104,16 @@ describe('ensureGatewayAgent → $connection / $activeGatewayProfile sync', () =
     expect(getConnectionFor).toHaveBeenCalledTimes(1)
   })
 
+  it('does not publish a profile when its gateway never opens', async () => {
+    ensureGatewayForProfile.mockResolvedValueOnce(false)
+    getConnection.mockResolvedValue(localConn({ profile: 'research' }))
+
+    await ensureGatewayProfile('research')
+
+    expect($activeGatewayProfile.get()).toBe('default')
+    expect($connection.get()?.profile).toBe('default')
+  })
+
   it('falls through to the profile path for a null connectionId', async () => {
     getConnection.mockResolvedValue(agentConn({ mode: 'local', profile: 'research' }))
 
@@ -133,6 +143,8 @@ describe('ensureGatewayAgent shares the gatewaySwitch mutex with profile switche
     ensureGatewayForProfile.mockImplementation(async (profile: string) => {
       order.push(`profile:${profile}`)
       await profileGate.promise
+
+      return true
     })
     ensureGatewayForAgent.mockImplementation(async (_connectionId, profile) => {
       order.push(`agent:${profile}`)
@@ -174,6 +186,8 @@ describe('ensureGatewayAgent shares the gatewaySwitch mutex with profile switche
     })
     ensureGatewayForProfile.mockImplementation(async (profile: string) => {
       order.push(`profile:${profile}`)
+
+      return true
     })
     getConnection.mockResolvedValue(localConn({ profile: 'worker' }))
     getConnectionFor.mockResolvedValue(agentConn())

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -6,7 +6,7 @@ import type { ProfileInfo } from '@/types/hermes'
 
 // Keep profile.ts's side-effecting imports inert: the gateway socket layer and
 // the REST query client must not run for real in a unit test.
-const ensureGatewayForProfile = vi.fn(async () => undefined)
+const ensureGatewayForProfile = vi.fn(async () => true)
 const ensureGatewayForAgent = vi.fn(async () => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -344,7 +344,16 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     // syncConnectionToActiveProfile await left a window where $gateway
     // already targeted the new backend while $connection still described the
     // previous one, and remote-aware paths announced the wrong mode (#46651).
-    const [connection] = await Promise.all([resolveConnectionForProfile(target), ensureGatewayForProfile(target)])
+    const [connection, activated] = await Promise.all([
+      resolveConnectionForProfile(target),
+      ensureGatewayForProfile(target)
+    ])
+
+    if (!activated) {
+      console.warn(`[profile] profile gateway activation for "${target}" did not land`)
+
+      return
+    }
 
     // ONE publication frame. batch() defers Nanostores' notifications to the
     // end of the callback, so the profile pointer and the connection


### PR DESCRIPTION
## Summary
- Retry a foreground secondary activation once immediately after a transient cold-start WebSocket failure.
- Publish a secondary route only when its registered gateway is open; otherwise keep the previous route active and leave normal backoff recovery in place.
- Propagate failed profile activation to the profile switcher and make Bot Mode verify source, profile, and open-gateway state before opening the canonical chat.

## Root cause
`openSecondary` stored a connection descriptor before the WebSocket handshake completed. The activation paths treated that non-null descriptor as success, so a transient first dial could select a closed gateway. Profile switches also published their active profile after the low-level activation returned without a success result. Bot Mode could additionally accept a same-connection, wrong-profile landing.

## Testing
- `tsc -p apps/desktop/tsconfig.json --noEmit` — passed.
- `tsc -p apps/desktop/tsconfig.electron.json --noEmit` — passed.
- `tsc -p apps/desktop/tsconfig.e2e.json --noEmit` — passed.
- ESLint over `apps/desktop/src electron/` — 0 errors; existing warnings only.
- Focused gateway/profile UI regression set — 32/32 passed.
- Renderer Vite build — passed.
- Standalone plugin compatibility/profile tests — passed. The full plugin suite has two unrelated Windows-environment failures because its security tests invoke unavailable `sh`.
- The full UI suite was also exercised; its remaining failures are unrelated existing session/billing/assistant-ui baseline failures, while the changed gateway/profile tests pass.

Fixes #92265