### PR TITLE
fix(memory): a bad nudge_interval no longer disables memory entirely

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -509,6 +509,35 @@ def _normalize_run_budget_seconds(value) -> Optional[float]:
     return seconds
 
 
+def _memory_int_setting(mem_config: dict, key: str, default: int) -> int:
+    """An int memory setting that can never abort memory initialization.
+
+    The whole memory block runs under one ``except``, so a bare ``int()`` on
+    a user-supplied value put a cosmetic tuning knob in front of the store:
+    ``nudge_interval: ten`` — or a bare ``nudge_interval:``, which YAML reads
+    as ``None`` — raised before ``MemoryStore`` was ever constructed and took
+    the entire feature down with it, silently.
+
+    Bad values fall back to *default* and say so once, so the setting is
+    diagnosable instead of invisible. ``bool`` is rejected because it is an
+    ``int`` subclass, and ``nudge_interval: true`` meaning "every turn" is
+    not what anyone writes on purpose.
+    """
+    raw = mem_config.get(key, default)
+    if isinstance(raw, bool) or not isinstance(raw, (int, str)):
+        logger.warning(
+            "memory.%s: expected an integer, got %r — using %d", key, raw, default
+        )
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "memory.%s: %r is not an integer — using %d", key, raw, default
+        )
+        return default
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -1850,7 +1879,9 @@ def init_agent(
             agent._memory_enabled, agent._user_profile_enabled = get_builtin_memory_store_flags(
                 _agent_cfg
             )
-            agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
+            agent._memory_nudge_interval = _memory_int_setting(
+                mem_config, "nudge_interval", 10
+            )
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
                 agent._memory_store = MemoryStore(
@@ -1861,7 +1892,13 @@ def init_agent(
                 )
                 agent._memory_store.load_from_disk()
         except Exception:
-            pass  # Memory is optional -- don't break agent init
+            # Memory is optional -- don't break agent init. But say so: a
+            # silently absent memory store is indistinguishable from one the
+            # user never enabled, and that made a bad tuning value look like
+            # the feature simply not working.
+            logger.warning(
+                "Memory initialization failed; continuing without it", exc_info=True
+            )
     
 
 

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -522,6 +522,11 @@ def _memory_int_setting(mem_config: dict, key: str, default: int) -> int:
     diagnosable instead of invisible. ``bool`` is rejected because it is an
     ``int`` subclass, and ``nudge_interval: true`` meaning "every turn" is
     not what anyone writes on purpose.
+
+    A valid non-positive value is passed through, not clamped: every consumer
+    gates on ``_memory_nudge_interval > 0`` (``agent/turn_context.py``), so
+    ``0`` — and any negative — is the documented way to turn nudges off. It is
+    the same value the review/curator agents set on themselves.
     """
     raw = mem_config.get(key, default)
     if isinstance(raw, bool) or not isinstance(raw, (int, str)):

--- a/tests/agent/test_memory_init_resilience.py
+++ b/tests/agent/test_memory_init_resilience.py
@@ -28,6 +28,18 @@ class TestCoercion:
             == expected
         )
 
+    @pytest.mark.parametrize("off", [0, -1, "0"])
+    def test_non_positive_values_pass_through_as_the_off_switch(self, off):
+        """Every consumer gates on `> 0`, so <=0 is how nudges are disabled.
+
+        Clamping these to the default would silently switch nudges back ON
+        for someone who deliberately turned them off.
+        """
+        assert (
+            _memory_int_setting({"nudge_interval": off}, "nudge_interval", 10)
+            == int(off)
+        )
+
     def test_an_absent_key_uses_the_default(self):
         assert _memory_int_setting({}, "nudge_interval", 10) == 10
 

--- a/tests/agent/test_memory_init_resilience.py
+++ b/tests/agent/test_memory_init_resilience.py
@@ -1,0 +1,56 @@
+"""A bad memory tuning value must not silently disable memory.
+
+`agent_init` builds the whole memory subsystem under one
+`except Exception: pass`. `nudge_interval` — a cosmetic "how often to nudge"
+knob — was read with a bare `int()` *before* `MemoryStore` was constructed,
+so `nudge_interval: ten`, or a bare `nudge_interval:` (YAML `None`), raised
+and took the store, `load_from_disk()`, and the entire feature down with it.
+No error, no log line: indistinguishable from memory never having been
+enabled.
+"""
+
+import logging
+
+import pytest
+
+from agent.agent_init import _memory_int_setting
+
+
+class TestCoercion:
+    @pytest.mark.parametrize("bad", ["ten", "10s", "", None, {"a": 1}, [1], True, False])
+    def test_a_bad_value_never_raises(self, bad):
+        assert _memory_int_setting({"nudge_interval": bad}, "nudge_interval", 10) == 10
+
+    @pytest.mark.parametrize("good,expected", [(7, 7), ("42", 42), (0, 0), (-1, -1)])
+    def test_real_values_pass_through(self, good, expected):
+        assert (
+            _memory_int_setting({"nudge_interval": good}, "nudge_interval", 10)
+            == expected
+        )
+
+    def test_an_absent_key_uses_the_default(self):
+        assert _memory_int_setting({}, "nudge_interval", 10) == 10
+
+    def test_a_bad_value_is_reported(self, caplog):
+        """Silent fallback would just move the invisibility, not remove it."""
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            _memory_int_setting({"nudge_interval": "ten"}, "nudge_interval", 10)
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("nudge_interval" in m for m in messages), messages
+        assert any("ten" in m for m in messages), messages
+
+    def test_true_is_not_taken_as_one(self):
+        """bool subclasses int; `nudge_interval: true` is a typo, not 1."""
+        assert _memory_int_setting({"nudge_interval": True}, "nudge_interval", 10) == 10
+
+
+class TestTheOriginalFailure:
+    @pytest.mark.parametrize("bad", ["ten", None])
+    def test_the_old_bare_int_aborted_on_these(self, bad):
+        """Documents the shape this replaced — a raise before the store existed."""
+        with pytest.raises((ValueError, TypeError)):
+            int({"nudge_interval": bad}.get("nudge_interval", 10))
+
+    def test_the_helper_survives_exactly_those(self):
+        for bad in ("ten", None):
+            assert _memory_int_setting({"nudge_interval": bad}, "nudge_interval", 10) == 10


### PR DESCRIPTION
## The bug

`agent_init` builds the whole memory subsystem under one `except Exception: pass`, and read `nudge_interval` with a bare `int()` **before** constructing the store:

```python
try:
    ...
    agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
    if agent._memory_enabled or agent._user_profile_enabled:
        agent._memory_store = MemoryStore(...)
        agent._memory_store.load_from_disk()
except Exception:
    pass  # Memory is optional -- don't break agent init
```

So `nudge_interval: ten` raises `ValueError`, and a bare `nudge_interval:` — which YAML reads as `None` — raises `TypeError`, both on that line, before `MemoryStore` exists. The `except` swallows it and **the entire memory feature is gone**: no store, no `load_from_disk()`, no nudges.

A cosmetic "how often to nudge" knob was sitting in front of memory itself.

The failure is invisible by construction: there is no error, no warning, and an absent memory store looks exactly like memory the user never turned on. Running the real block shape both ways:

```
bare int(), nudge_interval='ten' -> store = None
helper,     nudge_interval='ten' -> store = MemoryStore(created)
```

## The change

`_memory_int_setting()` cannot raise. A value that will not convert falls back to the default and is reported once, naming the key and the value, so the setting is diagnosable instead of invisible.

`bool` is rejected rather than coerced — it subclasses `int`, and `nudge_interval: true` is a typo, not a request for "every turn".

The bare `except` now logs with `exc_info`. It still never breaks agent init; it just stops making *any* failure in that block look like the feature was switched off.

## Scope

`memory_char_limit` / `user_char_limit` are deliberately untouched: **#58769** is open on exactly those lines.

Worth flagging for that PR, though — it adds two more bare `int()` calls *inside this same `try`*, which widens this hole rather than narrowing it. Its intent is right; routing those two casts through this helper would make them safe as well. Happy to do that here if the maintainers would rather see one change, or leave it to #58769.

## Tests

18 in `tests/agent/test_memory_init_resilience.py`: every non-int-able shape falls back rather than raising, real values (including `"42"`, `0`, negatives) pass through, an absent key uses the default, a bad value is reported with the key and the value in the message, and `true` is not taken as `1`. Two of them pin the original failure directly — `int()` raising on exactly the inputs the helper survives.

Baseline-checked against pristine `main` over the same four memory test files: identical results, no regressions.