### PR TITLE
docs(1password): document silent-hang failure mode + timeout / env_passthrough / resolve-and-stash guardrails

### DIFF
--- a/optional-skills/security/1password/SKILL.md
+++ b/optional-skills/security/1password/SKILL.md
@@ -179,10 +179,21 @@ subprocess.run(["op","read","op://Vault/Item/field"], timeout=30, capture_output
 # ~/.hermes/config.yaml
 terminal:
   env_passthrough:
-    - OP_SERVICE_ACCOUNT_TOKEN
+    - OP_SERVICE_ACCOUNT_TOKEN        # SA auth itself (scrubbed as a secret by default)
+    - OP_LOAD_DESKTOP_APP_SETTINGS    # set to "false": skip the desktop-app probe that wedges headless
+    - OP_CACHE                        # set to "false": belt-and-braces vs the op-daemon TCC spawn
 ```
 
-(Skills that declare `required_environment_variables: [OP_SERVICE_ACCOUNT_TOKEN]` in frontmatter get the same effect automatically on `skill_view`.)
+with matching values in `~/.hermes/.env`:
+
+```bash
+OP_LOAD_DESKTOP_APP_SETTINGS=false
+OP_CACHE=false
+```
+
+(Skills that declare `required_environment_variables: [OP_SERVICE_ACCOUNT_TOKEN]` in frontmatter get the same passthrough effect automatically on `skill_view` — but the two `OP_` behavior flags are non-secret so they're stripped unless listed in `env_passthrough`.)
+
+**Verified recipe (macOS 26.6.1, op 2.39.0, gateway on Hermes 2026.8.13):** with all three vars passed through, `op whoami` inside `execute_code` returns in ~0.1s; missing any one of the token / `OP_LOAD_DESKTOP_APP_SETTINGS=false`, it hangs until externally killed.
 
 **For long-lived unattended paths** (cron, LaunchAgents, HA `shell_command`), the most robust pattern is **resolve-and-stash**: resolve the secret once in an interactive shell, store it in a `chmod 600` file, read the file at runtime, keep `op` as a manual-only fallback. This removes `op` from the hot path entirely.
 

--- a/optional-skills/security/1password/SKILL.md
+++ b/optional-skills/security/1password/SKILL.md
@@ -155,6 +155,37 @@ op run -- sh -c '[ -n "$DB_PASSWORD" ] && echo "DB_PASSWORD is set" || echo "DB_
 For non-interactive use, authenticate with `OP_SERVICE_ACCOUNT_TOKEN` and avoid interactive `op signin`.
 Service accounts require CLI v2.18.0+.
 
+## ⚠️ Silent-hang failure mode (macOS headless / stripped env)
+
+`op` can **hang indefinitely with no stdout/stderr and no exit** instead of failing fast. Three independent triggers, same symptom:
+
+1. **Missing auth context.** If `OP_SERVICE_ACCOUNT_TOKEN` is absent from the *child process* env (e.g. Hermes' `execute_code`/`terminal` sandboxes deliberately scrub secret-looking vars — `TOKEN` matches the filter), `op` falls back to desktop-app auth and blocks on a socket/prompt that can never answer.
+2. **`op` daemon + TCC (upstream bug).** Even with a valid service-account token, `op` spawns `op daemon --background`; on macOS 26 (Tahoe) headless/LaunchAgent contexts that daemon triggers a TCC permission dialog that never resolves → hang. `OP_CACHE=false` / `--cache=false` do NOT suppress daemon spawning. Upstream: https://github.com/1Password/op-js/issues/216
+3. **Wedged desktop-app container** — the desktop-integration probe itself can block with no timeout.
+
+**Rule: never call bare `op` in automation. Always wrap with a hard timeout**, so failure is loud and fast instead of a silent stall:
+
+```bash
+# macOS has no `timeout(1)` by default — use a subprocess-level timeout:
+python3 -c 'import subprocess,sys; r=subprocess.run(["op"]+sys.argv[1:],capture_output=True,text=True,timeout=30); print(r.stdout,end=""); sys.exit(r.returncode)' read "op://Vault/Item/field"
+
+# or in Python directly:
+subprocess.run(["op","read","op://Vault/Item/field"], timeout=30, capture_output=True, text=True)
+```
+
+**Hermes-specific:** to make `op` work *inside* `execute_code`/`terminal` sandboxes (instead of avoiding them), opt the token through the secret scrubber explicitly:
+
+```yaml
+# ~/.hermes/config.yaml
+terminal:
+  env_passthrough:
+    - OP_SERVICE_ACCOUNT_TOKEN
+```
+
+(Skills that declare `required_environment_variables: [OP_SERVICE_ACCOUNT_TOKEN]` in frontmatter get the same effect automatically on `skill_view`.)
+
+**For long-lived unattended paths** (cron, LaunchAgents, HA `shell_command`), the most robust pattern is **resolve-and-stash**: resolve the secret once in an interactive shell, store it in a `chmod 600` file, read the file at runtime, keep `op` as a manual-only fallback. This removes `op` from the hot path entirely.
+
 ## References
 
 - `references/get-started.md`


### PR DESCRIPTION
## Problem

`op` (1Password CLI) **hangs indefinitely with no stdout/stderr and no exit** when invoked from stripped or headless environments — Hermes `execute_code`/`terminal` sandboxes, LaunchAgents, Home Assistant `shell_command`, CI. Three independent sessions on the same host hit this in one day; each burned multiple 300s tool timeouts before diagnosis.

Three triggers, same symptom:

1. **Hermes secret-env scrubbing.** `execute_code` deliberately drops secret-looking vars (`tools/code_execution_tool.py::_scrub_child_env`, #27303) — `OP_SERVICE_ACCOUNT_TOKEN` matches the `TOKEN` filter. Inside the sandbox, `op` then falls back to desktop-app auth and blocks on a socket/prompt that can never answer.
2. **Upstream `op` daemon + TCC bug** ([1Password/op-js#216](https://github.com/1Password/op-js/issues/216)): even with a valid service-account token, `op` spawns `op daemon --background`; on macOS 26 headless/LaunchAgent contexts the daemon triggers a TCC permission dialog that never resolves. `OP_CACHE=false` / `--cache=false` do **not** suppress daemon spawning.
3. **Wedged desktop-app container** — the desktop-integration probe itself can block with no timeout.

Repro (on a host where `op` works interactively):

```bash
env -i HOME="$HOME" PATH=/usr/bin:/bin:/opt/homebrew/bin op read "op://Vault/Item/field"
# hangs forever — no output, no exit
```

## Fix

Docs-only: adds a **"Silent-hang failure mode"** section to the bundled `optional-skills/security/1password` skill so agents hit the guardrails *before* burning timeouts:

- **Always wrap `op` in a hard timeout** in automation (with a macOS-appropriate recipe — no `timeout(1)` by default).
- **`terminal.env_passthrough` in `config.yaml` with all THREE vars** (the token alone is not enough — verified live):

```yaml
terminal:
  env_passthrough:
    - OP_SERVICE_ACCOUNT_TOKEN        # SA auth itself (scrubbed as a secret by default)
    - OP_LOAD_DESKTOP_APP_SETTINGS    # set to "false": skip the desktop-app probe that wedges headless
    - OP_CACHE                        # set to "false": belt-and-braces vs the op-daemon TCC spawn
```

with matching values in `~/.hermes/.env`:

```bash
OP_LOAD_DESKTOP_APP_SETTINGS=false
OP_CACHE=false
```

**Verified recipe (macOS 26.6.1, op 2.39.0, Hermes 2026.8.13):** all three passed through → `op whoami` in `execute_code` ~0.1s; missing the token *or* `OP_LOAD_DESKTOP_APP_SETTINGS=false` → hang until killed. The wedged desktop-probe mechanism is the same one fe8c0f7e fixed for the secret-source's own op-child env allowlist — this PR covers the *other* path that reaches it (the agent-sandbox env scrubber).
- **Resolve-and-stash** (600-perm file, `op` as manual-only fallback) for long-lived unattended paths — removes `op` from the hot path entirely.

Docs fix over code fix per CONTRIBUTING ("capabilities that can be expressed as instructions + existing tools → skill"); the passthrough mechanism already exists and works. Possible follow-up (not in this PR): have `agent/secret_sources/onepassword.py::_op_child_env` set `OP_CACHE=false` for its own `op read` invocations as cheap defense-in-depth against the TCC-daemon path — it has a 30s timeout so it fails safe today, but the daemon spawn is pure overhead under service-account auth.

## Checklist

- [x] Searched open/merged PRs + issues for duplicates (`1password`, `op hang`) — none
- [x] Docs-only change; no code paths touched
- [x] Workarounds verified on a live macOS 26.6.1 host (op 2.39.0): bare stripped-env repro hangs; token-present env succeeds; `env_passthrough` mechanism confirmed in-tree (`tools/env_passthrough.py`)

