### PR TITLE
fix(kanban): respawn guard must not treat branch slugs as auth blockers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7983,11 +7983,17 @@ KANBAN_TERMINAL_TIMEOUT_GRACE_SECONDS = 30
 
 # Patterns in last_failure_error that indicate a quota / auth blocker.
 # These errors won't resolve by retrying immediately — auto-block instead.
+#
+# Boundaries deliberately reject ``-``, ``/`` and ``.`` neighbours instead of
+# plain ``\b``: error text often embeds git branch names / paths / URLs
+# (e.g. "git worktree add failed ... on branch dev/3627-auth-login-..."),
+# and a bare \b would match the "auth" inside such slugs — parking the task
+# as a phantom auth blocker forever even though nothing auth-related failed.
 _RESPAWN_BLOCKER_RE = re.compile(
-    r"\b(quota|rate[\s_\-]?limit|429|403|auth\w*|"
+    r"(?<![\w\-/.])(quota|rate[\s_\-]?limit|429|403|auth\w*|"
     r"unauthorized|forbidden|billing|subscription|"
     r"access[\s_]denied|permission[\s_]denied|"
-    r"invalid[\s_]api[\s_]key)\b",
+    r"invalid[\s_]api[\s_]key)(?![\w\-/])",
     re.IGNORECASE,
 )
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -367,6 +367,53 @@ def test_respawn_guard_defers_rate_limited_within_cooldown(
         assert kb.check_respawn_guard(conn, tid) is None
 
 
+def test_respawn_guard_branch_slug_containing_auth_is_not_auth_blocker(
+    kanban_home,
+):
+    """A workspace/git error that merely embeds a branch name containing
+    ``auth`` must not classify as ``blocker_auth`` — that parks the task
+    forever (respawn guard defers every tick) even though nothing
+    auth-related failed."""
+    err = (
+        "workspace: git worktree add failed for /mnt/d/wt/main/t_x on branch "
+        "dev/3627-auth-auth-login-and-auth-change-password-share: "
+        "Preparing worktree (checking out "
+        "'dev/3627-auth-auth-login-and-auth-change-password-share')\n"
+        "fatal: 'dev/3627-auth-auth-login-and-auth-change-password-share' is "
+        "already used by worktree at '/mnt/d/wt/main/t_y'"
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="wt-conflict", assignee="a")
+        conn.execute(
+            "UPDATE tasks SET status='ready', last_failure_error=? WHERE id=?",
+            (err, tid),
+        )
+        conn.commit()
+        assert kb.check_respawn_guard(conn, tid) is None
+
+
+def test_respawn_guard_still_flags_real_auth_and_quota_errors(kanban_home):
+    """Genuine quota/auth failures — standalone words in prose — still defer
+    as ``blocker_auth``."""
+    cases = [
+        "provider returned 403 Forbidden: invalid api key",
+        "worker exited: authentication required (HTTP 401 Unauthorized)",
+        "EX_TEMPFAIL quota exceeded for tenant; retry later",
+        "rate limit hit on provider — back off",
+        "billing subscription expired for model access",
+    ]
+    with kb.connect() as conn:
+        for i, err in enumerate(cases):
+            tid = kb.create_task(conn, title=f"real-auth-{i}", assignee="a")
+            conn.execute(
+                "UPDATE tasks SET status='ready', last_failure_error=? "
+                "WHERE id=?",
+                (err, tid),
+            )
+            conn.commit()
+            assert kb.check_respawn_guard(conn, tid) == "blocker_auth", err
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

`check_respawn_guard()` classifies a task as `"blocker_auth"` (deferred every tick until human intervention) when `last_failure_error` matches `_RESPAWN_BLOCKER_RE`. The regex used plain `\b` word boundaries, so any error text that merely *embeds* a git branch name, path, or URL containing an auth-ish word triggers a false positive that parks the task forever.

Real-world incident from our board: a task whose branch was named `dev/3627-auth-auth-login-and-auth-change-password-share` failed with

```
workspace: git worktree add failed for ... on branch dev/3627-auth-auth-login-and-auth-change-password-share:
fatal: 'dev/3627-...' is already used by worktree at '...'
```

`\bauth\w*\b` matched the literal "auth" inside the branch slug, so the dispatcher stamped `respawn_guarded {"reason": "blocker_auth"}` (~70/day observed) and never re-spawned the task — even after the underlying worktree conflict was resolved.

This PR replaces the plain `\b` boundaries with slug-aware ones — tokens must not be glued to `-`, `/`, `.`:

```python
r"(?<![\w\-/.])(quota|rate[\s_\-]?limit|429|403|auth\w*|...)(?![\w\-/])"
```

Standalone prose still matches ("HTTP 401 Unauthorized", "invalid api key", "quota exceeded", "permission denied"), while identifiers like `dev/3627-auth-login`, `/mnt/x/dev-4628-accounting-generated-at`, or counts like `1429 rows` do not (`oauth` remains non-matching as before).

## Related Issue

No existing issue — observed and root-caused on a production board (happy to file one if preferred).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`: `_RESPAWN_BLOCKER_RE` boundaries changed from `\b...\b` to `(?<![\w\-/.])...(?![\w\-/])`; comment added documenting why.
- `tests/hermes_cli/test_kanban_db.py`: two regression tests (see below).

## How to Test

1. `pytest tests/hermes_cli/test_kanban_db.py -k respawn_guard -q`
2. `test_respawn_guard_branch_slug_containing_auth_is_not_auth_blocker`: seeds the exact incident error (worktree conflict whose branch name contains `auth`) and asserts the guard returns `None`, not `"blocker_auth"`.
3. `test_respawn_guard_still_flags_real_auth_and_quota_errors`: five genuine quota/auth error strings (403 + invalid key, 401 Unauthorized, quota exceeded, rate limit, billing) still return `"blocker_auth"`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(the targeted respawn-guard tests pass; note pytest is not installed in my deployment venv, so I verified with an equivalent standalone harness exercising the same assertions)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu 22.04 (HermesUbuntu distro), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring/comment updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure regex change, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
