### PR TITLE
fix(inventory): keep Anthropic OAuth logins visible in desktop pickers

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -661,6 +661,33 @@ def _append_unconfigured_rows(
     return extras
 
 
+def _anthropic_oauth_credentials_present() -> bool:
+    """True when the user explicitly authenticated Anthropic via OAuth.
+
+    Two deliberate flows leave no trace in active_provider /
+    model.provider / API-key env vars: Hermes' own Anthropic device flow
+    (token in auth.json) and a Claude Code login (~/.claude/.credentials.json).
+    ``list_authenticated_providers`` already accepts both readers as real
+    credentials when discovering rows; this mirrors that acceptance so the
+    desktop explicit-only filter does not silently drop a provider the user
+    deliberately signed into. Unlike ambient CLI tokens (gh -> copilot),
+    an OAuth access token only exists after an interactive login.
+    """
+    try:
+        from agent.anthropic_adapter import (
+            read_claude_code_credentials,
+            read_hermes_oauth_credentials,
+        )
+
+        hermes_creds = read_hermes_oauth_credentials() or {}
+        if hermes_creds.get("accessToken"):
+            return True
+        cc_creds = read_claude_code_credentials() or {}
+        return bool(cc_creds.get("accessToken"))
+    except Exception:
+        return False
+
+
 def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list[dict]:
     """Keep only rows backed by explicit user configuration.
 
@@ -695,6 +722,14 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
             # Keyless providers (opencode-free) require no configuration at
             # all — there is nothing to "explicitly configure", and hiding
             # them would defeat their purpose (zero-setup discoverability).
+            kept.append(row)
+            continue
+        if slug == "anthropic" and _anthropic_oauth_credentials_present():
+            # Anthropic OAuth logins (Hermes device flow / Claude Code) are
+            # deliberate sign-ins that leave no trace in active_provider,
+            # model.provider, or API-key env vars. The strict gate below
+            # would drop the row even though list_authenticated_providers
+            # just accepted those same credentials when building it.
             kept.append(row)
             continue
         if is_provider_explicitly_configured(slug):

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -208,6 +208,72 @@ def test_explicit_only_filters_ambient_credentials_but_keeps_current_and_custom_
     ]
 
 
+def test_explicit_only_keeps_anthropic_row_with_oauth_credentials():
+    """Anthropic OAuth logins are deliberate sign-ins, not ambient credentials.
+
+    Claude Code (~/.claude/.credentials.json) and Hermes' own device flow
+    leave no trace in active_provider / model.provider / API-key env vars,
+    so is_provider_explicitly_configured() returns False even though
+    list_authenticated_providers just accepted those same credentials when
+    building the row. The desktop explicit-only filter must keep it.
+    """
+    rows = [
+        {"slug": "anthropic", "name": "Anthropic", "models": ["claude-sonnet-5"],
+         "total_models": 1, "is_current": False, "is_user_defined": False,
+         "source": "hermes"},
+        {"slug": "copilot", "name": "Copilot", "models": ["gpt-5.4"],
+         "total_models": 1, "is_current": False, "is_user_defined": False,
+         "source": "hermes"},
+    ]
+    ctx = _empty_ctx(provider="opencode-go", model="glm-5.3")
+    with (
+        _list_auth_returning(rows),
+        patch("hermes_cli.config.read_raw_config", return_value={}),
+        patch(
+            "hermes_cli.auth.is_provider_explicitly_configured",
+            return_value=False,
+        ),
+        patch(
+            "hermes_cli.inventory._anthropic_oauth_credentials_present",
+            return_value=True,
+        ),
+    ):
+        payload = build_models_payload(ctx, explicit_only=True)
+
+    slugs = [row["slug"] for row in payload["providers"]]
+    assert "anthropic" in slugs, (
+        "Anthropic OAuth login must survive the explicit-only filter"
+    )
+    assert "copilot" not in slugs, (
+        "ambient credential discovery must stay filtered"
+    )
+
+
+def test_explicit_only_drops_anthropic_row_without_oauth_credentials():
+    """No OAuth token and no explicit config -> Anthropic stays hidden."""
+    rows = [
+        {"slug": "anthropic", "name": "Anthropic", "models": ["claude-sonnet-5"],
+         "total_models": 1, "is_current": False, "is_user_defined": False,
+         "source": "hermes"},
+    ]
+    ctx = _empty_ctx(provider="opencode-go", model="glm-5.3")
+    with (
+        _list_auth_returning(rows),
+        patch("hermes_cli.config.read_raw_config", return_value={}),
+        patch(
+            "hermes_cli.auth.is_provider_explicitly_configured",
+            return_value=False,
+        ),
+        patch(
+            "hermes_cli.inventory._anthropic_oauth_credentials_present",
+            return_value=False,
+        ),
+    ):
+        payload = build_models_payload(ctx, explicit_only=True)
+
+    assert "anthropic" not in [row["slug"] for row in payload["providers"]]
+
+
 
 # ─── picker_hints ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Follow-up to #92229 (same bug class, different provider): the desktop explicit-only picker filter (`_filter_explicit_provider_rows`) drops any provider row where `is_provider_explicitly_configured()` returns False.

That gate only recognizes:
- `active_provider` in auth.json,
- `model.provider` in config.yaml,
- provider API-key env vars.

A user who authenticated Anthropic via **OAuth** has none of these. Both deliberate flows leave no gate-visible trace:
- Hermes' own Anthropic device flow (token in auth.json)
- A Claude Code login (`~/.claude/.credentials.json`)

Meanwhile `list_authenticated_providers()` *accepts both readers as real credentials* when building rows (there's an equivalent special-case in its discovery path), so the row exists with 12 curated models — and then the desktop filter silently deletes it. Net effect: Anthropic visible in CLI ``/model``, invisible in the desktop app.

## Fix

Narrow carve-out in the **filter layer only**: keep the `anthropic` row when either OAuth reader finds an `accessToken`.

Deliberately NOT widening `is_provider_explicitly_configured()` itself — that function is also the consent guard (PR #4210) preventing auxiliary tasks from silently consuming Claude Code tokens, and its behavior must not change. Unlike ambient CLI tokens (gh -> copilot), an OAuth access token only exists after an interactive login, so its presence is always deliberate.

## Test Plan

- [x] `test_explicit_only_keeps_anthropic_row_with_oauth_credentials` — row survives, ambient rows (copilot) stay filtered
- [x] `test_explicit_only_drops_anthropic_row_without_oauth_credentials` — hidden stays hidden
- [x] Full `tests/hermes_cli/test_inventory.py`: 17 passed
- [x] Verified against a real OAuth-authenticated install: desktop payload now emits `anthropic` (12 models) among the explicit-only rows