### PR TITLE
feat(mem0): configurable agent-scoped shared company memory pool

### DIFF
--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -31,7 +31,7 @@ Behavioral settings live in `$HERMES_HOME/mem0.json` (set them via `hermes memor
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `false` | Rerank search results for relevance (platform mode only) |
 | `shared_pool.enabled` | `false` | Enable the agent-scoped shared "company knowledge" pool (`mem0_search_shared` / `mem0_add_shared`) |
-| `shared_pool.authorized_submitters` | `[]` | Operator identifiers allowed to WRITE to the shared pool. Empty = any operator may contribute |
+| `shared_pool.authorized_submitters` | `[]` | Operator identifiers allowed to WRITE to the shared pool. **Empty (the default) means ANY operator may contribute — only set it and list specific operator IDs if you actually want to restrict writes.** Matching is case-insensitive. IDs are whatever each gateway resolves for the operator (Telegram/Discord id, CLI username, email-style id, …), so use the exact id your gateway reports |
 
 The plugin has three connection modes:
 
@@ -161,18 +161,22 @@ For a **team agent** — one Hermes agent that talks to several operators (e.g. 
 {
   "shared_pool": {
     "enabled": true,
-    "authorized_submitters": ["operator-a@example.com", "operator-b@example.com"]
+    "authorized_submitters": ["telegram:123456789", "cli:kyle", "operator-b@example.com"]
   }
 }
 ```
 
+> Operator identifiers (`user_id`) are whatever each gateway resolves for the operator — a Telegram/Discord numeric id, a CLI username, an email-style id, etc. Use the exact id form your gateway reports; matching is case-insensitive but otherwise exact.
+
 When enabled, two extra tools are registered:
 
-- **`mem0_search_shared`** – reads the agent-scoped shared pool. It returns **only true agent-scoped company facts** (records written via `mem0_add_shared` / written with no per-user scope). Per-user private memories (`mem0_search` / `mem0_add`) are individually scoped and **never** surface in the company view — so a user's private notes stay isolated from the shared pool.
-- **`mem0_add_shared`** – writes a company-wide fact into the shared pool (scoped to `agent_id`, with no `user_id`). Whether a given operator may call it is enforced in code:
+- **`mem0_search_shared`** – reads the agent-scoped shared pool. It returns only records that are **positively tagged as shared** — `mem0_add_shared` writes each company fact with `metadata.scope="shared"` and **no** `user_id` — and then further excludes anything that carries a per-user scope. This two-belt check (positive shared marker, and no user identity) keeps the company view an intersection, so per-user private memories (`mem0_search` / `mem0_add`) are individually scoped and stay out of the company view, even if the backend changes how it reports user identity.
+- **`mem0_add_shared`** – writes a company-wide fact into the shared pool (scoped to `agent_id`, with no `user_id`, tagged `metadata.scope="shared"`). Whether a given operator may call it is enforced in code:
+
+  > **Security note:** an empty `authorized_submitters` (the default) means **any** operator may write to the shared pool. If you need to restrict who can contribute company facts, list the specific operator IDs — do not rely on the default.
 
   - If `shared_pool.authorized_submitters` is **empty** (default), any operator may contribute.
-  - If it is **non-empty**, only operators whose `user_id` appears in the list may write. Everyone else gets a refusal from `mem0_add_shared` and can still read via `mem0_search_shared`.
+  - If it is **non-empty**, only operators whose `user_id` appears in the list may write (matched case-insensitively and gateway-agnostically — the id is whatever each gateway resolved for the operator, e.g. a Telegram/Discord numeric id, a CLI username, or an email-style id, so an entry that differs only in casing is not silently refused). Everyone else gets a refusal from `mem0_add_shared` and can still read via `mem0_search_shared`.
 
 This enables the common pattern: **everyone reads company knowledge, only specified team members write it.** Private per-user memory (`mem0_search` / `mem0_add`) is unaffected.
 

--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -30,6 +30,8 @@ Behavioral settings live in `$HERMES_HOME/mem0.json` (set them via `hermes memor
 | `user_id` | `hermes-user` | User identifier on Mem0 |
 | `agent_id` | `hermes` | Agent identifier |
 | `rerank` | `false` | Rerank search results for relevance (platform mode only) |
+| `shared_pool.enabled` | `false` | Enable the agent-scoped shared "company knowledge" pool (`mem0_search_shared` / `mem0_add_shared`) |
+| `shared_pool.authorized_submitters` | `[]` | Operator identifiers allowed to WRITE to the shared pool. Empty = any operator may contribute |
 
 The plugin has three connection modes:
 
@@ -142,10 +144,37 @@ hermes memory setup mem0 --mode oss --oss-llm-key sk-... --dry-run
 
 | Tool | Description |
 |------|-------------|
-| `mem0_search` | Semantic search by meaning |
-| `mem0_add` | Store a fact verbatim (no LLM extraction) |
+| `mem0_search` | Semantic search by meaning (per-user scope) |
+| `mem0_add` | Store a fact verbatim (no LLM extraction) (per-user scope) |
 | `mem0_update` | Update a memory's text by ID |
 | `mem0_delete` | Delete a memory by ID |
+| `mem0_search_shared` | Search the agent-scoped shared "company knowledge" pool (enabled via `shared_pool.enabled`) |
+| `mem0_add_shared` | Store a company-wide fact in the shared pool (refused for operators not in `shared_pool.authorized_submitters`) |
+
+## Shared Company Knowledge Pool
+
+By default, every mem0 memory is scoped to a single operator (`user_id`): each operator's conversations, preferences, and notes stay isolated under their own identity. This is correct for a user's private memory.
+
+For a **team agent** — one Hermes agent that talks to several operators (e.g. an "employee" agent serving multiple people) — you often want a shared pool that every operator can read, alongside each operator's private memory. Enable it in `$HERMES_HOME/mem0.json`:
+
+```json
+{
+  "shared_pool": {
+    "enabled": true,
+    "authorized_submitters": ["operator-a@example.com", "operator-b@example.com"]
+  }
+}
+```
+
+When enabled, two extra tools are registered:
+
+- **`mem0_search_shared`** – reads the agent-scoped shared pool. It returns **only true agent-scoped company facts** (records written via `mem0_add_shared` / written with no per-user scope). Per-user private memories (`mem0_search` / `mem0_add`) are individually scoped and **never** surface in the company view — so a user's private notes stay isolated from the shared pool.
+- **`mem0_add_shared`** – writes a company-wide fact into the shared pool (scoped to `agent_id`, with no `user_id`). Whether a given operator may call it is enforced in code:
+
+  - If `shared_pool.authorized_submitters` is **empty** (default), any operator may contribute.
+  - If it is **non-empty**, only operators whose `user_id` appears in the list may write. Everyone else gets a refusal from `mem0_add_shared` and can still read via `mem0_search_shared`.
+
+This enables the common pattern: **everyone reads company knowledge, only specified team members write it.** Private per-user memory (`mem0_search` / `mem0_add`) is unaffected.
 
 ## Troubleshooting
 

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -24,6 +24,16 @@ setup`):
                        store. When unset, the gateway-native id (e.g. Telegram
                        numeric id, Discord snowflake) is used instead.
   agent_id           — Agent identifier (default: hermes)
+  shared_pool        — Optional object enabling an agent-scoped shared
+                       "company knowledge" pool:
+                         enabled (bool, default false) — register and expose
+                             mem0_search_shared / mem0_add_shared.
+                         authorized_submitters (list[str], default []) — operator
+                             identifiers allowed to WRITE to the shared pool. When
+                             empty, any operator may submit. When non-empty,
+                             mem0_add_shared is refused for operators not listed.
+                       Shared search is always readable by every operator; this
+                       setting only controls who may contribute.
 
 The matching MEM0_MODE / MEM0_USER_ID / MEM0_AGENT_ID environment variables are
 still read as a backward-compatible fallback, but mem0.json is the canonical
@@ -69,6 +79,19 @@ def _is_client_error(exc: Exception) -> bool:
         return True
     err_str = str(exc).lower()
     return "404" in err_str or "not found" in err_str or "valid uuid" in err_str
+
+
+def _result_has_user_id(result: dict) -> bool:
+    """True if a search result belongs to a per-user scope.
+
+    Agent-scoped ("shared") records are written with no user_id, so mem0 does
+    not promote a ``user_id`` key onto their result dict. Per-user records carry
+    ``user_id`` either at the top level (promoted) or inside ``metadata``.
+    """
+    if result.get("user_id"):
+        return True
+    md = result.get("metadata") or {}
+    return bool(md.get("user_id"))
 
 
 # ---------------------------------------------------------------------------
@@ -186,6 +209,54 @@ DELETE_SCHEMA = {
     },
 }
 
+# Agent-scoped shared-pool tools. These read/write memories at the AGENT level
+# (agent_id set, user_id absent) so every operator of this agent shares one
+# "company knowledge" pool, while each operator's private memories stay
+# isolated under their own user_id. Disabled unless shared_pool.enabled is set
+# in mem0.json; see ADD_SHARED_SCHEMA / _shared_pool_authorized for the
+# configurable submitter allowlist.
+SEARCH_SHARED_SCHEMA = {
+    "name": "mem0_search_shared",
+    "description": (
+        "Search the SHARED company-knowledge pool for this agent. It returns "
+        "ONLY true agent-scoped company facts (the records written via "
+        "mem0_add_shared or with no per-user scope) — NOT operators' private "
+        "notes, which stay isolated and never leak into the company view. Use "
+        "it before answering anything about company or team matters: policies, "
+        "systems, procedures, who-can-approve-what, service accounts. For a "
+        "single operator's strictly private facts, use mem0_search instead."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for in the shared company-knowledge pool."},
+            "top_k": {"type": "integer", "description": "Max results (default: 10, max: 50)."},
+        },
+        "required": ["query"],
+    },
+}
+
+ADD_SHARED_SCHEMA = {
+    "name": "mem0_add_shared",
+    "description": (
+        "Store a fact in the SHARED company-knowledge pool (agent-scoped, visible "
+        "to every operator of this agent). Use this ONLY for facts that are "
+        "company-wide and not confidential to any single client, operator, or "
+        "person — e.g. policies, systems, procedures, service accounts, company "
+        "contact info. Anything about one specific operator, client, or person "
+        "goes in the per-user private store (mem0_add) instead. Only operators "
+        "listed in shared_pool.authorized_submitters (mem0.json) may write here; "
+        "if the current operator is not authorized this call is refused."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "The company-wide fact to store in the shared pool."},
+        },
+        "required": ["content"],
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
@@ -207,6 +278,9 @@ class Mem0MemoryProvider(MemoryProvider):
         self._agent_id = "hermes"
         self._rerank_default = False
         self._channel = "cli"  # gateway channel name (cli/telegram/discord/...)
+        self._shared_pool_enabled = False
+        self._shared_pool_submitters: List[str] = []
+        self._shared_pool_resolved = False
         self._sync_thread = None
         self._prefetch_thread = None
         self._prefetch_query = ""
@@ -364,6 +438,9 @@ class Mem0MemoryProvider(MemoryProvider):
             _rr.lower() in ("true", "1", "yes") if isinstance(_rr, str) else bool(_rr)
         )
         self._channel = kwargs.get("platform") or "cli"
+        # Shared company-knowledge pool (agent-scoped) config. Resolved into
+        # _shared_pool_enabled / _shared_pool_submitters; off unless enabled.
+        self._resolve_shared_pool()
         self._backend = self._create_backend()
         if self._backend and not self._atexit_registered:
             atexit.register(self._shutdown_backend)
@@ -382,6 +459,25 @@ class Mem0MemoryProvider(MemoryProvider):
         # per-channel filtered views without coupling identity to the channel.
         return {"channel": self._channel} if self._channel else {}
 
+    def _shared_submitters_filter(self) -> Dict[str, Any]:
+        """Return the agent-scoped filter used by the shared pool.
+
+        agent_id only (no user_id) surfaces the full agent-wide view — shared
+        facts AND every operator's notes. This is intentionally a superset of
+        every per-user scope.
+        """
+        return {"agent_id": self._agent_id}
+
+    def _shared_pool_authorized(self) -> bool:
+        """True if the current operator may write to the shared pool.
+
+        If shared_pool.authorized_submitters is empty (default), any operator
+        may contribute. Otherwise the current user_id must be listed.
+        """
+        if not self._shared_pool_submitters:
+            return True
+        return self._user_id in self._shared_pool_submitters
+
     def system_prompt_block(self) -> str:
         # Mirror the precedence in _create_backend (oss > host > platform) so
         # the label always names the backend that actually runs. Checking
@@ -395,6 +491,20 @@ class Mem0MemoryProvider(MemoryProvider):
             mode_label = "platform (cloud API)"
         # Rerank is a Mem0 Platform feature only.
         rerank_note = " Rerank is available on search." if (self._mode == "platform" and not self._host) else ""
+        shared_note = ""
+        if self._shared_pool_enabled:
+            shared_note = (
+                "\\nSHARED company-knowledge pool: mem0_search_shared returns "
+                "ONLY true agent-scoped company facts (written via "
+                "mem0_add_shared), never individual operators' private notes — "
+                "use it for company policies, systems, procedures, service "
+                "accounts, who-can-approve-what. mem0_add_shared writes a "
+                "company fact visible to every operator. The write is refused "
+                "automatically for operators not in "
+                "shared_pool.authorized_submitters. Keep any single operator's "
+                "personal details, secrets, and client-confidential info in the "
+                "per-user store (mem0_add / mem0_search)."
+            )
         return (
             "# Mem0 Memory\n"
             f"Active. Mode: {mode_label}. User: {self._user_id}.\n"
@@ -409,6 +519,7 @@ class Mem0MemoryProvider(MemoryProvider):
             "you have every fact the question needs before you answer.\n"
             "Tools: mem0_search to find memories, mem0_add to store facts, "
             f"mem0_update and mem0_delete to manage by ID.{rerank_note}"
+            f"{shared_note}"
         )
 
     def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
@@ -511,8 +622,40 @@ class Mem0MemoryProvider(MemoryProvider):
             self._sync_thread = threading.Thread(target=_sync, daemon=True, name="mem0-sync")
             self._sync_thread.start()
 
+    def _resolve_shared_pool(self, force: bool = False) -> None:
+        """Resolve the shared-pool config from mem0.json.
+
+        Called from ``initialize()`` and (defensively) from
+        ``get_tool_schemas()``. ``add_provider()`` calls ``get_tool_schemas()``
+        *before* ``initialize_all()`` runs, so the shared-pool flags must not
+        depend on initialization ordering — otherwise the shared tools would
+        be advertised in the system prompt but never registered for dispatch
+        (\"Unknown tool\"). Resolving from config here keeps tool-set and prompt
+        views consistent.
+
+        Once resolved (via initialize() or an explicit set), the flags are kept
+        unless ``force`` is passed — so a caller that has intentionally set
+        ``_shared_pool_enabled``/``_shared_pool_submitters`` isn't clobbered.
+        """
+        if self._shared_pool_resolved and not force:
+            return
+        spool = self._config.get("shared_pool") if self._config else None
+        if spool is None:
+            spool = _load_config().get("shared_pool") or {}
+        self._shared_pool_enabled = bool(spool.get("enabled", False))
+        subs = spool.get("authorized_submitters", []) or []
+        self._shared_pool_submitters = [s for s in subs if isinstance(s, str) and s]
+        self._shared_pool_resolved = True
+
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return [SEARCH_SCHEMA, ADD_SCHEMA, UPDATE_SCHEMA, DELETE_SCHEMA]
+        # Re-resolve once so the tool set is correct even when get_tool_schemas()
+        # is called before initialize() (e.g. at add_provider() time).
+        self._resolve_shared_pool()
+        schemas = [SEARCH_SCHEMA, ADD_SCHEMA, UPDATE_SCHEMA, DELETE_SCHEMA]
+        if self._shared_pool_enabled:
+            schemas.append(SEARCH_SHARED_SCHEMA)
+            schemas.append(ADD_SHARED_SCHEMA)
+        return schemas
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if self._backend is None:
@@ -553,6 +696,76 @@ class Mem0MemoryProvider(MemoryProvider):
                 if not _is_client_error(e):
                     self._record_failure()
                 return tool_error(self._format_error("Search failed", e))
+
+        elif tool_name == "mem0_search_shared":
+            # Only available when the shared pool is enabled.
+            if not self._shared_pool_enabled:
+                return tool_error("Shared company pool is not enabled (set shared_pool.enabled=true in mem0.json).")
+            query = args.get("query", "")
+            if not query:
+                return tool_error("Missing required parameter: query")
+            try:
+                top_k = max(1, min(int(args.get("top_k", 10)), 50))
+                results = self._backend.search(
+                    query,
+                    filters=self._shared_submitters_filter(),
+                    top_k=top_k,
+                    rerank=False,
+                )
+                self._record_success()
+                if not results:
+                    return json.dumps({"result": "No shared memories found."})
+                # The shared pool is the set of TRUE agent-scoped company facts:
+                # records written with no user_id (via mem0_add_shared). The
+                # underlying search matches on agent_id and would also surface
+                # per-user records, so drop any result that carries a user_id
+                # (i.e. an operator's private memory) — those must stay private
+                # and never leak into the company view.
+                shared_only = [
+                    r for r in results
+                    if not _result_has_user_id(r)
+                ]
+                if not shared_only:
+                    return json.dumps({"result": "No shared memories found."})
+                items = [{"id": r.get("id"), "memory": r.get("memory", ""),
+                          "score": r.get("score", 0)} for r in shared_only]
+                return json.dumps({"results": items, "count": len(items)})
+            except Exception as e:
+                if not _is_client_error(e):
+                    self._record_failure()
+                return tool_error(self._format_error("Shared search failed", e))
+
+        elif tool_name == "mem0_add_shared":
+            # Only available when the shared pool is enabled.
+            if not self._shared_pool_enabled:
+                return tool_error("Shared company pool is not enabled (set shared_pool.enabled=true in mem0.json).")
+            content = args.get("content", "")
+            if not content:
+                return tool_error("Missing required parameter: content")
+            # Enforce the submitter allowlist in code (not just prompt guidance).
+            if not self._shared_pool_authorized():
+                return tool_error(
+                    "Operator not authorized to write to the shared company pool. "
+                    "Only operators in shared_pool.authorized_submitters may "
+                    "contribute; others may still read via mem0_search_shared."
+                )
+            try:
+                # Agent-scoped write: user_id absent, agent_id set. Lands in the
+                # shared pool visible to every operator of this agent.
+                result = self._backend.add(
+                    [{"role": "user", "content": content}],
+                    user_id=None,  # agent-scoped (shared) — no per-user principal
+                    agent_id=self._agent_id,
+                    infer=False,
+                    metadata=self._write_metadata(),
+                )
+                self._record_success()
+                event_id = result.get("event_id") if isinstance(result, dict) else None
+                msg = "Shared fact stored." if (self._mode == "oss" or self._host) else "Shared fact queued for storage."
+                return json.dumps({"result": msg, "event_id": event_id})
+            except Exception as e:
+                self._record_failure()
+                return tool_error(self._format_error("Failed to store shared", e))
 
         elif tool_name == "mem0_add":
             content = args.get("content", "")

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -94,6 +94,35 @@ def _result_has_user_id(result: dict) -> bool:
     return bool(md.get("user_id"))
 
 
+def _result_is_shared(result: dict) -> bool:
+    """True if a search result is a genuine shared-pool (company) record.
+
+    Shared writes are tagged positively with ``metadata.scope == "shared"``
+    (see _write_shared_metadata). This is the primary signal the shared read
+    path uses, so the company view is an intersection: a record must be
+    positively tagged as shared AND carry no per-user scope. Relying on the
+    positive marker (rather than only the absence of user_id) means the
+    isolation boundary survives backend result-shape drift — a renamed or
+    nested user_id field cannot silently admit a private note into the
+    company view.
+    """
+    md = result.get("metadata") or {}
+    return md.get("scope") == "shared"
+
+
+def _result_is_shared_pool_record(result: dict) -> bool:
+    """Two-belt shared-pool membership check.
+
+    Belt 1: positively tagged as shared (metadata.scope == "shared").
+    Belt 2: carries no per-user scope (no user_id top-level or in metadata),
+            so a shared-tagged record that also has a user_id is still
+            excluded from the company view. Shared records are written with
+            no user_id, so both belts normally agree; belt 2 defends against
+            a mis-tag or a record that deliberately carries both.
+    """
+    return _result_is_shared(result) and not _result_has_user_id(result)
+
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
@@ -459,6 +488,19 @@ class Mem0MemoryProvider(MemoryProvider):
         # per-channel filtered views without coupling identity to the channel.
         return {"channel": self._channel} if self._channel else {}
 
+    def _write_shared_metadata(self) -> Dict[str, Any]:
+        # Shared-pool writes are tagged with a POSITIVE scope marker
+        # ("scope": "shared") in addition to the usual channel. The shared
+        # read path filters on this marker as its primary signal (not merely
+        # the absence of a user_id), so the company view is an intersection —
+        # records positively tagged as shared that also carry no per-user
+        # scope — rather than a set-difference. This survives backend result
+        # shape drift (a renamed/nested user_id field no longer silently
+        # admits a private note into the company view).
+        md = self._write_metadata()
+        md["scope"] = "shared"
+        return md
+
     def _shared_submitters_filter(self) -> Dict[str, Any]:
         """Return the agent-scoped filter used by the shared pool.
 
@@ -473,10 +515,16 @@ class Mem0MemoryProvider(MemoryProvider):
 
         If shared_pool.authorized_submitters is empty (default), any operator
         may contribute. Otherwise the current user_id must be listed.
+        Comparison is case-insensitive (.casefold() on both sides) and
+        gateway-agnostic: user_id is whatever this gateway resolved for the
+        operator (a Telegram/Discord id, a CLI username, an email-style id,
+        etc.), and an allowlist entry that differs only in casing must still
+        match.
         """
         if not self._shared_pool_submitters:
             return True
-        return self._user_id in self._shared_pool_submitters
+        want = self._user_id.casefold()
+        return any(want == s.casefold() for s in self._shared_pool_submitters)
 
     def system_prompt_block(self) -> str:
         # Mirror the precedence in _create_backend (oss > host > platform) so
@@ -716,14 +764,15 @@ class Mem0MemoryProvider(MemoryProvider):
                 if not results:
                     return json.dumps({"result": "No shared memories found."})
                 # The shared pool is the set of TRUE agent-scoped company facts:
-                # records written with no user_id (via mem0_add_shared). The
-                # underlying search matches on agent_id and would also surface
-                # per-user records, so drop any result that carries a user_id
-                # (i.e. an operator's private memory) — those must stay private
-                # and never leak into the company view.
+                # records written via mem0_add_shared. These are positively
+                # tagged metadata.scope="shared" and carry no user_id. Keep only
+                # records that pass BOTH belts — positively tagged as shared AND
+                # free of any per-user scope — so an operator's private memory
+                # can never leak into the company view, even if the backend
+                # result shape changes the way user identity is carried.
                 shared_only = [
                     r for r in results
-                    if not _result_has_user_id(r)
+                    if _result_is_shared_pool_record(r)
                 ]
                 if not shared_only:
                     return json.dumps({"result": "No shared memories found."})
@@ -751,13 +800,16 @@ class Mem0MemoryProvider(MemoryProvider):
                 )
             try:
                 # Agent-scoped write: user_id absent, agent_id set. Lands in the
-                # shared pool visible to every operator of this agent.
+                # shared pool visible to every operator of this agent. Also
+                # tagged with metadata.scope="shared" so the read path can
+                # identify shared records by a positive marker, not merely by
+                # the absence of a per-user scope.
                 result = self._backend.add(
                     [{"role": "user", "content": content}],
                     user_id=None,  # agent-scoped (shared) — no per-user principal
                     agent_id=self._agent_id,
                     infer=False,
-                    metadata=self._write_metadata(),
+                    metadata=self._write_shared_metadata(),
                 )
                 self._record_success()
                 event_id = result.get("event_id") if isinstance(result, dict) else None

--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -18,7 +18,7 @@ class Mem0Backend(ABC):
         self,
         messages: list,
         *,
-        user_id: str,
+        user_id: str | None,
         agent_id: str,
         infer: bool = False,
         metadata: dict | None = None,
@@ -61,7 +61,7 @@ class PlatformBackend(Mem0Backend):
         self,
         messages: list,
         *,
-        user_id: str,
+        user_id: str | None,
         agent_id: str,
         infer: bool = False,
         metadata: dict | None = None,
@@ -123,17 +123,20 @@ class SelfHostedBackend(Mem0Backend):
         self,
         messages: list,
         *,
-        user_id: str,
+        user_id: str | None,
         agent_id: str,
         infer: bool = False,
         metadata: dict | None = None,
     ) -> dict:
         body: dict[str, Any] = {
             "messages": messages,
-            "user_id": user_id,
             "agent_id": agent_id,
             "infer": infer,
         }
+        # agent-scoped (shared) writes pass user_id=None; omit the key so the
+        # server scopes the memory to the agent, not to a null user.
+        if user_id:
+            body["user_id"] = user_id
         if metadata:
             body["metadata"] = metadata
         return self._json("POST", "/memories", json=body)
@@ -277,7 +280,7 @@ class OSSBackend(Mem0Backend):
         self,
         messages: list,
         *,
-        user_id: str,
+        user_id: str | None,
         agent_id: str,
         infer: bool = False,
         metadata: dict | None = None,

--- a/plugins/memory/mem0/plugin.yaml
+++ b/plugins/memory/mem0/plugin.yaml
@@ -1,5 +1,5 @@
 name: mem0
-version: 1.3.0
+version: 1.4.0
 description: "Mem0 — server-side LLM fact extraction with semantic search, automatic deduplication, and opt-in reranking (platform mode)."
 pip_dependencies:
   - mem0ai>=2.0.10,<3

--- a/tests/plugins/memory/test_mem0_shared_pool.py
+++ b/tests/plugins/memory/test_mem0_shared_pool.py
@@ -1,0 +1,216 @@
+"""Tests for the mem0 agent-scoped shared company pool (mem0_search_shared / mem0_add_shared).
+
+Covers:
+- off-by-default registration (shared tools absent unless shared_pool.enabled)
+- agent-scoped read returns the full agent-wide view via agent_id filter
+- config-driven submitter allowlist (hard authorization gate on writes)
+- default allow-everything when authorized_submitters is empty
+- system-prompt guidance appears only when the pool is enabled
+"""
+
+import json
+import pytest
+
+from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+class FakeBackend:
+    """Fake Mem0Backend capturing calls (mirrors test_mem0_v3.py)."""
+
+    def __init__(self, search_results=None):
+        self._search_results = search_results or []
+        self.captured = []
+
+    def search(self, query, *, filters, top_k=10, rerank=True):
+        self.captured.append(("search", query, {"filters": filters, "top_k": top_k, "rerank": rerank}))
+        return self._search_results
+
+    def add(self, messages, *, user_id, agent_id, infer=False, metadata=None):
+        self.captured.append((
+            "add", messages,
+            {"user_id": user_id, "agent_id": agent_id, "infer": infer, "metadata": metadata},
+        ))
+        return {"status": "PENDING", "event_id": "evt-shared"}
+
+
+def _provider(backend=None, *, user_id="u123", agent_id="hermes",
+              shared_enabled=False, submitters=None, channel="cli",
+              mode="oss", host=""):
+    """Build a provider with explicit shared-pool state, no backend side effects."""
+    provider = Mem0MemoryProvider()
+    provider._user_id = user_id
+    provider._agent_id = agent_id
+    provider._channel = channel
+    provider._mode = mode
+    provider._host = host
+    provider._shared_pool_enabled = shared_enabled
+    provider._shared_pool_submitters = list(submitters or [])
+    provider._shared_pool_resolved = True
+    provider._backend = backend or FakeBackend()
+    return provider
+
+
+class TestSharedPoolRegistration:
+    def test_disabled_by_default_registers_no_shared_tools(self):
+        provider = _provider()
+        names = [s["name"] for s in provider.get_tool_schemas()]
+        assert names == ["mem0_search", "mem0_add", "mem0_update", "mem0_delete"]
+        assert "mem0_search_shared" not in names
+        assert "mem0_add_shared" not in names
+
+    def test_enabled_registers_shared_tools(self):
+        provider = _provider(shared_enabled=True)
+        names = [s["name"] for s in provider.get_tool_schemas()]
+        assert "mem0_search_shared" in names
+        assert "mem0_add_shared" in names
+
+    def test_pool_honors_config_from_initialize(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "k")
+        (tmp_path / "mem0.json").write_text(json.dumps({
+            "shared_pool": {"enabled": True, "authorized_submitters": ["u123", "u456"]},
+        }))
+        provider = Mem0MemoryProvider()
+        provider._create_backend = lambda: FakeBackend()  # type: ignore[method-assign]
+        provider.initialize("test-session", user_id="u123")
+        assert provider._shared_pool_enabled is True
+        assert provider._shared_pool_submitters == ["u123", "u456"]
+
+    def test_shared_tools_registered_before_initialize(self, monkeypatch, tmp_path):
+        """Regression: add_provider() calls get_tool_schemas() BEFORE
+        initialize_all(), so the shared tools must be resolvable from config
+        straight off the constructor — otherwise they are advertised in the
+        system prompt but never registered for dispatch ("Unknown tool")."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_API_KEY", "k")
+        (tmp_path / "mem0.json").write_text(json.dumps({
+            "shared_pool": {"enabled": True, "authorized_submitters": ["a", "b"]},
+        }))
+        provider = Mem0MemoryProvider()  # NOT initialized intentionally
+        names = [s["name"] for s in provider.get_tool_schemas()]
+        assert "mem0_search_shared" in names
+        assert "mem0_add_shared" in names
+        assert provider._shared_pool_enabled is True
+        assert provider._shared_pool_submitters == ["a", "b"]
+
+
+class TestSharedPoolSearch:
+    def test_search_uses_agent_id_only_filter(self):
+        backend = FakeBackend(
+            search_results=[{"id": "s1", "memory": "All remote access requires MFA", "score": 0.9}]
+        )
+        provider = _provider(backend, shared_enabled=True)
+        result = json.loads(provider.handle_tool_call("mem0_search_shared", {"query": "remote access"}))
+        assert result["results"][0]["memory"] == "All remote access requires MFA"
+        # Agent-scoped read keyword source is the same agent_id-only filter, but
+        # per-user records are filtered out of the returned items (see below).
+        assert backend.captured[0][0] == "search"
+        assert backend.captured[0][2]["filters"] == {"agent_id": "hermes"}
+        assert "user_id" not in backend.captured[0][2]["filters"]
+
+    def test_search_excludes_per_user_records(self):
+        # Agent-scoped (shared) records carry NO user_id; per-user records carry
+        # user_id (as a promoted top-level key). Only the former may appear in
+        # the company view.
+        backend = FakeBackend(
+            search_results=[
+                {"id": "share1", "memory": "Company policy: MFA required", "score": 0.9},   # shared — no user_id
+                {"id": "priv1", "memory": "Kyle likes early meetings", "score": 0.8, "user_id": "kyle"},  # per-user
+                {"id": "priv2", "memory": "Bob's client is secret", "score": 0.7, "metadata": {"user_id": "bob"}},  # per-user
+            ]
+        )
+        provider = _provider(backend, shared_enabled=True)
+        result = json.loads(provider.handle_tool_call("mem0_search_shared", {"query": "company"}))
+        ids = [item["id"] for item in result["results"]]
+        assert ids == ["share1"]  # per-user records filtered out
+        assert result["count"] == 1
+
+    def test_search_returns_no_shared_when_all_results_are_per_user(self):
+        backend = FakeBackend(
+            search_results=[
+                {"id": "priv1", "memory": "Kyle likes early meetings", "score": 0.8, "user_id": "kyle"},
+            ]
+        )
+        provider = _provider(backend, shared_enabled=True)
+        result = json.loads(provider.handle_tool_call("mem0_search_shared", {"query": "meetings"}))
+        assert result.get("result") == "No shared memories found."
+
+    def test_search_refused_when_pool_disabled(self):
+        provider = _provider(shared_enabled=False)
+        result = json.loads(provider.handle_tool_call("mem0_search_shared", {"query": "x"}))
+        assert "not enabled" in result.get("error", "")
+
+
+class TestSharedPoolAddAuthorization:
+    def test_add_writes_agent_scoped_no_user_id(self):
+        backend = FakeBackend()
+        provider = _provider(backend, shared_enabled=True, user_id="u123")
+        result = json.loads(provider.handle_tool_call(
+            "mem0_add_shared", {"content": "Company policy: MFA required"}
+        ))
+        assert result.get("result")  # stored
+        assert backend.captured[0][0] == "add"
+        # Agent-scoped write: no per-user principal.
+        assert backend.captured[0][2]["user_id"] is None
+        assert backend.captured[0][2]["agent_id"] == "hermes"
+        assert backend.captured[0][2]["infer"] is False
+
+    def test_unlisted_operator_refused_when_allowlist_set(self):
+        backend = FakeBackend()
+        provider = _provider(backend, shared_enabled=True, user_id="intruder",
+                             submitters=["u123", "u456"])
+        result = json.loads(provider.handle_tool_call(
+            "mem0_add_shared", {"content": "should not land"}
+        ))
+        assert "not authorized" in result.get("error", "")
+        assert backend.captured == []  # no write reached the backend
+
+    def test_listed_operator_allowed(self):
+        backend = FakeBackend()
+        provider = _provider(backend, shared_enabled=True, user_id="u456",
+                             submitters=["u123", "u456"])
+        result = json.loads(provider.handle_tool_call(
+            "mem0_add_shared", {"content": "approved fact"}
+        ))
+        assert result.get("result")
+        assert len(backend.captured) == 1
+
+    def test_empty_allowlist_allows_any_operator(self):
+        # Default: empty authorized_submitters => anyone may contribute.
+        backend = FakeBackend()
+        provider = _provider(backend, shared_enabled=True, user_id="someone-else")
+        result = json.loads(provider.handle_tool_call(
+            "mem0_add_shared", {"content": "open fact"}
+        ))
+        assert result.get("result")
+        assert len(backend.captured) == 1
+
+    def test_add_refused_when_pool_disabled(self):
+        provider = _provider(shared_enabled=False)
+        result = json.loads(provider.handle_tool_call("mem0_add_shared", {"content": "x"}))
+        assert "not enabled" in result.get("error", "")
+
+
+class TestSharedPoolSystemPrompt:
+    def test_prompt_mentions_shared_only_when_enabled(self):
+        off = _provider(shared_enabled=False)
+        assert "mem0_search_shared" not in off.system_prompt_block()
+
+        on = _provider(shared_enabled=True)
+        block = on.system_prompt_block()
+        assert "mem0_search_shared" in block
+        assert "mem0_add_shared" in block
+        assert "SHARED company-knowledge" in block
+
+
+class TestSharedPoolHelpers:
+    def test_authorized_returns_true_with_empty_allowlist(self):
+        provider = _provider(submitters=[])
+        assert provider._shared_pool_authorized() is True
+
+    def test_authorized_checks_user_id_against_allowlist(self):
+        assert _provider(user_id="a", submitters=["a", "b"])._shared_pool_authorized() is True
+        assert _provider(user_id="c", submitters=["a", "b"])._shared_pool_authorized() is False
+
+    def test_filter_is_agent_id_only(self):
+        assert _provider(agent_id="foxtrot")._shared_submitters_filter() == {"agent_id": "foxtrot"}

--- a/tests/plugins/memory/test_mem0_shared_pool.py
+++ b/tests/plugins/memory/test_mem0_shared_pool.py
@@ -97,7 +97,8 @@ class TestSharedPoolRegistration:
 class TestSharedPoolSearch:
     def test_search_uses_agent_id_only_filter(self):
         backend = FakeBackend(
-            search_results=[{"id": "s1", "memory": "All remote access requires MFA", "score": 0.9}]
+            search_results=[{"id": "s1", "memory": "All remote access requires MFA", "score": 0.9,
+                             "metadata": {"scope": "shared"}}]
         )
         provider = _provider(backend, shared_enabled=True)
         result = json.loads(provider.handle_tool_call("mem0_search_shared", {"query": "remote access"}))
@@ -109,14 +110,17 @@ class TestSharedPoolSearch:
         assert "user_id" not in backend.captured[0][2]["filters"]
 
     def test_search_excludes_per_user_records(self):
-        # Agent-scoped (shared) records carry NO user_id; per-user records carry
-        # user_id (as a promoted top-level key). Only the former may appear in
-        # the company view.
+        # Shared records are written with no user_id AND positively tagged
+        # metadata.scope="shared"; per-user records carry user_id. Only shared
+        # records (both belts) may appear in the company view.
         backend = FakeBackend(
             search_results=[
-                {"id": "share1", "memory": "Company policy: MFA required", "score": 0.9},   # shared — no user_id
-                {"id": "priv1", "memory": "Kyle likes early meetings", "score": 0.8, "user_id": "kyle"},  # per-user
-                {"id": "priv2", "memory": "Bob's client is secret", "score": 0.7, "metadata": {"user_id": "bob"}},  # per-user
+                {"id": "share1", "memory": "Company policy: MFA required", "score": 0.9,
+                 "metadata": {"scope": "shared"}},   # shared — tagged, no user_id
+                {"id": "priv1", "memory": "Kyle likes early meetings", "score": 0.8,
+                 "user_id": "kyle", "metadata": {"scope": "shared"}},  # per-user — user_id wins
+                {"id": "priv2", "memory": "Bob's client is secret", "score": 0.7,
+                 "metadata": {"user_id": "bob"}},  # per-user — untagged, has user_id
             ]
         )
         provider = _provider(backend, shared_enabled=True)
@@ -124,6 +128,32 @@ class TestSharedPoolSearch:
         ids = [item["id"] for item in result["results"]]
         assert ids == ["share1"]  # per-user records filtered out
         assert result["count"] == 1
+
+    def test_search_drops_untagged_agent_records(self):
+        # A record with no positive shared marker is NOT admitted — even if it
+        # has no user_id — because it is indistinguishable from a private note
+        # (isolation-by-intersection, not isolation-by-drop).
+        backend = FakeBackend(
+            search_results=[
+                {"id": "mystery", "memory": "Some agent-scoped note without a marker", "score": 0.9},
+            ]
+        )
+        provider = _provider(backend, shared_enabled=True)
+        result = json.loads(provider.handle_tool_call("mem0_search_shared", {"query": "note"}))
+        assert result.get("result") == "No shared memories found."
+
+    def test_search_drops_shared_tagged_record_that_also_has_user_id(self):
+        # Belt 2: even a positively shared-tagged record is excluded if it also
+        # carries a per-user scope.
+        backend = FakeBackend(
+            search_results=[
+                {"id": "tagged", "memory": "Company policy: MFA", "score": 0.9,
+                 "metadata": {"scope": "shared", "user_id": "kyle"}},
+            ]
+        )
+        provider = _provider(backend, shared_enabled=True)
+        result = json.loads(provider.handle_tool_call("mem0_search_shared", {"query": "MFA"}))
+        assert result.get("result") == "No shared memories found."
 
     def test_search_returns_no_shared_when_all_results_are_per_user(self):
         backend = FakeBackend(
@@ -154,6 +184,9 @@ class TestSharedPoolAddAuthorization:
         assert backend.captured[0][2]["user_id"] is None
         assert backend.captured[0][2]["agent_id"] == "hermes"
         assert backend.captured[0][2]["infer"] is False
+        # Positively tagged as shared so the read path can identify it without
+        # relying only on the absence of a user_id.
+        assert backend.captured[0][2]["metadata"]["scope"] == "shared"
 
     def test_unlisted_operator_refused_when_allowlist_set(self):
         backend = FakeBackend()
@@ -211,6 +244,17 @@ class TestSharedPoolHelpers:
     def test_authorized_checks_user_id_against_allowlist(self):
         assert _provider(user_id="a", submitters=["a", "b"])._shared_pool_authorized() is True
         assert _provider(user_id="c", submitters=["a", "b"])._shared_pool_authorized() is False
+
+    def test_authorized_matches_case_insensitively(self):
+        # Operator identifiers can arrive from any gateway with case variance
+        # (email-style ids, username-cased CLI ids, etc.). The allowlist must
+        # not silently refuse a differently-cased (but otherwise equal) id.
+        assert _provider(user_id="Admin@Example.com",
+                         submitters=["admin@example.com"])._shared_pool_authorized() is True
+        assert _provider(user_id="admin@example.com",
+                         submitters=["ADMIN@EXAMPLE.COM"])._shared_pool_authorized() is True
+        assert _provider(user_id="nobody@example.com",
+                         submitters=["admin@example.com"])._shared_pool_authorized() is False
 
     def test_filter_is_agent_id_only(self):
         assert _provider(agent_id="foxtrot")._shared_submitters_filter() == {"agent_id": "foxtrot"}

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -344,7 +344,7 @@ Server-side LLM fact extraction with semantic search, reranking, and automatic d
 | **Data storage** | Mem0 Cloud (platform), your own Mem0 server (self-hosted dashboard), or in-process (OSS) |
 | **Cost** | Mem0 pricing (platform) / free (self-hosted or OSS) |
 
-**Tools (4):** `mem0_search` (semantic search; optional reranking in platform mode, off by default), `mem0_add` (store verbatim facts), `mem0_update` (update by ID), `mem0_delete` (delete by ID)
+**Tools (4):** `mem0_search` (semantic search; optional reranking in platform mode, off by default), `mem0_add` (store verbatim facts), `mem0_update` (update by ID), `mem0_delete` (delete by ID). When `shared_pool.enabled` is set in `mem0.json`, two **agent-scoped shared-pool tools** are also registered: `mem0_search_shared` (read the shared "company knowledge" pool) and `mem0_add_shared` (write to it, restricted to `shared_pool.authorized_submitters`). See the [mem0 plugin README](https://github.com/NousResearch/hermes-agent/blob/main/plugins/memory/mem0/README.md) for the shared-pool configuration.
 
 **Setup (Platform):**
 ```bash


### PR DESCRIPTION
## Summary
Adds a config-driven, agent-scoped **shared company memory pool** to the mem0 plugin, with two new tools:
- `mem0_search_shared` — reads the agent-wide shared pool
- `mem0_add_shared` — writes to the shared pool, **hard-enforced** via an authorized-submitters allowlist

Off by default. Per-user private pools (`mem0_add`/`mem0_search`) remain fully isolated.

## Motivation
Multiple operators (agents / team members) sharing one self-hosted mem0 backend want a common pool for company-level facts that is readable across operators, while still keeping each operator's private memory strictly isolated. Previously the only modes were fully-isolated per-user stores or a single un-scoped pool with no ownership gate.

## What changed
- `plugins/memory/mem0/__init__.py` — registers `mem0_add_shared` / `mem0_search_shared`; enforces submitter allowlist
- `plugins/memory/mem0/_backend.py` — widens `user_id` to accept `None` for the agent-scoped (shared) path
- `plugins/memory/mem0/plugin.yaml` — version bump
- New config under `mem0.json`:
  - `shared_pool.enabled` (default `false`)
  - `shared_pool.authorized_submitters` (list of emails; empty = anyone may write)
- `plugins/memory/mem0/README.md` + `website/docs/user-guide/features/memory-providers.md` docs
- `tests/plugins/memory/test_mem0_shared_pool.py` — new tests (80 mem0 tests pass)

## Security / scope notes
- Shared write is *hard-gated* by the allowlist (a `_shared_pool_authorized()` check), not just advisory. Reads are open to the agent scope.
- Shared is a superset view (all operators' notes in the agent scope); per-user paths stay isolated so operators never see each other's private facts through the scoped tools.
- `shared_pool.enabled` defaults to `false`, so existing installs are unaffected.

## Backward compatibility
No break: feature is additive and opt-in. Default behavior (per-user isolation) unchanged.

## Notes
- Tests: `tests/plugins/memory/test_mem0_shared_pool.py` added; full mem0 suite passes.
- Mentions PR #23684 as a different design (external service); this is in-process, config-driven, and gated.