### PR TITLE
fix(tools): sanitize task ids used as sandbox path components

### DIFF
--- a/tests/tools/test_sandbox_task_id_paths.py
+++ b/tests/tools/test_sandbox_task_id_paths.py
@@ -1,0 +1,54 @@
+"""Sanitized task-id path components for sandbox storage (#92271).
+
+Session-scoped container ids look like ``session:<key>`` and are used as
+directory names under the sandbox root. Windows forbids ``:`` in path
+segments, so the raw id made every persistent Docker/Singularity backend
+crash with ``NotADirectoryError (WinError 267)``.
+"""
+
+import os
+
+import pytest
+
+from tools.environments.base import sanitize_task_id_for_path
+
+
+def test_session_scoped_task_id_loses_colon():
+    safe = sanitize_task_id_for_path("session:20260822_210946_71d78a")
+    assert ":" not in safe
+    assert safe == "session-20260822_210946_71d78a"
+
+
+def test_plain_task_ids_pass_through_unchanged():
+    assert sanitize_task_id_for_path("default") == "default"
+    assert sanitize_task_id_for_path("rl-bench-42") == "rl-bench-42"
+
+
+def test_all_windows_forbidden_characters_replaced():
+    raw = 'a<b>c:"d/e\\f|g?h*i'
+    safe = sanitize_task_id_for_path(raw)
+    assert not set('<>:"/\\|?*') & set(safe)
+
+
+def test_whitespace_only_id_falls_back_to_default():
+    assert sanitize_task_id_for_path("   ") == "default"
+
+
+def test_sanitized_dir_is_creatable(tmp_path):
+    target = tmp_path / "docker" / sanitize_task_id_for_path(
+        "session:20260822_210946_71d78a"
+    )
+    target.mkdir(parents=True)
+    assert target.is_dir()
+
+
+@pytest.mark.parametrize("backend_dir", ["docker", "hermes-overlays"])
+def test_persistent_layout_uses_sanitized_names(backend_dir, tmp_path, monkeypatch):
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(tmp_path))
+    from tools.environments.base import get_sandbox_dir
+
+    raw_id = "session:20260822_210946_71d78a"
+    target = get_sandbox_dir() / backend_dir / sanitize_task_id_for_path(raw_id)
+    target.mkdir(parents=True)
+    assert target.is_dir()
+    assert ":" not in str(target.relative_to(tmp_path))

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -294,6 +294,21 @@ def get_sandbox_dir() -> Path:
     return p
 
 
+def sanitize_task_id_for_path(task_id: str) -> str:
+    """Return *task_id* reduced to a safe single filesystem path component.
+
+    Session-scoped container ids carry a scheme prefix with a colon (e.g.
+    ``session:<key>`` from terminal_tool._resolve_container_task_id). Windows
+    forbids ``:`` (plus ``< > " / \\ | ? *`` and control characters) inside
+    path segments, so using the raw id as a directory name makes every
+    ``os.makedirs()`` on the sandbox dir fail with WinError 267. Characters
+    are replaced unconditionally — not just on win32 — so the same task id
+    resolves to the same directory on every host.
+    """
+    cleaned = re.sub(r'[<>:"/\\|?*\x00-\x1f]', "-", task_id.strip())
+    return cleaned or "default"
+
+
 # ---------------------------------------------------------------------------
 # Shared constants and utilities
 # ---------------------------------------------------------------------------

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -947,7 +947,10 @@ class DockerEnvironment(BaseEnvironment):
         # Persistent workspace via bind mounts from a configurable host directory
         # (TERMINAL_SANDBOX_DIR, default ~/.hermes/sandboxes/). Non-persistent
         # mode uses tmpfs (ephemeral, fast, gone on cleanup).
-        from tools.environments.base import get_sandbox_dir
+        from tools.environments.base import (
+            get_sandbox_dir,
+            sanitize_task_id_for_path,
+        )
 
         # User-configured volume mounts (from config.yaml docker_volumes)
         volume_args = []
@@ -980,7 +983,7 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            sandbox = get_sandbox_dir() / "docker" / sanitize_task_id_for_path(task_id)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -189,9 +189,11 @@ class SingularityEnvironment(BaseEnvironment):
         self._memory = memory
 
         if self._persistent:
+            from tools.environments.base import sanitize_task_id_for_path
+
             overlay_base = _get_scratch_dir() / "hermes-overlays"
             overlay_base.mkdir(parents=True, exist_ok=True)
-            self._overlay_dir = overlay_base / f"overlay-{task_id}"
+            self._overlay_dir = overlay_base / f"overlay-{sanitize_task_id_for_path(task_id)}"
             self._overlay_dir.mkdir(parents=True, exist_ok=True)
 
         self._start_instance()


### PR DESCRIPTION
Fixes #92271

## What & why

Session-scoped container ids produced by `_resolve_container_task_id()` look like `session:<key>` (e.g. `session:20260822_210946_71d78a`). On a native Windows host with a persistent container backend, that raw id is used verbatim as a directory name:

- `tools/environments/docker.py` — `get_sandbox_dir() / "docker" / task_id`
- `tools/environments/singularity.py` — `overlay_base / f"overlay-{task_id}"`

Windows forbids `:` in path segments, so `os.makedirs()` fails on every tool call: `NotADirectoryError: [WinError 267] ...sandboxes\docker\session:<key>`.

This adds `sanitize_task_id_for_path()` to `tools/environments/base.py`, which replaces the Windows-forbidden characters (`< > : " / \ | ? *` + control chars) with `-`, and applies it at both path-construction sites. Replacement is unconditional (not gated on `win32`) so the same task id resolves to the same sandbox directory on every host. Container/label naming is untouched — this only affects on-disk paths.

## How to test

```
scripts/run_tests.sh tests/tools/test_sandbox_task_id_paths.py -q
```

New tests assert:
- `session:<key>` ids are sanitized (`:` removed), plain ids pass through unchanged
- all Windows-forbidden characters are replaced
- the sanitized name is actually creatable as a directory
- both persistent layouts (Docker `docker/<id>`, Singularity `hermes-overlays/overlay-<id>`) produce colon-free paths under `TERMINAL_SANDBOX_DIR`

Repro of the original crash on Windows before the fix: set `terminal.backend: docker`, send any message from a session-keyed surface (gateway/WebUI) → every terminal tool call raises WinError 267; after the fix the sandbox dir `sandboxes/docker/session-<key>` is created and the call succeeds.

## Platforms tested

- Native Windows 11 (Python 3.12): new tests pass; existing `tests/tools/test_docker_environment.py` shows no new failures vs clean `HEAD`.
- The sanitization itself is host-independent (pure function), covered by host-independent tests.
