### PR TITLE
fix(docker): persistent sandbox path keeps session-key colons, so docker run fails with exit 125

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -590,6 +590,113 @@ def test_run_command_sanitizes_unsafe_task_id(monkeypatch):
     )
 
 
+def _bind_mount_specs(run_args):
+    """Return every spec string passed via ``-v``."""
+    return [
+        run_args[i + 1]
+        for i, flag in enumerate(run_args[:-1])
+        if flag == "-v"
+    ]
+
+
+def test_persistent_bind_mounts_survive_a_session_key_task_id(monkeypatch, tmp_path):
+    """A gateway session key reaches the persistent sandbox path as-is, and it
+    carries colons (``session:agent:main:telegram:dm:<chat_id>``). Docker reads
+    every colon in a ``-v`` spec as a field separator, so the raw key made
+    ``docker run`` fail with "invalid spec ... too many colons" (exit 125) and
+    no tool call could run for any Telegram DM session."""
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(tmp_path))
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        task_id="session:agent:main:telegram:dm:8439114563",
+        persistent_filesystem=True,
+    )
+
+    specs = _bind_mount_specs(_run_args_from_calls(calls))
+    mounts = [s for s in specs if s.endswith((":/root", ":/workspace"))]
+    assert len(mounts) == 2, f"expected /root and /workspace binds; got {specs}"
+    for spec in mounts:
+        source, _, target = spec.rpartition(":")
+        assert ":" not in source, (
+            f"bind source still contains a colon, docker run would fail with "
+            f"'too many colons': {spec}"
+        )
+        # Docker splits on ':' — a sane spec has exactly source:target.
+        assert spec.count(":") == 1, f"spec is not a two-field bind: {spec}"
+        assert target in {"/root", "/workspace"}
+
+
+def test_distinct_session_keys_get_distinct_sandbox_dirs(monkeypatch, tmp_path):
+    """Sanitizing colons to underscores is not injective on its own: two
+    different chats must not be collapsed onto one persistent sandbox, or one
+    DM's ``/root`` (shell history, credentials, installed packages) shows up in
+    another's container."""
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(tmp_path))
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    sources = []
+    for task_id in (
+        "session:agent:main:telegram:dm:111",
+        "session:agent:main:telegram:dm:222",
+        # Collides with the first key under a plain ':' -> '_' rewrite.
+        "session_agent_main_telegram_dm_111",
+    ):
+        calls = _mock_subprocess_run(monkeypatch)
+        _make_dummy_env(task_id=task_id, persistent_filesystem=True)
+        specs = _bind_mount_specs(_run_args_from_calls(calls))
+        sources.append(
+            next(s.rpartition(":")[0] for s in specs if s.endswith(":/root"))
+        )
+
+    assert len(set(sources)) == 3, f"sandbox sources collided: {sources}"
+
+
+def test_sandbox_dir_name_keeps_existing_names_verbatim():
+    """The shared container and RL/benchmark rollouts must keep resolving to the
+    directory they already use — renaming those strands a user's installed
+    packages and /root state in an orphaned sandbox."""
+    for value in ("default", "bench-env", "astropy__astropy-12907", "v1.2.3_x"):
+        assert docker_env._sandbox_dir_name(value) == value
+
+
+def test_sandbox_dir_name_drops_separators_docker_and_the_fs_reserve():
+    """':' is what docker's -v parser splits on; '/' and '\\' would place the
+    sandbox outside its root entirely."""
+    for value in (
+        "session:agent:main:telegram:dm:8439114563",
+        "task/with:weird*chars",
+        "..\\..\\escape",
+        "../../etc",
+    ):
+        name = docker_env._sandbox_dir_name(value)
+        assert not (set(name) & set(':/\\')), name
+
+
+def test_sandbox_dir_name_is_stable_across_calls():
+    """Cross-process container reuse resolves the sandbox by name, so the
+    mapping must be a pure function of the id — no randomness, no pid."""
+    value = "session:agent:main:discord:guild:1:2"
+    assert docker_env._sandbox_dir_name(value) == docker_env._sandbox_dir_name(value)
+
+
+def test_sandbox_dir_name_bounds_pathological_ids():
+    """Long keys (a Matrix room plus thread id) must stay inside the
+    per-component filesystem limit."""
+    name = docker_env._sandbox_dir_name("session:" + "x:" * 500)
+    assert 0 < len(name) <= 128
+
+
+def test_sandbox_dir_name_never_resolves_to_the_sandbox_root():
+    """'.'/'..' would mount the docker sandbox root, and an empty component
+    would bind every task's state into one container."""
+    for value in ("", ".", "..", "  ", None):
+        name = docker_env._sandbox_dir_name(value)
+        assert name not in {"", ".", ".."}, repr(value)
+        assert not (set(name) & set(':/\\')), name
+
+
 def test_labels_attribute_populated_after_init(monkeypatch):
     """``self._labels`` must be set to the same key/value pairs that went onto
     docker run, so subsequent reuse / reaper paths can match without re-running

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -130,6 +130,54 @@ def _sanitize_label_value(value: str) -> str:
     return cleaned
 
 
+# A persistent sandbox's host directory is named after task_id, and that name
+# then becomes the source half of a `-v <source>:<target>` spec. Docker splits
+# the spec on ':', so a colon-bearing name arrives as extra mount fields and
+# the run is refused outright ("invalid spec ... too many colons", exit 125).
+# Path separators would additionally escape the sandbox root.
+_SANDBOX_DIR_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._-]")
+_SANDBOX_DIR_MAX_LEN = 128
+_SANDBOX_DIR_HASH_LEN = 12
+
+
+def _sandbox_dir_name(task_id: str) -> str:
+    """Return a bind-mountable directory name for *task_id*'s sandbox.
+
+    Names that are already safe are returned verbatim, so the shared
+    ``default`` sandbox and RL/benchmark task ids keep resolving to the
+    directory they have always used — no installed package or ``/root`` state
+    moves. Only ids that could never have produced a working bind mount are
+    rewritten.
+
+    A rewrite also appends a digest of the original id, because the character
+    substitution alone is not injective: ``a:b`` and ``a_b`` would otherwise
+    share one persistent sandbox and leak one session's ``/root`` into
+    another's container. The digest is a pure function of the id, so the same
+    session resolves to the same directory in every process — cross-process
+    container reuse depends on that.
+    """
+    value = task_id if isinstance(task_id, str) else ""
+    if not value:
+        # An empty component collapses the path onto the docker sandbox root,
+        # which would bind-mount every task's state at once.
+        return "default"
+
+    cleaned = _SANDBOX_DIR_UNSAFE_RE.sub("_", value)
+    if (
+        cleaned == value
+        and len(value) <= _SANDBOX_DIR_MAX_LEN
+        and value not in {".", ".."}
+        # Windows silently strips trailing dots/spaces, aliasing two ids onto
+        # one directory.
+        and not value.endswith((".", " "))
+    ):
+        return value
+
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:_SANDBOX_DIR_HASH_LEN]
+    stem = cleaned[: _SANDBOX_DIR_MAX_LEN - _SANDBOX_DIR_HASH_LEN - 1].strip("._")
+    return f"{stem or 'task'}-{digest}"
+
+
 def _get_active_profile_name() -> str:
     """Return the active Hermes profile name, or ``"default"`` on any error.
 
@@ -980,7 +1028,9 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            # _sandbox_dir_name(): a raw session-key task_id carries colons,
+            # which `-v` reads as extra spec fields (exit 125).
+            sandbox = get_sandbox_dir() / "docker" / _sandbox_dir_name(task_id)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([


### PR DESCRIPTION
## What does this PR do?

Makes the persistent Docker sandbox usable for gateway sessions. The host directory backing `/root` and `/workspace` is named after `task_id`, and that name becomes the source half of a `-v` spec — so it has to be a name Docker can actually parse.

### Symptom

With `terminal.backend: docker` and `container_persistent: true`, the first tool call of any gateway session dies before the agent runs anything:

```
Docker sandbox failed to start (exit 125):
docker: Error response from daemon: invalid spec: ...:/root: too many colons
```

### Impact

Every messaging-platform session on the Docker backend with persistent storage. `default` (CLI) is unaffected, which is why this hides in local testing — the id only picks up colons once a session key exists.

### Bug cause

**Trigger:** `tools/environments/docker.py` / `DockerEnvironment.__init__` / persistent-filesystem setup.

**Causal chain:**
1. `_resolve_container_task_id()` returns `session:<key>` whenever a session key is present.
2. Gateway session keys are colon-delimited: `session:agent:main:telegram:dm:<chat_id>`.
3. That id is joined into the sandbox path verbatim: `.../sandboxes/docker/session:agent:main:telegram:dm:<id>/home`.
4. The path becomes `-v <that>:/root`. Docker splits a `-v` spec on `:`, reads the trailing fields as extra mount options, and refuses the whole run.

**Why it is wrong:** a session key is a logical identifier; nothing guarantees it is legal in a mount spec. Note `makedirs()` succeeds first (a colon is a fine POSIX directory name), so the failure surfaces later as an opaque daemon error rather than at the path that caused it.

**Working sibling / contrast:** the container label a few lines below routes the same value through `_sanitize_label_value()` precisely because Docker restricts label values. The bind-mount source had no equivalent guard.

**Ruled out:** not `docker_volumes`, not `docker_mount_cwd_to_workspace`, and not the label sanitizer — reproducible with no user volumes configured, and the labels are already correct.

### Fix

Derive the directory name through `_sandbox_dir_name()`.

- Ids that already work are returned **verbatim**, so the shared `default` sandbox and RL/benchmark rollouts keep the exact directory they use today — no installed packages or `/root` state move. Only ids that could never have produced a working mount are rewritten.
- A rewrite appends a short digest of the *original* id. The substitution alone is not injective, and without the digest `session:...:111` and `session_..._111` would share one persistent `/root` — leaking one chat's shell history and credentials into another's container.
- The mapping is a pure function of the id, so cross-process container reuse still resolves the same sandbox.

## Relationship to #92275 / #92271

#92275 fixes the **Windows** face of this same line (`WinError 267`, colon illegal in a Windows directory name) and I do not want to duplicate it. Two notes for whoever merges first:

- The failures are distinct: on Linux/macOS a colon directory is created fine and it is **Docker's `-v` parser** that rejects it, so #92271's Windows-only framing does not cover the POSIX exit 125 above.
- If #92275 lands first, its `_sandbox_task_dir()` still returns the raw colon path on POSIX when a legacy directory exists (`allow_legacy = os.name != "nt"`). The buggy code calls `makedirs()` *before* `docker run` fails, so that legacy directory exists for every already-affected user — the exit 125 would persist for them. Excluding colon-bearing names from the legacy branch would close both faces in one change, and I am happy for this PR to be closed in favour of that.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/docker.py` — derive the persistent sandbox directory with `_sandbox_dir_name()`; preserve already-working names, digest the rest.
- `tests/tools/test_docker_environment.py` — regression coverage.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_docker_environment.py -q
```

Reverting the one-line call site makes `test_persistent_bind_mounts_survive_a_session_key_task_id` fail with the real spec, which is the reproduction:

```
bind source still contains a colon, docker run would fail with 'too many colons':
  .../docker/session:agent:main:telegram:dm:8439114563/home:/root
```

End to end, with `terminal.backend: docker` + `container_persistent: true`, send any message from Telegram and run a terminal tool call: the container starts and `ls -a /root` persists across turns.