### PR TITLE
fix(tools): quote regex/glob match args without Windows path translation

### DIFF
--- a/contributors/emails/salch-cred@users.noreply.github.com
+++ b/contributors/emails/salch-cred@users.noreply.github.com
@@ -1,0 +1,1 @@
+salch-cred

--- a/tests/tools/test_search_pattern_escaping.py
+++ b/tests/tools/test_search_pattern_escaping.py
@@ -59,9 +59,13 @@ def test_escape_match_arg_preserves_backslashes():
 
 
 def test_escape_shell_arg_still_translates_windows_paths(monkeypatch):
+    from tools.environments import local as _local_env
     from tools.file_operations import ShellFileOperations
 
-    monkeypatch.setattr("sys.platform", "win32")
+    # _bash_safe_path gates on the module-level _IS_WINDOWS (computed once at
+    # import), not sys.platform — patch the flag the code actually reads so the
+    # translation runs on any host (Linux CI included), not just real Win11.
+    monkeypatch.setattr(_local_env, "_IS_WINDOWS", True)
     env = ShellFileOperations.__new__(ShellFileOperations)
     quoted = env._escape_shell_arg("C:\\Users\\x\\file.py")
     assert "\\" not in quoted

--- a/tests/tools/test_search_pattern_escaping.py
+++ b/tests/tools/test_search_pattern_escaping.py
@@ -1,0 +1,68 @@
+"""Regression tests for regex/glob pattern escaping (#92260).
+
+On native Windows, ``_escape_shell_arg()`` ran match expressions through
+the Git Bash path translator (``_bash_safe_path``), rewriting backslashes
+to forward slashes: ``syncBalance\\(`` became ``syncBalance/(`` (rg
+"unclosed group" failure) and ``currency\\.`` became ``currency/.``
+(silent false-zero results). Match expressions are not paths and must be
+quoted without path translation.
+"""
+
+import json
+
+from tools.file_tools import search_tool
+
+
+def _make_project(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    (d / "wallet.kt").write_text(
+        "fun syncBalance(amount: Int) {\n"
+        "    val rate = currency.value\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    return d
+
+
+def test_escaped_paren_pattern_matches(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    d = _make_project(tmp_path)
+    r = json.loads(search_tool(r"syncBalance\(", path=str(d), task_id="t-esc1"))
+    assert r.get("error") is None
+    assert "unclosed group" not in json.dumps(r)
+    assert r["total_count"] == 1
+
+
+def test_escaped_dot_pattern_is_not_false_zero(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    d = _make_project(tmp_path)
+    r = json.loads(search_tool(r"currency\.", path=str(d), task_id="t-esc2"))
+    assert r.get("error") is None
+    assert r["total_count"] >= 1
+
+
+def test_file_name_glob_with_brackets_matches(tmp_path, monkeypatch):
+    # find -name / rg -g glob expressions are match args too, not paths.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    d = _make_project(tmp_path)
+    r = json.loads(search_tool("wallet[.]kt", target="files", path=str(d), task_id="t-esc3"))
+    assert any(f.endswith("wallet.kt") for f in r.get("files", []))
+
+
+def test_escape_match_arg_preserves_backslashes():
+    from tools.file_operations import ShellFileOperations
+
+    env = ShellFileOperations.__new__(ShellFileOperations)
+    quoted = env._escape_match_arg(r"syncBalance\( \. [a-z]")
+    assert quoted == r"'syncBalance\( \. [a-z]'"
+
+
+def test_escape_shell_arg_still_translates_windows_paths(monkeypatch):
+    from tools.file_operations import ShellFileOperations
+
+    monkeypatch.setattr("sys.platform", "win32")
+    env = ShellFileOperations.__new__(ShellFileOperations)
+    quoted = env._escape_shell_arg("C:\\Users\\x\\file.py")
+    assert "\\" not in quoted
+    assert quoted.startswith("'") and quoted.endswith("'")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1192,6 +1192,18 @@ class ShellFileOperations(FileOperations):
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
+    def _escape_match_arg(self, arg: str) -> str:
+        r"""Escape a regex pattern or glob expression for shell use.
+
+        Unlike ``_escape_shell_arg`` this does NOT run the value through
+        ``_bash_safe_path``: match expressions are not filesystem paths,
+        and on Windows the path translation rewrites backslashes to
+        forward slashes — corrupting ``syncBalance\(`` into
+        ``syncBalance/(`` (rg "unclosed group" failure) and ``currency\.``
+        into ``currency/.`` (silent false-zero results). See issue #92260.
+        """
+        return "'" + arg.replace("'", "'\"'\"'") + "'"
+
     def _escape_native_tool_arg(self, arg: str) -> str:
         """Escape a path argument destined for a NATIVE Windows binary.
 
@@ -2987,10 +2999,10 @@ class ShellFileOperations(FileOperations):
             extra = len(per_file) - cap
             return shown + (f" (+{extra} more)" if extra > 0 else "")
 
-        glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        glob_expr = f" --glob {self._escape_match_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_match_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -3007,7 +3019,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+            f"{self._escape_match_arg(pattern)} {self._escape_native_tool_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -3021,7 +3033,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_native_tool_arg(path)} "
+                f"{self._escape_match_arg(pattern)} {self._escape_native_tool_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -3087,7 +3099,7 @@ class ShellFileOperations(FileOperations):
             )
             prune_expr = f" \\( {prune_terms} \\) -prune -o"
 
-        cmd = f"find {self._escape_shell_arg(path)}{prune_expr}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+        cmd = f"find {self._escape_shell_arg(path)}{prune_expr}{hidden_filter_expr} -type f -name {self._escape_match_arg(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
 
         result = self._exec(cmd, timeout=60)
@@ -3095,7 +3107,7 @@ class ShellFileOperations(FileOperations):
 
         if not stdout.strip() and not limit_reason:
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{prune_expr}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+            cmd_simple = f"find {self._escape_shell_arg(path)}{prune_expr}{hidden_filter_expr} -type f -name {self._escape_match_arg(search_pattern)} " \
                         f"2>/dev/null | sort -rn{pagination_expr}"
             result = self._exec(cmd_simple, timeout=60)
             stdout, limit_reason = _search_stdout_and_limit(result)
@@ -3157,7 +3169,7 @@ class ShellFileOperations(FileOperations):
         exclusion_args = f" {exclusion_globs}" if exclusion_globs else ""
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
-            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)}"
+            f"rg --files --sortr=modified -g {self._escape_match_arg(glob_pattern)}"
             f"{exclusion_args} "
             f"{self._escape_native_tool_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
@@ -3169,7 +3181,7 @@ class ShellFileOperations(FileOperations):
         if not all_files and not limit_reason:
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
-                f"rg --files -g {self._escape_shell_arg(glob_pattern)}"
+                f"rg --files -g {self._escape_match_arg(glob_pattern)}"
                 f"{exclusion_args} "
                 f"{self._escape_native_tool_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
@@ -3249,7 +3261,7 @@ class ShellFileOperations(FileOperations):
 
         # Add file glob filter (must be quoted to prevent shell expansion)
         if file_glob:
-            cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--glob", self._escape_match_arg(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -3258,7 +3270,7 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")  # Count per file
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_match_arg(pattern))
         # rg is a native Windows binary when installed via winget/cargo/choco:
         # it needs the C:/... path form, not the MSYS /c/... form (which
         # nothing converts back — Hermes sets MSYS_NO_PATHCONV for its bash).
@@ -3405,7 +3417,7 @@ class ShellFileOperations(FileOperations):
         
         # Add file pattern filter (must be quoted to prevent shell expansion)
         if file_glob:
-            cmd_parts.extend(["--include", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--include", self._escape_match_arg(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -3418,7 +3430,7 @@ class ShellFileOperations(FileOperations):
         # ``.*`` to exclude the entire search. Anchor relative paths at the
         # shell's live cwd; quoting $PWD separately keeps user paths escaped
         # while working across local, container, and remote backends.
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_match_arg(pattern))
         is_absolute = path.startswith(("/", "\\\\")) or bool(
             re.match(r"^[A-Za-z]:[\\/]", path)
         )


### PR DESCRIPTION
Fixes #92260

## What & why

`_escape_shell_arg()` runs every shell argument through `_bash_safe_path()`, which rewrites backslashes to forward slashes for Git Bash. Correct for paths — corrupting for match expressions:

- `search_files(pattern="syncBalance\\(")` → rg received `syncBalance/(` → loud `regex parse error: unclosed group`
- `search_files(pattern="currency\\.")` → rg received `currency/.` → **silent false-zero results** (`total_count: 0`, no error)

This adds `ShellFileOperations._escape_match_arg()`, which single-quotes a value **without** path translation, and applies it to every match-expression site (rg patterns, grep patterns, `find -name` globs, `--glob`/`-g`/`--include` filters) while path args stay on `_escape_shell_arg` / `_escape_native_tool_arg`.

Rebased onto current `main` (head `7aa8133f0`): main's macOS search-exclusion/prune logic is preserved, and the match-arg fix is applied to user patterns.

## Tests

- `tests/tools/test_search_pattern_escaping.py` — regression for the issue's exact repros (`syncBalance\(`, `currency\.`) plus path-translation-still-works coverage.
- Fixed `test_escape_shell_arg_still_translates_windows_paths` to patch `_IS_WINDOWS` (the flag `_bash_safe_path` actually reads) instead of `sys.platform`, so it runs on Linux CI too.
