### PR TITLE
fix: stop child hermes chat inheriting Kanban worker ownership

### DIFF
--- a/agent/delegation_context.py
+++ b/agent/delegation_context.py
@@ -10,6 +10,13 @@ Cron jobs need the same treatment for the same reason: ``cronjob(action="run")``
 executes ``run_job()`` in-process, so a cron agent fired from inside a Kanban
 worker would otherwise inherit that worker's dispatcher identity.
 ``non_dispatcher_owned_context()`` covers both cases.
+
+A third leak is a nested ``hermes chat`` subprocess launched from a worker
+terminal (for example ``hermes chat -Q … --source tool`` for Browser Use).
+Those children inherit ``os.environ`` and are a new process, so ContextVars
+cannot help. ``scrub_kanban_lifecycle_ownership`` / the cmd_chat startup
+drop close that path unless the process was explicitly launched as the
+board worker.
 """
 from __future__ import annotations
 
@@ -43,6 +50,20 @@ KANBAN_ENV_KEYS: tuple[str, ...] = (
     "HERMES_KANBAN_BOARD",
     "HERMES_KANBAN_DB",
 )
+
+# Lifecycle ownership only. Board routing pins (BOARD / DB) stay on ordinary
+# terminal children so ``hermes kanban`` shell-outs remain on the same board
+# (#20074). A child ``hermes chat`` must not inherit the run identity that
+# makes ``kanban_complete`` default to the parent card.
+KANBAN_LIFECYCLE_OWNERSHIP_KEYS: tuple[str, ...] = (
+    "HERMES_KANBAN_TASK",
+    "HERMES_KANBAN_RUN_ID",
+    "HERMES_KANBAN_WORKSPACE",
+    "HERMES_KANBAN_WORKSPACES_ROOT",
+    "HERMES_KANBAN_CLAIM_LOCK",
+)
+
+_BOARD_WORKER_QUERY_PREFIX = "work kanban task "
 
 
 @contextmanager
@@ -137,6 +158,71 @@ def scrub_kanban_env(env: Mapping[str, str] | MutableMapping[str, str]) -> dict[
         cleaned.pop(key, None)
     cleaned[DELEGATED_CHILD_ENV_MARKER] = "1"
     return cleaned
+
+
+def scrub_kanban_lifecycle_ownership(
+    env: Mapping[str, str] | MutableMapping[str, str],
+) -> dict[str, str]:
+    """Strip run/workspace ownership from a child-process environment.
+
+    Unlike :func:`scrub_kanban_env`, this does **not** set the delegated-child
+    marker and does **not** remove board routing pins. Use it on every
+    subprocess spawn from a Kanban worker so a nested ``hermes chat`` cannot
+    inherit ``HERMES_KANBAN_TASK``.
+    """
+    cleaned = dict(env)
+    for key in KANBAN_LIFECYCLE_OWNERSHIP_KEYS:
+        cleaned.pop(key, None)
+    return cleaned
+
+
+def is_explicit_board_worker_launch(
+    *,
+    query: str | None,
+    source: str | None,
+    task_id: str | None,
+) -> bool:
+    """True only for the dispatcher worker argv/env contract.
+
+    ``_default_spawn`` launches ``hermes chat -q "work kanban task <id>"``
+    with ``HERMES_SESSION_SOURCE=kanban``. Any other child chat — including
+    ``hermes chat --source tool`` used by Browser Use benchmarks — is not
+    the board worker, even if it inherited the parent's env.
+    """
+    tid = (task_id or "").strip()
+    if not tid:
+        return False
+    if (source or "").strip() != "kanban":
+        return False
+    return (query or "").strip() == f"{_BOARD_WORKER_QUERY_PREFIX}{tid}"
+
+
+def drop_inherited_kanban_lifecycle_if_not_board_worker(
+    *,
+    query: str | None = None,
+    source: str | None = None,
+    environ: MutableMapping[str, str] | None = None,
+) -> bool:
+    """Drop inherited lifecycle ownership unless this process is the worker.
+
+    Returns True when vars were removed. Mutates *environ* (default
+    ``os.environ``) so a child ``hermes chat`` that slipped past spawn-time
+    scrubbing still cannot ``kanban_complete`` the parent card.
+    """
+    import os
+
+    env = os.environ if environ is None else environ
+    task = (env.get("HERMES_KANBAN_TASK") or "").strip()
+    if not task:
+        return False
+    resolved_source = source if source is not None else env.get("HERMES_SESSION_SOURCE")
+    if is_explicit_board_worker_launch(
+        query=query, source=resolved_source, task_id=task
+    ):
+        return False
+    for key in KANBAN_LIFECYCLE_OWNERSHIP_KEYS:
+        env.pop(key, None)
+    return True
 
 
 def delegated_child_subprocess_env(

--- a/contributors/emails/shermanlye@Shermans-MacBook-Pro.local
+++ b/contributors/emails/shermanlye@Shermans-MacBook-Pro.local
@@ -1,0 +1,2 @@
+ming0627
+# map local git author email from 2abc0a841 transplant (kanban child-session ownership)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2866,6 +2866,26 @@ def _pin_kanban_board_env() -> None:
         pass
 
 
+def _drop_inherited_kanban_lifecycle(args) -> None:
+    """Child chats must not inherit dispatcher run ownership.
+
+    A Kanban worker that shells out to ``hermes chat --source tool`` (Browser
+    Use benchmarks, local-model evals) used to keep ``HERMES_KANBAN_TASK``
+    and could ``kanban_complete`` the parent card. The dispatcher worker
+    itself is identified by source ``kanban`` plus ``work kanban task <id>``.
+    """
+    try:
+        from agent.delegation_context import (
+            drop_inherited_kanban_lifecycle_if_not_board_worker,
+        )
+    except Exception:
+        return
+    drop_inherited_kanban_lifecycle_if_not_board_worker(
+        query=getattr(args, "query", None),
+        source=os.environ.get("HERMES_SESSION_SOURCE"),
+    )
+
+
 def _sync_bundled_skills_quietly() -> None:
     """Seed ``~/.hermes/skills/`` with the bundled skill library on first launch.
 
@@ -3184,6 +3204,12 @@ def cmd_chat(args):
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
 
+    # Defer the drop when the query is still on disk: a --query-file board
+    # worker would otherwise look like an interactive child and lose ownership
+    # before the prompt is loaded.
+    if getattr(args, "query", None) or not getattr(args, "query_file", None):
+        _drop_inherited_kanban_lifecycle(args)
+
     _pin_kanban_board_env()
     _confirm_startup_expensive_model_override(args)
 
@@ -3233,6 +3259,9 @@ def cmd_chat(args):
         if not (args.query or "").strip():
             print(f"Error: --query-file {_qfile} is empty", file=sys.stderr)
             sys.exit(2)
+
+    # Query may have arrived via --query-file after the first ownership check.
+    _drop_inherited_kanban_lifecycle(args)
 
     # Build kwargs from args
     kwargs = {

--- a/tests/hermes_cli/test_kanban_child_chat_startup.py
+++ b/tests/hermes_cli/test_kanban_child_chat_startup.py
@@ -1,0 +1,169 @@
+"""Child ``hermes chat`` must drop inherited Kanban lifecycle ownership.
+
+Defense in depth for the same incident as
+``tests/tools/test_kanban_child_chat_env_isolation.py``: even if a child
+process is launched with a raw ``os.environ`` copy (outside the terminal
+sanitize path), ``cmd_chat`` must refuse to become the board worker unless
+it was explicitly launched as one (source ``kanban`` +
+``work kanban task <id>``).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import types
+from argparse import Namespace
+
+import pytest
+
+
+_OWNERSHIP_KEYS = (
+    "HERMES_KANBAN_TASK",
+    "HERMES_KANBAN_RUN_ID",
+    "HERMES_KANBAN_WORKSPACE",
+    "HERMES_KANBAN_WORKSPACES_ROOT",
+    "HERMES_KANBAN_CLAIM_LOCK",
+)
+
+
+def _chat_args(**overrides):
+    base = {
+        "continue_last": None,
+        "model": None,
+        "provider": None,
+        "resume": None,
+        "no_restore_cwd": False,
+        "toolsets": None,
+        "skills": None,
+        "tui": False,
+        "tui_dev": False,
+        "cli": True,
+        "verbose": None,
+        "quiet": True,
+        "query": "hello",
+        "query_file": None,
+        "image": None,
+        "worktree": False,
+        "checkpoints": False,
+        "pass_session_id": False,
+        "max_turns": None,
+        "ignore_rules": False,
+        "ignore_user_config": False,
+        "safe_mode": False,
+        "compact": False,
+        "source": None,
+        "yolo": False,
+        "accept_hooks": False,
+        "in_dir": None,
+        "reasoning": None,
+        "run_budget": None,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+@pytest.fixture
+def main_mod(monkeypatch):
+    import hermes_cli.main as mod
+
+    monkeypatch.setattr(mod, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(mod, "_sync_bundled_skills_for_startup", lambda: None)
+    monkeypatch.setattr(mod, "_termux_should_prefetch_update_check", lambda: False)
+    monkeypatch.setattr(mod, "_pin_kanban_board_env", lambda: None)
+    monkeypatch.setattr(mod, "_confirm_startup_expensive_model_override", lambda args: None)
+    monkeypatch.setattr(mod, "_resolve_session_by_name_or_id", lambda val: val)
+    monkeypatch.setattr(mod, "_oneshot_cleanup_done", False)
+    return mod
+
+
+@pytest.fixture
+def fake_cli(monkeypatch):
+    captured = {}
+
+    def fake_cli_main(**kwargs):
+        captured.update(kwargs)
+        captured["env"] = {
+            key: os.environ.get(key) for key in (
+                *_OWNERSHIP_KEYS,
+                "HERMES_SESSION_SOURCE",
+                "HERMES_KANBAN_BOARD",
+                "HERMES_KANBAN_DB",
+            )
+        }
+
+    monkeypatch.setitem(sys.modules, "cli", types.SimpleNamespace(main=fake_cli_main))
+    import cli
+
+    monkeypatch.setattr(cli, "main", fake_cli_main)
+    return captured
+
+
+def _inherit_worker_identity(monkeypatch, tmp_path, task_id="t_parent"):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "18")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(tmp_path / "ws"))
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(tmp_path / "workspaces"))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "lock-parent")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "kanban")
+
+
+def test_source_tool_child_chat_drops_inherited_ownership(
+    main_mod, fake_cli, monkeypatch, tmp_path
+):
+    _inherit_worker_identity(monkeypatch, tmp_path)
+    main_mod.cmd_chat(
+        _chat_args(
+            source="tool",
+            query="Benchmark Browser Use on books.toscrape.com",
+            quiet=True,
+        )
+    )
+
+    env = fake_cli["env"]
+    for key in _OWNERSHIP_KEYS:
+        assert env.get(key) is None, key
+    assert env["HERMES_SESSION_SOURCE"] == "tool"
+    assert env["HERMES_KANBAN_BOARD"] == "default"
+    assert env["HERMES_KANBAN_DB"] == str(tmp_path / "kanban.db")
+
+
+def test_inherited_kanban_source_without_worker_prompt_drops_ownership(
+    main_mod, fake_cli, monkeypatch, tmp_path
+):
+    _inherit_worker_identity(monkeypatch, tmp_path)
+    main_mod.cmd_chat(_chat_args(source=None, query="do a local model benchmark"))
+
+    env = fake_cli["env"]
+    for key in _OWNERSHIP_KEYS:
+        assert env.get(key) is None, key
+    # Inherited source tag is not enough to keep ownership.
+    assert env["HERMES_SESSION_SOURCE"] == "kanban"
+
+
+def test_explicit_board_worker_launch_keeps_ownership(
+    main_mod, fake_cli, monkeypatch, tmp_path
+):
+    _inherit_worker_identity(monkeypatch, tmp_path, task_id="t_board_worker")
+    main_mod.cmd_chat(
+        _chat_args(source=None, query="work kanban task t_board_worker")
+    )
+
+    env = fake_cli["env"]
+    assert env["HERMES_KANBAN_TASK"] == "t_board_worker"
+    assert env["HERMES_KANBAN_RUN_ID"] == "18"
+    assert env["HERMES_KANBAN_CLAIM_LOCK"] == "lock-parent"
+    assert env["HERMES_SESSION_SOURCE"] == "kanban"
+
+
+def test_source_kanban_with_mismatched_prompt_drops_ownership(
+    main_mod, fake_cli, monkeypatch, tmp_path
+):
+    _inherit_worker_identity(monkeypatch, tmp_path, task_id="t_board_worker")
+    main_mod.cmd_chat(
+        _chat_args(source="kanban", query="work kanban task t_other")
+    )
+
+    env = fake_cli["env"]
+    assert env.get("HERMES_KANBAN_TASK") is None

--- a/tests/tools/test_kanban_child_chat_env_isolation.py
+++ b/tests/tools/test_kanban_child_chat_env_isolation.py
@@ -1,0 +1,252 @@
+"""Child hermes chat must not inherit Kanban lifecycle ownership.
+
+Incident: a Kanban worker ran ``hermes chat -Q … --source tool`` for a
+Browser Use benchmark. The child inherited ``HERMES_KANBAN_TASK`` and
+called ``kanban_complete``, closing the parent card and triggering
+scratch-workspace cleanup while the real worker was still running.
+
+These tests lock the spawn-path contract: terminal / subprocess env
+builders drop lifecycle ownership vars for every child, while board
+routing pins (``HERMES_KANBAN_BOARD`` / ``HERMES_KANBAN_DB``) and
+ordinary tool credentials stay intact. Dispatcher ``_default_spawn``
+still injects ownership into the real worker.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_OWNERSHIP_KEYS = (
+    "HERMES_KANBAN_TASK",
+    "HERMES_KANBAN_RUN_ID",
+    "HERMES_KANBAN_WORKSPACE",
+    "HERMES_KANBAN_WORKSPACES_ROOT",
+    "HERMES_KANBAN_CLAIM_LOCK",
+)
+
+_SAFE_SAMPLE = {
+    "PATH": "/usr/bin:/bin",
+    "HOME": "/home/user",
+    "USER": "testuser",
+    "HERMES_HOME": "/tmp/hermes-home",
+    "MY_APP_VAR": "keep-me",
+    "BROWSERBASE_API_KEY": "bb-keep",
+    "FIRECRAWL_API_KEY": "fc-keep",
+}
+
+
+def _python_with_repo_path(code: str) -> str:
+    return (
+        f"PYTHONPATH={shlex.quote(str(_REPO_ROOT))} "
+        f"{shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+    )
+
+
+def _worker_env(tmp_path: Path) -> dict[str, str]:
+    env = dict(_SAFE_SAMPLE)
+    env.update(
+        {
+            "HERMES_HOME": str(tmp_path / ".hermes"),
+            "HERMES_KANBAN_TASK": "t_parent",
+            "HERMES_KANBAN_RUN_ID": "18",
+            "HERMES_KANBAN_WORKSPACE": str(tmp_path / "parent-workspace"),
+            "HERMES_KANBAN_WORKSPACES_ROOT": str(tmp_path / "workspaces"),
+            "HERMES_KANBAN_CLAIM_LOCK": "lock-parent",
+            "HERMES_KANBAN_BOARD": "default",
+            "HERMES_KANBAN_DB": str(tmp_path / ".hermes" / "kanban.db"),
+            "HERMES_SESSION_SOURCE": "kanban",
+        }
+    )
+    return env
+
+
+def _make_running_kanban_task(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    workspace = tmp_path / "parent-workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "parent-worker")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "kanban")
+
+    from hermes_cli import kanban_db as kb
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="parent",
+            assignee="parent-worker",
+            workspace_kind="scratch",
+            workspace_path=str(workspace),
+        )
+        claim = kb.claim_task(conn, tid)
+        assert claim is not None
+        run_id = claim.id
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    if claim.claim_lock:
+        monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", claim.claim_lock)
+    return kb, tid, workspace
+
+
+def _assert_ownership_stripped(env: dict[str, str]) -> None:
+    leaked = [key for key in _OWNERSHIP_KEYS if key in env]
+    assert not leaked, f"child inherited lifecycle ownership: {leaked}"
+
+
+class TestTerminalChildEnvStripsLifecycleOwnership:
+    def test_make_run_env_strips_ownership_but_keeps_board_and_tools(self, tmp_path):
+        from tools.environments.local import _make_run_env
+
+        parent = _worker_env(tmp_path)
+        with patch.dict(os.environ, parent, clear=True):
+            child = _make_run_env({})
+            assert os.environ["HERMES_KANBAN_TASK"] == "t_parent"
+
+        _assert_ownership_stripped(child)
+        assert child["HERMES_KANBAN_BOARD"] == "default"
+        assert child["HERMES_KANBAN_DB"] == parent["HERMES_KANBAN_DB"]
+        assert child["HERMES_HOME"] == parent["HERMES_HOME"]
+        assert child["MY_APP_VAR"] == "keep-me"
+        assert child["PATH"]
+
+    def test_sanitize_subprocess_env_strips_ownership(self, tmp_path):
+        from tools.environments.local import _sanitize_subprocess_env
+
+        parent = _worker_env(tmp_path)
+        child = _sanitize_subprocess_env(parent)
+        _assert_ownership_stripped(child)
+        assert child["HERMES_KANBAN_BOARD"] == "default"
+        assert child["MY_APP_VAR"] == "keep-me"
+
+    def test_hermes_subprocess_env_strips_ownership(self, tmp_path):
+        from tools.environments.local import hermes_subprocess_env
+
+        with patch.dict(os.environ, _worker_env(tmp_path), clear=True):
+            child = hermes_subprocess_env(inherit_credentials=True)
+
+        _assert_ownership_stripped(child)
+        assert child["HERMES_KANBAN_BOARD"] == "default"
+        assert child["BROWSERBASE_API_KEY"] == "bb-keep"
+        assert child["FIRECRAWL_API_KEY"] == "fc-keep"
+
+
+def test_lifecycle_keys_are_a_subset_of_full_kanban_env_keys():
+    from agent.delegation_context import (
+        KANBAN_ENV_KEYS,
+        KANBAN_LIFECYCLE_OWNERSHIP_KEYS,
+    )
+
+    extra = set(KANBAN_LIFECYCLE_OWNERSHIP_KEYS) - set(KANBAN_ENV_KEYS)
+    assert not extra, extra
+    assert "HERMES_KANBAN_BOARD" not in KANBAN_LIFECYCLE_OWNERSHIP_KEYS
+    assert "HERMES_KANBAN_DB" not in KANBAN_LIFECYCLE_OWNERSHIP_KEYS
+
+
+def test_default_spawn_still_injects_worker_ownership(monkeypatch, tmp_path):
+    """Dispatcher-owned workers must still receive lifecycle vars."""
+    from hermes_cli import kanban_db as kb
+
+    captured = {}
+
+    class _Proc:
+        pid = 4242
+
+    def _fake_popen(cmd, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _Proc()
+
+    monkeypatch.setattr("subprocess.Popen", _fake_popen)
+    monkeypatch.setattr(kb, "_retag_legacy_worker_sessions", lambda _root: None)
+    monkeypatch.setattr(kb, "worker_logs_dir", lambda board=None: tmp_path / "logs")
+
+    task = kb.Task(
+        id="t_board_worker",
+        title="ship it",
+        body=None,
+        assignee="default",
+        status="in_progress",
+        priority=0,
+        created_by=None,
+        created_at=0,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="scratch",
+        workspace_path=None,
+        claim_lock="lock-worker",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=7,
+    )
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    kb._default_spawn(task, str(workspace))
+
+    env = captured["env"]
+    assert env["HERMES_KANBAN_TASK"] == "t_board_worker"
+    assert env["HERMES_KANBAN_RUN_ID"] == "7"
+    assert env["HERMES_KANBAN_WORKSPACE"] == str(workspace)
+    assert env["HERMES_KANBAN_CLAIM_LOCK"] == "lock-worker"
+    assert env["HERMES_SESSION_SOURCE"] == "kanban"
+
+
+def test_terminal_child_cannot_complete_parent_and_parent_stays_running(
+    monkeypatch, tmp_path
+):
+    """Exact incident: child session finishes, parent card must stay running."""
+    kb, tid, workspace = _make_running_kanban_task(monkeypatch, tmp_path)
+    from tools.environments.local import LocalEnvironment
+
+    code = (
+        "import json, os, sys; "
+        "from tools import kanban_tools as kt; "
+        "print('CHILD_TASK=' + os.environ.get('HERMES_KANBAN_TASK', '')); "
+        "print(kt._handle_complete({'summary': 'child stole the card'}))"
+    )
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=20)
+    try:
+        result = env.execute(_python_with_repo_path(code), timeout=20)
+    finally:
+        env.cleanup()
+
+    assert "CHILD_TASK=" in result["output"]
+    child_task_line = next(
+        line for line in result["output"].splitlines() if line.startswith("CHILD_TASK=")
+    )
+    assert child_task_line == "CHILD_TASK="
+
+    payload = None
+    for line in result["output"].splitlines():
+        line = line.strip()
+        if line.startswith("{") and ("ok" in line or "error" in line):
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+    assert payload is not None
+    assert payload.get("ok") is not True
+    assert "error" in payload
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "running"
+        assert task.workspace_path == str(workspace)
+        assert os.path.isdir(workspace)
+    finally:
+        conn.close()

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -526,6 +526,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     _apply_windows_msys_bash_env_defaults(sanitized)
 
     sanitized = _scrub_delegated_child_kanban_env(sanitized)
+    sanitized = _scrub_kanban_lifecycle_ownership(sanitized)
 
     return sanitized
 
@@ -543,6 +544,30 @@ def _scrub_delegated_child_kanban_env(env: dict[str, str]) -> dict[str, str]:
     except Exception:
         pass
     return env
+
+
+def _scrub_kanban_lifecycle_ownership(env: dict[str, str]) -> dict[str, str]:
+    """Strip Kanban run ownership from every child process.
+
+    A Kanban worker's terminal / browser / ACP children inherit ``os.environ``.
+    Without this, ``hermes chat --source tool`` becomes a second board worker
+    and can ``kanban_complete`` the parent card. Fail closed if the helper
+    cannot be imported: drop the known ownership keys locally.
+    """
+    try:
+        from agent.delegation_context import scrub_kanban_lifecycle_ownership
+
+        return scrub_kanban_lifecycle_ownership(env)
+    except Exception:
+        for key in (
+            "HERMES_KANBAN_TASK",
+            "HERMES_KANBAN_RUN_ID",
+            "HERMES_KANBAN_WORKSPACE",
+            "HERMES_KANBAN_WORKSPACES_ROOT",
+            "HERMES_KANBAN_CLAIM_LOCK",
+        ):
+            env.pop(key, None)
+        return env
 
 
 # Tier-1 secrets: stripped from EVERY spawned subprocess unconditionally —
@@ -667,6 +692,7 @@ def hermes_subprocess_env(*, inherit_credentials: bool = False) -> dict[str, str
     # context that later imports Kanban DB code in the spawned process would
     # still see the parent's HERMES_HOME but lose the DB mutation guard.
     env = _scrub_delegated_child_kanban_env(env)
+    env = _scrub_kanban_lifecycle_ownership(env)
 
     return env
 
@@ -1338,6 +1364,7 @@ def _make_run_env(env: dict) -> dict:
     _apply_windows_msys_bash_env_defaults(run_env)
 
     run_env = _scrub_delegated_child_kanban_env(run_env)
+    run_env = _scrub_kanban_lifecycle_ownership(run_env)
 
     return run_env
 


### PR DESCRIPTION
## Bug Description

A dispatcher-owned Kanban worker that shells out to `hermes chat` (for example `hermes chat -Q … --source tool` for Browser Use) inherited `HERMES_KANBAN_TASK` / `RUN_ID` / `WORKSPACE` / `CLAIM_LOCK`. The child process is a new interpreter, so in-process ContextVars cannot help: `is_dispatcher_owned_worker_context()` defaults True, and the child can `kanban_complete` the parent card, which then deletes the scratch workspace while the real worker is still running.

Fixes #70809

Related (open, not landed, different or incomplete approaches): #70898, #81843.

## Root Cause

1. Terminal / subprocess env builders copied `os.environ` and only fully scrubbed Kanban identity inside `delegate_task` / in-process cron contexts.
2. A nested `hermes chat` is a new process, so ContextVar isolation from #56647 / #69837 / cron isolation does not apply.

## Fix

Defense in depth, transplanted from locally tested commit `2abc0a841` onto current `origin/main`:

- Spawn path: `_make_run_env`, `_sanitize_subprocess_env`, and `hermes_subprocess_env` drop lifecycle ownership keys (`TASK`, `RUN_ID`, `WORKSPACE`, `WORKSPACES_ROOT`, `CLAIM_LOCK`). Board routing pins (`BOARD` / `DB`) stay so `hermes kanban` shell-outs remain on the same board (#20074). `build_subprocess_env(scrub_secrets=True)` inherits this via `_sanitize_subprocess_env`.
- Startup path: `cmd_chat` drops the same keys unless this process is the explicit dispatcher worker (`HERMES_SESSION_SOURCE=kanban` AND query `work kanban task <id>`). `--query-file` is checked after the prompt is loaded.
- Dispatcher `_default_spawn` still injects ownership into the real worker.

Authorship of the functional commit is preserved (`Sherman Lye`). A follow-up mapping commit attributes the local author email to `ming0627` for contributor-check CI.

## How to Verify

1. Run the targeted isolation suite (see Test Plan).
2. Confirm a child env from `LocalEnvironment.execute` / `_make_run_env` has no `HERMES_KANBAN_TASK` while `HERMES_KANBAN_BOARD` / provider-style keys remain.
3. Confirm `cmd_chat --source tool` drops inherited ownership, a mismatched `work kanban task` prompt drops it, and an explicit board-worker launch keeps it.
4. Confirm `kanban_complete` from that child env errors and the parent task stays `running` with its workspace intact.

## Test Plan

- [x] Added regression tests for spawn-path isolation and cmd_chat startup
- [x] Existing sibling isolation tests still pass
- [x] Exact incident test: `test_terminal_child_cannot_complete_parent_and_parent_stays_running`

Verified on this PR branch (fresh clone of current `origin/main` + transplant), not the live checkout:

```
scripts/run_tests.sh \
  tests/tools/test_kanban_child_chat_env_isolation.py \
  tests/hermes_cli/test_kanban_child_chat_startup.py \
  tests/tools/test_hermes_subprocess_env.py \
  tests/tools/test_delegate_kanban_isolation.py \
  tests/cron/test_cron_kanban_env_isolation.py \
  tests/tools/test_kanban_tools.py \
  tests/hermes_cli/test_pin_kanban_board_env.py \
  tests/hermes_cli/test_kanban_worker_session_source.py \
  tests/hermes_cli/test_kanban_worker_spawn_toolsets.py \
  tests/tools/test_build_subprocess_env.py \
  tests/agent/test_subprocess_env_guard.py
```

Result: **11 files, 100 tests passed, 0 failed**.

## Risk Assessment

Low / Medium — blast radius is env inheritance for subprocesses launched from a Kanban worker and `cmd_chat` startup. Board pins and Browser Use / provider-key passthrough (`inherit_credentials`, `_BROWSER_PASSTHROUGH_KEYS`) are unchanged. Dispatcher workers keep ownership via the explicit argv/env contract.

This is **not** claiming a local-only commit as landed upstream. Merge to `NousResearch/hermes-agent` main is the durable landing.
