### PR TITLE
fix(slack): keep clarify choices readable

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7102,21 +7102,28 @@ class SlackAdapter(BasePlatformAdapter):
             # wrapper never pushes the block over the limit (overflow →
             # invalid_blocks → no buttons).
             q = (question or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-            body = f"❓ {q}"
-            budget = 3000 - len("...")
-            if len(body) > budget:
-                body = body[:budget] + "..."
-
-            # One button per choice + a free-text "Other" button.  Slack caps
-            # an actions block at 5 elements; the clarify tool caps choices at
-            # 4 (+ Other = 5) so this is normally one block, but chunk anyway
-            # so a larger choice list degrades gracefully instead of 400ing.
-            elements = []
+            choice_lines = []
             for idx, choice in enumerate(choices):
-                label = str(choice).strip() or f"Option {idx + 1}"
+                full_choice = str(choice).strip() or f"Option {idx + 1}"
+                escaped_choice = full_choice.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                choice_lines.append(f"{idx + 1}. {escaped_choice}")
+            body = f"❓ {q}\n\n" + "\n".join(choice_lines)
+
+            # Slack button labels are single-line and capped at 75 characters.
+            # Keep the complete choices in readable section text and make the
+            # buttons compact numeric shortcuts. Split oversized section text
+            # across blocks rather than silently truncating any option.
+            section_texts = [body[start:start + 3000] for start in range(0, len(body), 3000)] or ["❓"]
+
+            # One numbered button per choice + a free-text "Other" button.
+            # Slack caps an actions block at 5 elements; the clarify tool caps
+            # choices at 4 (+ Other = 5) so this is normally one block, but
+            # chunk anyway so a larger choice list degrades gracefully.
+            elements = []
+            for idx, _choice in enumerate(choices):
                 elements.append({
                     "type": "button",
-                    "text": {"type": "plain_text", "text": label[:75], "emoji": True},
+                    "text": {"type": "plain_text", "text": str(idx + 1), "emoji": True},
                     "action_id": f"hermes_clarify_choice_{idx}",
                     "value": f"{clarify_id}|{idx}",
                 })
@@ -7128,7 +7135,8 @@ class SlackAdapter(BasePlatformAdapter):
             })
 
             blocks: list = [
-                {"type": "section", "text": {"type": "mrkdwn", "text": body}},
+                {"type": "section", "text": {"type": "mrkdwn", "text": section_text}}
+                for section_text in section_texts
             ]
             for start in range(0, len(elements), 5):
                 blocks.append({"type": "actions", "elements": elements[start:start + 5]})

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -124,7 +124,9 @@ class TestSlackSendClarify:
         assert elements[0]["value"] == "cid1|0"
         assert elements[1]["action_id"] == "hermes_clarify_choice_1"
         assert elements[1]["value"] == "cid1|1"
-        assert elements[0]["text"]["text"] == "staging"
+        assert elements[0]["text"]["text"] == "1"
+        assert "1. staging" in blocks[0]["text"]["text"]
+        assert "2. production" in blocks[0]["text"]["text"]
         # Final button is the free-text "Other"
         assert elements[2]["action_id"] == "hermes_clarify_other"
         assert elements[2]["value"] == "cid1|other"
@@ -133,6 +135,34 @@ class TestSlackSendClarify:
                 action_ids = [element["action_id"] for element in block["elements"]]
                 assert len(action_ids) == len(set(action_ids))
 
+    @pytest.mark.asyncio
+    async def test_long_choices_render_in_full_with_numbered_buttons(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5679"})
+        choices = [
+            "Run a complete keyword audit and rebuild the organic recommendation list",
+            "Only tag competitor brands and leave the remaining keywords unchanged",
+            "Export the full audit trail with every exclusion reason for review",
+        ]
+
+        result = await adapter.send_clarify(
+            chat_id="C1",
+            question="Which action should I take?",
+            choices=choices,
+            clarify_id="cid-long",
+            session_key="sk-long",
+        )
+
+        assert result.success is True
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        body = kwargs["blocks"][0]["text"]["text"]
+        for idx, choice in enumerate(choices, start=1):
+            assert f"{idx}. {choice}" in body
+
+        buttons = kwargs["blocks"][1]["elements"]
+        assert [button["text"]["text"] for button in buttons[:-1]] == ["1", "2", "3"]
+        assert buttons[-1]["text"]["text"] == "✏️ Other…"
 
     @pytest.mark.asyncio
     async def test_mrkdwn_escapes_question(self):


### PR DESCRIPTION
## Summary

- render complete clarify choices as a numbered list in Slack section text
- use compact numeric buttons so long option text is not cut off by Slack's 75-character single-line button limit
- preserve one-tap selection and the existing Other flow
- split oversized option text across section blocks instead of silently truncating it

## Verification

- added a regression test that fails on current main for long choices
- canonical runner: 6 tests passed in tests/gateway/test_slack_clarify_buttons.py
- Ruff passed for the changed adapter and tests
- git diff --check passed

## User impact

Slack users can read every option in full and either tap 1/2/3/4 or type the corresponding number. This keeps the fast interaction while avoiding truncated labels.