### PR TITLE
feat(api): inject trusted request-scoped MCP context

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -913,6 +913,58 @@ def _session_chat_user_message(body: Dict[str, Any], *, param: str = "message") 
         return None, _multimodal_validation_error(exc, param=param)
 
 
+_MCP_CONTEXT_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
+_MCP_CONTEXT_MAX_BYTES = 16 * 1024
+
+
+def _session_chat_mcp_context(
+    body: Dict[str, Any],
+) -> tuple[Dict[str, Dict[str, Any]], Optional[Any]]:
+    """Validate trusted per-turn MCP arguments without persisting them."""
+    raw = body.get("mcp_context")
+    if raw is None:
+        return {}, None
+    if not isinstance(raw, dict) or len(raw) > 16:
+        return {}, web.json_response(
+            _openai_error("mcp_context must be an object", code="invalid_mcp_context"), status=400,
+        )
+    try:
+        encoded = json.dumps(raw, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    except (TypeError, ValueError):
+        encoded = b""
+    if not encoded or len(encoded) > _MCP_CONTEXT_MAX_BYTES:
+        return {}, web.json_response(
+            _openai_error("mcp_context is invalid or too large", code="invalid_mcp_context"), status=400,
+        )
+    clean: Dict[str, Dict[str, Any]] = {}
+    for server_name, values in raw.items():
+        if not isinstance(server_name, str) or not _MCP_CONTEXT_NAME_RE.fullmatch(server_name):
+            return {}, web.json_response(
+                _openai_error("mcp_context contains an invalid server name", code="invalid_mcp_context"), status=400,
+            )
+        if not isinstance(values, dict) or len(values) > 32:
+            return {}, web.json_response(
+                _openai_error("mcp_context server values must be objects", code="invalid_mcp_context"), status=400,
+            )
+        clean_values: Dict[str, Any] = {}
+        for key, value in values.items():
+            if not isinstance(key, str) or not _MCP_CONTEXT_NAME_RE.fullmatch(key):
+                return {}, web.json_response(
+                    _openai_error("mcp_context contains an invalid argument name", code="invalid_mcp_context"), status=400,
+                )
+            if not isinstance(value, (str, int, float, bool)) and value is not None:
+                return {}, web.json_response(
+                    _openai_error("mcp_context values must be scalar", code="invalid_mcp_context"), status=400,
+                )
+            if isinstance(value, str) and len(value) > 8192:
+                return {}, web.json_response(
+                    _openai_error("mcp_context string value is too large", code="invalid_mcp_context"), status=400,
+                )
+            clean_values[key] = value
+        clean[server_name] = clean_values
+    return clean, None
+
+
 def check_api_server_requirements() -> bool:
     """Check if API server dependencies are available."""
     return AIOHTTP_AVAILABLE
@@ -4540,6 +4592,9 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        mcp_context, context_error = _session_chat_mcp_context(body)
+        if context_error is not None:
+            return context_error
         # Runtime selection. A backend-acknowledged Browser model lock
         # (require_model_lock in the body, or a previously confirmed lock
         # persisted on the session row) is an execution contract and wins.
@@ -4596,6 +4651,7 @@ class APIServerAdapter(BasePlatformAdapter):
             user_message=user_message,
             conversation_history=history,
             ephemeral_system_prompt=system_prompt,
+            mcp_context=mcp_context,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
             route=route,
@@ -4657,6 +4713,9 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = body.get("system_message") or body.get("instructions")
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        mcp_context, context_error = _session_chat_mcp_context(body)
+        if context_error is not None:
+            return context_error
         # Runtime selection — mirrors _handle_session_chat (lock wins,
         # otherwise session-persisted model then per-request values).
         runtime_request = self._effective_session_runtime_request(
@@ -4766,6 +4825,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     user_message=user_message,
                     conversation_history=history,
                     ephemeral_system_prompt=system_prompt,
+                    mcp_context=mcp_context,
                     session_id=session_id,
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
@@ -7125,6 +7185,7 @@ class APIServerAdapter(BasePlatformAdapter):
         user_message: str,
         conversation_history: List[Dict[str, str]],
         ephemeral_system_prompt: Optional[str] = None,
+        mcp_context: Optional[Dict[str, Dict[str, Any]]] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
@@ -7185,6 +7246,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         def _run():
             from gateway.session_context import clear_session_vars
+            from tools.mcp_tool import (
+                bind_trusted_mcp_context,
+                reset_trusted_mcp_context,
+            )
 
             with self._profile_scope(request_profile):
                 tokens = self._bind_api_server_session(
@@ -7196,6 +7261,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         request_browser_control_transport_family
                     ),
                 )
+                trusted_mcp_token = bind_trusted_mcp_context(mcp_context)
                 agent = None
                 try:
                     agent = self._create_agent(
@@ -7367,6 +7433,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         # shutdown.  pop() is a no-op when _create_agent
                         # succeeded but the turn never reached registration.
                         self._shutdown_interruptible_agents.pop(id(agent), None)
+                    reset_trusted_mcp_context(trusted_mcp_token)
                     clear_session_vars(tokens)
 
         self._activate_admitted_request()

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -133,12 +133,16 @@ async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeyp
         def run_conversation(self, user_message, conversation_history, task_id):
             from gateway.session_context import get_session_env
             from tools.environments.local import _make_run_env
+            from tools.mcp_tool import _inject_trusted_mcp_arguments
 
             observed["task_id"] = task_id
             observed["context_session_id"] = get_session_env("HERMES_SESSION_ID")
             observed["context_platform"] = get_session_env("HERMES_SESSION_PLATFORM")
             observed["context_session_key"] = get_session_env("HERMES_SESSION_KEY")
             observed["child_session_id"] = _make_run_env({}).get("HERMES_SESSION_ID")
+            observed["mcp_args"] = _inject_trusted_mcp_arguments(
+                "carlo_webapi", {"act_as_token": "model"}, {"act_as_token", "turn_id"}
+            )
             return {"final_response": "ok"}
 
     def fake_create_agent(**kwargs):
@@ -151,6 +155,7 @@ async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeyp
         conversation_history=[],
         session_id="request-session",
         gateway_session_key="request-key",
+        mcp_context={"carlo_webapi": {"act_as_token": "trusted", "turn_id": "a" * 32}},
     )
 
     assert result["session_id"] == "request-session"
@@ -164,7 +169,13 @@ async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeyp
         "context_platform": "api_server",
         "context_session_key": "request-key",
         "child_session_id": "request-session",
+        "mcp_args": {"act_as_token": "trusted", "turn_id": "a" * 32},
     }
+    from tools.mcp_tool import _inject_trusted_mcp_arguments
+    original = {"act_as_token": "model"}
+    assert _inject_trusted_mcp_arguments(
+        "carlo_webapi", original, {"act_as_token"}
+    ) is original
 
 
 @pytest.mark.asyncio
@@ -461,6 +472,71 @@ async def test_session_chat_stream_treats_pre_existing_poisoned_row_as_no_model(
 
 def _register_session_model_route(app, adapter):
     app.router.add_post("/api/sessions/{session_id}/model", adapter._handle_session_model_lock)
+
+
+@pytest.mark.asyncio
+async def test_session_chat_forwards_validated_mcp_context(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = session_db
+    session_id = session_db.create_session("mcp-context-session", "api_server")
+    mock_run = AsyncMock(return_value=({"final_response": "ok", "session_id": session_id}, {"total_tokens": 1}))
+    context = {"carlo_webapi": {"act_as_token": "jwt", "turn_id": "a" * 32}}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hi", "mcp_context": context},
+            )
+            assert response.status == 200
+
+    assert mock_run.call_args.kwargs["mcp_context"] == context
+
+
+@pytest.mark.asyncio
+async def test_session_chat_stream_forwards_validated_mcp_context(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = session_db
+    session_id = session_db.create_session("mcp-context-stream", "api_server")
+    mock_run = AsyncMock(return_value=({"final_response": "ok", "session_id": session_id}, {"total_tokens": 1}))
+    context = {"carlo_webapi": {"confirmed_action_token": "", "turn_id": "b" * 32}}
+
+    app = _create_session_app(adapter)
+    with patch.object(adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                f"/api/sessions/{session_id}/chat/stream",
+                json={"message": "hi", "mcp_context": context},
+            )
+            assert response.status == 200
+            await response.text()
+
+    assert mock_run.call_args.kwargs["mcp_context"] == context
+
+
+@pytest.mark.asyncio
+async def test_session_chat_rejects_invalid_or_oversized_mcp_context(session_db):
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = session_db
+    session_id = session_db.create_session("mcp-context-invalid", "api_server")
+    mock_run = AsyncMock()
+    app = _create_session_app(adapter)
+
+    with patch.object(adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            invalid = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hi", "mcp_context": {"bad server": {"x": "y"}}},
+            )
+            oversized = await cli.post(
+                f"/api/sessions/{session_id}/chat",
+                json={"message": "hi", "mcp_context": {"server": {"token": "x" * 20000}}},
+            )
+
+    assert invalid.status == 400
+    assert oversized.status == 400
+    mock_run.assert_not_called()
 
 
 def _patch_api_server_runtime(monkeypatch):

--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -319,6 +319,28 @@ class TestCacheLoadDescriptionScan:
 
         mock_scan.assert_called_once_with("playwright", "browser_navigate", "Navigate")
 
+    def test_cached_tool_handler_receives_schema_argument_names(self):
+        from tools.registry import registry
+
+        entry = _fake_cache_entry()
+        entry["tools"][0]["inputSchema"]["properties"] = {
+            "act_as_token": {"type": "string"},
+            "query": {"type": "string"},
+        }
+        config = {"command": "npx", "args": [], "lazy": True}
+
+        with patch.object(mcp, "_make_tool_handler", return_value=lambda _args: "ok") as make_handler, \
+             patch.object(registry, "register"), \
+             patch.object(
+                 registry,
+                 "get_toolset_for_tool",
+                 side_effect=[None, "mcp-playwright"],
+             ), \
+             patch.object(mcp, "_track_mcp_tool_server"):
+            mcp._register_from_cache_sync("playwright", config, entry)
+
+        assert make_handler.call_args.args[3] == {"act_as_token", "query"}
+
 
 class TestResolveServerLazy:
     def test_default_off(self):

--- a/tests/tools/test_mcp_trusted_context.py
+++ b/tests/tools/test_mcp_trusted_context.py
@@ -1,0 +1,47 @@
+"""Trusted request-scoped MCP argument injection."""
+
+from tools.mcp_tool import (
+    _inject_trusted_mcp_arguments,
+    bind_trusted_mcp_context,
+    reset_trusted_mcp_context,
+)
+
+
+def test_trusted_context_overwrites_matching_args_without_mutating_input():
+    original = {"act_as_token": "model-value", "query": "Meyer"}
+    token = bind_trusted_mcp_context({
+        "carlo_webapi": {
+            "act_as_token": "trusted-value",
+            "turn_id": "a" * 32,
+            "confirmed_action_token": "",
+            "ignored": "not-in-schema",
+        }
+    })
+    try:
+        result = _inject_trusted_mcp_arguments(
+            "carlo_webapi", original,
+            {"act_as_token", "turn_id", "confirmed_action_token", "query"},
+        )
+        untouched = _inject_trusted_mcp_arguments(
+            "mcp_logit", original, {"act_as_token", "query"}
+        )
+    finally:
+        reset_trusted_mcp_context(token)
+
+    assert result == {
+        "act_as_token": "trusted-value",
+        "turn_id": "a" * 32,
+        "confirmed_action_token": "",
+        "query": "Meyer",
+    }
+    assert untouched is original
+    assert original == {"act_as_token": "model-value", "query": "Meyer"}
+
+
+def test_trusted_context_resets_after_turn():
+    token = bind_trusted_mcp_context({"carlo_webapi": {"act_as_token": "trusted"}})
+    reset_trusted_mcp_context(token)
+    original = {"act_as_token": "model"}
+    assert _inject_trusted_mcp_arguments(
+        "carlo_webapi", original, {"act_as_token"}
+    ) is original

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4228,6 +4228,39 @@ _connect_server_claim: contextvars.ContextVar[
     Optional[Callable[[MCPServerTask], None]]
 ] = contextvars.ContextVar("mcp_connect_server_claim", default=None)
 
+# Trusted, request-scoped arguments supplied by an authenticated API caller.
+# They live only for one agent turn and are filtered against each MCP tool's
+# declared schema before dispatch.
+_trusted_mcp_context: contextvars.ContextVar[Dict[str, Dict[str, Any]]] = (
+    contextvars.ContextVar("trusted_mcp_context", default={})
+)
+
+
+def bind_trusted_mcp_context(context: Optional[Dict[str, Dict[str, Any]]]):
+    clean = {
+        str(server): dict(values)
+        for server, values in (context or {}).items()
+        if isinstance(server, str) and isinstance(values, dict)
+    }
+    return _trusted_mcp_context.set(clean)
+
+
+def reset_trusted_mcp_context(token) -> None:
+    _trusted_mcp_context.reset(token)
+
+
+def _inject_trusted_mcp_arguments(
+    server_name: str, args: dict, allowed_arguments: Optional[set[str]],
+) -> dict:
+    trusted = _trusted_mcp_context.get().get(server_name) or {}
+    if not trusted or not allowed_arguments:
+        return args
+    merged = dict(args)
+    for key, value in trusted.items():
+        if key in allowed_arguments:
+            merged[key] = value
+    return merged
+
 # Connection-retry cooldown (per-server isolation against restart storms).
 #
 # A single stdio MCP server that fails to spawn (bad PATH, ``exec: not
@@ -5743,7 +5776,12 @@ def _mark_server_call_started(server: Any) -> None:
         mark_tool_call()
 
 
-def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
+def _make_tool_handler(
+    server_name: str,
+    tool_name: str,
+    tool_timeout: float,
+    allowed_arguments: Optional[set[str]] = None,
+):
     """Return a sync handler that calls an MCP tool via the background loop.
 
     The handler conforms to the registry's dispatch interface:
@@ -5758,6 +5796,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
         gate_error = _trust_gate_check(server_name, tool_name)
         if gate_error is not None:
             return gate_error
+
+        call_args = _inject_trusted_mcp_arguments(
+            server_name, args, allowed_arguments
+        )
 
         # Circuit breaker: if this server has failed too many times
         # consecutively, short-circuit with a clear message so the model
@@ -5827,7 +5869,9 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 # it and detect the gateway platform / session for routing.
                 server._pending_call_context = contextvars.copy_context()
                 try:
-                    result = await server.session.call_tool(tool_name, arguments=args)
+                    result = await server.session.call_tool(
+                        tool_name, arguments=call_args
+                    )
                 finally:
                     server._pending_call_context = None
             # The RPC round-trip completed — the session is demonstrably
@@ -6818,7 +6862,10 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                 "origin": f"tool {mcp_tool.name!r}",
                 "schema": schema,
                 "handler": _make_tool_handler(
-                    name, mcp_tool.name, server.tool_timeout
+                    name,
+                    mcp_tool.name,
+                    server.tool_timeout,
+                    set(((schema.get("parameters") or {}).get("properties") or {}).keys()),
                 ),
                 "check_fn": check_fn,
             }
@@ -7100,7 +7147,12 @@ def _register_from_cache_sync(name: str, config: dict, entry: dict) -> List[str]
             name=registry_name,
             toolset=toolset_name,
             schema=schema,
-            handler=_make_tool_handler(name, raw_name, tool_timeout),
+            handler=_make_tool_handler(
+                name,
+                raw_name,
+                tool_timeout,
+                set(((schema.get("parameters") or {}).get("properties") or {}).keys()),
+            ),
             check_fn=check_fn,
             is_async=False,
             description=schema["description"],


### PR DESCRIPTION
## Summary
- validate bounded per-turn mcp_context on native session chat and streaming routes
- bind trusted MCP arguments only for the current executor turn and reset them in finally
- filter trusted values against each tool schema and override model-supplied values
- cover both eager and lazy cached MCP registration paths

## Verification
- session/API context tests: 25 passed
- MCP handler/discovery/lazy regressions: 152 passed
- independent cross-repository blocker review: GO

This enables authenticated applications to provide short-lived MCP credentials and confirmation grants without placing them in the model prompt or persisted transcript.