### PR TITLE
fix(prompt): invalidate skills index LRU when skills dir changes (fixes #92313)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1902,8 +1902,22 @@ def _build_skills_system_prompt_inner(
     _platform_hint = _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
     project_dirs = project_dirs or []
+    # Fingerprint the skills directory so a skill install/uninstall/edit made
+    # by a *different* process (e.g. `hermes skills install` while the gateway
+    # keeps running) invalidates this process's cached index. Without this,
+    # the LRU serves a stale skill list for the lifetime of the gateway and
+    # newly installed skills never reach the model's system prompt. The
+    # manifest is the same mtime/size fingerprint the disk snapshot uses for
+    # validation — cheap to compute and catches any content change.
+    _skills_fingerprint = tuple(
+        sorted(
+            f"{rel}:{mtime_ns}:{size}"
+            for rel, (mtime_ns, size) in _build_skills_manifest(skills_dir).items()
+        )
+    )
     cache_key = (
         str(skills_dir),
+        _skills_fingerprint,
         tuple(str(d) for d in external_dirs),
         tuple(str(d) for d in project_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1628,7 +1628,7 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     try:
         st = os.stat(marker_path)
         manifest[ORG_MIRROR_DIR_NAME + "/" + ORG_ACTIVE_MARKER] = [
-            int(st.st_mtime), int(st.st_size),
+            st.st_mtime_ns, int(st.st_size),
         ]
     except OSError:
         pass
@@ -1654,6 +1654,35 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
                 continue
             manifest[path[prefix_len:]] = [st.st_mtime_ns, st.st_size]
     return manifest
+
+
+def _index_dirs_fingerprint(dirs: "list[Path]") -> tuple[str, ...]:
+    """Fingerprint the skill index files under *dirs* by relative path, mtime_ns,
+    and size.
+
+    Used as part of the in-process prompt-cache key so that a skill
+    install/uninstall/edit made by a *different* process (e.g. ``hermes skills
+    install`` while the gateway keeps running) invalidates the cached index for
+    the external and project skill tiers as well as the local one. Mirrors the
+    ``mtime_ns + size`` scheme of ``_build_skills_manifest`` (nanosecond
+    resolution, so a same-second edit preserving size still invalidates).
+    ``iter_skill_index_files`` applies the same exclusion rules (metadata,
+    support dirs, org mirrors) as the index scan itself, so touching an ignored
+    file does not spuriously invalidate the cache.
+    """
+    entries: list[str] = []
+    for root in dirs:
+        if not root.exists():
+            continue
+        prefix = len(os.path.join(str(root), ""))
+        for filename in ("SKILL.md", "DESCRIPTION.md"):
+            for path in iter_skill_index_files(root, filename):
+                try:
+                    st = os.stat(path)
+                except OSError:
+                    continue
+                entries.append(f"{str(path)[prefix:]}:{st.st_mtime_ns}:{st.st_size}")
+    return tuple(sorted(entries))
 
 
 def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
@@ -1902,22 +1931,30 @@ def _build_skills_system_prompt_inner(
     _platform_hint = _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
     project_dirs = project_dirs or []
-    # Fingerprint the skills directory so a skill install/uninstall/edit made
+    # Fingerprint the skill directories so a skill install/uninstall/edit made
     # by a *different* process (e.g. `hermes skills install` while the gateway
     # keeps running) invalidates this process's cached index. Without this,
     # the LRU serves a stale skill list for the lifetime of the gateway and
     # newly installed skills never reach the model's system prompt. The
-    # manifest is the same mtime/size fingerprint the disk snapshot uses for
-    # validation — cheap to compute and catches any content change.
+    # manifest is the same mtime_ns+size fingerprint the disk snapshot uses for
+    # validation — cheap to compute and catches any content change, including
+    # a same-second edit that preserves byte size.
     _skills_fingerprint = tuple(
         sorted(
             f"{rel}:{mtime_ns}:{size}"
             for rel, (mtime_ns, size) in _build_skills_manifest(skills_dir).items()
         )
     )
+    # External and project skill tiers feed the same index but are keyed by
+    # path alone; fingerprint their contents too so a skill added to an
+    # external/project dir by another process invalidates the cache as well.
+    _external_fingerprint = _index_dirs_fingerprint(list(external_dirs))
+    _project_fingerprint = _index_dirs_fingerprint(project_dirs)
     cache_key = (
         str(skills_dir),
         _skills_fingerprint,
+        _external_fingerprint,
+        _project_fingerprint,
         tuple(str(d) for d in external_dirs),
         tuple(str(d) for d in project_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -365,6 +365,47 @@ class TestBuildSkillsSystemPrompt:
         assert "cached-skill" not in second
 
 
+    def test_rebuilds_prompt_when_new_skill_installed_while_gateway_runs(
+        self, monkeypatch, tmp_path
+    ):
+        """A skill installed after the first prompt build (e.g. by a separate
+        `hermes skills install` CLI process) must appear on the next build —
+        the LRU cache must not serve a stale index. Regression test for
+        #92313: the skills-dir manifest fingerprint is part of the cache key.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "tools"
+        skills_dir.mkdir(parents=True)
+        existing = skills_dir / "existing-skill"
+        existing.mkdir()
+        (existing / "SKILL.md").write_text(
+            "---\nname: existing-skill\ndescription: Existing\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "existing-skill" in first
+        assert "new-skill" not in first
+
+        # Simulate an install from another process: add a SKILL.md, then bump
+        # its mtime so the manifest fingerprint changes even on coarse-grained
+        # filesystems (the manifest is mtime_ns + size based).
+        new_dir = skills_dir / "new-skill"
+        new_dir.mkdir()
+        (new_dir / "SKILL.md").write_text(
+            "---\nname: new-skill\ndescription: Freshly installed\n---\n"
+        )
+        import os
+        import time
+
+        os.utime(new_dir / "SKILL.md", (time.time() + 5, time.time() + 5))
+
+        second = build_skills_system_prompt()
+        assert "new-skill" in second, (
+            "newly installed skill must appear even though the LRU was warm"
+        )
+        assert "existing-skill" in second
+
+
 
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -386,24 +386,89 @@ class TestBuildSkillsSystemPrompt:
         assert "existing-skill" in first
         assert "new-skill" not in first
 
-        # Simulate an install from another process: add a SKILL.md, then bump
-        # its mtime so the manifest fingerprint changes even on coarse-grained
-        # filesystems (the manifest is mtime_ns + size based).
+        # Simulate an install from another process: add a SKILL.md. The write
+        # gives it a fresh mtime_ns, so the manifest fingerprint changes even
+        # if it lands within the same whole second.
         new_dir = skills_dir / "new-skill"
         new_dir.mkdir()
         (new_dir / "SKILL.md").write_text(
             "---\nname: new-skill\ndescription: Freshly installed\n---\n"
         )
-        import os
-        import time
-
-        os.utime(new_dir / "SKILL.md", (time.time() + 5, time.time() + 5))
 
         second = build_skills_system_prompt()
         assert "new-skill" in second, (
             "newly installed skill must appear even though the LRU was warm"
         )
         assert "existing-skill" in second
+
+    def test_same_second_same_size_edit_invalidates_cache(self, monkeypatch, tmp_path):
+        """An edit within the same whole second that preserves byte size must
+        still invalidate the LRU: the fingerprint uses mtime_ns, not the
+        whole-second mtime, so the +1ns change is enough to rebuild.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "tools" / "s"
+        skill_dir.mkdir(parents=True)
+        p = skill_dir / "SKILL.md"
+        base_ns = 1_700_000_000_000_000_000  # fixed epoch ns (deterministic)
+        p.write_text("---\nname: s\ndescription: v1\n---\n")
+        os.utime(p, ns=(base_ns, base_ns))
+
+        first = build_skills_system_prompt()
+        assert "v1" in first
+
+        # Same byte size, content changed, mtime bumped by a single nanosecond
+        # — the whole-second mtime is identical, so only ns resolution can
+        # detect this.
+        p.write_text("---\nname: s\ndescription: v2\n---\n")
+        os.utime(p, ns=(base_ns + 1, base_ns + 1))
+
+        second = build_skills_system_prompt()
+        assert "v2" in second, (
+            "same-second, same-size edit must invalidate (mtime_ns resolution)"
+        )
+
+    def test_rebuilds_prompt_when_skill_added_to_external_dir(
+        self, monkeypatch, tmp_path
+    ):
+        """A skill added to an external skills dir (config `skills.external_dirs`)
+        after the first build must appear on the next build even with a warm
+        LRU — external-dir contents are fingerprinted too, not just the local
+        skills_dir.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        local = tmp_path / "skills" / "tools" / "local-skill"
+        local.mkdir(parents=True)
+        (local / "SKILL.md").write_text(
+            "---\nname: local-skill\ndescription: Local\n---\n"
+        )
+        ext = tmp_path / "ext-skills"
+        ext.mkdir()
+        ext_skill = ext / "ext-skill"
+        ext_skill.mkdir()
+        (ext_skill / "SKILL.md").write_text(
+            "---\nname: ext-skill\ndescription: Ext\n---\n"
+        )
+        (tmp_path / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {ext}\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "local-skill" in first
+        assert "ext-skill" in first
+
+        # Simulate another process installing a skill into the external dir.
+        new_skill = ext / "ext-new"
+        new_skill.mkdir()
+        (new_skill / "SKILL.md").write_text(
+            "---\nname: ext-new\ndescription: New ext\n---\n"
+        )
+
+        second = build_skills_system_prompt()
+        assert "ext-new" in second, (
+            "new external-dir skill must appear despite warm LRU"
+        )
+        assert "ext-skill" in second
 
 
 


### PR DESCRIPTION
## Summary

Fixes #92313 — newly installed skills stay invisible to the model's system prompt when the gateway has been running since before the install.

`build_skills_system_prompt()` caches the rendered skill index in a process-global LRU (`_SKILLS_PROMPT_CACHE`) keyed by `(skills_dir, external_dirs, tools, toolsets, platform_hint, disabled, compact_categories)` — **not** by the skills directory contents. `clear_skills_system_prompt_cache()` is called by the install CLI (`hermes_cli/skills_hub.py`, `do_install(…, invalidate_cache=True)`), but that runs in a **different process** from the long-running gateway. The gateway's own cache (populated when it first built the index) is never invalidated, so a skill installed mid-flight never reaches `<available_skills>` in the system prompt for the gateway's lifetime — silently.

## Fix

Add the skills-dir **manifest fingerprint** (the same `mtime_ns + size` manifest `_build_skills_manifest()` already computes for disk-snapshot validation) to the LRU cache key. Any skill install/uninstall/edit — from any process — changes the fingerprint and self-invalidates the cache on the next prompt build.

This fixes the whole bug class (not just the install path): uninstalls, manual edits, and repo pulls that add/change `SKILL.md` files all invalidate the index automatically. The manifest walk is the same cost the snapshot validation already pays per build.

## Test

New regression test `test_rebuilds_prompt_when_new_skill_installed_while_gateway_runs`:
1. Build the prompt with an existing skill (LRU warms).
2. Add a new `SKILL.md` (simulating an install from a separate process) and bump its mtime.
3. Build again — the new skill **must** appear.

Also verified live against the exact issue repro: warm LRU → install new skill without any cache-clear call → next `build_skills_system_prompt()` includes it.

## Test results

```
tests/agent/test_prompt_builder.py  -> 73 passed
tests/agent/test_org_skill_namespace.py
tests/agent/test_system_prompt.py   -> 59 passed
```

## Checklist

- [x] Fixes a real, reproduced bug (#92313)
- [x] Fixes the whole bug class (any skills-dir change invalidates, not just install)
- [x] E2E-style regression test against a temp `HERMES_HOME`
- [x] Cache- and invariant-safe: no mid-conversation mutation, byte-stable per conversation
- [x] Narrow footprint: one cache-key addition, reuses existing manifest code
