### PR TITLE
feat(profiles): restrict file tools to configured paths

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2453,6 +2453,14 @@ DEFAULT_CONFIG = {
         # fnmatch globs matched against the basename (e.g. "*.mdc").
         "protected_instruction_files": True,
         "protected_instruction_extra_patterns": [],
+        # Optional profile-local least-privilege boundary for the built-in
+        # file toolset. Empty lists preserve the historical unrestricted
+        # behavior. deny_dirs takes precedence over both allowlists.
+        "file_scope": {
+            "read_dirs": [],
+            "write_dirs": [],
+            "deny_dirs": [],
+        },
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,

--- a/tests/tools/test_file_scope.py
+++ b/tests/tools/test_file_scope.py
@@ -1,0 +1,333 @@
+"""Behavior tests for profile-local file tool path scopes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import PurePosixPath
+
+import pytest
+
+
+def _write_scope_config(home, *, read_dirs=None, write_dirs=None, deny_dirs=None):
+    home.mkdir(exist_ok=True)
+    scope = {}
+    if read_dirs is not None:
+        scope["read_dirs"] = [str(path) for path in read_dirs]
+    if write_dirs is not None:
+        scope["write_dirs"] = [str(path) for path in write_dirs]
+    if deny_dirs is not None:
+        scope["deny_dirs"] = [str(path) for path in deny_dirs]
+    (home / "config.yaml").write_text(
+        json.dumps({"security": {"file_scope": scope}}),
+        encoding="utf-8",
+    )
+
+
+def test_read_file_rejects_path_outside_profile_read_dirs(tmp_path, monkeypatch):
+    from tools.file_tools import read_file_tool
+
+    home = tmp_path / "profile-home"
+    allowed = tmp_path / "vault"
+    outside = tmp_path / "private"
+    allowed.mkdir()
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("must not leak\n", encoding="utf-8")
+    _write_scope_config(home, read_dirs=[allowed])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = json.loads(read_file_tool(str(secret), task_id="file-scope-read-deny"))
+
+    assert "error" in result
+    assert "outside security.file_scope.read_dirs" in result["error"]
+    assert "must not leak" not in json.dumps(result)
+
+
+def test_write_file_enforces_profile_write_dirs(tmp_path, monkeypatch):
+    from tools.file_tools import write_file_tool
+
+    home = tmp_path / "profile-home"
+    queue = tmp_path / "queue"
+    outside = tmp_path / "outside"
+    queue.mkdir()
+    outside.mkdir()
+    _write_scope_config(home, write_dirs=[queue])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    denied = json.loads(write_file_tool(
+        str(outside / "message.txt"),
+        "blocked\n",
+        task_id="file-scope-write-deny",
+    ))
+    allowed = json.loads(write_file_tool(
+        str(queue / "message.txt"),
+        "queued\n",
+        task_id="file-scope-write-allow",
+    ))
+
+    assert "outside security.file_scope.write_dirs" in denied["error"]
+    assert not (outside / "message.txt").exists()
+    assert allowed.get("error") is None
+    assert (queue / "message.txt").read_text(encoding="utf-8") == "queued\n"
+
+
+def test_search_files_rejects_root_outside_profile_read_dirs(tmp_path, monkeypatch):
+    from tools.file_tools import search_tool
+
+    home = tmp_path / "profile-home"
+    allowed = tmp_path / "vault"
+    outside = tmp_path / "private"
+    allowed.mkdir()
+    outside.mkdir()
+    (outside / "secret.txt").write_text("needle\n", encoding="utf-8")
+    _write_scope_config(home, read_dirs=[allowed])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = json.loads(search_tool(
+        "needle",
+        path=str(outside),
+        task_id="file-scope-search-deny",
+    ))
+
+    assert "outside security.file_scope.read_dirs" in result["error"]
+    assert "needle" not in json.dumps(result)
+
+
+def test_patch_rejects_target_outside_profile_write_dirs(tmp_path, monkeypatch):
+    from tools.file_tools import patch_tool
+
+    home = tmp_path / "profile-home"
+    queue = tmp_path / "queue"
+    outside = tmp_path / "outside"
+    queue.mkdir()
+    outside.mkdir()
+    target = outside / "message.txt"
+    target.write_text("before\n", encoding="utf-8")
+    _write_scope_config(home, write_dirs=[queue])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = json.loads(patch_tool(
+        mode="replace",
+        path=str(target),
+        old_string="before",
+        new_string="after",
+        task_id="file-scope-patch-deny",
+    ))
+
+    assert "outside security.file_scope.write_dirs" in result["error"]
+    assert target.read_text(encoding="utf-8") == "before\n"
+
+
+def test_search_omits_results_from_denied_subdirectory(tmp_path, monkeypatch):
+    from tools.file_tools import search_tool
+
+    home = tmp_path / "profile-home"
+    vault = tmp_path / "vault"
+    denied_dir = vault / "private"
+    allowed_dir = vault / "public"
+    denied_dir.mkdir(parents=True)
+    allowed_dir.mkdir()
+    (denied_dir / "secret.txt").write_text("needle secret\n", encoding="utf-8")
+    (allowed_dir / "note.txt").write_text("needle public\n", encoding="utf-8")
+    _write_scope_config(home, read_dirs=[vault], deny_dirs=[denied_dir])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = json.loads(search_tool(
+        "needle",
+        path=str(vault),
+        task_id="file-scope-search-filter",
+    ))
+
+    rendered = json.dumps(result)
+    assert "needle public" in rendered
+    assert "needle secret" not in rendered
+    assert "file scope" in result["_omitted"]
+
+
+def test_read_scope_resolves_traversal_and_symlink_targets(tmp_path, monkeypatch):
+    from tools.file_tools import read_file_tool
+
+    home = tmp_path / "profile-home"
+    vault = tmp_path / "vault"
+    outside = tmp_path / "outside"
+    vault.mkdir()
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("must not leak\n", encoding="utf-8")
+    link = vault / "linked-secret.txt"
+    try:
+        link.symlink_to(secret)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+    _write_scope_config(home, read_dirs=[vault])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    traversal = json.loads(read_file_tool(
+        str(vault / ".." / "outside" / "secret.txt"),
+        task_id="file-scope-traversal-deny",
+    ))
+    symlink = json.loads(read_file_tool(
+        str(link),
+        task_id="file-scope-symlink-deny",
+    ))
+
+    assert "outside security.file_scope.read_dirs" in traversal["error"]
+    assert "outside security.file_scope.read_dirs" in symlink["error"]
+
+
+def test_deny_dirs_override_read_and_write_allowlists(tmp_path, monkeypatch):
+    from tools.file_tools import read_file_tool, write_file_tool
+
+    home = tmp_path / "profile-home"
+    vault = tmp_path / "vault"
+    denied_dir = vault / "private"
+    denied_dir.mkdir(parents=True)
+    target = denied_dir / "note.txt"
+    target.write_text("private\n", encoding="utf-8")
+    _write_scope_config(
+        home,
+        read_dirs=[vault],
+        write_dirs=[vault],
+        deny_dirs=[denied_dir],
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    read_result = json.loads(read_file_tool(
+        str(target),
+        task_id="file-scope-deny-read",
+    ))
+    write_result = json.loads(write_file_tool(
+        str(target),
+        "changed\n",
+        task_id="file-scope-deny-write",
+    ))
+
+    assert "security.file_scope.deny_dirs" in read_result["error"]
+    assert "security.file_scope.deny_dirs" in write_result["error"]
+    assert target.read_text(encoding="utf-8") == "private\n"
+
+
+def test_empty_scope_lists_preserve_unrestricted_behavior(tmp_path, monkeypatch):
+    from tools.file_tools import read_file_tool, write_file_tool
+
+    home = tmp_path / "profile-home"
+    workspace = tmp_path / "任意目录"
+    workspace.mkdir()
+    source = workspace / "资料.txt"
+    source.write_text("unicode content\n", encoding="utf-8")
+    output = workspace / "输出.txt"
+    _write_scope_config(home, read_dirs=[], write_dirs=[], deny_dirs=[])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    read_result = json.loads(read_file_tool(
+        str(source),
+        task_id="file-scope-empty-read",
+    ))
+    write_result = json.loads(write_file_tool(
+        str(output),
+        "unicode output\n",
+        task_id="file-scope-empty-write",
+    ))
+
+    assert "unicode content" in read_result["content"]
+    assert write_result.get("error") is None
+    assert output.read_text(encoding="utf-8") == "unicode output\n"
+
+
+def test_remote_scope_uses_backend_realpath_for_symlink_targets(monkeypatch):
+    import tools.file_tools as file_tools
+
+    class Result:
+        exit_code = 0
+
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    class RemoteOps:
+        def _exec(self, command):
+            if "/vault/link" in command:
+                return Result("/outside/secret.txt\n/vault\n")
+            return Result("/vault\n")
+
+        @staticmethod
+        def _escape_shell_arg(value):
+            return f"'{value}'"
+
+    monkeypatch.setattr(
+        file_tools,
+        "_terminal_env_type_for_task",
+        lambda task_id="default": "ssh",
+    )
+    monkeypatch.setattr(
+        file_tools,
+        "_resolve_path_for_task",
+        lambda path, task_id="default": PurePosixPath(path),
+    )
+    monkeypatch.setattr(file_tools, "_get_file_ops", lambda task_id="default": RemoteOps())
+    monkeypatch.setattr(
+        file_tools,
+        "_file_scope_config",
+        lambda: {"read_dirs": ["/vault"]},
+    )
+
+    error = file_tools._check_file_scope("/vault/link", "read", "remote-task")
+    assert "outside security.file_scope.read_dirs" in error
+
+
+def test_v4a_patch_rejects_entire_batch_when_one_target_is_outside(tmp_path, monkeypatch):
+    from tools.file_tools import patch_tool
+
+    home = tmp_path / "profile-home"
+    queue = tmp_path / "queue"
+    outside = tmp_path / "outside"
+    queue.mkdir()
+    outside.mkdir()
+    allowed_file = queue / "allowed.txt"
+    outside_file = outside / "outside.txt"
+    allowed_file.write_text("before allowed\n", encoding="utf-8")
+    outside_file.write_text("before outside\n", encoding="utf-8")
+    _write_scope_config(home, write_dirs=[queue])
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = json.loads(patch_tool(
+        mode="patch",
+        patch=(
+            "*** Begin Patch\n"
+            f"*** Update File: {allowed_file}\n"
+            "@@\n"
+            "-before allowed\n"
+            "+after allowed\n"
+            f"*** Update File: {outside_file}\n"
+            "@@\n"
+            "-before outside\n"
+            "+after outside\n"
+            "*** End Patch"
+        ),
+        task_id="file-scope-v4a-atomic-deny",
+    ))
+
+    assert "outside security.file_scope.write_dirs" in result["error"]
+    assert allowed_file.read_text(encoding="utf-8") == "before allowed\n"
+    assert outside_file.read_text(encoding="utf-8") == "before outside\n"
+
+
+def test_malformed_allowlist_fails_closed(tmp_path, monkeypatch):
+    from tools.file_tools import read_file_tool
+
+    home = tmp_path / "profile-home"
+    home.mkdir()
+    target = tmp_path / "note.txt"
+    target.write_text("content\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        json.dumps({"security": {"file_scope": {"read_dirs": str(tmp_path)}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    result = json.loads(read_file_tool(
+        str(target),
+        task_id="file-scope-invalid-config",
+    ))
+
+    assert "could not safely apply security.file_scope" in result["error"]
+    assert "must be a list of paths" in result["error"]

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -403,6 +403,131 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     return resolved.resolve()
 
 
+def _canonical_scope_paths(filepaths: list[str], task_id: str = "default") -> list[str]:
+    """Return comparison-safe paths, batching remote canonicalization."""
+    resolved = [_resolve_path_for_task(path, task_id) for path in filepaths]
+    remote_paths = _terminal_env_type_for_task(task_id) != "local"
+    if remote_paths:
+        file_ops = _get_file_ops(task_id)
+        escaped = " ".join(file_ops._escape_shell_arg(str(path)) for path in resolved)
+        result = file_ops._exec(f"realpath -m -- {escaped}")
+        canonical = result.stdout.splitlines() if result.exit_code == 0 else []
+        if len(canonical) != len(filepaths):
+            raise RuntimeError(
+                "backend could not canonicalize all security.file_scope paths"
+            )
+        return [posixpath.normpath(path) for path in canonical]
+    return [
+        (
+            posixpath.normpath(str(path))
+            if isinstance(path, PurePosixPath)
+            else os.path.normcase(os.path.realpath(os.fspath(path)))
+        )
+        for path in resolved
+    ]
+
+
+def _canonical_path_within(candidate: str, root: str, *, remote_paths: bool) -> bool:
+    path_module = posixpath if remote_paths else os.path
+    try:
+        if path_module.commonpath((candidate, root)) == root:
+            return True
+    except ValueError:
+        return False
+    if remote_paths:
+        return False
+
+    # ``normcase`` handles Windows. On a case-insensitive macOS volume it is
+    # intentionally a no-op, so compare existing ancestors by filesystem
+    # identity as a fallback. This still rejects a differently-cased sibling
+    # on a case-sensitive volume because ``samefile`` will not match it.
+    root_path = Path(root)
+    for ancestor in (Path(candidate), *Path(candidate).parents):
+        try:
+            if ancestor.exists() and root_path.exists() and os.path.samefile(ancestor, root_path):
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _file_scope_config() -> dict:
+    """Load the active profile's file scope without mutating config state."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+    except Exception:
+        return {}
+    security = config.get("security") if isinstance(config, dict) else None
+    scope = security.get("file_scope") if isinstance(security, dict) else None
+    return scope if isinstance(scope, dict) else {}
+
+
+def _scope_roots(scope: dict, key: str) -> list[str]:
+    raw = scope.get(key, [])
+    if raw in (None, []):
+        return []
+    if not isinstance(raw, list) or any(
+        not isinstance(path, str) or not path for path in raw
+    ):
+        raise RuntimeError(f"security.file_scope.{key} must be a list of paths")
+    return raw
+
+
+def _file_scope_errors(
+    filepaths: list[str], access: str, task_id: str = "default"
+) -> list[str | None]:
+    """Return one scope error per path, canonicalizing each backend in one pass."""
+    scope = _file_scope_config()
+    try:
+        deny_dirs = _scope_roots(scope, "deny_dirs")
+        allow_key = "read_dirs" if access == "read" else "write_dirs"
+        allowed_dirs = _scope_roots(scope, allow_key)
+        if not deny_dirs and not allowed_dirs:
+            return [None] * len(filepaths)
+
+        canonical = _canonical_scope_paths(
+            [*filepaths, *deny_dirs, *allowed_dirs], task_id
+        )
+        candidates = canonical[:len(filepaths)]
+        deny_roots = canonical[len(filepaths):len(filepaths) + len(deny_dirs)]
+        allow_roots = canonical[len(filepaths) + len(deny_dirs):]
+        remote_paths = _terminal_env_type_for_task(task_id) != "local"
+        errors: list[str | None] = []
+        for filepath, candidate in zip(filepaths, candidates):
+            if any(
+                _canonical_path_within(candidate, root, remote_paths=remote_paths)
+                for root in deny_roots
+            ):
+                errors.append(
+                    f"Refusing {access} access to '{filepath}': path is inside "
+                    "security.file_scope.deny_dirs."
+                )
+            elif allowed_dirs and not any(
+                _canonical_path_within(candidate, root, remote_paths=remote_paths)
+                for root in allow_roots
+            ):
+                errors.append(
+                    f"Refusing {access} access to '{filepath}': path is outside "
+                    f"security.file_scope.{allow_key}."
+                )
+            else:
+                errors.append(None)
+        return errors
+    except Exception as exc:
+        return [
+            f"Refusing {access} access to '{filepath}': could not safely "
+            f"apply security.file_scope ({exc})."
+            for filepath in filepaths
+        ]
+
+
+def _check_file_scope(filepath: str, access: str, task_id: str = "default") -> str | None:
+    """Return an error when *filepath* falls outside the active profile scope."""
+    return _file_scope_errors([filepath], access, task_id)[0]
+
+
 def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
     """Warn when a relative path resolved OUTSIDE the task's workspace root.
 
@@ -634,6 +759,48 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
         allowed_counts = {}
         for file_path, count in result.counts.items():
             if _search_result_read_block_error(file_path, task_id):
+                omitted += 1
+                continue
+            allowed_counts[file_path] = count
+        result.counts = allowed_counts
+
+    return omitted
+
+
+def _filter_file_scope_search_results(result, task_id: str = "default") -> int:
+    """Remove search results whose resolved paths are outside the read scope."""
+    omitted = 0
+
+    if hasattr(result, "matches") and result.matches:
+        errors = _file_scope_errors(
+            [match.path for match in result.matches], "read", task_id
+        )
+        allowed_matches = []
+        for match, error in zip(result.matches, errors):
+            if error:
+                omitted += 1
+                continue
+            allowed_matches.append(match)
+        result.matches = allowed_matches
+
+    if hasattr(result, "files") and result.files:
+        errors = _file_scope_errors(list(result.files), "read", task_id)
+        allowed_files = []
+        for file_path, error in zip(result.files, errors):
+            if error:
+                omitted += 1
+                continue
+            allowed_files.append(file_path)
+        result.files = allowed_files
+
+    if hasattr(result, "counts") and result.counts:
+        count_items = list(result.counts.items())
+        errors = _file_scope_errors(
+            [file_path for file_path, _ in count_items], "read", task_id
+        )
+        allowed_counts = {}
+        for (file_path, count), error in zip(count_items, errors):
+            if error:
                 omitted += 1
                 continue
             allowed_counts[file_path] = count
@@ -1626,6 +1793,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
     try:
         offset, limit = normalize_read_pagination(offset, limit)
 
+        scope_err = _check_file_scope(path, "read", task_id)
+        if scope_err:
+            return tool_error(scope_err)
+
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
         # blocking on input).  Pure path check — no I/O.
@@ -2230,6 +2401,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     Pass ``True`` after explicit user direction — same shape as ``force``
     on the terminal tool.
     """
+    scope_err = _check_file_scope(path, "write", task_id)
+    if scope_err:
+        return tool_error(scope_err)
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
         return tool_error(sensitive_err)
@@ -2373,7 +2547,10 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 if _err:
                     return _err
                 _paths_to_check.append(v4a_path)
-    for _p in _paths_to_check:
+    _scope_errors = _file_scope_errors(_paths_to_check, "write", task_id)
+    for _p, scope_err in zip(_paths_to_check, _scope_errors):
+        if scope_err:
+            return tool_error(scope_err)
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
             return tool_error(sensitive_err)
@@ -2540,6 +2717,10 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     try:
         offset, limit = normalize_search_pagination(offset, limit)
 
+        scope_err = _check_file_scope(path, "read", task_id)
+        if scope_err:
+            return tool_error(scope_err)
+
         # Track searches to detect *consecutive* repeated search loops.
         # Include pagination args so users can page through truncated
         # results without tripping the repeated-search guard.
@@ -2599,6 +2780,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
         omitted = _filter_read_blocked_search_results(result, task_id)
+        scope_omitted = _filter_file_scope_search_results(result, task_id)
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
@@ -2610,6 +2792,14 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 f"{omitted} result(s) omitted because they target credential, "
                 "token, cache, or secret-bearing environment files."
             )
+        if scope_omitted:
+            scope_message = (
+                f"{scope_omitted} result(s) omitted by the active profile file scope."
+            )
+            if result_dict.get("_omitted"):
+                result_dict["_omitted"] += " " + scope_message
+            else:
+                result_dict["_omitted"] = scope_message
 
         # Populate negative cache when search root was missing. No early
         # return — same rationale as the read path: error results keep

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2375,6 +2375,10 @@ Pre-execution security scanning and secret redaction:
 ```yaml
 security:
   redact_secrets: true           # Redact API key patterns in tool output and logs (on by default)
+  file_scope:                    # Optional per-profile boundary for the file toolset
+    read_dirs: []                # Allowed roots for read_file and search_files
+    write_dirs: []               # Allowed roots for write_file and patch
+    deny_dirs: []                # Denied roots; takes precedence over both allowlists
   tirith_enabled: true           # Enable Tirith security scanning for terminal commands
   tirith_path: "tirith"          # Path to tirith binary (default: "tirith" in $PATH)
   tirith_timeout: 5              # Seconds to wait for tirith scan before timing out
@@ -2386,6 +2390,7 @@ security:
 ```
 
 - `redact_secrets` — when `true`, automatically detects and redacts patterns that look like API keys, tokens, and passwords in tool output before it enters the conversation context and logs. **On by default**. Set to `false` explicitly only when you need raw credential-like strings for debugging or redactor development.
+- `file_scope` — optional path boundary for the active profile's built-in file tools. `read_dirs` applies to `read_file` and `search_files`; `write_dirs` applies to `write_file` and `patch`; `deny_dirs` always wins. Unset or empty lists preserve unrestricted file-tool behavior. Paths accept `~`, are resolved against the active task workspace, and are canonicalized before comparison so `..` and symlinks cannot escape a configured root. This does not restrict the `terminal` tool; disable `terminal` for a profile or use an OS/container sandbox when shell access must also be constrained.
 - `tirith_enabled` — when `true`, terminal commands are scanned by [Tirith](https://github.com/sheeki03/tirith) before execution to detect potentially dangerous operations.
 - `tirith_path` — path to the tirith binary. Set this if tirith is installed in a non-standard location.
 - `tirith_timeout` — maximum seconds to wait for a tirith scan. Commands proceed if the scan times out.

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -652,6 +652,26 @@ When a blocked URL is requested, the tool returns an error explaining the domain
 
 See [Website Blocklist](/user-guide/configuration#website-blocklist) in the configuration guide for full details.
 
+### Profile File Access Scope
+
+Profiles can apply least-privilege path boundaries to the built-in file tools:
+
+```yaml
+# In the profile's config.yaml
+security:
+  file_scope:
+    read_dirs:
+      - "~/Documents/Obsidian Vault"
+    write_dirs:
+      - "~/Documents/Obsidian Vault/Yonda queue"
+    deny_dirs:
+      - "~/Documents/Obsidian Vault/Private"
+```
+
+`read_dirs` controls `read_file` and `search_files`; `write_dirs` controls `write_file` and `patch`. Denials take precedence over allowlists. Missing or empty lists retain the historical unrestricted behavior, so existing profiles do not change after upgrading. Hermes canonicalizes paths before access, including `~`, `..`, symlinks, Unicode names, and the host filesystem's case behavior. Search results are filtered again so a denied subtree or symlink target cannot leak through a broader allowed search root.
+
+This boundary covers the `file` toolset only. It does not sandbox `terminal`, `execute_code`, plugins, or external processes that run as the same OS user. Disable those capabilities for a low-trust profile or combine this setting with an OS/container sandbox when they must not bypass the file-tool policy. The older `HERMES_WRITE_SAFE_ROOT` environment variable remains a deployment-level write boundary; `security.file_scope` is the profile-local configuration surface and adds separate read/write policy.
+
 ### SSRF Protection
 
 All URL-capable tools (web search, web extract, vision, browser) validate URLs before fetching them to prevent Server-Side Request Forgery (SSRF) attacks. Blocked addresses include:


### PR DESCRIPTION
## What does this PR do?

Adds a profile-local filesystem boundary for the built-in file toolset. Operators can give a low-trust profile read access to selected roots, write access to a narrower set of roots, and explicit denied subtrees without changing the model-facing tool names.

### Motivation

Profiles can currently enable or disable the `file` toolset only as a whole. A profile intended to read an Obsidian vault or write to one queue directory otherwise receives the same file-tool reach as a fully trusted profile running under the same OS account.

### Behavior

`security.file_scope.read_dirs` controls `read_file` and `search_files`. `write_dirs` controls `write_file` and `patch`, while `deny_dirs` takes precedence over both allowlists. Missing or empty lists preserve the existing unrestricted behavior.

The boundary covers the built-in `file` toolset only. It does not restrict `terminal`, `execute_code`, plugins, or other processes running as the same OS user.

### Implementation

Paths are resolved against the active task workspace and canonicalized before comparison. Local paths use host realpath and case semantics; remote and container paths use backend-side `realpath` in a batched call. Search results are filtered again so denied subtrees and symlink targets cannot leak through a broader allowed search root. Invalid scope lists and failed backend canonicalization fail closed.

## Related Issue

Closes #92424

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/file_tools.py` - enforce read, write, deny, symlink, traversal, and remote-backend scope checks across all four file tools.
- `hermes_cli/config_defaults.py` - add backward-compatible empty `security.file_scope` defaults.
- `tests/tools/test_file_scope.py` - cover read/write separation, search filtering, deny precedence, traversal, symlinks, V4A atomic rejection, Unicode, malformed config, and remote canonicalization.
- `website/docs/user-guide/configuration.md` and `website/docs/user-guide/security.md` - document configuration, semantics, and the file-tool-only boundary.

## How to Test

1. Configure a profile with separate `read_dirs`, `write_dirs`, and a nested `deny_dirs` entry.
2. Confirm `read_file` and `search_files` reject paths outside the read roots, while allowed files remain readable.
3. Confirm `write_file` and `patch` reject paths outside the write roots and that denied subtrees override both allowlists.
4. Run:

```bash
scripts/run_tests.sh tests/tools/test_file_scope.py tests/hermes_cli/test_config_loader_e2e.py tests/hermes_cli/test_config_validation.py -q
```

Result: 24 tests passed on Windows 11. Ruff and `git diff --check` also pass for the changed Python files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the repository test entrypoint on the relevant tests and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` update is N/A because runtime defaults and the configuration guide define this optional nested key
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow contract changed
- [x] I've considered Windows, macOS, Linux, and remote POSIX backend path semantics
- [x] Tool description/schema updates are N/A because tool names and model-facing arguments are unchanged

## Screenshots / Logs

N/A - this is a configuration and tool-policy change with automated behavior coverage.
