### PR TITLE
fix(desktop): workspace pane no longer crash-loops on duplicate toolCallIds (#87857, salvage #87871)

### DIFF
--- a/apps/desktop/src/app/chat/runtime-repository.test.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.test.ts
@@ -79,4 +79,108 @@ describe('useRuntimeMessageRepository', () => {
 
     expect(windowedParents.get('a-1')).toBe(windowedParents.get('a-2'))
   })
+
+  it('renames a duplicated toolCallId within one message instead of crashing useResources (#87857)', () => {
+    // The streaming path can append the same tool call twice inside ONE message
+    // (optimistic write racing the authoritative event). @assistant-ui/tap's
+    // useResources throws on duplicate resource keys, so the repository must
+    // never emit two parts of one message keyed by the same `toolCallId-<id>`.
+    const duplicated: ChatMessage = {
+      id: 'assistant-dup',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'running…' },
+        { type: 'tool-call', toolCallId: 'call_00_DUP', toolName: 'terminal', args: {}, argsText: '' },
+        { type: 'tool-call', toolCallId: 'call_00_DUP', toolName: 'terminal', args: { done: true }, argsText: '{"done":true}' }
+      ] as ChatMessage['parts']
+    }
+
+    const { result } = renderHook(() => useRuntimeMessageRepository([text('user-1', 'user', 'go'), duplicated]))
+
+    const assistant = result.current.messages.find(item => item.message.id === 'assistant-dup')
+    expect(assistant).toBeDefined()
+
+    const toolParts = (assistant!.message.content as readonly { type: string; toolCallId?: string }[]).filter(
+      part => part.type === 'tool-call'
+    )
+    expect(toolParts).toHaveLength(2)
+    expect(new Set(toolParts.map(part => part.toolCallId)).size).toBe(2)
+
+    // And the runtime can link it end to end without throwing.
+    expect(feedToRepository(result.current).map(item => item.id)).toEqual(['user-1', 'assistant-dup'])
+  })
+
+  it('drops the carried-over copy when coalescing folds a repeated toolCallId into one message (#87857)', () => {
+    // Two individually-clean rows can share a toolCallId (structural carry-over
+    // re-attaching a cached row's calls while the same turn also exists as a
+    // committed row). Per-row that is harmless — assistant-ui's key space is
+    // per-message — but coalesceToolOnlyAssistants folds the tool-only
+    // follow-up into its predecessor, which used to manufacture the duplicate
+    // key. The fold must drop the copy the predecessor already carries while
+    // keeping the genuinely-new call.
+    const tool = (toolCallId: string): ChatMessage['parts'][number] =>
+      ({ type: 'tool-call', toolCallId, toolName: 'terminal', args: {}, argsText: '' }) as ChatMessage['parts'][number]
+
+    const committed: ChatMessage = {
+      id: 'committed-49-assistant',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'working' }, tool('call-a'), tool('call-b')] as ChatMessage['parts']
+    }
+    const streamed: ChatMessage = {
+      id: 'assistant-stream-49',
+      role: 'assistant',
+      parts: [tool('call-b'), tool('call-c')] as ChatMessage['parts']
+    }
+
+    const { result } = renderHook(() => useRuntimeMessageRepository([text('user-1', 'user', 'go'), committed, streamed]))
+
+    const assistant = result.current.messages.find(item => item.message.id === 'committed-49-assistant')
+    expect(assistant).toBeDefined()
+
+    const ids = (assistant!.message.content as readonly { type: string; toolCallId?: string }[])
+      .filter(part => part.type === 'tool-call')
+      .map(part => part.toolCallId)
+
+    // call-b appears once, call-c (genuinely new) survives the fold.
+    expect(ids).toEqual(['call-a', 'call-b', 'call-c'])
+
+    expect(feedToRepository(result.current).map(item => item.id)).toEqual(['user-1', 'committed-49-assistant'])
+  })
+
+  it('leaves a toolCallId repeated across DIFFERENT non-folded messages untouched', () => {
+    // anthropic_messages-mode providers (e.g. Kimi) number tool_use blocks per
+    // API response — `terminal_0` legitimately recurs on every turn. The key
+    // space is per-message, so cross-message repeats are NOT collisions and
+    // must never be renamed (renaming would defeat the identity cache and
+    // churn re-renders on every stream delta).
+    const turn = (n: number): ChatMessage[] => [
+      text(`user-${n}`, 'user', 'go'),
+      {
+        id: `assistant-${n}`,
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'ok' },
+          { type: 'tool-call', toolCallId: 'terminal_0', toolName: 'terminal', args: {}, argsText: '' }
+        ] as ChatMessage['parts']
+      }
+    ]
+
+    const { result } = renderHook(() => useRuntimeMessageRepository([...turn(1), ...turn(2)]))
+
+    for (const id of ['assistant-1', 'assistant-2']) {
+      const item = result.current.messages.find(entry => entry.message.id === id)
+      const ids = (item!.message.content as readonly { type: string; toolCallId?: string }[])
+        .filter(part => part.type === 'tool-call')
+        .map(part => part.toolCallId)
+
+      expect(ids).toEqual(['terminal_0'])
+    }
+
+    expect(feedToRepository(result.current).map(item => item.id)).toEqual([
+      'user-1',
+      'assistant-1',
+      'user-2',
+      'assistant-2'
+    ])
+  })
 })

--- a/apps/desktop/src/app/chat/runtime-repository.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.ts
@@ -3,6 +3,7 @@ import type { ExportedMessageRepository, ThreadMessage } from '@assistant-ui/rea
 import { useMemo, useRef } from 'react'
 
 import type { ChatMessage } from '@/lib/chat-messages'
+import { withUniqueToolCallIdsWithinMessage } from '@/lib/chat-messages'
 import { coalesceToolOnlyAssistants, createToolMergeCache, toRuntimeMessage } from '@/lib/chat-runtime'
 
 // The exact fallback status ExportedMessageRepository.fromBranchableArray uses.
@@ -56,10 +57,17 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
         parentId = branchParentByGroup.get(message.branchGroupId) ?? null
       }
 
+      // Guard against two `tool-call` parts of one message sharing a
+      // `toolCallId`: assistant-ui's `useResources` throws on the duplicate key
+      // and crash-loops the renderer (#87857). Same class of defensive dedup as
+      // the repeated-`message.id` skip above, one level down at the parts. Keeps
+      // identity when clean, so the cache below is unaffected in the common case.
+      const deduped = withUniqueToolCallIdsWithinMessage(message)
+
       const cachedMessage = cacheRef.current.get(message)
 
       const runtimeMessage =
-        cachedMessage ?? fromThreadMessageLike(toRuntimeMessage(message), message.id, FALLBACK_STATUS)
+        cachedMessage ?? fromThreadMessageLike(toRuntimeMessage(deduped), message.id, FALLBACK_STATUS)
 
       if (!cachedMessage) {
         cacheRef.current.set(message, runtimeMessage)

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -15,8 +15,44 @@ import {
   renderMediaTags,
   sealOpenToolParts,
   toChatMessages,
-  upsertToolPart
+  upsertToolPart,
+  withUniqueToolCallIdsWithinMessage
 } from './chat-messages'
+
+const toolCallPart = (toolCallId: string): ChatMessagePart =>
+  ({ type: 'tool-call' as const, toolCallId, toolName: 'read_file', args: {} as never, argsText: '{}' }) as ChatMessagePart
+
+const assistantWith = (parts: ChatMessagePart[]): ChatMessage =>
+  ({ id: 'm1', role: 'assistant', parts, timestamp: 0 }) as unknown as ChatMessage
+
+describe('withUniqueToolCallIdsWithinMessage', () => {
+  it('renames a duplicate toolCallId within one message (#87857)', () => {
+    const message = assistantWith([toolCallPart('call_x'), toolCallPart('call_x')])
+
+    const result = withUniqueToolCallIdsWithinMessage(message)
+
+    const ids = result.parts
+      .filter((part): part is Extract<ChatMessagePart, { type: 'tool-call' }> => part.type === 'tool-call')
+      .map(part => part.toolCallId)
+
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids[0]).toBe('call_x')
+    expect(ids[1]).not.toBe('call_x')
+  })
+
+  it('returns the same reference when there is no duplicate', () => {
+    const message = assistantWith([toolCallPart('call_a'), toolCallPart('call_b')])
+
+    expect(withUniqueToolCallIdsWithinMessage(message)).toBe(message)
+  })
+
+  it('does not touch parts without a toolCallId', () => {
+    const textPart = { type: 'text' as const, text: 'hi' } as ChatMessagePart
+    const message = assistantWith([textPart, toolCallPart('call_a')])
+
+    expect(withUniqueToolCallIdsWithinMessage(message)).toBe(message)
+  })
+})
 
 describe('toChatMessages', () => {
   it('rebuilds the full command from a gateway tool row carrying args', () => {

--- a/apps/desktop/src/lib/chat-messages/index.ts
+++ b/apps/desktop/src/lib/chat-messages/index.ts
@@ -14,5 +14,5 @@ export {
 } from './parts'
 export type { UnspokenTurnSpeech } from './parts'
 export { branchGroupForUser, preserveLocalAssistantErrors } from './reconciliation'
-export { sealOpenToolParts, upsertToolPart } from './tool-parts'
+export { sealOpenToolParts, upsertToolPart, withUniqueToolCallIdsWithinMessage } from './tool-parts'
 export type { ChatMessage, ChatMessagePart, GatewayEventPayload, TimelinePartMetadata } from './types'

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -577,3 +577,53 @@ export function withUniqueToolCallIds(messages: ChatMessage[]): ChatMessage[] {
     return changed ? { ...message, parts } : message
   })
 }
+
+/**
+ * Ensure no two `tool-call` parts of a SINGLE message share a `toolCallId`.
+ *
+ * assistant-ui's `useResources` derives one resource key per content part
+ * (`toolCallId-<id>`) and throws `Duplicate key <key> in useResources` on a
+ * collision, which the desktop error boundary turns into a renderer crash loop
+ * that blanks the window (#87857). Two paths can produce a message whose parts
+ * carry the same id: the streaming reducer appends the same tool-call part
+ * twice under a specific optimistic-update ordering, and coalescing tool-only
+ * assistant turns can fold two parts with the same id into one message. Neither
+ * passes through {@link withUniqueToolCallIds} — that runs only on the static
+ * `toChatMessages` output, not the live runtime boundary — so the dedup is
+ * applied again at the point ChatMessages are converted for the runtime.
+ *
+ * The scope is deliberately per-message (a fresh seen-set each call): the
+ * assistant-ui key space is per-message, so a `toolCallId` shared across
+ * different messages is not a collision and must not be renamed. Only the
+ * later duplicate within one message is renamed, mirroring the list-level
+ * helper. Returns the same reference when nothing changes, so the runtime
+ * repository's identity cache is preserved for the common no-duplicate case.
+ */
+export function withUniqueToolCallIdsWithinMessage(message: ChatMessage): ChatMessage {
+  let seen: null | Set<string> = null
+  let changed = false
+
+  const parts = message.parts.map((part, index) => {
+    if (part.type !== 'tool-call' || !part.toolCallId) {
+      return part
+    }
+
+    if (seen === null) {
+      seen = new Set<string>()
+    }
+
+    if (!seen.has(part.toolCallId)) {
+      seen.add(part.toolCallId)
+
+      return part
+    }
+
+    changed = true
+    const uniqueId = `${part.toolCallId}-dup-${index}`
+    seen.add(uniqueId)
+
+    return { ...part, toolCallId: uniqueId } as ChatMessagePart
+  })
+
+  return changed ? { ...message, parts } : message
+}

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
+import type { ChatMessage, ChatMessagePart } from '@/lib/chat-messages'
 import type { ComposerAttachment } from '@/store/composer'
 
 import {
   attachmentDisplayText,
   attachmentId,
+  coalesceToolOnlyAssistants,
   coerceThinkingText,
+  createToolMergeCache,
   messageCreatedAt,
   optimisticAttachmentRef,
   parseCommandDispatch,
@@ -249,5 +252,50 @@ describe('toRuntimeMessage timeline metadata', () => {
     })
 
     expect((runtime.metadata?.custom as { timelineTimestamp?: number }).timelineTimestamp).toBeUndefined()
+  })
+})
+
+describe('coalesceToolOnlyAssistants toolCallId uniqueness', () => {
+  // Regression contract for #87857: two individually-clean assistant rows can
+  // share a toolCallId (structural carry-over re-attaching a cached row's tool
+  // calls while the same turn also exists as a committed row). Folding them
+  // used to manufacture ONE message carrying the id twice — the exact shape
+  // that makes assistant-ui's useResources throw and crash-loop the pane.
+  const tool = (toolCallId: string): ChatMessagePart =>
+    ({ type: 'tool-call', toolCallId, toolName: 'terminal', args: {} as never, argsText: '' }) as ChatMessagePart
+
+  const assistant = (id: string, parts: ChatMessagePart[]): ChatMessage =>
+    ({ id, role: 'assistant', parts }) as unknown as ChatMessage
+
+  it('drops the copy the predecessor already carries, keeps the new call', () => {
+    const merged = coalesceToolOnlyAssistants(
+      [
+        assistant('committed-49-assistant', [{ type: 'text', text: 'working' } as ChatMessagePart, tool('call-a'), tool('call-b')]),
+        assistant('assistant-stream-49', [tool('call-b'), tool('call-c')])
+      ],
+      createToolMergeCache()
+    )
+
+    expect(merged).toHaveLength(1)
+
+    const ids = merged[0].parts.filter(part => part.type === 'tool-call').map(part => (part as { toolCallId: string }).toolCallId)
+
+    expect(ids).toEqual(['call-a', 'call-b', 'call-c'])
+  })
+
+  it('folds a clean follow-up unchanged', () => {
+    const merged = coalesceToolOnlyAssistants(
+      [
+        assistant('a1', [{ type: 'text', text: 'ok' } as ChatMessagePart, tool('call-a')]),
+        assistant('a2', [tool('call-b')])
+      ],
+      createToolMergeCache()
+    )
+
+    expect(merged).toHaveLength(1)
+
+    const ids = merged[0].parts.filter(part => part.type === 'tool-call').map(part => (part as { toolCallId: string }).toolCallId)
+
+    expect(ids).toEqual(['call-a', 'call-b'])
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -517,6 +517,45 @@ function isToolOnlyAssistant(message: ChatMessage): boolean {
 }
 
 /**
+ * Concatenate a tool-only follow-up message's parts onto its predecessor's,
+ * dropping any incoming `tool-call` part whose `toolCallId` the predecessor
+ * already carries. A repeated id here is the SAME call re-attached (structural
+ * carry-over re-adding a cached row's tool calls, or a live-turn projection
+ * that also exists as a committed row — #87857): folding both copies into one
+ * message manufactures the duplicate key that crashes assistant-ui's
+ * `useResources`, and renaming it would render the same call twice. Genuinely
+ * new calls in the same follow-up row are preserved.
+ */
+export function concatToolPartsUnique(
+  prevParts: readonly ChatMessagePart[],
+  nextParts: readonly ChatMessagePart[]
+): ChatMessagePart[] {
+  const seen = new Set<string>()
+
+  for (const part of prevParts) {
+    if (part.type === 'tool-call' && part.toolCallId) {
+      seen.add(part.toolCallId)
+    }
+  }
+
+  const out = [...prevParts]
+
+  for (const part of nextParts) {
+    if (part.type === 'tool-call' && part.toolCallId) {
+      if (seen.has(part.toolCallId)) {
+        continue
+      }
+
+      seen.add(part.toolCallId)
+    }
+
+    out.push(part)
+  }
+
+  return out
+}
+
+/**
  * Fold each settled tool-only assistant message into the preceding assistant
  * message so its calls join that message's tool group (and can collapse into
  * the auto-scrolling window). Render-only — never mutates the `$messages` store
@@ -544,7 +583,7 @@ export function coalesceToolOnlyAssistants(messages: ChatMessage[], cache: ToolM
                   (latest, value) => (latest === undefined ? value : Math.max(latest, value)),
                   undefined
                 ),
-              parts: [...prev.parts, ...message.parts]
+              parts: concatToolPartsUnique(prev.parts, message.parts)
             }
 
       cache.set(message, { merged, parts: message.parts, prev, prevParts: prev.parts })

--- a/apps/desktop/src/store/transcript-tail-cache.test.ts
+++ b/apps/desktop/src/store/transcript-tail-cache.test.ts
@@ -91,4 +91,29 @@ describe('transcript tail cache', () => {
     expect(loadTranscriptTail('sess-5')).not.toBeNull()
     expect(loadTranscriptTail('sess-54')).not.toBeNull()
   })
+
+  it('repairs a poisoned persisted tail carrying a duplicate toolCallId (#87857)', () => {
+    // A tail written by an older build can hold one message with two tool-call
+    // parts sharing an id. This path paints DIRECTLY into the view and the same
+    // bytes are re-read every launch — without repair-on-read, an affected
+    // install crash-loops forever even after upgrading.
+    const tool = (toolCallId: string) => ({ type: 'tool-call', toolCallId, toolName: 'terminal', args: {}, argsText: '' })
+    const poisoned = {
+      messages: [{ id: 'assistant-p', role: 'assistant', parts: [tool('call-b'), tool('call-b')] }],
+      savedAt: Date.now()
+    }
+    window.localStorage.setItem('hermes.transcript-tail.v1:sess-poisoned', JSON.stringify(poisoned))
+
+    const loaded = loadTranscriptTail('sess-poisoned')
+
+    expect(loaded).toHaveLength(1)
+
+    const ids = (loaded![0].parts as { type: string; toolCallId?: string }[])
+      .filter(part => part.type === 'tool-call')
+      .map(part => part.toolCallId)
+
+    expect(ids).toHaveLength(2)
+    expect(new Set(ids).size).toBe(2)
+    expect(ids[0]).toBe('call-b')
+  })
 })

--- a/apps/desktop/src/store/transcript-tail-cache.ts
+++ b/apps/desktop/src/store/transcript-tail-cache.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage } from '@/lib/chat-messages'
+import { withUniqueToolCallIdsWithinMessage } from '@/lib/chat-messages'
 
 // ── Durable transcript-tail cache (#89206 "feels instant" layer) ────────────
 // The in-memory warm cache (sessionStateByRuntimeIdRef) makes same-window
@@ -153,7 +154,13 @@ export function loadTranscriptTail(storedSessionId: string): ChatMessage[] | nul
       throw new Error('empty')
     }
 
-    return parsed.messages
+    // Repair, don't just trust: a tail persisted by an older build (or by a
+    // producer bug) can carry two `tool-call` parts with one `toolCallId`
+    // inside a single message. This path paints DIRECTLY into the view, and a
+    // poisoned entry is re-read identically on every launch — the "one pane
+    // permanently broken" shape of #87857. Renaming at read keeps already-
+    // affected installs from crash-looping forever on upgraded builds.
+    return parsed.messages.map(withUniqueToolCallIdsWithinMessage)
   } catch {
     try {
       store.removeItem(PREFIX + id)


### PR DESCRIPTION
## Summary

The Desktop workspace pane no longer crash-loops on `Duplicate key toolCallId-… in useResources` (#87857, related #70206) — the fix covers all three proven trigger paths, including installs already carrying a poisoned cached transcript.

Root cause (analysis by @marketing2981): assistant-ui's key space is per-message, and in the poisoned-pane transcripts no single stored row ever held a duplicate — `coalesceToolOnlyAssistants` folded two individually-clean rows sharing a `toolCallId` (structural carry-over re-attaching a cached row's calls) into one message, manufacturing the collision at render time. Two more paths were field-confirmed: the streaming/optimistic ordering that duplicates a part inside one in-memory message (#87857 OP, @XCh373's interrupt path with zero matching DB rows), and a poisoned `hermes.transcript-tail.v1:*` entry that repaints the same collision on every launch.

## Changes

Three layers, one per trigger path:

- `lib/chat-runtime.ts`: `coalesceToolOnlyAssistants` now folds via `concatToolPartsUnique` — an incoming tool-call part whose id the predecessor already carries is the SAME call re-attached and is dropped (not renamed, which would render the call twice); genuinely-new calls in the same row survive.
- `app/chat/runtime-repository.ts` + `lib/chat-messages/tool-parts.ts`: per-message `withUniqueToolCallIdsWithinMessage` guard at the runtime boundary, salvaged from #87871 by @PRATHAMESH75 (authorship preserved; relocated into the `chat-messages/` split layout). Scope is deliberately per-message: cross-message id repeats are legal (anthropic_messages providers like Kimi number tool_use per response — root-cause credit @M7MMAD-OMAR, #90545) and renaming them would defeat the identity cache. Returns the same reference when clean.
- `store/transcript-tail-cache.ts`: `loadTranscriptTail` repairs a poisoned persisted tail on read — already-affected installs stop crash-looping after upgrade instead of re-deriving the same collision every launch.

## Validation

| Check | Result |
|---|---|
| Targeted tests (4 files) | 118/118 pass |
| Full desktop suite | 7020 passed, 3 skipped |
| `tsc -p tsconfig.json --noEmit` | clean |
| Sabotage runs (each layer reverted individually) | its regression test fails, others pass — 3/3 |

New coverage: end-to-end `MessageRepository` link test (from #92093 by @RasputinKaiser), fold-level dedup repro (marketing2981's exact scenario), cross-message ids-stay-untouched contract, poisoned-tail repair, plus #87871's unit tests.

Supersedes #87871, #90545, #92093. Closes #87857.

## Infographic

![Desktop crash fix: duplicate tool call IDs](https://v3b.fal.media/files/b/0aa762a4/vZljwR-WM8_v-h7aNvr4__wWNwUjvJ.png)
