### PR TITLE
fix(codex): keep sessions usable after provider switches

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -389,7 +389,8 @@ _RESPONSE_MESSAGE_STATUSES = {"completed", "incomplete", "in_progress"}
 # HTTP 400 ("string too long"). Codex-issued assistant message ids are
 # server-assigned base64 blobs that can run 400+ chars, while Hermes-minted
 # ids (msg_...) stay well under this cap and are worth keeping for
-# prefix-cache hits. Drop only the oversized ones on replay.
+# prefix-cache hits. The ChatGPT Codex backend additionally rejects ids that
+# do not begin with ``msg``; foreign Responses issuers may mint short UUIDs.
 _MAX_RESPONSES_ITEM_ID_LENGTH = 64
 
 
@@ -447,7 +448,7 @@ def _chat_messages_to_responses_input(
     ``status``/``content`` are still replayed; only ``id`` is unsafe to
     reuse across a Copilot connection.
 
-    ``current_issuer_kind`` enables a per-item cross-issuer guard. The
+    ``current_issuer_kind`` enables per-item cross-issuer guards. The
     Responses API's ``encrypted_content`` blob is decryptable only by the
     endpoint that minted it — replaying a Codex-issued blob against xAI
     (or vice versa) always yields HTTP 400 ``invalid_encrypted_content``
@@ -458,7 +459,10 @@ def _chat_messages_to_responses_input(
     (backwards-compatible).  The two guards compose:
     ``replay_encrypted_reasoning=False`` is the session-wide kill switch
     (drops ALL replay); ``current_issuer_kind`` is the per-item filter
-    that runs only when replay is still enabled.
+    that runs only when replay is still enabled. The ChatGPT Codex backend
+    also requires replayed message ids to begin with ``msg``. Foreign short
+    ids are omitted there while native Codex ids and other issuers' policies
+    remain unchanged.
 
     ``native_compaction_eligible`` mirrors, for THIS request, the decision
     made by ``native_compaction.native_compaction_context_management`` — it
@@ -624,7 +628,13 @@ def _chat_messages_to_responses_input(
                             and item_id.strip()
                         ):
                             stripped_id = item_id.strip()
-                            if len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH:
+                            if (
+                                len(stripped_id) <= _MAX_RESPONSES_ITEM_ID_LENGTH
+                                and (
+                                    current_issuer_kind != "codex_backend"
+                                    or stripped_id.startswith("msg")
+                                )
+                            ):
                                 replay_item["id"] = stripped_id
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -259,6 +259,7 @@ def test_normalize_codex_response_treats_summary_only_reasoning_as_incomplete():
 
 _OVERSIZED_ITEM_ID = "x" * 408
 _VALID_ITEM_ID = "msg_abc123"
+_FOREIGN_ITEM_ID = "123e4567-e89b-12d3-a456-426614174000"
 
 
 
@@ -354,6 +355,38 @@ def test_preflight_codex_input_items_drops_short_id_for_github_responses():
     assert items[0]["status"] == "in_progress"
     assert items[0]["phase"] == "final_answer"
     assert items[0]["content"] == [{"type": "output_text", "text": "pong"}]
+
+
+def test_chat_messages_to_responses_input_drops_foreign_id_for_codex_backend():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "pong",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                    "id": _FOREIGN_ITEM_ID,
+                    "phase": "final_answer",
+                }
+            ],
+        }
+    ]
+
+    codex_items = _chat_messages_to_responses_input(
+        messages, current_issuer_kind="codex_backend"
+    )
+    xai_items = _chat_messages_to_responses_input(
+        messages, current_issuer_kind="xai_responses"
+    )
+
+    codex_message = next(item for item in codex_items if item.get("type") == "message")
+    xai_message = next(item for item in xai_items if item.get("type") == "message")
+    assert "id" not in codex_message
+    assert codex_message["phase"] == "final_answer"
+    assert xai_message["id"] == _FOREIGN_ITEM_ID
 
 
 def test_preflight_codex_api_kwargs_drops_oversized_message_id_end_to_end():

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -151,6 +151,35 @@ class TestCodexBuildKwargs:
         message_item = next(item for item in kw["input"] if item.get("type") == "message")
         assert message_item["id"] == "msg_short_id"
 
+    def test_codex_backend_drops_foreign_message_item_id_end_to_end(self, transport):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "pong",
+                "codex_message_items": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "pong"}],
+                        "id": "123e4567-e89b-12d3-a456-426614174000",
+                        "phase": "final_answer",
+                    }
+                ],
+            },
+        ]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+            is_codex_backend=True,
+        )
+
+        message_item = next(item for item in kw["input"] if item.get("type") == "message")
+        assert "id" not in message_item
+        assert message_item["phase"] == "final_answer"
+
     @pytest.mark.parametrize("model", [
         "gpt-5.5",
         "gpt-5.5-pro",


### PR DESCRIPTION
## What does this PR do?

Prevents a live session from becoming unusable on the ChatGPT Codex Responses backend after switching from another provider. Replayed assistant message items now omit foreign short IDs that Codex rejects, while native `msg*` IDs remain available for prefix-cache hits and other Responses issuers keep their existing behavior.

### Symptom

After a provider switch, Codex rejects every subsequent turn with HTTP 400: `Invalid input[N].id ... Expected an ID that begins with 'msg'`.

### Impact

Sessions containing a foreign assistant message ID cannot continue on Codex until the user starts a new session. The persisted invalid item is replayed on every later turn.

### Bug Cause

**Trigger:** `agent/codex_responses_adapter.py` in `_chat_messages_to_responses_input`, when replaying `codex_message_items` for `current_issuer_kind == "codex_backend"`.

**Causal chain:**
1. A non-Codex provider stores a short assistant message ID such as a UUID.
2. The replay converter accepts it because it is non-empty and no longer than 64 characters.
3. The ChatGPT Codex backend requires message IDs to begin with `msg`, rejects the request with HTTP 400, and the persisted ID breaks later turns too.

**Why it is wrong:** The existing replay guard validates only length and the Copilot connection policy, not the stricter Codex message-ID namespace.

**Working sibling / contrast:** Native Codex `msg*` IDs already satisfy the backend contract and remain useful for prefix caching. xAI and custom Responses issuers do not use this Codex-only prefix rule.

**Ruled out:** This is not the oversized-ID replay bug: a 36-character UUID is below the existing 64-character limit and still reproduces the invalid-value path.

### Fix

Apply the `msg` prefix requirement only when the current issuer is the ChatGPT Codex backend. Preserve valid native IDs, omit foreign IDs without altering message content, phase, or status, and leave other issuer policies unchanged.

## Related Issue

Closes #92311

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_responses_adapter.py` - filter foreign assistant message IDs during Codex replay.
- `tests/agent/test_codex_responses_adapter.py` - cover Codex filtering and xAI preservation at the converter boundary.
- `tests/agent/transports/test_codex_transport.py` - cover the complete transport kwargs path.

## How to Test

1. Run the adapter regression suite.
2. Run the Codex transport regression suite.

```bash
scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py -q
scripts/run_tests.sh tests/agent/transports/test_codex_transport.py -q
```

Result: 117 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant test files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings - N/A beyond the converter contract updated in this PR
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - host-independent payload conversion
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - automated payload assertions cover the provider request shape.
