### PR TITLE
fix(codex): classify masked replay rejections behind the invalid_prompt envelope

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -42,6 +42,7 @@ class FailoverReason(enum.Enum):
     content_policy_blocked = "content_policy_blocked"  # Provider safety filter rejected this prompt — don't retry unchanged
     format_error = "format_error"        # 400 bad request — abort or strip + retry
     invalid_encrypted_content = "invalid_encrypted_content"  # Responses replay blob rejected — strip replay state and retry
+    codex_reasoning_replay_rejected = "codex_reasoning_replay_rejected"  # ChatGPT Codex masked a replay rejection as invalid_prompt
     multimodal_tool_content_unsupported = "multimodal_tool_content_unsupported"  # Provider rejected list-type content in tool messages (e.g. Xiaomi MiMo) — downgrade to text and retry
     reasoning_mandatory = "reasoning_mandatory"  # Route rejects reasoning: {enabled: false} — send the disable no more this session and retry
 
@@ -486,6 +487,30 @@ def _provider_special_cases(c: _Ctx) -> Optional[Verdict]:
     # to format_error and a status-less block isn't left retryable (#18028).
     if any(p in msg for p in _CONTENT_POLICY_BLOCKED_PATTERNS):
         return _V_CONTENT_BLOCKED
+    # ChatGPT Codex OAuth can mask a rejected encrypted-reasoning replay behind
+    # ``invalid_prompt: Request blocked.``. Keep this signature intentionally narrow:
+    # provider + structured code + exact body shape + status None/400. Recovery is
+    # still gated on cached codex_reasoning_items in turn_recovery.py.
+    if c.provider_slug == "openai-codex" and c.code == "invalid_prompt":
+        err_obj = _error_obj(c.body)
+        if not err_obj and isinstance(c.body, dict):
+            err_obj = c.body
+        codex_message = str(err_obj.get("message") or "").strip().lower()
+        matches_masked_replay = (
+            c.status_code in {None, 400}
+            and codex_message == "request blocked."
+            and err_obj.get("type") == "invalid_request_error"
+            and "param" in err_obj
+            and err_obj.get("param") is None
+        )
+        if matches_masked_replay:
+            return _v(_R.codex_reasoning_replay_rejected, retryable=False, should_fallback=False)
+        logger.debug(
+            "OpenAI Codex invalid_prompt did not match the masked replay signature: "
+            "status=%r message=%r type=%r param_present=%s param_is_null=%s",
+            c.status_code, codex_message[:160], err_obj.get("type"),
+            "param" in err_obj, err_obj.get("param") is None,
+        )
     # Anthropic thinking-block 400s (signature mismatch after transcript
     # mutation). Not gated on provider — OpenRouter proxies Anthropic errors.
     if status == 400 and "thinking" in msg and any(p in msg for p in _THINKING_MUTATION_WORDS):

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -377,7 +377,10 @@ def _recover_format_errors(
     # 400 ``invalid_encrypted_content`` on a stale ``codex_reasoning_items`` blob:
     # disable replay for the session, strip cached items, retry once.
     if (
-        classified.reason == FailoverReason.invalid_encrypted_content
+        classified.reason in {
+            FailoverReason.invalid_encrypted_content,
+            FailoverReason.codex_reasoning_replay_rejected,
+        }
         and not _retry.invalid_encrypted_content_retry_attempted
         and agent.api_mode == "codex_responses"
         and bool(getattr(agent, "_codex_reasoning_replay_enabled", True))
@@ -402,6 +405,18 @@ def _recover_format_errors(
             agent.log_prefix, replay_stats["items"], replay_stats["messages"],
         )
         return True
+
+    if (
+        classified.reason == FailoverReason.codex_reasoning_replay_rejected
+        and not _retry.invalid_encrypted_content_retry_attempted
+        and agent.api_mode == "codex_responses"
+        and bool(getattr(agent, "_codex_reasoning_replay_enabled", True))
+    ):
+        logger.debug(
+            "%sCodex masked replay rejection matched, but no cached "
+            "codex_reasoning_items were present; replay-strip recovery is a no-op",
+            agent.log_prefix,
+        )
 
     # Structured 400 naming ``context_management``: disable native compaction for the
     # session, retry once; local compression takes over.

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -64,6 +64,7 @@ class TestFailoverReason:
             "image_corrupt",
             "model_not_found", "format_error",
             "invalid_encrypted_content",
+            "codex_reasoning_replay_rejected",
             "multimodal_tool_content_unsupported",
             "reasoning_mandatory",
             "provider_policy_blocked",
@@ -1596,3 +1597,67 @@ class TestServerInjectedParameterRejection:
         assert result.retryable is False
 
 
+
+
+
+def test_openai_codex_masked_invalid_prompt_is_replay_rejection_candidate():
+    e = MockAPIError(
+        "Error code: 400 - Request blocked.",
+        status_code=400,
+        body={"error": {
+            "message": "Request blocked.",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "invalid_prompt",
+        }},
+    )
+    result = classify_api_error(e, provider="openai-codex", model="gpt-5.6-terra")
+    assert result.reason == FailoverReason.codex_reasoning_replay_rejected
+    assert result.retryable is False
+    assert result.should_fallback is False
+
+
+def test_openai_codex_direct_statusless_invalid_prompt_is_replay_rejection_candidate():
+    e = MockAPIError(
+        "Request blocked.",
+        body={
+            "message": "Request blocked.",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "invalid_prompt",
+        },
+    )
+    result = classify_api_error(e, provider="openai-codex", model="gpt-5.6-terra")
+    assert result.reason == FailoverReason.codex_reasoning_replay_rejected
+
+
+def test_openai_codex_masked_invalid_prompt_near_miss_stays_format_error(caplog):
+    e = MockAPIError(
+        "Error code: 400 - Request blocked",
+        status_code=400,
+        body={"error": {
+            "message": "Request blocked",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "invalid_prompt",
+        }},
+    )
+    with caplog.at_level("DEBUG", logger="agent.error_classifier"):
+        result = classify_api_error(e, provider="openai-codex", model="gpt-5.6-terra")
+    assert result.reason == FailoverReason.format_error
+    assert "did not match the masked replay signature" in caplog.text
+
+
+def test_masked_invalid_prompt_other_provider_stays_format_error():
+    e = MockAPIError(
+        "Error code: 400 - Request blocked.",
+        status_code=400,
+        body={"error": {
+            "message": "Request blocked.",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "invalid_prompt",
+        }},
+    )
+    result = classify_api_error(e, provider="openai", model="gpt-5.6-terra")
+    assert result.reason == FailoverReason.format_error

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2,7 +2,9 @@ import sys
 import types
 from types import SimpleNamespace
 
+import httpx
 import pytest
+from openai import APIError as OpenAIAPIError
 
 
 sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
@@ -2624,3 +2626,53 @@ def test_run_codex_stream_retired_request_stops_firing_callbacks(monkeypatch):
 
     assert streamed == ["keep"]
     assert "DROPPED" not in streamed
+
+
+
+def test_openai_codex_masked_replay_rejection_strips_reasoning_and_retries(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.provider = "openai-codex"
+    agent.base_url = "https://chatgpt.com/backend-api/codex"
+    request_payloads = []
+
+    live_error = OpenAIAPIError(
+        message="Request blocked.",
+        request=httpx.Request("POST", "https://chatgpt.com/backend-api/codex/responses"),
+        body={
+            "message": "Request blocked.",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "invalid_prompt",
+        },
+    )
+    assert not hasattr(live_error, "status_code")
+    responses = [live_error, _codex_message_response("Recovered without replay.")]
+
+    def _fake_api_call(api_kwargs):
+        request_payloads.append(api_kwargs)
+        current = responses.pop(0)
+        if isinstance(current, Exception):
+            raise current
+        return current
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+    history = [{
+        "role": "assistant",
+        "content": "",
+        "finish_reason": "incomplete",
+        "codex_reasoning_items": [
+            {"type": "reasoning", "id": "rs_001", "encrypted_content": "enc_bad", "summary": []},
+        ],
+    }]
+
+    result = agent.run_conversation("continue", conversation_history=history)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered without replay."
+    assert len(request_payloads) == 2
+    assert any(item.get("type") == "reasoning" for item in request_payloads[0]["input"])
+    assert not any(item.get("type") == "reasoning" for item in request_payloads[1]["input"])
+    assert request_payloads[0].get("include") == ["reasoning.encrypted_content"]
+    assert request_payloads[1].get("include") == []
+    assert result["messages"][0].get("codex_reasoning_items") is None
+    assert agent._codex_reasoning_replay_enabled is False


### PR DESCRIPTION
## Summary

Follow-up to #68087 (salvaged via #75860): the defang preflight removed the primary trigger of Codex's generic `invalid_prompt: Request blocked.` 400s, but masked *encrypted-reasoning replay* failures still land in the generic format-error bucket — burning retries and forcing fallback although the existing one-shot `codex_reasoning_items` replay-strip repairs exactly this class.

Closes #92353. Refs #68087, #75860.

## Exact behavior

- `classify_api_error`: new candidate reason `codex_reasoning_replay_rejected` (`retryable=false`, `should_fallback=false`). Matches only provider `openai-codex`, HTTP 400 (or SSE `APIError` without `.status_code`), `code=invalid_prompt`, `message="Request blocked."`, `type=invalid_request_error`, `param=null`. Both wrapped and direct OpenAI error-body shapes accepted.
- `conversation_loop`: the existing one-shot replay-strip guard accepts the new reason alongside `invalid_encrypted_content`. No new recovery machinery; the strip stays gated on cached `codex_reasoning_items`.
- Observability: a DEBUG diagnostic records near-miss `openai-codex invalid_prompt` signatures (with the normalized provider message bounded to 160 characters), and a separate DEBUG diagnostic identifies masked matches for which replay-strip recovery is a no-op because no cached reasoning items exist.
- `invalid_encrypted_content` now cross-references the masked Codex variant in the failure taxonomy.

## Scope / intentional exclusions

- No behavior change for any non-Codex provider; no changes to the defang preflight.
- Near-miss and no-op diagnostics do not broaden classification or retry behavior.

## Verification

- `tests/agent/test_error_classifier.py` + `tests/run_agent/test_run_agent_codex_responses.py`: **173 passed**, including wrapped-envelope, direct-body, SSE-without-status, near-miss observability, no-cached-replay observability, and negative-provider cases.
- Ruff, `py_compile`, and `git diff --check`: passed.
