### PR TITLE
fix: cleanup_vm pops the resolved default environment key

### DIFF
--- a/tests/tools/test_shared_container_task_id.py
+++ b/tests/tools/test_shared_container_task_id.py
@@ -55,6 +55,29 @@ def test_cwd_only_override_collapses_to_default():
         terminal_tool.clear_task_env_overrides("acp-session-abc")
 
 
+def test_cleanup_vm_pops_the_resolved_default_key():
+    """API sessions store the env under 'default' but close with the UUID."""
+
+    class _Env:
+        def __init__(self):
+            self.cleaned = False
+
+        def cleanup(self):
+            self.cleaned = True
+
+    env = _Env()
+    terminal_tool._active_environments["default"] = env
+    terminal_tool._last_activity["default"] = 0
+    try:
+        terminal_tool.cleanup_vm("api-session-uuid")
+        assert "default" not in terminal_tool._active_environments
+        assert env.cleaned
+    finally:
+        terminal_tool._active_environments.pop("default", None)
+        terminal_tool._last_activity.pop("default", None)
+        terminal_tool._active_environments.pop("api-session-uuid", None)
+
+
 def test_env_type_override_keeps_own_id():
     """env_type is an isolation key — must trigger per-task container."""
     terminal_tool.register_task_env_overrides(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2235,48 +2235,63 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     # Remove from tracking dicts while holding the lock, but defer the
     # actual (potentially slow) env.cleanup() call to outside the lock
     # so other tool calls aren't blocked.
-    env = None
+    #
+    # Creation stores the env under ``_resolve_container_task_id(task_id)``
+    # (often ``"default"``). Popping only the raw session UUID would miss
+    # it and silently leak the sandbox (#91440).
+    keys = {_resolve_container_task_id(task_id)}
+    if task_id:
+        keys.add(task_id)
+    envs = []
+    seen = set()
     with _env_lock:
-        env = _active_environments.pop(task_id, None)
-        _last_activity.pop(task_id, None)
+        for key in keys:
+            env = _active_environments.pop(key, None)
+            _last_activity.pop(key, None)
+            if env is not None and id(env) not in seen:
+                seen.add(id(env))
+                envs.append(env)
 
     # Clean up per-task creation lock
     with _creation_locks_lock:
-        _creation_locks.pop(task_id, None)
+        for key in keys:
+            _creation_locks.pop(key, None)
 
     # Invalidate stale file_ops cache entry
     try:
         from tools.file_tools import clear_file_ops_cache
-        clear_file_ops_cache(task_id)
+        for key in keys:
+            clear_file_ops_cache(key)
     except ImportError:
         pass
 
-    if env is None:
+    if not envs:
         return
 
-    try:
-        if hasattr(env, 'cleanup'):
-            # Pass force_remove only if the env's cleanup() accepts it
-            # (DockerEnvironment after issue #20561; other backends don't).
-            import inspect
-            sig = inspect.signature(env.cleanup)
-            if "force_remove" in sig.parameters:
-                env.cleanup(force_remove=force_remove)
+    for env in envs:
+        try:
+            if hasattr(env, 'cleanup'):
+                # Pass force_remove only if the env's cleanup() accepts it
+                # (DockerEnvironment after issue #20561; other backends don't).
+                import inspect
+                sig = inspect.signature(env.cleanup)
+                if "force_remove" in sig.parameters:
+                    env.cleanup(force_remove=force_remove)
+                else:
+                    env.cleanup()
+            elif hasattr(env, 'stop'):
+                env.stop()
+            elif hasattr(env, 'terminate'):
+                env.terminate()
+
+            logger.info("Manually cleaned up environment for task: %s", task_id)
+
+        except Exception as e:
+            error_str = str(e)
+            if "404" in error_str or "not found" in error_str.lower():
+                logger.info("Environment for task %s already cleaned up", task_id)
             else:
-                env.cleanup()
-        elif hasattr(env, 'stop'):
-            env.stop()
-        elif hasattr(env, 'terminate'):
-            env.terminate()
-
-        logger.info("Manually cleaned up environment for task: %s", task_id)
-
-    except Exception as e:
-        error_str = str(e)
-        if "404" in error_str or "not found" in error_str.lower():
-            logger.info("Environment for task %s already cleaned up", task_id)
-        else:
-            logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+                logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
 
 
 def _atexit_cleanup():


### PR DESCRIPTION
## Problem

Terminal environment creation stores the sandbox under `_resolve_container_task_id(task_id)` (often `"default"` for API sessions). `cleanup_vm()` popped only the raw session UUID, so cleanup silently returned and later `terminal` calls reused a stale shell snapshot.

Fixes #91440.

## Change

Evict both the resolved key and the raw id, matching `_evict_environment_for_task`.

## Test

```
pytest tests/tools/test_shared_container_task_id.py -q
# 12 passed
```
