### PR TITLE
feat(gateway): loop-watchdog tuning knobs, wired end-to-end (salvage of #89134, downscoped)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -983,7 +983,23 @@ class GatewayConfig:
     # missed probes it dumps all-thread stacks and hard-exits with the
     # service-restart code so the supervisor can revive the process. On by
     # default; set gateway.loop_watchdog: false in config.yaml to disable.
+    #
+    # Tuning knobs (all seconds unless noted) make the watchdog tolerate
+    # *transient, self-recovering* event-loop stalls — e.g. Telegram/Discord
+    # reconnect doing synchronous socket I/O during a network blip — so a
+    # short block does not force exit code 75 and trigger a restart churn
+    # that stalls cron dispatch (recurring fleet incidents on 2026-08-17,
+    # kanban t_0f76430f/t_70483f23). A genuine wedge (event loop frozen for
+    # the full tolerance window) still escalates to a supervised restart.
     loop_watchdog: bool = True
+    # Seconds the watchdog waits between liveness probes.
+    loop_watchdog_probe_interval_s: float = 30.0
+    # Seconds a single probe may go unprocessed before it counts as a miss.
+    loop_watchdog_probe_timeout_s: float = 10.0
+    # Consecutive missed probes allowed before the watchdog hard-exits.
+    # Default raised from 3 to 8: a transient reconnect stall (~60-120s) is
+    # tolerated while a genuine multi-minute wedge still escalates.
+    loop_watchdog_max_strikes: int = 8
 
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
@@ -1124,6 +1140,9 @@ class GatewayConfig:
             "multiplex_profile_allowlist": self.multiplex_profile_allowlist,
             "systemd_watchdog_seconds": self.systemd_watchdog_seconds,
             "loop_watchdog": self.loop_watchdog,
+            "loop_watchdog_probe_interval_s": self.loop_watchdog_probe_interval_s,
+            "loop_watchdog_probe_timeout_s": self.loop_watchdog_probe_timeout_s,
+            "loop_watchdog_max_strikes": self.loop_watchdog_max_strikes,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
@@ -1207,6 +1226,30 @@ class GatewayConfig:
         else:
             loop_watchdog_raw = nested_gateway.get("loop_watchdog")
         loop_watchdog = _coerce_bool(loop_watchdog_raw, True)
+        loop_watchdog_probe_interval_s = _coerce_float(
+            data.get("loop_watchdog_probe_interval_s")
+            if "loop_watchdog_probe_interval_s" in data
+            else nested_gateway.get("loop_watchdog_probe_interval_s"),
+            30.0,
+        )
+        loop_watchdog_probe_timeout_s = _coerce_float(
+            data.get("loop_watchdog_probe_timeout_s")
+            if "loop_watchdog_probe_timeout_s" in data
+            else nested_gateway.get("loop_watchdog_probe_timeout_s"),
+            10.0,
+        )
+        loop_watchdog_max_strikes = _coerce_int(
+            data.get("loop_watchdog_max_strikes")
+            if "loop_watchdog_max_strikes" in data
+            else nested_gateway.get("loop_watchdog_max_strikes"),
+            8,
+        )
+        if loop_watchdog_probe_interval_s < 1.0:
+            loop_watchdog_probe_interval_s = 30.0
+        if loop_watchdog_probe_timeout_s < 1.0:
+            loop_watchdog_probe_timeout_s = 10.0
+        if loop_watchdog_max_strikes < 1:
+            loop_watchdog_max_strikes = 8
         if multiplex_profiles is None and isinstance(nested_gateway, dict):
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.
@@ -1269,6 +1312,9 @@ class GatewayConfig:
             multiplex_profile_allowlist=multiplex_profile_allowlist,
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             loop_watchdog=loop_watchdog,
+            loop_watchdog_probe_interval_s=loop_watchdog_probe_interval_s,
+            loop_watchdog_probe_timeout_s=loop_watchdog_probe_timeout_s,
+            loop_watchdog_max_strikes=loop_watchdog_max_strikes,
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -18,6 +18,11 @@ from enum import Enum
 
 from hermes_cli.config import get_hermes_home
 from agent.secret_scope import current_secret_scope, get_secret as _get_secret
+from gateway.shutdown_watchdog import (
+    DEFAULT_LOOP_WATCHDOG_INTERVAL_S,
+    DEFAULT_LOOP_WATCHDOG_MAX_STRIKES,
+    DEFAULT_LOOP_WATCHDOG_TIMEOUT_S,
+)
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
@@ -993,13 +998,15 @@ class GatewayConfig:
     # the full tolerance window) still escalates to a supervised restart.
     loop_watchdog: bool = True
     # Seconds the watchdog waits between liveness probes.
-    loop_watchdog_probe_interval_s: float = 30.0
+    loop_watchdog_probe_interval_s: float = DEFAULT_LOOP_WATCHDOG_INTERVAL_S
     # Seconds a single probe may go unprocessed before it counts as a miss.
-    loop_watchdog_probe_timeout_s: float = 10.0
+    loop_watchdog_probe_timeout_s: float = DEFAULT_LOOP_WATCHDOG_TIMEOUT_S
     # Consecutive missed probes allowed before the watchdog hard-exits.
-    # Default raised from 3 to 8: a transient reconnect stall (~60-120s) is
-    # tolerated while a genuine multi-minute wedge still escalates.
-    loop_watchdog_max_strikes: int = 8
+    # Default stays at 3 (~90-120s of sustained loop block): the transient
+    # false-positive class (the watchdog's own on-loop heartbeat fsync)
+    # is fixed at the root by the off-loop write + two-witness probe, so
+    # raising this fleet-wide would only delay genuine-wedge recovery.
+    loop_watchdog_max_strikes: int = DEFAULT_LOOP_WATCHDOG_MAX_STRIKES
 
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
@@ -1230,26 +1237,26 @@ class GatewayConfig:
             data.get("loop_watchdog_probe_interval_s")
             if "loop_watchdog_probe_interval_s" in data
             else nested_gateway.get("loop_watchdog_probe_interval_s"),
-            30.0,
+            DEFAULT_LOOP_WATCHDOG_INTERVAL_S,
         )
         loop_watchdog_probe_timeout_s = _coerce_float(
             data.get("loop_watchdog_probe_timeout_s")
             if "loop_watchdog_probe_timeout_s" in data
             else nested_gateway.get("loop_watchdog_probe_timeout_s"),
-            10.0,
+            DEFAULT_LOOP_WATCHDOG_TIMEOUT_S,
         )
         loop_watchdog_max_strikes = _coerce_int(
             data.get("loop_watchdog_max_strikes")
             if "loop_watchdog_max_strikes" in data
             else nested_gateway.get("loop_watchdog_max_strikes"),
-            8,
+            DEFAULT_LOOP_WATCHDOG_MAX_STRIKES,
         )
         if loop_watchdog_probe_interval_s < 1.0:
-            loop_watchdog_probe_interval_s = 30.0
+            loop_watchdog_probe_interval_s = DEFAULT_LOOP_WATCHDOG_INTERVAL_S
         if loop_watchdog_probe_timeout_s < 1.0:
-            loop_watchdog_probe_timeout_s = 10.0
+            loop_watchdog_probe_timeout_s = DEFAULT_LOOP_WATCHDOG_TIMEOUT_S
         if loop_watchdog_max_strikes < 1:
-            loop_watchdog_max_strikes = 8
+            loop_watchdog_max_strikes = DEFAULT_LOOP_WATCHDOG_MAX_STRIKES
         if multiplex_profiles is None and isinstance(nested_gateway, dict):
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -9,6 +9,7 @@ Handles loading and validating configuration for:
 """
 
 import logging
+import math
 import os
 import json
 from pathlib import Path
@@ -157,7 +158,9 @@ def _coerce_int(value: Any, default: int) -> int:
         return default
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: int(float("inf")) — a non-finite YAML value must
+        # degrade to the default, not abort gateway config loading.
         return default
 
 
@@ -1251,11 +1254,19 @@ class GatewayConfig:
             else nested_gateway.get("loop_watchdog_max_strikes"),
             DEFAULT_LOOP_WATCHDOG_MAX_STRIKES,
         )
-        if loop_watchdog_probe_interval_s < 1.0:
+        if (
+            not math.isfinite(loop_watchdog_probe_interval_s)
+            or loop_watchdog_probe_interval_s < 1.0
+            or loop_watchdog_probe_interval_s > 3600.0
+        ):
             loop_watchdog_probe_interval_s = DEFAULT_LOOP_WATCHDOG_INTERVAL_S
-        if loop_watchdog_probe_timeout_s < 1.0:
+        if (
+            not math.isfinite(loop_watchdog_probe_timeout_s)
+            or loop_watchdog_probe_timeout_s < 1.0
+            or loop_watchdog_probe_timeout_s > 600.0
+        ):
             loop_watchdog_probe_timeout_s = DEFAULT_LOOP_WATCHDOG_TIMEOUT_S
-        if loop_watchdog_max_strikes < 1:
+        if loop_watchdog_max_strikes < 1 or loop_watchdog_max_strikes > 1000:
             loop_watchdog_max_strikes = DEFAULT_LOOP_WATCHDOG_MAX_STRIKES
         if multiplex_profiles is None and isinstance(nested_gateway, dict):
             # Also honor gateway.multiplex_profiles written by
@@ -1522,6 +1533,23 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["write_sessions_json"] = yaml_cfg["write_sessions_json"]
             elif isinstance(gateway_section, dict) and "write_sessions_json" in gateway_section:
                 gw_data["write_sessions_json"] = gateway_section["write_sessions_json"]
+
+            # Loop-liveness watchdog toggle + tuning knobs: top-level wins;
+            # nested gateway.* fallback. GatewayConfig.from_dict has its own
+            # nested fallback, but this loader builds gw_data FLAT and never
+            # forwards the yaml `gateway:` section — without this bridge the
+            # documented keys (including the pre-existing loop_watchdog bool)
+            # were silently ignored on the real gateway startup path.
+            for _wd_key in (
+                "loop_watchdog",
+                "loop_watchdog_probe_interval_s",
+                "loop_watchdog_probe_timeout_s",
+                "loop_watchdog_max_strikes",
+            ):
+                if _wd_key in yaml_cfg:
+                    gw_data[_wd_key] = yaml_cfg[_wd_key]
+                elif isinstance(gateway_section, dict) and _wd_key in gateway_section:
+                    gw_data[_wd_key] = gateway_section[_wd_key]
 
             if "filter_silence_narration" in yaml_cfg:
                 gw_data["filter_silence_narration"] = yaml_cfg[

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2689,6 +2689,9 @@ from gateway.platforms.base import (
 )
 from gateway.shutdown_watchdog import (
     DEFAULT_HEARTBEAT_INTERVAL_S,
+    DEFAULT_LOOP_WATCHDOG_INTERVAL_S,
+    DEFAULT_LOOP_WATCHDOG_MAX_STRIKES,
+    DEFAULT_LOOP_WATCHDOG_TIMEOUT_S,
     _arm_loop_floor_timer,
     arm_shutdown_watchdog,
     loop_heartbeat_forever,
@@ -12349,25 +12352,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         watchdog = getattr(self, "_loop_liveness_watchdog", None)
         if watchdog is None or not watchdog.is_alive():
             try:
-                from gateway.shutdown_watchdog import (
-                    DEFAULT_LOOP_WATCHDOG_INTERVAL_S as _WD_INTERVAL,
-                    DEFAULT_LOOP_WATCHDOG_MAX_STRIKES as _WD_STRIKES,
-                    DEFAULT_LOOP_WATCHDOG_TIMEOUT_S as _WD_TIMEOUT,
+                # getattr defaults cover the config=None / bare-object test
+                # path; config-loaded values are already validated+clamped
+                # by GatewayConfig.from_dict, so no re-clamping here.
+                interval = getattr(
+                    config,
+                    "loop_watchdog_probe_interval_s",
+                    DEFAULT_LOOP_WATCHDOG_INTERVAL_S,
                 )
-
-                interval = _WD_INTERVAL
-                timeout = _WD_TIMEOUT
-                strikes = _WD_STRIKES
-                if config is not None:
-                    interval = getattr(
-                        config, "loop_watchdog_probe_interval_s", _WD_INTERVAL
-                    ) or _WD_INTERVAL
-                    timeout = getattr(
-                        config, "loop_watchdog_probe_timeout_s", _WD_TIMEOUT
-                    ) or _WD_TIMEOUT
-                    strikes = getattr(
-                        config, "loop_watchdog_max_strikes", _WD_STRIKES
-                    ) or _WD_STRIKES
+                timeout = getattr(
+                    config,
+                    "loop_watchdog_probe_timeout_s",
+                    DEFAULT_LOOP_WATCHDOG_TIMEOUT_S,
+                )
+                strikes = getattr(
+                    config,
+                    "loop_watchdog_max_strikes",
+                    DEFAULT_LOOP_WATCHDOG_MAX_STRIKES,
+                )
                 self._loop_liveness_watchdog = start_loop_liveness_watchdog(
                     loop,
                     probe_interval=float(interval),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12349,7 +12349,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         watchdog = getattr(self, "_loop_liveness_watchdog", None)
         if watchdog is None or not watchdog.is_alive():
             try:
-                self._loop_liveness_watchdog = start_loop_liveness_watchdog(loop)
+                interval = 30.0
+                timeout = 10.0
+                strikes = 8
+                if config is not None:
+                    interval = getattr(
+                        config, "loop_watchdog_probe_interval_s", 30.0
+                    ) or 30.0
+                    timeout = getattr(
+                        config, "loop_watchdog_probe_timeout_s", 10.0
+                    ) or 10.0
+                    strikes = getattr(
+                        config, "loop_watchdog_max_strikes", 8
+                    ) or 8
+                self._loop_liveness_watchdog = start_loop_liveness_watchdog(
+                    loop,
+                    probe_interval=float(interval),
+                    probe_timeout=float(timeout),
+                    max_strikes=int(strikes),
+                )
             except Exception:
                 logger.debug("Failed to start gateway loop liveness watchdog", exc_info=True)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12349,19 +12349,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         watchdog = getattr(self, "_loop_liveness_watchdog", None)
         if watchdog is None or not watchdog.is_alive():
             try:
-                interval = 30.0
-                timeout = 10.0
-                strikes = 8
+                from gateway.shutdown_watchdog import (
+                    DEFAULT_LOOP_WATCHDOG_INTERVAL_S as _WD_INTERVAL,
+                    DEFAULT_LOOP_WATCHDOG_MAX_STRIKES as _WD_STRIKES,
+                    DEFAULT_LOOP_WATCHDOG_TIMEOUT_S as _WD_TIMEOUT,
+                )
+
+                interval = _WD_INTERVAL
+                timeout = _WD_TIMEOUT
+                strikes = _WD_STRIKES
                 if config is not None:
                     interval = getattr(
-                        config, "loop_watchdog_probe_interval_s", 30.0
-                    ) or 30.0
+                        config, "loop_watchdog_probe_interval_s", _WD_INTERVAL
+                    ) or _WD_INTERVAL
                     timeout = getattr(
-                        config, "loop_watchdog_probe_timeout_s", 10.0
-                    ) or 10.0
+                        config, "loop_watchdog_probe_timeout_s", _WD_TIMEOUT
+                    ) or _WD_TIMEOUT
                     strikes = getattr(
-                        config, "loop_watchdog_max_strikes", 8
-                    ) or 8
+                        config, "loop_watchdog_max_strikes", _WD_STRIKES
+                    ) or _WD_STRIKES
                 self._loop_liveness_watchdog = start_loop_liveness_watchdog(
                     loop,
                     probe_interval=float(interval),

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -48,12 +48,13 @@ DEFAULT_HEARTBEAT_INTERVAL_S = 30.0
 DEFAULT_LOOP_FLOOR_TIMER_INTERVAL_S = 5.0
 DEFAULT_LOOP_WATCHDOG_INTERVAL_S = 30.0
 DEFAULT_LOOP_WATCHDOG_TIMEOUT_S = 10.0
-# Raised from 3 to 8 (kanban t_70483f23): tolerate transient, self-recovering
-# event-loop stalls during Telegram/Discord reconnect (sync socket I/O on a
-# network blip) so a short block does not force exit code 75. A genuine
-# multi-minute wedge still escalates. Tuned via gateway.loop_watchdog_* in
-# config.yaml when the default is too loose or too tight for a deployment.
-DEFAULT_LOOP_WATCHDOG_MAX_STRIKES = 8
+# 3 sustained misses (~90-120s of loop block) escalate. The false-positive
+# class that motivated raising this (the watchdog's own on-loop heartbeat
+# fsync stalling the loop it monitors) is fixed at the root by the off-loop
+# heartbeat write + two-witness probe (#90502), so the default stays tight
+# for genuine wedges. Deployments with legitimately slow loops can tune via
+# gateway.loop_watchdog_* in config.yaml.
+DEFAULT_LOOP_WATCHDOG_MAX_STRIKES = 3
 _HEARTBEAT_RELATIVE = ("state", "gateway.heartbeat")
 _WATCHDOG_DUMP_RELATIVE = ("logs", "gateway-shutdown-watchdog.log")
 

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -48,7 +48,12 @@ DEFAULT_HEARTBEAT_INTERVAL_S = 30.0
 DEFAULT_LOOP_FLOOR_TIMER_INTERVAL_S = 5.0
 DEFAULT_LOOP_WATCHDOG_INTERVAL_S = 30.0
 DEFAULT_LOOP_WATCHDOG_TIMEOUT_S = 10.0
-DEFAULT_LOOP_WATCHDOG_MAX_STRIKES = 3
+# Raised from 3 to 8 (kanban t_70483f23): tolerate transient, self-recovering
+# event-loop stalls during Telegram/Discord reconnect (sync socket I/O on a
+# network blip) so a short block does not force exit code 75. A genuine
+# multi-minute wedge still escalates. Tuned via gateway.loop_watchdog_* in
+# config.yaml when the default is too loose or too tight for a deployment.
+DEFAULT_LOOP_WATCHDOG_MAX_STRIKES = 8
 _HEARTBEAT_RELATIVE = ("state", "gateway.heartbeat")
 _WATCHDOG_DUMP_RELATIVE = ("logs", "gateway-shutdown-watchdog.log")
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2919,6 +2919,16 @@ DEFAULT_CONFIG = {
         # of leaving a wedged-but-alive zombie. Set to false to disable.
         "loop_watchdog": True,
 
+        # Loop-liveness watchdog tuning (defaults mirror
+        # gateway/shutdown_watchdog.py constants). probe_interval = seconds
+        # between liveness probes; probe_timeout = seconds a probe may go
+        # unprocessed before counting as a miss; max_strikes = consecutive
+        # misses before the watchdog hard-exits 75 for a service respawn
+        # (~90-120s of sustained loop block at the defaults).
+        "loop_watchdog_probe_interval_s": 30.0,
+        "loop_watchdog_probe_timeout_s": 10.0,
+        "loop_watchdog_max_strikes": 3,
+
         # Whether the gateway keeps writing the legacy sessions.json mirror of
         # its routing index. The primary copy lives in state.db (the
         # gateway_routing table). Default True for backward compatibility with

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -166,12 +166,67 @@ def test_gateway_config_loop_watchdog_round_trip():
     assert config.to_dict()["loop_watchdog"] is False
 
 
+def test_gateway_config_loop_watchdog_tuning_round_trip():
+    """Watchdog tolerance knobs parse, serialize, and clamp malformed values."""
+    from gateway.config import GatewayConfig
+
+    # Defaults
+    default = GatewayConfig.from_dict({})
+    assert default.loop_watchdog is True
+    assert default.loop_watchdog_probe_interval_s == 30.0
+    assert default.loop_watchdog_probe_timeout_s == 10.0
+    assert default.loop_watchdog_max_strikes == 8
+
+    # Explicit values round-trip
+    cfg = GatewayConfig.from_dict(
+        {
+            "loop_watchdog_probe_interval_s": 45,
+            "loop_watchdog_probe_timeout_s": 15,
+            "loop_watchdog_max_strikes": 12,
+        }
+    )
+    assert cfg.loop_watchdog_probe_interval_s == 45.0
+    assert cfg.loop_watchdog_probe_timeout_s == 15.0
+    assert cfg.loop_watchdog_max_strikes == 12
+    d = cfg.to_dict()
+    assert d["loop_watchdog_probe_interval_s"] == 45.0
+    assert d["loop_watchdog_probe_timeout_s"] == 15.0
+    assert d["loop_watchdog_max_strikes"] == 12
+
+    # Nested gateway.* form honored
+    nested = GatewayConfig.from_dict(
+        {
+            "gateway": {
+                "loop_watchdog_probe_interval_s": 60,
+                "loop_watchdog_probe_timeout_s": 20,
+                "loop_watchdog_max_strikes": 20,
+            }
+        }
+    )
+    assert nested.loop_watchdog_probe_interval_s == 60.0
+    assert nested.loop_watchdog_probe_timeout_s == 20.0
+    assert nested.loop_watchdog_max_strikes == 20
+
+    # Malformed / degenerate values fall back to safe defaults
+    clamped = GatewayConfig.from_dict(
+        {
+            "loop_watchdog_probe_interval_s": 0,
+            "loop_watchdog_probe_timeout_s": -5,
+            "loop_watchdog_max_strikes": 0,
+        }
+    )
+    assert clamped.loop_watchdog_probe_interval_s == 30.0
+    assert clamped.loop_watchdog_probe_timeout_s == 10.0
+    assert clamped.loop_watchdog_max_strikes == 8
+
+
 def test_gateway_runner_liveness_guards_start_and_stop():
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
     runner._loop_floor_timer_handle = None
     runner._loop_liveness_watchdog = None
+    runner.config = None
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
     floor_timer = MagicMock()
     watchdog = MagicMock()
@@ -188,7 +243,12 @@ def test_gateway_runner_liveness_guards_start_and_stop():
         runner._start_loop_liveness_guards(loop)
 
     arm_floor.assert_called_once_with(loop)
-    start_watchdog.assert_called_once_with(loop)
+    start_watchdog.assert_called_once_with(
+        loop,
+        probe_interval=30.0,
+        probe_timeout=10.0,
+        max_strikes=8,
+    )
     assert runner._loop_floor_timer_handle is floor_timer
     assert runner._loop_liveness_watchdog is watchdog
 

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -220,6 +220,58 @@ def test_gateway_config_loop_watchdog_tuning_round_trip():
     assert clamped.loop_watchdog_max_strikes == 3
 
 
+def test_gateway_config_loop_watchdog_nonfinite_values_degrade():
+    """NaN/Inf tuning values fall back to defaults instead of reaching the
+    watchdog's Event.wait loop (or aborting config load via int(inf))."""
+    from gateway.config import GatewayConfig
+
+    cfg = GatewayConfig.from_dict(
+        {
+            "loop_watchdog_probe_interval_s": float("inf"),
+            "loop_watchdog_probe_timeout_s": float("nan"),
+            "loop_watchdog_max_strikes": float("inf"),  # int() would raise
+        }
+    )
+    assert cfg.loop_watchdog_probe_interval_s == 30.0
+    assert cfg.loop_watchdog_probe_timeout_s == 10.0
+    assert cfg.loop_watchdog_max_strikes == 3
+
+    # Oversized-but-finite values also clamp to defaults.
+    big = GatewayConfig.from_dict(
+        {
+            "loop_watchdog_probe_interval_s": 86400,
+            "loop_watchdog_probe_timeout_s": 7200,
+            "loop_watchdog_max_strikes": 10**9,
+        }
+    )
+    assert big.loop_watchdog_probe_interval_s == 30.0
+    assert big.loop_watchdog_probe_timeout_s == 10.0
+    assert big.loop_watchdog_max_strikes == 3
+
+
+def test_load_gateway_config_bridges_loop_watchdog_keys(tmp_path, monkeypatch):
+    """The real startup loader must honor gateway.loop_watchdog* from
+    config.yaml — from_dict's nested fallback never sees the yaml gateway
+    section because load_gateway_config builds gw_data flat."""
+    from gateway.config import load_gateway_config
+
+    (tmp_path / "config.yaml").write_text(
+        "gateway:\n"
+        "  loop_watchdog: false\n"
+        "  loop_watchdog_probe_interval_s: 45\n"
+        "  loop_watchdog_probe_timeout_s: 15\n"
+        "  loop_watchdog_max_strikes: 12\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("gateway.config.get_hermes_home", lambda: tmp_path)
+
+    cfg = load_gateway_config()
+    assert cfg.loop_watchdog is False
+    assert cfg.loop_watchdog_probe_interval_s == 45.0
+    assert cfg.loop_watchdog_probe_timeout_s == 15.0
+    assert cfg.loop_watchdog_max_strikes == 12
+
+
 def test_gateway_runner_liveness_guards_start_and_stop():
     from gateway.run import GatewayRunner
 

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -175,7 +175,7 @@ def test_gateway_config_loop_watchdog_tuning_round_trip():
     assert default.loop_watchdog is True
     assert default.loop_watchdog_probe_interval_s == 30.0
     assert default.loop_watchdog_probe_timeout_s == 10.0
-    assert default.loop_watchdog_max_strikes == 8
+    assert default.loop_watchdog_max_strikes == 3
 
     # Explicit values round-trip
     cfg = GatewayConfig.from_dict(
@@ -217,7 +217,7 @@ def test_gateway_config_loop_watchdog_tuning_round_trip():
     )
     assert clamped.loop_watchdog_probe_interval_s == 30.0
     assert clamped.loop_watchdog_probe_timeout_s == 10.0
-    assert clamped.loop_watchdog_max_strikes == 8
+    assert clamped.loop_watchdog_max_strikes == 3
 
 
 def test_gateway_runner_liveness_guards_start_and_stop():
@@ -247,7 +247,7 @@ def test_gateway_runner_liveness_guards_start_and_stop():
         loop,
         probe_interval=30.0,
         probe_timeout=10.0,
-        max_strikes=8,
+        max_strikes=3,
     )
     assert runner._loop_floor_timer_handle is floor_timer
     assert runner._loop_liveness_watchdog is watchdog


### PR DESCRIPTION
## Summary
Salvage of #89134 by @sycamoregroupltd, downscoped per review: the loop-watchdog tuning knobs land (real operator value), but the fleet-wide default raise 3→8 does not — that raise was symptom tolerance for the false-positive class the off-loop heartbeat + two-witness probe (#92239's sibling, salvaged from #90502) fixes at the root. Raising the default would only delay genuine-wedge recovery ~2.7x.

## Changes
- gateway/config.py: `loop_watchdog_probe_interval_s` / `loop_watchdog_probe_timeout_s` / `loop_watchdog_max_strikes` parse, serialize, clamp (contributor's work, authorship preserved)
- gateway/run.py: watchdog start honors the knobs
- Follow-up (ours): default max_strikes back to 3 everywhere; gateway/config.py + run.py now reference the shutdown_watchdog DEFAULT_* constants instead of duplicating literals in three places; knobs registered in hermes_cli/config_defaults.py next to the sibling `gateway.loop_watchdog` bool
- Review follow-up (@egilewski, both verified): finite-bounded validation (int(inf) OverflowError previously ABORTED config load; NaN/Inf/oversized now degrade to defaults) and the loader gap — `load_gateway_config` never forwarded ANY loop_watchdog* key including the pre-existing bool; bridged top-level-wins/nested-fallback, E2E through the real loader
- /simplify-code follow-up: constants hoisted to the canonical import; dead `or`-fallbacks dropped

## Validation
| | |
|---|---|
| test_loop_liveness_watchdog + test_config | 84 passed |
| live smoke | defaults resolve to 3/30/10 via constants; explicit + nested gateway.* values honored; clamp falls back to constants |
| ruff | clean |

Closes #89134.

## Infographic

![watchdog-tuning-knobs](https://v3b.fal.media/files/b/0aa75f90/WKPESVDVMRGUVov0j5tX0_sZ8GKG8X.png)
