### PR TITLE
feat(desktop): give a renamed default profile its own mark in the profile rail

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
@@ -49,6 +49,8 @@ vi.mock('@/store/profile', () => ({
   normalizeProfileKey: (name: string) => name,
   profileLabel: (profile: { display_name?: string; name: string }) =>
     (profile.display_name ?? '').trim() || profile.name,
+  profileWearsHomeGlyph: (profile: { display_name?: string; is_default: boolean }) =>
+    profile.is_default && (profile.display_name ?? '').trim() === '',
   refreshActiveProfile: vi.fn().mockResolvedValue(undefined),
   selectProfile: vi.fn(),
   setProfileColor: vi.fn(),

--- a/apps/desktop/src/app/chat/sidebar/profile-rail-default-identity.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-default-identity.test.tsx
@@ -1,0 +1,208 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ProfileRail } from './profile-switcher'
+
+// `hermes profile rename default <Name>` gives the default profile a
+// display_name — the rail already puts it in the tooltip, but the pill kept the
+// generic home codicon, so the one profile a user lives in was the only one
+// without a face (#92033). These pin both halves of the rule: a named default
+// gets a mark, an anonymous one keeps home, and ALL stays a view rather than an
+// identity.
+
+const { selectProfile, setShowAllProfiles } = vi.hoisted(() => ({
+  selectProfile: vi.fn(),
+  setShowAllProfiles: vi.fn()
+}))
+
+vi.mock('react-router', () => ({
+  useNavigate: () => vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { cancel: 'Cancel' },
+      profiles: {
+        allProfiles: 'All profiles',
+        connectGateway: 'Manage gateways…',
+        failedLoadSoul: 'Failed to load SOUL.md',
+        failedSaveSoul: 'Failed to save SOUL.md',
+        importProfile: 'Import profile…',
+        manageProfiles: 'Manage profiles…',
+        newProfile: 'New profile',
+        saveSoul: 'Save',
+        saving: 'Saving…',
+        showAllProfiles: 'Show all profiles',
+        soulSaved: 'SOUL.md saved',
+        switchToProfile: (name: string) => `Switch to ${name}`,
+        title: 'Profiles'
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/profile', () => ({
+  $activeGatewayProfile: atom('default'),
+  $profileColors: atom({}),
+  $profileCreateRequest: atom(0),
+  $profileOrder: atom([]),
+  $profiles: atom([{ is_default: true, name: 'default' }]),
+  $profileScope: atom('default'),
+  ALL_PROFILES: '__all__',
+  normalizeProfileKey: (name: string) => (name ?? '').trim() || 'default',
+  profileLabel: (profile: { display_name?: string; name: string }) =>
+    (profile.display_name ?? '').trim() || profile.name,
+  profileWearsHomeGlyph: (profile: { display_name?: string; is_default: boolean }) =>
+    profile.is_default && (profile.display_name ?? '').trim() === '',
+  refreshActiveProfile: vi.fn().mockResolvedValue(undefined),
+  selectProfile,
+  setProfileColor: vi.fn(),
+  setProfileOrder: vi.fn(),
+  setShowAllProfiles,
+  sortByProfileOrder: (profiles: unknown[]) => profiles
+}))
+
+vi.mock('@/store/connections', () => ({ $hasMultipleConnections: atom(false) }))
+
+vi.mock('@/store/profile-share', () => ({
+  runExportProfileFlow: vi.fn(),
+  runImportProfileFlow: vi.fn()
+}))
+
+vi.mock('./use-profile-prewarm', () => ({
+  useProfilePrewarm: () => ({ cancelPrewarm: vi.fn(), startPrewarm: vi.fn() })
+}))
+
+vi.mock('@/hermes', () => ({
+  getProfileSoul: vi.fn().mockResolvedValue({ content: '' }),
+  updateProfileSoul: vi.fn()
+}))
+
+vi.mock('@/components/chat/code-editor', () => ({ CodeEditor: () => null }))
+vi.mock('../../profiles/create-profile-dialog', () => ({ CreateProfileDialog: () => null }))
+vi.mock('../../profiles/delete-profile-dialog', () => ({ DeleteProfileDialog: () => null }))
+vi.mock('../../profiles/rename-profile-dialog', () => ({ RenameProfileDialog: () => null }))
+
+interface RailProfile {
+  display_name?: string
+  is_default: boolean
+  name: string
+}
+
+const store = await import('@/store/profile')
+const profiles = store.$profiles as ReturnType<typeof atom<RailProfile[]>>
+const gatewayProfile = store.$activeGatewayProfile as ReturnType<typeof atom<string>>
+const scope = store.$profileScope as ReturnType<typeof atom<string>>
+
+const ANONYMOUS_DEFAULT: RailProfile = { is_default: true, name: 'default' }
+const NAMED_DEFAULT: RailProfile = { display_name: 'Hermes', is_default: true, name: 'default' }
+const WORK: RailProfile = { is_default: false, name: 'work' }
+
+// The default profile is pinned leftmost (profile-switcher.tsx), so position —
+// not accessible name — identifies it: the name differs between the
+// single-profile and multi-profile branches, and both carry the same rule.
+const rail = () => screen.getByRole('group', { name: 'Profiles' })
+const defaultSlot = () => within(rail()).getAllByRole('button')[0]
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  profiles.set([ANONYMOUS_DEFAULT])
+  gatewayProfile.set('default')
+  scope.set('default')
+})
+
+describe('ProfileRail default-profile identity (#92033)', () => {
+  it('gives a display-renamed default profile a face, not the generic home glyph', () => {
+    profiles.set([NAMED_DEFAULT])
+    render(<ProfileRail />)
+
+    expect(defaultSlot().querySelector('.codicon-home')).toBeNull()
+    expect(defaultSlot().textContent).toBe('H')
+  })
+
+  it('keeps the home glyph while the default profile has no name of its own', () => {
+    render(<ProfileRail />)
+
+    expect(defaultSlot().querySelector('.codicon-home')).not.toBeNull()
+    expect(defaultSlot().textContent).toBe('')
+  })
+
+  it('keeps the renamed default pinned left of the named profiles', () => {
+    profiles.set([NAMED_DEFAULT, WORK])
+    render(<ProfileRail />)
+
+    expect(defaultSlot().querySelector('.codicon-home')).toBeNull()
+    expect(defaultSlot().textContent).toBe('H')
+    expect(within(rail()).getAllByRole('button')[1]).toBe(screen.getByRole('button', { name: 'work' }))
+  })
+
+  it('keeps the layers face while the scope is all profiles', () => {
+    profiles.set([NAMED_DEFAULT, WORK])
+    scope.set('__all__')
+    render(<ProfileRail />)
+
+    // ALL is a view, not a profile — the default's mark must not claim it.
+    expect(defaultSlot().querySelector('.codicon-layers')).not.toBeNull()
+    expect(defaultSlot().textContent).toBe('')
+  })
+
+  it('keeps the scope toggle: on the default profile the pill switches to all profiles', () => {
+    profiles.set([NAMED_DEFAULT, WORK])
+    render(<ProfileRail />)
+
+    fireEvent.click(defaultSlot())
+
+    expect(setShowAllProfiles).toHaveBeenCalledWith(true)
+    expect(selectProfile).not.toHaveBeenCalled()
+  })
+
+  it('keeps the scope toggle: from a named profile the pill returns to the default', () => {
+    profiles.set([NAMED_DEFAULT, WORK])
+    gatewayProfile.set('work')
+    render(<ProfileRail />)
+
+    fireEvent.click(defaultSlot())
+
+    // The canonical id routes, never the display name.
+    expect(selectProfile).toHaveBeenCalledWith('default')
+  })
+
+  it('keeps the mark when the rail condenses to a dropdown', () => {
+    // Past the threshold the named profiles collapse into a select, but the
+    // default pill sits outside that swap — its face must survive.
+    profiles.set([
+      NAMED_DEFAULT,
+      ...Array.from({ length: 14 }, (_, index) => ({ is_default: false, name: `P${index}` }))
+    ])
+    render(<ProfileRail />)
+
+    expect(screen.getByRole('button', { name: 'Profiles' })).toBeTruthy()
+    expect(defaultSlot().querySelector('.codicon-home')).toBeNull()
+    expect(defaultSlot().textContent).toBe('H')
+  })
+
+  it('falls back to the placeholder initial for a display name with no letters', () => {
+    profiles.set([{ display_name: '🌙', is_default: true, name: 'default' }])
+    render(<ProfileRail />)
+
+    expect(defaultSlot().querySelector('.codicon-home')).toBeNull()
+    expect(defaultSlot().textContent).toBe('?')
+  })
+
+  it('still names the pill by the display name once it carries a mark', () => {
+    profiles.set([NAMED_DEFAULT])
+    const single = render(<ProfileRail />)
+
+    expect(screen.getByRole('button', { name: 'Hermes' })).toBeTruthy()
+    single.unmount()
+
+    profiles.set([NAMED_DEFAULT, WORK])
+    gatewayProfile.set('work')
+    render(<ProfileRail />)
+
+    expect(screen.getByRole('button', { name: 'Switch to Hermes' })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/profile-rail-default-identity.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-default-identity.test.tsx
@@ -192,6 +192,19 @@ describe('ProfileRail default-profile identity (#92033)', () => {
     expect(defaultSlot().textContent).toBe('?')
   })
 
+  it('draws the mark from the same name the tooltip shows', () => {
+    profiles.set([NAMED_DEFAULT])
+    render(<ProfileRail />)
+
+    const slot = defaultSlot()
+    const tooltipName = slot.getAttribute('aria-label') ?? ''
+
+    // Deliberately not a hardcoded 'H': the initial is asserted against the
+    // pill's own label, so the mark and the tooltip cannot drift apart.
+    expect(tooltipName).toBe('Hermes')
+    expect(slot.textContent).toBe(tooltipName.charAt(0).toUpperCase())
+  })
+
   it('still names the pill by the display name once it carries a mark', () => {
     profiles.set([NAMED_DEFAULT])
     const single = render(<ProfileRail />)

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -19,7 +19,7 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { useStore } from '@nanostores/react'
-import { useEffect, useRef, useState } from 'react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { CodeEditor } from '@/components/chat/code-editor'
@@ -63,6 +63,7 @@ import {
   ALL_PROFILES,
   normalizeProfileKey,
   profileLabel,
+  profileWearsHomeGlyph,
   refreshActiveProfile,
   selectProfile,
   setProfileColor,
@@ -175,6 +176,19 @@ export function ProfileRail() {
 
   const multiProfile = profiles.length > 1
 
+  // The default profile's face: the generic home glyph while it is anonymous,
+  // its own mark once `hermes profile rename default <Name>` names it (#92033).
+  const defaultMark =
+    defaultProfile && !profileWearsHomeGlyph(defaultProfile) ? (
+      <ProfileGlyph
+        aria-hidden="true"
+        color={resolveProfileColor(defaultProfile.name, colors)}
+        isDefault={false}
+        label={profileLabel(defaultProfile)}
+        name={defaultProfile.name}
+      />
+    ) : null
+
   // distance constraint: a small drag reorders, a tap still selects the profile.
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -251,6 +265,8 @@ export function ProfileRail() {
             active={isAll || onDefault}
             glyph={isAll ? 'layers' : 'home'}
             label={onDefault ? p.showAllProfiles : p.switchToProfile(profileLabel(defaultProfile))}
+            // ALL is a view, not a profile — the layers face keeps that slot.
+            mark={isAll ? null : defaultMark}
             onSelect={() => (onDefault ? setShowAllProfiles(true) : selectProfile(defaultProfile.name))}
           />
         ) : (
@@ -263,6 +279,7 @@ export function ProfileRail() {
           active
           glyph="home"
           label={profileLabel(defaultProfile)}
+          mark={defaultMark}
           onSelect={() => selectProfile(defaultProfile.name)}
         />
       )}
@@ -583,13 +600,16 @@ function ProfileDropdownItem({ color, label, name }: { color: null | string; lab
 
 interface ProfilePillProps {
   active: boolean
-  // home / All / Manage are glyph action buttons (navigation, not identity).
+  // All / Manage / Gateways are glyph action buttons (navigation, not identity).
   glyph: string
   label: string
+  // The default profile's pill is the one identity slot on this row: it carries
+  // a mark instead of its glyph once the profile has a name of its own (#92033).
+  mark?: ReactNode
   onSelect: () => void
 }
 
-function ProfilePill({ active, glyph, label, onSelect }: ProfilePillProps) {
+function ProfilePill({ active, glyph, label, mark, onSelect }: ProfilePillProps) {
   return (
     <Tip label={label}>
       <Button
@@ -604,7 +624,7 @@ function ProfilePill({ active, glyph, label, onSelect }: ProfilePillProps) {
         type="button"
         variant="ghost"
       >
-        <Codicon name={glyph} size="0.875rem" />
+        {mark ?? <Codicon name={glyph} size="0.875rem" />}
       </Button>
     </Tip>
   )

--- a/apps/desktop/src/app/profiles/index.test.tsx
+++ b/apps/desktop/src/app/profiles/index.test.tsx
@@ -59,6 +59,8 @@ vi.mock('@/store/profile', () => ({
   normalizeProfileKey: (name: null | string | undefined) => (name ?? '').trim() || 'default',
   profileLabel: (profile: { display_name?: string; name: string }) =>
     (profile.display_name ?? '').trim() || profile.name,
+  profileWearsHomeGlyph: (profile: { display_name?: string; is_default: boolean }) =>
+    profile.is_default && (profile.display_name ?? '').trim() === '',
   refreshProfiles: vi.fn(async () => [] as ProfileInfo[]),
   selectProfile: vi.fn(),
   setActiveProfile: vi.fn()
@@ -151,6 +153,32 @@ describe('ProfilesView', () => {
     )
     await waitFor(() => expect(selectProfile).toHaveBeenCalledWith('default'))
     expect(setActiveProfile).toHaveBeenCalledWith('default')
+  })
+
+  // This overlay is the only in-app door to renaming the default profile, so it
+  // is the surface the user is looking at when the rename lands — and it used to
+  // paint the new title right beside the generic home icon (#92033).
+  it('gives a display-renamed default profile its own mark in the list', async () => {
+    vi.mocked(refreshProfiles).mockResolvedValue([{ ...makeProfile('default', true), display_name: 'Hermes' }])
+
+    await renderProfilesView()
+
+    // The row's select target is named by the title; its lead cell is the mark.
+    const row = (await screen.findAllByRole('button', { name: 'Hermes' }))[0]
+
+    expect(row.querySelector('.codicon-home')).toBeNull()
+    expect(row.firstElementChild?.textContent).toBe('H')
+  })
+
+  it('keeps the home glyph on a default profile that was never renamed', async () => {
+    vi.mocked(refreshProfiles).mockResolvedValue([makeProfile('default', true)])
+
+    await renderProfilesView()
+
+    const row = (await screen.findAllByRole('button', { name: 'default' }))[0]
+
+    expect(row.querySelector('.codicon-home')).not.toBeNull()
+    expect(row.firstElementChild?.textContent).toBe('')
   })
 
   it('leaves the active profile alone when a different profile is deleted', async () => {

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -13,7 +13,7 @@ import { AlertTriangle, Save } from '@/lib/icons'
 import { resolveProfileColor } from '@/lib/profile-color'
 import { normalize } from '@/lib/text'
 import { notify, notifyError } from '@/store/notifications'
-import { $profileColors, profileLabel, refreshProfiles } from '@/store/profile'
+import { $profileColors, profileLabel, profileWearsHomeGlyph, refreshProfiles } from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import {
@@ -210,7 +210,8 @@ function ProfileRow({
         <ProfileGlyph
           aria-hidden="true"
           color={resolveProfileColor(profile.name, colors)}
-          isDefault={profile.is_default}
+          isDefault={profileWearsHomeGlyph(profile)}
+          label={profileLabel(profile)}
           name={profile.name}
         />
       }

--- a/apps/desktop/src/components/ui/profile-glyph.tsx
+++ b/apps/desktop/src/components/ui/profile-glyph.tsx
@@ -3,19 +3,25 @@ import { cn } from '@/lib/utils'
 
 import { Codicon } from './codicon'
 
-/** A profile's mark, in one place: the default profile is the `home` icon (it
- *  has no color of its own and an initial would read as just another named
- *  profile); every other profile is a soft tint of its color carrying its
- *  initial. Presentational — callers resolve the color from `$profileColors`. */
+/** A profile's mark, in one place: an anonymous default profile is the `home`
+ *  icon (it has no color of its own and an initial would read as just another
+ *  named profile); every other profile is a soft tint of its color carrying its
+ *  initial. Once the default is display-renamed it is a named agent like the
+ *  rest, so callers pass `isDefault={profileWearsHomeGlyph(profile)}` and it
+ *  earns a mark too (#92033). Presentational — callers resolve the color from
+ *  `$profileColors` and the initial's source from `profileLabel`. */
 export function ProfileGlyph({
   className,
   color,
   isDefault,
+  label,
   name,
   ...props
 }: Omit<React.ComponentProps<'span'>, 'color'> & {
   color: null | string
   isDefault: boolean
+  /** Initial source when it differs from the canonical id — a display name. */
+  label?: string
   name: string
 }) {
   if (isDefault) {
@@ -26,7 +32,7 @@ export function ProfileGlyph({
     )
   }
 
-  const initial = name.replace(/[^a-z0-9]/gi, '').charAt(0) || '?'
+  const initial = (label?.trim() || name).replace(/[^a-z0-9]/gi, '').charAt(0) || '?'
 
   return (
     <span

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -26,6 +26,7 @@ const {
   ensureGatewayProfile,
   invalidateProfileListFetches,
   prewarmProfileBackend,
+  profileLabel,
   profileWearsHomeGlyph,
   refreshProfiles
 } = await import('./profile')
@@ -254,6 +255,23 @@ describe('profileWearsHomeGlyph — who gets a face (#92033)', () => {
 
   it('treats a blank display name as no name at all', () => {
     expect(profileWearsHomeGlyph({ ...profile('default', true), display_name: '   ' })).toBe(true)
+  })
+
+  it('agrees with profileLabel — the mark appears exactly when the label is not the id', () => {
+    // Both helpers read `display_name` through the same trim, so the mark and
+    // the tooltip can never disagree about which name a profile is wearing.
+    // Pinned here so a refactor of either one has to keep them in step.
+    for (const profileUnderTest of [
+      profile('default', true),
+      { ...profile('default', true), display_name: 'Hermes' },
+      { ...profile('default', true), display_name: '   ' },
+      profile('work'),
+      { ...profile('work'), display_name: 'Work' }
+    ]) {
+      const labelIsTheCanonicalId = profileLabel(profileUnderTest) === profileUnderTest.name
+
+      expect(profileWearsHomeGlyph(profileUnderTest)).toBe(profileUnderTest.is_default && labelIsTheCanonicalId)
+    }
   })
 
   it('never claims the home glyph for a named profile', () => {

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -26,6 +26,7 @@ const {
   ensureGatewayProfile,
   invalidateProfileListFetches,
   prewarmProfileBackend,
+  profileWearsHomeGlyph,
   refreshProfiles
 } = await import('./profile')
 
@@ -237,5 +238,26 @@ describe('stale profile-list fetches across a backend switch (#85731)', () => {
     await oldFetch
 
     expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'coder'])
+  })
+})
+
+describe('profileWearsHomeGlyph — who gets a face (#92033)', () => {
+  it('keeps the home glyph while the default profile is anonymous', () => {
+    expect(profileWearsHomeGlyph(profile('default', true))).toBe(true)
+  })
+
+  it('drops the home glyph once the default profile is display-renamed', () => {
+    // `hermes profile rename default <Name>` sets display_name and leaves the
+    // canonical id alone — that rename is the whole trigger.
+    expect(profileWearsHomeGlyph({ ...profile('default', true), display_name: 'Hermes' })).toBe(false)
+  })
+
+  it('treats a blank display name as no name at all', () => {
+    expect(profileWearsHomeGlyph({ ...profile('default', true), display_name: '   ' })).toBe(true)
+  })
+
+  it('never claims the home glyph for a named profile', () => {
+    expect(profileWearsHomeGlyph(profile('work'))).toBe(false)
+    expect(profileWearsHomeGlyph({ ...profile('work'), display_name: 'Work' })).toBe(false)
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -33,6 +33,15 @@ export function profileLabel(profile: Pick<ProfileInfo, 'display_name' | 'name'>
   return (profile.display_name ?? '').trim() || profile.name
 }
 
+// The default profile wears the generic home glyph only while it is anonymous:
+// "default" is a slot, not a name, so an initial there would read as just
+// another named profile. `hermes profile rename default <Name>` sets a
+// display_name, and from that point it is a named agent like the rest and needs
+// a face of its own (#92033).
+export function profileWearsHomeGlyph(profile: Pick<ProfileInfo, 'display_name' | 'is_default'>): boolean {
+  return profile.is_default && (profile.display_name ?? '').trim() === ''
+}
+
 // The profile the running local backend is actually scoped to (mirrors
 // /api/profiles/active `current`). "default" is the root ~/.hermes. This is the
 // display source of truth for the statusbar pill; the desktop's *stored*


### PR DESCRIPTION
## What does this PR do?

If you rename your default profile — `hermes profile rename default Hermes` — the Desktop profile rail keeps showing a generic house icon for it, while every other profile gets its own little colored square with its initial. So the agent you use most is the only one without a face, and the only way to tell which one it is, is to hover and read the tooltip.

This PR gives a renamed default profile the same square-with-an-initial that every other profile already has, in the profile rail and in the Manage Profiles list.

If you have **never** renamed your default profile, nothing changes at all — the house icon stays exactly as it is.

## Related Issue

Fixes #92033

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

The rule is written down in exactly one place so the two screens can't drift apart later:

- **`apps/desktop/src/store/profile.ts`** — new `profileWearsHomeGlyph()` helper, right next to the existing `profileLabel()`. It says: a profile keeps the house icon only while it has no name of its own.
- **`apps/desktop/src/components/ui/profile-glyph.tsx`** — the shared profile mark can now take an optional `label`, so the letter it shows comes from the display name rather than the internal id (`default` would have shown a "D").
- **`apps/desktop/src/app/chat/sidebar/profile-switcher.tsx`** — the rail's pill can now carry a mark instead of an icon. Both places that render the default profile use it: the default↔all toggle, and the single-profile pill.
- **`apps/desktop/src/app/profiles/index.tsx`** — the Manage Profiles list follows the same rule. It's the only place in the app where you can rename the default, so it's the screen you're looking at when the rename happens.

### What deliberately did *not* change

- The **"all profiles" view keeps its layers icon.** A view is not an identity, so the default profile's mark never takes that slot.
- The default profile stays **pinned on the left**, and its **toggle behavior is untouched** — on the default it switches to all-profiles, from anywhere else it returns to the default.
- **Routing still uses the canonical `default` id** everywhere. The display name is presentation only, exactly as `profileLabel()` already treats it.
- An unrenamed default renders **byte-for-byte as before**.

### One deliberate limitation

The mark is a neutral grey tint rather than a color. `resolveProfileColor()` returns `null` for `default` on purpose, and lifting that guard would also repaint the kanban plugin's avatars (`plugins/kanban/ui.tsx` calls `profileColor` directly). That felt like a separate change, so it's left as a follow-up — the safe version is to move the `default` guard after the overrides lookup, so only an explicitly picked color applies.

## How to Test

1. Run `hermes profile rename default Hermes` (this sets a display name; the internal id stays `default`).
2. Open Hermes Desktop and look at the profile rail at the bottom-left of the Sessions/Projects sidebar.
3. The leftmost pill now shows an **H** in a small square instead of the house icon. Clicking it still toggles to the all-profiles view exactly as before.
4. Open **Manage Profiles** — the default profile's row shows the same **H** mark next to its name.
5. To check nothing changed for everyone else: on a profile you have never renamed, the house icon is still there.

**Platform tested:** macOS 15 (Darwin 25.4.0). The change is renderer-only React/TypeScript — no file I/O, no process handling, no terminal handling — so there is no platform-specific code path here.

### Automated checks

Run from `apps/desktop`:

- `npm run test:ui` — **570 files / 5438 tests pass**
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (warning count identical to `main`)
- `npx prettier --check` on every touched file — clean

Python side — this PR changes **no Python** (all 8 changed files are under `apps/desktop/src/`), but since some Python tests do read `apps/desktop` paths, I ran those explicitly, then the whole suite:

- every Python test file referencing `apps/desktop` (12 files, including `tests/ci/test_classify_changes.py` and `tests/ci/test_lockfile_diff.py`) plus the profiles CLI tests — **879 passed, 4 skipped, 0 failed**
- the full suite via `scripts/run_tests_parallel.py` — **36,458 passed, 104 failed**. Every failure needs a credential, an external service, or Linux: provider wiring (`test_nous_portal_anthropic_wire`, `test_auxiliary_*`), gateway/systemd (`test_systemd_notify`, `test_readiness`, `test_scale_to_zero`), sandbox and media tooling (`test_daytona_environment`, `test_modal_snapshot_isolation`, `test_fal_plugin`, `test_video_generation_tool_surface_matrix`, voice/wake/transcription), and `test_linux_desktop_entry` (Linux-only, run on macOS). None are in desktop, profile, or UI code, and none are reachable from this diff.

Worth flagging for anyone reproducing: a plain `pytest tests/ -q` reports far more failures than `scripts/run_tests_parallel.py` on the same tree, because the per-file interpreter isolation the runner provides is exactly what `AGENTS.md` says prevents cross-file state leakage. The runner's numbers are the ones above.

New coverage: `apps/desktop/src/app/chat/sidebar/profile-rail-default-identity.test.tsx` (10 cases), plus cases in `store/profile.test.ts` and `app/profiles/index.test.tsx`.

Second commit (`test(desktop): tie the profile mark to its label`) came from review feedback asking for an assertion tying the glyph choice to the field the tooltip renders from. `profileWearsHomeGlyph` and `profileLabel` already read `display_name` through the same trim, so the mark appears exactly when the label is not the canonical id — these tests pin that rather than assume it: one in the store across the anonymous / named / whitespace-only / named-profile cases, and one in the rail asserting the mark's initial against the pill's own rendered `aria-label` instead of a hardcoded letter. Both mutation-verified.

**Mutation-verified**, since coverage that never executes the path isn't coverage:

| Break this | Test that goes red |
|---|---|
| drop `mark` from the single-profile pill | "gives a display-renamed default profile a face" |
| drop `mark` from the default↔all toggle | "keeps the renamed default pinned left of the named profiles" |
| let the mark hijack the all-profiles face | "keeps the layers face while the scope is all profiles" |
| revert the Manage Profiles row | "gives a display-renamed default profile its own mark in the list" |
| make the glyph ignore the label | 3 cases across two files |
| make the rule ignore `display_name` | "drops the home glyph once the default profile is display-renamed" |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **ran it, deliberately left unchecked.** The full suite finished at 36,458 passed / 104 failed on my machine, and every failure needs a credential, an external service, or Linux (details in Automated checks). This PR is renderer-only TypeScript changing no Python, and the Python tests that can actually see it all pass — but I'm not ticking a box that says "all tests pass" when 104 didn't, so: deferring to CI on those.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, but the two rationale comments this change amends (`profile-glyph.tsx` JSDoc and the `ProfilePillProps` comment) were updated rather than deleted
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys added (see note below)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, renderer-only rendering change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes for reviewers

**Why always-on rather than a setting.** The issue floats `desktop.default_profile_identity_square` as an alternative. I went with always-on because running `hermes profile rename default <Name>` is *already* the opt-in — an unrenamed default is untouched, so a flag would gate behavior nobody would reach by accident. It also keeps this to zero config keys and zero new i18n strings (the pill labels already come from `profileLabel()`), and #89027 had already plumbed the display name into this exact rail's tooltip and the Manage list's title. This finishes that thread rather than starting a new one.

**Known gaps left alone on purpose,** so this stays one logical change:

- `ProfileTag` (session rows) receives a bare profile key, not a `ProfileInfo`, so it can't see `display_name` without threading the roster into a hot render path. Its existing home-glyph test stays green.
- The sidebar's grouped-by-profile headers drop `display_name` at construction time — #90305 is already fixing that same class in that file.
- Right-clicking the default pill still offers no Rename; only Manage Profiles and the CLI do. Giving it a face arguably raises that expectation, but wiring the menu drags in Delete/Export/Recolor semantics the default doesn't support.

**Adjacent open PRs — checked, no overlap on the actual bug.** #91983 and #89915 both touch `profile-switcher.tsx`. #91983 changes *where* the default pill navigates and adds a context menu; this changes *what it looks like*, and both promise the same toggle behavior. Expect a small textual rebase for whichever lands second — the diff is kept surgical for that reason.

Branch is rebased onto current `main`.
