### PR TITLE
fix(kanban): let read-only CLI commands work in delegated-child contexts

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2775,7 +2775,12 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         "SELECT name FROM sqlite_master WHERE type='table' AND name='task_runs'"
     ).fetchone() is not None
     if runs_exist:
-        with write_txn(conn):
+        # Schema-init/migration write: runs under the cross-process init
+        # lock and is idempotent + CAS-guarded, so it is allowed to proceed
+        # even in a delegated-child context (a child spawning `hermes kanban
+        # list` must be able to complete init before reading). See
+        # write_txn's allow_delegated docstring.
+        with write_txn(conn, allow_delegated=True):
             inflight = conn.execute(
                 "SELECT id, assignee, claim_lock, claim_expires, worker_pid, "
                 "       max_runtime_seconds, last_heartbeat_at, started_at "
@@ -3041,7 +3046,12 @@ def _execute_boundary_with_retry(conn: sqlite3.Connection, sql: str) -> None:
 
 
 @contextlib.contextmanager
-def write_txn(conn: sqlite3.Connection, *, allow_nested: bool = False):
+def write_txn(
+    conn: sqlite3.Connection,
+    *,
+    allow_nested: bool = False,
+    allow_delegated: bool = False,
+):
     """Context manager for an IMMEDIATE write transaction.
 
     Use for any multi-statement write (creating a task + link, claiming a
@@ -3062,8 +3072,20 @@ def write_txn(conn: sqlite3.Connection, *, allow_nested: bool = False):
     The explicit ROLLBACK on exception is wrapped in try/except so that
     a SQLite auto-rollback (which leaves no active transaction) does not
     shadow the original exception with a spurious rollback error.
+
+    ``allow_delegated`` opts this particular write out of the
+    delegated-child fail-closed guard (``HERMES_DELEGATED_CHILD_CONTEXT``
+    set): use it ONLY for idempotent, cross-process-safe schema-init /
+    migration writes inside ``connect()``'s init path, which runs under
+    the cross-process init lock and which a child-spawned ``hermes kanban
+    list``/``stats`` MUST execute before it can report anything. Without
+    the opt-in, a delegated child shelling out to the CLI dies on the
+    init migration and every read command fails with the mutation
+    refusal. Ordinary task/board mutations keep the default fail-closed
+    behavior; there is no opt-in surface on the durable state itself.
     """
-    _assert_not_delegated_child_mutation()
+    if not allow_delegated:
+        _assert_not_delegated_child_mutation()
     if getattr(conn, "in_transaction", False):
         if not allow_nested:
             raise RuntimeError(
@@ -4542,7 +4564,14 @@ def recompute_ready(
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     promoted = 0
-    with write_txn(conn):
+    # allow_delegated: recompute is an idempotent, transaction-scoped
+    # derived-state refresh that every `hermes kanban list` performs
+    # regardless of caller. A delegated child shelling out to the CLI must
+    # get the same read-path behavior as any other invocation; the
+    # fail-closed guard is for durable task/board mutations, not this
+    # recompute pass (which the dispatcher and CLI both run routinely, and
+    # SQLite's write lock serializes across processes).
+    with write_txn(conn, allow_delegated=True):
         todo_rows = conn.execute(
             "SELECT id, status, consecutive_failures, max_retries "
             "FROM tasks WHERE status IN ('todo', 'blocked')"

--- a/tests/hermes_cli/test_kanban_cli_exit_status.py
+++ b/tests/hermes_cli/test_kanban_cli_exit_status.py
@@ -58,3 +58,28 @@ def test_delegated_child_kanban_cli_refusal_returns_nonzero_exit_status(tmp_path
 
     assert refused.returncode == 1
     assert "delegate_task child contexts cannot mutate Kanban tasks via the CLI" in refused.stderr
+
+
+def test_delegated_child_can_still_read_kanban(tmp_path):
+    """A delegated child shelling out to the CLI must be able to read.
+
+    Regression for the board-list "(empty)" + "could not initialize
+    database" bug: `init_db()` runs an idempotent migration within
+    `connect()`'s init path, and `recompute_ready` runs inside `list` — both
+    are harmless writes that a child MUST be allowed to perform so read
+    commands return real data instead of failing on the mutation guard.
+    """
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    seeded = _run_hermes(home, "kanban", "create", "seed for read", "--json")
+    assert seeded.returncode == 0, seeded.stderr
+
+    listed = _run_hermes(home, "kanban", "list", marker=True)
+    assert listed.returncode == 0, listed.stderr
+    assert "seed" in listed.stdout and "for" in listed.stdout
+
+    boards = _run_hermes(home, "kanban", "boards", "list", marker=True)
+    assert boards.returncode == 0, boards.stderr
+    assert "(empty)" not in boards.stdout
+    assert "ready=1" in boards.stdout


### PR DESCRIPTION
## Symptom

When `HERMES_DELEGATED_CHILD_CONTEXT=1` reaches the environment of a `hermes kanban` invocation:
- `hermes kanban boards list` prints `(empty)` counts for every board (real boards with tasks)
- `hermes kanban list` / `stats` fail with `kanban: could not initialize database: delegate_task child contexts cannot mutate Kanban tasks or boards`

## Root cause

Every non-repair kanban CLI action auto-runs `kb.init_db()`, and `_cmd_list` additionally runs `recompute_ready(conn)`. Both execute writes through `write_txn()`, which unconditionally calls `_assert_not_delegated_child_mutation()` — the fail-closed guard designed to stop delegate-task **children mutating durable task/board state** from inside the same process.

That same guard fires when a delegated child shells out to the CLI: the child process inherits the env marker, then dies on the idempotent **init migration backfill** and on the idempotent **recompute_ready** pass before it can report anything. A CLI subprocess is a separate OS process — its writes are serialized by SQLite's own write lock and the cross-process init lock, so the same-process rationale for the guard does not apply to subprocess reads.

## Fix

- Add `write_txn(conn, *, allow_delegated=False)` — an explicit opt-in that skips only the delegated-child guard, defaulting to the existing fail-closed behavior.
- Use the opt-in at exactly two idempotent, cross-process-safe sites:
  1. `connect()`'s init-time migration backfill (`task_runs` synthesis for in-flight tasks, CAS-guarded, runs under the cross-process init lock)
  2. `recompute_ready()` — the derived-state refresh that every `hermes kanban list` already performs regardless of caller

All ~55 durable task/board mutation sites keep failing closed, and the CLI-level mutation refusal for delegated children is unchanged (`kanban comment` from a child still returns exit 1 with the existing message).

## Tests

- Added `test_delegated_child_can_still_read_kanban` (regression): a child process with the marker set can `kanban list` and `boards list` and see real data.
- Existing `test_delegated_child_kanban_cli_refusal_returns_nonzero_exit_status` still passes — mutation refusal preserved.
- Full focused suite green: 80 passed, 1 skipped (kanban db / init / repair / exit-status / delegate-kanban-isolation / kanban-tools).

## Verification

Live reproduction under `HERMES_DELEGATED_CHILD_CONTEXT=1` before fix:

```
kanban: could not initialize database: delegate_task child contexts cannot mutate Kanban tasks or boards
```

After fix, same env:

```
dads-estate               Dad's Estate — Administration  blocked=18, done=15, ready=1, todo=1, triage=1
●   hermes-botmode-android    Hermes BotMode Android        done=2, running=5, todo=2
```

`list` / `stats` / `show` all return real data; `comment` from a child is still refused (exit 1).