### PR TITLE
fix(kanban): resume tasks after PR requeue

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9438,6 +9438,8 @@ def check_respawn_guard(
         A GitHub PR URL appears in a recent task comment (within
         ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
         opened a PR; re-spawning risks a duplicate PR on the same task.
+        Bypassed when an explicit re-queue event or ``changes_requested``
+        run arrives after the newest matching comment.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -9526,12 +9528,36 @@ def check_respawn_guard(
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    As with recent_success, an explicit re-queue AFTER the newest matching
+    #    comment is a deliberate request to resume work on that PR, not create
+    #    a duplicate. Review changes are recorded as a terminal task run rather
+    #    than one of the generic task_events re-queue kinds, so include both.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    newest_pr_comment_at: Optional[int] = None
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+            newest_pr_comment_at = int(c["created_at"])
+            break
+    if newest_pr_comment_at is not None:
+        requeued_after = conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? AND created_at >= ? "
+            "AND kind IN ('status', 'promoted', 'unblocked', 'reclaimed') "
+            "LIMIT 1",
+            (task_id, newest_pr_comment_at),
+        ).fetchone()
+        changes_requested_after = conn.execute(
+            "SELECT 1 FROM task_runs "
+            "WHERE task_id = ? AND outcome = 'changes_requested' "
+            "AND ended_at >= ? LIMIT 1",
+            (task_id, newest_pr_comment_at),
+        ).fetchone()
+        if not requeued_after and not changes_requested_after:
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -510,6 +510,68 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    ("signal_source", "signal_kind"),
+    [
+        ("event", "status"),
+        ("event", "promoted"),
+        ("event", "unblocked"),
+        ("event", "reclaimed"),
+        ("run", "changes_requested"),
+    ],
+)
+def test_active_pr_guard_allows_newer_explicit_requeue_signal(
+    kanban_home, monkeypatch, signal_source, signal_kind
+):
+    comment_at = 1_800_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: comment_at)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="rework merged PR", assignee="builder")
+        kb.add_comment(
+            conn,
+            task_id,
+            author="builder",
+            body="Opened https://github.com/example/repo/pull/123",
+        )
+        with kb.write_txn(conn):
+            if signal_source == "event":
+                conn.execute(
+                    "INSERT INTO task_events (task_id, kind, created_at) "
+                    "VALUES (?, ?, ?)",
+                    (task_id, signal_kind, comment_at),
+                )
+            else:
+                conn.execute(
+                    "INSERT INTO task_runs "
+                    "(task_id, profile, status, started_at, ended_at, outcome) "
+                    "VALUES (?, 'reviewer', 'done', ?, ?, ?)",
+                    (task_id, comment_at, comment_at, signal_kind),
+                )
+
+        monkeypatch.setattr(kb.time, "time", lambda: comment_at + 2)
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_active_pr_guard_still_defers_without_newer_requeue_signal(
+    kanban_home, monkeypatch
+):
+    comment_at = 1_800_000_000
+    monkeypatch.setattr(kb.time, "time", lambda: comment_at)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="PR still active", assignee="builder")
+        kb.add_comment(
+            conn,
+            task_id,
+            author="builder",
+            body="Opened https://github.com/example/repo/pull/123",
+        )
+
+        monkeypatch.setattr(kb.time, "time", lambda: comment_at + 1)
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
 
 
 


### PR DESCRIPTION
## Summary

- bypass the ready-lane `active_pr` guard when a newer explicit re-queue event exists
- also bypass it after a newer `changes_requested` run from review
- retain the duplicate-PR guard when no newer re-queue signal exists
- keep the dispatcher guard offline with SQLite-only checks

## Regression proof

Unmodified `origin/main`, after adding the regression tests:

```text
FFFFF.                                                                   [100%]
5 failed, 1 passed, 31 deselected in 0.90s
```

Each failing case returned `"active_pr"` instead of `None` for a newer `status`, `promoted`, `unblocked`, `reclaimed`, or `changes_requested` signal. The unchanged duplicate-PR case passed before the fix.

After the fix:

```text
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py -k "active_pr_guard_allows_newer_explicit_requeue_signal or active_pr_guard_still_defers_without_newer_requeue_signal" -q
=== Summary: 1 files, 6 tests passed, 0 failed (100% complete) in 0.5s (36 workers) ===

scripts/run_tests.sh tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py -q
=== Summary: 2 files, 41 tests passed, 0 failed (100% complete) in 2.6s (36 workers) ===

scripts/run_tests.sh tests/hermes_cli/ -k "respawn or guard or dispatch" -q
=== Summary: 691 files, 415 tests passed, 0 failed, 4 skipped (100% complete) in 116.8s (36 workers) ===
```

No network or shell call was added inside `check_respawn_guard`:

```text
git diff -U0 -- hermes_cli/kanban_db.py | grep -nE 'requests|urllib|subprocess|gh '
# no output
```

## Risk

Low. The bypass is limited to signals timestamped at or after the newest fresh PR-URL comment. Without such a signal, `active_pr` still defers the task.
