### PR TITLE
fix(update): bound the update prompts so an unattended run cannot hang

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -31,6 +31,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
 import time as _time
 from datetime import datetime
 from pathlib import Path
@@ -1987,6 +1988,126 @@ def _park_stashed_changes(stash_ref: str) -> None:
     print(f"  Restore manually with: git stash apply {stash_ref}")
 
 
+# How long an update prompt waits for an answer before taking its documented
+# default. Bounding these is the only portable answer to #92303: an unanswered
+# prompt is not the same thing as a closed stdin, and this module has no way to
+# tell the two apart up front.
+#
+# A Windows Scheduled Task launched with `-WindowStyle Hidden` gets a REAL
+# console. `sys.stdin.isatty()` is True, so every isatty-based guard here
+# (including `_non_interactive_update`) classifies it as interactive, and the
+# handle is open, so `input()` never raises EOFError either. It simply blocks
+# until something external kills the process: the report has a 44 minute hang
+# ending in exit code 0x40010004.
+#
+# Five minutes is chosen to be far longer than a human reading a four line
+# prompt and far shorter than "forever". It is a judgement call, not a derived
+# number; see the PR for the alternatives.
+_UPDATE_PROMPT_TIMEOUT_SECONDS = 300.0
+
+# Latched by the first prompt that goes unanswered. This is PROOF that nobody is
+# at the keyboard, as opposed to the inference every isatty check makes, so
+# later prompts in the same run can stop asking.
+#
+# It also closes a hazard the timeout would otherwise open: the reader thread
+# for a timed-out prompt is still parked on `input()`, so without the latch a
+# later prompt could arm a second reader and have its answer swallowed by the
+# first one.
+_prompt_proven_unattended = False
+
+
+def _reset_prompt_interactivity() -> None:
+    """Clear the unattended latch.
+
+    Called at the top of ``_cmd_update_impl`` so the latch scopes to one update
+    rather than to the interpreter.
+    """
+    global _prompt_proven_unattended
+    _prompt_proven_unattended = False
+
+
+def _read_line_with_timeout(
+    default: str,
+    timeout: Optional[float] = None,
+    read_fn=None,
+) -> tuple[str, bool]:
+    """Read one line from stdin, giving up after ``timeout`` seconds.
+
+    Returns ``(response, timed_out)``. On timeout the caller gets ``default``
+    and the unattended latch is set, so this is the detection as well as the
+    mitigation.
+
+    ``timeout <= 0`` restores today's unbounded blocking read, which is what
+    makes the old behaviour reachable from a test rather than only from a
+    revert.
+    """
+    global _prompt_proven_unattended
+
+    if read_fn is None:
+        read_fn = input
+    if timeout is None:
+        timeout = _UPDATE_PROMPT_TIMEOUT_SECONDS
+
+    if _prompt_proven_unattended:
+        # Already proven unattended by an earlier prompt this run. Do not ask,
+        # and in particular do not start a second reader on the same stdin.
+        return default, True
+
+    def _read() -> str:
+        try:
+            return read_fn()
+        except (EOFError, KeyboardInterrupt, UnicodeDecodeError):
+            # Callers already treat all three as "take the default"; keeping
+            # that here means the bounded path and the blocking path agree.
+            return default
+
+    if timeout <= 0:
+        return _read(), False
+
+    box: dict = {}
+
+    def _target() -> None:
+        try:
+            box["value"] = _read()
+        except Exception:
+            # A reader thread must never take the update down with it.
+            box["value"] = default
+
+    # daemon=True is load bearing: on timeout this thread stays blocked on
+    # stdin for the life of the process, and a non-daemon thread there would
+    # stop the interpreter from ever exiting, turning a bounded prompt back
+    # into the hang it was meant to fix.
+    thread = threading.Thread(
+        target=_target, name="hermes-update-prompt", daemon=True
+    )
+    thread.start()
+    thread.join(timeout)
+
+    if thread.is_alive():
+        _prompt_proven_unattended = True
+        return default, True
+    return box.get("value", default), False
+
+
+def _report_unanswered_prompt(what: str, consequence: str) -> None:
+    """Explain a timed-out prompt in the log an unattended run leaves behind.
+
+    Without this the scheduled-task transcript ends at a bare prompt line,
+    which is indistinguishable from a crash. #92303 asked for this even in the
+    do-nothing-else version of the fix.
+    """
+    print()
+    print(
+        "\u26a0 No answer to '%s' after %ds, so this run is being treated as "
+        "unattended." % (what, int(_UPDATE_PROMPT_TIMEOUT_SECONDS))
+    )
+    print("  %s" % consequence)
+    print(
+        "  Pass --yes (and --keep-stash where you want the stash left parked) "
+        "to skip these prompts in scripted runs."
+    )
+
+
 def _restore_stashed_changes(
     git_cmd: list[str],
     cwd: Path,
@@ -2005,15 +2126,19 @@ def _restore_stashed_changes(
         if input_fn is not None:
             response = input_fn("Restore local changes now? [Y/n]", "y")
         else:
-            try:
-                response = input().strip().lower()
-            except (EOFError, UnicodeDecodeError):
-                # Mirror the config-migration prompt's fix: don't let a
-                # terminal-encoding issue or a closed stdin crash the
-                # update mid-restore. Falls through to the existing
-                # skip-restore path below, which already explains how to
-                # restore manually from git stash.
-                response = "n"
+            # Bounded (#92303). The EOFError/UnicodeDecodeError handling
+            # this replaces now lives in _read_line_with_timeout, and the
+            # default is the same "n": fall through to the existing
+            # skip-restore path below, which already explains how to restore
+            # manually from git stash. That is also why a timeout here is
+            # safe: nothing is lost, the stash is still on disk.
+            response, timed_out = _read_line_with_timeout("n")
+            if timed_out:
+                _report_unanswered_prompt(
+                    "Restore local changes now?",
+                    "Not restoring. Your changes are preserved in git stash.",
+                )
+            response = (response or "").strip().lower()
         if response not in {"", "y", "yes"}:
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")
@@ -2296,13 +2421,28 @@ def _sync_with_upstream_if_needed(git_cmd: list[str], cwd: Path) -> None:
         print("ℹ Your fork is not tracking the official Hermes repository.")
         print("  This means you may miss updates from NousResearch/hermes-agent.")
         print()
-        try:
-            response = (
-                input("Add official repo as 'upstream' remote? [Y/n]: ").strip().lower()
+        # Bounded for the same reason as the stash prompt (#92303), and worth
+        # bounding even though that one is what got reported: this prompt runs
+        # EARLIER in the same update, so on a fork with no upstream remote an
+        # unattended run hangs here and never reaches the reported hang at all.
+        def _ask_upstream() -> str:
+            # Kept as its own reader so the exception path keeps the blank line
+            # it always printed, and the success path keeps NOT printing one.
+            # The helper would also default these to "n", but it cannot know
+            # about the spacing.
+            try:
+                return input("Add official repo as 'upstream' remote? [Y/n]: ")
+            except (EOFError, KeyboardInterrupt, UnicodeDecodeError):
+                print()
+                return "n"
+
+        response, timed_out = _read_line_with_timeout("n", read_fn=_ask_upstream)
+        if timed_out:
+            _report_unanswered_prompt(
+                "Add official repo as 'upstream' remote?",
+                "Not adding it. The update continues without upstream sync.",
             )
-        except (EOFError, KeyboardInterrupt, UnicodeDecodeError):
-            print()
-            response = "n"
+        response = (response or "").strip().lower()
 
         if response in {"", "y", "yes"}:
             print("→ Adding upstream remote...")
@@ -5485,6 +5625,10 @@ def _rebuild_desktop_after_update(
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
+    # The unattended latch (#92303) describes THIS run. Clearing it here keeps
+    # it per-invocation rather than per-process, so a long-lived interpreter
+    # that updates twice does not carry one run's silence into the next.
+    _reset_prompt_interactivity()
     # A managed-runtime refresh can replace site-packages before the normal
     # ``.[all]`` install runs. Snapshot while the old environment can still
     # prove which optional backends the user had activated.
@@ -6913,7 +7057,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     .strip()
                     .lower()
                 )
-            elif not (sys.stdin.isatty() and sys.stdout.isatty()):
+            elif _prompt_proven_unattended or not (
+                sys.stdin.isatty() and sys.stdout.isatty()
+            ):
+                # _prompt_proven_unattended (#92303): an earlier prompt in
+                # this run went unanswered, which is stronger evidence than
+                # isatty can give. Deliberately routed into this existing
+                # branch rather than given its own: the "auto" default and
+                # everything downstream of it are unchanged, so a better
+                # signal is all that is new here.
                 print("  ℹ Non-interactive session — applying safe config migrations.")
                 response = "auto"
             else:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2084,22 +2084,43 @@ def _read_line_with_timeout(
     thread.join(timeout)
 
     if thread.is_alive():
+        # The reader is abandoned here, not stopped. There is no portable way
+        # to cancel a thread parked on input(), and closing stdin under it
+        # would break the console for everything downstream, so it keeps its
+        # claim on stdin for the life of the process. A line typed after the
+        # timeout therefore races between this thread and any git subprocess
+        # that inherits the same handle.
+        #
+        # Accepted rather than fixed. The run has just produced evidence that
+        # nobody is typing, and the alternative (routing every later
+        # subprocess to DEVNULL on the strength of one timeout) would change
+        # how git behaves in a run that merely paused, which is a bigger
+        # claim than one unanswered prompt supports. Whoever comes back late
+        # gets the report below, which says the run stopped asking.
         _prompt_proven_unattended = True
         return default, True
     return box.get("value", default), False
 
 
-def _report_unanswered_prompt(what: str, consequence: str) -> None:
+def _report_unanswered_prompt(
+    what: str, consequence: str, timeout: Optional[float] = None
+) -> None:
     """Explain a timed-out prompt in the log an unattended run leaves behind.
 
     Without this the scheduled-task transcript ends at a bare prompt line,
     which is indistinguishable from a crash. #92303 asked for this even in the
     do-nothing-else version of the fix.
+
+    ``timeout`` resolves exactly as it does in ``_read_line_with_timeout``, so
+    a caller that overrides the bound for one prompt reports the number it
+    actually waited instead of the module default.
     """
+    if timeout is None:
+        timeout = _UPDATE_PROMPT_TIMEOUT_SECONDS
     print()
     print(
         "\u26a0 No answer to '%s' after %ds, so this run is being treated as "
-        "unattended." % (what, int(_UPDATE_PROMPT_TIMEOUT_SECONDS))
+        "unattended." % (what, int(timeout))
     )
     print("  %s" % consequence)
     print(

--- a/tests/hermes_cli/test_update_prompt_timeout.py
+++ b/tests/hermes_cli/test_update_prompt_timeout.py
@@ -1,0 +1,310 @@
+"""`hermes update` must not hang forever on a prompt nobody can answer (#92303).
+
+The reported shape is a Windows Scheduled Task launched with
+``-WindowStyle Hidden``. That process gets a **real** console, so
+``sys.stdin.isatty()`` is ``True`` and every isatty-based guard in
+``update_cmd`` classifies the run as interactive, and the handle is open, so
+``input()`` never raises ``EOFError`` either. It simply blocks. The report has a
+44 minute hang ending in exit code ``0x40010004``, an external kill rather than
+an exit.
+
+So the prompts are bounded instead of predicted. A prompt that goes unanswered
+takes its documented default, says so, and latches the run as unattended, which
+is a stronger signal than any isatty check can produce because it is an
+observation rather than an inference.
+
+Every test here pins one of three things:
+
+* the bound exists, and the default it takes is the safe one
+* the answered paths are **unchanged**, including the exception paths that
+  predate this fix
+* the latch, which is both the generalisation the reporter asked for and the
+  thing that stops a parked reader thread from stealing the next prompt's answer
+"""
+
+import threading
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+@pytest.fixture(autouse=True)
+def _clear_latch():
+    """The latch is module state, so a leaked one would silently pass tests."""
+    update_cmd._reset_prompt_interactivity()
+    yield
+    update_cmd._reset_prompt_interactivity()
+
+
+class _Blocker:
+    """A reader that never returns, like a hidden console nobody types into."""
+
+    def __init__(self):
+        self.released = threading.Event()
+        self.calls = 0
+
+    def __call__(self, *_args, **_kwargs):
+        # The stash prompt calls bare `input()`; the upstream prompt calls
+        # `input("Add official repo...")`. Same stub serves both.
+        self.calls += 1
+        self.released.wait(30)  # bounded so a broken test cannot wedge CI
+        return "y"
+
+    def release(self):
+        self.released.set()
+
+
+@pytest.fixture
+def blocker():
+    b = _Blocker()
+    try:
+        yield b
+    finally:
+        b.release()
+
+
+# ── the bound itself ───────────────────────────────────────────────────
+
+
+class TestBoundedRead:
+    def test_an_unanswerable_prompt_gives_up(self, blocker):
+        response, timed_out = update_cmd._read_line_with_timeout(
+            "n", timeout=0.05, read_fn=blocker
+        )
+
+        assert timed_out is True
+        assert response == "n", (
+            "the caller must get the documented default, not an empty string "
+            "that a downstream `in {'', 'y', 'yes'}` check would read as YES"
+        )
+
+    def test_an_answered_prompt_is_not_disturbed(self):
+        response, timed_out = update_cmd._read_line_with_timeout(
+            "n", timeout=5, read_fn=lambda: "  YeS  "
+        )
+
+        assert timed_out is False
+        assert response == "  YeS  ", (
+            "the helper must not normalise; callers still own .strip().lower()"
+        )
+
+    @pytest.mark.parametrize("boom", [EOFError, UnicodeDecodeError, KeyboardInterrupt])
+    def test_the_pre_existing_exception_paths_still_take_the_default(self, boom):
+        """These three were already handled before #92303 and must stay handled.
+
+        They are also not timeouts: a closed stdin answers immediately, so
+        latching the run unattended on them would be wrong.
+        """
+        if boom is UnicodeDecodeError:
+            exc = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte")
+        else:
+            exc = boom()
+
+        def _raise():
+            raise exc
+
+        response, timed_out = update_cmd._read_line_with_timeout(
+            "n", timeout=5, read_fn=_raise
+        )
+
+        assert response == "n"
+        assert timed_out is False
+        assert update_cmd._prompt_proven_unattended is False
+
+    def test_a_non_positive_timeout_restores_the_blocking_read(self):
+        """The escape hatch, so the old behaviour is reachable without a revert."""
+        response, timed_out = update_cmd._read_line_with_timeout(
+            "n", timeout=0, read_fn=lambda: "y"
+        )
+
+        assert (response, timed_out) == ("y", False)
+
+    def test_the_reader_thread_cannot_keep_the_process_alive(self, blocker):
+        """The fix must not become the bug.
+
+        On timeout the reader is still parked on stdin for the life of the
+        process. A non-daemon thread there would block interpreter shutdown,
+        which is the same unbounded wait wearing a different hat.
+        """
+        before = set(threading.enumerate())
+        update_cmd._read_line_with_timeout("n", timeout=0.05, read_fn=blocker)
+        leaked = [t for t in threading.enumerate() if t not in before]
+
+        assert leaked, "expected the parked reader to still be running"
+        assert all(t.daemon for t in leaked), (
+            f"reader thread must be a daemon; got {[(t.name, t.daemon) for t in leaked]}"
+        )
+
+
+# ── the latch ──────────────────────────────────────────────────────────
+
+
+class TestUnattendedLatch:
+    def test_a_timeout_proves_the_run_unattended(self, blocker):
+        assert update_cmd._prompt_proven_unattended is False
+        update_cmd._read_line_with_timeout("n", timeout=0.05, read_fn=blocker)
+        assert update_cmd._prompt_proven_unattended is True
+
+    def test_a_later_prompt_does_not_ask_again(self, blocker):
+        update_cmd._read_line_with_timeout("n", timeout=0.05, read_fn=blocker)
+        first_calls = blocker.calls
+
+        second = _Blocker()
+        try:
+            response, timed_out = update_cmd._read_line_with_timeout(
+                "n", timeout=30, read_fn=second
+            )
+        finally:
+            second.release()
+
+        assert (response, timed_out) == ("n", True)
+        assert second.calls == 0, (
+            "a second reader on the same stdin can have its answer swallowed by "
+            "the first, still-parked one; the latch exists to prevent that"
+        )
+        assert blocker.calls == first_calls
+        assert timed_out is True, "and it must return fast, not after 30s"
+
+    def test_an_answered_prompt_never_latches(self):
+        update_cmd._read_line_with_timeout("n", timeout=5, read_fn=lambda: "y")
+        assert update_cmd._prompt_proven_unattended is False
+
+
+# ── the reported call site ─────────────────────────────────────────────
+
+
+class TestStashRestorePrompt:
+    """`_restore_stashed_changes` is where the reporter's update actually hung."""
+
+    def test_the_reported_hang_now_ends(self, tmp_path, capsys, blocker, monkeypatch):
+        monkeypatch.setattr(update_cmd, "_UPDATE_PROMPT_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr("builtins.input", blocker)
+
+        result = update_cmd._restore_stashed_changes(
+            ["git"], tmp_path, "stash@{0}", prompt_user=True, input_fn=None,
+        )
+
+        assert result is False, (
+            "unanswered must mean skip-restore: it is the only default that "
+            "cannot lose work, since the stash stays on disk"
+        )
+        out = capsys.readouterr().out
+        assert "unattended" in out, (
+            f"an unattended log ending at a bare prompt is unreadable; got {out!r}"
+        )
+        assert "--yes" in out, "the log must say how to avoid the prompt next time"
+        assert "git stash apply stash@{0}" in out
+
+    def test_a_human_answering_yes_is_unaffected(self, tmp_path, monkeypatch):
+        """The guard must be invisible to everyone it was not built for."""
+        monkeypatch.setattr("builtins.input", lambda: "y")
+        calls = []
+        monkeypatch.setattr(
+            update_cmd.subprocess,
+            "run",
+            lambda *a, **kw: calls.append(a) or _ok(),
+        )
+
+        update_cmd._restore_stashed_changes(
+            ["git"], tmp_path, "stash@{0}", prompt_user=True, input_fn=None,
+        )
+
+        assert calls, "an answered 'y' must still reach `git stash apply`"
+
+    def test_a_human_answering_no_is_unaffected(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr("builtins.input", lambda: "n")
+
+        result = update_cmd._restore_stashed_changes(
+            ["git"], tmp_path, "stash@{0}", prompt_user=True, input_fn=None,
+        )
+
+        assert result is False
+        out = capsys.readouterr().out
+        assert "Skipped restoring local changes" in out
+        assert "unattended" not in out, (
+            "a deliberate 'no' is not an unattended run and must not be "
+            "reported as one"
+        )
+
+    def test_the_gateway_input_fn_path_is_untouched(self, tmp_path, monkeypatch):
+        """Gateway mode answers over file-based IPC and never touches stdin."""
+        monkeypatch.setattr(update_cmd, "_UPDATE_PROMPT_TIMEOUT_SECONDS", 0.05)
+        seen = []
+        monkeypatch.setattr(
+            update_cmd.subprocess, "run", lambda *a, **kw: _ok(),
+        )
+
+        update_cmd._restore_stashed_changes(
+            ["git"],
+            tmp_path,
+            "stash@{0}",
+            prompt_user=True,
+            input_fn=lambda prompt, default: seen.append(prompt) or "y",
+        )
+
+        assert seen, "input_fn must still be consulted"
+        assert update_cmd._prompt_proven_unattended is False
+
+
+# ── the site that is reached even earlier ──────────────────────────────
+
+
+class TestUpstreamRemotePrompt:
+    """This one runs BEFORE the reported prompt, so it can hang first."""
+
+    def _run(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(update_cmd, "_has_upstream_remote", lambda *a, **kw: False)
+        monkeypatch.setattr(update_cmd, "_should_skip_upstream_prompt", lambda: False)
+        added = []
+        monkeypatch.setattr(
+            update_cmd, "_add_upstream_remote", lambda *a, **kw: added.append(1) or True
+        )
+        update_cmd._sync_with_upstream_if_needed(["git"], tmp_path)
+        return added
+
+    def test_it_stops_waiting_too(self, tmp_path, capsys, blocker, monkeypatch):
+        monkeypatch.setattr(update_cmd, "_UPDATE_PROMPT_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr("builtins.input", blocker)
+
+        added = self._run(monkeypatch, tmp_path)
+
+        assert added == [], "unanswered must not silently add a remote"
+        assert "unattended" in capsys.readouterr().out
+
+    def test_eof_keeps_the_blank_line_it_always_printed(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """Guards a spacing regression the obvious refactor introduces.
+
+        The original printed a blank line only on the exception path. Routing
+        this through the shared helper makes it easy to print it on the
+        success path instead, which is backwards and invisible to any
+        assertion about the return value.
+        """
+        def _raise(*_args, **_kwargs):
+            raise EOFError()
+
+        monkeypatch.setattr("builtins.input", _raise)
+        self._run(monkeypatch, tmp_path)
+        eof_out = capsys.readouterr().out
+
+        monkeypatch.setattr("builtins.input", lambda _p: "n")
+        self._run(monkeypatch, tmp_path)
+        answered_out = capsys.readouterr().out
+
+        # Counting "\n\n" does not work: str.count does not overlap, so a
+        # triple newline scores the same 1 as a double. Compare exactly.
+        assert eof_out != answered_out, "the two paths must not print the same"
+        assert eof_out.replace("\n\n\n", "\n\n", 1) == answered_out, (
+            "the ONLY difference between the two paths should be one blank "
+            f"line on the exception path.\n  eof: {eof_out!r}\n  ans: {answered_out!r}"
+        )
+
+
+class _ok:
+    """Stand-in for a successful ``subprocess.run`` result."""
+
+    returncode = 0
+    stdout = ""
+    stderr = ""

--- a/tests/hermes_cli/test_update_prompt_timeout.py
+++ b/tests/hermes_cli/test_update_prompt_timeout.py
@@ -171,6 +171,35 @@ class TestUnattendedLatch:
         assert update_cmd._prompt_proven_unattended is False
 
 
+class TestUnansweredReport:
+    """The report must name the bound the run actually waited on.
+
+    ``_read_line_with_timeout`` already takes a per-prompt ``timeout``, so a
+    report that reads the module constant instead would start lying the first
+    time a call site overrides it. These pin the two resolutions apart.
+    """
+
+    def test_it_reports_the_module_default_when_no_bound_is_given(self, capsys):
+        update_cmd._report_unanswered_prompt(
+            "Restore local changes now?", "Not restoring."
+        )
+        out = capsys.readouterr().out
+        assert "after %ds" % int(update_cmd._UPDATE_PROMPT_TIMEOUT_SECONDS) in out
+
+    def test_it_reports_an_overridden_bound(self, capsys):
+        update_cmd._report_unanswered_prompt(
+            "Add official repo as 'upstream' remote?",
+            "Not adding it.",
+            timeout=12,
+        )
+        out = capsys.readouterr().out
+        assert "after 12s" in out
+        assert (
+            "after %ds" % int(update_cmd._UPDATE_PROMPT_TIMEOUT_SECONDS)
+            not in out
+        )
+
+
 # ── the reported call site ─────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

`hermes update` can block forever on a prompt nobody is able to answer. The
report is a Windows Scheduled Task with `-WindowStyle Hidden`: 44 minutes parked
on `Restore local changes now? [Y/n]`, ending in exit code `0x40010004`, which is
an external kill rather than an exit. The update neither completed nor failed.

**Why every existing guard misses it.** A hidden console is still a *real*
console. `sys.stdin.isatty()` returns `True`, so `_non_interactive_update` and
the `prompt_for_restore` predicate both classify the run as interactive:

```python
prompt_for_restore = (
    auto_stash_ref is not None
    and not assume_yes
    and (gateway_mode or (sys.stdin.isatty() and sys.stdout.isatty()))
)
```

And the handle is open, so `input()` never raises `EOFError` either. The
existing `except (EOFError, UnicodeDecodeError)` guard is not wrong, it is simply
never reached. There is no property of the process that distinguishes "console
a human is watching" from "console nobody will ever type into".

**So the prompts are bounded rather than predicted.** An unanswered prompt takes
its documented default, says so in the log, and latches the run as unattended.
The latch is the interesting part: a prompt that went unanswered is an
*observation* that nobody is at the keyboard, which is strictly stronger than
anything `isatty` can infer, so later prompts in the same run stop asking.

### The route I did not take

My first instinct was `GetConsoleWindow()` + `IsWindowVisible()`: a console
nobody can see is a console nobody can type into. I dropped it because ConPTY
hosts (Windows Terminal, the VS Code terminal) are reported to leave a hidden
console window on the process, which would misclassify a large fraction of
Windows users as unattended, and the failure would be **silent**: their local
changes would just stop being offered for restore.

I could not verify that ConPTY behaviour from where I was working (with stdin
redirected, `GetConsoleWindow()` returns `0` and `isatty()` is already `False`,
which is the case the existing guards already handle). I would rather not ship a
silent-failure detector on a behaviour I am taking on trust. Flagging it in case
a maintainer knows it cold and prefers that route.

### Two calls I am handing to a maintainer rather than making quietly

1. **The timeout value, 300s.** Long enough that a human reading a four-line
   prompt is never affected, short enough that "forever" becomes "five minutes".
   It is a judgement call, not a derived number. Happy to change it, or to put it
   behind config/env if you want it tunable; I did not add a config key because
   that is a new public surface for what is currently one constant.
2. **What a timeout should default to.** I chose skip-restore, matching the
   `EOFError` path that already exists. It is the only default that cannot lose
   work: the stash stays on disk and the existing `git stash apply <ref>`
   guidance still prints. The argument for the other side is real, though, and I
   want it on the record: `[Y/n]` means a human pressing enter gets *restore*, so
   an argument exists that a timeout should match the visible default. I think
   "unattended" is a different situation from "pressed enter" and should be
   allowed a more conservative answer, but this is your semantics to set.

## Related Issue

Fixes #92303

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

All in `hermes_cli/update_cmd.py`.

- **`_read_line_with_timeout(default, timeout=None, read_fn=None)`** (new).
  Reads one line on a daemon thread and gives up after `timeout`, returning
  `(response, timed_out)`. `timeout <= 0` restores today's unbounded blocking
  read, so the old behaviour stays reachable from a test rather than only from a
  revert. `daemon=True` is load bearing: the reader stays parked on stdin for the
  life of the process, and a non-daemon thread there would block interpreter
  shutdown, which is the same unbounded wait wearing a different hat.
- **`_prompt_proven_unattended`** (new) plus `_reset_prompt_interactivity()`,
  called at the top of `_cmd_update_impl` so the latch scopes to one update
  rather than to the interpreter. It also closes a hazard the timeout would
  otherwise open: without it, a later prompt could arm a **second** reader on the
  same stdin and have its answer swallowed by the first, still-parked one.
- **`_report_unanswered_prompt`** (new). Names the prompt, the consequence, and
  `--yes` / `--keep-stash`, so an unattended transcript explains itself instead
  of ending at a bare prompt line. This is the reporter's option 3, folded in.
- **`_restore_stashed_changes`**: the reported site, now bounded. Default `"n"`,
  identical to the `EOFError` path it replaces.
- **`_sync_with_upstream_if_needed`**: bounded too, and this one is worth calling
  out because it was not in the report. It runs at line 6046 while the stash
  restore runs at 6053, so on a fork with **no upstream remote** an unattended
  run hangs *here* and never reaches the reported hang at all. Fixing only what
  was reported would have left the same bug one prompt earlier.
- **The config-migration prompt** now reads
  `elif _prompt_proven_unattended or not (sys.stdin.isatty() and ...)`. That is
  deliberately routed into the branch that already exists rather than given its
  own: the `"auto"` default and everything downstream are unchanged, so the only
  new thing is a better signal. This is the generalisation asked for at the end
  of the report, without changing any prompt's semantics under cover of a stash
  fix.

## How to Test

```bash
pytest tests/hermes_cli/test_update_prompt_timeout.py -q
# 16 passed
```

16 new tests in a new file, covering three things: the bound exists and takes the
safe default; the answered paths are unchanged, including the `EOFError`,
`UnicodeDecodeError` and `KeyboardInterrupt` paths that predate this fix; and the
latch.

**Sabotage proof.** Each mutation applied to `hermes_cli/update_cmd.py` alone,
with the new suite re-run:

| Mutation | Tests that fail |
|---|---|
| Remove the bound entirely (back to a blocking read) | `test_an_unanswerable_prompt_gives_up`, `test_the_reader_thread_cannot_keep_the_process_alive`, `test_a_timeout_proves_the_run_unattended`, `test_a_later_prompt_does_not_ask_again`, `test_the_reported_hang_now_ends`, `test_it_stops_waiting_too` |
| Time out, but do not latch the run unattended | `test_a_timeout_proves_the_run_unattended`, `test_a_later_prompt_does_not_ask_again` |
| `daemon=False` on the reader thread | `test_the_reader_thread_cannot_keep_the_process_alive` |
| Return `""` on timeout instead of the default | `test_an_unanswerable_prompt_gives_up`, `test_it_stops_waiting_too` |
| Print the blank line on the answered path instead of the exception path | `test_eof_keeps_the_blank_line_it_always_printed` |

Two rows worth a second look.

**Row 4** is the reason the helper returns an explicit `default` rather than
`""`. Both call sites test `response in {"", "y", "yes"}`, so an empty string
does not mean "no answer", it means **yes**. A timeout that returned `""` would
have silently added an upstream remote and silently restored a stash on exactly
the unattended runs this PR exists to make safe, and every "did it time out?"
assertion would still have passed.

**Row 5** is a spacing inversion, and it is in here because I made it. Routing
that prompt through the shared helper made it natural to print its blank line on
the *answered* path instead of the exception path, which is backwards and which
no assertion about a return value would ever notice.

**Existing suites.** `test_update_yes_flag.py`, `test_update_autostash.py` and
`test_update_streaming.py`: 15 passed, 7 failed, 1 skipped, and the **same 7 fail
identically on the unpatched tree**. They are Windows-only console-encoding
crashes (`UnicodeEncodeError: 'charmap' codec can't encode character '✓'`
out of a `print()`), unrelated to this change. Verified by stashing only
`hermes_cli/update_cmd.py` and re-running the same command.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (26200), Python 3.13

<sub>Leaving that box honest rather than ticked: `pytest tests/ -q` does not
collect on Windows at all. `tests/hermes_cli/test_doctor_journal_modes.py` raises
`AttributeError: module 'os' has no attribute 'geteuid'` at import and aborts the
run. What I did run is the new suite plus every existing suite that touches these
functions, with a stashed baseline for the pre-existing failures, as above. Linux
CI on this PR is the authority for the full-tree line.</sub>

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): the new
      helpers carry the reasoning, including why `daemon=True` matters and why
      the latch exists
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A.
      The timeout is a module constant, deliberately not a config key yet (see
      the maintainer calls above)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility):
      the whole point is that it is **not** platform-specific. `threading` plus a
      bounded `join` behaves the same everywhere, which is exactly why I rejected
      the Win32 console-handle route. The bug is reported on Windows but the same
      shape reaches CI and remote automation on any OS whenever stdin is a live
      handle nobody answers
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A

## Screenshots / Logs

Before, from the report:

```
⚠ Local changes were stashed before updating.
  Restoring them may reapply local customizations onto the updated codebase.
  Review the result afterward if Hermes behaves unexpectedly.
Restore local changes now? [Y/n]
<44 minutes of nothing, then exit code 1073807364>
```

After:

```
⚠ Local changes were stashed before updating.
  Restoring them may reapply local customizations onto the updated codebase.
  Review the result afterward if Hermes behaves unexpectedly.
Restore local changes now? [Y/n]

⚠ No answer to 'Restore local changes now?' after 300s, so this run is being treated as unattended.
  Not restoring. Your changes are preserved in git stash.
  Pass --yes (and --keep-stash where you want the stash left parked) to skip these prompts in scripted runs.
Skipped restoring local changes.
Your changes are still preserved in git stash.
Restore manually with: git stash apply stash@{0}
```
