### PR TITLE
feat: add secure browser human handoff

### DIFF
--- a/agent/browser_provider.py
+++ b/agent/browser_provider.py
@@ -97,6 +97,7 @@ class BrowserProvider(abc.ABC):
                 "session_name": str,    # unique name for agent-browser --session
                 "bb_session_id": str,   # provider session ID (for close/cleanup)
                 "cdp_url": str,         # CDP websocket URL
+                "live_url": str,        # optional human-control URL
                 "expires_at": str,      # optional provider-authoritative ISO timestamp
                 "features": dict,       # feature flags that were enabled
             }

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3221,13 +3221,26 @@ def cleanup_task_resources(agent, task_id: str) -> None:
         if agent.verbose_logging:
             logger.warning("Failed to cleanup VM for task %s: %s", task_id, e)
     try:
+        preserve_handoff_browser = bool(
+            getattr(agent, "_preserve_browser_after_turn", False)
+        )
+        # One turn only. Explicit AIAgent.close()/session cleanup still owns a
+        # hard teardown, while the browser inactivity reaper independently
+        # keeps only browsers with a live pending handoff.
+        agent._preserve_browser_after_turn = False
         headed = False
         try:
             from tools.browser_tool import _is_headed_mode
             headed = _is_headed_mode()
         except Exception:
             headed = bool(os.environ.get("AGENT_BROWSER_HEADED"))
-        if headed:
+        if preserve_handoff_browser:
+            if agent.verbose_logging:
+                logging.debug(
+                    "Skipping per-turn cleanup_browser for pending human "
+                    f"handoff {task_id}"
+                )
+        elif headed:
             if agent.verbose_logging:
                 logging.debug(
                     f"Skipping per-turn cleanup_browser for headed session {task_id}; "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -118,6 +118,25 @@ RUN_BUDGET_WRAPUP_NOTICE = (
 )
 
 
+def _browser_handoff_wait_message(tool_messages: List[Dict[str, Any]]) -> str:
+    """Return a terminal turn message after a successful browser handoff."""
+    for message in tool_messages:
+        if message.get("role") != "tool" or message.get("name") != "browser_exec":
+            continue
+        content = message.get("content")
+        try:
+            payload = json.loads(content) if isinstance(content, str) else content
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        meta = payload.get("meta")
+        if isinstance(meta, dict) and meta.get("browser_handoff") is True:
+            output = str(payload.get("output") or "").strip()
+            return output or "Waiting for the browser handoff to be completed."
+    return ""
+
+
 def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) -> bool:
     """Inject the one-time wall-clock wrap-up notice when past 80% of budget.
 
@@ -7330,7 +7349,10 @@ def run_conversation(
                     except Exception:
                         pass
 
-                agent._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
+                _tool_result_start = len(messages)
+                agent._execute_tool_calls(
+                    assistant_message, messages, effective_task_id, api_call_count
+                )
 
                 if getattr(agent, "_incremental_persistence_failed", False):
                     # A tool result could not be made canonical. Do not send
@@ -7362,6 +7384,27 @@ def run_conversation(
                                 agent.stream_delta_callback(None)
                             except Exception:
                                 pass
+                    break
+
+                # A successful browser handoff is a deterministic turn
+                # boundary. Do not ask the model for another action while the
+                # owner controls the browser; Done will inject the next user
+                # turn into this exact persisted session.
+                _handoff_wait = _browser_handoff_wait_message(
+                    messages[_tool_result_start:]
+                )
+                if _handoff_wait:
+                    _turn_exit_reason = "waiting_for_browser_handoff"
+                    final_response = _handoff_wait
+                    append_message(
+                        messages, {"role": "assistant", "content": final_response}
+                    )
+                    if agent.stream_delta_callback:
+                        try:
+                            agent.stream_delta_callback(final_response)
+                            agent.stream_delta_callback(None)
+                        except Exception:
+                            pass
                     break
 
                 # Reset per-turn retry counters after successful tool

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7395,6 +7395,10 @@ def run_conversation(
                 )
                 if _handoff_wait:
                     _turn_exit_reason = "waiting_for_browser_handoff"
+                    # Normal finalization tears down task browsers at every
+                    # turn boundary. This one must survive until Done, expiry,
+                    # or explicit session cleanup.
+                    agent._preserve_browser_after_turn = True
                     final_response = _handoff_wait
                     append_message(
                         messages, {"role": "assistant", "content": final_response}

--- a/docs/superpowers/specs/2026-08-22-browser-human-handoff-design.md
+++ b/docs/superpowers/specs/2026-08-22-browser-human-handoff-design.md
@@ -35,6 +35,8 @@ The Browser Use provider will preserve `liveUrl` as `live_url` in the existing s
 
 The Browser Use CLI/backend path will reuse Hermes's existing Browser Use provider session instead of asking the harness to auto-provision a second, opaque browser. The harness attaches to that session's CDP endpoint, while Hermes retains its ID, expiry, and live URL. Handoff is available only when the active session has both a live Browser Use session and a non-empty `live_url`; local-browser handoff is outside this change.
 
+Every Hermes bot/task receives a deterministic private harness-daemon name and a distinct Browser Use cloud session key, even when the model omits the optional session name. Two bots that choose the same friendly session name still receive separate managed Chrome instances, so they can work concurrently in the background without sharing tabs, focus, cookies, or browser process state. Repeated calls from the same bot and friendly session reuse its instance. Local Chrome remains one shared browser and can isolate only tabs; the multi-bot guarantee therefore uses Browser Use cloud.
+
 ### Handoff manager
 
 A focused handoff manager owns lifecycle and persistence. It creates a cryptographically random token and persists only its SHA-256 digest with:
@@ -82,7 +84,7 @@ The Discord delivery path uses the connected Discord adapter when available and 
 
 The completion endpoint claims the pending handoff in one transaction, revokes its public capability, and uses Hermes's existing session wake mechanism to enqueue an internal continuation for the raw originating session ID. The continuation says that the owner completed the browser handoff and instructs Hermes to inspect the current page before taking the next action.
 
-The browser remains alive during the wait. Handoff completion does not automatically submit forms, close the browser, or assume success. Hermes must verify page state after waking. Normal task cleanup closes the browser later.
+The browser remains alive during the wait. Handoff completion does not automatically submit forms, close the browser, or assume success. Hermes must verify page state after waking. Normal task cleanup closes every cloud browser owned by that bot after the resumed task finishes; the inactivity reaper also closes abandoned instances after the handoff is completed, cancelled, or expired.
 
 ## State and Concurrency Rules
 
@@ -135,6 +137,7 @@ browser:
 Focused automated coverage will prove behavior rather than source layout:
 
 - Browser Use provider create responses preserve `liveUrl`; other providers remain valid without it.
+- Browser and daemon keys are stable within one bot/task but distinct across bots, including unnamed sessions and identical friendly session names.
 - Token plaintext is absent from SQLite and logs.
 - Pending GET renders the instruction and live controller; invalid, expired, completed, cancelled, and browser-mismatched tokens never expose `live_url`.
 - Completion is atomic and concurrent Done requests schedule exactly one wake.

--- a/docs/superpowers/specs/2026-08-22-browser-human-handoff-design.md
+++ b/docs/superpowers/specs/2026-08-22-browser-human-handoff-design.md
@@ -1,0 +1,154 @@
+# Browser Human Handoff Design
+
+## Outcome
+
+When Hermes reaches a human-only step while driving a Browser Use cloud browser, it can pause the task and send Alex a Discord DM containing a no-login handoff link. The link opens a mobile-friendly page containing the exact instruction, the live Browser Use controller for the existing browser, and a **Done — resume Hermes** button.
+
+The handoff link is a bearer credential. It expires after 30 minutes, is bound to one Hermes task and one Browser Use session, and is revoked immediately when the user completes the handoff or the browser session ends. Completing the handoff wakes the exact paused Hermes session, which verifies browser state before continuing.
+
+This design does not attempt to bypass CAPTCHA, MFA, consent, or account-selection controls. It hands those steps to the owner.
+
+## User Experience
+
+Hermes recognizes that progress requires human interaction, such as a CAPTCHA, password entry, MFA, consent screen, or ambiguous account selection. Hermes invokes the handoff action with a short imperative instruction, for example:
+
+> Sign in to Shopify and complete the verification prompt. Do not navigate away after the dashboard loads.
+
+Alex receives this Discord DM:
+
+> yo, I need you to sign in to Shopify and complete the verification prompt. This link controls the browser I am using and expires in 30 minutes: <handoff URL>
+
+The handoff page shows:
+
+1. The instruction and remaining validity time.
+2. The live Browser Use controller embedded in the page.
+3. A fallback **Open live browser** link if embedding is blocked by the client.
+4. A fixed **Done — resume Hermes** button.
+
+Pressing Done changes the page to a completed state, disables further browser access through the handoff URL, and resumes Hermes. Reopening a completed or expired link shows only a terminal status and never reveals the Browser Use live URL.
+
+## Architecture
+
+### Browser session metadata
+
+The Browser Use provider will preserve `liveUrl` as `live_url` in the existing session metadata alongside `bb_session_id`, `cdp_url`, and `expires_at`. The provider contract will define `live_url` as optional so Browserbase, local Chrome, CDP overrides, and providers without human-control links remain compatible.
+
+The Browser Use CLI/backend path will reuse Hermes's existing Browser Use provider session instead of asking the harness to auto-provision a second, opaque browser. The harness attaches to that session's CDP endpoint, while Hermes retains its ID, expiry, and live URL. Handoff is available only when the active session has both a live Browser Use session and a non-empty `live_url`; local-browser handoff is outside this change.
+
+### Handoff manager
+
+A focused handoff manager owns lifecycle and persistence. It creates a cryptographically random token and persists only its SHA-256 digest with:
+
+- Hermes profile/home scope
+- raw session ID and task ID
+- browser session ID and live URL
+- human instruction
+- Discord recipient user ID
+- creation and expiry timestamps
+- state: `pending`, `completed`, `expired`, or `cancelled`
+- completion timestamp and wake-delivery status
+
+State lives in a small profile-scoped SQLite database under the active Hermes home so a gateway restart does not lose pending handoffs. Updates use transactions so two Done requests cannot resume the agent twice.
+
+The public token is returned once for URL construction and is never logged, persisted in plaintext, or placed in agent history. Logs use a short handoff ID that is not sufficient to authenticate.
+
+### Public handoff routes
+
+Hermes's always-running gateway API server will expose two deliberately unauthenticated, token-authenticated routes:
+
+- `GET /browser-handoff/{token}` renders the handoff page.
+- `POST /browser-handoff/{token}/complete` atomically marks the handoff complete and schedules the wake.
+
+These two handlers intentionally do not use `API_SERVER_KEY`; possession of a valid handoff token is their authorization mechanism. Every other API-server route retains its existing authentication. The page response sets `Cache-Control: no-store`, `Referrer-Policy: no-referrer`, a restrictive Content Security Policy, and no session cookie. The live URL is never returned for an invalid, expired, completed, cancelled, or browser-mismatched token.
+
+The operator configures `browser.handoff.public_base_url` in `config.yaml`. Hermes refuses to create a handoff unless this is an absolute HTTPS origin. On Alex's deployment, the existing Cloudflare tunnel/reverse-proxy process will route this prefix to the Hermes HTTP service; tunnel URL rotation remains an operational concern of the existing tunnel supervisor.
+
+### Agent-facing action
+
+The capability extends the existing Browser Use tool surface instead of adding a new permanent core tool. The Browser Use schema gains an optional handoff action with one required field: a concise instruction describing exactly what Alex must do.
+
+The action:
+
+1. Resolves the active Browser Use session for the calling task/session name.
+2. Validates that a live URL exists and that the browser has not expired.
+3. Creates the 30-minute handoff record.
+4. Opens or resolves a Discord DM for configured owner user `1063878950851448853` and sends the message.
+5. Returns a structured `waiting_for_human` result to the agent loop without exposing the bearer URL to model context.
+6. Suspends further work for that Hermes session until completion, expiry, cancellation, or interruption.
+
+The Discord delivery path uses the connected Discord adapter when available and a bot-token REST fallback otherwise. It creates a DM channel from the recipient user ID rather than treating the user ID as a channel ID. A failed DM cancels the handoff immediately and returns an actionable error.
+
+### Resume path
+
+The completion endpoint claims the pending handoff in one transaction, revokes its public capability, and uses Hermes's existing session wake mechanism to enqueue an internal continuation for the raw originating session ID. The continuation says that the owner completed the browser handoff and instructs Hermes to inspect the current page before taking the next action.
+
+The browser remains alive during the wait. Handoff completion does not automatically submit forms, close the browser, or assume success. Hermes must verify page state after waking. Normal task cleanup closes the browser later.
+
+## State and Concurrency Rules
+
+- At most one pending handoff may exist for a given Hermes task and browser session. A retry returns the existing pending handoff and may re-send the DM without minting another live capability.
+- Done is idempotent. Only the transaction that changes `pending` to `completed` schedules a wake.
+- Expiry is the earlier of 30 minutes and the provider-authoritative browser expiry.
+- Browser cleanup cancels all pending handoffs bound to that browser before stopping it.
+- A gateway restart reloads pending rows, expires stale rows, and can still accept Done for valid rows.
+- A session reset or explicit interruption cancels its pending handoffs and does not wake the replacement session.
+- The live URL remains server-side. The public page may embed it, but the DM contains only the Hermes handoff URL.
+
+## Security Properties
+
+- Tokens contain at least 256 bits of randomness and are compared by digest using constant-time comparison.
+- Tokens are single-purpose, single-session, one-time, and bounded to 30 minutes.
+- No login is required, so anyone possessing the URL can control that browser during the validity window. The DM copy states that the link must not be forwarded.
+- Query strings, bearer tokens, Browser Use live URLs, CDP URLs, and credentials are redacted from logs and error messages.
+- The page cannot navigate its parent, access Hermes cookies, or call unrelated Hermes endpoints. Completion uses a same-origin POST and rejects cross-origin requests.
+- Responses are never cached. The page sends no analytics or third-party telemetry beyond the Browser Use controller it intentionally embeds.
+- The completion route validates current handoff state, expiry, profile scope, and browser-session binding before waking anything.
+- Rate limiting applies per source IP and per handoff digest, while valid single-click completion remains reliable.
+
+## Failure Handling
+
+- No Browser Use live URL: Hermes reports that this backend cannot be handed off and does not send a DM.
+- Public base URL missing or non-HTTPS: handoff creation fails closed with setup guidance.
+- Discord DM failure: the new handoff is cancelled and the agent receives the delivery error.
+- Browser expires while waiting: the handoff becomes expired, its page loses access, and the originating session is woken with an expiry result when possible.
+- Done wake delivery fails: completion remains recorded and a retry worker re-attempts the internal wake; the button never reopens the capability.
+- Duplicate Done requests: all but the first receive the already-completed page and cause no additional wake.
+- Tunnel unavailable: the DM send may succeed but the page cannot load. Hermes keeps the pending row until expiry; a future operational health check can surface tunnel reachability without weakening token validation.
+
+## Configuration
+
+Behavioral settings live in `config.yaml`:
+
+```yaml
+browser:
+  handoff:
+    enabled: true
+    public_base_url: "https://hermes.example.com"
+    ttl_minutes: 30
+    discord_user_id: "1063878950851448853"
+```
+
+`ttl_minutes` defaults to 30 and is capped at 30 for the initial implementation. The Discord bot credential remains a secret in Hermes's existing secret store; this feature introduces no new secret environment variable.
+
+## Verification
+
+Focused automated coverage will prove behavior rather than source layout:
+
+- Browser Use provider create responses preserve `liveUrl`; other providers remain valid without it.
+- Token plaintext is absent from SQLite and logs.
+- Pending GET renders the instruction and live controller; invalid, expired, completed, cancelled, and browser-mismatched tokens never expose `live_url`.
+- Completion is atomic and concurrent Done requests schedule exactly one wake.
+- Effective expiry is capped by both the configured 30 minutes and Browser Use `timeoutAt`.
+- Discord user IDs are resolved into DM channels and delivery failure cancels the record.
+- Session reset, interruption, browser cleanup, and provider expiry revoke pending handoffs.
+- A persisted pending handoff survives service restart and completes against the exact raw originating session.
+- The handoff routes work without dashboard login while unrelated routes remain protected.
+- Response headers enforce no-store, no-referrer, and the intended CSP.
+
+One end-to-end test will create a fake Browser Use session, request a handoff through the real tool/manager boundary against a temporary Hermes home, receive the DM through a test adapter, load the public page, press Done, and assert that exactly the originating session receives the continuation.
+
+## Rollout Boundary
+
+The first release supports Browser Use cloud sessions and one configured Discord owner DM. It does not support local Chrome remote desktop, multiple approvers, arbitrary messaging targets, approval decisions, file uploads, or automatic CAPTCHA solving. Those are separate features.
+
+The change will ship through a production PR because it introduces a public bearer-authenticated route and cross-session wake behavior. It will not be merged without explicit owner approval.

--- a/gateway/browser_handoff.py
+++ b/gateway/browser_handoff.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Optional
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import requests
 
@@ -36,6 +36,17 @@ _TOKEN_HEX_LENGTH = _TOKEN_BYTES * 2
 # Wake turns may legitimately use tools for several minutes. Reclaim only
 # after the existing wake self-post's 10-minute ceiling plus safety margin.
 _WAKE_RECLAIM_SECONDS = 900
+WAKE_MESSAGE = (
+    "The human browser handoff is complete. Resume this exact task now. "
+    "First inspect the current page with browser_exec and verify the requested "
+    "login, CAPTCHA, or other blocking step succeeded; then continue from "
+    "where you paused."
+)
+EXPIRED_WAKE_MESSAGE = (
+    "The browser handoff expired before the owner clicked Done. Inspect the "
+    "current browser if it is still available, then explain the blocker or "
+    "request a new handoff instead of assuming the human step succeeded."
+)
 
 
 class BrowserHandoffError(RuntimeError):
@@ -298,7 +309,7 @@ class BrowserHandoffStore:
                 """
                 UPDATE browser_handoffs
                 SET wake_status='delivering', wake_claimed_at=?
-                WHERE id=? AND status='completed' AND (
+                WHERE id=? AND status IN ('completed', 'expired') AND (
                     wake_status='pending' OR
                     (wake_status='delivering' AND COALESCE(wake_claimed_at, 0) < ?)
                 )
@@ -321,12 +332,20 @@ class BrowserHandoffStore:
             )
 
     def pending_wake_ids(self, limit: int = 20) -> list[int]:
-        reclaim_before = time.time() - _WAKE_RECLAIM_SECONDS
+        now = time.time()
+        reclaim_before = now - _WAKE_RECLAIM_SECONDS
         with self._lock, self._connect() as db:
+            # Expiry is a wake event. The agent already ended its turn at the
+            # handoff boundary and must not remain dormant forever.
+            db.execute(
+                "UPDATE browser_handoffs SET status='expired' "
+                "WHERE status='pending' AND expires_at<=?",
+                (now,),
+            )
             rows = db.execute(
                 """
                 SELECT id FROM browser_handoffs
-                WHERE status='completed' AND (
+                WHERE status IN ('completed', 'expired') AND (
                     wake_status='pending' OR
                     (wake_status='delivering' AND COALESCE(wake_claimed_at, 0) < ?)
                 ) ORDER BY id LIMIT ?
@@ -353,6 +372,39 @@ class BrowserHandoffStore:
                 (browser_id,),
             )
         return int(cur.rowcount)
+
+    def retains_browser(self, browser_id: str) -> bool:
+        if not browser_id:
+            return False
+        now = time.time()
+        with self._lock, self._connect() as db:
+            db.execute(
+                "UPDATE browser_handoffs SET status='expired' "
+                "WHERE browser_id=? AND status='pending' AND expires_at<=?",
+                (browser_id, now),
+            )
+            row = db.execute(
+                "SELECT 1 FROM browser_handoffs "
+                "WHERE browser_id=? AND (status='pending' OR ("
+                "status IN ('completed', 'expired') AND wake_status!='delivered'"
+                ")) LIMIT 1",
+                (browser_id,),
+            ).fetchone()
+        return row is not None
+
+
+def browser_handoff_retains_browser(browser_id: str) -> bool:
+    try:
+        return BrowserHandoffStore().retains_browser(browser_id)
+    except Exception:
+        logger.debug(
+            "Failed to check pending browser handoff for %s",
+            browser_id,
+            exc_info=True,
+        )
+        # Fail closed for resource retention: a database failure must not pin
+        # a paid browser indefinitely.
+        return False
 
 
 def _source_from_context() -> dict[str, Any]:
@@ -446,13 +498,12 @@ def create_browser_handoff(
 
     from gateway.session_context import get_session_env
     from tools.browser_tool import _get_session_info
+    from tools.browser_use_cli import _provider_session_cache_key
 
-    browser_key = (
-        f"bu-named-{session_name}"
-        if session_name
-        else (task_id or "browser-exec-default")
-    )
+    browser_key = _provider_session_cache_key(task_id, session_name)
     info = _get_session_info(browser_key) or {}
+    if isinstance(info, dict):
+        info["owner_task_id"] = str(task_id or "browser-exec-default")
     if not bool((info.get("features") or {}).get("browser_use")):
         raise BrowserHandoffError(
             "Human handoff is currently supported only for Browser Use cloud sessions"
@@ -486,6 +537,7 @@ def create_browser_handoff(
         except (TypeError, ValueError):
             logger.warning("Ignoring malformed Browser Use expires_at value")
     handoff_store = store or BrowserHandoffStore()
+    source = _source_from_context()
     record = handoff_store.create(
         token_digest=digest,
         session_id=session_id,
@@ -493,14 +545,22 @@ def create_browser_handoff(
         browser_id=browser_id,
         live_url=live_url,
         instruction=clean_instruction,
-        source=_source_from_context(),
+        source=source,
         ttl_seconds=ttl_seconds,
     )
-    link = f"{base_url}/browser-handoff/{token}"
+    profile = str(source.get("profile") or "").strip()
+    profile_prefix = (
+        f"/p/{quote(profile, safe='')}"
+        if profile and profile not in {"default", "custom"}
+        else ""
+    )
+    link = f"{base_url}{profile_prefix}/browser-handoff/{token}"
+    effective_minutes = max(1, int((record.expires_at - time.time() + 59) // 60))
     message = (
         f"yo i need u to do this: {clean_instruction}\n\n"
         f"Take control here (no login required): {link}\n\n"
-        f"This link expires in {cfg.ttl_minutes} minutes. "
+        f"This link expires in {effective_minutes} minute"
+        f"{'s' if effective_minutes != 1 else ''}. "
         "Click Done on the page when finished. Do not forward this link."
     )
     try:
@@ -512,7 +572,9 @@ def create_browser_handoff(
         "handoff_id": record.id,
         "expires_at": record.expires_at,
         "message": (
-            "I sent Alex a Discord DM with a 30-minute browser-control link. "
+            "I sent Alex a Discord DM with a browser-control link valid for "
+            f"about {effective_minutes} minute"
+            f"{'s' if effective_minutes != 1 else ''}. "
             "End this turn now and wait. The same Hermes session will be woken "
             "when Alex clicks Done; then inspect the current page before continuing."
         ),
@@ -577,11 +639,3 @@ font-size:17px;font-weight:700;cursor:pointer}}
 a{{color:#a9c7ff}}.fallback{{margin:.75em 0}}form{{margin-top:16px}}
 </style></head><body><main><h1>{html.escape(title)}</h1><p>{body}</p>{frame}</main></body></html>"""
     return doc, status
-
-
-WAKE_MESSAGE = (
-    "The human browser handoff is complete. Resume this exact task now. "
-    "First inspect the current page with browser_exec and verify the requested "
-    "login, CAPTCHA, or other blocking step succeeded; then continue from "
-    "where you paused."
-)

--- a/gateway/browser_handoff.py
+++ b/gateway/browser_handoff.py
@@ -1,0 +1,587 @@
+"""Secure, short-lived human control handoffs for Browser Use sessions.
+
+The public handoff token is a bearer credential.  Only its SHA-256 digest is
+stored; the Browser Use live URL is released solely while the row is pending
+and unexpired.  Completion and wake delivery are separate, idempotent state
+transitions so repeated clicks cannot start duplicate agent turns.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import logging
+import os
+import secrets
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+from urllib.parse import urlparse
+
+import requests
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_MINUTES = 30
+MAX_TTL_MINUTES = 30
+_TOKEN_BYTES = 32
+_TOKEN_HEX_LENGTH = _TOKEN_BYTES * 2
+# Wake turns may legitimately use tools for several minutes. Reclaim only
+# after the existing wake self-post's 10-minute ceiling plus safety margin.
+_WAKE_RECLAIM_SECONDS = 900
+
+
+class BrowserHandoffError(RuntimeError):
+    """A safe, user-facing browser handoff failure."""
+
+
+@dataclass(frozen=True)
+class BrowserHandoffConfig:
+    enabled: bool
+    public_base_url: str
+    ttl_minutes: int
+    discord_user_id: str
+
+
+@dataclass(frozen=True)
+class BrowserHandoff:
+    id: int
+    token_digest: str
+    status: str
+    wake_status: str
+    session_id: str
+    browser_key: str
+    browser_id: str
+    live_url: str
+    instruction: str
+    source: dict[str, Any]
+    created_at: float
+    expires_at: float
+
+
+def load_browser_handoff_config() -> BrowserHandoffConfig:
+    from hermes_cli.config import cfg_get, read_raw_config
+
+    raw = read_raw_config()
+    section = cfg_get(raw, "browser", "handoff", default={})
+    if not isinstance(section, dict):
+        section = {}
+    enabled = bool(section.get("enabled", False))
+    base = str(section.get("public_base_url") or "").strip().rstrip("/")
+    try:
+        ttl = int(section.get("ttl_minutes", DEFAULT_TTL_MINUTES))
+    except (TypeError, ValueError):
+        ttl = DEFAULT_TTL_MINUTES
+    ttl = max(1, min(ttl, MAX_TTL_MINUTES))
+    user_id = str(section.get("discord_user_id") or "").strip()
+    return BrowserHandoffConfig(enabled, base, ttl, user_id)
+
+
+def _validate_public_base_url(value: str) -> str:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password:
+        raise BrowserHandoffError(
+            "browser.handoff.public_base_url must be a public HTTPS URL"
+        )
+    if parsed.query or parsed.fragment:
+        raise BrowserHandoffError(
+            "browser.handoff.public_base_url cannot contain a query or fragment"
+        )
+    return value.rstrip("/")
+
+
+def _validate_live_url(value: str) -> str:
+    parsed = urlparse(value)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not (
+        host == "browser-use.com" or host.endswith(".browser-use.com")
+    ):
+        raise BrowserHandoffError(
+            "The active browser does not expose a trusted Browser Use live-control URL"
+        )
+    return value
+
+
+def _db_path() -> Path:
+    path = get_hermes_home() / "state" / "browser-handoffs.db"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+class BrowserHandoffStore:
+    def __init__(self, path: Optional[Path] = None):
+        self.path = Path(path) if path is not None else _db_path()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(str(self.path), timeout=10)
+        db.row_factory = sqlite3.Row
+        db.execute("PRAGMA busy_timeout=10000")
+        return db
+
+    def _init_db(self) -> None:
+        with self._lock, self._connect() as db:
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS browser_handoffs (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    token_digest TEXT NOT NULL UNIQUE,
+                    status TEXT NOT NULL,
+                    wake_status TEXT NOT NULL DEFAULT 'pending',
+                    wake_claimed_at REAL,
+                    session_id TEXT NOT NULL,
+                    browser_key TEXT NOT NULL,
+                    browser_id TEXT NOT NULL,
+                    live_url TEXT NOT NULL,
+                    instruction TEXT NOT NULL,
+                    source_json TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    expires_at REAL NOT NULL,
+                    completed_at REAL
+                )
+                """
+            )
+            db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_browser_handoffs_browser "
+                "ON browser_handoffs(browser_id, status)"
+            )
+            db.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_browser_handoffs_one_pending "
+                "ON browser_handoffs(browser_id) WHERE status='pending'"
+            )
+            try:
+                os.chmod(self.path, 0o600)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _record(row: sqlite3.Row) -> BrowserHandoff:
+        try:
+            source = json.loads(row["source_json"] or "{}")
+        except (TypeError, ValueError):
+            source = {}
+        return BrowserHandoff(
+            id=int(row["id"]),
+            token_digest=str(row["token_digest"]),
+            status=str(row["status"]),
+            wake_status=str(row["wake_status"]),
+            session_id=str(row["session_id"]),
+            browser_key=str(row["browser_key"]),
+            browser_id=str(row["browser_id"]),
+            live_url=str(row["live_url"]),
+            instruction=str(row["instruction"]),
+            source=source if isinstance(source, dict) else {},
+            created_at=float(row["created_at"]),
+            expires_at=float(row["expires_at"]),
+        )
+
+    def create(
+        self,
+        *,
+        token_digest: str,
+        session_id: str,
+        browser_key: str,
+        browser_id: str,
+        live_url: str,
+        instruction: str,
+        source: dict[str, Any],
+        ttl_seconds: int,
+    ) -> BrowserHandoff:
+        now = time.time()
+        expires = now + ttl_seconds
+        with self._lock, self._connect() as db:
+            db.execute(
+                "UPDATE browser_handoffs SET status='expired' "
+                "WHERE browser_id=? AND status='pending' AND expires_at<=?",
+                (browser_id, now),
+            )
+            existing = db.execute(
+                "SELECT id FROM browser_handoffs "
+                "WHERE browser_id=? AND status='pending'",
+                (browser_id,),
+            ).fetchone()
+            if existing is not None:
+                raise BrowserHandoffError(
+                    "A human handoff is already pending for this browser; "
+                    "use the link already sent by Discord"
+                )
+            try:
+                cur = db.execute(
+                    """
+                    INSERT INTO browser_handoffs (
+                        token_digest, status, wake_status, session_id, browser_key,
+                        browser_id, live_url, instruction, source_json,
+                        created_at, expires_at
+                    ) VALUES (?, 'pending', 'pending', ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        token_digest,
+                        session_id,
+                        browser_key,
+                        browser_id,
+                        live_url,
+                        instruction,
+                        json.dumps(source, separators=(",", ":"), sort_keys=True),
+                        now,
+                        expires,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise BrowserHandoffError(
+                    "A human handoff is already pending for this browser; "
+                    "use the link already sent by Discord"
+                ) from exc
+            row = db.execute(
+                "SELECT * FROM browser_handoffs WHERE id=?", (cur.lastrowid,)
+            ).fetchone()
+        return self._record(row)
+
+    def lookup(
+        self, token: str, *, now: Optional[float] = None
+    ) -> Optional[BrowserHandoff]:
+        if len(token) != _TOKEN_HEX_LENGTH:
+            return None
+        try:
+            bytes.fromhex(token)
+        except ValueError:
+            return None
+        digest = hashlib.sha256(token.encode("ascii")).hexdigest()
+        at = time.time() if now is None else now
+        with self._lock, self._connect() as db:
+            row = db.execute(
+                "SELECT * FROM browser_handoffs WHERE token_digest=?", (digest,)
+            ).fetchone()
+            if row is None:
+                return None
+            if row["status"] == "pending" and float(row["expires_at"]) <= at:
+                db.execute(
+                    "UPDATE browser_handoffs SET status='expired' "
+                    "WHERE id=? AND status='pending'",
+                    (row["id"],),
+                )
+                row = db.execute(
+                    "SELECT * FROM browser_handoffs WHERE id=?", (row["id"],)
+                ).fetchone()
+        return self._record(row)
+
+    def complete(self, token: str) -> Optional[BrowserHandoff]:
+        record = self.lookup(token)
+        if record is None:
+            return None
+        if record.status == "pending":
+            with self._lock, self._connect() as db:
+                db.execute(
+                    "UPDATE browser_handoffs SET status='completed', completed_at=? "
+                    "WHERE id=? AND status='pending'",
+                    (time.time(), record.id),
+                )
+                row = db.execute(
+                    "SELECT * FROM browser_handoffs WHERE id=?", (record.id,)
+                ).fetchone()
+            return self._record(row)
+        return record
+
+    def claim_wake(self, record_id: int) -> Optional[BrowserHandoff]:
+        now = time.time()
+        reclaim_before = now - _WAKE_RECLAIM_SECONDS
+        with self._lock, self._connect() as db:
+            cur = db.execute(
+                """
+                UPDATE browser_handoffs
+                SET wake_status='delivering', wake_claimed_at=?
+                WHERE id=? AND status='completed' AND (
+                    wake_status='pending' OR
+                    (wake_status='delivering' AND COALESCE(wake_claimed_at, 0) < ?)
+                )
+                """,
+                (now, record_id, reclaim_before),
+            )
+            if cur.rowcount != 1:
+                return None
+            row = db.execute(
+                "SELECT * FROM browser_handoffs WHERE id=?", (record_id,)
+            ).fetchone()
+        return self._record(row)
+
+    def finish_wake(self, record_id: int, *, delivered: bool) -> None:
+        with self._lock, self._connect() as db:
+            db.execute(
+                "UPDATE browser_handoffs SET wake_status=?, wake_claimed_at=NULL "
+                "WHERE id=? AND wake_status='delivering'",
+                ("delivered" if delivered else "pending", record_id),
+            )
+
+    def pending_wake_ids(self, limit: int = 20) -> list[int]:
+        reclaim_before = time.time() - _WAKE_RECLAIM_SECONDS
+        with self._lock, self._connect() as db:
+            rows = db.execute(
+                """
+                SELECT id FROM browser_handoffs
+                WHERE status='completed' AND (
+                    wake_status='pending' OR
+                    (wake_status='delivering' AND COALESCE(wake_claimed_at, 0) < ?)
+                ) ORDER BY id LIMIT ?
+                """,
+                (reclaim_before, int(limit)),
+            ).fetchall()
+        return [int(row["id"]) for row in rows]
+
+    def cancel(self, record_id: int) -> None:
+        with self._lock, self._connect() as db:
+            db.execute(
+                "UPDATE browser_handoffs SET status='cancelled' "
+                "WHERE id=? AND status='pending'",
+                (record_id,),
+            )
+
+    def cancel_for_browser(self, browser_id: str) -> int:
+        if not browser_id:
+            return 0
+        with self._lock, self._connect() as db:
+            cur = db.execute(
+                "UPDATE browser_handoffs SET status='cancelled' "
+                "WHERE browser_id=? AND status='pending'",
+                (browser_id,),
+            )
+        return int(cur.rowcount)
+
+
+def _source_from_context() -> dict[str, Any]:
+    from gateway.session_context import get_session_env
+
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+    if not platform:
+        return {}
+    source: dict[str, Any] = {
+        "platform": platform,
+        "chat_id": get_session_env("HERMES_SESSION_CHAT_ID", ""),
+        "chat_type": get_session_env("HERMES_SESSION_CHAT_TYPE", "") or "dm",
+    }
+    names = {
+        "chat_name": "HERMES_SESSION_CHAT_NAME",
+        "thread_id": "HERMES_SESSION_THREAD_ID",
+        "user_id": "HERMES_SESSION_USER_ID",
+        "user_id_alt": "HERMES_SESSION_USER_ID_ALT",
+        "user_name": "HERMES_SESSION_USER_NAME",
+        "scope_id": "HERMES_SESSION_SCOPE_ID",
+        "message_id": "HERMES_SESSION_MESSAGE_ID",
+        "profile": "HERMES_SESSION_PROFILE",
+    }
+    for key, env_name in names.items():
+        value = get_session_env(env_name, "")
+        if value:
+            source[key] = value
+    return source
+
+
+def _discord_bot_token() -> str:
+    try:
+        from agent.secret_scope import get_secret
+
+        return str(get_secret("DISCORD_BOT_TOKEN", "") or "")
+    except Exception:
+        return str(os.getenv("DISCORD_BOT_TOKEN", "") or "")
+
+
+def send_discord_handoff_dm(user_id: str, message: str) -> None:
+    """Create a Discord DM channel and send the handoff notification."""
+    token = _discord_bot_token()
+    if not token:
+        raise BrowserHandoffError("DISCORD_BOT_TOKEN is not configured")
+    headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
+    try:
+        opened = requests.post(
+            "https://discord.com/api/v10/users/@me/channels",
+            headers=headers,
+            json={"recipient_id": user_id},
+            timeout=15,
+        )
+        opened.raise_for_status()
+        channel_id = str(opened.json().get("id") or "")
+        if not channel_id:
+            raise RuntimeError("Discord returned no DM channel ID")
+        sent = requests.post(
+            f"https://discord.com/api/v10/channels/{channel_id}/messages",
+            headers=headers,
+            json={"content": message},
+            timeout=15,
+        )
+        sent.raise_for_status()
+    except requests.RequestException as exc:
+        raise BrowserHandoffError(f"Discord DM delivery failed: {exc}") from exc
+
+
+def create_browser_handoff(
+    *,
+    instruction: str,
+    task_id: str,
+    session_name: str = "",
+    store: Optional[BrowserHandoffStore] = None,
+    notifier: Callable[[str, str], None] = send_discord_handoff_dm,
+) -> dict[str, Any]:
+    """Persist a handoff and DM its public URL to the configured owner."""
+    clean_instruction = " ".join(str(instruction or "").split()).strip()
+    if not clean_instruction:
+        raise BrowserHandoffError(
+            "A short description of what the human must do is required"
+        )
+    if len(clean_instruction) > 500:
+        raise BrowserHandoffError("The handoff instruction must be 500 characters or fewer")
+
+    cfg = load_browser_handoff_config()
+    if not cfg.enabled:
+        raise BrowserHandoffError("Browser handoff is disabled in browser.handoff.enabled")
+    base_url = _validate_public_base_url(cfg.public_base_url)
+    if not cfg.discord_user_id.isdigit():
+        raise BrowserHandoffError("browser.handoff.discord_user_id must be a Discord user ID")
+
+    from gateway.session_context import get_session_env
+    from tools.browser_tool import _get_session_info
+
+    browser_key = (
+        f"bu-named-{session_name}"
+        if session_name
+        else (task_id or "browser-exec-default")
+    )
+    info = _get_session_info(browser_key) or {}
+    if not bool((info.get("features") or {}).get("browser_use")):
+        raise BrowserHandoffError(
+            "Human handoff is currently supported only for Browser Use cloud sessions"
+        )
+    browser_id = str(info.get("bb_session_id") or "")
+    live_url = _validate_live_url(str(info.get("live_url") or ""))
+    if not browser_id:
+        raise BrowserHandoffError("The active Browser Use session has no browser ID")
+
+    session_id = get_session_env("HERMES_SESSION_ID", "") or str(task_id or "")
+    if not session_id:
+        raise BrowserHandoffError("Hermes could not identify the paused session to resume")
+
+    token = secrets.token_hex(_TOKEN_BYTES)
+    digest = hashlib.sha256(token.encode("ascii")).hexdigest()
+    ttl_seconds = cfg.ttl_minutes * 60
+    provider_expiry = str(info.get("expires_at") or "").strip()
+    if provider_expiry:
+        try:
+            parsed_expiry = datetime.fromisoformat(
+                provider_expiry.replace("Z", "+00:00")
+            )
+            if parsed_expiry.tzinfo is None:
+                parsed_expiry = parsed_expiry.replace(tzinfo=timezone.utc)
+            provider_seconds = int(parsed_expiry.timestamp() - time.time())
+            if provider_seconds <= 0:
+                raise BrowserHandoffError("The Browser Use session has already expired")
+            ttl_seconds = min(ttl_seconds, provider_seconds)
+        except BrowserHandoffError:
+            raise
+        except (TypeError, ValueError):
+            logger.warning("Ignoring malformed Browser Use expires_at value")
+    handoff_store = store or BrowserHandoffStore()
+    record = handoff_store.create(
+        token_digest=digest,
+        session_id=session_id,
+        browser_key=browser_key,
+        browser_id=browser_id,
+        live_url=live_url,
+        instruction=clean_instruction,
+        source=_source_from_context(),
+        ttl_seconds=ttl_seconds,
+    )
+    link = f"{base_url}/browser-handoff/{token}"
+    message = (
+        f"yo i need u to do this: {clean_instruction}\n\n"
+        f"Take control here (no login required): {link}\n\n"
+        f"This link expires in {cfg.ttl_minutes} minutes. "
+        "Click Done on the page when finished. Do not forward this link."
+    )
+    try:
+        notifier(cfg.discord_user_id, message)
+    except Exception:
+        handoff_store.cancel(record.id)
+        raise
+    return {
+        "handoff_id": record.id,
+        "expires_at": record.expires_at,
+        "message": (
+            "I sent Alex a Discord DM with a 30-minute browser-control link. "
+            "End this turn now and wait. The same Hermes session will be woken "
+            "when Alex clicks Done; then inspect the current page before continuing."
+        ),
+    }
+
+
+def cancel_browser_handoffs(browser_id: str) -> None:
+    try:
+        BrowserHandoffStore().cancel_for_browser(browser_id)
+    except Exception:
+        logger.debug("Failed to revoke browser handoffs for %s", browser_id, exc_info=True)
+
+
+def security_headers() -> dict[str, str]:
+    return {
+        "Cache-Control": "no-store, max-age=0",
+        "Pragma": "no-cache",
+        "Referrer-Policy": "no-referrer",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "Content-Security-Policy": (
+            "default-src 'none'; frame-src https://browser-use.com "
+            "https://*.browser-use.com; style-src 'unsafe-inline'; "
+            "form-action 'self'; base-uri 'none'; frame-ancestors 'none'"
+        ),
+    }
+
+
+def render_handoff_page(
+    record: Optional[BrowserHandoff], *, complete_path: str = ""
+) -> tuple[str, int]:
+    if record is None or record.status in {"expired", "cancelled"}:
+        title = "Link unavailable"
+        body = "This handoff link is invalid or has expired."
+        status = 410
+        frame = ""
+    elif record.status == "completed":
+        title = "Done"
+        body = "Hermes has been notified and will continue the task."
+        status = 200
+        frame = ""
+    else:
+        title = "Take over the browser"
+        body = html.escape(record.instruction)
+        status = 200
+        live = html.escape(record.live_url, quote=True)
+        action = html.escape(complete_path, quote=True)
+        frame = (
+            f'<iframe title="Remote browser" src="{live}" allow="clipboard-read; clipboard-write"></iframe>'
+            f'<p class="fallback"><a href="{live}" target="_blank" '
+            'rel="noreferrer noopener">Open the live browser in a new tab</a></p>'
+            f'<form method="post" action="{action}"><button type="submit">Done</button></form>'
+        )
+    doc = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{html.escape(title)}</title><style>
+html,body{{margin:0;background:#0b0d12;color:#f4f5f7;font:16px system-ui,sans-serif}}
+main{{max-width:1200px;margin:auto;padding:20px}}h1{{margin:.2em 0}}p{{color:#c9ccd3}}
+iframe{{width:100%;height:min(72vh,820px);border:1px solid #343947;border-radius:12px;background:white}}
+button{{background:#6d5dfc;color:white;border:0;border-radius:10px;padding:13px 28px;
+font-size:17px;font-weight:700;cursor:pointer}}
+a{{color:#a9c7ff}}.fallback{{margin:.75em 0}}form{{margin-top:16px}}
+</style></head><body><main><h1>{html.escape(title)}</h1><p>{body}</p>{frame}</main></body></html>"""
+    return doc, status
+
+
+WAKE_MESSAGE = (
+    "The human browser handoff is complete. Resume this exact task now. "
+    "First inspect the current page with browser_exec and verify the requested "
+    "login, CAPTCHA, or other blocking step succeeded; then continue from "
+    "where you paused."
+)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -60,6 +60,7 @@ import time
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 # Sentinel returned by _resolve_request_profile when a /p/<profile>/ prefix
 # names a profile this gateway does not serve (→ 404). Distinct from None
@@ -108,10 +109,12 @@ def _approval_event_choices(*, smart_denied: bool, allow_permanent: bool) -> lis
 
 try:
     from aiohttp import web
+    from aiohttp.web_log import AccessLogger
     AIOHTTP_AVAILABLE = True
 except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
+    AccessLogger = object  # type: ignore[assignment,misc]
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -170,6 +173,39 @@ def _get_scoped_secret(name, default=None):
 
 
 logger = logging.getLogger(__name__)
+
+
+_BROWSER_HANDOFF_LOG_PATH_RE = re.compile(
+    r"^(?P<prefix>/p/[^/]+)?/browser-handoff/[^/]+(?P<complete>/complete)?$"
+)
+
+
+def _redact_browser_handoff_log_path(path: str) -> str:
+    match = _BROWSER_HANDOFF_LOG_PATH_RE.match(path)
+    if match is None:
+        return path
+    return (
+        f"{match.group('prefix') or ''}/browser-handoff/[REDACTED]"
+        f"{match.group('complete') or ''}"
+    )
+
+
+class _RedactingAccessLogger(AccessLogger):
+    """Keep handoff bearer tokens out of aiohttp access logs."""
+
+    def log(self, request, response, elapsed: float) -> None:
+        redacted = _redact_browser_handoff_log_path(str(request.path))
+        if redacted != request.path:
+            self.logger.info(
+                '%s "%s %s" %s %.3fs',
+                request.remote or "-",
+                request.method,
+                redacted,
+                response.status,
+                elapsed,
+            )
+            return
+        super().log(request, response, elapsed)
 
 
 def _browser_controller_ws_sender(ws, loop, *, wait_timeout: float = 10.0):
@@ -1589,6 +1625,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # _inject_browser_control_artifacts().
         self._browser_control_artifacts: Dict[str, ArtifactStore] = {}
         self._browser_control_artifact_limiter: Optional[ArtifactRateLimiter] = None
+        self._browser_handoff_attempts: Dict[str, List[float]] = {}
 
     def active_agent_work_count(self) -> int:
         """Return all live agent work owned by this API adapter.
@@ -2175,6 +2212,175 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return profile_prefix_middleware
 
+    def _browser_handoff_rate_limited(self, request: "web.Request", token: str) -> bool:
+        """Bound token probing without retaining raw bearer URLs in memory."""
+        now = time.monotonic()
+        peer = request.remote or "unknown"
+        peer_key = "ip:" + hashlib.sha256(peer.encode("utf-8")).hexdigest()
+        token_key = "token:" + hashlib.sha256(token.encode("utf-8")).hexdigest()
+        limited = False
+        for key, limit in ((peer_key, 60), (token_key, 30)):
+            attempts = self._browser_handoff_attempts.setdefault(key, [])
+            attempts[:] = [stamp for stamp in attempts if now - stamp < 60]
+            attempts.append(now)
+            limited = limited or len(attempts) > limit
+        if len(self._browser_handoff_attempts) > 2048:
+            self._browser_handoff_attempts = {
+                k: values for k, values in self._browser_handoff_attempts.items()
+                if values and now - values[-1] < 60
+            }
+        return limited
+
+    @staticmethod
+    def _browser_handoff_response(body: str, status: int) -> "web.Response":
+        from gateway.browser_handoff import security_headers
+
+        return web.Response(
+            text=body,
+            status=status,
+            content_type="text/html",
+            charset="utf-8",
+            headers=security_headers(),
+        )
+
+    async def _handle_browser_handoff_get(self, request: "web.Request") -> "web.Response":
+        from gateway.browser_handoff import (
+            BrowserHandoffStore,
+            load_browser_handoff_config,
+            render_handoff_page,
+        )
+
+        token = str(request.match_info.get("token") or "")
+        if self._browser_handoff_rate_limited(request, token):
+            body, _ = render_handoff_page(None)
+            return self._browser_handoff_response(body, 429)
+        cfg = load_browser_handoff_config()
+        record = (
+            await asyncio.to_thread(BrowserHandoffStore().lookup, token)
+            if cfg.enabled
+            else None
+        )
+        body, status = render_handoff_page(
+            record, complete_path=f"{request.path.rstrip('/')}/complete"
+        )
+        return self._browser_handoff_response(body, status)
+
+    async def _deliver_browser_handoff_wake(self, record_id: int) -> None:
+        from gateway.browser_handoff import BrowserHandoffStore, WAKE_MESSAGE
+        from gateway.session import SessionSource
+        from gateway.wake import deliver_wake
+
+        store = BrowserHandoffStore()
+        record = await asyncio.to_thread(store.claim_wake, record_id)
+        if record is None:
+            return
+        delivered = False
+        try:
+            source = SessionSource.from_dict(record.source) if record.source else None
+            runner = self.gateway_runner
+            if runner is None and self._app is not None:
+                runner = self._app.get("gateway_runner")
+            adapter = None
+            session_key = ""
+            if source is not None and runner is not None:
+                resolver = getattr(runner, "_adapter_for_source", None)
+                if callable(resolver):
+                    adapter = resolver(source)
+                key_resolver = getattr(runner, "_session_key_for_source", None)
+                if callable(key_resolver):
+                    session_key = str(key_resolver(source) or "")
+                if session_key:
+                    entry = await runner.async_session_store.lookup_by_session_key(
+                        session_key
+                    )
+                    if entry is None or entry.session_id != record.session_id:
+                        # A /new, reset or replacement occurred while the human
+                        # had control. Never wake the replacement conversation.
+                        logger.warning(
+                            "[api_server] discarding browser handoff wake for "
+                            "stale session row %s",
+                            record_id,
+                        )
+                        delivered = True
+                        return
+            # Programmatic/cron origins have no push adapter. The API server's
+            # raw-session wake path resumes the exact SessionDB entry instead.
+            if adapter is None:
+                adapter = self
+                source = None
+            await deliver_wake(
+                adapter,
+                text=WAKE_MESSAGE,
+                session_id=record.session_id,
+                session_key=session_key,
+                source=source,
+            )
+            delivered = True
+        except Exception:
+            logger.exception(
+                "[api_server] browser handoff wake failed for row %s; will retry",
+                record_id,
+            )
+        finally:
+            await asyncio.to_thread(store.finish_wake, record_id, delivered=delivered)
+
+    def _schedule_browser_handoff_wake(self, record_id: int) -> None:
+        task = asyncio.create_task(self._deliver_browser_handoff_wake(record_id))
+        try:
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+        except (AttributeError, TypeError):
+            pass
+
+    async def _handle_browser_handoff_complete(self, request: "web.Request") -> "web.Response":
+        from gateway.browser_handoff import (
+            BrowserHandoffStore,
+            load_browser_handoff_config,
+            render_handoff_page,
+        )
+
+        token = str(request.match_info.get("token") or "")
+        if self._browser_handoff_rate_limited(request, token):
+            body, _ = render_handoff_page(None)
+            return self._browser_handoff_response(body, 429)
+
+        # Ordinary browser form posts include Origin. Reject a cross-origin
+        # submit, while allowing privacy tools that omit Origin entirely.
+        origin = str(request.headers.get("Origin") or "").rstrip("/")
+        cfg = load_browser_handoff_config()
+        expected_url = urlparse(cfg.public_base_url)
+        expected_origin = (
+            f"{expected_url.scheme}://{expected_url.netloc}" if expected_url.netloc else ""
+        ).lower()
+        if not cfg.enabled or (
+            origin
+            and (
+                not expected_origin
+                or not hmac.compare_digest(origin.lower(), expected_origin)
+            )
+        ):
+            body, _ = render_handoff_page(None)
+            return self._browser_handoff_response(body, 403)
+
+        store = BrowserHandoffStore()
+        record = await asyncio.to_thread(store.complete, token)
+        if record is not None and record.status == "completed" and record.wake_status != "delivered":
+            self._schedule_browser_handoff_wake(record.id)
+        body, status = render_handoff_page(record)
+        return self._browser_handoff_response(body, status)
+
+    async def _sweep_browser_handoff_wakes(self) -> None:
+        from gateway.browser_handoff import BrowserHandoffStore
+
+        while True:
+            await asyncio.sleep(15)
+            try:
+                ids = await asyncio.to_thread(BrowserHandoffStore().pending_wake_ids)
+                for record_id in ids:
+                    self._schedule_browser_handoff_wake(record_id)
+            except Exception:
+                logger.debug("Browser handoff wake sweep failed", exc_info=True)
+
     def _http_route_table(self) -> List[tuple]:
         """Return (method, path, handler) rows registered by ``connect()``.
 
@@ -2182,6 +2388,15 @@ class APIServerAdapter(BasePlatformAdapter):
         mirrors without starting a real aiohttp listener.
         """
         routes: List[tuple] = [
+            # Deliberately outside API_SERVER_KEY auth: possession of the
+            # random 256-bit URL token is the handoff credential. Handlers
+            # apply their own expiry, one-shot state, origin and rate checks.
+            ("GET", "/browser-handoff/{token}", self._handle_browser_handoff_get),
+            (
+                "POST",
+                "/browser-handoff/{token}/complete",
+                self._handle_browser_handoff_complete,
+            ),
             ("GET", "/health", self._handle_health),
             ("GET", "/health/detailed", self._handle_health_detailed),
             ("GET", "/v1/health", self._handle_health),
@@ -8326,6 +8541,21 @@ class APIServerAdapter(BasePlatformAdapter):
             if hasattr(sweep_task, "add_done_callback"):
                 sweep_task.add_done_callback(self._background_tasks.discard)
 
+            from gateway.browser_handoff import load_browser_handoff_config
+
+            if load_browser_handoff_config().enabled:
+                handoff_sweep_task = asyncio.create_task(
+                    self._sweep_browser_handoff_wakes()
+                )
+                try:
+                    self._background_tasks.add(handoff_sweep_task)
+                except TypeError:
+                    pass
+                if hasattr(handoff_sweep_task, "add_done_callback"):
+                    handoff_sweep_task.add_done_callback(
+                        self._background_tasks.discard
+                    )
+
             # Loud warning when a network-accessible API server runs against an
             # unsandboxed local terminal backend. The API server can drive the
             # agent's terminal/file tools as the host user; on a public bind
@@ -8354,7 +8584,9 @@ class APIServerAdapter(BasePlatformAdapter):
                         self.name, self._host,
                     )
 
-            self._runner = web.AppRunner(self._app)
+            self._runner = web.AppRunner(
+                self._app, access_log_class=_RedactingAccessLogger
+            )
             await self._runner.setup()
             # Bind directly instead of probing 127.0.0.1 first — the old
             # single-family pre-probe raced the real bind and reported a

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -58,6 +58,7 @@ import sys
 import threading
 import time
 import uuid
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
@@ -1625,7 +1626,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # _inject_browser_control_artifacts().
         self._browser_control_artifacts: Dict[str, ArtifactStore] = {}
         self._browser_control_artifact_limiter: Optional[ArtifactRateLimiter] = None
-        self._browser_handoff_attempts: Dict[str, List[float]] = {}
+        self._browser_handoff_attempts: "OrderedDict[str, List[float]]" = (
+            OrderedDict()
+        )
 
     def active_agent_work_count(self) -> int:
         """Return all live agent work owned by this API adapter.
@@ -2218,18 +2221,31 @@ class APIServerAdapter(BasePlatformAdapter):
         peer = request.remote or "unknown"
         peer_key = "ip:" + hashlib.sha256(peer.encode("utf-8")).hexdigest()
         token_key = "token:" + hashlib.sha256(token.encode("utf-8")).hexdigest()
-        limited = False
-        for key, limit in ((peer_key, 60), (token_key, 30)):
-            attempts = self._browser_handoff_attempts.setdefault(key, [])
+        buckets = self._browser_handoff_attempts
+        if not isinstance(buckets, OrderedDict):
+            buckets = OrderedDict(buckets)
+            self._browser_handoff_attempts = buckets
+
+        def record(key: str, limit: int) -> bool:
+            attempts = buckets.get(key)
+            if attempts is None:
+                # Hard cap first, then insert. OrderedDict gives O(1) LRU
+                # eviction even under distributed random-token probing.
+                while len(buckets) >= 2048:
+                    buckets.popitem(last=False)
+                attempts = []
+                buckets[key] = attempts
+            else:
+                buckets.move_to_end(key)
             attempts[:] = [stamp for stamp in attempts if now - stamp < 60]
             attempts.append(now)
-            limited = limited or len(attempts) > limit
-        if len(self._browser_handoff_attempts) > 2048:
-            self._browser_handoff_attempts = {
-                k: values for k, values in self._browser_handoff_attempts.items()
-                if values and now - values[-1] < 60
-            }
-        return limited
+            return len(attempts) > limit
+
+        # Once a peer is blocked, do not allocate a bucket for its arbitrary
+        # token. This prevents one attacker from growing token state at all.
+        if record(peer_key, 60):
+            return True
+        return record(token_key, 30)
 
     @staticmethod
     def _browser_handoff_response(body: str, status: int) -> "web.Response":
@@ -2266,9 +2282,13 @@ class APIServerAdapter(BasePlatformAdapter):
         return self._browser_handoff_response(body, status)
 
     async def _deliver_browser_handoff_wake(self, record_id: int) -> None:
-        from gateway.browser_handoff import BrowserHandoffStore, WAKE_MESSAGE
+        from gateway.browser_handoff import (
+            BrowserHandoffStore,
+            EXPIRED_WAKE_MESSAGE,
+            WAKE_MESSAGE,
+        )
         from gateway.session import SessionSource
-        from gateway.wake import deliver_wake
+        from gateway.wake import adapter_supports_push, deliver_wake
 
         store = BrowserHandoffStore()
         record = await asyncio.to_thread(store.claim_wake, record_id)
@@ -2286,23 +2306,29 @@ class APIServerAdapter(BasePlatformAdapter):
                 resolver = getattr(runner, "_adapter_for_source", None)
                 if callable(resolver):
                     adapter = resolver(source)
-                key_resolver = getattr(runner, "_session_key_for_source", None)
-                if callable(key_resolver):
-                    session_key = str(key_resolver(source) or "")
-                if session_key:
-                    entry = await runner.async_session_store.lookup_by_session_key(
-                        session_key
-                    )
-                    if entry is None or entry.session_id != record.session_id:
-                        # A /new, reset or replacement occurred while the human
-                        # had control. Never wake the replacement conversation.
-                        logger.warning(
-                            "[api_server] discarding browser handoff wake for "
-                            "stale session row %s",
-                            record_id,
+                if adapter is not None and adapter_supports_push(adapter):
+                    key_resolver = getattr(runner, "_session_key_for_source", None)
+                    if callable(key_resolver):
+                        session_key = str(key_resolver(source) or "")
+                    if session_key:
+                        entry = await runner.async_session_store.lookup_by_session_key(
+                            session_key
                         )
-                        delivered = True
-                        return
+                        if entry is None or entry.session_id != record.session_id:
+                            # A /new, reset or replacement occurred while the human
+                            # had control. Never wake the replacement conversation.
+                            logger.warning(
+                                "[api_server] discarding browser handoff wake for "
+                                "stale session row %s",
+                                record_id,
+                            )
+                            delivered = True
+                            return
+                else:
+                    # API-server sessions live under the raw session id and do
+                    # not have a gateway routing-key row to validate.
+                    adapter = self
+                    source = None
             # Programmatic/cron origins have no push adapter. The API server's
             # raw-session wake path resumes the exact SessionDB entry instead.
             if adapter is None:
@@ -2310,10 +2336,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 source = None
             await deliver_wake(
                 adapter,
-                text=WAKE_MESSAGE,
+                text=(
+                    EXPIRED_WAKE_MESSAGE
+                    if record.status == "expired"
+                    else WAKE_MESSAGE
+                ),
                 session_id=record.session_id,
                 session_key=session_key,
                 source=source,
+                profile=str(record.source.get("profile") or ""),
             )
             delivered = True
         except Exception:
@@ -2369,17 +2400,44 @@ class APIServerAdapter(BasePlatformAdapter):
         body, status = render_handoff_page(record)
         return self._browser_handoff_response(body, status)
 
+    def _browser_handoff_sweep_profiles(self) -> list[Optional[str]]:
+        runner_cfg = getattr(getattr(self, "gateway_runner", None), "config", None)
+        if not bool(getattr(runner_cfg, "multiplex_profiles", False)):
+            return [None]
+        from hermes_cli.profiles import profiles_to_serve
+
+        served = profiles_to_serve(
+            multiplex=True,
+            profile_allowlist=getattr(
+                runner_cfg, "multiplex_profile_allowlist", None
+            ),
+        )
+        return [None if name == "default" else name for name, _ in served]
+
     async def _sweep_browser_handoff_wakes(self) -> None:
-        from gateway.browser_handoff import BrowserHandoffStore
+        from gateway.browser_handoff import (
+            BrowserHandoffStore,
+            load_browser_handoff_config,
+        )
 
         while True:
             await asyncio.sleep(15)
-            try:
-                ids = await asyncio.to_thread(BrowserHandoffStore().pending_wake_ids)
-                for record_id in ids:
-                    self._schedule_browser_handoff_wake(record_id)
-            except Exception:
-                logger.debug("Browser handoff wake sweep failed", exc_info=True)
+            for profile in self._browser_handoff_sweep_profiles():
+                try:
+                    with self._profile_scope(profile):
+                        if not load_browser_handoff_config().enabled:
+                            continue
+                        ids = await asyncio.to_thread(
+                            BrowserHandoffStore().pending_wake_ids
+                        )
+                        for record_id in ids:
+                            self._schedule_browser_handoff_wake(record_id)
+                except Exception:
+                    logger.debug(
+                        "Browser handoff wake sweep failed for profile %s",
+                        profile or "default",
+                        exc_info=True,
+                    )
 
     def _http_route_table(self) -> List[tuple]:
         """Return (method, path, handler) rows registered by ``connect()``.
@@ -8541,20 +8599,21 @@ class APIServerAdapter(BasePlatformAdapter):
             if hasattr(sweep_task, "add_done_callback"):
                 sweep_task.add_done_callback(self._background_tasks.discard)
 
-            from gateway.browser_handoff import load_browser_handoff_config
-
-            if load_browser_handoff_config().enabled:
-                handoff_sweep_task = asyncio.create_task(
-                    self._sweep_browser_handoff_wakes()
+            # Always start one lightweight handoff sweep. It scopes each pass
+            # across every served profile and skips profiles where the feature
+            # is disabled; checking only the default profile here would strand
+            # secondary-profile handoffs after a restart.
+            handoff_sweep_task = asyncio.create_task(
+                self._sweep_browser_handoff_wakes()
+            )
+            try:
+                self._background_tasks.add(handoff_sweep_task)
+            except TypeError:
+                pass
+            if hasattr(handoff_sweep_task, "add_done_callback"):
+                handoff_sweep_task.add_done_callback(
+                    self._background_tasks.discard
                 )
-                try:
-                    self._background_tasks.add(handoff_sweep_task)
-                except TypeError:
-                    pass
-                if hasattr(handoff_sweep_task, "add_done_callback"):
-                    handoff_sweep_task.add_done_callback(
-                        self._background_tasks.discard
-                    )
 
             # Loud warning when a network-accessible API server runs against an
             # unsandboxed local terminal backend. The API server can drive the

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -27,7 +27,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from typing import Any, Optional
+from urllib.parse import quote
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +62,7 @@ async def deliver_wake(
     session_id: str = "",
     session_key: str = "",
     source: Any = None,
+    profile: str = "",
 ) -> None:
     """Deliver a wake turn to the session behind ``adapter``.
 
@@ -103,11 +106,16 @@ async def deliver_wake(
             "deliver_wake: non-push adapter (supports_async_delivery=False) "
             "requires the raw session id to self-post the wake turn"
         )
-    await _self_post_chat_completion(adapter, text=text, session_id=session_id)
+    await _self_post_chat_completion(
+        adapter,
+        text=text,
+        session_id=session_id,
+        profile=profile,
+    )
 
 
 async def _self_post_chat_completion(
-    adapter: Any, *, text: str, session_id: str
+    adapter: Any, *, text: str, session_id: str, profile: str = ""
 ) -> None:
     """POST the wake text to the in-pod API server as a normal session turn.
 
@@ -134,7 +142,14 @@ async def _self_post_chat_completion(
 
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"  # bare IPv6 literal
-    url = f"http://{host}:{port}/v1/chat/completions"
+    clean_profile = str(profile or "").strip()
+    if clean_profile and clean_profile not in {"default", "custom"}:
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}", clean_profile):
+            raise ValueError("wake self-post received an invalid profile name")
+        route_prefix = f"/p/{quote(clean_profile, safe='')}"
+    else:
+        route_prefix = ""
+    url = f"http://{host}:{port}{route_prefix}/v1/chat/completions"
     headers = {
         "Authorization": f"Bearer {api_key}",
         "X-Hermes-Session-Id": session_id,

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -58,6 +58,7 @@ async def deliver_wake(
     *,
     text: str,
     session_id: str = "",
+    session_key: str = "",
     source: Any = None,
 ) -> None:
     """Deliver a wake turn to the session behind ``adapter``.
@@ -65,7 +66,9 @@ async def deliver_wake(
     ``session_id`` is the RAW session id (the ``X-Hermes-Session-Id`` value /
     ``state.db`` key) — required for non-push adapters. ``source`` is the
     ``SessionSource`` used to build the synthetic event — required for
-    push-capable adapters.
+    push-capable adapters. When both ``session_key`` and ``session_id`` are
+    supplied for a push adapter, the gateway rejects the event if that route
+    was reset or replaced before delivery.
 
     Raises on failure (bad arguments, exhausted retries, HTTP error) so the
     caller can rewind/retry instead of treating the wake as delivered.
@@ -82,6 +85,15 @@ async def deliver_wake(
             message_type=MessageType.TEXT,
             source=source,
             internal=True,
+            metadata=(
+                {
+                    "gateway_session_key": session_key,
+                    "gateway_session_id": session_id,
+                    "gateway_session_strict": True,
+                }
+                if session_key and session_id
+                else {}
+            ),
         )
         await adapter.handle_message(synth_event)
         return

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -106,12 +106,21 @@ async def deliver_wake(
             "deliver_wake: non-push adapter (supports_async_delivery=False) "
             "requires the raw session id to self-post the wake turn"
         )
-    await _self_post_chat_completion(
-        adapter,
-        text=text,
-        session_id=session_id,
-        profile=profile,
-    )
+    if str(profile or "").strip() not in {"", "default", "custom"}:
+        await _self_post_chat_completion(
+            adapter,
+            text=text,
+            session_id=session_id,
+            profile=profile,
+        )
+    else:
+        # Preserve the long-standing internal call contract for ordinary
+        # single-profile wake paths and test/operator monkeypatches.
+        await _self_post_chat_completion(
+            adapter,
+            text=text,
+            session_id=session_id,
+        )
 
 
 async def _self_post_chat_completion(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -530,6 +530,16 @@ DEFAULT_CONFIG = {
         # "off"         — force the built-in browser tools
         #                 (browser_navigate, browser_click, …)
         "backend": "",
+        # Optional passwordless human takeover for Browser Use cloud sessions.
+        # The public URL must reverse-proxy the gateway API server's
+        # /browser-handoff/ path over HTTPS. Tokens are one-shot and TTL is
+        # hard-capped at 30 minutes.
+        "handoff": {
+            "enabled": False,
+            "public_base_url": "",
+            "ttl_minutes": 30,
+            "discord_user_id": "",
+        },
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
         "record_sessions": False,  # Auto-record browser sessions as WebM videos

--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -284,6 +284,9 @@ class BrowserUseBrowserProvider(BrowserProvider):
             "session_name": session_name,
             "bb_session_id": session_data["id"],
             "cdp_url": cdp_url,
+            # Passwordless human-control surface for a short-lived Hermes
+            # handoff. It remains task-scoped until a handoff is requested.
+            "live_url": session_data.get("liveUrl"),
             # Browser Use sessions have a fixed server-side lifetime. Preserve
             # the authority returned by the API so the dispatcher can retire an
             # expired CDP endpoint instead of reconnecting to it indefinitely.

--- a/tests/gateway/test_browser_handoff.py
+++ b/tests/gateway/test_browser_handoff.py
@@ -1,0 +1,241 @@
+import hashlib
+import json
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from gateway import browser_handoff as handoff
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _create(store, *, token="a" * 64, ttl=1800):
+    return store.create(
+        token_digest=hashlib.sha256(token.encode("ascii")).hexdigest(),
+        session_id="session-exact",
+        browser_key="task-1",
+        browser_id="browser-1",
+        live_url="https://live.browser-use.com/?session=secret",
+        instruction="Complete the CAPTCHA",
+        source={"platform": "discord", "chat_id": "123", "chat_type": "dm"},
+        ttl_seconds=ttl,
+    )
+
+
+def test_store_hashes_token_and_completion_is_one_shot(tmp_path):
+    path = tmp_path / "handoffs.db"
+    store = handoff.BrowserHandoffStore(path)
+    token = "b" * 64
+    record = _create(store, token=token)
+
+    raw = path.read_bytes()
+    assert token.encode() not in raw
+    assert store.lookup(token).status == "pending"
+    assert store.complete(token).status == "completed"
+    assert store.complete(token).status == "completed"
+    assert store.claim_wake(record.id) is not None
+    assert store.claim_wake(record.id) is None
+    store.finish_wake(record.id, delivered=True)
+    assert store.lookup(token).wake_status == "delivered"
+
+
+def test_expired_and_revoked_handoffs_never_render_live_url(tmp_path):
+    store = handoff.BrowserHandoffStore(tmp_path / "handoffs.db")
+    expired_token = "c" * 64
+    expired = _create(store, token=expired_token, ttl=-1)
+    expired = store.lookup(expired_token)
+    page, status = handoff.render_handoff_page(expired)
+    assert status == 410
+    assert "live.browser-use.com" not in page
+
+    active_token = "d" * 64
+    active = _create(store, token=active_token)
+    assert store.cancel_for_browser(active.browser_id) == 1
+    page, status = handoff.render_handoff_page(store.lookup(active_token))
+    assert status == 410
+    assert "live.browser-use.com" not in page
+
+
+def test_second_pending_handoff_does_not_invalidate_first(tmp_path):
+    store = handoff.BrowserHandoffStore(tmp_path / "handoffs.db")
+    token = "1" * 64
+    _create(store, token=token)
+
+    with pytest.raises(handoff.BrowserHandoffError, match="already pending"):
+        _create(store, token="2" * 64)
+
+    assert store.lookup(token).status == "pending"
+
+
+def test_active_page_has_remote_browser_done_and_security_headers(tmp_path):
+    store = handoff.BrowserHandoffStore(tmp_path / "handoffs.db")
+    token = "e" * 64
+    page, status = handoff.render_handoff_page(_create(store, token=token))
+    headers = handoff.security_headers()
+
+    assert status == 200
+    assert "<iframe" in page and ">Done</button>" in page
+    assert "Complete the CAPTCHA" in page
+    assert headers["Cache-Control"].startswith("no-store")
+    assert headers["Referrer-Policy"] == "no-referrer"
+    assert "frame-ancestors 'none'" in headers["Content-Security-Policy"]
+
+
+def test_create_handoff_dms_owner_without_persisting_bearer(
+    isolated_home, monkeypatch
+):
+    config = handoff.BrowserHandoffConfig(
+        enabled=True,
+        public_base_url="https://handoff.example",
+        ttl_minutes=30,
+        discord_user_id="1063878950851448853",
+    )
+    monkeypatch.setattr(handoff, "load_browser_handoff_config", lambda: config)
+    monkeypatch.setattr(
+        "tools.browser_tool._get_session_info",
+        lambda key: {
+            "bb_session_id": "browser-1",
+            "live_url": "https://live.browser-use.com/?session=secret",
+            "features": {"browser_use": True},
+        },
+    )
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-exact")
+    sent = []
+
+    result = handoff.create_browser_handoff(
+        instruction="Log in and solve the CAPTCHA",
+        task_id="task-1",
+        notifier=lambda user_id, message: sent.append((user_id, message)),
+    )
+
+    assert result["handoff_id"]
+    assert sent[0][0] == "1063878950851448853"
+    assert "yo i need u to do this" in sent[0][1]
+    assert "https://handoff.example/browser-handoff/" in sent[0][1]
+    token = sent[0][1].split("/browser-handoff/", 1)[1].splitlines()[0]
+    assert len(token) == 64
+    db_bytes = (isolated_home / "state" / "browser-handoffs.db").read_bytes()
+    assert token.encode() not in db_bytes
+
+
+@pytest.mark.asyncio
+async def test_public_done_handler_has_atomic_single_wake_boundary(isolated_home, monkeypatch):
+    from gateway.platforms.api_server import APIServerAdapter
+
+    token = "f" * 64
+    record = _create(handoff.BrowserHandoffStore(), token=token)
+    adapter = object.__new__(APIServerAdapter)
+    adapter._browser_handoff_attempts = {}
+    scheduled = []
+    adapter._schedule_browser_handoff_wake = scheduled.append
+    monkeypatch.setattr(
+        handoff,
+        "load_browser_handoff_config",
+        lambda: handoff.BrowserHandoffConfig(
+            True, "https://handoff.example", 30, "1063878950851448853"
+        ),
+    )
+    request = SimpleNamespace(
+        match_info={"token": token},
+        headers={"Origin": "https://handoff.example"},
+        remote="127.0.0.1",
+    )
+
+    first = await adapter._handle_browser_handoff_complete(request)
+    second = await adapter._handle_browser_handoff_complete(request)
+
+    assert first.status == second.status == 200
+    assert scheduled == [record.id, record.id]
+    # Scheduling may repeat, but BrowserHandoffStore.claim_wake is the atomic
+    # single-flight boundary that permits only one actual wake delivery.
+    store = handoff.BrowserHandoffStore()
+    assert store.claim_wake(record.id) is not None
+    assert store.claim_wake(record.id) is None
+
+
+def test_tool_schema_exposes_handoff_without_requiring_dummy_code():
+    from tools.browser_use_cli import BROWSER_EXEC_SCHEMA
+
+    params = BROWSER_EXEC_SCHEMA["parameters"]
+    assert params["properties"]["action"]["enum"] == ["exec", "handoff"]
+    assert "code" not in params["required"]
+
+
+def test_browser_exec_handoff_returns_waiting_result_without_running_cli(monkeypatch):
+    import tools.browser_use_cli as browser_use_cli
+
+    monkeypatch.setattr(
+        handoff,
+        "create_browser_handoff",
+        lambda **kwargs: {
+            "handoff_id": 42,
+            "expires_at": 1234.0,
+            "message": "wait for Done",
+        },
+    )
+    monkeypatch.setattr(
+        browser_use_cli,
+        "_find_cli",
+        lambda: (_ for _ in ()).throw(AssertionError("CLI must not run")),
+    )
+
+    result = json.loads(
+        browser_use_cli.browser_exec(
+            action="handoff",
+            instruction="Complete CAPTCHA",
+            task_id="task-1",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "wait for Done"
+    assert result["meta"]["handoff_id"] == 42
+
+
+def test_public_routes_use_separate_get_and_complete_paths():
+    from gateway.platforms.api_server import APIServerAdapter
+
+    adapter = object.__new__(APIServerAdapter)
+    routes = {(method, path) for method, path, _ in adapter._http_route_table()}
+    assert ("GET", "/browser-handoff/{token}") in routes
+    assert ("POST", "/browser-handoff/{token}/complete") in routes
+
+
+def test_access_log_redacts_handoff_bearer_token():
+    from gateway.platforms.api_server import _redact_browser_handoff_log_path
+
+    token = "a" * 64
+    assert _redact_browser_handoff_log_path(
+        f"/browser-handoff/{token}/complete"
+    ) == "/browser-handoff/[REDACTED]/complete"
+    assert _redact_browser_handoff_log_path(
+        f"/p/work/browser-handoff/{token}"
+    ) == "/p/work/browser-handoff/[REDACTED]"
+    assert _redact_browser_handoff_log_path("/v1/models") == "/v1/models"
+
+
+def test_successful_handoff_is_a_deterministic_turn_boundary():
+    from agent.conversation_loop import _browser_handoff_wait_message
+
+    messages = [
+        {
+            "role": "tool",
+            "name": "browser_exec",
+            "content": json.dumps(
+                {
+                    "success": True,
+                    "output": "DM sent; waiting for Done",
+                    "meta": {"browser_handoff": True},
+                }
+            ),
+        }
+    ]
+    assert _browser_handoff_wait_message(messages) == "DM sent; waiting for Done"
+    assert _browser_handoff_wait_message(
+        [{"role": "tool", "name": "browser_exec", "content": "{}"}]
+    ) == ""

--- a/tests/gateway/test_browser_handoff.py
+++ b/tests/gateway/test_browser_handoff.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
-import sqlite3
+import time
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -14,7 +15,7 @@ def isolated_home(tmp_path, monkeypatch):
     return tmp_path
 
 
-def _create(store, *, token="a" * 64, ttl=1800):
+def _create(store, *, token="a" * 64, ttl=1800, source=None):
     return store.create(
         token_digest=hashlib.sha256(token.encode("ascii")).hexdigest(),
         session_id="session-exact",
@@ -22,7 +23,8 @@ def _create(store, *, token="a" * 64, ttl=1800):
         browser_id="browser-1",
         live_url="https://live.browser-use.com/?session=secret",
         instruction="Complete the CAPTCHA",
-        source={"platform": "discord", "chat_id": "123", "chat_type": "dm"},
+        source=source
+        or {"platform": "discord", "chat_id": "123", "chat_type": "dm"},
         ttl_seconds=ttl,
     )
 
@@ -70,6 +72,34 @@ def test_second_pending_handoff_does_not_invalidate_first(tmp_path):
         _create(store, token="2" * 64)
 
     assert store.lookup(token).status == "pending"
+    assert store.retains_browser("browser-1") is True
+    store.cancel_for_browser("browser-1")
+    assert store.retains_browser("browser-1") is False
+
+
+def test_expiry_is_wakeable_and_retains_browser_until_delivery(tmp_path):
+    store = handoff.BrowserHandoffStore(tmp_path / "handoffs.db")
+    record = _create(store, token="3" * 64, ttl=-1)
+
+    assert store.pending_wake_ids() == [record.id]
+    claimed = store.claim_wake(record.id)
+    assert claimed is not None and claimed.status == "expired"
+    assert store.retains_browser(record.browser_id) is True
+
+    store.finish_wake(record.id, delivered=True)
+    assert store.retains_browser(record.browser_id) is False
+
+
+def test_completed_handoff_retains_browser_through_wake(tmp_path):
+    store = handoff.BrowserHandoffStore(tmp_path / "handoffs.db")
+    token = "4" * 64
+    record = _create(store, token=token)
+    assert store.complete(token).status == "completed"
+    assert store.retains_browser(record.browser_id) is True
+    assert store.claim_wake(record.id) is not None
+    assert store.retains_browser(record.browser_id) is True
+    store.finish_wake(record.id, delivered=True)
+    assert store.retains_browser(record.browser_id) is False
 
 
 def test_active_page_has_remote_browser_done_and_security_headers(tmp_path):
@@ -98,7 +128,7 @@ def test_create_handoff_dms_owner_without_persisting_bearer(
     monkeypatch.setattr(handoff, "load_browser_handoff_config", lambda: config)
     monkeypatch.setattr(
         "tools.browser_tool._get_session_info",
-        lambda key: {
+        lambda key: seen_keys.append(key) or {
             "bb_session_id": "browser-1",
             "live_url": "https://live.browser-use.com/?session=secret",
             "features": {"browser_use": True},
@@ -106,6 +136,7 @@ def test_create_handoff_dms_owner_without_persisting_bearer(
     )
     monkeypatch.setenv("HERMES_SESSION_ID", "session-exact")
     sent = []
+    seen_keys = []
 
     result = handoff.create_browser_handoff(
         instruction="Log in and solve the CAPTCHA",
@@ -114,6 +145,9 @@ def test_create_handoff_dms_owner_without_persisting_bearer(
     )
 
     assert result["handoff_id"]
+    from tools.browser_use_cli import _provider_session_cache_key
+
+    assert seen_keys == [_provider_session_cache_key("task-1")]
     assert sent[0][0] == "1063878950851448853"
     assert "yo i need u to do this" in sent[0][1]
     assert "https://handoff.example/browser-handoff/" in sent[0][1]
@@ -121,6 +155,55 @@ def test_create_handoff_dms_owner_without_persisting_bearer(
     assert len(token) == 64
     db_bytes = (isolated_home / "state" / "browser-handoffs.db").read_bytes()
     assert token.encode() not in db_bytes
+
+
+def test_secondary_profile_handoff_link_uses_profile_prefix(
+    isolated_home, monkeypatch
+):
+    config = handoff.BrowserHandoffConfig(
+        enabled=True,
+        public_base_url="https://handoff.example",
+        ttl_minutes=30,
+        discord_user_id="1063878950851448853",
+    )
+    monkeypatch.setattr(handoff, "load_browser_handoff_config", lambda: config)
+    monkeypatch.setattr(
+        "tools.browser_tool._get_session_info",
+        lambda key: {
+            "bb_session_id": "browser-profile",
+            "live_url": "https://live.browser-use.com/?session=secret",
+            "features": {"browser_use": True},
+        },
+    )
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-exact")
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_SESSION_PROFILE", "worker")
+    sent = []
+
+    handoff.create_browser_handoff(
+        instruction="Sign in",
+        task_id="task-profile",
+        notifier=lambda user_id, message: sent.append(message),
+    )
+
+    assert "https://handoff.example/p/worker/browser-handoff/" in sent[0]
+
+
+def test_rate_limit_state_is_hard_bounded_and_stops_token_allocation_for_peer():
+    from gateway.platforms.api_server import APIServerAdapter
+
+    adapter = object.__new__(APIServerAdapter)
+    adapter._browser_handoff_attempts = {}
+    request = SimpleNamespace(remote="203.0.113.1")
+    for index in range(500):
+        adapter._browser_handoff_rate_limited(request, f"{index:064x}")
+    # One peer bucket plus token buckets admitted before the peer was blocked.
+    assert len(adapter._browser_handoff_attempts) <= 61
+
+    for index in range(2200):
+        distributed = SimpleNamespace(remote=f"198.51.{index // 256}.{index % 256}")
+        adapter._browser_handoff_rate_limited(distributed, f"{index + 500:064x}")
+    assert len(adapter._browser_handoff_attempts) <= 2048
 
 
 @pytest.mark.asyncio
@@ -156,6 +239,89 @@ async def test_public_done_handler_has_atomic_single_wake_boundary(isolated_home
     store = handoff.BrowserHandoffStore()
     assert store.claim_wake(record.id) is not None
     assert store.claim_wake(record.id) is None
+
+
+@pytest.mark.asyncio
+async def test_api_origin_wake_uses_raw_session_without_gateway_lookup(
+    isolated_home, monkeypatch
+):
+    from gateway.platforms.api_server import APIServerAdapter
+
+    token = "5" * 64
+    store = handoff.BrowserHandoffStore()
+    record = _create(
+        store,
+        token=token,
+        source={
+            "platform": "api_server",
+            "chat_id": "raw-session",
+            "chat_type": "dm",
+            "profile": "worker",
+        },
+    )
+    store.complete(token)
+
+    class NoGatewayLookup:
+        async def lookup_by_session_key(self, key):
+            raise AssertionError("API sessions do not have gateway routing rows")
+
+    class Runner:
+        async_session_store = NoGatewayLookup()
+
+        @staticmethod
+        def _adapter_for_source(source):
+            return adapter
+
+        @staticmethod
+        def _session_key_for_source(source):
+            return "must-not-be-used"
+
+    adapter = object.__new__(APIServerAdapter)
+    adapter.gateway_runner = Runner()
+    adapter._app = None
+    delivered = []
+
+    async def fake_deliver(target, **kwargs):
+        delivered.append((target, kwargs))
+
+    monkeypatch.setattr("gateway.wake.deliver_wake", fake_deliver)
+
+    await adapter._deliver_browser_handoff_wake(record.id)
+
+    assert delivered[0][0] is adapter
+    assert delivered[0][1]["session_id"] == "session-exact"
+    assert delivered[0][1]["source"] is None
+    assert delivered[0][1]["profile"] == "worker"
+    assert store.lookup(token).wake_status == "delivered"
+
+
+def test_dm_reports_provider_capped_effective_expiry(isolated_home, monkeypatch):
+    config = handoff.BrowserHandoffConfig(
+        True, "https://handoff.example", 30, "1063878950851448853"
+    )
+    monkeypatch.setattr(handoff, "load_browser_handoff_config", lambda: config)
+    monkeypatch.setattr(
+        "tools.browser_tool._get_session_info",
+        lambda key: {
+            "bb_session_id": "browser-short",
+            "live_url": "https://live.browser-use.com/?session=secret",
+            "expires_at": datetime.fromtimestamp(
+                time.time() + 20, tz=timezone.utc
+            ).isoformat(),
+            "features": {"browser_use": True},
+        },
+    )
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-exact")
+    sent = []
+
+    result = handoff.create_browser_handoff(
+        instruction="Complete MFA",
+        task_id="task-short",
+        notifier=lambda user_id, message: sent.append(message),
+    )
+
+    assert "expires in 1 minute." in sent[0]
+    assert "valid for about 1 minute." in result["message"]
 
 
 def test_tool_schema_exposes_handoff_without_requiring_dummy_code():
@@ -239,3 +405,23 @@ def test_successful_handoff_is_a_deterministic_turn_boundary():
     assert _browser_handoff_wait_message(
         [{"role": "tool", "name": "browser_exec", "content": "{}"}]
     ) == ""
+
+
+def test_per_turn_cleanup_preserves_handoff_browser_once(monkeypatch):
+    from agent import chat_completion_helpers as helpers
+    import run_agent
+
+    calls = []
+    monkeypatch.setattr(helpers, "is_persistent_env", lambda task_id: True)
+    monkeypatch.setattr(run_agent, "cleanup_browser", lambda task_id: calls.append(task_id))
+    agent = SimpleNamespace(
+        _preserve_browser_after_turn=True,
+        verbose_logging=False,
+    )
+
+    helpers.cleanup_task_resources(agent, "task-1")
+    assert calls == []
+    assert agent._preserve_browser_after_turn is False
+
+    helpers.cleanup_task_resources(agent, "task-1")
+    assert calls == ["task-1"]

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -61,6 +61,18 @@ class TestApiServerProfileResolution:
             is _PROFILE_REJECTED
         )
 
+    def test_handoff_sweeper_visits_every_served_profile(self, monkeypatch):
+        adapter = _make_adapter(multiplex=True, allowlist=["worker"])
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profiles_to_serve",
+            lambda multiplex, profile_allowlist=None: [
+                ("default", "/profiles/default"),
+                ("worker", "/profiles/worker"),
+            ],
+        )
+
+        assert adapter._browser_handoff_sweep_profiles() == [None, "worker"]
+
 
 class TestApiServerRouteTable:
     def test_route_table_includes_models_options_and_chat(self):

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -73,12 +73,12 @@ def test_push_wake_can_pin_exact_gateway_session():
     }
 
 
-async def _serve(handler):
+async def _serve(handler, path="/v1/chat/completions"):
     """Spin an in-process aiohttp server on an ephemeral loopback port."""
     from aiohttp import web
 
     app = web.Application()
-    app.router.add_post("/v1/chat/completions", handler)
+    app.router.add_post(path, handler)
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, "127.0.0.1", 0)
@@ -118,6 +118,34 @@ def test_deliver_wake_non_push_self_posts_raw_session_id(monkeypatch):
     ]
 
 
+def test_deliver_wake_non_push_targets_multiplex_profile():
+    from aiohttp import web
+
+    seen = {}
+
+    async def handler(request):
+        seen["path"] = request.path
+        return web.json_response({"choices": []})
+
+    async def run():
+        runner, port = await _serve(
+            handler, "/p/worker/v1/chat/completions"
+        )
+        try:
+            adapter = ApiServerLikeAdapter(port=port)
+            await deliver_wake(
+                adapter,
+                text="resume",
+                session_id="raw-sid-42",
+                profile="worker",
+            )
+        finally:
+            await runner.cleanup()
+
+    asyncio.run(run())
+    assert seen["path"] == "/p/worker/v1/chat/completions"
+
+
 def test_deliver_wake_retries_429_then_succeeds(monkeypatch):
     """HTTP 429 (max_concurrent_runs cap) is transient — retried with backoff."""
     from aiohttp import web
@@ -143,4 +171,3 @@ def test_deliver_wake_retries_429_then_succeeds(monkeypatch):
 
     asyncio.run(run())
     assert calls["n"] == 2
-

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -53,6 +53,26 @@ def test_adapter_supports_push_default_true():
     assert adapter_supports_push(ApiServerLikeAdapter()) is False
 
 
+def test_push_wake_can_pin_exact_gateway_session():
+    adapter = PushAdapter()
+
+    asyncio.run(
+        deliver_wake(
+            adapter,
+            text="resume",
+            source=_source(),
+            session_key="agent:main:telegram:group:chat-1",
+            session_id="raw-sid-42",
+        )
+    )
+
+    assert adapter.handled[0].metadata == {
+        "gateway_session_key": "agent:main:telegram:group:chat-1",
+        "gateway_session_id": "raw-sid-42",
+        "gateway_session_strict": True,
+    }
+
+
 async def _serve(handler):
     """Spin an in-process aiohttp server on an ephemeral loopback port."""
     from aiohttp import web
@@ -123,5 +143,4 @@ def test_deliver_wake_retries_429_then_succeeds(monkeypatch):
 
     asyncio.run(run())
     assert calls["n"] == 2
-
 

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -408,9 +408,7 @@ class TestBackendCdpResolution:
         assert err and "no" in err.lower() and "CDP" in err
 
     def test_named_session_composes_with_provider_backend(self, tmp_path, monkeypatch):
-        """session=<name> composes with a configured provider backend: the
-        name keys its OWN provider browser (bu-named-<name>), so concurrent
-        named sessions never share one browser (#86894)."""
+        """A named session gets one provider browser inside its bot scope."""
         import tools.browser_tool as bt
 
         seen = []
@@ -424,16 +422,17 @@ class TestBackendCdpResolution:
         monkeypatch.setattr(bt, "_get_session_info", fake_session_info)
         cli = _fake_cli(tmp_path, 'cat > /dev/null\necho "bu:$BU_NAME ws:$BU_CDP_WS"\n')
         monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
-        result = json.loads(bu_cli.browser_exec("print(1)", session="r7k2"))
+        result = json.loads(
+            bu_cli.browser_exec("print(1)", session="r7k2", task_id="bot-A")
+        )
+        key = bu_cli._provider_session_cache_key("bot-A", "r7k2")
         assert result["success"] is True
-        assert seen == ["bu-named-r7k2"]
-        assert "bu:r7k2" in result["output"]
-        assert "ws:wss://browser.example/cdp/bu-named-r7k2" in result["output"]
+        assert seen == [key]
+        assert f"bu:{bu_cli._harness_session_name('bot-A', 'r7k2')}" in result["output"]
+        assert f"ws:wss://browser.example/cdp/{key}" in result["output"]
 
-    def test_named_session_key_stable_across_tasks(self, monkeypatch):
-        """The same session name maps to the same provider cache key no
-        matter which task calls it — that is what lets a follow-up call
-        reattach to the same cloud browser."""
+    def test_same_named_session_is_isolated_across_bots(self, monkeypatch):
+        """Two bots cannot collide even when they choose the same name."""
         import tools.browser_tool as bt
 
         seen = []
@@ -446,7 +445,52 @@ class TestBackendCdpResolution:
         env1, env2 = {}, {}
         assert bu_cli._resolve_backend_cdp(env1, "task-A", session_name="research") is None
         assert bu_cli._resolve_backend_cdp(env2, "task-B", session_name="research") is None
-        assert seen == ["bu-named-research", "bu-named-research"]
+        assert seen == [
+            bu_cli._provider_session_cache_key("task-A", "research"),
+            bu_cli._provider_session_cache_key("task-B", "research"),
+        ]
+        assert seen[0] != seen[1]
+
+    def test_unnamed_sessions_are_stable_per_bot_and_isolated(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        seen = []
+        monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt, "_get_cloud_provider", lambda: object())
+        monkeypatch.setattr(
+            bt,
+            "_get_session_info",
+            lambda key: seen.append(key) or {"cdp_url": "wss://x/cdp/a"},
+        )
+
+        for task_id in ("task-A", "task-A", "task-B"):
+            assert bu_cli._resolve_backend_cdp({}, task_id) is None
+
+        assert seen[0] == seen[1]
+        assert seen[0] != seen[2]
+
+    def test_task_cleanup_closes_all_bot_owned_provider_browsers(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        closed = []
+        monkeypatch.setattr(
+            bt,
+            "_active_sessions",
+            {
+                "bu-task-a": {"owner_task_id": "task-A"},
+                "bu-task-b": {"owner_task_id": "task-A"},
+                "bu-task-other": {"owner_task_id": "task-B"},
+            },
+        )
+        monkeypatch.setattr(bt, "_session_last_activity", {})
+        monkeypatch.setattr(bt, "_last_active_session_key", {})
+        monkeypatch.setattr(
+            bt, "_cleanup_single_browser_session", lambda key: closed.append(key)
+        )
+
+        bt.cleanup_browser("task-A")
+
+        assert closed == ["task-A", "bu-task-a", "bu-task-b"]
 
     def test_named_session_direct_api_bu_cloud_reuses_provider(self, monkeypatch):
         """Direct Browser Use sessions are Hermes-owned so liveUrl survives."""
@@ -465,13 +509,12 @@ class TestBackendCdpResolution:
         monkeypatch.setattr(bu_cli, "_read_browser_cfg", lambda: {"cloud_provider": "browser-use"})
         env = {}
         assert bu_cli._resolve_backend_cdp(env, "t1", session_name="r7k2") is None
-        assert seen == ["bu-named-r7k2"]
+        assert seen == [bu_cli._provider_session_cache_key("t1", "r7k2")]
         assert env["BU_CDP_WS"] == "wss://browser.example/cdp/owned"
 
 
 class TestOwnTabPreamble:
-    """Named sessions on SHARED browsers get the own-tab preamble prepended;
-    private per-name browsers and unnamed sessions do not."""
+    """Bot daemons on shared browsers pin a tab; private browsers do not."""
 
     def _run(self, tmp_path, monkeypatch, *, session="", private=False, provider=False):
         import tools.browser_tool as bt
@@ -497,10 +540,10 @@ class TestOwnTabPreamble:
         # model code still present, after the preamble
         assert result["output"].index("_hermes_ensure_own_tab") < result["output"].index("print('payload')")
 
-    def test_unnamed_session_gets_no_preamble(self, tmp_path, monkeypatch):
+    def test_unnamed_session_gets_preamble_on_shared_browser(self, tmp_path, monkeypatch):
         result = self._run(tmp_path, monkeypatch, session="")
         assert result["success"] is True
-        assert "_hermes_ensure_own_tab" not in result["output"]
+        assert "_hermes_ensure_own_tab" in result["output"]
 
     def test_named_provider_browser_skips_preamble(self, tmp_path, monkeypatch):
         """Per-name provider browsers are private — preamble would leak a tab."""
@@ -813,15 +856,28 @@ class TestBrowserExec:
         result = json.loads(bu_cli.browser_exec('print("hi")'))
         assert result["success"] is True
         assert result["exit_code"] == 0
-        assert 'got:print("hi")' in result["output"]
+        assert result["output"].rstrip().endswith('print("hi")')
         assert "session" not in result
 
     def test_session_sets_bu_name(self, tmp_path, monkeypatch):
         cli = _fake_cli(tmp_path, 'cat > /dev/null\necho "bu:$BU_NAME"\n')
         monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
-        result = json.loads(bu_cli.browser_exec("print(1)", session="r7k2"))
-        assert "bu:r7k2" in result["output"]
+        result = json.loads(
+            bu_cli.browser_exec("print(1)", session="r7k2", task_id="bot-A")
+        )
+        assert f"bu:{bu_cli._harness_session_name('bot-A', 'r7k2')}" in result["output"]
         assert result["session"] == "r7k2"
+
+    def test_unnamed_bots_get_separate_background_daemons(self, tmp_path, monkeypatch):
+        cli = _fake_cli(tmp_path, 'cat > /dev/null\necho "bu:$BU_NAME"\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        first = json.loads(bu_cli.browser_exec("print(1)", task_id="bot-A"))
+        repeat = json.loads(bu_cli.browser_exec("print(1)", task_id="bot-A"))
+        other = json.loads(bu_cli.browser_exec("print(1)", task_id="bot-B"))
+
+        assert first["output"] == repeat["output"]
+        assert first["output"] != other["output"]
 
     def test_invalid_session_name_rejected(self, monkeypatch, tmp_path):
         cli = _fake_cli(tmp_path, "cat > /dev/null\n")

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -294,13 +294,25 @@ class TestLegacyCloudMigration:
         monkeypatch.setattr(bu_cli, "_find_cli", lambda: None)
         assert bu_cli.is_browser_use_cli_mode() is False
 
-    def test_migrated_config_gets_bu_autospawn(self, tmp_path, monkeypatch):
+    def test_migrated_config_reuses_hermes_provider_session(self, tmp_path, monkeypatch):
+        import tools.browser_tool as bt
+
         monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: self._LEGACY)
         monkeypatch.setenv("BROWSER_USE_API_KEY", "bu-key")
-        cli = _fake_cli(tmp_path, 'cat > /dev/null\necho "autospawn:$BU_AUTOSPAWN"\n')
+        monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt, "_get_cloud_provider", lambda: object())
+        monkeypatch.setattr(
+            bt,
+            "_get_session_info",
+            lambda key: {"cdp_url": "wss://browser.example/cdp/owned"},
+        )
+        cli = _fake_cli(
+            tmp_path,
+            'cat > /dev/null\necho "autospawn:${BU_AUTOSPAWN:-} ws:$BU_CDP_WS"\n',
+        )
         monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
         result = json.loads(bu_cli.browser_exec("print(1)"))
-        assert "autospawn:1" in result["output"]
+        assert "autospawn: ws:wss://browser.example/cdp/owned" in result["output"]
 
     def test_explicit_backend_does_not_set_bu_autospawn(self, tmp_path, monkeypatch):
         monkeypatch.setattr(
@@ -436,27 +448,25 @@ class TestBackendCdpResolution:
         assert bu_cli._resolve_backend_cdp(env2, "task-B", session_name="research") is None
         assert seen == ["bu-named-research", "bu-named-research"]
 
-    def test_named_session_direct_api_bu_cloud_still_skips_provider(
-        self, tmp_path, monkeypatch
-    ):
-        """Direct-API Browser Use cloud configs keep the native named-daemon
-        path: resolving through the provider would double-session and
-        double-bill."""
+    def test_named_session_direct_api_bu_cloud_reuses_provider(self, monkeypatch):
+        """Direct Browser Use sessions are Hermes-owned so liveUrl survives."""
         import tools.browser_tool as bt
 
         class _BUProvider:
             name = "browser-use"
 
+        seen = []
         monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
         monkeypatch.setattr(bt, "_get_cloud_provider", lambda: _BUProvider())
         monkeypatch.setattr(
             bt, "_get_session_info",
-            lambda key: (_ for _ in ()).throw(AssertionError("must skip provider")),
+            lambda key: seen.append(key) or {"cdp_url": "wss://browser.example/cdp/owned"},
         )
         monkeypatch.setattr(bu_cli, "_read_browser_cfg", lambda: {"cloud_provider": "browser-use"})
         env = {}
         assert bu_cli._resolve_backend_cdp(env, "t1", session_name="r7k2") is None
-        assert "BU_CDP_WS" not in env and "BU_CDP_URL" not in env
+        assert seen == ["bu-named-r7k2"]
+        assert env["BU_CDP_WS"] == "wss://browser.example/cdp/owned"
 
 
 class TestOwnTabPreamble:

--- a/tests/tools/test_browser_use_session_expiry.py
+++ b/tests/tools/test_browser_use_session_expiry.py
@@ -22,6 +22,7 @@ def test_browser_use_preserves_provider_timeout(monkeypatch):
     response.json.return_value = {
         "id": "browser-session-1",
         "cdpUrl": "ws://browser-use.example/devtools/browser/1",
+        "liveUrl": "https://live.browser-use.com/?session=one",
         "timeoutAt": "2030-01-01T00:05:00Z",
     }
 
@@ -39,6 +40,7 @@ def test_browser_use_preserves_provider_timeout(monkeypatch):
     session = provider.create_session("task-1")
 
     assert session["expires_at"] == "2030-01-01T00:05:00Z"
+    assert session["live_url"] == "https://live.browser-use.com/?session=one"
 
 
 def test_live_cloud_session_is_reused(monkeypatch):

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1780,7 +1780,20 @@ def _cleanup_inactive_browser_sessions():
     with _cleanup_lock:
         for task_id, last_time in list(_session_last_activity.items()):
             if current_time - last_time > BROWSER_SESSION_INACTIVITY_TIMEOUT:
-                sessions_to_cleanup.append(task_id)
+                session_info = _active_sessions.get(task_id) or {}
+                browser_id = str(session_info.get("bb_session_id") or "")
+                preserve = False
+                if bool((session_info.get("features") or {}).get("browser_use")):
+                    try:
+                        from gateway.browser_handoff import (
+                            browser_handoff_retains_browser,
+                        )
+
+                        preserve = browser_handoff_retains_browser(browser_id)
+                    except Exception:
+                        preserve = False
+                if not preserve:
+                    sessions_to_cleanup.append(task_id)
 
     for task_id in sessions_to_cleanup:
         try:
@@ -4908,8 +4921,9 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
     if task_id is None:
         task_id = "default"
 
-    # Expand to the full set of session keys to reap. For a bare task_id
-    # that includes the cloud/primary key + the local sidecar if one exists.
+    # Expand to the full set of session keys to reap. For a bare task_id that
+    # includes the cloud/primary key, local sidecar, and any opaque provider
+    # keys owned by this bot (for example Browser Use per-bot isolation).
     if _is_local_sidecar_key(task_id):
         session_keys = [task_id]
         bare_task_id = task_id[: -len(_LOCAL_SUFFIX)]
@@ -4919,6 +4933,12 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
         with _cleanup_lock:
             if sidecar_key in _active_sessions:
                 session_keys.append(sidecar_key)
+            session_keys.extend(
+                key
+                for key, info in _active_sessions.items()
+                if key not in session_keys
+                and str(info.get("owner_task_id") or "") == task_id
+            )
         bare_task_id = task_id
 
     for session_key in session_keys:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -4965,6 +4965,16 @@ def _cleanup_single_browser_session(task_id: str) -> None:
         bb_session_id = session_info.get("bb_session_id", "unknown")
         logger.debug("Found session for task %s: bb_session_id=%s", task_id, bb_session_id)
 
+        # Revoke any public live-control link before the provider browser is
+        # closed, regardless of the link's nominal expiration time.
+        if bool((session_info.get("features") or {}).get("browser_use")):
+            try:
+                from gateway.browser_handoff import cancel_browser_handoffs
+
+                cancel_browser_handoffs(str(bb_session_id))
+            except Exception:
+                logger.debug("Browser handoff revocation failed", exc_info=True)
+
         # Stop auto-recording before closing (saves the file)
         _maybe_stop_recording(task_id)
 

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -463,8 +463,7 @@ def _resolve_backend_cdp(
        ``_get_session_info()`` so browser_exec shares the SAME provider
        session machinery — per-task session cache, expiry replacement,
        inactivity reaper, and atexit cleanup — instead of duplicating it.
-    4. Nothing configured: return None; the harness attaches to local
-       Chrome (or Browser Use cloud via BU_AUTOSPAWN for legacy configs).
+    4. Nothing configured: return None; the harness attaches to local Chrome.
 
     ``session_name`` (the tool's ``session`` argument / BU_NAME) keys the
     provider session cache when set, so every distinct name gets its OWN
@@ -503,21 +502,6 @@ def _resolve_backend_cdp(
     if provider is None:
         return None
 
-    # Browser Use direct-API configs: the CLI talks to Browser Use cloud
-    # natively (BU_AUTOSPAWN / auth login) — routing through the legacy
-    # provider here would just create a second, redundant session. The
-    # Nous-gateway variant (use_gateway: true) DOES resolve through the
-    # provider: the gateway provisions the cloud browser server-side and
-    # returns its CDP URL, giving subscribers CLI mode with no raw key.
-    provider_key = str(getattr(provider, "name", "") or "").strip().lower()
-    if provider_key == _BACKEND_KEY and not is_truthy_value(
-        _read_browser_cfg().get("use_gateway"), default=False
-    ):
-        # Named BU cloud browsers are exclusive to their daemon — no shared
-        # tab to isolate from.
-        env[_PRIVATE_BROWSER_SENTINEL] = "1"
-        return None
-
     try:
         # Named sessions get their OWN provider browser, keyed by name so the
         # same name reuses one browser across calls and tasks, and different
@@ -547,13 +531,40 @@ def _resolve_backend_cdp(
 
 
 def browser_exec(
-    code: str,
+    code: str = "",
     session: str = "",
     timeout_s: int = _DEFAULT_TIMEOUT_S,
     task_id: Optional[str] = None,
+    action: str = "exec",
+    instruction: str = "",
 ):
     """Run Python code through the browser-use CLI, and return its output"""
     from tools.registry import tool_error, tool_result
+
+    if action == "handoff":
+        try:
+            from gateway.browser_handoff import create_browser_handoff
+
+            result = create_browser_handoff(
+                instruction=instruction,
+                task_id=task_id or "",
+                session_name=session,
+            )
+            return tool_result(
+                {
+                    "success": True,
+                    "output": result["message"],
+                    "meta": {
+                        "browser_handoff": True,
+                        "handoff_id": result["handoff_id"],
+                        "expires_at": result["expires_at"],
+                    },
+                },
+            )
+        except Exception as exc:
+            return tool_error(str(exc))
+    if action != "exec":
+        return tool_error("Invalid browser_exec action; use 'exec' or 'handoff'.")
 
     if not code or not code.strip():
         return tool_error("No code provided. Pass Python that uses the pre-imported helpers, e.g. new_tab(\"https://example.com\") then print(page_info()).")
@@ -584,9 +595,9 @@ def browser_exec(
     # with the backend: BU_NAME namespaces the harness daemon (its IPC
     # socket, log, and pid), and on provider backends the name additionally
     # keys its own cloud browser — so concurrent sessions stop clobbering
-    # each other's daemon (#86894). Browser Use direct-API cloud configs
-    # are the one exception: the CLI manages named cloud browsers natively,
-    # and _resolve_backend_cdp skips provider resolution for them.
+    # each other's daemon (#86894). Browser Use cloud also resolves through
+    # this provider path so Hermes retains its browser ID and live URL for a
+    # possible human handoff while the CLI attaches over CDP.
     backend_err = _resolve_backend_cdp(env, task_id, session_name=session)
     if backend_err:
         return tool_error(backend_err)
@@ -603,11 +614,6 @@ def browser_exec(
     workspace = _workspace_dir(task_id)
     if workspace:
         env["BH_AGENT_WORKSPACE"] = workspace
-
-    # BU_AUTOSPAWN makes the CLI start a Browser Use cloud browser when no
-    # local Chrome/CDP endpoint is reachable (their API key authenticates it)
-    if "BU_AUTOSPAWN" not in env and is_legacy_browser_use_cloud_config(_read_browser_cfg()):
-        env["BU_AUTOSPAWN"] = "1"
 
     try:
         timeout = max(_MIN_TIMEOUT_S, min(int(timeout_s), _MAX_TIMEOUT_S))
@@ -763,7 +769,9 @@ _HELPERS_DIGEST = (
     "role/name/backendDOMNodeId (filter in Python before printing; it is "
     "thousands of nodes), then cdp('DOM.getBoxModel', backendNodeId=n) gives "
     "click coordinates. ensure_real_tab() recovers from a stale/internal "
-    "tab. Login walls: stop and ask the user; never guess credentials."
+    "tab. Login/CAPTCHA walls: never guess credentials or bypass them. If "
+    "browser handoff is configured, call this tool with action='handoff' and "
+    "a precise instruction, then end the turn and wait for the resumed session."
 )
 
 
@@ -793,9 +801,31 @@ BROWSER_EXEC_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["exec", "handoff"],
+                "description": (
+                    "Use exec to control or inspect the browser. Use handoff only "
+                    "when a human must solve a login, CAPTCHA, or similar blocker; "
+                    "it DMs the owner a 30-minute remote-control link and pauses "
+                    "this session."
+                ),
+                "default": "exec",
+            },
             "code": {
                 "type": "string",
-                "description": "Python code to execute using the pre-imported browser helpers. Use print(...) for any data you need back.",
+                "description": (
+                    "For action=exec: Python code using the pre-imported browser "
+                    "helpers. Use print(...) for data you need back."
+                ),
+            },
+            "instruction": {
+                "type": "string",
+                "description": (
+                    "For action=handoff: a concise description of exactly what the "
+                    "human must do, such as 'Complete the CAPTCHA and sign in with "
+                    "your account'."
+                ),
             },
             "session": {
                 "type": "string",
@@ -807,7 +837,7 @@ BROWSER_EXEC_SCHEMA = {
                 "default": _DEFAULT_TIMEOUT_S,
             },
         },
-        "required": ["code"],
+        "required": [],
     },
 }
 
@@ -826,6 +856,8 @@ registry.register(
         session=args.get("session", "") or "",
         timeout_s=args.get("timeout_s", _DEFAULT_TIMEOUT_S),
         task_id=kw.get("task_id"),
+        action=args.get("action", "exec") or "exec",
+        instruction=args.get("instruction", "") or "",
     ),
     check_fn=is_browser_use_cli_mode,
     dynamic_schema_overrides=_dynamic_schema_overrides,

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -4,6 +4,7 @@ When browser.backend is "browser-use", the model gets ``browser_exec`` tool
 instead of default browser tools
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -25,15 +26,39 @@ BACKEND_DISABLED = "off"
 _SESSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 
 # Internal marker set by _resolve_backend_cdp on the env dict when the
-# resolved browser is EXCLUSIVE to this named session (per-name provider
-# browser, or a named Browser Use cloud browser). Popped before the
+# resolved browser is EXCLUSIVE to this bot/task (a provider-managed browser).
+# Popped before the
 # subprocess launches — never exported to the CLI.
 _PRIVATE_BROWSER_SENTINEL = "_HERMES_BU_PRIVATE_BROWSER"
 
-# Preamble prepended to the model's code for named sessions on SHARED
+
+def _browser_instance_digest(
+    task_id: Optional[str], session_name: str = ""
+) -> str:
+    """Return a stable, non-sensitive scope for one bot browser instance."""
+    owner = str(task_id or "browser-exec-default")
+    material = f"{owner}\0{session_name}".encode("utf-8", errors="replace")
+    return hashlib.sha256(material).hexdigest()[:16]
+
+
+def _provider_session_cache_key(
+    task_id: Optional[str], session_name: str = ""
+) -> str:
+    """Key the provider browser by bot/task, with an optional sub-session."""
+    return f"bu-task-{_browser_instance_digest(task_id, session_name)}"
+
+
+def _harness_session_name(
+    task_id: Optional[str], session_name: str = ""
+) -> str:
+    """Namespace the background harness daemon for the same browser scope."""
+    return f"hermes-{_browser_instance_digest(task_id, session_name)}"
+
+
+# Preamble prepended to the model's code for bot daemons on SHARED
 # browsers (local Chrome / CDP override). The harness daemon attaches to the
 # first existing page at startup, so two fresh named daemons can land on the
-# SAME tab; steering this daemon onto a tab it created keeps concurrent named
+# SAME tab; steering this daemon onto a tab it created keeps concurrent bot
 # sessions from clobbering each other before their first new_tab(). Runs
 # once per daemon (marker file keyed by BU_NAME under the harness runtime
 # state), costs one IPC round-trip on later calls.
@@ -465,11 +490,9 @@ def _resolve_backend_cdp(
        inactivity reaper, and atexit cleanup — instead of duplicating it.
     4. Nothing configured: return None; the harness attaches to local Chrome.
 
-    ``session_name`` (the tool's ``session`` argument / BU_NAME) keys the
-    provider session cache when set, so every distinct name gets its OWN
-    cloud browser and the same name reuses one — that is what makes named
-    sessions actually concurrent-safe on provider backends instead of all
-    names sharing a single per-task browser.
+    Every bot/task gets its OWN provider browser and harness daemon. The
+    optional ``session_name`` creates an additional isolated browser within
+    that bot without allowing two bots that chose the same name to collide.
 
     Returns an error string on provider failure, None on success.
     """
@@ -503,11 +526,12 @@ def _resolve_backend_cdp(
         return None
 
     try:
-        # Named sessions get their OWN provider browser, keyed by name so the
-        # same name reuses one browser across calls and tasks, and different
-        # names never collide. Unnamed calls keep the per-task key.
-        cache_key = f"bu-named-{session_name}" if session_name else (task_id or "browser-exec-default")
+        cache_key = _provider_session_cache_key(task_id, session_name)
         session_info = _get_session_info(cache_key)
+        # cleanup_browser() receives the public Hermes task id. Preserve that
+        # ownership even though the provider cache key is intentionally opaque.
+        if isinstance(session_info, dict):
+            session_info["owner_task_id"] = str(task_id or "browser-exec-default")
     except Exception as e:
         return (
             f"Cloud browser provider {type(provider).__name__} failed to "
@@ -522,11 +546,10 @@ def _resolve_backend_cdp(
             "the built-in browser tools for this provider."
         )
     env["BU_CDP_URL" if cdp.startswith(("http://", "https://")) else "BU_CDP_WS"] = cdp
-    # A provider browser keyed bu-named-<name> is exclusive to this session —
-    # the own-tab preamble is unnecessary there (it would just leak a blank
-    # tab into a browser nobody else touches).
-    if session_name:
-        env[_PRIVATE_BROWSER_SENTINEL] = "1"
+    # Every provider browser is exclusive to this bot/task scope. The own-tab
+    # preamble is unnecessary there (it would leak a blank tab into a browser
+    # nobody else touches).
+    env[_PRIVATE_BROWSER_SENTINEL] = "1"
     return None
 
 
@@ -583,32 +606,32 @@ def browser_exec(
         )
 
     env = _base_subprocess_env()
-    if session:
-        if not _SESSION_RE.match(session):
-            return tool_error(
-                f"Invalid session name {session!r}: use 1-64 letters, digits, "
-                "dashes, or underscores (e.g. 'r7k2')."
-            )
-        env["BU_NAME"] = session
+    if session and not _SESSION_RE.match(session):
+        return tool_error(
+            f"Invalid session name {session!r}: use 1-64 letters, digits, "
+            "dashes, or underscores (e.g. 'r7k2')."
+        )
+    # Never use the harness default daemon. A bot-scoped BU_NAME lets browser
+    # work continue in the background and prevents concurrent bots from
+    # sharing daemon IPC state, even when the model omitted session=<name>.
+    env["BU_NAME"] = _harness_session_name(task_id, session)
     # Route through the configured browser backend (Browserbase, Firecrawl,
-    # Nous gateway, CDP override, local Chrome, …). Named sessions compose
-    # with the backend: BU_NAME namespaces the harness daemon (its IPC
-    # socket, log, and pid), and on provider backends the name additionally
-    # keys its own cloud browser — so concurrent sessions stop clobbering
-    # each other's daemon (#86894). Browser Use cloud also resolves through
-    # this provider path so Hermes retains its browser ID and live URL for a
-    # possible human handoff while the CLI attaches over CDP.
+    # Nous gateway, CDP override, local Chrome, …). BU_NAME namespaces one
+    # background harness daemon per bot/task and provider backends add one
+    # fresh managed Chrome instance per scope. Browser Use cloud also resolves
+    # through this provider path so Hermes retains its browser ID and live URL
+    # for a possible human handoff while the CLI attaches over CDP.
     backend_err = _resolve_backend_cdp(env, task_id, session_name=session)
     if backend_err:
         return tool_error(backend_err)
 
-    # On a SHARED browser (local Chrome / CDP override) a fresh named daemon
+    # On a SHARED browser (local Chrome / CDP override) a fresh bot daemon
     # attaches to the first existing page — the same page a sibling daemon
-    # may hold. Pin each named session to a tab it created before running
-    # the model's code. Private per-name browsers (provider-keyed or BU
-    # cloud) skip this: no one to collide with, and the extra tab would leak.
+    # may hold. Pin each bot scope to a tab it created before running the
+    # model's code. Private provider browsers (including Browser Use cloud)
+    # skip this: no one to collide with, and the extra tab would leak.
     private_browser = env.pop(_PRIVATE_BROWSER_SENTINEL, None)
-    if session and not private_browser:
+    if not private_browser:
         code = _OWN_TAB_PREAMBLE + code
 
     workspace = _workspace_dir(task_id)
@@ -704,9 +727,10 @@ _HEADER_BASE = (
     "— do not spend a call per action — but for long extractions prefer "
     "several medium calls that append to workspace files over one giant "
     "call, so progress survives timeouts. For an isolated concurrent "
-    "browser session (parallel tasks that must not share tabs), pass "
-    "session=<name> (never BU_NAME env syntax) and reuse the same name on "
-    "every related call."
+    "browser session inside the same bot, pass session=<name> (never BU_NAME "
+    "env syntax) and reuse the same name on every related call. Separate bots "
+    "are isolated automatically; a cloud provider gives each one a separate "
+    "managed Chrome, while local Chrome can provide only separate tabs."
 )
 
 _HEADER_VISION = (
@@ -829,7 +853,7 @@ BROWSER_EXEC_SCHEMA = {
             },
             "session": {
                 "type": "string",
-                "description": "Named isolated browser session (sets BU_NAME): each name gets its own harness daemon — and on cloud backends its own browser — so concurrent tasks don't clobber each other. Omit for the shared default session. Reuse the same name across calls to keep working in that session (and the name passed to start_remote_daemon(), if used).",
+                "description": "Optional additional isolated browser within this bot. Reuse the same name across related calls. Bot/task isolation is automatic even when omitted; on cloud backends every bot gets its own managed Chrome.",
             },
             "timeout_s": {
                 "type": "integer",


### PR DESCRIPTION
## What changed

- retain Browser Use live-control URLs in Hermes-owned cloud sessions and reuse those sessions from `browser_exec`
- give every bot/task a separate background harness daemon and separate managed cloud Chrome instance, including unnamed sessions and identical friendly session names
- add a 30-minute, no-login bearer handoff page with embedded remote control, fallback link, and Done action
- DM the configured Discord owner with precise instructions and the handoff URL
- hash handoff tokens at rest, expire/revoke them, redact them from access logs, and cancel them on browser cleanup
- preserve the exact cloud browser while the human controls it and throughout the resumed agent turn, then close every browser owned by the bot during normal task cleanup
- resume only the exact pinned Hermes session after Done or expiry, including raw API sessions and multiplex profiles
- hard-bound public-route rate-limit state and add profile-aware retry sweeping

## Configuration

```yaml
browser:
  handoff:
    enabled: true
    public_base_url: "https://hermes.example.com"
    ttl_minutes: 30
    discord_user_id: "1063878950851448853"
```

The HTTPS reverse proxy must route `/browser-handoff/` and multiplex `/p/<profile>/browser-handoff/` paths to the gateway API server. Browser handoff is available only for Browser Use cloud sessions that provide `liveUrl`; cloud mode is what provides full per-bot Chrome-process isolation and background concurrency.

## Risk / blast radius

This adds two intentionally API-key-free, bearer-token-authenticated routes. Tokens have 256 bits of randomness, are stored only by SHA-256 digest, expire in at most 30 minutes, are one-shot, profile-scoped, hard-rate-limited, no-store/no-referrer, redacted from access logs, and pinned to one browser and one Hermes session. All other API server routes retain their existing authentication.

## Validation

- 186 focused tests passed across browser isolation/session expiry, handoff state/security, gateway routing/browser-control surfaces, multiplex routing, wake delivery, and turn finalization
- Python compile checks passed for all touched production modules
- `git diff --check` passed
- independent `gpt-5.6-sol` high-reasoning review completed; all seven substantive findings were fixed and regression-tested

## Merge

Owner approval to merge was given in the implementation thread.