### PR TITLE
fix(desktop): stop reaping the healthy standalone gateway on desktop startup (salvage of #87158)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2288,10 +2288,19 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     # the Scheduled-Task bootstrap's argv (``gateway run``) matches the
     # gateway scan — killing that bootstrap takes the detached gateway it
     # spawned down with it.
+    #
+    # Probe the record with cleanup_stale=False so the sweep never deletes
+    # the registration it is about to use as exclusion evidence.  With the
+    # default cleanup, a record that fails liveness validation is unlinked
+    # mid-sweep; the recorded PID then never joins the exclusion set, and a
+    # healthy standalone gateway (no service supervisor — e.g. `hermes
+    # gateway run` on Windows) is hard-killed by the sweep.  On Windows
+    # SIGTERM is TerminateProcess, so the gateway's own planned-stop watcher
+    # never gets a chance to shut down gracefully.
     try:
         from gateway.status import get_running_pid
 
-        recorded = get_running_pid()
+        recorded = get_running_pid(cleanup_stale=False)
         if recorded and recorded > 0:
             own.add(recorded)
             try:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2289,19 +2289,37 @@ def _reap_unsupervised_gateway_orphans(extra_exclude: set | None = None) -> bool
     # gateway scan — killing that bootstrap takes the detached gateway it
     # spawned down with it.
     #
-    # Probe the record with cleanup_stale=False so the sweep never deletes
-    # the registration it is about to use as exclusion evidence.  With the
-    # default cleanup, a record that fails liveness validation is unlinked
-    # mid-sweep; the recorded PID then never joins the exclusion set, and a
+    # Exclusion evidence comes from the RAW registration record, not the
+    # liveness-validated probe.  ``get_running_pid`` (any flags) returns
+    # None whenever a record fails validation — start-time mismatch after
+    # PID-reuse checks, argv drift, lock hiccups — which is exactly when a
     # healthy standalone gateway (no service supervisor — e.g. `hermes
-    # gateway run` on Windows) is hard-killed by the sweep.  On Windows
-    # SIGTERM is TerminateProcess, so the gateway's own planned-stop watcher
-    # never gets a chance to shut down gracefully.
+    # gateway run` on Windows) is at risk: its PID never joins the
+    # exclusion set and the sweep hard-kills it.  On Windows SIGTERM is
+    # TerminateProcess, so the gateway's planned-stop watcher never gets a
+    # chance to drain.  Reading the raw pidfile + lock records (no
+    # validation, no unlink side effects) is strictly safer for a KILL
+    # exclusion list: a stale recorded PID at worst spares one process this
+    # sweep, while a validation false-negative would kill a live gateway.
+    # The validated probe is still consulted for the runtime-status
+    # fallback PID it can surface when no pidfile exists.
     try:
-        from gateway.status import get_running_pid
+        from gateway.status import (
+            _pid_from_record,
+            _read_gateway_lock_record,
+            _read_pid_record,
+            get_running_pid,
+        )
 
-        recorded = get_running_pid(cleanup_stale=False)
-        if recorded and recorded > 0:
+        recorded_pids = set()
+        for _record in (_read_pid_record(), _read_gateway_lock_record()):
+            _raw_pid = _pid_from_record(_record)
+            if _raw_pid and _raw_pid > 0:
+                recorded_pids.add(_raw_pid)
+        _probed = get_running_pid(cleanup_stale=False)
+        if _probed and _probed > 0:
+            recorded_pids.add(_probed)
+        for recorded in recorded_pids:
             own.add(recorded)
             try:
                 import psutil  # type: ignore

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -471,10 +471,23 @@ async def _lifespan(app: "FastAPI"):
         # the old gateway to launchd (PPID=1). It keeps holding the QQ
         # WebSocket, and a newly forked gateway then races the same credential,
         # splitting messages across parallel session trees (#77276).
+        #
+        # Only reap when no live, registered gateway is in the record: a
+        # healthy standalone gateway (launched via `hermes gateway run`, no
+        # service supervisor) is not an orphan, and the sweep would kill it.
+        # On Windows every layer of the launcher chain (stub -> venv python ->
+        # runtime python) carries "gateway run" in its command line, so
+        # find_gateway_pids() matches processes the pidfile exclusion cannot
+        # see, and os.kill(SIGTERM) is a hard TerminateProcess — the
+        # gateway's planned-stop watcher (0.5s poll) has no time to drain.
+        # cleanup_stale=False keeps the probe from deleting the registration
+        # record it is checking.
         try:
+            from gateway.status import get_running_pid
             from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
 
-            _reap_unsupervised_gateway_orphans()
+            if get_running_pid(cleanup_stale=False) is None:
+                _reap_unsupervised_gateway_orphans()
         except Exception:
             _log.exception("Desktop startup: orphan gateway reap failed")
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -472,22 +472,22 @@ async def _lifespan(app: "FastAPI"):
         # WebSocket, and a newly forked gateway then races the same credential,
         # splitting messages across parallel session trees (#77276).
         #
-        # Only reap when no live, registered gateway is in the record: a
-        # healthy standalone gateway (launched via `hermes gateway run`, no
-        # service supervisor) is not an orphan, and the sweep would kill it.
-        # On Windows every layer of the launcher chain (stub -> venv python ->
-        # runtime python) carries "gateway run" in its command line, so
+        # The sweep itself still runs unconditionally — a stale-but-present
+        # registration must not veto the #77276 orphan reap. Protection for
+        # a healthy standalone gateway (launched via `hermes gateway run`,
+        # no service supervisor) lives INSIDE the reaper: it probes the
+        # registration with cleanup_stale=False so the recorded PID always
+        # joins the exclusion set, even when liveness validation would have
+        # unlinked the record mid-sweep. That matters most on Windows, where
+        # every layer of the launcher chain (stub -> venv python -> runtime
+        # python) carries "gateway run" in its command line, so
         # find_gateway_pids() matches processes the pidfile exclusion cannot
         # see, and os.kill(SIGTERM) is a hard TerminateProcess — the
         # gateway's planned-stop watcher (0.5s poll) has no time to drain.
-        # cleanup_stale=False keeps the probe from deleting the registration
-        # record it is checking.
         try:
-            from gateway.status import get_running_pid
             from hermes_cli.gateway import _reap_unsupervised_gateway_orphans
 
-            if get_running_pid(cleanup_stale=False) is None:
-                _reap_unsupervised_gateway_orphans()
+            _reap_unsupervised_gateway_orphans()
         except Exception:
             _log.exception("Desktop startup: orphan gateway reap failed")
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -677,7 +677,9 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         self._install_fake_psutil(monkeypatch, [recorded, bootstrap])
 
         # get_running_pid() returns the recorded healthy gateway PID.
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda: recorded_pid)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda cleanup_stale=True: recorded_pid
+        )
 
         # find_gateway_pids returns the recorded PID, its bootstrap parent
         # and a real orphan. The reaper should only kill the orphan.
@@ -720,7 +722,9 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         recorded = SimpleNamespace(pid=recorded_pid, parent=lambda: bootstrap)
         self._install_fake_psutil(monkeypatch, [recorded, bootstrap])
 
-        monkeypatch.setattr("gateway.status.get_running_pid", lambda: recorded_pid)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", lambda cleanup_stale=True: recorded_pid
+        )
 
         # find_gateway_pids would return the recorded PID and its bootstrap
         # parent, but both are excluded.

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -746,6 +746,58 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         assert result is False  # no orphans reaped
         assert killed_pids == []  # nothing was killed
 
+    def test_windows_probe_never_cleans_stale_registration(self, monkeypatch):
+        """The reaper's registration probe must pass cleanup_stale=False.
+
+        With the destructive default, a registration that fails liveness
+        validation is unlinked mid-sweep, the recorded PID never joins the
+        exclusion set, and a healthy standalone gateway (`hermes gateway
+        run`, no service supervisor) is hard-killed. On Windows SIGTERM is
+        TerminateProcess — no graceful drain (#87158).
+        """
+        recorded_pid = 52615
+
+        monkeypatch.setattr(gateway, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+
+        recorded = SimpleNamespace(pid=recorded_pid, parent=lambda: None)
+        self._install_fake_psutil(monkeypatch, [recorded])
+
+        # Simulate the failing-liveness-validation registration: the probe
+        # only returns the recorded PID when asked NOT to clean up; the
+        # destructive default path would unlink the record and return None.
+        seen_kwargs = []
+
+        def probing_get_running_pid(cleanup_stale=True):
+            seen_kwargs.append(cleanup_stale)
+            return None if cleanup_stale else recorded_pid
+
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid", probing_get_running_pid
+        )
+        monkeypatch.setattr(
+            gateway,
+            "find_gateway_pids",
+            lambda exclude_pids=None: [
+                p for p in [recorded_pid] if p not in (exclude_pids or set())
+            ],
+        )
+
+        killed_pids = []
+        monkeypatch.setattr(
+            gateway.os, "kill", lambda pid, sig: killed_pids.append((pid, sig))
+        )
+
+        result = gateway._reap_unsupervised_gateway_orphans()
+
+        assert seen_kwargs == [False], (
+            "reaper probe must use cleanup_stale=False so the sweep never "
+            f"deletes its own exclusion evidence, got {seen_kwargs}"
+        )
+        assert result is False
+        assert killed_pids == []  # the standalone gateway survived
+
 
 class TestReaperCandidateIsSupervisorOwned:
     """Regression for the Windows pidfile-less supervisor-owned case (#83683).

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -746,14 +746,18 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         assert result is False  # no orphans reaped
         assert killed_pids == []  # nothing was killed
 
-    def test_windows_probe_never_cleans_stale_registration(self, monkeypatch):
-        """The reaper's registration probe must pass cleanup_stale=False.
+    def test_windows_raw_record_supplies_exclusion_when_validation_fails(
+        self, monkeypatch
+    ):
+        """A registration that fails liveness VALIDATION must still shield
+        the recorded PID from the sweep.
 
-        With the destructive default, a registration that fails liveness
-        validation is unlinked mid-sweep, the recorded PID never joins the
-        exclusion set, and a healthy standalone gateway (`hermes gateway
-        run`, no service supervisor) is hard-killed. On Windows SIGTERM is
-        TerminateProcess — no graceful drain (#87158).
+        get_running_pid returns None whenever the record fails validation
+        (start-time mismatch, argv drift, lock hiccup) — regardless of
+        cleanup_stale, which only controls unlinking. The exclusion set is
+        therefore built from the RAW pidfile/lock records: a stale recorded
+        PID at worst spares one process, while a validation false-negative
+        would TerminateProcess a healthy standalone gateway (#87158).
         """
         recorded_pid = 52615
 
@@ -764,17 +768,21 @@ class TestReapUnsupervisedGatewayOrphansWindows:
         recorded = SimpleNamespace(pid=recorded_pid, parent=lambda: None)
         self._install_fake_psutil(monkeypatch, [recorded])
 
-        # Simulate the failing-liveness-validation registration: the probe
-        # only returns the recorded PID when asked NOT to clean up; the
-        # destructive default path would unlink the record and return None.
-        seen_kwargs = []
+        # The raw record is present on disk; the validated probe rejects it.
+        monkeypatch.setattr(
+            "gateway.status._read_pid_record", lambda *a, **k: {"pid": recorded_pid}
+        )
+        monkeypatch.setattr(
+            "gateway.status._read_gateway_lock_record", lambda *a, **k: None
+        )
+        probe_kwargs = []
 
-        def probing_get_running_pid(cleanup_stale=True):
-            seen_kwargs.append(cleanup_stale)
-            return None if cleanup_stale else recorded_pid
+        def failing_validation(*a, cleanup_stale=True, **k):
+            probe_kwargs.append(cleanup_stale)
+            return None
 
         monkeypatch.setattr(
-            "gateway.status.get_running_pid", probing_get_running_pid
+            "gateway.status.get_running_pid", failing_validation
         )
         monkeypatch.setattr(
             gateway,
@@ -791,9 +799,9 @@ class TestReapUnsupervisedGatewayOrphansWindows:
 
         result = gateway._reap_unsupervised_gateway_orphans()
 
-        assert seen_kwargs == [False], (
-            "reaper probe must use cleanup_stale=False so the sweep never "
-            f"deletes its own exclusion evidence, got {seen_kwargs}"
+        assert probe_kwargs == [False], (
+            "the fallback probe must still be non-destructive so the sweep "
+            f"never unlinks the record it just read, got {probe_kwargs}"
         )
         assert result is False
         assert killed_pids == []  # the standalone gateway survived


### PR DESCRIPTION
## Summary
Opening Hermes Desktop on Windows killed a healthy standalone gateway (`hermes gateway run`, no service supervisor): the orphan reaper's registration probe used the destructive default, which unlinks a record that fails liveness validation mid-sweep — so the recorded PID never joined the exclusion set and the sweep TerminateProcess'd the gateway it was supposed to protect. Salvage of #87158 by @butbutbutbutbutbut (authorship preserved).

## Changes
- hermes_cli/gateway.py: the reaper probes the registration with `cleanup_stale=False` so the sweep never deletes its own exclusion evidence (contributor's fix, kept verbatim)
- Follow-up (ours): the PR's second hunk — a web_server.py gate skipping the whole sweep whenever any registration exists — is dropped: a stale-but-present registration must not veto the #77276 orphan reap the sweep exists for; the reaper-side probe fix alone fully protects the standalone gateway. New mutation-checked regression test drives the exact failure (registration only surfaces its PID when probed non-destructively; reverting the probe to the destructive default fails the test)
- /simplify-code follow-up (efficiency HIGH, verified + verdict-changing): `cleanup_stale=False` never delivered the exclusion — `get_running_pid` returns None on validation failure regardless of the flag (it only controls unlinking). Exclusion now built from the RAW pidfile+lock records; validated probe kept for the runtime-status fallback. Test reworked to real semantics; mutation-checked both directions

## Validation
| | |
|---|---|
| test_gateway.py | 30 passed, 3 skipped |
| mutation check | reverting `cleanup_stale=False` → guard test fails; restored → passes |
| ruff | clean |

Closes #87158.

## Infographic

![do-not-reap-the-living](https://v3b.fal.media/files/b/0aa75f93/u7YeAYlvdIKtat5074gPA_thto3nDs.png)
