### PR TITLE
fix(cli): symlinked venv shebang breaks .desktop entry on uv-managed installs

### DIFF
--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -98,16 +98,47 @@ def _needs_interpreter(bin_path: Path) -> bool:
         # Native binary (uv tool shim, PyInstaller, distro package) — its own
         # loader is self-sufficient.
         return False
-    shebang = head.decode("utf-8", errors="replace").strip().lower()
-    if "python" not in shebang:
+    shebang = head.decode("utf-8", errors="replace").strip()
+    if "python" not in shebang.lower():
         # A shell wrapper (e.g. the installer's bash launcher) execs the venv
         # python itself — leave it alone.
         return False
     # A python shebang pointing INSIDE the running interpreter's environment
     # already resolves correctly; anything else (``/usr/bin/env python3``,
     # a system path) would escape the venv when spawned by the DE.
+    #
+    # Resolve *both* sides before comparing: uv-managed venvs create a venv
+    # python (``…/venv/bin/python3``) that symlinks to the uv binary
+    # (``…/uv/python/…/python3.X``).  ``sys.executable`` reports the venv
+    # path, but ``.resolve()`` follows it to the uv binary.  Comparing the
+    # resolved parent dir against the raw shebang text misses the match,
+    # prefixes the uv Python, and the uv Python has no venv site-packages →
+    # ``ModuleNotFoundError``.  Instead, resolve the shebang interpreter too
+    # and compare the canonical binaries.
+    shebang_interp = _extract_shebang_interpreter(shebang)
+    if shebang_interp:
+        try:
+            if Path(shebang_interp).resolve() == Path(sys.executable).resolve():
+                return False
+        except OSError:
+            pass
     exe_dir = str(Path(sys.executable).resolve().parent)
-    return exe_dir not in shebang
+    return exe_dir not in shebang.lower()
+
+
+def _extract_shebang_interpreter(shebang_line: str) -> str:
+    """Return the interpreter path from a ``#!…`` line, or ``''``."""
+    line = shebang_line.strip()
+    if not line.startswith("#!"):
+        return ""
+    rest = line[2:].strip()
+    # ``#!/usr/bin/env python3`` → skip ``/usr/bin/env`` and return ``python3``
+    parts = rest.split()
+    if not parts:
+        return ""
+    if parts[0].endswith("/env") and len(parts) > 1:
+        return parts[1]
+    return parts[0]
 
 
 def _quote_exec_arg(arg: str) -> str:

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -149,6 +149,54 @@ def test_exec_leaves_venv_shebang_scripts_alone(tmp_path, xdg_home, monkeypatch)
     assert exec_line == f"{hermes_bin} desktop"
 
 
+# uv-managed venvs create a venv python (e.g. ``…/venv/bin/python3``) that
+# symlinks to the uv binary (``…/uv/python/…/bin/python3.X``).
+# ``sys.executable`` returns the venv path, but ``.resolve()`` follows the
+# symlink to the uv binary.  The old ``_needs_interpreter`` compared the
+# resolved parent dir against the raw shebang text, missed the match,
+# prefixed the uv Python, and the uv Python had no venv site-packages →
+# ``ModuleNotFoundError``.  This test simulates that exact scenario.
+def test_exec_leaves_symlinked_venv_shebang_alone(tmp_path, xdg_home, monkeypatch):
+    import sys
+
+    root = _make_project(tmp_path)
+
+    # Simulate a uv-managed venv: the "real" python lives elsewhere.
+    real_python_name = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    uv_tag = f"cpython-{sys.version_info.major}.{sys.version_info.minor}"
+    real_python_dir = tmp_path / "uv-python" / uv_tag / "bin"
+    real_python_dir.mkdir(parents=True)
+    real_python = real_python_dir / real_python_name
+    real_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    real_python.chmod(0o755)
+
+    # The venv python is a symlink to the real one.
+    venv_dir = tmp_path / "venv" / "bin"
+    venv_dir.mkdir(parents=True)
+    venv_python = venv_dir / "python3"
+    venv_python.symlink_to(real_python)
+
+    # The hermes script has a venv-prefix shebang pointing at the symlink.
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir()
+    hermes_bin.write_text(f"#!{venv_python}\nimport hermes_cli\n", encoding="utf-8")
+    hermes_bin.chmod(0o755)
+
+    # sys.executable reports the unresolved venv path (like uv venvs do).
+    monkeypatch.setattr(lde.sys, "executable", str(venv_python))
+    monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin))
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
+
+    entry = lde.install_desktop_entry(root)
+    exec_line = _parse(entry.read_text(encoding="utf-8"))["Exec"]
+
+    # The venv shebang is valid — don't prefix with sys.executable.
+    assert exec_line == f"{hermes_bin} desktop", (
+        "symlinked venv shebang should NOT get an interpreter prefix; "
+        f"got Exec={exec_line}"
+    )
+
+
 def test_install_is_idempotent_and_skips_cache_refresh(tmp_path, xdg_home, monkeypatch):
     root = _make_project(tmp_path)
     monkeypatch.setattr("hermes_cli.relaunch.resolve_hermes_bin", lambda: "/usr/bin/hermes")


### PR DESCRIPTION
## Problem

`_needs_interpreter()` in `linux_desktop_entry.py` incorrectly prefixes the
`Exec=` line with `sys.executable` on **uv-managed venv** installations,
causing the `.desktop` entry to crash silently with
`ModuleNotFoundError: No module named 'hermes_cli'`.

### Root cause

The function compares `Path(sys.executable).resolve().parent` against the raw
shebang text. In uv-managed venvs:

- `sys.executable` = `…/venv/bin/python3` (the venv path)
- `.resolve()` follows the symlink → `…/uv/python/cpython-3.11…/bin/python3.11`
- `exe_dir` = `…/uv/python/cpython-3.11…/bin` — **not** in the shebang
- Result: `_needs_interpreter` returns `True` → prefixes the uv Python

The uv Python has no venv site-packages → `ModuleNotFoundError` → silent death
(`Terminal=false`).

The existing test `test_exec_leaves_venv_shebang_scripts_alone` doesn't catch
this because it writes the shebang using `Path(sys.executable).resolve()` (the
uv path), so the string match succeeds. Real venvs have the unresolved venv
path in their shebang.

### Introduced by

`d9d967e07` (PR #90292) — the fix for `#!/usr/bin/env python3` shebangs broke
symlinked venv shebangs.

## Fix

Resolve **both** the shebang interpreter and `sys.executable` before comparing.
If they point to the same binary, the shebang is valid — no prefix needed.

Also normalize case on the fallback `exe_dir not in shebang` check (the old
code lowered the shebang but not `exe_dir`).

## Files changed

- `hermes_cli/linux_desktop_entry.py` — `_needs_interpreter()` + new
  `_extract_shebang_interpreter()` helper
- `tests/hermes_cli/test_linux_desktop_entry.py` — new
  `test_exec_leaves_symlinked_venv_shebang_alone` covering the exact uv-managed
  venv scenario

## Verification

All 5 shebang scenarios pass:

| Scenario | `_needs_interpreter` | Correct? |
|---|---|---|
| `#!/usr/bin/env python3` | `True` (prefix) | ✅ #90292 case |
| `#!{sys.executable}` (exact match) | `False` | ✅ |
| `#!{venv_python}` → symlink to uv binary | `False` | ✅ **this fix** |
| `#!/bin/bash` (shell wrapper) | `False` | ✅ |
| ELF binary (no shebang) | `False` | ✅ |