### PR TITLE
feat(proxy): add OpenAI Codex subscription adapter

### DIFF
--- a/hermes_cli/proxy/adapters/__init__.py
+++ b/hermes_cli/proxy/adapters/__init__.py
@@ -9,12 +9,14 @@ from typing import Dict, Type
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter
 from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+from hermes_cli.proxy.adapters.openai_codex import OpenAICodexAdapter
 from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
 # Registry of available adapter classes keyed by provider name as used on
 # the ``hermes proxy start --provider <name>`` CLI flag.
 ADAPTERS: Dict[str, Type[UpstreamAdapter]] = {
     "nous": NousPortalAdapter,
+    "openai-codex": OpenAICodexAdapter,
     "xai": XAIGrokAdapter,
 }
 

--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -34,6 +34,9 @@ class UpstreamCredential:
     expires_at: Optional[str] = None
     """ISO-8601 expiry timestamp for the bearer, when known. Informational."""
 
+    headers: tuple[tuple[str, str], ...] = ()
+    """Provider-required outbound headers that override inbound values."""
+
 
 class UpstreamAdapter(ABC):
     """Contract for an upstream provider the proxy can forward to."""
@@ -47,6 +50,11 @@ class UpstreamAdapter(ABC):
     @abstractmethod
     def display_name(self) -> str:
         """Human-readable provider name for logs and ``proxy status``."""
+
+    @property
+    def health_contract(self) -> str:
+        """Machine-readable proof that this is a zero-agent pass-through."""
+        return "hermes-subscription-proxy-v1"
 
     @property
     @abstractmethod

--- a/hermes_cli/proxy/adapters/openai_codex.py
+++ b/hermes_cli/proxy/adapters/openai_codex.py
@@ -1,0 +1,90 @@
+"""OpenAI Codex subscription adapter using Hermes-managed ChatGPT OAuth."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import FrozenSet, Optional
+
+from agent.auxiliary_client import _codex_cloudflare_headers
+from hermes_cli.auth import get_codex_auth_status, resolve_codex_runtime_credentials
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_PATHS: FrozenSet[str] = frozenset({"/responses"})
+
+
+class OpenAICodexAdapter(UpstreamAdapter):
+    """Raw Responses proxy for an OpenAI Codex subscription."""
+
+    auth_hint = "hermes auth add openai-codex --type oauth"
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    @property
+    def name(self) -> str:
+        return "openai-codex"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenAI Codex"
+
+    @property
+    def health_contract(self) -> str:
+        return "hermes-codex-responses-v1"
+
+    @property
+    def allowed_paths(self) -> FrozenSet[str]:
+        return _ALLOWED_PATHS
+
+    def is_authenticated(self) -> bool:
+        try:
+            status = get_codex_auth_status()
+            return bool(status.get("logged_in") and not status.get("rate_limited"))
+        except Exception:
+            return False
+
+    def get_credential(self) -> UpstreamCredential:
+        return self._get_credential(force_refresh=False)
+
+    def get_retry_credential(
+        self,
+        *,
+        failed_credential: UpstreamCredential,
+        status_code: int,
+    ) -> Optional[UpstreamCredential]:
+        _ = failed_credential
+        if status_code != 401:
+            return None
+        logger.info("proxy: Codex upstream rejected bearer; refreshing once")
+        return self._get_credential(force_refresh=True)
+
+    def _get_credential(self, *, force_refresh: bool) -> UpstreamCredential:
+        with self._lock:
+            try:
+                resolved = resolve_codex_runtime_credentials(
+                    force_refresh=force_refresh
+                )
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Failed to resolve OpenAI Codex credentials: {exc}"
+                ) from exc
+
+            bearer = str(resolved.get("api_key") or "").strip()
+            base_url = str(resolved.get("base_url") or "").strip().rstrip("/")
+            if not bearer or not base_url:
+                raise RuntimeError(
+                    "OpenAI Codex authentication is unavailable. Run "
+                    "`hermes auth add openai-codex --type oauth` first."
+                )
+
+            return UpstreamCredential(
+                bearer=bearer,
+                base_url=base_url,
+                headers=tuple(_codex_cloudflare_headers(bearer).items()),
+            )
+
+
+__all__ = ["OpenAICodexAdapter"]

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
 from typing import Any
 
@@ -52,19 +53,36 @@ def cmd_proxy_start(args: Any) -> int:
 
     host = getattr(args, "host", None) or DEFAULT_HOST
     port = getattr(args, "port", None) or DEFAULT_PORT
+    auth_key_env = str(getattr(args, "auth_key_env", None) or "").strip()
+    inbound_bearer_key = (
+        os.environ.get(auth_key_env, "").strip() if auth_key_env else None
+    )
+    if auth_key_env and not inbound_bearer_key:
+        print(
+            f"Proxy inbound authentication variable {auth_key_env} is unset.",
+            file=sys.stderr,
+        )
+        return 2
 
     print(
         f"Starting Hermes proxy for {adapter.display_name}\n"
         f"  Listening on:  http://{host}:{port}/v1\n"
         f"  Forwarding to: (resolved per-request from your subscription)\n"
-        f"  Use any bearer token in the client — the proxy attaches your real credential.\n"
+        f"  Inbound auth:  {'bearer required' if inbound_bearer_key else 'any bearer accepted'}\n"
         f"\n"
         f"Press Ctrl+C to stop.",
         file=sys.stderr,
     )
 
     try:
-        asyncio.run(run_server(adapter, host=host, port=port))
+        asyncio.run(
+            run_server(
+                adapter,
+                host=host,
+                port=port,
+                inbound_bearer_key=inbound_bearer_key,
+            )
+        )
     except KeyboardInterrupt:
         print("\nproxy: stopped", file=sys.stderr)
     except OSError as exc:

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -12,6 +12,7 @@ or rewrite request/response bodies. It's a credential-attaching forwarder.
 from __future__ import annotations
 
 import asyncio
+import hmac
 import logging
 import signal
 from typing import Optional
@@ -85,7 +86,11 @@ def _filter_response_headers(headers) -> dict:
     return out
 
 
-def create_app(adapter: UpstreamAdapter) -> "web.Application":
+def create_app(
+    adapter: UpstreamAdapter,
+    *,
+    inbound_bearer_key: Optional[str] = None,
+) -> "web.Application":
     """Build the aiohttp application bound to a specific upstream adapter."""
     if not AIOHTTP_AVAILABLE:
         raise RuntimeError(
@@ -98,16 +103,31 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
     _adapter_key = web.AppKey("adapter", UpstreamAdapter)
     app[_adapter_key] = adapter
 
+    def _authorized(request: "web.Request") -> bool:
+        if not inbound_bearer_key:
+            return True
+        supplied = request.headers.get("Authorization", "")
+        return hmac.compare_digest(supplied, f"Bearer {inbound_bearer_key}")
+
     async def handle_health(request: "web.Request") -> "web.Response":
+        if not _authorized(request):
+            return _json_error(401, "unauthorized", code="proxy_unauthorized")
         return web.json_response(
             {
                 "status": "ok",
                 "upstream": adapter.display_name,
                 "authenticated": adapter.is_authenticated(),
+                "contract": adapter.health_contract,
+                "provider": adapter.name,
+                "agent": False,
+                "memory": False,
+                "tools_resolved": 0,
             }
         )
 
     async def handle_proxy(request: "web.Request") -> "web.StreamResponse":
+        if not _authorized(request):
+            return _json_error(401, "unauthorized", code="proxy_unauthorized")
         # Extract the path *after* /v1
         rel_path = request.match_info.get("tail", "")
         rel_path = "/" + rel_path.lstrip("/")
@@ -142,7 +162,10 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                 upstream_url = f"{upstream_url}?{request.query_string}"
 
             fwd_headers = _filter_request_headers(request.headers)
-            fwd_headers["Authorization"] = f"{active_cred.token_type} {active_cred.bearer}"
+            fwd_headers["Authorization"] = (
+                f"{active_cred.token_type} {active_cred.bearer}"
+            )
+            fwd_headers.update(dict(active_cred.headers))
 
             logger.debug(
                 "proxy: forwarding %s %s -> %s (body=%d bytes)",
@@ -248,6 +271,7 @@ async def run_server(
     host: str = DEFAULT_HOST,
     port: int = DEFAULT_PORT,
     shutdown_event: Optional[asyncio.Event] = None,
+    inbound_bearer_key: Optional[str] = None,
 ) -> None:
     """Run the proxy in the current event loop until shutdown_event is set.
 
@@ -258,7 +282,7 @@ async def run_server(
             "aiohttp is required for `hermes proxy`. Run `hermes setup` to install it."
         )
 
-    app = create_app(adapter)
+    app = create_app(adapter, inbound_bearer_key=inbound_bearer_key)
     runner = web.AppRunner(app, access_log=None)
     await runner.setup()
     site = web.TCPSite(runner, host=host, port=port)

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -319,8 +319,8 @@ def build_gateway_parser(
         description=(
             "Run a local HTTP server that forwards OpenAI-compatible requests "
             "to an OAuth-authenticated provider (e.g. Nous Portal). External "
-            "apps can point at the proxy with any bearer token; the proxy "
-            "attaches your real credentials."
+            "apps can point at the proxy; the proxy attaches your real "
+            "credentials without running the Hermes agent loop."
         ),
     )
     proxy_subparsers = proxy_parser.add_subparsers(dest="proxy_command")
@@ -331,7 +331,7 @@ def build_gateway_parser(
     proxy_start.add_argument(
         "--provider",
         default="nous",
-        help="Upstream provider: nous or xai (default: nous). See `hermes proxy providers`.",
+        help="Upstream provider (default: nous). See `hermes proxy providers`.",
     )
     proxy_start.add_argument(
         "--host",
@@ -343,6 +343,14 @@ def build_gateway_parser(
         type=int,
         default=None,
         help="Bind port (default: 8645)",
+    )
+    proxy_start.add_argument(
+        "--auth-key-env",
+        default=None,
+        help=(
+            "Require an inbound bearer read from this environment variable. "
+            "The value is never printed or stored by the proxy."
+        ),
     )
 
     proxy_subparsers.add_parser(

--- a/tests/hermes_cli/test_proxy_openai_codex.py
+++ b/tests/hermes_cli/test_proxy_openai_codex.py
@@ -1,0 +1,177 @@
+"""OpenAI Codex subscription-proxy behavior contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, FrozenSet
+
+import pytest
+
+from hermes_cli.proxy.adapters import ADAPTERS, get_adapter
+from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+from hermes_cli.proxy.adapters.openai_codex import OpenAICodexAdapter
+
+
+def test_registry_constructs_openai_codex_adapter() -> None:
+    assert ADAPTERS["openai-codex"] is OpenAICodexAdapter
+    assert isinstance(get_adapter("openai-codex"), OpenAICodexAdapter)
+
+
+def test_codex_adapter_reports_rate_limited_pool_as_unavailable(monkeypatch) -> None:
+    import hermes_cli.proxy.adapters.openai_codex as module
+
+    monkeypatch.setattr(
+        module,
+        "get_codex_auth_status",
+        lambda: {"logged_in": True, "rate_limited": True},
+    )
+    assert OpenAICodexAdapter().is_authenticated() is False
+
+
+def test_codex_adapter_adds_provider_headers_and_refreshes_once(monkeypatch) -> None:
+    import hermes_cli.proxy.adapters.openai_codex as module
+
+    refresh_calls: list[bool] = []
+    monkeypatch.setattr(module, "get_codex_auth_status", lambda: {"logged_in": True})
+
+    def resolve(*, force_refresh: bool):
+        refresh_calls.append(force_refresh)
+        return {
+            "api_key": "header.payload.signature",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+        }
+
+    monkeypatch.setattr(module, "resolve_codex_runtime_credentials", resolve)
+    adapter = OpenAICodexAdapter()
+
+    assert adapter.is_authenticated() is True
+    first = adapter.get_credential()
+    assert first.base_url == "https://chatgpt.com/backend-api/codex"
+    assert dict(first.headers)["originator"] == "codex_cli_rs"
+    retry = adapter.get_retry_credential(
+        failed_credential=first,
+        status_code=401,
+    )
+    assert retry is not None
+    assert refresh_calls == [False, True]
+    assert (
+        adapter.get_retry_credential(failed_credential=first, status_code=429) is None
+    )
+
+
+aiohttp = pytest.importorskip("aiohttp")
+from aiohttp import web  # noqa: E402
+
+from hermes_cli.proxy.server import create_app  # noqa: E402
+
+
+class _CodexLikeAdapter(UpstreamAdapter):
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url
+
+    @property
+    def name(self) -> str:
+        return "openai-codex"
+
+    @property
+    def display_name(self) -> str:
+        return "OpenAI Codex"
+
+    @property
+    def health_contract(self) -> str:
+        return "hermes-codex-responses-v1"
+
+    @property
+    def allowed_paths(self) -> FrozenSet[str]:
+        return frozenset({"/responses"})
+
+    def is_authenticated(self) -> bool:
+        return True
+
+    def get_credential(self) -> UpstreamCredential:
+        return UpstreamCredential(
+            bearer="upstream-secret",
+            base_url=self._base_url,
+            headers=(
+                ("originator", "codex_cli_rs"),
+                ("User-Agent", "codex_cli_rs/0.0.0 (Hermes Agent)"),
+            ),
+        )
+
+
+async def _start_runner(app: "web.Application"):
+    runner = web.AppRunner(app, access_log=None)
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+    sockets = list(site._server.sockets)  # type: ignore[union-attr]
+    return runner, f"http://127.0.0.1:{sockets[0].getsockname()[1]}"
+
+
+def test_authenticated_proxy_forwards_raw_responses_with_zero_agent_health() -> None:
+    async def run() -> None:
+        captured: dict[str, Any] = {}
+
+        async def responses(request: "web.Request") -> "web.Response":
+            captured["body"] = await request.read()
+            captured["authorization"] = request.headers.get("Authorization")
+            captured["originator"] = request.headers.get("originator")
+            return web.Response(
+                body=b'data: {"type":"response.completed"}\n\n',
+                headers={"Content-Type": "text/event-stream"},
+            )
+
+        upstream_app = web.Application()
+        upstream_app.router.add_post("/responses", responses)
+        upstream_runner, upstream_base = await _start_runner(upstream_app)
+        proxy_runner, proxy_base = await _start_runner(
+            create_app(
+                _CodexLikeAdapter(upstream_base),
+                inbound_bearer_key="local-secret",
+            )
+        )
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{proxy_base}/health") as rejected:
+                    assert rejected.status == 401
+
+                headers = {"Authorization": "Bearer local-secret"}
+                async with session.get(
+                    f"{proxy_base}/health", headers=headers
+                ) as health_response:
+                    health = await health_response.json()
+                assert health == {
+                    "status": "ok",
+                    "upstream": "OpenAI Codex",
+                    "authenticated": True,
+                    "contract": "hermes-codex-responses-v1",
+                    "provider": "openai-codex",
+                    "agent": False,
+                    "memory": False,
+                    "tools_resolved": 0,
+                }
+
+                raw_body = b'{"model":"gpt-test","stream":true}'
+                async with session.post(
+                    f"{proxy_base}/v1/responses",
+                    data=raw_body,
+                    headers={
+                        **headers,
+                        "originator": "untrusted-client-value",
+                        "Content-Type": "application/json",
+                    },
+                ) as response:
+                    streamed = await response.read()
+                assert response.status == 200
+                assert streamed.startswith(b"data:")
+
+            assert captured == {
+                "body": raw_body,
+                "authorization": "Bearer upstream-secret",
+                "originator": "codex_cli_rs",
+            }
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())

--- a/website/docs/user-guide/features/subscription-proxy.md
+++ b/website/docs/user-guide/features/subscription-proxy.md
@@ -18,7 +18,7 @@ This is different from the [API server](./api-server.md):
 |---|---|---|
 | What it serves | Your agent (full toolset, memory, skills) | Raw model inference |
 | Use case | "Use Hermes as a chat backend" | "Use my Portal sub from another app" |
-| Auth | Your `API_SERVER_KEY` | Any bearer (proxy attaches the real one) |
+| Auth | Your `API_SERVER_KEY` | Any bearer by default; optional required bearer |
 | Tool calls | Yes — the agent runs tools | No — passthrough only |
 
 Use the API server when you want the **agent** as a backend. Use the
@@ -46,7 +46,7 @@ hermes proxy start
 Starting Hermes proxy for Nous Portal
   Listening on:  http://127.0.0.1:8645/v1
   Forwarding to: (resolved per-request from your subscription)
-  Use any bearer token in the client — the proxy attaches your real credential.
+  Inbound auth:  any bearer accepted
 ```
 
 Leave this running in the foreground. Use `tmux`, `nohup`, or a systemd
@@ -72,7 +72,8 @@ automatically when the bearer approaches expiry.
 hermes proxy providers
 ```
 
-Currently shipped: `nous` (Nous Portal) and `xai` (xAI / Grok). More
+Currently shipped: `nous` (Nous Portal), `openai-codex` (OpenAI Codex), and
+`xai` (xAI / Grok). More
 OAuth providers can be added by implementing the `UpstreamAdapter`
 interface in `hermes_cli/proxy/adapters/`.
 
@@ -95,7 +96,10 @@ happens if you signed out from the Portal web UI) — just re-run
 
 ## Allowed paths
 
-The proxy only forwards paths the upstream actually serves. For Nous
+The proxy only forwards paths the upstream actually serves. OpenAI Codex
+forwards raw `/v1/responses` requests only; it adds the first-party provider
+headers required by the subscription endpoint but does not add Hermes agent
+instructions, tools, memory, sessions, or an agent loop. For Nous
 Portal:
 
 | Path | Purpose |
@@ -161,6 +165,19 @@ OpenAI-compatible client.
 
 ## Exposing on LAN
 
+By default the proxy binds `127.0.0.1` (localhost only). For local applications
+that need an authenticated listener, put a secret in an environment variable
+and name that variable on startup:
+
+```bash
+hermes proxy start --provider openai-codex --auth-key-env MY_PROXY_KEY
+```
+
+Both `/health` and `/v1/*` then require `Authorization: Bearer <value>`. The
+health response declares `agent: false`, `memory: false`, and
+`tools_resolved: 0`; the Codex adapter also reports contract
+`hermes-codex-responses-v1`.
+
 By default the proxy binds `127.0.0.1` (localhost only). To let other
 machines on your network use it:
 
@@ -168,10 +185,9 @@ machines on your network use it:
 hermes proxy start --host 0.0.0.0 --port 8645
 ```
 
-⚠ **Be aware:** anyone on your network can now use your Portal
-subscription. The proxy has no auth of its own — it accepts any bearer.
-Use a firewall, VPN, or reverse proxy with proper auth if you expose
-this beyond your trusted network.
+⚠ **Be aware:** without `--auth-key-env`, anyone on your network can use your
+subscription. Require an inbound bearer and also use a firewall or VPN when
+exposing the listener beyond localhost.
 
 ## Rate limits
 
@@ -184,7 +200,7 @@ subscription quota. Monitor usage at
 
 The proxy is intentionally minimal. Per request:
 
-1. Receive `POST /v1/chat/completions` from your app
+1. Receive an adapter-allowed `/v1/*` request from your app
 2. Look up the adapter's current credential (refresh if expiring)
 3. Forward the request body verbatim, with `Authorization: Bearer <minted-key>`
 4. Stream the response back unchanged (SSE preserved)


### PR DESCRIPTION
## Summary

- add an `openai-codex` subscription-proxy adapter backed by Hermes-managed Codex OAuth
- forward raw `/v1/responses` requests with the provider-required Codex headers and one 401 credential refresh
- add optional inbound bearer authentication and an explicit zero-agent, zero-memory, zero-tools health contract
- document the adapter and authenticated loopback usage

## Why

The regular Hermes API server adds the agent prompt, tools, memory, and loop. Raw narrative consumers need the subscription authentication without that large agent context. Keeping this in `hermes proxy` also avoids downstream patches being overwritten on every Hermes update.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_proxy_openai_codex.py` (4 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_proxy.py` (4 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_subcommands_profile_gateway.py` (2 passed)
- `ruff check hermes_cli/proxy hermes_cli/subcommands/gateway.py tests/hermes_cli/test_proxy_openai_codex.py`
- `git diff --check`