### PR TITLE
fix(sessions): keep local CLI workspaces in project groups

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9929,6 +9929,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             if self._session_db:
                 try:
+                    from run_agent import _launch_cwd_for_session
+
                     self.agent._session_db_created = False
                     self._session_db.create_session(
                         session_id=self.session_id,
@@ -9938,6 +9940,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             "max_iterations": self.max_turns,
                             "reasoning_config": self.reasoning_config,
                         },
+                        cwd=_launch_cwd_for_session("cli"),
                     )
                     self.agent._session_db_created = True
                 except Exception:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1417,6 +1417,8 @@ class CLICommandsMixin:
         # /sessions even after the parent is reopened and re-ended with a
         # different end_reason (e.g. tui_shutdown overwriting 'branched').
         try:
+            from run_agent import _launch_cwd_for_session
+
             self._session_db.create_session(
                 session_id=new_session_id,
                 source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
@@ -1427,6 +1429,7 @@ class CLICommandsMixin:
                     "_branched_from": parent_session_id,
                 },
                 parent_session_id=parent_session_id,
+                cwd=_launch_cwd_for_session("cli"),
             )
         except Exception as e:
             _cprint(f"  Failed to create branch session: {e}")

--- a/run_agent.py
+++ b/run_agent.py
@@ -66,7 +66,7 @@ from types import SimpleNamespace
 from hermes_constants import get_hermes_home
 
 
-def _launch_cwd_for_session(source: str) -> Optional[str]:
+def _launch_cwd_for_session(platform: str) -> Optional[str]:
     """Working directory to stamp on a new session row, or None.
 
     Only local CLI sessions get a recorded cwd: the directory the process was
@@ -78,7 +78,7 @@ def _launch_cwd_for_session(source: str) -> Optional[str]:
     a non-"local" backend (docker/ssh/modal/...) means the host cwd is
     irrelevant to the agent's tools, so we skip it there too.
     """
-    if source != "cli":
+    if platform != "cli":
         return None
     backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
     if backend and backend != "local":
@@ -669,7 +669,11 @@ class AIAgent:
                 system_prompt=self._cached_system_prompt,
                 user_id=None,
                 parent_session_id=self._parent_session_id,
-                cwd=_launch_cwd_for_session(source),
+                # Workspace locality belongs to the runtime surface, not the
+                # durable source label. ``--source`` / HERMES_SESSION_SOURCE
+                # may relabel a local CLI row (for example as ``desktop`` or
+                # ``tool``), but it does not make its launch cwd remote.
+                cwd=_launch_cwd_for_session(self.platform or "cli"),
                 profile_name=_profile_for_session,
             )
             self._session_db_created = True

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -65,9 +65,17 @@ def cli_instance(tmp_path, session_db):
 class TestBranchCommandCLI:
     """Test the /branch command logic for the CLI."""
 
-    def test_branch_creates_new_session(self, cli_instance, session_db):
+    def test_branch_creates_new_session(
+        self, cli_instance, session_db, tmp_path, monkeypatch
+    ):
         """Branching should create a new session in the DB."""
         from cli import HermesCLI
+
+        workspace = tmp_path / "project"
+        workspace.mkdir()
+        monkeypatch.chdir(workspace)
+        monkeypatch.setenv("HERMES_SESSION_SOURCE", "desktop")
+        monkeypatch.setenv("TERMINAL_ENV", "local")
 
         # Call the real method on the mock, using the real implementation
         HermesCLI._handle_branch_command(cli_instance, "/branch")
@@ -76,6 +84,8 @@ class TestBranchCommandCLI:
         assert cli_instance.session_id != "20260403_120000_abc123"
         new_session = session_db.get_session(cli_instance.session_id)
         assert new_session is not None
+        assert new_session["source"] == "desktop"
+        assert new_session["cwd"] == str(workspace)
 
     def test_branch_copies_history(self, cli_instance, session_db):
         """Branching should copy all messages to the new session."""

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -149,7 +149,14 @@ def _reset_session_id_context():
     _VAR_MAP["HERMES_SESSION_ID"].set(_UNSET)
 
 
-def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path):
+def test_new_command_creates_real_fresh_session_and_resets_agent_state(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "desktop")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
     cli = _prepare_cli_with_active_session(tmp_path)
     old_session_id = cli.session_id
     old_session_start = cli.session_start
@@ -164,6 +171,8 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
 
     new_session = cli._session_db.get_session(cli.session_id)
     assert new_session is not None
+    assert new_session["source"] == "desktop"
+    assert new_session["cwd"] == str(workspace)
 
     cli._session_db.append_message(cli.session_id, role="user", content="next turn")
 

--- a/tests/run_agent/test_session_launch_cwd.py
+++ b/tests/run_agent/test_session_launch_cwd.py
@@ -1,0 +1,73 @@
+"""Regression tests for local CLI launch-directory persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+@pytest.mark.parametrize("platform", ["cli", None])
+def test_cli_source_override_keeps_launch_cwd(monkeypatch, tmp_path, platform):
+    """A durable source label must not erase the local CLI workspace."""
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "desktop")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        session_db=db,
+        session_id="source-override",
+        platform=platform,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    try:
+        agent._ensure_db_session()
+        row = db.get_session(agent.session_id)
+
+        assert row["source"] == "desktop"
+        assert Path(row["cwd"]) == workspace
+    finally:
+        agent.close()
+        db.close()
+
+
+def test_non_cli_platform_does_not_borrow_cli_source_cwd(monkeypatch, tmp_path):
+    """A relabeled gateway session must not inherit the process launch cwd."""
+    workspace = tmp_path / "gateway-launch"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "cli")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        session_db=db,
+        session_id="gateway-source-override",
+        platform="desktop",
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    try:
+        agent._ensure_db_session()
+        row = db.get_session(agent.session_id)
+
+        assert row["source"] == "cli"
+        assert row["cwd"] is None
+    finally:
+        agent.close()
+        db.close()


### PR DESCRIPTION
## What does this PR do?

Local CLI sessions now keep their launch working directory even when `--source` or `HERMES_SESSION_SOURCE` assigns a different durable source label. Without this, affected sessions were stored with `cwd = NULL`, so `projects.tree` could not place them under their declared project in Desktop.

### Symptom

A local CLI session started inside a project, including via `hermes chat --in <project>`, can be persisted with a null cwd when its durable source is overridden. The Desktop project sidebar then has no workspace metadata with which to group that session.

### Impact

Affected CLI sessions lose their project association in shared session state and appear outside their expected Desktop project group. Existing transcript data is not modified.

### Bug Cause

**Trigger:** `run_agent.py:636` / `AIAgent._ensure_db_session()` when a local CLI runtime has a non-`cli` durable source label.

**Causal chain:**
1. A local CLI session resolves `HERMES_SESSION_SOURCE` or `--source` into the row's durable `source` value.
2. `_ensure_db_session()` also passes that value to `_launch_cwd_for_session()`, which treats every value except `cli` as a non-local surface.
3. Session creation writes `cwd = NULL`, leaving the project tree without the workspace path required for membership.

**Why it is wrong:** A durable source label describes how a session should be categorized; it does not describe whether the runtime surface has a meaningful local launch directory.

**Working sibling / contrast:** TUI and Desktop session creation already track surface and explicit-workspace state separately in `tui_gateway`, so an explicit Desktop cwd is persisted while an unselected Desktop launch artifact stays null.

**Ruled out:** `git_repo_root` is not required for this case. The project-tree builder matches explicit project folders against `cwd`, supports non-Git folders, and already emits explicit projects with zero sessions.

### Fix

Use `AIAgent.platform` to decide whether the launch cwd is meaningful while preserving the independently resolved durable source label. The default `None` platform retains the existing direct-CLI behavior. Regression tests cover both directions: a relabeled CLI still persists cwd, and a non-CLI platform does not borrow cwd merely because its source label says `cli`.

## Related Issue

Fixes #92398

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` - separate runtime-surface cwd policy from the durable session source label.
- `tests/run_agent/test_session_launch_cwd.py` - verify local CLI persistence and non-CLI isolation with a real temporary `SessionDB`.

## How to Test

1. Run the launch-cwd regression tests.
2. Run the project-tree RPC tests, including terminal cwd and non-Git project behavior.
3. Run the session-state cwd/project subset.

```bash
scripts/run_tests.sh tests/run_agent/test_session_launch_cwd.py -q
scripts/run_tests.sh tests/tui_gateway/test_projects_rpc.py -q
scripts/run_tests.sh tests/test_hermes_state.py -k 'cwd or project' -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not applicable; behavior and regression coverage are self-contained
- [x] Config example update is not applicable; no config keys changed
- [x] Architecture guide update is not applicable; no architecture or workflow changed
- [x] I've considered cross-platform impact; the policy is surface-based and path comparisons remain delegated to `Path`
- [x] Tool description/schema update is not applicable; no model tool changed
