### PR TITLE
fix(desktop): drain every live speech session on barge-in (#91991)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-overlap.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-overlap.test.tsx
@@ -4,6 +4,7 @@
 // must not resurrect the interrupted one, and must leave every socket/context
 // closed with no stale text feeding later turns.
 
+import type * as SharedTypes from '@hermes/shared'
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -90,7 +91,8 @@ vi.mock('@/i18n', () => ({
 }))
 
 vi.mock('@hermes/shared', async importOriginal => {
-  const actual = await importOriginal<typeof import('@hermes/shared')>()
+  const actual = await importOriginal<typeof SharedTypes>()
+
   return {
     ...actual,
     resolveGatewayWsUrl: async () => 'ws://gateway.test/api/ws'

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-overlap.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-overlap.test.tsx
@@ -89,12 +89,17 @@ vi.mock('@/i18n', () => ({
   })
 }))
 
-vi.mock('@hermes/shared', () => ({
-  resolveGatewayWsUrl: async () => 'ws://gateway.test/api/ws'
-}))
+vi.mock('@hermes/shared', async importOriginal => {
+  const actual = await importOriginal<typeof import('@hermes/shared')>()
+  return {
+    ...actual,
+    resolveGatewayWsUrl: async () => 'ws://gateway.test/api/ws'
+  }
+})
 
 vi.mock('@/hermes', () => ({
   getApiRequestProfile: () => null,
+  getApiRequestConnection: () => null,
   speakText: vi.fn(async () => ({
     data_url: 'data:audio/mpeg;base64,AAAA',
     mime_type: 'audio/mpeg',

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-overlap.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-overlap.test.tsx
@@ -1,0 +1,304 @@
+// Integration coverage for #91991: with the REAL voice-playback module, a
+// barge-in followed by an out-of-order stream discovery (turn 1's stale start
+// resolving after turn 2's session went live) must not kill the current reply,
+// must not resurrect the interrupted one, and must leave every socket/context
+// closed with no stale text feeding later turns.
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { BargeMonitorCallbacks } from '@/lib/voice-barge-in'
+import { $voicePlayback } from '@/store/voice-playback'
+
+import { useVoiceConversation } from './use-voice-conversation'
+
+const control = vi.hoisted(() => {
+  const pending: Array<() => void> = []
+
+  return {
+    getConnection: () =>
+      new Promise<object>(resolve => {
+        pending.push(() => resolve({ profile: 'test' }))
+      }),
+    pendingCount: () => pending.length,
+    releaseLatest() {
+      pending.pop()?.()
+    }
+  }
+})
+
+const bargeCalls: BargeMonitorCallbacks[] = []
+
+vi.mock('@/lib/voice-barge-in', () => ({
+  monitorSpeechDuringPlayback: (callbacks: BargeMonitorCallbacks) => {
+    bargeCalls.push(callbacks)
+
+    return vi.fn()
+  }
+}))
+
+const micHandle = vi.hoisted(() => {
+  let onSilence: null | (() => void) = null
+
+  return {
+    cancel: vi.fn(),
+    handle: {
+      cancel: vi.fn(),
+      start: vi.fn(async (options: { onSilence: () => void }) => {
+        onSilence = options.onSilence
+      }),
+      stop: vi.fn(async () => ({
+        audio: new Blob(['voice'], { type: 'audio/webm' }),
+        heardSpeech: true
+      }))
+    },
+    triggerSilence() {
+      onSilence?.()
+    }
+  }
+})
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({ handle: micHandle.handle, level: 0 })
+}))
+
+vi.mock('@/lib/thinking-sound', () => ({
+  startThinkingSound: vi.fn(),
+  stopThinkingSound: vi.fn()
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: vi.fn(),
+  notifyError: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          configureSpeechToText: '',
+          couldNotStartSession: '',
+          microphoneFailed: '',
+          playbackFailed: '',
+          transcriptionFailed: '',
+          unavailable: ''
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@hermes/shared', () => ({
+  resolveGatewayWsUrl: async () => 'ws://gateway.test/api/ws'
+}))
+
+vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => null,
+  speakText: vi.fn(async () => ({
+    data_url: 'data:audio/mpeg;base64,AAAA',
+    mime_type: 'audio/mpeg',
+    ok: true
+  }))
+}))
+
+class FakeSocket {
+  static readonly OPEN = 1
+  static readonly CONNECTING = 0
+  static instances: FakeSocket[] = []
+
+  binaryType = 'blob'
+  readyState = FakeSocket.CONNECTING
+  sent: string[] = []
+  url: string
+
+  close = vi.fn(() => {
+    this.readyState = 3
+  })
+  send = vi.fn((data: string) => {
+    this.sent.push(data)
+  })
+
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string | ArrayBuffer }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    FakeSocket.instances.push(this)
+  }
+
+  serverOpen() {
+    this.readyState = FakeSocket.OPEN
+    this.onopen?.()
+  }
+
+  serverFrame(frame: object) {
+    this.onmessage?.({ data: JSON.stringify(frame) })
+  }
+
+  serverPcm(bytes: number) {
+    this.onmessage?.({ data: new ArrayBuffer(bytes) })
+  }
+
+  serverClose() {
+    this.onclose?.()
+  }
+}
+
+class FakeAudioContext {
+  static instances: FakeAudioContext[] = []
+
+  closed = false
+  currentTime = 0
+  destination = {}
+  state = 'running'
+
+  close = vi.fn(() => {
+    this.closed = true
+
+    return Promise.resolve()
+  })
+  resume = vi.fn(() => Promise.resolve())
+  createBuffer = vi.fn((_channels: number, length: number, rate: number) => ({
+    duration: length / rate,
+    getChannelData: () => new Float32Array(length)
+  }))
+  createBufferSource = vi.fn(() => ({
+    buffer: null as unknown,
+    connect: vi.fn(),
+    start: vi.fn()
+  }))
+
+  constructor() {
+    FakeAudioContext.instances.push(this)
+  }
+}
+
+interface PendingReply {
+  id: string
+  pending: boolean
+  text: string
+}
+
+describe('useVoiceConversation overlapping stream discovery (#91991)', () => {
+  beforeEach(() => {
+    FakeSocket.instances = []
+    FakeAudioContext.instances = []
+    bargeCalls.length = 0
+    vi.stubGlobal('WebSocket', FakeSocket)
+    vi.stubGlobal('AudioContext', FakeAudioContext)
+    vi.stubGlobal('hermesDesktop', { getConnection: control.getConnection })
+    $voicePlayback.set({ audioElement: null, messageId: null, sequence: 0, source: null, status: 'idle' })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not let a stale stream start kill the current reply or feed later turns', async () => {
+    let response: PendingReply | null = null
+    let transcriptions = 0
+
+    const hook = renderHook(
+      ({ enabled }) =>
+        useVoiceConversation({
+          busy: false,
+          // Mirrors the real consumer: consuming removes the pending reply so
+          // a later turn can never re-speak an already-consumed one.
+          consumePendingResponse: () => {
+            response = null
+          },
+          enabled,
+          onSubmit: async (text: string) => {
+            // The agent's reply only exists once the turn is in flight — never
+            // during transcription. Mirrors the real submit/generate round trip.
+            await new Promise(resolve => window.setTimeout(resolve, 0))
+
+            response =
+              text === 'start conversation'
+                ? { id: 'reply-1', pending: false, text: 'First reply' }
+                : { id: 'reply-2', pending: false, text: 'Second reply' }
+          },
+          onTranscribeAudio: async () =>
+            transcriptions++ === 0 ? 'start conversation' : 'interrupting with a question',
+          pendingResponse: () => response
+        }),
+      { initialProps: { enabled: false } }
+    )
+
+    hook.rerender({ enabled: true })
+
+    await waitFor(() => expect(micHandle.handle.start).toHaveBeenCalled())
+
+    await act(async () => {
+      micHandle.triggerSilence()
+    })
+
+    // Turn 1's stream discovery is in flight (getConnection pending) when the
+    // user barges in — the captured utterance submits turn 2.
+    await waitFor(() => expect(control.pendingCount()).toBe(1))
+
+    act(() => {
+      bargeCalls.at(-1)?.onSpeech()
+    })
+
+    await act(async () => {
+      bargeCalls.at(-1)?.onUtterance?.(new Blob(['interruption'], { type: 'audio/webm' }))
+    })
+
+    await waitFor(() => expect(control.pendingCount()).toBe(2))
+
+    // Turn 2's discovery resolves first — its session goes live and speaks.
+    act(() => {
+      control.releaseLatest()
+    })
+
+    await waitFor(() => expect(FakeSocket.instances).toHaveLength(1))
+
+    const currentSocket = FakeSocket.instances[0]
+
+    currentSocket.serverOpen()
+    currentSocket.serverFrame({ type: 'start', sample_rate: 24_000 })
+    currentSocket.serverPcm(64)
+
+    await waitFor(() => expect($voicePlayback.get().status).toBe('speaking'))
+
+    // Turn 1's stale discovery resolves — it must not settle the current reply
+    // and must not open a socket of its own.
+    act(() => {
+      control.releaseLatest()
+    })
+
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 0))
+    })
+
+    expect($voicePlayback.get().status).toBe('speaking')
+    expect(currentSocket.close).not.toHaveBeenCalled()
+    expect(FakeSocket.instances).toHaveLength(1)
+    expect(hook.result.current.status).toBe('speaking')
+
+    // Let the current reply finish naturally — the server streams the tail,
+    // the session settles, and the conversation re-arms the microphone.
+    currentSocket.serverFrame({ type: 'end' })
+
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+
+    // The turn's socket and audio context are closed and no stale text was
+    // fed after the dust settled.
+    expect(currentSocket.close).toHaveBeenCalled()
+    expect(FakeAudioContext.instances.every(ctx => ctx.closed)).toBe(true)
+
+    const sentAfterSettle = [...currentSocket.sent]
+
+    await act(async () => {
+      await new Promise(resolve => window.setTimeout(resolve, 400))
+    })
+
+    expect(currentSocket.sent).toEqual(sentAfterSettle)
+  })
+})

--- a/apps/desktop/src/lib/voice-playback.test.ts
+++ b/apps/desktop/src/lib/voice-playback.test.ts
@@ -3,6 +3,7 @@
 // and data-URL audio elements — and a settled session must never resume or
 // write stale state into a newer turn.
 
+import type * as SharedTypes from '@hermes/shared'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $voicePlayback } from '@/store/voice-playback'
@@ -21,7 +22,8 @@ const gateway = vi.hoisted(() => {
 })
 
 vi.mock('@hermes/shared', async importOriginal => {
-  const actual = await importOriginal<typeof import('@hermes/shared')>()
+  const actual = await importOriginal<typeof SharedTypes>()
+
   return {
     ...actual,
     resolveGatewayWsUrl: async () => gateway.currentUrl()

--- a/apps/desktop/src/lib/voice-playback.test.ts
+++ b/apps/desktop/src/lib/voice-playback.test.ts
@@ -1,0 +1,258 @@
+// Teardown contract for voice-playback (#91991): a barge-in (stopVoicePlayback)
+// must drain EVERY live playback — streaming sessions (WebSocket + AudioContext)
+// and data-URL audio elements — and a settled session must never resume or
+// write stale state into a newer turn.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $voicePlayback } from '@/store/voice-playback'
+
+import { playSpeechText, startSpeechStream, stopVoicePlayback } from './voice-playback'
+
+const gateway = vi.hoisted(() => {
+  let nextUrl: string | null = 'ws://gateway.test/api/ws'
+
+  return {
+    currentUrl: () => nextUrl,
+    setNextUrl: (url: string | null) => {
+      nextUrl = url
+    }
+  }
+})
+
+vi.mock('@hermes/shared', () => ({
+  resolveGatewayWsUrl: async () => gateway.currentUrl()
+}))
+
+vi.mock('@/hermes', () => ({
+  getApiRequestProfile: () => null,
+  speakText: vi.fn(async () => ({
+    data_url: 'data:audio/mpeg;base64,AAAA',
+    mime_type: 'audio/mpeg',
+    ok: true
+  }))
+}))
+
+class FakeSocket {
+  static readonly OPEN = 1
+  static readonly CONNECTING = 0
+  static instances: FakeSocket[] = []
+
+  binaryType = 'blob'
+  readyState = FakeSocket.CONNECTING
+  sent: string[] = []
+  url: string
+
+  close = vi.fn(() => {
+    this.readyState = 3
+  })
+  send = vi.fn((data: string) => {
+    this.sent.push(data)
+  })
+
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: string | ArrayBuffer }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    FakeSocket.instances.push(this)
+  }
+
+  serverOpen() {
+    this.readyState = FakeSocket.OPEN
+    this.onopen?.()
+  }
+
+  serverFrame(frame: object) {
+    this.onmessage?.({ data: JSON.stringify(frame) })
+  }
+
+  serverPcm(bytes: number) {
+    this.onmessage?.({ data: new ArrayBuffer(bytes) })
+  }
+
+  serverClose() {
+    this.onclose?.()
+  }
+
+  serverError() {
+    this.onerror?.()
+  }
+}
+
+class FakeAudioContext {
+  static instances: FakeAudioContext[] = []
+
+  closed = false
+  currentTime = 0
+  destination = {}
+  state = 'running'
+
+  close = vi.fn(() => {
+    this.closed = true
+
+    return Promise.resolve()
+  })
+  resume = vi.fn(() => Promise.resolve())
+  createBuffer = vi.fn((_channels: number, length: number, rate: number) => ({
+    duration: length / rate,
+    getChannelData: () => new Float32Array(length)
+  }))
+  createBufferSource = vi.fn(() => ({
+    buffer: null as unknown,
+    connect: vi.fn(),
+    start: vi.fn()
+  }))
+
+  constructor() {
+    FakeAudioContext.instances.push(this)
+  }
+}
+
+class FakeAudio {
+  static instances: FakeAudio[] = []
+
+  paused = false
+  src: string
+
+  addEventListener = vi.fn()
+  load = vi.fn()
+  pause = vi.fn(() => {
+    this.paused = true
+  })
+  play = vi.fn(() => {
+    this.paused = false
+
+    return Promise.resolve()
+  })
+  removeEventListener = vi.fn()
+
+  constructor(src: string) {
+    this.src = src
+    FakeAudio.instances.push(this)
+  }
+}
+
+async function liveSession() {
+  const session = await startSpeechStream({ source: 'voice-conversation' })
+
+  if (!session) {
+    throw new Error('expected a live speech stream')
+  }
+
+  return session
+}
+
+describe('voice-playback teardown (#91991)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    FakeSocket.instances = []
+    FakeAudioContext.instances = []
+    FakeAudio.instances = []
+    gateway.setNextUrl('ws://gateway.test/api/ws')
+    vi.stubGlobal('WebSocket', FakeSocket)
+    vi.stubGlobal('AudioContext', FakeAudioContext)
+    vi.stubGlobal('Audio', FakeAudio)
+    vi.stubGlobal('hermesDesktop', { getConnection: vi.fn(async () => ({ profile: 'test' })) })
+    $voicePlayback.set({ audioElement: null, messageId: null, sequence: 0, source: null, status: 'idle' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('abandons a stream start that crosses a stop instead of resuming playback', async () => {
+    // Stream discovery (gateway connection) is in flight when the user barges.
+    const pending = startSpeechStream({ source: 'voice-conversation' })
+
+    stopVoicePlayback()
+
+    const session = await pending
+
+    expect(session).toBeNull()
+    expect(FakeSocket.instances).toHaveLength(0)
+    expect($voicePlayback.get().status).toBe('idle')
+  })
+
+  it('does not let a settled session reset the playback state of a newer turn', async () => {
+    const first = await liveSession()
+    const second = await liveSession()
+
+    // Starting the second session settles the first (its socket closes), but
+    // the settled session's completion callback must not stomp the state the
+    // newer session just wrote.
+    expect(FakeSocket.instances[0]?.close).toHaveBeenCalled()
+    expect($voicePlayback.get().status).toBe('preparing')
+
+    stopVoicePlayback()
+  })
+
+  it('a barge-in closes the socket and audio context of a live streaming session and settles it', async () => {
+    const session = await liveSession()
+    const ws = FakeSocket.instances[0]
+
+    ws.serverOpen()
+    ws.serverFrame({ type: 'start', sample_rate: 24_000 })
+    ws.serverPcm(64)
+
+    expect($voicePlayback.get().status).toBe('speaking')
+
+    stopVoicePlayback()
+
+    expect(ws.close).toHaveBeenCalled()
+    expect(FakeAudioContext.instances[0]?.closed).toBe(true)
+    expect($voicePlayback.get().status).toBe('idle')
+    await expect(session.done).resolves.toBe('done')
+
+    // A settled session can no longer feed text — nothing reaches the socket.
+    const sentBefore = ws.sent.length
+
+    session.append('stale text')
+    session.finish()
+
+    expect(ws.sent.length).toBe(sentBefore)
+  })
+
+  it('a barge-in during the drain window settles the session and the late drain is a no-op', async () => {
+    const session = await liveSession()
+    const ws = FakeSocket.instances[0]
+
+    ws.serverOpen()
+    ws.serverFrame({ type: 'start', sample_rate: 24_000 })
+    ws.serverPcm(64)
+    ws.serverFrame({ type: 'end' }) // drains, then settles — timer pending
+
+    stopVoicePlayback()
+
+    await expect(session.done).resolves.toBe('done')
+    expect(ws.close).toHaveBeenCalled()
+
+    // The pending drain timer fires later — it must not double-settle or
+    // disturb anything that started since.
+    await vi.runOnlyPendingTimersAsync()
+
+    expect($voicePlayback.get().status).toBe('idle')
+  })
+
+  it('a barge-in cuts a data-url playback and clears the audio element', async () => {
+    gateway.setNextUrl(null) // no streaming endpoint → data-url fallback
+
+    const playback = playSpeechText('hello world', { messageId: 'm1', source: 'read-aloud' })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect($voicePlayback.get().status).toBe('speaking')
+    expect(FakeAudio.instances).toHaveLength(1)
+
+    stopVoicePlayback()
+
+    expect(FakeAudio.instances[0]?.pause).toHaveBeenCalled()
+    expect(FakeAudio.instances[0]?.src).toBe('')
+    expect(FakeAudio.instances[0]?.load).toHaveBeenCalled()
+    expect($voicePlayback.get().status).toBe('idle')
+    await expect(playback).resolves.toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/voice-playback.test.ts
+++ b/apps/desktop/src/lib/voice-playback.test.ts
@@ -20,12 +20,17 @@ const gateway = vi.hoisted(() => {
   }
 })
 
-vi.mock('@hermes/shared', () => ({
-  resolveGatewayWsUrl: async () => gateway.currentUrl()
-}))
+vi.mock('@hermes/shared', async importOriginal => {
+  const actual = await importOriginal<typeof import('@hermes/shared')>()
+  return {
+    ...actual,
+    resolveGatewayWsUrl: async () => gateway.currentUrl()
+  }
+})
 
 vi.mock('@/hermes', () => ({
   getApiRequestProfile: () => null,
+  getApiRequestConnection: () => null,
   speakText: vi.fn(async () => ({
     data_url: 'data:audio/mpeg;base64,AAAA',
     mime_type: 'audio/mpeg',

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -206,6 +206,12 @@ function openClientDirectSpeechSession(tts: DirectTtsConfig, options: VoicePlayb
 
   let settle: (value: 'done' | 'fallback') => void = () => undefined
 
+  // stopVoicePlayback() → immediate barge-in: settle this session so its
+  // queued audio never resumes. Registered until settle, so a barge always
+  // reaches this session even while another playback is live alongside it
+  // (#91991).
+  const stop = () => settle(started ? 'done' : 'fallback')
+
   const done = new Promise<'done' | 'fallback'>(resolve => {
     settle = value => {
       if (settled) {
@@ -213,7 +219,7 @@ function openClientDirectSpeechSession(tts: DirectTtsConfig, options: VoicePlayb
       }
 
       settled = true
-      currentStop = null
+      liveStops.delete(stop)
 
       if (playing) {
         playing.pause()
@@ -225,7 +231,7 @@ function openClientDirectSpeechSession(tts: DirectTtsConfig, options: VoicePlayb
     }
   })
 
-  currentStop = () => settle(started ? 'done' : 'fallback')
+  liveStops.add(stop)
 
   const pump = async () => {
     if (synthesizing || settled) {

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -23,7 +23,13 @@ import { sanitizeTextForSpeech } from './speech-text'
 const PLAYBACK_STALL_MS = 15_000
 
 let currentAudio: HTMLAudioElement | null = null
-let currentStop: (() => void) | null = null
+// Every live playback registers its barge-in stop here: streaming sessions
+// (kill the WebSocket + AudioContext) and data-URL audio elements (cut
+// playback). A single slot cannot represent two overlapping playbacks — the
+// overwritten session keeps its socket open, keeps scheduling buffers, and
+// its audio resurfaces on a later turn (#91991). Draining the whole set keeps
+// stopVoicePlayback() deterministic no matter how playbacks overlap.
+const liveStops = new Set<() => void>()
 let sequence = 0
 
 // A shared, lazily-created AudioContext used only to nudge the browser's
@@ -77,8 +83,14 @@ export interface VoicePlaybackOptions {
 
 export function stopVoicePlayback() {
   sequence += 1
-  currentStop?.()
-  currentStop = null
+
+  // Drain EVERY live playback, not just the newest. Each stop is idempotent
+  // and unregisters itself; the snapshot keeps the iteration safe.
+  for (const stop of [...liveStops]) {
+    stop()
+  }
+
+  liveStops.clear()
 
   if (currentAudio) {
     currentAudio.pause()
@@ -342,6 +354,10 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
 
   let settle: (value: 'done' | 'fallback') => void = () => undefined
 
+  // stopVoicePlayback() → immediate barge-in: kill the socket (the server
+  // aborts synthesis on disconnect) and the audio context (cuts sound now).
+  const stop = () => settle('done')
+
   const done = new Promise<'done' | 'fallback'>(resolve => {
     settle = value => {
       if (settled) {
@@ -349,7 +365,7 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
       }
 
       settled = true
-      currentStop = null
+      liveStops.delete(stop)
 
       try {
         ws.close()
@@ -373,9 +389,9 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
     }
   }
 
-  // stopVoicePlayback() → immediate barge-in: kill the socket (the server
-  // aborts synthesis on disconnect) and the audio context (cuts sound now).
-  currentStop = () => settle('done')
+  // Registered until settle, so a barge always reaches this session even
+  // while another playback is live alongside it (#91991).
+  liveStops.add(stop)
 
   const finishWhenDrained = () => {
     const remainingMs = context ? Math.max(0, nextStartAt - context.currentTime) * 1_000 : 0
@@ -503,16 +519,27 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
  * `playSpeechText`).
  */
 export async function startSpeechStream(options: VoicePlaybackOptions): Promise<null | SpeechStreamSession> {
+  const startSequence = sequence
+
   const direct = await directTtsConfig().catch(() => null)
 
   if (direct) {
+    // A stop (barge-in, Stop button, another playback) landed while the
+    // direct TTS config was resolving — do not resurrect stopped playback.
+    if (sequence !== startSequence) {
+      return null
+    }
+
     stopVoicePlayback()
     setVoicePlaybackState(currentState('preparing', options))
 
     const session = openClientDirectSpeechSession(direct, options)
+    const sessionSequence = sequence
 
     void session.done.then(outcome => {
-      if (outcome === 'done') {
+      // A settled session must not reset the state of a NEWER playback —
+      // only write idle when no other playback started since this one.
+      if (outcome === 'done' && sessionSequence === sequence) {
         setVoicePlaybackState(currentState('idle'))
       }
     })
@@ -520,9 +547,16 @@ export async function startSpeechStream(options: VoicePlaybackOptions): Promise<
     return session
   }
 
+
   const wsUrl = await resolveSpeakStreamUrl()
 
   if (!wsUrl) {
+    return null
+  }
+
+  // A stop (barge-in, Stop button, another playback) landed while the stream
+  // URL was resolving — do not resurrect playback that was already stopped.
+  if (sequence !== startSequence) {
     return null
   }
 
@@ -530,9 +564,12 @@ export async function startSpeechStream(options: VoicePlaybackOptions): Promise<
   setVoicePlaybackState(currentState('preparing', options))
 
   const session = openSpeechStream(wsUrl, options)
+  const sessionSequence = sequence
 
   void session.done.then(outcome => {
-    if (outcome === 'done') {
+    // A settled session must not reset the state of a NEWER playback — only
+    // write idle when no other playback started since this one was created.
+    if (outcome === 'done' && sessionSequence === sequence) {
       setVoicePlaybackState(currentState('idle'))
     }
   })
@@ -576,7 +613,7 @@ async function playSpeechDataUrl(
       audio.removeEventListener('ended', onEnded)
       audio.removeEventListener('error', onError)
       audio.removeEventListener('timeupdate', armStall)
-      currentStop = null
+      liveStops.delete(stop)
     }
 
     const armStall = () => {
@@ -600,10 +637,12 @@ async function playSpeechDataUrl(
       reject(new Error('Playback failed'))
     }
 
-    currentStop = () => {
+    const stop = () => {
       cleanup()
       resolve()
     }
+
+    liveStops.add(stop)
 
     audio.addEventListener('ended', onEnded, { once: true })
     audio.addEventListener('error', onError, { once: true })
@@ -703,7 +742,6 @@ export async function playSpeechText(text: string, options: VoicePlaybackOptions
     return played
   } catch (error) {
     if (isCurrent()) {
-      currentStop = null
       currentAudio = null
       setVoicePlaybackState(currentState('idle'))
     }

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,68 @@
+## Summary
+
+Barge-in teardown for desktop voice playback was kept in a single module-level slot that two overlapping playbacks could not both fit. This PR makes teardown deterministic: `stopVoicePlayback()` now drains **every** live speech session (streaming WebSocket + AudioContext, and data-URL audio), a stream start that crosses a stop is abandoned instead of resurrecting playback, and a settled session can no longer write stale state over a newer turn.
+
+## Root cause
+
+`apps/desktop/src/lib/voice-playback.ts` tracked the current playback's barge-in stop in one slot — `let currentStop: (() => void) | null` — with five writers, none of which checks ownership:
+
+| writer | what it does |
+| --- | --- |
+| `settle` (~L173) | unconditionally nulls the slot, even if it now belongs to a *newer* session |
+| `openSpeechStream` (~L199) | unconditionally installs its hook over whatever is live |
+| `playSpeechDataUrl` `cleanup` (~L381) | unconditionally nulls the slot |
+| `playSpeechDataUrl` stop install (~L405) | installs |
+| `playSpeechText` catch (~L484) | unconditionally nulls the slot |
+
+`stopVoicePlayback()` was `currentStop?.(); currentStop = null` — it reaches **at most one** session. The comment next to the install states the invariant this breaks: "stopVoicePlayback() → immediate barge-in: kill the socket … and the audio context" — true of one session at a time, silently false of two. For a streaming session the stop hook is the **only** teardown path: a session whose hook is overwritten/nullified keeps its WebSocket open (the server keeps synthesising), keeps scheduling PCM buffers into its AudioContext, its `done` never resolves (the hook's feed timer leaks), and its queued audio re-emerges audibly on a later turn — "reads an old reply from several turns ago" — while a manual stop only ever settles the (possibly stale) slot holder, which is why "only a manual interruption struggles".
+
+### Overlap entry condition (from code)
+
+`startSpeechStream()` is the only playback entry point whose `stopVoicePlayback()` runs **after** its async gap — `resolveSpeakStreamUrl()` awaits `desktop.getConnection(profile)`, a credential-mint + gateway round trip. The barge-in flow re-points the caller's state inside that gap: `onSpeech` → `stopVoicePlayback()`; `onUtterance` → `submitCapturedUtterance` → `dropSpeechSession()` / `consumePendingResponse()` + `onSubmit` → the next response → `openLiveSpeech` → a second `startSpeechStream`. Whichever gap resolves second then:
+
+- installs its session **after** the stop — playback "resumes" after the user barged — and
+- its own post-gap `stopVoicePlayback()` settles **the current turn's live session** through the shared slot (a stop targeting a session other than the caller's); the caller's `responseIdRef` guard (`use-voice-conversation.ts` ~L506) then settles the fresh stale session too, and the extra sequence bumps trip `stoppedDuringStart` (~L536) for the next turn — a current reply cut plus a silently dropped reply.
+
+With two hooks in flight, a single slot cannot represent both — which hook survives is arbitrary, so teardown is exactly non-deterministic after a barge-in.
+
+## Fix (minimal, `voice-playback.ts` only)
+
+1. **Registry instead of a slot.** Every playback registers its idempotent stop in a `liveStops` set and unregisters on settle/cleanup; `stopVoicePlayback()` drains the whole set (snapshot iteration), so a barge closes every socket and AudioContext no matter how playbacks overlap.
+2. **Stale-start guard.** `startSpeechStream()` captures the sequence at entry; if any stop landed during stream discovery it returns `null` — an already-stopped playback can never resume (same `isCurrent()` pattern `playSpeechText` already uses). `openLiveSpeech` already handles a null session via its `responseIdRef` and sequence checks.
+3. **Stale-completion guard.** The `session.done` completion callback is sequence-scoped so a settled session never writes `idle` over a newer turn's state (which could let the next playback start on top of a live one).
+
+No changes to `use-voice-conversation.ts`; the existing `responseIdRef` / `stoppedDuringStart` / `isCurrent` guards remain as-is.
+
+Out of scope / follow-up: an independent review of this patch identified one pre-existing hook-layer window (generation-phase barge re-invoking `openLiveSpeech` for the barged reply before it is consumed) that the module-level fix deliberately does not address — every session it opens is still torn down deterministically by the next start's drain. That belongs with the voice state-machine family (#74337, #80257, #85770), not this playback-teardown fix.
+
+## Repro level
+
+**Code-path analysis + unit tests — not a hardware reproduction.** This is a Windows hands-free voice path (mic VAD barge-in, Edge TTS); the failing interleaving depends on event-loop ordering of async gaps and cannot be reproduced live on this machine. What the tests do is pin the teardown contract directly with fakes: the stale-start race, the stale state-stomp, and every barge teardown path (live session, drain window, data-URL audio) are exercised.
+
+## Tests
+
+New files:
+
+- `apps/desktop/src/lib/voice-playback.test.ts` — 5 unit tests (fake WebSocket/AudioContext/Audio).
+- `apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-overlap.test.tsx` — 1 integration test: the REAL `voice-playback` module driven through the REAL `useVoiceConversation` hook; two turns' stream discoveries overlap around a barge-in, resolved out of order.
+
+Red before / green after (recorded on the pre-fix tree):
+
+- "abandons a stream start that crosses a stop instead of resuming playback" — RED: returned a live session and opened a socket after a stop. GREEN: returns null, opens no socket, state stays idle.
+- "does not let a settled session reset the playback state of a newer turn" — RED: `$voicePlayback.status` ended `idle` (the settled session's completion callback stomped the newer session's `preparing`). GREEN: stays `preparing`.
+- integration — RED: turn 1's stale discovery settled turn 2's live session (`status` fell to `idle`, its socket was closed, a second socket was opened). GREEN: the current reply keeps speaking, no extra socket, and after the session settles naturally no further text is sent to any socket (stale text cannot feed the next turn).
+
+Suites run (all green):
+
+- 12 voice-related files: `voice-playback.test.ts`, `voice-stop-word.test.ts`, `speech-text.test.ts`, `wake-sound.test.ts`, `thinking-sound.test.ts`, `spoken-reply.test.ts`, `voice-prefs.test.ts`, `use-voice-conversation.test.tsx`, `use-voice-conversation-rearm.test.tsx`, `use-voice-conversation-overlap.test.tsx`, `voice-field-visible.test.ts`, `voice-provider-fields.test.ts` — **77/77**.
+- `assistant-message.test.tsx` (read-aloud consumer of `playSpeechText`) — **4/4**.
+- Broad sweep `src/lib` + `src/store` + `src/app/chat/composer` — **2478 tests**; the only failures were 1–2 timeout flakes in unrelated files (`markdown-blocks.test.ts` property fuzz, `session-unread-tile.test.ts`) under batch CPU load — both pass standalone (9/9). All voice tests green in both sweeps.
+- Typecheck (`tsc -p .`, `tsc -p tsconfig.electron.json`, `tsc -p tsconfig.e2e.json`, all `--noEmit`) — clean.
+- ESLint on the three changed/added files — clean.
+
+## Verification
+
+- The two red tests were confirmed failing on the pre-fix tree (outputs captured), then green after the fix; the full voice suite was run twice more after the fix with no flakes.
+- `stopVoicePlayback()` semantics for the single-playback case are unchanged (existing `use-voice-conversation*.test.tsx` behavior preserved — 17/17 across those plus the new files, run repeatedly).
+
+Closes #91991


### PR DESCRIPTION
## Summary

Barge-in teardown for desktop voice playback was kept in a single module-level slot that two overlapping playbacks could not both fit. This PR makes teardown deterministic: `stopVoicePlayback()` now drains **every** live speech session (streaming WebSocket + AudioContext, client-direct TTS sessions, and data-URL audio), a stream start that crosses a stop is abandoned instead of resurrecting playback, and a settled session can no longer write stale state over a newer turn.

## Root cause

`apps/desktop/src/lib/voice-playback.ts` tracked the current playback's barge-in stop in one slot — `let currentStop: (() => void) | null` — with five writers, none of which checks ownership:

| writer | what it does |
| --- | --- |
| `settle` (~L173) | unconditionally nulls the slot, even if it now belongs to a *newer* session |
| `openSpeechStream` (~L199) | unconditionally installs its hook over whatever is live |
| `playSpeechDataUrl` `cleanup` (~L381) | unconditionally nulls the slot |
| `playSpeechDataUrl` stop install (~L405) | installs |
| `playSpeechText` catch (~L484) | unconditionally nulls the slot |

`stopVoicePlayback()` was `currentStop?.(); currentStop = null` — it reaches **at most one** session. The comment next to the install states the invariant this breaks: "stopVoicePlayback() → immediate barge-in: kill the socket … and the audio context" — true of one session at a time, silently false of two. For a streaming session the stop hook is the **only** teardown path: a session whose hook is overwritten/nullified keeps its WebSocket open (the server keeps synthesising), keeps scheduling PCM buffers into its AudioContext, its `done` never resolves (the hook's feed timer leaks), and its queued audio re-emerges audibly on a later turn — "reads an old reply from several turns ago" — while a manual stop only ever settles the (possibly stale) slot holder, which is why "only a manual interruption struggles".

### Overlap entry condition (from code)

`startSpeechStream()` is the only playback entry point whose `stopVoicePlayback()` runs **after** its async gap — `resolveSpeakStreamUrl()` awaits `desktop.getConnection(profile)`, a credential-mint + gateway round trip. The barge-in flow re-points the caller's state inside that gap: `onSpeech` → `stopVoicePlayback()`; `onUtterance` → `submitCapturedUtterance` → `dropSpeechSession()` / `consumePendingResponse()` + `onSubmit` → the next response → `openLiveSpeech` → a second `startSpeechStream`. Whichever gap resolves second then:

- installs its session **after** the stop — playback "resumes" after the user barged — and
- its own post-gap `stopVoicePlayback()` settles **the current turn's live session** through the shared slot (a stop targeting a session other than the caller's); the caller's `responseIdRef` guard (`use-voice-conversation.ts` ~L506) then settles the fresh stale session too, and the extra sequence bumps trip `stoppedDuringStart` (~L536) for the next turn — a current reply cut plus a silently dropped reply.

With two hooks in flight, a single slot cannot represent both — which hook survives is arbitrary, so teardown is exactly non-deterministic after a barge-in.

## Fix (minimal, `voice-playback.ts` only)

1. **Registry instead of a slot.** Every playback registers its idempotent stop in a `liveStops` set and unregisters on settle/cleanup; `stopVoicePlayback()` drains the whole set (snapshot iteration), so a barge closes every socket and AudioContext no matter how playbacks overlap. After the rebase onto `main` the new client-direct TTS path registers its sessions in the same registry (follow-up commit on this branch, which also restores typecheck).
2. **Stale-start guard.** `startSpeechStream()` captures the sequence at entry; if any stop landed during stream discovery it returns `null` — an already-stopped playback can never resume (same `isCurrent()` pattern `playSpeechText` already uses). `openLiveSpeech` already handles a null session via its `responseIdRef` and sequence checks.
3. **Stale-completion guard.** The `session.done` completion callback is sequence-scoped so a settled session never writes `idle` over a newer turn's state (which could let the next playback start on top of a live one).

No changes to `use-voice-conversation.ts`; the existing `responseIdRef` / `stoppedDuringStart` / `isCurrent` guards remain as-is.

Out of scope / follow-up: an independent review of this patch identified one pre-existing hook-layer window (generation-phase barge re-invoking `openLiveSpeech` for the barged reply before it is consumed) that the module-level fix deliberately does not address — every session it opens is still torn down deterministically by the next start's drain. That belongs with the voice state-machine family (#74337, #80257, #85770), not this playback-teardown fix.

## Repro level

**Code-path analysis + unit tests — not a hardware reproduction.** This is a Windows hands-free voice path (mic VAD barge-in, Edge TTS); the failing interleaving depends on event-loop ordering of async gaps and cannot be reproduced live on this machine. What the tests do is pin the teardown contract directly with fakes: the stale-start race, the stale state-stomp, and every barge teardown path (live session, drain window, data-URL audio) are exercised.

## Tests

New files:

- `apps/desktop/src/lib/voice-playback.test.ts` — 5 unit tests (fake WebSocket/AudioContext/Audio).
- `apps/desktop/src/app/chat/composer/hooks/use-voice-conversation-overlap.test.tsx` — 1 integration test: the REAL `voice-playback` module driven through the REAL `useVoiceConversation` hook; two turns' stream discoveries overlap around a barge-in, resolved out of order.

Red before / green after (recorded on the pre-fix tree):

- "abandons a stream start that crosses a stop instead of resuming playback" — RED: returned a live session and opened a socket after a stop. GREEN: returns null, opens no socket, state stays idle.
- "does not let a settled session reset the playback state of a newer turn" — RED: `$voicePlayback.status` ended `idle` (the settled session's completion callback stomped the newer session's `preparing`). GREEN: stays `preparing`.
- integration — RED: turn 1's stale discovery settled turn 2's live session (`status` fell to `idle`, its socket was closed, a second socket was opened). GREEN: the current reply keeps speaking, no extra socket, and after the session settles naturally no further text is sent to any socket (stale text cannot feed the next turn).

Suites run (all green):

- 12 voice-related files: `voice-playback.test.ts`, `voice-stop-word.test.ts`, `speech-text.test.ts`, `wake-sound.test.ts`, `thinking-sound.test.ts`, `spoken-reply.test.ts`, `voice-prefs.test.ts`, `use-voice-conversation.test.tsx`, `use-voice-conversation-rearm.test.tsx`, `use-voice-conversation-overlap.test.tsx`, `voice-field-visible.test.ts`, `voice-provider-fields.test.ts` — **77/77**.
- `assistant-message.test.tsx` (read-aloud consumer of `playSpeechText`) — **4/4**.
- Broad sweep `src/lib` + `src/store` + `src/app/chat/composer` — **2478 tests**; the only failures were 1–2 timeout flakes in unrelated files (`markdown-blocks.test.ts` property fuzz, `session-unread-tile.test.ts`) under batch CPU load — both pass standalone (9/9). All voice tests green in both sweeps.
- Typecheck (`tsc -p .`, `tsc -p tsconfig.electron.json`, `tsc -p tsconfig.e2e.json`, all `--noEmit`) — clean (re-verified after the rebase follow-up commit; before it, the rebase left the client-direct path referencing the removed `currentStop` slot, which the follow-up restores).
- ESLint on the three changed/added files — clean.

## Verification

- The two red tests were confirmed failing on the pre-fix tree (outputs captured), then green after the fix; the full voice suite was run twice more after the fix with no flakes.
- `stopVoicePlayback()` semantics for the single-playback case are unchanged (existing `use-voice-conversation*.test.tsx` behavior preserved — 17/17 across those plus the new files, run repeatedly).

Closes #91991
