### PR TITLE
fix(model-picker): paginated button grid with dedup, sort, and free filter

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1871,7 +1871,7 @@ class GatewaySlashCommandsMixin:
                         current_model=current_model,
                         user_providers=user_provs,
                         custom_providers=custom_provs,
-                        max_models=50,
+                        max_models=500,
                         include_moa=True,
                         excluded_providers=excluded_provs,
                     )

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3974,11 +3974,17 @@ def list_picker_providers(
             try:
                 live = fetch_openrouter_models()
                 live_ids = [mid for mid, _ in live]
+                free_ids = [mid for mid, tag in live if tag == "free"]
             except Exception:
                 live_ids = list(p.get("models", []))
+                free_ids = []
             p = dict(p)
             p["models"] = live_ids[:max_models] if max_models is not None else live_ids
             p["total_models"] = len(live_ids)
+            if free_ids:
+                p["free_models"] = (
+                    free_ids[:max_models] if max_models is not None else free_ids
+                )
 
         has_models = bool(p.get("models"))
         is_custom_endpoint = bool(p.get("is_user_defined")) and bool(p.get("api_url"))

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2087,6 +2087,18 @@ def fetch_openrouter_models(
             desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
         curated.append((preferred_id, desc))
 
+    # Also surface free, tool-capable models from the live catalog that
+    # aren't in the curated preferred list. Keeps the picker responsive
+    # to new free models without waiting for the curated list to update.
+    curated_ids = {mid for mid, _ in curated}
+    for mid, live_item in live_by_id.items():
+        if mid in curated_ids:
+            continue
+        if not _openrouter_model_supports_tools(live_item):
+            continue
+        if _openrouter_model_is_free(live_item.get("pricing")):
+            curated.append((mid, "free"))
+
     if not curated:
         return list(_openrouter_catalog_cache or fallback)
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -9187,6 +9187,9 @@ def _define_discord_view_classes() -> None:
             self.resolved = False
             self._selected_provider: str = ""
             self._pending_expensive_model: str = ""
+            self._model_page: int = 0
+            self._model_pages: int = 1
+            self._free_only: bool = True
 
             self._build_provider_select()
 
@@ -9231,15 +9234,16 @@ def _define_discord_view_classes() -> None:
             self.add_item(cancel_btn)
 
         def _build_model_select(self, provider_slug: str):
-            """Build the model dropdown(s) for a specific provider.
+            """Build the model picker as a paginated button grid.
 
-            Discord caps each ``discord.ui.Select`` at 25 options and a View at
-            5 action rows. We keep 2 rows for Back/Cancel, so partition the
-            model list across up to 3 select menus (75 slots) instead of
-            truncating at 25. This matters for providers like Nous whose
-            curated + Portal free-recommendation list exceeds 25 entries — the
-            tail (typically the ``:free`` Portal picks) was previously dropped
-            on Discord, so free-tier models never surfaced there.
+            A Discord View caps at 5 action rows, which a select-menu picker
+            spends on up to 3 partitioned dropdowns (75 models) plus Back/Cancel
+            — anything past that silently clips. Buttons fit 20 models per page
+            (4 rows × 5 columns) with a persistent 5th row for pagination and
+            actions, so providers with hundreds of models (e.g. NVIDIA NIM at
+            139) are fully reachable. Models are sorted alphabetically and
+            deduplicated — duplicate select/button values from flaky APIs (NIM
+            returns dupes) cause HTTP 400 on submit.
             """
             self.clear_items()
             provider = next(
@@ -9248,58 +9252,88 @@ def _define_discord_view_classes() -> None:
             if not provider:
                 return
 
-            models = provider.get("models", [])
+            # Free-only mode shows the provider's free subset when one is
+            # available (OpenRouter free picks, Portal recommendations).
+            has_free = bool(provider.get("free_models"))
+            models = (
+                provider["free_models"]
+                if self._free_only and has_free
+                else provider.get("models", [])
+            )
             if not models:
                 return
 
-            # Slice the model list into <= 25-option chunks across (up to) 3
-            # select rows: 3 selects + Back/Cancel = 5 rows, Discord's View cap.
-            # Providers past that would still clip, but none currently do.
-            chunks = [
-                models[
-                    i : i + _DISCORD_SELECT_MAX_OPTIONS
-                ]
-                for i in range(0, len(models), _DISCORD_SELECT_MAX_OPTIONS)
-            ][
-                : _DISCORD_SELECT_MAX_ROWS - 2
-            ]  # keep 2 rows for Back/Cancel
+            # Sort alphabetically (case-insensitive), then dedupe. Dedup after
+            # sort so the first occurrence of a repeated id wins deterministically.
+            sorted_models = sorted(models, key=lambda m: m.lower())
+            seen: set = set()
+            deduped = [m for m in sorted_models if not (m in seen or seen.add(m))]
 
-            placeholder_base = f"Choose a model from {provider.get('name', provider_slug)}"
-            for idx, chunk in enumerate(chunks):
-                options = []
-                for model_id in chunk:
-                    short = model_id.split("/")[-1] if "/" in model_id else model_id
-                    options.append(
-                        discord.SelectOption(
-                            label=_truncate_discord_component_text(
-                                short,
-                                _DISCORD_SELECT_FIELD_LIMIT,
-                            ),
-                            value=_truncate_discord_component_text(
-                                model_id,
-                                _DISCORD_SELECT_FIELD_LIMIT,
-                            ),
-                        )
-                    )
-                suffix = f" ({idx + 1}/{len(chunks)})" if len(chunks) > 1 else ""
-                select = discord.ui.Select(
-                    placeholder=f"{placeholder_base}{suffix}...",
-                    options=options,
-                    custom_id=f"model_model_select_{idx}",
+            per_page = 20  # 4 rows × 5 buttons; row 4 (0-indexed) is nav/actions
+            total_pages = max(1, (len(deduped) + per_page - 1) // per_page)
+            page = min(self._model_page, total_pages - 1)
+            self._model_page = page
+            self._model_pages = total_pages
+            page_models = deduped[page * per_page : (page + 1) * per_page]
+
+            row = 0
+            col = 0
+            for model_id in page_models:
+                short = model_id.split("/")[-1] if "/" in model_id else model_id
+                btn = discord.ui.Button(
+                    label=_truncate_discord_component_text(
+                        short, _DISCORD_BUTTON_LABEL_LIMIT
+                    ),
+                    style=discord.ButtonStyle.secondary,
+                    row=row,
                 )
-                # All model selects resolve through the same handler — the
-                # selected value is the model id, identical across rows.
-                select.callback = self._on_model_selected
-                self.add_item(select)
+                mid = model_id
+                btn.callback = lambda i, m=mid: self._model_button_clicked(i, m)
+                self.add_item(btn)
+                col += 1
+                if col >= 5:
+                    col = 0
+                    row += 1
+
+            # Row 4: pagination + actions (always visible — no closing the
+            # view to flip pages).
+            row4 = 4
+            if total_pages > 1:
+                if page > 0:
+                    prev_btn = discord.ui.Button(
+                        label="◀ Prev", style=discord.ButtonStyle.grey, row=row4
+                    )
+                    prev_btn.callback = self._on_model_prev
+                    self.add_item(prev_btn)
+                if page < total_pages - 1:
+                    nxt_btn = discord.ui.Button(
+                        label="Next ▶", style=discord.ButtonStyle.grey, row=row4
+                    )
+                    nxt_btn.callback = self._on_model_next
+                    self.add_item(nxt_btn)
+
+            if has_free:
+                free_label = "🆓 Free" if self._free_only else "💳 All"
+                free_btn = discord.ui.Button(
+                    label=free_label,
+                    style=(
+                        discord.ButtonStyle.green
+                        if self._free_only
+                        else discord.ButtonStyle.grey
+                    ),
+                    row=row4,
+                )
+                free_btn.callback = self._on_free_toggle
+                self.add_item(free_btn)
 
             back_btn = discord.ui.Button(
-                label="◀ Back", style=discord.ButtonStyle.grey, custom_id="model_back"
+                label="◀ Back", style=discord.ButtonStyle.grey, row=row4
             )
             back_btn.callback = self._on_back
             self.add_item(back_btn)
 
             cancel_btn = discord.ui.Button(
-                label="Cancel", style=discord.ButtonStyle.red, custom_id="model_cancel2"
+                label="Cancel", style=discord.ButtonStyle.red, row=row4
             )
             cancel_btn.callback = self._on_cancel
             self.add_item(cancel_btn)
@@ -9348,6 +9382,7 @@ def _define_discord_view_classes() -> None:
 
             provider_slug = interaction.data["values"][0]
             self._selected_provider = provider_slug
+            self._model_page = 0
             provider = next(
                 (p for p in self.providers if p["slug"] == provider_slug), None
             )
@@ -9355,21 +9390,11 @@ def _define_discord_view_classes() -> None:
 
             self._build_model_select(provider_slug)
 
-            # `shown` counts models actually rendered across the partitioned
-            # select menus (up to 3×25 = 75); the old code hard-capped at 25
-            # and silently dropped the tail (e.g. Nous `:free` Portal picks).
-            total = provider.get("total_models", 0) if provider else 0
-            shown = (
-                min(len(provider.get("models", [])), _DISCORD_MODEL_SELECT_CAPACITY)
-                if provider
-                else 0
-            )
-            extra = f"\n*{total - shown} more available — type `/model <name>` directly*" if total > shown else ""
-
+            page_info = f" (page 1/{self._model_pages})" if self._model_pages > 1 else ""
             await interaction.response.edit_message(
                 embed=discord.Embed(
                     title="⚙ Model Configuration",
-                    description=f"Provider: **{pname}**\nSelect a model:{extra}",
+                    description=f"Provider: **{pname}**{page_info}\nSelect a model:",
                     color=discord.Color.blue(),
                 ),
                 view=self,
@@ -9420,7 +9445,11 @@ def _define_discord_view_classes() -> None:
                 view=None,
             )
 
-        async def _on_model_selected(self, interaction: discord.Interaction):
+        async def _model_button_clicked(
+            self, interaction: discord.Interaction, model_id: str
+        ):
+            """Handle a model button click — switch immediately (or confirm
+            when the model is unusually expensive)."""
             if self.resolved:
                 await interaction.response.send_message(
                     "Already resolved~", ephemeral=True
@@ -9432,7 +9461,6 @@ def _define_discord_view_classes() -> None:
                 )
                 return
 
-            model_id = interaction.data["values"][0]
             warning = await self._expensive_warning_for(model_id)
             if warning is not None:
                 self._build_expensive_confirm(model_id)
@@ -9447,6 +9475,60 @@ def _define_discord_view_classes() -> None:
                 return
 
             await self._switch_selected_model(interaction, model_id)
+
+        async def _render_model_page(self, interaction: discord.Interaction):
+            """Rebuild the model grid after a page/filter change and re-render."""
+            self._build_model_select(self._selected_provider)
+            provider = next(
+                (p for p in self.providers if p["slug"] == self._selected_provider),
+                None,
+            )
+            pname = (
+                provider.get("name", self._selected_provider)
+                if provider
+                else self._selected_provider
+            )
+            page_info = (
+                f" (page {self._model_page + 1}/{self._model_pages})"
+                if self._model_pages > 1
+                else ""
+            )
+            await interaction.response.edit_message(
+                embed=discord.Embed(
+                    title="⚙ Model Configuration",
+                    description=f"Provider: **{pname}**{page_info}\nSelect a model:",
+                    color=discord.Color.blue(),
+                ),
+                view=self,
+            )
+
+        async def _on_model_prev(self, interaction: discord.Interaction):
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized~", ephemeral=True
+                )
+                return
+            self._model_page = max(0, self._model_page - 1)
+            await self._render_model_page(interaction)
+
+        async def _on_model_next(self, interaction: discord.Interaction):
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized~", ephemeral=True
+                )
+                return
+            self._model_page = min(self._model_pages - 1, self._model_page + 1)
+            await self._render_model_page(interaction)
+
+        async def _on_free_toggle(self, interaction: discord.Interaction):
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized~", ephemeral=True
+                )
+                return
+            self._free_only = not self._free_only
+            self._model_page = 0
+            await self._render_model_page(interaction)
 
         async def _on_expensive_confirm(self, interaction: discord.Interaction):
             if not self._check_auth(interaction):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -9391,10 +9391,22 @@ def _define_discord_view_classes() -> None:
             self._build_model_select(provider_slug)
 
             page_info = f" (page 1/{self._model_pages})" if self._model_pages > 1 else ""
+
+            filter_note = ""
+            if provider and provider.get("free_models"):
+                shown_total = len(provider.get("models", []))
+                free_total = len(provider["free_models"])
+                if self._free_only:
+                    filter_note = f"\n*Showing {free_total} free of {shown_total} models*"
+                else:
+                    filter_note = f"\n*All {shown_total} models*"
+
             await interaction.response.edit_message(
                 embed=discord.Embed(
                     title="⚙ Model Configuration",
-                    description=f"Provider: **{pname}**{page_info}\nSelect a model:",
+                    description=(
+                        f"Provider: **{pname}**{page_info}\nSelect a model:{filter_note}"
+                    ),
                     color=discord.Color.blue(),
                 ),
                 view=self,
@@ -9493,10 +9505,23 @@ def _define_discord_view_classes() -> None:
                 if self._model_pages > 1
                 else ""
             )
+
+            # Make the free filter self-explanatory: "showing N free of M".
+            filter_note = ""
+            if provider and provider.get("free_models"):
+                shown_total = len(provider.get("models", []))
+                free_total = len(provider["free_models"])
+                if self._free_only:
+                    filter_note = f"\n*Showing {free_total} free of {shown_total} models*"
+                else:
+                    filter_note = f"\n*All {shown_total} models*"
+
             await interaction.response.edit_message(
                 embed=discord.Embed(
                     title="⚙ Model Configuration",
-                    description=f"Provider: **{pname}**{page_info}\nSelect a model:",
+                    description=(
+                        f"Provider: **{pname}**{page_info}\nSelect a model:{filter_note}"
+                    ),
                     color=discord.Color.blue(),
                 ),
                 view=self,

--- a/tests/gateway/test_discord_model_picker.py
+++ b/tests/gateway/test_discord_model_picker.py
@@ -71,7 +71,7 @@ async def test_model_picker_clears_controls_before_running_switch_callback():
         edit_original_response=AsyncMock(side_effect=edit_original_response),
     )
 
-    await view._on_model_selected(interaction)
+    await view._model_button_clicked(interaction, "gpt-5.4")
 
     assert events == [
         ("initial-edit", "⚙ Switching Model", "Switching to `gpt-5.4`...", None),

--- a/tests/gateway/test_discord_model_picker_partition.py
+++ b/tests/gateway/test_discord_model_picker_partition.py
@@ -1,12 +1,15 @@
 """Regression test: Discord /model picker must surface ALL models for a
 provider whose list exceeds 25 entries (e.g. Nous curated + Portal free
-recommendations), not silently truncate the tail at 25 options.
+recommendations), not silently truncate the tail.
 
-Discord caps a single Select at 25 options and a View at 5 action rows. The
-picker keeps 2 rows for Back/Cancel, so it must partition the model list
-across up to 3 select menus. This is what makes free-tier ``:free`` Portal
-picks (appended after the curated list) appear on Discord — they previously
-fell off the 25-option cliff.
+The picker is a paginated button grid: 4 rows × 5 buttons per page (20
+models/page) with a persistent 5th row for Prev/Next navigation. A select-menu
+picker caps at 3 dropdowns × 25 options (75 models) inside Discord's 5-row
+View limit — anything past that clips. Buttons page arbitrarily deep, so even
+providers with hundreds of models (NVIDIA NIM: 139) are fully reachable.
+
+The :free Portal tail is the original regression: it used to fall off the
+25-option cliff, and the multi-select partition that replaced it capped at 75.
 """
 
 from types import SimpleNamespace
@@ -15,22 +18,66 @@ from gateway.platforms.base import utf16_len
 from plugins.platforms.discord.adapter import ModelPickerView
 
 
-def _all_options(view: "ModelPickerView"):
-    """Flatten every model select menu's options into (label, value).
+def _model_buttons(view: "ModelPickerView"):
+    """Return (label, value) for every model button in the grid.
 
-    Detect selects by their ``model_model_select*`` custom_id (and presence of
-    ``.options``) rather than class name — the discord mock in conftest uses a
-    ``_FakeSelect`` class, while the real library uses ``discord.ui.Select``.
+    Model buttons carry their model id in the callback default arg; nav/action
+    buttons (row 4) are excluded because they use bound methods instead.
     """
     out = []
     for child in view.children:
-        custom_id = getattr(child, "custom_id", "")
-        if isinstance(custom_id, str) and custom_id.startswith("model_model_select"):
-            out.extend((opt.label, opt.value) for opt in getattr(child, "options", []))
+        row = getattr(child, "row", None)
+        if row is None or row >= 4:
+            continue
+        cb = getattr(child, "callback", None)
+        defaults = getattr(cb, "__defaults__", None) or ()
+        if defaults:
+            out.append((child.label, defaults[0]))
     return out
 
 
-def test_nous_free_models_render_across_partitioned_selects():
+def _nav_labels(view: "ModelPickerView"):
+    """Labels of the row-4 action buttons (Prev/Next/Free/Back/Cancel)."""
+    return [
+        child.label
+        for child in view.children
+        if getattr(child, "row", None) == 4 and getattr(child, "label", None)
+    ]
+
+
+def _make_view(models, *, free_models=None, current="tencent/hy3"):
+    view = ModelPickerView(
+        providers=[
+            {
+                "slug": "nous",
+                "name": "Nous Portal",
+                "models": list(models),
+                **({"free_models": list(free_models)} if free_models else {}),
+                "total_models": len(models),
+                "is_current": True,
+            }
+        ],
+        current_model=current,
+        current_provider="nous",
+        session_key="session-1",
+        on_model_selected=lambda *a, **k: None,
+        allowed_user_ids={"123"},
+    )
+    view._selected_provider = "nous"
+    return view
+
+
+def _collect_all(view, total_pages):
+    """Walk every page and collect all rendered model ids."""
+    rendered = []
+    for page in range(total_pages):
+        view._model_page = page
+        view._build_model_select("nous")
+        rendered.extend(v for _label, v in _model_buttons(view))
+    return rendered
+
+
+def test_nous_free_models_render_across_pages():
     # 37 models: 32 curated + 5 free Portal recommendations appended at the tail
     # (the real-world shape that was getting clipped at 25 on Discord).
     models = [
@@ -75,83 +122,121 @@ def test_nous_free_models_render_across_partitioned_selects():
     ]
     assert len(models) == 37
 
-    view = ModelPickerView(
-        providers=[
-            {
-                "slug": "nous",
-                "name": "Nous Portal",
-                "models": list(models),
-                "total_models": len(models),
-                "is_current": True,
-            }
-        ],
-        current_model="tencent/hy3",
-        current_provider="nous",
-        session_key="session-1",
-        on_model_selected=lambda *a, **k: None,
-        allowed_user_ids={"123"},
-    )
-    view._selected_provider = "nous"
+    view = _make_view(models)
+    view._model_page = 0
     view._build_model_select("nous")
 
-    # The tail must render — this is the regression that was failing before
-    # multi-select partitioning.
-    rendered = [v for _label, v in _all_options(view)]
+    # Page 1 shows 20 of 37; the tail lives on page 2.
+    assert len(_model_buttons(view)) == 20
+    assert view._model_pages == 2
+
+    # Every model must be reachable across pages — the original regression.
+    rendered = _collect_all(view, view._model_pages)
+    assert len(rendered) == 37
     assert "tencent/hy3:free" in rendered
     assert "stepfun/step-3.7-flash:free" in rendered
     assert "poolside/laguna-s-2.1:free" in rendered
     assert "inclusionai/ling-3.0-flash:free" in rendered
     assert "poolside/laguna-xs-2.1:free" in rendered
 
-    # Every model must appear exactly once (no truncation, no dupes).
+    # No truncation, no dupes.
     assert sorted(rendered) == sorted(models)
-    assert len(rendered) == 37
 
-    # 37 models => 2 select rows of 25 + 12, plus Back/Cancel = 4 action rows.
-    select_rows = [
-        c for c in view.children
-        if isinstance(getattr(c, "custom_id", ""), str)
-        and c.custom_id.startswith("model_model_select")
+    # Navigation buttons present on page 1 of a multi-page provider.
+    view._model_page = 0
+    view._build_model_select("nous")
+    nav = _nav_labels(view)
+    assert "◀ Prev" not in nav  # first page: nothing to go back to
+    assert "Next ▶" in nav
+
+    # ... and on the last page, Next disappears but Prev remains.
+    view._model_page = view._model_pages - 1
+    view._build_model_select("nous")
+    nav = _nav_labels(view)
+    assert "◀ Prev" in nav
+    assert "Next ▶" not in nav
+
+    # Each button label respects Discord's 80-char limit.
+    for label, _value in _model_buttons(view):
+        assert utf16_len(label) <= 80
+
+
+def test_models_sorted_alphabetically_and_deduped():
+    # Deliberately unsorted + containing a duplicate (NVIDIA NIM returns
+    # duplicate entries; duplicate button values cause HTTP 400 on submit).
+    models = [
+        "z-ai/glm-5.2",
+        "openai/gpt-5.6-sol",
+        "deepseek/deepseek-v4-flash",
+        "openai/gpt-5.6-sol",
+        "anthropic/claude-fable-5",
+        "openai/gpt-5.6-sol",
     ]
-    assert len(select_rows) == 2
-    assert len(select_rows[0].options) == 25
-    assert len(select_rows[1].options) == 12
+    view = _make_view(models)
+    view._model_page = 0
+    view._build_model_select("nous")
 
-    # Each option still respects Discord's 100-char utf16 field limit.
-    for _label, value in _all_options(view):
-        assert utf16_len(value) <= 100
-
-    # No single select exceeds Discord's 25-option hard cap.
-    for sel in select_rows:
-        assert len(sel.options) <= 25
-
-
-def test_small_provider_single_select_unchanged():
-    """A <25-model provider still renders as a single select menu."""
-    models = [f"m/{i}" for i in range(10)]
-    view = ModelPickerView(
-        providers=[
-            {
-                "slug": "emoji",
-                "name": "Emoji",
-                "models": models,
-                "total_models": len(models),
-                "is_current": False,
-            }
-        ],
-        current_model="m/0",
-        current_provider="emoji",
-        session_key="session-1",
-        on_model_selected=lambda *a, **k: None,
-        allowed_user_ids={"123"},
+    rendered = [v for _label, v in _model_buttons(view)]
+    assert rendered == sorted(
+        ["anthropic/claude-fable-5", "deepseek/deepseek-v4-flash",
+         "openai/gpt-5.6-sol", "z-ai/glm-5.2"]
     )
-    view._selected_provider = "emoji"
-    view._build_model_select("emoji")
+    assert len(rendered) == 4  # deduped from 6
+    assert view._model_pages == 1
 
-    select_rows = [
-        c for c in view.children
-        if isinstance(getattr(c, "custom_id", ""), str)
-        and c.custom_id.startswith("model_model_select")
+
+def test_small_provider_single_page_no_nav():
+    """A <20-model provider renders one page with no pagination buttons."""
+    models = [f"m/{i}" for i in range(10)]
+    view = _make_view(models)
+    view._build_model_select("nous")
+
+    assert len(_model_buttons(view)) == 10
+    assert view._model_pages == 1
+    nav = _nav_labels(view)
+    assert "◀ Prev" not in nav
+    assert "Next ▶" not in nav
+    assert "◀ Back" in nav
+    assert "Cancel" in nav
+
+
+def test_free_toggle_shows_free_subset_first():
+    """Free-only mode (default) shows the free subset; toggling shows all."""
+    models = [
+        "anthropic/claude-fable-5",
+        "openai/gpt-5.6-sol",
+        "tencent/hy3:free",
+        "stepfun/step-3.7-flash:free",
     ]
-    assert len(select_rows) == 1
-    assert len(select_rows[0].options) == 10
+    free = ["tencent/hy3:free", "stepfun/step-3.7-flash:free"]
+    view = _make_view(models, free_models=free)
+    view._model_page = 0
+    view._build_model_select("nous")
+
+    # Default is free-only.
+    rendered = [v for _label, v in _model_buttons(view)]
+    assert rendered == sorted(free)
+    nav = _nav_labels(view)
+    assert "🆓 Free" in nav
+
+    # Toggle to all models.
+    view._free_only = False
+    view._build_model_select("nous")
+    rendered = [v for _label, v in _model_buttons(view)]
+    assert rendered == sorted(models)
+    nav = _nav_labels(view)
+    assert "💳 All" in nav
+
+
+def test_139_model_provider_fully_reachable():
+    """NVIDIA NIM returns 139 models — the case the 75-cap partition clips."""
+    models = [f"nvidia/nim-model-{i:03d}" for i in range(139)]
+    view = _make_view(models)
+    view._model_page = 0
+    view._build_model_select("nous")
+
+    assert view._model_pages == 7  # ceil(139/20)
+    rendered = _collect_all(view, view._model_pages)
+    assert len(rendered) == 139
+    assert rendered[0] == "nvidia/nim-model-000"
+    assert rendered[-1] == "nvidia/nim-model-138"

--- a/tests/gateway/test_discord_model_picker_partition.py
+++ b/tests/gateway/test_discord_model_picker_partition.py
@@ -13,6 +13,9 @@ The :free Portal tail is the original regression: it used to fall off the
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import asyncio
 
 from gateway.platforms.base import utf16_len
 from plugins.platforms.discord.adapter import ModelPickerView
@@ -226,6 +229,51 @@ def test_free_toggle_shows_free_subset_first():
     assert rendered == sorted(models)
     nav = _nav_labels(view)
     assert "💳 All" in nav
+
+
+def test_free_filter_note_in_embed():
+    """The embed reports 'showing N free of M' so the filter is self-explanatory."""
+    models = [
+        "anthropic/claude-fable-5",
+        "openai/gpt-5.6-sol",
+        "tencent/hy3:free",
+        "stepfun/step-3.7-flash:free",
+    ]
+    free = ["tencent/hy3:free", "stepfun/step-3.7-flash:free"]
+    view = _make_view(models, free_models=free)
+
+    captured = {}
+
+    async def edit_message(**kwargs):
+        captured["description"] = kwargs["embed"].description
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=123),
+        channel_id=456,
+        data={"values": ["nous"]},
+        response=SimpleNamespace(
+            defer=AsyncMock(),
+            send_message=AsyncMock(),
+            edit_message=AsyncMock(side_effect=edit_message),
+        ),
+        edit_original_response=AsyncMock(),
+    )
+
+    # Free-only default: "showing 2 free of 4 models"
+    view._free_only = True
+    view._model_page = 0
+    view._selected_provider = "nous"
+    asyncio.get_event_loop().run_until_complete(
+        view._render_model_page(interaction)
+    )
+    assert "Showing 2 free of 4 models" in captured["description"]
+
+    # All-models toggle: "All 4 models"
+    view._free_only = False
+    asyncio.get_event_loop().run_until_complete(
+        view._render_model_page(interaction)
+    )
+    assert "All 4 models" in captured["description"]
 
 
 def test_139_model_provider_fully_reachable():


### PR DESCRIPTION
## Summary

Resurrects the Discord `/model` picker design from #19996 — a **paginated button grid** — on top of current main, replacing the partition-dropdown approach that landed in #92150.

**Why this matters:** #92150 partitions the model list across up to 3 select menus (25×3 = **75 models hard cap**) inside Discord's 5-row View limit, with a code comment admitting *"Providers past that would still clip, but none currently do."* They do — NVIDIA NIM returns **139 models**, and the current `max_models=50` in slash_commands trims the list before it even reaches the picker. A button grid fits **20 models per page** (4 rows × 5 columns) with a persistent 5th row for Prev/Next, so arbitrarily large catalogs are fully reachable with no clipping.

## Changes

### `plugins/platforms/discord/adapter.py` — button grid picker
- `_build_model_select` renders a **4×5 button grid (20 models/page)** with a persistent row 4 for navigation — no more closing dropdowns to flip pages
- **Alphabetical sort** (case-insensitive) within each provider
- **Dedup**: duplicate model IDs (NVIDIA NIM returns dupes) cause HTTP 400 on submit — deduped after sort so the first occurrence wins deterministically
- **Free filter**: when a provider exposes `free_models`, the picker defaults to free-only with a **🆓 Free / 💳 All** toggle on row 4
- Pagination state (`_model_page`, `_model_pages`) resets on provider change; page indicator in the embed (`page 1/7`)
- Model buttons route through the existing expensive-model confirmation and `_switch_selected_model` paths — no behavior regression there
- `_on_model_selected` replaced by `_model_button_clicked(interaction, model_id)`; nav handlers `_on_model_prev` / `_on_model_next` / `_on_free_toggle` added

### `hermes_cli/model_switch.py` — free model plumbing (from #19996)
- `list_picker_providers` splits `free_ids` out of the live OpenRouter fetch and exposes them as `free_models` on the provider row (guarded against `max_models=None`)

### `hermes_cli/models.py` — live free model surfacing (from #19996)
- `fetch_openrouter_models` also surfaces free, tool-capable models from the live catalog that aren't in the curated preferred list — new free models appear without waiting for the curated manifest to update

### `gateway/slash_commands.py`
- `max_models=50` → `500` for the interactive picker so large catalogs (NIM: 139) actually reach it

## Testing

- `test_discord_model_picker_partition.py` rewritten for the grid: 37-model Nous list (curated + `:free` tail) fully reachable across pages, 139-model NIM provider pages 7×20 with first/last correct, dedup, alphabetical sort, free-toggle subset, nav bounds (no Prev on page 1, no Next on last page)
- `test_discord_model_picker.py` updated to call `_model_button_clicked`
- Full picker surface: **29 passed** (picker grid, persistence, stale-base-url picker-tap path, component auth, lazy install views)
- `ruff check` clean on all touched files
- End-to-end verified against the live OpenRouter catalog: `free_models` correctly extracts 19 free entries (including `stealth/ox-alpha`, a $0 model without the `:free` suffix — caught by pricing, not slug convention)

## Credits

- Original design + free-model plumbing from #19996 by @coe0718 (cherry-picked to preserve authorship)
- Port to current main (button grid, tests) by @tuck-coe
