### PR TITLE
fix(matrix): pass origin_server_ts to MessageEvent timestamp

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -62,6 +62,7 @@ import shutil
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from dataclasses import dataclass, field
 
@@ -3504,6 +3505,14 @@ class MatrixAdapter(BasePlatformAdapter):
             # top-level fields. Mirror them so matrix matches signal/slack.
             user_id=sender,
             user_name=display_name,
+            # Pass the Matrix origin_server_ts (seconds) as the event
+            # timestamp so downstream consumers (session persistence,
+            # cron feedback bridges, debugging) see when the user
+            # actually sent the message — not when the adapter processed
+            # it.  Without this, MessageEvent falls back to
+            # datetime.now() at construction, losing the original
+            # server-side timestamp.
+            timestamp=datetime.fromtimestamp(event_ts, tz=timezone.utc) if event_ts else datetime.now(tz=timezone.utc),
         )
 
         if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
@@ -3735,6 +3744,9 @@ class MatrixAdapter(BasePlatformAdapter):
             reply_to_author_name=reply_to_author_name,
             user_id=sender,
             user_name=display_name,
+            # Pass the Matrix origin_server_ts (seconds) as the event
+            # timestamp — see _handle_text_message for rationale.
+            timestamp=datetime.fromtimestamp(event_ts, tz=timezone.utc) if event_ts else datetime.now(tz=timezone.utc),
         )
 
         await self.handle_message(msg_event)

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -471,7 +471,7 @@ class TestMatrixBangCommandAlias:
         self.adapter._background_read_receipt = MagicMock()
         self.adapter._text_batch_delay_seconds = 0
 
-    async def _dispatch_text(self, body: str, *, is_dm: bool = True):
+    async def _dispatch_text(self, body: str, *, is_dm: bool = True, event_ts: float = 0.0):
         captured_event = None
         self.adapter._is_dm_room = AsyncMock(return_value=is_dm)
         self.adapter._require_mention = True
@@ -486,7 +486,7 @@ class TestMatrixBangCommandAlias:
             room_id="!room:example.org",
             sender="@alice:example.org",
             event_id="$matrix-command-test",
-            event_ts=0.0,
+            event_ts=event_ts,
             source_content={"msgtype": "m.text", "body": body},
             relates_to={},
         )
@@ -577,6 +577,42 @@ class TestMatrixBangCommandAlias:
         assert captured_event is not None
         assert captured_event.text == "/model"
         assert captured_event.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_text_message_preserves_event_ts_as_timestamp(self):
+        """The Matrix adapter must pass origin_server_ts (event_ts) to the
+        MessageEvent timestamp field, not fall back to datetime.now().
+
+        Regression test: event_ts was available in _handle_text_message but
+        never passed to MessageEvent, so downstream consumers (session
+        persistence, cron feedback bridges) saw the adapter processing time
+        instead of when the user actually sent the message.
+        """
+        from datetime import datetime, timezone
+
+        # Use a fixed epoch: 2026-01-15 09:30:00 UTC = 1768481400.0
+        fixed_ts = 1768481400.0
+        expected_dt = datetime.fromtimestamp(fixed_ts, tz=timezone.utc)
+
+        captured_event = await self._dispatch_text(
+            "hello world", event_ts=fixed_ts
+        )
+
+        assert captured_event is not None
+        assert captured_event.timestamp == expected_dt
+
+    @pytest.mark.asyncio
+    async def test_text_message_falls_back_to_now_when_no_event_ts(self):
+        """When event_ts is 0.0 or falsy, the adapter should fall back to
+        datetime.now() rather than producing a 1970 epoch timestamp."""
+        captured_event = await self._dispatch_text(
+            "hello world", event_ts=0.0
+        )
+
+        assert captured_event is not None
+        # Should be a recent timestamp, not epoch
+        from datetime import datetime, timezone
+        assert captured_event.timestamp.year >= 2025
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #92400

The Matrix adapter receives `origin_server_ts` (as `event_ts` in seconds) from every incoming Matrix event, but **never passes it to the `MessageEvent` constructor** in either `_handle_text_message` or `_handle_media_message`. `MessageEvent.timestamp` falls back to `datetime.now()` — the adapter processing time, not the server-side send time.

## Impact

Downstream consumers that rely on `MessageEvent.timestamp` — session persistence, cron feedback bridges, debugging, any cross-platform feature that needs to know *when* the user sent a message — see the wrong timestamp. For users in different time zones or with delayed message processing, the drift can be significant.

Other adapters (Telegram, Discord, Signal, DingTalk, ntfy, SimpleX, Photon) all correctly pass the platform timestamp. Matrix is the only major adapter that drops it.

## Root cause

- `_handle_text_message` (~line 3491): `event_ts` is a function parameter but not passed to `MessageEvent(`
- `_handle_media_message` (~line 3724): same pattern

## Fix

Pass `event_ts` to `MessageEvent.timestamp`:
```python
timestamp=datetime.fromtimestamp(event_ts, tz=timezone.utc) if event_ts else datetime.now(tz=timezone.utc),
```

With `datetime.now()` fallback when `event_ts` is 0/falsy (matches Signal/Telegram behavior).

## Verification

```
tests/gateway/test_matrix.py::TestMatrixBangCommandAlias::test_text_message_preserves_event_ts_as_timestamp PASSED
tests/gateway/test_matrix.py::TestMatrixBangCommandAlias::test_text_message_falls_back_to_now_when_no_event_ts PASSED
```

## Files changed

- `plugins/platforms/matrix/adapter.py` — added `from datetime import datetime, timezone` import; pass `timestamp=` in both `MessageEvent(` constructor calls
- `tests/gateway/test_matrix.py` — two new tests + `_dispatch_text` helper now accepts `event_ts` parameter