### PR TITLE
fix(agent): relax local model stale watchdogs

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -629,6 +629,23 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _local_stream_stale_timeout_default() -> float:
+    """Return the configured local-provider stale-stream ceiling."""
+    local_default = 900.0
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()  # read-only consumer — no deepcopy
+        agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else None
+        if isinstance(agent_cfg, dict):
+            value = agent_cfg.get("local_stream_stale_timeout")
+            if isinstance(value, (int, float)):
+                local_default = float(value)
+    except Exception:
+        pass
+    return _env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", local_default)
+
+
 def _estimate_chunk_bytes(chunk: Any) -> int:
     """Cheap per-chunk size estimate for the stream diagnostic counters.
 
@@ -1547,9 +1564,27 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # reconnect promptly when the socket is genuinely wedged. Set
     # HERMES_CODEX_TTFB_TIMEOUT_SECONDS=0 to disable this watchdog entirely.
     _ttfb_enabled = _codex_watchdog_enabled
+    _ttfb_timeout_explicit = os.getenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS") is not None
     _ttfb_timeout = _env_float("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", 120.0)
     if _ttfb_timeout <= 0:
         _ttfb_enabled = False
+    elif (
+        _codex_watchdog_enabled
+        and not _ttfb_timeout_explicit
+        and agent.base_url
+        and is_local_endpoint(agent.base_url)
+    ):
+        _local_ttfb_timeout = _local_stream_stale_timeout_default()
+        if _local_ttfb_timeout > 0 and _ttfb_timeout < _local_ttfb_timeout:
+            logger.info(
+                "Scaling Codex no-byte TTFB watchdog from %.0fs to %.0fs "
+                "for local provider %s. Set HERMES_CODEX_TTFB_TIMEOUT_SECONDS "
+                "to keep a smaller explicit cutoff.",
+                _ttfb_timeout,
+                _local_ttfb_timeout,
+                agent.base_url,
+            )
+            _ttfb_timeout = _local_ttfb_timeout
     elif _openai_codex_backend:
         _ttfb_disable_above = _env_float("HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS", 10_000.0)
         _ttfb_strict = os.environ.get("HERMES_CODEX_TTFB_STRICT", "").strip().lower() in {
@@ -5042,21 +5077,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     # local ceiling with HERMES_LOCAL_STREAM_STALE_TIMEOUT (documented in
     # website/docs/reference/environment-variables.md).
     if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        # Read config.yaml ``agent.local_stream_stale_timeout`` (default 900),
-        # env var ``HERMES_LOCAL_STREAM_STALE_TIMEOUT`` overrides for escape-hatch.
-        _local_default = 900.0
-        try:
-            from hermes_cli.config import load_config_readonly
-
-            _cfg = load_config_readonly()  # read-only consumer — no deepcopy
-            _agent_cfg = _cfg.get("agent") if isinstance(_cfg, dict) else None
-            if isinstance(_agent_cfg, dict):
-                _v = _agent_cfg.get("local_stream_stale_timeout")
-                if isinstance(_v, (int, float)):
-                    _local_default = float(_v)
-        except Exception:
-            pass
-        _stream_stale_timeout = env_float("HERMES_LOCAL_STREAM_STALE_TIMEOUT", _local_default)
+        _stream_stale_timeout = _local_stream_stale_timeout_default()
         logger.debug(
             "Local provider detected (%s) — stale stream timeout set to %.0fs",
             agent.base_url, _stream_stale_timeout,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1449,14 +1449,14 @@ class AIAgent:
         # (Nemotron 3 Ultra, OpenAI o1/o3, Anthropic Opus 4.x thinking,
         # DeepSeek R1, Qwen QwQ, xAI Grok reasoning, etc.) whose cloud
         # gateways idle-kill before the model's thinking phase ends.
-        # uses_implicit_default is False here so the local-endpoint
-        # short-circuit in _compute_non_stream_stale_timeout does not
-        # disable stale detection for users running reasoning models on a
-        # local NIM endpoint.
+        # This is still implicit (not user-configured), so local endpoints keep
+        # the local-provider stale detector disable. A local Qwen/DeepSeek
+        # prefill can legitimately run longer than the hosted-cloud floor; only
+        # explicit provider/env stale_timeout_seconds should opt back in.
         from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
         reasoning_floor = get_reasoning_stale_timeout_floor(self.model)
         if reasoning_floor is not None:
-            return reasoning_floor, False
+            return reasoning_floor, True
 
         return 90.0, True
 

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -34,6 +34,11 @@ def _make_codex_agent(tmp_path, monkeypatch):
     (tmp_path / ".env").write_text("", encoding="utf-8")
     (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
     from run_agent import AIAgent
+    monkeypatch.setattr(
+        AIAgent,
+        "_create_openai_client",
+        lambda self, *args, **kwargs: object(),
+    )
 
     agent = AIAgent(
         model="gpt-5.5",
@@ -54,6 +59,14 @@ def _make_codex_agent(tmp_path, monkeypatch):
     monkeypatch.setattr(
         agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 60.0
     )
+    return agent
+
+
+def _make_local_codex_agent(tmp_path, monkeypatch):
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    agent.model = "qwen3.8:27b"
+    agent.provider = "custom:local-ollama"
+    agent.base_url = "http://127.0.0.1:11434/v1"
     return agent
 
 
@@ -146,6 +159,92 @@ def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):
     resp = h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
     assert resp is sentinel
     assert "codex_ttfb_kill" not in closes
+
+
+def test_local_codex_ttfb_uses_local_stale_ceiling_when_not_explicit(
+    tmp_path, monkeypatch
+):
+    """Local Codex-compatible providers get the local prefill ceiling, not 120s."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_local_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.delenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.setattr(h, "_local_stream_stale_timeout_default", lambda: 2.0)
+    real_env_float = h._env_float
+    monkeypatch.setattr(
+        h,
+        "_env_float",
+        lambda name, default: 0.4
+        if name == "HERMES_CODEX_TTFB_TIMEOUT_SECONDS"
+        else real_env_float(name, default),
+    )
+
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    sentinel = SimpleNamespace(ok=True)
+
+    def fake_local_prefill(api_kwargs, client=None, on_first_delta=None):
+        time.sleep(0.7)
+        return sentinel
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_local_prefill)
+
+    resp = h.interruptible_api_call(agent, {"model": "qwen3.8:27b", "input": "hi"})
+
+    assert resp is sentinel
+    assert "codex_ttfb_kill" not in closes
+
+
+def test_local_codex_ttfb_honors_explicit_cutoff(tmp_path, monkeypatch):
+    """Explicit TTFB tuning remains an opt-in kill threshold on local endpoints."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_local_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.4")
+    monkeypatch.setattr(h, "_local_stream_stale_timeout_default", lambda: 2.0)
+
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    stop = {"flag": False}
+
+    def fake_hang(api_kwargs, client=None, on_first_delta=None):
+        deadline = time.time() + 30
+        while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
+            time.sleep(0.02)
+        raise RuntimeError("connection closed")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_hang)
+
+    try:
+        with pytest.raises(TimeoutError):
+            h.interruptible_api_call(agent, {"model": "qwen3.8:27b", "input": "hi"})
+        assert "codex_ttfb_kill" in closes
+    finally:
+        stop["flag"] = True
 
 
 

--- a/tests/agent/test_run_budget.py
+++ b/tests/agent/test_run_budget.py
@@ -42,6 +42,11 @@ def _make_agent(tmp_path, monkeypatch, config_body: str = "", **overrides):
     _write_config(tmp_path, config_body)
 
     from run_agent import AIAgent
+    monkeypatch.setattr(
+        AIAgent,
+        "_create_openai_client",
+        lambda self, *args, **kwargs: object(),
+    )
     kwargs = dict(
         model="gpt-5.5",
         provider="openai",
@@ -131,9 +136,10 @@ def test_active_budget_caps_implicit_reasoning_floor(monkeypatch, tmp_path):
         model="deepseek/deepseek-v4-pro",
         run_budget_seconds=900,
     )
-    # Sanity: implicit reasoning floor is 600s without a running clock.
+    # Sanity: reasoning floor is implicit user config (not explicit), so local
+    # endpoints can still disable the detector unless the user opts in.
     base, implicit = agent._resolved_api_call_stale_timeout_base()
-    assert base == 600.0 and implicit is False
+    assert base == 600.0 and implicit is True
 
     agent._run_budget_started_at = time.time() - 800
     assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 60.0
@@ -195,6 +201,22 @@ def test_budget_without_started_clock_is_inert(monkeypatch, tmp_path):
     )
     agent._run_budget_started_at = None
     assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == 600.0
+
+
+def test_local_reasoning_model_disables_implicit_stale_timeout(monkeypatch, tmp_path):
+    """Local reasoning-model prefill must not be killed by cloud timeout floors."""
+    import run_agent
+
+    monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *a, **k: None)
+    agent = _make_agent(
+        tmp_path,
+        monkeypatch,
+        model="qwen3.8:27b",
+        provider="custom:local-ollama",
+        base_url="http://127.0.0.1:11434/v1",
+    )
+
+    assert agent._compute_non_stream_stale_timeout({"input": "hi"}) == float("inf")
 
 
 # ── wrap-up injection one-time-ness ────────────────────────────────────────


### PR DESCRIPTION
Summary
Local reasoning models served through loopback/private endpoints could still trip Hermes' cloud-oriented stale watchdogs during long prefill: reasoning-model floors were treated as non-local-explicit stale timeouts, and Codex-compatible local providers inherited the 120s no-byte TTFB cutoff. This PR keeps explicit user timeout overrides intact while letting implicit local timeouts use the local-provider stale ceiling instead of killing healthy local prefill.

Changes
agent/chat_completion_helpers.py: centralizes local stream stale ceiling lookup and uses it to scale local Codex no-byte TTFB when HERMES_CODEX_TTFB_TIMEOUT_SECONDS is not explicitly set.
run_agent.py: treats reasoning-model stale floors as implicit so local endpoints still disable the non-stream stale detector unless the user explicitly opts in.
tests/agent/test_codex_ttfb_watchdog.py: adds local Codex TTFB regression coverage and preserves explicit cutoff behavior.
tests/agent/test_run_budget.py: adds local reasoning-model non-stream stale coverage and stubs the OpenAI client factory for this SDK-less test environment.

How to Test
python -m pytest tests/agent/test_codex_ttfb_watchdog.py tests/agent/test_run_budget.py -q
# ✅ 39/39 passed
ruff check .
# ✅ passed
python scripts/check-windows-footguns.py --diff upstream/main
# ✅ passed

Full suite note: scripts/run_tests.sh was attempted in Termux and failed at the runner/environment layer with 3181 PermissionError/permission-denied patterns before meaningful test execution, matching the known Termux sandbox failure mode.

Checklist
- [x] Tests pass — 39/39 targeted
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

Risk & Impact
Low. The change only relaxes implicit watchdogs for detected local endpoints; explicit user/provider/env timeouts still win.
Type: Bug fix
Closes: #92302
