### PR TITLE
fix(cli): line-buffer stdout when headless so piped output streams live

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12432,6 +12432,15 @@ def main():
     except Exception:
         pass
 
+    # Headless runners pipe stdout; line-buffer it so live agent output
+    # streams incrementally instead of arriving as end-of-run bursts
+    # that read as a hang (#92281). No-op for interactive TTYs.
+    try:
+        from hermes_cli.stdio import configure_headless_stdout_buffering
+        configure_headless_stdout_buffering()
+    except Exception:
+        pass
+
     # Sweep stale ``hermes.exe.old.*`` quarantine files left by previous
     # ``hermes update`` runs on Windows. Silent no-op on non-Windows or when
     # there's nothing to clean. See ``_quarantine_running_hermes_exe``.

--- a/hermes_cli/stdio.py
+++ b/hermes_cli/stdio.py
@@ -32,7 +32,11 @@ from __future__ import annotations
 import os
 import sys
 
-__all__ = ["configure_windows_stdio", "is_windows"]
+__all__ = [
+    "configure_windows_stdio",
+    "configure_headless_stdout_buffering",
+    "is_windows",
+]
 
 
 _CONFIGURED = False
@@ -41,6 +45,35 @@ _CONFIGURED = False
 def is_windows() -> bool:
     """Return True iff running on native Windows (not WSL)."""
     return sys.platform == "win32"
+
+
+def configure_headless_stdout_buffering() -> bool:
+    """Line-buffer stdout when it is not a TTY (#92281).
+
+    Python block-buffers stdout whenever it is a pipe or file — the normal
+    topology for headless supervisors and agent-runner integrations. The
+    agent loop then delivers minutes of steady work in a single flush
+    burst, which is indistinguishable from a hang from the log stream
+    alone. Line buffering restores incremental delivery; interactive TTYs
+    are already line-buffered and are left untouched.
+    """
+    stream = sys.stdout
+    if stream is None:
+        return False
+    try:
+        if stream.isatty():
+            return False
+    except (AttributeError, ValueError, OSError):
+        # Not a real console stream (closed / replaced) — treat as headless.
+        pass
+    try:
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            return False
+        reconfigure(line_buffering=True)
+        return True
+    except Exception:
+        return False
 
 
 def _flip_console_code_page_to_utf8() -> None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -9025,6 +9025,15 @@ def main(
     """
     print("🤖 AI Agent with Tool Calling")
     print("=" * 50)
+
+    # Headless runners pipe stdout; line-buffer it so live agent output
+    # streams incrementally instead of arriving as end-of-run bursts
+    # that read as a hang (#92281). No-op for interactive TTYs.
+    try:
+        from hermes_cli.stdio import configure_headless_stdout_buffering
+        configure_headless_stdout_buffering()
+    except Exception:
+        pass
     
     # Handle tool listing
     if list_tools:

--- a/tests/hermes_cli/test_stdio_line_buffering.py
+++ b/tests/hermes_cli/test_stdio_line_buffering.py
@@ -1,0 +1,66 @@
+"""Headless stdout line-buffering (#92281).
+
+When hermes runs under a headless supervisor (stdout piped to a log),
+Python's default block buffering delivered minutes of steady agent work
+as one flush burst — indistinguishable from a hang from the log stream.
+``configure_headless_stdout_buffering()`` must line-buffer non-TTY
+stdout and leave interactive TTYs untouched.
+"""
+
+import io
+from unittest.mock import patch
+
+from hermes_cli.stdio import configure_headless_stdout_buffering
+
+
+class _FakeStream(io.TextIOBase):
+    """Text stream double that records reconfigure() calls."""
+
+    def __init__(self, tty):
+        self._tty = tty
+        self.reconfigure_kwargs = None
+
+    def isatty(self):
+        return self._tty
+
+    def reconfigure(self, **kwargs):
+        self.reconfigure_kwargs = kwargs
+
+    def write(self, text):
+        return len(text)
+
+
+def test_piped_stdout_gets_line_buffering():
+    stream = _FakeStream(tty=False)
+    with patch("sys.stdout", stream):
+        assert configure_headless_stdout_buffering() is True
+    assert stream.reconfigure_kwargs == {"line_buffering": True}
+
+
+def test_tty_stdout_is_left_alone():
+    stream = _FakeStream(tty=True)
+    with patch("sys.stdout", stream):
+        assert configure_headless_stdout_buffering() is False
+    assert stream.reconfigure_kwargs is None
+
+
+def test_stream_without_reconfigure_support_is_skipped():
+    class _Legacy(_FakeStream):
+        reconfigure = None  # type: ignore[assignment]
+
+    stream = _Legacy(tty=False)
+    with patch("sys.stdout", stream):
+        assert configure_headless_stdout_buffering() is False
+
+
+def test_missing_stdout_is_survivable():
+    with patch("sys.stdout", None):
+        assert configure_headless_stdout_buffering() is False
+
+
+def test_real_piped_textiowrapper_is_reconfigured():
+    stream = io.StringIO()
+    assert not stream.isatty()
+    with patch("sys.stdout", stream):
+        # StringIO has no reconfigure(); the helper must skip it silently.
+        configure_headless_stdout_buffering()

--- a/tests/hermes_cli/test_stdio_line_buffering.py
+++ b/tests/hermes_cli/test_stdio_line_buffering.py
@@ -59,8 +59,14 @@ def test_missing_stdout_is_survivable():
 
 
 def test_real_piped_textiowrapper_is_reconfigured():
-    stream = io.StringIO()
+    """Use a real TextIOWrapper (has reconfigure, isatty=False when wrapped
+    around BytesIO) to verify the reconfigure call actually happens."""
+    stream = io.TextIOWrapper(io.BytesIO())
     assert not stream.isatty()
+    reconfigured = []
+    original_reconfigure = stream.reconfigure
+    stream.reconfigure = lambda **kw: (reconfigured.append(kw), original_reconfigure(**kw))
     with patch("sys.stdout", stream):
-        # StringIO has no reconfigure(); the helper must skip it silently.
-        configure_headless_stdout_buffering()
+        result = configure_headless_stdout_buffering()
+    assert result is True
+    assert reconfigured == [{"line_buffering": True}]


### PR DESCRIPTION
Fixes #92281

## What & why

When `hermes` is launched non-interactively (stdout attached to a pipe/file — the common headless/agent-runner topology), Python block-buffers stdout. The reporter captured 24 minutes of log silence while the agent worked steadily, then the completed output arrived in a single ~20ms burst; file mtimes proved the work happened incrementally and only *delivery* was buffered.

This adds `hermes_cli.stdio.configure_headless_stdout_buffering()`:

- reconfigures `sys.stdout` to `line_buffering=True` **only when it is not a TTY** (interactive TTYs are already line-buffered)
- skips silently for streams without `reconfigure` support, missing stdout, or any reconfiguration failure
- is called from both entry points: `hermes_cli.main:main` (right after Windows UTF-8 stdio setup) and `run_agent:main`

Bulk-writers that genuinely want block buffering can still reconfigure themselves later — this only changes the default for the piped case where the current default produces misleading logs.

## How to test

```
scripts/run_tests.sh tests/hermes_cli/test_stdio_line_buffering.py -q
```

Covers: piped stream gets `{line_buffering: True}`, TTY streams are left untouched, streams without `reconfigure` are skipped, `sys.stdout=None` survives, and real `TextIOWrapper` behavior via StringIO.

Manual check: pipe `hermes -q "..."` through a file and confirm lines appear incrementally during the run instead of all at once at exit.

## Platforms tested

- Native Windows 11 (Python 3.12): new suite passes 5/5 in ~4s.
- The helper is host-independent (TTY detection, not platform detection), covered by host-independent tests.
