### PR TITLE
fix(peer): reuse hidden canonical Bot Chat sessions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4203,11 +4203,13 @@ class APIServerAdapter(BasePlatformAdapter):
         offset = self._parse_nonnegative_int(request.query.get("offset"), default=0, maximum=1_000_000)
         source = request.query.get("source") or None
         include_children = _coerce_request_bool(request.query.get("include_children"), default=False)
+        include_hidden = _coerce_request_bool(request.query.get("include_hidden"), default=False)
         sessions = await asyncio.to_thread(db.list_sessions_rich,
             source=source,
             limit=limit,
             offset=offset,
             include_children=include_children,
+            include_hidden=include_hidden,
             order_by_last_active=True,
             # A pin means "always reachable", so a pinned conversation that has
             # aged past the recency window is back-filled rather than dropped.

--- a/hermes_cli/subcommands/peer.py
+++ b/hermes_cli/subcommands/peer.py
@@ -109,7 +109,7 @@ def _base_url(peer: dict, profile: str | None) -> str:
 
 def _find_bot_chat(base: str, key: str) -> str | None:
     """The remote canonical Bot Chat's session id, or None."""
-    listing = _request(f"{base}/api/sessions?limit=200", key)
+    listing = _request(f"{base}/api/sessions?limit=200&include_hidden=true", key)
     for session in listing.get("data") or []:
         if isinstance(session, dict) and (session.get("title") or "").strip() == BOT_CHAT_TITLE:
             return str(session.get("id") or "") or None

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -83,6 +83,34 @@ async def test_capabilities_advertises_session_control_surface(adapter):
 
 
 @pytest.mark.asyncio
+async def test_list_sessions_include_hidden_is_authenticated_opt_in(
+    auth_adapter, session_db
+):
+    visible_id = session_db.create_session("visible-session", "api_server")
+    hidden_id = session_db.create_session("hidden-bot-chat", "desktop")
+    assert session_db.set_session_hidden(hidden_id, True) is True
+
+    app = _create_session_app(auth_adapter)
+    headers = {"Authorization": "Bearer sk-test"}
+    async with TestClient(TestServer(app)) as cli:
+        default_resp = await cli.get("/api/sessions?limit=200", headers=headers)
+        assert default_resp.status == 200
+        default_payload = await default_resp.json()
+
+        hidden_resp = await cli.get(
+            "/api/sessions?limit=200&include_hidden=true", headers=headers
+        )
+        assert hidden_resp.status == 200
+        hidden_payload = await hidden_resp.json()
+
+    default_ids = {row["id"] for row in default_payload["data"]}
+    hidden_ids = {row["id"] for row in hidden_payload["data"]}
+    assert visible_id in default_ids
+    assert hidden_id not in default_ids
+    assert {visible_id, hidden_id} <= hidden_ids
+
+
+@pytest.mark.asyncio
 async def test_session_messages_default_to_latest_bounded_page(adapter, session_db):
     session_id = session_db.create_session("bounded-messages", "api_server")
     session_db.replace_messages(

--- a/tests/hermes_cli/test_peer_cmd.py
+++ b/tests/hermes_cli/test_peer_cmd.py
@@ -40,6 +40,31 @@ def test_base_url_bare_and_profile():
     assert peer_cmd._base_url(peer, "researcher") == "http://spark.lan:8377/p/researcher"
 
 
+def test_find_bot_chat_requests_hidden_and_reuses_canonical_session(monkeypatch):
+    requests = []
+
+    def fake_request(url, key, *, method="GET", body=None, timeout=peer_cmd.LIST_TIMEOUT_S):
+        requests.append((url, key, method, body, timeout))
+        assert url == "http://sp08/api/sessions?limit=200&include_hidden=true"
+        assert key == "peer-key"
+        assert method == "GET"
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": "20260822_085223_35c294",
+                    "title": "Bot Chat",
+                    "hidden": True,
+                }
+            ],
+        }
+
+    monkeypatch.setattr(peer_cmd, "_request", fake_request)
+
+    assert peer_cmd._ensure_bot_chat("http://sp08", "peer-key") == "20260822_085223_35c294"
+    assert len(requests) == 1
+
+
 # ── registry round-trip (isolated config) ────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- expose hidden sessions from `GET /api/sessions` only when an authenticated caller explicitly passes `include_hidden=true`
- make `hermes peer dm` request hidden sessions when resolving the remote canonical `Bot Chat`
- preserve the default session-list behavior and the canonical session's `hidden` metadata

## Problem

Bot Mode's canonical `Bot Chat` can be hidden from ordinary session listings. `hermes peer dm` previously searched only `GET /api/sessions?limit=200`, so it could miss the existing hidden session and attempt to create another `Bot Chat`. Title uniqueness then rejected the request with HTTP 400:

```text
Title already in use by session <session-id>
```

This blocked authenticated cross-gateway DMs even though the tunnel, API key, and canonical session were valid.

## Fix

The API session-list handler now forwards an opt-in `include_hidden` query flag to `SessionDB.list_sessions_rich`. The default remains `false`.

The peer client explicitly requests:

```text
/api/sessions?limit=200&include_hidden=true
```

It can therefore reuse the canonical hidden `Bot Chat` instead of trying to create a duplicate.

## Security

- `/api/sessions` remains protected by `API_SERVER_KEY` authentication.
- Hidden sessions remain excluded by default.
- Inclusion requires the explicit `include_hidden=true` query parameter.
- No credential handling or session metadata mutation was added.

## Tests

```text
141 passed, 53 pre-existing warnings in 27.62s
```

Covered suites:

- `tests/hermes_cli/test_peer_cmd.py`
- `tests/gateway/test_session_api.py`
- `tests/gateway/test_api_server.py`

Additional checks:

- `py_compile`: passed
- `git diff --check`: passed
- independent security/logic review: passed with no findings

## Live verification

Verified across two Windows Hermes hosts over an authenticated localhost SSH tunnel:

- health endpoint: HTTP 200
- authenticated models endpoint: HTTP 200
- `hermes peer dm` returned a reply from the remote host
- the existing canonical `Bot Chat` was reused
- session ID, title, source, and `hidden=True` metadata remained unchanged
