### PR TITLE
fix(tui): capitalize Shift+letter decoded from CSI-u and modifyOtherKeys

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts
@@ -63,3 +63,40 @@ describe('enhanced keyboard modifier parsing', () => {
     expect(right.key.super).toBe(true)
   })
 })
+
+describe('shifted letter decoding under enhanced keyboard reporting', () => {
+  // Terminals with modifyOtherKeys level 2 active (Ghostty since #23350's
+  // push was dropped for it, WezTerm, tmux, VS Code) re-encode EVERY
+  // Shift+letter as an escape sequence — some with the resulting (shifted)
+  // codepoint, some with the base key. The composer inserts `event.input`,
+  // so a lowercase reconstruction here silently disables capitalization.
+  it.each([
+    ['kitty CSI-u, unshifted codepoint', '\u001b[97;2u'],
+    ['kitty CSI-u, shifted codepoint', '\u001b[65;2u'],
+    ['xterm modifyOtherKeys, unshifted keycode', '\u001b[27;2;97~'],
+    ['xterm modifyOtherKeys, shifted keycode', '\u001b[27;2;65~']
+  ])('capitalizes %s (%j)', (_label, sequence) => {
+    const parsed = parseOne(sequence)
+    const event = new InputEvent(parsed)
+
+    expect(parsed.name).toBe('A')
+    expect(event.input).toBe('A')
+    expect(event.key.shift).toBe(true)
+    expect(event.key.ctrl).toBe(false)
+  })
+
+  it('keeps unmodified letters lowercase across protocols', () => {
+    expect(new InputEvent(parseOne('\u001b[97u')).input).toBe('a')
+    expect(new InputEvent(parseOne('a')).input).toBe('a')
+  })
+
+  it('keeps ctrl+shift+letter a lowercase control chord, not text', () => {
+    const parsed = parseOne('\u001b[100;6u')
+    const event = new InputEvent(parsed)
+
+    expect(parsed.name).toBe('d')
+    expect(event.key.ctrl).toBe(true)
+    expect(event.key.shift).toBe(true)
+    expect(event.input).toBe('d')
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -532,8 +532,21 @@ function decodeModifier(modifier: number): {
  *
  * Numpad codepoints are from Unicode Private Use Area, defined at:
  * https://sw.kovidgoyal.net/kitty/keyboard-protocol/#functional-key-definitions
+ *
+ * ``shift`` uppercases printable ASCII letters because these branches
+ * RECONSTRUCT typed text from the returned name (input-event.ts builds
+ * ``input`` from ``name``, not from the raw bytes). Terminals disagree on
+ * which codepoint they report — kitty-style CSI-u sends the base key
+ * (Shift+A ⇒ ESC[97;2u), xterm modifyOtherKeys usually the shifted result
+ * (ESC[27;2;65~) but not everywhere — so the shift modifier is the only
+ * reliable case signal. Dropping it here silently disables capitalization
+ * whenever a terminal re-encodes Shift+letter (Ghostty/WezTerm/tmux/VS Code
+ * under modifyOtherKeys level 2; mirrors #87390 on the classic CLI).
+ * Control chords keep the lowercase name: callers match readline/Ctrl
+ * chords against ``ch.toLowerCase()``, and input-event.ts only rebuilds
+ * printable text from ``name`` when ctrl is clear.
  */
-function keycodeToName(keycode: number): string | undefined {
+function keycodeToName(keycode: number, shift = false): string | undefined {
   switch (keycode) {
     case 9:
       return 'tab'
@@ -605,7 +618,19 @@ function keycodeToName(keycode: number): string | undefined {
     default:
       // Printable ASCII characters
       if (keycode >= 32 && keycode <= 126) {
-        return String.fromCharCode(keycode).toLowerCase()
+        const ch = String.fromCharCode(keycode)
+
+        // Terminals disagree on WHICH codepoint Shift+letter reports:
+        // kitty-style CSI-u sends the base key (Shift+A ⇒ 97) while xterm
+        // modifyOtherKeys sends the shifted result (⇒ 65). With the shift
+        // bit set, capitalize a lowercase report and preserve an already-
+        // uppercase one; without it, keep the historical lowercase name.
+        // Non-letters pass through unchanged in both branches.
+        if (shift) {
+          return ch >= 'a' && ch <= 'z' ? ch.toUpperCase() : ch
+        }
+
+        return ch.toLowerCase()
       }
 
       return undefined
@@ -716,7 +741,11 @@ function parseKeypress(s: string = ''): ParsedKey {
     // Modifier defaults to 1 (no modifiers) when not present
     const modifier = match[2] ? parseInt(match[2], 10) : 1
     const mods = decodeModifier(modifier)
-    const name = keycodeToName(codepoint)
+    // Pass the shift bit so Shift+letter reconstructs as the capital —
+    // see keycodeToName for why the name carries the case. Control
+    // chords (ctrl+shift+<key>) keep the lowercase name because
+    // input-event.ts takes `input = name` verbatim when ctrl is set.
+    const name = keycodeToName(codepoint, mods.shift && !mods.ctrl)
 
     return {
       kind: 'key',
@@ -738,7 +767,8 @@ function parseKeypress(s: string = ''): ParsedKey {
   // would leave the tail as garbage if it partially matched.
   if ((match = MODIFY_OTHER_KEYS_RE.exec(s))) {
     const mods = decodeModifier(parseInt(match[1]!, 10))
-    const name = keycodeToName(parseInt(match[2]!, 10))
+    // Same shift-without-ctrl gating as the CSI-u branch above.
+    const name = keycodeToName(parseInt(match[2]!, 10), mods.shift && !mods.ctrl)
 
     return {
       kind: 'key',


### PR DESCRIPTION
## Problem

On terminals that re-encode modified keys, pressing **Shift+letter** in the TUI composer inserts a lowercase letter — capitalization silently stops working. As of this week this affects **every Ghostty user by default**, but the underlying gap breaks Shift+letter for any terminal/report-shape listed below.

### Root cause

Under enhanced key reporting, Shift+letter does not arrive as the literal byte `A`. It arrives as an escape sequence, and hermes-ink rebuilds typed text from the parsed key **name**, not the raw bytes: `InputEvent`'s `parseKey()` takes `input = keypress.name` when ctrl is clear (printable case), and `keycodeToName()` unconditionally lowercases printable ASCII while discarding the shift modifier. So every shape decodes lowercase:

| wire sequence | meaning | decoded today |
|---|---|---|
| `ESC[97;2u` | kitty CSI-u, base-key codepoint (kitty-style senders) | `a` |
| `ESC[65;2u` | kitty CSI-u, shifted codepoint | `a` |
| `ESC[27;2;65~` | xterm modifyOtherKeys, shifted keycode (Ghostty/WezTerm/xterm) | `a` |
| `ESC[27;2;97~` | modifyOtherKeys, unshifted keycode (some senders) | `a` |

### Why it just became a default-path regression

The Ink TUI pushes enhanced key reporting only for an allowlisted terminal set. For Ghostty, the kitty-protocol push was recently skipped (mirroring `cli.py`'s Ghostty exception — Ghostty's kitty disambiguate mode strips the Alt modifier from Backspace), leaving **xterm modifyOtherKeys level 2 as the only enhanced mode**. Under level 2 Ghostty re-encodes *every* Shift+letter, so what previously worked by accident (Ghostty answered the kitty push, where shifted letters arrive as plain uppercase text) now goes through the broken decoder.

The same decoder-level gap was reported on the classic CLI in #87390 / #87631 (non-Latin scripts still broken there). #37687 addresses the TUI side but patches the composer consumption point instead of the parser, which leaves any other consumer of parsed keys broken and will need re-touching per call site.

## Change

Fix where the information is lost — the parser:

- `keycodeToName(keycode, shift)`: with the shift bit set, promote a lowercase letter report to uppercase and preserve an already-uppercase report; without it, keep the historical lowercase name. Non-letters are untouched.
- Both enhanced-sequence call sites (CSI-u and modifyOtherKeys) pass `shift && !ctrl`, so control chords keep their canonical lowercase name — `input-event.ts` takes `input = name` verbatim when ctrl is set, and all chord matching downstream is case-folded, so no chord behavior changes.

Terminals disagree on which codepoint they report for Shift+letter, so the modifier bit is the only reliable case signal; handling it at the name level covers both conventions and every current and future consumer of `ParsedKey`.

## Tests

Added a describe block in `events/cmd-shortcuts.test.ts`, written first and confirmed failing before the fix:

- all four wire shapes above decode to `'A'` with `key.shift === true`
- unmodified letters stay lowercase across legacy text and CSI-u
- ctrl+shift+letter remains a lowercase control chord, not text

Validation on this branch (hermes-ink tree byte-identical to the checkout used):

- `vitest run` in `packages/hermes-ink`: green except a pre-existing, unrelated `ink-backpressure` failure that fails identically without this patch
- full `ui-tui` suite A/B: identical pre-existing failures with and without the change; +6 passing tests from this PR
- `tsc --noEmit` clean; eslint clean on touched files

## Risks

Low. Behavior changes only for events carrying shift-without-ctrl on a printable letter — exactly the events that previously produced wrong text. If #37687 also lands, its composer-side guard becomes redundant but harmless (uppercasing an already-uppercase character is idempotent).

Related: #87390, #87631, #37687, #87637
