### PR TITLE
fix(kanban): route implicit reviews away from implementers

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2615,6 +2615,11 @@ DEFAULT_CONFIG = {
         # the assigned profile with the bundled sdlc-review skill. Disable for
         # boards where every review is performed manually from the dashboard.
         "review_dispatch": True,
+        # Reviewer used when kanban_request_review omits reviewer=. It must name
+        # an installed profile other than the implementer; when unset or
+        # unavailable Hermes deterministically chooses any installed alternative.
+        # Single-profile installations fall back to self-review.
+        "default_reviewer": "",
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2686,6 +2686,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
+            "skipped_review_self_capped": [
+                {"task_id": tid, "assignee": who, "current": current}
+                for (tid, who, current) in res.skipped_review_self_capped
+            ],
             "auto_assigned_default": res.auto_assigned_default,
         }, indent=2))
         return 0
@@ -2718,6 +2722,12 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         for tid, who, current in res.skipped_per_profile_capped:
             print(
                 f"Deferred ({who} at per-profile cap, {current} running): {tid}"
+            )
+    if res.skipped_review_self_capped:
+        for tid, who, current in res.skipped_review_self_capped:
+            print(
+                f"Review stalled (self-reviewer {who} at per-profile cap, "
+                f"{current} running; configure kanban.default_reviewer): {tid}"
             )
     if res.skipped_nonspawnable:
         print(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -342,6 +342,7 @@ def _fire_dispatch_tick_hook(
             result.auto_assigned_default,
             result.respawn_guarded,
             result.skipped_per_profile_capped,
+            result.skipped_review_self_capped,
             result.skipped_unassigned,
             result.skipped_nonspawnable,
         )):
@@ -6487,6 +6488,33 @@ def redact_review_value(value: Any) -> Any:
     return value
 
 
+def _resolve_implicit_reviewer(implementer: Optional[str]) -> Optional[str]:
+    """Choose a real reviewer profile distinct from the implementer.
+
+    ``kanban.default_reviewer`` wins when it names an installed profile other
+    than the implementer. Otherwise use the first installed alternative.
+    Single-profile installations deliberately fall back to self-review; the
+    dispatcher reports that capped edge case in a dedicated diagnostic bucket.
+    """
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.profiles import list_profile_names, profile_exists
+
+        kanban_cfg = (load_config().get("kanban") or {})
+        configured = (kanban_cfg.get("default_reviewer") or "").strip()
+        if configured:
+            configured = _canonical_assignee(configured)
+            if configured != implementer and profile_exists(configured):
+                return configured
+        for candidate in list_profile_names():
+            candidate = _canonical_assignee(candidate)
+            if candidate != implementer and profile_exists(candidate):
+                return candidate
+    except Exception as exc:
+        _log.debug("kanban review: implicit reviewer resolution failed: %s", exc)
+    return implementer
+
+
 def request_review(
     conn: sqlite3.Connection,
     task_id: str,
@@ -6585,6 +6613,8 @@ def request_review(
                         "malformed); pass reviewer= explicitly",
                     )
                 reviewer = prior_reviewer
+        if reviewer is None and trow["status"] == "running":
+            reviewer = _resolve_implicit_reviewer(implementer)
         reviewer = _canonical_assignee(reviewer) if reviewer is not None else None
         assignee_sql = ", assignee = ?" if reviewer is not None else ""
         params: tuple[Any, ...]
@@ -8049,6 +8079,11 @@ class DispatchResult:
     subsequent tick when the assignee has capacity. Separate bucket so
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
+    skipped_review_self_capped: list[tuple[str, str, int]] = field(default_factory=list)
+    """Review tasks deferred because their reviewer is also the implementer
+    and that profile is already at its concurrency cap. Unlike ordinary cap
+    deferrals this can starve indefinitely on a single-profile installation,
+    so it is surfaced as a distinct operator-actionable diagnostic."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -10332,9 +10367,26 @@ def _dispatch_once_locked(
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row["assignee"], 0)
             if current >= _per_profile_cap:
-                result.skipped_per_profile_capped.append(
-                    (row["id"], row["assignee"], current)
+                review_event = conn.execute(
+                    "SELECT payload FROM task_events "
+                    "WHERE task_id = ? AND kind = 'review_requested' "
+                    "ORDER BY id DESC LIMIT 1",
+                    (row["id"],),
+                ).fetchone()
+                try:
+                    review_payload = (
+                        json.loads(review_event["payload"])
+                        if review_event and review_event["payload"]
+                        else {}
+                    )
+                except (json.JSONDecodeError, TypeError):
+                    review_payload = {}
+                bucket = (
+                    result.skipped_review_self_capped
+                    if review_payload.get("implementer") == row["assignee"]
+                    else result.skipped_per_profile_capped
                 )
+                bucket.append((row["id"], row["assignee"], current))
                 continue
         guard_reason = check_respawn_guard(conn, row["id"], lane="review")
         if guard_reason is not None:

--- a/tests/hermes_cli/test_kanban_review_reviewer_routing.py
+++ b/tests/hermes_cli/test_kanban_review_reviewer_routing.py
@@ -1,0 +1,152 @@
+"""Regression coverage for review routing under per-profile caps."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _add_profile(home: Path, name: str) -> None:
+    (home / "profiles" / name).mkdir(parents=True)
+
+
+def test_implicit_reviewer_avoids_busy_implementer_and_dispatches(
+    kanban_home: Path,
+) -> None:
+    """A review without reviewer= must not remain behind its implementer's cap."""
+    _add_profile(kanban_home, "builder")
+    spawned: list[tuple[str, str]] = []
+
+    def spawn(task, _workspace):
+        spawned.append((task.id, task.assignee or ""))
+        return 12345
+
+    with kb.connect() as conn:
+        busy_id = kb.create_task(conn, title="long implementation", assignee="builder")
+        assert kb.claim_task(conn, busy_id) is not None
+
+        review_id = kb.create_task(conn, title="finished implementation", assignee="builder")
+        implementation = kb.claim_task(conn, review_id)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            review_id,
+            summary="ready",
+            expected_run_id=implementation.current_run_id,
+        )
+
+        review = kb.get_task(conn, review_id)
+        assert review is not None
+        assert review.assignee == "default"
+
+        first = kb.dispatch_once(
+            conn,
+            spawn_fn=spawn,
+            max_in_progress=2,
+            max_in_progress_per_profile=1,
+        )
+        assert first.spawned == [(review_id, "default", first.spawned[0][2])]
+        assert not first.skipped_per_profile_capped
+        assert spawned == [(review_id, "default")]
+
+
+def test_explicit_reviewer_is_honored_verbatim(kanban_home: Path) -> None:
+    _add_profile(kanban_home, "builder")
+    _add_profile(kanban_home, "verifier")
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="explicit handoff", assignee="builder")
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            reviewer="Verifier",
+            expected_run_id=implementation.current_run_id,
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.assignee == "verifier"
+
+
+def test_configured_default_reviewer_wins_over_other_profiles(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _add_profile(kanban_home, "builder")
+    _add_profile(kanban_home, "auditor")
+    _add_profile(kanban_home, "verifier")
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"kanban": {"default_reviewer": "Verifier"}},
+    )
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="configured handoff", assignee="builder")
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            task_id,
+            expected_run_id=implementation.current_run_id,
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.assignee == "verifier"
+
+
+def test_ready_lane_still_enforces_per_profile_cap(kanban_home: Path) -> None:
+    _add_profile(kanban_home, "builder")
+
+    with kb.connect() as conn:
+        running_id = kb.create_task(conn, title="running", assignee="builder")
+        assert kb.claim_task(conn, running_id) is not None
+        ready_id = kb.create_task(conn, title="queued", assignee="builder")
+
+        result = kb.dispatch_once(
+            conn,
+            dry_run=True,
+            max_in_progress=2,
+            max_in_progress_per_profile=1,
+        )
+
+        assert ready_id not in [task_id for task_id, _who, _ws in result.spawned]
+        assert result.skipped_per_profile_capped == [(ready_id, "builder", 1)]
+
+
+def test_single_profile_self_review_has_distinct_cap_diagnostic(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        busy_id = kb.create_task(conn, title="running", assignee="default")
+        assert kb.claim_task(conn, busy_id) is not None
+        review_id = kb.create_task(conn, title="review", assignee="default")
+        implementation = kb.claim_task(conn, review_id)
+        assert implementation is not None
+        assert kb.request_review(
+            conn,
+            review_id,
+            expected_run_id=implementation.current_run_id,
+        )
+
+        result = kb.dispatch_once(
+            conn,
+            dry_run=True,
+            max_in_progress=2,
+            max_in_progress_per_profile=1,
+        )
+
+        assert result.skipped_review_self_capped == [(review_id, "default", 1)]
+        assert not result.skipped_per_profile_capped

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -229,6 +229,9 @@ kanban:
   review_dispatch: true            # default: spawn the assigned profile with
                                    # the bundled sdlc-review skill. Set false
                                    # for human-only review boards.
+  default_reviewer: verifier       # optional: reviewer used when a worker omits
+                                   # reviewer=. Otherwise Hermes chooses any
+                                   # installed profile except the implementer.
 ```
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`


### PR DESCRIPTION
## What

- Route worker-requested reviews with no explicit `reviewer=` to `kanban.default_reviewer`, or deterministically to another installed profile.
- Keep explicit reviewer assignments and re-review provenance unchanged.
- Surface the single-profile fallback as `skipped_review_self_capped` instead of a generic capped skip.
- Document `kanban.default_reviewer`.

## Why

A review left assigned to its implementer can remain unclaimable forever when that profile is already at `kanban.max_in_progress_per_profile`. The global review-slot reservation cannot overcome that profile cap.

Chosen mechanism: assign implicit worker reviews to an independent profile. This preserves the concurrency gate and matches independent-review semantics.

Rejected alternative: exempt review dispatch from the per-profile cap. That would let a profile run at cap+1 and weaken the gate to make this case pass.

## Regression proof

Real SQLite board and real `dispatch_once()` path:

- Before on `origin/main`: `test_implicit_reviewer_avoids_busy_implementer_and_dispatches` fails because the review remains assigned to `builder` (`assert 'builder' == 'default'`).
- After: the implicit review is assigned to `default` and dispatched while `builder` remains capped.

Also covered:

- `test_ready_lane_still_enforces_per_profile_cap`
- `test_explicit_reviewer_is_honored_verbatim`
- `test_configured_default_reviewer_wins_over_other_profiles`
- `test_single_profile_self_review_has_distinct_cap_diagnostic`

## Verification

- `python -m pytest tests/hermes_cli/test_kanban_review_reviewer_routing.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py -q` -> 50 passed
- `python -m ruff check hermes_cli/config_defaults.py hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_review_reviewer_routing.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
