### PR TITLE
fix(nvidia): gate NIM tool reasoning echoes

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2208,8 +2208,8 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     if raw_reasoning_content is not None:
         msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
     elif assistant_tool_calls and agent._needs_thinking_reasoning_pad():
-        # DeepSeek v4 thinking mode and Kimi / Moonshot thinking mode
-        # both require reasoning_content on every assistant tool-call
+        # DeepSeek v4, Kimi / Moonshot, and NVIDIA NIM thinking modes
+        # require reasoning_content on every assistant tool-call
         # message. Without it, replaying the persisted message causes
         # HTTP 400 ("The reasoning_content in the thinking mode must
         # be passed back to the API"). Include streamed reasoning

--- a/agent/nim_reasoning.py
+++ b/agent/nim_reasoning.py
@@ -1,0 +1,31 @@
+"""NVIDIA NIM thinking-model classification.
+
+NIM exposes ordinary instruct models and models whose tool-call messages must
+round-trip ``reasoning_content`` through the same OpenAI-compatible endpoint.
+Keep that distinction model-driven so enabling reasoning on an instruct model
+does not add a field that strict backends may reject.
+"""
+
+from __future__ import annotations
+
+
+_EXPLICIT_THINKING_MARKERS = (
+    "-thinking",
+    "-reasoning",
+    "/deepseek-r1",
+    "/deepseek-v3",
+    "/deepseek-v4",
+)
+
+
+def is_nim_thinking_model(model: str | None) -> bool:
+    """Return whether *model* belongs to a NIM thinking-output family."""
+    normalized = (model or "").strip().lower()
+    if not normalized:
+        return False
+    if any(marker in normalized for marker in _EXPLICIT_THINKING_MARKERS):
+        return True
+    # Qwen3's thinking-capable variants use either an explicit ``thinking``
+    # suffix or the base family name.  ``*-instruct`` variants are strict
+    # non-thinking chat models and must not receive reasoning_content.
+    return "/qwen3" in normalized and "-instruct" not in normalized

--- a/run_agent.py
+++ b/run_agent.py
@@ -7906,8 +7906,12 @@ class AIAgent:
 
         # NVIDIA NIM re-exports DeepSeek alongside strict instruct models and
         # has its own reasoning enable/disable contract. Let the NIM gate own
-        # this endpoint instead of the generic model-name rule below.
-        if base_url_host_matches(self.base_url, "integrate.api.nvidia.com"):
+        # both hosted and local/on-prem NVIDIA endpoints instead of the generic
+        # model-name rule below.
+        provider = (self.provider or "").strip().lower()
+        if provider in {"nvidia", "nvidia-nim"} or base_url_host_matches(
+            self.base_url, "integrate.api.nvidia.com"
+        ):
             return self._needs_nim_tool_reasoning()
 
         from agent.message_sanitization import matches_reasoning_echo_family
@@ -7940,9 +7944,13 @@ class AIAgent:
         from agent.nim_reasoning import is_nim_thinking_model
         from utils import base_url_host_matches
 
-        if not base_url_host_matches(self.base_url, "integrate.api.nvidia.com"):
-            return False
-        if (self.provider or "").lower() not in {"nvidia", "nvidia-nim", "custom"}:
+        provider = (self.provider or "").strip().lower()
+        official_host = base_url_host_matches(
+            self.base_url, "integrate.api.nvidia.com"
+        )
+        if provider not in {"nvidia", "nvidia-nim"} and not (
+            provider == "custom" and official_host
+        ):
             return False
         config = self.reasoning_config
         if not isinstance(config, dict):

--- a/run_agent.py
+++ b/run_agent.py
@@ -7810,7 +7810,8 @@ class AIAgent:
     def _needs_thinking_reasoning_pad(self) -> bool:
         """Return True when the active provider enforces reasoning_content echo-back.
 
-        DeepSeek v4 thinking and Kimi / Moonshot thinking both reject replays
+        DeepSeek v4 thinking, Kimi / Moonshot thinking, and NVIDIA NIM
+        thinking models reject replays
         of assistant tool-call messages that omit ``reasoning_content`` (refs
         #15250, #17400). Xiaomi MiMo thinking mode has the same requirement.
 
@@ -7830,6 +7831,7 @@ class AIAgent:
             self._needs_deepseek_tool_reasoning()
             or self._needs_kimi_tool_reasoning()
             or self._needs_mimo_tool_reasoning()
+            or self._needs_nim_tool_reasoning()
             or self._reasoning_echo_opt_in()
         )
         self._thinking_pad_cache = (key, result)
@@ -7900,6 +7902,14 @@ class AIAgent:
 
         Rule table owner: ``agent.message_sanitization.reasoning_echo_family``.
         """
+        from utils import base_url_host_matches
+
+        # NVIDIA NIM re-exports DeepSeek alongside strict instruct models and
+        # has its own reasoning enable/disable contract. Let the NIM gate own
+        # this endpoint instead of the generic model-name rule below.
+        if base_url_host_matches(self.base_url, "integrate.api.nvidia.com"):
+            return self._needs_nim_tool_reasoning()
+
         from agent.message_sanitization import matches_reasoning_echo_family
         return matches_reasoning_echo_family(
             "deepseek", (self.provider or "").lower(), self.model, self.base_url
@@ -7918,6 +7928,30 @@ class AIAgent:
         return matches_reasoning_echo_family(
             "mimo", (self.provider or "").lower(), self.model, self.base_url
         )
+
+    def _needs_nim_tool_reasoning(self) -> bool:
+        """Return True for thinking models on NVIDIA's NIM endpoint.
+
+        NIM serves strict instruct and reasoning models from the same OpenAI-
+        compatible endpoint.  Gate on endpoint, model family, and the active
+        reasoning configuration so ordinary NIM models never receive the
+        provider-specific ``reasoning_content`` replay field.
+        """
+        from agent.nim_reasoning import is_nim_thinking_model
+        from utils import base_url_host_matches
+
+        if not base_url_host_matches(self.base_url, "integrate.api.nvidia.com"):
+            return False
+        if (self.provider or "").lower() not in {"nvidia", "nvidia-nim", "custom"}:
+            return False
+        config = self.reasoning_config
+        if not isinstance(config, dict):
+            return False
+        enabled = config.get("enabled", True)
+        effort = str(config.get("effort") or "").strip().lower()
+        if enabled is False or effort == "none":
+            return False
+        return is_nim_thinking_model(self.model)
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.copy_reasoning_content_for_api``."""

--- a/tests/run_agent/test_nim_reasoning_content_echo.py
+++ b/tests/run_agent/test_nim_reasoning_content_echo.py
@@ -1,0 +1,86 @@
+"""Regression coverage for NVIDIA NIM thinking-model reasoning replay."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.nim_reasoning import is_nim_thinking_model
+from run_agent import AIAgent
+
+
+def _agent(*, provider="nvidia", model="deepseek-ai/deepseek-r1", base_url="https://integrate.api.nvidia.com/v1", reasoning_config=None):
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.reasoning_config = reasoning_config
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+def _tool_message():
+    return SimpleNamespace(
+        content=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+        codex_reasoning_items=None,
+        codex_message_items=None,
+        tool_calls=[SimpleNamespace(
+            id="call_1", call_id=None, response_item_id=None, type="function",
+            function=SimpleNamespace(name="terminal", arguments="{}"),
+        )],
+    )
+
+
+@pytest.mark.parametrize("model", [
+    "deepseek-ai/deepseek-r1",
+    "deepseek-ai/deepseek-v4-flash-0731",
+    "qwen/qwen3-next-80b-a3b-thinking",
+    "moonshotai/kimi-k2-thinking",
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+])
+def test_nim_thinking_model_families(model):
+    assert is_nim_thinking_model(model)
+
+
+@pytest.mark.parametrize("model", [
+    "nvidia/llama-3.1-nemotron-70b-instruct",
+    "meta/llama-3.3-70b-instruct",
+    "deepseek-ai/deepseek-coder-6.7b-instruct",
+])
+def test_nim_non_thinking_models(model):
+    assert not is_nim_thinking_model(model)
+
+
+def test_nim_tool_call_pins_reasoning_content():
+    agent = _agent(reasoning_config={"enabled": True, "effort": "medium"})
+    message = agent._build_assistant_message(_tool_message(), "tool_calls")
+    assert message["reasoning_content"] == " "
+
+
+def test_custom_provider_on_official_nim_host_is_supported():
+    agent = _agent(provider="custom", reasoning_config={"enabled": True})
+    assert agent._needs_nim_tool_reasoning()
+
+
+@pytest.mark.parametrize("reasoning_config", [None, {"enabled": False}, {"effort": "none"}])
+def test_nim_echo_requires_enabled_reasoning(reasoning_config):
+    agent = _agent(reasoning_config=reasoning_config)
+    assert not agent._needs_nim_tool_reasoning()
+    assert not agent._needs_thinking_reasoning_pad()
+    assert "reasoning_content" not in agent._build_assistant_message(
+        _tool_message(), "tool_calls"
+    )
+
+
+def test_nim_model_on_aggregator_does_not_enable_echo():
+    agent = _agent(
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        reasoning_config={"enabled": True},
+    )
+    assert not agent._needs_nim_tool_reasoning()

--- a/tests/run_agent/test_nim_reasoning_content_echo.py
+++ b/tests/run_agent/test_nim_reasoning_content_echo.py
@@ -67,6 +67,28 @@ def test_custom_provider_on_official_nim_host_is_supported():
     assert agent._needs_nim_tool_reasoning()
 
 
+def test_local_nim_qwen_tool_call_pins_reasoning_content():
+    agent = _agent(
+        model="qwen/qwen3-next-80b-a3b-thinking",
+        base_url="http://localhost:8000/v1",
+        reasoning_config={"enabled": True},
+    )
+    message = agent._build_assistant_message(_tool_message(), "tool_calls")
+    assert agent._needs_nim_tool_reasoning()
+    assert message["reasoning_content"] == " "
+
+
+def test_local_nim_deepseek_respects_disabled_reasoning():
+    agent = _agent(
+        base_url="http://localhost:8000/v1",
+        reasoning_config={"enabled": False},
+    )
+    message = agent._build_assistant_message(_tool_message(), "tool_calls")
+    assert not agent._needs_nim_tool_reasoning()
+    assert not agent._needs_deepseek_tool_reasoning()
+    assert "reasoning_content" not in message
+
+
 @pytest.mark.parametrize("reasoning_config", [None, {"enabled": False}, {"effort": "none"}])
 def test_nim_echo_requires_enabled_reasoning(reasoning_config):
     agent = _agent(reasoning_config=reasoning_config)


### PR DESCRIPTION
## Summary

- classify NVIDIA NIM model families that require thinking-content replay
- gate `reasoning_content` echo-back on NVIDIA NIM endpoints, including supported local and on-prem deployments, and enabled reasoning configuration
- prevent NIM-hosted DeepSeek models from bypassing the NIM reasoning gate through generic model-name detection

## Testing

- `scripts/run_tests.sh tests/run_agent/test_nim_reasoning_content_echo.py tests/run_agent/test_deepseek_reasoning_content_echo.py -q` (37 passed)

## Related Issue

Closes #92359
