### PR TITLE
fix(terminal): keep docker persistent sessions on shared container

### DIFF
--- a/tests/tools/test_shared_container_task_id.py
+++ b/tests/tools/test_shared_container_task_id.py
@@ -77,12 +77,14 @@ def test_env_type_override_keeps_own_id():
 # the shared "default" slot silently runs commands on the wrong remote host.
 
 
-def test_session_key_scopes_to_its_own_slot(monkeypatch):
+def test_session_key_scopes_to_its_own_slot_for_ssh(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
     monkeypatch.setenv("HERMES_SESSION_KEY", "sess-A")
     assert terminal_tool._resolve_container_task_id(None) == "session:sess-A"
 
 
-def test_distinct_session_keys_get_distinct_slots(monkeypatch):
+def test_distinct_session_keys_get_distinct_slots_for_ssh(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
     monkeypatch.setenv("HERMES_SESSION_KEY", "sess-A")
     a = terminal_tool._resolve_container_task_id(None)
     monkeypatch.setenv("HERMES_SESSION_KEY", "sess-B")
@@ -92,9 +94,10 @@ def test_distinct_session_keys_get_distinct_slots(monkeypatch):
     assert a != b
 
 
-def test_subagent_collapses_onto_parent_session(monkeypatch):
+def test_subagent_collapses_onto_parent_session_for_ssh(monkeypatch):
     # Subagents inherit the parent's session key, so they share the parent's
     # container (the #16177 intent) rather than a global "default".
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
     monkeypatch.setenv("HERMES_SESSION_KEY", "sess-A")
     assert (
         terminal_tool._resolve_container_task_id("subagent-3-cafef00d")
@@ -102,7 +105,8 @@ def test_subagent_collapses_onto_parent_session(monkeypatch):
     )
 
 
-def test_rl_override_wins_over_session_key(monkeypatch):
+def test_rl_override_wins_over_session_key_for_ssh(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
     monkeypatch.setenv("HERMES_SESSION_KEY", "sess-A")
     terminal_tool.register_task_env_overrides("tb2-z", {"docker_image": "z:1"})
     try:
@@ -114,6 +118,16 @@ def test_rl_override_wins_over_session_key(monkeypatch):
 def test_no_session_key_still_defaults(monkeypatch):
     # CLI mode: no session key -> unchanged "default" behaviour.
     monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    assert terminal_tool._resolve_container_task_id(None) == "default"
+
+
+def test_docker_persistent_mode_ignores_session_key(monkeypatch):
+    # Shared-container contract: docker + persistent=true must keep "default"
+    # even when gateway/webhook binds a session key.
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
+    monkeypatch.setenv("HERMES_SESSION_KEY", "sess-A")
     assert terminal_tool._resolve_container_task_id(None) == "default"
 
 
@@ -128,11 +142,12 @@ def test_no_session_key_still_defaults(monkeypatch):
 # HERMES_SESSION_KEY absent from os.environ.
 
 
-def test_session_key_from_contextvar_without_environ(monkeypatch):
+def test_session_key_from_contextvar_without_environ_for_ssh(monkeypatch):
     # Prove the fix works on the gateway path: HERMES_SESSION_KEY is NOT in
     # os.environ; the key lives only in the ContextVar bound by the gateway.
     from gateway.session_context import clear_session_vars, set_session_vars
 
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
     monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
     tokens = set_session_vars(session_key="sess-ctx")
     try:
@@ -148,18 +163,32 @@ def test_session_key_from_contextvar_without_environ(monkeypatch):
         clear_session_vars(tokens)
 
 
-def test_contextvar_session_key_wins_over_environ(monkeypatch):
+def test_contextvar_session_key_wins_over_environ_for_ssh(monkeypatch):
     # Two concurrent gateway sessions in one process must not cross-contaminate:
     # the ContextVar is authoritative even when a *different* value lingers in
     # os.environ (e.g. a CLI-set or previously-leaked global). The container
     # slot must follow the ContextVar-bound session, not the process global.
     from gateway.session_context import clear_session_vars, set_session_vars
 
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
     monkeypatch.setenv("HERMES_SESSION_KEY", "sess-ENV")
     tokens = set_session_vars(session_key="sess-CTX")
     try:
         assert (
             terminal_tool._resolve_container_task_id(None) == "session:sess-CTX"
         )
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_contextvar_session_key_does_not_scope_docker_persistent(monkeypatch):
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    tokens = set_session_vars(session_key="sess-ctx")
+    try:
+        assert terminal_tool._resolve_container_task_id(None) == "default"
     finally:
         clear_session_vars(tokens)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1394,21 +1394,15 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
         return task_id
     if task_id and _docker_session_isolation_enabled():
         return _resolve_container_alias(task_id)
-    # Per-session isolation: when a session key is present (the WebUI streaming
-    # layer sets it per-session, the gateway per-message via contextvars), scope
-    # the container to it so switching profiles can't reuse a previous profile's
-    # SSHEnvironment and silently run commands on the wrong remote host. Subagents
-    # inherit the same session key, so they still collapse onto the parent's
-    # container (the #16177 shared-container intent). CLI mode has no session key
-    # and falls through to "default", behaviour unchanged. See commit e00f940a9.
-    #
-    # This runs *after* the isolation-override and docker/container_persistent
-    # branches above: those paths already key containers per task_id, so they
-    # stay authoritative where they apply and this only covers the cases that
-    # would otherwise collapse to the shared "default" key (notably SSH).
-    session_key = _current_session_key()
-    if session_key:
-        return f"session:{session_key}"
+    # Per-session scoping is SSH-only: switching profiles/sessions must not
+    # reuse a prior SSHEnvironment (wrong host risk), but Docker with
+    # container_persistent=true is explicitly documented to share one
+    # long-lived container across surfaces. Keep SSH isolation while preserving
+    # Docker's shared-container contract.
+    if os.getenv("TERMINAL_ENV", "local") == "ssh":
+        session_key = _current_session_key()
+        if session_key:
+            return f"session:{session_key}"
     return "default"
 
 


### PR DESCRIPTION
## Summary
This fixes a docker terminal regression shape where gateway/webhook turns could be mapped to session-scoped container keys even when `terminal.container_persistent: true`, causing behavior to diverge from the shared-container contract.

The intended behavior for docker persistent mode is a shared `default` container across surfaces. Session-key scoping is still needed for SSH to avoid cross-session host reuse.

## Root Cause
`_resolve_container_task_id` applied session-key scoping broadly via `HERMES_SESSION_KEY` context, not just SSH. In docker persistent mode, that can split runs into session-scoped task IDs instead of `default`.

## Changes
- `tools/terminal_tool.py`
  - Restrict session-key container slot scoping to `TERMINAL_ENV=ssh` only.
  - Preserve existing precedence for explicit isolation overrides and docker session isolation mode.
- `tests/tools/test_shared_container_task_id.py`
  - Scope existing session-key tests explicitly to SSH.
  - Add docker-persistent tests proving session keys do **not** split the container in env-var and ContextVar paths.

## Validation
### Automated
- `uv run --with pytest pytest -q tests/tools/test_shared_container_task_id.py tests/tools/test_docker_session_isolation.py`
- Result: `40 passed`

### Manual runtime check (local)
- Restarted gateway.
- Sent signed webhook V2 request to `/webhooks/new-intake-paperwork`.
- Response: `202 Accepted`.
- Verified docker labels: no new `hermes-task-id=session:*` container appeared.
- Observed reuse on `hermes-task-id=default` container in logs.

## Platform tested
- macOS

## Related
- Original bug/fix context: #37361 and #41822



Fixes #92422
