### PR TITLE
fix(tui): keep slow MCP servers visible in slash worker tools

### DIFF
--- a/tests/tui_gateway/test_slash_worker_mcp_discovery.py
+++ b/tests/tui_gateway/test_slash_worker_mcp_discovery.py
@@ -26,6 +26,50 @@ if not hasattr(_mcp_server_mod, "MCPServer"):
     )
 
 
+class _FakeCLI:
+    console = None
+
+    def __init__(self, on_command):
+        self._on_command = on_command
+
+    def process_command(self, cmd: str) -> None:
+        self._on_command(cmd)
+
+
+def test_tools_waits_for_inflight_discovery_before_enumerating(monkeypatch):
+    from hermes_cli import mcp_startup
+    from tui_gateway import slash_worker
+
+    discovery_joined = False
+
+    def _join(*, timeout):
+        nonlocal discovery_joined
+        assert timeout == 30.0
+        discovery_joined = True
+        return True
+
+    monkeypatch.setattr(mcp_startup, "join_mcp_discovery", _join)
+    cli = _FakeCLI(lambda cmd: (
+        discovery_joined or pytest.fail(f"{cmd} enumerated tools before MCP discovery joined")
+    ))
+
+    slash_worker._run(cli, "/tools")
+
+    assert discovery_joined is True
+
+
+def test_non_catalog_command_does_not_wait_for_mcp_discovery(monkeypatch):
+    from hermes_cli import mcp_startup
+    from tui_gateway import slash_worker
+
+    def _unexpected_join(*, timeout):
+        pytest.fail(f"/help unexpectedly waited {timeout}s for MCP discovery")
+
+    monkeypatch.setattr(mcp_startup, "join_mcp_discovery", _unexpected_join)
+
+    slash_worker._run(_FakeCLI(lambda _cmd: None), "/help")
+
+
 def test_profile_local_mcp_tool_is_visible_in_slash_worker(tmp_path):
     profile_home = tmp_path / "profile-home"
     profile_home.mkdir()

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -97,6 +97,15 @@ def _run(cli: HermesCLI, command: str) -> str:
     if not cmd.startswith("/"):
         cmd = f"/{cmd}"
 
+    # This process has no late-refresh path: once bare /tools renders its
+    # catalog, a slow profile-local MCP server stays invisible in that output.
+    # Wait only at this worker-owned inspection boundary so interactive TUI/CLI
+    # surfaces and unrelated slash commands keep their short startup bound.
+    if cmd.casefold() == "/tools":
+        from hermes_cli.mcp_startup import join_mcp_discovery
+
+        join_mcp_discovery(timeout=30.0)
+
     buf = io.StringIO()
 
     # Rich Console captures its file handle at construction time, so


### PR DESCRIPTION
## What does this PR do?

A profile-local MCP server that connects slowly can be missing from the slash worker's bare `/tools` output even though discovery is still progressing successfully. This change gives only that worker-owned catalog inspection a generous bounded wait, so installation checks no longer return a complete-looking but stale catalog while interactive TUI and CLI paths keep their existing short startup bound.

### Symptom

Bare `/tools` in the persistent slash worker can omit a healthy profile-local MCP tool when its stdio handshake exceeds the initial bounded discovery wait.

### Impact

Users checking an MCP installation through `/tools` can receive a false negative and conclude that the server failed to install or connect. The affected population and frequency are not measured.

### Bug Cause

**Trigger:** `tui_gateway/slash_worker.py:93` / `_run()` executing bare `/tools` while background MCP discovery remains in flight.

**Causal chain:**
1. Slash-worker startup begins MCP discovery and waits only for the short interactive discovery bound.
2. A slow stdio server remains in flight when the worker accepts bare `/tools`.
3. The worker enumerates its current registry without a late refresh, so the response silently omits that server's tools.

**Why it is wrong:** The one-shot catalog output looks authoritative even though its discovery owner is still running, and this separate worker process has no later response update.

**Working sibling / contrast:** The TUI session path schedules a bounded late refresh after slow discovery completes. The slash worker has no equivalent refresh path.

**Ruled out:** Profile configuration propagation is not the cause; the existing subprocess integration test proves that the worker reads profile-local `HERMES_HOME` and discovers its MCP server when the handshake finishes within the short bound.

### Fix

Before the slash worker executes bare `/tools`, join its in-flight MCP discovery for up to 30 seconds. The wait returns immediately after normal discovery completion and is scoped to this worker command, so unrelated slash commands and interactive surfaces do not inherit the longer bound.

## Related Issue

Closes #92330

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/slash_worker.py` - wait for in-flight MCP discovery at the worker-only bare `/tools` catalog boundary.
- `tests/tui_gateway/test_slash_worker_mcp_discovery.py` - verify catalog enumeration waits and unrelated commands remain non-blocking.

## How to Test

1. Run the slash-worker MCP discovery and ANSI regression tests:

```bash
scripts/run_tests.sh tests/tui_gateway/test_slash_worker_mcp_discovery.py tests/tui_gateway/test_slash_worker_ansi.py -q
```

2. Confirm all 4 tests pass, including the real profile-local MCP subprocess probe.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing contract changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A, no architecture or workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - the change uses portable Python thread joining
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no model tool behavior changed
