### PR TITLE
fix(kanban): infra spawn failures must not consume task retry budget

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -471,6 +471,25 @@ def _resolve_rate_limit_cooldown_seconds() -> int:
     return DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
 
 
+def _resolve_infra_cooldown_seconds() -> int:
+    """Return the infra spawn-failure cooldown in seconds.
+
+    Mirrors ``_resolve_rate_limit_cooldown_seconds``: reads
+    ``HERMES_KANBAN_INFRA_COOLDOWN_SECONDS`` from the environment; falls back
+    to ``DEFAULT_INFRA_COOLDOWN_SECONDS`` when absent, empty, non-integer, or
+    negative. A value of 0 disables the cooldown (re-spawn on the next tick).
+    """
+    raw = os.environ.get("HERMES_KANBAN_INFRA_COOLDOWN_SECONDS", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = -1
+        if parsed >= 0:
+            return parsed
+    return DEFAULT_INFRA_COOLDOWN_SECONDS
+
+
 # Worker-context caps so build_worker_context() stays bounded on
 # pathological boards (retry-heavy tasks, comment storms, giant
 # summaries). Values chosen to fit a typical 100k-char LLM prompt with
@@ -7994,6 +8013,28 @@ _RESPAWN_BLOCKER_RE = re.compile(
 # Within this window a completed run counts as "recent proof"; don't re-spawn.
 _RESPAWN_GUARD_SUCCESS_WINDOW = 3600  # 1 hour
 
+# Patterns that identify a spawn failure as an *infrastructure / environment*
+# problem rather than a task defect: workspace resolution errors (bad repo,
+# worktree branch collisions, missing mounts), disk exhaustion, etc. These
+# affect every task equally and resolve on their own (or need operator
+# action), so they must not consume the per-task retry budget — otherwise one
+# bad environment trips every queued task's circuit breaker into ``blocked``
+# at once.
+_SPAWN_INFRA_RE = re.compile(
+    r"^\s*workspace:\s"
+    r"|\bis not inside a git repo\b"
+    r"|\balready used by worktree\b"
+    r"|\bNo space left on device\b",
+    re.IGNORECASE,
+)
+
+# Cooldown after an infra-classified spawn failure before the dispatcher
+# probes the task again. Mirrors the rate-limit cooldown: without it, a task
+# whose spawn keeps failing on a broken workspace would be re-claimed every
+# tick, burning a worker slot and spamming spawn_failed events. Overridable
+# via ``HERMES_KANBAN_INFRA_COOLDOWN_SECONDS``; 0 disables the cooldown.
+DEFAULT_INFRA_COOLDOWN_SECONDS = 300  # 5 minutes
+
 # Cooldown after a rate-limited (quota-wall) requeue before the dispatcher
 # re-spawns the worker. Without this, a task released by the rate-limit path
 # would be re-spawned on the very next tick and immediately bounce off the
@@ -9203,6 +9244,15 @@ def _record_task_failure(
     ``detect_crashed_workers``, which resolves the per-task
     ``max_retries`` override against the violation streak itself. The
     failure is still counted into ``consecutive_failures``.
+
+    Infra-classified spawn failures: when ``outcome == "spawn_failed"`` and
+    the error matches ``_SPAWN_INFRA_RE`` (workspace resolution failures,
+    worktree branch collisions, disk exhaustion), the failure is an
+    *environment* problem rather than a task defect. It is recorded (event +
+    ``last_failure_error``) but does NOT increment ``consecutive_failures``
+    and can never trip the breaker — one broken environment must not park
+    every queued task in ``blocked``. Back-off is handled by the respawn
+    guard's ``infra_cooldown`` reason instead.
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
@@ -9219,7 +9269,19 @@ def _record_task_failure(
             if release_claim
             else ("review" if row["status"] == "review" else "ready")
         )
-        failures = int(row["consecutive_failures"]) + 1
+        # Infra-classified spawn failures (broken workspace, disk full, …)
+        # are environment problems, not task defects: they hit every task
+        # equally and consume no per-task retry budget. The respawn guard
+        # applies its own cooldown (``infra_cooldown``) so the dispatcher
+        # backs off without ever parking the task in ``blocked``.
+        infra_only = (
+            outcome == "spawn_failed"
+            and not force_trip
+            and bool(_SPAWN_INFRA_RE.search(error or ""))
+        )
+        failures = int(row["consecutive_failures"]) + (
+            0 if infra_only else 1
+        )
 
         # Per-task override wins over both caller-supplied and default
         # thresholds. None (the common case) falls through.
@@ -9233,7 +9295,7 @@ def _record_task_failure(
             effective_limit = int(failure_limit)
             limit_source = "dispatcher"
 
-        if force_trip or failures >= effective_limit:
+        if not infra_only and (force_trip or failures >= effective_limit):
             # Trip the breaker.
             if release_claim:
                 # Spawn path: still running, also clear claim state.
@@ -9303,22 +9365,30 @@ def _record_task_failure(
                 )
             if end_run:
                 # Spawn path: close the open run with outcome.
+                _spawn_payload = {
+                    "error": error[:500],
+                    "failures": failures,
+                    "retry_status": retry_status,
+                }
+                _spawn_run_meta = {
+                    "failures": failures,
+                    "retry_status": retry_status,
+                }
+                if infra_only:
+                    # Mark environment-classified failures so board tooling
+                    # can distinguish them from task defects.
+                    _spawn_payload["infra"] = True
+                    _spawn_run_meta["infra"] = True
+                # Spawn path: close the open run with outcome.
                 run_id = _end_run(
                     conn, task_id,
                     outcome=outcome, status=outcome,
                     error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    metadata=_spawn_run_meta,
                 )
                 _append_event(
                     conn, task_id, outcome,
-                    {
-                        "error": error[:500],
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    _spawn_payload,
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.
@@ -9400,8 +9470,9 @@ def check_respawn_guard(
     ``recent_success`` and ``active_pr`` rules are skipped: a recent PR
     URL comment (and often a recent completed run) is the *precondition*
     of the canonical review handoff — a worker opened a PR and requested
-    review — not a duplicate-work signal. Rate-limit cooldown and the
-    auth-blocker check still apply in every lane.
+    review — not a duplicate-work signal. Rate-limit cooldown, the
+    infra spawn-failure cooldown and the auth-blocker check still apply in
+    every lane.
 
     Checks in priority order:
 
@@ -9416,6 +9487,18 @@ def check_respawn_guard(
         auth-blocker regex and park the task forever (the rate-limit path
         never increments ``consecutive_failures``, so the breaker can't free
         it). Once the cooldown elapses the task falls through and respawns.
+
+    ``"infra_cooldown"``
+        The task's most recent run ended with the ``spawn_failed`` outcome
+        and the error matches ``_SPAWN_INFRA_RE`` (workspace resolution
+        failure, worktree branch collision, disk exhaustion). These are
+        environment problems, not task defects: they consume no retry
+        budget and can never trip the breaker, so instead of hammering the
+        same broken workspace every tick we defer on a cooldown (mirrors
+        the rate-limit cooldown; ``HERMES_KANBAN_INFRA_COOLDOWN_SECONDS``,
+        default 300s) and then allow a cheap probe. Checked BEFORE
+        ``blocker_auth`` because workspace errors often embed branch names /
+        paths whose text can accidentally match auth-ish patterns.
 
     ``"blocker_auth"``
         The task's last failure error matches a quota / authentication
@@ -9489,8 +9572,32 @@ def check_respawn_guard(
         # crash/completion supersedes it.
         return None
 
-    # 2. Quota / auth blocker: retrying immediately will not help.
+    # 2. Infra spawn-failure cooldown. The most recent ended run was an
+    #    infra-classified ``spawn_failed`` (bad workspace, worktree
+    #    collision, disk full) — defer on a cooldown, then allow a cheap
+    #    probe. Must run BEFORE the blocker_auth regex check: workspace
+    #    errors embed branch names / paths that can accidentally match
+    #    auth-ish patterns (e.g. a branch literally named
+    #    ``dev/3627-auth-login-...``) and would otherwise park the task as a
+    #    phantom auth blocker forever — infra failures never increment the
+    #    counter, so the breaker can't free it.
     err = row["last_failure_error"]
+    if (
+        latest_run is not None
+        and latest_run["outcome"] == "spawn_failed"
+        and err
+        and _SPAWN_INFRA_RE.search(err)
+    ):
+        if _resolve_infra_cooldown_seconds() <= 0:
+            return None
+        ended_at = latest_run["ended_at"]
+        if ended_at is None or (now - int(ended_at)) < _resolve_infra_cooldown_seconds():
+            return "infra_cooldown"
+        # Cooldown elapsed — allow the respawn, skipping the blocker_auth
+        # regex for the same reason as the rate-limit path above.
+        return None
+
+    # 3. Quota / auth blocker: retrying immediately will not help.
     if err and _RESPAWN_BLOCKER_RE.search(err):
         return "blocker_auth"
 
@@ -9500,7 +9607,7 @@ def check_respawn_guard(
     if lane == "review":
         return None
 
-    # 3. Completed run within guard window — proof of recent success.
+    # 4. Completed run within guard window — proof of recent success.
     #    Exception: an explicit re-queue AFTER that success (an operator
     #    dragging done→ready, a dependency re-promotion, an unblock, a
     #    reclaim) is a deliberate "run it again" — honor it instead of

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -367,6 +367,133 @@ def test_respawn_guard_defers_rate_limited_within_cooldown(
         assert kb.check_respawn_guard(conn, tid) is None
 
 
+def test_infra_spawn_failures_never_trip_breaker(kanban_home):
+    """Workspace/environment spawn failures are infra problems: they must
+    not increment ``consecutive_failures`` nor trip the auto-block breaker,
+    no matter how many times they repeat — otherwise one broken environment
+    parks every queued task in ``blocked`` at once."""
+    err = (
+        "workspace: git worktree add failed for /mnt/wt/main/t_x on branch "
+        "dev/3627-auth-login-and-change-password-share: fatal: already used "
+        "by worktree at '/mnt/wt/main/t_y'"
+    )
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="infra-spawn", assignee="a")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        conn.commit()
+        for _ in range(kb.DEFAULT_FAILURE_LIMIT * 3):
+            blocked = kb._record_task_failure(
+                conn, tid, error=err,
+                outcome="spawn_failed",
+                failure_limit=kb.DEFAULT_FAILURE_LIMIT,
+                release_claim=False, end_run=False,
+            )
+            assert not blocked
+            row = conn.execute(
+                "SELECT status, consecutive_failures FROM tasks WHERE id=?",
+                (tid,),
+            ).fetchone()
+            assert row["status"] == "ready"
+            assert row["consecutive_failures"] == 0
+
+
+def test_non_infra_spawn_failures_still_trip_breaker(kanban_home):
+    """Regular spawn failures keep the old behaviour — counter increments
+    and the breaker trips at ``failure_limit``."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="plain-spawn", assignee="a")
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        conn.commit()
+        blocked = False
+        for _ in range(4):
+            blocked = kb._record_task_failure(
+                conn, tid, error="worker exited before ready (exit 1)",
+                outcome="spawn_failed",
+                failure_limit=kb.DEFAULT_FAILURE_LIMIT,
+                release_claim=False, end_run=False,
+            )
+        assert blocked
+        row = conn.execute(
+            "SELECT status, consecutive_failures FROM tasks WHERE id=?",
+            (tid,),
+        ).fetchone()
+        assert row["status"] == "blocked"
+        # Counter freezes at the trip value: once 'blocked', further
+        # failure-record updates no-op on the status guard.
+        assert row["consecutive_failures"] == kb.DEFAULT_FAILURE_LIMIT
+
+
+def test_respawn_guard_defers_infra_spawn_failure_within_cooldown(
+    kanban_home, monkeypatch,
+):
+    """After an infra-classified spawn failure the guard defers on its own
+    cooldown, then allows a probe — and does NOT fall into ``blocker_auth``
+    even though the workspace error embeds branch slugs containing
+    ``auth``."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_KANBAN_INFRA_COOLDOWN_SECONDS", "300")
+    now = 6_000_000
+    err = (
+        "workspace: git worktree add failed for /mnt/wt/main/t_x on branch "
+        "dev/3627-auth-auth-login-and-auth-change-password-share: fatal: "
+        "already used by worktree at '/mnt/wt/main/t_y'"
+    )
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="infra-guard", assignee="a")
+        # Seed a spawn_failed run that just ended + the stamped error.
+        kb.claim_task(conn, tid)
+        run_id = kb.get_task(conn, tid).current_run_id
+        conn.execute(
+            "UPDATE task_runs SET outcome='spawn_failed', "
+            "status='spawn_failed', ended_at=? WHERE id=?",
+            (now, run_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET status='ready', current_run_id=NULL, "
+            "claim_lock=NULL, claim_expires=NULL, worker_pid=NULL, "
+            "last_failure_error=? WHERE id=?",
+            (err, tid),
+        )
+        conn.commit()
+
+        # Inside cooldown → defer with the infra-specific reason.
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 100)
+        assert kb.check_respawn_guard(conn, tid) == "infra_cooldown"
+
+        # Past cooldown → allowed (None), NOT trapped by blocker_auth.
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 400)
+        assert kb.check_respawn_guard(conn, tid) is None
+
+        # Cooldown disabled via env → respawn immediately.
+        monkeypatch.setenv("HERMES_KANBAN_INFRA_COOLDOWN_SECONDS", "0")
+        monkeypatch.setattr(_kb.time, "time", lambda: now + 100)
+        assert kb.check_respawn_guard(conn, tid) is None
+
+
+def test_respawn_guard_real_spawn_failure_not_deferred_as_infra(kanban_home):
+    """A genuine (non-infra) spawn failure must still hit the normal paths —
+    here the auth blocker — rather than the infra cooldown."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="real-failure", assignee="a")
+        kb.claim_task(conn, tid)
+        run_id = kb.get_task(conn, tid).current_run_id
+        conn.execute(
+            "UPDATE task_runs SET outcome='spawn_failed', "
+            "status='spawn_failed', ended_at=? WHERE id=?",
+            (5_900_000, run_id),
+        )
+        conn.execute(
+            "UPDATE tasks SET status='ready', current_run_id=NULL, "
+            "claim_lock=NULL, claim_expires=NULL, worker_pid=NULL, "
+            "last_failure_error=? WHERE id=?",
+            ("provider returned 403 Forbidden: invalid api key", tid),
+        )
+        conn.commit()
+        assert kb.check_respawn_guard(conn, tid) == "blocker_auth"
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

When the dispatcher fails to spawn a worker because of an *environment* problem — bad workspace path, `git worktree add` branch collision, repo not mounted, disk full — the failure is recorded through `_record_task_failure(outcome="spawn_failed")`, which increments the task's `consecutive_failures`. After `failure_limit` consecutive failures the circuit breaker parks the task in `blocked`.

On a real board this caused mass breakers: one broken environment (a workspace that stopped being recognized as a git repo) made *queued* tasks fail 4× each without ever being worked, flipping hundreds of tasks straight from `ready` to `blocked`. The gateway logged `kanban dispatcher stuck: ready queue non-empty ... but 0 workers spawned` for hours. Environment errors are not task defects — the per-task retry budget is the wrong tool for them.

This PR:

1. **Classifies infra spawn failures** — new `_SPAWN_INFRA_RE` matches workspace-resolution errors, worktree branch collisions, and disk exhaustion. In `_record_task_failure`, when `outcome == "spawn_failed"` matches, the failure is still recorded (`spawn_failed` event + `last_failure_error`, now tagged `"infra": true`) but does **not** increment `consecutive_failures` and can never trip the breaker. `force_trip` paths (protocol violations, systemic crashes) are unaffected.

2. **Adds back-off without parking** — new respawn-guard reason `"infra_cooldown"`, checked before `blocker_auth` and mirroring the existing `rate_limit_cooldown` pattern: defers re-spawn for a cooldown (default 300s, overridable via `HERMES_KANBAN_INFRA_COOLDOWN_SECONDS`, 0 disables), then allows a cheap probe. It runs before `blocker_auth` because workspace errors embed branch names/paths that can accidentally match auth-ish patterns.

Result: a broken environment now costs a slow, observable retry loop instead of permanently blocking every affected task; the board self-heals once the environment is fixed.

## Related Issue

No existing issue — observed and root-caused on a production board (happy to file one if preferred).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`:
  - new `_SPAWN_INFRA_RE` + `DEFAULT_INFRA_COOLDOWN_SECONDS` constants and `_resolve_infra_cooldown_seconds()` resolver
  - `_record_task_failure`: infra-classified spawn failures record without incrementing the counter or tripping the breaker; event/run metadata tagged `"infra": true`; docstring updated
  - `check_respawn_guard`: new `"infra_cooldown"` reason (documented in the docstring's priority order), checked before `blocker_auth`
- `tests/hermes_cli/test_kanban_db.py`: four regression tests (see below)

## How to Test

1. `pytest tests/hermes_cli/test_kanban_db.py -k "respawn_guard or spawn_failures" -q`
2. `test_infra_spawn_failures_never_trip_breaker`: repeated workspace-error spawn failures leave status `ready`, counter `0`.
3. `test_non_infra_spawn_failures_still_trip_breaker`: regular spawn failures keep incrementing and trip at `failure_limit`.
4. `test_respawn_guard_defers_infra_spawn_failure_within_cooldown`: inside cooldown → `"infra_cooldown"`; past cooldown → `None` (not trapped by `blocker_auth` despite auth-flavored branch slugs); `HERMES_KANBAN_INFRA_COOLDOWN_SECONDS=0` respawns immediately.
5. `test_respawn_guard_real_spawn_failure_not_deferred_as_infra`: genuine non-infra spawn failure text still routes to `"blocker_auth"`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass *(the targeted respawn-guard/spawn-failure tests pass; note pytest is not installed in my deployment venv, so I verified with an equivalent standalone harness exercising the same assertions)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 Ubuntu 22.04 (HermesUbuntu distro), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env-var only, documented in code)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — regex + SQLite logic, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
