### PR TITLE
fix: make the ACP auxiliary client awaitable for async callers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6131,6 +6131,28 @@ def _effective_provider_for_client(client: Any, fallback: str) -> str:
 # below — never look up auth env vars ad-hoc.
 
 
+class _AsyncACPShim:
+    """Make a synchronous ACP client awaitable for async callers.
+
+    Runs the blocking create() on a worker thread so the event loop is not
+    stalled by the subprocess round-trip. Everything else proxies through.
+    """
+
+    def __init__(self, sync_client):
+        self._sync = sync_client
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(create=self._acreate))
+
+    async def _acreate(self, **kwargs):
+        import asyncio
+
+        return await asyncio.to_thread(
+            self._sync.chat.completions.create, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._sync, name)
+
+
 def _to_async_client(sync_client, model: str, is_vision: bool = False):
     """Convert a sync client to its async counterpart, preserving Codex routing.
 
@@ -6159,7 +6181,11 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     try:
         from agent.copilot_acp_client import CopilotACPClient
         if isinstance(sync_client, CopilotACPClient):
-            return sync_client, model
+            # The ACP client is synchronous. Returning it unchanged makes every
+            # async caller (async_call_llm, vision_analyze, ...) crash the
+            # moment it awaits chat.completions.create():
+            #   TypeError: object SimpleNamespace can't be used in 'await' expression
+            return _AsyncACPShim(sync_client), model
     except ImportError:
         pass
 


### PR DESCRIPTION
## What

`_to_async_client()` returns the synchronous `CopilotACPClient` unchanged. Every async caller then crashes the moment it awaits:

```
TypeError: object types.SimpleNamespace can't be used in 'await' expression
```

Concretely, `async_call_llm(task="vision", ...)` → `vision_analyze` fails on every image when the main provider is `copilot-acp`, and the gateway's inbound image pre-analysis (`Image routing: text ... Pre-analyzing N image(s)`) logs an error per image with a ~7 second penalty before failing. On our single-user deployment that was ~50 errors a day.

## How

A small shim whose `chat.completions.create` is a coroutine running the blocking call via `asyncio.to_thread`, so the event loop stays free during the ACP subprocess round-trip. All other attributes proxy to the wrapped client.

An alternative would be skipping ACP transports during vision auto-detection entirely (the JSON-RPC prompt path flattens multimodal parts to text in `_render_message_content`, so the vision model never sees pixels even when the call succeeds). Happy to rework in that direction if you prefer — this PR just stops the await crash, which also affects any future non-vision async use of the ACP aux client.