### PR TITLE
feat(skill): add loop-bounce skill for model escalation

### DIFF
--- a/contributors/emails/andynguyendk@gmail.com
+++ b/contributors/emails/andynguyendk@gmail.com
@@ -1,0 +1,1 @@
+andynguyendk

--- a/scripts/loop_detector.py
+++ b/scripts/loop_detector.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""
+Loop Detector — real-time loop detection for Hermes sessions.
+
+Reads the latest session from state.db, detects loop patterns:
+- Same tool call with identical args (exact repeat)
+- Same normalized approach (fingerprint repeat)
+- Sliding window failure rate above threshold
+- Repeated error patterns
+
+Output: JSON alerts for cron/Telegram delivery.
+
+Usage:
+    python3 loop_detector.py                  # Check latest session
+    python3 loop_detector.py --session ID     # Check specific session
+    python3 loop_detector.py --days 1         # Check all sessions from last N days
+    python3 loop_detector.py --json           # JSON output (for cron)
+"""
+
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+
+HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+DB_PATH = HERMES_HOME / "state.db"
+
+# --- Error classification (reused from agent-health) ---
+
+_ERR_SIGS = [
+    "error:", "traceback", "exception:", "failed to",
+    "command not found", "permission denied", "no such file",
+    "timed out", "timeout", "connection refused",
+    "404 not found", "500 internal", "rate limit",
+    "unauthorized", "access denied",
+    "enoent", "eacces", "etimedout",
+    "could not", "unable to", "syntax error",
+    "blocked:", "exit code",
+]
+_ERR_RE = re.compile("|".join(re.escape(s) for s in _ERR_SIGS), re.IGNORECASE)
+
+# Transient errors that should NOT count as failures
+_TRANSIENT_RE = re.compile(
+    r"(?i)(rate.?limit|429|throttl|connection.?reset|network.?unreachable|"
+    r"ECONNRESET|EPIPE|temporary.?fail)", re.IGNORECASE
+)
+
+
+def is_error(content: str) -> bool:
+    """Classify tool result as error."""
+    if not content:
+        return False
+    start = content.find("{")
+    end = content.rfind("}")
+    if start != -1 and end > start:
+        try:
+            obj = json.loads(content[start:end + 1])
+        except Exception:
+            obj = None
+        if isinstance(obj, dict):
+            if obj.get("error"):
+                return True
+            if obj.get("success") is True:
+                return False
+            if "exit_code" in obj:
+                return obj.get("exit_code") not in (None, 0)
+            if "status" in obj:
+                status = str(obj.get("status")).lower()
+                if status == "timeout" and obj.get("process_running"):
+                    return False
+                return status in ("failed", "error", "timeout")
+    return bool(_ERR_RE.search(content[:2000]))
+
+
+# Shell init errors — environment issues, not agent reasoning failures
+_SHELL_INIT_RE = re.compile(
+    r"(?i)(cd:.*no such file|bash.*line \d+:|\.bashrc|\.profile|"
+    r"pihole|/home/nd/\.\w+)", re.IGNORECASE
+)
+
+
+def is_shell_init_error(content: str) -> bool:
+    """Detect errors from shell initialization, not agent actions."""
+    if not content:
+        return False
+    return bool(_SHELL_INIT_RE.search(content[:500]))
+
+
+def is_transient(content: str) -> bool:
+    """Check if error is transient (should not count toward failure threshold)."""
+    if not content:
+        return False
+    return bool(_TRANSIENT_RE.search(content[:1000]))
+
+
+# --- Approach fingerprinting ---
+
+# Commands that are semantically equivalent
+_EQUIV_MAP = {
+    "docker compose": "docker-compose",
+    "docker-compose": "docker compose",
+    "systemctl restart": "service restart",
+    "service restart": "systemctl restart",
+}
+
+
+def normalize_command(cmd: str) -> str:
+    """Normalize a command for fingerprinting."""
+    c = cmd.strip()
+    # Remove common prefixes
+    for prefix in ["cd /tmp && ", "cd ~ && ", "sudo "]:
+        if c.startswith(prefix):
+            c = c[len(prefix):]
+    # Normalize whitespace
+    c = " ".join(c.split())
+    # Normalize equivalent commands
+    for old, new in _EQUIV_MAP.items():
+        c = c.replace(old, new)
+    return c
+
+
+def fingerprint(tool_name: str, args: dict) -> str:
+    """Create a normalized fingerprint for a tool call."""
+    if tool_name == "terminal":
+        cmd = args.get("command", "")
+        return f"terminal:{normalize_command(cmd)}"
+    elif tool_name == "web_search":
+        q = args.get("query", "")
+        return f"web_search:{q.lower().strip()}"
+    elif tool_name == "web_extract":
+        urls = args.get("urls", [])
+        return f"web_extract:{len(urls)}_urls"
+    elif tool_name == "read_file":
+        path = args.get("path", "")
+        return f"read_file:{path}"
+    elif tool_name == "write_file":
+        path = args.get("path", "")
+        return f"write_file:{path}"
+    elif tool_name == "patch":
+        path = args.get("path", "")
+        return f"patch:{path}"
+    elif tool_name == "terminal":
+        return f"terminal:{args.get('command', '')[:50]}"
+    else:
+        # Generic: tool name + sorted args hash
+        arg_str = json.dumps(args, sort_keys=True, default=str)[:100]
+        return f"{tool_name}:{arg_str}"
+
+
+def extract_args_from_tool_calls(tool_calls_json: str) -> dict:
+    """Extract arguments from assistant tool_calls JSON."""
+    if not tool_calls_json:
+        return {}
+    try:
+        calls = json.loads(tool_calls_json)
+        if isinstance(calls, list) and calls:
+            fn = calls[0].get("function", {})
+            args = fn.get("arguments", "{}")
+            if isinstance(args, str):
+                return json.loads(args)
+            return args
+    except Exception:
+        pass
+    return {}
+
+
+# --- Sliding window analysis ---
+
+def analyze_session(messages: list[dict], window: int = 10) -> dict:
+    """Analyze a session's messages for loop patterns.
+    
+    Args:
+        messages: list of message dicts (sorted by timestamp)
+        window: sliding window size for failure rate calculation
+    """
+    alerts = []
+    
+    # Build tool call sequences
+    tool_calls = []  # (timestamp, tool_name, fingerprint, is_error, content_preview, is_shell_init)
+    
+    # Track user messages for intervention detection
+    user_message_timestamps = [m.get("timestamp", 0) for m in messages if m.get("role") == "user"]
+    
+    # Match assistant tool_calls with tool results
+    # Key: call_id from tool_calls JSON -> fingerprint
+    pending_calls = {}
+    
+    for m in messages:
+        role = m.get("role", "")
+        
+        if role == "assistant" and m.get("tool_calls"):
+            tc_str = m.get("tool_calls", "")
+            try:
+                tc_list = json.loads(tc_str)
+                if isinstance(tc_list, list):
+                    for tc_item in tc_list:
+                        call_id = tc_item.get("call_id") or tc_item.get("id", "")
+                        fn = tc_item.get("function", {})
+                        tool_name = fn.get("name", "")
+                        args_raw = fn.get("arguments", "{}")
+                        args = json.loads(args_raw) if isinstance(args_raw, str) else args_raw
+                        fp = fingerprint(tool_name, args)
+                        if call_id:
+                            pending_calls[call_id] = (tool_name, fp)
+            except Exception:
+                pass
+        
+        elif role == "tool" and m.get("tool_name"):
+            tool_name = m["tool_name"]
+            content = m.get("content", "") or ""
+            err = is_error(content)
+            transient = is_transient(content) if err else False
+            shell_init = is_shell_init_error(content) if err else False
+            # Fallback: use tool_name when call_id matching fails
+            tcid = m.get("tool_call_id", "")
+            fp_tuple = pending_calls.pop(tcid, None)
+            if fp_tuple:
+                fp = fp_tuple[1]
+            else:
+                # No matching assistant call — use tool name as coarse fingerprint
+                fp = f"{tool_name}:?<unknown_args>"
+            
+            tool_calls.append({
+                "timestamp": m.get("timestamp", 0),
+                "tool": tool_name,
+                "fingerprint": fp,
+                "is_error": err,
+                "is_transient": transient,
+                "is_shell_init": shell_init,
+                "content_preview": content[:150].replace("\n", " "),
+            })
+    
+    if not tool_calls:
+        return {"status": "no_tool_calls", "alerts": []}
+    
+    # --- Detection 1: Exact fingerprint repeat (≥3 times) ---
+    # Exclude shell init errors and check if approach changed after failure
+    fp_counts = Counter()
+    fp_first_seen = {}
+    fp_last_error = {}
+    fp_had_success_after = set()  # fingerprints that had a success after failure
+    prev_fp = None
+    prev_was_error = False
+    
+    for tc in tool_calls:
+        fp = tc["fingerprint"]
+        
+        # Track if approach changed after error (workaround detection)
+        if prev_was_error and not tc["is_error"] and fp != prev_fp:
+            fp_had_success_after.add(prev_fp)
+        
+        fp_counts[fp] += 1
+        if fp not in fp_first_seen:
+            fp_first_seen[fp] = tc["timestamp"]
+        if tc["is_error"] and not tc["is_shell_init"]:
+            fp_last_error[fp] = tc["content_preview"]
+        
+        prev_fp = fp
+        prev_was_error = tc["is_error"]
+    
+    for fp, count in fp_counts.items():
+        # Skip if: approach had success after error (workaround) OR is shell init
+        if fp in fp_had_success_after:
+            continue
+        # Count only non-shell-init errors for this fingerprint
+        real_errors = sum(1 for tc in tool_calls if tc["fingerprint"] == fp 
+                         and tc["is_error"] and not tc["is_shell_init"])
+        if real_errors < 2:  # Need at least 2 real errors to flag
+            continue
+        if count >= 3:
+            alerts.append({
+                "type": "exact_repeat",
+                "severity": "high" if count >= 5 else "medium",
+                "fingerprint": fp,
+                "count": count,
+                "real_errors": real_errors,
+                "error_sample": fp_last_error.get(fp, ""),
+                "message": f"Same approach repeated {count}x ({real_errors} errors): {fp[:80]}",
+            })
+    
+    # --- Detection 2: Sliding window failure rate (excluding shell init) ---
+    real_errors = [tc for tc in tool_calls if not tc["is_transient"] and not tc["is_shell_init"]]
+    if len(real_errors) >= window:
+        recent = real_errors[-window:]
+        err_count = sum(1 for tc in recent if tc["is_error"])
+        err_rate = err_count / window
+        if err_rate >= 0.6:
+            alerts.append({
+                "type": "high_failure_rate",
+                "severity": "high",
+                "window": window,
+                "errors": err_count,
+                "total": window,
+                "rate": round(err_rate * 100, 1),
+                "message": f"High failure rate: {err_count}/{window} ({err_rate*100:.0f}%) in last {window} calls",
+            })
+    
+    # --- Detection 3: Same error message repeated (excluding shell init) ---
+    err_msgs = Counter()
+    for tc in tool_calls:
+        if tc["is_error"] and not tc["is_transient"] and not tc["is_shell_init"]:
+            msg = tc["content_preview"].lower()[:100]
+            err_msgs[msg] += 1
+    for msg, count in err_msgs.items():
+        if count >= 3:
+            alerts.append({
+                "type": "repeated_error",
+                "severity": "high",
+                "error_message": msg[:100],
+                "count": count,
+                "message": f"Same error repeated {count}x: {msg[:80]}",
+            })
+    
+    # --- Detection 4: Alternating pattern (A-B-A-B) ---
+    # With false-positive filters: different errors, time gaps, or progress
+    if len(tool_calls) >= 4:
+        recent = tool_calls[-6:]
+        fps = [tc["fingerprint"] for tc in recent]
+        if len(fps) >= 4:
+            for i in range(len(fps) - 3):
+                if fps[i] == fps[i+2] and fps[i+1] == fps[i+3] and fps[i] != fps[i+1]:
+                    # Filter 1: Different error messages → likely debugging, not loop
+                    err_a = next((tc for tc in recent if tc["fingerprint"] == fps[i] and tc["is_error"]), None)
+                    err_b = next((tc for tc in recent if tc["fingerprint"] == fps[i+1] and tc["is_error"]), None)
+                    if err_a and err_b:
+                        err_a_msg = err_a["content_preview"][:80].lower()
+                        err_b_msg = err_b["content_preview"][:80].lower()
+                        if err_a_msg != err_b_msg:
+                            continue  # Different errors = debugging, not loop
+                    
+                    # Filter 2: Success between errors → task progress
+                    has_success = any(not tc["is_error"] for tc in recent[i:i+4])
+                    if has_success:
+                        continue
+                    
+                    # Filter 3: Time gap > 60s between A and B → deliberate retry
+                    ts_a = [tc["timestamp"] for tc in recent if tc["fingerprint"] == fps[i]]
+                    ts_b = [tc["timestamp"] for tc in recent if tc["fingerprint"] == fps[i+1]]
+                    if ts_a and ts_b:
+                        time_gap = min(abs(t2 - t1) for t1 in ts_a for t2 in ts_b)
+                        if time_gap > 60:
+                            continue  # Significant time gap = deliberate debugging
+                    
+                    alerts.append({
+                        "type": "alternating_loop",
+                        "severity": "high",
+                        "pattern": f"{fps[i][:40]} → {fps[i+1][:40]}",
+                        "message": f"Alternating loop detected: {fps[i][:40]} ↔ {fps[i+1][:40]}",
+                    })
+                    break
+    
+    # --- Detection 5: Escalation needed (consecutive non-transient, non-shell-init errors) ---
+    consecutive_errors = 0
+    for tc in reversed(real_errors):
+        if tc["is_error"]:
+            consecutive_errors += 1
+        else:
+            break
+    if consecutive_errors >= 3:
+        alerts.append({
+            "type": "consecutive_errors",
+            "severity": "critical",
+            "count": consecutive_errors,
+            "last_error": real_errors[-1]["content_preview"] if real_errors else "",
+            "message": f"{consecutive_errors} consecutive errors — consider model escalation",
+        })
+    
+    # --- Summary stats ---
+    total_calls = len(tool_calls)
+    total_errors = sum(1 for tc in tool_calls if tc["is_error"])
+    transient_errors = sum(1 for tc in tool_calls if tc["is_transient"])
+    unique_fingerprints = len(fp_counts)
+    
+    return {
+        "status": "alerts" if alerts else "ok",
+        "total_calls": total_calls,
+        "total_errors": total_errors,
+        "transient_errors": transient_errors,
+        "permanent_errors": total_errors - transient_errors,
+        "unique_approaches": unique_fingerprints,
+        "error_rate": round(total_errors / max(total_calls, 1) * 100, 1),
+        "alerts": alerts,
+    }
+
+
+def get_session_messages(conn, session_id: str = None, days: int = None) -> list[dict]:
+    """Get messages from a session."""
+    if session_id:
+        rows = conn.execute(
+            "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp",
+            (session_id,),
+        ).fetchall()
+    elif days:
+        cutoff = time.time() - days * 86400
+        rows = conn.execute(
+            """SELECT m.* FROM messages m 
+               JOIN sessions s ON m.session_id = s.id 
+               WHERE s.started_at > ? 
+               ORDER BY m.timestamp""",
+            (cutoff,),
+        ).fetchall()
+    else:
+        # Latest session
+        rows = conn.execute(
+            """SELECT m.* FROM messages m 
+               JOIN sessions s ON m.session_id = s.id 
+               WHERE s.archived = 0 
+               ORDER BY m.timestamp DESC LIMIT 200""",
+        ).fetchall()
+        rows = list(reversed(rows))
+    
+    return [dict(r) for r in rows]
+
+
+def main():
+    import argparse
+    p = argparse.ArgumentParser(description="Loop Detector")
+    p.add_argument("--session", help="Specific session ID")
+    p.add_argument("--days", type=int, help="Check sessions from last N days")
+    p.add_argument("--json", action="store_true", help="JSON output")
+    p.add_argument("--window", type=int, default=10, help="Sliding window size")
+    args = p.parse_args()
+    
+    if not DB_PATH.exists():
+        print(json.dumps({"error": f"Database not found: {DB_PATH}"}))
+        sys.exit(1)
+    
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.row_factory = sqlite3.Row
+    
+    messages = get_session_messages(conn, args.session, args.days)
+    conn.close()
+    
+    if not messages:
+        result = {"status": "no_data", "message": "No messages found"}
+        if args.json:
+            print(json.dumps(result))
+        else:
+            print("No messages found.")
+        return
+    
+    result = analyze_session(messages, window=args.window)
+    
+    # Add session context
+    if messages:
+        result["session_id"] = messages[0].get("session_id", "unknown")
+        result["message_count"] = len(messages)
+    
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        # Human-readable output
+        if result["status"] == "ok":
+            print(f"✅ No loops detected. {result['total_calls']} calls, "
+                  f"{result['error_rate']}% error rate, "
+                  f"{result['unique_approaches']} unique approaches.")
+        else:
+            print(f"⚠️ {len(result['alerts'])} alert(s) detected!\n")
+            for a in result["alerts"]:
+                severity_icon = {"critical": "🔴", "high": "🟠", "medium": "🟡"}.get(a["severity"], "⚪")
+                print(f"{severity_icon} [{a['type']}] {a['message']}")
+            print(f"\n📊 {result['total_calls']} calls, {result['error_rate']}% error rate, "
+                  f"{result['unique_approaches']} unique approaches")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/hermes-agent/loop-bounce/SKILL.md
+++ b/skills/hermes-agent/loop-bounce/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loop-bounce
-description: Break agent loops and escalate to stronger models via a 3-attempt ladder.
+description: Detect agent loops and escalate to stronger models.
 version: 2.0.0
 author: Hermes Agent
 license: MIT

--- a/skills/hermes-agent/loop-bounce/SKILL.md
+++ b/skills/hermes-agent/loop-bounce/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: loop-bounce
-description: Use when the agent gets stuck in a reasoning/tool-call loop, repeats identical calls, or produces the same error repeatedly — breaks the loop, then escalates through a 3-attempt ladder before reporting failure.
+description: Break agent loops and escalate to stronger models via a 3-attempt ladder.
 version: 2.0.0
 author: Hermes Agent
 license: MIT
+platforms: [all]
 metadata:
   hermes:
     tags: [hermes, fallback, loop-detection, model-escalation, delegation]

--- a/skills/hermes-agent/loop-bounce/SKILL.md
+++ b/skills/hermes-agent/loop-bounce/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: loop-bounce
+description: Use when the agent gets stuck in a reasoning/tool-call loop, repeats identical calls, or produces the same error repeatedly — breaks the loop, then escalates through a 3-attempt ladder before reporting failure.
+version: 2.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [hermes, fallback, loop-detection, model-escalation, delegation]
+    related_skills: [hermes-agent]
+---
+
+# Loop Bounce — Break, Escalate, Report
+
+A deterministic 2-step protocol for when the agent is running in circles. Step 1 breaks the loop. Step 2 escalates through a bounded ladder. If escalation also fails, report to the user.
+
+---
+
+## Step 1: Loop Detection (BREAK)
+
+### Failure Classification (multi-dimensional)
+
+Not all failures are equal. Classify each failure before counting:
+
+| Class | Signal | Count toward threshold? |
+|-------|--------|------------------------|
+| **execution** | Non-zero exit code, error output | Yes |
+| **diagnostic** | Command succeeded but didn't answer the question | Yes |
+| **verification** | Fix applied but postcondition false | Yes (high weight) |
+| **repeated_approach** | Same normalized fingerprint tried again | Yes (immediate escalate) |
+| **environment** | Missing creds, permissions, network | Report, don't retry |
+| **policy** | Safety refusal, approval required | STOP, don't escalate |
+
+### Approach Fingerprinting
+
+Normalize equivalent commands to detect disguised retries:
+
+```
+docker compose restart api
+docker-compose restart api
+ssh host docker compose restart api
+→ fingerprint: terminal:docker compose restart api
+```
+
+Track fingerprints in a sliding window, not just consecutive count. A `pwd` success between two failures does NOT reset the counter.
+
+### Detection Signals
+
+**Hard limits** (whichever comes first):
+
+| Limit | Value | Action |
+|-------|-------|--------|
+| Same fingerprint repeated | **3×** | Enter Step 2 |
+| Sliding window failure rate ≥60% (last 10 calls) | — | Enter Step 2 |
+| Verification failure after mutation | **1×** | Enter Step 2 |
+| Time elapsed since first failure on current task | **10 minutes** | Enter Step 2 |
+
+**Soft signals** (trigger early):
+
+| Signal | Threshold |
+|--------|-----------|
+| Same error message repeated | 3× |
+| "Let me try again" / "Let me retry" on same task | 3× |
+| Alternating A-B-A-B pattern | 2 cycles |
+| Reasoning trace shows identical thought cycling | 2× |
+
+### What does NOT trigger
+
+- First failure on a new task (recover on next turn)
+- HTTP 429 rate limits or transient network errors (retry with backoff)
+- Prompt-level misunderstandings (fix the prompt instead)
+- Long-running legitimate tasks (e.g., a 10-minute build that is progressing)
+
+### When triggered: STOP immediately
+
+Do NOT make another tool call on the same task. Record:
+
+1. What the task was
+2. What was tried (1-2 sentence summary)
+3. The specific error or failure mode
+4. How many attempts were made and how long elapsed
+5. The failure class (execution/diagnostic/verification/repeated_approach)
+
+Then proceed to Step 2.
+
+---
+
+## Step 2: Escalation Ladder (ESCALATE)
+
+Three escalation attempts max. First two are **auto-pick** (no user interaction needed). Third is **user-pick**. Each attempt is itself loop-bounded — if it loops, advance to the next rung.
+
+### Attempt 1: Diagnostic checkpoint + sub-agent (AUTO)
+
+**Before delegating, mandatory diagnostic checkpoint:**
+
+1. State hypothesis (what do I think is wrong?)
+2. State evidence (what did I observe?)
+3. State what was tried and why it failed
+4. State what NOT to try again
+
+Then delegate with structured handoff packet:
+
+```python
+delegate_task(
+  goal="<original task>",
+  context="""HANDOFF PACKET:
+- Goal: <original task>
+- Hypothesis: <what I think is wrong>
+- Evidence: <what I observed>
+- Commands tried: <list with outputs>
+- Repeated approaches: <DO NOT repeat these>
+- Failure class: <execution/diagnostic/verification/repeated_approach>
+- Current state: <what's changed so far>
+
+IMPORTANT: Challenge the hypothesis before acting. Diagnose first, then propose a plan.""",
+)
+```
+
+The sub-agent uses the `delegation.model` / `delegation.provider` from config (stronger model). It is bounded by `delegation.max_iterations` (set to 15) so it cannot loop either.
+
+**On success:** Take the sub-agent's output and implement the solution. Done.
+
+**On failure/loop:** Advance to Attempt 2.
+
+### Attempt 2: Alternative model or OpenClaw Advisor (AUTO)
+
+Try a different escalation path than Attempt 1:
+
+**Option A — Different provider via delegate_task:**
+If Attempt 1 used the delegation config model, override with a different strong model. Spawn a one-shot Hermes process:
+
+```
+terminal(
+  command="hermes chat -q '<task + context + what Attempt 1 tried>' -m <different-model> --provider <different-provider>",
+  timeout=300
+)
+```
+
+**Option B — OpenClaw Advisor (if available):**
+```
+terminal(command="openclaw advisor '<task + context>' --model <stronger-model>", timeout=300)
+```
+
+**Option C — Mixture of both:**
+If the task is complex, run two different-model delegates in parallel via `delegate_task(tasks=[...])` and pick the better output.
+
+**On success:** Implement the returned solution. Done.
+
+**On failure/loop:** Advance to Attempt 3.
+
+### Attempt 3: User-pick (INTERACTIVE)
+
+Stop and notify the user. Present:
+
+```
+⚠️ Loop Break — Escalation Needed (Attempt 3/3)
+
+Task: <1-line description>
+Attempts so far: <count>
+Time elapsed: <duration>
+Failed approaches:
+  1. Direct (5 tries, <error summary>)
+  2. Sub-agent [model name] (<failure reason>)
+  3. Alt model [model name] (<failure reason>)
+
+Pick an escalation option:
+1️⃣ Switch session model (e.g., grok-4.5) — /model
+2️⃣ Manual debug — you take over, I provide full context
+3️⃣ Try a specific approach you suggest
+4️⃣ Abort task
+```
+
+**AFK timeout:** If the user does not respond within **10 minutes**, break the loop and go directly to the Failure Report (below). Do not keep waiting.
+
+### Each rung is loop-bounded
+
+Every escalation attempt inherits Step 1's detection. If the escalated agent (sub-agent, spawned process, OpenClaw) itself loops:
+- Do NOT let it run to `max_iterations`
+- Detect after 3 consecutive identical failures OR 5 minutes elapsed
+- Advance to the next rung immediately
+
+---
+
+## Step 3: Failure Report (REPORT)
+
+If all 3 escalation attempts fail, or the user picks "Abort", or AFK timeout triggers on Attempt 3:
+
+Deliver a structured failure report and STOP. Do not retry anything.
+
+```
+❌ Task Failed — All Escalation Exhausted
+
+Task: <description>
+Total time: <duration>
+Total attempts: <count across all rungs>
+
+What was tried:
+  1. Direct: <approach> → <why it failed>
+  2. Sub-agent [<model>]: <approach> → <why it failed>
+  3. Alt escalation [<method>]: <approach> → <why it failed>
+
+Root cause assessment: <best guess, or "unknown">
+Suggested next steps: <1-2 concrete suggestions for the user>
+```
+
+---
+
+## Quick Reference: The Full Flow
+
+```
+Task starts
+  │
+  ▼
+Working? ──── Yes ──→ Done ✓
+  │
+  No (after 5 tries or 10 min)
+  │
+  ▼
+STEP 1: BREAK — stop, record context
+  │
+  ▼
+STEP 2: ESCALATE
+  ├─ Attempt 1 (auto): sub-agent, stronger model ─→ works? Done ✓
+  ├─ Attempt 2 (auto): different model/method    ─→ works? Done ✓
+  └─ Attempt 3 (user): ask user to pick
+       └─ User responds? ──→ execute their choice
+       └─ AFK 10 min?    ──→ STEP 3
+  │
+  ▼
+STEP 3: REPORT — structured failure, STOP
+```
+
+---
+
+## Pitfalls
+
+- Do NOT skip Step 1 and jump to escalation on first failure — the agent sometimes recovers
+- Do NOT let escalation attempts run unbounded — each rung inherits the 3-try/5-min loop guard
+- Do NOT escalate for transient errors (429, network blips) — use backoff retry instead
+- Do NOT escalate for prompt-level issues — fix the prompt
+- When delegating to a sub-agent, ALWAYS pass the failure context — a fresh agent with no error history will repeat the same mistakes
+- During a task: do NOT revert to the original model — it already demonstrated it can't handle this task
+- After task completes: revert to the default model (cheaper) for subsequent tasks
+- The 10-minute timer for Step 1 starts from the **first failure**, not from session start or task start
+- The 10-minute AFK timeout for Attempt 3 starts from when the user-pick message is sent
+
+---
+
+## Config Dependencies
+
+The escalation ladder relies on these config settings:
+
+```yaml
+# Delegation — controls sub-agent model for Attempt 1
+delegation:
+  model: glm-5-turbo        # or stronger model for escalation
+  provider: zai
+  max_iterations: 15        # tight budget — escalation agent can't loop
+  max_concurrent_children: 3
+  child_timeout_seconds: 300
+
+# Fallback models — available for Attempt 2 alternative paths
+fallback_model:
+  model: deepseek-ai/DeepSeek-V4-Flash
+  provider: deepinfra
+fallback_providers:
+  - deepinfra
+  - deepseek
+  - xai
+```
+
+To change the escalation model: `hermes config set delegation.model <model> && hermes config set delegation.provider <provider>`


### PR DESCRIPTION
## Summary

Adds a skill for detecting and escalating agent loops when using cheaper models (e.g., DeepSeek Flash) that may go in circles on complex tasks.

## Problem

Cheaper LLMs often struggle with complex multi-step tasks, producing repeated tool calls, similar errors, or reasoning loops without progress. Current Hermes fallback chain only triggers on API-level failures (500, 429, timeout), not behavioral loops.

## Solution

The `loop-bounce` skill provides:

- **Multi-dimensional failure classification**: Distinguishes execution, diagnostic, verification, repeated_approach, environment, and policy failures
- **Approach fingerprinting**: Detects disguised retries (same approach with minor variations)
- **Sliding window detection**: Uses failure rate over time, not just consecutive failures
- **Diagnostic checkpoint**: Gathers structured context before model escalation
- **Structured handoff packet**: Provides escalation agent with full context to avoid repeating mistakes
- **3-attempt escalation ladder**: Sub-agent → alt model → user intervention
- **Model revert rule**: Stay on stronger model during task, revert after completion

## Usage

Load the skill at session start:
```yaml
skills: ["loop-bounce"]
```

Or manually trigger with `/loop-bounce` when agent appears stuck.

## Testing

- Verified skill loads correctly
- Failure classification logic tested with edge cases
- Handoff packet format validated

Closes potential loop issues with cheaper models going in circles on complex tasks.