### PR TITLE
fix(tui): open personality choices

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -219,6 +219,11 @@ describe('createSlashHandler', () => {
     expect(createSlashHandler(ctx)('/personality')).toBe(true)
     expect(ctx.gateway.rpc).not.toHaveBeenCalled()
 
+    // The reopen is deferred past dispatchSubmission's post-handler clearIn
+    // (useSubmission.ts): a synchronous setInput here would be wiped by that
+    // clear and bare /personality would dead-end again.
+    expect(ctx.composer.setInput).not.toHaveBeenCalled()
+
     await Promise.resolve()
     expect(ctx.composer.setInput).toHaveBeenCalledWith('/personality ')
   })

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -213,6 +213,29 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.rpc).not.toHaveBeenCalled()
   })
 
+  it('opens personality choices for bare /personality', async () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/personality')).toBe(true)
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+
+    await Promise.resolve()
+    expect(ctx.composer.setInput).toHaveBeenCalledWith('/personality ')
+  })
+
+  it('sets an explicit personality without reopening choices', () => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/personality helpful')).toBe(true)
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', {
+      key: 'personality',
+      session_id: 'sid-abc',
+      value: 'helpful'
+    })
+    expect(ctx.composer.setInput).not.toHaveBeenCalled()
+  })
+
   it('honors TUI picker session scope without adding --global', async () => {
     patchUiState({ sid: 'sid-abc' })
 

--- a/ui-tui/src/__tests__/inlineSlashSkill.test.ts
+++ b/ui-tui/src/__tests__/inlineSlashSkill.test.ts
@@ -86,6 +86,14 @@ describe('completionRequestForInput — inline skill references', () => {
     }
   })
 
+  it('routes the bare personality picker seed to argument completion', () => {
+    expect(completionRequestForInput('/personality ')).toEqual({
+      method: 'complete.slash',
+      params: { text: '/personality ' },
+      replaceFrom: 1
+    })
+  })
+
   it('routes a real mid-message path to path completion, not skills', () => {
     expect(completionRequestForInput('open src/foo/ba')).toMatchObject({ method: 'complete.path' })
     expect(completionRequestForInput('open /usr/lo')).toMatchObject({ method: 'complete.path' })

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -198,7 +198,13 @@ export const sessionCommands: SlashCommand[] = [
     help: 'switch personality for this session',
     name: 'personality',
     run: (arg, ctx) => {
-      if (!arg) {
+      if (!arg.trim()) {
+        // Reuse the dynamic argument-completion menu instead of maintaining a
+        // second personality inventory in the TUI. dispatchSubmission clears
+        // the submitted slash command after this handler returns, so reopen
+        // the composer on the next microtask, after that clear has landed.
+        queueMicrotask(() => ctx.composer.setInput('/personality '))
+
         return
       }
 


### PR DESCRIPTION
## What does this PR do?

Bare `/personality` in the Ink TUI currently submits successfully but then
silently returns without showing any choices. This conflicts with the shared
slash-completion contract, which already classifies `personality` as a picker
command.

This fix reopens the composer at the existing `/personality ` argument stage
after submission cleanup. The established completion UI then supplies the
selectable built-in and custom personalities, so the TUI keeps one dynamic
personality inventory rather than adding another RPC or hardcoded list.

Explicit commands such as `/personality helpful` continue through the existing
session-scoped `config.set` path unchanged.

## Related Issue

None found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Reopen the TUI composer at `/personality ` when the command has no argument.
- Preserve the existing direct personality-selection behavior.
- Add regression coverage for the bare-command handoff, explicit selection,
  and the argument-completion request.

## How to Test

1. Start `hermes --tui`.
2. Submit `/personality` with no argument and confirm the personality choices
   appear in the completion menu.
3. Choose a personality and confirm the normal session-scoped selection path
   still applies it.
4. Submit `/personality helpful` directly and confirm it still works.

Automated validation:

- `npm run build:ink`
- `npm test` — 159 files passed; 1,710 tests passed and 1 skipped
- `npm run typecheck`
- `npm run lint` — 0 errors; 2 pre-existing warnings in unrelated files
- Prettier check on all changed TypeScript files
- `git diff --check`

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched existing open and closed PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass — not applicable to this
  TUI-only TypeScript change; the full TUI suite is reported above.
- [x] I've added tests for my changes.
- [x] I've tested on macOS 26.6.2.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing syntax changed.
- [x] `cli-config.yaml.example` update: N/A; no config changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered: the change uses the existing portable TUI completion path.
- [x] Tool descriptions/schemas update: N/A; no model tool changed.

## Screenshots / Logs

Not included; the regression is covered by the TUI command and completion tests.
