### PR TITLE
fix(agent): rebound once after blocked tool batch

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -864,6 +864,10 @@ def init_agent(
     agent._executing_tools = False
     agent._tool_guardrails = ToolCallGuardrailController()
     agent._tool_guardrail_halt_decision: ToolGuardrailDecision | None = None
+    # A recoverable ``block`` gets one model rebound per consecutive blocked
+    # batch.  Count at the conversation-loop batch boundary, never in
+    # per-call callbacks, so concurrent blocks consume one chance (#64322).
+    agent._tool_guardrail_rebound_used = False
 
     # Interrupt mechanism for breaking out of tool loops
     agent._interrupt_requested = False

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7343,6 +7343,27 @@ def run_conversation(
 
                 if agent._tool_guardrail_halt_decision is not None:
                     decision = agent._tool_guardrail_halt_decision
+                    if (
+                        decision.action == "block"
+                        and not agent._tool_guardrail_rebound_used
+                    ):
+                        # ``block`` rejects this tool call, not the user's
+                        # task.  The synthetic tool result is already in the
+                        # transcript, so let the model see it and choose a
+                        # different strategy.  This branch runs once after the
+                        # WHOLE tool batch, which makes concurrent blocks one
+                        # rebound event rather than one strike per callback.
+                        agent._tool_guardrail_rebound_used = True
+                        agent._tool_guardrail_halt_decision = None
+                        agent._tool_guardrails.clear_halt_decision()
+                        truncated_tool_call_retries = 0
+                        agent._stream_needs_break = True
+                        agent._emit_status(
+                            f"⚠️ Tool guardrail blocked {decision.tool_name}; "
+                            "requesting a different strategy"
+                        )
+                        continue
+
                     _turn_exit_reason = "guardrail_halt"
                     final_response = agent._toolguard_controlled_halt_response(decision)
                     agent._emit_status(

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -373,6 +373,10 @@ class ToolCallGuardrailController:
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision
 
+    def clear_halt_decision(self) -> None:
+        """Clear a recoverable decision after the runtime grants a rebound."""
+        self._halt_decision = None
+
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -581,6 +581,7 @@ def build_turn_context(
     agent._unicode_sanitization_passes = 0
     agent._tool_guardrails.reset_for_turn()
     agent._tool_guardrail_halt_decision = None
+    agent._tool_guardrail_rebound_used = False
     _reset_consol = getattr(agent._memory_store, "reset_consolidation_failures", None)
     if callable(_reset_consol):
         _reset_consol()

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -376,49 +376,162 @@ def test_default_run_conversation_warns_without_guardrail_halt():
 
 
 
-def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
-    """Regression for #30770: when the guardrail halts the loop, the
-    synthesized halt message must be pushed through ``stream_delta_callback``
-    so SSE/TUI clients see why the agent stopped instead of a silent stream
-    close.  Without this the chat-completions SSE writer drains an empty
-    queue and emits a finish chunk with zero content (indistinguishable
-    from a crash for Open WebUI and similar clients).
-    """
-    agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
-    same_args = {"query": "same"}
-    responses = [
-        _mock_response(
-            content="",
-            finish_reason="tool_calls",
-            tool_calls=[_mock_tool_call("web_search", json.dumps(same_args), f"c{i}")],
-        )
-        for i in range(1, 10)
-    ]
-    agent.client.chat.completions.create.side_effect = responses
-
-    deltas: list = []
-    agent.stream_delta_callback = lambda d: deltas.append(d)
-    # The mocked client returns SimpleNamespace responses which aren't
-    # iterable as streaming chunks; force the non-streaming code path so
-    # the guardrail-halt branch is reached without engaging the real
-    # streaming machinery.
-    agent._disable_streaming = True
-
+def _run_with_tool_handler(agent: AIAgent, handler):
     with (
-        patch("run_agent.handle_function_call", return_value=json.dumps({"error": "boom"})),
+        patch("run_agent.handle_function_call", side_effect=handler) as dispatch,
         patch.object(agent, "_persist_session"),
         patch.object(agent, "_save_trajectory"),
         patch.object(agent, "_cleanup_task_resources"),
     ):
         result = agent.run_conversation("search repeatedly")
+    return result, dispatch
+
+
+def _query_result(_name, args, _task_id, **_kwargs):
+    if str(args.get("query", "")).startswith("same"):
+        return json.dumps({"error": "boom"})
+    return json.dumps({"ok": args.get("query")})
+
+
+def test_first_guardrail_block_rebounds_to_changed_strategy():
+    agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
+    same = json.dumps({"query": "same"})
+    changed = json.dumps({"query": "changed"})
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c1")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c2")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c3")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", changed, "c4")]),
+        _mock_response(content="recovered", finish_reason="stop", tool_calls=None),
+    ]
+
+    result, dispatch = _run_with_tool_handler(agent, _query_result)
+
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert result["final_response"] == "recovered"
+    assert dispatch.call_count == 3  # c3 was blocked, changed strategy ran.
+    assert agent.client.chat.completions.create.call_count == 5
+    assert "guardrail" not in result
+    assert agent._tool_guardrails.halt_decision is None
+
+
+def test_concurrent_blocked_batch_consumes_one_rebound():
+    config = _hard_stop_config(
+        hard_stop_after={
+            "exact_failure": 1,
+            "same_tool_failure": 8,
+            "idempotent_no_progress": 5,
+        }
+    )
+    agent = _make_agent("web_search", max_iterations=10, config=config)
+    same_a = json.dumps({"query": "same-a"})
+    same_b = json.dumps({"query": "same-b"})
+    changed = json.dumps({"query": "changed"})
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call("web_search", same_a, "c1"),
+                _mock_tool_call("web_search", same_b, "c2"),
+            ],
+        ),
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call("web_search", same_a, "c3"),
+                _mock_tool_call("web_search", same_b, "c4"),
+            ],
+        ),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", changed, "c5")]),
+        _mock_response(content="recovered", finish_reason="stop", tool_calls=None),
+    ]
+
+    result, dispatch = _run_with_tool_handler(agent, _query_result)
+
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert result["final_response"] == "recovered"
+    assert dispatch.call_count == 3  # Initial pair + changed strategy; blocked pair refused.
+    assert agent.client.chat.completions.create.call_count == 4
+    blocked_results = [
+        message
+        for message in result["messages"]
+        if message.get("role") == "tool"
+        and "repeated_exact_failure_block" in message.get("content", "")
+    ]
+    assert {message["tool_call_id"] for message in blocked_results} == {"c3", "c4"}
+
+
+def test_rebound_budget_remains_spent_after_an_unblocked_batch():
+    agent = _make_agent("web_search", max_iterations=12, config=_hard_stop_config())
+    same = json.dumps({"query": "same"})
+    changed_one = json.dumps({"query": "changed-one"})
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c1")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c2")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c3")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", changed_one, "c4")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c5")]),
+    ]
+
+    result, dispatch = _run_with_tool_handler(agent, _query_result)
 
     assert result["turn_exit_reason"] == "guardrail_halt"
+    assert result["guardrail"]["code"] == "repeated_exact_failure_block"
+    assert dispatch.call_count == 3  # c3 and c5 were blocked; c4 changed strategy.
+    assert agent.client.chat.completions.create.call_count == 5
+
+
+def test_terminal_same_tool_halt_does_not_get_a_rebound():
+    config = _hard_stop_config(
+        hard_stop_after={
+            "exact_failure": 99,
+            "same_tool_failure": 2,
+            "idempotent_no_progress": 99,
+        }
+    )
+    agent = _make_agent("web_search", max_iterations=10, config=config)
+    first = json.dumps({"query": "same-a"})
+    second = json.dumps({"query": "same-b"})
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", first, "c1")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", second, "c2")]),
+    ]
+
+    result, dispatch = _run_with_tool_handler(agent, _query_result)
+
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert result["guardrail"]["code"] == "same_tool_failure_halt"
+    assert dispatch.call_count == 2
+    assert agent.client.chat.completions.create.call_count == 2
+
+
+def test_second_consecutive_guardrail_block_halts_and_streams_explanation():
+    """Preserve #30770 after one model rebound opportunity is exhausted."""
+    agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
+    same = json.dumps({"query": "same"})
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c1")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c2")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c3")]),
+        _mock_response(content="", finish_reason="tool_calls", tool_calls=[_mock_tool_call("web_search", same, "c4")]),
+    ]
+
+    deltas: list = []
+    agent.stream_delta_callback = lambda d: deltas.append(d)
+    agent._disable_streaming = True
+
+    result, dispatch = _run_with_tool_handler(agent, _query_result)
+
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert dispatch.call_count == 2  # c3 and c4 were both blocked before dispatch.
+    assert agent.client.chat.completions.create.call_count == 4
     halt_text = result["final_response"]
     assert "stopped retrying" in halt_text
+    assert result["guardrail"]["code"] == "repeated_exact_failure_block"
 
-    # The halt message must have been pushed through the callback at least
-    # once.  Empty-queue SSE writers were the bug — clients saw no content
-    # delta before the finish chunk.
+    # Empty-queue SSE writers must still receive the terminal explanation.
     text_deltas = [d for d in deltas if isinstance(d, str)]
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"


### PR DESCRIPTION
## What does this PR do?

A recoverable tool-guardrail `block` currently appends a synthetic tool result, then immediately ends the turn before the model can read it. This patch gives the model one rebound after the first blocked tool batch.

Counting happens after the whole batch, so concurrent blocks consume one rebound. The allowance resets only at the next user turn. A terminal `halt`, or any later blocked batch in the same turn, still ends the turn.

This implements the consolidation requested on #64322 and preserves credit to #64363 for the original rebound design.

## Related Issue

Fixes #64322
Supersedes #64363

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Add per-turn rebound state.
- Continue after the first recoverable blocked batch.
- Preserve terminal halt and second-block behavior.
- Add sequential recovery, concurrent-batch, per-turn budget, terminal-halt and streaming tests.

## How to Test

1. Run `pytest -q tests/run_agent/test_tool_call_guardrail_runtime.py`.
2. Run the affected guardrail and turn-finalizer suites.
3. On unpatched `main`, the four recovery tests fail with premature `guardrail_halt`.

## Checklist

- [x] Read the contributing guide.
- [x] Conventional commit.
- [x] Existing PRs reviewed; this supersedes the partial #64363 with its credit preserved.
- [x] Only related changes.
- [x] Tests added and run on Linux/Python 3.11.
- [x] Documentation/config/tool schemas: N/A.
- [x] Cross-platform impact considered; change is platform-neutral loop state.

## Verification

- Unpatched upstream `main` (`0cde4dd93a`): 4/4 recovery-contract tests fail with premature `guardrail_halt`.
- Patched focused and adjacent suites: 75 passed.
- Full `tests/run_agent` with `dev` + `anthropic` extras: 1761 passed, 8 skipped, 2 deselected.
- Contributor map: 7 passed.
- `ruff check`, `compileall`, and `git diff --check`: passed.
