### PR TITLE
fix(cli): deduplicate built-in providers in custom_providers model picker (#92430)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2675,15 +2675,22 @@ def list_authenticated_providers(
         try:
             from hermes_cli.auth import PROVIDER_REGISTRY as _reg
         except Exception:
-            return
+            _reg = {}
         pcfg = _reg.get(slug)
-        if not pcfg:
-            return
         url = ""
-        if getattr(pcfg, "base_url_env_var", ""):
-            url = os.environ.get(pcfg.base_url_env_var, "") or ""
+        if pcfg:
+            if getattr(pcfg, "base_url_env_var", ""):
+                url = os.environ.get(pcfg.base_url_env_var, "") or ""
+            if not url:
+                url = getattr(pcfg, "inference_base_url", "") or ""
         if not url:
-            url = getattr(pcfg, "inference_base_url", "") or ""
+            try:
+                from providers import get_provider_profile as _gpp
+                prof = _gpp(slug)
+                if prof:
+                    url = getattr(prof, "base_url", "") or ""
+            except Exception:
+                pass
         normed = _norm_url(url)
         if normed:
             _builtin_endpoints.add(normed)
@@ -3697,7 +3704,23 @@ def list_authenticated_providers(
             # If the slug is already claimed by a built-in / overlay /
             # user-provider row (sections 1-3), skip this custom group
             # to avoid shadowing a real provider.
-            if slug.lower() in seen_slugs and slug.lower() not in _section4_emitted_slugs:
+            #
+            # For exact slug matches (e.g. user-provider from section 3),
+            # skip unconditionally. For bare-slug / alias matches, gate on
+            # endpoint URL matching a built-in endpoint so custom proxies
+            # sharing a vendor name on a private host (e.g. a local OpenAI
+            # or Groq proxy) are not suppressed. Fixes #92430.
+            _grp_url_norm = str(grp["api_url"]).strip().rstrip("/").lower()
+            bare_slug = slug[7:] if slug.lower().startswith("custom:") else slug
+            _name_matches_builtin = (
+                bare_slug.lower() in seen_slugs
+                or any(str(alias).lower() in seen_slugs for alias in grp.get("aliases", set()))
+            )
+            _claimed = (
+                slug.lower() in seen_slugs
+                or (_name_matches_builtin and _grp_url_norm in _builtin_endpoints)
+            )
+            if _claimed and slug.lower() not in _section4_emitted_slugs:
                 continue
             # If a prior section-4 group already used this slug (two custom
             # endpoints with the same cleaned name — e.g. two OpenAI-

--- a/tests/hermes_cli/test_openrouter_picker_dedup.py
+++ b/tests/hermes_cli/test_openrouter_picker_dedup.py
@@ -1,0 +1,217 @@
+"""Tests for OpenRouter provider deduplication in the /model picker (#92430).
+
+When OpenRouter is configured in config.yaml under ``providers:``, gateway and CLI
+flows call ``get_compatible_custom_providers(cfg)`` which materializes
+a custom_providers entry for OpenRouter. When passed to ``list_authenticated_providers``
+or ``list_picker_providers``, Section 1 emits the canonical "openrouter" entry, and
+Section 4 must NOT emit a duplicate "custom:openrouter" entry.
+"""
+
+import pytest
+from hermes_cli import model_switch
+from hermes_cli.config import get_compatible_custom_providers
+
+
+@pytest.fixture(autouse=True)
+def _disable_live_custom_provider_model_probe(monkeypatch):
+    """Keep custom-provider picker fixtures independent of local model servers."""
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *_a, **_kw: None)
+
+
+def test_openrouter_in_providers_config_not_duplicated_in_picker(monkeypatch):
+    """Configuring openrouter in providers: should yield exactly one picker row (#92430)."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test-key")
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        "openrouter": {"name": "OpenRouter", "env": ["OPENROUTER_API_KEY"]},
+    })
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {
+        "openrouter": "openrouter",
+    })
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models", lambda *a, **kw: [("openrouter/auto", "Auto")])
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", lambda slug: ["openrouter/auto"])
+
+    cfg = {
+        "providers": {
+            "openrouter": {
+                "name": "OpenRouter",
+                "api": "https://openrouter.ai/api/v1",
+                "key_env": "OPENROUTER_API_KEY",
+                "transport": "chat_completions",
+                "default_model": "openrouter/auto",
+                "discover_models": False,
+                "models": [],
+            }
+        }
+    }
+
+    user_provs = cfg.get("providers")
+    custom_provs = get_compatible_custom_providers(cfg)
+
+    rows = model_switch.list_picker_providers(
+        user_providers=user_provs,
+        custom_providers=custom_provs,
+        max_models=50,
+    )
+
+    openrouter_rows = [
+        r for r in rows
+        if r.get("slug") == "openrouter" or "openrouter" in str(r.get("slug", "")).lower() or r.get("name") == "OpenRouter"
+    ]
+
+    assert len(openrouter_rows) == 1, (
+        f"Expected exactly 1 OpenRouter row in picker, got {len(openrouter_rows)}: "
+        f"{[r.get('slug') for r in openrouter_rows]}"
+    )
+    assert openrouter_rows[0]["slug"] == "openrouter"
+
+
+def test_openrouter_in_custom_providers_list_deduplicated(monkeypatch):
+    """Directly passing openrouter in custom_providers must not create duplicate (#92430)."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test-key")
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        "openrouter": {"name": "OpenRouter", "env": ["OPENROUTER_API_KEY"]},
+    })
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {
+        "openrouter": "openrouter",
+    })
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", lambda slug: ["openrouter/auto"])
+
+    custom_provs = [
+        {
+            "name": "OpenRouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "key_env": "OPENROUTER_API_KEY",
+            "model": "openrouter/auto",
+            "discover_models": False,
+        }
+    ]
+
+    rows = model_switch.list_authenticated_providers(
+        custom_providers=custom_provs,
+        max_models=50,
+    )
+
+    slugs = [r["slug"] for r in rows]
+    openrouter_slugs = [s for s in slugs if "openrouter" in s.lower()]
+
+    assert openrouter_slugs == ["openrouter"], (
+        f"Expected only ['openrouter'], got: {openrouter_slugs}"
+    )
+
+
+def test_openrouter_custom_display_name_deduplicated_by_key_and_url(monkeypatch):
+    """Non-canonical display name with OpenRouter provider_key/base_url is deduplicated."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test-key")
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        "openrouter": {"name": "OpenRouter", "env": ["OPENROUTER_API_KEY"]},
+    })
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {
+        "openrouter": "openrouter",
+    })
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", lambda slug: ["openrouter/auto"])
+
+    custom_provs = [
+        {
+            "name": "My Custom Aggregator",
+            "provider_key": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "key_env": "OPENROUTER_API_KEY",
+            "model": "openrouter/auto",
+            "discover_models": False,
+        },
+        {
+            "name": "Another Router",
+            "base_url": "https://openrouter.ai/api/v1",
+            "key_env": "OPENROUTER_API_KEY",
+            "model": "openrouter/auto",
+            "discover_models": False,
+        },
+    ]
+
+    rows = model_switch.list_authenticated_providers(
+        custom_providers=custom_provs,
+        max_models=50,
+    )
+
+    slugs = [r["slug"] for r in rows]
+    openrouter_slugs = [s for s in slugs if "openrouter" in s.lower()]
+
+    assert openrouter_slugs == ["openrouter"], (
+        f"Expected only ['openrouter'], got: {slugs}"
+    )
+
+
+def test_distinct_non_canonical_custom_provider_preserved(monkeypatch):
+    """Legitimately distinct custom endpoints are not suppressed."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test-key")
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        "openrouter": {"name": "OpenRouter", "env": ["OPENROUTER_API_KEY"]},
+    })
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {
+        "openrouter": "openrouter",
+    })
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", lambda slug: ["openrouter/auto"])
+
+    custom_provs = [
+        {
+            "name": "Local Ollama",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "ollama",
+            "model": "llama3.3:70b",
+            "discover_models": False,
+        }
+    ]
+
+    rows = model_switch.list_authenticated_providers(
+        custom_providers=custom_provs,
+        max_models=50,
+    )
+
+    slugs = [r["slug"] for r in rows]
+    assert "openrouter" in slugs
+    assert "custom:local-ollama" in slugs
+    ollama_row = next(r for r in rows if r["slug"] == "custom:local-ollama")
+    assert ollama_row["name"] == "Local Ollama"
+    assert ollama_row["models"] == ["llama3.3:70b"]
+
+
+def test_custom_proxy_sharing_builtin_name_preserved(monkeypatch):
+    """A custom proxy named after a built-in provider on a custom URL is preserved."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-test-key")
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {
+        "openrouter": {"name": "OpenRouter", "env": ["OPENROUTER_API_KEY"]},
+    })
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {
+        "openrouter": "openrouter",
+    })
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", lambda slug: ["openrouter/auto"])
+
+    custom_provs = [
+        {
+            "name": "OpenRouter",
+            "base_url": "https://my-internal-proxy.company.internal/v1",
+            "api_key": "sk-internal",
+            "model": "company-model-1",
+            "discover_models": False,
+        }
+    ]
+
+    rows = model_switch.list_authenticated_providers(
+        custom_providers=custom_provs,
+        max_models=50,
+    )
+
+    slugs = [r["slug"] for r in rows]
+    # Both canonical built-in and the distinct custom proxy should appear
+    assert "openrouter" in slugs
+    assert "custom:openrouter" in slugs
+    proxy_row = next(r for r in rows if r["slug"] == "custom:openrouter")
+    assert proxy_row["is_user_defined"] is True
+    assert proxy_row["api_url"] == "https://my-internal-proxy.company.internal/v1"
+    assert proxy_row["models"] == ["company-model-1"]
+


### PR DESCRIPTION
## What does this PR do?

Deduplicates built-in providers (specifically aggregators like OpenRouter) when listed alongside custom endpoints in `list_authenticated_providers` and `list_picker_providers`.

When a user defines OpenRouter under `providers:` in `config.yaml`, downstream callers like the Telegram and Discord `/switch` model pickers convert configured providers into custom provider entries via `get_compatible_custom_providers()`. Section 1 in `list_authenticated_providers` emits the built-in `openrouter` row, while Section 4 previously failed to detect the duplication because `custom_provider_slug()` added a `custom:` prefix (`custom:openrouter`), and `_record_builtin_endpoint()` failed for providers omitted from `PROVIDER_REGISTRY`. This resulted in duplicate OpenRouter rows (`OpenRouter (421)` and `OpenRouter (41)`) appearing in interactive pickers.

This change:
1. Enhances `_record_builtin_endpoint` to fall back to `providers.get_provider_profile(slug).base_url` for built-in providers not in `PROVIDER_REGISTRY`.
2. Checks bare slugs (without `custom:` prefix) and provider aliases against `seen_slugs` in Section 4 deduplication.

## Related Issue

Fixes #92430

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_switch.py`:
  - In `_record_builtin_endpoint()`: Added fallback to `providers.get_provider_profile(slug)` so aggregators like OpenRouter have their canonical `base_url` registered in `_builtin_endpoints`.
  - In Section 4 custom provider loop: Checked `bare_slug` and group `aliases` against `seen_slugs` to prevent duplicate custom rows for built-in providers.
- `tests/hermes_cli/test_openrouter_picker_dedup.py`: Added unit regression tests for OpenRouter single-row deduplication across both `providers:` config and direct `custom_providers` lists.

## How to Test

1. Run the new regression test suite:
   ```bash
   pytest tests/hermes_cli/test_openrouter_picker_dedup.py
   ```
2. Run related model switch / picker tests:
   ```bash
   pytest tests/hermes_cli/test_list_picker_providers.py tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_model_picker_excluded_providers.py
   ```
   All 99 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 10 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
