### PR TITLE
fix(web): CJK font fallback + i18n sync tool with CI gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "audit:fix:root": "npm audit fix --workspaces=false",
     "audit:fix:web": "npm audit fix --workspace web",
     "audit:fix:tui": "npm audit fix --workspace ui-tui",
+    "i18n:sync": "node scripts/i18n-sync.mjs --fix",
+    "i18n:check": "node scripts/i18n-sync.mjs --check",
     "check": "npm run --ws check",
     "fix": "npm run --ws fix"
   },

--- a/scripts/i18n-sync.mjs
+++ b/scripts/i18n-sync.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+/**
+ * i18n sync tool — keeps every locale structurally in lockstep with en.ts.
+ *
+ * en.ts is the single source of truth. Every other locale is migrated to the
+ * partial-locale pattern (`defineLocale({...})`), listing ONLY the keys whose
+ * value differs from English; everything else inherits English automatically
+ * at runtime. This means:
+ *
+ *   - When en.ts GAINS a key, every locale inherits it for free — no locale
+ *     can silently lag behind (the failure mode that left 79 keys untranslated
+ *     across all locales).
+ *   - When en.ts DROPS a key, `--check` flags the now-orphaned override so it
+ *     cannot linger as dead weight.
+ *
+ * Usage:
+ *   node scripts/i18n-sync.mjs --check   # CI gate: fail on any drift
+ *   node scripts/i18n-sync.mjs --fix     # rewrite locales to the synced form
+ *
+ * Run `--fix` after editing en.ts, then commit. `--check` runs in CI to ensure
+ * nobody merges a drifted tree. No third-party dependencies — plain Node, so it
+ * runs in CI, locally, and on deployment hosts alike.
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const I18N_DIR = join(__dirname, "..", "web", "src", "i18n");
+
+const SKIP = new Set(["en.ts", "types.ts", "define-locale.ts", "index.ts", "context.tsx"]);
+
+// ── Loading locale objects without a TS toolchain ───────────────────────────
+// Locale files are simple data modules. We strip the TS-only bits and evaluate
+// the object literal so we get the real JS values (no fragile regex parsing of
+// nested structures). For `defineLocale({...})` files we evaluate just the
+// override argument and merge it onto en ourselves.
+
+function stripTsImports(src) {
+  return src.replace(/^\s*import[^\n]*\n/gm, "");
+}
+
+/** Extract the balanced `{...}` starting at the first `{` at/after `from`. */
+function extractObjectLiteral(src, from) {
+  const start = src.indexOf("{", from);
+  if (start === -1) return null;
+  let depth = 0;
+  let quote = null;
+  let escape = false;
+  for (let i = start; i < src.length; i++) {
+    const ch = src[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (quote) {
+      if (ch === "\\") escape = true;
+      else if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function evalObject(literal) {
+  // eslint-disable-next-line no-new-func
+  return new Function(`return (${literal});`)();
+}
+
+/** Deep-merge `override` onto `base` (override wins), mirroring defineLocale. */
+function deepMerge(base, override) {
+  if (!isRecord(base) || !isRecord(override)) return override ?? base;
+  const out = { ...base };
+  for (const [k, v] of Object.entries(override)) {
+    if (v === undefined) continue;
+    out[k] = isRecord(out[k]) && isRecord(v) ? deepMerge(out[k], v) : v;
+  }
+  return out;
+}
+
+function isRecord(v) {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function loadEn() {
+  const src = stripTsImports(readFileSync(join(I18N_DIR, "en.ts"), "utf8"));
+  const lit = extractObjectLiteral(src, src.indexOf("="));
+  if (!lit) throw new Error("could not parse en.ts object literal");
+  return evalObject(lit);
+}
+
+function loadLocale(file) {
+  const raw = readFileSync(join(I18N_DIR, file), "utf8");
+  const exportName = (raw.match(/export\s+const\s+([A-Za-z0-9_]+)\s*[=:]/) || [])[1];
+  if (!exportName) throw new Error(`${file}: no 'export const NAME' found`);
+  const isPartial = /defineLocale\s*\(/.test(raw);
+  const stripped = stripTsImports(raw);
+  let resolved;
+  let enRef;
+  if (isPartial) {
+    const argStart = stripped.indexOf("defineLocale(");
+    const argLit = extractObjectLiteral(stripped, argStart + "defineLocale(".length - 1);
+    if (!argLit) throw new Error(`${file}: could not parse defineLocale(...) argument`);
+    const overrides = evalObject(argLit);
+    enRef = loadEn();
+    resolved = deepMerge(enRef, overrides);
+  } else {
+    const lit = extractObjectLiteral(stripped, stripped.indexOf("="));
+    if (!lit) throw new Error(`${file}: could not parse object literal`);
+    resolved = evalObject(lit);
+    enRef = loadEn();
+  }
+  // Preserve any leading comment block above the first import/export.
+  const headerLines = [];
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (t === "" || t.startsWith("//") || t.startsWith("/*") || t.startsWith("*") || t.startsWith("*/")) {
+      headerLines.push(line);
+    } else break;
+  }
+  const header = headerLines.join("\n").replace(/\n+$/, "");
+  return { exportName, resolved, enRef, header, isPartial };
+}
+
+// ── Diffing: build the minimal override tree (keys that differ from en) ─────
+
+function leafEqual(a, b) {
+  if (typeof a === "function" && typeof b === "function") return a.toString() === b.toString();
+  if (Array.isArray(a) && Array.isArray(b)) return JSON.stringify(a) === JSON.stringify(b);
+  return a === b;
+}
+
+/**
+ * Walk en's structure against the locale's resolved structure. Returns the
+ * override subtree containing only leaves that differ from en (orphans in the
+ * locale that en no longer has are dropped and reported separately).
+ */
+function buildOverride(enNode, locNode, path, orphans) {
+  if (!isRecord(enNode)) {
+    // en leaf — locale should match or inherit; nothing to override here.
+    return undefined;
+  }
+  const out = {};
+  let hasKey = false;
+  for (const k of Object.keys(enNode)) {
+    const childPath = path ? `${path}.${k}` : k;
+    const enChild = enNode[k];
+    const locChild = isRecord(locNode) ? locNode[k] : undefined;
+    if (isRecord(enChild)) {
+      const sub = buildOverride(enChild, locChild, childPath, orphans);
+      if (sub !== undefined) {
+        out[k] = sub;
+        hasKey = true;
+      }
+    } else {
+      // en leaf. Include only if the locale's resolved value differs.
+      if (locChild !== undefined && !leafEqual(locChild, enChild)) {
+        out[k] = locChild;
+        hasKey = true;
+      }
+    }
+  }
+  // Detect orphan keys present in the locale but absent from en.
+  if (isRecord(locNode)) {
+    for (const k of Object.keys(locNode)) {
+      if (!(k in enNode)) orphans.push(path ? `${path}.${k}` : k);
+    }
+  }
+  return hasKey ? out : undefined;
+}
+
+function leafCount(node) {
+  if (!isRecord(node)) return 1;
+  return Object.values(node).reduce((n, v) => n + leafCount(v), 0);
+}
+
+function collectLeafPaths(node, path = "", out = []) {
+  if (!isRecord(node)) {
+    out.push(path);
+    return out;
+  }
+  for (const k of Object.keys(node)) collectLeafPaths(node[k], path ? `${path}.${k}` : k, out);
+  return out;
+}
+
+// ── Deterministic serializer for the override tree ──────────────────────────
+
+function serializeValue(v, indent) {
+  if (typeof v === "function") return v.toString();
+  if (Array.isArray(v)) return JSON.stringify(v);
+  if (typeof v === "string") return serializeString(v);
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  if (v === null || v === undefined) return "null";
+  return serializeObject(v, indent);
+}
+
+function serializeString(s) {
+  // Use double quotes; escape backslashes, double quotes, and control chars.
+  const escaped = s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+  return `"${escaped}"`;
+}
+
+function keyNeedsQuotes(k) {
+  return !/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(k);
+}
+
+function serializeObject(obj, indent) {
+  const entries = Object.entries(obj);
+  if (entries.length === 0) return "{}";
+  const pad = " ".repeat(indent);
+  const inner = " ".repeat(indent + 2);
+  const lines = entries.map(([k, v]) => {
+    const key = keyNeedsQuotes(k) ? serializeString(k) : k;
+    return `${inner}${key}: ${serializeValue(v, indent + 2)},`;
+  });
+  return `{\n${lines.join("\n")}\n${pad}}`;
+}
+
+function renderFile(exportName, override, header) {
+  const body =
+    override === undefined
+      ? "defineLocale({})"
+      : `defineLocale(${serializeObject(override, 0)})`;
+  const preamble = header ? `${header}\n` : "";
+  return (
+    `${preamble}import { defineLocale } from "./define-locale";
+
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run \`npm run i18n:sync\` to propagate, and \`npm run i18n:check\`
+// (wired into CI) guards against drift.
+export const ${exportName} = ${body};
+`
+  );
+}
+
+// ── Commands ────────────────────────────────────────────────────────────────
+
+function localeFiles() {
+  return readdirSync(I18N_DIR)
+    .filter((f) => /^[a-z][a-z0-9-]*\.ts$/.test(f) && !SKIP.has(f))
+    .sort();
+}
+
+function cmdCheck() {
+  const en = loadEn();
+  const enPaths = new Set(collectLeafPaths(en));
+  let failures = 0;
+  for (const file of localeFiles()) {
+    const { resolved } = loadLocale(file);
+    const locPaths = collectLeafPaths(resolved);
+    const missing = [...enPaths].filter((p) => !new Set(locPaths).has(p));
+    const extra = locPaths.filter((p) => !enPaths.has(p));
+    if (missing.length || extra.length) {
+      failures++;
+      console.error(`✗ ${file} drifted from en.ts`);
+      if (missing.length) console.error(`    missing ${missing.length} key(s): ${missing.slice(0, 5).join(", ")}${missing.length > 5 ? ", …" : ""}`);
+      if (extra.length) console.error(`    orphan  ${extra.length} key(s): ${extra.slice(0, 5).join(", ")}${extra.length > 5 ? ", …" : ""}`);
+    }
+  }
+  if (failures) {
+    console.error(`\n${failures} locale(s) out of sync. Run \`npm run i18n:sync\` to fix.`);
+    process.exit(1);
+  }
+  console.log(`✓ all ${localeFiles().length} locales in sync with en.ts (${enPaths.size} keys)`);
+}
+
+function cmdFix() {
+  const en = loadEn();
+  let changed = 0;
+  for (const file of localeFiles()) {
+    const { exportName, resolved, header } = loadLocale(file);
+    const orphans = [];
+    const override = buildOverride(en, resolved, "", orphans);
+    const out = renderFile(exportName, override, header);
+    const path = join(I18N_DIR, file);
+    const before = readFileSync(path, "utf8");
+    if (before !== out) {
+      writeFileSync(path, out);
+      changed++;
+      const kept = override ? leafCount(override) : 0;
+      console.log(`↻ ${file} → defineLocale (${kept} translated key(s)${orphans.length ? `, ${orphans.length} orphan(s) dropped` : ""})`);
+    } else {
+      console.log(`· ${file} already synced`);
+    }
+  }
+  console.log(`\n${changed} file(s) updated. Run \`npm run i18n:check\` to confirm parity.`);
+}
+
+const arg = process.argv[2];
+if (arg === "--check") cmdCheck();
+else if (arg === "--fix") cmdFix();
+else {
+  console.error("Usage: node scripts/i18n-sync.mjs --check | --fix");
+  process.exit(2);
+}

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,9 @@
     "preview": "vite preview",
     "typecheck": "tsc -p . --noEmit",
     "test": "vitest run",
-    "check": "npm run typecheck && npm run test && npm run lint"
+    "i18n:check": "node ../scripts/i18n-sync.mjs --check",
+    "i18n:sync": "node ../scripts/i18n-sync.mjs --fix",
+    "check": "npm run i18n:check && npm run typecheck && npm run test && npm run lint"
   },
   "dependencies": {
     "@hermes/shared": "file:../apps/shared",

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const af: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const af = defineLocale({
   common: {
     save: "Stoor",
     saving: "Besig om te stoor...",
@@ -43,20 +47,12 @@ export const af: Translations = {
     expand: "Vou uit",
     general: "Algemeen",
     messaging: "Boodskappe",
-    pluginLoadFailed:
-      "Kon nie hierdie inprop se skrip laai nie. Kontroleer die Netwerk-oortjie (dashboard-plugins/…) en die bediener se inprop-pad.",
-    pluginNotRegistered:
-      "Die inprop se skrip het nie register() geroep nie, of die skrip het 'n fout gegee. Maak die blaaier-konsole oop vir besonderhede.",
+    pluginLoadFailed: "Kon nie hierdie inprop se skrip laai nie. Kontroleer die Netwerk-oortjie (dashboard-plugins/…) en die bediener se inprop-pad.",
+    pluginNotRegistered: "Die inprop se skrip het nie register() geroep nie, of die skrip het 'n fout gegee. Maak die blaaier-konsole oop vir besonderhede.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Maak navigasie toe",
     closeModelTools: "Maak model en gereedskap toe",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Aktiewe Sessies:",
     gatewayStatusLabel: "Gateway-status:",
     gatewayStrip: {
@@ -70,10 +66,8 @@ export const af: Translations = {
       analytics: "Analise",
       chat: "Klets",
       config: "Konfigurasie",
-      cron: "Cron",
       documentation: "Dokumentasie",
       keys: "Sleutels",
-      logs: "Logs",
       models: "Modelle",
       profiles: "profiele : multi-agente",
       plugins: "Inproppe",
@@ -81,7 +75,6 @@ export const af: Translations = {
       skills: "Vaardighede",
     },
     modelToolsSheetSubtitle: "& gereedskap",
-    modelToolsSheetTitle: "Model",
     navigation: "Navigasie",
     openDocumentation: "Maak dokumentasie in 'n nuwe oortjie oop",
     openNavigation: "Maak navigasie oop",
@@ -89,26 +82,21 @@ export const af: Translations = {
     sessionsActiveCount: "{count} aktief",
     statusOverview: "Statusoorsig",
     system: "Stelsel",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "Aksie het misluk",
     actionFinished: "Voltooi",
     actions: "Aksies",
-    agent: "Agent",
     activeSessions: "Aktiewe Sessies",
     connected: "Gekoppel",
     connectedPlatforms: "Gekoppelde Platforms",
     disconnected: "Ontkoppel",
     error: "Fout",
     failed: "Misluk",
-    gateway: "Gateway",
     gatewayFailedToStart: "Gateway kon nie begin nie",
     lastUpdate: "Laaste opdatering",
     noneRunning: "Geen",
     notRunning: "Loop nie",
-    pid: "PID",
     platformDisconnected: "ontkoppel",
     platformError: "fout",
     recentSessions: "Onlangse Sessies",
@@ -124,7 +112,6 @@ export const af: Translations = {
     updatingHermes: "Besig om Hermes op te werk…",
     waitingForOutput: "Wag vir uitset…",
   },
-
   sessions: {
     title: "Sessies",
     history: "Geskiedenis",
@@ -143,14 +130,12 @@ export const af: Translations = {
     untitledSession: "Sessie sonder titel",
     deleteSession: "Skrap sessie",
     confirmDeleteTitle: "Skrap sessie?",
-    confirmDeleteMessage:
-      "Dit verwyder die gesprek en al sy boodskappe permanent. Dit kan nie ongedaan gemaak word nie.",
+    confirmDeleteMessage: "Dit verwyder die gesprek en al sy boodskappe permanent. Dit kan nie ongedaan gemaak word nie.",
     sessionDeleted: "Sessie geskrap",
     failedToDelete: "Kon nie sessie skrap nie",
     deleteEmpty: "Skrap leë",
     deleteEmptyConfirmTitle: "Skrap leë sessies?",
-    deleteEmptyConfirmMessage:
-      "Dit verwyder permanent {count} sessies wat geen boodskappe het nie. Aktiewe en geargiveerde sessies word oorgeslaan. Dit kan nie ongedaan gemaak word nie.",
+    deleteEmptyConfirmMessage: "Dit verwyder permanent {count} sessies wat geen boodskappe het nie. Aktiewe en geargiveerde sessies word oorgeslaan. Dit kan nie ongedaan gemaak word nie.",
     emptySessionsDeleted: "{count} leë sessies geskrap",
     failedToDeleteEmpty: "Kon nie leë sessies skrap nie",
     selectSession: "Kies sessie",
@@ -159,8 +144,7 @@ export const af: Translations = {
     selectedCount: "{count} gekies",
     deleteSelected: "Skrap {count}",
     deleteSelectedConfirmTitle: "Skrap {count} sessies?",
-    deleteSelectedConfirmMessage:
-      "Dit verwyder {count} gekose sessies en al hul boodskappe permanent. Dit kan nie ongedaan gemaak word nie.",
+    deleteSelectedConfirmMessage: "Dit verwyder {count} gekose sessies en al hul boodskappe permanent. Dit kan nie ongedaan gemaak word nie.",
     selectedSessionsDeleted: "{count} sessies geskrap",
     failedToDeleteSelected: "Kon nie gekose sessies skrap nie",
     resumeInChat: "Hervat in Klets",
@@ -174,7 +158,6 @@ export const af: Translations = {
       tool: "Gereedskap",
     },
   },
-
   analytics: {
     period: "Tydperk:",
     totalTokens: "Totale Tokens",
@@ -194,17 +177,13 @@ export const af: Translations = {
     noUsageData: "Geen gebruiksdata vir hierdie tydperk nie",
     startSession: "Begin 'n sessie om analise hier te sien",
     date: "Datum",
-    model: "Model",
-    tokens: "Tokens",
     perDayAvg: "/dag gem.",
     acrossModels: "oor {count} modelle",
     inOut: "{input} in / {output} uit",
   },
-
   models: {
     modelsUsed: "Modelle Gebruik",
     estimatedCost: "Geskatte Koste",
-    tokens: "tokens",
     sessions: "sessies",
     avgPerSession: "gem./sessie",
     apiCalls: "API-oproepe",
@@ -212,9 +191,7 @@ export const af: Translations = {
     noModelsData: "Geen modelgebruiksdata vir hierdie tydperk nie",
     startSession: "Begin 'n sessie om modeldata hier te sien",
   },
-
   logs: {
-    title: "Logs",
     autoRefresh: "Outo-herlaai",
     file: "Lêer",
     level: "Vlak",
@@ -222,10 +199,8 @@ export const af: Translations = {
     lines: "Reëls",
     noLogLines: "Geen logreëls gevind nie",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Dit verwyder die taak van die skedule. Dit kan nie ongedaan gemaak word nie.",
+    confirmDeleteMessage: "Dit verwyder die taak van die skedule. Dit kan nie ongedaan gemaak word nie.",
     confirmDeleteTitle: "Skrap geskeduleerde taak?",
     newJob: "Nuwe Cron-taak",
     nameOptional: "Naam (opsioneel)",
@@ -233,7 +208,6 @@ export const af: Translations = {
     prompt: "Opdrag",
     promptPlaceholder: "Wat moet die agent met elke uitvoering doen?",
     schedule: "Skedule (cron-uitdrukking)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Skedule",
     scheduleModes: {
       interval: "Herhalende interval",
@@ -249,18 +223,15 @@ export const af: Translations = {
       unitDays: "dae",
       timeOfDay: "Tyd van die dag",
       weekdays: "Dae van die week",
-      weekdaysShort: ["Son", "Maa", "Din", "Woe", "Don", "Vry", "Sat"],
+      weekdaysShort: ["Son","Maa","Din","Woe","Don","Vry","Sat"],
       dayOfMonth: "Dag van die maand",
       onceAt: "Hardloop op",
       customLabel: "Cron-uitdrukking",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "Cron-uitdrukking met vyf velde (minuut, uur, dag, maand, weekdag).",
+      customHint: "Cron-uitdrukking met vyf velde (minuut, uur, dag, maand, weekdag).",
       preview: "Word gestuur as",
       previewEmpty: "(onvolledig)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "Elke {n} min",
       everyHours: "Elke {n} u",
       everyDays: "Elke {n} d",
@@ -279,27 +250,20 @@ export const af: Translations = {
     triggerNow: "Voer nou uit",
     delivery: {
       local: "Plaaslik",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "Nuwe Profiel",
     name: "Naam",
     namePlaceholder: "bv. coder, writer, ens.",
     nameRequired: "Naam word vereis",
-    nameRule:
-      "Slegs kleinletters, syfers, _ en -; moet met 'n letter of syfer begin; tot 64 karakters.",
-    invalidName: "Ongeldige profielnaam",    cloneFrom: "Kloon konfigurasie vanaf profiel",
+    nameRule: "Slegs kleinletters, syfers, _ en -; moet met 'n letter of syfer begin; tot 64 karakters.",
+    invalidName: "Ongeldige profielnaam",
+    cloneFrom: "Kloon konfigurasie vanaf profiel",
     cloneFromNone: "Geen (leeg)",
     allProfiles: "Profiele",
     noProfiles: "Geen profiele gevind nie.",
     defaultBadge: "verstek",
-    hasEnv: "env",
-    model: "Model",
     skills: "Vaardighede",
     rename: "Hernoem",
     editSoul: "Wysig SOUL.md",
@@ -311,13 +275,11 @@ export const af: Translations = {
     commandCopied: "Na knipbord gekopieer",
     copyFailed: "Kon nie kopieer nie",
     confirmDeleteTitle: "Skrap profiel?",
-    confirmDeleteMessage:
-      "Dit skrap profiel '{name}' permanent — konfigurasie, sleutels, geheue, sessies, vaardighede, cron-take. Kan nie ongedaan gemaak word nie.",
+    confirmDeleteMessage: "Dit skrap profiel '{name}' permanent — konfigurasie, sleutels, geheue, sessies, vaardighede, cron-take. Kan nie ongedaan gemaak word nie.",
     created: "Geskep",
     deleted: "Geskrap",
     renamed: "Hernoem",
   },
-
   pluginsPage: {
     contextEngineLabel: "Konteks-enjin",
     dashboardSlots: "Dashboard-gleuwe",
@@ -325,8 +287,7 @@ export const af: Translations = {
     enableAfterInstall: "Aktiveer ná installasie",
     enableRuntime: "Aktiveer",
     forceReinstall: "Forseer herinstallasie (skrap eers bestaande gids)",
-    headline:
-      "Ontdek, installeer, aktiveer en werk Hermes-inproppe op (`hermes plugins` ekwivalent).",
+    headline: "Ontdek, installeer, aktiveer en werk Hermes-inproppe op (`hermes plugins` ekwivalent).",
     identifierLabel: "Git-URL of owner/repo",
     inactive: "onaktief",
     installBtn: "Installeer",
@@ -340,8 +301,7 @@ export const af: Translations = {
     pluginListHeading: "Geïnstalleerde inproppe",
     providerDefaults: "ingebou / verstek",
     providersHeading: "Looptyd-verskafferinproppe",
-    providersHint:
-      "Skryf memory.provider (leeg = ingebou) en context.engine na config.yaml. Tree volgende sessie in werking.",
+    providersHint: "Skryf memory.provider (leeg = ingebou) en context.engine na config.yaml. Tree volgende sessie in werking.",
     refreshDashboard: "Herskandeer dashboard-uitbreidings",
     removeConfirm: "Verwyder hierdie inprop uit ~/.hermes/plugins/?",
     removeHint: "Slegs gebruiker-geïnstalleerde inproppe onder ~/.hermes/plugins kan verwyder word.",
@@ -353,19 +313,16 @@ export const af: Translations = {
     sourceBadge: "Bron",
     authRequired: "Verifikasie vereis",
     authRequiredHint: "Voer hierdie opdrag uit om te verifieer:",
-    updateGit: "Git pull",
     versionBadge: "Weergawe",
     showInSidebar: "Wys in sybalk",
     hideFromSidebar: "Versteek van sybalk",
   },
-
   skills: {
     title: "Vaardighede",
     searchPlaceholder: "Soek vaardighede en gereedskapstelle...",
     enabledOf: "{enabled}/{total} geaktiveer",
     all: "Alles",
     categories: "Kategorieë",
-    filters: "Filters",
     noSkills: "Geen vaardighede gevind nie. Vaardighede word gelaai uit ~/.hermes/skills/",
     noSkillsMatch: "Geen vaardighede stem ooreen met jou soektog of filter nie.",
     skillCount: "{count} vaardighe{s}id",
@@ -378,13 +335,9 @@ export const af: Translations = {
     disabledForCli: "Gedeaktiveer vir CLI",
     more: "+{count} meer",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
-    filters: "Filters",
     sections: "Afdelings",
     exportConfig: "Voer konfigurasie uit as JSON",
-    importConfig: "Voer konfigurasie in vanaf JSON",
     resetDefaults: "Stel terug na verstek",
     resetScopeTooltip: "Stel {scope} terug na verstek",
     confirmResetScope: "Stel alle {scope}-instellings terug na hul verstek? Dit werk slegs die vorm op — veranderinge word nie na config.yaml geskryf voordat jy Stoor druk nie.",
@@ -392,7 +345,7 @@ export const af: Translations = {
     rawYaml: "Rou YAML-konfigurasie",
     searchResults: "Soekresultate",
     fields: "veld{s}",
-    noFieldsMatch: 'Geen velde stem ooreen met "{query}" nie',
+    noFieldsMatch: "Geen velde stem ooreen met \"{query}\" nie",
     configSaved: "Konfigurasie gestoor",
     yamlConfigSaved: "YAML-konfigurasie gestoor",
     failedToSave: "Kon nie stoor nie",
@@ -402,7 +355,6 @@ export const af: Translations = {
     invalidJson: "Ongeldige JSON-lêer",
     categories: {
       general: "Algemeen",
-      agent: "Agent",
       terminal: "Terminaal",
       display: "Vertoon",
       delegation: "Delegasie",
@@ -414,15 +366,12 @@ export const af: Translations = {
       tts: "Teks-na-Spraak",
       stt: "Spraak-na-Teks",
       logging: "Aantekening",
-      discord: "Discord",
       auxiliary: "Hulpmiddels",
     },
   },
-
   env: {
     changesNote: "Veranderinge word onmiddellik na skyf gestoor. Aktiewe sessies tel nuwe sleutels outomaties op.",
-    confirmClearMessage:
-      "Die gestoorde waarde vir hierdie veranderlike sal uit jou .env-lêer verwyder word. Dit kan nie vanaf die UI ongedaan gemaak word nie.",
+    confirmClearMessage: "Die gestoorde waarde vir hierdie veranderlike sal uit jou .env-lêer verwyder word. Dit kan nie vanaf die UI ongedaan gemaak word nie.",
     confirmClearTitle: "Vee hierdie sleutel uit?",
     description: "Bestuur API-sleutels en geheime gestoor in",
     hideAdvanced: "Versteek Gevorderd",
@@ -448,12 +397,10 @@ export const af: Translations = {
     add: "Voeg by",
     invalidKeyName: "Gebruik slegs letters, syfers en onderstrepe (moet met 'n letter of onderstreep begin).",
   },
-
   oauth: {
     title: "Verskaffer-aanmeldings (OAuth)",
     providerLogins: "Verskaffer-aanmeldings (OAuth)",
-    description:
-      "{connected} van {total} OAuth-verskaffers gekoppel. Gebruik Meld aan vir vloeie wat die kontroleskerm ondersteun; CLI-opdragte bly beskikbaar vir eksterne of terugval-opstelling.",
+    description: "{connected} van {total} OAuth-verskaffers gekoppel. Gebruik Meld aan vir vloeie wat die kontroleskerm ondersteun; CLI-opdragte bly beskikbaar vir eksterne of terugval-opstelling.",
     connected: "Gekoppel",
     expired: "Verval",
     notConnected: "Nie gekoppel nie. Gebruik Meld aan indien beskikbaar, of voer {command} uit in 'n terminaal.",
@@ -490,24 +437,17 @@ export const af: Translations = {
     },
     expiresIn: "verval oor {time}",
   },
-
   language: {
     switchTo: "Verander taal",
   },
-
   theme: {
     title: "Tema",
     switchTheme: "Wissel tema",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Versamelbare Hermes-kentekens wat verdien word uit werklike sessiegeskiedenis. Bekende, onvoltooide prestasies word as Ontdek vertoon; Geheime prestasies bly verborge totdat die eerste ooreenstemmende gedrag verskyn.",
-      scan_subtitle:
-        "Hermes-sessiegeskiedenis word geskandeer. Die eerste skandering kan 5–10 sekondes neem op groot geskiedenisse.",
+      subtitle: "Versamelbare Hermes-kentekens wat verdien word uit werklike sessiegeskiedenis. Bekende, onvoltooide prestasies word as Ontdek vertoon; Geheime prestasies bly verborge totdat die eerste ooreenstemmende gedrag verskyn.",
+      scan_subtitle: "Hermes-sessiegeskiedenis word geskandeer. Die eerste skandering kan 5–10 sekondes neem op groot geskiedenisse.",
     },
     actions: {
       rescan: "Herskandeer",
@@ -520,7 +460,6 @@ export const af: Translations = {
       secrets: "Geheime",
       secrets_hint: "verborge tot eerste sein",
       highest_tier: "Hoogste vlak",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "Jongste",
       latest_hint_empty: "gebruik Hermes meer",
       none_yet: "Nog geen",
@@ -541,25 +480,19 @@ export const af: Translations = {
     },
     scan: {
       building_headline: "Prestasieprofiel word gebou…",
-      building_detail:
-        "Sessies, gereedskaproepe, modelmetadata en ontsluitstatus word gelees.",
+      building_detail: "Sessies, gereedskaproepe, modelmetadata en ontsluitstatus word gelees.",
       starting_headline: "Prestasieskandering begin…",
-      progress_detail:
-        "{scanned} van {total} sessies geskandeer · {pct}%. Kentekens ontsluit soos meer geskiedenis instroom.",
-      idle_detail:
-        "Sessies, gereedskaproepe, modelmetadata en ontsluitstatus word gelees. Kentekens verskyn hier soos hulle ontsluit.",
+      progress_detail: "{scanned} van {total} sessies geskandeer · {pct}%. Kentekens ontsluit soos meer geskiedenis instroom.",
+      idle_detail: "Sessies, gereedskaproepe, modelmetadata en ontsluitstatus word gelees. Kentekens verskyn hier soos hulle ontsluit.",
     },
     guide: {
       tiers_header: "Vlakke",
       secret_header: "Geheime prestasies",
-      secret_body:
-        "Geheime hou hul presiese sneller verborge. Sodra Hermes 'n verwante sein sien, word die kaart Ontdek en wys sy vereiste.",
+      secret_body: "Geheime hou hul presiese sneller verborge. Sodra Hermes 'n verwante sein sien, word die kaart Ontdek en wys sy vereiste.",
       scan_status_header: "Skanderingstatus",
-      scan_status_body:
-        "Hermes skandeer plaaslike geskiedenis een keer, daarna verskyn kaarte outomaties. Niks is vasgevang as dit 'n paar sekondes neem nie.",
+      scan_status_body: "Hermes skandeer plaaslike geskiedenis een keer, daarna verskyn kaarte outomaties. Niks is vasgevang as dit 'n paar sekondes neem nie.",
       what_scanned_header: "Wat geskandeer word",
-      what_scanned_body:
-        "Sessies, gereedskaproepe, modelmetadata, foute, prestasies en plaaslike ontsluitstatus.",
+      what_scanned_body: "Sessies, gereedskaproepe, modelmetadata, foute, prestasies en plaaslike ontsluitstatus.",
     },
     card: {
       share_title: "Deel hierdie prestasie",
@@ -576,8 +509,7 @@ export const af: Translations = {
     },
     empty: {
       no_secrets_header: "Geen verborge geheime in hierdie skandering oor nie.",
-      no_secrets_body:
-        "Wenk: geheime begin gewoonlik by ongewone mislukkings of magsgebruikerspatrone — poortbotsings, toestemmingsmure, ontbrekende env-veranderlikes, YAML-foute, Docker-botsings, terugrol/kontrolepunt-gebruik, kasterugslae of klein regstellings na baie rooi teks.",
+      no_secrets_body: "Wenk: geheime begin gewoonlik by ongewone mislukkings of magsgebruikerspatrone — poortbotsings, toestemmingsmure, ontbrekende env-veranderlikes, YAML-foute, Docker-botsings, terugrol/kontrolepunt-gebruik, kasterugslae of klein regstellings na baie rooi teks.",
     },
     filters: {
       all_categories: "Alles",
@@ -599,31 +531,19 @@ export const af: Translations = {
       copy_button: "Kopieer beeld",
       copied: "Gekopieer ✓",
       download_button: "Laai PNG af",
-      hint:
-        "Deel op X maak 'n vooraf-ingevulde plasing in 'n nuwe oortjie oop. Klik eers op Kopieer beeld as jy die 1200×630-kenteken aangeheg wil hê — X laat jou dit direk in die tweet-skrywer plak. Laai PNG af stoor die lêer om enige plek te gebruik.",
-      clipboard_unsupported:
-        "Beeldkopiëring na knipbord word nie in hierdie blaaier ondersteun nie — gebruik eerder Aflaai.",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "Deel op X maak 'n vooraf-ingevulde plasing in 'n nuwe oortjie oop. Klik eers op Kopieer beeld as jy die 1200×630-kenteken aangeheg wil hê — X laat jou dit direk in die tweet-skrywer plak. Laai PNG af stoor die lêer om enige plek te gebruik.",
+      clipboard_unsupported: "Beeldkopiëring na knipbord word nie in hierdie blaaier ondersteun nie — gebruik eerder Aflaai.",
     },
   },
   kanban: {
     loading: "Kanban-bord word gelaai…",
     loadFailed: "Kon nie Kanban-bord laai nie: ",
-    loadFailedHint:
-      "Die agterkant skep kanban.db outomaties met die eerste lees. Indien hierdie probleem aanhou, raadpleeg die paneellogboeke.",
+    loadFailedHint: "Die agterkant skep kanban.db outomaties met die eerste lees. Indien hierdie probleem aanhou, raadpleeg die paneellogboeke.",
     board: "Bord",
     newBoard: "+ Nuwe bord",
     newBoardTitle: "Nuwe bord",
-    newBoardDescription:
-      "Borde laat u toe om onverwante werkstrome te skei — een per projek, repositorium of domein. Werkers op een bord sien nooit 'n ander bord se take nie.",
-    slug: "Slug",
+    newBoardDescription: "Borde laat u toe om onverwante werkstrome te skei — een per projek, repositorium of domein. Werkers op een bord sien nooit 'n ander bord se take nie.",
     slugHint: "— kleinletters, koppeltekens, bv. atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Vertoonnaam",
     displayNameHint: "(opsioneel)",
     description: "Beskrywing",
@@ -656,7 +576,6 @@ export const af: Translations = {
     loadingDetail: "Word gelaai…",
     addComment: "Voeg 'n opmerking by… (Enter om in te dien)",
     comment: "Opmerking",
-    status: "Status",
     workspace: "Werkruimte",
     skills: "Vaardighede",
     createdBy: "Geskep deur",
@@ -666,8 +585,7 @@ export const af: Translations = {
     runHistory: "Uitvoergeskiedenis",
     workerLog: "Werker-log",
     loadingLog: "Log word gelaai…",
-    noWorkerLog:
-      "— nog geen werker-log nie (taak is nog nie ontketen nie of die log is geroteer) —",
+    noWorkerLog: "— nog geen werker-log nie (taak is nog nie ontketen nie of die log is geroteer) —",
     noDescription: "— geen beskrywing —",
     noComments: "— geen opmerkings —",
     edit: "redigeer",
@@ -698,8 +616,7 @@ export const af: Translations = {
     reassign: "Hertoeken",
     renderingError: "Kanban-oortjie het 'n weergawefout teëgekom",
     reloadView: "Herlaai aansig",
-    wsAuthFailed:
-      "WebSocket-verifikasie het misluk — herlaai die bladsy om die sessietoken te verfris.",
+    wsAuthFailed: "WebSocket-verifikasie het misluk — herlaai die bladsy om die sessietoken te verfris.",
     markDone: "Merk {n} take as klaar?",
     markArchived: "Argiveer {n} take?",
     warning: "Waarskuwing",
@@ -710,8 +627,7 @@ export const af: Translations = {
     showAllAttempts: "Wys alle pogings",
     sendingUpdates: "Stuur opdaterings na",
     sendNotifications: "Stuur completed / blocked / gave_up kennisgewings na",
-    archiveBoardConfirm:
-      "Argiveer bord '{name}'? Dit sal na boards/_archived/ geskuif word sodat u dit later kan herstel. Take op hierdie bord sal nie meer in die UI verskyn nie.",
+    archiveBoardConfirm: "Argiveer bord '{name}'? Dit sal na boards/_archived/ geskuif word sodat u dit later kan herstel. Take op hierdie bord sal nie meer in die UI verskyn nie.",
     archiveBoardTitle: "Argiveer hierdie bord",
     boardSwitcherHint: "Borde laat u toe om onverwante werkstrome te skei",
     taskCreatedWarning: "Taak geskep, maar: ",
@@ -731,7 +647,6 @@ export const af: Translations = {
     clickToEditAssignee: "Klik om toegewysde te redigeer",
     emptyAssignee: "(leeg = ontbind toekenning)",
     columnLabels: {
-      triage: "Triage",
       todo: "Te doen",
       scheduled: "Geskeduleerd",
       ready: "Gereed",
@@ -750,28 +665,20 @@ export const af: Translations = {
       done: "Voltooi",
       archived: "Gearchiveer",
     },
-    confirmDone:
-      "Merk hierdie taak as klaar? Die werker se eis word vrygestel en afhanklike kinders word gereed.",
-    confirmArchive:
-      "Argiveer hierdie taak? Dit verdwyn uit die verstek-bordaansig.",
-    confirmBlocked:
-      "Merk hierdie taak as geblokkeer? Die werker se eis word vrygestel.",
-    completionSummary:
-      "Voltooiingsopsomming vir {label}. Dit word as die taak se result gestoor.",
-    completionSummaryRequired:
-      "'n Voltooiingsopsomming is verpligtend voordat 'n taak as klaar gemerk word.",
+    confirmDone: "Merk hierdie taak as klaar? Die werker se eis word vrygestel en afhanklike kinders word gereed.",
+    confirmArchive: "Argiveer hierdie taak? Dit verdwyn uit die verstek-bordaansig.",
+    confirmBlocked: "Merk hierdie taak as geblokkeer? Die werker se eis word vrygestel.",
+    completionSummary: "Voltooiingsopsomming vir {label}. Dit word as die taak se result gestoor.",
+    completionSummaryRequired: "'n Voltooiingsopsomming is verpligtend voordat 'n taak as klaar gemerk word.",
     triagePlaceholder: "Rowwe idee — KI sal dit spesifiseer…",
     taskTitlePlaceholder: "Nuwe taaktitel…",
     specifier: "spesifiseerder",
     assigneePlaceholder: "toegewysde",
     priority: "Prioriteit",
-    skillsPlaceholder:
-      "vaardighede (opsioneel, kommageskei): translation, github-code-review",
+    skillsPlaceholder: "vaardighede (opsioneel, kommageskei): translation, github-code-review",
     noParent: "— geen ouer —",
     workspacePathDir: "werkruimtepad (verpligtend, bv. ~/projects/my-app)",
-    workspacePathOptional:
-      "werkruimtepad (opsioneel, afgelei van toegewysde indien leeg)",
+    workspacePathOptional: "werkruimtepad (opsioneel, afgelei van toegewysde indien leeg)",
     logTruncated: "(toon laaste 100 KB — volledige log by ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/ar.ts
+++ b/web/src/i18n/ar.ts
@@ -1,5 +1,9 @@
 import { defineLocale } from "./define-locale";
 
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
 export const ar = defineLocale({
   common: {
     save: "حفظ",
@@ -43,20 +47,12 @@ export const ar = defineLocale({
     expand: "توسيع",
     general: "عام",
     messaging: "مراسلة",
-    pluginLoadFailed:
-      "تعذر تحميل سكربت هذا المكوِّن الإضافي. تفقَّد علامة الشبكة (dashboard-plugins/…) ومسار ملحقات الخادم.",
-    pluginNotRegistered:
-      "لم يستدعِ سكربت المكوِّن الإضافي register()، أو حدث خطأ في السكربت. افتح وحدة تحكم المتصفح للتفاصيل.",
+    pluginLoadFailed: "تعذر تحميل سكربت هذا المكوِّن الإضافي. تفقَّد علامة الشبكة (dashboard-plugins/…) ومسار ملحقات الخادم.",
+    pluginNotRegistered: "لم يستدعِ سكربت المكوِّن الإضافي register()، أو حدث خطأ في السكربت. افتح وحدة تحكم المتصفح للتفاصيل.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "إغلاق التنقل",
     closeModelTools: "إغلاق النموذج والأدوات",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "الجلسات النشطة:",
     gatewayStatusLabel: "حالة البوابة:",
     gatewayStrip: {
@@ -91,7 +87,6 @@ export const ar = defineLocale({
     system: "النظام",
     webUi: "واجهة الويب",
   },
-
   status: {
     actionFailed: "فشلت الإجراء",
     actionFinished: "انتهى",
@@ -108,7 +103,6 @@ export const ar = defineLocale({
     lastUpdate: "آخر تحديث",
     noneRunning: "لا شيء",
     notRunning: "لا يعمل",
-    pid: "PID",
     platformDisconnected: "غير متصل",
     platformError: "خطأ",
     recentSessions: "الجلسات الأخيرة",
@@ -124,7 +118,6 @@ export const ar = defineLocale({
     updatingHermes: "جاري تحديث Hermes…",
     waitingForOutput: "في انتظار الناتج…",
   },
-
   sessions: {
     title: "الجلسات",
     filterChats: "الدردشات",
@@ -132,17 +125,16 @@ export const ar = defineLocale({
     filterAll: "الكل",
     sourceFilter: "مصدر الجلسة",
     anySource: "أي مصدر",
-    noSessionsInFilter: "لا توجد جلسات في هذا الفلتر",
     searchPlaceholder: "بحث في محتوى الرسائل...",
-        noSessions: "لا توجد جلسات حتى الآن",
+    noSessions: "لا توجد جلسات حتى الآن",
+    noSessionsInFilter: "لا توجد جلسات في هذا الفلتر",
     noMatch: "لا توجد جلسات تطابق بحثك",
     startConversation: "ابدأ محادثة لتظهر هنا",
     noMessages: "لا توجد رسائل",
     untitledSession: "جلسة بدون عنوان",
     deleteSession: "حذف الجلسة",
     confirmDeleteTitle: "حذف الجلسة؟",
-    confirmDeleteMessage:
-      "سيزيل هذا نهائيًا المحادثة وجميع رسائلها. لا يمكن التراجع عن هذا الإجراء.",
+    confirmDeleteMessage: "سيزيل هذا نهائيًا المحادثة وجميع رسائلها. لا يمكن التراجع عن هذا الإجراء.",
     sessionDeleted: "تم حذف الجلسة",
     failedToDelete: "فشل حذف الجلسة",
     resumeInChat: "استئناف في المحادثة",
@@ -155,7 +147,6 @@ export const ar = defineLocale({
       tool: "أداة",
     },
   },
-
   analytics: {
     period: "الفترة:",
     totalTokens: "إجمالي الرموز",
@@ -181,7 +172,6 @@ export const ar = defineLocale({
     acrossModels: "عبر {count} نموذج",
     inOut: "{input} إدخال / {output} إخراج",
   },
-
   models: {
     modelsUsed: "النماذج المستخدمة",
     estimatedCost: "التكلفة التقريبية",
@@ -193,7 +183,6 @@ export const ar = defineLocale({
     noModelsData: "لا توجد بيانات نموذج لهذه الفترة",
     startSession: "ابدأ جلسة لرؤية بيانات النماذج هنا",
   },
-
   logs: {
     title: "السجلات",
     autoRefresh: "تحديث تلقائي",
@@ -203,10 +192,8 @@ export const ar = defineLocale({
     lines: "الأسطر",
     noLogLines: "لم يُعثر على أسطر سجل",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "يزيل هذا المهمة من الجدولة. لا يمكن التراجع عن الإجراء.",
+    confirmDeleteMessage: "يزيل هذا المهمة من الجدولة. لا يمكن التراجع عن الإجراء.",
     confirmDeleteTitle: "حذف المهمة المجدولة؟",
     newJob: "مهمة cron جديدة",
     nameOptional: "الاسم (اختياري)",
@@ -214,7 +201,6 @@ export const ar = defineLocale({
     prompt: "المطالبة",
     promptPlaceholder: "ماذا يجب أن يفعل العامل في كل تشغيل؟",
     schedule: "الجدولة (تعبير cron)",
-    schedulePlaceholder: "0 9 * * *",
     deliverTo: "التسليم إلى",
     scheduledJobs: "المهام المجدولة",
     noJobs: "لم يتم تكوين أي مهام cron. أنشئ واحدة أعلاه.",
@@ -225,25 +211,19 @@ export const ar = defineLocale({
     triggerNow: "تشغيل الآن",
     delivery: {
       local: "محلي",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
       email: "البريد الإلكتروني",
     },
   },
-
   profiles: {
     newProfile: "ملف شخصي جديد",
     name: "الاسم",
     namePlaceholder: "مثال: coder, writer, إلخ.",
     nameRequired: "الاسم مطلوب",
-    nameRule:
-      "حروف صغيرة، أرقام، _ و - فقط؛ يجب البدء بحرف أو رقم؛ حتى 64 حرفًا.",
+    nameRule: "حروف صغيرة، أرقام، _ و - فقط؛ يجب البدء بحرف أو رقم؛ حتى 64 حرفًا.",
     invalidName: "اسم ملف شخصي غير صالح",
     allProfiles: "الملفات الشخصية",
     noProfiles: "لم يُعثر على ملفات شخصية.",
     defaultBadge: "افتراضي",
-    hasEnv: "env",
     model: "النموذج",
     skills: "المهارات",
     rename: "إعادة تسمية",
@@ -256,13 +236,11 @@ export const ar = defineLocale({
     commandCopied: "تم النسخ إلى الحافظة",
     copyFailed: "تعذر النسخ",
     confirmDeleteTitle: "حذف الملف الشخصي؟",
-    confirmDeleteMessage:
-      "هذا يحذف نهائيًا الملف الشخصي '{name}' — الإعدادات، المفاتيح، الذكريات، الجلسات، المهارات، مهام cron. لا يمكن التراجع عن الإجراء.",
+    confirmDeleteMessage: "هذا يحذف نهائيًا الملف الشخصي '{name}' — الإعدادات، المفاتيح، الذكريات، الجلسات، المهارات، مهام cron. لا يمكن التراجع عن الإجراء.",
     created: "تم الإنشاء",
     deleted: "تم الحذف",
     renamed: "تمت إعادة التسمية",
   },
-
   pluginsPage: {
     contextEngineLabel: "محرك السياق",
     dashboardSlots: "فتحات لوحة التحكم",
@@ -270,8 +248,7 @@ export const ar = defineLocale({
     enableAfterInstall: "تفعيل بعد التثبيت",
     enableRuntime: "تفعيل",
     forceReinstall: "إعادة تثبيت إجباري (حذف المجلد الموجود أولاً)",
-    headline:
-      "اكتشف وثبِّت وفعِّل وحدِّث مكوِّنات Hermes الإضافية (مطابقة `hermes plugins`).",
+    headline: "اكتشف وثبِّت وفعِّل وحدِّث مكوِّنات Hermes الإضافية (مطابقة `hermes plugins`).",
     identifierLabel: "رابط Git أو owner/repo",
     inactive: "غير نشط",
     installBtn: "تثبيت من Git",
@@ -285,8 +262,7 @@ export const ar = defineLocale({
     pluginListHeading: "المكوِّنات الإضافية المثبتة",
     providerDefaults: "مدمج / افتراضي",
     providersHeading: "مكوِّنات مزوِّدات وقت التشغيل",
-    providersHint:
-      "يكتب memory.provider (فارغ = مدمج) و context.engine إلى config.yaml. يسري في الجلسة التالية.",
+    providersHint: "يكتب memory.provider (فارغ = مدمج) و context.engine إلى config.yaml. يسري في الجلسة التالية.",
     refreshDashboard: "إعادة فحص امتدادات لوحة التحكم",
     removeConfirm: "إزالة هذا المكوِّن الإضافي من ~/.hermes/plugins/؟",
     removeHint: "يمكن إزالة المكوِّنات المثبتة من المستخدم تحت ~/.hermes/plugins فقط.",
@@ -303,7 +279,6 @@ export const ar = defineLocale({
     showInSidebar: "إظهار في الشريط الجانبي",
     hideFromSidebar: "إخفاء من الشريط الجانبي",
   },
-
   skills: {
     title: "المهارات",
     searchPlaceholder: "بحث في المهارات ومجموعات الأدوات...",
@@ -323,22 +298,18 @@ export const ar = defineLocale({
     disabledForCli: "معطَّل لواجهة CLI",
     more: "+{count} المزيد",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "الفلاتر",
     sections: "الأقسام",
     exportConfig: "تصدير الإعدادات كـ JSON",
-    importConfig: "استيراد الإعدادات من JSON",
     resetDefaults: "إعادة التعيين للافتراضيات",
     resetScopeTooltip: "إعادة تعيين {scope} للافتراضيات",
-    confirmResetScope:
-      "إعادة تعيين جميع إعدادات {scope} للافتراضيات؟ هذا يحدِّث النموذج فقط — لا تُكتب التغييرات في config.yaml حتى تضغط على حفظ.",
+    confirmResetScope: "إعادة تعيين جميع إعدادات {scope} للافتراضيات؟ هذا يحدِّث النموذج فقط — لا تُكتب التغييرات في config.yaml حتى تضغط على حفظ.",
     resetScopeToast: "تمت إعادة تعيين {scope} للافتراضيات — راجع واحفظ للتثبيت",
     rawYaml: "إعدادات YAML الأولية",
     searchResults: "نتائج البحث",
     fields: "حقل{s}",
-    noFieldsMatch: 'لا توجد حقول تطابق "{query}"',
+    noFieldsMatch: "لا توجد حقول تطابق \"{query}\"",
     configSaved: "تم حفظ الإعدادات",
     yamlConfigSaved: "تم حفظ إعدادات YAML",
     failedToSave: "فشل الحفظ",
@@ -360,15 +331,12 @@ export const ar = defineLocale({
       tts: "تحويل النص إلى كلام",
       stt: "تحويل الكلام إلى نص",
       logging: "التسجيل",
-      discord: "Discord",
       auxiliary: "إضافي",
     },
   },
-
   env: {
     changesNote: "يتم حفظ التغييرات على القرص فورًا. تلتقط الجلسات النشطة المفاتيح الجديدة تلقائيًا.",
-    confirmClearMessage:
-      "سيتم إزالة القيمة المخزنة لهذا المتغير من ملف .env. لا يمكن التراجع عن هذا من الواجهة.",
+    confirmClearMessage: "سيتم إزالة القيمة المخزنة لهذا المتغير من ملف .env. لا يمكن التراجع عن هذا من الواجهة.",
     confirmClearTitle: "مسح هذا المفتاح؟",
     description: "إدارة مفاتيح API والأسرار المخزَّنة في",
     hideAdvanced: "إخفاء المتقدمة",
@@ -384,12 +352,10 @@ export const ar = defineLocale({
     showValue: "إظهار القيمة الحقيقية",
     hideValue: "إخفاء القيمة",
   },
-
   oauth: {
     title: "عمليات تسجيل دخول المزوِّدين (OAuth)",
     providerLogins: "عمليات تسجيل دخول المزوِّدين (OAuth)",
-    description:
-      "{connected} من {total} مزوِّدي OAuth متصلون. تتدفق عمليات تسجيل الدخول حاليًا عبر CLI؛ انسخ الأمر وألصقه في طرفية للإعداد.",
+    description: "{connected} من {total} مزوِّدي OAuth متصلون. تتدفق عمليات تسجيل الدخول حاليًا عبر CLI؛ انسخ الأمر وألصقه في طرفية للإعداد.",
     connected: "متصل",
     expired: "منتهي الصلاحية",
     notConnected: "غير متصل. شغِّل {command} في طرفية.",
@@ -424,24 +390,18 @@ export const ar = defineLocale({
     },
     expiresIn: "تنتهي خلال {time}",
   },
-
   language: {
     switchTo: "التبديل إلى الإنجليزية",
   },
-
   theme: {
     title: "السمة",
     switchTheme: "تبديل السمة",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
       title: "إنجازات Hermes",
-      subtitle:
-        "شارات Hermes قابلة للجمع مكتسبة من سجل الجلسات الفعلي. الإنجازات غير المكتملة المعروفة تُعرض كـ Discovered؛ تبقى الإنجازات السرية مخفية حتى يظهر السلوك المطابق لأول مرة.",
-      scan_subtitle:
-        "فحص سجل جلسات Hermes. يمكن أن يستغرق الفحص الأول 5–10 ثوانٍ على السجلات الكبيرة.",
+      subtitle: "شارات Hermes قابلة للجمع مكتسبة من سجل الجلسات الفعلي. الإنجازات غير المكتملة المعروفة تُعرض كـ Discovered؛ تبقى الإنجازات السرية مخفية حتى يظهر السلوك المطابق لأول مرة.",
+      scan_subtitle: "فحص سجل جلسات Hermes. يمكن أن يستغرق الفحص الأول 5–10 ثوانٍ على السجلات الكبيرة.",
     },
     actions: {
       rescan: "إعادة الفحص",
@@ -475,25 +435,19 @@ export const ar = defineLocale({
     },
     scan: {
       building_headline: "إنشاء ملف الإنجاز…",
-      building_detail:
-        "قراءة الجلسات، استدعاءات الأدوات، بيانات تعريف النموذج، وحالة الفتح.",
+      building_detail: "قراءة الجلسات، استدعاءات الأدوات، بيانات تعريف النموذج، وحالة الفتح.",
       starting_headline: "بدء فحص الإنجازات…",
-      progress_detail:
-        "تم فحص {scanned} من {total} جلسة · {pct}%. تنفتح الشارات مع تدفق المزيد من السجل.",
-      idle_detail:
-        "قراءة الجلسات، استدعاءات الأدوات، بيانات تعريف النموذج، وحالة الفتح. تظهر الشارات هنا عند فتحها.",
+      progress_detail: "تم فحص {scanned} من {total} جلسة · {pct}%. تنفتح الشارات مع تدفق المزيد من السجل.",
+      idle_detail: "قراءة الجلسات، استدعاءات الأدوات، بيانات تعريف النموذج، وحالة الفتح. تظهر الشارات هنا عند فتحها.",
     },
     guide: {
       tiers_header: "المستويات",
       secret_header: "الإنجازات السرية",
-      secret_body:
-        "تخفى الأسرار محددها الدقيق. بمجرد أن ترى Hermes إشارة ذات صلة، تصبح البطاقة مكتشفة وتعرض متطلباتها.",
+      secret_body: "تخفى الأسرار محددها الدقيق. بمجرد أن ترى Hermes إشارة ذات صلة، تصبح البطاقة مكتشفة وتعرض متطلباتها.",
       scan_status_header: "حالة الفحص",
-      scan_status_body:
-        "تُفحص Hermes السجل المحلي مرة واحدة، ثم تظهر البطاقات تلقائيًا. لا يوجد توقف إذا استغرق هذا بضع ثوانٍ.",
+      scan_status_body: "تُفحص Hermes السجل المحلي مرة واحدة، ثم تظهر البطاقات تلقائيًا. لا يوجد توقف إذا استغرق هذا بضع ثوانٍ.",
       what_scanned_header: "ما يتم فحصه",
-      what_scanned_body:
-        "الجلسات، استدعاءات الأدوات، بيانات تعريف النموذج، الأخطاء، الإنجازات، وحالة الفتح المحلية.",
+      what_scanned_body: "الجلسات، استدعاءات الأدوات، بيانات تعريف النموذج، الأخطاء، الإنجازات، وحالة الفتح المحلية.",
     },
     card: {
       share_title: "مشاركة هذا الإنجاز",
@@ -510,8 +464,7 @@ export const ar = defineLocale({
     },
     empty: {
       no_secrets_header: "لا توجد أسرار مخفية متبقية في هذا الفحص.",
-      no_secrets_body:
-        "تلميح: تبدأ الأسرار عادة من أنماط الفشل غير العادية أو أنماط المستخدم المتقدم — تعارضات المنافذ، حواجز الأذونات، متغيرات بيئة مفقودة، أخطاء YAML، تصادمات Docker، استخدام الإرجاع أو التبقي، ضربات التخزين المؤقت، أو إصلاحات صغيرة بعد الكثير من الأخطاء الحمراء."
+      no_secrets_body: "تلميح: تبدأ الأسرار عادة من أنماط الفشل غير العادية أو أنماط المستخدم المتقدم — تعارضات المنافذ، حواجز الأذونات، متغيرات بيئة مفقودة، أخطاء YAML، تصادمات Docker، استخدام الإرجاع أو التبقي، ضربات التخزين المؤقت، أو إصلاحات صغيرة بعد الكثير من الأخطاء الحمراء.",
     },
     filters: {
       all_categories: "الكل",
@@ -533,32 +486,21 @@ export const ar = defineLocale({
       copy_button: "نسخ الصورة",
       copied: "تم النسخ ✓",
       download_button: "تنزيل PNG",
-      hint:
-        "المشاركة على X تفتح منشورًا معدَّلاً مسبقًا في تبويب جديد. انقر نسخ الصورة أولاً إذا أردت شارة الإنجاز 1200×630 مرفقة — يسمح X باللصق مباشرة في مؤلف التغريد. تنزيل PNG يحفظ الملف للاستخدام anywhere.",
-      clipboard_unsupported:
-        "نسخ صورة الحافظة غير مدعوم في هذا المتصفح — استخدم التنزيل بدلاً من ذلك.",
-      tweet_text: "فتحت للتو {tier_part}\"{name}\" في Hermes Agent ☤"
+      hint: "المشاركة على X تفتح منشورًا معدَّلاً مسبقًا في تبويب جديد. انقر نسخ الصورة أولاً إذا أردت شارة الإنجاز 1200×630 مرفقة — يسمح X باللصق مباشرة في مؤلف التغريد. تنزيل PNG يحفظ الملف للاستخدام anywhere.",
+      clipboard_unsupported: "نسخ صورة الحافظة غير مدعوم في هذا المتصفح — استخدم التنزيل بدلاً من ذلك.",
+      tweet_text: "فتحت للتو {tier_part}\"{name}\" في Hermes Agent ☤",
     },
   },
-
   kanban: {
     loading: "جاري تحميل لوحة Kanban…",
     loadFailed: "فشل تحميل لوحة Kanban: ",
-    loadFailedHint:
-      "يُنشئ الواجهة الخلفية kanban.db تلقائيًا عند أول قراءة. إذا استمرت المشكلة، تفقَّد سجلات لوحة التحكم.",
+    loadFailedHint: "يُنشئ الواجهة الخلفية kanban.db تلقائيًا عند أول قراءة. إذا استمرت المشكلة، تفقَّد سجلات لوحة التحكم.",
     board: "لوحة",
     newBoard: "+ لوحة جديدة",
     newBoardTitle: "لوحة جديدة",
-    newBoardDescription:
-      "تتيح اللوحات فصل تدفقات العمل غير المرتبطة — واحدة لكل مشروع أو مستودع أو مجال.",
+    newBoardDescription: "تتيح اللوحات فصل تدفقات العمل غير المرتبطة — واحدة لكل مشروع أو مستودع أو مجال.",
     slug: "المعرِّف",
     slugHint: "— أحرف صغيرة، واصلات، مثال atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "الاسم المعروض",
     displayNameHint: "(اختياري)",
     description: "الوصف",
@@ -588,8 +530,7 @@ export const ar = defineLocale({
     noTasks: "— لا توجد مهام —",
     unassigned: "غير مكلَّف",
     needsAssignee: "يحتاج مكلِّف",
-    needsAssigneeHint:
-      "المتطلبات مُلباة، لكن المُجلِّب يتخطى هذه المهمة حتى تعيّن ملفًا شخصيًا.",
+    needsAssigneeHint: "المتطلبات مُلباة، لكن المُجلِّب يتخطى هذه المهمة حتى تعيّن ملفًا شخصيًا.",
     untitled: "(بدون عنوان)",
     loadingDetail: "جاري التحميل…",
     addComment: "إضافة تعليق… (Enter للتقديم)",
@@ -604,8 +545,7 @@ export const ar = defineLocale({
     runHistory: "سجل التنفيذ",
     workerLog: "سجل العامل",
     loadingLog: "جاري تحميل السجل…",
-    noWorkerLog:
-      "— لا يوجد سجل عامل بعد (لم تُنشَ المهمة أو تم تدوير السجل) —",
+    noWorkerLog: "— لا يوجد سجل عامل بعد (لم تُنشَ المهمة أو تم تدوير السجل) —",
     noDescription: "— لا يوجد وصف —",
     noComments: "— لا توجد تعليقات —",
     edit: "تعديل",
@@ -636,8 +576,7 @@ export const ar = defineLocale({
     reassign: "إعادة تعيين",
     renderingError: "اصطدم تبويب Kanban بخطأ عرض",
     reloadView: "إعادة تحميل العرض",
-    wsAuthFailed:
-      "فشلت مصادقة WebSocket — أعد تحميل الصفحة لتحديث رمز الجلسة.",
+    wsAuthFailed: "فشلت مصادقة WebSocket — أعد تحميل الصفحة لتحديث رمز الجلسة.",
     markDone: "تحديد {n} مهمة كمكتملة؟",
     markArchived: "أرشفة {n} مهمة؟",
     warning: "تحذير",
@@ -648,8 +587,7 @@ export const ar = defineLocale({
     showAllAttempts: "إظهار كل المحاولات",
     sendingUpdates: "إرسال التحديثات إلى",
     sendNotifications: "إرسال إشعارات مكتمل / محظور / متروك لـ",
-    archiveBoardConfirm:
-      "أرشفة لوحة '{name}'؟ ستُنقَل إلى boards/_archived/ لتتمكن من استرجاعها لاحقًا. المهام على هذه اللوحة لن تظهر بعد الآن في أي مكان في الواجهة.",
+    archiveBoardConfirm: "أرشفة لوحة '{name}'؟ ستُنقَل إلى boards/_archived/ لتتمكن من استرجاعها لاحقًا. المهام على هذه اللوحة لن تظهر بعد الآن في أي مكان في الواجهة.",
     archiveBoardTitle: "أرشفة هذه اللوحة",
     boardSwitcherHint: "تتيح اللوحات فصل تدفقات عمل غير مرتبطة",
     taskCreatedWarning: "تم إنشاء المهمة، لكن: ",
@@ -686,28 +624,20 @@ export const ar = defineLocale({
       done: "مكتمل",
       archived: "مؤرشف",
     },
-    confirmDone:
-      "تحديد هذه المهمة كمكتملة؟ سيتم تحرير مطالبة العامل ويصبح الأبناء المعتمدون جاهزين.",
-    confirmArchive:
-      "أرشفة هذه المهمة؟ ستختفي من عرض اللوحة الافتراضي.",
-    confirmBlocked:
-      "تحديد هذه المهمة كمحظورة؟ سيتم تحرير مطالبة العامل.",
-    completionSummary:
-      "ملخص الإنجاز لـ {label}. يُخزَّن كنتيجة للمهمة.",
-    completionSummaryRequired:
-      "ملخص الإنجاز مطلوب قبل تحديد المهمة كمكتملة.",
+    confirmDone: "تحديد هذه المهمة كمكتملة؟ سيتم تحرير مطالبة العامل ويصبح الأبناء المعتمدون جاهزين.",
+    confirmArchive: "أرشفة هذه المهمة؟ ستختفي من عرض اللوحة الافتراضي.",
+    confirmBlocked: "تحديد هذه المهمة كمحظورة؟ سيتم تحرير مطالبة العامل.",
+    completionSummary: "ملخص الإنجاز لـ {label}. يُخزَّن كنتيجة للمهمة.",
+    completionSummaryRequired: "ملخص الإنجاز مطلوب قبل تحديد المهمة كمكتملة.",
     triagePlaceholder: "فكرةrough — سيقوم الذكاء الاصطناعي بصياغة المواصفات…",
     taskTitlePlaceholder: "عنوان المهمة الجديد…",
     specifier: "محدِّد المواصفات",
     assigneePlaceholder: "المكلَّف",
     priority: "الأولوية",
-    skillsPlaceholder:
-      "مهارات (اختياري، مفصولة بفواصل): translation, github-code-review",
+    skillsPlaceholder: "مهارات (اختياري، مفصولة بفواصل): translation, github-code-review",
     noParent: "— لا يوجد أب —",
     workspacePathDir: "مسار مساحة العمل (مطلوب، مثال ~/projects/my-app)",
-    workspacePathOptional:
-      "مسار مساحة العمل (اختياري، مستنتج من المكلَّف إذا كان فارغًا)",
+    workspacePathOptional: "مسار مساحة العمل (اختياري، مستنتج من المكلَّف إذا كان فارغًا)",
     logTruncated: "(عرض آخر 100 كيلوبايت — السجل الكامل في ",
-    logAt: ")",
   },
 });

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const de: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const de = defineLocale({
   common: {
     save: "Speichern",
     saving: "Speichern...",
@@ -17,7 +21,6 @@ export const de: Translations = {
     set: "Festlegen",
     replace: "Ersetzen",
     clear: "Leeren",
-    live: "Live",
     off: "Aus",
     enabled: "aktiviert",
     disabled: "deaktiviert",
@@ -42,21 +45,12 @@ export const de: Translations = {
     collapse: "Einklappen",
     expand: "Ausklappen",
     general: "Allgemein",
-    messaging: "Messaging",
-    pluginLoadFailed:
-      "Das Skript dieses Plugins konnte nicht geladen werden. Prüfe den Netzwerk-Tab (dashboard-plugins/…) und den Plugin-Pfad des Servers.",
-    pluginNotRegistered:
-      "Das Skript des Plugins hat register() nicht aufgerufen oder ist fehlgeschlagen. Öffne die Browser-Konsole für Details.",
+    pluginLoadFailed: "Das Skript dieses Plugins konnte nicht geladen werden. Prüfe den Netzwerk-Tab (dashboard-plugins/…) und den Plugin-Pfad des Servers.",
+    pluginNotRegistered: "Das Skript des Plugins hat register() nicht aufgerufen oder ist fehlgeschlagen. Öffne die Browser-Konsole für Details.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Navigation schließen",
     closeModelTools: "Modell und Werkzeuge schließen",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Aktive Sitzungen:",
     gatewayStatusLabel: "Gateway-Status:",
     gatewayStrip: {
@@ -68,47 +62,35 @@ export const de: Translations = {
     },
     nav: {
       analytics: "Analyse",
-      chat: "Chat",
       config: "Konfiguration",
-      cron: "Cron",
       documentation: "Dokumentation",
       keys: "Schlüssel",
       logs: "Protokolle",
       models: "Modelle",
       profiles: "Profile : Multi-Agenten",
-      plugins: "Plugins",
       sessions: "Sitzungen",
-      skills: "Skills",
     },
     modelToolsSheetSubtitle: "& Werkzeuge",
     modelToolsSheetTitle: "Modell",
-    navigation: "Navigation",
     openDocumentation: "Dokumentation in neuem Tab öffnen",
     openNavigation: "Navigation öffnen",
-    pluginNavSection: "Plugins",
     sessionsActiveCount: "{count} aktiv",
     statusOverview: "Statusübersicht",
-    system: "System",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "Aktion fehlgeschlagen",
     actionFinished: "Abgeschlossen",
     actions: "Aktionen",
-    agent: "Agent",
     activeSessions: "Aktive Sitzungen",
     connected: "Verbunden",
     connectedPlatforms: "Verbundene Plattformen",
     disconnected: "Getrennt",
     error: "Fehler",
     failed: "Fehlgeschlagen",
-    gateway: "Gateway",
     gatewayFailedToStart: "Gateway konnte nicht gestartet werden",
     lastUpdate: "Letzte Aktualisierung",
     noneRunning: "Keine",
     notRunning: "Läuft nicht",
-    pid: "PID",
     platformDisconnected: "getrennt",
     platformError: "Fehler",
     recentSessions: "Letzte Sitzungen",
@@ -124,12 +106,10 @@ export const de: Translations = {
     updatingHermes: "Hermes wird aktualisiert…",
     waitingForOutput: "Warte auf Ausgabe…",
   },
-
   sessions: {
     title: "Sitzungen",
     history: "Verlauf",
     overview: "Übersicht",
-    filterChats: "Chats",
     filterAutomation: "Automatisierung",
     filterAll: "Alle",
     sourceFilter: "Sitzungsquelle",
@@ -143,14 +123,12 @@ export const de: Translations = {
     untitledSession: "Sitzung ohne Titel",
     deleteSession: "Sitzung löschen",
     confirmDeleteTitle: "Sitzung löschen?",
-    confirmDeleteMessage:
-      "Dies entfernt die Unterhaltung und alle Nachrichten dauerhaft. Dies kann nicht rückgängig gemacht werden.",
+    confirmDeleteMessage: "Dies entfernt die Unterhaltung und alle Nachrichten dauerhaft. Dies kann nicht rückgängig gemacht werden.",
     sessionDeleted: "Sitzung gelöscht",
     failedToDelete: "Sitzung konnte nicht gelöscht werden",
     deleteEmpty: "Leere löschen",
     deleteEmptyConfirmTitle: "Leere Sitzungen löschen?",
-    deleteEmptyConfirmMessage:
-      "Dies entfernt dauerhaft {count} Sitzungen ohne Nachrichten. Aktive und archivierte Sitzungen werden übersprungen. Dies kann nicht rückgängig gemacht werden.",
+    deleteEmptyConfirmMessage: "Dies entfernt dauerhaft {count} Sitzungen ohne Nachrichten. Aktive und archivierte Sitzungen werden übersprungen. Dies kann nicht rückgängig gemacht werden.",
     emptySessionsDeleted: "{count} leere Sitzungen gelöscht",
     failedToDeleteEmpty: "Leere Sitzungen konnten nicht gelöscht werden",
     selectSession: "Sitzung auswählen",
@@ -159,8 +137,7 @@ export const de: Translations = {
     selectedCount: "{count} ausgewählt",
     deleteSelected: "{count} löschen",
     deleteSelectedConfirmTitle: "{count} Sitzungen löschen?",
-    deleteSelectedConfirmMessage:
-      "Dies entfernt {count} ausgewählte Sitzungen und alle zugehörigen Nachrichten dauerhaft. Dies kann nicht rückgängig gemacht werden.",
+    deleteSelectedConfirmMessage: "Dies entfernt {count} ausgewählte Sitzungen und alle zugehörigen Nachrichten dauerhaft. Dies kann nicht rückgängig gemacht werden.",
     selectedSessionsDeleted: "{count} Sitzungen gelöscht",
     failedToDeleteSelected: "Ausgewählte Sitzungen konnten nicht gelöscht werden",
     resumeInChat: "Im Chat fortsetzen",
@@ -170,11 +147,9 @@ export const de: Translations = {
     roles: {
       user: "Benutzer",
       assistant: "Assistent",
-      system: "System",
       tool: "Werkzeug",
     },
   },
-
   analytics: {
     period: "Zeitraum:",
     totalTokens: "Tokens gesamt",
@@ -184,7 +159,6 @@ export const de: Translations = {
     dailyBreakdown: "Tagesaufschlüsselung",
     perModelBreakdown: "Aufschlüsselung pro Modell",
     topSkills: "Top-Skills",
-    skill: "Skill",
     loads: "Agent geladen",
     edits: "Agent verwaltet",
     lastUsed: "Zuletzt verwendet",
@@ -195,12 +169,10 @@ export const de: Translations = {
     startSession: "Starte eine Sitzung, um hier Analysen zu sehen",
     date: "Datum",
     model: "Modell",
-    tokens: "Tokens",
     perDayAvg: "/Tag Ø",
     acrossModels: "über {count} Modelle",
     inOut: "{input} ein / {output} aus",
   },
-
   models: {
     modelsUsed: "Verwendete Modelle",
     estimatedCost: "Gesch. Kosten",
@@ -212,7 +184,6 @@ export const de: Translations = {
     noModelsData: "Keine Modellnutzungsdaten für diesen Zeitraum",
     startSession: "Starte eine Sitzung, um hier Modelldaten zu sehen",
   },
-
   logs: {
     title: "Protokolle",
     autoRefresh: "Auto-Aktualisierung",
@@ -222,18 +193,13 @@ export const de: Translations = {
     lines: "Zeilen",
     noLogLines: "Keine Protokollzeilen gefunden",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Damit wird die Aufgabe aus dem Zeitplan entfernt. Dies kann nicht rückgängig gemacht werden.",
+    confirmDeleteMessage: "Damit wird die Aufgabe aus dem Zeitplan entfernt. Dies kann nicht rückgängig gemacht werden.",
     confirmDeleteTitle: "Geplante Aufgabe löschen?",
     newJob: "Neue Cron-Aufgabe",
-    nameOptional: "Name (optional)",
     namePlaceholder: "z. B. Tägliche Zusammenfassung",
-    prompt: "Prompt",
     promptPlaceholder: "Was soll der Agent bei jedem Lauf tun?",
     schedule: "Zeitplan (Cron-Ausdruck)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Zeitplan",
     scheduleModes: {
       interval: "Wiederkehrendes Intervall",
@@ -249,18 +215,15 @@ export const de: Translations = {
       unitDays: "Tage",
       timeOfDay: "Uhrzeit",
       weekdays: "Wochentage",
-      weekdaysShort: ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
+      weekdaysShort: ["So","Mo","Di","Mi","Do","Fr","Sa"],
       dayOfMonth: "Tag des Monats",
       onceAt: "Ausführen am",
       customLabel: "Cron-Ausdruck",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "Cron-Ausdruck mit fünf Feldern (Minute, Stunde, Tag, Monat, Wochentag).",
+      customHint: "Cron-Ausdruck mit fünf Feldern (Minute, Stunde, Tag, Monat, Wochentag).",
       preview: "Wird gesendet als",
       previewEmpty: "(unvollständig)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "Alle {n} Min.",
       everyHours: "Alle {n} Std.",
       everyDays: "Alle {n} Tage",
@@ -279,28 +242,20 @@ export const de: Translations = {
     triggerNow: "Jetzt auslösen",
     delivery: {
       local: "Lokal",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "Neues Profil",
-    name: "Name",
     namePlaceholder: "z. B. coder, writer usw.",
     nameRequired: "Name ist erforderlich",
-    nameRule:
-      "Nur Kleinbuchstaben, Ziffern, _ und -; muss mit einem Buchstaben oder einer Ziffer beginnen; maximal 64 Zeichen.",
-    invalidName: "Ungültiger Profilname",    cloneFrom: "Konfiguration klonen von",
+    nameRule: "Nur Kleinbuchstaben, Ziffern, _ und -; muss mit einem Buchstaben oder einer Ziffer beginnen; maximal 64 Zeichen.",
+    invalidName: "Ungültiger Profilname",
+    cloneFrom: "Konfiguration klonen von",
     cloneFromNone: "Keine (leer)",
     allProfiles: "Profile",
     noProfiles: "Keine Profile gefunden.",
     defaultBadge: "Standard",
-    hasEnv: "env",
     model: "Modell",
-    skills: "Skills",
     rename: "Umbenennen",
     editSoul: "SOUL.md bearbeiten",
     soulSection: "SOUL.md (Persönlichkeit / System-Prompt)",
@@ -311,13 +266,11 @@ export const de: Translations = {
     commandCopied: "In Zwischenablage kopiert",
     copyFailed: "Kopieren fehlgeschlagen",
     confirmDeleteTitle: "Profil löschen?",
-    confirmDeleteMessage:
-      "Damit wird das Profil '{name}' dauerhaft gelöscht — Konfiguration, Schlüssel, Erinnerungen, Sitzungen, Skills, Cron-Aufgaben. Kann nicht rückgängig gemacht werden.",
+    confirmDeleteMessage: "Damit wird das Profil '{name}' dauerhaft gelöscht — Konfiguration, Schlüssel, Erinnerungen, Sitzungen, Skills, Cron-Aufgaben. Kann nicht rückgängig gemacht werden.",
     created: "Erstellt",
     deleted: "Gelöscht",
     renamed: "Umbenannt",
   },
-
   pluginsPage: {
     contextEngineLabel: "Kontext-Engine",
     dashboardSlots: "Dashboard-Slots",
@@ -325,8 +278,7 @@ export const de: Translations = {
     enableAfterInstall: "Nach Installation aktivieren",
     enableRuntime: "Aktivieren",
     forceReinstall: "Neuinstallation erzwingen (bestehenden Ordner zuerst löschen)",
-    headline:
-      "Hermes-Plugins entdecken, installieren, aktivieren und aktualisieren (entspricht `hermes plugins`).",
+    headline: "Hermes-Plugins entdecken, installieren, aktivieren und aktualisieren (entspricht `hermes plugins`).",
     identifierLabel: "Git-URL oder owner/repo",
     inactive: "inaktiv",
     installBtn: "Installieren",
@@ -340,8 +292,7 @@ export const de: Translations = {
     pluginListHeading: "Installierte Plugins",
     providerDefaults: "eingebaut / Standard",
     providersHeading: "Laufzeit-Anbieter-Plugins",
-    providersHint:
-      "Schreibt memory.provider (leer = eingebaut) und context.engine in config.yaml. Wirkt sich auf die nächste Sitzung aus.",
+    providersHint: "Schreibt memory.provider (leer = eingebaut) und context.engine in config.yaml. Wirkt sich auf die nächste Sitzung aus.",
     refreshDashboard: "Dashboard-Erweiterungen erneut scannen",
     removeConfirm: "Dieses Plugin aus ~/.hermes/plugins/ entfernen?",
     removeHint: "Nur vom Benutzer installierte Plugins unter ~/.hermes/plugins können entfernt werden.",
@@ -353,14 +304,10 @@ export const de: Translations = {
     sourceBadge: "Quelle",
     authRequired: "Authentifizierung erforderlich",
     authRequiredHint: "Führe diesen Befehl aus, um dich zu authentifizieren:",
-    updateGit: "Git pull",
-    versionBadge: "Version",
     showInSidebar: "In Sidebar anzeigen",
     hideFromSidebar: "Aus Sidebar ausblenden",
   },
-
   skills: {
-    title: "Skills",
     searchPlaceholder: "Skills und Toolsets suchen...",
     enabledOf: "{enabled}/{total} aktiviert",
     all: "Alle",
@@ -371,20 +318,16 @@ export const de: Translations = {
     skillCount: "{count} Skill{s}",
     resultCount: "{count} Ergebnis{s}",
     noDescription: "Keine Beschreibung verfügbar.",
-    toolsets: "Toolsets",
     toolsetLabel: "{name} Toolset",
     noToolsetsMatch: "Keine Toolsets entsprechen der Suche.",
     setupNeeded: "Einrichtung erforderlich",
     disabledForCli: "Für CLI deaktiviert",
     more: "+{count} weitere",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "Filter",
     sections: "Bereiche",
     exportConfig: "Konfiguration als JSON exportieren",
-    importConfig: "Konfiguration aus JSON importieren",
     resetDefaults: "Auf Standardwerte zurücksetzen",
     resetScopeTooltip: "{scope} auf Standardwerte zurücksetzen",
     confirmResetScope: "Alle {scope}-Einstellungen auf ihre Standardwerte zurücksetzen? Dies aktualisiert nur das Formular — Änderungen werden erst in config.yaml geschrieben, wenn du auf Speichern drückst.",
@@ -392,7 +335,7 @@ export const de: Translations = {
     rawYaml: "Rohe YAML-Konfiguration",
     searchResults: "Suchergebnisse",
     fields: "Feld{s}",
-    noFieldsMatch: 'Keine Felder entsprechen "{query}"',
+    noFieldsMatch: "Keine Felder entsprechen \"{query}\"",
     configSaved: "Konfiguration gespeichert",
     yamlConfigSaved: "YAML-Konfiguration gespeichert",
     failedToSave: "Speichern fehlgeschlagen",
@@ -402,27 +345,20 @@ export const de: Translations = {
     invalidJson: "Ungültige JSON-Datei",
     categories: {
       general: "Allgemein",
-      agent: "Agent",
-      terminal: "Terminal",
       display: "Anzeige",
-      delegation: "Delegation",
       memory: "Speicher",
       compression: "Komprimierung",
       security: "Sicherheit",
-      browser: "Browser",
       voice: "Stimme",
       tts: "Text-zu-Sprache",
       stt: "Sprache-zu-Text",
       logging: "Protokollierung",
-      discord: "Discord",
       auxiliary: "Hilfs",
     },
   },
-
   env: {
     changesNote: "Änderungen werden sofort auf der Festplatte gespeichert. Aktive Sitzungen übernehmen neue Schlüssel automatisch.",
-    confirmClearMessage:
-      "Der gespeicherte Wert für diese Variable wird aus deiner .env-Datei entfernt. Dies kann über die UI nicht rückgängig gemacht werden.",
+    confirmClearMessage: "Der gespeicherte Wert für diese Variable wird aus deiner .env-Datei entfernt. Dies kann über die UI nicht rückgängig gemacht werden.",
     confirmClearTitle: "Diesen Schlüssel löschen?",
     description: "Verwalte API-Schlüssel und Geheimnisse, die hier gespeichert sind",
     hideAdvanced: "Erweitert ausblenden",
@@ -448,12 +384,10 @@ export const de: Translations = {
     add: "Hinzufügen",
     invalidKeyName: "Nur Buchstaben, Zahlen und Unterstriche verwenden (muss mit einem Buchstaben oder Unterstrich beginnen).",
   },
-
   oauth: {
     title: "Anbieter-Logins (OAuth)",
     providerLogins: "Anbieter-Logins (OAuth)",
-    description:
-      "{connected} von {total} OAuth-Anbietern verbunden. Nutze Anmelden für vom Dashboard unterstützte Abläufe; CLI-Befehle bleiben für externe oder Fallback-Einrichtung verfügbar.",
+    description: "{connected} von {total} OAuth-Anbietern verbunden. Nutze Anmelden für vom Dashboard unterstützte Abläufe; CLI-Befehle bleiben für externe oder Fallback-Einrichtung verfügbar.",
     connected: "Verbunden",
     expired: "Abgelaufen",
     notConnected: "Nicht verbunden. Nutze Anmelden, falls verfügbar, oder führe {command} in einem Terminal aus.",
@@ -490,23 +424,17 @@ export const de: Translations = {
     },
     expiresIn: "läuft in {time} ab",
   },
-
   language: {
     switchTo: "Sprache wechseln",
   },
-
   theme: {
     title: "Design",
     switchTheme: "Design wechseln",
   },
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Sammelbare Hermes-Abzeichen, verdient durch echten Sitzungsverlauf. Bekannte, noch nicht abgeschlossene Achievements werden als Entdeckt angezeigt; geheime Achievements bleiben verborgen, bis das erste passende Verhalten auftritt.",
-      scan_subtitle:
-        "Hermes-Sitzungsverlauf wird gescannt. Der erste Scan kann bei umfangreichem Verlauf 5–10 Sekunden dauern.",
+      subtitle: "Sammelbare Hermes-Abzeichen, verdient durch echten Sitzungsverlauf. Bekannte, noch nicht abgeschlossene Achievements werden als Entdeckt angezeigt; geheime Achievements bleiben verborgen, bis das erste passende Verhalten auftritt.",
+      scan_subtitle: "Hermes-Sitzungsverlauf wird gescannt. Der erste Scan kann bei umfangreichem Verlauf 5–10 Sekunden dauern.",
     },
     actions: {
       rescan: "Neu scannen",
@@ -519,7 +447,6 @@ export const de: Translations = {
       secrets: "Geheimnisse",
       secrets_hint: "verborgen bis zum ersten Signal",
       highest_tier: "Höchste Stufe",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "Neueste",
       latest_hint_empty: "nutze Hermes mehr",
       none_yet: "Noch keine",
@@ -540,25 +467,19 @@ export const de: Translations = {
     },
     scan: {
       building_headline: "Achievement-Profil wird erstellt…",
-      building_detail:
-        "Sitzungen, Tool-Aufrufe, Modell-Metadaten und Freischaltstatus werden gelesen.",
+      building_detail: "Sitzungen, Tool-Aufrufe, Modell-Metadaten und Freischaltstatus werden gelesen.",
       starting_headline: "Achievement-Scan wird gestartet…",
-      progress_detail:
-        "{scanned} von {total} Sitzungen gescannt · {pct}%. Abzeichen werden freigeschaltet, sobald mehr Verlauf eingelesen wird.",
-      idle_detail:
-        "Sitzungen, Tool-Aufrufe, Modell-Metadaten und Freischaltstatus werden gelesen. Abzeichen erscheinen hier, sobald sie freigeschaltet werden.",
+      progress_detail: "{scanned} von {total} Sitzungen gescannt · {pct}%. Abzeichen werden freigeschaltet, sobald mehr Verlauf eingelesen wird.",
+      idle_detail: "Sitzungen, Tool-Aufrufe, Modell-Metadaten und Freischaltstatus werden gelesen. Abzeichen erscheinen hier, sobald sie freigeschaltet werden.",
     },
     guide: {
       tiers_header: "Stufen",
       secret_header: "Geheime Achievements",
-      secret_body:
-        "Geheimnisse verbergen ihren genauen Auslöser. Sobald Hermes ein verwandtes Signal erkennt, wird die Karte zu Entdeckt und zeigt ihre Anforderung an.",
+      secret_body: "Geheimnisse verbergen ihren genauen Auslöser. Sobald Hermes ein verwandtes Signal erkennt, wird die Karte zu Entdeckt und zeigt ihre Anforderung an.",
       scan_status_header: "Scan-Status",
-      scan_status_body:
-        "Hermes scannt den lokalen Verlauf einmalig, danach erscheinen die Karten automatisch. Es ist nichts hängengeblieben, wenn dies ein paar Sekunden dauert.",
+      scan_status_body: "Hermes scannt den lokalen Verlauf einmalig, danach erscheinen die Karten automatisch. Es ist nichts hängengeblieben, wenn dies ein paar Sekunden dauert.",
       what_scanned_header: "Was gescannt wird",
-      what_scanned_body:
-        "Sitzungen, Tool-Aufrufe, Modell-Metadaten, Fehler, Achievements und lokaler Freischaltstatus.",
+      what_scanned_body: "Sitzungen, Tool-Aufrufe, Modell-Metadaten, Fehler, Achievements und lokaler Freischaltstatus.",
     },
     card: {
       share_title: "Dieses Achievement teilen",
@@ -575,8 +496,7 @@ export const de: Translations = {
     },
     empty: {
       no_secrets_header: "Keine verborgenen Geheimnisse mehr in diesem Scan.",
-      no_secrets_body:
-        "Hinweis: Geheimnisse beginnen meist bei ungewöhnlichen Fehlern oder Power-User-Mustern – Port-Konflikten, Berechtigungswänden, fehlenden Umgebungsvariablen, YAML-Fehlern, Docker-Kollisionen, Rollback-/Checkpoint-Nutzung, Cache-Treffern oder kleinen Fixes nach viel rotem Text.",
+      no_secrets_body: "Hinweis: Geheimnisse beginnen meist bei ungewöhnlichen Fehlern oder Power-User-Mustern – Port-Konflikten, Berechtigungswänden, fehlenden Umgebungsvariablen, YAML-Fehlern, Docker-Kollisionen, Rollback-/Checkpoint-Nutzung, Cache-Treffern oder kleinen Fixes nach viel rotem Text.",
     },
     filters: {
       all_categories: "Alle",
@@ -598,35 +518,20 @@ export const de: Translations = {
       copy_button: "Bild kopieren",
       copied: "Kopiert ✓",
       download_button: "PNG herunterladen",
-      hint:
-        "Auf X teilen öffnet einen vorgefertigten Post in einem neuen Tab. Klicke zuerst auf Bild kopieren, wenn du das 1200×630-Abzeichen anhängen möchtest – X lässt dich es direkt in den Tweet-Editor einfügen. PNG herunterladen speichert die Datei zur Nutzung an beliebiger Stelle.",
-      clipboard_unsupported:
-        "Bildkopie über die Zwischenablage wird in diesem Browser nicht unterstützt – nutze stattdessen Herunterladen.",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "Auf X teilen öffnet einen vorgefertigten Post in einem neuen Tab. Klicke zuerst auf Bild kopieren, wenn du das 1200×630-Abzeichen anhängen möchtest – X lässt dich es direkt in den Tweet-Editor einfügen. PNG herunterladen speichert die Datei zur Nutzung an beliebiger Stelle.",
+      clipboard_unsupported: "Bildkopie über die Zwischenablage wird in diesem Browser nicht unterstützt – nutze stattdessen Herunterladen.",
     },
   },
   kanban: {
     loading: "Kanban-Board wird geladen…",
     loadFailed: "Laden des Kanban-Boards fehlgeschlagen: ",
-    loadFailedHint:
-      "Das Backend erstellt kanban.db beim ersten Lesen automatisch. Wenn das Problem bestehen bleibt, prüfe die Dashboard-Logs.",
-    board: "Board",
+    loadFailedHint: "Das Backend erstellt kanban.db beim ersten Lesen automatisch. Wenn das Problem bestehen bleibt, prüfe die Dashboard-Logs.",
     newBoard: "+ Neues Board",
     newBoardTitle: "Neues Board",
-    newBoardDescription:
-      "Mit Boards kannst du voneinander unabhängige Arbeitsabläufe trennen — eines pro Projekt, Repository oder Domäne. Worker auf einem Board sehen niemals die Aufgaben eines anderen Boards.",
-    slug: "Slug",
+    newBoardDescription: "Mit Boards kannst du voneinander unabhängige Arbeitsabläufe trennen — eines pro Projekt, Repository oder Domäne. Worker auf einem Board sehen niemals die Aufgaben eines anderen Boards.",
     slugHint: "— Kleinbuchstaben, Bindestriche, z. B. atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Anzeigename",
-    displayNameHint: "(optional)",
     description: "Beschreibung",
-    descriptionHint: "(optional)",
     icon: "Symbol",
     iconHint: "(einzelnes Zeichen oder Emoji)",
     switchAfterCreate: "Nach dem Erstellen zu diesem Board wechseln",
@@ -635,7 +540,6 @@ export const de: Translations = {
     createBoard: "Board erstellen",
     search: "Suchen",
     filterCards: "Karten filtern…",
-    tenant: "Tenant",
     allTenants: "Alle Tenants",
     assignee: "Zuständige Person",
     allProfiles: "Alle Profile",
@@ -655,7 +559,6 @@ export const de: Translations = {
     loadingDetail: "Wird geladen…",
     addComment: "Kommentar hinzufügen… (Enter zum Senden)",
     comment: "Kommentar",
-    status: "Status",
     workspace: "Arbeitsbereich",
     skills: "Fähigkeiten",
     createdBy: "Erstellt von",
@@ -665,8 +568,7 @@ export const de: Translations = {
     runHistory: "Ausführungsverlauf",
     workerLog: "Worker-Log",
     loadingLog: "Log wird geladen…",
-    noWorkerLog:
-      "— noch kein Worker-Log (Aufgabe wurde nicht gestartet oder Log wurde rotiert) —",
+    noWorkerLog: "— noch kein Worker-Log (Aufgabe wurde nicht gestartet oder Log wurde rotiert) —",
     noDescription: "— keine Beschreibung —",
     noComments: "— keine Kommentare —",
     edit: "bearbeiten",
@@ -697,8 +599,7 @@ export const de: Translations = {
     reassign: "Neu zuweisen",
     renderingError: "Im Kanban-Tab ist ein Renderfehler aufgetreten",
     reloadView: "Ansicht neu laden",
-    wsAuthFailed:
-      "WebSocket-Authentifizierung fehlgeschlagen — lade die Seite neu, um das Sitzungs-Token zu aktualisieren.",
+    wsAuthFailed: "WebSocket-Authentifizierung fehlgeschlagen — lade die Seite neu, um das Sitzungs-Token zu aktualisieren.",
     markDone: "{n} Aufgabe(n) als erledigt markieren?",
     markArchived: "{n} Aufgabe(n) archivieren?",
     warning: "Warnung",
@@ -709,13 +610,11 @@ export const de: Translations = {
     showAllAttempts: "Alle Versuche anzeigen",
     sendingUpdates: "Aktualisierungen werden gesendet an ",
     sendNotifications: "Benachrichtigungen für Abgeschlossen / Blockiert / Aufgegeben senden an",
-    archiveBoardConfirm:
-      "Board „{name}“ archivieren? Es wird nach boards/_archived/ verschoben, sodass du es später wiederherstellen kannst. Aufgaben auf diesem Board erscheinen nirgendwo mehr in der UI.",
+    archiveBoardConfirm: "Board „{name}“ archivieren? Es wird nach boards/_archived/ verschoben, sodass du es später wiederherstellen kannst. Aufgaben auf diesem Board erscheinen nirgendwo mehr in der UI.",
     archiveBoardTitle: "Dieses Board archivieren",
     boardSwitcherHint: "Mit Boards kannst du voneinander unabhängige Arbeitsabläufe trennen",
     taskCreatedWarning: "Aufgabe erstellt, aber: ",
     moveFailed: "Verschieben fehlgeschlagen: ",
-    bulkFailed: "Bulk: ",
     completionBlockedHallucination: "⚠ Abschluss blockiert — Phantom-Karten-IDs",
     suspectedHallucinatedReferences: "⚠ Text verweist auf Phantom-Karten-IDs",
     pickProfileFirst: "Wähle zuerst ein Profil aus.",
@@ -730,7 +629,6 @@ export const de: Translations = {
     clickToEditAssignee: "Klicken, um zuständige Person zu bearbeiten",
     emptyAssignee: "(leer = Zuweisung aufheben)",
     columnLabels: {
-      triage: "Triage",
       todo: "Zu erledigen",
       scheduled: "Geplant",
       ready: "Bereit",
@@ -749,28 +647,20 @@ export const de: Translations = {
       done: "Abgeschlossen",
       archived: "Archiviert",
     },
-    confirmDone:
-      "Diese Aufgabe als erledigt markieren? Der Anspruch des Workers wird freigegeben und abhängige untergeordnete Aufgaben werden bereit.",
-    confirmArchive:
-      "Diese Aufgabe archivieren? Sie verschwindet aus der Standard-Board-Ansicht.",
-    confirmBlocked:
-      "Diese Aufgabe als blockiert markieren? Der Anspruch des Workers wird freigegeben.",
-    completionSummary:
-      "Abschluss-Zusammenfassung für {label}. Diese wird als Ergebnis der Aufgabe gespeichert.",
-    completionSummaryRequired:
-      "Eine Abschluss-Zusammenfassung ist erforderlich, bevor eine Aufgabe als erledigt markiert werden kann.",
+    confirmDone: "Diese Aufgabe als erledigt markieren? Der Anspruch des Workers wird freigegeben und abhängige untergeordnete Aufgaben werden bereit.",
+    confirmArchive: "Diese Aufgabe archivieren? Sie verschwindet aus der Standard-Board-Ansicht.",
+    confirmBlocked: "Diese Aufgabe als blockiert markieren? Der Anspruch des Workers wird freigegeben.",
+    completionSummary: "Abschluss-Zusammenfassung für {label}. Diese wird als Ergebnis der Aufgabe gespeichert.",
+    completionSummaryRequired: "Eine Abschluss-Zusammenfassung ist erforderlich, bevor eine Aufgabe als erledigt markiert werden kann.",
     triagePlaceholder: "Grobe Idee — die KI wird die Spezifikation erstellen…",
     taskTitlePlaceholder: "Titel der neuen Aufgabe…",
     specifier: "Specifier",
     assigneePlaceholder: "Zuständige Person",
     priority: "Priorität",
-    skillsPlaceholder:
-      "Fähigkeiten (optional, kommagetrennt): translation, github-code-review",
+    skillsPlaceholder: "Fähigkeiten (optional, kommagetrennt): translation, github-code-review",
     noParent: "— keine übergeordnete Aufgabe —",
     workspacePathDir: "Arbeitsbereichs-Pfad (erforderlich, z. B. ~/projects/my-app)",
-    workspacePathOptional:
-      "Arbeitsbereichs-Pfad (optional, wird aus zuständiger Person abgeleitet, wenn leer)",
+    workspacePathOptional: "Arbeitsbereichs-Pfad (optional, wird aus zuständiger Person abgeleitet, wenn leer)",
     logTruncated: "(zeige die letzten 100 KB — vollständiges Log unter ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const es: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const es = defineLocale({
   common: {
     save: "Guardar",
     saving: "Guardando...",
@@ -41,22 +45,13 @@ export const es: Translations = {
     failedToReveal: "No se pudo mostrar",
     collapse: "Contraer",
     expand: "Expandir",
-    general: "General",
     messaging: "Mensajería",
-    pluginLoadFailed:
-      "No se pudo cargar el script de este complemento. Revisa la pestaña Network (dashboard-plugins/…) y la ruta del complemento del servidor.",
-    pluginNotRegistered:
-      "El script del complemento no llamó a register(), o falló. Abre la consola del navegador para más detalles.",
+    pluginLoadFailed: "No se pudo cargar el script de este complemento. Revisa la pestaña Network (dashboard-plugins/…) y la ruta del complemento del servidor.",
+    pluginNotRegistered: "El script del complemento no llamó a register(), o falló. Abre la consola del navegador para más detalles.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Cerrar navegación",
     closeModelTools: "Cerrar modelo y herramientas",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Sesiones activas:",
     gatewayStatusLabel: "Estado del Gateway:",
     gatewayStrip: {
@@ -68,9 +63,7 @@ export const es: Translations = {
     },
     nav: {
       analytics: "Analíticas",
-      chat: "Chat",
       config: "Configuración",
-      cron: "Cron",
       documentation: "Documentación",
       keys: "Claves",
       logs: "Registros",
@@ -89,9 +82,7 @@ export const es: Translations = {
     sessionsActiveCount: "{count} activas",
     statusOverview: "Resumen de estado",
     system: "Sistema",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "Acción fallida",
     actionFinished: "Finalizado",
@@ -101,16 +92,12 @@ export const es: Translations = {
     connected: "Conectado",
     connectedPlatforms: "Plataformas conectadas",
     disconnected: "Desconectado",
-    error: "Error",
     failed: "Fallido",
-    gateway: "Gateway",
     gatewayFailedToStart: "El Gateway no pudo iniciarse",
     lastUpdate: "Última actualización",
     noneRunning: "Ninguno",
     notRunning: "No en ejecución",
-    pid: "PID",
     platformDisconnected: "desconectado",
-    platformError: "error",
     recentSessions: "Sesiones recientes",
     restartGateway: "Reiniciar Gateway",
     restartingGateway: "Reiniciando gateway…",
@@ -124,12 +111,10 @@ export const es: Translations = {
     updatingHermes: "Actualizando Hermes…",
     waitingForOutput: "Esperando salida…",
   },
-
   sessions: {
     title: "Sesiones",
     history: "Historial",
     overview: "Resumen",
-    filterChats: "Chats",
     filterAutomation: "Automatización",
     filterAll: "Todas",
     sourceFilter: "Origen de la sesión",
@@ -143,14 +128,12 @@ export const es: Translations = {
     untitledSession: "Sesión sin título",
     deleteSession: "Eliminar sesión",
     confirmDeleteTitle: "¿Eliminar sesión?",
-    confirmDeleteMessage:
-      "Esto elimina permanentemente la conversación y todos sus mensajes. No se puede deshacer.",
+    confirmDeleteMessage: "Esto elimina permanentemente la conversación y todos sus mensajes. No se puede deshacer.",
     sessionDeleted: "Sesión eliminada",
     failedToDelete: "No se pudo eliminar la sesión",
     deleteEmpty: "Eliminar vacías",
     deleteEmptyConfirmTitle: "¿Eliminar sesiones vacías?",
-    deleteEmptyConfirmMessage:
-      "Esto elimina permanentemente {count} sesiones que no tienen mensajes. Se omiten las sesiones activas y archivadas. Esta acción no se puede deshacer.",
+    deleteEmptyConfirmMessage: "Esto elimina permanentemente {count} sesiones que no tienen mensajes. Se omiten las sesiones activas y archivadas. Esta acción no se puede deshacer.",
     emptySessionsDeleted: "{count} sesiones vacías eliminadas",
     failedToDeleteEmpty: "No se pudieron eliminar las sesiones vacías",
     selectSession: "Seleccionar sesión",
@@ -159,8 +142,7 @@ export const es: Translations = {
     selectedCount: "{count} seleccionadas",
     deleteSelected: "Eliminar {count}",
     deleteSelectedConfirmTitle: "¿Eliminar {count} sesiones?",
-    deleteSelectedConfirmMessage:
-      "Esto elimina permanentemente {count} sesiones seleccionadas y todos sus mensajes. No se puede deshacer.",
+    deleteSelectedConfirmMessage: "Esto elimina permanentemente {count} sesiones seleccionadas y todos sus mensajes. No se puede deshacer.",
     selectedSessionsDeleted: "{count} sesiones eliminadas",
     failedToDeleteSelected: "No se pudieron eliminar las sesiones seleccionadas",
     resumeInChat: "Reanudar en el chat",
@@ -174,7 +156,6 @@ export const es: Translations = {
       tool: "Herramienta",
     },
   },
-
   analytics: {
     period: "Período:",
     totalTokens: "Tokens totales",
@@ -190,21 +171,17 @@ export const es: Translations = {
     lastUsed: "Último uso",
     input: "Entrada",
     output: "Salida",
-    total: "Total",
     noUsageData: "No hay datos de uso para este período",
     startSession: "Inicia una sesión para ver analíticas aquí",
     date: "Fecha",
     model: "Modelo",
-    tokens: "Tokens",
     perDayAvg: "/día prom.",
     acrossModels: "en {count} modelos",
     inOut: "{input} entrada / {output} salida",
   },
-
   models: {
     modelsUsed: "Modelos utilizados",
     estimatedCost: "Coste est.",
-    tokens: "tokens",
     sessions: "sesiones",
     avgPerSession: "prom./sesión",
     apiCalls: "llamadas API",
@@ -212,7 +189,6 @@ export const es: Translations = {
     noModelsData: "No hay datos de uso de modelos para este período",
     startSession: "Inicia una sesión para ver datos de modelos aquí",
   },
-
   logs: {
     title: "Registros",
     autoRefresh: "Actualización automática",
@@ -222,18 +198,14 @@ export const es: Translations = {
     lines: "Líneas",
     noLogLines: "No se encontraron líneas de registro",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Esto elimina la tarea de la programación. No se puede deshacer.",
+    confirmDeleteMessage: "Esto elimina la tarea de la programación. No se puede deshacer.",
     confirmDeleteTitle: "¿Eliminar tarea programada?",
     newJob: "Nueva tarea Cron",
     nameOptional: "Nombre (opcional)",
     namePlaceholder: "p. ej. Resumen diario",
-    prompt: "Prompt",
     promptPlaceholder: "¿Qué debe hacer el agente en cada ejecución?",
     schedule: "Programación (expresión cron)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Programación",
     scheduleModes: {
       interval: "Cada intervalo",
@@ -249,18 +221,15 @@ export const es: Translations = {
       unitDays: "días",
       timeOfDay: "Hora del día",
       weekdays: "Días de la semana",
-      weekdaysShort: ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"],
+      weekdaysShort: ["Dom","Lun","Mar","Mié","Jue","Vie","Sáb"],
       dayOfMonth: "Día del mes",
       onceAt: "Ejecutar el",
       customLabel: "Expresión cron",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "Expresión cron de cinco campos (minuto, hora, día, mes, día de la semana).",
+      customHint: "Expresión cron de cinco campos (minuto, hora, día, mes, día de la semana).",
       preview: "Se envía como",
       previewEmpty: "(incompleta)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "Cada {n} min",
       everyHours: "Cada {n} h",
       everyDays: "Cada {n} d",
@@ -277,29 +246,19 @@ export const es: Translations = {
     pause: "Pausar",
     resume: "Reanudar",
     triggerNow: "Ejecutar ahora",
-    delivery: {
-      local: "Local",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
-    },
   },
-
   profiles: {
     newProfile: "Nuevo perfil",
     name: "Nombre",
     namePlaceholder: "p. ej. coder, writer, etc.",
     nameRequired: "El nombre es obligatorio",
-    nameRule:
-      "Solo letras minúsculas, dígitos, _ y -; debe comenzar con una letra o dígito; hasta 64 caracteres.",
+    nameRule: "Solo letras minúsculas, dígitos, _ y -; debe comenzar con una letra o dígito; hasta 64 caracteres.",
     invalidName: "Nombre de perfil no válido",
     cloneFrom: "Clonar desde el perfil",
     cloneFromNone: "Ninguno (vacío)",
     allProfiles: "Perfiles",
     noProfiles: "No se encontraron perfiles.",
     defaultBadge: "predeterminado",
-    hasEnv: "env",
     model: "Modelo",
     skills: "Habilidades",
     rename: "Renombrar",
@@ -312,13 +271,11 @@ export const es: Translations = {
     commandCopied: "Copiado al portapapeles",
     copyFailed: "No se pudo copiar",
     confirmDeleteTitle: "¿Eliminar perfil?",
-    confirmDeleteMessage:
-      "Esto elimina permanentemente el perfil '{name}' — configuración, claves, memorias, sesiones, habilidades, tareas cron. No se puede deshacer.",
+    confirmDeleteMessage: "Esto elimina permanentemente el perfil '{name}' — configuración, claves, memorias, sesiones, habilidades, tareas cron. No se puede deshacer.",
     created: "Creado",
     deleted: "Eliminado",
     renamed: "Renombrado",
   },
-
   pluginsPage: {
     contextEngineLabel: "Motor de contexto",
     dashboardSlots: "Slots del panel",
@@ -326,8 +283,7 @@ export const es: Translations = {
     enableAfterInstall: "Habilitar tras instalar",
     enableRuntime: "Habilitar",
     forceReinstall: "Forzar reinstalación (eliminar carpeta existente primero)",
-    headline:
-      "Descubre, instala, habilita y actualiza complementos de Hermes (equivalente a `hermes plugins`).",
+    headline: "Descubre, instala, habilita y actualiza complementos de Hermes (equivalente a `hermes plugins`).",
     identifierLabel: "URL de Git u owner/repo",
     inactive: "inactivo",
     installBtn: "Instalar",
@@ -341,8 +297,7 @@ export const es: Translations = {
     pluginListHeading: "Complementos instalados",
     providerDefaults: "incorporado / predeterminado",
     providersHeading: "Complementos de proveedor en tiempo de ejecución",
-    providersHint:
-      "Escribe memory.provider (vacío = incorporado) y context.engine en config.yaml. Surte efecto en la próxima sesión.",
+    providersHint: "Escribe memory.provider (vacío = incorporado) y context.engine en config.yaml. Surte efecto en la próxima sesión.",
     refreshDashboard: "Volver a escanear extensiones del panel",
     removeConfirm: "¿Eliminar este complemento de ~/.hermes/plugins/?",
     removeHint: "Solo se pueden eliminar complementos instalados por el usuario en ~/.hermes/plugins.",
@@ -354,12 +309,10 @@ export const es: Translations = {
     sourceBadge: "Fuente",
     authRequired: "Autenticación requerida",
     authRequiredHint: "Ejecuta este comando para autenticarte:",
-    updateGit: "Git pull",
     versionBadge: "Versión",
     showInSidebar: "Mostrar en barra lateral",
     hideFromSidebar: "Ocultar de la barra lateral",
   },
-
   skills: {
     title: "Habilidades",
     searchPlaceholder: "Buscar habilidades y conjuntos de herramientas...",
@@ -379,13 +332,10 @@ export const es: Translations = {
     disabledForCli: "Deshabilitado para CLI",
     more: "+{count} más",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "Filtros",
     sections: "Secciones",
     exportConfig: "Exportar configuración como JSON",
-    importConfig: "Importar configuración desde JSON",
     resetDefaults: "Restablecer valores predeterminados",
     resetScopeTooltip: "Restablecer {scope} a los valores predeterminados",
     confirmResetScope: "¿Restablecer todos los ajustes de {scope} a sus valores predeterminados? Esto solo actualiza el formulario — los cambios no se escriben en config.yaml hasta que pulses Guardar.",
@@ -393,7 +343,7 @@ export const es: Translations = {
     rawYaml: "Configuración YAML en bruto",
     searchResults: "Resultados de búsqueda",
     fields: "campo{s}",
-    noFieldsMatch: 'Ningún campo coincide con "{query}"',
+    noFieldsMatch: "Ningún campo coincide con \"{query}\"",
     configSaved: "Configuración guardada",
     yamlConfigSaved: "Configuración YAML guardada",
     failedToSave: "No se pudo guardar",
@@ -402,9 +352,7 @@ export const es: Translations = {
     configImported: "Configuración importada — revisa y guarda",
     invalidJson: "Archivo JSON no válido",
     categories: {
-      general: "General",
       agent: "Agente",
-      terminal: "Terminal",
       display: "Pantalla",
       delegation: "Delegación",
       memory: "Memoria",
@@ -415,15 +363,12 @@ export const es: Translations = {
       tts: "Texto a voz",
       stt: "Voz a texto",
       logging: "Registro",
-      discord: "Discord",
       auxiliary: "Auxiliar",
     },
   },
-
   env: {
     changesNote: "Los cambios se guardan en disco inmediatamente. Las sesiones activas adoptan las nuevas claves automáticamente.",
-    confirmClearMessage:
-      "El valor almacenado para esta variable se eliminará de tu archivo .env. Esto no se puede deshacer desde la UI.",
+    confirmClearMessage: "El valor almacenado para esta variable se eliminará de tu archivo .env. Esto no se puede deshacer desde la UI.",
     confirmClearTitle: "¿Limpiar esta clave?",
     description: "Gestiona claves API y secretos almacenados en",
     hideAdvanced: "Ocultar avanzado",
@@ -449,12 +394,10 @@ export const es: Translations = {
     add: "Añadir",
     invalidKeyName: "Usa solo letras, números y guiones bajos (debe empezar por una letra o un guion bajo).",
   },
-
   oauth: {
     title: "Inicios de sesión de proveedores (OAuth)",
     providerLogins: "Inicios de sesión de proveedores (OAuth)",
-    description:
-      "{connected} de {total} proveedores OAuth conectados. Usa Iniciar sesión para los flujos compatibles con el panel; los comandos CLI siguen disponibles para configuración externa o de respaldo.",
+    description: "{connected} de {total} proveedores OAuth conectados. Usa Iniciar sesión para los flujos compatibles con el panel; los comandos CLI siguen disponibles para configuración externa o de respaldo.",
     connected: "Conectado",
     expired: "Caducado",
     notConnected: "No conectado. Usa Iniciar sesión si está disponible, o ejecuta {command} en una terminal.",
@@ -491,23 +434,17 @@ export const es: Translations = {
     },
     expiresIn: "caduca en {time}",
   },
-
   language: {
     switchTo: "Cambiar idioma",
   },
-
   theme: {
     title: "Tema",
     switchTheme: "Cambiar tema",
   },
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Insignias coleccionables de Hermes ganadas a partir del historial real de sesiones. Los logros conocidos no completados se muestran como Descubiertos; los logros secretos permanecen ocultos hasta que aparece el primer comportamiento coincidente.",
-      scan_subtitle:
-        "Escaneando el historial de sesiones de Hermes. El primer escaneo puede tardar 5–10 segundos en historiales grandes.",
+      subtitle: "Insignias coleccionables de Hermes ganadas a partir del historial real de sesiones. Los logros conocidos no completados se muestran como Descubiertos; los logros secretos permanecen ocultos hasta que aparece el primer comportamiento coincidente.",
+      scan_subtitle: "Escaneando el historial de sesiones de Hermes. El primer escaneo puede tardar 5–10 segundos en historiales grandes.",
     },
     actions: {
       rescan: "Volver a escanear",
@@ -520,7 +457,6 @@ export const es: Translations = {
       secrets: "Secretos",
       secrets_hint: "ocultos hasta la primera señal",
       highest_tier: "Nivel más alto",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "Más reciente",
       latest_hint_empty: "usa Hermes más",
       none_yet: "Ninguno aún",
@@ -541,25 +477,19 @@ export const es: Translations = {
     },
     scan: {
       building_headline: "Construyendo perfil de logros…",
-      building_detail:
-        "Leyendo sesiones, llamadas a herramientas, metadatos del modelo y estado de desbloqueo.",
+      building_detail: "Leyendo sesiones, llamadas a herramientas, metadatos del modelo y estado de desbloqueo.",
       starting_headline: "Iniciando escaneo de logros…",
-      progress_detail:
-        "Escaneadas {scanned} de {total} sesiones · {pct}%. Las insignias se desbloquean a medida que se procesa más historial.",
-      idle_detail:
-        "Leyendo sesiones, llamadas a herramientas, metadatos del modelo y estado de desbloqueo. Las insignias aparecerán aquí a medida que se desbloqueen.",
+      progress_detail: "Escaneadas {scanned} de {total} sesiones · {pct}%. Las insignias se desbloquean a medida que se procesa más historial.",
+      idle_detail: "Leyendo sesiones, llamadas a herramientas, metadatos del modelo y estado de desbloqueo. Las insignias aparecerán aquí a medida que se desbloqueen.",
     },
     guide: {
       tiers_header: "Niveles",
       secret_header: "Logros secretos",
-      secret_body:
-        "Los secretos ocultan su disparador exacto. Una vez que Hermes detecta una señal relacionada, la tarjeta pasa a Descubierto y muestra su requisito.",
+      secret_body: "Los secretos ocultan su disparador exacto. Una vez que Hermes detecta una señal relacionada, la tarjeta pasa a Descubierto y muestra su requisito.",
       scan_status_header: "Estado del escaneo",
-      scan_status_body:
-        "Hermes está escaneando el historial local una vez, después las tarjetas aparecerán automáticamente. No hay nada bloqueado si tarda unos segundos.",
+      scan_status_body: "Hermes está escaneando el historial local una vez, después las tarjetas aparecerán automáticamente. No hay nada bloqueado si tarda unos segundos.",
       what_scanned_header: "Qué se escanea",
-      what_scanned_body:
-        "Sesiones, llamadas a herramientas, metadatos del modelo, errores, logros y estado de desbloqueo local.",
+      what_scanned_body: "Sesiones, llamadas a herramientas, metadatos del modelo, errores, logros y estado de desbloqueo local.",
     },
     card: {
       share_title: "Compartir este logro",
@@ -576,8 +506,7 @@ export const es: Translations = {
     },
     empty: {
       no_secrets_header: "No quedan secretos ocultos en este escaneo.",
-      no_secrets_body:
-        "Pista: los secretos suelen comenzar a partir de fallos inusuales o patrones de usuario avanzado: conflictos de puertos, muros de permisos, variables de entorno faltantes, errores de YAML, colisiones de Docker, uso de rollback/checkpoint, aciertos de caché o pequeñas correcciones tras mucho texto rojo.",
+      no_secrets_body: "Pista: los secretos suelen comenzar a partir de fallos inusuales o patrones de usuario avanzado: conflictos de puertos, muros de permisos, variables de entorno faltantes, errores de YAML, colisiones de Docker, uso de rollback/checkpoint, aciertos de caché o pequeñas correcciones tras mucho texto rojo.",
     },
     filters: {
       all_categories: "Todos",
@@ -599,31 +528,19 @@ export const es: Translations = {
       copy_button: "Copiar imagen",
       copied: "Copiado ✓",
       download_button: "Descargar PNG",
-      hint:
-        "Compartir en X abre una publicación predefinida en una nueva pestaña. Haz clic primero en Copiar imagen si quieres adjuntar la insignia 1200×630: X te permite pegarla directamente en el redactor del tuit. Descargar PNG guarda el archivo para usarlo en cualquier lugar.",
-      clipboard_unsupported:
-        "Este navegador no admite copiar imágenes al portapapeles: usa Descargar en su lugar.",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "Compartir en X abre una publicación predefinida en una nueva pestaña. Haz clic primero en Copiar imagen si quieres adjuntar la insignia 1200×630: X te permite pegarla directamente en el redactor del tuit. Descargar PNG guarda el archivo para usarlo en cualquier lugar.",
+      clipboard_unsupported: "Este navegador no admite copiar imágenes al portapapeles: usa Descargar en su lugar.",
     },
   },
   kanban: {
     loading: "Cargando tablero Kanban…",
     loadFailed: "Error al cargar el tablero Kanban: ",
-    loadFailedHint:
-      "El backend crea automáticamente kanban.db en la primera lectura. Si el problema persiste, revisa los registros del panel.",
+    loadFailedHint: "El backend crea automáticamente kanban.db en la primera lectura. Si el problema persiste, revisa los registros del panel.",
     board: "Tablero",
     newBoard: "+ Nuevo tablero",
     newBoardTitle: "Nuevo tablero",
-    newBoardDescription:
-      "Los tableros te permiten separar flujos de trabajo no relacionados — uno por proyecto, repositorio o dominio. Los workers de un tablero nunca ven las tareas de otro.",
-    slug: "Slug",
+    newBoardDescription: "Los tableros te permiten separar flujos de trabajo no relacionados — uno por proyecto, repositorio o dominio. Los workers de un tablero nunca ven las tareas de otro.",
     slugHint: "— minúsculas, guiones, p. ej. atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Nombre visible",
     displayNameHint: "(opcional)",
     description: "Descripción",
@@ -636,7 +553,6 @@ export const es: Translations = {
     createBoard: "Crear tablero",
     search: "Buscar",
     filterCards: "Filtrar tarjetas…",
-    tenant: "Tenant",
     allTenants: "Todos los tenants",
     assignee: "Asignado a",
     allProfiles: "Todos los perfiles",
@@ -657,17 +573,14 @@ export const es: Translations = {
     addComment: "Añadir un comentario… (Enter para enviar)",
     comment: "Comentario",
     status: "Estado",
-    workspace: "Workspace",
     skills: "Habilidades",
     createdBy: "Creado por",
-    result: "Result",
     comments: "Comentarios",
     events: "Eventos",
     runHistory: "Historial de ejecuciones",
     workerLog: "Registro del worker",
     loadingLog: "Cargando registro…",
-    noWorkerLog:
-      "— aún no hay registro del worker (la tarea no se ha lanzado o el registro fue rotado) —",
+    noWorkerLog: "— aún no hay registro del worker (la tarea no se ha lanzado o el registro fue rotado) —",
     noDescription: "— sin descripción —",
     noComments: "— sin comentarios —",
     edit: "editar",
@@ -698,8 +611,7 @@ export const es: Translations = {
     reassign: "Reasignar",
     renderingError: "La pestaña Kanban tuvo un error de renderizado",
     reloadView: "Recargar vista",
-    wsAuthFailed:
-      "Error de autenticación de WebSocket — recarga la página para refrescar el token de sesión.",
+    wsAuthFailed: "Error de autenticación de WebSocket — recarga la página para refrescar el token de sesión.",
     markDone: "¿Marcar {n} tarea(s) como hechas?",
     markArchived: "¿Archivar {n} tarea(s)?",
     warning: "Advertencia",
@@ -710,8 +622,7 @@ export const es: Translations = {
     showAllAttempts: "Mostrar todos los intentos",
     sendingUpdates: "Enviando actualizaciones a",
     sendNotifications: "Enviar notificaciones de completed / blocked / gave_up a",
-    archiveBoardConfirm:
-      "¿Archivar el tablero '{name}'? Se moverá a boards/_archived/ para que puedas recuperarlo más tarde. Las tareas de este tablero ya no aparecerán en ninguna parte de la UI.",
+    archiveBoardConfirm: "¿Archivar el tablero '{name}'? Se moverá a boards/_archived/ para que puedas recuperarlo más tarde. Las tareas de este tablero ya no aparecerán en ninguna parte de la UI.",
     archiveBoardTitle: "Archivar este tablero",
     boardSwitcherHint: "Los tableros te permiten separar flujos de trabajo no relacionados",
     taskCreatedWarning: "Tarea creada, pero: ",
@@ -750,28 +661,19 @@ export const es: Translations = {
       done: "Completado",
       archived: "Archivado",
     },
-    confirmDone:
-      "¿Marcar esta tarea como hecha? Se libera el reclamo del worker y los hijos dependientes pasan a estar listos.",
-    confirmArchive:
-      "¿Archivar esta tarea? Desaparecerá de la vista por defecto del tablero.",
-    confirmBlocked:
-      "¿Marcar esta tarea como bloqueada? Se libera el reclamo del worker.",
-    completionSummary:
-      "Resumen de finalización para {label}. Se almacena como el result de la tarea.",
-    completionSummaryRequired:
-      "El resumen de finalización es obligatorio antes de marcar una tarea como hecha.",
+    confirmDone: "¿Marcar esta tarea como hecha? Se libera el reclamo del worker y los hijos dependientes pasan a estar listos.",
+    confirmArchive: "¿Archivar esta tarea? Desaparecerá de la vista por defecto del tablero.",
+    confirmBlocked: "¿Marcar esta tarea como bloqueada? Se libera el reclamo del worker.",
+    completionSummary: "Resumen de finalización para {label}. Se almacena como el result de la tarea.",
+    completionSummaryRequired: "El resumen de finalización es obligatorio antes de marcar una tarea como hecha.",
     triagePlaceholder: "Idea aproximada — la IA la especificará…",
     taskTitlePlaceholder: "Título de la nueva tarea…",
-    specifier: "specifier",
     assigneePlaceholder: "asignado",
     priority: "Prioridad",
-    skillsPlaceholder:
-      "habilidades (opcional, separadas por comas): translation, github-code-review",
+    skillsPlaceholder: "habilidades (opcional, separadas por comas): translation, github-code-review",
     noParent: "— sin padre —",
     workspacePathDir: "ruta del workspace (obligatoria, p. ej. ~/projects/my-app)",
-    workspacePathOptional:
-      "ruta del workspace (opcional, derivada del asignado si está vacía)",
+    workspacePathOptional: "ruta del workspace (opcional, derivada del asignado si está vacía)",
     logTruncated: "(mostrando los últimos 100 KB — registro completo en ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const fr: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const fr = defineLocale({
   common: {
     save: "Enregistrer",
     saving: "Enregistrement...",
@@ -29,8 +33,6 @@ export const fr: Translations = {
     form: "Formulaire",
     noResults: "Aucun résultat",
     of: "sur",
-    page: "Page",
-    msgs: "msgs",
     tools: "outils",
     match: "correspondance",
     other: "Autre",
@@ -43,20 +45,12 @@ export const fr: Translations = {
     expand: "Développer",
     general: "Général",
     messaging: "Messagerie",
-    pluginLoadFailed:
-      "Impossible de charger le script de ce plugin. Vérifiez l'onglet Réseau (dashboard-plugins/…) et le chemin des plugins du serveur.",
-    pluginNotRegistered:
-      "Le script du plugin n'a pas appelé register(), ou le script a échoué. Ouvrez la console du navigateur pour plus de détails.",
+    pluginLoadFailed: "Impossible de charger le script de ce plugin. Vérifiez l'onglet Réseau (dashboard-plugins/…) et le chemin des plugins du serveur.",
+    pluginNotRegistered: "Le script du plugin n'a pas appelé register(), ou le script a échoué. Ouvrez la console du navigateur pour plus de détails.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Fermer la navigation",
     closeModelTools: "Fermer modèle et outils",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Sessions actives:",
     gatewayStatusLabel: "État de la passerelle:",
     gatewayStrip: {
@@ -68,35 +62,24 @@ export const fr: Translations = {
     },
     nav: {
       analytics: "Analyses",
-      chat: "Chat",
       config: "Configuration",
-      cron: "Cron",
-      documentation: "Documentation",
       keys: "Clés",
       logs: "Journaux",
       models: "Modèles",
       profiles: "profils : multi agents",
-      plugins: "Plugins",
-      sessions: "Sessions",
       skills: "Compétences",
     },
     modelToolsSheetSubtitle: "& outils",
     modelToolsSheetTitle: "Modèle",
-    navigation: "Navigation",
     openDocumentation: "Ouvrir la documentation dans un nouvel onglet",
     openNavigation: "Ouvrir la navigation",
-    pluginNavSection: "Plugins",
     sessionsActiveCount: "{count} actives",
     statusOverview: "Aperçu de l'état",
     system: "Système",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "Action échouée",
     actionFinished: "Terminé",
-    actions: "Actions",
-    agent: "Agent",
     activeSessions: "Sessions actives",
     connected: "Connecté",
     connectedPlatforms: "Plateformes connectées",
@@ -108,7 +91,6 @@ export const fr: Translations = {
     lastUpdate: "Dernière mise à jour",
     noneRunning: "Aucun",
     notRunning: "Non lancé",
-    pid: "PID",
     platformDisconnected: "déconnecté",
     platformError: "erreur",
     recentSessions: "Sessions récentes",
@@ -124,9 +106,7 @@ export const fr: Translations = {
     updatingHermes: "Mise à jour de Hermes…",
     waitingForOutput: "En attente de la sortie…",
   },
-
   sessions: {
-    title: "Sessions",
     history: "Historique",
     overview: "Aperçu",
     filterChats: "Discussions",
@@ -143,14 +123,12 @@ export const fr: Translations = {
     untitledSession: "Session sans titre",
     deleteSession: "Supprimer la session",
     confirmDeleteTitle: "Supprimer la session ?",
-    confirmDeleteMessage:
-      "Cela supprime définitivement la conversation et tous ses messages. Cette action est irréversible.",
+    confirmDeleteMessage: "Cela supprime définitivement la conversation et tous ses messages. Cette action est irréversible.",
     sessionDeleted: "Session supprimée",
     failedToDelete: "Échec de la suppression de la session",
     deleteEmpty: "Supprimer les vides",
     deleteEmptyConfirmTitle: "Supprimer les sessions vides ?",
-    deleteEmptyConfirmMessage:
-      "Cela supprime définitivement {count} sessions sans messages. Les sessions actives et archivées sont ignorées. Cette action est irréversible.",
+    deleteEmptyConfirmMessage: "Cela supprime définitivement {count} sessions sans messages. Les sessions actives et archivées sont ignorées. Cette action est irréversible.",
     emptySessionsDeleted: "{count} sessions vides supprimées",
     failedToDeleteEmpty: "Échec de la suppression des sessions vides",
     selectSession: "Sélectionner la session",
@@ -159,8 +137,7 @@ export const fr: Translations = {
     selectedCount: "{count} sélectionnée(s)",
     deleteSelected: "Supprimer {count}",
     deleteSelectedConfirmTitle: "Supprimer {count} sessions ?",
-    deleteSelectedConfirmMessage:
-      "Cela supprime définitivement {count} sessions sélectionnées et tous leurs messages. Cette action est irréversible.",
+    deleteSelectedConfirmMessage: "Cela supprime définitivement {count} sessions sélectionnées et tous leurs messages. Cette action est irréversible.",
     selectedSessionsDeleted: "{count} sessions supprimées",
     failedToDeleteSelected: "Échec de la suppression des sessions sélectionnées",
     resumeInChat: "Reprendre dans le chat",
@@ -169,12 +146,10 @@ export const fr: Translations = {
     nextPage: "Page suivante",
     roles: {
       user: "Utilisateur",
-      assistant: "Assistant",
       system: "Système",
       tool: "Outil",
     },
   },
-
   analytics: {
     period: "Période:",
     totalTokens: "Tokens totaux",
@@ -190,29 +165,22 @@ export const fr: Translations = {
     lastUsed: "Dernière utilisation",
     input: "Entrée",
     output: "Sortie",
-    total: "Total",
     noUsageData: "Aucune donnée d'utilisation pour cette période",
     startSession: "Démarrez une session pour voir les analyses ici",
-    date: "Date",
     model: "Modèle",
-    tokens: "Tokens",
     perDayAvg: "/jour moy",
     acrossModels: "sur {count} modèles",
     inOut: "{input} entrée / {output} sortie",
   },
-
   models: {
     modelsUsed: "Modèles utilisés",
     estimatedCost: "Coût est.",
-    tokens: "tokens",
-    sessions: "sessions",
     avgPerSession: "moy/session",
     apiCalls: "appels API",
     toolCalls: "appels d'outil",
     noModelsData: "Aucune donnée de modèle pour cette période",
     startSession: "Démarrez une session pour voir les données de modèle ici",
   },
-
   logs: {
     title: "Journaux",
     autoRefresh: "Actualisation auto",
@@ -222,10 +190,8 @@ export const fr: Translations = {
     lines: "Lignes",
     noLogLines: "Aucune ligne de journal trouvée",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Cela supprime la tâche du planning. Cette action est irréversible.",
+    confirmDeleteMessage: "Cela supprime la tâche du planning. Cette action est irréversible.",
     confirmDeleteTitle: "Supprimer la tâche planifiée ?",
     newJob: "Nouvelle tâche cron",
     nameOptional: "Nom (facultatif)",
@@ -233,7 +199,6 @@ export const fr: Translations = {
     prompt: "Invite",
     promptPlaceholder: "Que doit faire l'agent à chaque exécution ?",
     schedule: "Planning (expression cron)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Planification",
     scheduleModes: {
       interval: "Intervalle récurrent",
@@ -244,23 +209,19 @@ export const fr: Translations = {
       custom: "Personnalisé (expression cron)",
       intervalEvery: "Toutes les",
       intervalUnit: "Unité",
-      unitMinutes: "minutes",
       unitHours: "heures",
       unitDays: "jours",
       timeOfDay: "Heure de la journée",
       weekdays: "Jours de la semaine",
-      weekdaysShort: ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam"],
+      weekdaysShort: ["Dim","Lun","Mar","Mer","Jeu","Ven","Sam"],
       dayOfMonth: "Jour du mois",
       onceAt: "Exécuter le",
       customLabel: "Expression cron",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "Expression cron à cinq champs (minute, heure, jour, mois, jour de la semaine).",
+      customHint: "Expression cron à cinq champs (minute, heure, jour, mois, jour de la semaine).",
       preview: "Envoyé sous la forme",
       previewEmpty: "(incomplet)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "Toutes les {n} min",
       everyHours: "Toutes les {n} h",
       everyDays: "Tous les {n} j",
@@ -274,32 +235,21 @@ export const fr: Translations = {
     noJobs: "Aucune tâche cron configurée. Créez-en une ci-dessus.",
     last: "Dernière",
     next: "Prochaine",
-    pause: "Pause",
     resume: "Reprendre",
     triggerNow: "Déclencher maintenant",
-    delivery: {
-      local: "Local",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
-    },
   },
-
   profiles: {
     newProfile: "Nouveau profil",
     name: "Nom",
     namePlaceholder: "ex. coder, writer, etc.",
     nameRequired: "Le nom est requis",
-    nameRule:
-      "Lettres minuscules, chiffres, _ et - uniquement ; doit commencer par une lettre ou un chiffre ; jusqu'à 64 caractères.",
+    nameRule: "Lettres minuscules, chiffres, _ et - uniquement ; doit commencer par une lettre ou un chiffre ; jusqu'à 64 caractères.",
     invalidName: "Nom de profil invalide",
     cloneFrom: "Cloner depuis le profil",
     cloneFromNone: "Aucun (vide)",
     allProfiles: "Profils",
     noProfiles: "Aucun profil trouvé.",
     defaultBadge: "défaut",
-    hasEnv: "env",
     model: "Modèle",
     skills: "Compétences",
     rename: "Renommer",
@@ -312,13 +262,11 @@ export const fr: Translations = {
     commandCopied: "Copié dans le presse-papiers",
     copyFailed: "Impossible de copier",
     confirmDeleteTitle: "Supprimer le profil ?",
-    confirmDeleteMessage:
-      "Cela supprime définitivement le profil '{name}' — configuration, clés, mémoires, sessions, compétences, tâches cron. Action irréversible.",
+    confirmDeleteMessage: "Cela supprime définitivement le profil '{name}' — configuration, clés, mémoires, sessions, compétences, tâches cron. Action irréversible.",
     created: "Créé",
     deleted: "Supprimé",
     renamed: "Renommé",
   },
-
   pluginsPage: {
     contextEngineLabel: "Moteur de contexte",
     dashboardSlots: "Emplacements du tableau de bord",
@@ -326,8 +274,7 @@ export const fr: Translations = {
     enableAfterInstall: "Activer après l'installation",
     enableRuntime: "Activer",
     forceReinstall: "Forcer la réinstallation (supprimer d'abord le dossier existant)",
-    headline:
-      "Découvrez, installez, activez et mettez à jour les plugins Hermes (parité avec `hermes plugins`).",
+    headline: "Découvrez, installez, activez et mettez à jour les plugins Hermes (parité avec `hermes plugins`).",
     identifierLabel: "URL Git ou owner/repo",
     inactive: "inactif",
     installBtn: "Installer",
@@ -341,8 +288,7 @@ export const fr: Translations = {
     pluginListHeading: "Plugins installés",
     providerDefaults: "intégré / par défaut",
     providersHeading: "Plugins fournisseurs d'exécution",
-    providersHint:
-      "Écrit memory.provider (vide = intégré) et context.engine dans config.yaml. Prend effet à la prochaine session.",
+    providersHint: "Écrit memory.provider (vide = intégré) et context.engine dans config.yaml. Prend effet à la prochaine session.",
     refreshDashboard: "Re-scanner les extensions du tableau de bord",
     removeConfirm: "Retirer ce plugin de ~/.hermes/plugins/ ?",
     removeHint: "Seuls les plugins installés par l'utilisateur sous ~/.hermes/plugins peuvent être supprimés.",
@@ -351,15 +297,11 @@ export const fr: Translations = {
     runtimeHeading: "Exécution de la passerelle (plugins YAML)",
     saveProviders: "Enregistrer les paramètres de fournisseur",
     savedProviders: "Paramètres de fournisseur enregistrés.",
-    sourceBadge: "Source",
     authRequired: "Authentification requise",
     authRequiredHint: "Exécutez cette commande pour vous authentifier:",
-    updateGit: "Git pull",
-    versionBadge: "Version",
     showInSidebar: "Afficher dans la barre latérale",
     hideFromSidebar: "Masquer de la barre latérale",
   },
-
   skills: {
     title: "Compétences",
     searchPlaceholder: "Rechercher des compétences et des outils...",
@@ -379,13 +321,9 @@ export const fr: Translations = {
     disabledForCli: "Désactivé pour CLI",
     more: "+{count} de plus",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "Filtres",
-    sections: "Sections",
     exportConfig: "Exporter la configuration en JSON",
-    importConfig: "Importer la configuration depuis JSON",
     resetDefaults: "Réinitialiser aux valeurs par défaut",
     resetScopeTooltip: "Réinitialiser {scope} aux valeurs par défaut",
     confirmResetScope: "Réinitialiser tous les paramètres de {scope} aux valeurs par défaut ? Cela ne met à jour que le formulaire — les modifications ne sont écrites dans config.yaml qu'après avoir appuyé sur Enregistrer.",
@@ -393,7 +331,7 @@ export const fr: Translations = {
     rawYaml: "Configuration YAML brute",
     searchResults: "Résultats de recherche",
     fields: "champ{s}",
-    noFieldsMatch: 'Aucun champ ne correspond à "{query}"',
+    noFieldsMatch: "Aucun champ ne correspond à \"{query}\"",
     configSaved: "Configuration enregistrée",
     yamlConfigSaved: "Configuration YAML enregistrée",
     failedToSave: "Échec de l'enregistrement",
@@ -403,27 +341,21 @@ export const fr: Translations = {
     invalidJson: "Fichier JSON invalide",
     categories: {
       general: "Général",
-      agent: "Agent",
-      terminal: "Terminal",
       display: "Affichage",
       delegation: "Délégation",
       memory: "Mémoire",
-      compression: "Compression",
       security: "Sécurité",
       browser: "Navigateur",
       voice: "Voix",
       tts: "Synthèse vocale",
       stt: "Reconnaissance vocale",
       logging: "Journalisation",
-      discord: "Discord",
       auxiliary: "Auxiliaire",
     },
   },
-
   env: {
     changesNote: "Les modifications sont enregistrées sur le disque immédiatement. Les sessions actives récupèrent les nouvelles clés automatiquement.",
-    confirmClearMessage:
-      "La valeur stockée pour cette variable sera supprimée de votre fichier .env. Cette action ne peut pas être annulée depuis l'interface.",
+    confirmClearMessage: "La valeur stockée pour cette variable sera supprimée de votre fichier .env. Cette action ne peut pas être annulée depuis l'interface.",
     confirmClearTitle: "Effacer cette clé ?",
     description: "Gérer les clés API et les secrets stockés dans",
     hideAdvanced: "Masquer les options avancées",
@@ -449,12 +381,10 @@ export const fr: Translations = {
     add: "Ajouter",
     invalidKeyName: "Utilisez uniquement des lettres, des chiffres et des traits de soulignement (doit commencer par une lettre ou un trait de soulignement).",
   },
-
   oauth: {
     title: "Connexions fournisseurs (OAuth)",
     providerLogins: "Connexions fournisseurs (OAuth)",
-    description:
-      "{connected} sur {total} fournisseurs OAuth connectés. Utilisez Connexion pour les flux pris en charge par le tableau de bord ; les commandes CLI restent disponibles pour une configuration externe ou de secours.",
+    description: "{connected} sur {total} fournisseurs OAuth connectés. Utilisez Connexion pour les flux pris en charge par le tableau de bord ; les commandes CLI restent disponibles pour une configuration externe ou de secours.",
     connected: "Connecté",
     expired: "Expiré",
     notConnected: "Non connecté. Utilisez Connexion si disponible, ou exécutez {command} dans un terminal.",
@@ -491,23 +421,17 @@ export const fr: Translations = {
     },
     expiresIn: "expire dans {time}",
   },
-
   language: {
     switchTo: "Changer de langue",
   },
-
   theme: {
     title: "Thème",
     switchTheme: "Changer de thème",
   },
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Badges Hermes à collectionner, gagnés à partir de l'historique réel des sessions. Les succès connus non terminés sont affichés comme Découverts ; les succès secrets restent cachés jusqu'à l'apparition du premier comportement correspondant.",
-      scan_subtitle:
-        "Analyse de l'historique des sessions Hermes en cours. Le premier scan peut prendre 5 à 10 secondes sur les historiques volumineux.",
+      subtitle: "Badges Hermes à collectionner, gagnés à partir de l'historique réel des sessions. Les succès connus non terminés sont affichés comme Découverts ; les succès secrets restent cachés jusqu'à l'apparition du premier comportement correspondant.",
+      scan_subtitle: "Analyse de l'historique des sessions Hermes en cours. Le premier scan peut prendre 5 à 10 secondes sur les historiques volumineux.",
     },
     actions: {
       rescan: "Relancer le scan",
@@ -517,10 +441,8 @@ export const fr: Translations = {
       unlocked_hint: "badges obtenus",
       discovered: "Découverts",
       discovered_hint: "connus, pas encore obtenus",
-      secrets: "Secrets",
       secrets_hint: "cachés jusqu'au premier signal",
       highest_tier: "Niveau le plus élevé",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "Dernier",
       latest_hint_empty: "utilisez Hermes davantage",
       none_yet: "Aucun pour l'instant",
@@ -528,7 +450,6 @@ export const fr: Translations = {
     state: {
       unlocked: "Débloqué",
       discovered: "Découvert",
-      secret: "Secret",
     },
     tier: {
       target: "Cible {tier}",
@@ -541,25 +462,19 @@ export const fr: Translations = {
     },
     scan: {
       building_headline: "Création du profil de succès…",
-      building_detail:
-        "Lecture des sessions, des appels d'outils, des métadonnées du modèle et de l'état de déblocage.",
+      building_detail: "Lecture des sessions, des appels d'outils, des métadonnées du modèle et de l'état de déblocage.",
       starting_headline: "Démarrage du scan des succès…",
-      progress_detail:
-        "{scanned} sessions analysées sur {total} · {pct}%. Les badges se débloquent à mesure que l'historique est traité.",
-      idle_detail:
-        "Lecture des sessions, des appels d'outils, des métadonnées du modèle et de l'état de déblocage. Les badges apparaissent ici à mesure qu'ils se débloquent.",
+      progress_detail: "{scanned} sessions analysées sur {total} · {pct}%. Les badges se débloquent à mesure que l'historique est traité.",
+      idle_detail: "Lecture des sessions, des appels d'outils, des métadonnées du modèle et de l'état de déblocage. Les badges apparaissent ici à mesure qu'ils se débloquent.",
     },
     guide: {
       tiers_header: "Niveaux",
       secret_header: "Succès secrets",
-      secret_body:
-        "Les secrets cachent leur déclencheur exact. Dès qu'Hermes détecte un signal lié, la carte passe à Découvert et affiche son exigence.",
+      secret_body: "Les secrets cachent leur déclencheur exact. Dès qu'Hermes détecte un signal lié, la carte passe à Découvert et affiche son exigence.",
       scan_status_header: "État du scan",
-      scan_status_body:
-        "Hermes analyse l'historique local une seule fois, puis les cartes apparaîtront automatiquement. Rien n'est bloqué si cela prend quelques secondes.",
+      scan_status_body: "Hermes analyse l'historique local une seule fois, puis les cartes apparaîtront automatiquement. Rien n'est bloqué si cela prend quelques secondes.",
       what_scanned_header: "Ce qui est analysé",
-      what_scanned_body:
-        "Sessions, appels d'outils, métadonnées du modèle, erreurs, succès et état de déblocage local.",
+      what_scanned_body: "Sessions, appels d'outils, métadonnées du modèle, erreurs, succès et état de déblocage local.",
     },
     card: {
       share_title: "Partager ce succès",
@@ -568,7 +483,6 @@ export const fr: Translations = {
       how_to_reveal: "Comment le révéler",
       what_counts: "Ce qui compte",
       evidence_label: "Preuve",
-      evidence_session_fallback: "session",
       no_evidence: "Pas encore de preuve",
     },
     latest: {
@@ -576,8 +490,7 @@ export const fr: Translations = {
     },
     empty: {
       no_secrets_header: "Plus aucun secret caché dans ce scan.",
-      no_secrets_body:
-        "Indice: les secrets démarrent généralement à partir d'échecs inhabituels ou de schémas d'utilisateurs avancés — conflits de ports, murs de permissions, variables d'environnement manquantes, erreurs YAML, collisions Docker, utilisation de rollback/checkpoint, succès de cache ou petits correctifs après beaucoup de texte rouge.",
+      no_secrets_body: "Indice: les secrets démarrent généralement à partir d'échecs inhabituels ou de schémas d'utilisateurs avancés — conflits de ports, murs de permissions, variables d'environnement manquantes, erreurs YAML, collisions Docker, utilisation de rollback/checkpoint, succès de cache ou petits correctifs après beaucoup de texte rouge.",
     },
     filters: {
       all_categories: "Tous",
@@ -599,34 +512,21 @@ export const fr: Translations = {
       copy_button: "Copier l'image",
       copied: "Copié ✓",
       download_button: "Télécharger le PNG",
-      hint:
-        "Partager sur X ouvre une publication préremplie dans un nouvel onglet. Cliquez d'abord sur Copier l'image si vous voulez joindre le badge 1200×630 — X vous laisse le coller directement dans l'éditeur de tweet. Télécharger le PNG enregistre le fichier pour l'utiliser n'importe où.",
-      clipboard_unsupported:
-        "La copie d'image dans le presse-papiers n'est pas prise en charge par ce navigateur — utilisez Télécharger à la place.",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "Partager sur X ouvre une publication préremplie dans un nouvel onglet. Cliquez d'abord sur Copier l'image si vous voulez joindre le badge 1200×630 — X vous laisse le coller directement dans l'éditeur de tweet. Télécharger le PNG enregistre le fichier pour l'utiliser n'importe où.",
+      clipboard_unsupported: "La copie d'image dans le presse-papiers n'est pas prise en charge par ce navigateur — utilisez Télécharger à la place.",
     },
   },
   kanban: {
     loading: "Chargement du tableau Kanban…",
     loadFailed: "Échec du chargement du tableau Kanban: ",
-    loadFailedHint:
-      "Le backend crée automatiquement kanban.db à la première lecture. Si le problème persiste, consultez les logs du dashboard.",
+    loadFailedHint: "Le backend crée automatiquement kanban.db à la première lecture. Si le problème persiste, consultez les logs du dashboard.",
     board: "Tableau",
     newBoard: "+ Nouveau tableau",
     newBoardTitle: "Nouveau tableau",
-    newBoardDescription:
-      "Les tableaux vous permettent de séparer des flux de travail indépendants — un par projet, dépôt ou domaine. Les workers d'un tableau ne voient jamais les tâches d'un autre.",
-    slug: "Slug",
+    newBoardDescription: "Les tableaux vous permettent de séparer des flux de travail indépendants — un par projet, dépôt ou domaine. Les workers d'un tableau ne voient jamais les tâches d'un autre.",
     slugHint: "— minuscules, tirets, par ex. atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Nom affiché",
     displayNameHint: "(facultatif)",
-    description: "Description",
     descriptionHint: "(facultatif)",
     icon: "Icône",
     iconHint: "(un seul caractère ou emoji)",
@@ -636,7 +536,6 @@ export const fr: Translations = {
     createBoard: "Créer le tableau",
     search: "Rechercher",
     filterCards: "Filtrer les cartes…",
-    tenant: "Tenant",
     allTenants: "Tous les tenants",
     assignee: "Assigné à",
     allProfiles: "Tous les profils",
@@ -657,23 +556,19 @@ export const fr: Translations = {
     addComment: "Ajouter un commentaire… (Enter pour envoyer)",
     comment: "Commentaire",
     status: "Statut",
-    workspace: "Workspace",
     skills: "Compétences",
     createdBy: "Créé par",
-    result: "Result",
     comments: "Commentaires",
     events: "Événements",
     runHistory: "Historique d'exécution",
     workerLog: "Log du worker",
     loadingLog: "Chargement du log…",
-    noWorkerLog:
-      "— pas encore de log du worker (la tâche n'a pas démarré ou le log a été effacé par rotation) —",
+    noWorkerLog: "— pas encore de log du worker (la tâche n'a pas démarré ou le log a été effacé par rotation) —",
     noDescription: "— aucune description —",
     noComments: "— aucun commentaire —",
     edit: "modifier",
     save: "Enregistrer",
     dependencies: "Dépendances",
-    parents: "Parents:",
     children: "Enfants:",
     none: "aucun",
     addParent: "— ajouter un parent —",
@@ -682,13 +577,10 @@ export const fr: Translations = {
     block: "Bloquer",
     unblock: "Débloquer",
     notifyHomeChannels: "Notifier les canaux home",
-    diagnostics: "Diagnostics",
     hide: "Masquer",
     show: "Afficher",
-    attention: "Attention",
     tasksNeedAttention: "tâches nécessitent une attention",
     taskNeedsAttention: "1 tâche nécessite une attention",
-    diagnostic: "diagnostic",
     open: "Ouvrir",
     close: "Fermer (Esc)",
     reassignTo: "Réassigner à:",
@@ -698,8 +590,7 @@ export const fr: Translations = {
     reassign: "Réassigner",
     renderingError: "L'onglet Kanban a rencontré une erreur de rendu",
     reloadView: "Recharger la vue",
-    wsAuthFailed:
-      "Échec d'authentification WebSocket — rechargez la page pour rafraîchir le jeton de session.",
+    wsAuthFailed: "Échec d'authentification WebSocket — rechargez la page pour rafraîchir le jeton de session.",
     markDone: "Marquer {n} tâche(s) comme terminée(s) ?",
     markArchived: "Archiver {n} tâche(s) ?",
     warning: "Avertissement",
@@ -710,8 +601,7 @@ export const fr: Translations = {
     showAllAttempts: "Afficher toutes les tentatives",
     sendingUpdates: "Envoi des mises à jour à",
     sendNotifications: "Envoyer les notifications completed / blocked / gave_up à",
-    archiveBoardConfirm:
-      "Archiver le tableau '{name}' ? Il sera déplacé vers boards/_archived/ pour pouvoir être récupéré plus tard. Les tâches de ce tableau n'apparaîtront plus nulle part dans l'UI.",
+    archiveBoardConfirm: "Archiver le tableau '{name}' ? Il sera déplacé vers boards/_archived/ pour pouvoir être récupéré plus tard. Les tâches de ce tableau n'apparaîtront plus nulle part dans l'UI.",
     archiveBoardTitle: "Archiver ce tableau",
     boardSwitcherHint: "Les tableaux vous permettent de séparer des flux de travail indépendants",
     taskCreatedWarning: "Tâche créée, mais: ",
@@ -731,7 +621,6 @@ export const fr: Translations = {
     clickToEditAssignee: "Cliquez pour modifier l'assigné",
     emptyAssignee: "(vide = désassigner)",
     columnLabels: {
-      triage: "Triage",
       todo: "À faire",
       scheduled: "Planifié",
       ready: "Prêt",
@@ -750,28 +639,19 @@ export const fr: Translations = {
       done: "Terminé",
       archived: "Archivé",
     },
-    confirmDone:
-      "Marquer cette tâche comme terminée ? La revendication du worker est libérée et les enfants dépendants deviennent prêts.",
-    confirmArchive:
-      "Archiver cette tâche ? Elle disparaîtra de la vue par défaut du tableau.",
-    confirmBlocked:
-      "Marquer cette tâche comme bloquée ? La revendication du worker est libérée.",
-    completionSummary:
-      "Résumé d'achèvement pour {label}. Stocké comme result de la tâche.",
-    completionSummaryRequired:
-      "Un résumé d'achèvement est requis avant de marquer une tâche comme terminée.",
+    confirmDone: "Marquer cette tâche comme terminée ? La revendication du worker est libérée et les enfants dépendants deviennent prêts.",
+    confirmArchive: "Archiver cette tâche ? Elle disparaîtra de la vue par défaut du tableau.",
+    confirmBlocked: "Marquer cette tâche comme bloquée ? La revendication du worker est libérée.",
+    completionSummary: "Résumé d'achèvement pour {label}. Stocké comme result de la tâche.",
+    completionSummaryRequired: "Un résumé d'achèvement est requis avant de marquer une tâche comme terminée.",
     triagePlaceholder: "Idée approximative — l'IA la spécifiera…",
     taskTitlePlaceholder: "Titre de la nouvelle tâche…",
-    specifier: "specifier",
     assigneePlaceholder: "assigné",
     priority: "Priorité",
-    skillsPlaceholder:
-      "compétences (facultatif, séparées par virgules): translation, github-code-review",
+    skillsPlaceholder: "compétences (facultatif, séparées par virgules): translation, github-code-review",
     noParent: "— aucun parent —",
     workspacePathDir: "chemin du workspace (requis, par ex. ~/projects/my-app)",
-    workspacePathOptional:
-      "chemin du workspace (facultatif, dérivé de l'assigné si vide)",
+    workspacePathOptional: "chemin du workspace (facultatif, dérivé de l'assigné si vide)",
     logTruncated: "(affichage des derniers 100 KB — log complet à ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const ga: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const ga = defineLocale({
   common: {
     save: "Sábháil",
     saving: "Á shábháil...",
@@ -43,20 +47,12 @@ export const ga: Translations = {
     expand: "Leathnaigh",
     general: "Ginearálta",
     messaging: "Teachtaireachtaí",
-    pluginLoadFailed:
-      "Níorbh fhéidir script an plugin seo a luchtú. Seiceáil an cluaisín Network (dashboard-plugins/…) agus conair plugin an fhreastalaí.",
-    pluginNotRegistered:
-      "Níor ghlaoigh script an plugin ar register(), nó tharla earráid sa script. Oscail consól an bhrabhsálaí le haghaidh sonraí.",
+    pluginLoadFailed: "Níorbh fhéidir script an plugin seo a luchtú. Seiceáil an cluaisín Network (dashboard-plugins/…) agus conair plugin an fhreastalaí.",
+    pluginNotRegistered: "Níor ghlaoigh script an plugin ar register(), nó tharla earráid sa script. Oscail consól an bhrabhsálaí le haghaidh sonraí.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Dún an nascleanúint",
     closeModelTools: "Dún an samhail agus na huirlisí",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Seisiúin gníomhacha:",
     gatewayStatusLabel: "Stádas an gateway:",
     gatewayStrip: {
@@ -70,13 +66,11 @@ export const ga: Translations = {
       analytics: "Anailís",
       chat: "Comhrá",
       config: "Cumraíocht",
-      cron: "Cron",
       documentation: "Doiciméadú",
       keys: "Eochracha",
       logs: "Logaí",
       models: "Samhlacha",
       profiles: "próifílí : il-agents",
-      plugins: "Plugins",
       sessions: "Seisiúin",
       skills: "Scileanna",
     },
@@ -85,30 +79,24 @@ export const ga: Translations = {
     navigation: "Nascleanúint",
     openDocumentation: "Oscail an doiciméadú i gcluaisín nua",
     openNavigation: "Oscail an nascleanúint",
-    pluginNavSection: "Plugins",
     sessionsActiveCount: "{count} gníomhach",
     statusOverview: "Forbhreathnú stádais",
     system: "Córas",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "Theip ar an ngníomh",
     actionFinished: "Críochnaithe",
     actions: "Gníomhartha",
-    agent: "Agent",
     activeSessions: "Seisiúin ghníomhacha",
     connected: "Ceangailte",
     connectedPlatforms: "Ardáin cheangailte",
     disconnected: "Dícheangailte",
     error: "Earráid",
     failed: "Theip",
-    gateway: "Gateway",
     gatewayFailedToStart: "Theip ar an gateway tosú",
     lastUpdate: "Nuashonrú deireanach",
     noneRunning: "Aon cheann",
     notRunning: "Níl ag rith",
-    pid: "PID",
     platformDisconnected: "dícheangailte",
     platformError: "earráid",
     recentSessions: "Seisiúin le déanaí",
@@ -124,7 +112,6 @@ export const ga: Translations = {
     updatingHermes: "Ag nuashonrú Hermes…",
     waitingForOutput: "Ag fanacht le haschur…",
   },
-
   sessions: {
     title: "Seisiúin",
     history: "Stair",
@@ -143,14 +130,12 @@ export const ga: Translations = {
     untitledSession: "Seisiún gan teideal",
     deleteSession: "Scrios an seisiún",
     confirmDeleteTitle: "Scrios an seisiún?",
-    confirmDeleteMessage:
-      "Baineann sé seo an comhrá agus a chuid teachtaireachtaí ar fad go buan. Ní féidir é seo a chealú.",
+    confirmDeleteMessage: "Baineann sé seo an comhrá agus a chuid teachtaireachtaí ar fad go buan. Ní féidir é seo a chealú.",
     sessionDeleted: "Seisiún scriosta",
     failedToDelete: "Theip ar scriosadh an tseisiúin",
     deleteEmpty: "Scrios folamh",
     deleteEmptyConfirmTitle: "Scrios seisiúin fholmha?",
-    deleteEmptyConfirmMessage:
-      "Baintear {count} seisiúin gan teachtaireachtaí ar bhealach buan. Ní scriostar seisiúin ghníomhacha agus seisiúin chartlainne. Ní féidir é seo a chealú.",
+    deleteEmptyConfirmMessage: "Baintear {count} seisiúin gan teachtaireachtaí ar bhealach buan. Ní scriostar seisiúin ghníomhacha agus seisiúin chartlainne. Ní féidir é seo a chealú.",
     emptySessionsDeleted: "{count} seisiúin fholmha scriosta",
     failedToDeleteEmpty: "Theip ar scriosadh na seisiún folmha",
     selectSession: "Roghnaigh seisiún",
@@ -159,8 +144,7 @@ export const ga: Translations = {
     selectedCount: "{count} roghnaithe",
     deleteSelected: "Scrios {count}",
     deleteSelectedConfirmTitle: "Scrios {count} seisiún?",
-    deleteSelectedConfirmMessage:
-      "Bainfear {count} seisiún roghnaithe agus a dteachtaireachtaí go léir go buan. Ní féidir é seo a chur ar ais.",
+    deleteSelectedConfirmMessage: "Bainfear {count} seisiún roghnaithe agus a dteachtaireachtaí go léir go buan. Ní féidir é seo a chur ar ais.",
     selectedSessionsDeleted: "Scriosadh {count} seisiún",
     failedToDeleteSelected: "Theip ar scriosadh na seisiún roghnaithe",
     resumeInChat: "Lean ar aghaidh sa chomhrá",
@@ -174,7 +158,6 @@ export const ga: Translations = {
       tool: "Uirlis",
     },
   },
-
   analytics: {
     period: "Tréimhse:",
     totalTokens: "Tokens iomlána",
@@ -195,16 +178,13 @@ export const ga: Translations = {
     startSession: "Tosaigh seisiún chun anailís a fheiceáil anseo",
     date: "Dáta",
     model: "Samhail",
-    tokens: "Tokens",
     perDayAvg: "/lá meán",
     acrossModels: "thar {count} samhail",
     inOut: "{input} isteach / {output} amach",
   },
-
   models: {
     modelsUsed: "Samhlacha úsáidte",
     estimatedCost: "Costas measta",
-    tokens: "tokens",
     sessions: "seisiúin",
     avgPerSession: "meán/seisiún",
     apiCalls: "glaonna API",
@@ -212,7 +192,6 @@ export const ga: Translations = {
     noModelsData: "Gan sonraí úsáide samhla don tréimhse seo",
     startSession: "Tosaigh seisiún chun sonraí samhla a fheiceáil anseo",
   },
-
   logs: {
     title: "Logaí",
     autoRefresh: "Athnuachan uathoibríoch",
@@ -222,18 +201,14 @@ export const ga: Translations = {
     lines: "Línte",
     noLogLines: "Níor aimsíodh línte loga",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Baineann sé seo an post ón sceideal. Ní féidir é seo a chealú.",
+    confirmDeleteMessage: "Baineann sé seo an post ón sceideal. Ní féidir é seo a chealú.",
     confirmDeleteTitle: "Scrios an post sceidealta?",
     newJob: "Post Cron Nua",
     nameOptional: "Ainm (roghnach)",
     namePlaceholder: "m.sh. Achoimre laethúil",
-    prompt: "Prompt",
     promptPlaceholder: "Cad ba chóir don agent a dhéanamh ag gach rith?",
     schedule: "Sceideal (slonn cron)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Sceideal",
     scheduleModes: {
       interval: "Eatramh athfhillteach",
@@ -249,26 +224,15 @@ export const ga: Translations = {
       unitDays: "lá",
       timeOfDay: "Am an lae",
       weekdays: "Laethanta na seachtaine",
-      weekdaysShort: [
-        "Domh",
-        "Luan",
-        "Máirt",
-        "Céad",
-        "Déar",
-        "Aoine",
-        "Sath",
-      ],
+      weekdaysShort: ["Domh","Luan","Máirt","Céad","Déar","Aoine","Sath"],
       dayOfMonth: "Lá den mhí",
       onceAt: "Rith ag",
       customLabel: "Slonn cron",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "Slonn cron cúig réimse (nóiméad, uair, lá, mí, lá den tseachtain).",
+      customHint: "Slonn cron cúig réimse (nóiméad, uair, lá, mí, lá den tseachtain).",
       preview: "Seoltar mar",
       previewEmpty: "(neamhiomlán)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "Gach {n} nóim",
       everyHours: "Gach {n} u",
       everyDays: "Gach {n} lá",
@@ -287,26 +251,20 @@ export const ga: Translations = {
     triggerNow: "Spreag anois",
     delivery: {
       local: "Áitiúil",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "Próifíl Nua",
     name: "Ainm",
     namePlaceholder: "m.sh. coder, writer, srl.",
     nameRequired: "Tá ainm riachtanach",
-    nameRule:
-      "Litreacha cás íochtair, digití, _ agus - amháin; caithfidh tús a chur le litir nó digit; suas le 64 carachtar.",
-    invalidName: "Ainm próifíle neamhbhailí",    cloneFrom: "Clónáil cumraíocht ón bpróifíl",
+    nameRule: "Litreacha cás íochtair, digití, _ agus - amháin; caithfidh tús a chur le litir nó digit; suas le 64 carachtar.",
+    invalidName: "Ainm próifíle neamhbhailí",
+    cloneFrom: "Clónáil cumraíocht ón bpróifíl",
     cloneFromNone: "Dada (folamh)",
     allProfiles: "Próifílí",
     noProfiles: "Níor aimsíodh próifílí.",
     defaultBadge: "réamhshocraithe",
-    hasEnv: "env",
     model: "Samhail",
     skills: "Scileanna",
     rename: "Athainmnigh",
@@ -319,13 +277,11 @@ export const ga: Translations = {
     commandCopied: "Cóipeáilte chuig an ngearrthaisce",
     copyFailed: "Níorbh fhéidir cóipeáil",
     confirmDeleteTitle: "Scrios an phróifíl?",
-    confirmDeleteMessage:
-      "Scriosann sé seo an phróifíl '{name}' go buan — cumraíocht, eochracha, cuimhní, seisiúin, scileanna, poist cron. Ní féidir é a chealú.",
+    confirmDeleteMessage: "Scriosann sé seo an phróifíl '{name}' go buan — cumraíocht, eochracha, cuimhní, seisiúin, scileanna, poist cron. Ní féidir é a chealú.",
     created: "Cruthaithe",
     deleted: "Scriosta",
     renamed: "Athainmnithe",
   },
-
   pluginsPage: {
     contextEngineLabel: "Inneall comhthéacs",
     dashboardSlots: "Slots an dashboard",
@@ -333,8 +289,7 @@ export const ga: Translations = {
     enableAfterInstall: "Cumasaigh tar éis suiteála",
     enableRuntime: "Cumasaigh",
     forceReinstall: "Cuir iallach ar athshuiteáil (scrios an fillteán atá ann ar dtús)",
-    headline:
-      "Faigh, suiteáil, cumasaigh agus nuashonraigh plugins Hermes (paireacht le `hermes plugins`).",
+    headline: "Faigh, suiteáil, cumasaigh agus nuashonraigh plugins Hermes (paireacht le `hermes plugins`).",
     identifierLabel: "URL Git nó owner/repo",
     inactive: "neamhghníomhach",
     installBtn: "Suiteáil",
@@ -348,8 +303,7 @@ export const ga: Translations = {
     pluginListHeading: "Plugins suiteáilte",
     providerDefaults: "ionsuite / réamhshocraithe",
     providersHeading: "Plugins soláthraí runtime",
-    providersHint:
-      "Scríobhann memory.provider (folamh = ionsuite) agus context.engine chuig config.yaml. Beidh éifeacht aige sa chéad seisiún eile.",
+    providersHint: "Scríobhann memory.provider (folamh = ionsuite) agus context.engine chuig config.yaml. Beidh éifeacht aige sa chéad seisiún eile.",
     refreshDashboard: "Athscan síntí an dashboard",
     removeConfirm: "Bain an plugin seo ó ~/.hermes/plugins/?",
     removeHint: "Ní féidir ach plugins atá suiteáilte ag an úsáideoir faoi ~/.hermes/plugins a bhaint.",
@@ -361,12 +315,10 @@ export const ga: Translations = {
     sourceBadge: "Foinse",
     authRequired: "Fíordheimhniú riachtanach",
     authRequiredHint: "Rith an t-ordú seo chun fíordheimhniú a dhéanamh:",
-    updateGit: "Git pull",
     versionBadge: "Leagan",
     showInSidebar: "Taispeáin sa bharra taoibh",
     hideFromSidebar: "Folaigh ón mbarra taoibh",
   },
-
   skills: {
     title: "Scileanna",
     searchPlaceholder: "Cuardaigh scileanna agus toolsets...",
@@ -379,20 +331,16 @@ export const ga: Translations = {
     skillCount: "{count} scil{s}",
     resultCount: "{count} torad{s}",
     noDescription: "Gan cur síos ar fáil.",
-    toolsets: "Toolsets",
     toolsetLabel: "toolset {name}",
     noToolsetsMatch: "Níl toolset ar bith ag teacht leis an gcuardach.",
     setupNeeded: "Socrú ag teastáil",
     disabledForCli: "Díchumasaithe don CLI",
     more: "+{count} eile",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "Scagairí",
     sections: "Ranna",
     exportConfig: "Easpórtáil cumraíocht mar JSON",
-    importConfig: "Iompórtáil cumraíocht ó JSON",
     resetDefaults: "Athshocraigh chuig réamhshocruithe",
     resetScopeTooltip: "Athshocraigh {scope} chuig réamhshocruithe",
     confirmResetScope: "Athshocraigh socruithe uile {scope} chuig a réamhshocruithe? Nuashonraíonn sé seo an fhoirm amháin — ní scríobhfar athruithe chuig config.yaml go dtí go mbrúnn tú Sábháil.",
@@ -400,7 +348,7 @@ export const ga: Translations = {
     rawYaml: "Cumraíocht YAML amh",
     searchResults: "Torthaí cuardaigh",
     fields: "réims{s}",
-    noFieldsMatch: 'Níl aon réimsí ag teacht le "{query}"',
+    noFieldsMatch: "Níl aon réimsí ag teacht le \"{query}\"",
     configSaved: "Cumraíocht sábháilte",
     yamlConfigSaved: "Cumraíocht YAML sábháilte",
     failedToSave: "Theip ar shábháil",
@@ -410,7 +358,6 @@ export const ga: Translations = {
     invalidJson: "Comhad JSON neamhbhailí",
     categories: {
       general: "Ginearálta",
-      agent: "Agent",
       terminal: "Teirminéal",
       display: "Taispeáint",
       delegation: "Tarmligean",
@@ -422,15 +369,12 @@ export const ga: Translations = {
       tts: "Téacs go Caint",
       stt: "Caint go Téacs",
       logging: "Logáil",
-      discord: "Discord",
       auxiliary: "Cúntach",
     },
   },
-
   env: {
     changesNote: "Sábháiltear athruithe chuig an diosca láithreach. Aimsíonn seisiúin ghníomhacha eochracha nua go huathoibríoch.",
-    confirmClearMessage:
-      "Bainfear an luach stóráilte don athróg seo ó do chomhad .env. Ní féidir é seo a chealú ón UI.",
+    confirmClearMessage: "Bainfear an luach stóráilte don athróg seo ó do chomhad .env. Ní féidir é seo a chealú ón UI.",
     confirmClearTitle: "Glan an eochair seo?",
     description: "Bainistigh eochracha API agus rúin atá stóráilte i",
     hideAdvanced: "Folaigh Ardroghanna",
@@ -456,12 +400,10 @@ export const ga: Translations = {
     add: "Cuir leis",
     invalidKeyName: "Úsáid litreacha, uimhreacha agus fostríoca amháin (caithfidh sé tosú le litir nó fostríoc).",
   },
-
   oauth: {
     title: "Logálacha isteach soláthraí (OAuth)",
     providerLogins: "Logálacha isteach soláthraí (OAuth)",
-    description:
-      "{connected} as {total} soláthraí OAuth ceangailte. Úsáid Logáil isteach le haghaidh sreabha a dtacaíonn an deais leo; tá orduithe CLI ar fáil i gcónaí do shocrú seachtrach nó cúltaca.",
+    description: "{connected} as {total} soláthraí OAuth ceangailte. Úsáid Logáil isteach le haghaidh sreabha a dtacaíonn an deais leo; tá orduithe CLI ar fáil i gcónaí do shocrú seachtrach nó cúltaca.",
     connected: "Ceangailte",
     expired: "As feidhm",
     notConnected: "Gan cheangal. Úsáid Logáil isteach má tá sé ar fáil, nó rith {command} i dteirminéal.",
@@ -498,24 +440,17 @@ export const ga: Translations = {
     },
     expiresIn: "as feidhm i {time}",
   },
-
   language: {
     switchTo: "Athraigh teanga",
   },
-
   theme: {
     title: "Téama",
     switchTheme: "Athraigh téama",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Suaitheantais Hermes inbhailithe a thuilltear ó stair fíor-session. Léirítear gnóthachtálacha aitheanta neamhchríochnaithe mar Discovered; fanann gnóthachtálacha Secret i bhfolach go dtí go bhfeictear an chéad iompar comhoiriúnach.",
-      scan_subtitle:
-        "Stair session Hermes á scanadh. Is féidir leis an gcéad scan 5–10 soicind a thógáil ar staireanna móra.",
+      subtitle: "Suaitheantais Hermes inbhailithe a thuilltear ó stair fíor-session. Léirítear gnóthachtálacha aitheanta neamhchríochnaithe mar Discovered; fanann gnóthachtálacha Secret i bhfolach go dtí go bhfeictear an chéad iompar comhoiriúnach.",
+      scan_subtitle: "Stair session Hermes á scanadh. Is féidir leis an gcéad scan 5–10 soicind a thógáil ar staireanna móra.",
     },
     actions: {
       rescan: "Athscan",
@@ -528,7 +463,6 @@ export const ga: Translations = {
       secrets: "Rúin",
       secrets_hint: "i bhfolach go dtí an chéad chomhartha",
       highest_tier: "An leibhéal is airde",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "An ceann is déanaí",
       latest_hint_empty: "rith Hermes níos mó",
       none_yet: "Aon cheann fós",
@@ -549,25 +483,19 @@ export const ga: Translations = {
     },
     scan: {
       building_headline: "Próifíl ghnóthachtála á tógáil…",
-      building_detail:
-        "Sessions, glaonna ar uirlisí, meiteashonraí samhla agus staid díghlasála á léamh.",
+      building_detail: "Sessions, glaonna ar uirlisí, meiteashonraí samhla agus staid díghlasála á léamh.",
       starting_headline: "Scan ghnóthachtála á thosú…",
-      progress_detail:
-        "{scanned} as {total} session scanta · {pct}%. Díghlasáiltear suaitheantais de réir mar a shníonn níos mó staire isteach.",
-      idle_detail:
-        "Sessions, glaonna ar uirlisí, meiteashonraí samhla agus staid díghlasála á léamh. Feicfear suaitheantais anseo de réir mar a dhíghlasáiltear iad.",
+      progress_detail: "{scanned} as {total} session scanta · {pct}%. Díghlasáiltear suaitheantais de réir mar a shníonn níos mó staire isteach.",
+      idle_detail: "Sessions, glaonna ar uirlisí, meiteashonraí samhla agus staid díghlasála á léamh. Feicfear suaitheantais anseo de réir mar a dhíghlasáiltear iad.",
     },
     guide: {
       tiers_header: "Leibhéil",
       secret_header: "Gnóthachtálacha rúnda",
-      secret_body:
-        "Coinníonn rúin a dtruicear cruinn faoi cheilt. Nuair a fheiceann Hermes comhartha gaolmhar, athraíonn an cárta go Aimsithe agus taispeánann sé a riachtanas.",
+      secret_body: "Coinníonn rúin a dtruicear cruinn faoi cheilt. Nuair a fheiceann Hermes comhartha gaolmhar, athraíonn an cárta go Aimsithe agus taispeánann sé a riachtanas.",
       scan_status_header: "Stádas an scanta",
-      scan_status_body:
-        "Scanann Hermes an stair logánta uair amháin, ansin feicfear cártaí go huathoibríoch. Níl aon rud sáinnithe má thógann sé cúpla soicind.",
+      scan_status_body: "Scanann Hermes an stair logánta uair amháin, ansin feicfear cártaí go huathoibríoch. Níl aon rud sáinnithe má thógann sé cúpla soicind.",
       what_scanned_header: "Cad a scantar",
-      what_scanned_body:
-        "Sessions, glaonna ar uirlisí, meiteashonraí samhla, earráidí, gnóthachtálacha agus staid díghlasála logánta.",
+      what_scanned_body: "Sessions, glaonna ar uirlisí, meiteashonraí samhla, earráidí, gnóthachtálacha agus staid díghlasála logánta.",
     },
     card: {
       share_title: "Comhroinn an gnóthachtáil seo",
@@ -576,7 +504,6 @@ export const ga: Translations = {
       how_to_reveal: "Conas é a nochtadh",
       what_counts: "Cad a chomhairtear",
       evidence_label: "Fianaise",
-      evidence_session_fallback: "session",
       no_evidence: "Níl fianaise ann fós",
     },
     latest: {
@@ -584,8 +511,7 @@ export const ga: Translations = {
     },
     empty: {
       no_secrets_header: "Níl aon rúin fhalaithe fágtha sa scan seo.",
-      no_secrets_body:
-        "Leid: tosaíonn rúin de ghnáth le patrúin teipe neamhghnácha nó patrúin power-user — coinbhleachtaí poirt, ballaí ceadanna, athróga env in easnamh, botúin YAML, imbhuailtí Docker, úsáid rollback/checkpoint, amais cache, nó mionchóirithe tar éis go leor téacs dheirg.",
+      no_secrets_body: "Leid: tosaíonn rúin de ghnáth le patrúin teipe neamhghnácha nó patrúin power-user — coinbhleachtaí poirt, ballaí ceadanna, athróga env in easnamh, botúin YAML, imbhuailtí Docker, úsáid rollback/checkpoint, amais cache, nó mionchóirithe tar éis go leor téacs dheirg.",
     },
     filters: {
       all_categories: "Gach rud",
@@ -607,31 +533,19 @@ export const ga: Translations = {
       copy_button: "Cóipeáil íomhá",
       copied: "Cóipeáilte ✓",
       download_button: "Íoslódáil PNG",
-      hint:
-        "Osclaíonn Comhroinn ar X post réamhlíonta i gcluaisín nua. Cliceáil Cóipeáil íomhá ar dtús más mian leat an suaitheantas 1200×630 a bheith ceangailte — ligeann X duit é a ghreamú díreach isteach i scríbhneoir an tweet. Sábhálann Íoslódáil PNG an comhad le húsáid áit ar bith.",
-      clipboard_unsupported:
-        "Ní thacaítear le cóipeáil íomhá chuig an ngearrthaisce sa bhrabhsálaí seo — úsáid Íoslódáil ina ionad sin.",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "Osclaíonn Comhroinn ar X post réamhlíonta i gcluaisín nua. Cliceáil Cóipeáil íomhá ar dtús más mian leat an suaitheantas 1200×630 a bheith ceangailte — ligeann X duit é a ghreamú díreach isteach i scríbhneoir an tweet. Sábhálann Íoslódáil PNG an comhad le húsáid áit ar bith.",
+      clipboard_unsupported: "Ní thacaítear le cóipeáil íomhá chuig an ngearrthaisce sa bhrabhsálaí seo — úsáid Íoslódáil ina ionad sin.",
     },
   },
   kanban: {
     loading: "Clár Kanban á luchtú…",
     loadFailed: "Theip ar luchtú an chláir Kanban: ",
-    loadFailedHint:
-      "Cruthaíonn an cúl-inneall kanban.db go huathoibríoch ar an gcéad léamh. Má leanann sé seo, féach logaí an dashboard.",
+    loadFailedHint: "Cruthaíonn an cúl-inneall kanban.db go huathoibríoch ar an gcéad léamh. Má leanann sé seo, féach logaí an dashboard.",
     board: "Clár",
     newBoard: "+ Clár nua",
     newBoardTitle: "Clár nua",
-    newBoardDescription:
-      "Ligeann boards duit sruthanna oibre neamhghaolmhara a scaradh — ceann amháin in aghaidh an tionscadail, an repo nó an fhearainn. Ní fheiceann workers ar bhord amháin tascanna board eile riamh.",
-    slug: "Slug",
+    newBoardDescription: "Ligeann boards duit sruthanna oibre neamhghaolmhara a scaradh — ceann amháin in aghaidh an tionscadail, an repo nó an fhearainn. Ní fheiceann workers ar bhord amháin tascanna board eile riamh.",
     slugHint: "— litreacha beaga, fleiscíní, m.sh. atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Ainm taispeána",
     displayNameHint: "(roghnach)",
     description: "Cur síos",
@@ -644,7 +558,6 @@ export const ga: Translations = {
     createBoard: "Cruthaigh clár",
     search: "Cuardaigh",
     filterCards: "Scag cártaí…",
-    tenant: "Tenant",
     allTenants: "Gach tenant",
     assignee: "Sannaí",
     allProfiles: "Gach profile",
@@ -665,7 +578,6 @@ export const ga: Translations = {
     addComment: "Cuir nóta tráchta… (Enter chun seoladh)",
     comment: "Nóta tráchta",
     status: "Stádas",
-    workspace: "Workspace",
     skills: "Scileanna",
     createdBy: "Cruthaithe ag",
     result: "Toradh",
@@ -674,8 +586,7 @@ export const ga: Translations = {
     runHistory: "Stair na rití",
     workerLog: "Loga an worker",
     loadingLog: "Loga á luchtú…",
-    noWorkerLog:
-      "— níl loga worker ann fós (níor sheol an tasc nó rinneadh an loga a rothlú) —",
+    noWorkerLog: "— níl loga worker ann fós (níor sheol an tasc nó rinneadh an loga a rothlú) —",
     noDescription: "— gan cur síos —",
     noComments: "— gan nótaí tráchta —",
     edit: "cuir in eagar",
@@ -706,8 +617,7 @@ export const ga: Translations = {
     reassign: "Athshann",
     renderingError: "Bhuail earráid rindreála an chluaisín Kanban",
     reloadView: "Athluchtaigh an radharc",
-    wsAuthFailed:
-      "Theip ar fhíordheimhniú WebSocket — athluchtaigh an leathanach chun an comhartha seisiúin a athnuachan.",
+    wsAuthFailed: "Theip ar fhíordheimhniú WebSocket — athluchtaigh an leathanach chun an comhartha seisiúin a athnuachan.",
     markDone: "Marcáil {n} tasc mar críochnaithe?",
     markArchived: "Cartlannaigh {n} tasc?",
     warning: "Rabhadh",
@@ -718,8 +628,7 @@ export const ga: Translations = {
     showAllAttempts: "Taispeáin gach iarracht",
     sendingUpdates: "Nuashonruithe á seoladh chuig",
     sendNotifications: "Seol fógraí completed / blocked / gave_up chuig",
-    archiveBoardConfirm:
-      "Cartlannaigh an clár '{name}'? Bogfar é go boards/_archived/ ionas gur féidir é a aisghabháil níos déanaí. Ní bheidh tascanna an chláir seo le feiceáil aon áit san UI a thuilleadh.",
+    archiveBoardConfirm: "Cartlannaigh an clár '{name}'? Bogfar é go boards/_archived/ ionas gur féidir é a aisghabháil níos déanaí. Ní bheidh tascanna an chláir seo le feiceáil aon áit san UI a thuilleadh.",
     archiveBoardTitle: "Cartlannaigh an clár seo",
     boardSwitcherHint: "Ligeann boards duit sruthanna oibre neamhghaolmhara a scaradh",
     taskCreatedWarning: "Cruthaíodh an tasc, ach: ",
@@ -758,28 +667,19 @@ export const ga: Translations = {
       done: "Críochnaithe",
       archived: "Cartlannaithe",
     },
-    confirmDone:
-      "Marcáil an tasc seo mar críochnaithe? Scaoiltear éileamh an worker agus éiríonn leanaí spleácha ready.",
-    confirmArchive:
-      "Cartlannaigh an tasc seo? Imíonn sé as an réamhradharc cláir.",
-    confirmBlocked:
-      "Marcáil an tasc seo mar bactha? Scaoiltear éileamh an worker.",
-    completionSummary:
-      "Achoimre chríochnaithe ar {label}. Stóráiltear é seo mar result an taisc.",
-    completionSummaryRequired:
-      "Tá achoimre chríochnaithe riachtanach sula marcáiltear tasc mar críochnaithe.",
+    confirmDone: "Marcáil an tasc seo mar críochnaithe? Scaoiltear éileamh an worker agus éiríonn leanaí spleácha ready.",
+    confirmArchive: "Cartlannaigh an tasc seo? Imíonn sé as an réamhradharc cláir.",
+    confirmBlocked: "Marcáil an tasc seo mar bactha? Scaoiltear éileamh an worker.",
+    completionSummary: "Achoimre chríochnaithe ar {label}. Stóráiltear é seo mar result an taisc.",
+    completionSummaryRequired: "Tá achoimre chríochnaithe riachtanach sula marcáiltear tasc mar críochnaithe.",
     triagePlaceholder: "Smaoineamh garbh — déanfaidh AI an spec…",
     taskTitlePlaceholder: "Teideal taisc nua…",
-    specifier: "specifier",
     assigneePlaceholder: "sannaí",
     priority: "Tosaíocht",
-    skillsPlaceholder:
-      "scileanna (roghnach, scartha le camóga): translation, github-code-review",
+    skillsPlaceholder: "scileanna (roghnach, scartha le camóga): translation, github-code-review",
     noParent: "— gan tuismitheoir —",
     workspacePathDir: "conair workspace (riachtanach, m.sh. ~/projects/my-app)",
-    workspacePathOptional:
-      "conair workspace (roghnach, díorthaithe ón sannaí má tá sé folamh)",
+    workspacePathOptional: "conair workspace (roghnach, díorthaithe ón sannaí má tá sé folamh)",
     logTruncated: "(taispeántar an 100 KB deireanach — loga iomlán ag ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const hu: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const hu = defineLocale({
   common: {
     save: "Mentés",
     saving: "Mentés...",
@@ -43,20 +47,12 @@ export const hu: Translations = {
     expand: "Kibontás",
     general: "Általános",
     messaging: "Üzenetküldés",
-    pluginLoadFailed:
-      "Nem sikerült betölteni a bővítmény szkriptjét. Ellenőrizze a Network fület (dashboard-plugins/…) és a kiszolgáló bővítmény-elérési útját.",
-    pluginNotRegistered:
-      "A bővítmény szkriptje nem hívta meg a register() függvényt, vagy hibára futott. A részletekért nyissa meg a böngésző konzolját.",
+    pluginLoadFailed: "Nem sikerült betölteni a bővítmény szkriptjét. Ellenőrizze a Network fület (dashboard-plugins/…) és a kiszolgáló bővítmény-elérési útját.",
+    pluginNotRegistered: "A bővítmény szkriptje nem hívta meg a register() függvényt, vagy hibára futott. A részletekért nyissa meg a böngésző konzolját.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Navigáció bezárása",
     closeModelTools: "Modell és eszközök bezárása",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Aktív munkamenetek:",
     gatewayStatusLabel: "Átjáró állapota:",
     gatewayStrip: {
@@ -70,7 +66,6 @@ export const hu: Translations = {
       analytics: "Analitika",
       chat: "Csevegés",
       config: "Beállítások",
-      cron: "Cron",
       documentation: "Dokumentáció",
       keys: "Kulcsok",
       logs: "Naplók",
@@ -89,9 +84,7 @@ export const hu: Translations = {
     sessionsActiveCount: "{count} aktív",
     statusOverview: "Állapot áttekintése",
     system: "Rendszer",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "Művelet sikertelen",
     actionFinished: "Befejezve",
@@ -108,7 +101,6 @@ export const hu: Translations = {
     lastUpdate: "Utolsó frissítés",
     noneRunning: "Nincs",
     notRunning: "Nem fut",
-    pid: "PID",
     platformDisconnected: "lekapcsolva",
     platformError: "hiba",
     recentSessions: "Legutóbbi munkamenetek",
@@ -124,7 +116,6 @@ export const hu: Translations = {
     updatingHermes: "Hermes frissítése…",
     waitingForOutput: "Várakozás a kimenetre…",
   },
-
   sessions: {
     title: "Munkamenetek",
     history: "Előzmények",
@@ -143,14 +134,12 @@ export const hu: Translations = {
     untitledSession: "Névtelen munkamenet",
     deleteSession: "Munkamenet törlése",
     confirmDeleteTitle: "Törli a munkamenetet?",
-    confirmDeleteMessage:
-      "Ez véglegesen eltávolítja a beszélgetést és minden üzenetét. A művelet nem vonható vissza.",
+    confirmDeleteMessage: "Ez véglegesen eltávolítja a beszélgetést és minden üzenetét. A művelet nem vonható vissza.",
     sessionDeleted: "Munkamenet törölve",
     failedToDelete: "Nem sikerült törölni a munkamenetet",
     deleteEmpty: "Üresek törlése",
     deleteEmptyConfirmTitle: "Üres munkamenetek törlése?",
-    deleteEmptyConfirmMessage:
-      "Ez véglegesen eltávolít {count} olyan munkamenetet, amely nem tartalmaz üzenetet. Az aktív és archivált munkameneteket kihagyja. Ez nem vonható vissza.",
+    deleteEmptyConfirmMessage: "Ez véglegesen eltávolít {count} olyan munkamenetet, amely nem tartalmaz üzenetet. Az aktív és archivált munkameneteket kihagyja. Ez nem vonható vissza.",
     emptySessionsDeleted: "{count} üres munkamenet törölve",
     failedToDeleteEmpty: "Nem sikerült törölni az üres munkameneteket",
     selectSession: "Munkamenet kijelölése",
@@ -159,8 +148,7 @@ export const hu: Translations = {
     selectedCount: "{count} kijelölve",
     deleteSelected: "{count} törlése",
     deleteSelectedConfirmTitle: "{count} munkamenet törlése?",
-    deleteSelectedConfirmMessage:
-      "Ez véglegesen eltávolítja a kijelölt {count} munkamenetet és minden üzenetüket. A művelet nem vonható vissza.",
+    deleteSelectedConfirmMessage: "Ez véglegesen eltávolítja a kijelölt {count} munkamenetet és minden üzenetüket. A művelet nem vonható vissza.",
     selectedSessionsDeleted: "{count} munkamenet törölve",
     failedToDeleteSelected: "Nem sikerült törölni a kijelölt munkameneteket",
     resumeInChat: "Folytatás a csevegésben",
@@ -174,7 +162,6 @@ export const hu: Translations = {
       tool: "Eszköz",
     },
   },
-
   analytics: {
     period: "Időszak:",
     totalTokens: "Összes token",
@@ -200,7 +187,6 @@ export const hu: Translations = {
     acrossModels: "{count} modellen át",
     inOut: "{input} be / {output} ki",
   },
-
   models: {
     modelsUsed: "Használt modellek",
     estimatedCost: "Becsült költség",
@@ -212,7 +198,6 @@ export const hu: Translations = {
     noModelsData: "Nincs modellhasználati adat erre az időszakra",
     startSession: "Indítson munkamenetet a modelladatok megtekintéséhez",
   },
-
   logs: {
     title: "Naplók",
     autoRefresh: "Automatikus frissítés",
@@ -222,18 +207,14 @@ export const hu: Translations = {
     lines: "Sorok",
     noLogLines: "Nem található naplóbejegyzés",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Ez eltávolítja a feladatot az ütemezésből. A művelet nem vonható vissza.",
+    confirmDeleteMessage: "Ez eltávolítja a feladatot az ütemezésből. A művelet nem vonható vissza.",
     confirmDeleteTitle: "Törli az ütemezett feladatot?",
     newJob: "Új Cron-feladat",
     nameOptional: "Név (opcionális)",
     namePlaceholder: "pl. Napi összegzés",
-    prompt: "Prompt",
     promptPlaceholder: "Mit tegyen az ügynök minden futtatáskor?",
     schedule: "Ütemezés (cron-kifejezés)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Ütemezés",
     scheduleModes: {
       interval: "Ismétlődő intervallum",
@@ -249,18 +230,15 @@ export const hu: Translations = {
       unitDays: "nap",
       timeOfDay: "Napszak",
       weekdays: "Hét napjai",
-      weekdaysShort: ["V", "H", "K", "Sze", "Cs", "P", "Szo"],
+      weekdaysShort: ["V","H","K","Sze","Cs","P","Szo"],
       dayOfMonth: "Hónap napja",
       onceAt: "Futtatás ekkor",
       customLabel: "Cron kifejezés",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "Öt mezős cron kifejezés (perc, óra, nap, hónap, hét napja).",
+      customHint: "Öt mezős cron kifejezés (perc, óra, nap, hónap, hét napja).",
       preview: "Elküldve mint",
       previewEmpty: "(hiányos)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "{n} percenként",
       everyHours: "{n} óránként",
       everyDays: "{n} naponta",
@@ -279,26 +257,20 @@ export const hu: Translations = {
     triggerNow: "Indítás most",
     delivery: {
       local: "Helyi",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "Új profil",
     name: "Név",
     namePlaceholder: "pl. coder, writer stb.",
     nameRequired: "A név kötelező",
-    nameRule:
-      "Csak kisbetűk, számjegyek, _ és - karakterek; betűvel vagy számjeggyel kell kezdődnie; legfeljebb 64 karakter.",
-    invalidName: "Érvénytelen profilnév",    cloneFrom: "Konfiguráció klónozása ebből a profilból",
+    nameRule: "Csak kisbetűk, számjegyek, _ és - karakterek; betűvel vagy számjeggyel kell kezdődnie; legfeljebb 64 karakter.",
+    invalidName: "Érvénytelen profilnév",
+    cloneFrom: "Konfiguráció klónozása ebből a profilból",
     cloneFromNone: "Nincs (üres)",
     allProfiles: "Profilok",
     noProfiles: "Nem található profil.",
     defaultBadge: "alapértelmezett",
-    hasEnv: "env",
     model: "Modell",
     skills: "Készségek",
     rename: "Átnevezés",
@@ -311,13 +283,11 @@ export const hu: Translations = {
     commandCopied: "Vágólapra másolva",
     copyFailed: "Nem sikerült másolni",
     confirmDeleteTitle: "Törli a profilt?",
-    confirmDeleteMessage:
-      "Ez véglegesen törli a(z) '{name}' profilt — konfigurációt, kulcsokat, emlékeket, munkameneteket, készségeket, cron-feladatokat. A művelet nem vonható vissza.",
+    confirmDeleteMessage: "Ez véglegesen törli a(z) '{name}' profilt — konfigurációt, kulcsokat, emlékeket, munkameneteket, készségeket, cron-feladatokat. A művelet nem vonható vissza.",
     created: "Létrehozva",
     deleted: "Törölve",
     renamed: "Átnevezve",
   },
-
   pluginsPage: {
     contextEngineLabel: "Kontextusmotor",
     dashboardSlots: "Vezérlőpult-slotok",
@@ -325,8 +295,7 @@ export const hu: Translations = {
     enableAfterInstall: "Engedélyezés a telepítés után",
     enableRuntime: "Engedélyezés",
     forceReinstall: "Kényszerített újratelepítés (a meglévő mappa előbb törlődik)",
-    headline:
-      "Hermes-bővítmények felfedezése, telepítése, engedélyezése és frissítése (a `hermes plugins` paritás).",
+    headline: "Hermes-bővítmények felfedezése, telepítése, engedélyezése és frissítése (a `hermes plugins` paritás).",
     identifierLabel: "Git URL vagy owner/repo",
     inactive: "inaktív",
     installBtn: "Telepítés",
@@ -340,8 +309,7 @@ export const hu: Translations = {
     pluginListHeading: "Telepített bővítmények",
     providerDefaults: "beépített / alapértelmezett",
     providersHeading: "Futási idejű szolgáltató-bővítmények",
-    providersHint:
-      "A memory.provider (üres = beépített) és a context.engine értékét írja a config.yaml fájlba. A következő munkamenetben lép életbe.",
+    providersHint: "A memory.provider (üres = beépített) és a context.engine értékét írja a config.yaml fájlba. A következő munkamenetben lép életbe.",
     refreshDashboard: "Vezérlőpult-bővítmények újraolvasása",
     removeConfirm: "Eltávolítja ezt a bővítményt a ~/.hermes/plugins/ mappából?",
     removeHint: "Csak a felhasználó által a ~/.hermes/plugins alá telepített bővítmények távolíthatók el.",
@@ -353,12 +321,10 @@ export const hu: Translations = {
     sourceBadge: "Forrás",
     authRequired: "Hitelesítés szükséges",
     authRequiredHint: "Futtassa ezt a parancsot a hitelesítéshez:",
-    updateGit: "Git pull",
     versionBadge: "Verzió",
     showInSidebar: "Megjelenítés az oldalsávon",
     hideFromSidebar: "Elrejtés az oldalsávról",
   },
-
   skills: {
     title: "Készségek",
     searchPlaceholder: "Készségek és eszközkészletek keresése...",
@@ -378,13 +344,10 @@ export const hu: Translations = {
     disabledForCli: "CLI-hez letiltva",
     more: "+{count} további",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "Szűrők",
     sections: "Szakaszok",
     exportConfig: "Konfiguráció exportálása JSON-ba",
-    importConfig: "Konfiguráció importálása JSON-ból",
     resetDefaults: "Visszaállítás alapértelmezettre",
     resetScopeTooltip: "{scope} visszaállítása alapértelmezettre",
     confirmResetScope: "Visszaállítja az összes {scope} beállítást alapértelmezettre? Ez csak az űrlapot frissíti — a változások nem íródnak be a config.yaml fájlba, amíg meg nem nyomja a Mentés gombot.",
@@ -392,7 +355,7 @@ export const hu: Translations = {
     rawYaml: "Nyers YAML-konfiguráció",
     searchResults: "Keresési eredmények",
     fields: "mező{s}",
-    noFieldsMatch: 'Nincs a(z) "{query}" keresésnek megfelelő mező',
+    noFieldsMatch: "Nincs a(z) \"{query}\" keresésnek megfelelő mező",
     configSaved: "Konfiguráció mentve",
     yamlConfigSaved: "YAML-konfiguráció mentve",
     failedToSave: "Mentés sikertelen",
@@ -414,15 +377,12 @@ export const hu: Translations = {
       tts: "Szövegfelolvasás",
       stt: "Beszédfelismerés",
       logging: "Naplózás",
-      discord: "Discord",
       auxiliary: "Kiegészítő",
     },
   },
-
   env: {
     changesNote: "A változások azonnal mentésre kerülnek a lemezre. Az aktív munkamenetek automatikusan átveszik az új kulcsokat.",
-    confirmClearMessage:
-      "A változó tárolt értéke törlődik a .env fájlból. Ez a felületről nem vonható vissza.",
+    confirmClearMessage: "A változó tárolt értéke törlődik a .env fájlból. Ez a felületről nem vonható vissza.",
     confirmClearTitle: "Törli ezt a kulcsot?",
     description: "API-kulcsok és titkok kezelése a következő helyen:",
     hideAdvanced: "Speciális elrejtése",
@@ -448,12 +408,10 @@ export const hu: Translations = {
     add: "Hozzáadás",
     invalidKeyName: "Csak betűket, számokat és aláhúzásokat használj (betűvel vagy aláhúzással kell kezdődnie).",
   },
-
   oauth: {
     title: "Szolgáltatói bejelentkezések (OAuth)",
     providerLogins: "Szolgáltatói bejelentkezések (OAuth)",
-    description:
-      "{connected} / {total} OAuth-szolgáltató csatlakoztatva. Használja a Bejelentkezés gombot az irányítópult által támogatott folyamatokhoz; a CLI-parancsok továbbra is elérhetők külső vagy tartalék beállításhoz.",
+    description: "{connected} / {total} OAuth-szolgáltató csatlakoztatva. Használja a Bejelentkezés gombot az irányítópult által támogatott folyamatokhoz; a CLI-parancsok továbbra is elérhetők külső vagy tartalék beállításhoz.",
     connected: "Csatlakoztatva",
     expired: "Lejárt",
     notConnected: "Nincs csatlakoztatva. Használja a Bejelentkezés gombot, ha elérhető, vagy futtassa a {command} parancsot egy terminálban.",
@@ -490,24 +448,17 @@ export const hu: Translations = {
     },
     expiresIn: "lejár {time} múlva",
   },
-
   language: {
     switchTo: "Nyelv váltása",
   },
-
   theme: {
     title: "Téma",
     switchTheme: "Téma váltása",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Gyűjthető Hermes-jelvények, valós munkamenet-előzmények alapján szerezve. Az ismert, de még nem szerzett teljesítmények Felfedezettként jelennek meg; a Titkos teljesítmények rejtve maradnak az első egyező viselkedésig.",
-      scan_subtitle:
-        "Hermes munkamenet-előzmények vizsgálata. Az első vizsgálat 5–10 másodpercig is eltarthat nagy előzmények esetén.",
+      subtitle: "Gyűjthető Hermes-jelvények, valós munkamenet-előzmények alapján szerezve. Az ismert, de még nem szerzett teljesítmények Felfedezettként jelennek meg; a Titkos teljesítmények rejtve maradnak az első egyező viselkedésig.",
+      scan_subtitle: "Hermes munkamenet-előzmények vizsgálata. Az első vizsgálat 5–10 másodpercig is eltarthat nagy előzmények esetén.",
     },
     actions: {
       rescan: "Újravizsgálat",
@@ -520,7 +471,6 @@ export const hu: Translations = {
       secrets: "Titkok",
       secrets_hint: "rejtve az első jelzésig",
       highest_tier: "Legmagasabb szint",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "Legutóbbi",
       latest_hint_empty: "futtasd többet a Hermest",
       none_yet: "Még semmi",
@@ -541,25 +491,19 @@ export const hu: Translations = {
     },
     scan: {
       building_headline: "Teljesítményprofil építése…",
-      building_detail:
-        "Munkamenetek, eszközhívások, modell-metaadatok és feloldási állapot olvasása.",
+      building_detail: "Munkamenetek, eszközhívások, modell-metaadatok és feloldási állapot olvasása.",
       starting_headline: "Teljesítmény-vizsgálat indítása…",
-      progress_detail:
-        "{scanned} / {total} munkamenet vizsgálva · {pct}%. A jelvények a további előzmények beolvasásával oldódnak fel.",
-      idle_detail:
-        "Munkamenetek, eszközhívások, modell-metaadatok és feloldási állapot olvasása. A jelvények itt jelennek meg, ahogy feloldódnak.",
+      progress_detail: "{scanned} / {total} munkamenet vizsgálva · {pct}%. A jelvények a további előzmények beolvasásával oldódnak fel.",
+      idle_detail: "Munkamenetek, eszközhívások, modell-metaadatok és feloldási állapot olvasása. A jelvények itt jelennek meg, ahogy feloldódnak.",
     },
     guide: {
       tiers_header: "Szintek",
       secret_header: "Titkos teljesítmények",
-      secret_body:
-        "A titkos teljesítmények elrejtik a pontos kiváltó eseményt. Amint a Hermes kapcsolódó jelet észlel, a kártya Felfedezettre vált, és megjeleníti a követelményt.",
+      secret_body: "A titkos teljesítmények elrejtik a pontos kiváltó eseményt. Amint a Hermes kapcsolódó jelet észlel, a kártya Felfedezettre vált, és megjeleníti a követelményt.",
       scan_status_header: "Vizsgálat állapota",
-      scan_status_body:
-        "A Hermes egyszer átvizsgálja a helyi előzményeket, majd a kártyák automatikusan megjelennek. Semmi sem akadt el, ha ez néhány másodpercig tart.",
+      scan_status_body: "A Hermes egyszer átvizsgálja a helyi előzményeket, majd a kártyák automatikusan megjelennek. Semmi sem akadt el, ha ez néhány másodpercig tart.",
       what_scanned_header: "Mit vizsgálunk",
-      what_scanned_body:
-        "Munkamenetek, eszközhívások, modell-metaadatok, hibák, teljesítmények és helyi feloldási állapot.",
+      what_scanned_body: "Munkamenetek, eszközhívások, modell-metaadatok, hibák, teljesítmények és helyi feloldási állapot.",
     },
     card: {
       share_title: "Teljesítmény megosztása",
@@ -576,8 +520,7 @@ export const hu: Translations = {
     },
     empty: {
       no_secrets_header: "Ebben a vizsgálatban nem maradt rejtett titok.",
-      no_secrets_body:
-        "Tipp: a titkok általában szokatlan hibákból vagy haladó felhasználói mintákból indulnak — portütközések, jogosultsági falak, hiányzó környezeti változók, YAML-hibák, Docker-ütközések, rollback/checkpoint használata, gyorsítótár-találatok vagy apró javítások sok piros szöveg után.",
+      no_secrets_body: "Tipp: a titkok általában szokatlan hibákból vagy haladó felhasználói mintákból indulnak — portütközések, jogosultsági falak, hiányzó környezeti változók, YAML-hibák, Docker-ütközések, rollback/checkpoint használata, gyorsítótár-találatok vagy apró javítások sok piros szöveg után.",
     },
     filters: {
       all_categories: "Összes",
@@ -599,31 +542,19 @@ export const hu: Translations = {
       copy_button: "Kép másolása",
       copied: "Másolva ✓",
       download_button: "PNG letöltése",
-      hint:
-        "A „Megosztás az X-en” új lapon nyit meg egy előre kitöltött bejegyzést. Először kattints a „Kép másolása” gombra, ha az 1200×630-as jelvényt is csatolnád — az X engedi, hogy közvetlenül beillesszd a bejegyzésszerkesztőbe. A „PNG letöltése” bárhol felhasználható fájlként menti.",
-      clipboard_unsupported:
-        "A kép vágólapra másolása nem támogatott ebben a böngészőben — használd inkább a Letöltést.",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "A „Megosztás az X-en” új lapon nyit meg egy előre kitöltött bejegyzést. Először kattints a „Kép másolása” gombra, ha az 1200×630-as jelvényt is csatolnád — az X engedi, hogy közvetlenül beillesszd a bejegyzésszerkesztőbe. A „PNG letöltése” bárhol felhasználható fájlként menti.",
+      clipboard_unsupported: "A kép vágólapra másolása nem támogatott ebben a böngészőben — használd inkább a Letöltést.",
     },
   },
   kanban: {
     loading: "Kanban tábla betöltése…",
     loadFailed: "Nem sikerült betölteni a Kanban táblát: ",
-    loadFailedHint:
-      "A backend első olvasáskor automatikusan létrehozza a kanban.db fájlt. Ha továbbra is fennáll, ellenőrizd a dashboard naplóit.",
+    loadFailedHint: "A backend első olvasáskor automatikusan létrehozza a kanban.db fájlt. Ha továbbra is fennáll, ellenőrizd a dashboard naplóit.",
     board: "Tábla",
     newBoard: "+ Új tábla",
     newBoardTitle: "Új tábla",
-    newBoardDescription:
-      "A táblákkal külön tudod választani az egymással nem összefüggő munkafolyamokat — egyet projektenként, repónként vagy területenként. Az egyik tábla workerei sosem látják a másik tábla feladatait.",
-    slug: "Slug",
+    newBoardDescription: "A táblákkal külön tudod választani az egymással nem összefüggő munkafolyamokat — egyet projektenként, repónként vagy területenként. Az egyik tábla workerei sosem látják a másik tábla feladatait.",
     slugHint: "— kisbetűk, kötőjelek, pl. atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Megjelenítendő név",
     displayNameHint: "(opcionális)",
     description: "Leírás",
@@ -636,7 +567,6 @@ export const hu: Translations = {
     createBoard: "Tábla létrehozása",
     search: "Keresés",
     filterCards: "Kártyák szűrése…",
-    tenant: "Tenant",
     allTenants: "Összes tenant",
     assignee: "Felelős",
     allProfiles: "Összes profil",
@@ -666,8 +596,7 @@ export const hu: Translations = {
     runHistory: "Futási előzmények",
     workerLog: "Worker napló",
     loadingLog: "Napló betöltése…",
-    noWorkerLog:
-      "— még nincs worker napló (a feladat nem indult el, vagy a napló rotálódott) —",
+    noWorkerLog: "— még nincs worker napló (a feladat nem indult el, vagy a napló rotálódott) —",
     noDescription: "— nincs leírás —",
     noComments: "— nincsenek hozzászólások —",
     edit: "szerkesztés",
@@ -698,8 +627,7 @@ export const hu: Translations = {
     reassign: "Újrakiosztás",
     renderingError: "A Kanban fülön renderelési hiba lépett fel",
     reloadView: "Nézet újratöltése",
-    wsAuthFailed:
-      "WebSocket-hitelesítés sikertelen — töltsd újra az oldalt a munkamenet-token frissítéséhez.",
+    wsAuthFailed: "WebSocket-hitelesítés sikertelen — töltsd újra az oldalt a munkamenet-token frissítéséhez.",
     markDone: "Megjelölöd {n} feladatot késznek?",
     markArchived: "Archiválsz {n} feladatot?",
     warning: "Figyelmeztetés",
@@ -710,8 +638,7 @@ export const hu: Translations = {
     showAllAttempts: "Összes próbálkozás megjelenítése",
     sendingUpdates: "Frissítések küldése ide:",
     sendNotifications: "completed / blocked / gave_up értesítések küldése ide:",
-    archiveBoardConfirm:
-      "Archiválod a(z) '{name}' táblát? Áthelyezzük a boards/_archived/ mappába, hogy később visszaállíthasd. A táblán lévő feladatok többé nem jelennek meg sehol az UI-ban.",
+    archiveBoardConfirm: "Archiválod a(z) '{name}' táblát? Áthelyezzük a boards/_archived/ mappába, hogy később visszaállíthasd. A táblán lévő feladatok többé nem jelennek meg sehol az UI-ban.",
     archiveBoardTitle: "Tábla archiválása",
     boardSwitcherHint: "A táblákkal külön tudod választani az egymással nem összefüggő munkafolyamokat",
     taskCreatedWarning: "Feladat létrehozva, de: ",
@@ -750,28 +677,19 @@ export const hu: Translations = {
       done: "Befejezve",
       archived: "Archiválva",
     },
-    confirmDone:
-      "Megjelölöd ezt a feladatot késznek? A worker foglalása felszabadul, és a függő gyermekek ready állapotba kerülnek.",
-    confirmArchive:
-      "Archiválod ezt a feladatot? Eltűnik az alapértelmezett tábla nézetből.",
-    confirmBlocked:
-      "Megjelölöd ezt a feladatot blokkoltként? A worker foglalása felszabadul.",
-    completionSummary:
-      "Befejezési összefoglaló a következőhöz: {label}. Ez a feladat eredményeként kerül tárolásra.",
-    completionSummaryRequired:
-      "A feladat késznek jelölése előtt kötelező megadni a befejezési összefoglalót.",
+    confirmDone: "Megjelölöd ezt a feladatot késznek? A worker foglalása felszabadul, és a függő gyermekek ready állapotba kerülnek.",
+    confirmArchive: "Archiválod ezt a feladatot? Eltűnik az alapértelmezett tábla nézetből.",
+    confirmBlocked: "Megjelölöd ezt a feladatot blokkoltként? A worker foglalása felszabadul.",
+    completionSummary: "Befejezési összefoglaló a következőhöz: {label}. Ez a feladat eredményeként kerül tárolásra.",
+    completionSummaryRequired: "A feladat késznek jelölése előtt kötelező megadni a befejezési összefoglalót.",
     triagePlaceholder: "Nyers ötlet — az AI specifikálja…",
     taskTitlePlaceholder: "Új feladat címe…",
-    specifier: "specifier",
     assigneePlaceholder: "felelős",
     priority: "Prioritás",
-    skillsPlaceholder:
-      "készségek (opcionális, vesszővel elválasztva): translation, github-code-review",
+    skillsPlaceholder: "készségek (opcionális, vesszővel elválasztva): translation, github-code-review",
     noParent: "— nincs szülő —",
     workspacePathDir: "munkaterület útvonala (kötelező, pl. ~/projects/my-app)",
-    workspacePathOptional:
-      "munkaterület útvonala (opcionális, üresen a felelősből származtatva)",
+    workspacePathOptional: "munkaterület útvonala (opcionális, üresen a felelősből származtatva)",
     logTruncated: "(az utolsó 100 KB látható — teljes napló: ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const it: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const it = defineLocale({
   common: {
     save: "Salva",
     saving: "Salvataggio...",
@@ -43,20 +47,12 @@ export const it: Translations = {
     expand: "Espandi",
     general: "Generale",
     messaging: "Messaggistica",
-    pluginLoadFailed:
-      "Impossibile caricare lo script di questo plugin. Controlla la scheda Network (dashboard-plugins/…) e il percorso dei plugin del server.",
-    pluginNotRegistered:
-      "Lo script del plugin non ha chiamato register(), oppure ha generato un errore. Apri la console del browser per i dettagli.",
+    pluginLoadFailed: "Impossibile caricare lo script di questo plugin. Controlla la scheda Network (dashboard-plugins/…) e il percorso dei plugin del server.",
+    pluginNotRegistered: "Lo script del plugin non ha chiamato register(), oppure ha generato un errore. Apri la console del browser per i dettagli.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Chiudi navigazione",
     closeModelTools: "Chiudi modello e strumenti",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Sessioni attive:",
     gatewayStatusLabel: "Stato gateway:",
     gatewayStrip: {
@@ -68,9 +64,7 @@ export const it: Translations = {
     },
     nav: {
       analytics: "Analisi",
-      chat: "Chat",
       config: "Configurazione",
-      cron: "Cron",
       documentation: "Documentazione",
       keys: "Chiavi",
       logs: "Log",
@@ -89,9 +83,7 @@ export const it: Translations = {
     sessionsActiveCount: "{count} attive",
     statusOverview: "Panoramica dello stato",
     system: "Sistema",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "Azione non riuscita",
     actionFinished: "Completata",
@@ -103,12 +95,10 @@ export const it: Translations = {
     disconnected: "Disconnesso",
     error: "Errore",
     failed: "Non riuscito",
-    gateway: "Gateway",
     gatewayFailedToStart: "Avvio del gateway non riuscito",
     lastUpdate: "Ultimo aggiornamento",
     noneRunning: "Nessuno",
     notRunning: "Non in esecuzione",
-    pid: "PID",
     platformDisconnected: "disconnesso",
     platformError: "errore",
     recentSessions: "Sessioni recenti",
@@ -124,7 +114,6 @@ export const it: Translations = {
     updatingHermes: "Aggiornamento di Hermes…",
     waitingForOutput: "In attesa di output…",
   },
-
   sessions: {
     title: "Sessioni",
     history: "Cronologia",
@@ -143,14 +132,12 @@ export const it: Translations = {
     untitledSession: "Sessione senza titolo",
     deleteSession: "Elimina sessione",
     confirmDeleteTitle: "Eliminare la sessione?",
-    confirmDeleteMessage:
-      "Questa operazione rimuove definitivamente la conversazione e tutti i suoi messaggi. Non può essere annullata.",
+    confirmDeleteMessage: "Questa operazione rimuove definitivamente la conversazione e tutti i suoi messaggi. Non può essere annullata.",
     sessionDeleted: "Sessione eliminata",
     failedToDelete: "Eliminazione della sessione non riuscita",
     deleteEmpty: "Elimina vuote",
     deleteEmptyConfirmTitle: "Eliminare le sessioni vuote?",
-    deleteEmptyConfirmMessage:
-      "Questa azione rimuove in modo permanente {count} sessioni senza messaggi. Le sessioni attive e archiviate vengono ignorate. L'azione non può essere annullata.",
+    deleteEmptyConfirmMessage: "Questa azione rimuove in modo permanente {count} sessioni senza messaggi. Le sessioni attive e archiviate vengono ignorate. L'azione non può essere annullata.",
     emptySessionsDeleted: "{count} sessioni vuote eliminate",
     failedToDeleteEmpty: "Impossibile eliminare le sessioni vuote",
     selectSession: "Seleziona sessione",
@@ -159,8 +146,7 @@ export const it: Translations = {
     selectedCount: "{count} selezionate",
     deleteSelected: "Elimina {count}",
     deleteSelectedConfirmTitle: "Eliminare {count} sessioni?",
-    deleteSelectedConfirmMessage:
-      "Verranno eliminate definitivamente {count} sessioni selezionate e tutti i loro messaggi. L'operazione non può essere annullata.",
+    deleteSelectedConfirmMessage: "Verranno eliminate definitivamente {count} sessioni selezionate e tutti i loro messaggi. L'operazione non può essere annullata.",
     selectedSessionsDeleted: "{count} sessioni eliminate",
     failedToDeleteSelected: "Impossibile eliminare le sessioni selezionate",
     resumeInChat: "Riprendi nella chat",
@@ -174,7 +160,6 @@ export const it: Translations = {
       tool: "Strumento",
     },
   },
-
   analytics: {
     period: "Periodo:",
     totalTokens: "Token totali",
@@ -188,8 +173,6 @@ export const it: Translations = {
     loads: "Caricato dall'agente",
     edits: "Gestito dall'agente",
     lastUsed: "Ultimo uso",
-    input: "Input",
-    output: "Output",
     total: "Totale",
     noUsageData: "Nessun dato di utilizzo per questo periodo",
     startSession: "Avvia una sessione per vedere le analisi qui",
@@ -198,9 +181,7 @@ export const it: Translations = {
     tokens: "Token",
     perDayAvg: "/giorno medio",
     acrossModels: "su {count} modelli",
-    inOut: "{input} in / {output} out",
   },
-
   models: {
     modelsUsed: "Modelli utilizzati",
     estimatedCost: "Costo stim.",
@@ -212,28 +193,22 @@ export const it: Translations = {
     noModelsData: "Nessun dato sull'uso dei modelli per questo periodo",
     startSession: "Avvia una sessione per vedere i dati dei modelli qui",
   },
-
   logs: {
     title: "Log",
     autoRefresh: "Aggiornamento automatico",
-    file: "File",
     level: "Livello",
     component: "Componente",
     lines: "Righe",
     noLogLines: "Nessuna riga di log trovata",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Questa operazione rimuove l'attività dalla pianificazione. Non può essere annullata.",
+    confirmDeleteMessage: "Questa operazione rimuove l'attività dalla pianificazione. Non può essere annullata.",
     confirmDeleteTitle: "Eliminare l'attività pianificata?",
     newJob: "Nuova attività cron",
     nameOptional: "Nome (facoltativo)",
     namePlaceholder: "es. Riepilogo giornaliero",
-    prompt: "Prompt",
     promptPlaceholder: "Cosa deve fare l'agente a ogni esecuzione?",
     schedule: "Pianificazione (espressione cron)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Pianificazione",
     scheduleModes: {
       interval: "Intervallo ricorrente",
@@ -249,18 +224,15 @@ export const it: Translations = {
       unitDays: "giorni",
       timeOfDay: "Ora del giorno",
       weekdays: "Giorni della settimana",
-      weekdaysShort: ["Dom", "Lun", "Mar", "Mer", "Gio", "Ven", "Sab"],
+      weekdaysShort: ["Dom","Lun","Mar","Mer","Gio","Ven","Sab"],
       dayOfMonth: "Giorno del mese",
       onceAt: "Esegui il",
       customLabel: "Espressione cron",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "Espressione cron a cinque campi (minuto, ora, giorno, mese, giorno della settimana).",
+      customHint: "Espressione cron a cinque campi (minuto, ora, giorno, mese, giorno della settimana).",
       preview: "Inviato come",
       previewEmpty: "(incompleta)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "Ogni {n} min",
       everyHours: "Ogni {n} h",
       everyDays: "Ogni {n} g",
@@ -279,26 +251,20 @@ export const it: Translations = {
     triggerNow: "Esegui ora",
     delivery: {
       local: "Locale",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "Nuovo profilo",
     name: "Nome",
     namePlaceholder: "es. coder, writer, ecc.",
     nameRequired: "Il nome è obbligatorio",
-    nameRule:
-      "Solo lettere minuscole, cifre, _ e -; deve iniziare con una lettera o cifra; fino a 64 caratteri.",
-    invalidName: "Nome del profilo non valido",    cloneFrom: "Clona configurazione dal profilo",
+    nameRule: "Solo lettere minuscole, cifre, _ e -; deve iniziare con una lettera o cifra; fino a 64 caratteri.",
+    invalidName: "Nome del profilo non valido",
+    cloneFrom: "Clona configurazione dal profilo",
     cloneFromNone: "Nessuno (vuoto)",
     allProfiles: "Profili",
     noProfiles: "Nessun profilo trovato.",
     defaultBadge: "predefinito",
-    hasEnv: "env",
     model: "Modello",
     skills: "Competenze",
     rename: "Rinomina",
@@ -311,13 +277,11 @@ export const it: Translations = {
     commandCopied: "Copiato negli appunti",
     copyFailed: "Impossibile copiare",
     confirmDeleteTitle: "Eliminare il profilo?",
-    confirmDeleteMessage:
-      "Questa operazione elimina definitivamente il profilo '{name}' — configurazione, chiavi, memorie, sessioni, competenze, attività cron. Non può essere annullata.",
+    confirmDeleteMessage: "Questa operazione elimina definitivamente il profilo '{name}' — configurazione, chiavi, memorie, sessioni, competenze, attività cron. Non può essere annullata.",
     created: "Creato",
     deleted: "Eliminato",
     renamed: "Rinominato",
   },
-
   pluginsPage: {
     contextEngineLabel: "Motore di contesto",
     dashboardSlots: "Slot del dashboard",
@@ -325,8 +289,7 @@ export const it: Translations = {
     enableAfterInstall: "Abilita dopo l'installazione",
     enableRuntime: "Abilita",
     forceReinstall: "Forza reinstallazione (elimina prima la cartella esistente)",
-    headline:
-      "Scopri, installa, abilita e aggiorna i plugin Hermes (parità con `hermes plugins`).",
+    headline: "Scopri, installa, abilita e aggiorna i plugin Hermes (parità con `hermes plugins`).",
     identifierLabel: "URL Git o owner/repo",
     inactive: "inattivo",
     installBtn: "Installa",
@@ -340,8 +303,7 @@ export const it: Translations = {
     pluginListHeading: "Plugin installati",
     providerDefaults: "integrato / predefinito",
     providersHeading: "Plugin provider runtime",
-    providersHint:
-      "Scrive memory.provider (vuoto = integrato) e context.engine in config.yaml. Effetto dalla prossima sessione.",
+    providersHint: "Scrive memory.provider (vuoto = integrato) e context.engine in config.yaml. Effetto dalla prossima sessione.",
     refreshDashboard: "Riscansiona estensioni dashboard",
     removeConfirm: "Rimuovere questo plugin da ~/.hermes/plugins/?",
     removeHint: "Solo i plugin installati dall'utente in ~/.hermes/plugins possono essere rimossi.",
@@ -353,12 +315,10 @@ export const it: Translations = {
     sourceBadge: "Origine",
     authRequired: "Autenticazione richiesta",
     authRequiredHint: "Esegui questo comando per autenticarti:",
-    updateGit: "Git pull",
     versionBadge: "Versione",
     showInSidebar: "Mostra nella barra laterale",
     hideFromSidebar: "Nascondi dalla barra laterale",
   },
-
   skills: {
     title: "Competenze",
     searchPlaceholder: "Cerca competenze e toolset...",
@@ -378,13 +338,10 @@ export const it: Translations = {
     disabledForCli: "Disabilitato per CLI",
     more: "+{count} in più",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "Filtri",
     sections: "Sezioni",
     exportConfig: "Esporta configurazione come JSON",
-    importConfig: "Importa configurazione da JSON",
     resetDefaults: "Ripristina predefiniti",
     resetScopeTooltip: "Ripristina {scope} ai valori predefiniti",
     confirmResetScope: "Ripristinare tutte le impostazioni di {scope} ai valori predefiniti? Questa operazione aggiorna solo il modulo — le modifiche non vengono scritte in config.yaml finché non premi Salva.",
@@ -392,7 +349,7 @@ export const it: Translations = {
     rawYaml: "Configurazione YAML grezza",
     searchResults: "Risultati della ricerca",
     fields: "camp{s}",
-    noFieldsMatch: 'Nessun campo corrisponde a "{query}"',
+    noFieldsMatch: "Nessun campo corrisponde a \"{query}\"",
     configSaved: "Configurazione salvata",
     yamlConfigSaved: "Configurazione YAML salvata",
     failedToSave: "Salvataggio non riuscito",
@@ -409,20 +366,16 @@ export const it: Translations = {
       memory: "Memoria",
       compression: "Compressione",
       security: "Sicurezza",
-      browser: "Browser",
       voice: "Voce",
       tts: "Sintesi vocale",
       stt: "Riconoscimento vocale",
       logging: "Log",
-      discord: "Discord",
       auxiliary: "Ausiliario",
     },
   },
-
   env: {
     changesNote: "Le modifiche vengono salvate immediatamente su disco. Le sessioni attive rilevano automaticamente le nuove chiavi.",
-    confirmClearMessage:
-      "Il valore memorizzato per questa variabile sarà rimosso dal tuo file .env. Non può essere annullato dall'interfaccia.",
+    confirmClearMessage: "Il valore memorizzato per questa variabile sarà rimosso dal tuo file .env. Non può essere annullato dall'interfaccia.",
     confirmClearTitle: "Cancellare questa chiave?",
     description: "Gestisci chiavi API e segreti memorizzati in",
     hideAdvanced: "Nascondi avanzate",
@@ -448,12 +401,10 @@ export const it: Translations = {
     add: "Aggiungi",
     invalidKeyName: "Usa solo lettere, numeri e trattini bassi (deve iniziare con una lettera o un trattino basso).",
   },
-
   oauth: {
     title: "Accessi provider (OAuth)",
     providerLogins: "Accessi provider (OAuth)",
-    description:
-      "{connected} di {total} provider OAuth connessi. Usa Accedi per i flussi supportati dalla dashboard; i comandi CLI restano disponibili per configurazioni esterne o di riserva.",
+    description: "{connected} di {total} provider OAuth connessi. Usa Accedi per i flussi supportati dalla dashboard; i comandi CLI restano disponibili per configurazioni esterne o di riserva.",
     connected: "Connesso",
     expired: "Scaduto",
     notConnected: "Non connesso. Usa Accedi se disponibile, oppure esegui {command} in un terminale.",
@@ -490,23 +441,17 @@ export const it: Translations = {
     },
     expiresIn: "scade tra {time}",
   },
-
   language: {
     switchTo: "Cambia lingua",
   },
-
   theme: {
     title: "Tema",
     switchTheme: "Cambia tema",
   },
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Badge Hermes da collezione, ottenuti dalla cronologia reale delle sessioni. Gli achievement noti non completati vengono mostrati come Scoperti; gli achievement segreti restano nascosti finché non compare il primo comportamento corrispondente.",
-      scan_subtitle:
-        "Scansione della cronologia delle sessioni Hermes in corso. La prima scansione può richiedere 5–10 secondi su cronologie ampie.",
+      subtitle: "Badge Hermes da collezione, ottenuti dalla cronologia reale delle sessioni. Gli achievement noti non completati vengono mostrati come Scoperti; gli achievement segreti restano nascosti finché non compare il primo comportamento corrispondente.",
+      scan_subtitle: "Scansione della cronologia delle sessioni Hermes in corso. La prima scansione può richiedere 5–10 secondi su cronologie ampie.",
     },
     actions: {
       rescan: "Riscansiona",
@@ -519,7 +464,6 @@ export const it: Translations = {
       secrets: "Segreti",
       secrets_hint: "nascosti fino al primo segnale",
       highest_tier: "Livello più alto",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "Più recente",
       latest_hint_empty: "usa Hermes di più",
       none_yet: "Nessuno ancora",
@@ -540,25 +484,19 @@ export const it: Translations = {
     },
     scan: {
       building_headline: "Costruzione del profilo achievement…",
-      building_detail:
-        "Lettura di sessioni, chiamate agli strumenti, metadati del modello e stato di sblocco.",
+      building_detail: "Lettura di sessioni, chiamate agli strumenti, metadati del modello e stato di sblocco.",
       starting_headline: "Avvio della scansione achievement…",
-      progress_detail:
-        "Scansionate {scanned} di {total} sessioni · {pct}%. I badge si sbloccano man mano che viene elaborata altra cronologia.",
-      idle_detail:
-        "Lettura di sessioni, chiamate agli strumenti, metadati del modello e stato di sblocco. I badge appaiono qui non appena vengono sbloccati.",
+      progress_detail: "Scansionate {scanned} di {total} sessioni · {pct}%. I badge si sbloccano man mano che viene elaborata altra cronologia.",
+      idle_detail: "Lettura di sessioni, chiamate agli strumenti, metadati del modello e stato di sblocco. I badge appaiono qui non appena vengono sbloccati.",
     },
     guide: {
       tiers_header: "Livelli",
       secret_header: "Achievement segreti",
-      secret_body:
-        "I segreti nascondono il loro trigger esatto. Quando Hermes rileva un segnale correlato, la carta passa a Scoperto e mostra il requisito.",
+      secret_body: "I segreti nascondono il loro trigger esatto. Quando Hermes rileva un segnale correlato, la carta passa a Scoperto e mostra il requisito.",
       scan_status_header: "Stato della scansione",
-      scan_status_body:
-        "Hermes sta scansionando la cronologia locale una sola volta, poi le carte appariranno automaticamente. Non è bloccato nulla se richiede qualche secondo.",
+      scan_status_body: "Hermes sta scansionando la cronologia locale una sola volta, poi le carte appariranno automaticamente. Non è bloccato nulla se richiede qualche secondo.",
       what_scanned_header: "Cosa viene scansionato",
-      what_scanned_body:
-        "Sessioni, chiamate agli strumenti, metadati del modello, errori, achievement e stato di sblocco locale.",
+      what_scanned_body: "Sessioni, chiamate agli strumenti, metadati del modello, errori, achievement e stato di sblocco locale.",
     },
     card: {
       share_title: "Condividi questo achievement",
@@ -575,8 +513,7 @@ export const it: Translations = {
     },
     empty: {
       no_secrets_header: "Nessun segreto nascosto rimasto in questa scansione.",
-      no_secrets_body:
-        "Indizio: i segreti di solito partono da fallimenti inusuali o pattern da utente esperto — conflitti di porte, muri di permessi, variabili d'ambiente mancanti, errori YAML, collisioni Docker, uso di rollback/checkpoint, cache hit o piccole correzioni dopo molto testo rosso.",
+      no_secrets_body: "Indizio: i segreti di solito partono da fallimenti inusuali o pattern da utente esperto — conflitti di porte, muri di permessi, variabili d'ambiente mancanti, errori YAML, collisioni Docker, uso di rollback/checkpoint, cache hit o piccole correzioni dopo molto testo rosso.",
     },
     filters: {
       all_categories: "Tutti",
@@ -589,7 +526,6 @@ export const it: Translations = {
       dialog_label: "Condividi achievement",
       header: "Condividi: {name}",
       close: "Chiudi",
-      rendering: "Rendering…",
       card_alt: "Carta di condivisione {name}",
       error_generic: "Qualcosa è andato storto.",
       x_title: "Apre X con un post precompilato",
@@ -598,31 +534,19 @@ export const it: Translations = {
       copy_button: "Copia immagine",
       copied: "Copiato ✓",
       download_button: "Scarica PNG",
-      hint:
-        "Condividi su X apre un post precompilato in una nuova scheda. Clicca prima su Copia immagine se vuoi allegare il badge 1200×630 — X ti permette di incollarlo direttamente nell'editor del tweet. Scarica PNG salva il file per l'uso ovunque.",
-      clipboard_unsupported:
-        "La copia delle immagini negli appunti non è supportata in questo browser — usa Scarica invece.",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "Condividi su X apre un post precompilato in una nuova scheda. Clicca prima su Copia immagine se vuoi allegare il badge 1200×630 — X ti permette di incollarlo direttamente nell'editor del tweet. Scarica PNG salva il file per l'uso ovunque.",
+      clipboard_unsupported: "La copia delle immagini negli appunti non è supportata in questo browser — usa Scarica invece.",
     },
   },
   kanban: {
     loading: "Caricamento bacheca Kanban…",
     loadFailed: "Caricamento della bacheca Kanban non riuscito: ",
-    loadFailedHint:
-      "Il backend crea automaticamente kanban.db alla prima lettura. Se il problema persiste, controlla i log del dashboard.",
+    loadFailedHint: "Il backend crea automaticamente kanban.db alla prima lettura. Se il problema persiste, controlla i log del dashboard.",
     board: "Bacheca",
     newBoard: "+ Nuova bacheca",
     newBoardTitle: "Nuova bacheca",
-    newBoardDescription:
-      "Le bacheche ti permettono di separare flussi di lavoro non correlati — una per progetto, repository o dominio. I worker su una bacheca non vedono mai le attività di un'altra.",
-    slug: "Slug",
+    newBoardDescription: "Le bacheche ti permettono di separare flussi di lavoro non correlati — una per progetto, repository o dominio. I worker su una bacheca non vedono mai le attività di un'altra.",
     slugHint: "— minuscolo, trattini, ad es. atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Nome visualizzato",
     displayNameHint: "(facoltativo)",
     description: "Descrizione",
@@ -635,7 +559,6 @@ export const it: Translations = {
     createBoard: "Crea bacheca",
     search: "Cerca",
     filterCards: "Filtra schede…",
-    tenant: "Tenant",
     allTenants: "Tutti i tenant",
     assignee: "Assegnatario",
     allProfiles: "Tutti i profili",
@@ -656,17 +579,14 @@ export const it: Translations = {
     addComment: "Aggiungi un commento… (Enter per inviare)",
     comment: "Commento",
     status: "Stato",
-    workspace: "Workspace",
     skills: "Competenze",
     createdBy: "Creato da",
-    result: "Result",
     comments: "Commenti",
     events: "Eventi",
     runHistory: "Cronologia esecuzioni",
     workerLog: "Log del worker",
     loadingLog: "Caricamento log…",
-    noWorkerLog:
-      "— nessun log del worker ancora (l'attività non è stata avviata o il log è stato ruotato) —",
+    noWorkerLog: "— nessun log del worker ancora (l'attività non è stata avviata o il log è stato ruotato) —",
     noDescription: "— nessuna descrizione —",
     noComments: "— nessun commento —",
     edit: "modifica",
@@ -697,8 +617,7 @@ export const it: Translations = {
     reassign: "Riassegna",
     renderingError: "La scheda Kanban ha avuto un errore di rendering",
     reloadView: "Ricarica vista",
-    wsAuthFailed:
-      "Autenticazione WebSocket non riuscita — ricarica la pagina per aggiornare il token di sessione.",
+    wsAuthFailed: "Autenticazione WebSocket non riuscita — ricarica la pagina per aggiornare il token di sessione.",
     markDone: "Contrassegnare {n} attività come completate?",
     markArchived: "Archiviare {n} attività?",
     warning: "Avviso",
@@ -709,8 +628,7 @@ export const it: Translations = {
     showAllAttempts: "Mostra tutti i tentativi",
     sendingUpdates: "Invio aggiornamenti a",
     sendNotifications: "Invia notifiche di completed / blocked / gave_up a",
-    archiveBoardConfirm:
-      "Archiviare la bacheca '{name}'? Verrà spostata in boards/_archived/ in modo da poterla recuperare in seguito. Le attività di questa bacheca non appariranno più da nessuna parte nell'UI.",
+    archiveBoardConfirm: "Archiviare la bacheca '{name}'? Verrà spostata in boards/_archived/ in modo da poterla recuperare in seguito. Le attività di questa bacheca non appariranno più da nessuna parte nell'UI.",
     archiveBoardTitle: "Archivia questa bacheca",
     boardSwitcherHint: "Le bacheche ti permettono di separare flussi di lavoro non correlati",
     taskCreatedWarning: "Attività creata, ma: ",
@@ -730,7 +648,6 @@ export const it: Translations = {
     clickToEditAssignee: "Clicca per modificare l'assegnatario",
     emptyAssignee: "(vuoto = rimuovi assegnazione)",
     columnLabels: {
-      triage: "Triage",
       todo: "Da fare",
       scheduled: "Pianificato",
       ready: "Pronto",
@@ -749,28 +666,19 @@ export const it: Translations = {
       done: "Completato",
       archived: "Archiviato",
     },
-    confirmDone:
-      "Contrassegnare questa attività come completata? La presa in carico del worker viene rilasciata e i figli dipendenti diventano pronti.",
-    confirmArchive:
-      "Archiviare questa attività? Sparirà dalla vista predefinita della bacheca.",
-    confirmBlocked:
-      "Contrassegnare questa attività come bloccata? La presa in carico del worker viene rilasciata.",
-    completionSummary:
-      "Riepilogo di completamento per {label}. Memorizzato come result dell'attività.",
-    completionSummaryRequired:
-      "Il riepilogo di completamento è obbligatorio prima di contrassegnare un'attività come completata.",
+    confirmDone: "Contrassegnare questa attività come completata? La presa in carico del worker viene rilasciata e i figli dipendenti diventano pronti.",
+    confirmArchive: "Archiviare questa attività? Sparirà dalla vista predefinita della bacheca.",
+    confirmBlocked: "Contrassegnare questa attività come bloccata? La presa in carico del worker viene rilasciata.",
+    completionSummary: "Riepilogo di completamento per {label}. Memorizzato come result dell'attività.",
+    completionSummaryRequired: "Il riepilogo di completamento è obbligatorio prima di contrassegnare un'attività come completata.",
     triagePlaceholder: "Idea approssimativa — l'IA la specificherà…",
     taskTitlePlaceholder: "Titolo della nuova attività…",
-    specifier: "specifier",
     assigneePlaceholder: "assegnatario",
     priority: "Priorità",
-    skillsPlaceholder:
-      "competenze (facoltative, separate da virgole): translation, github-code-review",
+    skillsPlaceholder: "competenze (facoltative, separate da virgole): translation, github-code-review",
     noParent: "— nessun padre —",
     workspacePathDir: "percorso del workspace (richiesto, ad es. ~/projects/my-app)",
-    workspacePathOptional:
-      "percorso del workspace (facoltativo, derivato dall'assegnatario se vuoto)",
+    workspacePathOptional: "percorso del workspace (facoltativo, derivato dall'assegnatario se vuoto)",
     logTruncated: "(mostrando ultimi 100 KB — log completo in ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const ja: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const ja = defineLocale({
   common: {
     save: "保存",
     saving: "保存中...",
@@ -43,20 +47,12 @@ export const ja: Translations = {
     expand: "展開",
     general: "一般",
     messaging: "メッセージング",
-    pluginLoadFailed:
-      "このプラグインのスクリプトを読み込めませんでした。Network タブ（dashboard-plugins/…）とサーバーのプラグインパスをご確認ください。",
-    pluginNotRegistered:
-      "プラグインのスクリプトが register() を呼び出していないか、スクリプトでエラーが発生しました。詳細はブラウザのコンソールをご確認ください。",
+    pluginLoadFailed: "このプラグインのスクリプトを読み込めませんでした。Network タブ（dashboard-plugins/…）とサーバーのプラグインパスをご確認ください。",
+    pluginNotRegistered: "プラグインのスクリプトが register() を呼び出していないか、スクリプトでエラーが発生しました。詳細はブラウザのコンソールをご確認ください。",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "ナビゲーションを閉じる",
     closeModelTools: "モデルとツールを閉じる",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "アクティブなセッション:",
     gatewayStatusLabel: "ゲートウェイの状態:",
     gatewayStrip: {
@@ -70,7 +66,6 @@ export const ja: Translations = {
       analytics: "分析",
       chat: "チャット",
       config: "設定",
-      cron: "Cron",
       documentation: "ドキュメント",
       keys: "キー",
       logs: "ログ",
@@ -89,9 +84,7 @@ export const ja: Translations = {
     sessionsActiveCount: "{count} 件アクティブ",
     statusOverview: "ステータス概要",
     system: "システム",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "アクションが失敗しました",
     actionFinished: "完了",
@@ -108,7 +101,6 @@ export const ja: Translations = {
     lastUpdate: "最終更新",
     noneRunning: "なし",
     notRunning: "実行されていません",
-    pid: "PID",
     platformDisconnected: "切断",
     platformError: "エラー",
     recentSessions: "最近のセッション",
@@ -124,7 +116,6 @@ export const ja: Translations = {
     updatingHermes: "Hermes を更新しています…",
     waitingForOutput: "出力を待機しています…",
   },
-
   sessions: {
     title: "セッション",
     history: "履歴",
@@ -143,14 +134,12 @@ export const ja: Translations = {
     untitledSession: "無題のセッション",
     deleteSession: "セッションを削除",
     confirmDeleteTitle: "セッションを削除しますか？",
-    confirmDeleteMessage:
-      "会話とそのすべてのメッセージが完全に削除されます。この操作は取り消せません。",
+    confirmDeleteMessage: "会話とそのすべてのメッセージが完全に削除されます。この操作は取り消せません。",
     sessionDeleted: "セッションを削除しました",
     failedToDelete: "セッションの削除に失敗しました",
     deleteEmpty: "空を削除",
     deleteEmptyConfirmTitle: "空のセッションを削除しますか？",
-    deleteEmptyConfirmMessage:
-      "メッセージのない {count} 件のセッションを完全に削除します。アクティブおよびアーカイブされたセッションはスキップされます。この操作は元に戻せません。",
+    deleteEmptyConfirmMessage: "メッセージのない {count} 件のセッションを完全に削除します。アクティブおよびアーカイブされたセッションはスキップされます。この操作は元に戻せません。",
     emptySessionsDeleted: "{count} 件の空のセッションを削除しました",
     failedToDeleteEmpty: "空のセッションの削除に失敗しました",
     selectSession: "セッションを選択",
@@ -159,8 +148,7 @@ export const ja: Translations = {
     selectedCount: "{count}件選択中",
     deleteSelected: "{count}件削除",
     deleteSelectedConfirmTitle: "{count}件のセッションを削除しますか？",
-    deleteSelectedConfirmMessage:
-      "選択した{count}件のセッションとそのすべてのメッセージが完全に削除されます。この操作は取り消せません。",
+    deleteSelectedConfirmMessage: "選択した{count}件のセッションとそのすべてのメッセージが完全に削除されます。この操作は取り消せません。",
     selectedSessionsDeleted: "{count}件のセッションを削除しました",
     failedToDeleteSelected: "選択したセッションの削除に失敗しました",
     resumeInChat: "チャットで再開",
@@ -174,7 +162,6 @@ export const ja: Translations = {
       tool: "ツール",
     },
   },
-
   analytics: {
     period: "期間:",
     totalTokens: "合計トークン数",
@@ -200,7 +187,6 @@ export const ja: Translations = {
     acrossModels: "{count} モデル全体",
     inOut: "{input} 入力 / {output} 出力",
   },
-
   models: {
     modelsUsed: "使用モデル",
     estimatedCost: "推定コスト",
@@ -212,7 +198,6 @@ export const ja: Translations = {
     noModelsData: "この期間のモデル使用データはありません",
     startSession: "セッションを開始するとモデルデータがここに表示されます",
   },
-
   logs: {
     title: "ログ",
     autoRefresh: "自動更新",
@@ -222,10 +207,8 @@ export const ja: Translations = {
     lines: "行数",
     noLogLines: "ログ行が見つかりません",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "ジョブをスケジュールから削除します。この操作は取り消せません。",
+    confirmDeleteMessage: "ジョブをスケジュールから削除します。この操作は取り消せません。",
     confirmDeleteTitle: "スケジュールされたジョブを削除しますか？",
     newJob: "新しい Cron ジョブ",
     nameOptional: "名前 (任意)",
@@ -233,7 +216,6 @@ export const ja: Translations = {
     prompt: "プロンプト",
     promptPlaceholder: "実行ごとにエージェントが行う内容は？",
     schedule: "スケジュール (cron 式)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "スケジュール",
     scheduleModes: {
       interval: "繰り返し間隔",
@@ -249,17 +231,15 @@ export const ja: Translations = {
       unitDays: "日",
       timeOfDay: "時刻",
       weekdays: "曜日",
-      weekdaysShort: ["日", "月", "火", "水", "木", "金", "土"],
+      weekdaysShort: ["日","月","火","水","木","金","土"],
       dayOfMonth: "日付",
       onceAt: "実行日時",
       customLabel: "cron式",
-      customPlaceholder: "0 9 * * *",
       customHint: "5フィールドのcron式（分、時、日、月、曜日）。",
       preview: "送信形式",
       previewEmpty: "（未入力）",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "{n}分ごと",
       everyHours: "{n}時間ごと",
       everyDays: "{n}日ごと",
@@ -278,26 +258,20 @@ export const ja: Translations = {
     triggerNow: "今すぐ実行",
     delivery: {
       local: "ローカル",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "新しいプロファイル",
     name: "名前",
     namePlaceholder: "例: coder, writer など",
     nameRequired: "名前は必須です",
-    nameRule:
-      "小文字、数字、_ および - のみ使用可能。最初は文字または数字で始める必要があります。最大 64 文字。",
-    invalidName: "無効なプロファイル名",    cloneFrom: "プロファイルから複製",
+    nameRule: "小文字、数字、_ および - のみ使用可能。最初は文字または数字で始める必要があります。最大 64 文字。",
+    invalidName: "無効なプロファイル名",
+    cloneFrom: "プロファイルから複製",
     cloneFromNone: "なし（空）",
     allProfiles: "プロファイル",
     noProfiles: "プロファイルが見つかりません。",
     defaultBadge: "デフォルト",
-    hasEnv: "env",
     model: "モデル",
     skills: "スキル",
     rename: "名前を変更",
@@ -310,13 +284,11 @@ export const ja: Translations = {
     commandCopied: "クリップボードにコピーしました",
     copyFailed: "コピーできませんでした",
     confirmDeleteTitle: "プロファイルを削除しますか？",
-    confirmDeleteMessage:
-      "プロファイル '{name}' を完全に削除します — 設定、キー、メモリ、セッション、スキル、cron ジョブ。この操作は取り消せません。",
+    confirmDeleteMessage: "プロファイル '{name}' を完全に削除します — 設定、キー、メモリ、セッション、スキル、cron ジョブ。この操作は取り消せません。",
     created: "作成しました",
     deleted: "削除しました",
     renamed: "名前を変更しました",
   },
-
   pluginsPage: {
     contextEngineLabel: "コンテキストエンジン",
     dashboardSlots: "ダッシュボードスロット",
@@ -324,8 +296,7 @@ export const ja: Translations = {
     enableAfterInstall: "インストール後に有効化",
     enableRuntime: "有効化",
     forceReinstall: "強制再インストール (既存のフォルダを先に削除)",
-    headline:
-      "Hermes プラグインを発見、インストール、有効化、更新します (`hermes plugins` 相当)。",
+    headline: "Hermes プラグインを発見、インストール、有効化、更新します (`hermes plugins` 相当)。",
     identifierLabel: "Git URL または owner/repo",
     inactive: "非アクティブ",
     installBtn: "インストール",
@@ -339,8 +310,7 @@ export const ja: Translations = {
     pluginListHeading: "インストール済みプラグイン",
     providerDefaults: "組み込み / デフォルト",
     providersHeading: "ランタイムプロバイダープラグイン",
-    providersHint:
-      "memory.provider (空 = 組み込み) と context.engine を config.yaml に書き込みます。次のセッションで有効になります。",
+    providersHint: "memory.provider (空 = 組み込み) と context.engine を config.yaml に書き込みます。次のセッションで有効になります。",
     refreshDashboard: "ダッシュボード拡張を再スキャン",
     removeConfirm: "このプラグインを ~/.hermes/plugins/ から削除しますか？",
     removeHint: "削除できるのは ~/.hermes/plugins 配下のユーザーがインストールしたプラグインのみです。",
@@ -352,12 +322,10 @@ export const ja: Translations = {
     sourceBadge: "ソース",
     authRequired: "認証が必要",
     authRequiredHint: "認証するには次のコマンドを実行してください:",
-    updateGit: "Git pull",
     versionBadge: "バージョン",
     showInSidebar: "サイドバーに表示",
     hideFromSidebar: "サイドバーから非表示",
   },
-
   skills: {
     title: "スキル",
     searchPlaceholder: "スキルとツールセットを検索...",
@@ -377,13 +345,10 @@ export const ja: Translations = {
     disabledForCli: "CLI では無効",
     more: "+{count} 件",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "フィルター",
     sections: "セクション",
     exportConfig: "設定を JSON としてエクスポート",
-    importConfig: "JSON から設定をインポート",
     resetDefaults: "デフォルトにリセット",
     resetScopeTooltip: "{scope} をデフォルトにリセット",
     confirmResetScope: "すべての {scope} 設定をデフォルトにリセットしますか？フォームのみ更新されます — 保存を押すまで config.yaml には書き込まれません。",
@@ -391,7 +356,7 @@ export const ja: Translations = {
     rawYaml: "生の YAML 設定",
     searchResults: "検索結果",
     fields: "フィールド{s}",
-    noFieldsMatch: '"{query}" に一致するフィールドはありません',
+    noFieldsMatch: "\"{query}\" に一致するフィールドはありません",
     configSaved: "設定を保存しました",
     yamlConfigSaved: "YAML 設定を保存しました",
     failedToSave: "保存に失敗しました",
@@ -413,15 +378,12 @@ export const ja: Translations = {
       tts: "音声合成",
       stt: "音声認識",
       logging: "ロギング",
-      discord: "Discord",
       auxiliary: "補助",
     },
   },
-
   env: {
     changesNote: "変更は即座にディスクへ保存されます。アクティブなセッションは新しいキーを自動的に取得します。",
-    confirmClearMessage:
-      "この変数の保存値が .env ファイルから削除されます。この操作は UI から取り消せません。",
+    confirmClearMessage: "この変数の保存値が .env ファイルから削除されます。この操作は UI から取り消せません。",
     confirmClearTitle: "このキーをクリアしますか？",
     description: "API キーとシークレットを管理します。保存先:",
     hideAdvanced: "詳細設定を隠す",
@@ -447,12 +409,10 @@ export const ja: Translations = {
     add: "追加",
     invalidKeyName: "英字・数字・アンダースコアのみ使用できます（英字またはアンダースコアで始める必要があります）。",
   },
-
   oauth: {
     title: "プロバイダーログイン (OAuth)",
     providerLogins: "プロバイダーログイン (OAuth)",
-    description:
-      "{connected} / {total} OAuth プロバイダーが接続されています。ダッシュボード対応のフローには「ログイン」を使用してください。外部またはフォールバック用のセットアップには引き続き CLI コマンドを利用できます。",
+    description: "{connected} / {total} OAuth プロバイダーが接続されています。ダッシュボード対応のフローには「ログイン」を使用してください。外部またはフォールバック用のセットアップには引き続き CLI コマンドを利用できます。",
     connected: "接続済み",
     expired: "期限切れ",
     notConnected: "未接続です。可能な場合は「ログイン」を使用するか、ターミナルで {command} を実行してください。",
@@ -489,24 +449,17 @@ export const ja: Translations = {
     },
     expiresIn: "{time} 後に期限切れ",
   },
-
   language: {
     switchTo: "言語を切り替え",
   },
-
   theme: {
     title: "テーマ",
     switchTheme: "テーマを切り替え",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "実際のセッション履歴から獲得できる Hermes のコレクタブル バッジです。既知の未達成の実績は「Discovered」として表示され、Secret 実績は最初の該当する挙動が検出されるまで非表示のままです。",
-      scan_subtitle:
-        "Hermes のセッション履歴をスキャンしています。履歴が大きい場合、初回スキャンには 5～10 秒かかることがあります。",
+      subtitle: "実際のセッション履歴から獲得できる Hermes のコレクタブル バッジです。既知の未達成の実績は「Discovered」として表示され、Secret 実績は最初の該当する挙動が検出されるまで非表示のままです。",
+      scan_subtitle: "Hermes のセッション履歴をスキャンしています。履歴が大きい場合、初回スキャンには 5～10 秒かかることがあります。",
     },
     actions: {
       rescan: "再スキャン",
@@ -519,7 +472,6 @@ export const ja: Translations = {
       secrets: "シークレット",
       secrets_hint: "最初のシグナルまで非表示",
       highest_tier: "最高ティア",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "最新",
       latest_hint_empty: "Hermes をもっと使ってみてください",
       none_yet: "まだありません",
@@ -540,25 +492,19 @@ export const ja: Translations = {
     },
     scan: {
       building_headline: "実績プロファイルを構築中…",
-      building_detail:
-        "セッション、ツール呼び出し、モデルのメタデータ、解除状態を読み込んでいます。",
+      building_detail: "セッション、ツール呼び出し、モデルのメタデータ、解除状態を読み込んでいます。",
       starting_headline: "実績スキャンを開始しています…",
-      progress_detail:
-        "{total} 件中 {scanned} 件のセッションをスキャンしました · {pct}%。履歴が読み込まれるにつれてバッジが解除されます。",
-      idle_detail:
-        "セッション、ツール呼び出し、モデルのメタデータ、解除状態を読み込んでいます。バッジは解除され次第ここに表示されます。",
+      progress_detail: "{total} 件中 {scanned} 件のセッションをスキャンしました · {pct}%。履歴が読み込まれるにつれてバッジが解除されます。",
+      idle_detail: "セッション、ツール呼び出し、モデルのメタデータ、解除状態を読み込んでいます。バッジは解除され次第ここに表示されます。",
     },
     guide: {
       tiers_header: "ティア",
       secret_header: "シークレット実績",
-      secret_body:
-        "シークレットはトリガー条件を隠しています。Hermes が関連するシグナルを検出すると、カードは「Discovered」になり、要件が表示されます。",
+      secret_body: "シークレットはトリガー条件を隠しています。Hermes が関連するシグナルを検出すると、カードは「Discovered」になり、要件が表示されます。",
       scan_status_header: "スキャン状況",
-      scan_status_body:
-        "Hermes はローカル履歴を一度スキャンし、その後カードが自動的に表示されます。数秒かかってもスタックしているわけではありません。",
+      scan_status_body: "Hermes はローカル履歴を一度スキャンし、その後カードが自動的に表示されます。数秒かかってもスタックしているわけではありません。",
       what_scanned_header: "スキャン対象",
-      what_scanned_body:
-        "セッション、ツール呼び出し、モデルのメタデータ、エラー、実績、ローカルの解除状態。",
+      what_scanned_body: "セッション、ツール呼び出し、モデルのメタデータ、エラー、実績、ローカルの解除状態。",
     },
     card: {
       share_title: "この実績を共有",
@@ -575,8 +521,7 @@ export const ja: Translations = {
     },
     empty: {
       no_secrets_header: "このスキャンに残っている隠しシークレットはありません。",
-      no_secrets_body:
-        "ヒント: シークレットは通常、想定外の失敗やパワーユーザー的なパターンから生まれます — ポート競合、権限の壁、環境変数の不足、YAML のミス、Docker の衝突、ロールバックやチェックポイントの利用、キャッシュヒット、あるいは大量の赤いエラーの後の小さな修正など。",
+      no_secrets_body: "ヒント: シークレットは通常、想定外の失敗やパワーユーザー的なパターンから生まれます — ポート競合、権限の壁、環境変数の不足、YAML のミス、Docker の衝突、ロールバックやチェックポイントの利用、キャッシュヒット、あるいは大量の赤いエラーの後の小さな修正など。",
     },
     filters: {
       all_categories: "すべて",
@@ -598,31 +543,20 @@ export const ja: Translations = {
       copy_button: "画像をコピー",
       copied: "コピーしました ✓",
       download_button: "PNG をダウンロード",
-      hint:
-        "「X で共有」は事前入力された投稿を新しいタブで開きます。1200×630 のバッジを添付したい場合は、先に「画像をコピー」を押してください — X では投稿エディタに直接貼り付けられます。「PNG をダウンロード」はファイルとして保存し、どこでも使えるようにします。",
-      clipboard_unsupported:
-        "このブラウザではクリップボードへの画像コピーがサポートされていません — 代わりに「ダウンロード」をご利用ください。",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "「X で共有」は事前入力された投稿を新しいタブで開きます。1200×630 のバッジを添付したい場合は、先に「画像をコピー」を押してください — X では投稿エディタに直接貼り付けられます。「PNG をダウンロード」はファイルとして保存し、どこでも使えるようにします。",
+      clipboard_unsupported: "このブラウザではクリップボードへの画像コピーがサポートされていません — 代わりに「ダウンロード」をご利用ください。",
     },
   },
   kanban: {
     loading: "Kanban ボードを読み込んでいます…",
     loadFailed: "Kanban ボードの読み込みに失敗しました: ",
-    loadFailedHint:
-      "バックエンドは初回読み込み時に kanban.db を自動作成します。問題が続く場合は、ダッシュボードのログをご確認ください。",
+    loadFailedHint: "バックエンドは初回読み込み時に kanban.db を自動作成します。問題が続く場合は、ダッシュボードのログをご確認ください。",
     board: "ボード",
     newBoard: "+ 新しいボード",
     newBoardTitle: "新しいボード",
-    newBoardDescription:
-      "ボードを使うと、関連のない作業の流れを分けられます — プロジェクト、リポジトリ、ドメインごとに 1 つずつ。あるボードのワーカーは、別のボードのタスクを見ることはありません。",
+    newBoardDescription: "ボードを使うと、関連のない作業の流れを分けられます — プロジェクト、リポジトリ、ドメインごとに 1 つずつ。あるボードのワーカーは、別のボードのタスクを見ることはありません。",
     slug: "スラッグ",
     slugHint: "— 小文字とハイフン、例: atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "表示名",
     displayNameHint: "（任意）",
     description: "説明",
@@ -665,8 +599,7 @@ export const ja: Translations = {
     runHistory: "実行履歴",
     workerLog: "ワーカーログ",
     loadingLog: "ログを読み込んでいます…",
-    noWorkerLog:
-      "— ワーカーログはまだありません（タスクが起動していないか、ログがローテーションされました）—",
+    noWorkerLog: "— ワーカーログはまだありません（タスクが起動していないか、ログがローテーションされました）—",
     noDescription: "— 説明はありません —",
     noComments: "— コメントはありません —",
     edit: "編集",
@@ -697,8 +630,7 @@ export const ja: Translations = {
     reassign: "再割り当て",
     renderingError: "Kanban タブで描画エラーが発生しました",
     reloadView: "ビューを再読み込み",
-    wsAuthFailed:
-      "WebSocket 認証に失敗しました — ページを再読み込みしてセッショントークンを更新してください。",
+    wsAuthFailed: "WebSocket 認証に失敗しました — ページを再読み込みしてセッショントークンを更新してください。",
     markDone: "{n} 件のタスクを完了にしますか？",
     markArchived: "{n} 件のタスクをアーカイブしますか？",
     warning: "警告",
@@ -709,8 +641,7 @@ export const ja: Translations = {
     showAllAttempts: "すべての試行を表示",
     sendingUpdates: "更新の送信先: ",
     sendNotifications: "完了 / ブロック / 諦めの通知の送信先",
-    archiveBoardConfirm:
-      "ボード「{name}」をアーカイブしますか？ボードは boards/_archived/ に移動され、後で復元できます。このボード上のタスクは UI のどこにも表示されなくなります。",
+    archiveBoardConfirm: "ボード「{name}」をアーカイブしますか？ボードは boards/_archived/ に移動され、後で復元できます。このボード上のタスクは UI のどこにも表示されなくなります。",
     archiveBoardTitle: "このボードをアーカイブ",
     boardSwitcherHint: "ボードを使うと、関連のない作業の流れを分けられます",
     taskCreatedWarning: "タスクは作成されましたが: ",
@@ -749,28 +680,21 @@ export const ja: Translations = {
       done: "完了",
       archived: "アーカイブ済み",
     },
-    confirmDone:
-      "このタスクを完了にしますか？ワーカーの取得は解放され、依存している子タスクが ready になります。",
-    confirmArchive:
-      "このタスクをアーカイブしますか？既定のボードビューから消えます。",
-    confirmBlocked:
-      "このタスクをブロック中にしますか？ワーカーの取得は解放されます。",
-    completionSummary:
-      "{label} の完了サマリ。これはタスクの結果として保存されます。",
-    completionSummaryRequired:
-      "タスクを完了にする前に、完了サマリの入力が必要です。",
+    confirmDone: "このタスクを完了にしますか？ワーカーの取得は解放され、依存している子タスクが ready になります。",
+    confirmArchive: "このタスクをアーカイブしますか？既定のボードビューから消えます。",
+    confirmBlocked: "このタスクをブロック中にしますか？ワーカーの取得は解放されます。",
+    completionSummary: "{label} の完了サマリ。これはタスクの結果として保存されます。",
+    completionSummaryRequired: "タスクを完了にする前に、完了サマリの入力が必要です。",
     triagePlaceholder: "おおまかなアイデア — AI が仕様化します…",
     taskTitlePlaceholder: "新しいタスクのタイトル…",
     specifier: "スペシファイア",
     assigneePlaceholder: "担当者",
     priority: "優先度",
-    skillsPlaceholder:
-      "スキル（任意、カンマ区切り）: translation, github-code-review",
+    skillsPlaceholder: "スキル（任意、カンマ区切り）: translation, github-code-review",
     noParent: "— 親タスクなし —",
     workspacePathDir: "ワークスペースのパス（必須、例: ~/projects/my-app）",
-    workspacePathOptional:
-      "ワークスペースのパス（任意、空の場合は担当者から導出）",
+    workspacePathOptional: "ワークスペースのパス（任意、空の場合は担当者から導出）",
     logTruncated: "（最後の 100 KB を表示中 — 完全なログは ",
     logAt: "）",
   },
-};
+});

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const ko: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const ko = defineLocale({
   common: {
     save: "저장",
     saving: "저장 중...",
@@ -43,20 +47,12 @@ export const ko: Translations = {
     expand: "펼치기",
     general: "일반",
     messaging: "메시징",
-    pluginLoadFailed:
-      "이 플러그인의 스크립트를 로드할 수 없습니다. Network 탭(dashboard-plugins/…)과 서버의 플러그인 경로를 확인하세요.",
-    pluginNotRegistered:
-      "플러그인 스크립트가 register()를 호출하지 않았거나 스크립트에 오류가 발생했습니다. 자세한 내용은 브라우저 콘솔을 열어 확인하세요.",
+    pluginLoadFailed: "이 플러그인의 스크립트를 로드할 수 없습니다. Network 탭(dashboard-plugins/…)과 서버의 플러그인 경로를 확인하세요.",
+    pluginNotRegistered: "플러그인 스크립트가 register()를 호출하지 않았거나 스크립트에 오류가 발생했습니다. 자세한 내용은 브라우저 콘솔을 열어 확인하세요.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "내비게이션 닫기",
     closeModelTools: "모델 및 도구 닫기",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "활성 세션:",
     gatewayStatusLabel: "게이트웨이 상태:",
     gatewayStrip: {
@@ -70,7 +66,6 @@ export const ko: Translations = {
       analytics: "분석",
       chat: "채팅",
       config: "설정",
-      cron: "Cron",
       documentation: "문서",
       keys: "키",
       logs: "로그",
@@ -89,9 +84,7 @@ export const ko: Translations = {
     sessionsActiveCount: "{count}개 활성",
     statusOverview: "상태 개요",
     system: "시스템",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "작업 실패",
     actionFinished: "완료됨",
@@ -108,7 +101,6 @@ export const ko: Translations = {
     lastUpdate: "마지막 업데이트",
     noneRunning: "없음",
     notRunning: "실행 중이 아님",
-    pid: "PID",
     platformDisconnected: "연결 끊김",
     platformError: "오류",
     recentSessions: "최근 세션",
@@ -124,7 +116,6 @@ export const ko: Translations = {
     updatingHermes: "Hermes 업데이트 중…",
     waitingForOutput: "출력 대기 중…",
   },
-
   sessions: {
     title: "세션",
     history: "기록",
@@ -143,14 +134,12 @@ export const ko: Translations = {
     untitledSession: "제목 없는 세션",
     deleteSession: "세션 삭제",
     confirmDeleteTitle: "세션을 삭제하시겠습니까?",
-    confirmDeleteMessage:
-      "이 작업은 대화와 모든 메시지를 영구적으로 제거합니다. 되돌릴 수 없습니다.",
+    confirmDeleteMessage: "이 작업은 대화와 모든 메시지를 영구적으로 제거합니다. 되돌릴 수 없습니다.",
     sessionDeleted: "세션이 삭제되었습니다",
     failedToDelete: "세션 삭제에 실패했습니다",
     deleteEmpty: "빈 세션 삭제",
     deleteEmptyConfirmTitle: "빈 세션을 삭제하시겠습니까?",
-    deleteEmptyConfirmMessage:
-      "메시지가 없는 {count}개의 세션을 영구적으로 삭제합니다. 활성 및 보관된 세션은 건너뜁니다. 이 작업은 되돌릴 수 없습니다.",
+    deleteEmptyConfirmMessage: "메시지가 없는 {count}개의 세션을 영구적으로 삭제합니다. 활성 및 보관된 세션은 건너뜁니다. 이 작업은 되돌릴 수 없습니다.",
     emptySessionsDeleted: "빈 세션 {count}개 삭제됨",
     failedToDeleteEmpty: "빈 세션 삭제에 실패했습니다",
     selectSession: "세션 선택",
@@ -159,8 +148,7 @@ export const ko: Translations = {
     selectedCount: "{count}개 선택됨",
     deleteSelected: "{count}개 삭제",
     deleteSelectedConfirmTitle: "{count}개 세션을 삭제하시겠습니까?",
-    deleteSelectedConfirmMessage:
-      "선택한 {count}개 세션과 모든 메시지가 영구적으로 제거됩니다. 이 작업은 취소할 수 없습니다.",
+    deleteSelectedConfirmMessage: "선택한 {count}개 세션과 모든 메시지가 영구적으로 제거됩니다. 이 작업은 취소할 수 없습니다.",
     selectedSessionsDeleted: "{count}개 세션이 삭제되었습니다",
     failedToDeleteSelected: "선택한 세션 삭제에 실패했습니다",
     resumeInChat: "채팅에서 다시 시작",
@@ -174,7 +162,6 @@ export const ko: Translations = {
       tool: "도구",
     },
   },
-
   analytics: {
     period: "기간:",
     totalTokens: "총 토큰",
@@ -200,7 +187,6 @@ export const ko: Translations = {
     acrossModels: "{count}개 모델 전반",
     inOut: "입력 {input} / 출력 {output}",
   },
-
   models: {
     modelsUsed: "사용된 모델",
     estimatedCost: "예상 비용",
@@ -212,7 +198,6 @@ export const ko: Translations = {
     noModelsData: "이 기간에 대한 모델 사용 데이터가 없습니다",
     startSession: "세션을 시작하면 여기에 모델 데이터가 표시됩니다",
   },
-
   logs: {
     title: "로그",
     autoRefresh: "자동 새로고침",
@@ -222,10 +207,8 @@ export const ko: Translations = {
     lines: "줄 수",
     noLogLines: "로그 줄을 찾을 수 없습니다",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "이 작업은 일정에서 작업을 제거합니다. 되돌릴 수 없습니다.",
+    confirmDeleteMessage: "이 작업은 일정에서 작업을 제거합니다. 되돌릴 수 없습니다.",
     confirmDeleteTitle: "예약된 작업을 삭제하시겠습니까?",
     newJob: "새 Cron 작업",
     nameOptional: "이름 (선택 사항)",
@@ -233,7 +216,6 @@ export const ko: Translations = {
     prompt: "프롬프트",
     promptPlaceholder: "에이전트가 매 실행 시 무엇을 해야 합니까?",
     schedule: "스케줄 (cron 표현식)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "일정",
     scheduleModes: {
       interval: "반복 간격",
@@ -249,17 +231,15 @@ export const ko: Translations = {
       unitDays: "일",
       timeOfDay: "시각",
       weekdays: "요일",
-      weekdaysShort: ["일", "월", "화", "수", "목", "금", "토"],
+      weekdaysShort: ["일","월","화","수","목","금","토"],
       dayOfMonth: "날짜",
       onceAt: "실행 시각",
       customLabel: "cron 표현식",
-      customPlaceholder: "0 9 * * *",
       customHint: "5개 필드의 cron 표현식 (분, 시, 일, 월, 요일).",
       preview: "전송 형식",
       previewEmpty: "(미완성)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "{n}분마다",
       everyHours: "{n}시간마다",
       everyDays: "{n}일마다",
@@ -278,26 +258,20 @@ export const ko: Translations = {
     triggerNow: "지금 실행",
     delivery: {
       local: "로컬",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "새 프로필",
     name: "이름",
     namePlaceholder: "예: coder, writer 등.",
     nameRequired: "이름은 필수입니다",
-    nameRule:
-      "소문자, 숫자, _ 및 - 만 사용 가능합니다. 문자나 숫자로 시작해야 하며 최대 64자입니다.",
-    invalidName: "잘못된 프로필 이름입니다",    cloneFrom: "프로필에서 복제",
+    nameRule: "소문자, 숫자, _ 및 - 만 사용 가능합니다. 문자나 숫자로 시작해야 하며 최대 64자입니다.",
+    invalidName: "잘못된 프로필 이름입니다",
+    cloneFrom: "프로필에서 복제",
     cloneFromNone: "없음 (빈 상태)",
     allProfiles: "프로필",
     noProfiles: "프로필을 찾을 수 없습니다.",
     defaultBadge: "기본",
-    hasEnv: "env",
     model: "모델",
     skills: "스킬",
     rename: "이름 변경",
@@ -310,13 +284,11 @@ export const ko: Translations = {
     commandCopied: "클립보드에 복사되었습니다",
     copyFailed: "복사할 수 없습니다",
     confirmDeleteTitle: "프로필을 삭제하시겠습니까?",
-    confirmDeleteMessage:
-      "이 작업은 '{name}' 프로필 — 설정, 키, 메모리, 세션, 스킬, cron 작업 — 을 영구적으로 삭제합니다. 되돌릴 수 없습니다.",
+    confirmDeleteMessage: "이 작업은 '{name}' 프로필 — 설정, 키, 메모리, 세션, 스킬, cron 작업 — 을 영구적으로 삭제합니다. 되돌릴 수 없습니다.",
     created: "생성됨",
     deleted: "삭제됨",
     renamed: "이름 변경됨",
   },
-
   pluginsPage: {
     contextEngineLabel: "컨텍스트 엔진",
     dashboardSlots: "대시보드 슬롯",
@@ -324,8 +296,7 @@ export const ko: Translations = {
     enableAfterInstall: "설치 후 활성화",
     enableRuntime: "활성화",
     forceReinstall: "강제 재설치 (기존 폴더를 먼저 삭제)",
-    headline:
-      "Hermes 플러그인을 검색, 설치, 활성화 및 업데이트합니다 (`hermes plugins` 동등).",
+    headline: "Hermes 플러그인을 검색, 설치, 활성화 및 업데이트합니다 (`hermes plugins` 동등).",
     identifierLabel: "Git URL 또는 owner/repo",
     inactive: "비활성",
     installBtn: "설치",
@@ -339,8 +310,7 @@ export const ko: Translations = {
     pluginListHeading: "설치된 플러그인",
     providerDefaults: "내장 / 기본",
     providersHeading: "런타임 제공자 플러그인",
-    providersHint:
-      "memory.provider (비어 있으면 = 내장)와 context.engine을 config.yaml에 기록합니다. 다음 세션부터 적용됩니다.",
+    providersHint: "memory.provider (비어 있으면 = 내장)와 context.engine을 config.yaml에 기록합니다. 다음 세션부터 적용됩니다.",
     refreshDashboard: "대시보드 확장 재스캔",
     removeConfirm: "~/.hermes/plugins/에서 이 플러그인을 제거하시겠습니까?",
     removeHint: "~/.hermes/plugins 아래에 사용자가 설치한 플러그인만 제거할 수 있습니다.",
@@ -352,12 +322,10 @@ export const ko: Translations = {
     sourceBadge: "소스",
     authRequired: "인증 필요",
     authRequiredHint: "이 명령을 실행하여 인증하세요:",
-    updateGit: "Git pull",
     versionBadge: "버전",
     showInSidebar: "사이드바에 표시",
     hideFromSidebar: "사이드바에서 숨기기",
   },
-
   skills: {
     title: "스킬",
     searchPlaceholder: "스킬 및 도구 세트 검색...",
@@ -377,13 +345,10 @@ export const ko: Translations = {
     disabledForCli: "CLI에서 비활성화됨",
     more: "+{count}개 더",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "필터",
     sections: "섹션",
     exportConfig: "설정을 JSON으로 내보내기",
-    importConfig: "JSON에서 설정 가져오기",
     resetDefaults: "기본값으로 재설정",
     resetScopeTooltip: "{scope}을(를) 기본값으로 재설정",
     confirmResetScope: "모든 {scope} 설정을 기본값으로 재설정하시겠습니까? 이 작업은 양식만 업데이트하며, 저장을 누르기 전까지는 변경 사항이 config.yaml에 기록되지 않습니다.",
@@ -391,7 +356,7 @@ export const ko: Translations = {
     rawYaml: "원본 YAML 설정",
     searchResults: "검색 결과",
     fields: "개 필드",
-    noFieldsMatch: '"{query}"와(과) 일치하는 필드가 없습니다',
+    noFieldsMatch: "\"{query}\"와(과) 일치하는 필드가 없습니다",
     configSaved: "설정이 저장되었습니다",
     yamlConfigSaved: "YAML 설정이 저장되었습니다",
     failedToSave: "저장에 실패했습니다",
@@ -413,15 +378,12 @@ export const ko: Translations = {
       tts: "텍스트 음성 변환",
       stt: "음성 텍스트 변환",
       logging: "로깅",
-      discord: "Discord",
       auxiliary: "보조",
     },
   },
-
   env: {
     changesNote: "변경 사항은 즉시 디스크에 저장됩니다. 활성 세션은 자동으로 새 키를 가져옵니다.",
-    confirmClearMessage:
-      "이 변수에 대해 저장된 값이 .env 파일에서 제거됩니다. UI에서는 이 작업을 되돌릴 수 없습니다.",
+    confirmClearMessage: "이 변수에 대해 저장된 값이 .env 파일에서 제거됩니다. UI에서는 이 작업을 되돌릴 수 없습니다.",
     confirmClearTitle: "이 키를 지우시겠습니까?",
     description: "다음 위치에 저장된 API 키와 비밀을 관리합니다",
     hideAdvanced: "고급 숨기기",
@@ -447,12 +409,10 @@ export const ko: Translations = {
     add: "추가",
     invalidKeyName: "문자, 숫자, 밑줄만 사용하세요(문자 또는 밑줄로 시작해야 합니다).",
   },
-
   oauth: {
     title: "제공자 로그인 (OAuth)",
     providerLogins: "제공자 로그인 (OAuth)",
-    description:
-      "{connected}/{total} OAuth 제공자가 연결되었습니다. 대시보드에서 지원되는 흐름에는 로그인을 사용하세요. 외부 또는 대체 설정에는 CLI 명령을 계속 사용할 수 있습니다.",
+    description: "{connected}/{total} OAuth 제공자가 연결되었습니다. 대시보드에서 지원되는 흐름에는 로그인을 사용하세요. 외부 또는 대체 설정에는 CLI 명령을 계속 사용할 수 있습니다.",
     connected: "연결됨",
     expired: "만료됨",
     notConnected: "연결되지 않음. 가능하면 로그인을 사용하거나 터미널에서 {command}을(를) 실행하세요.",
@@ -489,24 +449,17 @@ export const ko: Translations = {
     },
     expiresIn: "{time} 후 만료",
   },
-
   language: {
     switchTo: "언어 변경",
   },
-
   theme: {
     title: "테마",
     switchTheme: "테마 전환",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "실제 세션 기록에서 획득하는 Hermes 컬렉터블 배지입니다. 알려져 있지만 아직 달성되지 않은 업적은 Discovered로 표시되며, Secret 업적은 일치하는 동작이 처음 나타날 때까지 숨겨집니다.",
-      scan_subtitle:
-        "Hermes 세션 기록을 스캔하고 있습니다. 기록이 많으면 첫 스캔에 5~10초가 걸릴 수 있습니다.",
+      subtitle: "실제 세션 기록에서 획득하는 Hermes 컬렉터블 배지입니다. 알려져 있지만 아직 달성되지 않은 업적은 Discovered로 표시되며, Secret 업적은 일치하는 동작이 처음 나타날 때까지 숨겨집니다.",
+      scan_subtitle: "Hermes 세션 기록을 스캔하고 있습니다. 기록이 많으면 첫 스캔에 5~10초가 걸릴 수 있습니다.",
     },
     actions: {
       rescan: "다시 스캔",
@@ -519,7 +472,6 @@ export const ko: Translations = {
       secrets: "시크릿",
       secrets_hint: "첫 신호가 있을 때까지 숨겨짐",
       highest_tier: "최고 등급",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "최근",
       latest_hint_empty: "Hermes를 더 사용해 보세요",
       none_yet: "아직 없음",
@@ -540,25 +492,19 @@ export const ko: Translations = {
     },
     scan: {
       building_headline: "업적 프로필을 구성하고 있습니다…",
-      building_detail:
-        "세션, 도구 호출, 모델 메타데이터, 해제 상태를 읽고 있습니다.",
+      building_detail: "세션, 도구 호출, 모델 메타데이터, 해제 상태를 읽고 있습니다.",
       starting_headline: "업적 스캔을 시작합니다…",
-      progress_detail:
-        "{total}개 중 {scanned}개의 세션을 스캔했습니다 · {pct}%. 더 많은 기록이 들어오면 배지가 해제됩니다.",
-      idle_detail:
-        "세션, 도구 호출, 모델 메타데이터, 해제 상태를 읽고 있습니다. 배지가 해제되면 여기에 표시됩니다.",
+      progress_detail: "{total}개 중 {scanned}개의 세션을 스캔했습니다 · {pct}%. 더 많은 기록이 들어오면 배지가 해제됩니다.",
+      idle_detail: "세션, 도구 호출, 모델 메타데이터, 해제 상태를 읽고 있습니다. 배지가 해제되면 여기에 표시됩니다.",
     },
     guide: {
       tiers_header: "등급",
       secret_header: "시크릿 업적",
-      secret_body:
-        "시크릿은 정확한 트리거 조건을 숨깁니다. Hermes가 관련 신호를 감지하면 카드가 Discovered로 바뀌고 요건이 표시됩니다.",
+      secret_body: "시크릿은 정확한 트리거 조건을 숨깁니다. Hermes가 관련 신호를 감지하면 카드가 Discovered로 바뀌고 요건이 표시됩니다.",
       scan_status_header: "스캔 상태",
-      scan_status_body:
-        "Hermes는 로컬 기록을 한 번 스캔한 뒤 카드를 자동으로 표시합니다. 몇 초 걸리더라도 멈춘 것이 아닙니다.",
+      scan_status_body: "Hermes는 로컬 기록을 한 번 스캔한 뒤 카드를 자동으로 표시합니다. 몇 초 걸리더라도 멈춘 것이 아닙니다.",
       what_scanned_header: "스캔 대상",
-      what_scanned_body:
-        "세션, 도구 호출, 모델 메타데이터, 오류, 업적 및 로컬 해제 상태입니다.",
+      what_scanned_body: "세션, 도구 호출, 모델 메타데이터, 오류, 업적 및 로컬 해제 상태입니다.",
     },
     card: {
       share_title: "이 업적 공유",
@@ -575,8 +521,7 @@ export const ko: Translations = {
     },
     empty: {
       no_secrets_header: "이번 스캔에 남은 숨겨진 시크릿이 없습니다.",
-      no_secrets_body:
-        "힌트: 시크릿은 보통 비정상적인 실패나 파워 유저 패턴에서 시작됩니다 — 포트 충돌, 권한 차단, 누락된 환경 변수, YAML 실수, Docker 충돌, 롤백/체크포인트 사용, 캐시 적중, 또는 많은 오류 메시지 뒤의 작은 수정 등입니다.",
+      no_secrets_body: "힌트: 시크릿은 보통 비정상적인 실패나 파워 유저 패턴에서 시작됩니다 — 포트 충돌, 권한 차단, 누락된 환경 변수, YAML 실수, Docker 충돌, 롤백/체크포인트 사용, 캐시 적중, 또는 많은 오류 메시지 뒤의 작은 수정 등입니다.",
     },
     filters: {
       all_categories: "전체",
@@ -598,31 +543,20 @@ export const ko: Translations = {
       copy_button: "이미지 복사",
       copied: "복사됨 ✓",
       download_button: "PNG 다운로드",
-      hint:
-        "X에 공유를 누르면 새 탭에서 미리 작성된 게시물이 열립니다. 1200×630 배지를 첨부하려면 먼저 이미지 복사를 누르세요 — X 작성기에서 바로 붙여넣을 수 있습니다. PNG 다운로드는 파일을 저장하여 어디서나 사용할 수 있게 합니다.",
-      clipboard_unsupported:
-        "이 브라우저에서는 클립보드 이미지 복사를 지원하지 않습니다 — 대신 다운로드를 이용하세요.",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "X에 공유를 누르면 새 탭에서 미리 작성된 게시물이 열립니다. 1200×630 배지를 첨부하려면 먼저 이미지 복사를 누르세요 — X 작성기에서 바로 붙여넣을 수 있습니다. PNG 다운로드는 파일을 저장하여 어디서나 사용할 수 있게 합니다.",
+      clipboard_unsupported: "이 브라우저에서는 클립보드 이미지 복사를 지원하지 않습니다 — 대신 다운로드를 이용하세요.",
     },
   },
   kanban: {
     loading: "Kanban 보드를 불러오는 중입니다…",
     loadFailed: "Kanban 보드를 불러오지 못했습니다: ",
-    loadFailedHint:
-      "백엔드는 처음 읽을 때 kanban.db를 자동으로 생성합니다. 문제가 계속되면 대시보드 로그를 확인하십시오.",
+    loadFailedHint: "백엔드는 처음 읽을 때 kanban.db를 자동으로 생성합니다. 문제가 계속되면 대시보드 로그를 확인하십시오.",
     board: "보드",
     newBoard: "+ 새 보드",
     newBoardTitle: "새 보드",
-    newBoardDescription:
-      "보드를 사용하면 관련 없는 작업 흐름을 분리할 수 있습니다 — 프로젝트, 저장소, 도메인마다 하나씩. 한 보드의 워커는 다른 보드의 작업을 절대 보지 않습니다.",
+    newBoardDescription: "보드를 사용하면 관련 없는 작업 흐름을 분리할 수 있습니다 — 프로젝트, 저장소, 도메인마다 하나씩. 한 보드의 워커는 다른 보드의 작업을 절대 보지 않습니다.",
     slug: "슬러그",
     slugHint: "— 소문자, 하이픈, 예: atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "표시 이름",
     displayNameHint: "(선택)",
     description: "설명",
@@ -665,8 +599,7 @@ export const ko: Translations = {
     runHistory: "실행 기록",
     workerLog: "워커 로그",
     loadingLog: "로그를 불러오는 중…",
-    noWorkerLog:
-      "— 아직 워커 로그가 없습니다 (작업이 시작되지 않았거나 로그가 순환되었습니다) —",
+    noWorkerLog: "— 아직 워커 로그가 없습니다 (작업이 시작되지 않았거나 로그가 순환되었습니다) —",
     noDescription: "— 설명 없음 —",
     noComments: "— 댓글 없음 —",
     edit: "편집",
@@ -697,8 +630,7 @@ export const ko: Translations = {
     reassign: "재지정",
     renderingError: "Kanban 탭에서 렌더링 오류가 발생했습니다",
     reloadView: "뷰 다시 불러오기",
-    wsAuthFailed:
-      "WebSocket 인증 실패 — 페이지를 다시 불러와 세션 토큰을 갱신하십시오.",
+    wsAuthFailed: "WebSocket 인증 실패 — 페이지를 다시 불러와 세션 토큰을 갱신하십시오.",
     markDone: "{n}개의 작업을 완료로 표시하시겠습니까?",
     markArchived: "{n}개의 작업을 보관하시겠습니까?",
     warning: "경고",
@@ -709,8 +641,7 @@ export const ko: Translations = {
     showAllAttempts: "모든 시도 표시",
     sendingUpdates: "업데이트 전송 대상: ",
     sendNotifications: "완료 / 차단됨 / 포기 알림 전송 대상",
-    archiveBoardConfirm:
-      "보드 '{name}'을(를) 보관하시겠습니까? 보드는 boards/_archived/로 이동되어 나중에 복구할 수 있습니다. 이 보드의 작업은 더 이상 UI 어디에도 나타나지 않습니다.",
+    archiveBoardConfirm: "보드 '{name}'을(를) 보관하시겠습니까? 보드는 boards/_archived/로 이동되어 나중에 복구할 수 있습니다. 이 보드의 작업은 더 이상 UI 어디에도 나타나지 않습니다.",
     archiveBoardTitle: "이 보드 보관",
     boardSwitcherHint: "보드를 사용하면 관련 없는 작업 흐름을 분리할 수 있습니다",
     taskCreatedWarning: "작업이 생성되었지만: ",
@@ -749,28 +680,20 @@ export const ko: Translations = {
       done: "완료됨",
       archived: "보관됨",
     },
-    confirmDone:
-      "이 작업을 완료로 표시하시겠습니까? 워커의 점유가 해제되고 종속된 하위 작업이 ready 상태가 됩니다.",
-    confirmArchive:
-      "이 작업을 보관하시겠습니까? 기본 보드 보기에서 사라집니다.",
-    confirmBlocked:
-      "이 작업을 차단됨으로 표시하시겠습니까? 워커의 점유가 해제됩니다.",
-    completionSummary:
-      "{label}의 완료 요약입니다. 이는 작업 결과로 저장됩니다.",
-    completionSummaryRequired:
-      "작업을 완료로 표시하기 전에 완료 요약이 필요합니다.",
+    confirmDone: "이 작업을 완료로 표시하시겠습니까? 워커의 점유가 해제되고 종속된 하위 작업이 ready 상태가 됩니다.",
+    confirmArchive: "이 작업을 보관하시겠습니까? 기본 보드 보기에서 사라집니다.",
+    confirmBlocked: "이 작업을 차단됨으로 표시하시겠습니까? 워커의 점유가 해제됩니다.",
+    completionSummary: "{label}의 완료 요약입니다. 이는 작업 결과로 저장됩니다.",
+    completionSummaryRequired: "작업을 완료로 표시하기 전에 완료 요약이 필요합니다.",
     triagePlaceholder: "대략적인 아이디어 — AI가 사양을 작성합니다…",
     taskTitlePlaceholder: "새 작업 제목…",
     specifier: "스페시파이어",
     assigneePlaceholder: "담당자",
     priority: "우선순위",
-    skillsPlaceholder:
-      "스킬 (선택, 쉼표로 구분): translation, github-code-review",
+    skillsPlaceholder: "스킬 (선택, 쉼표로 구분): translation, github-code-review",
     noParent: "— 상위 작업 없음 —",
     workspacePathDir: "작업 공간 경로 (필수, 예: ~/projects/my-app)",
-    workspacePathOptional:
-      "작업 공간 경로 (선택, 비어 있으면 담당자에서 파생됨)",
+    workspacePathOptional: "작업 공간 경로 (선택, 비어 있으면 담당자에서 파생됨)",
     logTruncated: "(마지막 100 KB 표시 중 — 전체 로그 위치: ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const pt: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const pt = defineLocale({
   common: {
     save: "Guardar",
     saving: "A guardar...",
@@ -30,7 +34,6 @@ export const pt: Translations = {
     noResults: "Sem resultados",
     of: "de",
     page: "Página",
-    msgs: "msgs",
     tools: "ferramentas",
     match: "correspondência",
     other: "Outro",
@@ -43,20 +46,12 @@ export const pt: Translations = {
     expand: "Expandir",
     general: "Geral",
     messaging: "Mensagens",
-    pluginLoadFailed:
-      "Não foi possível carregar o script deste plugin. Verifique o separador Network (dashboard-plugins/…) e o caminho do plugin no servidor.",
-    pluginNotRegistered:
-      "O script do plugin não chamou register(), ou o script falhou. Abra a consola do browser para mais detalhes.",
+    pluginLoadFailed: "Não foi possível carregar o script deste plugin. Verifique o separador Network (dashboard-plugins/…) e o caminho do plugin no servidor.",
+    pluginNotRegistered: "O script do plugin não chamou register(), ou o script falhou. Abra a consola do browser para mais detalhes.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Fechar navegação",
     closeModelTools: "Fechar modelo e ferramentas",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Sessões ativas:",
     gatewayStatusLabel: "Estado do gateway:",
     gatewayStrip: {
@@ -68,15 +63,12 @@ export const pt: Translations = {
     },
     nav: {
       analytics: "Análise",
-      chat: "Chat",
       config: "Configuração",
-      cron: "Cron",
       documentation: "Documentação",
       keys: "Chaves",
       logs: "Registos",
       models: "Modelos",
       profiles: "perfis: multiagentes",
-      plugins: "Plugins",
       sessions: "Sessões",
       skills: "Competências",
     },
@@ -85,13 +77,10 @@ export const pt: Translations = {
     navigation: "Navegação",
     openDocumentation: "Abrir documentação num novo separador",
     openNavigation: "Abrir navegação",
-    pluginNavSection: "Plugins",
     sessionsActiveCount: "{count} ativa(s)",
     statusOverview: "Visão geral do estado",
     system: "Sistema",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "Ação falhou",
     actionFinished: "Concluído",
@@ -103,12 +92,10 @@ export const pt: Translations = {
     disconnected: "Desligado",
     error: "Erro",
     failed: "Falhou",
-    gateway: "Gateway",
     gatewayFailedToStart: "O gateway falhou ao iniciar",
     lastUpdate: "Última atualização",
     noneRunning: "Nenhum",
     notRunning: "Não está a executar",
-    pid: "PID",
     platformDisconnected: "desligado",
     platformError: "erro",
     recentSessions: "Sessões recentes",
@@ -124,7 +111,6 @@ export const pt: Translations = {
     updatingHermes: "A atualizar Hermes…",
     waitingForOutput: "À espera de saída…",
   },
-
   sessions: {
     title: "Sessões",
     history: "Histórico",
@@ -143,14 +129,12 @@ export const pt: Translations = {
     untitledSession: "Sessão sem título",
     deleteSession: "Eliminar sessão",
     confirmDeleteTitle: "Eliminar sessão?",
-    confirmDeleteMessage:
-      "Esta ação remove permanentemente a conversa e todas as suas mensagens. Não é possível anular.",
+    confirmDeleteMessage: "Esta ação remove permanentemente a conversa e todas as suas mensagens. Não é possível anular.",
     sessionDeleted: "Sessão eliminada",
     failedToDelete: "Falha ao eliminar a sessão",
     deleteEmpty: "Eliminar vazias",
     deleteEmptyConfirmTitle: "Eliminar sessões vazias?",
-    deleteEmptyConfirmMessage:
-      "Isto remove permanentemente {count} sessões sem mensagens. As sessões ativas e arquivadas são ignoradas. Esta ação não pode ser desfeita.",
+    deleteEmptyConfirmMessage: "Isto remove permanentemente {count} sessões sem mensagens. As sessões ativas e arquivadas são ignoradas. Esta ação não pode ser desfeita.",
     emptySessionsDeleted: "{count} sessões vazias eliminadas",
     failedToDeleteEmpty: "Falha ao eliminar sessões vazias",
     selectSession: "Selecionar sessão",
@@ -159,8 +143,7 @@ export const pt: Translations = {
     selectedCount: "{count} selecionadas",
     deleteSelected: "Eliminar {count}",
     deleteSelectedConfirmTitle: "Eliminar {count} sessões?",
-    deleteSelectedConfirmMessage:
-      "Isto remove permanentemente {count} sessões selecionadas e todas as suas mensagens. Não pode ser desfeito.",
+    deleteSelectedConfirmMessage: "Isto remove permanentemente {count} sessões selecionadas e todas as suas mensagens. Não pode ser desfeito.",
     selectedSessionsDeleted: "{count} sessões eliminadas",
     failedToDeleteSelected: "Falha ao eliminar as sessões selecionadas",
     resumeInChat: "Retomar no Chat",
@@ -174,7 +157,6 @@ export const pt: Translations = {
       tool: "Ferramenta",
     },
   },
-
   analytics: {
     period: "Período:",
     totalTokens: "Tokens totais",
@@ -190,21 +172,17 @@ export const pt: Translations = {
     lastUsed: "Última utilização",
     input: "Entrada",
     output: "Saída",
-    total: "Total",
     noUsageData: "Sem dados de utilização para este período",
     startSession: "Inicie uma sessão para ver as análises aqui",
     date: "Data",
     model: "Modelo",
-    tokens: "Tokens",
     perDayAvg: "/dia (média)",
     acrossModels: "em {count} modelos",
     inOut: "{input} entrada / {output} saída",
   },
-
   models: {
     modelsUsed: "Modelos utilizados",
     estimatedCost: "Custo est.",
-    tokens: "tokens",
     sessions: "sessões",
     avgPerSession: "média/sessão",
     apiCalls: "chamadas à API",
@@ -212,7 +190,6 @@ export const pt: Translations = {
     noModelsData: "Sem dados de utilização de modelos para este período",
     startSession: "Inicie uma sessão para ver os dados de modelos aqui",
   },
-
   logs: {
     title: "Registos",
     autoRefresh: "Atualização automática",
@@ -222,18 +199,14 @@ export const pt: Translations = {
     lines: "Linhas",
     noLogLines: "Não foram encontradas linhas de registo",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Esta ação remove a tarefa do agendamento. Não é possível anular.",
+    confirmDeleteMessage: "Esta ação remove a tarefa do agendamento. Não é possível anular.",
     confirmDeleteTitle: "Eliminar tarefa agendada?",
     newJob: "Nova tarefa cron",
     nameOptional: "Nome (opcional)",
     namePlaceholder: "ex: Resumo diário",
-    prompt: "Prompt",
     promptPlaceholder: "O que deve o agente fazer em cada execução?",
     schedule: "Agendamento (expressão cron)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Agendamento",
     scheduleModes: {
       interval: "Intervalo recorrente",
@@ -249,18 +222,15 @@ export const pt: Translations = {
       unitDays: "dias",
       timeOfDay: "Hora do dia",
       weekdays: "Dias da semana",
-      weekdaysShort: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"],
+      weekdaysShort: ["Dom","Seg","Ter","Qua","Qui","Sex","Sáb"],
       dayOfMonth: "Dia do mês",
       onceAt: "Executar em",
       customLabel: "Expressão cron",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "Expressão cron de cinco campos (minuto, hora, dia, mês, dia da semana).",
+      customHint: "Expressão cron de cinco campos (minuto, hora, dia, mês, dia da semana).",
       preview: "Enviado como",
       previewEmpty: "(incompleta)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "A cada {n} min",
       everyHours: "A cada {n} h",
       everyDays: "A cada {n} d",
@@ -277,29 +247,19 @@ export const pt: Translations = {
     pause: "Pausar",
     resume: "Retomar",
     triggerNow: "Acionar agora",
-    delivery: {
-      local: "Local",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
-    },
   },
-
   profiles: {
     newProfile: "Novo perfil",
     name: "Nome",
     namePlaceholder: "ex: coder, writer, etc.",
     nameRequired: "O nome é obrigatório",
-    nameRule:
-      "Apenas letras minúsculas, dígitos, _ e -; deve começar com letra ou dígito; até 64 caracteres.",
+    nameRule: "Apenas letras minúsculas, dígitos, _ e -; deve começar com letra ou dígito; até 64 caracteres.",
     invalidName: "Nome de perfil inválido",
     cloneFrom: "Clonar a partir do perfil",
     cloneFromNone: "Nenhum (vazio)",
     allProfiles: "Perfis",
     noProfiles: "Não foram encontrados perfis.",
     defaultBadge: "predefinido",
-    hasEnv: "env",
     model: "Modelo",
     skills: "Competências",
     rename: "Renomear",
@@ -312,13 +272,11 @@ export const pt: Translations = {
     commandCopied: "Copiado para a área de transferência",
     copyFailed: "Não foi possível copiar",
     confirmDeleteTitle: "Eliminar perfil?",
-    confirmDeleteMessage:
-      "Esta ação elimina permanentemente o perfil '{name}' — configuração, chaves, memórias, sessões, competências, tarefas cron. Não é possível anular.",
+    confirmDeleteMessage: "Esta ação elimina permanentemente o perfil '{name}' — configuração, chaves, memórias, sessões, competências, tarefas cron. Não é possível anular.",
     created: "Criado",
     deleted: "Eliminado",
     renamed: "Renomeado",
   },
-
   pluginsPage: {
     contextEngineLabel: "Motor de contexto",
     dashboardSlots: "Slots do dashboard",
@@ -326,8 +284,7 @@ export const pt: Translations = {
     enableAfterInstall: "Ativar após instalação",
     enableRuntime: "Ativar",
     forceReinstall: "Forçar reinstalação (eliminar pasta existente primeiro)",
-    headline:
-      "Descobrir, instalar, ativar e atualizar plugins Hermes (paridade com `hermes plugins`).",
+    headline: "Descobrir, instalar, ativar e atualizar plugins Hermes (paridade com `hermes plugins`).",
     identifierLabel: "URL Git ou owner/repo",
     inactive: "inativo",
     installBtn: "Instalar",
@@ -341,8 +298,7 @@ export const pt: Translations = {
     pluginListHeading: "Plugins instalados",
     providerDefaults: "incorporado / predefinido",
     providersHeading: "Plugins de fornecedor em runtime",
-    providersHint:
-      "Escreve memory.provider (vazio = incorporado) e context.engine no config.yaml. Aplicado na próxima sessão.",
+    providersHint: "Escreve memory.provider (vazio = incorporado) e context.engine no config.yaml. Aplicado na próxima sessão.",
     refreshDashboard: "Re-analisar extensões do dashboard",
     removeConfirm: "Remover este plugin de ~/.hermes/plugins/?",
     removeHint: "Apenas plugins instalados pelo utilizador em ~/.hermes/plugins podem ser removidos.",
@@ -354,12 +310,10 @@ export const pt: Translations = {
     sourceBadge: "Fonte",
     authRequired: "Autenticação necessária",
     authRequiredHint: "Execute este comando para autenticar:",
-    updateGit: "Git pull",
     versionBadge: "Versão",
     showInSidebar: "Mostrar na barra lateral",
     hideFromSidebar: "Ocultar da barra lateral",
   },
-
   skills: {
     title: "Competências",
     searchPlaceholder: "Pesquisar competências e conjuntos de ferramentas...",
@@ -379,13 +333,10 @@ export const pt: Translations = {
     disabledForCli: "Desativado para CLI",
     more: "+{count} mais",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "Filtros",
     sections: "Secções",
     exportConfig: "Exportar configuração como JSON",
-    importConfig: "Importar configuração de JSON",
     resetDefaults: "Repor predefinições",
     resetScopeTooltip: "Repor {scope} para predefinições",
     confirmResetScope: "Repor todas as definições de {scope} para os valores predefinidos? Isto apenas atualiza o formulário — as alterações só são escritas em config.yaml quando premir Guardar.",
@@ -393,7 +344,7 @@ export const pt: Translations = {
     rawYaml: "Configuração YAML em bruto",
     searchResults: "Resultados da pesquisa",
     fields: "campo{s}",
-    noFieldsMatch: 'Nenhum campo corresponde a "{query}"',
+    noFieldsMatch: "Nenhum campo corresponde a \"{query}\"",
     configSaved: "Configuração guardada",
     yamlConfigSaved: "Configuração YAML guardada",
     failedToSave: "Falha ao guardar",
@@ -404,26 +355,21 @@ export const pt: Translations = {
     categories: {
       general: "Geral",
       agent: "Agente",
-      terminal: "Terminal",
       display: "Visualização",
       delegation: "Delegação",
       memory: "Memória",
       compression: "Compressão",
       security: "Segurança",
-      browser: "Browser",
       voice: "Voz",
       tts: "Texto para fala",
       stt: "Fala para texto",
       logging: "Registo",
-      discord: "Discord",
       auxiliary: "Auxiliar",
     },
   },
-
   env: {
     changesNote: "As alterações são guardadas em disco imediatamente. As sessões ativas detetam novas chaves automaticamente.",
-    confirmClearMessage:
-      "O valor armazenado para esta variável será removido do seu ficheiro .env. Esta ação não pode ser anulada a partir da UI.",
+    confirmClearMessage: "O valor armazenado para esta variável será removido do seu ficheiro .env. Esta ação não pode ser anulada a partir da UI.",
     confirmClearTitle: "Limpar esta chave?",
     description: "Gerir chaves de API e segredos armazenados em",
     hideAdvanced: "Ocultar avançadas",
@@ -449,12 +395,10 @@ export const pt: Translations = {
     add: "Adicionar",
     invalidKeyName: "Use apenas letras, números e sublinhados (deve começar com uma letra ou sublinhado).",
   },
-
   oauth: {
     title: "Inícios de sessão de fornecedor (OAuth)",
     providerLogins: "Inícios de sessão de fornecedor (OAuth)",
-    description:
-      "{connected} de {total} fornecedores OAuth ligados. Use Iniciar sessão para fluxos suportados pelo painel; os comandos CLI continuam disponíveis para configuração externa ou de recurso.",
+    description: "{connected} de {total} fornecedores OAuth ligados. Use Iniciar sessão para fluxos suportados pelo painel; os comandos CLI continuam disponíveis para configuração externa ou de recurso.",
     connected: "Ligado",
     expired: "Expirado",
     notConnected: "Não ligado. Use Iniciar sessão quando disponível, ou execute {command} num terminal.",
@@ -491,24 +435,17 @@ export const pt: Translations = {
     },
     expiresIn: "expira em {time}",
   },
-
   language: {
     switchTo: "Mudar idioma",
   },
-
   theme: {
     title: "Tema",
     switchTheme: "Mudar tema",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Distintivos colecionáveis do Hermes obtidos a partir do histórico real de sessões. Conquistas conhecidas mas ainda não obtidas aparecem como Descobertas; conquistas Secretas permanecem ocultas até surgir o primeiro comportamento correspondente.",
-      scan_subtitle:
-        "A analisar o histórico de sessões do Hermes. A primeira análise pode demorar 5–10 segundos em históricos extensos.",
+      subtitle: "Distintivos colecionáveis do Hermes obtidos a partir do histórico real de sessões. Conquistas conhecidas mas ainda não obtidas aparecem como Descobertas; conquistas Secretas permanecem ocultas até surgir o primeiro comportamento correspondente.",
+      scan_subtitle: "A analisar o histórico de sessões do Hermes. A primeira análise pode demorar 5–10 segundos em históricos extensos.",
     },
     actions: {
       rescan: "Voltar a analisar",
@@ -521,7 +458,6 @@ export const pt: Translations = {
       secrets: "Secretas",
       secrets_hint: "ocultas até ao primeiro sinal",
       highest_tier: "Nível mais alto",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "Mais recente",
       latest_hint_empty: "execute mais o Hermes",
       none_yet: "Ainda nenhuma",
@@ -542,25 +478,19 @@ export const pt: Translations = {
     },
     scan: {
       building_headline: "A construir perfil de conquistas…",
-      building_detail:
-        "A ler sessões, chamadas de ferramentas, metadados de modelos e estado de desbloqueio.",
+      building_detail: "A ler sessões, chamadas de ferramentas, metadados de modelos e estado de desbloqueio.",
       starting_headline: "A iniciar análise de conquistas…",
-      progress_detail:
-        "Analisadas {scanned} de {total} sessões · {pct}%. Os distintivos são desbloqueados à medida que mais histórico é processado.",
-      idle_detail:
-        "A ler sessões, chamadas de ferramentas, metadados de modelos e estado de desbloqueio. Os distintivos aparecem aqui à medida que são desbloqueados.",
+      progress_detail: "Analisadas {scanned} de {total} sessões · {pct}%. Os distintivos são desbloqueados à medida que mais histórico é processado.",
+      idle_detail: "A ler sessões, chamadas de ferramentas, metadados de modelos e estado de desbloqueio. Os distintivos aparecem aqui à medida que são desbloqueados.",
     },
     guide: {
       tiers_header: "Níveis",
       secret_header: "Conquistas secretas",
-      secret_body:
-        "As secretas escondem o seu acionador exato. Assim que o Hermes detetar um sinal relacionado, o cartão passa a Descoberta e mostra o requisito.",
+      secret_body: "As secretas escondem o seu acionador exato. Assim que o Hermes detetar um sinal relacionado, o cartão passa a Descoberta e mostra o requisito.",
       scan_status_header: "Estado da análise",
-      scan_status_body:
-        "O Hermes analisa o histórico local uma vez e depois os cartões aparecem automaticamente. Nada está bloqueado se isto demorar alguns segundos.",
+      scan_status_body: "O Hermes analisa o histórico local uma vez e depois os cartões aparecem automaticamente. Nada está bloqueado se isto demorar alguns segundos.",
       what_scanned_header: "O que é analisado",
-      what_scanned_body:
-        "Sessões, chamadas de ferramentas, metadados de modelos, erros, conquistas e estado de desbloqueio local.",
+      what_scanned_body: "Sessões, chamadas de ferramentas, metadados de modelos, erros, conquistas e estado de desbloqueio local.",
     },
     card: {
       share_title: "Partilhar esta conquista",
@@ -577,8 +507,7 @@ export const pt: Translations = {
     },
     empty: {
       no_secrets_header: "Não restam segredos ocultos nesta análise.",
-      no_secrets_body:
-        "Pista: as secretas começam normalmente em padrões pouco comuns de falha ou de utilizador avançado — conflitos de portas, barreiras de permissões, variáveis de ambiente em falta, erros de YAML, colisões de Docker, uso de rollback/checkpoint, acertos de cache ou pequenas correções após muito texto a vermelho.",
+      no_secrets_body: "Pista: as secretas começam normalmente em padrões pouco comuns de falha ou de utilizador avançado — conflitos de portas, barreiras de permissões, variáveis de ambiente em falta, erros de YAML, colisões de Docker, uso de rollback/checkpoint, acertos de cache ou pequenas correções após muito texto a vermelho.",
     },
     filters: {
       all_categories: "Todas",
@@ -600,31 +529,19 @@ export const pt: Translations = {
       copy_button: "Copiar imagem",
       copied: "Copiado ✓",
       download_button: "Transferir PNG",
-      hint:
-        "Partilhar no X abre uma publicação pré-preenchida num novo separador. Clique primeiro em Copiar imagem se quiser anexar o distintivo 1200×630 — o X permite colá-lo diretamente no compositor da publicação. Transferir PNG guarda o ficheiro para utilização em qualquer lado.",
-      clipboard_unsupported:
-        "A cópia de imagens para a área de transferência não é suportada neste navegador — utilize Transferir.",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "Partilhar no X abre uma publicação pré-preenchida num novo separador. Clique primeiro em Copiar imagem se quiser anexar o distintivo 1200×630 — o X permite colá-lo diretamente no compositor da publicação. Transferir PNG guarda o ficheiro para utilização em qualquer lado.",
+      clipboard_unsupported: "A cópia de imagens para a área de transferência não é suportada neste navegador — utilize Transferir.",
     },
   },
   kanban: {
     loading: "A carregar o quadro Kanban…",
     loadFailed: "Falha ao carregar o quadro Kanban: ",
-    loadFailedHint:
-      "O backend cria automaticamente kanban.db na primeira leitura. Se persistir, consulte os registos do dashboard.",
+    loadFailedHint: "O backend cria automaticamente kanban.db na primeira leitura. Se persistir, consulte os registos do dashboard.",
     board: "Quadro",
     newBoard: "+ Novo quadro",
     newBoardTitle: "Novo quadro",
-    newBoardDescription:
-      "Os quadros permitem-lhe separar fluxos de trabalho não relacionados — um por projeto, repositório ou domínio. Os workers de um quadro nunca veem as tarefas de outro quadro.",
-    slug: "Slug",
+    newBoardDescription: "Os quadros permitem-lhe separar fluxos de trabalho não relacionados — um por projeto, repositório ou domínio. Os workers de um quadro nunca veem as tarefas de outro quadro.",
     slugHint: "— minúsculas, hífenes, p. ex. atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Nome a apresentar",
     displayNameHint: "(opcional)",
     description: "Descrição",
@@ -637,7 +554,6 @@ export const pt: Translations = {
     createBoard: "Criar quadro",
     search: "Pesquisar",
     filterCards: "Filtrar cartões…",
-    tenant: "Tenant",
     allTenants: "Todos os tenants",
     assignee: "Responsável",
     allProfiles: "Todos os perfis",
@@ -667,8 +583,7 @@ export const pt: Translations = {
     runHistory: "Histórico de execuções",
     workerLog: "Registo do worker",
     loadingLog: "A carregar registo…",
-    noWorkerLog:
-      "— ainda não há registo do worker (a tarefa não foi iniciada ou o registo foi rotacionado) —",
+    noWorkerLog: "— ainda não há registo do worker (a tarefa não foi iniciada ou o registo foi rotacionado) —",
     noDescription: "— sem descrição —",
     noComments: "— sem comentários —",
     edit: "editar",
@@ -699,8 +614,7 @@ export const pt: Translations = {
     reassign: "Reatribuir",
     renderingError: "O separador Kanban encontrou um erro de renderização",
     reloadView: "Recarregar vista",
-    wsAuthFailed:
-      "Falha de autenticação WebSocket — recarregue a página para atualizar o token de sessão.",
+    wsAuthFailed: "Falha de autenticação WebSocket — recarregue a página para atualizar o token de sessão.",
     markDone: "Marcar {n} tarefa(s) como concluídas?",
     markArchived: "Arquivar {n} tarefa(s)?",
     warning: "Aviso",
@@ -711,8 +625,7 @@ export const pt: Translations = {
     showAllAttempts: "Mostrar todas as tentativas",
     sendingUpdates: "A enviar atualizações para",
     sendNotifications: "Enviar notificações de completed / blocked / gave_up para",
-    archiveBoardConfirm:
-      "Arquivar o quadro '{name}'? Será movido para boards/_archived/ para que possa recuperá-lo mais tarde. As tarefas deste quadro deixarão de aparecer em qualquer parte da interface.",
+    archiveBoardConfirm: "Arquivar o quadro '{name}'? Será movido para boards/_archived/ para que possa recuperá-lo mais tarde. As tarefas deste quadro deixarão de aparecer em qualquer parte da interface.",
     archiveBoardTitle: "Arquivar este quadro",
     boardSwitcherHint: "Os quadros permitem-lhe separar fluxos de trabalho não relacionados",
     taskCreatedWarning: "Tarefa criada, mas: ",
@@ -751,28 +664,19 @@ export const pt: Translations = {
       done: "Concluído",
       archived: "Arquivado",
     },
-    confirmDone:
-      "Marcar esta tarefa como concluída? A reivindicação do worker é libertada e os filhos dependentes ficam prontos.",
-    confirmArchive:
-      "Arquivar esta tarefa? Desaparece da vista padrão do quadro.",
-    confirmBlocked:
-      "Marcar esta tarefa como bloqueada? A reivindicação do worker é libertada.",
-    completionSummary:
-      "Resumo de conclusão para {label}. Será guardado como o resultado da tarefa.",
-    completionSummaryRequired:
-      "É necessário um resumo de conclusão antes de marcar uma tarefa como concluída.",
+    confirmDone: "Marcar esta tarefa como concluída? A reivindicação do worker é libertada e os filhos dependentes ficam prontos.",
+    confirmArchive: "Arquivar esta tarefa? Desaparece da vista padrão do quadro.",
+    confirmBlocked: "Marcar esta tarefa como bloqueada? A reivindicação do worker é libertada.",
+    completionSummary: "Resumo de conclusão para {label}. Será guardado como o resultado da tarefa.",
+    completionSummaryRequired: "É necessário um resumo de conclusão antes de marcar uma tarefa como concluída.",
     triagePlaceholder: "Ideia aproximada — a IA irá especificá-la…",
     taskTitlePlaceholder: "Título da nova tarefa…",
-    specifier: "specifier",
     assigneePlaceholder: "responsável",
     priority: "Prioridade",
-    skillsPlaceholder:
-      "competências (opcional, separadas por vírgulas): translation, github-code-review",
+    skillsPlaceholder: "competências (opcional, separadas por vírgulas): translation, github-code-review",
     noParent: "— sem pai —",
     workspacePathDir: "caminho do espaço de trabalho (obrigatório, p. ex. ~/projects/my-app)",
-    workspacePathOptional:
-      "caminho do espaço de trabalho (opcional, derivado do responsável se vazio)",
+    workspacePathOptional: "caminho do espaço de trabalho (opcional, derivado do responsável se vazio)",
     logTruncated: "(a mostrar os últimos 100 KB — registo completo em ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const ru: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const ru = defineLocale({
   common: {
     save: "Сохранить",
     saving: "Сохранение...",
@@ -43,20 +47,12 @@ export const ru: Translations = {
     expand: "Развернуть",
     general: "Общие",
     messaging: "Мессенджеры",
-    pluginLoadFailed:
-      "Не удалось загрузить скрипт этого плагина. Проверьте вкладку «Сеть» (dashboard-plugins/…) и путь к плагинам на сервере.",
-    pluginNotRegistered:
-      "Скрипт плагина не вызвал register() или завершился с ошибкой. Откройте консоль браузера для подробностей.",
+    pluginLoadFailed: "Не удалось загрузить скрипт этого плагина. Проверьте вкладку «Сеть» (dashboard-plugins/…) и путь к плагинам на сервере.",
+    pluginNotRegistered: "Скрипт плагина не вызвал register() или завершился с ошибкой. Откройте консоль браузера для подробностей.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Закрыть навигацию",
     closeModelTools: "Закрыть модель и инструменты",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Активные сессии:",
     gatewayStatusLabel: "Статус шлюза:",
     gatewayStrip: {
@@ -70,7 +66,6 @@ export const ru: Translations = {
       analytics: "Аналитика",
       chat: "Чат",
       config: "Конфигурация",
-      cron: "Cron",
       documentation: "Документация",
       keys: "Ключи",
       logs: "Журналы",
@@ -89,9 +84,7 @@ export const ru: Translations = {
     sessionsActiveCount: "{count} активн.",
     statusOverview: "Обзор статуса",
     system: "Система",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "Ошибка действия",
     actionFinished: "Завершено",
@@ -108,7 +101,6 @@ export const ru: Translations = {
     lastUpdate: "Последнее обновление",
     noneRunning: "Нет",
     notRunning: "Не запущено",
-    pid: "PID",
     platformDisconnected: "отключено",
     platformError: "ошибка",
     recentSessions: "Недавние сессии",
@@ -124,7 +116,6 @@ export const ru: Translations = {
     updatingHermes: "Обновление Hermes…",
     waitingForOutput: "Ожидание вывода…",
   },
-
   sessions: {
     title: "Сессии",
     history: "История",
@@ -143,14 +134,12 @@ export const ru: Translations = {
     untitledSession: "Сессия без названия",
     deleteSession: "Удалить сессию",
     confirmDeleteTitle: "Удалить сессию?",
-    confirmDeleteMessage:
-      "Это безвозвратно удалит разговор и все его сообщения. Действие нельзя отменить.",
+    confirmDeleteMessage: "Это безвозвратно удалит разговор и все его сообщения. Действие нельзя отменить.",
     sessionDeleted: "Сессия удалена",
     failedToDelete: "Не удалось удалить сессию",
     deleteEmpty: "Удалить пустые",
     deleteEmptyConfirmTitle: "Удалить пустые сессии?",
-    deleteEmptyConfirmMessage:
-      "Это безвозвратно удалит {count} сессий без сообщений. Активные и архивные сессии будут пропущены. Это действие нельзя отменить.",
+    deleteEmptyConfirmMessage: "Это безвозвратно удалит {count} сессий без сообщений. Активные и архивные сессии будут пропущены. Это действие нельзя отменить.",
     emptySessionsDeleted: "Удалено пустых сессий: {count}",
     failedToDeleteEmpty: "Не удалось удалить пустые сессии",
     selectSession: "Выбрать сессию",
@@ -159,8 +148,7 @@ export const ru: Translations = {
     selectedCount: "Выбрано: {count}",
     deleteSelected: "Удалить {count}",
     deleteSelectedConfirmTitle: "Удалить {count} сессий?",
-    deleteSelectedConfirmMessage:
-      "Это безвозвратно удалит {count} выбранных сессий и все их сообщения. Это действие нельзя отменить.",
+    deleteSelectedConfirmMessage: "Это безвозвратно удалит {count} выбранных сессий и все их сообщения. Это действие нельзя отменить.",
     selectedSessionsDeleted: "Удалено сессий: {count}",
     failedToDeleteSelected: "Не удалось удалить выбранные сессии",
     resumeInChat: "Продолжить в чате",
@@ -174,7 +162,6 @@ export const ru: Translations = {
       tool: "Инструмент",
     },
   },
-
   analytics: {
     period: "Период:",
     totalTokens: "Всего токенов",
@@ -200,7 +187,6 @@ export const ru: Translations = {
     acrossModels: "по {count} моделям",
     inOut: "{input} вход / {output} выход",
   },
-
   models: {
     modelsUsed: "Использовано моделей",
     estimatedCost: "Оценка стоимости",
@@ -212,7 +198,6 @@ export const ru: Translations = {
     noModelsData: "Нет данных по моделям за этот период",
     startSession: "Начните сессию, чтобы увидеть данные по моделям",
   },
-
   logs: {
     title: "Журналы",
     autoRefresh: "Автообновление",
@@ -222,10 +207,8 @@ export const ru: Translations = {
     lines: "Строк",
     noLogLines: "Записи журнала не найдены",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Это удалит задачу из расписания. Действие нельзя отменить.",
+    confirmDeleteMessage: "Это удалит задачу из расписания. Действие нельзя отменить.",
     confirmDeleteTitle: "Удалить запланированную задачу?",
     newJob: "Новая Cron-задача",
     nameOptional: "Имя (необязательно)",
@@ -233,7 +216,6 @@ export const ru: Translations = {
     prompt: "Запрос",
     promptPlaceholder: "Что должен делать агент при каждом запуске?",
     schedule: "Расписание (cron-выражение)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Расписание",
     scheduleModes: {
       interval: "Повторяющийся интервал",
@@ -249,18 +231,15 @@ export const ru: Translations = {
       unitDays: "дней",
       timeOfDay: "Время суток",
       weekdays: "Дни недели",
-      weekdaysShort: ["Вс", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"],
+      weekdaysShort: ["Вс","Пн","Вт","Ср","Чт","Пт","Сб"],
       dayOfMonth: "День месяца",
       onceAt: "Выполнить в",
       customLabel: "Cron-выражение",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "Cron-выражение из пяти полей (минута, час, день, месяц, день недели).",
+      customHint: "Cron-выражение из пяти полей (минута, час, день, месяц, день недели).",
       preview: "Отправляется как",
       previewEmpty: "(не заполнено)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "Каждые {n} мин",
       everyHours: "Каждые {n} ч",
       everyDays: "Каждые {n} дн",
@@ -279,26 +258,20 @@ export const ru: Translations = {
     triggerNow: "Запустить сейчас",
     delivery: {
       local: "Локально",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "Новый профиль",
     name: "Имя",
     namePlaceholder: "напр. coder, writer и т.п.",
     nameRequired: "Имя обязательно",
-    nameRule:
-      "Только строчные буквы, цифры, _ и -; должно начинаться с буквы или цифры; до 64 символов.",
-    invalidName: "Недопустимое имя профиля",    cloneFrom: "Клонировать конфигурацию из профиля",
+    nameRule: "Только строчные буквы, цифры, _ и -; должно начинаться с буквы или цифры; до 64 символов.",
+    invalidName: "Недопустимое имя профиля",
+    cloneFrom: "Клонировать конфигурацию из профиля",
     cloneFromNone: "Нет (пусто)",
     allProfiles: "Профили",
     noProfiles: "Профили не найдены.",
     defaultBadge: "по умолчанию",
-    hasEnv: "env",
     model: "Модель",
     skills: "Навыки",
     rename: "Переименовать",
@@ -311,13 +284,11 @@ export const ru: Translations = {
     commandCopied: "Скопировано в буфер обмена",
     copyFailed: "Не удалось скопировать",
     confirmDeleteTitle: "Удалить профиль?",
-    confirmDeleteMessage:
-      "Это безвозвратно удалит профиль '{name}' — конфигурацию, ключи, память, сессии, навыки, cron-задачи. Отменить нельзя.",
+    confirmDeleteMessage: "Это безвозвратно удалит профиль '{name}' — конфигурацию, ключи, память, сессии, навыки, cron-задачи. Отменить нельзя.",
     created: "Создан",
     deleted: "Удалён",
     renamed: "Переименован",
   },
-
   pluginsPage: {
     contextEngineLabel: "Движок контекста",
     dashboardSlots: "Слоты панели",
@@ -325,8 +296,7 @@ export const ru: Translations = {
     enableAfterInstall: "Включить после установки",
     enableRuntime: "Включить",
     forceReinstall: "Принудительная переустановка (сначала удалить существующую папку)",
-    headline:
-      "Поиск, установка, включение и обновление плагинов Hermes (аналог `hermes plugins`).",
+    headline: "Поиск, установка, включение и обновление плагинов Hermes (аналог `hermes plugins`).",
     identifierLabel: "Git URL или owner/repo",
     inactive: "неактивно",
     installBtn: "Установить",
@@ -340,8 +310,7 @@ export const ru: Translations = {
     pluginListHeading: "Установленные плагины",
     providerDefaults: "встроенный / по умолчанию",
     providersHeading: "Плагины-провайдеры рантайма",
-    providersHint:
-      "Записывает memory.provider (пусто = встроенный) и context.engine в config.yaml. Применяется со следующей сессии.",
+    providersHint: "Записывает memory.provider (пусто = встроенный) и context.engine в config.yaml. Применяется со следующей сессии.",
     refreshDashboard: "Пересканировать расширения панели",
     removeConfirm: "Удалить этот плагин из ~/.hermes/plugins/?",
     removeHint: "Удалять можно только плагины, установленные пользователем в ~/.hermes/plugins.",
@@ -353,12 +322,10 @@ export const ru: Translations = {
     sourceBadge: "Источник",
     authRequired: "Требуется аутентификация",
     authRequiredHint: "Выполните эту команду для аутентификации:",
-    updateGit: "Git pull",
     versionBadge: "Версия",
     showInSidebar: "Показывать в боковой панели",
     hideFromSidebar: "Скрыть из боковой панели",
   },
-
   skills: {
     title: "Навыки",
     searchPlaceholder: "Поиск навыков и наборов инструментов...",
@@ -378,13 +345,10 @@ export const ru: Translations = {
     disabledForCli: "Отключено для CLI",
     more: "+{count} ещё",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "Фильтры",
     sections: "Разделы",
     exportConfig: "Экспортировать конфигурацию в JSON",
-    importConfig: "Импортировать конфигурацию из JSON",
     resetDefaults: "Сбросить к значениям по умолчанию",
     resetScopeTooltip: "Сбросить {scope} к значениям по умолчанию",
     confirmResetScope: "Сбросить все настройки {scope} к значениям по умолчанию? Это обновит только форму — изменения не будут записаны в config.yaml, пока вы не нажмёте «Сохранить».",
@@ -392,7 +356,7 @@ export const ru: Translations = {
     rawYaml: "Исходная YAML-конфигурация",
     searchResults: "Результаты поиска",
     fields: "пол{s}",
-    noFieldsMatch: 'Нет полей, соответствующих "{query}"',
+    noFieldsMatch: "Нет полей, соответствующих \"{query}\"",
     configSaved: "Конфигурация сохранена",
     yamlConfigSaved: "YAML-конфигурация сохранена",
     failedToSave: "Не удалось сохранить",
@@ -414,15 +378,12 @@ export const ru: Translations = {
       tts: "Синтез речи",
       stt: "Распознавание речи",
       logging: "Журналирование",
-      discord: "Discord",
       auxiliary: "Вспомогательные",
     },
   },
-
   env: {
     changesNote: "Изменения сохраняются на диск немедленно. Активные сессии автоматически подхватывают новые ключи.",
-    confirmClearMessage:
-      "Сохранённое значение этой переменной будет удалено из вашего файла .env. Это нельзя отменить из интерфейса.",
+    confirmClearMessage: "Сохранённое значение этой переменной будет удалено из вашего файла .env. Это нельзя отменить из интерфейса.",
     confirmClearTitle: "Очистить этот ключ?",
     description: "Управление API-ключами и секретами, хранящимися в",
     hideAdvanced: "Скрыть расширенные",
@@ -448,12 +409,10 @@ export const ru: Translations = {
     add: "Добавить",
     invalidKeyName: "Используйте только буквы, цифры и подчёркивания (должно начинаться с буквы или подчёркивания).",
   },
-
   oauth: {
     title: "Входы провайдеров (OAuth)",
     providerLogins: "Входы провайдеров (OAuth)",
-    description:
-      "Подключено {connected} из {total} OAuth-провайдеров. Используйте «Войти» для процессов, поддерживаемых панелью; команды CLI остаются доступными для внешней или резервной настройки.",
+    description: "Подключено {connected} из {total} OAuth-провайдеров. Используйте «Войти» для процессов, поддерживаемых панелью; команды CLI остаются доступными для внешней или резервной настройки.",
     connected: "Подключено",
     expired: "Срок истёк",
     notConnected: "Не подключено. Используйте «Войти», если доступно, или выполните {command} в терминале.",
@@ -490,24 +449,17 @@ export const ru: Translations = {
     },
     expiresIn: "истекает через {time}",
   },
-
   language: {
     switchTo: "Сменить язык",
   },
-
   theme: {
     title: "Тема",
     switchTheme: "Сменить тему",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Коллекционные значки Hermes, полученные на основе реальной истории сессий. Известные, но ещё не полученные достижения отображаются как «Обнаруженные»; «Секретные» достижения остаются скрытыми до появления первого подходящего поведения.",
-      scan_subtitle:
-        "Анализ истории сессий Hermes. Первое сканирование может занять 5–10 секунд при большой истории.",
+      subtitle: "Коллекционные значки Hermes, полученные на основе реальной истории сессий. Известные, но ещё не полученные достижения отображаются как «Обнаруженные»; «Секретные» достижения остаются скрытыми до появления первого подходящего поведения.",
+      scan_subtitle: "Анализ истории сессий Hermes. Первое сканирование может занять 5–10 секунд при большой истории.",
     },
     actions: {
       rescan: "Пересканировать",
@@ -520,7 +472,6 @@ export const ru: Translations = {
       secrets: "Секреты",
       secrets_hint: "скрыты до первого сигнала",
       highest_tier: "Высший уровень",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "Последнее",
       latest_hint_empty: "запускайте Hermes чаще",
       none_yet: "Пока нет",
@@ -541,25 +492,19 @@ export const ru: Translations = {
     },
     scan: {
       building_headline: "Создание профиля достижений…",
-      building_detail:
-        "Чтение сессий, вызовов инструментов, метаданных моделей и состояния разблокировки.",
+      building_detail: "Чтение сессий, вызовов инструментов, метаданных моделей и состояния разблокировки.",
       starting_headline: "Запуск сканирования достижений…",
-      progress_detail:
-        "Просканировано {scanned} из {total} сессий · {pct}%. Значки разблокируются по мере поступления истории.",
-      idle_detail:
-        "Чтение сессий, вызовов инструментов, метаданных моделей и состояния разблокировки. Значки появляются здесь по мере разблокировки.",
+      progress_detail: "Просканировано {scanned} из {total} сессий · {pct}%. Значки разблокируются по мере поступления истории.",
+      idle_detail: "Чтение сессий, вызовов инструментов, метаданных моделей и состояния разблокировки. Значки появляются здесь по мере разблокировки.",
     },
     guide: {
       tiers_header: "Уровни",
       secret_header: "Секретные достижения",
-      secret_body:
-        "Секретные достижения скрывают свой точный триггер. Как только Hermes обнаруживает связанный сигнал, карточка становится «Обнаруженной» и показывает требование.",
+      secret_body: "Секретные достижения скрывают свой точный триггер. Как только Hermes обнаруживает связанный сигнал, карточка становится «Обнаруженной» и показывает требование.",
       scan_status_header: "Статус сканирования",
-      scan_status_body:
-        "Hermes сканирует локальную историю один раз, затем карточки появятся автоматически. Если это занимает несколько секунд — ничего не зависло.",
+      scan_status_body: "Hermes сканирует локальную историю один раз, затем карточки появятся автоматически. Если это занимает несколько секунд — ничего не зависло.",
       what_scanned_header: "Что сканируется",
-      what_scanned_body:
-        "Сессии, вызовы инструментов, метаданные моделей, ошибки, достижения и локальное состояние разблокировки.",
+      what_scanned_body: "Сессии, вызовы инструментов, метаданные моделей, ошибки, достижения и локальное состояние разблокировки.",
     },
     card: {
       share_title: "Поделиться этим достижением",
@@ -576,8 +521,7 @@ export const ru: Translations = {
     },
     empty: {
       no_secrets_header: "В этом сканировании больше не осталось скрытых секретов.",
-      no_secrets_body:
-        "Подсказка: секреты обычно начинаются с необычных ошибок или паттернов опытных пользователей — конфликты портов, ограничения прав, отсутствующие переменные окружения, ошибки YAML, коллизии Docker, использование rollback/checkpoint, попадания в кеш или мелкие исправления после большого количества красного текста.",
+      no_secrets_body: "Подсказка: секреты обычно начинаются с необычных ошибок или паттернов опытных пользователей — конфликты портов, ограничения прав, отсутствующие переменные окружения, ошибки YAML, коллизии Docker, использование rollback/checkpoint, попадания в кеш или мелкие исправления после большого количества красного текста.",
     },
     filters: {
       all_categories: "Все",
@@ -599,31 +543,19 @@ export const ru: Translations = {
       copy_button: "Скопировать изображение",
       copied: "Скопировано ✓",
       download_button: "Скачать PNG",
-      hint:
-        "«Поделиться в X» открывает пост с заранее заполненным текстом в новой вкладке. Сначала нажмите «Скопировать изображение», если хотите прикрепить значок 1200×630 — X позволяет вставить его прямо в редактор твита. «Скачать PNG» сохраняет файл для использования где угодно.",
-      clipboard_unsupported:
-        "Копирование изображений в буфер обмена не поддерживается в этом браузере — используйте «Скачать».",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "«Поделиться в X» открывает пост с заранее заполненным текстом в новой вкладке. Сначала нажмите «Скопировать изображение», если хотите прикрепить значок 1200×630 — X позволяет вставить его прямо в редактор твита. «Скачать PNG» сохраняет файл для использования где угодно.",
+      clipboard_unsupported: "Копирование изображений в буфер обмена не поддерживается в этом браузере — используйте «Скачать».",
     },
   },
   kanban: {
     loading: "Загрузка доски Kanban…",
     loadFailed: "Не удалось загрузить доску Kanban: ",
-    loadFailedHint:
-      "Бэкенд автоматически создаёт kanban.db при первом чтении. Если ошибка повторяется, проверьте логи панели.",
+    loadFailedHint: "Бэкенд автоматически создаёт kanban.db при первом чтении. Если ошибка повторяется, проверьте логи панели.",
     board: "Доска",
     newBoard: "+ Новая доска",
     newBoardTitle: "Новая доска",
-    newBoardDescription:
-      "Доски позволяют разделять не связанные между собой потоки работы — по одной на проект, репозиторий или область. Воркеры одной доски никогда не видят задачи другой.",
-    slug: "Slug",
+    newBoardDescription: "Доски позволяют разделять не связанные между собой потоки работы — по одной на проект, репозиторий или область. Воркеры одной доски никогда не видят задачи другой.",
     slugHint: "— строчные буквы, дефисы, например atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Отображаемое имя",
     displayNameHint: "(необязательно)",
     description: "Описание",
@@ -636,7 +568,6 @@ export const ru: Translations = {
     createBoard: "Создать доску",
     search: "Поиск",
     filterCards: "Фильтр карточек…",
-    tenant: "Tenant",
     allTenants: "Все tenant'ы",
     assignee: "Исполнитель",
     allProfiles: "Все профили",
@@ -666,8 +597,7 @@ export const ru: Translations = {
     runHistory: "История запусков",
     workerLog: "Журнал воркера",
     loadingLog: "Загрузка журнала…",
-    noWorkerLog:
-      "— журнала воркера ещё нет (задача не запускалась или журнал был ротирован) —",
+    noWorkerLog: "— журнала воркера ещё нет (задача не запускалась или журнал был ротирован) —",
     noDescription: "— нет описания —",
     noComments: "— нет комментариев —",
     edit: "изменить",
@@ -698,8 +628,7 @@ export const ru: Translations = {
     reassign: "Переназначить",
     renderingError: "Во вкладке Kanban произошла ошибка отрисовки",
     reloadView: "Перезагрузить вид",
-    wsAuthFailed:
-      "Сбой аутентификации WebSocket — перезагрузите страницу, чтобы обновить токен сессии.",
+    wsAuthFailed: "Сбой аутентификации WebSocket — перезагрузите страницу, чтобы обновить токен сессии.",
     markDone: "Отметить {n} задач(и) как выполненные?",
     markArchived: "Архивировать {n} задач(и)?",
     warning: "Предупреждение",
@@ -710,8 +639,7 @@ export const ru: Translations = {
     showAllAttempts: "Показать все попытки",
     sendingUpdates: "Отправка обновлений в",
     sendNotifications: "Отправлять уведомления completed / blocked / gave_up в",
-    archiveBoardConfirm:
-      "Архивировать доску '{name}'? Она будет перемещена в boards/_archived/, чтобы её можно было восстановить позже. Задачи этой доски больше не будут отображаться нигде в интерфейсе.",
+    archiveBoardConfirm: "Архивировать доску '{name}'? Она будет перемещена в boards/_archived/, чтобы её можно было восстановить позже. Задачи этой доски больше не будут отображаться нигде в интерфейсе.",
     archiveBoardTitle: "Архивировать эту доску",
     boardSwitcherHint: "Доски позволяют разделять не связанные между собой потоки работы",
     taskCreatedWarning: "Задача создана, но: ",
@@ -750,28 +678,19 @@ export const ru: Translations = {
       done: "Завершено",
       archived: "В архиве",
     },
-    confirmDone:
-      "Отметить эту задачу как выполненную? Захват воркера будет освобождён, а зависимые потомки станут готовыми.",
-    confirmArchive:
-      "Архивировать эту задачу? Она исчезнет из стандартного вида доски.",
-    confirmBlocked:
-      "Отметить эту задачу как заблокированную? Захват воркера будет освобождён.",
-    completionSummary:
-      "Сводка завершения для {label}. Сохраняется как результат задачи.",
-    completionSummaryRequired:
-      "Перед отметкой задачи как выполненной требуется сводка завершения.",
+    confirmDone: "Отметить эту задачу как выполненную? Захват воркера будет освобождён, а зависимые потомки станут готовыми.",
+    confirmArchive: "Архивировать эту задачу? Она исчезнет из стандартного вида доски.",
+    confirmBlocked: "Отметить эту задачу как заблокированную? Захват воркера будет освобождён.",
+    completionSummary: "Сводка завершения для {label}. Сохраняется как результат задачи.",
+    completionSummaryRequired: "Перед отметкой задачи как выполненной требуется сводка завершения.",
     triagePlaceholder: "Черновая идея — ИИ её проспецифицирует…",
     taskTitlePlaceholder: "Название новой задачи…",
-    specifier: "specifier",
     assigneePlaceholder: "исполнитель",
     priority: "Приоритет",
-    skillsPlaceholder:
-      "навыки (необязательно, через запятую): translation, github-code-review",
+    skillsPlaceholder: "навыки (необязательно, через запятую): translation, github-code-review",
     noParent: "— без родителя —",
     workspacePathDir: "путь к рабочей области (обязательно, например ~/projects/my-app)",
-    workspacePathOptional:
-      "путь к рабочей области (необязательно, выводится из исполнителя, если не указан)",
+    workspacePathOptional: "путь к рабочей области (необязательно, выводится из исполнителя, если не указан)",
     logTruncated: "(показаны последние 100 KB — полный журнал в ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const tr: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const tr = defineLocale({
   common: {
     save: "Kaydet",
     saving: "Kaydediliyor...",
@@ -26,7 +30,6 @@ export const tr: Translations = {
     unknown: "bilinmiyor",
     untitled: "Başlıksız",
     none: "Yok",
-    form: "Form",
     noResults: "Sonuç yok",
     of: "/",
     page: "Sayfa",
@@ -43,20 +46,12 @@ export const tr: Translations = {
     expand: "Genişlet",
     general: "Genel",
     messaging: "Mesajlaşma",
-    pluginLoadFailed:
-      "Bu eklentinin betiği yüklenemedi. Ağ sekmesini (dashboard-plugins/…) ve sunucunun eklenti yolunu kontrol edin.",
-    pluginNotRegistered:
-      "Eklenti betiği register() çağırmadı veya betik hata verdi. Ayrıntılar için tarayıcı konsolunu açın.",
+    pluginLoadFailed: "Bu eklentinin betiği yüklenemedi. Ağ sekmesini (dashboard-plugins/…) ve sunucunun eklenti yolunu kontrol edin.",
+    pluginNotRegistered: "Eklenti betiği register() çağırmadı veya betik hata verdi. Ayrıntılar için tarayıcı konsolunu açın.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Gezintiyi kapat",
     closeModelTools: "Modeli ve araçları kapat",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Aktif Oturumlar:",
     gatewayStatusLabel: "Ağ Geçidi Durumu:",
     gatewayStrip: {
@@ -70,7 +65,6 @@ export const tr: Translations = {
       analytics: "Analiz",
       chat: "Sohbet",
       config: "Yapılandırma",
-      cron: "Cron",
       documentation: "Dokümantasyon",
       keys: "Anahtarlar",
       logs: "Günlükler",
@@ -81,7 +75,6 @@ export const tr: Translations = {
       skills: "Yetenekler",
     },
     modelToolsSheetSubtitle: "& araçlar",
-    modelToolsSheetTitle: "Model",
     navigation: "Gezinti",
     openDocumentation: "Dokümantasyonu yeni sekmede aç",
     openNavigation: "Gezintiyi aç",
@@ -89,14 +82,11 @@ export const tr: Translations = {
     sessionsActiveCount: "{count} aktif",
     statusOverview: "Durum özeti",
     system: "Sistem",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "İşlem başarısız",
     actionFinished: "Tamamlandı",
     actions: "İşlemler",
-    agent: "Agent",
     activeSessions: "Aktif Oturumlar",
     connected: "Bağlandı",
     connectedPlatforms: "Bağlı Platformlar",
@@ -108,7 +98,6 @@ export const tr: Translations = {
     lastUpdate: "Son güncelleme",
     noneRunning: "Yok",
     notRunning: "Çalışmıyor",
-    pid: "PID",
     platformDisconnected: "bağlantı kesildi",
     platformError: "hata",
     recentSessions: "Son Oturumlar",
@@ -124,7 +113,6 @@ export const tr: Translations = {
     updatingHermes: "Hermes güncelleniyor…",
     waitingForOutput: "Çıktı bekleniyor…",
   },
-
   sessions: {
     title: "Oturumlar",
     history: "Geçmiş",
@@ -143,14 +131,12 @@ export const tr: Translations = {
     untitledSession: "Başlıksız oturum",
     deleteSession: "Oturumu sil",
     confirmDeleteTitle: "Oturum silinsin mi?",
-    confirmDeleteMessage:
-      "Bu, konuşmayı ve tüm mesajlarını kalıcı olarak siler. Bu işlem geri alınamaz.",
+    confirmDeleteMessage: "Bu, konuşmayı ve tüm mesajlarını kalıcı olarak siler. Bu işlem geri alınamaz.",
     sessionDeleted: "Oturum silindi",
     failedToDelete: "Oturum silinemedi",
     deleteEmpty: "Boşları sil",
     deleteEmptyConfirmTitle: "Boş oturumlar silinsin mi?",
-    deleteEmptyConfirmMessage:
-      "Bu işlem, mesaj içermeyen {count} oturumu kalıcı olarak siler. Aktif ve arşivlenmiş oturumlar atlanır. Bu işlem geri alınamaz.",
+    deleteEmptyConfirmMessage: "Bu işlem, mesaj içermeyen {count} oturumu kalıcı olarak siler. Aktif ve arşivlenmiş oturumlar atlanır. Bu işlem geri alınamaz.",
     emptySessionsDeleted: "{count} boş oturum silindi",
     failedToDeleteEmpty: "Boş oturumlar silinemedi",
     selectSession: "Oturumu seç",
@@ -159,8 +145,7 @@ export const tr: Translations = {
     selectedCount: "{count} seçildi",
     deleteSelected: "{count} sil",
     deleteSelectedConfirmTitle: "{count} oturum silinsin mi?",
-    deleteSelectedConfirmMessage:
-      "Bu, seçilen {count} oturumu ve tüm mesajlarını kalıcı olarak siler. Bu işlem geri alınamaz.",
+    deleteSelectedConfirmMessage: "Bu, seçilen {count} oturumu ve tüm mesajlarını kalıcı olarak siler. Bu işlem geri alınamaz.",
     selectedSessionsDeleted: "{count} oturum silindi",
     failedToDeleteSelected: "Seçilen oturumlar silinemedi",
     resumeInChat: "Sohbette Devam Et",
@@ -174,7 +159,6 @@ export const tr: Translations = {
       tool: "Araç",
     },
   },
-
   analytics: {
     period: "Dönem:",
     totalTokens: "Toplam Token",
@@ -194,13 +178,11 @@ export const tr: Translations = {
     noUsageData: "Bu dönem için kullanım verisi yok",
     startSession: "Burada analizleri görmek için bir oturum başlatın",
     date: "Tarih",
-    model: "Model",
     tokens: "Token",
     perDayAvg: "/gün ort",
     acrossModels: "{count} model üzerinden",
     inOut: "{input} giriş / {output} çıkış",
   },
-
   models: {
     modelsUsed: "Kullanılan Modeller",
     estimatedCost: "Tahmini Maliyet",
@@ -212,7 +194,6 @@ export const tr: Translations = {
     noModelsData: "Bu dönem için model kullanım verisi yok",
     startSession: "Burada model verilerini görmek için bir oturum başlatın",
   },
-
   logs: {
     title: "Günlükler",
     autoRefresh: "Otomatik yenile",
@@ -222,10 +203,8 @@ export const tr: Translations = {
     lines: "Satırlar",
     noLogLines: "Günlük satırı bulunamadı",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Bu, görevi zamanlamadan kaldırır. Bu işlem geri alınamaz.",
+    confirmDeleteMessage: "Bu, görevi zamanlamadan kaldırır. Bu işlem geri alınamaz.",
     confirmDeleteTitle: "Zamanlanmış görev silinsin mi?",
     newJob: "Yeni Cron Görevi",
     nameOptional: "Ad (isteğe bağlı)",
@@ -233,7 +212,6 @@ export const tr: Translations = {
     prompt: "İstem",
     promptPlaceholder: "Agent her çalıştırmada ne yapmalı?",
     schedule: "Zamanlama (cron ifadesi)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Zamanlama",
     scheduleModes: {
       interval: "Tekrarlanan aralık",
@@ -249,18 +227,15 @@ export const tr: Translations = {
       unitDays: "gün",
       timeOfDay: "Günün saati",
       weekdays: "Haftanın günleri",
-      weekdaysShort: ["Paz", "Pzt", "Sal", "Çar", "Per", "Cum", "Cmt"],
+      weekdaysShort: ["Paz","Pzt","Sal","Çar","Per","Cum","Cmt"],
       dayOfMonth: "Ayın günü",
       onceAt: "Çalıştırma zamanı",
       customLabel: "Cron ifadesi",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "Beş alanlı cron ifadesi (dakika, saat, gün, ay, haftanın günü).",
+      customHint: "Beş alanlı cron ifadesi (dakika, saat, gün, ay, haftanın günü).",
       preview: "Gönderilecek olan",
       previewEmpty: "(eksik)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "Her {n} dk",
       everyHours: "Her {n} sa",
       everyDays: "Her {n} gün",
@@ -279,27 +254,20 @@ export const tr: Translations = {
     triggerNow: "Şimdi tetikle",
     delivery: {
       local: "Yerel",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "Yeni Profil",
     name: "Ad",
     namePlaceholder: "örn. coder, writer, vb.",
     nameRequired: "Ad gereklidir",
-    nameRule:
-      "Yalnızca küçük harfler, rakamlar, _ ve - kullanılabilir; harf veya rakamla başlamalı; en fazla 64 karakter.",
-    invalidName: "Geçersiz profil adı",    cloneFrom: "Profilden yapılandırmayı klonla",
+    nameRule: "Yalnızca küçük harfler, rakamlar, _ ve - kullanılabilir; harf veya rakamla başlamalı; en fazla 64 karakter.",
+    invalidName: "Geçersiz profil adı",
+    cloneFrom: "Profilden yapılandırmayı klonla",
     cloneFromNone: "Hiçbiri (boş)",
     allProfiles: "Profiller",
     noProfiles: "Profil bulunamadı.",
     defaultBadge: "varsayılan",
-    hasEnv: "env",
-    model: "Model",
     skills: "Yetenekler",
     rename: "Yeniden adlandır",
     editSoul: "SOUL.md'yi düzenle",
@@ -311,13 +279,11 @@ export const tr: Translations = {
     commandCopied: "Panoya kopyalandı",
     copyFailed: "Kopyalanamadı",
     confirmDeleteTitle: "Profil silinsin mi?",
-    confirmDeleteMessage:
-      "Bu, '{name}' profilini kalıcı olarak siler — yapılandırma, anahtarlar, hatıralar, oturumlar, yetenekler, cron görevleri. Geri alınamaz.",
+    confirmDeleteMessage: "Bu, '{name}' profilini kalıcı olarak siler — yapılandırma, anahtarlar, hatıralar, oturumlar, yetenekler, cron görevleri. Geri alınamaz.",
     created: "Oluşturuldu",
     deleted: "Silindi",
     renamed: "Yeniden adlandırıldı",
   },
-
   pluginsPage: {
     contextEngineLabel: "Bağlam motoru",
     dashboardSlots: "Pano yuvaları",
@@ -325,8 +291,7 @@ export const tr: Translations = {
     enableAfterInstall: "Yüklemeden sonra etkinleştir",
     enableRuntime: "Etkinleştir",
     forceReinstall: "Yeniden yüklemeyi zorla (önce mevcut klasörü sil)",
-    headline:
-      "Hermes eklentilerini keşfedin, yükleyin, etkinleştirin ve güncelleyin (`hermes plugins` ile eşdeğer).",
+    headline: "Hermes eklentilerini keşfedin, yükleyin, etkinleştirin ve güncelleyin (`hermes plugins` ile eşdeğer).",
     identifierLabel: "Git URL veya owner/repo",
     inactive: "pasif",
     installBtn: "Yükle",
@@ -340,8 +305,7 @@ export const tr: Translations = {
     pluginListHeading: "Yüklü eklentiler",
     providerDefaults: "yerleşik / varsayılan",
     providersHeading: "Çalışma zamanı sağlayıcı eklentileri",
-    providersHint:
-      "config.yaml'a memory.provider (boş = yerleşik) ve context.engine yazar. Bir sonraki oturumda etkili olur.",
+    providersHint: "config.yaml'a memory.provider (boş = yerleşik) ve context.engine yazar. Bir sonraki oturumda etkili olur.",
     refreshDashboard: "Pano uzantılarını yeniden tara",
     removeConfirm: "Bu eklenti ~/.hermes/plugins/ içinden kaldırılsın mı?",
     removeHint: "Yalnızca ~/.hermes/plugins altındaki kullanıcı tarafından yüklenmiş eklentiler kaldırılabilir.",
@@ -353,12 +317,10 @@ export const tr: Translations = {
     sourceBadge: "Kaynak",
     authRequired: "Kimlik doğrulama gerekli",
     authRequiredHint: "Kimlik doğrulamak için bu komutu çalıştırın:",
-    updateGit: "Git pull",
     versionBadge: "Sürüm",
     showInSidebar: "Kenar çubuğunda göster",
     hideFromSidebar: "Kenar çubuğundan gizle",
   },
-
   skills: {
     title: "Yetenekler",
     searchPlaceholder: "Yetenek ve araç setlerinde ara...",
@@ -378,13 +340,10 @@ export const tr: Translations = {
     disabledForCli: "CLI için devre dışı",
     more: "+{count} daha",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "Filtreler",
     sections: "Bölümler",
     exportConfig: "Yapılandırmayı JSON olarak dışa aktar",
-    importConfig: "Yapılandırmayı JSON'dan içe aktar",
     resetDefaults: "Varsayılanlara sıfırla",
     resetScopeTooltip: "{scope} varsayılanlara sıfırla",
     confirmResetScope: "{scope} ayarlarının tümü varsayılanlara sıfırlansın mı? Bu yalnızca formu günceller — değişiklikler Kaydet'e basılana kadar config.yaml'a yazılmaz.",
@@ -392,7 +351,7 @@ export const tr: Translations = {
     rawYaml: "Ham YAML Yapılandırması",
     searchResults: "Arama Sonuçları",
     fields: "alan{s}",
-    noFieldsMatch: '"{query}" ile eşleşen alan yok',
+    noFieldsMatch: "\"{query}\" ile eşleşen alan yok",
     configSaved: "Yapılandırma kaydedildi",
     yamlConfigSaved: "YAML yapılandırması kaydedildi",
     failedToSave: "Kaydedilemedi",
@@ -402,8 +361,6 @@ export const tr: Translations = {
     invalidJson: "Geçersiz JSON dosyası",
     categories: {
       general: "Genel",
-      agent: "Agent",
-      terminal: "Terminal",
       display: "Görüntü",
       delegation: "Yetkilendirme",
       memory: "Bellek",
@@ -414,15 +371,12 @@ export const tr: Translations = {
       tts: "Metinden Konuşmaya",
       stt: "Konuşmadan Metne",
       logging: "Günlükleme",
-      discord: "Discord",
       auxiliary: "Yardımcı",
     },
   },
-
   env: {
     changesNote: "Değişiklikler diske hemen kaydedilir. Aktif oturumlar yeni anahtarları otomatik olarak alır.",
-    confirmClearMessage:
-      "Bu değişken için saklanan değer .env dosyanızdan kaldırılacak. Bu işlem arayüzden geri alınamaz.",
+    confirmClearMessage: "Bu değişken için saklanan değer .env dosyanızdan kaldırılacak. Bu işlem arayüzden geri alınamaz.",
     confirmClearTitle: "Bu anahtar temizlensin mi?",
     description: "Şurada saklanan API anahtarlarını ve sırları yönetin",
     hideAdvanced: "Gelişmişi Gizle",
@@ -448,12 +402,10 @@ export const tr: Translations = {
     add: "Ekle",
     invalidKeyName: "Yalnızca harf, rakam ve alt çizgi kullanın (bir harf veya alt çizgi ile başlamalıdır).",
   },
-
   oauth: {
     title: "Sağlayıcı Girişleri (OAuth)",
     providerLogins: "Sağlayıcı Girişleri (OAuth)",
-    description:
-      "{connected}/{total} OAuth sağlayıcısı bağlandı. Panel destekli akışlar için Giriş'i kullanın; CLI komutları harici veya yedek kurulum için kullanılabilir.",
+    description: "{connected}/{total} OAuth sağlayıcısı bağlandı. Panel destekli akışlar için Giriş'i kullanın; CLI komutları harici veya yedek kurulum için kullanılabilir.",
     connected: "Bağlandı",
     expired: "Süresi doldu",
     notConnected: "Bağlı değil. Mümkünse Giriş'i kullanın veya bir terminalde {command} komutunu çalıştırın.",
@@ -490,24 +442,17 @@ export const tr: Translations = {
     },
     expiresIn: "{time} sonra sona erer",
   },
-
   language: {
     switchTo: "Dil değiştir",
   },
-
   theme: {
     title: "Tema",
     switchTheme: "Temayı değiştir",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Gerçek oturum geçmişinden kazanılan, koleksiyonluk Hermes rozetleri. Bilinen ama henüz tamamlanmamış başarılar Keşfedildi olarak gösterilir; Gizli başarılar ilk eşleşen davranış görünene kadar saklı kalır.",
-      scan_subtitle:
-        "Hermes oturum geçmişi taranıyor. Büyük geçmişlerde ilk tarama 5–10 saniye sürebilir.",
+      subtitle: "Gerçek oturum geçmişinden kazanılan, koleksiyonluk Hermes rozetleri. Bilinen ama henüz tamamlanmamış başarılar Keşfedildi olarak gösterilir; Gizli başarılar ilk eşleşen davranış görünene kadar saklı kalır.",
+      scan_subtitle: "Hermes oturum geçmişi taranıyor. Büyük geçmişlerde ilk tarama 5–10 saniye sürebilir.",
     },
     actions: {
       rescan: "Yeniden tara",
@@ -520,7 +465,6 @@ export const tr: Translations = {
       secrets: "Sırlar",
       secrets_hint: "ilk sinyale kadar gizli",
       highest_tier: "En yüksek kademe",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "En son",
       latest_hint_empty: "Hermes'i daha çok çalıştır",
       none_yet: "Henüz yok",
@@ -541,25 +485,19 @@ export const tr: Translations = {
     },
     scan: {
       building_headline: "Başarı profili oluşturuluyor…",
-      building_detail:
-        "Oturumlar, araç çağrıları, model meta verileri ve açılma durumu okunuyor.",
+      building_detail: "Oturumlar, araç çağrıları, model meta verileri ve açılma durumu okunuyor.",
       starting_headline: "Başarı taraması başlatılıyor…",
-      progress_detail:
-        "{total} oturumun {scanned} tanesi tarandı · %{pct}. Daha fazla geçmiş aktıkça rozetler açılır.",
-      idle_detail:
-        "Oturumlar, araç çağrıları, model meta verileri ve açılma durumu okunuyor. Rozetler açıldıkça burada görünür.",
+      progress_detail: "{total} oturumun {scanned} tanesi tarandı · %{pct}. Daha fazla geçmiş aktıkça rozetler açılır.",
+      idle_detail: "Oturumlar, araç çağrıları, model meta verileri ve açılma durumu okunuyor. Rozetler açıldıkça burada görünür.",
     },
     guide: {
       tiers_header: "Kademeler",
       secret_header: "Gizli başarılar",
-      secret_body:
-        "Sırlar, tetikleyicilerini saklı tutar. Hermes ilgili bir sinyal gördüğünde kart Keşfedildi durumuna geçer ve gereksinimini gösterir.",
+      secret_body: "Sırlar, tetikleyicilerini saklı tutar. Hermes ilgili bir sinyal gördüğünde kart Keşfedildi durumuna geçer ve gereksinimini gösterir.",
       scan_status_header: "Tarama durumu",
-      scan_status_body:
-        "Hermes yerel geçmişi bir kez tarıyor; sonra kartlar otomatik olarak görünür. Birkaç saniye sürmesi normaldir, hiçbir şey takılmadı.",
+      scan_status_body: "Hermes yerel geçmişi bir kez tarıyor; sonra kartlar otomatik olarak görünür. Birkaç saniye sürmesi normaldir, hiçbir şey takılmadı.",
       what_scanned_header: "Neler taranır",
-      what_scanned_body:
-        "Oturumlar, araç çağrıları, model meta verileri, hatalar, başarılar ve yerel açılma durumu.",
+      what_scanned_body: "Oturumlar, araç çağrıları, model meta verileri, hatalar, başarılar ve yerel açılma durumu.",
     },
     card: {
       share_title: "Bu başarıyı paylaş",
@@ -576,8 +514,7 @@ export const tr: Translations = {
     },
     empty: {
       no_secrets_header: "Bu taramada gizli sır kalmadı.",
-      no_secrets_body:
-        "İpucu: sırlar genellikle alışılmadık hata veya ileri kullanıcı kalıplarıyla başlar — port çakışmaları, izin duvarları, eksik ortam değişkenleri, YAML hataları, Docker çakışmaları, geri alma/checkpoint kullanımı, önbellek isabetleri ya da çokça kırmızı yazıdan sonra yapılan ufak düzeltmeler.",
+      no_secrets_body: "İpucu: sırlar genellikle alışılmadık hata veya ileri kullanıcı kalıplarıyla başlar — port çakışmaları, izin duvarları, eksik ortam değişkenleri, YAML hataları, Docker çakışmaları, geri alma/checkpoint kullanımı, önbellek isabetleri ya da çokça kırmızı yazıdan sonra yapılan ufak düzeltmeler.",
     },
     filters: {
       all_categories: "Tümü",
@@ -599,31 +536,19 @@ export const tr: Translations = {
       copy_button: "Görseli kopyala",
       copied: "Kopyalandı ✓",
       download_button: "PNG indir",
-      hint:
-        "X'te paylaş, yeni sekmede önceden doldurulmuş bir gönderi açar. 1200×630 rozetin eklenmesini istiyorsan önce Görseli kopyala'ya tıkla — X, görseli doğrudan tweet düzenleyiciye yapıştırmana izin verir. PNG indir, dosyayı her yerde kullanmak üzere kaydeder.",
-      clipboard_unsupported:
-        "Bu tarayıcıda panoya görsel kopyalama desteklenmiyor — bunun yerine İndir'i kullanın.",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "X'te paylaş, yeni sekmede önceden doldurulmuş bir gönderi açar. 1200×630 rozetin eklenmesini istiyorsan önce Görseli kopyala'ya tıkla — X, görseli doğrudan tweet düzenleyiciye yapıştırmana izin verir. PNG indir, dosyayı her yerde kullanmak üzere kaydeder.",
+      clipboard_unsupported: "Bu tarayıcıda panoya görsel kopyalama desteklenmiyor — bunun yerine İndir'i kullanın.",
     },
   },
   kanban: {
     loading: "Kanban panosu yükleniyor…",
     loadFailed: "Kanban panosu yüklenemedi: ",
-    loadFailedHint:
-      "Backend, ilk okumada kanban.db'yi otomatik olarak oluşturur. Sorun devam ederse panel günlüklerini kontrol edin.",
+    loadFailedHint: "Backend, ilk okumada kanban.db'yi otomatik olarak oluşturur. Sorun devam ederse panel günlüklerini kontrol edin.",
     board: "Pano",
     newBoard: "+ Yeni pano",
     newBoardTitle: "Yeni pano",
-    newBoardDescription:
-      "Panolar, ilgisiz iş akışlarını ayırmanızı sağlar — proje, depo veya alan başına bir pano. Bir panodaki worker'lar başka bir panonun görevlerini asla görmez.",
-    slug: "Slug",
+    newBoardDescription: "Panolar, ilgisiz iş akışlarını ayırmanızı sağlar — proje, depo veya alan başına bir pano. Bir panodaki worker'lar başka bir panonun görevlerini asla görmez.",
     slugHint: "— küçük harf, tire, ör. atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Görünen ad",
     displayNameHint: "(isteğe bağlı)",
     description: "Açıklama",
@@ -636,7 +561,6 @@ export const tr: Translations = {
     createBoard: "Pano oluştur",
     search: "Ara",
     filterCards: "Kartları filtrele…",
-    tenant: "Tenant",
     allTenants: "Tüm tenant'lar",
     assignee: "Atanan kişi",
     allProfiles: "Tüm profiller",
@@ -657,17 +581,14 @@ export const tr: Translations = {
     addComment: "Yorum ekle… (göndermek için Enter)",
     comment: "Yorum",
     status: "Durum",
-    workspace: "Workspace",
     skills: "Beceriler",
     createdBy: "Oluşturan",
-    result: "Result",
     comments: "Yorumlar",
     events: "Olaylar",
     runHistory: "Çalıştırma geçmişi",
     workerLog: "Worker günlüğü",
     loadingLog: "Günlük yükleniyor…",
-    noWorkerLog:
-      "— henüz worker günlüğü yok (görev başlatılmadı veya günlük döndürüldü) —",
+    noWorkerLog: "— henüz worker günlüğü yok (görev başlatılmadı veya günlük döndürüldü) —",
     noDescription: "— açıklama yok —",
     noComments: "— yorum yok —",
     edit: "düzenle",
@@ -698,8 +619,7 @@ export const tr: Translations = {
     reassign: "Yeniden ata",
     renderingError: "Kanban sekmesinde bir oluşturma hatası oluştu",
     reloadView: "Görünümü yeniden yükle",
-    wsAuthFailed:
-      "WebSocket kimlik doğrulaması başarısız — oturum jetonunu yenilemek için sayfayı yeniden yükleyin.",
+    wsAuthFailed: "WebSocket kimlik doğrulaması başarısız — oturum jetonunu yenilemek için sayfayı yeniden yükleyin.",
     markDone: "{n} görev tamamlandı olarak işaretlensin mi?",
     markArchived: "{n} görev arşivlensin mi?",
     warning: "Uyarı",
@@ -710,8 +630,7 @@ export const tr: Translations = {
     showAllAttempts: "Tüm denemeleri göster",
     sendingUpdates: "Güncellemeler şuraya gönderiliyor",
     sendNotifications: "completed / blocked / gave_up bildirimlerini şuraya gönder",
-    archiveBoardConfirm:
-      "'{name}' panosu arşivlensin mi? boards/_archived/ dizinine taşınacak, böylece daha sonra kurtarabilirsiniz. Bu panodaki görevler artık UI'nin hiçbir yerinde görünmeyecek.",
+    archiveBoardConfirm: "'{name}' panosu arşivlensin mi? boards/_archived/ dizinine taşınacak, böylece daha sonra kurtarabilirsiniz. Bu panodaki görevler artık UI'nin hiçbir yerinde görünmeyecek.",
     archiveBoardTitle: "Bu panoyu arşivle",
     boardSwitcherHint: "Panolar, ilgisiz iş akışlarını ayırmanızı sağlar",
     taskCreatedWarning: "Görev oluşturuldu, ancak: ",
@@ -750,28 +669,19 @@ export const tr: Translations = {
       done: "Tamamlandı",
       archived: "Arşivlendi",
     },
-    confirmDone:
-      "Bu görev tamamlandı olarak işaretlensin mi? Worker'ın sahiplenmesi serbest bırakılır ve bağımlı altlar hazır hale gelir.",
-    confirmArchive:
-      "Bu görev arşivlensin mi? Varsayılan pano görünümünden kaybolur.",
-    confirmBlocked:
-      "Bu görev engellendi olarak işaretlensin mi? Worker'ın sahiplenmesi serbest bırakılır.",
-    completionSummary:
-      "{label} için tamamlanma özeti. Görev result'ı olarak saklanır.",
-    completionSummaryRequired:
-      "Bir görevi tamamlandı olarak işaretlemeden önce tamamlanma özeti gereklidir.",
+    confirmDone: "Bu görev tamamlandı olarak işaretlensin mi? Worker'ın sahiplenmesi serbest bırakılır ve bağımlı altlar hazır hale gelir.",
+    confirmArchive: "Bu görev arşivlensin mi? Varsayılan pano görünümünden kaybolur.",
+    confirmBlocked: "Bu görev engellendi olarak işaretlensin mi? Worker'ın sahiplenmesi serbest bırakılır.",
+    completionSummary: "{label} için tamamlanma özeti. Görev result'ı olarak saklanır.",
+    completionSummaryRequired: "Bir görevi tamamlandı olarak işaretlemeden önce tamamlanma özeti gereklidir.",
     triagePlaceholder: "Kabataslak fikir — yapay zeka şartnameyi yazacak…",
     taskTitlePlaceholder: "Yeni görev başlığı…",
-    specifier: "specifier",
     assigneePlaceholder: "atanan",
     priority: "Öncelik",
-    skillsPlaceholder:
-      "beceriler (isteğe bağlı, virgülle ayrılmış): translation, github-code-review",
+    skillsPlaceholder: "beceriler (isteğe bağlı, virgülle ayrılmış): translation, github-code-review",
     noParent: "— üst yok —",
     workspacePathDir: "workspace yolu (zorunlu, ör. ~/projects/my-app)",
-    workspacePathOptional:
-      "workspace yolu (isteğe bağlı, boşsa atanan kişiden türetilir)",
+    workspacePathOptional: "workspace yolu (isteğe bağlı, boşsa atanan kişiden türetilir)",
     logTruncated: "(son 100 KB gösteriliyor — tam günlük şurada: ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const uk: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const uk = defineLocale({
   common: {
     save: "Зберегти",
     saving: "Збереження...",
@@ -43,20 +47,12 @@ export const uk: Translations = {
     expand: "Розгорнути",
     general: "Загальне",
     messaging: "Обмін повідомленнями",
-    pluginLoadFailed:
-      "Не вдалося завантажити скрипт цього плагіна. Перевірте вкладку Network (dashboard-plugins/…) та шлях до плагінів на сервері.",
-    pluginNotRegistered:
-      "Скрипт плагіна не викликав register(), або у скрипті сталася помилка. Відкрийте консоль браузера, щоб побачити деталі.",
+    pluginLoadFailed: "Не вдалося завантажити скрипт цього плагіна. Перевірте вкладку Network (dashboard-plugins/…) та шлях до плагінів на сервері.",
+    pluginNotRegistered: "Скрипт плагіна не викликав register(), або у скрипті сталася помилка. Відкрийте консоль браузера, щоб побачити деталі.",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "Закрити навігацію",
     closeModelTools: "Закрити модель та інструменти",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "Активні сесії:",
     gatewayStatusLabel: "Стан шлюзу:",
     gatewayStrip: {
@@ -70,7 +66,6 @@ export const uk: Translations = {
       analytics: "Аналітика",
       chat: "Чат",
       config: "Конфігурація",
-      cron: "Cron",
       documentation: "Документація",
       keys: "Ключі",
       logs: "Журнали",
@@ -89,9 +84,7 @@ export const uk: Translations = {
     sessionsActiveCount: "{count} активних",
     statusOverview: "Огляд стану",
     system: "Система",
-    webUi: "Web UI",
   },
-
   status: {
     actionFailed: "Дія не вдалася",
     actionFinished: "Завершено",
@@ -108,7 +101,6 @@ export const uk: Translations = {
     lastUpdate: "Останнє оновлення",
     noneRunning: "Немає",
     notRunning: "Не запущено",
-    pid: "PID",
     platformDisconnected: "відключено",
     platformError: "помилка",
     recentSessions: "Останні сесії",
@@ -124,7 +116,6 @@ export const uk: Translations = {
     updatingHermes: "Оновлення Hermes…",
     waitingForOutput: "Очікування виводу…",
   },
-
   sessions: {
     title: "Сесії",
     history: "Історія",
@@ -143,14 +134,12 @@ export const uk: Translations = {
     untitledSession: "Сесія без назви",
     deleteSession: "Видалити сесію",
     confirmDeleteTitle: "Видалити сесію?",
-    confirmDeleteMessage:
-      "Це назавжди видалить розмову та всі її повідомлення. Цю дію не можна скасувати.",
+    confirmDeleteMessage: "Це назавжди видалить розмову та всі її повідомлення. Цю дію не можна скасувати.",
     sessionDeleted: "Сесію видалено",
     failedToDelete: "Не вдалося видалити сесію",
     deleteEmpty: "Видалити порожні",
     deleteEmptyConfirmTitle: "Видалити порожні сесії?",
-    deleteEmptyConfirmMessage:
-      "Це остаточно видалить {count} сесій без повідомлень. Активні та архівні сесії пропускаються. Цю дію неможливо скасувати.",
+    deleteEmptyConfirmMessage: "Це остаточно видалить {count} сесій без повідомлень. Активні та архівні сесії пропускаються. Цю дію неможливо скасувати.",
     emptySessionsDeleted: "Видалено порожніх сесій: {count}",
     failedToDeleteEmpty: "Не вдалося видалити порожні сесії",
     selectSession: "Вибрати сесію",
@@ -159,8 +148,7 @@ export const uk: Translations = {
     selectedCount: "Вибрано: {count}",
     deleteSelected: "Видалити {count}",
     deleteSelectedConfirmTitle: "Видалити {count} сесій?",
-    deleteSelectedConfirmMessage:
-      "Це назавжди видалить {count} вибраних сесій і всі їхні повідомлення. Цю дію неможливо скасувати.",
+    deleteSelectedConfirmMessage: "Це назавжди видалить {count} вибраних сесій і всі їхні повідомлення. Цю дію неможливо скасувати.",
     selectedSessionsDeleted: "Видалено сесій: {count}",
     failedToDeleteSelected: "Не вдалося видалити вибрані сесії",
     resumeInChat: "Продовжити в чаті",
@@ -174,7 +162,6 @@ export const uk: Translations = {
       tool: "Інструмент",
     },
   },
-
   analytics: {
     period: "Період:",
     totalTokens: "Усього токенів",
@@ -200,7 +187,6 @@ export const uk: Translations = {
     acrossModels: "по {count} моделях",
     inOut: "{input} вх. / {output} вих.",
   },
-
   models: {
     modelsUsed: "Використано моделей",
     estimatedCost: "Орієнт. вартість",
@@ -212,7 +198,6 @@ export const uk: Translations = {
     noModelsData: "Немає даних про використання моделей за цей період",
     startSession: "Почніть сесію, щоб побачити дані моделей тут",
   },
-
   logs: {
     title: "Журнали",
     autoRefresh: "Автооновлення",
@@ -222,10 +207,8 @@ export const uk: Translations = {
     lines: "Рядки",
     noLogLines: "Записів журналу не знайдено",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "Це видаляє завдання з розкладу. Цю дію не можна скасувати.",
+    confirmDeleteMessage: "Це видаляє завдання з розкладу. Цю дію не можна скасувати.",
     confirmDeleteTitle: "Видалити заплановане завдання?",
     newJob: "Нове Cron-завдання",
     nameOptional: "Назва (необов'язково)",
@@ -233,7 +216,6 @@ export const uk: Translations = {
     prompt: "Запит",
     promptPlaceholder: "Що агент має робити при кожному запуску?",
     schedule: "Розклад (cron-вираз)",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "Розклад",
     scheduleModes: {
       interval: "Повторюваний інтервал",
@@ -249,18 +231,15 @@ export const uk: Translations = {
       unitDays: "днів",
       timeOfDay: "Час доби",
       weekdays: "Дні тижня",
-      weekdaysShort: ["Нд", "Пн", "Вт", "Ср", "Чт", "Пт", "Сб"],
+      weekdaysShort: ["Нд","Пн","Вт","Ср","Чт","Пт","Сб"],
       dayOfMonth: "День місяця",
       onceAt: "Виконати о",
       customLabel: "Cron-вираз",
-      customPlaceholder: "0 9 * * *",
-      customHint:
-        "П'ятиполевий cron-вираз (хвилина, година, день, місяць, день тижня).",
+      customHint: "П'ятиполевий cron-вираз (хвилина, година, день, місяць, день тижня).",
       preview: "Надсилається як",
       previewEmpty: "(не заповнено)",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "Кожні {n} хв",
       everyHours: "Кожні {n} год",
       everyDays: "Кожні {n} дн",
@@ -279,27 +258,20 @@ export const uk: Translations = {
     triggerNow: "Запустити зараз",
     delivery: {
       local: "Локально",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "Новий профіль",
     name: "Назва",
     namePlaceholder: "напр. coder, writer тощо.",
     nameRequired: "Назва обов'язкова",
-    nameRule:
-      "Лише малі літери, цифри, _ та -; має починатися з літери або цифри; до 64 символів.",
+    nameRule: "Лише малі літери, цифри, _ та -; має починатися з літери або цифри; до 64 символів.",
     invalidName: "Недопустима назва профілю",
     cloneFrom: "Клонувати з профілю",
     cloneFromNone: "Жоден (порожній)",
     allProfiles: "Профілі",
     noProfiles: "Профілів не знайдено.",
     defaultBadge: "за замовчуванням",
-    hasEnv: "env",
     model: "Модель",
     skills: "Навички",
     rename: "Перейменувати",
@@ -312,13 +284,11 @@ export const uk: Translations = {
     commandCopied: "Скопійовано в буфер обміну",
     copyFailed: "Не вдалося скопіювати",
     confirmDeleteTitle: "Видалити профіль?",
-    confirmDeleteMessage:
-      "Це назавжди видаляє профіль '{name}' — конфігурацію, ключі, спогади, сесії, навички, cron-завдання. Не можна скасувати.",
+    confirmDeleteMessage: "Це назавжди видаляє профіль '{name}' — конфігурацію, ключі, спогади, сесії, навички, cron-завдання. Не можна скасувати.",
     created: "Створено",
     deleted: "Видалено",
     renamed: "Перейменовано",
   },
-
   pluginsPage: {
     contextEngineLabel: "Контекстний рушій",
     dashboardSlots: "Слоти панелі",
@@ -326,8 +296,7 @@ export const uk: Translations = {
     enableAfterInstall: "Увімкнути після встановлення",
     enableRuntime: "Увімкнути",
     forceReinstall: "Примусово перевстановити (спершу видалити наявну теку)",
-    headline:
-      "Знаходьте, встановлюйте, вмикайте та оновлюйте плагіни Hermes (паритет з `hermes plugins`).",
+    headline: "Знаходьте, встановлюйте, вмикайте та оновлюйте плагіни Hermes (паритет з `hermes plugins`).",
     identifierLabel: "Git URL або owner/repo",
     inactive: "неактивний",
     installBtn: "Встановити",
@@ -341,8 +310,7 @@ export const uk: Translations = {
     pluginListHeading: "Встановлені плагіни",
     providerDefaults: "вбудований / за замовчуванням",
     providersHeading: "Плагіни постачальників часу виконання",
-    providersHint:
-      "Записує memory.provider (порожньо = вбудований) та context.engine у config.yaml. Набуває чинності в наступній сесії.",
+    providersHint: "Записує memory.provider (порожньо = вбудований) та context.engine у config.yaml. Набуває чинності в наступній сесії.",
     refreshDashboard: "Перескан розширень панелі",
     removeConfirm: "Видалити цей плагін з ~/.hermes/plugins/?",
     removeHint: "Видаляти можна лише плагіни, встановлені користувачем у ~/.hermes/plugins.",
@@ -354,12 +322,10 @@ export const uk: Translations = {
     sourceBadge: "Джерело",
     authRequired: "Потрібна автентифікація",
     authRequiredHint: "Виконайте цю команду, щоб автентифікуватися:",
-    updateGit: "Git pull",
     versionBadge: "Версія",
     showInSidebar: "Показати у бічній панелі",
     hideFromSidebar: "Сховати з бічної панелі",
   },
-
   skills: {
     title: "Навички",
     searchPlaceholder: "Пошук навичок та наборів інструментів...",
@@ -379,13 +345,10 @@ export const uk: Translations = {
     disabledForCli: "Вимкнено для CLI",
     more: "+ще {count}",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "Фільтри",
     sections: "Розділи",
     exportConfig: "Експортувати конфігурацію як JSON",
-    importConfig: "Імпортувати конфігурацію з JSON",
     resetDefaults: "Скинути до значень за замовчуванням",
     resetScopeTooltip: "Скинути {scope} до значень за замовчуванням",
     confirmResetScope: "Скинути всі налаштування {scope} до значень за замовчуванням? Це лише оновлює форму — зміни не записуються до config.yaml, доки ви не натиснете «Зберегти».",
@@ -393,7 +356,7 @@ export const uk: Translations = {
     rawYaml: "Сирий YAML-конфіг",
     searchResults: "Результати пошуку",
     fields: "поле(ів)",
-    noFieldsMatch: 'Немає полів, що відповідають "{query}"',
+    noFieldsMatch: "Немає полів, що відповідають \"{query}\"",
     configSaved: "Конфігурацію збережено",
     yamlConfigSaved: "YAML-конфігурацію збережено",
     failedToSave: "Не вдалося зберегти",
@@ -415,15 +378,12 @@ export const uk: Translations = {
       tts: "Синтез мовлення",
       stt: "Розпізнавання мовлення",
       logging: "Журналювання",
-      discord: "Discord",
       auxiliary: "Додатково",
     },
   },
-
   env: {
     changesNote: "Зміни одразу зберігаються на диск. Активні сесії автоматично підхоплюють нові ключі.",
-    confirmClearMessage:
-      "Збережене значення цієї змінної буде видалено з вашого .env-файлу. Цю дію не можна скасувати з UI.",
+    confirmClearMessage: "Збережене значення цієї змінної буде видалено з вашого .env-файлу. Цю дію не можна скасувати з UI.",
     confirmClearTitle: "Очистити цей ключ?",
     description: "Керуйте API-ключами та секретами, що зберігаються в",
     hideAdvanced: "Сховати розширене",
@@ -449,12 +409,10 @@ export const uk: Translations = {
     add: "Додати",
     invalidKeyName: "Використовуйте лише літери, цифри та підкреслення (має починатися з літери або підкреслення).",
   },
-
   oauth: {
     title: "Входи постачальників (OAuth)",
     providerLogins: "Входи постачальників (OAuth)",
-    description:
-      "Підключено {connected} з {total} постачальників OAuth. Використовуйте «Увійти» для процесів, підтримуваних панеллю; команди CLI залишаються доступними для зовнішнього або резервного налаштування.",
+    description: "Підключено {connected} з {total} постачальників OAuth. Використовуйте «Увійти» для процесів, підтримуваних панеллю; команди CLI залишаються доступними для зовнішнього або резервного налаштування.",
     connected: "Підключено",
     expired: "Прострочено",
     notConnected: "Не підключено. Використовуйте «Увійти», якщо доступно, або виконайте {command} у терміналі.",
@@ -491,24 +449,17 @@ export const uk: Translations = {
     },
     expiresIn: "завершується через {time}",
   },
-
   language: {
     switchTo: "Змінити мову",
   },
-
   theme: {
     title: "Тема",
     switchTheme: "Змінити тему",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "Колекційні значки Hermes, отримані з реальної історії сеансів. Відомі, але ще не виконані досягнення показані як Виявлені; Секретні досягнення залишаються прихованими, доки не з'явиться перший відповідний сигнал.",
-      scan_subtitle:
-        "Сканування історії сеансів Hermes. Перше сканування на великих історіях може тривати 5–10 секунд.",
+      subtitle: "Колекційні значки Hermes, отримані з реальної історії сеансів. Відомі, але ще не виконані досягнення показані як Виявлені; Секретні досягнення залишаються прихованими, доки не з'явиться перший відповідний сигнал.",
+      scan_subtitle: "Сканування історії сеансів Hermes. Перше сканування на великих історіях може тривати 5–10 секунд.",
     },
     actions: {
       rescan: "Повторне сканування",
@@ -521,7 +472,6 @@ export const uk: Translations = {
       secrets: "Секрети",
       secrets_hint: "приховані до першого сигналу",
       highest_tier: "Найвищий рівень",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "Останнє",
       latest_hint_empty: "запускайте Hermes частіше",
       none_yet: "Поки немає",
@@ -542,25 +492,19 @@ export const uk: Translations = {
     },
     scan: {
       building_headline: "Побудова профілю досягнень…",
-      building_detail:
-        "Читання сеансів, викликів інструментів, метаданих моделей і стану розблокування.",
+      building_detail: "Читання сеансів, викликів інструментів, метаданих моделей і стану розблокування.",
       starting_headline: "Запуск сканування досягнень…",
-      progress_detail:
-        "Проскановано {scanned} з {total} сеансів · {pct}%. Значки розблоковуються в міру надходження історії.",
-      idle_detail:
-        "Читання сеансів, викликів інструментів, метаданих моделей і стану розблокування. Значки з'являються тут у міру розблокування.",
+      progress_detail: "Проскановано {scanned} з {total} сеансів · {pct}%. Значки розблоковуються в міру надходження історії.",
+      idle_detail: "Читання сеансів, викликів інструментів, метаданих моделей і стану розблокування. Значки з'являються тут у міру розблокування.",
     },
     guide: {
       tiers_header: "Рівні",
       secret_header: "Секретні досягнення",
-      secret_body:
-        "Секрети приховують свій точний тригер. Щойно Hermes побачить пов'язаний сигнал, картка стає Виявленою та показує свою умову.",
+      secret_body: "Секрети приховують свій точний тригер. Щойно Hermes побачить пов'язаний сигнал, картка стає Виявленою та показує свою умову.",
       scan_status_header: "Стан сканування",
-      scan_status_body:
-        "Hermes одноразово сканує локальну історію, а потім картки з'являться автоматично. Якщо це триває кілька секунд — нічого не зависло.",
+      scan_status_body: "Hermes одноразово сканує локальну історію, а потім картки з'являться автоматично. Якщо це триває кілька секунд — нічого не зависло.",
       what_scanned_header: "Що сканується",
-      what_scanned_body:
-        "Сеанси, виклики інструментів, метадані моделей, помилки, досягнення та локальний стан розблокування.",
+      what_scanned_body: "Сеанси, виклики інструментів, метадані моделей, помилки, досягнення та локальний стан розблокування.",
     },
     card: {
       share_title: "Поділитися цим досягненням",
@@ -577,8 +521,7 @@ export const uk: Translations = {
     },
     empty: {
       no_secrets_header: "У цьому скануванні не залишилося прихованих секретів.",
-      no_secrets_body:
-        "Підказка: секрети зазвичай починаються з незвичних збоїв або шаблонів досвідчених користувачів — конфлікти портів, стіни дозволів, відсутні змінні середовища, помилки YAML, колізії Docker, відкат/контрольні точки, влучання в кеш або дрібні виправлення після купи червоного тексту.",
+      no_secrets_body: "Підказка: секрети зазвичай починаються з незвичних збоїв або шаблонів досвідчених користувачів — конфлікти портів, стіни дозволів, відсутні змінні середовища, помилки YAML, колізії Docker, відкат/контрольні точки, влучання в кеш або дрібні виправлення після купи червоного тексту.",
     },
     filters: {
       all_categories: "Усі",
@@ -600,31 +543,19 @@ export const uk: Translations = {
       copy_button: "Копіювати зображення",
       copied: "Скопійовано ✓",
       download_button: "Завантажити PNG",
-      hint:
-        "«Поділитися в X» відкриває попередньо заповнений допис у новій вкладці. Якщо хочете прикріпити значок 1200×630 — спочатку натисніть «Копіювати зображення»: X дозволить вставити його прямо в редактор твіта. «Завантажити PNG» збереже файл для використання будь-де.",
-      clipboard_unsupported:
-        "Цей браузер не підтримує копіювання зображень у буфер обміну — використайте «Завантажити».",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "«Поділитися в X» відкриває попередньо заповнений допис у новій вкладці. Якщо хочете прикріпити значок 1200×630 — спочатку натисніть «Копіювати зображення»: X дозволить вставити його прямо в редактор твіта. «Завантажити PNG» збереже файл для використання будь-де.",
+      clipboard_unsupported: "Цей браузер не підтримує копіювання зображень у буфер обміну — використайте «Завантажити».",
     },
   },
   kanban: {
     loading: "Завантаження дошки Kanban…",
     loadFailed: "Не вдалося завантажити дошку Kanban: ",
-    loadFailedHint:
-      "Бекенд автоматично створює kanban.db під час першого читання. Якщо помилка не зникає, перевірте журнали панелі.",
+    loadFailedHint: "Бекенд автоматично створює kanban.db під час першого читання. Якщо помилка не зникає, перевірте журнали панелі.",
     board: "Дошка",
     newBoard: "+ Нова дошка",
     newBoardTitle: "Нова дошка",
-    newBoardDescription:
-      "Дошки дозволяють розділяти непов'язані потоки роботи — по одній на проєкт, репозиторій або домен. Воркери на одній дошці ніколи не бачать задач іншої дошки.",
-    slug: "Slug",
+    newBoardDescription: "Дошки дозволяють розділяти непов'язані потоки роботи — по одній на проєкт, репозиторій або домен. Воркери на одній дошці ніколи не бачать задач іншої дошки.",
     slugHint: "— рядкові літери, дефіси, напр. atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "Відображувана назва",
     displayNameHint: "(необов'язково)",
     description: "Опис",
@@ -667,8 +598,7 @@ export const uk: Translations = {
     runHistory: "Історія запусків",
     workerLog: "Журнал воркера",
     loadingLog: "Завантаження журналу…",
-    noWorkerLog:
-      "— журналу воркера ще немає (задачу не запущено або журнал ротаційно видалено) —",
+    noWorkerLog: "— журналу воркера ще немає (задачу не запущено або журнал ротаційно видалено) —",
     noDescription: "— немає опису —",
     noComments: "— немає коментарів —",
     edit: "редагувати",
@@ -699,8 +629,7 @@ export const uk: Translations = {
     reassign: "Перепризначити",
     renderingError: "На вкладці Kanban сталася помилка рендерингу",
     reloadView: "Перезавантажити вигляд",
-    wsAuthFailed:
-      "Помилка автентифікації WebSocket — перезавантажте сторінку, щоб оновити токен сесії.",
+    wsAuthFailed: "Помилка автентифікації WebSocket — перезавантажте сторінку, щоб оновити токен сесії.",
     markDone: "Позначити {n} задач(у) як виконані?",
     markArchived: "Архівувати {n} задач(у)?",
     warning: "Попередження",
@@ -711,8 +640,7 @@ export const uk: Translations = {
     showAllAttempts: "Показати всі спроби",
     sendingUpdates: "Надсилання оновлень до",
     sendNotifications: "Надсилати сповіщення completed / blocked / gave_up до",
-    archiveBoardConfirm:
-      "Архівувати дошку «{name}»? Її буде переміщено до boards/_archived/, тож пізніше її можна відновити. Задачі цієї дошки більше не з'являтимуться в інтерфейсі.",
+    archiveBoardConfirm: "Архівувати дошку «{name}»? Її буде переміщено до boards/_archived/, тож пізніше її можна відновити. Задачі цієї дошки більше не з'являтимуться в інтерфейсі.",
     archiveBoardTitle: "Архівувати цю дошку",
     boardSwitcherHint: "Дошки дозволяють розділяти непов'язані потоки роботи",
     taskCreatedWarning: "Задачу створено, але: ",
@@ -751,28 +679,20 @@ export const uk: Translations = {
       done: "Завершено",
       archived: "Архівовано",
     },
-    confirmDone:
-      "Позначити цю задачу як виконану? Захоплення воркера буде звільнено, а залежні нащадки стануть готовими.",
-    confirmArchive:
-      "Архівувати цю задачу? Вона зникне з типового вигляду дошки.",
-    confirmBlocked:
-      "Позначити цю задачу як заблоковану? Захоплення воркера буде звільнено.",
-    completionSummary:
-      "Підсумок завершення для {label}. Зберігається як result задачі.",
-    completionSummaryRequired:
-      "Підсумок завершення обов'язковий перед позначенням задачі виконаною.",
+    confirmDone: "Позначити цю задачу як виконану? Захоплення воркера буде звільнено, а залежні нащадки стануть готовими.",
+    confirmArchive: "Архівувати цю задачу? Вона зникне з типового вигляду дошки.",
+    confirmBlocked: "Позначити цю задачу як заблоковану? Захоплення воркера буде звільнено.",
+    completionSummary: "Підсумок завершення для {label}. Зберігається як result задачі.",
+    completionSummaryRequired: "Підсумок завершення обов'язковий перед позначенням задачі виконаною.",
     triagePlaceholder: "Чорнова ідея — ШІ її специфікує…",
     taskTitlePlaceholder: "Назва нової задачі…",
     specifier: "специфікатор",
     assigneePlaceholder: "виконавець",
     priority: "Пріоритет",
-    skillsPlaceholder:
-      "навички (необов'язково, через кому): translation, github-code-review",
+    skillsPlaceholder: "навички (необов'язково, через кому): translation, github-code-review",
     noParent: "— без батька —",
     workspacePathDir: "шлях робочої області (обов'язково, напр. ~/projects/my-app)",
-    workspacePathOptional:
-      "шлях робочої області (необов'язково, виводиться з виконавця, якщо порожньо)",
+    workspacePathOptional: "шлях робочої області (необов'язково, виводиться з виконавця, якщо порожньо)",
     logTruncated: "(показано останні 100 KB — повний журнал у ",
-    logAt: ")",
   },
-};
+});

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const zhHant: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const zhHant = defineLocale({
   common: {
     save: "儲存",
     saving: "儲存中...",
@@ -43,20 +47,12 @@ export const zhHant: Translations = {
     expand: "展開",
     general: "一般",
     messaging: "訊息平台",
-    pluginLoadFailed:
-      "無法載入此外掛的指令碼。請檢查網路請求（dashboard-plugins/…）以及伺服器上的外掛路徑。",
-    pluginNotRegistered:
-      "外掛指令碼未呼叫 register()，或執行時發生錯誤。請開啟瀏覽器主控台查看詳細資訊。",
+    pluginLoadFailed: "無法載入此外掛的指令碼。請檢查網路請求（dashboard-plugins/…）以及伺服器上的外掛路徑。",
+    pluginNotRegistered: "外掛指令碼未呼叫 register()，或執行時發生錯誤。請開啟瀏覽器主控台查看詳細資訊。",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "關閉導覽",
     closeModelTools: "關閉模型與工具",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "使用中工作階段：",
     gatewayStatusLabel: "閘道狀態：",
     gatewayStrip: {
@@ -91,7 +87,6 @@ export const zhHant: Translations = {
     system: "系統",
     webUi: "管理面板",
   },
-
   status: {
     actionFailed: "動作失敗",
     actionFinished: "已完成",
@@ -108,7 +103,6 @@ export const zhHant: Translations = {
     lastUpdate: "最後更新",
     noneRunning: "無",
     notRunning: "未執行",
-    pid: "PID",
     platformDisconnected: "已中斷",
     platformError: "錯誤",
     recentSessions: "近期工作階段",
@@ -124,7 +118,6 @@ export const zhHant: Translations = {
     updatingHermes: "正在更新 Hermes…",
     waitingForOutput: "等待輸出…",
   },
-
   sessions: {
     title: "工作階段",
     history: "歷史",
@@ -143,14 +136,12 @@ export const zhHant: Translations = {
     untitledSession: "未命名工作階段",
     deleteSession: "刪除工作階段",
     confirmDeleteTitle: "刪除工作階段？",
-    confirmDeleteMessage:
-      "此操作將永久移除對話及其所有訊息，無法復原。",
+    confirmDeleteMessage: "此操作將永久移除對話及其所有訊息，無法復原。",
     sessionDeleted: "工作階段已刪除",
     failedToDelete: "刪除工作階段失敗",
     deleteEmpty: "刪除空工作階段",
     deleteEmptyConfirmTitle: "刪除空工作階段？",
-    deleteEmptyConfirmMessage:
-      "這將永久刪除 {count} 個沒有訊息的工作階段。活動中與已封存的工作階段將被略過。此動作無法復原。",
+    deleteEmptyConfirmMessage: "這將永久刪除 {count} 個沒有訊息的工作階段。活動中與已封存的工作階段將被略過。此動作無法復原。",
     emptySessionsDeleted: "已刪除 {count} 個空工作階段",
     failedToDeleteEmpty: "刪除空工作階段失敗",
     selectSession: "選擇工作階段",
@@ -159,8 +150,7 @@ export const zhHant: Translations = {
     selectedCount: "已選擇 {count} 個",
     deleteSelected: "刪除 {count} 個",
     deleteSelectedConfirmTitle: "刪除 {count} 個工作階段？",
-    deleteSelectedConfirmMessage:
-      "此操作將永久刪除所選的 {count} 個工作階段及其所有訊息。無法復原。",
+    deleteSelectedConfirmMessage: "此操作將永久刪除所選的 {count} 個工作階段及其所有訊息。無法復原。",
     selectedSessionsDeleted: "已刪除 {count} 個工作階段",
     failedToDeleteSelected: "刪除所選工作階段失敗",
     resumeInChat: "在對話中繼續",
@@ -174,7 +164,6 @@ export const zhHant: Translations = {
       tool: "工具",
     },
   },
-
   analytics: {
     period: "時間範圍：",
     totalTokens: "Token 總數",
@@ -200,7 +189,6 @@ export const zhHant: Translations = {
     acrossModels: "共 {count} 個模型",
     inOut: "輸入 {input} / 輸出 {output}",
   },
-
   models: {
     modelsUsed: "使用模型數",
     estimatedCost: "預估費用",
@@ -212,7 +200,6 @@ export const zhHant: Translations = {
     noModelsData: "此時間範圍內無模型使用資料",
     startSession: "開始工作階段後將於此處顯示模型資料",
   },
-
   logs: {
     title: "日誌",
     autoRefresh: "自動重新整理",
@@ -222,10 +209,8 @@ export const zhHant: Translations = {
     lines: "行數",
     noLogLines: "找不到日誌記錄",
   },
-
   cron: {
-    confirmDeleteMessage:
-      "將從排程移除此任務，此操作無法復原。",
+    confirmDeleteMessage: "將從排程移除此任務，此操作無法復原。",
     confirmDeleteTitle: "刪除排程任務？",
     newJob: "新增排程任務",
     nameOptional: "名稱（選填）",
@@ -233,7 +218,6 @@ export const zhHant: Translations = {
     prompt: "提示詞",
     promptPlaceholder: "代理每次執行時應做什麼？",
     schedule: "排程（cron 運算式）",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "排程",
     scheduleModes: {
       interval: "重複間隔",
@@ -249,17 +233,15 @@ export const zhHant: Translations = {
       unitDays: "天",
       timeOfDay: "時間",
       weekdays: "星期",
-      weekdaysShort: ["日", "一", "二", "三", "四", "五", "六"],
+      weekdaysShort: ["日","一","二","三","四","五","六"],
       dayOfMonth: "日期",
       onceAt: "執行時間",
       customLabel: "cron 運算式",
-      customPlaceholder: "0 9 * * *",
       customHint: "五欄位 cron 運算式（分、時、日、月、星期）。",
       preview: "傳送為",
       previewEmpty: "（未完成）",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "每 {n} 分鐘",
       everyHours: "每 {n} 小時",
       everyDays: "每 {n} 天",
@@ -278,26 +260,20 @@ export const zhHant: Translations = {
     triggerNow: "立即觸發",
     delivery: {
       local: "本機",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
-      email: "Email",
     },
   },
-
   profiles: {
     newProfile: "新增設定檔",
     name: "名稱",
     namePlaceholder: "例如：coder、writer 等",
     nameRequired: "名稱為必填",
-    nameRule:
-      "僅允許小寫字母、數字、底線及連字號；首字必須為字母或數字；最多 64 個字元。",
-    invalidName: "設定檔名稱無效",    cloneFrom: "從設定檔複製",
+    nameRule: "僅允許小寫字母、數字、底線及連字號；首字必須為字母或數字；最多 64 個字元。",
+    invalidName: "設定檔名稱無效",
+    cloneFrom: "從設定檔複製",
     cloneFromNone: "無（空白）",
     allProfiles: "設定檔",
     noProfiles: "找不到設定檔。",
     defaultBadge: "預設",
-    hasEnv: "env",
     model: "模型",
     skills: "技能",
     rename: "重新命名",
@@ -310,13 +286,11 @@ export const zhHant: Translations = {
     commandCopied: "已複製到剪貼簿",
     copyFailed: "複製失敗",
     confirmDeleteTitle: "刪除設定檔？",
-    confirmDeleteMessage:
-      "將永久刪除設定檔「{name}」 — 包括設定、金鑰、記憶、工作階段、技能、排程任務。無法復原。",
+    confirmDeleteMessage: "將永久刪除設定檔「{name}」 — 包括設定、金鑰、記憶、工作階段、技能、排程任務。無法復原。",
     created: "已建立",
     deleted: "已刪除",
     renamed: "已重新命名",
   },
-
   pluginsPage: {
     contextEngineLabel: "上下文引擎",
     dashboardSlots: "面板插槽",
@@ -324,8 +298,7 @@ export const zhHant: Translations = {
     enableAfterInstall: "安裝後啟用",
     enableRuntime: "啟用",
     forceReinstall: "強制重新安裝（先刪除既有資料夾）",
-    headline:
-      "探索、安裝、啟用並更新 Hermes 外掛（對齊 `hermes plugins` CLI）。",
+    headline: "探索、安裝、啟用並更新 Hermes 外掛（對齊 `hermes plugins` CLI）。",
     identifierLabel: "Git 網址或 owner/repo",
     inactive: "未啟用",
     installBtn: "安裝",
@@ -339,8 +312,7 @@ export const zhHant: Translations = {
     pluginListHeading: "已安裝的外掛",
     providerDefaults: "內建 / 預設",
     providersHeading: "執行階段提供者外掛",
-    providersHint:
-      "會寫入 config.yaml：memory.provider（留空為內建）與 context.engine。下一個工作階段生效。",
+    providersHint: "會寫入 config.yaml：memory.provider（留空為內建）與 context.engine。下一個工作階段生效。",
     refreshDashboard: "重新掃描儀表板擴充功能",
     removeConfirm: "從 ~/.hermes/plugins/ 移除此外掛？",
     removeHint: "僅可移除位於 ~/.hermes/plugins 下使用者安裝的外掛。",
@@ -352,12 +324,10 @@ export const zhHant: Translations = {
     sourceBadge: "來源",
     authRequired: "需要驗證",
     authRequiredHint: "執行此指令以完成驗證：",
-    updateGit: "Git pull",
     versionBadge: "版本",
     showInSidebar: "顯示於側邊欄",
     hideFromSidebar: "從側邊欄隱藏",
   },
-
   skills: {
     title: "技能",
     searchPlaceholder: "搜尋技能與工具集...",
@@ -377,13 +347,10 @@ export const zhHant: Translations = {
     disabledForCli: "CLI 已停用",
     more: "還有 {count} 個",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "篩選",
     sections: "分類",
     exportConfig: "匯出設定為 JSON",
-    importConfig: "從 JSON 匯入設定",
     resetDefaults: "重設為預設值",
     resetScopeTooltip: "將{scope}重設為預設值",
     confirmResetScope: "要將{scope}的所有設定重設為預設值嗎？此操作只更新表單，在按下「儲存」前不會寫入 config.yaml。",
@@ -391,7 +358,7 @@ export const zhHant: Translations = {
     rawYaml: "原始 YAML 設定",
     searchResults: "搜尋結果",
     fields: "個欄位",
-    noFieldsMatch: '沒有符合「{query}」的欄位',
+    noFieldsMatch: "沒有符合「{query}」的欄位",
     configSaved: "設定已儲存",
     yamlConfigSaved: "YAML 設定已儲存",
     failedToSave: "儲存失敗",
@@ -413,15 +380,12 @@ export const zhHant: Translations = {
       tts: "文字轉語音",
       stt: "語音轉文字",
       logging: "日誌",
-      discord: "Discord",
       auxiliary: "輔助",
     },
   },
-
   env: {
     changesNote: "變更會立即儲存到磁碟。使用中的工作階段將自動取得新金鑰。",
-    confirmClearMessage:
-      "此變數已儲存的值將從 .env 檔案中移除。無法從介面復原。",
+    confirmClearMessage: "此變數已儲存的值將從 .env 檔案中移除。無法從介面復原。",
     confirmClearTitle: "清除此金鑰？",
     description: "管理儲存於下列位置的 API 金鑰與密鑰",
     hideAdvanced: "隱藏進階選項",
@@ -447,12 +411,10 @@ export const zhHant: Translations = {
     add: "新增",
     invalidKeyName: "僅能使用字母、數字和底線（必須以字母或底線開頭）。",
   },
-
   oauth: {
     title: "提供者登入（OAuth）",
     providerLogins: "提供者登入（OAuth）",
-    description:
-      "已連線 {connected}/{total} 個 OAuth 提供者。儀表板支援的流程請使用「登入」；CLI 指令仍可用於外部或備用設定。",
+    description: "已連線 {connected}/{total} 個 OAuth 提供者。儀表板支援的流程請使用「登入」；CLI 指令仍可用於外部或備用設定。",
     connected: "已連線",
     expired: "已過期",
     notConnected: "未連線。可用時請使用「登入」，或在終端機執行 {command}。",
@@ -489,24 +451,17 @@ export const zhHant: Translations = {
     },
     expiresIn: "{time}後過期",
   },
-
   language: {
     switchTo: "切換語言",
   },
-
   theme: {
     title: "主題",
     switchTheme: "切換主題",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "從真實工作階段歷史中獲得的 Hermes 可收集徽章。已知尚未達成的成就會顯示為「已發現」；秘密成就在首次出現相符行為之前保持隱藏。",
-      scan_subtitle:
-        "正在掃描 Hermes 工作階段歷史。在歷史紀錄較多時，首次掃描可能需要 5–10 秒。",
+      subtitle: "從真實工作階段歷史中獲得的 Hermes 可收集徽章。已知尚未達成的成就會顯示為「已發現」；秘密成就在首次出現相符行為之前保持隱藏。",
+      scan_subtitle: "正在掃描 Hermes 工作階段歷史。在歷史紀錄較多時，首次掃描可能需要 5–10 秒。",
     },
     actions: {
       rescan: "重新掃描",
@@ -519,7 +474,6 @@ export const zhHant: Translations = {
       secrets: "秘密",
       secrets_hint: "在首次訊號出現前保持隱藏",
       highest_tier: "最高等級",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "最新",
       latest_hint_empty: "多多執行 Hermes",
       none_yet: "尚無",
@@ -540,25 +494,19 @@ export const zhHant: Translations = {
     },
     scan: {
       building_headline: "正在建立成就檔案…",
-      building_detail:
-        "正在讀取工作階段、工具呼叫、模型中繼資料以及解鎖狀態。",
+      building_detail: "正在讀取工作階段、工具呼叫、模型中繼資料以及解鎖狀態。",
       starting_headline: "正在開始成就掃描…",
-      progress_detail:
-        "已掃描 {scanned} / {total} 個工作階段 · {pct}%。隨著更多歷史串入，徽章會陸續解鎖。",
-      idle_detail:
-        "正在讀取工作階段、工具呼叫、模型中繼資料以及解鎖狀態。徽章解鎖後會顯示在這裡。",
+      progress_detail: "已掃描 {scanned} / {total} 個工作階段 · {pct}%。隨著更多歷史串入，徽章會陸續解鎖。",
+      idle_detail: "正在讀取工作階段、工具呼叫、模型中繼資料以及解鎖狀態。徽章解鎖後會顯示在這裡。",
     },
     guide: {
       tiers_header: "等級",
       secret_header: "秘密成就",
-      secret_body:
-        "秘密成就會隱藏其確切觸發條件。一旦 Hermes 偵測到相關訊號，卡片便會變為「已發現」並顯示其需求。",
+      secret_body: "秘密成就會隱藏其確切觸發條件。一旦 Hermes 偵測到相關訊號，卡片便會變為「已發現」並顯示其需求。",
       scan_status_header: "掃描狀態",
-      scan_status_body:
-        "Hermes 正在對本機歷史進行一次掃描，之後卡片會自動出現。即使需要幾秒鐘，也並未卡住。",
+      scan_status_body: "Hermes 正在對本機歷史進行一次掃描，之後卡片會自動出現。即使需要幾秒鐘，也並未卡住。",
       what_scanned_header: "掃描內容",
-      what_scanned_body:
-        "工作階段、工具呼叫、模型中繼資料、錯誤、成就以及本機解鎖狀態。",
+      what_scanned_body: "工作階段、工具呼叫、模型中繼資料、錯誤、成就以及本機解鎖狀態。",
     },
     card: {
       share_title: "分享此成就",
@@ -575,8 +523,7 @@ export const zhHant: Translations = {
     },
     empty: {
       no_secrets_header: "本次掃描已沒有隱藏的秘密。",
-      no_secrets_body:
-        "提示：秘密通常源自異常失敗或進階使用者的行為模式 —— 連接埠衝突、權限阻擋、缺少環境變數、YAML 錯誤、Docker 衝突、回復或檢查點的使用、快取命中，或在大量紅色錯誤後做出的小小修正。",
+      no_secrets_body: "提示：秘密通常源自異常失敗或進階使用者的行為模式 —— 連接埠衝突、權限阻擋、缺少環境變數、YAML 錯誤、Docker 衝突、回復或檢查點的使用、快取命中，或在大量紅色錯誤後做出的小小修正。",
     },
     filters: {
       all_categories: "全部",
@@ -598,31 +545,20 @@ export const zhHant: Translations = {
       copy_button: "複製圖片",
       copied: "已複製 ✓",
       download_button: "下載 PNG",
-      hint:
-        "「在 X 上分享」會在新分頁中開啟預先填寫的貼文。若想附上 1200×630 的徽章，請先點擊「複製圖片」—— X 允許你直接貼到推文編輯器中。「下載 PNG」會將檔案儲存下來，可在任何地方使用。",
-      clipboard_unsupported:
-        "此瀏覽器不支援剪貼簿圖片複製 —— 請改用「下載」。",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "「在 X 上分享」會在新分頁中開啟預先填寫的貼文。若想附上 1200×630 的徽章，請先點擊「複製圖片」—— X 允許你直接貼到推文編輯器中。「下載 PNG」會將檔案儲存下來，可在任何地方使用。",
+      clipboard_unsupported: "此瀏覽器不支援剪貼簿圖片複製 —— 請改用「下載」。",
     },
   },
   kanban: {
     loading: "正在載入看板…",
     loadFailed: "載入看板失敗：",
-    loadFailedHint:
-      "後端會在首次讀取時自動建立 kanban.db。如果問題持續，請檢查儀表板日誌。",
+    loadFailedHint: "後端會在首次讀取時自動建立 kanban.db。如果問題持續，請檢查儀表板日誌。",
     board: "看板",
     newBoard: "+ 新增看板",
     newBoardTitle: "新增看板",
-    newBoardDescription:
-      "看板可將不相關的工作流分開——每個專案、程式碼庫或網域一個看板。一個看板上的工作者不會看到另一個看板的任務。",
+    newBoardDescription: "看板可將不相關的工作流分開——每個專案、程式碼庫或網域一個看板。一個看板上的工作者不會看到另一個看板的任務。",
     slug: "識別碼",
     slugHint: "— 小寫字母、連字號，例如 atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "顯示名稱",
     displayNameHint: "（選填）",
     description: "描述",
@@ -665,8 +601,7 @@ export const zhHant: Translations = {
     runHistory: "執行紀錄",
     workerLog: "工作者日誌",
     loadingLog: "正在載入日誌…",
-    noWorkerLog:
-      "— 尚無工作者日誌（任務尚未啟動或日誌已被輪替）—",
+    noWorkerLog: "— 尚無工作者日誌（任務尚未啟動或日誌已被輪替）—",
     noDescription: "— 沒有描述 —",
     noComments: "— 沒有留言 —",
     edit: "編輯",
@@ -697,8 +632,7 @@ export const zhHant: Translations = {
     reassign: "重新指派",
     renderingError: "看板分頁發生繪製錯誤",
     reloadView: "重新載入檢視",
-    wsAuthFailed:
-      "WebSocket 驗證失敗 — 請重新載入頁面以更新工作階段權杖。",
+    wsAuthFailed: "WebSocket 驗證失敗 — 請重新載入頁面以更新工作階段權杖。",
     markDone: "將 {n} 個任務標記為完成？",
     markArchived: "封存 {n} 個任務？",
     warning: "警告",
@@ -709,8 +643,7 @@ export const zhHant: Translations = {
     showAllAttempts: "顯示所有嘗試",
     sendingUpdates: "正在傳送更新到",
     sendNotifications: "傳送完成 / 封鎖 / 放棄通知到",
-    archiveBoardConfirm:
-      "封存看板「{name}」？看板將會移至 boards/_archived/，以便日後復原。此看板上的任務將不再出現在 UI 中的任何位置。",
+    archiveBoardConfirm: "封存看板「{name}」？看板將會移至 boards/_archived/，以便日後復原。此看板上的任務將不再出現在 UI 中的任何位置。",
     archiveBoardTitle: "封存此看板",
     boardSwitcherHint: "看板可將不相關的工作流分開",
     taskCreatedWarning: "任務已建立，但：",
@@ -749,28 +682,21 @@ export const zhHant: Translations = {
       done: "已完成",
       archived: "已封存",
     },
-    confirmDone:
-      "將此任務標記為完成？工作者的領取將被釋放，下層相依任務將變為就緒。",
-    confirmArchive:
-      "封存此任務？它將從預設看板檢視中消失。",
-    confirmBlocked:
-      "將此任務標記為已封鎖？工作者的領取將被釋放。",
-    completionSummary:
-      "{label} 的完成摘要。這將作為任務結果儲存。",
-    completionSummaryRequired:
-      "在將任務標記為完成之前，必須提供完成摘要。",
+    confirmDone: "將此任務標記為完成？工作者的領取將被釋放，下層相依任務將變為就緒。",
+    confirmArchive: "封存此任務？它將從預設看板檢視中消失。",
+    confirmBlocked: "將此任務標記為已封鎖？工作者的領取將被釋放。",
+    completionSummary: "{label} 的完成摘要。這將作為任務結果儲存。",
+    completionSummaryRequired: "在將任務標記為完成之前，必須提供完成摘要。",
     triagePlaceholder: "粗略的想法 — AI 將完善規格…",
     taskTitlePlaceholder: "新任務標題…",
     specifier: "規格制定者",
     assigneePlaceholder: "負責人",
     priority: "優先順序",
-    skillsPlaceholder:
-      "技能（選填，以逗號分隔）：translation、github-code-review",
+    skillsPlaceholder: "技能（選填，以逗號分隔）：translation、github-code-review",
     noParent: "— 無上層任務 —",
     workspacePathDir: "工作區路徑（必填，例如 ~/projects/my-app）",
-    workspacePathOptional:
-      "工作區路徑（選填，留空則依負責人推導）",
+    workspacePathOptional: "工作區路徑（選填，留空則依負責人推導）",
     logTruncated: "（顯示最後 100 KB — 完整日誌位於 ",
     logAt: "）",
   },
-};
+});

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -1,6 +1,10 @@
-import type { Translations } from "./types";
+import { defineLocale } from "./define-locale";
 
-export const zh: Translations = {
+// Auto-synced by scripts/i18n-sync.mjs — only keys that differ from en.ts are
+// listed below; everything else inherits English automatically. After editing
+// en.ts, run `npm run i18n:sync` to propagate, and `npm run i18n:check`
+// (wired into CI) guards against drift.
+export const zh = defineLocale({
   common: {
     save: "保存",
     saving: "保存中...",
@@ -43,19 +47,12 @@ export const zh: Translations = {
     expand: "展开",
     general: "通用",
     messaging: "消息平台",
-    pluginLoadFailed:
-      "无法加载此插件的脚本。请检查网络请求（dashboard-plugins/…）以及服务器上的插件路径。",
+    pluginLoadFailed: "无法加载此插件的脚本。请检查网络请求（dashboard-plugins/…）以及服务器上的插件路径。",
     pluginNotRegistered: "插件脚本未调用 register()，或执行出错。请打开浏览器控制台查看详情。",
   },
-
   app: {
-    brand: "Hermes Agent",
-    brandShort: "HA",
     closeNavigation: "关闭导航",
     closeModelTools: "关闭模型与工具",
-    footer: {
-      org: "Nous Research",
-    },
     activeSessionsLabel: "活跃会话：",
     gatewayStatusLabel: "网关状态：",
     gatewayStrip: {
@@ -90,7 +87,6 @@ export const zh: Translations = {
     system: "系统",
     webUi: "管理面板",
   },
-
   status: {
     actionFailed: "操作失败",
     actionFinished: "已完成",
@@ -123,7 +119,6 @@ export const zh: Translations = {
     updatingHermes: "正在更新 Hermes…",
     waitingForOutput: "等待输出…",
   },
-
   sessions: {
     title: "会话",
     history: "历史",
@@ -147,8 +142,7 @@ export const zh: Translations = {
     failedToDelete: "删除会话失败",
     deleteEmpty: "删除空会话",
     deleteEmptyConfirmTitle: "删除空会话？",
-    deleteEmptyConfirmMessage:
-      "这将永久删除 {count} 个没有消息的会话。活动和已归档的会话将被跳过。此操作无法撤销。",
+    deleteEmptyConfirmMessage: "这将永久删除 {count} 个没有消息的会话。活动和已归档的会话将被跳过。此操作无法撤销。",
     emptySessionsDeleted: "已删除 {count} 个空会话",
     failedToDeleteEmpty: "删除空会话失败",
     selectSession: "选择会话",
@@ -157,8 +151,7 @@ export const zh: Translations = {
     selectedCount: "已选择 {count} 个",
     deleteSelected: "删除 {count} 个",
     deleteSelectedConfirmTitle: "删除 {count} 个会话？",
-    deleteSelectedConfirmMessage:
-      "此操作将永久删除所选的 {count} 个会话及其所有消息。无法撤销。",
+    deleteSelectedConfirmMessage: "此操作将永久删除所选的 {count} 个会话及其所有消息。无法撤销。",
     selectedSessionsDeleted: "已删除 {count} 个会话",
     failedToDeleteSelected: "删除所选会话失败",
     resumeInChat: "在对话中继续",
@@ -172,7 +165,6 @@ export const zh: Translations = {
       tool: "工具",
     },
   },
-
   analytics: {
     period: "时间范围：",
     totalTokens: "总 Token 数",
@@ -198,7 +190,6 @@ export const zh: Translations = {
     acrossModels: "共 {count} 个模型",
     inOut: "输入 {input} / 输出 {output}",
   },
-
   models: {
     modelsUsed: "使用模型数",
     estimatedCost: "预估费用",
@@ -210,7 +201,6 @@ export const zh: Translations = {
     noModelsData: "该时间段暂无模型使用数据",
     startSession: "开始会话后将在此显示模型数据",
   },
-
   logs: {
     title: "日志",
     autoRefresh: "自动刷新",
@@ -220,7 +210,6 @@ export const zh: Translations = {
     lines: "行数",
     noLogLines: "未找到日志记录",
   },
-
   cron: {
     confirmDeleteMessage: "将从此计划移除该任务，此操作无法撤销。",
     confirmDeleteTitle: "删除定时任务？",
@@ -230,7 +219,6 @@ export const zh: Translations = {
     prompt: "提示词",
     promptPlaceholder: "代理每次运行时应执行什么操作？",
     schedule: "调度表达式（cron）",
-    schedulePlaceholder: "0 9 * * *",
     scheduleMode: "调度",
     scheduleModes: {
       interval: "重复间隔",
@@ -246,17 +234,15 @@ export const zh: Translations = {
       unitDays: "天",
       timeOfDay: "时间",
       weekdays: "星期",
-      weekdaysShort: ["日", "一", "二", "三", "四", "五", "六"],
+      weekdaysShort: ["日","一","二","三","四","五","六"],
       dayOfMonth: "日期",
       onceAt: "执行时间",
       customLabel: "cron 表达式",
-      customPlaceholder: "0 9 * * *",
       customHint: "五字段 cron 表达式（分、时、日、月、星期）。",
       preview: "发送为",
       previewEmpty: "（未完成）",
     },
     scheduleDescribe: {
-      none: "—",
       everyMinutes: "每 {n} 分钟",
       everyHours: "每 {n} 小时",
       everyDays: "每 {n} 天",
@@ -275,21 +261,17 @@ export const zh: Translations = {
     triggerNow: "立即触发",
     delivery: {
       local: "本地",
-      telegram: "Telegram",
-      discord: "Discord",
-      slack: "Slack",
       email: "邮件",
     },
   },
-
   profiles: {
     newProfile: "新建多Agent配置",
     name: "名称",
     namePlaceholder: "例如：coder, writer 等",
     nameRequired: "名称必填",
-    nameRule:
-      "仅允许小写字母、数字、下划线和短横线；首字符必须是字母或数字；最多 64 个字符。",
-    invalidName: "多Agent配置名称非法",    cloneFrom: "从配置文件克隆",
+    nameRule: "仅允许小写字母、数字、下划线和短横线；首字符必须是字母或数字；最多 64 个字符。",
+    invalidName: "多Agent配置名称非法",
+    cloneFrom: "从配置文件克隆",
     cloneFromNone: "无（空白）",
     allProfiles: "多Agent配置列表",
     noProfiles: "暂无多Agent配置。",
@@ -307,13 +289,11 @@ export const zh: Translations = {
     commandCopied: "已复制到剪贴板",
     copyFailed: "复制失败",
     confirmDeleteTitle: "删除多Agent配置？",
-    confirmDeleteMessage:
-      "将永久删除多Agent配置 '{name}' — 包括配置、密钥、记忆、会话、技能、定时任务。此操作无法撤销。",
+    confirmDeleteMessage: "将永久删除多Agent配置 '{name}' — 包括配置、密钥、记忆、会话、技能、定时任务。此操作无法撤销。",
     created: "已创建",
     deleted: "已删除",
     renamed: "已重命名",
   },
-
   pluginsPage: {
     contextEngineLabel: "上下文引擎",
     dashboardSlots: "面板插槽",
@@ -335,8 +315,7 @@ export const zh: Translations = {
     pluginListHeading: "已安装插件",
     providerDefaults: "内置 / 默认",
     providersHeading: "运行时提供方插件",
-    providersHint:
-      "写入 config.yaml：memory.provider（留空为内置）、context.engine。下次会话生效。",
+    providersHint: "写入 config.yaml：memory.provider（留空为内置）、context.engine。下次会话生效。",
     refreshDashboard: "重新扫描仪表盘扩展",
     removeConfirm: "从 ~/.hermes/plugins/ 删除此插件？",
     removeHint: "仅可移除用户安装在 ~/.hermes/plugins 下的插件。",
@@ -353,7 +332,6 @@ export const zh: Translations = {
     showInSidebar: "在侧边栏显示",
     hideFromSidebar: "从侧边栏隐藏",
   },
-
   skills: {
     title: "技能",
     searchPlaceholder: "搜索技能和工具集...",
@@ -373,13 +351,10 @@ export const zh: Translations = {
     disabledForCli: "CLI 已禁用",
     more: "还有 {count} 个",
   },
-
   config: {
-    configPath: "~/.hermes/config.yaml",
     filters: "筛选",
     sections: "分类",
     exportConfig: "导出配置为 JSON",
-    importConfig: "从 JSON 导入配置",
     resetDefaults: "恢复默认值",
     resetScopeTooltip: "将{scope}恢复为默认值",
     confirmResetScope: "确定要将{scope}的所有设置恢复为默认值吗？此操作仅更新表单，在按下「保存」按钮前不会写入 config.yaml。",
@@ -387,7 +362,7 @@ export const zh: Translations = {
     rawYaml: "原始 YAML 配置",
     searchResults: "搜索结果",
     fields: "个字段",
-    noFieldsMatch: '没有匹配"{query}"的字段',
+    noFieldsMatch: "没有匹配\"{query}\"的字段",
     configSaved: "配置已保存",
     yamlConfigSaved: "YAML 配置已保存",
     failedToSave: "保存失败",
@@ -409,11 +384,9 @@ export const zh: Translations = {
       tts: "文字转语音",
       stt: "语音转文字",
       logging: "日志",
-      discord: "Discord",
       auxiliary: "辅助",
     },
   },
-
   env: {
     changesNote: "更改会立即保存到磁盘。活跃会话将自动获取新密钥。",
     confirmClearMessage: "该变量的已存值将从 .env 文件中删除。无法在此界面撤销。",
@@ -442,12 +415,10 @@ export const zh: Translations = {
     add: "添加",
     invalidKeyName: "只能使用字母、数字和下划线（必须以字母或下划线开头）。",
   },
-
   oauth: {
     title: "提供商登录（OAuth）",
     providerLogins: "提供商登录（OAuth）",
-    description:
-      "已连接 {connected}/{total} 个 OAuth 提供商。仪表板支持的流程请使用「登录」；CLI 命令仍可用于外部或备用设置。",
+    description: "已连接 {connected}/{total} 个 OAuth 提供商。仪表板支持的流程请使用「登录」；CLI 命令仍可用于外部或备用设置。",
     connected: "已连接",
     expired: "已过期",
     notConnected: "未连接。可用时请使用「登录」，或在终端中运行 {command}。",
@@ -484,24 +455,17 @@ export const zh: Translations = {
     },
     expiresIn: "{time}后过期",
   },
-
   language: {
     switchTo: "切换语言",
   },
-
   theme: {
     title: "主题",
     switchTheme: "切换主题",
   },
-
   achievements: {
     hero: {
-      kicker: "Agentic Gamerscore",
-      title: "Hermes Achievements",
-      subtitle:
-        "从真实会话历史中获得的 Hermes 可收集徽章。已知尚未达成的成就显示为「已发现」；秘密成就在首次出现匹配行为之前保持隐藏。",
-      scan_subtitle:
-        "正在扫描 Hermes 会话历史。在历史记录较多时，首次扫描可能需要 5–10 秒。",
+      subtitle: "从真实会话历史中获得的 Hermes 可收集徽章。已知尚未达成的成就显示为「已发现」；秘密成就在首次出现匹配行为之前保持隐藏。",
+      scan_subtitle: "正在扫描 Hermes 会话历史。在历史记录较多时，首次扫描可能需要 5–10 秒。",
     },
     actions: {
       rescan: "重新扫描",
@@ -514,7 +478,6 @@ export const zh: Translations = {
       secrets: "秘密",
       secrets_hint: "在首次信号出现前保持隐藏",
       highest_tier: "最高等级",
-      highest_tier_hint: "Copper → Silver → Gold → Diamond → Olympian",
       latest: "最新",
       latest_hint_empty: "多多运行 Hermes",
       none_yet: "暂无",
@@ -535,25 +498,19 @@ export const zh: Translations = {
     },
     scan: {
       building_headline: "正在构建成就档案…",
-      building_detail:
-        "正在读取会话、工具调用、模型元数据和解锁状态。",
+      building_detail: "正在读取会话、工具调用、模型元数据和解锁状态。",
       starting_headline: "正在开始成就扫描…",
-      progress_detail:
-        "已扫描 {scanned} / {total} 个会话 · {pct}%。随着更多历史流入，徽章会陆续解锁。",
-      idle_detail:
-        "正在读取会话、工具调用、模型元数据和解锁状态。徽章解锁后将在此显示。",
+      progress_detail: "已扫描 {scanned} / {total} 个会话 · {pct}%。随着更多历史流入，徽章会陆续解锁。",
+      idle_detail: "正在读取会话、工具调用、模型元数据和解锁状态。徽章解锁后将在此显示。",
     },
     guide: {
       tiers_header: "等级",
       secret_header: "秘密成就",
-      secret_body:
-        "秘密成就会隐藏其确切触发条件。一旦 Hermes 检测到相关信号，卡片将变为「已发现」并显示其要求。",
+      secret_body: "秘密成就会隐藏其确切触发条件。一旦 Hermes 检测到相关信号，卡片将变为「已发现」并显示其要求。",
       scan_status_header: "扫描状态",
-      scan_status_body:
-        "Hermes 正在对本地历史进行一次扫描，之后卡片会自动出现。即使这需要几秒钟，也没有卡住。",
+      scan_status_body: "Hermes 正在对本地历史进行一次扫描，之后卡片会自动出现。即使这需要几秒钟，也没有卡住。",
       what_scanned_header: "扫描内容",
-      what_scanned_body:
-        "会话、工具调用、模型元数据、错误、成就和本地解锁状态。",
+      what_scanned_body: "会话、工具调用、模型元数据、错误、成就和本地解锁状态。",
     },
     card: {
       share_title: "分享此成就",
@@ -570,8 +527,7 @@ export const zh: Translations = {
     },
     empty: {
       no_secrets_header: "本次扫描中已没有隐藏的秘密。",
-      no_secrets_body:
-        "提示：秘密通常源于异常失败或高级用户行为模式 —— 端口冲突、权限阻拦、缺少环境变量、YAML 错误、Docker 冲突、回滚或检查点使用、缓存命中，或在大量红色错误后做出的小小修复。",
+      no_secrets_body: "提示：秘密通常源于异常失败或高级用户行为模式 —— 端口冲突、权限阻拦、缺少环境变量、YAML 错误、Docker 冲突、回滚或检查点使用、缓存命中，或在大量红色错误后做出的小小修复。",
     },
     filters: {
       all_categories: "全部",
@@ -593,32 +549,20 @@ export const zh: Translations = {
       copy_button: "复制图片",
       copied: "已复制 ✓",
       download_button: "下载 PNG",
-      hint:
-        "「在 X 上分享」会在新标签页中打开预填好的帖子。如果想附上 1200×630 的徽章，请先点击「复制图片」—— X 允许你直接粘贴到推文编辑器中。「下载 PNG」会将文件保存下来，可在任意位置使用。",
-      clipboard_unsupported:
-        "此浏览器不支持复制剪贴板图片 —— 请改用「下载」。",
-      tweet_text: "Just unlocked {tier_part}\"{name}\" in Hermes Agent ☤",
+      hint: "「在 X 上分享」会在新标签页中打开预填好的帖子。如果想附上 1200×630 的徽章，请先点击「复制图片」—— X 允许你直接粘贴到推文编辑器中。「下载 PNG」会将文件保存下来，可在任意位置使用。",
+      clipboard_unsupported: "此浏览器不支持复制剪贴板图片 —— 请改用「下载」。",
     },
   },
-
   kanban: {
     loading: "正在加载看板…",
     loadFailed: "加载看板失败：",
-    loadFailedHint:
-      "后端会在首次读取时自动创建 kanban.db。如果问题持续，请检查仪表盘日志。",
+    loadFailedHint: "后端会在首次读取时自动创建 kanban.db。如果问题持续，请检查仪表盘日志。",
     board: "看板",
     newBoard: "+ 新建看板",
     newBoardTitle: "新建看板",
-    newBoardDescription:
-      "看板可以将不相关的工作流分开——每个项目、代码库或域一个看板。一个看板上的工作者不会看到另一个看板的任务。",
+    newBoardDescription: "看板可以将不相关的工作流分开——每个项目、代码库或域一个看板。一个看板上的工作者不会看到另一个看板的任务。",
     slug: "标识",
     slugHint: "— 小写字母、连字符，例如 atm10-server",
-    confirmDoneMany:
-      "Mark {n} tasks as done? The workers' claims are released and dependent children become ready.",
-    confirmArchiveMany:
-      "Archive {n} tasks? They disappear from the default board view.",
-    confirmBlockedMany:
-      "Mark {n} tasks as blocked? The workers' claims are released.",
     displayName: "显示名称",
     displayNameHint: "（可选）",
     description: "描述",
@@ -661,8 +605,7 @@ export const zh: Translations = {
     runHistory: "运行历史",
     workerLog: "工作日志",
     loadingLog: "正在加载日志…",
-    noWorkerLog:
-      "— 暂无工作日志（任务尚未启动或日志已被轮转）—",
+    noWorkerLog: "— 暂无工作日志（任务尚未启动或日志已被轮转）—",
     noDescription: "— 无描述 —",
     noComments: "— 无评论 —",
     edit: "编辑",
@@ -693,8 +636,7 @@ export const zh: Translations = {
     reassign: "重新分配",
     renderingError: "看板标签页发生渲染错误",
     reloadView: "重新加载视图",
-    wsAuthFailed:
-      "WebSocket 认证失败 — 请刷新页面以更新会话令牌。",
+    wsAuthFailed: "WebSocket 认证失败 — 请刷新页面以更新会话令牌。",
     markDone: "将 {n} 个任务标记为完成？",
     markArchived: "归档 {n} 个任务？",
     warning: "警告",
@@ -705,8 +647,7 @@ export const zh: Translations = {
     showAllAttempts: "显示所有尝试",
     sendingUpdates: "正在发送更新到",
     sendNotifications: "发送完成 / 阻塞 / 放弃通知到",
-    archiveBoardConfirm:
-      "归档看板 '{name}'？它将被移动到 boards/_archived/ 以便稍后恢复。此看板上的任务将不再出现在 UI 中的任何地方。",
+    archiveBoardConfirm: "归档看板 '{name}'？它将被移动到 boards/_archived/ 以便稍后恢复。此看板上的任务将不再出现在 UI 中的任何地方。",
     archiveBoardTitle: "归档此看板",
     boardSwitcherHint: "看板可以将不相关的工作流分开",
     taskCreatedWarning: "任务已创建，但：",
@@ -745,28 +686,21 @@ export const zh: Translations = {
       done: "已完成",
       archived: "已归档",
     },
-    confirmDone:
-      "将此任务标记为完成？工作者将被释放，依赖的子任务将变为就绪。",
-    confirmArchive:
-      "归档此任务？它将从默认看板视图中消失。",
-    confirmBlocked:
-      "将此任务标记为阻塞？工作者将被释放。",
-    completionSummary:
-      "{label} 的完成摘要。这将作为任务结果存储。",
-    completionSummaryRequired:
-      "在将任务标记为完成之前，必须提供完成摘要。",
+    confirmDone: "将此任务标记为完成？工作者将被释放，依赖的子任务将变为就绪。",
+    confirmArchive: "归档此任务？它将从默认看板视图中消失。",
+    confirmBlocked: "将此任务标记为阻塞？工作者将被释放。",
+    completionSummary: "{label} 的完成摘要。这将作为任务结果存储。",
+    completionSummaryRequired: "在将任务标记为完成之前，必须提供完成摘要。",
     triagePlaceholder: "粗略想法 — AI 将完善规格…",
     taskTitlePlaceholder: "新任务标题…",
     specifier: "规范制定者",
     assigneePlaceholder: "负责人",
     priority: "优先级",
-    skillsPlaceholder:
-      "技能（可选，逗号分隔）：翻译、github-code-review",
+    skillsPlaceholder: "技能（可选，逗号分隔）：翻译、github-code-review",
     noParent: "— 无父任务 —",
     workspacePathDir: "工作区路径（必填，例如 ~/projects/my-app）",
-    workspacePathOptional:
-      "工作区路径（可选，留空则根据负责人推导）",
+    workspacePathOptional: "工作区路径（可选，留空则根据负责人推导）",
     logTruncated: "（显示最后 100 KB — 完整日志位于 ",
     logAt: "）",
   },
-};
+});

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -62,11 +62,16 @@
   --background-alpha: 1;
 
   /* Typography tokens — rewritten by ThemeProvider. Defaults match the
-     system stack so themes that don't override look native. */
+     system stack so themes that don't override look native. CJK faces are
+     appended so Chinese/Japanese/Korean render with a real CJK font rather
+     than the generic fallback box (see web/src/themes/fonts.ts). */
   --theme-font-sans: system-ui, -apple-system, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+    "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB",
+    "Microsoft YaHei", "Noto Sans SC", "Source Han Sans SC",
+    "WenQuanYi Micro Hei", sans-serif;
   --theme-font-mono: ui-monospace, "SF Mono", "Cascadia Mono", Menlo,
-    Consolas, monospace;
+    Consolas, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei",
+    "Noto Sans SC", "Source Han Sans SC", "WenQuanYi Micro Hei", monospace;
   --theme-font-display: var(--theme-font-sans);
   --theme-base-size: 15px;
   --theme-line-height: 1.55;

--- a/web/src/themes/fonts.ts
+++ b/web/src/themes/fonts.ts
@@ -19,11 +19,23 @@
  * `hermes_cli/web_server.py` — the ids must match exactly.
  */
 
-/** System stacks reused from presets so "System" choices need no webfont. */
+/** System stacks reused from presets so "System" choices need no webfont.
+ *
+ * CJK fallbacks are appended after the Latin faces: every shipped theme ends
+ * its stack in one of these constants, so Chinese/Japanese/Korean glyphs
+ * resolve to a real CJK face (PingFang on macOS, YaHei on Windows, Noto /
+ * WenQuanYi on Linux) instead of falling through to the generic `monospace`
+ * / `sans-serif` box — which renders CJK as thin, broken glyphs. The Latin
+ * faces earlier in the stack still win for ASCII, so mono themes stay mono.
+ */
 const SYSTEM_SANS =
-  'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+  'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, ' +
+  '"PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", ' +
+  '"Source Han Sans SC", "WenQuanYi Micro Hei", sans-serif';
 const SYSTEM_MONO =
-  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace';
+  'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, ' +
+  '"PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans SC", ' +
+  '"Source Han Sans SC", "WenQuanYi Micro Hei", monospace';
 const SYSTEM_SERIF =
   'Georgia, Cambria, "Times New Roman", Times, serif';
 


### PR DESCRIPTION
## What

Two fixes for the dashboard's poor CJK rendering and half-translated UI, plus a process guarantee so translations can't silently drift again.

### 1. CJK font fallback
Chinese/Japanese/Korean were rendering as thin, broken glyphs because every theme's font stack (`SYSTEM_SANS` / `SYSTEM_MONO` in `web/src/themes/fonts.ts`, plus the `:root` `--theme-font-*` vars in `web/src/index.css`) ended in Latin-only faces and fell through to the generic `monospace`/`sans-serif` box for CJK. Appended real CJK faces — PingFang SC, Hiragino Sans GB, Microsoft YaHei, Noto Sans SC, Source Han Sans SC, WenQuanYi Micro Hei — covering macOS / Windows / Linux. Every theme inherits them automatically; ASCII still uses the mono faces, so mono themes stay mono.

### 2. i18n sync tool + migration to the partial-locale pattern
`en.ts` is meant to be the single source of truth, but every locale was a **hand-maintained full copy** that had silently drifted: I measured **79 keys present in `en.ts` but missing from all 16 other locales** (uniform across every language — a clear "en got new keys, nobody propagated them" signature). Those keys rendered as `undefined`/English in non-English UIs.

- Added `scripts/i18n-sync.mjs` — **zero-dependency Node**, runs in CI, locally, and on deploy hosts.
  - `--fix`: rewrites each locale to the existing `defineLocale({...})` partial pattern, listing **only the keys that differ from English**; everything else inherits English at runtime. So when `en.ts` gains a key, every locale picks it up for free — no locale can lag behind again.
  - `--check`: fails if any locale has an orphan key (en dropped it) or is missing a key en has.
- Migrated all 16 locales with `--fix`.
- Wired `--check` into the **web workspace `check` chain** (`web/package.json`), so it runs in the existing `js-tests` CI matrix — no workflow YAML changes. `npm run i18n:sync` / `npm run i18n:check` are also exposed at the repo root.

This is exactly the partial-locale mechanism `web/src/i18n/define-locale.ts` was already built for; the locales just weren't using it.

## Verification

- **Lossless migration**: snapshotted every locale's resolved translations before `--fix`, then compared key-by-key after — **10,223 existing translated values checked, 0 changed**. The 1,185 newly-inherited keys previously resolved to `undefined` and now fall back to English.
- `i18n-sync --check` passes (16 locales in sync with en.ts's 713 keys).
- `tsc -b` passes (confirmed via a full `npm run build` against the migrated tree).
- Built and deployed to a live NAS instance to confirm the CJK faces render and the synced bundle loads.

## Scope / follow-up

The config-page field labels (`MODEL`, `TOOLSETS`, `Max Concurrent Sessions`, …) are **not** in the i18n bundle — they come from the backend config schema (`hermes_cli/web_server.py`, English `description`/label metadata) and have no localization layer at all. That's a separate, larger feature and is intentionally out of scope here; flagging it so it isn't mistaken for a regression when those labels remain English.
