### PR TITLE
fix(desktop): align group chat and Bots footers

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.js
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.js
@@ -9649,11 +9649,14 @@ function GroupMentionInput({ members, onChange, onSubmitDraft, value, ...inputPr
         ref: inputRef,
         value,
         rows: 1,
+        size: 'sm',
         // Multi-line room prompts (#89884): the composer was a single-line
         // Input whose form submitted on every Enter — newlines were
         // impossible. Enter (no Shift) still submits via onSubmitDraft;
-        // Shift+Enter falls through to the textarea's native newline.
-        className: cn('max-h-40 min-h-9 resize-none', inputProps.className),
+        // Shift+Enter falls through to the textarea's native newline. The
+        // compact block resting state matches the adjacent Bots footer's
+        // 28px button, so both pane dividers share one baseline.
+        className: cn('block max-h-40 min-h-7 resize-none', inputProps.className),
         onChange: event => {
           onChange(event.target.value)
           refreshToken(event.target)

--- a/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
+++ b/apps/desktop/src/plugins/hermes-bots/tests/group-room-ux.test.mjs
@@ -36,6 +36,18 @@ test('both room composers wire onSubmitDraft (#89884)', () => {
   assert.match(source, /onSubmitDraft: \(\) => submitReply\(id\),/)
 })
 
+test('collapsed room composer matches the adjacent footer control height', () => {
+  const start = source.indexOf('function GroupMentionInput')
+  const nextFn = source.indexOf('\nfunction ', start + 1)
+  const component = source.slice(start, nextFn)
+
+  // The textarea may grow for Shift+Enter, but its one-row resting state must
+  // stay on the same 28px control grid as the Bots pane footer button. A
+  // taller minimum raises the room footer divider above the adjacent pane.
+  assert.match(component, /size: 'sm'/)
+  assert.match(component, /block max-h-40 min-h-7 resize-none/)
+})
+
 test('room log anchors to the bottom with a user-scroll guard (#89835)', () => {
   const workspace = source.slice(source.indexOf('function GroupChatWorkspace'))
   assert.match(workspace, /bottomSentinelRef/)


### PR DESCRIPTION
## What does this PR do?

Aligns the collapsed Bot Mode group-chat composer footer with the adjacent Bots pane footer.

The group composer remains a multiline `Textarea`. Shift+Enter, mention completion, attachments, and the existing maximum height are unchanged.

## Root cause

The group composer used a 36 px minimum height, while the adjacent **New Agent** footer uses the 28 px default `Button`. Both footer containers have the same padding, so the taller control raised the group-chat divider.

The textarea also participated in an inline baseline line box, which left extra space below it even after reducing the minimum height.

## Changes

- Use the compact `Textarea` size for the one-row resting state.
- Render the textarea as a block to remove inline baseline space.
- Keep `max-h-40`, `resize-none`, and all existing keyboard behavior.
- Add a regression contract for the collapsed 28 px control grid.

## Rendered evidence

Measured with the real Hermes Desktop `Button`, `Textarea`, and production CSS:

| State | Control height | Footer height |
| --- | ---: | ---: |
| New Agent button | 27.995 px | 44.540 px |
| Composer before | 35.998 px | 57.604 px |
| Composer after | 27.995 px | 44.540 px |

![Misaligned footers before the fix](https://raw.githubusercontent.com/rbressane/hermes-agent/issue-assets/group-chat-footer-alignment/.github/issue-assets/group-chat-footer-alignment.png)

## How to test

```bash
cd apps/desktop
node --test \
  src/plugins/hermes-bots/tests/group-room-ux.test.mjs \
  src/plugins/hermes-bots/tests/group-mention-composer.test.mjs \
  src/plugins/hermes-bots/tests/pane-dock-layout.test.mjs
npm run check:test:plugins
npm run check:lint
npm run build
```

Verified locally:

- Targeted Bot Mode tests: 13/13 passed
- Full desktop plugin tests: 363/363 passed
- TypeScript typecheck: passed
- ESLint: 0 errors, existing warning baseline only
- Production desktop build: passed
- Layout detector: no findings
- Independent pre-commit review: passed with no security or logic concerns

Tested on macOS 26.5.2, arm64.

Fixes #92322
