### PR TITLE
fix(bot-mode): stop message_agent leaking a temp file per DM

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30196,6 +30196,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         cleanup_video_cache,
     )
     from tools.tool_result_storage import cleanup_spillover_cache
+    from tools.bot_mode_dm import cleanup_bot_dm_cache
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -30215,6 +30216,7 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
         ("Video", cleanup_video_cache),
         ("Screenshot", cleanup_screenshot_cache),
         ("Spillover", cleanup_spillover_cache),
+        ("Bot DM", cleanup_bot_dm_cache),
     )
 
     logger.info("Gateway housekeeping started (interval=%ds)", interval)

--- a/tests/tools/test_bot_dm_payload_cache.py
+++ b/tests/tools/test_bot_dm_payload_cache.py
@@ -1,0 +1,89 @@
+"""DM payload files must be sweepable, not left in the OS temp dir.
+
+`message_agent` writes the message body to a file and hands the path to a
+*background* delivery, so it cannot be removed at the call site. Nothing
+reaped it either, so every agent-to-agent DM leaked one file for the life
+of the machine. `tools/tool_result_storage.py` states the convention this
+now follows: Hermes-owned payloads live under `$HERMES_HOME/cache/`
+"instead of littering the OS temp dir", where the housekeeping loop can
+prune them.
+"""
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from tools import bot_mode_dm
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+class TestLocation:
+    def test_payloads_land_in_the_sweepable_cache_dir(self, home):
+        path = Path(bot_mode_dm._write_dm_file("hello teammate"))
+
+        assert path.parent == home / "cache" / "bot-dm", (
+            f"payload written to {path.parent} — outside the swept cache dir, "
+            "so nothing will ever reap it"
+        )
+        assert path.read_text(encoding="utf-8") == "hello teammate"
+
+    def test_the_body_is_written_verbatim(self, home):
+        body = 'he said "ship it"; $(id) `id`\nsecond line\n'
+        path = Path(bot_mode_dm._write_dm_file(body))
+        assert path.read_text(encoding="utf-8") == body
+
+    def test_permissions_stay_owner_only(self, home):
+        path = Path(bot_mode_dm._write_dm_file("private"))
+        assert oct(path.stat().st_mode & 0o777) == "0o600"
+
+    def test_an_unusable_cache_dir_falls_back_instead_of_failing(self, home, monkeypatch):
+        """A read-only HERMES_HOME must degrade, never drop the DM."""
+        def _boom(*a, **k):
+            raise OSError("read-only")
+
+        monkeypatch.setattr(Path, "mkdir", _boom)
+        path = Path(bot_mode_dm._write_dm_file("still delivered"))
+        assert path.read_text(encoding="utf-8") == "still delivered"
+
+
+class TestCleanup:
+    def test_expired_payloads_are_removed(self, home):
+        old = Path(bot_mode_dm._write_dm_file("stale"))
+        fresh = Path(bot_mode_dm._write_dm_file("recent"))
+        past = time.time() - (bot_mode_dm.BOT_DM_MAX_AGE_HOURS + 1) * 3600
+        os.utime(old, (past, past))
+
+        removed = bot_mode_dm.cleanup_bot_dm_cache()
+
+        assert removed == 1
+        assert not old.exists()
+        assert fresh.exists(), "a payload still in flight was reaped"
+
+    def test_a_missing_dir_is_not_an_error(self, home):
+        assert bot_mode_dm.cleanup_bot_dm_cache() == 0
+
+    def test_cleanup_reports_how_many_it_removed(self, home):
+        past = time.time() - (bot_mode_dm.BOT_DM_MAX_AGE_HOURS + 1) * 3600
+        for _ in range(3):
+            p = Path(bot_mode_dm._write_dm_file("x"))
+            os.utime(p, (past, past))
+        assert bot_mode_dm.cleanup_bot_dm_cache() == 3
+
+    def test_the_once_per_process_prune_runs_at_most_once(self, home, monkeypatch):
+        """CLI-only installs never run gateway housekeeping."""
+        monkeypatch.setattr(bot_mode_dm, "_dm_pruned_once", False)
+        calls = []
+        monkeypatch.setattr(
+            bot_mode_dm, "cleanup_bot_dm_cache", lambda *a, **k: calls.append(1) or 0
+        )
+        bot_mode_dm._prune_bot_dm_once()
+        bot_mode_dm._prune_bot_dm_once()
+        assert len(calls) == 1
+

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -46,6 +46,7 @@ import os
 import re
 import shlex
 import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -310,9 +311,86 @@ def message_agent_tool(
     return _spawn_delivery(command, f"@{_handle(resolved)}", task_id=task_id, agent=agent)
 
 
+BOT_DM_SUBDIR = "cache/bot-dm"
+BOT_DM_MAX_AGE_HOURS = 6
+
+_dm_prune_lock = threading.Lock()
+_dm_pruned_once = False
+
+
+def get_bot_dm_dir() -> Path:
+    """Return ``$HERMES_HOME/cache/bot-dm`` as a Path (not created)."""
+    from hermes_constants import get_hermes_home
+
+    return Path(get_hermes_home()) / BOT_DM_SUBDIR
+
+
+def cleanup_bot_dm_cache(max_age_hours: int = BOT_DM_MAX_AGE_HOURS) -> int:
+    """Delete DM payload files older than *max_age_hours*.
+
+    Same contract as the other ``cleanup_*_cache`` helpers — returns the
+    number of files removed — so the gateway housekeeping loop can prune
+    this dir on the same hourly cadence as the media caches.
+    """
+    cutoff = time.time() - (max_age_hours * 3600)
+    removed = 0
+    try:
+        entries = list(get_bot_dm_dir().iterdir())
+    except OSError:
+        return 0
+    for f in entries:
+        try:
+            if f.is_file() and f.stat().st_mtime < cutoff:
+                f.unlink()
+                removed += 1
+        except OSError:
+            continue
+    return removed
+
+
+def _prune_bot_dm_once() -> None:
+    """Best-effort prune, at most once per process.
+
+    The gateway housekeeping loop prunes hourly, but a Bot Mode agent
+    driven from the CLI never runs it — without this, DM payloads would
+    accumulate forever on those installs.
+    """
+    global _dm_pruned_once
+    with _dm_prune_lock:
+        if _dm_pruned_once:
+            return
+        _dm_pruned_once = True
+    try:
+        removed = cleanup_bot_dm_cache()
+        if removed:
+            logger.debug("Pruned %d expired bot-DM payload(s)", removed)
+    except Exception as exc:  # noqa: BLE001 - never break a DM on cleanup
+        logger.debug("Bot-DM cache prune failed: %s", exc)
+
+
 def _write_dm_file(content: str) -> str:
-    """The message rides a temp file — never inline shell text."""
-    fd, path = tempfile.mkstemp(prefix="hermes-dm-", suffix=".txt", text=True)
+    """The message rides a file — never inline shell text.
+
+    Written under ``$HERMES_HOME/cache/bot-dm`` rather than the OS temp
+    dir: the delivery runs in the background, so the file has to outlive
+    this call and cannot be removed here, and nothing else was reaping it.
+    Keeping Hermes-owned payloads beside the other caches is what makes
+    them sweepable — the same reasoning ``tools/tool_result_storage.py``
+    gives for spillover.
+
+    Falls back to the OS temp dir if the cache dir cannot be created, so a
+    read-only or missing HERMES_HOME degrades to today's behavior instead
+    of failing the DM.
+    """
+    _prune_bot_dm_once()
+    try:
+        target_dir = get_bot_dm_dir()
+        target_dir.mkdir(parents=True, exist_ok=True)
+        fd, path = tempfile.mkstemp(
+            prefix="dm-", suffix=".txt", dir=str(target_dir), text=True
+        )
+    except OSError:
+        fd, path = tempfile.mkstemp(prefix="hermes-dm-", suffix=".txt", text=True)
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(content)
     return path


### PR DESCRIPTION
## The leak

`message_agent` (landed yesterday in `e26d91dc11`) writes the message body to a file and hands the path to `_spawn_delivery`, which runs the transport with `background=True`:

```python
def _write_dm_file(content: str) -> str:
    fd, path = tempfile.mkstemp(prefix="hermes-dm-", suffix=".txt", text=True)
    ...
    return path
```

Because the delivery is backgrounded, the file has to outlive the call and cannot be removed at the call site — and nothing else reaps it. `grep -rn "hermes-dm"` returns exactly one hit in the tree: the line that creates them.

So every agent-to-agent DM leaks one file, permanently, on a surface built for bots that message each other continuously.

Mode is `0600`, so this is accumulation rather than exposure. But on a container, or any host that does not clear its temp dir, it never stops growing.

## The fix follows a convention already in the tree

`tools/tool_result_storage.py` states it and owns the machinery:

> The canonical home is ALWAYS host-side: `$HERMES_HOME/cache/spillover/{tool_use_id}.txt` — **alongside the other Hermes-owned caches (images, audio, documents, ...) instead of littering the OS temp dir.**
> […] pruned two ways: the gateway housekeeping loop sweeps it hourly with the other media caches, and a once-per-process best-effort prune runs on the first spill so CLI-only installs (which never run gateway housekeeping) self-clean too.

DM payloads now do exactly that:

- `$HERMES_HOME/cache/bot-dm/`, beside `cache/spillover`, `cache/images`, `cache/audio`, …
- `cleanup_bot_dm_cache()` with the same `cleanup_*_cache` contract (returns the number removed)
- registered in `MEDIA_CACHE_CLEANUPS`, so the hourly loop prunes it with the rest
- the same once-per-process prune, because a Bot Mode agent driven from the CLI never runs gateway housekeeping

Retention is 6 hours — comfortably longer than any in-flight background delivery, short enough that payloads do not linger.

**Degradation:** if the cache dir cannot be created (read-only or missing `HERMES_HOME`), it falls back to the OS temp dir, so the DM is still delivered rather than dropped. That path is tested.

## Tests

Eight in `tests/tools/test_bot_dm_payload_cache.py`: payloads land in the swept dir, the body is written verbatim (quotes, `$(…)`, backticks, newlines), permissions stay `0600`, an unusable cache dir still delivers, expired payloads are removed while in-flight ones are not, a missing dir is not an error, the count is reported, and the once-per-process prune runs at most once.

Reverting `_write_dm_file` to the old body fails three of them.

No behavior change to delivery itself — the transports, quoting and roster validation are untouched.