### PR TITLE
fix(codex-runtime): forward dispatcher env to hermes-tools MCP subprocess (#92282)

### DIFF
--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from agent.delegation_context import KANBAN_ENV_KEYS
+
 logger = logging.getLogger(__name__)
 
 
@@ -71,6 +73,42 @@ _KEYS_DROPPED_WITH_WARNING = {"sampling"}
 _TIMEOUT_KEYS = (
     ("timeout", "tool_timeout_sec", "timeout (not numeric)"),
     ("connect_timeout", "startup_timeout_sec", "connect_timeout (not numeric)"))
+
+# Env vars the kanban dispatcher stamps onto worker subprocesses at dispatch
+# time (hermes_cli/kanban_db_dispatch.py::_default_spawn), plus the worker's
+# runtime identity. They materialize AFTER this migration has written
+# ~/.codex/config.toml, so they can never be captured from os.environ here —
+# codex must forward them BY NAME from its own process env (see
+# _build_hermes_tools_mcp_entry). KANBAN_ENV_KEYS tracks the dispatcher-
+# IDENTITY subset delegation_context scrubs from non-worker children; the
+# board / filesystem pins that subset deliberately leaves out (they carry no
+# identity) are listed explicitly, mirroring the (*KANBAN_ENV_KEYS,
+# HERMES_KANBAN_DB, HERMES_KANBAN_BOARD) scope codex_app_server grants its
+# own MCP endpoint. (The import is eager, unlike the lazy agent.transports
+# import below: agent.delegation_context is stdlib-only at module scope, so
+# it can't fail the way a codex-transport dependency can.)
+#
+# Deliberately NOT listed: HERMES_KANBAN_ROOT. The dispatcher never stamps
+# it — agent/transports/codex_app_server.py reads it (as a kanban-dir
+# fallback) from the codex subprocess' own env, which already inherits it
+# via hermes_subprocess_env(); the hermes-tools MCP child never consumes it.
+_KANBAN_WORKER_ENV_VARS: frozenset[str] = frozenset(
+    {
+        *KANBAN_ENV_KEYS,
+        # Dispatcher stamps outside the identity scrub-list: the board /
+        # filesystem pins, the worktree branch hint, and the profile
+        # kanban_comment attributes to.
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACE",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_BRANCH",
+        "HERMES_PROFILE",
+        # Worker session identity — lifecycle writes stamp the worker's
+        # session id onto board rows when it's present.
+        "HERMES_SESSION_ID",
+    }
+)
 
 
 def _str_map(d: dict) -> dict[str, str]:
@@ -345,6 +383,9 @@ def _build_hermes_tools_mcp_entry() -> dict:
     kanban), not a migrate-time default burned into config.toml that pins the wrong profile. The
     pytest-tempdir guard keeps a sibling test's monkeypatched HERMES_HOME out of the user's real
     config. PYTHONPATH passes through so a worktree-launched hermes finds the branch's modules.
+    Dynamic HERMES_* runtime vars (dispatcher-stamped kanban worker env, session identity,
+    launcher-injected context) are forwarded BY NAME via ``env_vars`` so codex copies their
+    values from its own process env when it spawns the MCP subprocess.
     """
     import sys
     env: dict[str, str] = {}
@@ -364,11 +405,73 @@ def _build_hermes_tools_mcp_entry() -> dict:
     # Quiet mode + redaction defaults so the MCP wire stays clean.
     env["HERMES_QUIET"] = "1"
     env["HERMES_REDACT_SECRETS"] = env.get("HERMES_REDACT_SECRETS", "true")
+
+    # Dispatch-time env forwarding (#92282). Codex's MCP client builds the
+    # hermes-tools subprocess env from the static `env` table plus the vars
+    # NAMED in `env_vars` — codex copies each name's value from ITS OWN
+    # process env at spawn time. The kanban dispatcher stamps HERMES_KANBAN_*
+    # onto workers only when it spawns them (after this migration already
+    # wrote config.toml), so without env_vars the hermes-tools subprocess
+    # never sees them, kanban tools fail their availability check, and a
+    # codex-runtime worker loses its entire lifecycle tool surface.
+    #  1. _KANBAN_WORKER_ENV_VARS — the dispatcher-owned set, forwarded by
+    #     name so it propagates no matter when the worker is dispatched.
+    #  2. Every other HERMES_* var present in this process at migration
+    #     time — launcher-injected runtime context (session, tenant, etc.)
+    #     that would otherwise need a code change per variable. Names
+    #     already pinned in the static `env` table are skipped (the static
+    #     values are the authoritative ones; listing them twice is
+    #     redundant either way).
+    env_vars: set[str] = set(_KANBAN_WORKER_ENV_VARS)
+    # The snapshot must honor the repo's strip-by-default spawn hygiene:
+    # hermes_cli.config.reload_env() injects ~/.hermes/.env (integration
+    # credentials like HERMES_<SLUG>_API_KEY) into os.environ, so a raw
+    # HERMES_* scan here would forward secret names that every other spawn
+    # site strips. Only names are ever written to config.toml, but codex
+    # copies their values from its own env at spawn time, and the MCP
+    # subprocess historically received only the curated static env — so
+    # apply the same classification the other spawn paths use.
+    try:
+        from tools.environments.local import (
+            _ALWAYS_STRIP_KEYS,
+            _HERMES_PROVIDER_ENV_BLOCKLIST,
+            _is_hermes_internal_secret,
+        )
+    except Exception:  # pragma: no cover - fail OPEN, not closed
+        # Empty strip sets + an always-False classifier leave only the
+        # suffix heuristic below as the guard: blocklisted/internal-secret
+        # names would be forwarded until the import recovers. Kept fail-open
+        # deliberately — a missing tools module must not break codex runtime
+        # migration — but the trade-off belongs in the record.
+        _ALWAYS_STRIP_KEYS = frozenset()
+        _HERMES_PROVIDER_ENV_BLOCKLIST = frozenset()
+        _is_hermes_internal_secret = lambda _k: False  # noqa: E731
+    # Suffix heuristic for custom provider keys the static blocklist can't
+    # know (HERMES_CUSTOM_<slug>_API_KEY etc.).
+    _secret_name_suffixes = (
+        "_API_KEY", "_SECRET", "_TOKEN", "_PASSWORD",
+        "_PRIVATE_KEY", "_CLIENT_SECRET",
+    )
+    for name in os.environ:
+        if not name.startswith("HERMES_"):
+            continue
+        upper = name.upper()
+        if name in env or upper in _ALWAYS_STRIP_KEYS:
+            continue
+        if upper in _HERMES_PROVIDER_ENV_BLOCKLIST:
+            continue
+        if _is_hermes_internal_secret(upper):
+            continue
+        if upper.endswith(_secret_name_suffixes):
+            continue
+        env_vars.add(name)
+
+    # Generous timeouts — browser_navigate or delegate_task can take a while.
     return {
         "command": sys.executable,
         "args": ["-m", "agent.transports.hermes_tools_mcp_server"],
         "env": env,
-        # Generous timeouts — browser_navigate or delegate_task can take a while.
+        "env_vars": sorted(env_vars),
         "startup_timeout_sec": 30.0,
         "tool_timeout_sec": 600.0}
 

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -380,6 +380,134 @@ class TestStripUnmanagedPluginTables:
         tomllib.loads(new_text)
 
 
+# ---- Issue #92282: HERMES_KANBAN_* forwarding to the hermes-tools MCP subprocess ----
+
+
+class TestHermesToolsEnvForwarding:
+    """Regression tests for issue #92282.
+
+    Codex spawns the hermes-tools MCP subprocess from the migrated
+    ``[mcp_servers.hermes-tools]`` entry, giving the child only the static
+    ``env`` table plus the vars *named* in ``env_vars`` (values copied from
+    codex's own process env at spawn time). That env_vars contract is
+    codex's documented MCP config behavior and was verified manually by
+    the issue reporter against a live codex install (adding the list made
+    codex discover ``kanban_show`` immediately) — the tests below emulate
+    the same construction without requiring a codex binary.
+
+    The kanban dispatcher stamps ``HERMES_KANBAN_*`` onto workers only at
+    dispatch time — after migration wrote config.toml — so without an
+    ``env_vars`` list those vars never reach the MCP subprocess,
+    ``_check_kanban_mode()`` fails there, and the worker's codex turn sees
+    none of the ``kanban_*`` lifecycle tools.
+    """
+
+    @staticmethod
+    def _codex_spawn_env(entry, parent_env):
+        """Emulate codex's stdio MCP spawn env construction."""
+        child_env = dict(entry.get("env") or {})
+        for name in entry.get("env_vars") or []:
+            if name in parent_env:
+                child_env[name] = parent_env[name]
+        return child_env
+
+    def test_kanban_env_reaches_mcp_subprocess(self, tmp_path, monkeypatch):
+        """End-to-end through the migrated config: the dispatcher-stamped
+        worker env must reach a subprocess spawned the way codex spawns the
+        hermes-tools MCP server."""
+        import json
+        import subprocess
+        import sys
+        import tomllib
+
+        # Migration runs once at runtime-switch time — no worker env yet.
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        report = migrate(
+            {}, codex_home=tmp_path, discover_plugins=False,
+            default_permission_profile=None, expose_hermes_tools=True,
+        )
+        assert report.written
+        cfg = tomllib.loads((tmp_path / "config.toml").read_text())
+        entry = cfg["mcp_servers"]["hermes-tools"]
+        assert entry.get("env_vars"), (
+            "hermes-tools entry must declare env_vars so codex forwards "
+            "dispatcher-stamped vars into the MCP subprocess (#92282)"
+        )
+
+        # The worker's dispatcher-stamped env (materializes at dispatch time,
+        # after migration; reaches codex via hermes_subprocess_env).
+        worker_env = {
+            "HERMES_KANBAN_TASK": "t_92282",
+            "HERMES_KANBAN_BOARD": "default",
+            "HERMES_KANBAN_DB": str(tmp_path / "kanban.db"),
+            "HERMES_KANBAN_CLAIM_LOCK": "lock-1",
+        }
+        child_env = self._codex_spawn_env(entry, worker_env)
+
+        # Fake stdio subprocess asserting the env reaches the child.
+        code = (
+            "import json, os;"
+            "print(json.dumps({k: os.environ.get(k) for k in %r}))"
+        ) % (sorted(worker_env),)
+        proc = subprocess.run(
+            [sys.executable, "-c", code], env=child_env,
+            capture_output=True, text=True, timeout=60,
+        )
+        assert proc.returncode == 0, proc.stderr
+        seen = json.loads(proc.stdout)
+        for name, value in worker_env.items():
+            assert seen[name] == value, (
+                f"{name} did not reach the hermes-tools MCP child env"
+            )
+
+    def test_env_vars_includes_dispatcher_kanban_names_without_env(self, monkeypatch):
+        """The dispatcher-owned kanban var names are forwarded by name even
+        when none of them are set at migration time."""
+        import os
+
+        from agent.delegation_context import KANBAN_ENV_KEYS
+
+        for name in list(os.environ):
+            if name.startswith("HERMES_"):
+                monkeypatch.delenv(name)
+        entry = _build_hermes_tools_mcp_entry()
+        env_vars = entry.get("env_vars") or []
+        for name in KANBAN_ENV_KEYS:
+            assert name in env_vars, f"{name} missing from env_vars"
+        # Deterministic output: rebuilding the entry yields the same list
+        # (no set-iteration-order drift between migration runs).
+        assert _build_hermes_tools_mcp_entry()["env_vars"] == env_vars
+
+    def test_env_vars_forwards_runtime_hermes_vars(self, monkeypatch):
+        """Non-secret HERMES_* vars already present at migration time
+        (launcher-injected session/tenant context, etc.) are forwarded too,
+        so the list doesn't need a code change per variable. HERMES_SESSION_ID
+        is covered by the static set; HERMES_TENANT exercises the runtime
+        snapshot."""
+        monkeypatch.setenv("HERMES_SESSION_ID", "sess-1")
+        monkeypatch.setenv("HERMES_TENANT", "acme")
+        entry = _build_hermes_tools_mcp_entry()
+        env_vars = entry.get("env_vars") or []
+        assert "HERMES_SESSION_ID" in env_vars
+        assert "HERMES_TENANT" in env_vars
+
+    def test_env_vars_snapshot_excludes_secret_like_names(self, monkeypatch):
+        """The runtime HERMES_* snapshot must honor the repo's strip-by-
+        default spawn hygiene: integration-credential names (~/.hermes/.env
+        values injected via reload_env) are never forwarded into the MCP
+        subprocess env."""
+        monkeypatch.setenv("HERMES_CUSTOM_ACME_API_KEY", "sk-secret")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "lfk-secret")
+        monkeypatch.setenv("HERMES_GATEWAY_RELAY_SECRET", "relay-secret")
+        monkeypatch.setenv("HERMES_SESSION_ID", "sess-1")  # not secret
+        entry = _build_hermes_tools_mcp_entry()
+        env_vars = entry.get("env_vars") or []
+        assert "HERMES_CUSTOM_ACME_API_KEY" not in env_vars
+        assert "HERMES_LANGFUSE_SECRET_KEY" not in env_vars
+        assert "HERMES_GATEWAY_RELAY_SECRET" not in env_vars
+        assert "HERMES_SESSION_ID" in env_vars
+
+
 # ---- Bug C: HERMES_HOME tempdir leak into ~/.codex/config.toml ----
 
 


### PR DESCRIPTION
## Root cause

Kanban workers dispatched with `model.openai_runtime: codex_app_server` lose their lifecycle tools because the dispatcher's `HERMES_KANBAN_*` environment never reaches the `hermes-tools` stdio MCP subprocess. The chain is:

1. **Dispatcher stamps the worker.** `hermes_cli/kanban_db.py::_default_spawn()` sets `HERMES_KANBAN_TASK`, `HERMES_KANBAN_DB`, `HERMES_KANBAN_BOARD`, `HERMES_KANBAN_WORKSPACE(S_ROOT)`, `HERMES_KANBAN_RUN_ID`, `HERMES_KANBAN_CLAIM_LOCK`, `HERMES_KANBAN_BRANCH`, `HERMES_KANBAN_GOAL_*`, `HERMES_PROFILE`, etc. on the worker subprocess.
2. **Codex sees them.** The worker spawns `codex app-server` via `CodexAppServerClient` (`agent/transports/codex_app_server.py`), whose env is built by `hermes_subprocess_env(inherit_credentials=True)` — a near-full `os.environ` copy, and `HERMES_KANBAN_*` are not on any strip list. So the codex process *does* have the variables.
3. **The hermes-tools MCP subprocess does not.** Codex spawns the `hermes-tools` MCP server from the migrated `~/.codex/config.toml [mcp_servers.hermes-tools]` entry. Its child env is only the static `env` table (HERMES_HOME, HERMES_QUIET, HERMES_REDACT_SECRETS, PYTHONPATH) plus the variables **named** in `env_vars`, whose values codex copies from its own process env at spawn time. `_build_hermes_tools_mcp_entry()` emitted no `env_vars` at all, so every dispatcher-stamped variable died at this boundary.
4. **Tool availability check fails in the child.** `tools/kanban_tools.py::_check_kanban_mode()` requires `HERMES_KANBAN_TASK` (plus `_is_dispatcher_owned_worker()`), so in the MCP subprocess `get_tool_definitions()` registers none of the `kanban_*` tools and the worker's codex turn reports "kanban_show is not available in this session".

The bug is structural, not just kanban-specific: **any** `HERMES_*` variable that only materializes after the runtime-switch migration wrote config.toml was silently dropped at the codex→hermes-tools boundary.

## Why not the issue's proposed fix (static 7-name list)?

The reporter's proposal — hardcoding `env_vars = [HERMES_KANBAN_TASK, HERMES_KANBAN_BOARD, HERMES_KANBAN_DB, HERMES_KANBAN_ROOT, HERMES_KANBAN_WORKSPACE, HERMES_KANBAN_WORKSPACES_ROOT, HERMES_KANBAN_BRANCH]` — would fix today's repro but was not adopted as-is because it rots in both directions:

- **Incomplete today.** The dispatcher also stamps `HERMES_KANBAN_RUN_ID` and `HERMES_KANBAN_CLAIM_LOCK`, both of which `kanban_tools.py` reads directly in-process (run-id scoping at `kanban_tools.py:158-166`, claim-lock heartbeat at `:334`/`:1055`). The 7-name list drops both, so lifecycle calls in the MCP subprocess would still behave subtly wrong (unscoped run id, claim-lock-less heartbeats). It also drops `HERMES_PROFILE` (the author `kanban_comment` attributes to) and `HERMES_SESSION_ID` (worker session stamping on board rows).
- **Stale names.** `HERMES_KANBAN_ROOT` is not stamped by the dispatcher at all — it is only read hermes-side as a sandbox fallback in `agent/transports/codex_app_server.py:108`, from the codex subprocess' own env (which already inherits it), not the MCP child's. Hardcoding it would enshrine a name nothing consumes in the child. A comment in the code documents this exclusion so nobody "completes" the list with a dead name later.
- **Brittle going forward.** Any future `HERMES_KANBAN_*` or other dynamic `HERMES_*` variable would need another code change per variable.

## The fix

`hermes_cli/codex_runtime_plugin_migration.py::_build_hermes_tools_mcp_entry()` now emits an `env_vars` list on the `hermes-tools` entry, built from two sources:

1. **`_KANBAN_WORKER_ENV_VARS`** — the dispatcher-owned worker env, forwarded by name. It reuses `agent/delegation_context.KANBAN_ENV_KEYS` (the same dispatcher-identity set `delegation_context` scrubs from non-worker children, so the two stay in lockstep) plus the additional dispatcher stamps that carry no identity: `HERMES_KANBAN_BRANCH`, `HERMES_KANBAN_GOAL_MODE`, `HERMES_KANBAN_GOAL_MAX_TURNS`, `HERMES_PROFILE`, and `HERMES_SESSION_ID`. These variables materialize at dispatch time — after migration wrote config.toml — so they can never be snapshotted from `os.environ` and must be forwarded by name.
2. **The filtered runtime `HERMES_*` snapshot** — every non-secret `HERMES_*` variable already present in the process env at migration time (launcher-injected session/tenant/UI context) is also forwarded by name, so future dynamic Hermes runtime variables propagate without a code change each. The snapshot applies the repo's own strip-by-default spawn hygiene (`_ALWAYS_STRIP_KEYS`, `_HERMES_PROVIDER_ENV_BLOCKLIST`, `_is_hermes_internal_secret` from `tools/environments/local.py`, plus a `_API_KEY/_SECRET/_TOKEN/_PASSWORD/_PRIVATE_KEY/_CLIENT_SECRET` suffix heuristic for custom provider keys the static registry can't know). This matters because `hermes_cli/config.py::reload_env()` injects `~/.hermes/.env` integration credentials (`HERMES_<SLUG>_API_KEY`, `HERMES_LANGFUSE_SECRET_KEY`, ...) into `os.environ` — a raw `HERMES_*` scan at migrate time would forward those secret names, and codex (spawned with `inherit_credentials=True`) would then copy their values into the MCP child. Names already pinned in the static `env` table are also skipped as redundant.

Only names are written into config.toml — values are copied by codex from its own process env at MCP spawn time, exactly the mechanism the issue reporter verified manually. The `hermes-tools` subprocess is Hermes itself (runs `agent.transports.hermes_tools_mcp_server` under `sys.executable` and already receives `HERMES_HOME`), but it historically received only the curated static env, so the secret filter keeps the new forwarding path consistent with the repo's spawn-hygiene policy.

**Note for existing installs:** the `env_vars` list is baked into `~/.codex/config.toml` only when the migration runs. An already-migrated config will not gain the forwarded names on upgrade — run `hermes codex-runtime migrate` once after updating to refresh the entry.

**Secret-filter posture:** if the strip-classification import (`tools/environments/local.py`) ever fails, the snapshot degrades fail-OPEN — empty strip sets and an always-`False` classifier leave only the `_API_KEY/…` suffix heuristic as the guard, so blocklisted names would be forwarded until the import recovers. This is deliberate (a missing tools module must not break runtime migration) and is now documented at the scan loop in the code.

## Repro evidence

Tested via `tests/hermes_cli/test_codex_runtime_plugin_migration.py::TestHermesToolsEnvForwarding` (new), which emulates the real chain without a codex install: run `migrate()` into a temp `CODEX_HOME`, parse the written `config.toml` with `tomllib`, construct the child env exactly as codex's MCP client does (static `env` + `env_vars` values from the parent env), then spawn a real stdio subprocess asserting the dispatcher-stamped `HERMES_KANBAN_*` values reach the child. The `env_vars` contract the test emulates is codex's documented MCP config behavior and was verified manually by the issue reporter against a live codex install.

Before the fix (RED):

```
FAILED ...::test_kanban_env_reaches_mcp_subprocess
FAILED ...::test_env_vars_includes_dispatcher_kanban_names_without_env - AssertionError: HERMES_KANBAN_TASK missing from env_vars; assert 'HERMES_KANBAN_TASK' in []
FAILED ...::test_env_vars_forwards_runtime_hermes_vars - AssertionError: assert 'HERMES_SESSION_ID' in []
3 failed in 1.52s
```

After the fix (GREEN): `4 passed in 0.79s` (3 original + 1 secret-exclusion test added after adversarial review).

## Tests run

- `tests/hermes_cli/test_codex_runtime_plugin_migration.py` — 24 passed (20 pre-existing + 4 new)
- `tests/hermes_cli/test_codex_runtime_switch.py` — 19 passed
- `tests/agent/transports/test_hermes_tools_mcp_server.py` — 8 passed
- `tests/agent/transports/test_codex_app_server_session.py` — 34 passed
- `tests/tools/test_hermes_subprocess_env.py` — 16 passed
- `tests/hermes_cli/test_kanban_worker_spawn_toolsets.py` — 3 passed
- `tests/agent/test_codex_app_server_event_bridge.py`, `tests/agent/test_codex_responses_adapter.py`, `tests/hermes_cli/test_pin_kanban_board_env.py`, `tests/hermes_cli/test_signal_handler_kanban_worker.py`, `tests/hermes_cli/test_kanban_worker_terminal_cwd.py` — 37 passed, 2 skipped

Pre-existing environmental failures (verified identical on the pristine baseline via `git stash`, unrelated to this change):
- `tests/hermes_cli/test_kanban_review_surfaces.py::test_review_tools_are_gated_and_visible_to_kanban_workers` — `ModuleNotFoundError: No module named 'acp'` (dev venv lacks the `acp` dependency).
- `tests/hermes_cli/test_doctor_journal_modes.py` — collection error on Windows (`os.geteuid`).

## Verification

- Rendered TOML for the migrated entry parses cleanly (`tomllib.loads`), emits a sorted deterministic `env_vars = [...]` array, and in a live env with integration credentials set, zero secret-like names leak into the list (46 names forwarded, 0 matching the secret filter).
- The forwarded set covers the issue's repro variables (`HERMES_KANBAN_TASK/BOARD/DB` are in `KANBAN_ENV_KEYS`) plus the dispatcher's full stamp set (10 `HERMES_KANBAN_*` names).
- An independent adversarial review pass was run against the diff; its SHOULD-FIX (secret filtering on the runtime snapshot) and documentation NITs were all addressed.

Closes #92282
