### PR TITLE
test(desktop): complete the locale-agnostic desktop UI tests

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -524,7 +524,7 @@ describe('renderRpcResult', () => {
   describe('session.usage', () => {
     it('formats calls / input / output / total with thousands separators', () => {
       expect(renderRpcResult({ calls: 12, input: 1_234_567, output: 89_012, total: 1_323_579 }, 'usage')).toBe(
-        'Usage: 12 calls · 1,234,567 in / 89,012 out · 1,323,579 total'
+        `Usage: 12 calls · ${(1_234_567).toLocaleString()} in / ${(89_012).toLocaleString()} out · ${(1_323_579).toLocaleString()} total`
       )
     })
 

--- a/apps/desktop/src/app/settings/billing/index.test.tsx
+++ b/apps/desktop/src/app/settings/billing/index.test.tsx
@@ -78,6 +78,11 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+// Intl separates the amount from the symbol with U+00A0 for locales that place
+// the symbol last ("10\u00A0US$"). getByText normalizes the element's text but
+// not a string matcher, so the expected string has to be normalized to match.
+const text = (value: string) => value.replace(/\s+/g, ' ').trim()
+
 describe('BillingSettings', () => {
   it('renders the deployed-today payload with buy controls hidden and usage rows visible', async () => {
     renderBilling()
@@ -169,7 +174,7 @@ describe('BillingSettings', () => {
       target: { value: '7.50' }
     })
 
-    expect(screen.getByText(`Threshold: minimum is ${formatMoney(10)}.`)).toBeTruthy()
+    expect(screen.getByText(text(`Threshold: minimum is ${formatMoney(10)}.`))).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Save' }).hasAttribute('disabled')).toBe(true)
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
@@ -220,7 +225,7 @@ describe('BillingSettings', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Manage' }))
 
     expect(screen.getByRole('spinbutton', { name: 'Auto-refill threshold' })).toBeTruthy()
-    expect(screen.queryByText(`Threshold: minimum is ${formatMoney(10)}.`)).toBeNull()
+    expect(screen.queryByText(text(`Threshold: minimum is ${formatMoney(10)}.`))).toBeNull()
     // Save is disabled because the prefilled config is invalid — but no error yet.
     expect(screen.getByRole('button', { name: 'Save' }).hasAttribute('disabled')).toBe(true)
   })
@@ -593,7 +598,7 @@ describe('BillingSettings', () => {
       ok: true
     })
 
-    await waitFor(() => expect(screen.getByText(`${formatMoney(25)} added. Balance is refreshing.`)).toBeTruthy())
+    await waitFor(() => expect(screen.getByText(text(`${formatMoney(25)} added. Balance is refreshing.`))).toBeTruthy())
   })
 
   it('renders logged-out as a connect card without normal account rows', async () => {

--- a/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
+++ b/apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts
@@ -391,7 +391,7 @@ describe('clampForDisplay', () => {
 
     expect(clamped.length).toBeLessThan(oversized.length)
     expect(clamped.startsWith('x'.repeat(MAX_TOOL_RENDER_CHARS))).toBe(true)
-    expect(clamped).toContain('5,000 more characters truncated')
+    expect(clamped).toContain(`${(5_000).toLocaleString()} more characters truncated`)
     expect(clamped).toContain('Copy')
   })
 })


### PR DESCRIPTION
## What does this PR do?

**Low priority — test-only, no user-visible change.**

`4c9e1e8223` (#73123) moved the billing assertions onto `formatMoney()` so they would stop hardcoding `$10`. They still fail on any locale that places the currency symbol *last*: `Intl` separates the amount from the symbol with a non-breaking space (U+00A0) there, and `getByText` normalizes the **element's** text without normalizing a **string matcher** — so the two can never be equal.

```
element text (after normalization):  'Threshold: minimum is 10\u0020US$.'
string matcher (never normalized):   'Threshold: minimum is 10\u00A0US$.'
```

That fix was verified on zh-CN, which renders `US$10` — symbol first, no space — so it genuinely works there, and CI is en-US. It only reappears on es/fr/de/pt/it/ru/nl/pl/et.

This normalizes the expected string the same way, and gives the two tests that still hardcoded thousands separators the same treatment. Runtime-locale output stays the intended behaviour, per #73123 — only the assertions change.

One side effect worth noting: the `queryByText(...).toBeNull()` assertion at `index.test.tsx:223` was passing *vacuously* on those locales (the matcher could never match anything), so it now actually tests what it claims.

## Related Issue

No issue filed — this completes #73123 / #71659.

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/settings/billing/index.test.tsx` — add a local `text()` normalizer, apply to the three `formatMoney` assertions
- `apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts` — assert the usage line through `toLocaleString()` instead of `1,234,567`
- `apps/desktop/src/components/assistant-ui/tool/fallback-model.test.ts` — same for `5,000 more characters truncated`

## How to Test

Node takes its default ICU locale from `LC_ALL` on Linux/macOS, so no special machine is needed:

```
cd apps/desktop
LC_ALL=es_ES.UTF-8 npx vitest run \
  src/app/settings/billing/index.test.tsx \
  src/app/session/hooks/use-prompt-actions/utils.test.ts \
  src/components/assistant-ui/tool/fallback-model.test.ts
```

- **Before:** 4 failed | 110 passed
- **After:** 114 passed

Full desktop suite: **7011 passed, 3 skipped, 0 failed** under `LC_ALL=es_ES.UTF-8`. The three files are also green under `LC_ALL=C`, `fr_FR.UTF-8` and `zh_CN.UTF-8`, so no locale is traded for another.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` — N/A, this touches no Python; ran the desktop vitest suite instead (7011 passed)
- [x] I've added tests for my changes — N/A in the usual sense: the changed files *are* the tests
- [x] I've tested on my platform: Ubuntu 24.04 (Linux 6.8), Node 22

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the fix is locale-driven rather than OS-driven; note that Node on Windows takes its ICU default from the OS and does not reliably honour `LC_ALL`, so the repro above is Linux/macOS
- [x] I've updated tool descriptions/schemas — N/A
