### PR TITLE
fix(gateway): guard /model against code skew at handler entry

### DIFF
--- a/gateway/code_skew.py
+++ b/gateway/code_skew.py
@@ -46,11 +46,28 @@ def record_boot_fingerprint() -> None:
 
 
 def _short(fingerprint: str) -> str:
-    """Render a ``git:<ref>:<sha>`` fingerprint as a compact label."""
-    sha = fingerprint.rsplit(":", 1)[-1]
-    if sha and sha != "unresolved" and len(sha) > 10:
-        return sha[:10]
-    return sha or fingerprint
+    """Render a ``git:<ref>:<sha>`` fingerprint as a compact ``<ref>@<sha>`` label.
+
+    The ref is kept alongside the sha because a branch switch is a common cause
+    of skew and two bare shas don't reveal it. This label is what the guard puts
+    in front of the user, and it's the line they paste into a bug report, so it
+    should say both *what* is running and *where it came from*. Unresolvable
+    refs keep the ``unresolved`` marker rather than collapsing to an empty label.
+    """
+    body = fingerprint[4:] if fingerprint.startswith("git:") else fingerprint
+    ref, sep, sha = body.rpartition(":")
+    if not sep:
+        # Not a ``<ref>:<sha>`` shape — hand it back untouched rather than
+        # truncating something that isn't a sha.
+        return fingerprint
+    if sha != "unresolved" and len(sha) > 10:
+        sha = sha[:10]
+    ref_label = ref
+    for prefix in ("refs/heads/", "refs/remotes/", "refs/tags/"):
+        if ref_label.startswith(prefix):
+            ref_label = ref_label[len(prefix):]
+            break
+    return f"{ref_label}@{sha}" if ref_label else sha
 
 
 def detect_code_skew() -> tuple[str, str] | None:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1760,6 +1760,16 @@ class GatewaySlashCommandsMixin:
           /model <name> --provider <provider> — switch provider + model
           /model --provider <provider>        — switch to provider, auto-detect model
         """
+        # Guard here — before the lazy hermes_cli.model_switch import below —
+        # not only at switch time. On a stale process that import can load a
+        # newer module whose call signatures no longer match this in-memory
+        # caller, so even displaying the picker crashes (e.g. the post-update
+        # "too many values to unpack (expected 4)" from the old tuple-returning
+        # parse_model_flags).
+        skew_error = _model_switch_skew_guard()
+        if skew_error:
+            return skew_error
+
         from gateway.run import _hermes_home, _load_gateway_config
         from hermes_cli.model_switch import (
             switch_model as _switch_model, parse_model_switch_args,

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -29,20 +29,44 @@ class TestDetectCodeSkew:
 
         monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:def4567890123")
         skew = code_skew.detect_code_skew()
-        assert skew == ("abc1234567", "def4567890")
+        assert skew == ("main@abc1234567", "main@def4567890")
+
+    def test_branch_switch_is_visible_in_the_labels(self, monkeypatch):
+        # A checkout switched to another branch is a common skew cause; two
+        # bare shas wouldn't say so, so the ref has to survive into the label.
+        monkeypatch.setattr(code_skew, "_fingerprint", lambda: "git:refs/heads/main:abc1234567890")
+        code_skew.record_boot_fingerprint()
+
+        monkeypatch.setattr(
+            code_skew, "_fingerprint", lambda: "git:refs/heads/hotfix:def4567890123"
+        )
+        assert code_skew.detect_code_skew() == ("main@abc1234567", "hotfix@def4567890")
 
 
 
 
 class TestShort:
-    def test_shortens_long_sha(self):
-        assert code_skew._short("git:refs/heads/main:abcdef0123456789") == "abcdef0123"
+    def test_shortens_long_sha_and_keeps_the_ref(self):
+        assert code_skew._short("git:refs/heads/main:abcdef0123456789") == "main@abcdef0123"
 
     def test_keeps_unresolved_marker(self):
-        assert code_skew._short("git:refs/heads/main:unresolved") == "unresolved"
+        assert code_skew._short("git:refs/heads/main:unresolved") == "main@unresolved"
 
     def test_passes_short_sha_through_untruncated(self):
-        assert code_skew._short("git:HEAD:abc1234") == "abc1234"
+        assert code_skew._short("git:HEAD:abc1234") == "HEAD@abc1234"
+
+    def test_keeps_nested_branch_names_whole(self):
+        # ``feature/x`` must not collapse to ``x`` — the prefix is the part
+        # that distinguishes it from an unrelated branch called ``x``.
+        assert (
+            code_skew._short("git:refs/heads/feature/x:0123456789abcdef")
+            == "feature/x@0123456789"
+        )
+
+    def test_non_fingerprint_is_returned_untouched(self):
+        # Anything that isn't ``<ref>:<sha>`` shaped is not a sha, so it must
+        # not be truncated as if it were one.
+        assert code_skew._short("weird-no-colon") == "weird-no-colon"
 
 
 class TestModelCommandEntryGuard:
@@ -91,9 +115,13 @@ class TestModelSwitchSkewGuard:
     def test_guard_message_names_revs_and_restart(self, monkeypatch):
         from gateway import slash_commands
 
-        monkeypatch.setattr(code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890"))
+        monkeypatch.setattr(
+            code_skew, "detect_code_skew", lambda: ("main@abc1234567", "hotfix@def4567890")
+        )
         msg = slash_commands._model_switch_skew_guard()
         assert msg is not None
-        assert "abc1234567" in msg
-        assert "def4567890" in msg
+        # Both sides identified — this message is what a user pastes into a
+        # bug report, so it has to carry the evidence for the diagnosis.
+        assert "main@abc1234567" in msg
+        assert "hotfix@def4567890" in msg
         assert "hermes gateway restart" in msg

--- a/tests/test_code_skew.py
+++ b/tests/test_code_skew.py
@@ -45,6 +45,42 @@ class TestShort:
         assert code_skew._short("git:HEAD:abc1234") == "abc1234"
 
 
+class TestModelCommandEntryGuard:
+    """Regression: the guard must fire at /model entry, before the handler's
+    lazy ``hermes_cli.model_switch`` import. On a stale process that import
+    loads a newer module whose signatures no longer match the in-memory
+    caller — the post-update ``too many values to unpack (expected 4)`` crash
+    from the old tuple-returning ``parse_model_flags``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_model_command_refuses_on_skew_before_parsing(self, monkeypatch):
+        from gateway.config import Platform
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        monkeypatch.setattr(
+            code_skew, "detect_code_skew", lambda: ("abc1234567", "def4567890")
+        )
+
+        # A bare runner with no attributes set: if the guard is truly the
+        # first thing the handler does, nothing else is ever touched.
+        runner = object.__new__(GatewayRunner)
+        event = MessageEvent(
+            text="/model gpt-5.5",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.TELEGRAM, chat_id="1", chat_type="dm"
+            ),
+        )
+
+        result = await runner._handle_model_command(event)
+
+        assert result is not None
+        assert "hermes gateway restart" in result
+
+
 class TestModelSwitchSkewGuard:
     def test_guard_returns_none_without_skew(self, monkeypatch):
         from gateway import slash_commands


### PR DESCRIPTION
## What does this PR do?

`_cmd_model` calls `_model_switch_skew_guard()` only at switch time — after the handler's lazy `from hermes_cli.model_switch import ...`. On a **stale process** (code updated on disk, gateway not yet restarted) that import pulls in a newer module whose call signatures no longer match the in-memory caller, so even *displaying* the picker crashes before the existing guard is ever reached.

The guard already exists for exactly this situation; it was simply placed too late to cover the parse/display path. This PR moves it to the top of the handler, before the lazy import.

**On the now-redundant switch-time guard:** the switch-time `_model_switch_skew_guard()` call is deliberately left in place. With the entry guard added, `/model <name>` returns the skew message before it can ever reach the switch path, so the later call is unreachable-on-skew and strictly redundant today. It is kept as defence in depth — if a future refactor moves, reorders, or adds an early-return ahead of the entry guard, the switch-time call is the thing that still stops a stale process from performing a real model switch. Please don't "clean it up" as dead code without re-checking that the entry guard still dominates every path into the switch.

## Related Issue

No existing issue covers this. #52266 reports a similar-looking `too many values to unpack` from `/model`, but its root cause is different (hyphenated model names in custom providers), so this is not a fix for it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Commit 1 — move the guard:

- `gateway/slash_commands.py` — call `_model_switch_skew_guard()` at `_cmd_model` entry, before the lazy `hermes_cli.model_switch` import (+10)
- `tests/test_code_skew.py` — `TestModelCommandEntryGuard`, a regression test asserting the guard fires at entry and that the handler returns the guard message instead of raising (+36)

Commit 2 — make the message identify both sides (from review feedback):

- `gateway/code_skew.py` — `_short()` now renders a fingerprint as `<ref>@<sha>` (`main@abcdef0123`) rather than the sha alone. The guard already named both shas, but the ref was discarded, so a checkout switched to another branch produced two bare shas with no hint that the *branch* had moved. Two edge cases fixed while there: nested branch names no longer collapse to their last segment (`feature/x` became `x`, indistinguishable from an unrelated branch actually named `x`), and an input that isn't `<ref>:<sha>` shaped is returned untouched instead of being truncated to 10 chars as if it were a sha.
- `tests/test_code_skew.py` — coverage for the branch-switch case, nested branch names, the `unresolved` marker, non-fingerprint passthrough, and that both labels reach the guard message.

## How to Test

Reproduction (what we hit in production on 2026-07-25):

1. Start the gateway and leave it running.
2. Run `hermes update` (or otherwise move the checkout forward) **without restarting the gateway**, so the running process holds pre-update code in memory while newer modules sit on disk.
3. Send `/model` from a connected platform (Discord in our case).
4. **Before this change:** the handler raises during the lazy import path — we saw `ValueError: too many values to unpack (expected 4)` from the then-tuple-returning `parse_model_flags`, so the picker never renders.
   **After this change:** the handler returns the skew message, now naming both sides, e.g. *"This gateway is running code from `main@abc1234567` but the checkout on disk is now `hotfix@def4567890`."*

Automated:

```bash
pytest tests/test_code_skew.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partially**: I ran the affected areas rather than the full suite (see below), so please let CI be the authority here.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 14.6 (Darwin 23.6.0, arm64), Python 3.11.15

Tests actually run locally (54 passed, 0 failed):

```
tests/test_code_skew.py                                  11 passed
tests/test_resource_limits.py                             \
tests/gateway/test_discord_model_picker.py                 |
tests/gateway/test_discord_model_picker_partition.py       |  43 passed
tests/gateway/test_48031_model_switch_after_auto_reset.py  |
tests/gateway/test_empty_model_recovery.py                 |
tests/gateway/test_discord_slash_commands.py              /
```

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated on `_short()`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (control-flow reorder plus string formatting, no platform-specific primitives)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
