### PR TITLE
feat(skills): add discernment-nudge — post-answer check-questions (port of Anthropic's Apache-2.0 skill)

### DIFF
--- a/optional-skills/productivity/discernment-nudge/LICENSE.txt
+++ b/optional-skills/productivity/discernment-nudge/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/optional-skills/productivity/discernment-nudge/SKILL.md
+++ b/optional-skills/productivity/discernment-nudge/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: discernment-nudge
+description: Use after substantive answers. Appends 2-3 check-questions.
+version: 1.0.0
+author: Anthropic (upstream) / Hermes port
+license: Apache-2.0
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [behavior, output-style, critical-thinking, follow-ups, prose-only]
+    related_skills: [humanizer, grounded-citations]
+---
+
+# Discernment nudge
+
+An opt-in output habit, not an identity or persona change: after a
+substantive answer or draft the user may act on — advice or
+recommendations, drafted artifacts such as goals, plans, pitches,
+proposals, or emails, estimates or projections, analysis or
+interpretation of data, factual claims they may rely on, or a
+multi-step argument — apply this skill BEFORE finalizing your reply
+and then, if it applies, append 2-3 short follow-up questions, each
+tied to something specific in what you just produced, that help the
+user check key facts, probe the reasoning or assumptions, and notice
+missing context. Do this at most once per conversation. Skip it when
+the user asked a trivial how-to or simple lookup, wants a purely
+educational explanation, asked you only to format, convert, or
+assemble a file from content they provided, is writing code they will
+run, is doing creative writing or casual chat, or already asked you
+to double-check, cite, or review — the sections below explain these
+boundaries and the exact output format.
+
+## Why this exists
+
+People often take an AI answer at face value, especially when it's
+confidently written and well-structured. That's usually fine — but for
+substantive answers the user is going to act on (spend money, make a
+health decision, cite a claim, commit to a plan), a small moment of
+reflection can catch a bad assumption or a missing piece of context
+before it matters. This skill adds that moment, gently, without getting
+in the way of the answer itself.
+
+The goal is to *model* three discernment habits from the AI Fluency
+framework, not to lecture about them:
+
+- **Checking facts** — which specific claims in this answer would be
+  worth verifying, and against what?
+- **Questioning reasoning** — where did the logic take a step the user
+  might want to see justified?
+- **Noticing missing context** — what did the answer have to assume
+  because the user didn't say?
+
+## When to offer the nudge
+
+Offer it when your answer contains content the user would benefit from
+scrutinizing before acting on it. The clearest cases:
+
+- You gave **estimates, projections, or numbers** (costs, timelines,
+  rates, probabilities) that are plausible but not grounded in the
+  user's specific situation.
+- You gave **advice or a recommendation** in a consequential domain —
+  business strategy, health, legal, financial, career, interpersonal —
+  where the right answer depends heavily on context you don't have.
+- You made **factual or historical claims** the user looks likely to
+  act on or repeat somewhere that matters — a decision, a report, a
+  claim they'll pass along. Claims they're reading purely to
+  understand a topic don't need the nudge; that's what the
+  educational carve-out below is for. (Questions people typically ask
+  when weighing whether to try something themselves — a diet, a
+  supplement, a treatment — still count as actable even if they don't
+  say so.)
+- You walked through **multi-step reasoning or analysis** where an
+  early assumption, if wrong, would change the conclusion.
+- You **interpreted data or research** on the user's behalf.
+- You **drafted a substantive artifact** the user will put to use —
+  goals, a plan, a pitch, a proposal, an email — whose content rests
+  on choices or assumptions about their situation. (If they supplied
+  the substance and you only reshaped or reformatted it, the "user
+  gave you the material" rule below applies instead.)
+
+## When not to
+
+Leave it off when the nudge would be noise — or worse, when it would
+override something the user already told you. Silence is the right
+default; only add the nudge when there's something concrete worth
+reflecting on *and* the user hasn't already signaled they've got
+verification covered.
+
+**Once per conversation.** Offer the nudge at most once in a
+conversation. If you have already offered it on an earlier turn, stay
+silent on later turns even when the new answer would otherwise qualify
+— the user has already been invited to reflect, and repeating it turns
+a light suggestion into nagging. This rule only limits repeats: if you
+have not nudged yet in this conversation, a qualifying answer on any
+turn (first or later) still gets the nudge.
+
+- **Creative writing** — poems, stories, brainstorming, drafting
+  copy. The user is the judge of whether it's good; there's nothing
+  to verify.
+- **Casual conversation** — greetings, small talk, opinion swapping.
+- **Code the user will execute** — running it is the verification.
+  (Architecture advice is different — there's no quick way to run it
+  and see, so assumptions about team size, stack, and conventions are
+  worth surfacing.)
+- **Simple lookups** — unit conversions, definitions, "what year did
+  X happen" — where the answer is trivially checkable or not worth a
+  reflection ritual.
+- **Purely educational explanations** — "how does X work," "explain
+  Y," "what caused historical event Z." The user is building
+  understanding, not about to make a decision on it. This includes
+  **definitional and comparison questions** — "what is X," "what's
+  the difference between X and Y" — even in consequential domains
+  like finance, health, or law, as long as the user hasn't described
+  their own situation or asked what they should do. Explaining what a
+  Roth IRA is isn't advice; "which one should I open?" is. (If the
+  explanation ends with a recommendation — "…so you should do X" —
+  that recommendation can merit a nudge even though the explanation
+  didn't.)
+
+And four patterns where the user has, in effect, already told you
+not to:
+
+- **The user asked you to verify, cite, or flag uncertainty.** If
+  their question included "double-check," "cite your sources," "flag
+  what you're unsure about," or similar — they've already put
+  themselves in a critical frame. A nudge on top of that reads as
+  not having listened, and the specific things it would prompt
+  ("verify that figure") are things they just asked you to do
+  inline. Do the verifying in the answer — name the source next to
+  each figure, flag the shaky ones inline — and skip the nudge. This
+  wins even when the answer is full of statistics, studies, or
+  estimates you would normally flag: the user already asked for the
+  checking, so a closing list of "verify this" questions is the one
+  thing they didn't ask for.
+- **The user asked for the quick version, or said they'll do their
+  own checking.** "Just the headline," "skip the caveats," "quick
+  version — I'll do my own research." They've explicitly opted out
+  of the scaffolding. A nudge overrides that preference, which lands
+  as paternalistic. Respect the ask; give them what they asked for
+  and stop.
+- **The user asked you to check something of theirs.** "Is this
+  correct?", "review this," "what's wrong with my reasoning?" Your
+  answer *is* the discernment step — you're the one doing the
+  checking. A nudge suggesting they re-check what you just checked
+  is circular. If your review surfaces open questions you can't
+  resolve — a timezone you don't know, a schema you can't see — ask
+  them inside the review, right where the issue is, and stop there.
+  Moving them into a closing "worth a second look" list turns your
+  review back into homework for the user.
+- **The user gave you the material.** Summarizing, reformatting, or
+  extracting action items from their own document, thread, or notes —
+  they have the source and they're the judge of whether you matched
+  it. Questions about the content itself ("is the Friday deadline
+  firm?") are for the people in that thread, not reflection prompts
+  about your summary. If you're unsure your summary is faithful, say
+  so in the answer. (Analyzing or interpreting data they handed you —
+  "what trends do you see?", "is this difference real?" — is
+  different: there the nudge is about your interpretation, not their
+  material.)
+
+One more that's easy to miss: **the user asked for your opinion or
+take.** "What do you think about X?", "what's your read?" You can
+still have data in your answer, but the frame is perspective, not
+authoritative claims. A nudge to "verify" a take is a category error
+— takes are weighed, not fact-checked. If your opinion rests on a
+specific factual claim you're unsure about, hedge it inline rather
+than nudging afterward.
+
+Boundary calls: pure brainstorming usually doesn't need it — the user
+is the judge of the ideas. If a brainstorm shades into concrete
+recommendations ("go with option B because…"), the recommendation
+part can merit a nudge even though the brainstorm didn't.
+
+## Writing the prompts
+
+The nudge is two
+or three follow-up questions the user could send back to you, each one
+referencing something concrete from the answer you just gave — a
+number, a named step, an assumption. Generic prompts ("Can you verify
+those facts?") defeat the purpose; the value is in the specificity.
+
+Each prompt should do one of:
+
+- Point at a **fact or figure** in the answer and ask how to check it
+  or how it compares to the user's own data. *"How do these CPL
+  estimates compare to benchmarks in my specific vertical?"*
+- Point at a **reasoning step or assumption** and invite the user to
+  probe it. *"Walk me through why you prioritized webinars over content
+  — what assumptions does that rest on?"*
+- Point at **missing context** the answer had to guess at. *"I didn't
+  mention my state — does the security-deposit rule change by
+  jurisdiction?"*
+
+Phrase each one as something the user could ask you verbatim — first
+person, conversational, question form. Two or three prompts, never
+more. Keep each under ~120 characters so it reads at a glance.
+
+## Output format
+
+Always answer the question completely first. The nudge comes after, and
+it should be easy to skip.
+
+The nudge is plain text: append it after a blank line at the end of
+your answer.
+
+```
+A few things worth a second look:
+- How do these CPL estimates compare to benchmarks in my specific vertical?
+- Walk me through the reasoning behind the 70/30 split — what assumptions does it rest on?
+```
+
+Use that exact lead-in line — "A few things worth a second look:" —
+followed by the prompts as plain bullets. No blockquote, no heading,
+no extra framing; it should read as a light suggestion, not a boxed
+warning. Plain text only — no HTML, no headings, no emoji.
+
+Don't add anything after the nudge — no "let me know
+if you'd like me to dig into any of these." The nudge is the closer.
+
+---
+
+Ported from anthropics/skills discernment-nudge (Apache-2.0), snapshot 3b3fad96af16a10759d930941b4520ba0c40edae.

--- a/tests/skills/test_discernment_nudge_skill.py
+++ b/tests/skills/test_discernment_nudge_skill.py
@@ -1,0 +1,76 @@
+"""Tests for the discernment-nudge optional skill port."""
+import re
+from pathlib import Path
+
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills/productivity/discernment-nudge"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+LICENSE = SKILL_DIR / "LICENSE.txt"
+
+# Permitted attribution lines: the upstream-credit footer and the author
+# frontmatter field crediting the upstream source.
+CREDIT_RE = re.compile(
+    r"ported from anthropics/skills|^author: ['\"]?Anthropic \(upstream\)", re.IGNORECASE
+)
+
+
+def _split_frontmatter():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), "SKILL.md must start with YAML frontmatter"
+    _, fm, body = text.split("---\n", 2)
+    return yaml.safe_load(fm), body
+
+
+def test_frontmatter_parses():
+    fm, _ = _split_frontmatter()
+    assert isinstance(fm, dict)
+    assert fm["name"] == "discernment-nudge"
+    assert fm["version"] == "1.0.0"
+
+
+def test_description_length():
+    fm, _ = _split_frontmatter()
+    desc = fm["description"]
+    assert isinstance(desc, str)
+    assert len(desc) <= 60, f"description is {len(desc)} chars (>60)"
+
+
+def test_license_field():
+    fm, _ = _split_frontmatter()
+    assert fm["license"] == "Apache-2.0"
+
+
+def test_license_file():
+    assert LICENSE.exists()
+    assert "Apache License" in LICENSE.read_text(encoding="utf-8")
+
+
+def test_no_claude_anthropic_residue():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    offending = []
+    for i, line in enumerate(text.splitlines(), 1):
+        if re.search(r"claude|anthropic", line, re.IGNORECASE):
+            if CREDIT_RE.search(line):
+                continue  # the upstream-credit line is permitted
+            offending.append((i, line.strip()))
+    assert not offending, f"residual claude/anthropic references: {offending}"
+
+
+def test_related_skills_resolve():
+    fm, _ = _split_frontmatter()
+    related = (fm.get("metadata", {}) or {}).get("hermes", {}).get("related_skills", [])
+    assert isinstance(related, list)
+    staging_root = Path(__file__).resolve().parents[2]
+    hermes_repo = Path.home() / ".hermes" / "hermes-agent"
+    for name in related:
+        found = False
+        for root in (staging_root, hermes_repo):
+            for sub in ("skills", "optional-skills"):
+                base = root / sub
+                if base.is_dir() and any(base.glob(f"*/{name}")) or (base / name).is_dir():
+                    found = True
+                    break
+            if found:
+                break
+        assert found, f"related skill {name!r} not found in staging tree or hermes-agent"

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -191,6 +191,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**canvas**](/docs/user-guide/skills/optional/productivity/productivity-canvas) | Fetch Canvas LMS courses and assignments via API token. |
+| [**discernment-nudge**](/docs/user-guide/skills/optional/productivity/productivity-discernment-nudge) | Use after substantive answers. Appends 2-3 check-questions. |
 | [**here-now**](/docs/user-guide/skills/optional/productivity/productivity-here-now) | Publish sites to &#123;slug&#125;.here.now and store files in Drives. |
 | [**memento-flashcards**](/docs/user-guide/skills/optional/productivity/productivity-memento-flashcards) | Spaced-repetition flashcards: create, review, quiz, export. |
 | [**shop**](/docs/user-guide/skills/optional/productivity/productivity-shop) | Shop catalog search, checkout, order tracking, returns. |

--- a/website/docs/user-guide/skills/optional/productivity/productivity-discernment-nudge.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-discernment-nudge.md
@@ -1,0 +1,239 @@
+---
+title: "Discernment Nudge — Use after substantive answers"
+sidebar_label: "Discernment Nudge"
+description: "Use after substantive answers"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Discernment Nudge
+
+Use after substantive answers. Appends 2-3 check-questions.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/productivity/discernment-nudge` |
+| Path | `optional-skills/productivity/discernment-nudge` |
+| Version | `1.0.0` |
+| Author | Anthropic (upstream) / Hermes port |
+| License | Apache-2.0 |
+| Tags | `behavior`, `output-style`, `critical-thinking`, `follow-ups`, `prose-only` |
+| Related skills | [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer), [`grounded-citations`](/docs/user-guide/skills/bundled/research/research-grounded-citations) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Discernment nudge
+
+An opt-in output habit, not an identity or persona change: after a
+substantive answer or draft the user may act on — advice or
+recommendations, drafted artifacts such as goals, plans, pitches,
+proposals, or emails, estimates or projections, analysis or
+interpretation of data, factual claims they may rely on, or a
+multi-step argument — apply this skill BEFORE finalizing your reply
+and then, if it applies, append 2-3 short follow-up questions, each
+tied to something specific in what you just produced, that help the
+user check key facts, probe the reasoning or assumptions, and notice
+missing context. Do this at most once per conversation. Skip it when
+the user asked a trivial how-to or simple lookup, wants a purely
+educational explanation, asked you only to format, convert, or
+assemble a file from content they provided, is writing code they will
+run, is doing creative writing or casual chat, or already asked you
+to double-check, cite, or review — the sections below explain these
+boundaries and the exact output format.
+
+## Why this exists
+
+People often take an AI answer at face value, especially when it's
+confidently written and well-structured. That's usually fine — but for
+substantive answers the user is going to act on (spend money, make a
+health decision, cite a claim, commit to a plan), a small moment of
+reflection can catch a bad assumption or a missing piece of context
+before it matters. This skill adds that moment, gently, without getting
+in the way of the answer itself.
+
+The goal is to *model* three discernment habits from the AI Fluency
+framework, not to lecture about them:
+
+- **Checking facts** — which specific claims in this answer would be
+  worth verifying, and against what?
+- **Questioning reasoning** — where did the logic take a step the user
+  might want to see justified?
+- **Noticing missing context** — what did the answer have to assume
+  because the user didn't say?
+
+## When to offer the nudge
+
+Offer it when your answer contains content the user would benefit from
+scrutinizing before acting on it. The clearest cases:
+
+- You gave **estimates, projections, or numbers** (costs, timelines,
+  rates, probabilities) that are plausible but not grounded in the
+  user's specific situation.
+- You gave **advice or a recommendation** in a consequential domain —
+  business strategy, health, legal, financial, career, interpersonal —
+  where the right answer depends heavily on context you don't have.
+- You made **factual or historical claims** the user looks likely to
+  act on or repeat somewhere that matters — a decision, a report, a
+  claim they'll pass along. Claims they're reading purely to
+  understand a topic don't need the nudge; that's what the
+  educational carve-out below is for. (Questions people typically ask
+  when weighing whether to try something themselves — a diet, a
+  supplement, a treatment — still count as actable even if they don't
+  say so.)
+- You walked through **multi-step reasoning or analysis** where an
+  early assumption, if wrong, would change the conclusion.
+- You **interpreted data or research** on the user's behalf.
+- You **drafted a substantive artifact** the user will put to use —
+  goals, a plan, a pitch, a proposal, an email — whose content rests
+  on choices or assumptions about their situation. (If they supplied
+  the substance and you only reshaped or reformatted it, the "user
+  gave you the material" rule below applies instead.)
+
+## When not to
+
+Leave it off when the nudge would be noise — or worse, when it would
+override something the user already told you. Silence is the right
+default; only add the nudge when there's something concrete worth
+reflecting on *and* the user hasn't already signaled they've got
+verification covered.
+
+**Once per conversation.** Offer the nudge at most once in a
+conversation. If you have already offered it on an earlier turn, stay
+silent on later turns even when the new answer would otherwise qualify
+— the user has already been invited to reflect, and repeating it turns
+a light suggestion into nagging. This rule only limits repeats: if you
+have not nudged yet in this conversation, a qualifying answer on any
+turn (first or later) still gets the nudge.
+
+- **Creative writing** — poems, stories, brainstorming, drafting
+  copy. The user is the judge of whether it's good; there's nothing
+  to verify.
+- **Casual conversation** — greetings, small talk, opinion swapping.
+- **Code the user will execute** — running it is the verification.
+  (Architecture advice is different — there's no quick way to run it
+  and see, so assumptions about team size, stack, and conventions are
+  worth surfacing.)
+- **Simple lookups** — unit conversions, definitions, "what year did
+  X happen" — where the answer is trivially checkable or not worth a
+  reflection ritual.
+- **Purely educational explanations** — "how does X work," "explain
+  Y," "what caused historical event Z." The user is building
+  understanding, not about to make a decision on it. This includes
+  **definitional and comparison questions** — "what is X," "what's
+  the difference between X and Y" — even in consequential domains
+  like finance, health, or law, as long as the user hasn't described
+  their own situation or asked what they should do. Explaining what a
+  Roth IRA is isn't advice; "which one should I open?" is. (If the
+  explanation ends with a recommendation — "…so you should do X" —
+  that recommendation can merit a nudge even though the explanation
+  didn't.)
+
+And four patterns where the user has, in effect, already told you
+not to:
+
+- **The user asked you to verify, cite, or flag uncertainty.** If
+  their question included "double-check," "cite your sources," "flag
+  what you're unsure about," or similar — they've already put
+  themselves in a critical frame. A nudge on top of that reads as
+  not having listened, and the specific things it would prompt
+  ("verify that figure") are things they just asked you to do
+  inline. Do the verifying in the answer — name the source next to
+  each figure, flag the shaky ones inline — and skip the nudge. This
+  wins even when the answer is full of statistics, studies, or
+  estimates you would normally flag: the user already asked for the
+  checking, so a closing list of "verify this" questions is the one
+  thing they didn't ask for.
+- **The user asked for the quick version, or said they'll do their
+  own checking.** "Just the headline," "skip the caveats," "quick
+  version — I'll do my own research." They've explicitly opted out
+  of the scaffolding. A nudge overrides that preference, which lands
+  as paternalistic. Respect the ask; give them what they asked for
+  and stop.
+- **The user asked you to check something of theirs.** "Is this
+  correct?", "review this," "what's wrong with my reasoning?" Your
+  answer *is* the discernment step — you're the one doing the
+  checking. A nudge suggesting they re-check what you just checked
+  is circular. If your review surfaces open questions you can't
+  resolve — a timezone you don't know, a schema you can't see — ask
+  them inside the review, right where the issue is, and stop there.
+  Moving them into a closing "worth a second look" list turns your
+  review back into homework for the user.
+- **The user gave you the material.** Summarizing, reformatting, or
+  extracting action items from their own document, thread, or notes —
+  they have the source and they're the judge of whether you matched
+  it. Questions about the content itself ("is the Friday deadline
+  firm?") are for the people in that thread, not reflection prompts
+  about your summary. If you're unsure your summary is faithful, say
+  so in the answer. (Analyzing or interpreting data they handed you —
+  "what trends do you see?", "is this difference real?" — is
+  different: there the nudge is about your interpretation, not their
+  material.)
+
+One more that's easy to miss: **the user asked for your opinion or
+take.** "What do you think about X?", "what's your read?" You can
+still have data in your answer, but the frame is perspective, not
+authoritative claims. A nudge to "verify" a take is a category error
+— takes are weighed, not fact-checked. If your opinion rests on a
+specific factual claim you're unsure about, hedge it inline rather
+than nudging afterward.
+
+Boundary calls: pure brainstorming usually doesn't need it — the user
+is the judge of the ideas. If a brainstorm shades into concrete
+recommendations ("go with option B because…"), the recommendation
+part can merit a nudge even though the brainstorm didn't.
+
+## Writing the prompts
+
+The nudge is two
+or three follow-up questions the user could send back to you, each one
+referencing something concrete from the answer you just gave — a
+number, a named step, an assumption. Generic prompts ("Can you verify
+those facts?") defeat the purpose; the value is in the specificity.
+
+Each prompt should do one of:
+
+- Point at a **fact or figure** in the answer and ask how to check it
+  or how it compares to the user's own data. *"How do these CPL
+  estimates compare to benchmarks in my specific vertical?"*
+- Point at a **reasoning step or assumption** and invite the user to
+  probe it. *"Walk me through why you prioritized webinars over content
+  — what assumptions does that rest on?"*
+- Point at **missing context** the answer had to guess at. *"I didn't
+  mention my state — does the security-deposit rule change by
+  jurisdiction?"*
+
+Phrase each one as something the user could ask you verbatim — first
+person, conversational, question form. Two or three prompts, never
+more. Keep each under ~120 characters so it reads at a glance.
+
+## Output format
+
+Always answer the question completely first. The nudge comes after, and
+it should be easy to skip.
+
+The nudge is plain text: append it after a blank line at the end of
+your answer.
+
+```
+A few things worth a second look:
+- How do these CPL estimates compare to benchmarks in my specific vertical?
+- Walk me through the reasoning behind the 70/30 split — what assumptions does it rest on?
+```
+
+Use that exact lead-in line — "A few things worth a second look:" —
+followed by the prompts as plain bullets. No blockquote, no heading,
+no extra framing; it should read as a light suggestion, not a boxed
+warning. Plain text only — no HTML, no headings, no emoji.
+
+Don't add anything after the nudge — no "let me know
+if you'd like me to dig into any of these." The nudge is the closer.
+
+---
+
+Ported from anthropics/skills discernment-nudge (Apache-2.0), snapshot 3b3fad96af16a10759d930941b4520ba0c40edae.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -551,6 +551,7 @@ const sidebars: SidebarsConfig = {
                   collapsed: true,
                   items: [
                     'user-guide/skills/optional/productivity/productivity-canvas',
+                    'user-guide/skills/optional/productivity/productivity-discernment-nudge',
                     'user-guide/skills/optional/productivity/productivity-here-now',
                     'user-guide/skills/optional/productivity/productivity-memento-flashcards',
                     'user-guide/skills/optional/productivity/productivity-shop',


### PR DESCRIPTION
## Summary

New optional skill `productivity/discernment-nudge`: after a substantive, actionable answer (advice, drafted artifacts, estimates, analysis, factual claims), append 2-3 short follow-up questions tied to specifics in the answer that help the user check key facts, probe the reasoning, and notice missing context — at most once per conversation, with explicit skip rules (trivial lookups, formatting/conversion, code the user will run, creative writing, or when they already asked for a double-check).

Port of Anthropic's official [anthropics/skills](https://github.com/anthropics/skills) `skills/discernment-nudge` (per-skill-dir **Apache-2.0** LICENSE.txt, carried verbatim — NOT one of the Proprietary office skills), added upstream Aug 17 2026. Snapshot `3b3fad96`. Fresh official vendor drop — one of only two new skills in the upstream repo this month. Found by the skill-ecosystem-scout cron (Aug 22 run).

## Changes

- `optional-skills/productivity/discernment-nudge/` — SKILL.md (upstream body kept essentially intact; reframed as an opt-in output habit, not an identity change; de-Clauded — only remaining upstream mentions are the credit lines), LICENSE.txt (verbatim Apache-2.0).
- `tests/skills/test_discernment_nudge_skill.py` — frontmatter, license identity, residue grep, related_skills resolution.
- Docs: catalog row, sidebar entry, generated skill page (regen scoped to this skill; unrelated drift reverted).

## Validation

| Check | Result |
|---|---|
| `tests/skills/test_discernment_nudge_skill.py` | 6 passed |
| `tests/skills/test_authoring_standards.py` | 1208 passed |
| Residue grep (`claude\|anthropic`) | only the 2 permitted credit lines + LICENSE.txt |

## Trust / overlap notes

- Prose-only: no scripts, no dependencies, no network access.
- Optional tier by design: it changes reply shape, so it should be a deliberate install, never default-on.
- No overlap: `humanizer` edits prose style, `grounded-citations` sources claims; neither appends reflective check-questions.

## Infographic

![discernment-nudge skill](https://v3b.fal.media/files/b/0aa7627a/OSZB6l9vHSDpr1NUq-9H0_8vp33ENH.png)
