### PR TITLE
fix(computer-use): share configured cua-driver daemon

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3551,6 +3551,14 @@ DEFAULT_CONFIG = {
         # Leave false to keep existing-profile attachment failing closed;
         # isolated driver-owned profiles work either way.
         "grant_existing_profile": False,
+        # Optional endpoint for an already-running cua-driver daemon. When set,
+        # standard-mode Computer Use starts only an MCP proxy with
+        # `mcp --socket <path>` so every Hermes process shares the daemon's
+        # process-owned desktop portal/EIS session. The daemon's permission mode
+        # and grants are fixed at daemon startup; Hermes does not forward
+        # grant_existing_profile to an existing endpoint. Empty preserves the
+        # default per-Hermes-process runtime.
+        "daemon_socket": "",
     },
 
     # =========================================================================

--- a/tests/computer_use/test_cua_cli_fallback_env.py
+++ b/tests/computer_use/test_cua_cli_fallback_env.py
@@ -56,3 +56,34 @@ def test_cli_fallback_strips_provider_secret_from_subprocess_env(monkeypatch):
     assert captured["env"].get("PATH") == "/usr/bin:/bin"
 
 
+def test_cli_fallback_keeps_the_configured_standard_daemon_socket(monkeypatch):
+    monkeypatch.setattr(
+        "tools.computer_use.cua_backend.resolve_cua_driver_cmd",
+        lambda: "/resolved/cua-driver",
+    )
+    monkeypatch.setattr(
+        "tools.computer_use.cua_backend._cua_daemon_socket",
+        lambda: "/run/user/1000/cua.sock",
+    )
+    captured = {}
+
+    def fake_run(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return _fake_completed_process(json.dumps({"windows": []}))
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    session = _make_session()
+    result = session._call_tool_via_cli("list_windows", {}, timeout=5.0)
+
+    assert result["isError"] is False
+    assert captured["cmd"] == [
+        "/resolved/cua-driver",
+        "call",
+        "list_windows",
+        "{}",
+        "--socket",
+        "/run/user/1000/cua.sock",
+    ]
+
+

--- a/tests/tools/test_computer_use_cua_0_10_permissions.py
+++ b/tests/tools/test_computer_use_cua_0_10_permissions.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -236,6 +237,142 @@ def test_standard_existing_profile_grant_stays_in_process_off_macos():
 
     assert args == ["mcp", "--grant", "existing-profile"]
     assert socket_path is None
+
+
+def test_standard_external_daemon_socket_uses_proxy_without_runtime_grants(tmp_path):
+    from tools.computer_use.cua_backend import _standard_runtime_launch_args
+
+    daemon_socket = tmp_path / "cua-driver.sock"
+    args, owned_socket = _standard_runtime_launch_args(
+        ["mcp"],
+        grant_existing_profile=True,
+        platform="linux",
+        daemon_socket=str(daemon_socket),
+    )
+
+    assert args == ["mcp", "--socket", str(daemon_socket)]
+    assert owned_socket is None
+
+
+def test_configured_daemon_socket_is_expanded_to_a_stable_absolute_path(
+    monkeypatch, tmp_path
+):
+    from tools.computer_use import cua_backend
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"computer_use": {"daemon_socket": "~/.cache/cua.sock"}},
+    ):
+        assert cua_backend._cua_daemon_socket() == str(
+            tmp_path / ".cache" / "cua.sock"
+        )
+
+
+@pytest.mark.parametrize("value", [123, [], {}])
+def test_configured_daemon_socket_rejects_non_string_values(value):
+    from tools.computer_use import cua_backend
+
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"computer_use": {"daemon_socket": value}},
+    ), pytest.raises(ValueError, match="must be a string"):
+        cua_backend._cua_daemon_socket()
+
+
+def test_configured_daemon_socket_rejects_relative_paths():
+    from tools.computer_use import cua_backend
+
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"computer_use": {"daemon_socket": "relative/cua.sock"}},
+    ), pytest.raises(ValueError, match="absolute path"):
+        cua_backend._cua_daemon_socket()
+
+
+def test_configured_windows_named_pipe_is_preserved(monkeypatch):
+    from tools.computer_use import cua_backend
+
+    monkeypatch.setattr(cua_backend.sys, "platform", "win32")
+    pipe = r"\\.\pipe\cua-driver"
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"computer_use": {"daemon_socket": pipe}},
+    ):
+        assert cua_backend._cua_daemon_socket() == pipe
+
+
+@pytest.mark.parametrize(
+    "manifest_args",
+    [
+        ["mcp", "--socket", "/manifest.sock"],
+        ["mcp", "--socket=/manifest.sock"],
+    ],
+)
+def test_configured_daemon_socket_rejects_a_manifest_socket(manifest_args):
+    from tools.computer_use.cua_backend import _standard_runtime_launch_args
+
+    with pytest.raises(ValueError, match="both select a socket"):
+        _standard_runtime_launch_args(
+            manifest_args,
+            grant_existing_profile=False,
+            platform="linux",
+            daemon_socket="/configured.sock",
+        )
+
+
+def test_standard_lifecycle_passes_the_configured_socket_to_mcp():
+    from tools.computer_use.cua_backend import _AsyncBridge, _CuaDriverSession
+
+    session = _CuaDriverSession(_AsyncBridge())
+    captured = {}
+
+    async def drive_lifecycle():
+        def capture_params(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        with patch(
+            "tools.computer_use.cua_backend.resolve_cua_driver_cmd",
+            return_value="/opt/cua-driver",
+        ), patch(
+            "tools.computer_use.cua_backend._resolve_mcp_invocation",
+            return_value=("/opt/cua-driver", ["mcp"]),
+        ), patch(
+            "tools.computer_use.cua_backend._cua_daemon_socket",
+            return_value="/run/user/1000/cua.sock",
+        ), patch(
+            "tools.computer_use.cua_backend._cua_grant_existing_profile",
+            return_value=True,
+        ), patch(
+            "mcp.StdioServerParameters", side_effect=capture_params
+        ), patch("mcp.client.stdio.stdio_client") as mock_stdio, patch(
+            "mcp.ClientSession"
+        ) as mock_session_class:
+            mock_stdio.return_value.__aenter__ = AsyncMock(
+                return_value=(MagicMock(), MagicMock())
+            )
+            mock_stdio.return_value.__aexit__ = AsyncMock(return_value=None)
+            fake_session = MagicMock()
+            fake_session.initialize = AsyncMock()
+            fake_session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
+            mock_session_class.return_value.__aenter__ = AsyncMock(
+                return_value=fake_session
+            )
+            mock_session_class.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            async def signal_shutdown():
+                while session._shutdown_event is None:
+                    await asyncio.sleep(0)
+                session._shutdown_event.set()
+
+            signal = asyncio.create_task(signal_shutdown())
+            await session._lifecycle_coro()
+            await signal
+
+    asyncio.run(drive_lifecycle())
+    assert captured["command"] == "/opt/cua-driver"
+    assert captured["args"] == ["mcp", "--socket", "/run/user/1000/cua.sock"]
 
 
 def test_transport_reset_invalidates_native_and_browser_capabilities():

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -289,6 +289,31 @@ def _cua_capability_manifest() -> Optional[str]:
     return raw.strip()
 
 
+def _cua_daemon_socket() -> Optional[str]:
+    """Configured long-lived cua-driver daemon endpoint, or ``None``.
+
+    ``computer_use.daemon_socket`` is a standard-mode transport selector. When
+    present, Hermes proxies MCP over this existing daemon instead of owning a
+    second runtime in the stdio child. This is particularly important for
+    desktop portals whose RemoteDesktop/EIS session is process-owned.
+    """
+    raw = _computer_use_cfg().get("daemon_socket")
+    if raw is None or raw == "":
+        return None
+    if not isinstance(raw, str):
+        raise ValueError("computer_use.daemon_socket must be a string")
+    if not raw.strip():
+        return None
+    expanded = os.path.expanduser(raw.strip())
+    if sys.platform == "win32" and expanded.startswith("\\\\.\\pipe\\"):
+        return expanded
+    if not os.path.isabs(expanded):
+        raise ValueError(
+            "computer_use.daemon_socket must be an absolute path or Windows named pipe"
+        )
+    return os.path.normpath(expanded)
+
+
 def _cua_grant_existing_profile() -> bool:
     """True when the user pre-authorized existing-profile browser attachment.
 
@@ -346,18 +371,29 @@ def _standard_runtime_launch_args(
     grant_existing_profile: bool,
     platform: str,
     socket_path: Optional[str] = None,
+    daemon_socket: Optional[str] = None,
 ) -> Tuple[List[str], Optional[str]]:
     """Return MCP args and any private runtime socket owned by this transport.
 
-    Windows and Linux run the standard runtime in the MCP process, so the
-    launch grant can be passed directly. macOS proxies through CuaDriver.app;
-    a grant must therefore launch a fresh app daemon on a private socket
-    instead of trying to reconfigure the default daemon.
+    A configured daemon socket is already running with its own immutable
+    permission mode and launch grants. Hermes therefore selects that endpoint
+    without forwarding runtime-only grants. Otherwise Windows and Linux run
+    the standard runtime in the MCP process, so the launch grant can be passed
+    directly. macOS proxies through CuaDriver.app; a grant must therefore
+    launch a fresh app daemon on a private socket instead of trying to
+    reconfigure the default daemon.
 
     ``platform`` is explicit so this policy can be tested as a pure function
     on every CI host.
     """
     result = list(args)
+    if daemon_socket:
+        if any(arg == "--socket" or arg.startswith("--socket=") for arg in result):
+            raise ValueError(
+                "cua-driver manifest and computer_use.daemon_socket both select a socket"
+            )
+        result.extend(["--socket", daemon_socket])
+        return result, None
     if not grant_existing_profile:
         return result, None
     result.extend(["--grant", "existing-profile"])
@@ -1610,6 +1646,7 @@ class _CuaDriverSession:
                     grant_existing_profile=_cua_grant_existing_profile(),
                     platform=sys.platform,
                     socket_path=self._owned_standard_runtime_socket,
+                    daemon_socket=_cua_daemon_socket(),
                 )
                 self._owned_standard_runtime_socket = owned_socket
                 child_env = cua_driver_child_env()
@@ -2085,6 +2122,10 @@ class _CuaDriverSession:
             driver_command = embedded_daemon.proxy_invocation()[0]
             child_env = embedded_daemon.child_env()
             socket_args = ["--socket", embedded_daemon.socket_path]
+        else:
+            daemon_socket = _cua_daemon_socket()
+            if daemon_socket:
+                socket_args = ["--socket", daemon_socket]
         cmd = [
             driver_command,
             "call",

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -121,8 +121,10 @@ computer_use:
   grant_existing_profile: true
 ```
 
-Hermes then launches the cua-driver runtime with the trusted-launcher grant
-(`--grant existing-profile`), and
+By default, Hermes launches the cua-driver runtime with the trusted-launcher
+grant (`--grant existing-profile`). When `computer_use.daemon_socket` selects
+an existing daemon, that daemon must have been started with the grant instead;
+launch settings cannot be changed by an MCP proxy connection. Then
 `cua_browser_prepare` with an existing profile succeeds against the exact
 `(pid, window_id)` the agent proves. Leave it `false` (the default) and
 existing-profile attachment fails closed; driver-owned isolated profiles work
@@ -412,7 +414,17 @@ computer_use:
   permission_mode: standard        # standard (default) | bounded
   capability_manifest: ""          # capability manifest path, required for bounded
   grant_existing_profile: false    # opt-in: attach in standard or unrestricted mode
+  daemon_socket: ""                # absolute Unix socket or Windows named pipe
 ```
+
+`daemon_socket` applies only to standard mode. It makes Hermes start
+`cua-driver mcp --socket <endpoint>` instead of a second in-process runtime, so
+multiple Hermes processes can share one long-lived daemon and its process-owned
+desktop portal/EIS session. The value must be an absolute path (after `~`
+expansion) or a Windows named pipe such as `\\.\pipe\cua-driver`; relative,
+non-string, and duplicate manifest socket selections fail closed. Hermes does
+not own or stop this daemon, and the daemon's permission mode, capability
+manifest, and grants must be configured when the daemon itself starts.
 
 Override the driver binary path (tests / CI / local builds):
 


### PR DESCRIPTION
## Current-head update — 2026-08-23

This PR has been rebased onto the live `NousResearch/main` at `f293e7206b4d` and remains a single commit. Current head: `070cb002f48e`.

The latest exact-head validation and upstream-context note is in the most recent PR comment. The older validation references below describe the pre-rebase head and should be read as historical context only.

## Summary

- add `computer_use.daemon_socket` for standard-mode MCP proxying through an existing cua-driver daemon
- keep the configured endpoint across both MCP startup and CLI fallback transport
- fail closed on non-string, relative, or duplicate manifest socket selections; support absolute Unix sockets and Windows named pipes
- document daemon-owned permission/grant/lifecycle semantics

## Why

On desktop portals, the RemoteDesktop/EIS session is process-owned. If each Hermes process launches an independent CUA runtime, one process can hold the restored portal session while another times out waiting for libei readiness. A configured long-lived daemon provides one owner while retaining per-Hermes MCP sessions and exact-target policy.

## Validation

- `env -u HERMES_CUA_DRIVER_CMD uv run --locked --extra dev python -m pytest tests/computer_use tests/tools/test_computer_use_cua_0_10_permissions.py tests/tools/test_computer_use.py -q` — 171 passed, 1 skipped
- focused daemon socket and CLI fallback tests — 27 passed
- Ruff on touched Python files
- `python scripts/check-windows-footguns.py --all`
- fresh-process read-only integration against a managed daemon confirmed the descendant command contained `mcp --socket <configured endpoint>` and returned windows
- independent exact-tree review of post-rebase head `470ab9ba7796bfefca66d7b82277247073bfff50` — no blockers

No installed CUA binary or live desktop action was used during final review.
