### PR TITLE
feat(agent): opt-in tool-iteration-budget signpost (cache-safe, default off)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -509,6 +509,23 @@ def _normalize_run_budget_seconds(value) -> Optional[float]:
     return seconds
 
 
+def _normalize_tool_loop_budget_warning(value):
+    """Normalize ``agent.tool_loop_budget_warning``: False | True | positive int."""
+    if value is None or value is False:
+        return False
+    if value is True:
+        return True
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return False
+    if isinstance(value, float) and value != value:  # NaN
+        return False
+    if n <= 0:
+        return False
+    return n
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -987,8 +1004,8 @@ def init_agent(
     # the iteration budget (api_call_count >= max_iterations).  At that
     # point we inject ONE message, allow one final API call, and if the
     # model doesn't produce a text response, force a user-message asking
-    # it to summarise.  No intermediate pressure warnings — they caused
-    # models to "give up" prematurely on complex tasks (#7915).
+    # it to summarise.  Intermediate pressure warnings stay default-off
+    # (#7915); opt-in only via agent.tool_loop_budget_warning below.
     agent._budget_exhausted_injected = False
     agent._budget_grace_call = False
 
@@ -1002,6 +1019,15 @@ def init_agent(
     agent._run_budget_started_at = None
     # One-shot latch for the 80% wrap-up notice (reset each turn).
     agent._run_budget_wrapup_injected = False
+
+    # Opt-in tool-iteration budget signpost (agent.tool_loop_budget_warning).
+    # Default off (preserves #7915); resolved from config further below.
+    # Watches this agent's IterationBudget only (parent: max_iterations;
+    # delegate_task children: separate delegation.max_iterations) — not shared
+    # across parent/child. Latch + budget reset each user turn in turn_context
+    # (including continue-after-budget-stop).
+    agent.tool_loop_budget_warning = False
+    agent._tool_loop_budget_wrapup_injected = False
 
     # Activity tracking — updated on each API call, tool execution, and
     # stream chunk.  Used by the gateway timeout handler to report what the
@@ -1980,6 +2006,13 @@ def init_agent(
         agent.run_budget_seconds = _normalize_run_budget_seconds(
             _agent_section.get("run_budget_seconds")
         )
+
+    # Opt-in tool-iteration budget signpost from config.
+    # true => fire at used >= 0.8*max; on tiny finite caps that degrades
+    # toward the last iteration (e.g. max=1 fires only when used>=1).
+    agent.tool_loop_budget_warning = _normalize_tool_loop_budget_warning(
+        _agent_section.get("tool_loop_budget_warning", False)
+    )
 
     # Empty-response retry guard config (NS-503): additive
     # ``agent.empty_response_guard`` subsection. Resolution is tolerant —

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -20,6 +20,7 @@ preserved.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import re
 import sys
@@ -515,9 +516,11 @@ def _normalize_tool_loop_budget_warning(value):
         return False
     if value is True:
         return True
+    if isinstance(value, float) and not math.isfinite(value):  # NaN / inf / -inf
+        return False
     try:
         n = int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return False
     if isinstance(value, float) and value != value:  # NaN
         return False

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -22,6 +22,7 @@ import os
 import random
 import re
 import ssl
+import sys
 import time
 from typing import Any, Dict, List, Optional
 
@@ -117,6 +118,43 @@ RUN_BUDGET_WRAPUP_NOTICE = (
     "the state you already have, completing only mandatory writes."
 )
 
+# One-time wrap-up notice when a finite tool-iteration budget approaches its
+# cap (agent.tool_loop_budget_warning). Same delivery channel as run-budget
+# wrap-up: append to newest role:"tool" message (cache-safe, no synthetic user).
+TOOL_LOOP_BUDGET_WRAPUP_NOTICE = (
+    "[SYSTEM NOTICE — tool iteration budget nearly exhausted] "
+    "Tool iteration budget is nearly exhausted. Stop starting new workstreams. "
+    "Finish or checkpoint what is in flight and deliver a concrete result from "
+    "the state you already have. A later user turn gets a fresh iteration budget "
+    "(including the continue path after a budget stop)."
+)
+
+
+def _append_to_newest_tool_message(
+    messages: List[Dict[str, Any]], notice: str
+) -> bool:
+    """Append ``notice`` to the newest ``role:\"tool\"`` message (cache-safe).
+
+    Shared by run-budget and tool-loop budget wrap-ups so append mechanics
+    cannot drift. Returns True when a tool message was updated.
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if isinstance(msg, dict) and msg.get("role") == "tool":
+            existing = msg.get("content", "")
+            if isinstance(existing, str):
+                msg["content"] = existing + f"\n\n{notice}"
+            else:
+                # Multimodal content blocks — append a text block.
+                try:
+                    blocks = list(existing) if existing else []
+                    blocks.append({"type": "text", "text": notice})
+                    msg["content"] = blocks
+                except Exception:
+                    return False
+            return True
+    return False
+
 
 def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) -> bool:
     """Inject the one-time wall-clock wrap-up notice when past 80% of budget.
@@ -141,28 +179,82 @@ def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) 
         return False
     if (time.time() - started) < 0.8 * float(budget):
         return False
-    for i in range(len(messages) - 1, -1, -1):
-        msg = messages[i]
-        if isinstance(msg, dict) and msg.get("role") == "tool":
-            existing = msg.get("content", "")
-            if isinstance(existing, str):
-                msg["content"] = existing + f"\n\n{RUN_BUDGET_WRAPUP_NOTICE}"
-            else:
-                # Multimodal content blocks — append a text block.
-                try:
-                    blocks = list(existing) if existing else []
-                    blocks.append({"type": "text", "text": RUN_BUDGET_WRAPUP_NOTICE})
-                    msg["content"] = blocks
-                except Exception:
-                    return False
-            agent._run_budget_wrapup_injected = True
-            logger.info(
-                "Run budget wrap-up notice injected (budget=%.0fs, elapsed=%.0fs)",
-                float(budget),
-                time.time() - started,
-            )
-            return True
-    return False
+    if not _append_to_newest_tool_message(messages, RUN_BUDGET_WRAPUP_NOTICE):
+        return False
+    agent._run_budget_wrapup_injected = True
+    logger.info(
+        "Run budget wrap-up notice injected (budget=%.0fs, elapsed=%.0fs)",
+        float(budget),
+        time.time() - started,
+    )
+    return True
+
+
+def _maybe_inject_tool_loop_budget_wrapup(
+    agent: Any,
+    messages: List[Dict[str, Any]],
+) -> bool:
+    """Inject a one-shot tool-iteration budget wrap-up notice near the cap.
+
+    Cache-safe delivery mirrors :func:`_maybe_inject_run_budget_wrapup`: append
+    to the NEWEST ``role:\"tool\"`` message only. No synthetic user message, no
+    system-prompt mutation, no rewrite of older messages.
+
+    Opt-in via ``agent.tool_loop_budget_warning`` (default off):
+
+    - ``False`` / absent → dormant (zero behavior change)
+    - ``True`` → warn once when used >= 80% of a *finite* max_iterations
+      (tiny caps: 0.8*max degrades toward the last iteration)
+    - positive ``int`` N → warn once when remaining <= N (finite cap only)
+
+    Unlimited caps (``max_iterations >= sys.maxsize``) never inject.
+    Latches ``_tool_loop_budget_wrapup_injected`` only on successful append
+    (reset each turn in ``turn_context``, including continue-after-budget-stop).
+    Parent and delegate_task children hold separate IterationBudget instances.
+    Returns True when injected.
+    """
+    warning = getattr(agent, "tool_loop_budget_warning", False)
+    if not warning:
+        return False
+    if getattr(agent, "_tool_loop_budget_wrapup_injected", False):
+        return False
+
+    budget = getattr(agent, "iteration_budget", None)
+    if budget is None:
+        return False
+    max_total = int(getattr(budget, "max_total", 0) or 0)
+    # Treat sys.maxsize (and larger sentinels) as unlimited — no signpost.
+    if max_total <= 0 or max_total >= sys.maxsize:
+        return False
+
+    used = int(getattr(budget, "used", 0) or 0)
+    remaining = int(getattr(budget, "remaining", max(0, max_total - used)) or 0)
+
+    if isinstance(warning, bool):
+        # true => 80% of finite cap
+        if used < 0.8 * max_total:
+            return False
+    else:
+        # positive int N => remaining <= N
+        try:
+            threshold = int(warning)
+        except (TypeError, ValueError):
+            return False
+        if threshold <= 0 or remaining > threshold:
+            return False
+
+    if not _append_to_newest_tool_message(messages, TOOL_LOOP_BUDGET_WRAPUP_NOTICE):
+        return False
+    agent._tool_loop_budget_wrapup_injected = True
+    logger.info(
+        "Tool-loop budget wrap-up notice injected "
+        "(used=%s/%s remaining=%s warning=%r)",
+        used,
+        max_total,
+        remaining,
+        warning,
+    )
+    return True
 
 
 def _restore_user_after_reference_handoff(
@@ -2086,6 +2178,13 @@ def run_conversation(
         # result); dormant when no budget is set.
         if getattr(agent, "run_budget_seconds", None):
             _maybe_inject_run_budget_wrapup(agent, messages)
+
+        # ── Tool-iteration budget wrap-up notice ───────────────────────
+        # Opt-in (agent.tool_loop_budget_warning). Same cache-safe channel
+        # as run-budget wrap-up; dormant when off or when max_iterations is
+        # unlimited. Only runs after tool results exist (helper no-ops).
+        if getattr(agent, "tool_loop_budget_warning", False):
+            _maybe_inject_tool_loop_budget_wrapup(agent, messages)
 
         # Prepare messages for API call
         # If we have an ephemeral system prompt, prepend it to the messages

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -603,6 +603,8 @@ def build_turn_context(
         agent._compression_warning = None  # send once
 
     # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
+    # Fresh iteration budget every user turn — including a later "continue"
+    # after a budget stop (continue is a new run_conversation → build_turn_context).
     agent.iteration_budget = IterationBudget(agent.max_iterations)
 
     # Wall-clock run budget: per-run_conversation clock. Only stamped when a
@@ -613,6 +615,9 @@ def build_turn_context(
     else:
         agent._run_budget_started_at = None
     agent._run_budget_wrapup_injected = False
+    # One-shot latch for the tool-iteration budget signpost (reset each turn,
+    # including the continue path after a budget stop).
+    agent._tool_loop_budget_wrapup_injected = False
 
     # Log conversation turn start for debugging/observability.
     _preview_text = summarize_user_message_for_log(user_message)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -958,6 +958,18 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Opt-in one-shot notice when a finite tool-iteration budget is nearly
+  # exhausted. false/absent = off. true = warn once at >= 80% used.
+  # positive integer N = warn once when remaining iterations <= N.
+  # Appended to the newest tool result (cache-safe); no synthetic user msg.
+  # Budget resets each user turn (including a later "continue" after a budget
+  # stop): turn_context rebuilds IterationBudget and clears the one-shot latch.
+  # Each agent watches its own IterationBudget — parent uses agent.max_turns /
+  # max_iterations; delegate_task children use separate delegation.max_iterations
+  # budgets — so a child cannot burn the parent's signpost threshold (or vice
+  # versa); size both caps if you need headroom for parent + children work.
+  # tool_loop_budget_warning: false
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -54,6 +54,11 @@ DEFAULT_CONFIG = {
         # implicit provider stale timeouts are capped to the remaining
         # budget. CLI one-shot equivalent: `hermes chat --run-budget N`.
         "run_budget_seconds": None,
+        # Opt-in signpost when a *finite* tool-iteration budget is nearly
+        # exhausted. false/absent = off (zero behavior change). true = warn
+        # once at >= 80% used. positive int N = warn once when remaining <= N.
+        # Delivered like run_budget wrap-up (append to newest tool message).
+        "tool_loop_budget_warning": False,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has
@@ -2918,16 +2923,6 @@ DEFAULT_CONFIG = {
         # code so the supervisor (systemd/launchd) revives the process instead
         # of leaving a wedged-but-alive zombie. Set to false to disable.
         "loop_watchdog": True,
-
-        # Loop-liveness watchdog tuning (defaults mirror
-        # gateway/shutdown_watchdog.py constants). probe_interval = seconds
-        # between liveness probes; probe_timeout = seconds a probe may go
-        # unprocessed before counting as a miss; max_strikes = consecutive
-        # misses before the watchdog hard-exits 75 for a service respawn
-        # (~90-120s of sustained loop block at the defaults).
-        "loop_watchdog_probe_interval_s": 30.0,
-        "loop_watchdog_probe_timeout_s": 10.0,
-        "loop_watchdog_max_strikes": 3,
 
         # Whether the gateway keeps writing the legacy sessions.json mirror of
         # its routing index. The primary copy lives in state.db (the

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -58,6 +58,10 @@ DEFAULT_CONFIG = {
         # exhausted. false/absent = off (zero behavior change). true = warn
         # once at >= 80% used. positive int N = warn once when remaining <= N.
         # Delivered like run_budget wrap-up (append to newest tool message).
+        # Tiny caps (max_iterations < 5, where 0.8*max rounds to the last
+        # iteration) may fire only as the budget runs out — a signpost cannot
+        # appear before the first tool message exists. max_iterations with an
+        # unlimited sentinel (>= sys.maxsize) never injects.
         "tool_loop_budget_warning": False,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
@@ -2923,6 +2927,16 @@ DEFAULT_CONFIG = {
         # code so the supervisor (systemd/launchd) revives the process instead
         # of leaving a wedged-but-alive zombie. Set to false to disable.
         "loop_watchdog": True,
+
+        # Loop-liveness watchdog tuning (defaults mirror
+        # gateway/shutdown_watchdog.py constants). probe_interval = seconds
+        # between liveness probes; probe_timeout = seconds a probe may go
+        # unprocessed before counting as a miss; max_strikes = consecutive
+        # misses before the watchdog hard-exits 75 for a service respawn
+        # (~90-120s of sustained loop block at the defaults).
+        "loop_watchdog_probe_interval_s": 30.0,
+        "loop_watchdog_probe_timeout_s": 10.0,
+        "loop_watchdog_max_strikes": 3,
 
         # Whether the gateway keeps writing the legacy sessions.json mirror of
         # its routing index. The primary copy lives in state.db (the

--- a/tests/agent/test_tool_loop_budget_warning.py
+++ b/tests/agent/test_tool_loop_budget_warning.py
@@ -1,0 +1,393 @@
+"""Tests for opt-in tool-iteration budget signpost (agent.tool_loop_budget_warning).
+
+Clones the run-budget wrap-up pattern: one-shot SYSTEM NOTICE appended to the
+newest role:\"tool\" message when a *finite* iteration cap is nearly exhausted.
+"""
+
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.iteration_budget import IterationBudget
+
+
+def _write_config(tmp_path: Path, body: str) -> None:
+    (tmp_path / "config.yaml").write_text(body or "{}\n", encoding="utf-8")
+
+
+def _make_agent(tmp_path, monkeypatch, config_body: str = "", **overrides):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    _write_config(tmp_path, config_body)
+
+    from run_agent import AIAgent
+
+    kwargs = dict(
+        model="gpt-5.5",
+        provider="openai",
+        api_key="sk-dummy",
+        base_url="https://api.openai.com/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+        max_iterations=10,
+    )
+    kwargs.update(overrides)
+    return AIAgent(**kwargs)
+
+
+# ── normalization ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, False),
+        (False, False),
+        (True, True),
+        (0, False),
+        ("abc", False),
+        (3, 3),
+        ("5", 5),
+    ],
+)
+def test_normalize_tool_loop_budget_warning(raw, expected):
+    from agent.agent_init import _normalize_tool_loop_budget_warning
+
+    assert _normalize_tool_loop_budget_warning(raw) == expected
+
+
+# ── constructor / config plumbing ─────────────────────────────────────────
+
+
+def test_warning_off_by_default(monkeypatch, tmp_path):
+    agent = _make_agent(tmp_path, monkeypatch)
+    assert agent.tool_loop_budget_warning is False
+    assert agent._tool_loop_budget_wrapup_injected is False
+
+
+def test_config_key_sets_warning_true(monkeypatch, tmp_path):
+    agent = _make_agent(
+        tmp_path,
+        monkeypatch,
+        config_body="agent:\n  tool_loop_budget_warning: true\n",
+    )
+    assert agent.tool_loop_budget_warning is True
+
+
+def test_config_key_sets_warning_int(monkeypatch, tmp_path):
+    agent = _make_agent(
+        tmp_path,
+        monkeypatch,
+        config_body="agent:\n  tool_loop_budget_warning: 2\n",
+    )
+    assert agent.tool_loop_budget_warning == 2
+
+
+# ── wrap-up injection ─────────────────────────────────────────────────────
+
+
+class _StubAgent:
+    def __init__(self, warning=False, max_total=10, used=0):
+        self.tool_loop_budget_warning = warning
+        self._tool_loop_budget_wrapup_injected = False
+        self.iteration_budget = IterationBudget(max_total)
+        self.iteration_budget._used = used
+        # Production prepare uses agent.max_iterations for the fresh budget.
+        self.max_iterations = max_total
+
+
+def _tool_messages():
+    return [
+        {"role": "user", "content": "do the task"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "result one"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "t2"}]},
+        {"role": "tool", "tool_call_id": "t2", "content": "result two"},
+    ]
+
+
+def test_off_never_mutates_messages():
+    from agent.conversation_loop import _maybe_inject_tool_loop_budget_wrapup
+
+    agent = _StubAgent(warning=False, max_total=10, used=9)
+    messages = _tool_messages()
+    before = copy.deepcopy(messages)
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is False
+    assert messages == before
+
+
+def test_unlimited_never_injects_even_if_warning_true():
+    from agent.conversation_loop import _maybe_inject_tool_loop_budget_wrapup
+
+    agent = _StubAgent(warning=True, max_total=sys.maxsize, used=sys.maxsize - 1)
+    messages = _tool_messages()
+    before = copy.deepcopy(messages)
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is False
+    assert messages == before
+    assert agent._tool_loop_budget_wrapup_injected is False
+
+
+def test_threshold_true_mode_injects_once_on_newest_tool():
+    from agent.conversation_loop import (
+        TOOL_LOOP_BUDGET_WRAPUP_NOTICE,
+        _maybe_inject_tool_loop_budget_wrapup,
+    )
+
+    # max=10, used=8 => 80% — should fire
+    agent = _StubAgent(warning=True, max_total=10, used=8)
+    messages = _tool_messages()
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is True
+    assert agent._tool_loop_budget_wrapup_injected is True
+    assert TOOL_LOOP_BUDGET_WRAPUP_NOTICE in messages[-1]["content"]
+    assert messages[-1]["content"].startswith("result two")
+    assert messages[2]["content"] == "result one"
+    assert [m["role"] for m in messages] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+        "tool",
+    ]
+
+    snapshot = copy.deepcopy(messages)
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is False
+    assert messages == snapshot
+    assert messages[-1]["content"].count(TOOL_LOOP_BUDGET_WRAPUP_NOTICE) == 1
+
+
+def test_threshold_true_mode_not_before_80_percent():
+    from agent.conversation_loop import _maybe_inject_tool_loop_budget_wrapup
+
+    agent = _StubAgent(warning=True, max_total=10, used=7)  # 70%
+    messages = _tool_messages()
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is False
+    assert agent._tool_loop_budget_wrapup_injected is False
+
+
+def test_threshold_remaining_int_mode():
+    from agent.conversation_loop import (
+        TOOL_LOOP_BUDGET_WRAPUP_NOTICE,
+        _maybe_inject_tool_loop_budget_wrapup,
+    )
+
+    # max=10, used=8 => remaining=2; warning=2 => fire
+    agent = _StubAgent(warning=2, max_total=10, used=8)
+    messages = _tool_messages()
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is True
+    assert TOOL_LOOP_BUDGET_WRAPUP_NOTICE in messages[-1]["content"]
+
+    agent2 = _StubAgent(warning=2, max_total=10, used=7)  # remaining=3
+    messages2 = _tool_messages()
+    assert _maybe_inject_tool_loop_budget_wrapup(agent2, messages2) is False
+
+
+def test_retries_when_no_tool_message_yet():
+    from agent.conversation_loop import (
+        TOOL_LOOP_BUDGET_WRAPUP_NOTICE,
+        _maybe_inject_tool_loop_budget_wrapup,
+    )
+
+    agent = _StubAgent(warning=True, max_total=5, used=4)
+    messages = [{"role": "user", "content": "do the task"}]
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is False
+    assert agent._tool_loop_budget_wrapup_injected is False
+
+    messages += [
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+        {"role": "tool", "tool_call_id": "t1", "content": "result"},
+    ]
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is True
+    assert TOOL_LOOP_BUDGET_WRAPUP_NOTICE in messages[-1]["content"]
+
+
+def test_multimodal_tool_content():
+    from agent.conversation_loop import (
+        TOOL_LOOP_BUDGET_WRAPUP_NOTICE,
+        _maybe_inject_tool_loop_budget_wrapup,
+    )
+
+    agent = _StubAgent(warning=True, max_total=5, used=4)
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+        {
+            "role": "tool",
+            "tool_call_id": "t1",
+            "content": [{"type": "text", "text": "block"}],
+        },
+    ]
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is True
+    blocks = messages[-1]["content"]
+    assert blocks[0] == {"type": "text", "text": "block"}
+    assert blocks[-1] == {"type": "text", "text": TOOL_LOOP_BUDGET_WRAPUP_NOTICE}
+
+
+def test_latch_reset_each_turn():
+    """After turn_context prepare resets the latch, a fresh turn can re-append."""
+    from agent.conversation_loop import (
+        TOOL_LOOP_BUDGET_WRAPUP_NOTICE,
+        _maybe_inject_tool_loop_budget_wrapup,
+    )
+
+    agent = _StubAgent(warning=True, max_total=10, used=8)
+    messages = _tool_messages()
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is True
+    assert agent._tool_loop_budget_wrapup_injected is True
+    # Still latched: no second inject on the same turn.
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is False
+
+    # Mirror turn_context.build_turn_context prepare (production path):
+    # fresh IterationBudget + one-shot latch reset each turn.
+    agent.iteration_budget = IterationBudget(agent.max_iterations)
+    agent.iteration_budget._used = 8
+    agent._tool_loop_budget_wrapup_injected = False
+
+    assert agent._tool_loop_budget_wrapup_injected is False
+    messages2 = _tool_messages()
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages2) is True
+    assert agent._tool_loop_budget_wrapup_injected is True
+    assert TOOL_LOOP_BUDGET_WRAPUP_NOTICE in messages2[-1]["content"]
+    assert messages2[-1]["content"].count(TOOL_LOOP_BUDGET_WRAPUP_NOTICE) == 1
+
+
+# ── integration-lite ───────────────────────────────────────────────────────
+
+
+def _mock_tool_call(name="web_search", arguments="{}", call_id="c1"):
+    fn = SimpleNamespace(name=name, arguments=arguments)
+    return SimpleNamespace(id=call_id, type="function", function=fn)
+
+
+def _mock_response(content="", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls, role="assistant")
+    choice = SimpleNamespace(message=msg, finish_reason=finish_reason)
+    usage = SimpleNamespace(
+        prompt_tokens=10,
+        completion_tokens=5,
+        total_tokens=15,
+    )
+    return SimpleNamespace(choices=[choice], usage=usage)
+
+
+def test_integration_notice_on_messages_before_final_call(monkeypatch, tmp_path):
+    """With warning on and max_iterations=5, tool-call loop should see the
+    notice on the newest tool content before the final text completion."""
+    from agent.conversation_loop import TOOL_LOOP_BUDGET_WRAPUP_NOTICE
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    _write_config(tmp_path, "agent:\n  tool_loop_budget_warning: true\n")
+
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "description": "search",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_iterations=5,
+            platform="cli",
+        )
+
+    agent.client = MagicMock()
+    agent.tool_loop_budget_warning = True
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent._disable_streaming = True
+    agent.api_mode = "chat_completions"
+
+    tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+    tool_resp = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+    text_resp = _mock_response(content="done from state", finish_reason="stop")
+
+    responses = [tool_resp, tool_resp, tool_resp, tool_resp, text_resp]
+    call_idx = {"i": 0}
+    captured = []
+
+    def _create(*args, **kwargs):
+        msgs = kwargs.get("messages")
+        if msgs is not None:
+            captured.append(copy.deepcopy(msgs))
+        i = call_idx["i"]
+        call_idx["i"] += 1
+        if i >= len(responses):
+            return text_resp
+        return responses[i]
+
+    agent.client.chat.completions.create = _create
+
+    with (
+        patch("run_agent.handle_function_call", return_value="ok"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("do multi-step work")
+
+    found = False
+    for msgs in captured:
+        for m in msgs:
+            if not isinstance(m, dict) or m.get("role") != "tool":
+                continue
+            content = m.get("content") or ""
+            if isinstance(content, str) and TOOL_LOOP_BUDGET_WRAPUP_NOTICE in content:
+                found = True
+                break
+            if isinstance(content, list):
+                for b in content:
+                    if isinstance(b, dict) and TOOL_LOOP_BUDGET_WRAPUP_NOTICE in (
+                        b.get("text") or ""
+                    ):
+                        found = True
+                        break
+        if found:
+            break
+    assert found, (
+        f"Expected tool-loop budget notice in some create() messages; "
+        f"captured {len(captured)} calls"
+    )
+
+    # Second turn: fresh budget (per-turn reset) can run on prior history.
+    history = result.get("messages") or []
+    captured.clear()
+    call_idx["i"] = 0
+    responses[:] = [text_resp]
+    with (
+        patch("run_agent.handle_function_call", return_value="ok"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result2 = agent.run_conversation(
+            "continue",
+            conversation_history=history if isinstance(history, list) else None,
+        )
+    assert result2 is not None
+    assert call_idx["i"] >= 1

--- a/tests/agent/test_tool_loop_budget_warning.py
+++ b/tests/agent/test_tool_loop_budget_warning.py
@@ -56,6 +56,9 @@ def _make_agent(tmp_path, monkeypatch, config_body: str = "", **overrides):
         ("abc", False),
         (3, 3),
         ("5", 5),
+        (float("inf"), False),
+        (float("-inf"), False),
+        (float("nan"), False),
     ],
 )
 def test_normalize_tool_loop_budget_warning(raw, expected):
@@ -161,6 +164,33 @@ def test_threshold_true_mode_injects_once_on_newest_tool():
     assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is False
     assert messages == snapshot
     assert messages[-1]["content"].count(TOOL_LOOP_BUDGET_WRAPUP_NOTICE) == 1
+
+
+def test_tiny_finite_cap_fires_only_as_budget_runs_out():
+    """Tiny finite caps (< 5) fire only near/at the wall — not before any
+    iteration has run, and (for max=1) only once the single budget is spent.
+    Documents the honest boundary rather than overclaiming an early signpost."""
+    from agent.conversation_loop import _maybe_inject_tool_loop_budget_wrapup
+
+    # max=1, nothing used yet: 0.8*1=0.8, used(0) < 0.8 => no injection.
+    agent = _StubAgent(warning=True, max_total=1, used=0)
+    messages = _tool_messages()
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is False
+    assert agent._tool_loop_budget_wrapup_injected is False
+
+    # max=1, budget spent: fires (a signpost cannot precede the first call).
+    agent = _StubAgent(warning=True, max_total=1, used=1)
+    messages = _tool_messages()
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is True
+    assert agent._tool_loop_budget_wrapup_injected is True
+
+    # max=4: 0.8*4=3.2 => fires only at used>=4 (last iteration).
+    agent = _StubAgent(warning=True, max_total=4, used=3)
+    messages = _tool_messages()
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is False
+    agent = _StubAgent(warning=True, max_total=4, used=4)
+    messages = _tool_messages()
+    assert _maybe_inject_tool_loop_budget_wrapup(agent, messages) is True
 
 
 def test_threshold_true_mode_not_before_80_percent():


### PR DESCRIPTION
## Summary
Adds an **opt-in** signpost for when an agent is nearing a *finite* tool-iteration cap, so it checkpoints/produces a concrete deliverable before the wall instead of being cut off mid-task.

Today, when `agent.max_turns` is set (finite cap), the model gets **no pre-wall signal** — it's only told after it's stopped, via a post-hoc summary request + a "send `continue`" explainer. For long multi-step tasks this means repeated **silent hard-stops mid-work** with no warning to finish up.

## What it does
When **enabled**, as the agent approaches a finite tool-iteration limit it appends a one-shot, cache-safe `SYSTEM NOTICE` to the **newest `role:"tool"` message** telling the model to stop opening new workstreams, finish/checkpoint the current task, and produce a concrete status/deliverable — and that a later user turn gets a fresh budget.

Config (config.yaml only):
```yaml
agent:
  tool_loop_budget_warning: false   # default — off, zero behavior change
  #   true  -> warn once when used >= 80% of a finite max
  #   N (int) -> warn once when remaining <= N (finite cap only)
```

## Design
- **Mirrors the existing `run_budget_seconds` wrap-up** (append to newest `role:"tool"` content, multimodal-safe, latch-once, reset each turn) — proven channel, no new mechanism.
- **Cache- / alternation-safe**: never injects a `role:"user"` message, never mutates the system prompt, never rewrites older messages. Append only to the newest tool result.
- **Zero cost when off**: single early-return guard + default `false`; `messages` byte-identical when disabled.
- **Fires only on a finite cap** (`max_turns` actually set); inert when cap is unlimited.
- **#7915 context**: Hermes previously removed intermediate *pressure* warnings because they made models give up prematurely on complex tasks. That behavior is **fully preserved** here — this is **default-off and opt-in only**, so stock users see no change. It primarily helps users who *deliberately set a finite limit* and want a graceful checkpoint instead of a silent cut. (Owned explicitly so this doesn't creep back into the #7915 default path.)

## Tests
New `tests/agent/test_tool_loop_budget_warning.py` mirroring `test_run_budget.py`: off-never-mutates, unlimited-inert, newest-tool-only + roles stable + one-shot latch, real turn-reset (latch resets across turns), multimodal, config plumbing via temp `HERMES_HOME`, and an integration-lite spy asserting the notice is present before the final model call.

```
pytest tests/agent/test_tool_loop_budget_warning.py -q   # 19 passed
pytest tests/agent/test_run_budget.py -q                # 28 passed (unchanged)
```

## Scope
6 files; no new tools, no `HERMES_*` env vars, no system-prompt mutation, no change to the summary path or the unlimited default. Resume already works via per-turn budget reset + "send `continue`" — this only removes the *silence* before the wall.
