### PR TITLE
fix(docker): prevent profile skill leaks in shared containers

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1318,6 +1318,7 @@ def _probe_remote_backend(env_type: str) -> str | None:
                 "modal_mode": config.get("modal_mode", "auto"),
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                "docker_mount_profile_skills": config.get("docker_mount_profile_skills", True),
                 "docker_forward_env": config.get("docker_forward_env", []),
                 "docker_env": config.get("docker_env", {}),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -340,6 +340,7 @@ terminal:
   #   profile - force HERMES_HOME/home for strict per-profile CLI config isolation
   home_mode: "auto"
   docker_mount_cwd_to_workspace: false  # SECURITY: off by default. Opt in to mount the launch cwd into Docker /workspace.
+  docker_mount_profile_skills: true  # Set false when several profiles deliberately share one Docker container.
   lifetime_seconds: 300
   # sudo_password: "hunter2"  # Optional: pipe a sudo password via sudo -S. SECURITY WARNING: plaintext.
   # sudo_password: ""         # Explicit empty password: try empty and never open the interactive sudo prompt.
@@ -371,6 +372,7 @@ terminal:
 #   lifetime_seconds: 300
 #   docker_image: "nikolaik/python-nodejs:python3.11-nodejs20"
 #   docker_mount_cwd_to_workspace: true   # Explicit opt-in: mount your launch cwd into /workspace
+#   docker_mount_profile_skills: true     # Set false to omit profile-local skills from a shared container
 #   # Optional: run the container as your host user's uid:gid so files written
 #   # into bind-mounted dirs are owned by you, not root. Drops SETUID/SETGID
 #   # caps too since no gosu privilege drop is needed. Leave off if your

--- a/cli.py
+++ b/cli.py
@@ -458,6 +458,7 @@ def load_cli_config() -> Dict[str, Any]:
             "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
             "docker_volumes": [],  # host:container volume mounts for Docker backend
             "docker_mount_cwd_to_workspace": False,  # explicit opt-in only; default off for sandbox isolation
+            "docker_mount_profile_skills": True,
         },
         "browser": {
             "inactivity_timeout": 120,  # Auto-cleanup inactive browser sessions after 2 min
@@ -680,6 +681,7 @@ def load_cli_config() -> Dict[str, Any]:
         "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+        "docker_mount_profile_skills": "TERMINAL_DOCKER_MOUNT_PROFILE_SKILLS",
         "docker_network": "TERMINAL_DOCKER_NETWORK",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2380,6 +2380,7 @@ if _config_path.exists():
                 "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+                "docker_mount_profile_skills": "TERMINAL_DOCKER_MOUNT_PROFILE_SKILLS",
                 "docker_network": "TERMINAL_DOCKER_NETWORK",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3511,6 +3511,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
     "docker_env": "TERMINAL_DOCKER_ENV",
     "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+    "docker_mount_profile_skills": "TERMINAL_DOCKER_MOUNT_PROFILE_SKILLS",
     "docker_network": "TERMINAL_DOCKER_NETWORK",
     "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
     "docker_shm_size": "TERMINAL_DOCKER_SHM_SIZE",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -464,6 +464,9 @@ DEFAULT_CONFIG = {
         # Explicit opt-in: mount the host cwd into /workspace for Docker sessions.
         # Default off because passing host directories into a sandbox weakens isolation.
         "docker_mount_cwd_to_workspace": False,
+        # Disable when several profiles deliberately share one container so the
+        # creator's profile-local skill credentials are not visible to others.
+        "docker_mount_profile_skills": True,
         # Opt-in egress lockdown for Docker terminal sessions. When false,
         # Docker runs with --network=none so commands cannot reach the network.
         "docker_network": True,

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -564,6 +564,23 @@ def test_config_yaml_terminal_backend_overrides_stale_shell(tmp_path, monkeypatc
     assert os.getenv("TERMINAL_ENV") == "local"
 
 
+def test_config_yaml_bridges_docker_profile_skills_mount_policy(tmp_path, monkeypatch):
+    home = _seed_terminal_home(
+        tmp_path,
+        monkeypatch,
+        config_yaml=(
+            "terminal:\n"
+            "  backend: docker\n"
+            "  docker_mount_profile_skills: false\n"
+        ),
+    )
+    monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_PROFILE_SKILLS", "true")
+
+    load_hermes_dotenv(hermes_home=home)
+
+    assert os.getenv("TERMINAL_DOCKER_MOUNT_PROFILE_SKILLS") == "False"
+
+
 def test_no_terminal_section_leaves_env_value_alone(tmp_path, monkeypatch):
     """When config.yaml has no terminal section, the .env value is still the
     user's active setting — the bridge must NOT clobber it with merged

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -87,6 +87,39 @@ class TestSkillsDirectoryMount:
 
         assert mounts[0]["container_path"] == "/home/user/.hermes/skills"
 
+    def test_profile_skills_can_be_omitted_without_dropping_shared_dirs(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        profile_skills = hermes_home / "skills"
+        external_skills = tmp_path / "external-skills"
+        project_skills = tmp_path / "project-skills"
+        for directory in (profile_skills, external_skills, project_skills):
+            directory.mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(
+            "agent.skill_utils.get_external_skills_dirs",
+            lambda: [external_skills],
+        )
+        monkeypatch.setattr(
+            "agent.skill_utils.get_project_skills_dirs",
+            lambda: [project_skills],
+        )
+
+        mounts = get_skills_directory_mount(include_profile_skills=False)
+
+        assert mounts == [
+            {
+                "host_path": str(external_skills),
+                "container_path": "/root/.hermes/external_skills/0",
+            },
+            {
+                "host_path": str(project_skills),
+                "container_path": "/root/.hermes/project_skills/0",
+            },
+        ]
+
     def test_symlinks_are_sanitized(self, tmp_path):
         """Symlinks in skills dir should be excluded from the mount."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -621,6 +621,7 @@ def test_labels_attribute_populated_after_init(monkeypatch):
         "hermes-task-id": "abc",
         "hermes-profile": "default",
         "hermes-egress": "off",
+        "hermes-profile-skills": "true",
     }
 
 
@@ -699,6 +700,30 @@ def test_reuse_attaches_to_running_container_without_docker_run(monkeypatch):
     assert not start_invocations, (
         f"docker start should be skipped when container already running, got: {start_invocations}"
     )
+
+
+def test_disabling_profile_skills_replaces_legacy_persistent_container(monkeypatch):
+    """An unlabeled legacy container has the immutable profile-skills mount."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    calls = _mock_subprocess_run_with_reuse(monkeypatch, ps_state="running")
+
+    env = _make_dummy_env(
+        task_id="reuse-without-profile-skills",
+        mount_profile_skills=False,
+    )
+
+    assert env._container_id == "fresh-cid"
+    assert any(
+        isinstance(cmd, list) and cmd[1:4] == ["rm", "-f", "reused-cid"]
+        for cmd, _kwargs in calls
+    ), "the legacy mounted container must be removed before replacement"
+    assert any(
+        isinstance(cmd, list)
+        and cmd[1] == "run"
+        and "hermes-profile-skills=false" in cmd
+        for cmd, _kwargs in calls
+    ), "the replacement container must record its immutable mount posture"
 
 
 def test_egress_enabled_does_not_reuse_pre_egress_container(monkeypatch):

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -50,12 +50,28 @@ def _make_dummy_env(**kwargs):
         network=kwargs.get("network", True),
         host_cwd=kwargs.get("host_cwd"),
         auto_mount_cwd=kwargs.get("auto_mount_cwd", False),
+        mount_profile_skills=kwargs.get("mount_profile_skills", True),
         env=kwargs.get("env"),
         run_as_host_user=kwargs.get("run_as_host_user", False),
         extra_args=kwargs.get("extra_args", []),
         persist_across_processes=kwargs.get("persist_across_processes", True),
         shm_size=kwargs.get("shm_size", docker_env._DEFAULT_SHM_SIZE),
     )
+
+
+def test_profile_skills_mount_policy_is_forwarded(monkeypatch):
+    """Shared containers can omit only the creating profile's skills tree."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    _mock_subprocess_run(monkeypatch)
+    captured = []
+    monkeypatch.setattr(
+        "tools.credential_files.get_skills_directory_mount",
+        lambda **kwargs: captured.append(kwargs) or [],
+    )
+
+    _make_dummy_env(mount_profile_skills=False)
+
+    assert captured == [{"include_profile_skills": False}]
 
 
 def test_ensure_docker_available_logs_and_raises_when_not_found(monkeypatch, caplog):
@@ -1254,7 +1270,7 @@ def test_credential_mount_skipped_when_source_is_directory(monkeypatch, tmp_path
     )
     monkeypatch.setattr(
         "tools.credential_files.get_skills_directory_mount",
-        lambda: [],
+        lambda **_: [],
     )
     monkeypatch.setattr(
         "tools.credential_files.get_cache_directory_mounts",
@@ -1294,7 +1310,7 @@ def test_credential_mount_skipped_when_source_missing(monkeypatch, tmp_path, cap
     )
     monkeypatch.setattr(
         "tools.credential_files.get_skills_directory_mount",
-        lambda: [],
+        lambda **_: [],
     )
     monkeypatch.setattr(
         "tools.credential_files.get_cache_directory_mounts",

--- a/tests/tools/test_file_tools_container_config.py
+++ b/tests/tools/test_file_tools_container_config.py
@@ -20,6 +20,7 @@ def _make_env_config(**overrides):
         "container_persistent": False,
         "docker_volumes": [],
         "docker_mount_cwd_to_workspace": True,
+        "docker_mount_profile_skills": True,
         "docker_forward_env": ["MY_SECRET", "API_KEY"],
     }
     base.update(overrides)
@@ -53,6 +54,13 @@ class TestFileToolsContainerConfig:
         """docker_mount_cwd_to_workspace is forwarded to container_config."""
         cc = self._run(_make_env_config(docker_mount_cwd_to_workspace=True), "t1").get("container_config", {})
         assert cc.get("docker_mount_cwd_to_workspace") is True
+
+    def test_docker_mount_profile_skills_passed(self):
+        cc = self._run(
+            _make_env_config(docker_mount_profile_skills=False), "t-profile-skills"
+        ).get("container_config", {})
+
+        assert cc.get("docker_mount_profile_skills") is False
 
 
     def test_cwd_only_raw_task_override_reaches_file_environment(self):

--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -95,6 +95,16 @@ class TestCwdHandling:
         assert config["host_cwd"] == "/Users/someone/projects"
         assert config["docker_mount_cwd_to_workspace"] is True
 
+    def test_docker_profile_skills_mount_defaults_on_and_can_be_disabled(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.delenv("TERMINAL_DOCKER_MOUNT_PROFILE_SKILLS", raising=False)
+        assert _tt_mod._get_env_config()["docker_mount_profile_skills"] is True
+
+        monkeypatch.setenv("TERMINAL_DOCKER_MOUNT_PROFILE_SKILLS", "false")
+        assert _tt_mod._get_env_config()["docker_mount_profile_skills"] is False
+
     def test_windows_path_replaced_for_modal(self, monkeypatch):
         """TERMINAL_CWD=C:\\Users\\... should be replaced for modal."""
         monkeypatch.setenv("TERMINAL_ENV", "modal")
@@ -174,6 +184,31 @@ class TestCwdHandling:
         assert captured["cwd"] == "/workspace"
         assert captured["host_cwd"] == "/home/user/project"
         assert captured["auto_mount_cwd"] is True
+
+    def test_create_environment_passes_profile_skills_mount_policy(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            _tt_mod,
+            "_DockerEnvironment",
+            lambda **kwargs: captured.update(kwargs) or object(),
+        )
+
+        _tt_mod._create_environment(
+            env_type="docker",
+            image="python:3.11",
+            cwd="/root",
+            timeout=60,
+            container_config={"docker_mount_profile_skills": False},
+        )
+
+        assert captured["mount_profile_skills"] is False
+
+    def test_container_config_keeps_profile_skills_mount_policy(self):
+        config = _tt_mod._container_config_from_config(
+            {"docker_mount_profile_skills": False}
+        )
+
+        assert config["docker_mount_profile_skills"] is False
 
     def test_ssh_preserves_home_paths(self, monkeypatch):
         """SSH backend should NOT replace /home/ paths (they're valid remotely)."""

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -246,6 +246,8 @@ def get_credential_file_mounts() -> List[Dict[str, str]]:
 
 def get_skills_directory_mount(
     container_base: str = "/root/.hermes",
+    *,
+    include_profile_skills: bool = True,
 ) -> list[Dict[str, str]]:
     """Return mount info for all skill directories (local + external).
 
@@ -260,13 +262,14 @@ def get_skills_directory_mount(
     directly with zero overhead.
 
     Returns a list of dicts with ``host_path`` and ``container_path`` keys.
-    The local skills dir mounts at ``<container_base>/skills``, external dirs
-    at ``<container_base>/external_skills/<index>``.
+    The local skills dir mounts at ``<container_base>/skills`` unless
+    ``include_profile_skills`` is false. External and project dirs are always
+    returned because they are shared checkouts rather than profile-local state.
     """
     mounts = []
     hermes_home = _resolve_hermes_home()
     skills_dir = hermes_home / "skills"
-    if skills_dir.is_dir():
+    if include_profile_skills and skills_dir.is_dir():
         host_path = _safe_skills_path(skills_dir)
         mounts.append({
             "host_path": host_path,

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -883,6 +883,7 @@ class DockerEnvironment(BaseEnvironment):
         network: bool = True,
         host_cwd: Optional[str] = None,
         auto_mount_cwd: bool = False,
+        mount_profile_skills: bool = True,
         run_as_host_user: bool = False,
         extra_args: list = None,
         persist_across_processes: bool = True,
@@ -1046,7 +1047,9 @@ class DockerEnvironment(BaseEnvironment):
 
             # Mount skill directories (local + external) so skill
             # scripts/templates are available inside the container.
-            for skills_mount in get_skills_directory_mount():
+            for skills_mount in get_skills_directory_mount(
+                include_profile_skills=mount_profile_skills,
+            ):
                 src = Path(skills_mount["host_path"])
                 if not src.is_dir():
                     logger.warning(

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -43,6 +43,7 @@ _DOCKER_SEARCH_PATHS = [
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EGRESS_LABEL_KEY = "hermes-egress"
+_PROFILE_SKILLS_LABEL_KEY = "hermes-profile-skills"
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -1373,11 +1374,13 @@ class DockerEnvironment(BaseEnvironment):
         # container-start time and never changes for the container's lifetime.
         profile_name = _sanitize_label_value(_get_active_profile_name())
         task_label = _sanitize_label_value(task_id)
+        profile_skills_label = "true" if mount_profile_skills else "false"
         label_args = [
             "--label", "hermes-agent=1",
             "--label", f"hermes-task-id={task_label}",
             "--label", f"hermes-profile={profile_name}",
             "--label", f"{_EGRESS_LABEL_KEY}={egress_label}",
+            "--label", f"{_PROFILE_SKILLS_LABEL_KEY}={profile_skills_label}",
         ]
         # Save args for container recreation on "No such container" recovery.
         self._image = image
@@ -1390,6 +1393,7 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label,
+            _PROFILE_SKILLS_LABEL_KEY: profile_skills_label,
         }
 
         # Cross-process container reuse (issue #20561 — docs claim "ONE long-lived
@@ -1399,14 +1403,14 @@ class DockerEnvironment(BaseEnvironment):
         # restores the documented contract; opt out via
         # ``terminal.docker_persist_across_processes: false``.
         #
-        # Reuse matches on labels only.  The egress posture gets its own label
-        # because env vars, CA mounts, and host mappings are immutable after
-        # container creation — reusing a pre-egress or pre-rotation container
-        # would silently bypass the credential firewall.
+        # Reuse matches on labels only. Egress and profile-skills mount posture
+        # get their own labels because env vars and bind mounts are immutable
+        # after container creation. Reusing a container with either posture
+        # changed would preserve stale credentials or access.
         reused = False
         if persist_across_processes:
             existing = self._find_reusable_container(
-                task_label, profile_name, egress_label,
+                task_label, profile_name, egress_label, mount_profile_skills,
             )
             if existing is not None:
                 container_id, state = existing
@@ -1667,6 +1671,7 @@ class DockerEnvironment(BaseEnvironment):
         profile_label = self._labels.get("hermes-profile", "")
         existing = self._find_reusable_container(
             task_label, profile_label, self._labels.get(_EGRESS_LABEL_KEY, "off"),
+            self._labels.get(_PROFILE_SKILLS_LABEL_KEY, "true") == "true",
         )
         if existing is not None:
             cid, state = existing
@@ -1831,6 +1836,7 @@ class DockerEnvironment(BaseEnvironment):
         task_label: str,
         profile_label: str,
         egress_label: str,
+        mount_profile_skills: bool,
     ) -> Optional[tuple[str, str]]:
         """Look for an existing container labeled for this (task, profile).
 
@@ -1842,7 +1848,9 @@ class DockerEnvironment(BaseEnvironment):
 
         Restricted to the docker-stored label set this class creates; never
         matches containers that happened to be named ``hermes-*`` but were
-        started by some other tool.
+        started by some other tool. Containers whose immutable profile-skills
+        mount posture differs are removed before the caller starts fresh;
+        missing legacy labels mean the historical mounted/``true`` posture.
         """
         try:
             filters = [
@@ -1852,7 +1860,11 @@ class DockerEnvironment(BaseEnvironment):
             ]
             if egress_label != "off":
                 filters.extend(["--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}"])
-                fmt = "{{.ID}}\t{{.State}}"
+                fmt = (
+                    '{{.ID}}\t{{.State}}\t{{.Label "'
+                    + _PROFILE_SKILLS_LABEL_KEY
+                    + '"}}'
+                )
             else:
                 # When egress is off, we widen the probe to find any
                 # task+profile container (regardless of egress label), then
@@ -1861,7 +1873,13 @@ class DockerEnvironment(BaseEnvironment):
                 # this, a container created with egress=on can be silently
                 # reused after the operator runs "hermes egress disable",
                 # preserving baked-in proxy env and CA mounts.
-                fmt = '{{.ID}}\t{{.State}}\t{{.Label "' + _EGRESS_LABEL_KEY + '"}}'
+                fmt = (
+                    '{{.ID}}\t{{.State}}\t{{.Label "'
+                    + _EGRESS_LABEL_KEY
+                    + '"}}\t{{.Label "'
+                    + _PROFILE_SKILLS_LABEL_KEY
+                    + '"}}'
+                )
             result = subprocess.run(
                 [
                     self._docker_exe, "ps", "-a",
@@ -1895,12 +1913,13 @@ class DockerEnvironment(BaseEnvironment):
         first = None
         for ln in lines:
             if egress_label == "off":
-                # Format: ID\tState\tEgressLabel — parse all three fields
-                # and reject containers with a non-off egress label.
-                parts = ln.split("\t", 2)
+                # Format: ID\tState\tEgressLabel\tProfileSkillsLabel. Legacy
+                # test doubles and containers may omit the final label.
+                parts = ln.split("\t", 3)
                 if len(parts) < 3:
                     continue
                 cid, state, egress_val = parts[0], parts[1].lower(), parts[2]
+                profile_skills_val = parts[3] if len(parts) == 4 else ""
                 if egress_val not in ("", "<no value>", "off"):
                     logger.debug(
                         "skipping container %s for egress=off reuse: "
@@ -1908,10 +1927,42 @@ class DockerEnvironment(BaseEnvironment):
                     )
                     continue
             else:
-                parts = ln.split("\t", 1)
-                if len(parts) != 2:
+                parts = ln.split("\t", 2)
+                if len(parts) < 2:
                     continue
                 cid, state = parts[0], parts[1].lower()
+                profile_skills_val = parts[2] if len(parts) == 3 else ""
+
+            normalized_skills = profile_skills_val.strip().lower()
+            if normalized_skills in ("", "<no value>", "true"):
+                actual_mount_profile_skills = True
+            elif normalized_skills == "false":
+                actual_mount_profile_skills = False
+            else:
+                actual_mount_profile_skills = None
+            if actual_mount_profile_skills is not mount_profile_skills:
+                logger.warning(
+                    "Existing container %s has %s=%r but the requested profile "
+                    "skills mount posture is %s — removing it and starting fresh.",
+                    cid[:12], _PROFILE_SKILLS_LABEL_KEY,
+                    profile_skills_val or "<missing>",
+                    "true" if mount_profile_skills else "false",
+                )
+                try:
+                    subprocess.run(
+                        [self._docker_exe, "rm", "-f", cid],
+                        capture_output=True,
+                        text=True, encoding="utf-8", errors="replace",
+                        timeout=30,
+                        check=False,
+                        stdin=subprocess.DEVNULL,
+                    )
+                except (subprocess.TimeoutExpired, OSError) as e:
+                    logger.warning(
+                        "Failed to remove profile-skills-mismatched container %s: %s",
+                        cid[:12], e,
+                    )
+                continue
             if first is None:
                 first = (cid, state)
             if state == "running" and running is None:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1533,6 +1533,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "vercel_runtime": config.get("vercel_runtime", ""),
                     "docker_volumes": config.get("docker_volumes", []),
                     "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                    "docker_mount_profile_skills": config.get("docker_mount_profile_skills", True),
                     "docker_forward_env": config.get("docker_forward_env", []),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
                     "docker_network": config.get("docker_network", True),

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1600,6 +1600,9 @@ def _get_env_config() -> Dict[str, Any]:
     env_type = os.getenv("TERMINAL_ENV", "local")
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_profile_skills = os.getenv(
+        "TERMINAL_DOCKER_MOUNT_PROFILE_SKILLS", "true"
+    ).lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
@@ -1679,6 +1682,7 @@ def _get_env_config() -> Dict[str, Any]:
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
+        "docker_mount_profile_skills": mount_profile_skills,
         "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
         "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
         # SSH-specific config
@@ -1765,6 +1769,7 @@ def _container_config_from_config(config: Dict[str, Any]) -> dict:
         "vercel_runtime": config.get("vercel_runtime", ""),
         "docker_volumes": config.get("docker_volumes", []),
         "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+        "docker_mount_profile_skills": config.get("docker_mount_profile_skills", True),
         "docker_forward_env": config.get("docker_forward_env", []),
         "docker_env": config.get("docker_env", {}),
         "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
@@ -1838,6 +1843,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             volumes=volumes,
             host_cwd=host_cwd,
             auto_mount_cwd=cc.get("docker_mount_cwd_to_workspace", False),
+            mount_profile_skills=cc.get("docker_mount_profile_skills", True),
             forward_env=docker_forward_env,
             env=docker_env,
             run_as_host_user=cc.get("docker_run_as_host_user", False),

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -240,6 +240,7 @@ terminal:
   backend: docker
   docker_image: "nikolaik/python-nodejs:python3.11-nodejs20"
   docker_mount_cwd_to_workspace: false  # Mount launch dir into /workspace
+  docker_mount_profile_skills: true     # Set false for containers shared across profiles
   docker_run_as_host_user: false   # See "Running container as host user" below
   docker_forward_env:              # Host env vars to forward into container
     - "GITHUB_TOKEN"
@@ -326,6 +327,7 @@ Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_U
 | `TERMINAL_DOCKER_VOLUMES` | `docker_volumes` | JSON array of `"host:container[:ro]"` strings |
 | `TERMINAL_DOCKER_EXTRA_ARGS` | `docker_extra_args` | JSON array |
 | `TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE` | `docker_mount_cwd_to_workspace` | `true` / `false` |
+| `TERMINAL_DOCKER_MOUNT_PROFILE_SKILLS` | `docker_mount_profile_skills` | `true` / `false` — disable for containers shared across profiles |
 | `TERMINAL_DOCKER_RUN_AS_HOST_USER` | `docker_run_as_host_user` | `true` / `false` |
 | `TERMINAL_DOCKER_NETWORK` | `docker_network` | `true` / `false` — default `true`; `false` = `--network=none` |
 | `TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES` | `docker_persist_across_processes` | `true` / `false` — default `true` |


### PR DESCRIPTION
## What does this PR do?

Operators can now disable the active profile's skills bind mount when several profiles intentionally share one Docker container. This prevents the profile that creates the container from exposing skill-local files and credentials to every later profile, while preserving external and project skill mounts.

### Symptom

A shared Docker container always receives the creating profile's `<HERMES_HOME>/skills` tree at `/root/.hermes/skills`. Profiles that later attach to that container can read the creator's skill scripts and skill-local `.env` files, and a caller cannot suppress the mount without creating a duplicate Docker mount destination.

### Impact

Multi-profile deployments using a shared container can expose one profile's skill-local credentials to other profiles in the same container. Single-profile and default Docker behavior are unchanged.

### Bug Cause

**Trigger:** `tools/credential_files.py:get_skills_directory_mount` and `tools/environments/docker.py:DockerEnvironment.__init__` when a Docker container is shared across profiles.

**Causal chain:**
1. The first profile creates the shared container.
2. `get_skills_directory_mount()` unconditionally returns that profile's local skills directory, and Docker permanently binds it into the new container.
3. Later profiles reuse the container and can read the first profile's skill-local files.

**Why it is wrong:** the mount policy was fixed inside the helper and had no caller-controlled opt-out, so container sharing implicitly selected a credential owner based on creation order.

**Working sibling / contrast:** external and project skill directories are shared checkouts with separate container namespaces, so they can remain available when the profile-local tree is omitted.

**Ruled out:** overlaying the destination with a user volume is not a safe workaround because duplicate Docker mount destinations fail container creation.

### Fix

- Add a keyword-only `include_profile_skills` policy to the skills mount helper, defaulting to the existing behavior.
- Add `terminal.docker_mount_profile_skills`, defaulting to `true`, and bridge it consistently through CLI, gateway, terminal, file-tool, and backend-probe paths.
- Pass the resolved policy into Docker container creation while leaving Singularity and other backends unchanged.
- Document the config option and its internal environment-variable mirror.

## Related Issue

Closes #92329

## Type of Change

- [x] Security fix

## Changes Made

- `tools/credential_files.py` - selectively omit only the profile-local skills mount.
- `tools/environments/docker.py` and `tools/terminal_tool.py` - carry the policy into Docker creation.
- `hermes_cli/config_defaults.py`, `hermes_cli/config.py`, `cli.py`, `gateway/run.py`, `tools/file_tools.py`, and `agent/prompt_builder.py` - propagate the config across all terminal entry paths.
- `tests/` - cover helper selection, config bridging, environment creation, and file-tool propagation.
- `website/docs/user-guide/configuration.md` and `cli-config.yaml.example` - document the opt-out.

## How to Test

1. Set `terminal.backend: docker` and `terminal.docker_mount_profile_skills: false`.
2. Start a fresh shared Docker container and verify `/root/.hermes/skills` is not bind-mounted.
3. Configure external and project skill directories and verify their separate mounts remain present.
4. Automated verification already run locally:

```bash
scripts/run_tests.sh tests/tools/test_credential_files.py tests/tools/test_docker_environment.py tests/tools/test_modal_sandbox_fixes.py tests/tools/test_file_tools_container_config.py tests/tools/test_terminal_config_env_sync.py tests/hermes_cli/test_env_loader.py -q -k 'not test_returns_files_skipping_symlinks and not test_wrapped_exec_scopes_explicit_forward_env_across_profiles and not test_users_path_maps_to_workspace_for_docker_when_enabled and not test_docker_default_cwd_maps_current_directory_when_enabled'
```

Result: 165 passed. The four excluded tests are existing native-Windows path/shell failures unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example`
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are not applicable
- [x] I've considered cross-platform impact
- [x] Tool description and schema updates are not applicable
