### PR TITLE
fix(x-search): default to Grok 4.6

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3447,10 +3447,10 @@ DEFAULT_CONFIG = {
     # OAuth or XAI_API_KEY) AND the x_search toolset is enabled in
     # `hermes tools`. These settings tune the backing Responses API call.
     "x_search": {
-        # xAI model used for the Responses call. grok-4.5 is the
+        # xAI model used for the Responses call. grok-4.6 is the
         # recommended default; any Grok model with x_search tool
         # access works.
-        "model": "grok-4.5",
+        "model": "grok-4.6",
         # Optional reasoning effort sent to xAI Responses API models that
         # support it. Leave null to preserve the selected model's default.
         "reasoning_effort": None,

--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -70,7 +70,7 @@ def test_x_search_posts_responses_request(monkeypatch):
     tool_def = captured["json"]["tools"][0]
     assert captured["url"] == "https://api.x.ai/v1/responses"
     assert captured["headers"]["User-Agent"] == f"Hermes-Agent/{__version__}"
-    assert captured["json"]["model"] == "grok-4.5"
+    assert captured["json"]["model"] == "grok-4.6"
     assert captured["json"]["store"] is False
     assert "reasoning" not in captured["json"]
     assert tool_def["type"] == "x_search"
@@ -80,6 +80,41 @@ def test_x_search_posts_responses_request(monkeypatch):
     assert tool_def["enable_image_understanding"] is True
     assert result["success"] is True
     assert result["answer"] == "People on X are discussing xAI's latest launch."
+
+
+def test_x_search_explicit_model_override_reaches_request(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    captured = {}
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _FakeResponse({"output_text": "result", "citations": []})
+
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr("requests.post", _fake_post)
+
+    result = json.loads(x_search_tool(query="latest xAI news", model="grok-4.6"))
+
+    assert result["success"] is True
+    assert result["model"] == "grok-4.6"
+    assert captured["json"]["model"] == "grok-4.6"
+
+
+def test_x_search_rejects_non_grok_model_override_before_request(monkeypatch):
+    from tools.x_search_tool import x_search_tool
+
+    calls = {"post": 0}
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-key")
+    monkeypatch.setattr(
+        "requests.post",
+        lambda *args, **kwargs: calls.__setitem__("post", calls["post"] + 1),
+    )
+
+    result = json.loads(x_search_tool(query="latest xAI news", model="not-grok"))
+
+    assert result["error"] == "x_search model must be a Grok model ID"
+    assert calls["post"] == 0
 
 
 def test_x_search_rejects_conflicting_handle_filters(monkeypatch):
@@ -431,4 +466,3 @@ def test_x_search_bearer_requests_prefer_api_key_from_shared_resolver(monkeypatc
     _api_key, _base_url, source = _resolve_xai_bearer()
     assert captured.get("prefer_api_key") is True
     assert source == "xai"
-

--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -101,6 +101,29 @@ def test_x_search_explicit_model_override_reaches_request(monkeypatch):
     assert captured["json"]["model"] == "grok-4.6"
 
 
+def test_x_search_handler_forwards_model_override(monkeypatch):
+    from tools import x_search_tool as tool_module
+
+    captured = {}
+    monkeypatch.setattr(
+        tool_module,
+        "x_search_tool",
+        lambda **kwargs: captured.update(kwargs) or "ok",
+    )
+
+    assert tool_module._handle_x_search(
+        {"query": "latest xAI news", "model": "grok-4.6"}
+    ) == "ok"
+    assert captured["model"] == "grok-4.6"
+    assert tool_module.X_SEARCH_SCHEMA["parameters"]["properties"]["model"] == {
+        "type": "string",
+        "description": (
+            "Optional Grok model ID for this search. Defaults to "
+            "x_search.model from config."
+        ),
+    }
+
+
 def test_x_search_rejects_non_grok_model_override_before_request(monkeypatch):
     from tools.x_search_tool import x_search_tool
 

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -59,7 +59,7 @@ from tools.xai_http import hermes_xai_user_agent, resolve_xai_http_credentials
 logger = logging.getLogger(__name__)
 
 DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
-DEFAULT_X_SEARCH_MODEL = "grok-4.5"
+DEFAULT_X_SEARCH_MODEL = "grok-4.6"
 DEFAULT_X_SEARCH_TIMEOUT_SECONDS = 180
 DEFAULT_X_SEARCH_RETRIES = 2
 X_SEARCH_REASONING_EFFORTS = ("low", "medium", "high", "xhigh")
@@ -82,6 +82,14 @@ def _load_x_search_config() -> Dict[str, Any]:
 def _get_x_search_model() -> str:
     cfg = _load_x_search_config()
     return (str(cfg.get("model") or "").strip() or DEFAULT_X_SEARCH_MODEL)
+
+
+def _resolve_x_search_model(override: str = "") -> str:
+    """Resolve an optional caller override without permitting non-Grok routes."""
+    model = str(override or "").strip() or _get_x_search_model()
+    if not model.lower().startswith("grok-"):
+        raise ValueError("x_search model must be a Grok model ID")
+    return model
 
 
 def _get_x_search_reasoning_effort() -> Optional[str]:
@@ -307,6 +315,7 @@ def x_search_tool(
     to_date: str = "",
     enable_image_understanding: bool = False,
     enable_video_understanding: bool = False,
+    model: str = "",
 ) -> str:
     if not query or not query.strip():
         return tool_error("query is required for x_search")
@@ -346,8 +355,13 @@ def x_search_tool(
         if enable_video_understanding:
             tool_def["enable_video_understanding"] = True
 
+        try:
+            selected_model = _resolve_x_search_model(model)
+        except ValueError as exc:
+            return tool_error(str(exc))
+
         payload = {
-            "model": _get_x_search_model(),
+            "model": selected_model,
             "input": [
                 {
                     "role": "user",

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -519,6 +519,13 @@ X_SEARCH_SCHEMA = {
                 "type": "string",
                 "description": "What to look up on X.",
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional Grok model ID for this search. Defaults to "
+                    "x_search.model from config."
+                ),
+            },
             "allowed_x_handles": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -556,6 +563,7 @@ X_SEARCH_SCHEMA = {
 def _handle_x_search(args, **kw):
     return x_search_tool(
         query=args.get("query", ""),
+        model=args.get("model", ""),
         allowed_x_handles=args.get("allowed_x_handles"),
         excluded_x_handles=args.get("excluded_x_handles"),
         from_date=args.get("from_date", ""),


### PR DESCRIPTION
## Summary

- make Grok 4.6 the default xAI native-X search model
- let CLI callers pass an explicit Grok model into the existing X Search function
- reject non-Grok overrides before any HTTP request

## Why

The xAI model catalog already promotes `grok-4.6`, but `x_search` and its config default still selected `grok-4.5`. External CLI wrappers also had no supported way to forward an explicit model selection to the core request.

## Verification

- `uv run --extra dev pytest -q tests/tools/test_x_search_tool.py tests/agent/test_model_metadata.py tests/agent/test_reasoning_stale_timeout_floor.py` — 141 passed
- `uv run --extra dev ruff check tools/x_search_tool.py tests/tools/test_x_search_tool.py hermes_cli/config_defaults.py`
- live xAI OAuth probes observed exact `grok-4.6` for both direct reasoning and native X Search
