### PR TITLE
fix(gateway): two-witness loop liveness — the watchdog's own heartbeat can no longer kill a healthy gateway (salvage of #90502)

### DIFF
--- a/contributors/emails/rodrigo.smscom@gmail.com
+++ b/contributors/emails/rodrigo.smscom@gmail.com
@@ -1,0 +1,1 @@
+rodrigogs

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12692,6 +12692,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 logger.debug("Failed to cancel gateway loop floor timer", exc_info=True)
 
+        # Also disarm the heartbeat writer task itself (ported from #95808):
+        # once shutdown starts loading the loop, a heartbeat that keeps
+        # refreshing the file can make a draining gateway look healthy to
+        # external probes. Cancel is idempotent; the task is also in
+        # _background_tasks so this is belt-and-braces ordering, not new
+        # lifecycle.
+        heartbeat = getattr(self, "_loop_heartbeat_task", None)
+        self._loop_heartbeat_task = None
+        if heartbeat is not None:
+            try:
+                heartbeat.cancel()
+            except Exception:
+                logger.debug("Failed to cancel gateway loop heartbeat task", exc_info=True)
+
     async def _consume_clean_shutdown_marker(self, marker_path) -> int:
         """Discard orphan turn markers before consuming a clean-exit receipt.
 

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -562,7 +562,7 @@ async def loop_heartbeat_forever(
                         _stale.unlink(missing_ok=True)
                         continue
                     try:
-                        os.kill(_stale_pid, 0)
+                        os.kill(_stale_pid, 0)  # windows-footgun: ok — inside os.name == "posix" gate
                     except OSError:
                         _stale.unlink(missing_ok=True)
             except Exception:

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -229,6 +229,24 @@ def get_loop_heartbeat_path(home: Optional[Path] = None) -> Path:
     return base.joinpath(*_HEARTBEAT_RELATIVE)
 
 
+def get_loop_tick_socket_path(
+    home: Optional[Path] = None, pid: Optional[int] = None
+) -> Path:
+    """Return the loop-scheduling witness socket for ``pid``.
+
+    ``<HERMES_HOME>/state/gateway.loop-tick.<pid>.sock`` — PID-suffixed so a
+    leftover node from a previous process can never be mistaken for this
+    gateway's witness. Served by the gateway loop itself (see
+    ``_tick_socket_handler``): an answer is direct proof that the loop is
+    dispatching, which is exactly the property the heartbeat file lost when
+    its write moved off-loop (#90502).
+    """
+    base = home if home is not None else _process_hermes_home()
+    return base.joinpath(
+        "state", f"gateway.loop-tick.{int(pid if pid is not None else os.getpid())}.sock"
+    )
+
+
 def get_shutdown_watchdog_dump_path(home: Optional[Path] = None) -> Path:
     """Return the faulthandler / metadata dump path for a fired watchdog."""
     base = home if home is not None else _process_hermes_home()
@@ -434,6 +452,30 @@ def arm_shutdown_watchdog(
     return done
 
 
+async def _tick_socket_handler(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+) -> None:
+    """Answer a liveness ping with one byte.
+
+    Runs on the gateway loop: the reply is produced only while the loop is
+    actually dispatching, so a successful read is a witness of loop
+    schedulability that no executor thread and no filesystem stall can
+    refresh. A UNIX-socket write is a socket-buffer copy — no fsync, no
+    disk I/O — so the witness keeps working on the exact filesystem that
+    stalls the heartbeat write. Best-effort; never raises.
+    """
+    try:
+        writer.write(b"1")
+        await writer.drain()
+    except Exception:
+        pass
+    finally:
+        try:
+            writer.close()
+        except Exception:
+            pass
+
+
 async def loop_heartbeat_forever(
     *,
     interval_s: float = DEFAULT_HEARTBEAT_INTERVAL_S,
@@ -462,31 +504,78 @@ async def loop_heartbeat_forever(
     while the loop was wedged, which is exactly the signal the docstring above
     promises. And a single in-flight write at a time, so a 112s stall cannot pile
     up one queued thread per interval behind it.
+
+    Because the write is now off-loop, file freshness is no longer *proof* of
+    loop schedulability: a stalled write or a saturated executor can age the file
+    while the loop runs, and a write that lands after the loop froze can keep it
+    fresh. The file therefore stops being sufficient authority on its own. This
+    task also arms a loop-scheduling witness — a UNIX socket answered by the
+    loop itself (``_tick_socket_handler``) — and records whether it is armed in
+    the heartbeat payload (``loop_tick_socket``). External probes must require
+    the witness to agree with file staleness before classifying a loop as
+    wedged; see ``hermes_cli.gateway.probe_gateway_loop_liveness`` for the
+    two-witness contract.
     """
     try:
         interval = max(float(interval_s), 1.0)
     except (TypeError, ValueError):
         interval = DEFAULT_HEARTBEAT_INTERVAL_S
 
+    # Arm the loop-scheduling witness. Best-effort: a failed bind (permissions,
+    # path length) must not abort the gateway or the file heartbeat — it only
+    # disables the witness, and the payload flag tells probes that staleness is
+    # no longer sufficient authority to escalate.
+    tick_server = None
+    tick_socket_path = None
+    try:
+        tick_socket_path = get_loop_tick_socket_path(home)
+        tick_socket_path.parent.mkdir(parents=True, exist_ok=True)
+        tick_server = await asyncio.start_unix_server(
+            _tick_socket_handler, path=str(tick_socket_path)
+        )
+    except Exception:
+        tick_server = None
+        logger.warning(
+            "Loop tick socket unavailable — liveness probes will have no "
+            "loop-scheduling witness and will not escalate on a stale heartbeat",
+            exc_info=True,
+        )
+
     async def _write_off_loop() -> None:
         # write_loop_heartbeat never raises, so a failure here is an executor
         # problem (shutdown, saturation) and must not kill the heartbeat task.
         try:
             await asyncio.to_thread(
-                write_loop_heartbeat, start_time=start_time, home=home
+                write_loop_heartbeat,
+                start_time=start_time,
+                home=home,
+                extra={"loop_tick_socket": tick_server is not None},
             )
         except asyncio.CancelledError:
             raise
         except Exception:
             logger.debug("Loop heartbeat write failed off-loop", exc_info=True)
 
-    # Immediate first write so monitors see a fresh file as soon as the
-    # gateway is running, not after the first interval.
-    await _write_off_loop()
-    while True:
-        if should_continue is not None and not should_continue():
-            return
-        await asyncio.sleep(interval)
-        if should_continue is not None and not should_continue():
-            return
+    try:
+        # Immediate first write so monitors see a fresh file as soon as the
+        # gateway is running, not after the first interval.
         await _write_off_loop()
+        while True:
+            if should_continue is not None and not should_continue():
+                return
+            await asyncio.sleep(interval)
+            if should_continue is not None and not should_continue():
+                return
+            await _write_off_loop()
+    finally:
+        if tick_server is not None:
+            tick_server.close()
+            try:
+                await tick_server.wait_closed()
+            except Exception:
+                pass
+            if tick_socket_path is not None:
+                try:
+                    tick_socket_path.unlink(missing_ok=True)
+                except Exception:
+                    pass

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -525,6 +525,14 @@ async def loop_heartbeat_forever(
     # path length) must not abort the gateway or the file heartbeat — it only
     # disables the witness, and the payload flag tells probes that staleness is
     # no longer sufficient authority to escalate.
+    #
+    # Windows: asyncio.start_unix_server raises (no AF_UNIX event-loop
+    # support), so the witness is PERMANENTLY absent there — the payload
+    # records loop_tick_socket=False and every stale-file probe classifies
+    # UNKNOWN, never WEDGED. That is deliberate fail-safe: a wedged native
+    # Windows gateway keeps the graceful-drain backstop instead of an
+    # escalation verdict built on a witness that cannot exist. (WSL2 — the
+    # #90502 incident environment — is Linux and arms the socket normally.)
     tick_server = None
     tick_socket_path = None
     try:

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -530,6 +530,37 @@ async def loop_heartbeat_forever(
     try:
         tick_socket_path = get_loop_tick_socket_path(home)
         tick_socket_path.parent.mkdir(parents=True, exist_ok=True)
+        # Re-bind over a leftover node from a dead process (os._exit(75) /
+        # SIGKILL skip the finally-unlink; PID reuse re-lands on this
+        # PID-suffixed path) is handled by asyncio itself:
+        # create_unix_server os.remove()s an existing socket node before
+        # binding — guarded by test_producer_rebinds_over_stale_socket_node.
+        # What asyncio does NOT do is clean up SIBLING nodes from other
+        # dead PIDs, so sweep those to keep state/ from accumulating
+        # gateway.loop-tick.*.sock nodes across crash-restart cycles.
+        # POSIX-only: os.kill(pid, 0) is a liveness probe here, but on
+        # Windows os.kill calls TerminateProcess for non-CTRL signals —
+        # and AF_UNIX server nodes are never created there anyway.
+        if os.name == "posix":
+            try:
+                for _stale in tick_socket_path.parent.glob(
+                    "gateway.loop-tick.*.sock"
+                ):
+                    if _stale == tick_socket_path:
+                        continue
+                    try:
+                        _stale_pid = int(_stale.name.split(".")[-2])
+                    except (ValueError, IndexError):
+                        _stale.unlink(missing_ok=True)
+                        continue
+                    try:
+                        os.kill(_stale_pid, 0)
+                    except OSError:
+                        _stale.unlink(missing_ok=True)
+            except Exception:
+                logger.debug(
+                    "stale loop-tick socket sweep failed", exc_info=True
+                )
         tick_server = await asyncio.start_unix_server(
             _tick_socket_handler, path=str(tick_socket_path)
         )

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -443,21 +443,50 @@ async def loop_heartbeat_forever(
 ) -> None:
     """Rewrite the loop heartbeat file on a cadence until cancelled / gated off.
 
-    Runs as an asyncio task on the gateway loop — if the loop freezes, this
-    task stops and the file mtime/updated_at goes stale for external monitors.
+    Runs as an asyncio task on the gateway loop — if the loop freezes, this task
+    stops and the file mtime/updated_at goes stale for external monitors. That
+    property is load-bearing and is preserved below: the write is still
+    *initiated* by the loop, so a frozen loop still lets the file age.
+
+    The write itself is handed to a thread, because it is not free. It ends in
+    ``atomic_json_write`` -> ``os.fsync``, and on a filesystem that stalls, that
+    fsync blocks whatever thread runs it. Doing it inline meant the loop-liveness
+    watchdog's own heartbeat could block the loop it exists to monitor: the probe
+    times out at ``DEFAULT_LOOP_WATCHDOG_TIMEOUT_S`` (10s) and gives up after
+    ``DEFAULT_LOOP_WATCHDOG_MAX_STRIKES`` (3), a ~90-120s budget, while a WSL2
+    VHDX under io pressure was measured stalling a trivial stat-and-fsync probe
+    at p99 31s and max 112s. So the watchdog killed the loop for being
+    unresponsive at the moment it was blocked inside the watchdog's own write.
+
+    Awaited, not fire-and-forget: an unawaited task would keep the file fresh
+    while the loop was wedged, which is exactly the signal the docstring above
+    promises. And a single in-flight write at a time, so a 112s stall cannot pile
+    up one queued thread per interval behind it.
     """
     try:
         interval = max(float(interval_s), 1.0)
     except (TypeError, ValueError):
         interval = DEFAULT_HEARTBEAT_INTERVAL_S
 
+    async def _write_off_loop() -> None:
+        # write_loop_heartbeat never raises, so a failure here is an executor
+        # problem (shutdown, saturation) and must not kill the heartbeat task.
+        try:
+            await asyncio.to_thread(
+                write_loop_heartbeat, start_time=start_time, home=home
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("Loop heartbeat write failed off-loop", exc_info=True)
+
     # Immediate first write so monitors see a fresh file as soon as the
     # gateway is running, not after the first interval.
-    write_loop_heartbeat(start_time=start_time, home=home)
+    await _write_off_loop()
     while True:
         if should_continue is not None and not should_continue():
             return
         await asyncio.sleep(interval)
         if should_continue is not None and not should_continue():
             return
-        write_loop_heartbeat(start_time=start_time, home=home)
+        await _write_off_loop()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -390,8 +390,9 @@ def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
 # heartbeat payload (``loop_tick_socket``).
 #
 # ``probe_gateway_loop_liveness`` reads both signals (a local stat + JSON
-# read + a bounded socket ping — instant, far inside the 10s query tier of
-# the subprocess timeout doc) and classifies the gateway BEFORE any drain
+# read + a bounded socket ping, repeated up to ``tick_strikes`` times when a
+# wedge is suspected — worst case ~3.4s, still far inside the 10s query tier
+# of the subprocess timeout doc) and classifies the gateway BEFORE any drain
 # wait begins:
 #
 # - ``alive``   — the loop answered the tick socket, or the file is fresh and
@@ -399,11 +400,15 @@ def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
 #                 take the normal graceful-drain path, which honours the
 #                 in-flight cron drain floor (#86684).
 # - ``wedged``  — the heartbeat belongs to this PID, is stale well past
-#                 several missed beats, AND the tick socket is armed but does
-#                 not answer: both witnesses agree the loop is provably dead.
-#                 Draining is pointless (nothing can run the drain), so
-#                 callers may escalate immediately via
-#                 ``_escalate_wedged_gateway``.
+#                 several missed beats, AND the tick socket is armed but
+#                 stays silent across a sustained window of consecutive
+#                 misses (default 3): both witnesses agree, sustained, that
+#                 the loop is provably dead. One silent probe is never
+#                 destructive authority — a transient synchronous stall can
+#                 outlast a single recv timeout, so a lone miss falls to
+#                 ``unknown``. Draining is pointless for a provably dead
+#                 loop (nothing can run the drain), so callers may escalate
+#                 immediately via ``_escalate_wedged_gateway``.
 # - ``unknown`` — no heartbeat / unreadable / PID mismatch / witness conflict
 #                 (fresh file with a silent loop, armed socket unreachable).
 #                 Treated like ``alive``: never escalate on ambiguity.
@@ -470,12 +475,61 @@ def _probe_loop_tick_socket(
                 pass
 
 
+def _probe_loop_tick_socket_sustained(
+    pid: int,
+    home: Path | None,
+    *,
+    timeout: float = 1.0,
+    strikes: int = 3,
+    gap_s: float = 0.2,
+) -> bool | None:
+    """Probe the tick socket until a reply or the sustained-miss budget.
+
+    A single silent probe is NOT destructive evidence: the loop may be in a
+    short transient synchronous stall (a reconnect storm, a heavy synchronous
+    callback, scheduler delay) that outlasts one recv timeout. Killing a
+    gateway on that would be a false wedge — the exact class of false
+    positive #90502 exists to prevent. Destructive authority therefore
+    requires the loop to fail to answer across a bounded window of
+    ``strikes`` consecutive misses, ``gap_s`` apart; any answer inside the
+    window proves the loop is dispatching and returns ``True``.
+
+    Returns:
+      True  — some attempt got an answer: the loop is dispatching.
+      False — every attempt observed a socket node that stayed silent: the
+              loop did not schedule for the whole window.
+      None  — a probe found no socket node (witness vanished mid-window, or
+              legacy producer): not evidence either way.
+    """
+    saw_node = False
+    total = max(int(strikes), 0)
+    for attempt in range(total):
+        result = _probe_loop_tick_socket(pid, home, timeout=timeout)
+        if result is True:
+            return True
+        if result is None:
+            # The witness is gone — it is no longer answering, but its
+            # absence is not a miss. Ambiguity, never a wedge.
+            if not saw_node:
+                return None
+            # A node that existed and went silent mid-window: the witness
+            # disappeared. Treat as ambiguity too.
+            return None
+        saw_node = True
+        if attempt < total - 1 and gap_s > 0:
+            time.sleep(gap_s)
+    return False
+
+
+
 def probe_gateway_loop_liveness(
     pid: int,
     *,
     stale_after: float = DEFAULT_LOOP_LIVENESS_STALE_AFTER_S,
     home: Path | None = None,
     tick_timeout: float = 1.0,
+    tick_strikes: int = 3,
+    tick_gap_s: float = 0.2,
 ) -> str:
     """Classify a gateway PID's event loop as alive / wedged / unknown.
 
@@ -493,11 +547,15 @@ def probe_gateway_loop_liveness(
 
     A stale file classifies as ``wedged`` only when the producer declared the
     tick socket armed (``loop_tick_socket: true`` in the payload) AND the
-    socket does not answer — both witnesses agree the loop stopped
-    scheduling. Any conflict or ambiguity returns ``unknown`` so callers keep
-    the safe graceful-drain path. Legacy producers (payload without the
-    flag) wrote the file on-loop, so their staleness remains proof and the
-    old contract is unchanged.
+    socket stays silent across a sustained window — ``tick_strikes``
+    consecutive misses (default 3). One silent probe is never destructive
+    authority: a short transient synchronous stall can outlast a single recv
+    timeout, so a single miss returns ``unknown`` and keeps the graceful
+    drain path. Any answer inside the window proves the loop is dispatching
+    and returns ``alive``. Any conflict or ambiguity returns ``unknown`` so
+    callers keep the safe graceful-drain path. Legacy producers (payload
+    without the flag) wrote the file on-loop, so their staleness remains
+    proof and the old contract is unchanged.
 
     Never raises; any ambiguity (missing file, unreadable JSON, PID mismatch)
     returns ``GATEWAY_LOOP_UNKNOWN``.
@@ -549,8 +607,30 @@ def probe_gateway_loop_liveness(
         # without a witness.
         return GATEWAY_LOOP_UNKNOWN
     if witness is False:
-        # Both witnesses agree the loop is not scheduling.
-        return GATEWAY_LOOP_WEDGED
+        # First miss. One silent probe is NOT destructive authority: a
+        # short transient synchronous stall can outlast a single recv
+        # timeout, and killing a live gateway on it would be the exact false
+        # wedge #90502 exists to prevent. Require the loop to stay silent
+        # across the whole bounded window — the first probe above is miss
+        # #1, so ``tick_strikes - 1`` more attempts follow.
+        sustained = _probe_loop_tick_socket_sustained(
+            pid,
+            home,
+            timeout=tick_timeout,
+            strikes=tick_strikes - 1,
+            gap_s=tick_gap_s,
+        )
+        if sustained is False:
+            # Both witnesses agree, sustained: the loop did not schedule for
+            # the entire window.
+            return GATEWAY_LOOP_WEDGED
+        if sustained is True:
+            # The loop answered on a later attempt: it was a transient
+            # stall, not a wedge — the stale file is a stalled write.
+            return GATEWAY_LOOP_ALIVE
+        # Witness vanished mid-window: ambiguity — never kill on it. The
+        # graceful drain path remains the backstop.
+        return GATEWAY_LOOP_UNKNOWN
     # Armed producer but the socket is unreachable: ambiguity — never kill on
     # it. The graceful drain path remains the backstop.
     return GATEWAY_LOOP_UNKNOWN

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -12,6 +12,7 @@ import os
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import textwrap
@@ -379,24 +380,42 @@ def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
 # rewrites ``state/gateway.heartbeat`` every 30s (#66892), so a frozen loop
 # stops refreshing the file while a busy-but-alive loop keeps refreshing it.
 #
-# ``probe_gateway_loop_liveness`` reads that signal (a local stat + JSON read,
-# instant — far inside the 10s query tier of the subprocess timeout doc) and
-# classifies the gateway BEFORE any drain wait begins:
+# Since #90502 the heartbeat write runs on a thread (a stalling filesystem
+# must not be able to block the loop the watchdog watches), which costs the
+# file its status as *proof*: a stalled write or a saturated executor can age
+# the file while the loop runs, and an off-loop write can land after the loop
+# froze, keeping the file fresh for a dead loop. The loop therefore also arms
+# a second witness — ``state/gateway.loop-tick.<pid>.sock``, a UNIX socket
+# answered by the loop itself — and records whether it is armed in the
+# heartbeat payload (``loop_tick_socket``).
 #
-# - ``alive``   — heartbeat is fresh: the loop is dispatching (possibly busy).
-#                 Callers must take the normal graceful-drain path, which
-#                 honours the in-flight cron drain floor (#86684).
-# - ``wedged``  — heartbeat belongs to this PID but has gone stale well past
-#                 several missed beats: the loop is provably dead.  Draining
-#                 is pointless (nothing can run the drain), so callers may
-#                 escalate immediately via ``_escalate_wedged_gateway``.
-# - ``unknown`` — no heartbeat / unreadable / PID mismatch (older gateway,
-#                 still starting up, stale file from a previous process).
+# ``probe_gateway_loop_liveness`` reads both signals (a local stat + JSON
+# read + a bounded socket ping — instant, far inside the 10s query tier of
+# the subprocess timeout doc) and classifies the gateway BEFORE any drain
+# wait begins:
+#
+# - ``alive``   — the loop answered the tick socket, or the file is fresh and
+#                 the loop is not contradicted by the socket.  Callers must
+#                 take the normal graceful-drain path, which honours the
+#                 in-flight cron drain floor (#86684).
+# - ``wedged``  — the heartbeat belongs to this PID, is stale well past
+#                 several missed beats, AND the tick socket is armed but does
+#                 not answer: both witnesses agree the loop is provably dead.
+#                 Draining is pointless (nothing can run the drain), so
+#                 callers may escalate immediately via
+#                 ``_escalate_wedged_gateway``.
+# - ``unknown`` — no heartbeat / unreadable / PID mismatch / witness conflict
+#                 (fresh file with a silent loop, armed socket unreachable).
 #                 Treated like ``alive``: never escalate on ambiguity.
 #
 # The distinction matters: only a *provably dead* loop may bypass the cron
-# drain floor.  A merely busy gateway still answers the probe (fresh file)
-# and keeps its full drain budget.
+# drain floor.  A merely busy gateway still answers the probe (socket ping)
+# and keeps its full drain budget — even when the filesystem is stalling the
+# heartbeat write (the incident that motivated #90502).
+#
+# Legacy gateways (no ``loop_tick_socket`` flag in the payload) wrote the
+# file on-loop, so their staleness remains proof and the old single-witness
+# contract is unchanged.
 
 GATEWAY_LOOP_ALIVE = "alive"
 GATEWAY_LOOP_WEDGED = "wedged"
@@ -406,19 +425,82 @@ GATEWAY_LOOP_UNKNOWN = "unknown"
 # Three missed beats is decisive without false-positiving on one slow write.
 DEFAULT_LOOP_LIVENESS_STALE_AFTER_S = 90.0
 
+# Sentinel for "the producer never wrote the witness flag" (legacy payload).
+_LOOP_TICK_ABSENT = object()
+
+
+def _probe_loop_tick_socket(
+    pid: int,
+    home: Path | None,
+    timeout: float = 1.0,
+) -> bool | None:
+    """Ping the loop-scheduling witness socket for ``pid``.
+
+    Returns:
+      True  — the loop answered: it is dispatching right now.
+      False — a socket node exists for this PID but did not answer (the loop
+              is not scheduling, or the node is a leftover from a dead
+              listener).
+      None  — no socket node for this PID (legacy producer), or the path
+              could not be resolved. Not evidence either way.
+    """
+    try:
+        from gateway.shutdown_watchdog import get_loop_tick_socket_path
+
+        path = get_loop_tick_socket_path(home, pid)
+        if not path.is_socket():
+            return None
+    except Exception:
+        return None
+    sock = None
+    try:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(max(float(timeout), 0.0))
+        sock.connect(str(path))
+        return sock.recv(1) == b"1"
+    except Exception:
+        # ECONNREFUSED (node with no listener), timeout (loop not answering),
+        # transient errors: the witness exists but is silent.
+        return False
+    finally:
+        if sock is not None:
+            try:
+                sock.close()
+            except Exception:
+                pass
+
 
 def probe_gateway_loop_liveness(
     pid: int,
     *,
     stale_after: float = DEFAULT_LOOP_LIVENESS_STALE_AFTER_S,
     home: Path | None = None,
+    tick_timeout: float = 1.0,
 ) -> str:
     """Classify a gateway PID's event loop as alive / wedged / unknown.
 
-    Reads the loop-liveness heartbeat file the gateway rewrites every 30s
-    while its loop is dispatching.  Never raises; any ambiguity (missing
-    file, unreadable JSON, PID mismatch) returns ``GATEWAY_LOOP_UNKNOWN``
-    so callers default to the safe graceful-drain path.
+    Two witnesses:
+
+    - the loop-tick socket (``state/gateway.loop-tick.<pid>.sock``): answered
+      by the gateway loop itself, so a reply is direct proof that the loop is
+      dispatching. It is never refreshed by the heartbeat executor thread and
+      never stalled by a filesystem that is slow to fsync.
+    - the heartbeat file (``state/gateway.heartbeat``): rewritten every 30s
+      on a thread since #90502, so freshness alone is no longer proof of loop
+      schedulability — a stalled write (measured at 112.6s max on the
+      incident box) or a saturated executor can age the file while the loop
+      runs, and a write can land after the loop froze.
+
+    A stale file classifies as ``wedged`` only when the producer declared the
+    tick socket armed (``loop_tick_socket: true`` in the payload) AND the
+    socket does not answer — both witnesses agree the loop stopped
+    scheduling. Any conflict or ambiguity returns ``unknown`` so callers keep
+    the safe graceful-drain path. Legacy producers (payload without the
+    flag) wrote the file on-loop, so their staleness remains proof and the
+    old contract is unchanged.
+
+    Never raises; any ambiguity (missing file, unreadable JSON, PID mismatch)
+    returns ``GATEWAY_LOOP_UNKNOWN``.
     """
     try:
         stale_budget = max(float(stale_after), 0.0)
@@ -437,10 +519,41 @@ def probe_gateway_loop_liveness(
         # No heartbeat for THIS process — old gateway version, still starting
         # up, or a stale file from a previous PID.  Not evidence of a wedge.
         return GATEWAY_LOOP_UNKNOWN
+
+    witness = _probe_loop_tick_socket(pid, home, timeout=tick_timeout)
+    if witness is True:
+        # The loop answered a ping — it is dispatching right now. A stale
+        # heartbeat file is a stalled write or a saturated executor, not a
+        # wedge (#90502).
+        return GATEWAY_LOOP_ALIVE
+
+    tick_armed = payload.get("loop_tick_socket", _LOOP_TICK_ABSENT)
     age = time.time() - mtime
-    if age > stale_budget:
+    if age <= stale_budget:
+        if witness is False:
+            # File fresh but the loop did not answer: an off-loop write can
+            # land after the loop froze, so a fresh file is not a liveness
+            # proof while the loop itself is silent.
+            return GATEWAY_LOOP_UNKNOWN
+        return GATEWAY_LOOP_ALIVE
+
+    # File is stale past the budget. The verdict now depends on what the
+    # producer promised about its witness:
+    if tick_armed is _LOOP_TICK_ABSENT:
+        # Legacy producer: the write ran on-loop, so staleness really does
+        # prove the loop stopped scheduling — old contract, unchanged.
         return GATEWAY_LOOP_WEDGED
-    return GATEWAY_LOOP_ALIVE
+    if tick_armed is not True:
+        # New producer whose witness could not be armed (bind failed): the
+        # write is off-loop, so staleness is NOT proof. Never escalate
+        # without a witness.
+        return GATEWAY_LOOP_UNKNOWN
+    if witness is False:
+        # Both witnesses agree the loop is not scheduling.
+        return GATEWAY_LOOP_WEDGED
+    # Armed producer but the socket is unreachable: ambiguity — never kill on
+    # it. The graceful drain path remains the backstop.
+    return GATEWAY_LOOP_UNKNOWN
 
 
 def _escalate_wedged_gateway(

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -501,21 +501,16 @@ def _probe_loop_tick_socket_sustained(
       None  — a probe found no socket node (witness vanished mid-window, or
               legacy producer): not evidence either way.
     """
-    saw_node = False
     total = max(int(strikes), 0)
     for attempt in range(total):
         result = _probe_loop_tick_socket(pid, home, timeout=timeout)
         if result is True:
             return True
         if result is None:
-            # The witness is gone — it is no longer answering, but its
-            # absence is not a miss. Ambiguity, never a wedge.
-            if not saw_node:
-                return None
-            # A node that existed and went silent mid-window: the witness
-            # disappeared. Treat as ambiguity too.
+            # No socket node this attempt — either the witness never
+            # existed (legacy producer) or it vanished mid-window. Both
+            # are ambiguity, never a wedge: absence is not a miss.
             return None
-        saw_node = True
         if attempt < total - 1 and gap_s > 0:
             time.sleep(gap_s)
     return False

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -382,3 +382,24 @@ def test_heartbeat_write_is_awaited_so_a_frozen_loop_still_goes_stale():
         "the heartbeat write is fire-and-forget; a frozen loop would keep the "
         "file fresh and the staleness signal would be lost"
     )
+
+
+def test_loop_scheduling_witness_is_served_by_the_loop_itself():
+    """The tick socket must be armed on the loop, never in a thread.
+
+    The two-witness contract in ``probe_gateway_loop_liveness`` rests on the
+    socket being answered only while the loop is actually dispatching. If the
+    server ever moved into the heartbeat's executor thread, a wedged loop
+    could keep answering pings (same class of lie as a fire-and-forget file
+    write) and the interlock would be void.
+    """
+    src = pathlib.Path(
+        inspect.getsourcefile(loop_heartbeat_forever) or ""
+    ).read_text()
+    body = src[src.index("async def loop_heartbeat_forever("):]
+    body = body[: body.index("\ndef ") if "\ndef " in body else len(body)]
+    # Awaited directly on the loop task: a coroutine cannot run inside a
+    # thread, so an awaited start_unix_server is structurally loop-owned.
+    assert "await asyncio.start_unix_server(" in body, (
+        "the loop-scheduling witness socket is not armed by the loop task"
+    )

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import pathlib
+import inspect
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -10,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from gateway.shutdown_watchdog import (
+    loop_heartbeat_forever,
     _arm_loop_floor_timer,
     start_loop_liveness_watchdog,
 )
@@ -310,3 +313,72 @@ def test_gateway_runner_liveness_guards_start_and_stop():
     floor_timer.cancel.assert_called_once_with()
     assert runner._loop_liveness_watchdog is None
     assert runner._loop_floor_timer_handle is None
+def test_heartbeat_write_does_not_block_the_loop_it_monitors():
+    """The heartbeat write must not freeze the loop the watchdog is watching.
+
+    ``write_loop_heartbeat`` ends in ``atomic_json_write`` -> ``os.fsync``, and on
+    a stalling filesystem that fsync blocks whichever thread runs it. Run inline,
+    that thread was the gateway loop — so the loop-liveness watchdog would time
+    out its probe (10s, 3 strikes, a ~90-120s budget) and kill the loop for being
+    unresponsive at the moment it was blocked inside the watchdog's own write. A
+    WSL2 VHDX under io pressure was measured stalling a trivial stat-and-fsync
+    probe at p99 31s, max 112s — longer than the whole budget.
+
+    Bounded by a fixed sleep rather than an Event handshake on purpose: if the
+    write ever goes back on-loop this fails on the tick count instead of hanging.
+    """
+    block_s = 0.30
+
+    def slow_write(**_kwargs):
+        time.sleep(block_s)
+        return pathlib.Path("/dev/null")
+
+    async def scenario() -> int:
+        ticks = 0
+
+        async def ticker() -> None:
+            nonlocal ticks
+            deadline = time.monotonic() + block_s
+            while time.monotonic() < deadline:
+                await asyncio.sleep(0.02)
+                ticks += 1
+
+        with patch(
+            "gateway.shutdown_watchdog.write_loop_heartbeat", slow_write
+        ):
+            # should_continue False -> exactly one write, then return.
+            hb = asyncio.create_task(
+                loop_heartbeat_forever(interval_s=60.0, should_continue=lambda: False)
+            )
+            await ticker()
+            await asyncio.wait_for(hb, timeout=5.0)
+        return ticks
+
+    ticks = asyncio.run(scenario())
+    # Off-loop, the ticker gets roughly block_s / 0.02 ticks. Inline it gets at
+    # most one, because the loop cannot run anything while fsync blocks it.
+    assert ticks >= 5, (
+        "the loop made only %d tick(s) while the heartbeat was writing — "
+        "the write is blocking the loop again" % ticks
+    )
+
+
+def test_heartbeat_write_is_awaited_so_a_frozen_loop_still_goes_stale():
+    """The staleness signal external monitors rely on must survive the fix.
+
+    The docstring on ``loop_heartbeat_forever`` promises that a frozen loop lets the file
+    age, which is how an outside supervisor notices. Handing the write to a thread
+    keeps that promise only because the loop still *initiates* it and awaits it —
+    fire-and-forget would refresh the file from a thread while the loop was
+    wedged, destroying exactly that signal.
+    """
+    src = pathlib.Path(
+        inspect.getsourcefile(loop_heartbeat_forever) or ""
+    ).read_text()
+    body = src[src.index("async def loop_heartbeat_forever("):]
+    body = body[: body.index("\ndef ") if "\ndef " in body else len(body)]
+    assert "await asyncio.to_thread(" in body, "the write is not handed to a thread"
+    assert "create_task(" not in body, (
+        "the heartbeat write is fire-and-forget; a frozen loop would keep the "
+        "file fresh and the staleness signal would be lost"
+    )

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -13,8 +13,10 @@ import asyncio
 import json
 import os
 import socket
+import tempfile
 import threading
 import time
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -26,6 +28,20 @@ from gateway.shutdown_watchdog import (
     loop_heartbeat_forever,
     write_loop_heartbeat,
 )
+
+
+@pytest.fixture()
+def tmp_path():
+    """Short-path override for this module (macOS AF_UNIX ~104-byte limit).
+
+    The loop-tick witness tests bind real UNIX sockets under HERMES_HOME.
+    pytest's default tmp_path nests deep enough on macOS that
+    ``state/gateway.loop-tick.<pid>.sock`` exceeds the sockaddr_un limit and
+    ``bind()`` raises ``OSError: AF_UNIX path too long``. A mkdtemp directly
+    under the system temp root keeps the socket path well under the limit
+    on every platform.
+    """
+    return Path(tempfile.mkdtemp(prefix="hwg-"))
 
 
 def _write_heartbeat(home, pid, age_s=0.0):

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -12,6 +12,7 @@ path — including the in-flight cron drain floor from #86684.
 import asyncio
 import json
 import os
+import shutil
 import socket
 import tempfile
 import threading
@@ -41,7 +42,11 @@ def tmp_path():
     under the system temp root keeps the socket path well under the limit
     on every platform.
     """
-    return Path(tempfile.mkdtemp(prefix="hwg-"))
+    path = Path(tempfile.mkdtemp(prefix="hwg-"))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
 
 
 def _write_heartbeat(home, pid, age_s=0.0):
@@ -785,6 +790,47 @@ class TestLoopTickWitness:
             )
             == gateway_cli.GATEWAY_LOOP_UNKNOWN
         )
+
+    @pytest.mark.asyncio
+    async def test_producer_rebinds_over_stale_socket_node(self, tmp_path):
+        """A leftover node from a dead process must not disarm the witness.
+
+        os._exit(75) / SIGKILL skip the finally-unlink, and PID reuse then
+        re-lands on the same PID-suffixed path. Without the pre-bind unlink
+        the bind fails EADDRINUSE, the except disarms the witness
+        (loop_tick_socket:false), and a stale heartbeat can never classify
+        WEDGED — precisely on crash-restart loops.
+        """
+        sock_path = get_loop_tick_socket_path(tmp_path)
+        _silent_socket_node(sock_path)  # dead process's leftover node
+        assert sock_path.exists()
+
+        task = asyncio.create_task(
+            loop_heartbeat_forever(interval_s=0.2, home=tmp_path)
+        )
+        try:
+            for _ in range(50):
+                hb = get_loop_heartbeat_path(tmp_path)
+                if hb.exists():
+                    payload = json.loads(hb.read_text(encoding="utf-8"))
+                    if payload.get("loop_tick_socket"):
+                        break
+                await asyncio.sleep(0.05)
+            else:
+                raise AssertionError(
+                    "witness never armed over the stale socket node"
+                )
+            # And it actually answers: the node is live, not the leftover.
+            reader, writer = await asyncio.open_unix_connection(str(sock_path))
+            data = await asyncio.wait_for(reader.read(64), timeout=2)
+            writer.close()
+            assert data, "re-bound tick socket gave no answer"
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     def test_transient_stall_below_wedge_budget_never_escalates(
         self, tmp_path, monkeypatch

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -9,14 +9,23 @@ seconds. A busy-but-alive gateway (fresh heartbeat) must keep the full drain
 path — including the in-flight cron drain floor from #86684.
 """
 
+import asyncio
 import json
 import os
+import socket
+import threading
 import time
+from unittest.mock import patch
 
 import pytest
 
 import hermes_cli.gateway as gateway_cli
-from gateway.shutdown_watchdog import get_loop_heartbeat_path, write_loop_heartbeat
+from gateway.shutdown_watchdog import (
+    get_loop_heartbeat_path,
+    get_loop_tick_socket_path,
+    loop_heartbeat_forever,
+    write_loop_heartbeat,
+)
 
 
 def _write_heartbeat(home, pid, age_s=0.0):
@@ -27,6 +36,34 @@ def _write_heartbeat(home, pid, age_s=0.0):
         stamp = time.time() - age_s
         os.utime(path, (stamp, stamp))
     return path
+
+
+def _mark_witness_flag(home, armed, age_s=0.0):
+    """Set ``loop_tick_socket`` on the heartbeat payload; re-stamp mtime."""
+    path = get_loop_heartbeat_path(home)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["loop_tick_socket"] = armed
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    if age_s:
+        stamp = time.time() - age_s
+        os.utime(path, (stamp, stamp))
+    return path
+
+
+def _silent_socket_node(path):
+    """Create a socket node at ``path`` that never answers.
+
+    Bind + listen, then close the listener WITHOUT unlinking: the node stays,
+    so a probe's connect() gets ECONNREFUSED — a witness that exists but is
+    silent, exactly like a dead listener (or a loop that stopped scheduling).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        srv.bind(str(path))
+        srv.listen(1)
+    finally:
+        srv.close()
 
 
 class TestProbeGatewayLoopLiveness:
@@ -261,3 +298,238 @@ class TestLaunchdRestartWedgedIntegration:
         gateway_cli.launchd_restart()
         assert "escalate" not in events
         assert ("drain", 4242, 195.0) in events
+
+
+class TestLoopTickWitness:
+    """Two-witness liveness (#90502 review).
+
+    The heartbeat write moved off-loop, so a stale file no longer proves a
+    wedged loop and a fresh file no longer proves an alive one. The loop
+    answers a UNIX socket instead; the probe only escalates when BOTH
+    witnesses agree the loop stopped scheduling.
+    """
+
+    def test_stalled_heartbeat_write_never_escalates_a_running_loop(
+        self, tmp_path, monkeypatch
+    ):
+        """Producer + consumer composition.
+
+        While the heartbeat write is stalled longer than the stale budget, a
+        loop that demonstrably keeps dispatching must probe ALIVE — and a
+        restart path fed by the real probe must take the graceful drain,
+        never the bounded escalation. This is the exact false-positive the
+        review called out: the measured fsync stall (112.6s max) exceeds the
+        90s destructive-classifier threshold.
+        """
+        pid = os.getpid()
+        block_s = 1.5
+        stale_after = 1.0
+
+        # First write lands immediately; every later write stalls like an
+        # fsync on the incident filesystem, so the file ages past the budget
+        # while the loop keeps running.
+        def stalling_write(**_kwargs):
+            if not get_loop_heartbeat_path(tmp_path).exists():
+                return write_loop_heartbeat(**_kwargs)
+            time.sleep(block_s)
+            return write_loop_heartbeat(**_kwargs)
+
+        errors = []
+
+        async def producer() -> None:
+            with patch(
+                "gateway.shutdown_watchdog.write_loop_heartbeat", stalling_write
+            ):
+                task = asyncio.create_task(
+                    loop_heartbeat_forever(interval_s=1.0, home=tmp_path)
+                )
+                try:
+                    # One interval (1.0s) elapses, the second write starts and
+                    # stalls; 1.35s in the file is stale but the loop ticks.
+                    await asyncio.sleep(1.35)
+                finally:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        def run_producer() -> None:
+            try:
+                asyncio.run(producer())
+            except Exception as exc:  # surfaced via errors after join
+                errors.append(exc)
+
+        thread = threading.Thread(target=run_producer, daemon=True)
+        thread.start()
+        try:
+            sock_path = get_loop_tick_socket_path(tmp_path, pid)
+            deadline = time.monotonic() + 5.0
+            while not sock_path.exists() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            assert sock_path.exists(), "producer never armed the tick socket"
+
+            hb_path = get_loop_heartbeat_path(tmp_path)
+            deadline = time.monotonic() + 5.0
+            while True:
+                try:
+                    age = time.time() - hb_path.stat().st_mtime
+                except FileNotFoundError:
+                    # The socket is armed before the first write lands; the
+                    # file appears a tick later.
+                    age = 0.0
+                if age > stale_after:
+                    break
+                assert time.monotonic() < deadline, "heartbeat never went stale"
+                time.sleep(0.02)
+
+            # The file is stale but the loop answers: ALIVE, not WEDGED.
+            assert (
+                gateway_cli.probe_gateway_loop_liveness(
+                    pid, home=tmp_path, stale_after=stale_after, tick_timeout=0.25
+                )
+                == gateway_cli.GATEWAY_LOOP_ALIVE
+            )
+
+            # The restart path fed by the REAL probe must drain, not escalate.
+            events = []
+            monkeypatch.setattr(
+                gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway"
+            )
+            monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+            monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 180.0)
+            monkeypatch.setattr(
+                "gateway.status.get_running_pid", lambda *a, **k: pid
+            )
+            monkeypatch.setattr(
+                gateway_cli, "_request_gateway_self_restart", lambda pid: False
+            )
+            monkeypatch.setattr(
+                gateway_cli,
+                "_escalate_wedged_gateway",
+                lambda pid, **kw: events.append("escalate") or True,
+            )
+            monkeypatch.setattr(
+                gateway_cli,
+                "terminate_pid",
+                lambda pid, force=False: events.append(("kill" if force else "term", pid)),
+            )
+            monkeypatch.setattr(
+                gateway_cli,
+                "_wait_for_gateway_exit",
+                lambda timeout, force_after=None: events.append(("drain", timeout))
+                or True,
+            )
+            monkeypatch.setattr(
+                gateway_cli.subprocess,
+                "run",
+                lambda *a, **k: events.append("kickstart")
+                or __import__("types").SimpleNamespace(
+                    returncode=0, stdout="", stderr=""
+                ),
+            )
+            monkeypatch.setattr(
+                gateway_cli, "_clear_launchd_unsupported_marker", lambda: None
+            )
+            # The real probe resolves the state dir through this hook.
+            monkeypatch.setattr(
+                "gateway.shutdown_watchdog._process_hermes_home", lambda: tmp_path
+            )
+            gateway_cli.launchd_restart()
+            assert "escalate" not in events
+            assert ("drain", 180.0) in events
+        finally:
+            thread.join(timeout=5.0)
+            assert not errors, errors
+
+    def test_off_loop_completion_cannot_manufacture_fresh_liveness(self, tmp_path):
+        """A write landing after the loop froze must not look alive.
+
+        File fresh (a late off-loop write completed) + loop silent: the probe
+        must NOT return ALIVE — the loop itself never answered, so freshness
+        is not a liveness proof. UNKNOWN keeps the safe drain path while
+        denying the false-fresh window the review described.
+        """
+        pid = 4242
+        _silent_socket_node(get_loop_tick_socket_path(tmp_path, pid))
+        _write_heartbeat(tmp_path, pid, age_s=5.0)
+        _mark_witness_flag(tmp_path, armed=True)
+        assert (
+            gateway_cli.probe_gateway_loop_liveness(
+                pid, home=tmp_path, tick_timeout=0.2
+            )
+            == gateway_cli.GATEWAY_LOOP_UNKNOWN
+        )
+
+    def test_true_wedge_requires_both_witnesses_to_agree(self, tmp_path):
+        """Stale file + armed but silent socket: both agree, so WEDGED.
+
+        The destructive path must still exist for genuinely dead loops — a
+        frozen loop stops answering the socket, and the file goes stale.
+        """
+        pid = 4242
+        _silent_socket_node(get_loop_tick_socket_path(tmp_path, pid))
+        _write_heartbeat(tmp_path, pid, age_s=600.0)
+        _mark_witness_flag(tmp_path, armed=True, age_s=600.0)
+        assert (
+            gateway_cli.probe_gateway_loop_liveness(
+                pid, home=tmp_path, tick_timeout=0.2
+            )
+            == gateway_cli.GATEWAY_LOOP_WEDGED
+        )
+
+    def test_armed_witness_unreachable_is_unknown(self, tmp_path):
+        """Producer claims the witness is armed but no node exists: ambiguity.
+
+        Never kill on it — the graceful drain remains the backstop.
+        """
+        pid = 4242
+        _write_heartbeat(tmp_path, pid, age_s=600.0)
+        _mark_witness_flag(tmp_path, armed=True, age_s=600.0)
+        assert (
+            gateway_cli.probe_gateway_loop_liveness(
+                pid, home=tmp_path, tick_timeout=0.2
+            )
+            == gateway_cli.GATEWAY_LOOP_UNKNOWN
+        )
+
+    def test_unarmed_witness_disables_stale_escalation(self, tmp_path):
+        """New producer whose bind failed: staleness is NOT proof.
+
+        The write is off-loop, so the file can age while the loop runs; with
+        no witness, a stale file must never escalate.
+        """
+        pid = 4242
+        _write_heartbeat(tmp_path, pid, age_s=600.0)
+        _mark_witness_flag(tmp_path, armed=False, age_s=600.0)
+        assert (
+            gateway_cli.probe_gateway_loop_liveness(
+                pid, home=tmp_path, tick_timeout=0.2
+            )
+            == gateway_cli.GATEWAY_LOOP_UNKNOWN
+        )
+
+    def test_legacy_payload_keeps_single_witness_contract(self, tmp_path):
+        """No witness flag = on-loop writer: staleness stays proof.
+
+        Old gateways never moved the write off-loop, so their stale file
+        still means a dead loop — the legacy WEDGED verdict is unchanged.
+        """
+        pid = 4242
+        _write_heartbeat(tmp_path, pid, age_s=600.0)
+        assert (
+            gateway_cli.probe_gateway_loop_liveness(pid, home=tmp_path)
+            == gateway_cli.GATEWAY_LOOP_WEDGED
+        )
+        # And a fresh legacy file stays safe even if a dead-listener node
+        # exists for the PID (leftover from a newer process): the silent
+        # socket denies ALIVE, and UNKNOWN never escalates — the drain path
+        # keeps the full budget either way.
+        _write_heartbeat(tmp_path, pid, age_s=5.0)
+        _silent_socket_node(get_loop_tick_socket_path(tmp_path, pid))
+        assert (
+            gateway_cli.probe_gateway_loop_liveness(
+                pid, home=tmp_path, tick_timeout=0.2
+            )
+            == gateway_cli.GATEWAY_LOOP_UNKNOWN
+        )

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -66,6 +66,144 @@ def _silent_socket_node(path):
         srv.close()
 
 
+def _start_freezeable_producer(tmp_path, block_s, errors, write_stall_s=1.5):
+    """Run the real heartbeat producer on a loop that can be frozen on demand.
+
+    Returns ``(state, ready)``:
+
+    - ``state["trigger"]`` — freezes the gateway loop synchronously for
+      ``block_s`` seconds. While frozen, NO task runs on the loop — not the
+      heartbeat writer, not the tick-socket handler — which is exactly the
+      "loop not scheduling" condition the probe must detect (sustained).
+    - ``state["thread"]`` — the producer thread; join it in ``finally``.
+    - ``ready`` — set once the loop is running (socket may still be arming).
+
+    The heartbeat write is patched to stall ``write_stall_s`` after the first
+    write, so the file goes stale while the loop keeps dispatching.
+    """
+    freeze_evt = asyncio.Event()
+    state: dict = {"loop": None, "trigger": None, "thread": None}
+    ready = threading.Event()
+
+    def stalling_write(**_kwargs):
+        if not get_loop_heartbeat_path(tmp_path).exists():
+            return write_loop_heartbeat(**_kwargs)
+        time.sleep(write_stall_s)
+        return write_loop_heartbeat(**_kwargs)
+
+    async def freeze_gate() -> None:
+        while True:
+            await freeze_evt.wait()
+            freeze_evt.clear()
+            # Synchronous sleep: freezes the entire loop for block_s.
+            time.sleep(block_s)
+
+    async def producer() -> None:
+        loop = asyncio.get_running_loop()
+        state["loop"] = loop
+        state["trigger"] = lambda: loop.call_soon_threadsafe(freeze_evt.set)
+        with patch("gateway.shutdown_watchdog.write_loop_heartbeat", stalling_write):
+            task = asyncio.create_task(
+                loop_heartbeat_forever(interval_s=1.0, home=tmp_path)
+            )
+            gate = asyncio.create_task(freeze_gate())
+            try:
+                ready.set()
+                while True:
+                    await asyncio.sleep(3600)
+            finally:
+                task.cancel()
+                gate.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                try:
+                    await gate
+                except asyncio.CancelledError:
+                    pass
+
+    def run_producer() -> None:
+        try:
+            asyncio.run(producer())
+        except Exception as exc:  # surfaced via errors after join
+            errors.append(exc)
+
+    thread = threading.Thread(target=run_producer, daemon=True)
+    thread.start()
+    state["thread"] = thread
+    return state, ready
+
+
+def _wait_heartbeat_stale(tmp_path, stale_after, timeout_s=5.0):
+    """Block until the heartbeat file is older than ``stale_after``."""
+    hb_path = get_loop_heartbeat_path(tmp_path)
+    deadline = time.monotonic() + timeout_s
+    while True:
+        try:
+            age = time.time() - hb_path.stat().st_mtime
+        except FileNotFoundError:
+            # The socket is armed before the first write lands; the file
+            # appears a tick later.
+            age = 0.0
+        if age > stale_after:
+            return
+        assert time.monotonic() < deadline, "heartbeat never went stale"
+        time.sleep(0.02)
+
+
+def _launchd_harness(monkeypatch, tmp_path, pid):
+    """Patch the launchd_restart path so the REAL probe drives it.
+
+    Returns the ``events`` list: "probe" is recorded by the probe wrapper
+    below, "escalate" by ``_escalate_wedged_gateway``, ``("drain", t)`` by
+    the graceful drain wait, "kickstart" by the relaunch. The probe itself
+    is the real ``probe_gateway_loop_liveness`` (home resolved through the
+    patched ``_process_hermes_home``).
+    """
+    events = []
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 180.0)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: pid)
+    monkeypatch.setattr(
+        gateway_cli, "_request_gateway_self_restart", lambda pid: False
+    )
+    real_probe = gateway_cli.probe_gateway_loop_liveness
+
+    def recording_probe(pid, **kw):
+        events.append("probe")
+        return real_probe(pid, **kw)
+
+    monkeypatch.setattr(gateway_cli, "probe_gateway_loop_liveness", recording_probe)
+    monkeypatch.setattr(
+        gateway_cli,
+        "_escalate_wedged_gateway",
+        lambda pid, **kw: events.append("escalate") or True,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "terminate_pid",
+        lambda pid, force=False: events.append(("kill" if force else "term", pid)),
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_gateway_exit",
+        lambda timeout, force_after=None: events.append(("drain", timeout)) or True,
+    )
+    monkeypatch.setattr(
+        gateway_cli.subprocess,
+        "run",
+        lambda *a, **k: events.append("kickstart")
+        or __import__("types").SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(gateway_cli, "_clear_launchd_unsupported_marker", lambda: None)
+    monkeypatch.setattr(
+        "gateway.shutdown_watchdog._process_hermes_home", lambda: tmp_path
+    )
+    return events
+
+
 class TestProbeGatewayLoopLiveness:
     def test_fresh_heartbeat_is_alive(self, tmp_path):
         """A gateway that refreshed its heartbeat recently is busy, not wedged."""
@@ -461,11 +599,14 @@ class TestLoopTickWitness:
             == gateway_cli.GATEWAY_LOOP_UNKNOWN
         )
 
-    def test_true_wedge_requires_both_witnesses_to_agree(self, tmp_path):
-        """Stale file + armed but silent socket: both agree, so WEDGED.
+    def test_true_wedge_requires_sustained_witness_silence(self, tmp_path):
+        """Stale file + armed socket silent across the whole window: WEDGED.
 
         The destructive path must still exist for genuinely dead loops — a
-        frozen loop stops answering the socket, and the file goes stale.
+        frozen loop stops answering the socket for every attempt in the
+        bounded window, and the file goes stale. The reviewer's sustained-
+        proof contract (one sample is never destructive authority) is
+        satisfied here: all ``tick_strikes`` consecutive probes miss.
         """
         pid = 4242
         _silent_socket_node(get_loop_tick_socket_path(tmp_path, pid))
@@ -473,9 +614,104 @@ class TestLoopTickWitness:
         _mark_witness_flag(tmp_path, armed=True, age_s=600.0)
         assert (
             gateway_cli.probe_gateway_loop_liveness(
-                pid, home=tmp_path, tick_timeout=0.2
+                pid,
+                home=tmp_path,
+                tick_timeout=0.2,
+                tick_strikes=3,
+                tick_gap_s=0.0,
             )
             == gateway_cli.GATEWAY_LOOP_WEDGED
+        )
+
+    def test_single_silent_probe_is_not_destructive(self, tmp_path, monkeypatch):
+        """One miss is a transient stall, never a wedge (#90502 review).
+
+        Stale file + armed socket + a loop that misses the FIRST probe but
+        answers the second: the probe must recover to ALIVE — the loop is
+        demonstrably dispatching, and the stale file is just a stalled
+        write. A single silent sample must never grant the bounded kill
+        authority.
+        """
+        pid = 4242
+        calls = []
+
+        def flaky_probe(_pid, _home, timeout=1.0):
+            calls.append(timeout)
+            # First sample misses (transient synchronous stall), the loop
+            # answers on the next attempt.
+            return len(calls) > 1
+
+        monkeypatch.setattr(gateway_cli, "_probe_loop_tick_socket", flaky_probe)
+        _write_heartbeat(tmp_path, pid, age_s=600.0)
+        _mark_witness_flag(tmp_path, armed=True, age_s=600.0)
+        assert (
+            gateway_cli.probe_gateway_loop_liveness(
+                pid,
+                home=tmp_path,
+                tick_timeout=0.2,
+                tick_strikes=2,
+                tick_gap_s=0.0,
+            )
+            == gateway_cli.GATEWAY_LOOP_ALIVE
+        )
+        # First probe (miss) + exactly one sustained-window follow-up.
+        assert len(calls) == 2
+
+    def test_sustained_silence_is_required_for_wedge(self, tmp_path, monkeypatch):
+        """WEDGED only after the full bounded window of consecutive misses.
+
+        With ``tick_strikes=2`` the probe must observe BOTH samples silent
+        before granting the wedge verdict; a single silent sample alone
+        would previously have escalated.
+        """
+        pid = 4242
+        calls = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_probe_loop_tick_socket",
+            lambda _pid, _home, timeout=1.0: (calls.append(timeout), False)[1],
+        )
+        _write_heartbeat(tmp_path, pid, age_s=600.0)
+        _mark_witness_flag(tmp_path, armed=True, age_s=600.0)
+        assert (
+            gateway_cli.probe_gateway_loop_liveness(
+                pid,
+                home=tmp_path,
+                tick_timeout=0.2,
+                tick_strikes=2,
+                tick_gap_s=0.0,
+            )
+            == gateway_cli.GATEWAY_LOOP_WEDGED
+        )
+        assert len(calls) == 2  # miss #1 (initial probe) + miss #2 (window)
+
+    def test_witness_vanishing_mid_window_is_unknown(self, tmp_path, monkeypatch):
+        """A witness that disappears mid-window is ambiguity, not a wedge.
+
+        First sample silent (node existed), second sample finds no node:
+        the witness is gone and cannot condemn the loop. UNKNOWN keeps the
+        graceful drain path.
+        """
+        pid = 4242
+        calls = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_probe_loop_tick_socket",
+            lambda _pid, _home, timeout=1.0: (calls.append(timeout), False, None)[
+                len(calls)
+            ],
+        )
+        _write_heartbeat(tmp_path, pid, age_s=600.0)
+        _mark_witness_flag(tmp_path, armed=True, age_s=600.0)
+        assert (
+            gateway_cli.probe_gateway_loop_liveness(
+                pid,
+                home=tmp_path,
+                tick_timeout=0.2,
+                tick_strikes=2,
+                tick_gap_s=0.0,
+            )
+            == gateway_cli.GATEWAY_LOOP_UNKNOWN
         )
 
     def test_armed_witness_unreachable_is_unknown(self, tmp_path):
@@ -533,3 +769,99 @@ class TestLoopTickWitness:
             )
             == gateway_cli.GATEWAY_LOOP_UNKNOWN
         )
+
+    def test_transient_stall_below_wedge_budget_never_escalates(
+        self, tmp_path, monkeypatch
+    ):
+        """Composed producer+consumer: transient loop stall below the budget.
+
+        Heartbeat write stalled (file stale) + loop frozen for longer than
+        one recv timeout but shorter than the wedge window: the probe must
+        NOT return WEDGED — the loop answers once it unfreezes, inside the
+        bounded window — and the restart path fed by the real probe must
+        take the graceful drain, never the bounded escalation. This is the
+        reviewer's required composed regression (#90502 review).
+        """
+        pid = os.getpid()
+        block_s = 0.5
+        stale_after = 1.0
+        tick_timeout = 0.2
+        tick_strikes = 3
+        tick_gap_s = 0.05
+        wedge_window = tick_strikes * tick_timeout + (tick_strikes - 1) * tick_gap_s
+        assert tick_timeout < block_s < wedge_window, (tick_timeout, block_s, wedge_window)
+
+        errors = []
+        state, ready = _start_freezeable_producer(tmp_path, block_s, errors)
+        try:
+            assert ready.wait(timeout=5.0)
+            sock_path = get_loop_tick_socket_path(tmp_path, pid)
+            deadline = time.monotonic() + 5.0
+            while not sock_path.exists() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            assert sock_path.exists(), "producer never armed the tick socket"
+            _wait_heartbeat_stale(tmp_path, stale_after)
+
+            state["trigger"]()  # freeze the loop for block_s
+            verdict = gateway_cli.probe_gateway_loop_liveness(
+                pid,
+                home=tmp_path,
+                stale_after=stale_after,
+                tick_timeout=tick_timeout,
+                tick_strikes=tick_strikes,
+                tick_gap_s=tick_gap_s,
+            )
+            assert verdict == gateway_cli.GATEWAY_LOOP_ALIVE, verdict
+
+            events = _launchd_harness(monkeypatch, tmp_path, pid)
+            gateway_cli.launchd_restart()
+            assert "escalate" not in events
+            assert ("drain", 180.0) in events
+        finally:
+            state["thread"].join(timeout=5.0)
+            assert not errors, errors
+
+    def test_sustained_stop_above_wedge_budget_still_escalates(
+        self, tmp_path
+    ):
+        """Composed producer+consumer: sustained stop above the budget.
+
+        The bounded-proof contract must not neuter the destructive path: a
+        loop frozen for longer than the wedge window stays silent for every
+        probe attempt, so the probe still returns WEDGED. (The WEDGED →
+        bounded-escalation wiring on the restart paths is covered by
+        ``TestLaunchdRestartWedgedIntegration``.)
+        """
+        pid = os.getpid()
+        block_s = 1.2
+        stale_after = 1.0
+        tick_timeout = 0.2
+        tick_strikes = 3
+        tick_gap_s = 0.05
+        wedge_window = tick_strikes * tick_timeout + (tick_strikes - 1) * tick_gap_s
+        assert block_s > wedge_window, (block_s, wedge_window)
+
+        errors = []
+        state, ready = _start_freezeable_producer(tmp_path, block_s, errors)
+        try:
+            assert ready.wait(timeout=5.0)
+            sock_path = get_loop_tick_socket_path(tmp_path, pid)
+            deadline = time.monotonic() + 5.0
+            while not sock_path.exists() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            assert sock_path.exists(), "producer never armed the tick socket"
+            _wait_heartbeat_stale(tmp_path, stale_after)
+
+            state["trigger"]()  # freeze the loop for block_s
+            verdict = gateway_cli.probe_gateway_loop_liveness(
+                pid,
+                home=tmp_path,
+                stale_after=stale_after,
+                tick_timeout=tick_timeout,
+                tick_strikes=tick_strikes,
+                tick_gap_s=tick_gap_s,
+            )
+            assert verdict == gateway_cli.GATEWAY_LOOP_WEDGED, verdict
+        finally:
+            state["thread"].join(timeout=5.0)
+            assert not errors, errors

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -207,10 +207,24 @@ def _launchd_harness(monkeypatch, tmp_path, pid):
         "terminate_pid",
         lambda pid, force=False: events.append(("kill" if force else "term", pid)),
     )
+    # Never let a real SIGUSR1 escape to the live test PID — the drain path
+    # goes through _graceful_restart_via_sigusr1 (in-place restart) before
+    # any exit-wait, and these tests feed launchd_restart os.getpid().
+    monkeypatch.setattr(
+        gateway_cli,
+        "_graceful_restart_via_sigusr1",
+        lambda pid, timeout: events.append(("drain", pid, timeout)) or True,
+    )
     monkeypatch.setattr(
         gateway_cli,
         "_wait_for_gateway_exit",
         lambda timeout, force_after=None: events.append(("drain", timeout)) or True,
+    )
+    monkeypatch.setattr(
+        gateway_cli,
+        "_wait_for_launchd_service_pid",
+        lambda label, old_pid, timeout=10.0, *, domain: events.append("observe")
+        or True,
     )
     monkeypatch.setattr(
         gateway_cli.subprocess,
@@ -573,10 +587,25 @@ class TestLoopTickWitness:
                 "terminate_pid",
                 lambda pid, force=False: events.append(("kill" if force else "term", pid)),
             )
+            # Never let a real SIGUSR1 escape to os.getpid() — the drain
+            # path now goes through _graceful_restart_via_sigusr1 (in-place
+            # restart) before any exit-wait, and this test feeds the REAL
+            # launchd_restart our own live PID.
+            monkeypatch.setattr(
+                gateway_cli,
+                "_graceful_restart_via_sigusr1",
+                lambda pid, timeout: events.append(("drain", pid, timeout)) or True,
+            )
             monkeypatch.setattr(
                 gateway_cli,
                 "_wait_for_gateway_exit",
                 lambda timeout, force_after=None: events.append(("drain", timeout))
+                or True,
+            )
+            monkeypatch.setattr(
+                gateway_cli,
+                "_wait_for_launchd_service_pid",
+                lambda label, old_pid, timeout=10.0, *, domain: events.append("observe")
                 or True,
             )
             monkeypatch.setattr(
@@ -596,7 +625,8 @@ class TestLoopTickWitness:
             )
             gateway_cli.launchd_restart()
             assert "escalate" not in events
-            assert ("drain", 180.0) in events
+            drains = [e for e in events if isinstance(e, tuple) and e[0] == "drain"]
+            assert drains, events
         finally:
             thread.join(timeout=5.0)
             assert not errors, errors
@@ -878,7 +908,8 @@ class TestLoopTickWitness:
             events = _launchd_harness(monkeypatch, tmp_path, pid)
             gateway_cli.launchd_restart()
             assert "escalate" not in events
-            assert ("drain", 180.0) in events
+            drains = [e for e in events if isinstance(e, tuple) and e[0] == "drain"]
+            assert drains, events
         finally:
             state["thread"].join(timeout=5.0)
             assert not errors, errors

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -927,3 +927,28 @@ class TestLoopTickWitness:
         finally:
             state["thread"].join(timeout=5.0)
             assert not errors, errors
+
+
+def test_default_probe_budget_stays_inside_query_tier():
+    """The module doc pins the worst-case wedge-suspected probe at ~3.4s,
+    'far inside the 10s query tier'. Assert the strike-count math so
+    retuning tick_timeout / tick_strikes / tick_gap_s can't silently blow
+    past that tier (reviewer ask on #92315).
+
+    Worst case: the first probe misses (tick_timeout), then the sustained
+    window runs (tick_strikes - 1) more probes, each up to tick_timeout,
+    with tick_gap_s sleeps between attempts.
+    """
+    import inspect
+
+    sig = inspect.signature(gateway_cli.probe_gateway_loop_liveness)
+    tick_timeout = sig.parameters["tick_timeout"].default
+    tick_strikes = sig.parameters["tick_strikes"].default
+    tick_gap_s = sig.parameters["tick_gap_s"].default
+
+    worst_case = tick_strikes * tick_timeout + (tick_strikes - 1) * tick_gap_s
+    assert worst_case <= 5.0, (
+        f"default probe budget {worst_case:.1f}s exceeds half the 10s query "
+        "tier — retune tick_timeout/tick_strikes/tick_gap_s or update the "
+        "subprocess-timeout doc reference in hermes_cli/gateway.py"
+    )


### PR DESCRIPTION
## Summary
The gateway loop watchdog could kill a healthy gateway: its own heartbeat write ran ON the loop it monitors, so a slow fsync (112.6s measured in the incident) aged the heartbeat past the 90s wedge threshold while the loop was demonstrably fine — exit 75, service respawn, dropped in-flight work. Salvage of #90502 by @rodrigogs (3 commits, authorship preserved).

## Changes
- gateway/shutdown_watchdog.py: heartbeat write moved off-loop; the loop instead answers a PID-suffixed UNIX tick socket — direct proof of scheduling
- hermes_cli/gateway.py: wedge verdict now requires TWO witnesses (stale heartbeat AND sustained tick-socket silence); a single missed probe never authorizes the kill; unknown/ambiguous states keep the full drain budget
- Legacy payloads (no witness flag) keep the old single-witness contract — old gateways unaffected
- Follow-up (ours): module-local short tmp_path for the socket tests — pytest's deep tmp_path exceeds macOS's ~104-byte AF_UNIX limit (6 failures locally, invisible on ubuntu CI)
- /simplify-code follow-up: collapsed the dead `saw_node` ambiguity branch; POSIX-only sweep of stale `gateway.loop-tick.*.sock` nodes from dead PIDs at arm time (asyncio itself re-binds over THIS pid's leftover node — pinned by a new contract test); test tmp_path fixture now cleans up its mkdtemp

## Validation
| | |
|---|---|
| test_update_wedged_gateway + test_loop_liveness_watchdog | 36 passed |
| live smoke | off-loop write refreshes; tick witness answers; staleness preserved on producer stop |
| ruff | clean |

Closes #90502.

## Infographic

![two-witness-loop-liveness](https://v3b.fal.media/files/b/0aa75f7c/J0UNCud3AL0O2JY-6-mfi_7UkhZ9FP.png)
