### PR TITLE
fix(acp): simulate single-file V4A patches for honest edit-approval previews

### DIFF
--- a/acp_adapter/edit_approval.py
+++ b/acp_adapter/edit_approval.py
@@ -152,6 +152,49 @@ def _extract_v4a_patch_paths(patch_body: str) -> list[str]:
     return paths
 
 
+class _VirtualFileOps:
+    """Duck-typed file_ops for in-memory V4A simulation.
+
+    Mirrors the subset of the real interface that
+    ``patch_parser._validate_operations`` and hunk simulation touch:
+    ``read_file_raw``, ``write_file`` (capture only), ``delete_file``,
+    ``move_file``. Nothing ever touches the real filesystem.
+    """
+
+    def __init__(self, base: dict[str, str]):
+        self.files = dict(base)
+        self.results: list = []
+
+    class _R:
+        def __init__(self, content: str | None, error: str | None):
+            self.content = content
+            self.error = error
+
+    def read_file_raw(self, path: str):
+        if path in self.files:
+            return self._R(self.files[path], None)
+        return self._R(None, "file not found")
+
+    def write_file(self, path: str, content: str, **_kwargs):
+        self.files[path] = content
+        self.results.append(("write", path))
+        return self._R(content, None)
+
+    def delete_file(self, path: str):
+        if path not in self.files:
+            return self._R(None, "file not found")
+        del self.files[path]
+        self.results.append(("delete", path))
+        return self._R(None, None)
+
+    def move_file(self, src: str, dst: str):
+        if src not in self.files:
+            return self._R(None, "file not found")
+        self.files[dst] = self.files.pop(src)
+        self.results.append(("move", src, dst))
+        return self._R(None, None)
+
+
 def _proposal_for_patch_v4a(arguments: dict[str, Any]) -> EditProposal:
     patch_body = arguments.get("patch")
     if not isinstance(patch_body, str) or not patch_body:
@@ -161,16 +204,43 @@ def _proposal_for_patch_v4a(arguments: dict[str, Any]) -> EditProposal:
     if not paths:
         raise ValueError("no file paths found in V4A patch")
 
-    proposal_path = paths[0] if len(paths) == 1 else ", ".join(paths)
-    old_text = _read_text_if_exists(paths[0]) if len(paths) == 1 else None
+    multi = len(paths) > 1
+
+    # For a single-file patch we can do better than showing the raw patch
+    # body as the "new file": simulate the patch in memory (the exact same
+    # validate + hunk-application path the real tool uses, on a virtual
+    # filesystem) and hand the ACP client an honest before/after diff.
+    # Multi-file patches and parse/simulation failures fall back to the
+    # previous behavior: ACP carries only one diff payload per request, so
+    # we surface the raw patch body for the human to read.
+    new_text: str | None = None
+    old_text: str | None = None
+    if not multi:
+        from tools.patch_parser import parse_v4a_patch, apply_v4a_operations
+
+        old_text = _read_text_if_exists(paths[0])
+        operations, parse_error = parse_v4a_patch(patch_body)
+        if not parse_error and len(operations) == 1:
+            virtual = _VirtualFileOps({paths[0]: old_text or ""})
+            result = apply_v4a_operations(operations, virtual)
+            if result.success:
+                if paths[0] in virtual.files:
+                    new_text = virtual.files[paths[0]]
+                else:
+                    # Single-file DELETE: the honest preview is "file becomes
+                    # empty" (the ACP diff has no delete-file kind).
+                    new_text = ""
+
     return EditProposal(
         tool_name="patch",
-        path=proposal_path,
-        old_text=old_text,
-        # ACP only supports a single diff payload here.  Surface the exact V4A
-        # patch content before execution so patch-mode calls are permissioned
-        # and denied patches cannot mutate.
-        new_text=patch_body,
+        path=paths[0] if not multi else ", ".join(paths),
+        old_text=old_text if not multi else None,
+        # ACP only supports a single diff payload here.  For simulated
+        # single-file patches new_text is the honest post-patch content;
+        # otherwise surface the exact V4A patch content before execution so
+        # patch-mode calls are still permissioned and denied patches cannot
+        # mutate.
+        new_text=new_text if new_text is not None else patch_body,
         arguments=dict(arguments),
     )
 

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from acp_adapter.edit_approval import (
     EditProposal,
     build_acp_edit_tool_call,
+    build_edit_proposal,
     clear_edit_approval_requester,
     set_edit_approval_requester,
     should_auto_approve_edit,
@@ -122,3 +123,136 @@ def test_workspace_auto_approval_allows_workspace_and_tmp_but_not_sensitive(tmp_
         "session",
         str(tmp_path),
     )
+
+
+def test_v4a_proposal_shows_simulated_result_not_patch_body(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\ngamma\n", encoding="utf-8")
+
+    proposal = build_edit_proposal(
+        "patch",
+        {
+            "mode": "patch",
+            "patch": (
+                "*** Begin Patch\n"
+                f"*** Update File: {target}\n"
+                "@@\n"
+                "-beta\n"
+                "+BETA\n"
+                "*** End Patch"
+            ),
+        },
+    )
+
+    assert proposal is not None
+    assert proposal.path == str(target)
+    assert proposal.old_text == "alpha\nbeta\ngamma\n"
+    assert proposal.new_text == "alpha\nBETA\ngamma\n"
+    assert "*** Begin Patch" not in proposal.new_text
+
+
+def test_v4a_proposal_delete_shows_empty_result(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    proposal = build_edit_proposal(
+        "patch",
+        {
+            "mode": "patch",
+            "patch": (
+                "*** Begin Patch\n"
+                f"*** Delete File: {target}\n"
+                "*** End Patch"
+            ),
+        },
+    )
+
+    assert proposal is not None
+    assert proposal.old_text == "alpha\nbeta\n"
+    assert proposal.new_text == ""
+
+
+def test_v4a_proposal_multi_file_falls_back_to_patch_body(tmp_path):
+    a = tmp_path / "a.txt"
+    b = tmp_path / "b.txt"
+    a.write_text("aaa\n", encoding="utf-8")
+    b.write_text("bbb\n", encoding="utf-8")
+
+    proposal = build_edit_proposal(
+        "patch",
+        {
+            "mode": "patch",
+            "patch": (
+                "*** Begin Patch\n"
+                f"*** Update File: {a}\n"
+                "@@\n"
+                "-aaa\n"
+                "+AAA\n"
+                f"*** Update File: {b}\n"
+                "@@\n"
+                "-bbb\n"
+                "+BBB\n"
+                "*** End Patch"
+            ),
+        },
+    )
+
+    # ACP carries a single diff payload; multi-file patches keep the raw body.
+    assert proposal is not None
+    assert proposal.new_text.startswith("*** Begin Patch")
+    assert proposal.old_text is None
+
+
+def test_v4a_proposal_invalid_hunk_falls_back_to_patch_body(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\n", encoding="utf-8")
+
+    proposal = build_edit_proposal(
+        "patch",
+        {
+            "mode": "patch",
+            "patch": (
+                "*** Begin Patch\n"
+                f"*** Update File: {target}\n"
+                "@@\n"
+                "-not-in-file\n"
+                "+replacement\n"
+                "*** End Patch"
+            ),
+        },
+    )
+
+    # Simulation failed validation -> keep the previous behavior so the call
+    # is still permissioned with the raw body (and would be rejected at
+    # execution anyway).
+    assert proposal is not None
+    assert proposal.new_text.startswith("*** Begin Patch")
+
+
+def test_v4a_rejection_does_not_mutate(tmp_path):
+    target = tmp_path / "sample.txt"
+    target.write_text("alpha\nbeta\n", encoding="utf-8")
+
+    set_edit_approval_requester(lambda _proposal: False)
+
+    result = json.loads(
+        handle_function_call(
+            "patch",
+            {
+                "mode": "patch",
+                "patch": (
+                    "*** Begin Patch\n"
+                    f"*** Update File: {target}\n"
+                    "@@\n"
+                    "-beta\n"
+                    "+gamma\n"
+                    "*** End Patch"
+                ),
+            },
+            task_id="acp-v4a-reject",
+        )
+    )
+
+    assert "error" in result
+    assert "Edit approval denied" in result["error"]
+    assert target.read_text(encoding="utf-8") == "alpha\nbeta\n"


### PR DESCRIPTION
Fixes #92339

## What

In ACP sessions (VS Code / Zed / JetBrains), `patch` tool calls with
`mode='patch'` (V4A format) rendered their edit-approval card as
"replace the whole file with the raw patch text" — because the proposal
handed the client the patch **body** as `new_text` instead of the patched
result. Users see a diff that deletes all their file lines and inserts
`*** Begin Patch ...`, and naturally reject the edit.

The executed patch itself was always fine (validate-then-apply in
`tools/patch_parser.py`); only the approval preview lied.

## Root cause

`acp_adapter/edit_approval.py`, `_proposal_for_patch_v4a()`:

```python
new_text=patch_body,   # raw patch body presented as the new file content
```

Replace-mode proposals already run their replacement through
`fuzzy_find_and_replace` in memory and send a real before/after — that is
why replace previews look correct in the same clients.

## Fix

Single-file V4A patches are now **simulated in memory** through the same
pipeline the executor uses — `parse_v4a_patch` + `apply_v4a_operations`
against a small virtual filesystem (`_VirtualFileOps`: `read_file_raw` /
`write_file` / `delete_file` / `move_file`) — and the resulting content
becomes `new_text`, giving the client an honest before/after diff.

- Single-file `Delete File` previews as "file becomes empty" (the ACP diff
  payload has no delete-file kind).
- Multi-file patches and simulation failures keep the previous raw-body
  fallback, since ACP carries a single diff payload per permission request.
- Denied edits still leave files untouched; simulation never writes to the
  real filesystem.

## Tests

`tests/acp/test_edit_approval.py` — 5 new tests on top of the existing 4:

- simulated result for a single-file UPDATE (new_text is the patched file, not the patch body)
- single-file DELETE previews as empty content
- multi-file patch falls back to the raw body
- failed hunk validation falls back to the raw body
- rejection does not mutate the file in patch mode

`pytest tests/acp/test_edit_approval.py` → 9 passed;
`pytest tests/acp_adapter/` → 15 passed (run against a worktree of current
`main` with only this change applied).
