### PR TITLE
fix(vertex): detect ADC so a GCE/GKE deployment keeps its auxiliary tasks

### DIFF
--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -281,25 +281,56 @@ def get_vertex_config(
 
 
 def _adc_well_known_path() -> str:
-    """Path gcloud writes for `auth application-default login`."""
-    if os.name == "nt":
-        base = os.environ.get("APPDATA", "")
-        return os.path.join(base, "gcloud", "application_default_credentials.json")
-    return os.path.join(
-        os.path.expanduser("~"),
-        ".config",
-        "gcloud",
-        "application_default_credentials.json",
-    )
+    """Path gcloud writes for `auth application-default login`.
+
+    Mirrors ``google.auth._cloud_sdk.get_config_path()`` deliberately, branch
+    for branch, rather than approximating it. The whole purpose of this
+    function is to predict whether ``google.auth.default()`` will find a
+    credential, so any divergence in the path is a wrong answer:
+
+    * ``CLOUDSDK_CONFIG`` relocates gcloud's entire config directory and wins
+      over everything on every platform. CI images and managed devcontainers
+      set it routinely, so ignoring it means missing the file that is actually
+      there.
+    * POSIX: ``~/.config/gcloud``.
+    * Windows: ``%APPDATA%\\gcloud``, falling back to ``%SystemDrive%\\gcloud``
+      (default ``C:``) when APPDATA is unset — google-auth covers that case,
+      and building a bare relative ``gcloud\\…`` instead would silently probe
+      the wrong place.
+
+    Not imported from google-auth on purpose: this module's callers require no
+    google-auth import (see :func:`has_vertex_credentials`).
+    """
+    filename = "application_default_credentials.json"
+
+    explicit = os.environ.get("CLOUDSDK_CONFIG")
+    if explicit:
+        return os.path.join(explicit, filename)
+
+    if os.name != "nt":
+        return os.path.join(os.path.expanduser("~"), ".config", "gcloud", filename)
+
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        return os.path.join(appdata, "gcloud", filename)
+    drive = os.environ.get("SystemDrive", "C:")
+    return os.path.join(drive, "\\", "gcloud", filename)
 
 
 def _on_gce() -> bool:
     """True when this host looks like GCE/GKE, without touching the network.
 
-    On GCE the DMI product name is exactly "Google Compute Engine". Reading
-    it is a single small file read, so this keeps the no-network promise that
+    On GCE the DMI product name is "Google Compute Engine". Reading it is a
+    single small file read, so this keeps the no-network promise that
     :func:`has_vertex_credentials` makes to startup paths — a metadata-server
     ping would not.
+
+    Substring rather than exact match, deliberately. The two failure directions
+    are not symmetric: too strict silently restores the very bug this function
+    exists to fix (credentials reported absent on a host that has them), while
+    too loose merely lets `google.auth.default()` fail later with a clear
+    message. Given that asymmetry, tolerating an unexpected suffix is the safer
+    default.
     """
     try:
         with open("/sys/class/dmi/id/product_name", "r", encoding="utf-8") as fh:
@@ -321,6 +352,18 @@ def has_adc_available() -> bool:
       writes, and
     * running on GCE/GKE, where the metadata server *is* the credential and no
       file exists at all.
+
+    Known and intended behaviour change: a workstation carrying a leftover
+    `gcloud auth application-default login` file now reports Vertex credentials
+    as present even with no project configured, so provider auto-detection can
+    surface Vertex where it previously stayed hidden. That is accepted rather
+    than special-cased. Bare ADC on a workstation is a supported google-auth
+    setup, and the consequence is bounded: this gate makes Vertex *offerable*,
+    it does not select it or spend anything, and a stale ADC file surfaces as a
+    normal auth error on first use rather than as silent misbehaviour. The
+    reverse bias — accepting ADC only on GCE — would keep the picker tidy at
+    the cost of ignoring a real credential, which is the class of bug this
+    function is being fixed for.
     """
     if os.path.exists(_adc_well_known_path()):
         return True

--- a/agent/vertex_adapter.py
+++ b/agent/vertex_adapter.py
@@ -280,19 +280,78 @@ def get_vertex_config(
     return token, base_url
 
 
+def _adc_well_known_path() -> str:
+    """Path gcloud writes for `auth application-default login`."""
+    if os.name == "nt":
+        base = os.environ.get("APPDATA", "")
+        return os.path.join(base, "gcloud", "application_default_credentials.json")
+    return os.path.join(
+        os.path.expanduser("~"),
+        ".config",
+        "gcloud",
+        "application_default_credentials.json",
+    )
+
+
+def _on_gce() -> bool:
+    """True when this host looks like GCE/GKE, without touching the network.
+
+    On GCE the DMI product name is exactly "Google Compute Engine". Reading
+    it is a single small file read, so this keeps the no-network promise that
+    :func:`has_vertex_credentials` makes to startup paths — a metadata-server
+    ping would not.
+    """
+    try:
+        with open("/sys/class/dmi/id/product_name", "r", encoding="utf-8") as fh:
+            return "Google Compute Engine" in fh.read()
+    except Exception:
+        return False
+
+
+def has_adc_available() -> bool:
+    """True when Application Default Credentials are plausibly resolvable.
+
+    Deliberately a cheap heuristic rather than a real ADC resolution: the
+    caller is a startup/display path, and `google.auth.default()` both imports
+    google-auth and can hit the metadata server.
+
+    Two signals, either sufficient:
+
+    * the well-known ADC file that `gcloud auth application-default login`
+      writes, and
+    * running on GCE/GKE, where the metadata server *is* the credential and no
+      file exists at all.
+    """
+    if os.path.exists(_adc_well_known_path()):
+        return True
+    return _on_gce()
+
+
 def has_vertex_credentials() -> bool:
     """Fast check for whether Vertex credentials appear configured.
 
     No network calls and no google-auth import — safe for provider
-    auto-detection and setup-status display. True when either a service
-    account JSON path is resolvable, or an explicit project ID is configured
-    (env or config.yaml, implying ADC is intended).
+    auto-detection and setup-status display. True when a service account JSON
+    path is resolvable, an explicit project ID is configured (env or
+    config.yaml, implying ADC is intended), or ADC itself is plausibly
+    available.
+
+    The ADC branch matters most where it is least visible: on a GCE VM the
+    credential is the metadata server, so there is no JSON file to find and no
+    reason for an operator to restate a project ID that
+    ``google.auth.default()`` already returns. Without it, such a deployment
+    reports "no GCP credentials found" and
+    ``resolve_provider_client("vertex")`` returns ``(None, None)``, silently
+    disabling every auxiliary task (vision, compression, curator,
+    session_search, title generation, web extract) while the main conversation
+    path — which resolves credentials properly — keeps working. That split
+    failure is very hard to read from the symptoms.
     """
     if _resolve_credentials_path(None):
         return True
     if _resolve_project_override():
         return True
-    return False
+    return has_adc_available()
 
 
 def has_explicit_vertex_config() -> bool:

--- a/tests/agent/test_vertex_adapter.py
+++ b/tests/agent/test_vertex_adapter.py
@@ -102,8 +102,71 @@ def test_has_vertex_credentials_via_config_project(vertex_adapter, monkeypatch):
     assert vertex_adapter.has_vertex_credentials() is True
 
 
-def test_has_vertex_credentials_false_when_nothing_set(vertex_adapter):
+def test_has_vertex_credentials_false_when_nothing_set(vertex_adapter, monkeypatch):
+    # ADC is stubbed out explicitly rather than left to the host: the ADC
+    # branch below is exactly what makes this environment-sensitive, so the
+    # "nothing set" case has to state that ADC is absent to mean anything.
+    monkeypatch.setattr(vertex_adapter, "has_adc_available", lambda: False)
     assert vertex_adapter.has_vertex_credentials() is False
+
+
+def test_has_vertex_credentials_via_adc_without_project(vertex_adapter, monkeypatch):
+    """ADC alone is sufficient — no SA file, no project override.
+
+    This is the GCE/GKE shape: the metadata server is the credential, so there
+    is no JSON path to discover and the project comes from
+    ``google.auth.default()``. Before this branch existed, such a host reported
+    no credentials and silently lost every auxiliary task.
+    """
+    monkeypatch.setattr(vertex_adapter, "_vertex_config", lambda: {})
+    monkeypatch.setattr(vertex_adapter, "has_adc_available", lambda: True)
+    assert vertex_adapter.has_vertex_credentials() is True
+
+
+def test_has_adc_available_detects_gce_without_network(vertex_adapter, monkeypatch):
+    monkeypatch.setattr(vertex_adapter.os.path, "exists", lambda _p: False)
+    monkeypatch.setattr(vertex_adapter, "_on_gce", lambda: True)
+    assert vertex_adapter.has_adc_available() is True
+
+
+def test_has_adc_available_detects_well_known_file(vertex_adapter, monkeypatch):
+    target = vertex_adapter._adc_well_known_path()
+    monkeypatch.setattr(vertex_adapter.os.path, "exists", lambda p: p == target)
+    monkeypatch.setattr(vertex_adapter, "_on_gce", lambda: False)
+    assert vertex_adapter.has_adc_available() is True
+
+
+def test_has_adc_available_false_when_neither(vertex_adapter, monkeypatch):
+    monkeypatch.setattr(vertex_adapter.os.path, "exists", lambda _p: False)
+    monkeypatch.setattr(vertex_adapter, "_on_gce", lambda: False)
+    assert vertex_adapter.has_adc_available() is False
+
+
+def test_on_gce_reads_dmi_product_name(vertex_adapter, monkeypatch, tmp_path):
+    """`_on_gce` must not make a network call — it reads DMI."""
+    import builtins
+
+    real_open = builtins.open
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/sys/class/dmi/id/product_name":
+            dmi = tmp_path / "product_name"
+            dmi.write_text("Google Compute Engine\n", encoding="utf-8")
+            return real_open(dmi, *args, **kwargs)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    assert vertex_adapter._on_gce() is True
+
+
+def test_on_gce_false_when_dmi_missing(vertex_adapter, monkeypatch):
+    import builtins
+
+    def boom(path, *args, **kwargs):
+        raise FileNotFoundError(path)
+
+    monkeypatch.setattr(builtins, "open", boom)
+    assert vertex_adapter._on_gce() is False
 
 
 

--- a/tests/agent/test_vertex_adapter.py
+++ b/tests/agent/test_vertex_adapter.py
@@ -123,10 +123,60 @@ def test_has_vertex_credentials_via_adc_without_project(vertex_adapter, monkeypa
     assert vertex_adapter.has_vertex_credentials() is True
 
 
-def test_has_adc_available_detects_gce_without_network(vertex_adapter, monkeypatch):
+def test_has_adc_available_via_gce_signal(vertex_adapter, monkeypatch):
+    # Named for what it actually asserts: `_on_gce` is stubbed here, so this
+    # covers the GCE *branch*, not the no-network property. That property is
+    # covered by test_on_gce_reads_dmi_product_name below.
     monkeypatch.setattr(vertex_adapter.os.path, "exists", lambda _p: False)
     monkeypatch.setattr(vertex_adapter, "_on_gce", lambda: True)
     assert vertex_adapter.has_adc_available() is True
+
+
+def test_adc_path_honours_cloudsdk_config(vertex_adapter, monkeypatch):
+    """CLOUDSDK_CONFIG relocates gcloud's config dir and must win.
+
+    Mirrors google.auth._cloud_sdk.get_config_path(), which checks this first
+    on every platform. CI images and devcontainers set it routinely, so missing
+    it means probing a path where the credential is not.
+    """
+    monkeypatch.setenv("CLOUDSDK_CONFIG", "/custom/gcloud/root")
+    assert vertex_adapter._adc_well_known_path() == (
+        "/custom/gcloud/root/application_default_credentials.json"
+    )
+
+
+def test_adc_path_posix_default(vertex_adapter, monkeypatch):
+    monkeypatch.delenv("CLOUDSDK_CONFIG", raising=False)
+    monkeypatch.setattr(vertex_adapter.os, "name", "posix")
+    monkeypatch.setattr(vertex_adapter.os.path, "expanduser", lambda _p: "/home/u")
+    assert vertex_adapter._adc_well_known_path() == (
+        "/home/u/.config/gcloud/application_default_credentials.json"
+    )
+
+
+def test_adc_path_windows_uses_appdata(vertex_adapter, monkeypatch):
+    monkeypatch.delenv("CLOUDSDK_CONFIG", raising=False)
+    monkeypatch.setattr(vertex_adapter.os, "name", "nt")
+    monkeypatch.setenv("APPDATA", "C:\\Users\\u\\AppData\\Roaming")
+    assert vertex_adapter._adc_well_known_path().endswith(
+        "application_default_credentials.json"
+    )
+    assert "gcloud" in vertex_adapter._adc_well_known_path()
+
+
+def test_adc_path_windows_falls_back_to_system_drive(vertex_adapter, monkeypatch):
+    """google-auth covers APPDATA being unset; so must we.
+
+    Without this branch the path would be built from an empty base, silently
+    probing a bare relative `gcloud/...` instead of the real location.
+    """
+    monkeypatch.delenv("CLOUDSDK_CONFIG", raising=False)
+    monkeypatch.delenv("APPDATA", raising=False)
+    monkeypatch.setattr(vertex_adapter.os, "name", "nt")
+    monkeypatch.setenv("SystemDrive", "D:")
+    path = vertex_adapter._adc_well_known_path()
+    assert path.startswith("D:")
+    assert "gcloud" in path
 
 
 def test_has_adc_available_detects_well_known_file(vertex_adapter, monkeypatch):


### PR DESCRIPTION
# fix(vertex): detect ADC so a GCE/GKE deployment keeps its auxiliary tasks

## The problem

`has_vertex_credentials()` returns true only when a service-account JSON path
resolves or an explicit project ID is configured:

```python
def has_vertex_credentials() -> bool:
    if _resolve_credentials_path(None):
        return True
    if _resolve_project_override():
        return True
    return False
```

On GCE or GKE neither holds. The credential *is* the metadata server, so there
is no JSON file to find, and there is no reason for an operator to restate a
project ID that `google.auth.default()` already returns — `vertex.project_id`
is documented as an override, not a requirement.

## Why it matters more than it looks

`get_vertex_credentials()` resolves the credential correctly on such a host, via
`google.auth.default()`. So the failure is not "Vertex doesn't work". It is:

- `resolve_provider_client("vertex")` hits the `has_vertex_credentials()` guard
  at `agent/auxiliary_client.py` and returns `(None, None)`
- every auxiliary task silently disappears — vision, compression, curator,
  session_search, title generation, web extract
- the agent otherwise behaves normally

Nothing looks broken. Image analysis and context compression are simply gone,
and the only signal is a DEBUG line reading "no GCP credentials found". The
user-visible errors say `No LLM provider configured for task=vision
provider=auto`, which points at task configuration rather than at a Vertex
credential probe two modules away.

It also makes `vertex.project_id` load-bearing for a reason unrelated to its
documented purpose: it is an *override*, yet removing it disables the entire
auxiliary surface.

## The fix

Adds `has_adc_available()` as a third accepted signal:

- the well-known file that `gcloud auth application-default login` writes, and
- GCE/GKE detection via the DMI product name.

Both are single small file reads. That is deliberate — this function promises
"no network calls and no google-auth import" because it is called from
provider auto-detection and setup-status paths, and a metadata-server ping
would break that promise. `google.auth.default()` remains the thing that
actually resolves the credential; this is only the cheap "is it plausible"
gate, and it runs solely when the two existing branches have already failed.

## Tests

- ADC alone is sufficient — no SA file, no project override (the GCE shape).
- `has_adc_available` detects GCE, detects the well-known file, and is false
  when neither is present.
- `_on_gce` reads DMI, and is false when that file is missing — asserted
  without any network access.
- `test_has_vertex_credentials_false_when_nothing_set` now stubs
  `has_adc_available` explicitly. Left as it was, it would pass in CI and fail
  on any developer machine that has run `gcloud auth application-default
  login`. That environment sensitivity is exactly what this change introduces,
  so the "nothing set" case has to state that ADC is absent for the assertion
  to mean anything.

## Verification

On a GCE VM (e2-standard-2, NixOS, ADC via the metadata server, no
service-account JSON, no `vertex.project_id`):

- `_on_gce()` → True, well-known file absent, `has_adc_available()` → True
- `has_vertex_credentials()` → True, where it previously returned False
- an explicit project override still short-circuits ahead of the ADC probe
- with ADC stubbed absent it still returns False

Then end-to-end on that host with all project configuration removed: six
auxiliary probes (vision, title generation, compression, session_search,
curator, web extract) all pass, having all failed before the change.

## Compatibility

Additive and ordered last. Deployments with a service-account JSON or an
explicit project ID take the same two branches in the same order and are
unaffected.

## Note for maintainers

We carry a downstream fork with Anthropic-on-Vertex support that is not yet
upstream. It has a second, structurally identical gate
(`has_anthropic_vertex_credentials`) that needs the same treatment. That half
is deliberately **not** in this PR, since the file it touches does not exist
here — we mention it only because if that work is ever upstreamed, the two
gates should be kept in agreement. We found this the hard way: fixing one and
not the other took a host down completely rather than partially, because
`provider=auto` routes the auxiliary path through the Anthropic gate as well.
