### PR TITLE
fix(dashboard-auth): serve the login page and auth fetches under a reverse-proxy prefix

### DIFF
--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -40,34 +40,37 @@ _LOGIN_HTML_TEMPLATE = """\
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Sign in — Hermes Agent</title>
 <style>
-  /* Brand fonts shipped by @nous-research/ui — same files the SPA loads. */
+  /* Brand fonts shipped by @nous-research/ui — same files the SPA loads.
+     ``{base_prefix}`` = the reverse-proxy path prefix (empty at root),
+     spliced by ``render_login_html`` so the page also loads its fonts
+     from the proxy-served dashboard under a sub-path mount. */
   @font-face {{
     font-family: 'Collapse';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('/fonts/Collapse-Regular.woff2') format('woff2');
+    src: url('{base_prefix}/fonts/Collapse-Regular.woff2') format('woff2');
   }}
   @font-face {{
     font-family: 'Collapse';
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url('/fonts/Collapse-Bold.woff2') format('woff2');
+    src: url('{base_prefix}/fonts/Collapse-Bold.woff2') format('woff2');
   }}
   @font-face {{
     font-family: 'Rules Compressed';
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url('/fonts/RulesCompressed-Regular.woff2') format('woff2');
+    src: url('{base_prefix}/fonts/RulesCompressed-Regular.woff2') format('woff2');
   }}
   @font-face {{
     font-family: 'Rules Compressed';
     font-style: normal;
     font-weight: 600;
     font-display: swap;
-    src: url('/fonts/RulesCompressed-Medium.woff2') format('woff2');
+    src: url('{base_prefix}/fonts/RulesCompressed-Medium.woff2') format('woff2');
   }}
 
   :root {{
@@ -402,13 +405,20 @@ auth gate (not recommended on untrusted networks).</p>
 
 
 # Inline script that wires every password provider form to POST JSON to
-# ``/auth/password-login`` and navigate on success. Emitted ONLY when at
-# least one ``supports_password`` provider is listed (OAuth-only login
-# pages stay script-free, preserving the no-JS contract for that case).
+# ``{prefix}/auth/password-login`` and navigate on success. Emitted ONLY
+# when at least one ``supports_password`` provider is listed (OAuth-only
+# login pages stay script-free, preserving the no-JS contract for that case).
 #
 # Plain string (NOT run through ``str.format``), so braces are literal —
 # do not double them. A single delegated submit handler covers all forms;
 # the provider name is read from the form's ``data-provider`` attribute.
+#
+# Reverse-proxy prefix: the two root-absolute URLs are spliced with the
+# proxy prefix in ``render_login_html`` (``_js_safe_prefix``). Behind a
+# ``/hermes`` mount the raw ``/auth/password-login`` would resolve against
+# the *proxy* origin and silently fail — the classic "login works on
+# Firefox, not Chrome" bug, since the two browsers may serve the login
+# page from different cache/cookie states.
 _PASSWORD_FORM_SCRIPT = """\
 <script>
 (function () {
@@ -425,7 +435,7 @@ _PASSWORD_FORM_SCRIPT = """\
         password: (form.querySelector('input[name=password]') || {}).value || '',
         next: (form.querySelector('input[name=next]') || {}).value || ''
       };
-      fetch('/auth/password-login', {
+      fetch('__HERMES_PREFIX__/auth/password-login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -433,7 +443,13 @@ _PASSWORD_FORM_SCRIPT = """\
       }).then(function (resp) {
         if (resp.ok) {
           return resp.json().then(function (data) {
-            window.location.assign((data && data.next) || '/');
+            // ``data.next`` is a dashboard-relative path — the backend
+            // returns it unprefixed — so re-prefix it here; a native-app
+            // loopback (absolute ``http://127.0.0.1:…``) is left alone.
+            var next = (data && data.next) || '/';
+            window.location.assign(
+              next.charAt(0) === '/' ? '__HERMES_PREFIX__' + next : next
+            );
           });
         }
         var msg = resp.status === 429
@@ -455,7 +471,19 @@ _PASSWORD_FORM_SCRIPT = """\
 """
 
 
-def render_login_html(*, next_path: str = "") -> str:
+def _js_safe_prefix(prefix: str) -> str:
+    """Escape a normalised prefix for embedding in a JS single-quoted
+    string literal.
+
+    ``normalise_prefix`` already rejects quotes, angle brackets,
+    whitespace, ``..`` and non-printable bytes, so this is defence in
+    depth against a future loosening of the normaliser — never trust a
+    header value near a code sink without a second check.
+    """
+    return prefix.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def render_login_html(*, next_path: str = "", prefix: str = "") -> str:
     """Return the full HTML for ``GET /login``.
 
     ``next_path`` — when set, the post-login landing path the user
@@ -464,7 +492,20 @@ def render_login_html(*, next_path: str = "") -> str:
     end-to-end. The caller (``routes.login_page``) is responsible for
     validating ``next_path`` against the same-origin rules before we
     emit it; we still HTML-escape it as defence in depth.
+
+    ``prefix`` — the reverse-proxy path prefix (normalised, e.g.
+    ``/hermes`` or ``""`` at root). The page is served *through* the
+    proxy, so every URL it emits must be prefixed too: the password
+    form's fetch target, the post-login navigation, the OAuth button
+    hrefs, and the font ``@font-face`` URLs. A root-absolute
+    ``/auth/password-login`` under a ``/hermes`` mount resolves
+    against the *proxy* origin (a dead 200) instead of the dashboard,
+    which is why phone logins can fail on a sub-path deployment while
+    a root deployment works.
     """
+    from hermes_cli.dashboard_auth.prefix import normalise_prefix
+
+    prefix = normalise_prefix(prefix)
     providers = list_session_providers()
     if not providers:
         return _EMPTY_HTML
@@ -488,13 +529,22 @@ def render_login_html(*, next_path: str = "") -> str:
         else:
             buttons.append(
                 f'      <a class="provider-btn" '
-                f'href="/auth/login?provider={html.escape(p.name, quote=True)}{next_qs}">'
+                f'href="{prefix}/auth/login?provider={html.escape(p.name, quote=True)}{next_qs}">'
                 f'Sign in with {html.escape(p.display_name)}</a>'
             )
-    script = _PASSWORD_FORM_SCRIPT if needs_password_script else ""
+    # Splice the proxy prefix into the script's two root-absolute URLs.
+    # The script is a plain (non-format) string, so a simple replace is
+    # safe; the value is JS-escaped as defence in depth.
+    js_prefix = _js_safe_prefix(prefix)
+    script = (
+        _PASSWORD_FORM_SCRIPT.replace("__HERMES_PREFIX__", js_prefix)
+        if needs_password_script
+        else ""
+    )
     return _LOGIN_HTML_TEMPLATE.format(
         provider_buttons="\n".join(buttons),
         password_script=script,
+        base_prefix=prefix,
     )
 
 

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -139,7 +139,7 @@ async def login_page(request: Request) -> HTMLResponse:
         request.query_params.get("next", "")
     )
     return HTMLResponse(
-        render_login_html(next_path=next_path),
+        render_login_html(next_path=next_path, prefix=_prefix(request)),
         headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
     )
 
@@ -588,6 +588,14 @@ async def auth_callback(
     # that lets attacker-controlled bytes into the cookie would otherwise
     # produce an open redirect.
     landing = _validate_post_login_target(next_from_cookie) or "/"
+    # ``landing`` is a dashboard-relative same-origin path; the redirect is
+    # followed by the *browser* (not a fetch), so it must carry the
+    # reverse-proxy prefix — a root-absolute ``/sessions`` under a
+    # ``/hermes`` mount would land on the proxy origin, not the dashboard.
+    # (The password-login JSON twin is intentionally left unprefixed: the
+    # login page's script re-prefixes it client-side.)
+    if landing.startswith("/") and not landing.startswith("//"):
+        landing = f"{_prefix(request)}{landing}"
     resp = RedirectResponse(url=landing, status_code=302)
     set_session_cookies(
         resp,

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -373,3 +373,112 @@ class TestLoginPageRender:
         finally:
             clear_providers()
 
+
+# ---------------------------------------------------------------------------
+# Reverse-proxy prefix (X-Forwarded-Prefix) contract
+# ---------------------------------------------------------------------------
+
+
+class TestProxiedPasswordLogin:
+    """The password-login JSON ``next`` stays dashboard-relative
+    (unprefixed) behind a proxy: the login page's inline script is the
+    one responsible for re-prefixing it client-side. The wire contract
+    is pinned here so a future "helpful" server-side prefixing of
+    ``next`` (which would double-prefix after the client re-prefixes)
+    fails loudly, and so direct deploys stay byte-identical.
+    """
+
+    def _login(self, client, *, next_path, proxied=False):
+        headers = {"X-Forwarded-Prefix": "/hermes"} if proxied else {}
+        return client.post(
+            "/auth/password-login",
+            json={
+                "provider": "testpw",
+                "username": "admin",
+                "password": "hunter2",
+                "next": next_path,
+            },
+            headers=headers,
+        )
+
+    def test_proxied_empty_next_stays_root_unprefixed(self, gated_app):
+        # Behind /hermes the JSON next must remain "/" — NOT "/hermes/" —
+        # because the login page's script prepends the prefix client-side.
+        resp = self._login(gated_app, next_path="", proxied=True)
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "next": "/"}
+
+    def test_proxied_next_sessions_stays_relative_unprefixed(self, gated_app):
+        # The proxied header must NOT make the backend prefix the JSON
+        # next — re-prefixing is the client's job. A future server-side
+        # prefixing would double-prefix and fail here.
+        resp = self._login(
+            gated_app,
+            next_path="/sessions",
+            proxied=True,
+        )
+        assert resp.status_code == 200
+        # Unprefixed: the client-side script turns this into /hermes/sessions.
+        assert resp.json() == {"ok": True, "next": "/sessions"}
+
+    def test_direct_deploy_invariant_matches(self, gated_app):
+        # No X-Forwarded-Prefix header at all (direct deploy): the
+        # responses are identical to the proxied ones — prefixing is a
+        # client-side concern, so the wire contract does not change.
+        no_next = self._login(gated_app, next_path="")
+        sessions = self._login(gated_app, next_path="/sessions")
+        assert no_next.json() == {"ok": True, "next": "/"}
+        assert sessions.json() == {"ok": True, "next": "/sessions"}
+
+    def test_proxied_login_page_splices_prefix_into_fetch_and_fonts(
+        self, gated_app
+    ):
+        # The served /login page (behind /hermes) must point its fetch
+        # and its @font-face urls at the prefixed dashboard, not the
+        # proxy origin.
+        resp = gated_app.get(
+            "/login", headers={"X-Forwarded-Prefix": "/hermes"}
+        )
+        assert resp.status_code == 200
+        html = resp.text
+        # The password form's fetch target is spliced with the prefix.
+        assert "fetch('/hermes/auth/password-login'" in html
+        # The raw placeholder must not survive splicing.
+        assert "__HERMES_PREFIX__" not in html
+        # Font @font-face urls are prefixed too.
+        assert "url('/hermes/fonts/Collapse-Regular.woff2')" in html
+        assert "url('/hermes/fonts/RulesCompressed-Regular.woff2')" in html
+        # Root-absolute (unprefixed) forms of these must be gone.
+        assert "url('/fonts/" not in html
+
+    def test_direct_deploy_login_page_is_unprefixed(self, gated_app):
+        # No prefix header → the page is byte-identical to the root
+        # deploy (no accidental "/hermes" leakage, no leftover
+        # placeholder).
+        resp = gated_app.get("/login")
+        assert resp.status_code == 200
+        html = resp.text
+        assert "fetch('/auth/password-login'" in html
+        assert "url('/fonts/Collapse-Regular.woff2')" in html
+        assert "__HERMES_PREFIX__" not in html
+
+
+class TestProxiedLoginPagePrefixEscaping:
+    """Defence-in-depth: the prefix is normalised AND JS-escaped before
+    it is embedded in a single-quoted JS string literal. The normaliser
+    already rejects quotes, so this pins the second line — a future
+    loosening of ``normalise_prefix`` cannot become a JS injection.
+    """
+
+    def test_js_safe_prefix_escapes_quotes_and_backslash(self):
+        from hermes_cli.dashboard_auth.login_page import _js_safe_prefix
+
+        assert _js_safe_prefix("/hermes") == "/hermes"
+        # A quote (if it ever survived the normaliser) is escaped so it
+        # cannot terminate the JS string literal.
+        assert _js_safe_prefix("/a'b") == "/a\\'b"
+        # A backslash is doubled.
+        assert _js_safe_prefix("/a\\b") == "/a\\\\b"
+        # Combined.
+        assert _js_safe_prefix("/a\\'b") == "/a\\\\\\'b"
+

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -366,7 +366,11 @@ export const api = {
       // /auth/logout returns 302 → /login. Follow that with a full-page
       // navigation rather than letting fetch() opaquely consume the
       // redirect — the SPA needs to leave the protected area.
-      window.location.assign("/login");
+      // Honour the reverse-proxy prefix: behind ``/hermes`` this must be
+      // ``/hermes/login`` (root-absolute ``/login`` would land on the
+      // proxy's own /login, not the dashboard's). ``HERMES_BASE_PATH``
+      // is "" at root, so local/root deploys are unchanged.
+      window.location.assign(`${HERMES_BASE_PATH}/login`);
       return r;
     }),
   getSessions: (


### PR DESCRIPTION
## What does this PR do?

When the dashboard is served behind a path mount (e.g. Caddy `handle_path /hermes/*` with `X-Forwarded-Prefix: /hermes`), the login page emits root-absolute URLs that resolve against the *proxy* origin instead of the dashboard:

- `@font-face` urls point at `/fonts/…` → the proxy's own (missing) fonts,
- the password form fetches `/auth/password-login` → the proxy's (missing) endpoint,
- the OAuth callback's browser redirect lands on the proxy origin,
- `api.logout` navigates to `/login` → the proxy's (missing) login page.

Symptom: password login fails with "Network error" in Chrome (strict about cross-origin fetches) while Firefox appears to work — verified end-to-end on a Caddy `handle_path /hermes/*` deployment before and after this change. Same failure class as #48625 and the in-thread comment there.

Three cases covered (complementary to #48625 — opened as its own PR per @liuhao1024's suggestion so each has its own review trail):

1. **Login-page font URLs** — `render_login_html` now prefixes the `@font-face` `url()`s.
2. **`data.next` re-prefix** — the backend JSON `next` for password login stays *dashboard-relative and unprefixed*; the SPA's inline script re-prefixes dashboard-relative paths client-side and leaves absolute (loopback/native-app) URLs alone. The OAuth callback's browser redirect is prefixed server-side (it is followed by the browser, not a fetch).
3. **Defence-in-depth `_js_safe_prefix`** — the prefix is normalised and then JS-escaped before being embedded in a single-quoted JS string literal, so a future loosening of the normaliser cannot become a script-injection.

**Mechanism note (design fork with #48625):** this PR splices a `__HERMES_PREFIX__` placeholder inside `render_login_html`; #48625 reads a `data-prefix` attribute off `<main>`. Either composes with the other; happy to rebase onto whichever mechanism the maintainers pick.

## Related Issue

Related: #48625 (complementary PR, comment thread), #50889 (cookie `Path` consistency — out of scope here, cross-referenced).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (prefix escaping pins the JS-embedding sink)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/dashboard_auth/login_page.py` — prefix on font urls, `__HERMES_PREFIX__` splice for the password-form fetch, client-side `data.next` re-prefix, `_js_safe_prefix`
- `hermes_cli/dashboard_auth/routes.py` — pass `prefix` into `render_login_html`; OAuth-callback `landing` prefixed
- `web/src/lib/api.ts` — logout redirect honours `HERMES_BASE_PATH`
- `tests/hermes_cli/test_dashboard_auth_password_login.py` — proxied password-login contract (JSON `next` stays unprefixed behind a prefix; direct deploy byte-identical), login-page prefix splicing, `_js_safe_prefix` escaping

## How to Test

1. `PYTHONPATH=. pytest tests/hermes_cli/test_dashboard_auth_password_login.py -q` → 19 passed; full `tests/hermes_cli/ -k dashboard_auth` → 141 passed, no regressions (verified locally).
2. End-to-end: Caddy `handle_path /hermes/*` reverse-proxying `:9119` with `X-Forwarded-Prefix` — password login verified on Chrome + Firefox before/after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — `tests/hermes_cli/ -k dashboard_auth` (141 passed, no regressions); full suite not run locally, CI covers it
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Bazzite Linux (Caddy `handle_path /hermes/*` + Chrome/Firefox, end-to-end)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: docstrings on the changed functions
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — deploy-shape concern (reverse proxy), no OS-specific code; direct/root deploys are byte-identical (pinned by test)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A
